### PR TITLE
feat: forward ANTHROPIC_BASE_URL to agent containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,5 @@ services:
     environment:
       - SUPERAGENT_DATA_DIR=${HOME}/.superagent
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL:-}
       - PORT=47891

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "clsx": "^2.1.1",
         "cron-parser": "^5.5.0",
         "date-fns": "^4.1.0",
+        "dotenv": "^17.3.1",
         "drizzle-orm": "^0.33.0",
         "electron-updater": "^6.7.3",
         "eventsource": "^4.1.0",
@@ -5022,6 +5023,19 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/app-builder-lib/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/app-builder-lib/node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -7273,10 +7287,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -7294,6 +7307,19 @@
       "dependencies": {
         "dotenv": "^16.4.5"
       },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "clsx": "^2.1.1",
     "cron-parser": "^5.5.0",
     "date-fns": "^4.1.0",
+    "dotenv": "^17.3.1",
     "drizzle-orm": "^0.33.0",
     "electron-updater": "^6.7.3",
     "eventsource": "^4.1.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,11 @@
 import { app, BrowserWindow, ipcMain, nativeTheme, shell, Notification } from 'electron'
 import path from 'path'
+import { config as loadEnv } from 'dotenv'
+
+// Load .env.local from project root (dist/main/ -> ../../.env.local)
+// override: false ensures CLI env vars take precedence
+loadEnv({ path: path.resolve(app.getAppPath(), '.env.local'), override: false })
+
 import { EventSource } from 'eventsource'
 import { createTray, destroyTray, updateTrayWindow, setTrayVisible } from './tray'
 import { createAppMenu, updateAppMenuWindow, destroyAppMenu } from './app-menu'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,7 +18,9 @@ if (!app.isPackaged) {
 // This uses ~/Library/Application Support/Superagent (or Superagent-Dev) on macOS
 // or %APPDATA%/Superagent (or Superagent-Dev) on Windows
 // Note: app.getPath() works synchronously before app.whenReady()
-process.env.SUPERAGENT_DATA_DIR = app.getPath('userData')
+if (!process.env.SUPERAGENT_DATA_DIR) {
+  process.env.SUPERAGENT_DATA_DIR = app.getPath('userData')
+}
 console.log(`Data directory: ${process.env.SUPERAGENT_DATA_DIR}`)
 
 // Register auto-update IPC handlers early (before window creation)

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -801,7 +801,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   private buildEnvFlags(additionalEnvVars?: Record<string, string>): string {
     const envVars: Record<string, string | undefined> = {
       ANTHROPIC_API_KEY: getEffectiveAnthropicApiKey(),
-      ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+      ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL?.replace('localhost', 'host.docker.internal'),
       CLAUDE_CONFIG_DIR: '/workspace/.claude',
       ...this.config.envVars,
       ...additionalEnvVars,

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -801,6 +801,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   private buildEnvFlags(additionalEnvVars?: Record<string, string>): string {
     const envVars: Record<string, string | undefined> = {
       ANTHROPIC_API_KEY: getEffectiveAnthropicApiKey(),
+      ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
       CLAUDE_CONFIG_DIR: '/workspace/.claude',
       ...this.config.envVars,
       ...additionalEnvVars,


### PR DESCRIPTION
## Summary
- Forward `ANTHROPIC_BASE_URL` env var to Docker agent containers via `buildEnvFlags()` in `base-container-client.ts`
- Add `ANTHROPIC_BASE_URL` to `docker-compose.yml` (defaults to empty if unset)
- This allows routing all Anthropic API calls through a custom proxy (e.g. AI gateway for logging, rate limiting, etc.)

## Test plan
- Set `ANTHROPIC_BASE_URL=http://localhost:8787/.../anthropic` in `.env.local`
- Start an agent container and verify it receives the env var (`docker exec <container> env | grep ANTHROPIC`)
- Verify API calls from the container go through the configured proxy
- Without the env var set, verify containers still call Anthropic directly (no regression)

Made with [Cursor](https://cursor.com)