### PR TITLE
fix: respect SUPERAGENT_DATA_DIR env var when already set

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,7 +18,9 @@ if (!app.isPackaged) {
 // This uses ~/Library/Application Support/Superagent (or Superagent-Dev) on macOS
 // or %APPDATA%/Superagent (or Superagent-Dev) on Windows
 // Note: app.getPath() works synchronously before app.whenReady()
-process.env.SUPERAGENT_DATA_DIR = app.getPath('userData')
+if (!process.env.SUPERAGENT_DATA_DIR) {
+  process.env.SUPERAGENT_DATA_DIR = app.getPath('userData')
+}
 console.log(`Data directory: ${process.env.SUPERAGENT_DATA_DIR}`)
 
 // Register auto-update IPC handlers early (before window creation)


### PR DESCRIPTION
## Summary
- The main process was unconditionally overwriting `SUPERAGENT_DATA_DIR` with `app.getPath('userData')`, ignoring any value passed via the environment.
- Now it only falls back to the Electron default when the variable is not already set.

## Test plan
- Run `SUPERAGENT_DATA_DIR="$HOME/.superagent" npm run dev:electron` and verify the log shows `Data directory: /Users/<you>/.superagent`
- Run `npm run dev:electron` without the env var and verify it still defaults to `~/Library/Application Support/Superagent-Dev`

Made with [Cursor](https://cursor.com)