### PR TITLE
fix: release idle session processes to prevent memory leak

### DIFF
--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -128,18 +128,7 @@ export class SessionManager extends EventEmitter {
       subscribers: new Set(),
     };
 
-    // Set up event listeners
-    process.on('message', (message: SDKMessage) => {
-      this.handleMessage(sessionId, message);
-    });
-
-    process.on('stderr', (error: string) => {
-      console.error(`[Session ${sessionId}] stderr:`, error);
-    });
-
-    process.on('exit', (code: number | null) => {
-      console.log(`Session ${sessionId} exited with code ${code}`);
-    });
+    this.wireProcessEvents(sessionId, process);
 
     // Persist the session
     this.persistence.saveSession({
@@ -175,21 +164,7 @@ export class SessionManager extends EventEmitter {
     console.log(`Attempting to resume session ${sessionId} with Claude session ID ${persisted.claudeSessionId}`);
 
     try {
-      // Create a new Claude Code process with resume
-      const process = new ClaudeCodeProcess({
-        sessionId,
-        workingDirectory: persisted.workingDirectory,
-        claudeSessionId: persisted.claudeSessionId,
-        userSystemPrompt: persisted.systemPrompt,
-        availableEnvVars: persisted.availableEnvVars,
-        model: persisted.model,
-        browserModel: persisted.browserModel,
-        maxOutputTokens: persisted.maxOutputTokens,
-        maxThinkingTokens: persisted.maxThinkingTokens,
-        maxTurns: persisted.maxTurns,
-        maxBudgetUsd: persisted.maxBudgetUsd,
-        customEnvVars: persisted.customEnvVars,
-      });
+      const process = this.createProcess(sessionId, persisted);
 
       const session: Session = {
         id: sessionId,
@@ -207,19 +182,7 @@ export class SessionManager extends EventEmitter {
         subscribers: new Set(),
       };
 
-      // Set up event listeners (same as createSession)
-      process.on('message', (message: SDKMessage) => {
-        this.handleMessage(sessionId, message);
-      });
-
-      process.on('stderr', (error: string) => {
-        console.error(`[Session ${sessionId}] stderr:`, error);
-      });
-
-      process.on('exit', (code: number | null) => {
-        console.log(`Resumed session ${sessionId} exited with code ${code}`);
-      });
-
+      this.wireProcessEvents(sessionId, process);
       this.sessions.set(sessionId, sessionData);
 
       // Start the process (which will resume the Claude session)
@@ -253,16 +216,9 @@ export class SessionManager extends EventEmitter {
     const sessionData = this.sessions.get(sessionId);
     if (!sessionData) return false;
 
-    // Stop the process
     await sessionData.process.stop();
-
-    // Clean up subscribers
     sessionData.subscribers.clear();
-
-    // Remove from map
     this.sessions.delete(sessionId);
-
-    // Remove from persistence
     this.persistence.deleteSession(sessionId);
 
     console.log(`Deleted session ${sessionId}`);
@@ -278,6 +234,10 @@ export class SessionManager extends EventEmitter {
       if (!sessionData) {
         throw new Error(`Session ${sessionId} not found`);
       }
+    }
+
+    if (!sessionData.process.isRunning()) {
+      await this.reattachProcess(sessionId);
     }
 
     // Update last activity
@@ -340,6 +300,10 @@ export class SessionManager extends EventEmitter {
 
     // Update last activity
     sessionData.session.lastActivity = new Date();
+
+    if ((message as any).type === 'result') {
+      this.releaseProcess(sessionId);
+    }
   }
 
   getAllSessions(): Session[] {
@@ -385,5 +349,78 @@ export class SessionManager extends EventEmitter {
 
     this.sessions.clear();
     console.log('All sessions stopped.');
+  }
+
+  // ── Process lifecycle ─────────────────────────────────────────
+
+  /**
+   * Wire up event listeners from a ClaudeCodeProcess to this manager.
+   * Extracted so createSession, resumeSession, and reattachProcess
+   * all share the same wiring logic.
+   */
+  private wireProcessEvents(sessionId: string, process: ClaudeCodeProcess): void {
+    process.on('message', (message: SDKMessage) => {
+      this.handleMessage(sessionId, message);
+    });
+    process.on('stderr', (error: string) => {
+      console.error(`[Session ${sessionId}] stderr:`, error);
+    });
+    process.on('exit', (code: number | null) => {
+      console.log(`[Session ${sessionId}] exited with code ${code}`);
+    });
+  }
+
+  private createProcess(sessionId: string, persisted: ReturnType<SessionPersistence['getSession']> & {}): ClaudeCodeProcess {
+    return new ClaudeCodeProcess({
+      sessionId,
+      workingDirectory: persisted.workingDirectory,
+      claudeSessionId: persisted.claudeSessionId,
+      userSystemPrompt: persisted.systemPrompt,
+      availableEnvVars: persisted.availableEnvVars,
+      model: persisted.model,
+      browserModel: persisted.browserModel,
+      maxOutputTokens: persisted.maxOutputTokens,
+      maxThinkingTokens: persisted.maxThinkingTokens,
+      maxTurns: persisted.maxTurns,
+      maxBudgetUsd: persisted.maxBudgetUsd,
+      customEnvVars: persisted.customEnvVars,
+    });
+  }
+
+  /**
+   * Stop the process to free SDK resources (MessageQueue, API connection)
+   * while keeping session data and WebSocket subscribers intact.
+   * The next sendMessage will reattach a fresh process.
+   */
+  private async releaseProcess(sessionId: string): Promise<void> {
+    const sessionData = this.sessions.get(sessionId);
+    if (!sessionData) return;
+
+    try {
+      await sessionData.process.stop();
+      console.log(`[SessionManager] Session ${sessionId} process released`);
+    } catch (e) {
+      console.error(`[SessionManager] Error releasing session ${sessionId}:`, e);
+    }
+  }
+
+  /**
+   * Replace a stopped process on an existing SessionData with a fresh
+   * one. Subscribers and session metadata are preserved — only the
+   * underlying ClaudeCodeProcess is swapped out.
+   */
+  private async reattachProcess(sessionId: string): Promise<void> {
+    const sessionData = this.sessions.get(sessionId);
+    if (!sessionData) return;
+
+    const persisted = this.persistence.getSession(sessionId);
+    if (!persisted) throw new Error(`No persisted data for session ${sessionId}`);
+
+    const process = this.createProcess(sessionId, persisted);
+    this.wireProcessEvents(sessionId, process);
+    sessionData.process = process;
+    await process.start();
+
+    console.log(`[SessionManager] Session ${sessionId} process reattached`);
   }
 }

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -128,7 +128,18 @@ export class SessionManager extends EventEmitter {
       subscribers: new Set(),
     };
 
-    this.wireProcessEvents(sessionId, process);
+    // Set up event listeners
+    process.on('message', (message: SDKMessage) => {
+      this.handleMessage(sessionId, message);
+    });
+
+    process.on('stderr', (error: string) => {
+      console.error(`[Session ${sessionId}] stderr:`, error);
+    });
+
+    process.on('exit', (code: number | null) => {
+      console.log(`Session ${sessionId} exited with code ${code}`);
+    });
 
     // Persist the session
     this.persistence.saveSession({
@@ -164,7 +175,21 @@ export class SessionManager extends EventEmitter {
     console.log(`Attempting to resume session ${sessionId} with Claude session ID ${persisted.claudeSessionId}`);
 
     try {
-      const process = this.createProcess(sessionId, persisted);
+      // Create a new Claude Code process with resume
+      const process = new ClaudeCodeProcess({
+        sessionId,
+        workingDirectory: persisted.workingDirectory,
+        claudeSessionId: persisted.claudeSessionId,
+        userSystemPrompt: persisted.systemPrompt,
+        availableEnvVars: persisted.availableEnvVars,
+        model: persisted.model,
+        browserModel: persisted.browserModel,
+        maxOutputTokens: persisted.maxOutputTokens,
+        maxThinkingTokens: persisted.maxThinkingTokens,
+        maxTurns: persisted.maxTurns,
+        maxBudgetUsd: persisted.maxBudgetUsd,
+        customEnvVars: persisted.customEnvVars,
+      });
 
       const session: Session = {
         id: sessionId,
@@ -182,7 +207,19 @@ export class SessionManager extends EventEmitter {
         subscribers: new Set(),
       };
 
-      this.wireProcessEvents(sessionId, process);
+      // Set up event listeners (same as createSession)
+      process.on('message', (message: SDKMessage) => {
+        this.handleMessage(sessionId, message);
+      });
+
+      process.on('stderr', (error: string) => {
+        console.error(`[Session ${sessionId}] stderr:`, error);
+      });
+
+      process.on('exit', (code: number | null) => {
+        console.log(`Resumed session ${sessionId} exited with code ${code}`);
+      });
+
       this.sessions.set(sessionId, sessionData);
 
       // Start the process (which will resume the Claude session)
@@ -216,9 +253,16 @@ export class SessionManager extends EventEmitter {
     const sessionData = this.sessions.get(sessionId);
     if (!sessionData) return false;
 
+    // Stop the process
     await sessionData.process.stop();
+
+    // Clean up subscribers
     sessionData.subscribers.clear();
+
+    // Remove from map
     this.sessions.delete(sessionId);
+
+    // Remove from persistence
     this.persistence.deleteSession(sessionId);
 
     console.log(`Deleted session ${sessionId}`);
@@ -236,8 +280,39 @@ export class SessionManager extends EventEmitter {
       }
     }
 
+    // Reattach process if it was released after going idle
     if (!sessionData.process.isRunning()) {
-      await this.reattachProcess(sessionId);
+      const persisted = this.persistence.getSession(sessionId);
+      if (!persisted) throw new Error(`No persisted data for session ${sessionId}`);
+
+      const process = new ClaudeCodeProcess({
+        sessionId,
+        workingDirectory: persisted.workingDirectory,
+        claudeSessionId: persisted.claudeSessionId,
+        userSystemPrompt: persisted.systemPrompt,
+        availableEnvVars: persisted.availableEnvVars,
+        model: persisted.model,
+        browserModel: persisted.browserModel,
+        maxOutputTokens: persisted.maxOutputTokens,
+        maxThinkingTokens: persisted.maxThinkingTokens,
+        maxTurns: persisted.maxTurns,
+        maxBudgetUsd: persisted.maxBudgetUsd,
+        customEnvVars: persisted.customEnvVars,
+      });
+
+      process.on('message', (message: SDKMessage) => {
+        this.handleMessage(sessionId, message);
+      });
+      process.on('stderr', (error: string) => {
+        console.error(`[Session ${sessionId}] stderr:`, error);
+      });
+      process.on('exit', (code: number | null) => {
+        console.log(`[Session ${sessionId}] exited with code ${code}`);
+      });
+
+      sessionData.process = process;
+      await process.start();
+      console.log(`[SessionManager] Session ${sessionId} process reattached`);
     }
 
     // Update last activity
@@ -301,6 +376,8 @@ export class SessionManager extends EventEmitter {
     // Update last activity
     sessionData.session.lastActivity = new Date();
 
+    // Release the process when a query completes to free SDK resources.
+    // The next sendMessage call will reattach a fresh process.
     if ((message as any).type === 'result') {
       this.releaseProcess(sessionId);
     }
@@ -351,42 +428,6 @@ export class SessionManager extends EventEmitter {
     console.log('All sessions stopped.');
   }
 
-  // ── Process lifecycle ─────────────────────────────────────────
-
-  /**
-   * Wire up event listeners from a ClaudeCodeProcess to this manager.
-   * Extracted so createSession, resumeSession, and reattachProcess
-   * all share the same wiring logic.
-   */
-  private wireProcessEvents(sessionId: string, process: ClaudeCodeProcess): void {
-    process.on('message', (message: SDKMessage) => {
-      this.handleMessage(sessionId, message);
-    });
-    process.on('stderr', (error: string) => {
-      console.error(`[Session ${sessionId}] stderr:`, error);
-    });
-    process.on('exit', (code: number | null) => {
-      console.log(`[Session ${sessionId}] exited with code ${code}`);
-    });
-  }
-
-  private createProcess(sessionId: string, persisted: ReturnType<SessionPersistence['getSession']> & {}): ClaudeCodeProcess {
-    return new ClaudeCodeProcess({
-      sessionId,
-      workingDirectory: persisted.workingDirectory,
-      claudeSessionId: persisted.claudeSessionId,
-      userSystemPrompt: persisted.systemPrompt,
-      availableEnvVars: persisted.availableEnvVars,
-      model: persisted.model,
-      browserModel: persisted.browserModel,
-      maxOutputTokens: persisted.maxOutputTokens,
-      maxThinkingTokens: persisted.maxThinkingTokens,
-      maxTurns: persisted.maxTurns,
-      maxBudgetUsd: persisted.maxBudgetUsd,
-      customEnvVars: persisted.customEnvVars,
-    });
-  }
-
   /**
    * Stop the process to free SDK resources (MessageQueue, API connection)
    * while keeping session data and WebSocket subscribers intact.
@@ -402,25 +443,5 @@ export class SessionManager extends EventEmitter {
     } catch (e) {
       console.error(`[SessionManager] Error releasing session ${sessionId}:`, e);
     }
-  }
-
-  /**
-   * Replace a stopped process on an existing SessionData with a fresh
-   * one. Subscribers and session metadata are preserved — only the
-   * underlying ClaudeCodeProcess is swapped out.
-   */
-  private async reattachProcess(sessionId: string): Promise<void> {
-    const sessionData = this.sessions.get(sessionId);
-    if (!sessionData) return;
-
-    const persisted = this.persistence.getSession(sessionId);
-    if (!persisted) throw new Error(`No persisted data for session ${sessionId}`);
-
-    const process = this.createProcess(sessionId, persisted);
-    this.wireProcessEvents(sessionId, process);
-    sessionData.process = process;
-    await process.start();
-
-    console.log(`[SessionManager] Session ${sessionId} process reattached`);
   }
 }

--- a/src/api/routes/admin-users.ts
+++ b/src/api/routes/admin-users.ts
@@ -3,7 +3,6 @@ import { eq, and } from 'drizzle-orm'
 import { Authenticated, IsAdmin } from '../middleware/auth'
 import { db } from '@shared/lib/db'
 import { user, authAccount } from '@shared/lib/db/schema'
-import { hashPassword } from 'better-auth/crypto'
 
 const adminUsersRouter = new Hono()
 adminUsersRouter.use('*', Authenticated(), IsAdmin())
@@ -28,6 +27,7 @@ adminUsersRouter.post('/invite', async (c) => {
 
   try {
     const userId = crypto.randomUUID()
+    const { hashPassword } = await import('better-auth/crypto')
     const hashedPassword = await hashPassword(password)
     const now = new Date()
 
@@ -86,6 +86,7 @@ adminUsersRouter.post('/reset-password', async (c) => {
   }
 
   try {
+    const { hashPassword } = await import('better-auth/crypto')
     const hashedPassword = await hashPassword(password)
 
     db.update(authAccount)

--- a/src/api/routes/admin-users.ts
+++ b/src/api/routes/admin-users.ts
@@ -3,6 +3,7 @@ import { eq, and } from 'drizzle-orm'
 import { Authenticated, IsAdmin } from '../middleware/auth'
 import { db } from '@shared/lib/db'
 import { user, authAccount } from '@shared/lib/db/schema'
+import { hashPassword } from 'better-auth/crypto'
 
 const adminUsersRouter = new Hono()
 adminUsersRouter.use('*', Authenticated(), IsAdmin())
@@ -27,7 +28,6 @@ adminUsersRouter.post('/invite', async (c) => {
 
   try {
     const userId = crypto.randomUUID()
-    const { hashPassword } = await import('better-auth/crypto')
     const hashedPassword = await hashPassword(password)
     const now = new Date()
 
@@ -86,7 +86,6 @@ adminUsersRouter.post('/reset-password', async (c) => {
   }
 
   try {
-    const { hashPassword } = await import('better-auth/crypto')
     const hashedPassword = await hashPassword(password)
 
     db.update(authAccount)


### PR DESCRIPTION
## Summary

- **Session memory leak fix**: After the agent finishes responding (`result` message), immediately stop the `ClaudeCodeProcess` to free SDK resources (MessageQueue, API connection). Each idle session was holding ~270MB with no cleanup path because the MessageQueue blocks indefinitely.`.

## Test plan

- [x] Create a session, send a message, verify agent responds normally
- [x] After response completes, check container logs for `process released`
- [x] Send another message to same session, verify `process reattached` in logs and response works
- [x] Verify memory drops after process release (via `docker stats`)




