### PR TITLE
feat: add pause/resume for scheduled tasks

### DIFF
--- a/agent-container/src/mcp-server.ts
+++ b/agent-container/src/mcp-server.ts
@@ -12,6 +12,7 @@ import { searchConnectedAccountServicesTool } from './tools/search-connected-acc
 import { requestRemoteMcpTool } from './tools/request-remote-mcp'
 import { searchRemoteMcpServicesTool } from './tools/search-remote-mcp-services'
 import { scheduleTaskTool } from './tools/schedule-task'
+import { manageScheduledTasksTool } from './tools/manage-scheduled-tasks'
 import { deliverFileTool } from './tools/deliver-file'
 import { requestFileTool } from './tools/request-file'
 import { browserTools } from './tools/browser'
@@ -31,7 +32,7 @@ export function createUserInputMcpServer() {
   return createSdkMcpServer({
     name: 'user-input',
     version: '1.0.0',
-    tools: [requestSecretTool, requestConnectedAccountTool, searchConnectedAccountServicesTool, requestRemoteMcpTool, searchRemoteMcpServicesTool, scheduleTaskTool, deliverFileTool, requestFileTool],
+    tools: [requestSecretTool, requestConnectedAccountTool, searchConnectedAccountServicesTool, requestRemoteMcpTool, searchRemoteMcpServicesTool, scheduleTaskTool, manageScheduledTasksTool, deliverFileTool, requestFileTool],
   })
 }
 

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -259,7 +259,8 @@ name: "Meeting Reminder"
 
 **Important:**
 - Scheduled tasks run in new sessions with full access to your skills and tools
-- Users can view and cancel scheduled tasks from the UI
+- Users can view, pause, resume, and cancel scheduled tasks from the UI
+- Paused tasks retain their schedule but skip execution until resumed
 - One-time tasks are removed after execution; recurring tasks continue until cancelled
 
 ## File Handling

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -257,9 +257,18 @@ prompt: "Remind the user about their 3pm meeting with the design team"
 name: "Meeting Reminder"
 ```
 
+### Managing Scheduled Tasks
+
+You can also manage existing scheduled tasks using `mcp__user-input__manage_scheduled_tasks`:
+- `action: "list"` — List all active (pending + paused) tasks for this agent
+- `action: "pause", taskId: "<id>"` — Pause a pending task
+- `action: "resume", taskId: "<id>"` — Resume a paused task
+- `action: "cancel", taskId: "<id>"` — Cancel a task permanently
+
+Use "list" first to get task IDs before performing pause/resume/cancel.
+
 **Important:**
 - Scheduled tasks run in new sessions with full access to your skills and tools
-- Users can view, pause, resume, and cancel scheduled tasks from the UI
 - Paused tasks retain their schedule but skip execution until resumed
 - One-time tasks are removed after execution; recurring tasks continue until cancelled
 

--- a/agent-container/src/tools/manage-scheduled-tasks.ts
+++ b/agent-container/src/tools/manage-scheduled-tasks.ts
@@ -1,0 +1,56 @@
+/**
+ * Manage Scheduled Tasks Tool
+ *
+ * Allows agents to list, pause, resume, and cancel their own scheduled tasks.
+ * Like schedule_task, this tool only validates input — the actual DB operations
+ * are handled by the API server's message-persister which intercepts the tool call.
+ */
+
+import { tool } from '@anthropic-ai/claude-agent-sdk'
+import { z } from 'zod'
+
+export const manageScheduledTasksTool = tool(
+  'manage_scheduled_tasks',
+  `Manage your scheduled tasks. You can list all active tasks, pause a running task, resume a paused task, or cancel a task entirely.
+
+Actions:
+- "list" — List all active (pending + paused) scheduled tasks for this agent. No taskId needed.
+- "pause" — Pause a pending task so it stops executing until resumed. Requires taskId.
+- "resume" — Resume a paused task so it starts executing again. Requires taskId.
+- "cancel" — Cancel a task permanently. Requires taskId.
+
+Use "list" first to see available tasks and their IDs before performing other actions.`,
+  {
+    action: z
+      .enum(['list', 'pause', 'resume', 'cancel'])
+      .describe('The action to perform on scheduled tasks'),
+    taskId: z
+      .string()
+      .optional()
+      .describe('The ID of the task to act on. Required for pause, resume, and cancel actions.'),
+  },
+  async (args) => {
+    if (args.action !== 'list' && !args.taskId) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Action "${args.action}" requires a taskId. Use action "list" first to see available tasks and their IDs.`,
+          },
+        ],
+        isError: true,
+      }
+    }
+
+    console.log(`[manage_scheduled_tasks] ${args.action}${args.taskId ? ` task ${args.taskId}` : ''}`)
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Task management action "${args.action}" is being processed.${args.taskId ? ` Task ID: ${args.taskId}` : ''}`,
+        },
+      ],
+    }
+  }
+)

--- a/agent-container/src/tools/manage-scheduled-tasks.ts
+++ b/agent-container/src/tools/manage-scheduled-tasks.ts
@@ -1,13 +1,21 @@
 /**
  * Manage Scheduled Tasks Tool
  *
- * Allows agents to list, pause, resume, and cancel their own scheduled tasks.
- * Like schedule_task, this tool only validates input — the actual DB operations
- * are handled by the API server's message-persister which intercepts the tool call.
+ * Allows agents to list, pause, resume, and cancel their own scheduled tasks
+ * by calling the host app API. The message-persister also intercepts this tool
+ * call to broadcast SSE events for frontend UI refresh.
  */
 
 import { tool } from '@anthropic-ai/claude-agent-sdk'
 import { z } from 'zod'
+
+function hostFetch(path: string, method = 'GET'): Promise<Response> {
+  const base = process.env.HOST_APP_URL
+  if (!base) throw new Error('HOST_APP_URL not configured')
+  const headers: Record<string, string> = {}
+  if (process.env.PROXY_TOKEN) headers['Authorization'] = `Bearer ${process.env.PROXY_TOKEN}`
+  return fetch(`${base}${path}`, { method, headers })
+}
 
 export const manageScheduledTasksTool = tool(
   'manage_scheduled_tasks',
@@ -32,25 +40,33 @@ Use "list" first to see available tasks and their IDs before performing other ac
   async (args) => {
     if (args.action !== 'list' && !args.taskId) {
       return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Action "${args.action}" requires a taskId. Use action "list" first to see available tasks and their IDs.`,
