### PR TITLE
docs: clarify local setup for DB dir and Composio token masking

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ The image is published to `ghcr.io/iddogino/superagent` on every push to main an
 | `CONTAINER_STATUS_SYNC_INTERVAL_SECONDS` | How often to sync container status with Docker (seconds) | `300` |
 | `RUNNER_AVAILABILITY_CACHE_TTL_SECONDS` | How long to cache Docker/Podman availability checks (seconds) | `60` |
 
+### Optional: Composio OAuth setup
+
+If you connect accounts through Composio (Slack/Gmail/GitHub, etc.), make sure token masking is disabled in your Composio project settings, otherwise SuperAgent cannot read usable access tokens and proxy calls may fail.
+
+In the Composio dashboard, go to:
+- `Project Settings`
+- `Project Configuration`
+- Disable `Mask Connected Account Secrets`
+
+After changing this setting, reconnect the account in SuperAgent.
+
 Create a `.env.local` file in the project root:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -85,12 +85,17 @@ The image is published to `ghcr.io/iddogino/superagent` on every push to main an
 
 3. Set up environment variables (see below)
 
-4. Run database migrations:
+4. Create the local data directory:
+   ```bash
+   mkdir -p ~/.superagent
+   ```
+
+5. Run database migrations:
    ```bash
    npm run db:migrate
    ```
 
-5. Start the development server:
+6. Start the development server:
    ```bash
    npm run dev
    ```


### PR DESCRIPTION
## Summary
- add an explicit setup step to create `~/.superagent` before running `npm run db:migrate`
- add optional Composio setup note to disable token masking in Project Settings > Project Configuration
- note that accounts should be reconnected in SuperAgent after changing the Composio masking setting

## Test plan
- [x] Review README changes for setup flow clarity
- [x] Validate command syntax: `mkdir -p ~/.superagent`
- [x] Validate Composio navigation wording against current dashboard UI
- [ ] Optional manual check in fresh environment: run source setup steps end-to-end


Made with [Cursor](https://cursor.com)