-          },
-        ],
+        content: [{ type: 'text' as const, text: `Action "${args.action}" requires a taskId. Use "list" first.` }],
         isError: true,
       }
     }
 
-    console.log(`[manage_scheduled_tasks] ${args.action}${args.taskId ? ` task ${args.taskId}` : ''}`)
+    const agentId = process.env.AGENT_ID
+    if (!agentId) {
+      return { content: [{ type: 'text' as const, text: 'AGENT_ID not configured.' }], isError: true }
+    }
 
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: `Task management action "${args.action}" is being processed.${args.taskId ? ` Task ID: ${args.taskId}` : ''}`,
-        },
-      ],
+    try {
+      if (args.action === 'list') {
+        const res = await hostFetch(`/api/agents/${agentId}/scheduled-tasks?status=active`)
+        if (!res.ok) return { content: [{ type: 'text' as const, text: `Failed to list tasks: ${res.statusText}` }], isError: true }
+        const tasks = await res.json() as Array<{ id: string; name: string; scheduleType: string; scheduleExpression: string; status: string; executionCount: number; nextExecutionAt: string | null }>
+        if (tasks.length === 0) return { content: [{ type: 'text' as const, text: 'No active scheduled tasks.' }] }
+        const lines = tasks.map(t => `- ${t.name} (ID: ${t.id}) [${t.status}] ${t.scheduleType}="${t.scheduleExpression}" executions=${t.executionCount}${t.nextExecutionAt ? ` next=${t.nextExecutionAt}` : ''}`)
+        return { content: [{ type: 'text' as const, text: lines.join('\n') }] }
+      }
+
+      const actionMap = { pause: ['POST', `/api/scheduled-tasks/${args.taskId}/pause`], resume: ['POST', `/api/scheduled-tasks/${args.taskId}/resume`], cancel: ['DELETE', `/api/scheduled-tasks/${args.taskId}`] } as const
+      const [method, path] = actionMap[args.action as keyof typeof actionMap]
+      const res = await hostFetch(path, method)
+      if (!res.ok) return { content: [{ type: 'text' as const, text: `Failed to ${args.action} task: ${res.statusText}` }], isError: true }
+      return { content: [{ type: 'text' as const, text: `Successfully ${args.action}d task ${args.taskId}.` }] }
+    } catch (err) {
+      return { content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : err}` }], isError: true }
     }
   }
 )

--- a/src/api/routes/admin-users.ts
+++ b/src/api/routes/admin-users.ts
@@ -3,8 +3,6 @@ import { eq, and } from 'drizzle-orm'
 import { Authenticated, IsAdmin } from '../middleware/auth'
 import { db } from '@shared/lib/db'
 import { user, authAccount } from '@shared/lib/db/schema'
-import { hashPassword } from 'better-auth/crypto'
-
 const adminUsersRouter = new Hono()
 adminUsersRouter.use('*', Authenticated(), IsAdmin())
 
@@ -27,6 +25,7 @@ adminUsersRouter.post('/invite', async (c) => {
   }
 
   try {
+    const { hashPassword } = await import('better-auth/crypto')
     const userId = crypto.randomUUID()
     const hashedPassword = await hashPassword(password)
     const now = new Date()
@@ -86,6 +85,7 @@ adminUsersRouter.post('/reset-password', async (c) => {
   }
 
   try {
+    const { hashPassword } = await import('better-auth/crypto')
     const hashedPassword = await hashPassword(password)
 
     db.update(authAccount)

--- a/src/api/routes/admin-users.ts
+++ b/src/api/routes/admin-users.ts
@@ -3,6 +3,8 @@ import { eq, and } from 'drizzle-orm'
 import { Authenticated, IsAdmin } from '../middleware/auth'
 import { db } from '@shared/lib/db'
 import { user, authAccount } from '@shared/lib/db/schema'
+import { hashPassword } from 'better-auth/crypto'
+
 const adminUsersRouter = new Hono()
 adminUsersRouter.use('*', Authenticated(), IsAdmin())
 
@@ -25,7 +27,6 @@ adminUsersRouter.post('/invite', async (c) => {
   }
 
   try {
-    const { hashPassword } = await import('better-auth/crypto')
     const userId = crypto.randomUUID()
     const hashedPassword = await hashPassword(password)
     const now = new Date()
@@ -85,7 +86,6 @@ adminUsersRouter.post('/reset-password', async (c) => {
   }
 
   try {
-    const { hashPassword } = await import('better-auth/crypto')
     const hashedPassword = await hashPassword(password)
 
     db.update(authAccount)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -38,6 +38,7 @@ import {
 import {
   listScheduledTasks,
   listPendingScheduledTasks,
+  listActiveScheduledTasks,
 } from '@shared/lib/services/scheduled-task-service'
 import { db } from '@shared/lib/db'
 import { connectedAccounts, agentConnectedAccounts, proxyAuditLog, remoteMcpServers, agentRemoteMcps, mcpAuditLog, agentAcl, user as userTable } from '@shared/lib/db/schema'
@@ -1619,6 +1620,8 @@ agents.get('/:id/scheduled-tasks', AgentRead(), async (c) => {
     let tasks
     if (status === 'pending') {
       tasks = await listPendingScheduledTasks(slug)
+    } else if (status === 'active') {
+      tasks = await listActiveScheduledTasks(slug)
     } else {
       tasks = await listScheduledTasks(slug)
     }

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -11,6 +11,8 @@ import { and, eq } from 'drizzle-orm'
 import {
   getScheduledTask,
   cancelScheduledTask,
+  pauseScheduledTask,
+  resumeScheduledTask,
   resetScheduledTask,
 } from '@shared/lib/services/scheduled-task-service'
 import { getSessionsByScheduledTask } from '@shared/lib/services/session-service'
@@ -95,6 +97,42 @@ scheduledTasksRouter.delete('/:taskId', TaskAgentRole('user'), async (c) => {
   } catch (error) {
     console.error('Failed to cancel scheduled task:', error)
     return c.json({ error: 'Failed to cancel scheduled task' }, 500)
+  }
+})
+
+// POST /api/scheduled-tasks/:taskId/pause - Pause a pending scheduled task
+scheduledTasksRouter.post('/:taskId/pause', TaskAgentRole('user'), async (c) => {
+  try {
+    const task = c.get('scheduledTask' as never) as Awaited<ReturnType<typeof getScheduledTask>>
+    const paused = await pauseScheduledTask(task!.id)
+
+    if (!paused) {
+      return c.json({ error: 'Scheduled task not found or not in pending state' }, 404)
+    }
+
+    const updated = await getScheduledTask(task!.id)
+    return c.json(updated)
+  } catch (error) {
+    console.error('Failed to pause scheduled task:', error)
+    return c.json({ error: 'Failed to pause scheduled task' }, 500)
+  }
+})
+
+// POST /api/scheduled-tasks/:taskId/resume - Resume a paused scheduled task
+scheduledTasksRouter.post('/:taskId/resume', TaskAgentRole('user'), async (c) => {
+  try {
+    const task = c.get('scheduledTask' as never) as Awaited<ReturnType<typeof getScheduledTask>>
+    const resumed = await resumeScheduledTask(task!.id)
+
+    if (!resumed) {
+      return c.json({ error: 'Scheduled task not found or not in paused state' }, 404)
+    }
+
+    const updated = await getScheduledTask(task!.id)
+    return c.json(updated)
+  } catch (error) {
+    console.error('Failed to resume scheduled task:', error)
+    return c.json({ error: 'Failed to resume scheduled task' }, 500)
   }
 })
 

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -1,5 +1,5 @@
 
-import { ChevronRight, Plus, Settings, AlertTriangle, Clock, LayoutDashboard, Loader2, WifiOff, LogOut, User, Users } from 'lucide-react'
+import { ChevronRight, Plus, Settings, AlertTriangle, Clock, Pause, LayoutDashboard, Loader2, WifiOff, LogOut, User, Users } from 'lucide-react'
 import { ErrorBoundary } from '@renderer/components/ui/error-boundary'
 import { useState, useEffect, useRef } from 'react'
 import { isElectron, getPlatform } from '@renderer/lib/env'
@@ -113,19 +113,20 @@ function ScheduledTaskSubItem({
   // Format next execution time for tooltip
   const nextExecution = new Date(task.nextExecutionAt)
   const timeString = nextExecution.toLocaleString()
+  const isPaused = task.status === 'paused'
 
   return (
     <SidebarMenuSubItem>
       <SidebarMenuSubButton
         asChild
         isActive={isSelected}
-        title={`Scheduled for: ${timeString}`}
+        title={isPaused ? 'Paused' : `Scheduled for: ${timeString}`}
       >
         <button
           onClick={handleClick}
-          className="flex items-center gap-2 w-full text-muted-foreground opacity-70"
+          className={`flex items-center gap-2 w-full text-muted-foreground ${isPaused ? 'opacity-50' : 'opacity-70'}`}
         >
-          <Clock className="h-3 w-3 shrink-0" />
+          {isPaused ? <Pause className="h-3 w-3 shrink-0" /> : <Clock className="h-3 w-3 shrink-0" />}
           <span className="truncate">{task.name || 'Scheduled Task'}</span>
         </button>
       </SidebarMenuSubButton>
@@ -173,7 +174,7 @@ function AgentMenuItem({ agent }: { agent: ApiAgent }) {
   const { selectedAgentSlug, selectAgent } = useSelection()
   const { agentMemberCount } = useUser()
   const { data: sessions } = useSessions(agent.slug)
-  const { data: scheduledTasks } = useScheduledTasks(agent.slug, 'pending')
+  const { data: scheduledTasks } = useScheduledTasks(agent.slug, 'active')
   const { data: artifacts } = useArtifacts(agent.slug)
   const isSelected = agent.slug === selectedAgentSlug
   const [isOpen, setIsOpen] = useState(isSelected)
@@ -182,7 +183,7 @@ function AgentMenuItem({ agent }: { agent: ApiAgent }) {
 
   const visibleSessions = showAll ? sessions : sessions?.slice(0, 5)
   const hasMore = (sessions?.length ?? 0) > 5
-  const pendingTasks = scheduledTasks || []
+  const activeTasks = scheduledTasks || []
   const dashboards = Array.isArray(artifacts) ? artifacts : []
 
   const handleClick = () => {
@@ -210,7 +211,7 @@ function AgentMenuItem({ agent }: { agent: ApiAgent }) {
             />
           </SidebarMenuButton>
         </AgentContextMenu>
-        {(sessions?.length || pendingTasks.length || dashboards.length) ? (
+        {(sessions?.length || activeTasks.length || dashboards.length) ? (
           <>
             <CollapsibleTrigger asChild>
               <SidebarMenuAction className="data-[state=open]:rotate-90">
@@ -229,7 +230,7 @@ function AgentMenuItem({ agent }: { agent: ApiAgent }) {
                   />
                 ))}
                 {/* Pending scheduled tasks */}
-                {pendingTasks.map((task) => (
+                {activeTasks.map((task) => (
                   <ScheduledTaskSubItem
                     key={task.id}
                     task={task}

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -111,11 +111,15 @@ export function GlobalNotificationHandler() {
             queryClient.invalidateQueries({ queryKey: ['agents'] })
             break
 
-          case 'scheduled_task_created': {
-            // Scheduled task created - update task list for that agent
+          case 'scheduled_task_created':
+          case 'scheduled_task_updated': {
             const agentSlug = data.agentSlug as string | undefined
             if (agentSlug) {
               queryClient.invalidateQueries({ queryKey: ['scheduled-tasks', agentSlug] })
+            }
+            const taskId = data.taskId as string | undefined
+            if (taskId) {
+              queryClient.invalidateQueries({ queryKey: ['scheduled-task', taskId] })
             }
             break
           }

--- a/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
+++ b/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
@@ -182,7 +182,7 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
             </div>
           ) : task.status === 'paused' ? (
             <div className="text-lg text-yellow-600">
-              Paused — will resume from {nextExecution.toLocaleString()}
+              Paused
             </div>
           ) : (
             <div className="text-lg capitalize">{task.status}</div>
@@ -211,7 +211,9 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
                 This prompt will be sent to the agent{' '}
                 {task.status === 'pending'
                   ? `on ${nextExecution.toLocaleString()}`
-                  : 'when executed'}
+                  : task.status === 'paused'
+                    ? 'when resumed'
+                    : 'when executed'}
               </span>
             </div>
             <div className="whitespace-pre-wrap text-sm">{task.prompt}</div>

--- a/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
+++ b/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
@@ -5,11 +5,13 @@
  * that will be executed and options to cancel the task.
  */
 
-import { Clock, Calendar, Repeat, Trash2, MessageSquare } from 'lucide-react'
+import { Clock, Calendar, Repeat, Trash2, Pause, Play, MessageSquare } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import {
   useScheduledTask,
   useCancelScheduledTask,
+  usePauseScheduledTask,
+  useResumeScheduledTask,
   useScheduledTaskSessions,
 } from '@renderer/hooks/use-scheduled-tasks'
 import { useSelection } from '@renderer/context/selection-context'
@@ -35,9 +37,27 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
   const { data: task, isLoading, error } = useScheduledTask(taskId)
   const { data: sessions = [] } = useScheduledTaskSessions(taskId)
   const cancelTask = useCancelScheduledTask()
+  const pauseTask = usePauseScheduledTask()
+  const resumeTask = useResumeScheduledTask()
   const { handleScheduledTaskDeleted, selectSession } = useSelection()
   const { canUseAgent } = useUser()
   const canCancel = canUseAgent(agentSlug)
+
+  const handlePause = async () => {
+    try {
+      await pauseTask.mutateAsync({ taskId, agentSlug })
+    } catch (err) {
+      console.error('Failed to pause scheduled task:', err)
+    }
+  }
+
+  const handleResume = async () => {
+    try {
+      await resumeTask.mutateAsync({ taskId, agentSlug })
+    } catch (err) {
+      console.error('Failed to resume scheduled task:', err)
+    }
+  }
 
   const handleCancel = async () => {
     try {
@@ -92,33 +112,59 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
             </div>
           </div>
 
-          {task.status === 'pending' && canCancel && (
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button variant="destructive" size="sm">
-                  <Trash2 className="h-4 w-4 mr-2" />
-                  Cancel Task
+          {canCancel && (
+            <div className="flex items-center gap-2">
+              {task.status === 'pending' && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handlePause}
+                  disabled={pauseTask.isPending}
+                >
+                  <Pause className="h-4 w-4 mr-2" />
+                  {pauseTask.isPending ? 'Pausing...' : 'Pause'}
                 </Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Cancel Scheduled Task</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    Are you sure you want to cancel this scheduled task? This action cannot be undone.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Keep Task</AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={handleCancel}
-                    disabled={cancelTask.isPending}
-                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                  >
-                    {cancelTask.isPending ? 'Cancelling...' : 'Cancel Task'}
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
+              )}
+              {task.status === 'paused' && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleResume}
+                  disabled={resumeTask.isPending}
+                >
+                  <Play className="h-4 w-4 mr-2" />
+                  {resumeTask.isPending ? 'Resuming...' : 'Resume'}
+                </Button>
+              )}
+              {(task.status === 'pending' || task.status === 'paused') && (
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button variant="destructive" size="sm">
+                      <Trash2 className="h-4 w-4 mr-2" />
+                      Cancel Task
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Cancel Scheduled Task</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Are you sure you want to cancel this scheduled task? This action cannot be undone.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Keep Task</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={handleCancel}
+                        disabled={cancelTask.isPending}
+                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                      >
+                        {cancelTask.isPending ? 'Cancelling...' : 'Cancel Task'}
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              )}
+            </div>
           )}
         </div>
       </div>
@@ -133,6 +179,10 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
           {task.status === 'pending' ? (
             <div className="text-lg">
               {nextExecution.toLocaleString()}
+            </div>
+          ) : task.status === 'paused' ? (
+            <div className="text-lg text-yellow-600">
+              Paused — will resume from {nextExecution.toLocaleString()}
             </div>
           ) : (
             <div className="text-lg capitalize">{task.status}</div>

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -453,11 +453,14 @@ function getOrCreateEventSource(
         queryClient.invalidateQueries({ queryKey: ['sessions'] })
         queryClient.invalidateQueries({ queryKey: ['session', sessionId] })
       }
-      else if (data.type === 'scheduled_task_created') {
-        // A scheduled task was created - invalidate scheduled tasks cache
+      else if (data.type === 'scheduled_task_created' || data.type === 'scheduled_task_updated') {
         const taskAgentSlug = (data as { agentSlug?: string }).agentSlug
         if (taskAgentSlug) {
           queryClient.invalidateQueries({ queryKey: ['scheduled-tasks', taskAgentSlug] })
+        }
+        const taskId = (data as { taskId?: string }).taskId
+        if (taskId) {
+          queryClient.invalidateQueries({ queryKey: ['scheduled-task', taskId] })
         }
       }
       else if (data.type === 'subagent_updated') {

--- a/src/renderer/hooks/use-scheduled-tasks.ts
+++ b/src/renderer/hooks/use-scheduled-tasks.ts
@@ -14,7 +14,7 @@ export type { ApiScheduledTask }
 /**
  * Fetch all scheduled tasks for an agent
  */
-export function useScheduledTasks(agentSlug: string | null, status?: 'pending') {
+export function useScheduledTasks(agentSlug: string | null, status?: 'pending' | 'active') {
   return useQuery<ApiScheduledTask[]>({
     queryKey: ['scheduled-tasks', agentSlug, status],
     queryFn: async () => {
@@ -61,6 +61,44 @@ export function useCancelScheduledTask() {
       // Invalidate all scheduled tasks queries for this agent
       queryClient.invalidateQueries({ queryKey: ['scheduled-tasks', variables.agentSlug] })
       // Invalidate the specific task query
+      queryClient.invalidateQueries({ queryKey: ['scheduled-task', variables.taskId] })
+    },
+  })
+}
+
+/**
+ * Pause a scheduled task
+ */
+export function usePauseScheduledTask() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ taskId, agentSlug }: { taskId: string; agentSlug: string }) => {
+      const res = await apiFetch(`/api/scheduled-tasks/${taskId}/pause`, { method: 'POST' })
+      if (!res.ok) throw new Error('Failed to pause scheduled task')
+      return { taskId, agentSlug }
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['scheduled-tasks', variables.agentSlug] })
+      queryClient.invalidateQueries({ queryKey: ['scheduled-task', variables.taskId] })
+    },
+  })
+}
+
+/**
+ * Resume a paused scheduled task
+ */
+export function useResumeScheduledTask() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ taskId, agentSlug }: { taskId: string; agentSlug: string }) => {
+      const res = await apiFetch(`/api/scheduled-tasks/${taskId}/resume`, { method: 'POST' })
+      if (!res.ok) throw new Error('Failed to resume scheduled task')
+      return { taskId, agentSlug }
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['scheduled-tasks', variables.agentSlug] })
       queryClient.invalidateQueries({ queryKey: ['scheduled-task', variables.taskId] })
     },
   })

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -398,12 +398,13 @@ class ContainerManager {
         envVars['REMOTE_MCPS'] = JSON.stringify(mcpConfigs)
       }
 
+      envVars['HOST_APP_URL'] = `http://${hostUrl}:${appPort}`
+      envVars['AGENT_ID'] = agentId
+
       // Pass host browser env vars if a host browser provider is selected
       const settings = getSettings()
       if (settings.app?.hostBrowserProvider) {
         envVars['AGENT_BROWSER_USE_HOST'] = '1'
-        envVars['HOST_APP_URL'] = `http://${hostUrl}:${appPort}`
-        envVars['AGENT_ID'] = agentId
       }
 
       // Copy Chrome profile data into workspace if configured

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1,6 +1,13 @@
 import type { ContainerClient, StreamMessage, SlashCommandInfo } from './types'
 import type { SessionUsage } from '@shared/lib/types/agent'
-import { createScheduledTask } from '@shared/lib/services/scheduled-task-service'
+import {
+  createScheduledTask,
+  listActiveScheduledTasks,
+  pauseScheduledTask,
+  resumeScheduledTask,
+  cancelScheduledTask,
+  getScheduledTask,
+} from '@shared/lib/services/scheduled-task-service'
 import { updateSessionMetadata } from '@shared/lib/services/session-service'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
 import { getAgentSessionsDir } from '@shared/lib/utils/file-storage'
@@ -810,6 +817,15 @@ class MessagePersister {
             )
           }
 
+          if (state.currentToolUse.name === 'mcp__user-input__manage_scheduled_tasks') {
+            this.handleManageScheduledTasksTool(
+              sessionId,
+              state.currentToolUse.id,
+              state.currentToolInput,
+              state.agentSlug
+            )
+          }
+
           // Check if this is an AskUserQuestion tool
           if (state.currentToolUse.name === 'AskUserQuestion') {
             this.handleAskUserQuestionTool(
@@ -1011,6 +1027,92 @@ class MessagePersister {
         })
       } catch (error) {
         console.error('[MessagePersister] Error handling schedule task:', error)
+      }
+    })()
+  }
+
+  private handleManageScheduledTasksTool(
+    sessionId: string,
+    toolUseId: string,
+    toolInput: string,
+    agentSlug?: string
+  ): void {
+    ;(async () => {
+      try {
+        let input: { action: string; taskId?: string }
+        try {
+          input = JSON.parse(toolInput)
+        } catch {
+          console.error('[MessagePersister] Failed to parse manage_scheduled_tasks input:', toolInput)
+          return
+        }
+
+        const { action, taskId } = input
+
+        if (action === 'list') {
+          if (!agentSlug) {
+            console.error('[MessagePersister] manage_scheduled_tasks list missing agentSlug')
+            return
+          }
+          const tasks = await listActiveScheduledTasks(agentSlug)
+          this.broadcastToSSE(sessionId, {
+            type: 'scheduled_tasks_list',
+            toolUseId,
+            tasks: tasks.map(t => ({
+              id: t.id,
+              name: t.name,
+              scheduleType: t.scheduleType,
+              scheduleExpression: t.scheduleExpression,
+              status: t.status,
+              nextExecutionAt: t.nextExecutionAt?.toISOString() ?? null,
+            })),
+          })
+          return
+        }
+
+        if (!taskId) {
+          console.error(`[MessagePersister] manage_scheduled_tasks ${action} missing taskId`)
+          return
+        }
+
+        let success = false
+        switch (action) {
+          case 'pause':
+            success = await pauseScheduledTask(taskId)
+            break
+          case 'resume':
+            success = await resumeScheduledTask(taskId)
+            break
+          case 'cancel':
+            success = await cancelScheduledTask(taskId)
+            break
+          default:
+            console.error(`[MessagePersister] Unknown manage_scheduled_tasks action: ${action}`)
+            return
+        }
+
+        if (success) {
+          const updated = await getScheduledTask(taskId)
+          this.broadcastToSSE(sessionId, {
+            type: 'scheduled_task_updated',
+            toolUseId,
+            taskId,
+            action,
+            task: updated ? {
+              id: updated.id,
+              name: updated.name,
+              status: updated.status,
+              nextExecutionAt: updated.nextExecutionAt?.toISOString() ?? null,
+            } : null,
+          })
+          this.broadcastGlobal({
+            type: 'scheduled_task_updated',
+            taskId,
+            agentSlug,
+          })
+        }
+      } catch (error) {
+        console.error('[MessagePersister] Error handling manage_scheduled_tasks:', error)
       }
     })()
   }

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -2,11 +2,6 @@ import type { ContainerClient, StreamMessage, SlashCommandInfo } from './types'
 import type { SessionUsage } from '@shared/lib/types/agent'
 import {
   createScheduledTask,
-  listActiveScheduledTasks,
-  pauseScheduledTask,
-  resumeScheduledTask,
-  cancelScheduledTask,
-  getScheduledTask,
 } from '@shared/lib/services/scheduled-task-service'
 import { updateSessionMetadata } from '@shared/lib/services/session-service'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
@@ -818,12 +813,7 @@ class MessagePersister {
           }
 
           if (state.currentToolUse.name === 'mcp__user-input__manage_scheduled_tasks') {
-            this.handleManageScheduledTasksTool(
-              sessionId,
-              state.currentToolUse.id,
-              state.currentToolInput,
-              state.agentSlug
-            )
+            this.handleManageScheduledTasksTool(state.currentToolInput, state.agentSlug)
           }
 
           // Check if this is an AskUserQuestion tool
@@ -1031,90 +1021,30 @@ class MessagePersister {
     })()
   }
 
-  private handleManageScheduledTasksTool(
-    sessionId: string,
-    toolUseId: string,
-    toolInput: string,
-    agentSlug?: string
-  ): void {
-    ;(async () => {
-      try {
-        let input: { action: string; taskId?: string }
-        try {
-          input = JSON.parse(toolInput)
-        } catch {
-          console.error('[MessagePersister] Failed to parse manage_scheduled_tasks input:', toolInput)
-          return
-        }
+  /**
+   * The tool calls the host API directly for DB operations.
+   * Here we only broadcast a global SSE event so the frontend UI refreshes.
+   */
+  private handleManageScheduledTasksTool(toolInput: string, agentSlug?: string): void {
+    if (!agentSlug) return
 
-        const { action, taskId } = input
+    let input: { action: string; taskId?: string }
+    try {
+      input = JSON.parse(toolInput)
+    } catch {
+      return
+    }
 
-        if (action === 'list') {
-          if (!agentSlug) {
-            console.error('[MessagePersister] manage_scheduled_tasks list missing agentSlug')
-            return
-          }
-          const tasks = await listActiveScheduledTasks(agentSlug)
-          this.broadcastToSSE(sessionId, {
-            type: 'scheduled_tasks_list',
-            toolUseId,
-            tasks: tasks.map(t => ({
-              id: t.id,
-              name: t.name,
-              scheduleType: t.scheduleType,
-              scheduleExpression: t.scheduleExpression,
-              status: t.status,
-              nextExecutionAt: t.nextExecutionAt?.toISOString() ?? null,
-            })),
-          })
-          return
-        }
+    if (input.action === 'list') return
 
-        if (!taskId) {
-          console.error(`[MessagePersister] manage_scheduled_tasks ${action} missing taskId`)
-          return
-        }
-
-        let success = false
-        switch (action) {
-          case 'pause':
-            success = await pauseScheduledTask(taskId)
-            break
-          case 'resume':
-            success = await resumeScheduledTask(taskId)
-            break
-          case 'cancel':
-            success = await cancelScheduledTask(taskId)
-            break
-          default:
-            console.error(`[MessagePersister] Unknown manage_scheduled_tasks action: ${action}`)
-            return
-        }
-
-        if (success) {
-          const updated = await getScheduledTask(taskId)
-          this.broadcastToSSE(sessionId, {
-            type: 'scheduled_task_updated',
-            toolUseId,
-            taskId,
-            action,
-            task: updated ? {
-              id: updated.id,
-              name: updated.name,
-              status: updated.status,
-              nextExecutionAt: updated.nextExecutionAt?.toISOString() ?? null,
-            } : null,
-          })
-          this.broadcastGlobal({
-            type: 'scheduled_task_updated',
-            taskId,
-            agentSlug,
-          })
-        }
-      } catch (error) {
-        console.error('[MessagePersister] Error handling manage_scheduled_tasks:', error)
-      }
-    })()
+    // Delay so the tool's API call completes before frontend refetches
+    setTimeout(() => {
+      this.broadcastGlobal({
+        type: 'scheduled_task_updated',
+        taskId: input.taskId,
+        agentSlug,
+      })
+    }, 1000)
   }
 
   // Handle AskUserQuestion tool - broadcast to SSE clients so they can show the UI

--- a/src/shared/lib/db/schema.ts
+++ b/src/shared/lib/db/schema.ts
@@ -142,8 +142,8 @@ export const scheduledTasks = sqliteTable('scheduled_tasks', {
   prompt: text('prompt').notNull(),
   name: text('name'),
 
-  // Status: pending, executed, cancelled, failed
-  status: text('status', { enum: ['pending', 'executed', 'cancelled', 'failed'] })
+  // Status: pending, paused, executed, cancelled, failed
+  status: text('status', { enum: ['pending', 'paused', 'executed', 'cancelled', 'failed'] })
     .notNull()
     .default('pending'),
 

--- a/src/shared/lib/services/scheduled-task-service.test.ts
+++ b/src/shared/lib/services/scheduled-task-service.test.ts
@@ -32,6 +32,8 @@ import {
   listPendingScheduledTasks,
   getDueTasks,
   cancelScheduledTask,
+  pauseScheduledTask,
+  resumeScheduledTask,
   markTaskExecuted,
   updateNextExecution,
   markTaskFailed,
@@ -244,6 +246,23 @@ describe('scheduled-task-service', () => {
       expect(dueTasks).toHaveLength(0)
     })
 
+    it('does not return paused tasks', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 30 minutes',
+        prompt: 'Paused task',
+      })
+
+      await pauseScheduledTask(taskId)
+
+      // Advance time
+      vi.setSystemTime(new Date('2024-06-15T13:00:00.000Z'))
+
+      const dueTasks = await getDueTasks()
+      expect(dueTasks).toHaveLength(0)
+    })
+
     it('does not return executed tasks', async () => {
       const taskId = await createScheduledTask({
         agentSlug: 'test-agent',
@@ -301,6 +320,135 @@ describe('scheduled-task-service', () => {
 
     it('returns false for nonexistent tasks', async () => {
       const result = await cancelScheduledTask('nonexistent-id')
+      expect(result).toBe(false)
+    })
+  })
+
+  // ============================================================================
+  // pauseScheduledTask Tests
+  // ============================================================================
+
+  describe('pauseScheduledTask', () => {
+    it('sets status to paused', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Test',
+      })
+
+      const result = await pauseScheduledTask(taskId)
+      expect(result).toBe(true)
+
+      const task = await getScheduledTask(taskId)
+      expect(task!.status).toBe('paused')
+    })
+
+    it('returns false for already paused tasks', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Test',
+      })
+
+      await pauseScheduledTask(taskId)
+      const result = await pauseScheduledTask(taskId)
+      expect(result).toBe(false)
+    })
+
+    it('returns false for cancelled tasks', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Test',
+      })
+
+      await cancelScheduledTask(taskId)
+      const result = await pauseScheduledTask(taskId)
+      expect(result).toBe(false)
+    })
+
+    it('returns false for nonexistent tasks', async () => {
+      const result = await pauseScheduledTask('nonexistent-id')
+      expect(result).toBe(false)
+    })
+  })
+
+  // ============================================================================
+  // resumeScheduledTask Tests
+  // ============================================================================
+
+  describe('resumeScheduledTask', () => {
+    it('sets status back to pending', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Test',
+      })
+
+      await pauseScheduledTask(taskId)
+      const result = await resumeScheduledTask(taskId)
+      expect(result).toBe(true)
+
+      const task = await getScheduledTask(taskId)
+      expect(task!.status).toBe('pending')
+    })
+
+    it('keeps the original nextExecutionAt if it has not passed', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 2 hours',
+        prompt: 'Test',
+      })
+
+      const original = await getScheduledTask(taskId)
+      await pauseScheduledTask(taskId)
+
+      // Advance time but not past the execution time
+      vi.setSystemTime(new Date('2024-06-15T13:00:00.000Z'))
+
+      await resumeScheduledTask(taskId)
+      const resumed = await getScheduledTask(taskId)
+      expect(resumed!.nextExecutionAt.getTime()).toBe(original!.nextExecutionAt.getTime())
+    })
+
+    it('recalculates nextExecutionAt for cron tasks if time has passed', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'cron',
+        scheduleExpression: '0 * * * *',
+        prompt: 'Test',
+      })
+
+      const original = await getScheduledTask(taskId)
+      await pauseScheduledTask(taskId)
+
+      // Advance time past the original execution time
+      vi.setSystemTime(new Date('2024-06-15T14:30:00.000Z'))
+
+      await resumeScheduledTask(taskId)
+      const resumed = await getScheduledTask(taskId)
+      expect(resumed!.nextExecutionAt.getTime()).toBeGreaterThan(original!.nextExecutionAt.getTime())
+    })
+
+    it('returns false for pending tasks', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Test',
+      })
+
+      const result = await resumeScheduledTask(taskId)
+      expect(result).toBe(false)
+    })
+
+    it('returns false for nonexistent tasks', async () => {
+      const result = await resumeScheduledTask('nonexistent-id')
       expect(result).toBe(false)
     })
   })

--- a/src/shared/lib/services/scheduled-task-service.ts
+++ b/src/shared/lib/services/scheduled-task-service.ts
@@ -7,7 +7,7 @@
 
 import { db } from '@shared/lib/db'
 import { scheduledTasks, type ScheduledTask, type NewScheduledTask } from '@shared/lib/db/schema'
-import { eq, and, lte } from 'drizzle-orm'
+import { eq, and, or, lte } from 'drizzle-orm'
 import { getNextCronTime, parseAtSyntax } from './schedule-parser'
 
 // Re-export the ScheduledTask type for external use
@@ -114,6 +114,24 @@ export async function listPendingScheduledTasks(agentSlug: string): Promise<Sche
 }
 
 /**
+ * List active scheduled tasks for an agent (pending + paused)
+ */
+export async function listActiveScheduledTasks(agentSlug: string): Promise<ScheduledTask[]> {
+  return db
+    .select()
+    .from(scheduledTasks)
+    .where(
+      and(
+        eq(scheduledTasks.agentSlug, agentSlug),
+        or(
+          eq(scheduledTasks.status, 'pending'),
+          eq(scheduledTasks.status, 'paused')
+        )
+      )
+    )
+}
+
+/**
  * Get all tasks that are due for execution
  * (nextExecutionAt <= now and status = 'pending')
  */
@@ -146,7 +164,64 @@ export async function cancelScheduledTask(taskId: string): Promise<boolean> {
     .where(
       and(
         eq(scheduledTasks.id, taskId),
+        or(
+          eq(scheduledTasks.status, 'pending'),
+          eq(scheduledTasks.status, 'paused')
+        )
+      )
+    )
+
+  return (result.changes ?? 0) > 0
+}
+
+/**
+ * Pause a scheduled task (keeps schedule, stops execution until resumed)
+ */
+export async function pauseScheduledTask(taskId: string): Promise<boolean> {
+  const result = await db
+    .update(scheduledTasks)
+    .set({
+      status: 'paused',
+    })
+    .where(
+      and(
+        eq(scheduledTasks.id, taskId),
         eq(scheduledTasks.status, 'pending')
+      )
+    )
+
+  return (result.changes ?? 0) > 0
+}
+
+/**
+ * Resume a paused scheduled task back to pending
+ */
+export async function resumeScheduledTask(taskId: string): Promise<boolean> {
+  const task = await getScheduledTask(taskId)
+  if (!task || task.status !== 'paused') return false
+
+  // Recalculate next execution time if the original one has passed
+  let nextExecutionAt = task.nextExecutionAt
+  const now = new Date()
+  if (new Date(nextExecutionAt) < now) {
+    if (task.scheduleType === 'cron') {
+      nextExecutionAt = getNextCronTime(task.scheduleExpression)
+    } else {
+      // For 'at' tasks, recalculate from the expression
+      nextExecutionAt = parseAtSyntax(task.scheduleExpression)
+    }
+  }
+
+  const result = await db
+    .update(scheduledTasks)
+    .set({
+      status: 'pending',
+      nextExecutionAt,
+    })
+    .where(
+      and(
+        eq(scheduledTasks.id, taskId),
+        eq(scheduledTasks.status, 'paused')
       )
     )
 

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -229,7 +229,7 @@ export interface ApiScheduledTask {
   scheduleExpression: string
   prompt: string
   name: string | null
-  status: 'pending' | 'executed' | 'cancelled' | 'failed'
+  status: 'pending' | 'paused' | 'executed' | 'cancelled' | 'failed'
   nextExecutionAt: Date
   lastExecutedAt: Date | null
   isRecurring: boolean


### PR DESCRIPTION
## Summary
- Add pause/resume functionality for scheduled tasks
- Fix misleading UI copy: paused task now shows "Paused" instead of "Paused — will resume from ..." and prompt description shows "when resumed"
- Add test coverage for `pauseScheduledTask`, `resumeScheduledTask`, and paused task exclusion in `getDueTasks`

## Test plan
- [ ] Pause a scheduled task and verify it no longer triggers
- [ ] Resume a paused task and verify it becomes pending again
- [ ] Resume a task whose scheduled time has passed and verify the next execution time is recalculated
- [ ] `npm run test:run` passes (31 tests in scheduled-task-service.test.ts)