### PR TITLE
feat: Voice input with real-time streaming STT (Deepgram & OpenAI)

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -15,6 +15,7 @@ import remoteMcps from './routes/remote-mcps'
 import commonMcpServers from './routes/common-mcp-servers'
 import userSettingsRouter from './routes/user-settings'
 import runtimeStatusRouter from './routes/runtime-status'
+import sttRouter from './routes/stt'
 import adminUsersRouter from './routes/admin-users'
 import { initializeServices } from '@shared/lib/startup'
 import { isAuthMode } from '@shared/lib/auth/mode'
@@ -128,6 +129,7 @@ app.route('/api/common-mcp-servers', commonMcpServers)
 app.route('/api/user-settings', userSettingsRouter)
 app.route('/api/runtime-status', runtimeStatusRouter)
 app.route('/api/admin/users', adminUsersRouter)
+app.route('/api/stt', sttRouter)
 
 // Global error handler
 app.onError((err, c) => {

--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -14,6 +14,9 @@ const mockGetComposioUserId = vi.fn()
 const mockGetEffectiveModels = vi.fn()
 const mockGetEffectiveAgentLimits = vi.fn()
 const mockGetCustomEnvVars = vi.fn()
+const mockGetDeepgramApiKeyStatus = vi.fn()
+const mockGetOpenaiApiKeyStatus = vi.fn()
+const mockGetVoiceSettings = vi.fn()
 
 vi.mock('@shared/lib/config/settings', () => ({
   getSettings: (...args: unknown[]) => mockGetSettings(...args),
@@ -25,6 +28,9 @@ vi.mock('@shared/lib/config/settings', () => ({
   getEffectiveModels: (...args: unknown[]) => mockGetEffectiveModels(...args),
   getEffectiveAgentLimits: (...args: unknown[]) => mockGetEffectiveAgentLimits(...args),
   getCustomEnvVars: (...args: unknown[]) => mockGetCustomEnvVars(...args),
+  getDeepgramApiKeyStatus: (...args: unknown[]) => mockGetDeepgramApiKeyStatus(...args),
+  getOpenaiApiKeyStatus: (...args: unknown[]) => mockGetOpenaiApiKeyStatus(...args),
+  getVoiceSettings: (...args: unknown[]) => mockGetVoiceSettings(...args),
 }))
 
 const mockHasRunningAgents = vi.fn()
@@ -139,6 +145,9 @@ function setupDefaults() {
   mockGetEffectiveModels.mockReturnValue({ summarizerModel: 'claude-3-haiku', agentModel: 'claude-sonnet-4-20250514', browserModel: 'claude-3-haiku' })
   mockGetEffectiveAgentLimits.mockReturnValue({ maxTurns: 100 })
   mockGetCustomEnvVars.mockReturnValue({ FOO: 'bar' })
+  mockGetDeepgramApiKeyStatus.mockReturnValue({ isConfigured: false, source: 'none' })
+  mockGetOpenaiApiKeyStatus.mockReturnValue({ isConfigured: false, source: 'none' })
+  mockGetVoiceSettings.mockReturnValue({})
   mockGetReadiness.mockReturnValue({ ready: true })
   mockEnsureImageReady.mockResolvedValue(undefined)
   mockClearClients.mockReturnValue(undefined)

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -11,6 +11,9 @@ import {
   getAnthropicApiKeyStatus,
   getComposioApiKeyStatus,
   getComposioUserId,
+  getDeepgramApiKeyStatus,
+  getOpenaiApiKeyStatus,
+  getVoiceSettings,
   getEffectiveModels,
   getEffectiveAgentLimits,
   getCustomEnvVars,
@@ -47,6 +50,8 @@ settings.get('/', async (c) => {
       apiKeyStatus: {
         anthropic: getAnthropicApiKeyStatus(),
         composio: getComposioApiKeyStatus(),
+        deepgram: getDeepgramApiKeyStatus(),
+        openai: getOpenaiApiKeyStatus(),
       },
       models: getEffectiveModels(),
       agentLimits: getEffectiveAgentLimits(),
@@ -56,6 +61,7 @@ settings.get('/', async (c) => {
       hostBrowserStatus: { providers: detectAllProviders() },
       runtimeReadiness: containerManager.getReadiness(),
       auth: currentSettings.auth,
+      voice: getVoiceSettings(),
     }
 
     return c.json(response)
@@ -132,6 +138,9 @@ settings.put('/', async (c) => {
       auth: body.auth !== undefined
         ? { ...currentSettings.auth, ...body.auth }
         : currentSettings.auth,
+      voice: body.voice !== undefined
+        ? { ...currentSettings.voice, ...body.voice }
+        : currentSettings.voice,
     }
 
     // Handle API key updates
@@ -191,6 +200,28 @@ settings.put('/', async (c) => {
         }
       }
 
+      // Handle Deepgram API key
+      if (body.apiKeys.deepgramApiKey === '') {
+        newSettings.apiKeys = { ...newSettings.apiKeys }
+        delete newSettings.apiKeys.deepgramApiKey
+      } else if (body.apiKeys.deepgramApiKey) {
+        newSettings.apiKeys = {
+          ...newSettings.apiKeys,
+          deepgramApiKey: body.apiKeys.deepgramApiKey,
+        }
+      }
+
+      // Handle OpenAI API key
+      if (body.apiKeys.openaiApiKey === '') {
+        newSettings.apiKeys = { ...newSettings.apiKeys }
+        delete newSettings.apiKeys.openaiApiKey
+      } else if (body.apiKeys.openaiApiKey) {
+        newSettings.apiKeys = {
+          ...newSettings.apiKeys,
+          openaiApiKey: body.apiKeys.openaiApiKey,
+        }
+      }
+
       // Clean up empty object
       if (
         newSettings.apiKeys &&
@@ -236,6 +267,8 @@ settings.put('/', async (c) => {
       apiKeyStatus: {
         anthropic: getAnthropicApiKeyStatus(),
         composio: getComposioApiKeyStatus(),
+        deepgram: getDeepgramApiKeyStatus(),
+        openai: getOpenaiApiKeyStatus(),
       },
       models: getEffectiveModels(),
       agentLimits: getEffectiveAgentLimits(),
@@ -245,6 +278,7 @@ settings.put('/', async (c) => {
       hostBrowserStatus: { providers: detectAllProviders() },
       runtimeReadiness: containerManager.getReadiness(),
       auth: newSettings.auth,
+      voice: getVoiceSettings(),
     })
   } catch (error) {
     console.error('Failed to update settings:', error)
@@ -397,6 +431,58 @@ settings.post('/validate-composio-key', async (c) => {
         return c.json({ valid: false, error: 'Invalid API key' })
       }
       return c.json({ valid: false, error: `Composio API error: ${response.status}` })
+    }
+
+    return c.json({ valid: true })
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Validation failed'
+    return c.json({ valid: false, error: message })
+  }
+})
+
+// POST /api/settings/validate-deepgram-key - Validate a Deepgram API key
+settings.post('/validate-deepgram-key', async (c) => {
+  try {
+    const { apiKey } = await c.req.json()
+    if (!apiKey || typeof apiKey !== 'string') {
+      return c.json({ valid: false, error: 'API key is required' }, 400)
+    }
+
+    const response = await fetch('https://api.deepgram.com/v1/projects', {
+      headers: { Authorization: `Token ${apiKey}` },
+    })
+
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        return c.json({ valid: false, error: 'Invalid API key' })
+      }
+      return c.json({ valid: false, error: `Deepgram API error: ${response.status}` })
+    }
+
+    return c.json({ valid: true })
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Validation failed'
+    return c.json({ valid: false, error: message })
+  }
+})
+
+// POST /api/settings/validate-openai-key - Validate an OpenAI API key
+settings.post('/validate-openai-key', async (c) => {
+  try {
+    const { apiKey } = await c.req.json()
+    if (!apiKey || typeof apiKey !== 'string') {
+      return c.json({ valid: false, error: 'API key is required' }, 400)
+    }
+
+    const response = await fetch('https://api.openai.com/v1/models', {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    })
+
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        return c.json({ valid: false, error: 'Invalid API key' })
+      }
+      return c.json({ valid: false, error: `OpenAI API error: ${response.status}` })
     }
 
     return c.json({ valid: true })

--- a/src/api/routes/stt.ts
+++ b/src/api/routes/stt.ts
@@ -1,0 +1,47 @@
+import { Hono } from 'hono'
+import { Authenticated } from '../middleware/auth'
+import {
+  getEffectiveDeepgramApiKey,
+  getEffectiveOpenaiApiKey,
+  getVoiceSettings,
+  type SttProvider,
+} from '@shared/lib/config/settings'
+
+const stt = new Hono()
+
+stt.use('*', Authenticated())
+
+stt.get('/token', async (c) => {
+  try {
+    const voiceSettings = getVoiceSettings()
+    const provider = (c.req.query('provider') as SttProvider) || voiceSettings.sttProvider
+
+    if (!provider) {
+      return c.json({ error: 'No STT provider configured. Set one in Settings > Voice.' }, 400)
+    }
+
+    let apiKey: string | undefined
+    switch (provider) {
+      case 'deepgram':
+        apiKey = getEffectiveDeepgramApiKey()
+        break
+      case 'openai':
+        apiKey = getEffectiveOpenaiApiKey()
+        break
+      default:
+        return c.json({ error: `Unknown STT provider: ${provider}` }, 400)
+    }
+
+    if (!apiKey) {
+      return c.json({ error: `No API key configured for ${provider}. Add one in Settings > Voice.` }, 400)
+    }
+
+    return c.json({ provider, token: apiKey })
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to get STT credentials'
+    console.error('Failed to get STT credentials:', error)
+    return c.json({ error: message }, 500)
+  }
+})
+
+export default stt

--- a/src/api/routes/stt.ts
+++ b/src/api/routes/stt.ts
@@ -6,6 +6,19 @@ import {
   getVoiceSettings,
   type SttProvider,
 } from '@shared/lib/config/settings'
+import { db } from '@shared/lib/db'
+import { sttUsage } from '@shared/lib/db/schema'
+import { isAuthMode } from '@shared/lib/auth/mode'
+import { getCurrentUserId } from '@shared/lib/auth/config'
+import { randomUUID } from 'crypto'
+
+// Cost per millisecond in micro-dollars (1 micro-dollar = 1/1,000,000 USD)
+// Deepgram Nova 3: $4.30 / 1000 min = $0.00007167 / sec = 71.67 µ$ / sec = 0.07167 µ$ / ms
+// OpenAI gpt-4o-mini-transcribe: $3.00 / 1000 min = $0.00005 / sec = 50 µ$ / sec = 0.05 µ$ / ms
+const STT_PRICING: Record<SttProvider, { model: string; microDollarsPerMs: number }> = {
+  deepgram: { model: 'nova-3', microDollarsPerMs: 0.07167 },
+  openai: { model: 'gpt-4o-mini-transcribe', microDollarsPerMs: 0.05 },
+}
 
 const stt = new Hono()
 
@@ -40,6 +53,42 @@ stt.get('/token', async (c) => {
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'Failed to get STT credentials'
     console.error('Failed to get STT credentials:', error)
+    return c.json({ error: message }, 500)
+  }
+})
+
+stt.post('/usage', async (c) => {
+  try {
+    const body = await c.req.json<{ provider: SttProvider; durationMs: number; agentSlug?: string }>()
+    const { provider, durationMs, agentSlug } = body
+
+    if (!provider || !STT_PRICING[provider]) {
+      return c.json({ error: 'Invalid provider' }, 400)
+    }
+    if (!durationMs || durationMs <= 0 || durationMs > 14_400_000) { // add 4 hour limit
+      return c.json({ error: 'Invalid duration' }, 400)
+    }
+
+    const pricing = STT_PRICING[provider]
+    const costMicro = Math.round(durationMs * pricing.microDollarsPerMs)
+
+    const userId = isAuthMode() ? getCurrentUserId(c) : null
+
+    await db.insert(sttUsage).values({
+      id: randomUUID(),
+      provider,
+      model: pricing.model,
+      durationMs,
+      cost: costMicro,
+      agentSlug: agentSlug || null,
+      userId,
+      createdAt: new Date(),
+    })
+
+    return c.json({ ok: true, model: pricing.model, costUsd: costMicro / 1_000_000 })
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to record STT usage'
+    console.error('Failed to record STT usage:', error)
     return c.json({ error: message }, 500)
   }
 })

--- a/src/api/routes/usage.test.ts
+++ b/src/api/routes/usage.test.ts
@@ -45,19 +45,33 @@ vi.mock('../middleware/auth', () => ({
 // Mock DB
 const mockDbWhere = vi.fn()
 const mockDbFrom = vi.fn()
+const mockSttGroupBy = vi.fn().mockResolvedValue([])
+const mockSttWhere = vi.fn().mockReturnValue({ groupBy: mockSttGroupBy })
+const mockSttFrom = vi.fn().mockReturnValue({ where: mockSttWhere })
+const mockSttSelect = vi.fn().mockReturnValue({ from: mockSttFrom })
 
 vi.mock('@shared/lib/db', () => ({
   db: {
-    select: () => ({ from: mockDbFrom }),
+    select: (...args: unknown[]) => {
+      // If called with stt-shaped fields (has 'date' key), route to STT mock chain
+      if (args.length > 0 && typeof args[0] === 'object' && args[0] !== null && 'date' in (args[0] as Record<string, unknown>)) {
+        return mockSttSelect(...args)
+      }
+      return { from: mockDbFrom }
+    },
   },
 }))
 
 vi.mock('@shared/lib/db/schema', () => ({
   agentAcl: { userId: 'user_id', agentSlug: 'agent_slug' },
+  sttUsage: { createdAt: 'created_at', model: 'model', agentSlug: 'agent_slug', cost: 'cost_micro', userId: 'user_id' },
 }))
 
 vi.mock('drizzle-orm', () => ({
   eq: (col: string, val: string) => ({ col, val }),
+  gte: (col: string, val: unknown) => ({ col, val, op: 'gte' }),
+  and: (...conditions: unknown[]) => conditions,
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values, as: () => 'sql' }),
 }))
 
 import usage from './usage'

--- a/src/api/routes/usage.ts
+++ b/src/api/routes/usage.ts
@@ -7,8 +7,8 @@ import { Authenticated } from '../middleware/auth'
 import { isAuthMode } from '@shared/lib/auth/mode'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { db } from '@shared/lib/db'
-import { agentAcl } from '@shared/lib/db/schema'
-import { eq } from 'drizzle-orm'
+import { agentAcl, sttUsage } from '@shared/lib/db/schema'
+import { eq, gte, and, sql } from 'drizzle-orm'
 
 const usage = new Hono()
 
@@ -93,6 +93,58 @@ usage.get('/', async (c) => {
       for (const mb of day.modelBreakdowns) {
         const prev = entry.byModel.get(mb.modelName) || 0
         entry.byModel.set(mb.modelName, prev + mb.cost)
+      }
+    }
+  }
+
+  // Merge STT usage from the database
+  const sttConditions = [gte(sttUsage.createdAt, sinceDate)]
+  if (isAuthMode() && !globalView) {
+    const userId = getCurrentUserId(c)
+    sttConditions.push(eq(sttUsage.userId, userId))
+  }
+
+  const sttRows = await db
+    .select({
+      date: sql<string>`date(${sttUsage.createdAt} / 1000, 'unixepoch')`.as('date'),
+      model: sttUsage.model,
+      agentSlug: sttUsage.agentSlug,
+      totalCostMicro: sql<number>`sum(${sttUsage.cost})`.as('total_cost_micro'),
+    })
+    .from(sttUsage)
+    .where(and(...sttConditions))
+    .groupBy(sql`date(${sttUsage.createdAt} / 1000, 'unixepoch')`, sttUsage.model, sttUsage.agentSlug)
+
+  // Build a name cache for agent slugs referenced by STT rows
+  const sttAgentSlugs = new Set(sttRows.map(r => r.agentSlug).filter(Boolean) as string[])
+  const agentNameMap = new Map<string, string>()
+  await Promise.all(Array.from(sttAgentSlugs).map(async (slug) => {
+    const a = await getAgent(slug)
+    agentNameMap.set(slug, a ? a.frontmatter.name : slug)
+  }))
+
+  for (const row of sttRows) {
+    const costUsd = row.totalCostMicro / 1_000_000
+    let entry = dateMap.get(row.date)
+    if (!entry) {
+      entry = { totalCost: 0, byAgent: new Map(), byModel: new Map() }
+      dateMap.set(row.date, entry)
+    }
+    entry.totalCost += costUsd
+
+    const prev = entry.byModel.get(row.model) || 0
+    entry.byModel.set(row.model, prev + costUsd)
+
+    if (row.agentSlug) {
+      const existing = entry.byAgent.get(row.agentSlug)
+      if (existing) {
+        existing.cost += costUsd
+      } else {
+        entry.byAgent.set(row.agentSlug, {
+          agentSlug: row.agentSlug,
+          agentName: agentNameMap.get(row.agentSlug) || row.agentSlug,
+          cost: costUsd,
+        })
       }
     }
   }

--- a/src/renderer/components/agents/agent-landing.tsx
+++ b/src/renderer/components/agents/agent-landing.tsx
@@ -236,6 +236,7 @@ export function AgentLanding({ agent, onSessionCreated }: AgentLandingProps) {
     onTranscriptUpdate: useCallback((text: string) => {
       setMessage(text)
     }, []),
+    agentSlug: agent.slug,
   })
 
   const handleVoiceToggle = useCallback(() => {

--- a/src/renderer/components/agents/agent-landing.tsx
+++ b/src/renderer/components/agents/agent-landing.tsx
@@ -5,8 +5,11 @@ import { Input } from '@renderer/components/ui/input'
 import { Textarea } from '@renderer/components/ui/textarea'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { Checkbox } from '@renderer/components/ui/checkbox'
-import { Send, Loader2, Sparkles, Paperclip, Search, RefreshCw, ChevronLeft, ChevronRight, Filter, Eye, Maximize2, Minimize2 } from 'lucide-react'
+import { Send, Loader2, Sparkles, Paperclip, Search, RefreshCw, ChevronLeft, ChevronRight, Filter, Eye, Maximize2, Minimize2, Mic, MicOff } from 'lucide-react'
 import { useCreateSession } from '@renderer/hooks/use-sessions'
+import { useSettings } from '@renderer/hooks/use-settings'
+import { useDialogs } from '@renderer/context/dialog-context'
+import { useVoiceInput } from '@renderer/hooks/use-voice-input'
 import { useAgentSkills, useDiscoverableSkills, useRefreshAgentSkills } from '@renderer/hooks/use-agent-skills'
 import { AgentSkillCard } from './agent-skill-card'
 import { DiscoverableSkillCard } from './discoverable-skill-card'
@@ -129,6 +132,11 @@ export function AgentLanding({ agent, onSessionCreated }: AgentLandingProps) {
         setIsUploading(false)
       }
 
+      // Stop voice recording if active
+      if (voiceInput.isRecording || voiceInput.isConnecting) {
+        voiceInput.stopRecording()
+      }
+
       // Create session with the message (including file paths)
       const session = await createSession.mutateAsync({
         agentSlug: agent.slug,
@@ -215,6 +223,32 @@ export function AgentLanding({ agent, onSessionCreated }: AgentLandingProps) {
   useEffect(() => {
     setSkillPage(0)
   }, [skillSearch, selectedSkillsets])
+
+  const { data: settingsData } = useSettings()
+  const { openSettings } = useDialogs()
+
+  const hasVoiceConfigured = settingsData?.voice?.sttProvider && (
+    (settingsData.voice.sttProvider === 'deepgram' && settingsData.apiKeyStatus?.deepgram?.isConfigured) ||
+    (settingsData.voice.sttProvider === 'openai' && settingsData.apiKeyStatus?.openai?.isConfigured)
+  )
+
+  const voiceInput = useVoiceInput({
+    onTranscriptUpdate: useCallback((text: string) => {
+      setMessage(text)
+    }, []),
+  })
+
+  const handleVoiceToggle = useCallback(() => {
+    if (!hasVoiceConfigured) {
+      openSettings('voice')
+      return
+    }
+    if (voiceInput.isRecording || voiceInput.isConnecting) {
+      voiceInput.stopRecording()
+    } else {
+      voiceInput.startRecording(message)
+    }
+  }, [hasVoiceConfigured, openSettings, voiceInput, message])
 
   const isDisabled = createSession.isPending || isUploading || !isRuntimeReady
 
@@ -307,6 +341,31 @@ export function AgentLanding({ agent, onSessionCreated }: AgentLandingProps) {
                   >
                     <Paperclip className="h-4 w-4" />
                   </Button>
+                  {voiceInput.isSupported && (
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant={voiceInput.isRecording ? 'destructive' : 'ghost'}
+                      className={`h-8 w-8 ${voiceInput.isRecording ? 'animate-pulse' : ''}`}
+                      onClick={handleVoiceToggle}
+                      disabled={isDisabled && !voiceInput.isRecording}
+                      title={
+                        !hasVoiceConfigured
+                          ? 'Set up voice input'
+                          : voiceInput.isRecording
+                            ? 'Stop recording'
+                            : 'Voice input'
+                      }
+                    >
+                      {voiceInput.isConnecting ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : voiceInput.isRecording ? (
+                        <MicOff className="h-4 w-4" />
+                      ) : (
+                        <Mic className="h-4 w-4" />
+                      )}
+                    </Button>
+                  )}
                   <Button
                     type="submit"
                     size="icon"

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -110,6 +110,7 @@ const mockDialogContext = {
 }
 vi.mock('@renderer/context/dialog-context', () => ({
   useDialogs: () => mockDialogContext,
+  DialogProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
 // Mock selection context

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -47,6 +47,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent }: MessageInp
     onTranscriptUpdate: useCallback((text: string) => {
       setMessage(text)
     }, []),
+    agentSlug,
   })
 
   const handleVoiceToggle = useCallback(() => {

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -3,9 +3,12 @@ import { Button } from '@renderer/components/ui/button'
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import { useSendMessage, useUploadFile, useInterruptSession } from '@renderer/hooks/use-messages'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
-import { Send, Loader2, StopCircle, Paperclip, WifiOff } from 'lucide-react'
+import { Send, Loader2, StopCircle, Paperclip, WifiOff, Mic, MicOff } from 'lucide-react'
 import { useIsOnline } from '@renderer/context/connectivity-context'
 import { useUser } from '@renderer/context/user-context'
+import { useDialogs } from '@renderer/context/dialog-context'
+import { useSettings } from '@renderer/hooks/use-settings'
+import { useVoiceInput } from '@renderer/hooks/use-voice-input'
 import { AttachmentPreview, type Attachment } from './attachment-preview'
 import { SlashCommandMenu } from './slash-command-menu'
 
@@ -32,6 +35,31 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent }: MessageInp
   const { isActive, slashCommands } = useMessageStream(sessionId, agentSlug)
   const isOnline = useIsOnline()
   const isOffline = !isOnline
+  const { data: settingsData } = useSettings()
+  const { openSettings } = useDialogs()
+
+  const hasVoiceConfigured = settingsData?.voice?.sttProvider && (
+    (settingsData.voice.sttProvider === 'deepgram' && settingsData.apiKeyStatus?.deepgram?.isConfigured) ||
+    (settingsData.voice.sttProvider === 'openai' && settingsData.apiKeyStatus?.openai?.isConfigured)
+  )
+
+  const voiceInput = useVoiceInput({
+    onTranscriptUpdate: useCallback((text: string) => {
+      setMessage(text)
+    }, []),
+  })
+
+  const handleVoiceToggle = useCallback(() => {
+    if (!hasVoiceConfigured) {
+      openSettings('voice')
+      return
+    }
+    if (voiceInput.isRecording || voiceInput.isConnecting) {
+      voiceInput.stopRecording()
+    } else {
+      voiceInput.startRecording(message)
+    }
+  }, [hasVoiceConfigured, openSettings, voiceInput, message])
 
   // Extract the slash command prefix being typed (e.g. "co" from "/co")
   const slashFilter = useMemo(() => {
@@ -156,6 +184,11 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent }: MessageInp
       setIsUploading(false)
     }
 
+    // Stop voice recording if active
+    if (voiceInput.isRecording || voiceInput.isConnecting) {
+      voiceInput.stopRecording()
+    }
+
     // Clear state before sending
     onMessageSent?.(content)
     setMessage('')
@@ -277,6 +310,31 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent }: MessageInp
         >
           <Paperclip className="h-4 w-4" />
         </Button>
+        {voiceInput.isSupported && (
+          <Button
+            type="button"
+            size="icon"
+            variant={voiceInput.isRecording ? 'destructive' : 'ghost'}
+            className={`h-[34px] w-[34px] ${voiceInput.isRecording ? 'animate-pulse' : ''}`}
+            onClick={handleVoiceToggle}
+            disabled={isDisabled && !voiceInput.isRecording}
+            title={
+              !hasVoiceConfigured
+                ? 'Set up voice input'
+                : voiceInput.isRecording
+                  ? 'Stop recording'
+                  : 'Voice input'
+            }
+          >
+            {voiceInput.isConnecting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : voiceInput.isRecording ? (
+              <MicOff className="h-4 w-4" />
+            ) : (
+              <Mic className="h-4 w-4" />
+            )}
+          </Button>
+        )}
         <textarea
           ref={textareaRef}
           value={message}

--- a/src/renderer/components/settings/global-settings-dialog.tsx
+++ b/src/renderer/components/settings/global-settings-dialog.tsx
@@ -1,5 +1,5 @@
 
-import { Settings, Link2, Container, Bell, Globe, Library, BarChart3, Plug, Brain, Users, Shield, ShieldEllipsis, User } from 'lucide-react'
+import { Settings, Link2, Container, Bell, Globe, Library, BarChart3, Plug, Brain, Users, Shield, ShieldEllipsis, User, Mic } from 'lucide-react'
 import { SettingsDialog, SettingsDialogTab, SettingsDialogGroup } from '@renderer/components/ui/settings-dialog'
 import { ProfileTab } from './profile-tab'
 import { GeneralTab } from './general-tab'
@@ -15,6 +15,7 @@ import { AccountsTab } from './accounts-tab'
 import { UsersTab } from './users-tab'
 import { AuthTab } from './auth-tab'
 import { AdminTab } from './admin-tab'
+import { VoiceTab } from './voice-tab'
 import { useUser } from '@renderer/context/user-context'
 
 interface GlobalSettingsDialogProps {
@@ -56,6 +57,9 @@ export function GlobalSettingsDialog({
       </SettingsDialogTab>
       <SettingsDialogTab id="usage" label="Usage" icon={<BarChart3 className="h-4 w-4" />}>
         <UsageTab />
+      </SettingsDialogTab>
+      <SettingsDialogTab id="voice" label="Voice" icon={<Mic className="h-4 w-4" />}>
+        <VoiceTab />
       </SettingsDialogTab>
     </>
   )

--- a/src/renderer/components/settings/voice-tab.tsx
+++ b/src/renderer/components/settings/voice-tab.tsx
@@ -17,8 +17,20 @@ import { createSttAdapter } from '@renderer/lib/stt'
 import type { ApiKeyStatus, SttProvider } from '@shared/lib/config/settings'
 
 const STT_PROVIDERS = [
-  { value: 'deepgram' as const, label: 'Deepgram', model: 'Nova 3' },
-  { value: 'openai' as const, label: 'OpenAI', model: 'GPT-4o Mini Transcribe' },
+  {
+    value: 'deepgram' as const,
+    label: 'Deepgram',
+    model: 'Nova 3',
+    docsUrl: 'https://developers.deepgram.com/docs/models-languages-overview',
+    note: 'Lowest latency (~200ms). 47 languages — Chinese not yet supported.',
+  },
+  {
+    value: 'openai' as const,
+    label: 'OpenAI',
+    model: 'GPT-4o Mini Transcribe',
+    docsUrl: 'https://platform.openai.com/docs/guides/speech-to-text#supported-languages',
+    note: 'Most accurate & affordable. 57 languages including Chinese.',
+  },
 ]
 
 const PROVIDER_CONFIG: Record<SttProvider, {
@@ -317,8 +329,20 @@ function VoiceTest({ provider }: { provider: SttProvider }) {
   const audioCtxRef = useRef<AudioContext | null>(null)
   const processorRef = useRef<ScriptProcessorNode | null>(null)
   const analyserRef = useRef<AnalyserNode | null>(null)
+  const testStartRef = useRef<number>(0)
 
   const stopTest = useCallback(() => {
+    // Report usage
+    const durationMs = testStartRef.current > 0 ? Date.now() - testStartRef.current : 0
+    if (durationMs > 0) {
+      apiFetch('/api/stt/usage', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider, durationMs }),
+      }).catch((err) => console.error('Failed to report STT usage:', err))
+    }
+    testStartRef.current = 0
+
     processorRef.current?.disconnect()
     processorRef.current = null
     analyserRef.current = null
@@ -331,7 +355,7 @@ function VoiceTest({ provider }: { provider: SttProvider }) {
     setTestState('idle')
     setInterimText('')
     setSegments([])
-  }, [])
+  }, [provider])
 
   const startTest = useCallback(async () => {
     setTestState('connecting')
@@ -412,6 +436,7 @@ function VoiceTest({ provider }: { provider: SttProvider }) {
       source.connect(processor)
       processor.connect(audioContext.destination)
 
+      testStartRef.current = Date.now()
       setTestState('recording')
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Test failed'
@@ -530,8 +555,26 @@ export function VoiceTab() {
             </SelectContent>
           </Select>
           <p className="text-xs text-muted-foreground">
-            Choose which service to use for voice-to-text transcription. A microphone button will appear in the message input once configured.
+            Choose which service to use for voice-to-text transcription.
           </p>
+          {selectedProvider && (() => {
+            const info = STT_PROVIDERS.find(p => p.value === selectedProvider)
+            if (!info) return null
+            return (
+              <p className="text-xs text-muted-foreground">
+                {info.note}{' '}
+                <a
+                  href={info.docsUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline inline-flex items-center gap-0.5"
+                >
+                  View details
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              </p>
+            )
+          })()}
         </div>
       </div>
 

--- a/src/renderer/components/settings/voice-tab.tsx
+++ b/src/renderer/components/settings/voice-tab.tsx
@@ -22,14 +22,14 @@ const STT_PROVIDERS = [
     label: 'Deepgram',
     model: 'Nova 3',
     docsUrl: 'https://developers.deepgram.com/docs/models-languages-overview',
-    note: 'Lowest latency (~200ms). 47 languages — Chinese not yet supported.',
+    note: 'Lowest latency (~200ms). 47 languages supported.',
   },
   {
     value: 'openai' as const,
     label: 'OpenAI',
     model: 'GPT-4o Mini Transcribe',
     docsUrl: 'https://platform.openai.com/docs/guides/speech-to-text#supported-languages',
-    note: 'Most accurate & affordable. 57 languages including Chinese.',
+    note: 'Most accurate & affordable. 57 languages supported.',
   },
 ]
 

--- a/src/renderer/components/settings/voice-tab.tsx
+++ b/src/renderer/components/settings/voice-tab.tsx
@@ -1,0 +1,556 @@
+import { useState, useRef, useCallback, useEffect } from 'react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@renderer/components/ui/select'
+import { Input } from '@renderer/components/ui/input'
+import { Label } from '@renderer/components/ui/label'
+import { Button } from '@renderer/components/ui/button'
+import { Alert, AlertDescription } from '@renderer/components/ui/alert'
+import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
+import { apiFetch } from '@renderer/lib/api'
+import { AlertTriangle, Eye, EyeOff, Check, Loader2, ExternalLink, Square, Volume2 } from 'lucide-react'
+import { createSttAdapter } from '@renderer/lib/stt'
+import type { ApiKeyStatus, SttProvider } from '@shared/lib/config/settings'
+
+const STT_PROVIDERS = [
+  { value: 'deepgram' as const, label: 'Deepgram', model: 'Nova 3' },
+  { value: 'openai' as const, label: 'OpenAI', model: 'GPT-4o Mini Transcribe' },
+]
+
+const PROVIDER_CONFIG: Record<SttProvider, {
+  envVar: string
+  placeholder: string
+  validateEndpoint: string
+  apiKeyField: 'deepgramApiKey' | 'openaiApiKey'
+  statusField: 'deepgram' | 'openai'
+  dashboardUrl: string
+  dashboardLabel: string
+}> = {
+  deepgram: {
+    envVar: 'DEEPGRAM_API_KEY',
+    placeholder: 'Enter your Deepgram API key',
+    validateEndpoint: '/api/settings/validate-deepgram-key',
+    apiKeyField: 'deepgramApiKey',
+    statusField: 'deepgram',
+    dashboardUrl: 'https://console.deepgram.com/',
+    dashboardLabel: 'Deepgram Console',
+  },
+  openai: {
+    envVar: 'OPENAI_API_KEY',
+    placeholder: 'sk-...',
+    validateEndpoint: '/api/settings/validate-openai-key',
+    apiKeyField: 'openaiApiKey',
+    statusField: 'openai',
+    dashboardUrl: 'https://platform.openai.com/api-keys',
+    dashboardLabel: 'OpenAI Dashboard',
+  },
+}
+
+function SttApiKeyInput({ provider, disabled }: { provider: SttProvider; disabled: boolean }) {
+  const { data: settings } = useSettings()
+  const updateSettings = useUpdateSettings()
+  const config = PROVIDER_CONFIG[provider]
+
+  const [apiKeyInput, setApiKeyInput] = useState('')
+  const [showApiKey, setShowApiKey] = useState(false)
+  const [isValidating, setIsValidating] = useState(false)
+  const [validationResult, setValidationResult] = useState<{ valid: boolean; error?: string } | null>(null)
+  const [isRemoving, setIsRemoving] = useState(false)
+
+  const apiKeyStatus: ApiKeyStatus | undefined = settings?.apiKeyStatus?.[config.statusField]
+  const isBusy = isValidating || isRemoving
+
+  const handleValidateAndSave = async () => {
+    if (!apiKeyInput.trim()) return
+    setIsValidating(true)
+    setValidationResult(null)
+
+    try {
+      const res = await apiFetch(config.validateEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ apiKey: apiKeyInput.trim() }),
+      })
+      const result = await res.json()
+      setValidationResult(result)
+
+      if (result.valid) {
+        await updateSettings.mutateAsync({
+          apiKeys: { [config.apiKeyField]: apiKeyInput.trim() },
+        })
+        setApiKeyInput('')
+        setShowApiKey(false)
+      }
+    } catch {
+      setValidationResult({ valid: false, error: 'Failed to validate API key' })
+    } finally {
+      setIsValidating(false)
+    }
+  }
+
+  const handleRemoveApiKey = async () => {
+    setIsRemoving(true)
+    try {
+      await updateSettings.mutateAsync({
+        apiKeys: { [config.apiKeyField]: '' },
+      })
+      setValidationResult(null)
+    } catch (error) {
+      console.error('Failed to remove API key:', error)
+    } finally {
+      setIsRemoving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={`${provider}-api-key`}>
+        {STT_PROVIDERS.find(p => p.value === provider)?.label} API Key
+      </Label>
+
+      {apiKeyStatus?.isConfigured && (
+        <div className="flex items-center gap-2">
+          <span
+            className={`text-xs px-2 py-0.5 rounded-full ${
+              apiKeyStatus.source === 'settings'
+                ? 'bg-green-500/10 text-green-700 dark:text-green-400'
+                : 'bg-blue-500/10 text-blue-700 dark:text-blue-400'
+            }`}
+          >
+            {apiKeyStatus.source === 'settings'
+              ? 'Using saved setting'
+              : 'Using environment variable'}
+          </span>
+        </div>
+      )}
+
+      <div className="relative">
+        <Input
+          id={`${provider}-api-key`}
+          type={showApiKey ? 'text' : 'password'}
+          value={apiKeyInput}
+          onChange={(e) => {
+            setApiKeyInput(e.target.value)
+            setValidationResult(null)
+          }}
+          placeholder={apiKeyStatus?.isConfigured ? '••••••••••••••••' : config.placeholder}
+          className="pr-10"
+          disabled={disabled || isBusy}
+        />
+        <button
+          type="button"
+          onClick={() => setShowApiKey(!showApiKey)}
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          disabled={disabled || isBusy}
+        >
+          {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+        </button>
+      </div>
+
+      {validationResult && (
+        <Alert variant={validationResult.valid ? 'default' : 'destructive'}>
+          {validationResult.valid ? (
+            <Check className="h-4 w-4" />
+          ) : (
+            <AlertTriangle className="h-4 w-4" />
+          )}
+          <AlertDescription>
+            {validationResult.valid
+              ? 'API key is valid and has been saved.'
+              : validationResult.error || 'Invalid API key'}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <p className="text-xs text-muted-foreground">
+        {apiKeyStatus?.source === 'settings'
+          ? 'Your API key is saved locally. Enter a new key to replace it.'
+          : apiKeyStatus?.source === 'env'
+            ? `Save a key here to override the ${config.envVar} environment variable.`
+            : (
+              <>
+                Get your API key from the{' '}
+                <a
+                  href={config.dashboardUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline inline-flex items-center gap-1"
+                >
+                  {config.dashboardLabel}
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              </>
+            )}
+      </p>
+
+      <div className="flex gap-2">
+        {apiKeyInput.trim() && (
+          <Button size="sm" onClick={handleValidateAndSave} disabled={isBusy}>
+            {isValidating ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Validating...
+              </>
+            ) : (
+              'Validate & Save'
+            )}
+          </Button>
+        )}
+        {apiKeyStatus?.source === 'settings' && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleRemoveApiKey}
+            disabled={isBusy}
+          >
+            {isRemoving ? 'Removing...' : 'Remove Saved Key'}
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+type TestState = 'idle' | 'connecting' | 'recording'
+
+interface TranscriptSegment {
+  id: number
+  text: string
+}
+
+function WaveformCanvas({ analyserRef }: { analyserRef: React.RefObject<AnalyserNode | null> }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const animFrameRef = useRef<number>(0)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const dpr = window.devicePixelRatio || 1
+    const rect = canvas.getBoundingClientRect()
+    canvas.width = rect.width * dpr
+    canvas.height = rect.height * dpr
+    ctx.scale(dpr, dpr)
+
+    const LINE_COUNT = 48
+    const smoothed = new Float32Array(LINE_COUNT).fill(0)
+    const DECAY = 0.88
+    const RISE = 0.35
+
+    const style = getComputedStyle(canvas)
+    const fg = style.getPropertyValue('--foreground').trim()
+
+    function draw() {
+      animFrameRef.current = requestAnimationFrame(draw)
+      const analyser = analyserRef.current
+      if (!canvas || !ctx) return
+
+      const w = rect.width
+      const h = rect.height
+      const midY = h / 2
+
+      ctx.clearRect(0, 0, w, h)
+
+      if (!analyser) return
+      const freqData = new Uint8Array(analyser.frequencyBinCount)
+      analyser.getByteFrequencyData(freqData)
+
+      const binSize = Math.floor(freqData.length / LINE_COUNT)
+      for (let i = 0; i < LINE_COUNT; i++) {
+        let sum = 0
+        for (let j = 0; j < binSize; j++) {
+          sum += freqData[i * binSize + j]
+        }
+        const target = (sum / binSize) / 255
+        smoothed[i] = target > smoothed[i]
+          ? smoothed[i] + (target - smoothed[i]) * RISE
+          : smoothed[i] * DECAY
+      }
+
+      const gap = w / LINE_COUNT
+      const lineW = Math.max(1.5, gap * 0.35)
+
+      for (let i = 0; i < LINE_COUNT; i++) {
+        const amp = smoothed[i]
+        const barH = Math.max(2, amp * h * 0.8)
+        const x = gap * (i + 0.5)
+
+        const alpha = 0.15 + amp * 0.65
+        ctx.strokeStyle = fg ? `hsl(${fg} / ${alpha})` : `rgba(128, 128, 128, ${alpha})`
+        ctx.lineWidth = lineW
+        ctx.lineCap = 'round'
+        ctx.beginPath()
+        ctx.moveTo(x, midY - barH / 2)
+        ctx.lineTo(x, midY + barH / 2)
+        ctx.stroke()
+      }
+    }
+
+    draw()
+    return () => cancelAnimationFrame(animFrameRef.current)
+  }, [analyserRef])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="w-full h-8"
+      style={{ width: '100%', height: '32px' }}
+    />
+  )
+}
+
+function VoiceTest({ provider }: { provider: SttProvider }) {
+  const [testState, setTestState] = useState<TestState>('idle')
+  const [segments, setSegments] = useState<TranscriptSegment[]>([])
+  const [interimText, setInterimText] = useState('')
+  const [testError, setTestError] = useState<string | null>(null)
+  const nextIdRef = useRef(0)
+
+  const adapterRef = useRef<ReturnType<typeof createSttAdapter> | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const audioCtxRef = useRef<AudioContext | null>(null)
+  const processorRef = useRef<ScriptProcessorNode | null>(null)
+  const analyserRef = useRef<AnalyserNode | null>(null)
+
+  const stopTest = useCallback(() => {
+    processorRef.current?.disconnect()
+    processorRef.current = null
+    analyserRef.current = null
+    audioCtxRef.current?.close()
+    audioCtxRef.current = null
+    streamRef.current?.getTracks().forEach(t => t.stop())
+    streamRef.current = null
+    adapterRef.current?.close()
+    adapterRef.current = null
+    setTestState('idle')
+    setInterimText('')
+    setSegments([])
+  }, [])
+
+  const startTest = useCallback(async () => {
+    setTestState('connecting')
+    setSegments([])
+    setInterimText('')
+    setTestError(null)
+    nextIdRef.current = 0
+
+    try {
+      const credRes = await apiFetch(`/api/stt/token?provider=${provider}`)
+      const credData = await credRes.json()
+      if (!credRes.ok) {
+        throw new Error(credData.error || 'Failed to get STT credentials')
+      }
+
+      const adapter = createSttAdapter(credData.provider)
+      adapterRef.current = adapter
+      const sampleRate = adapter.sampleRate ?? 16000
+
+      adapter.onTranscript((event) => {
+        if (event.type === 'interim') {
+          setInterimText(event.text)
+        } else if (event.type === 'final') {
+          setInterimText('')
+          setSegments(prev => [...prev, {
+            id: nextIdRef.current++,
+            text: event.text,
+          }])
+        }
+      })
+
+      adapter.onError((err) => {
+        setTestError(err.message)
+        processorRef.current?.disconnect()
+        processorRef.current = null
+        analyserRef.current = null
+        audioCtxRef.current?.close()
+        audioCtxRef.current = null
+        streamRef.current?.getTracks().forEach(t => t.stop())
+        streamRef.current = null
+        adapterRef.current?.close()
+        adapterRef.current = null
+        setTestState('idle')
+      })
+
+      await adapter.connect(credData.token)
+
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: { channelCount: 1, sampleRate, echoCancellation: true, noiseSuppression: true },
+      })
+      streamRef.current = stream
+
+      const audioContext = new AudioContext({ sampleRate })
+      audioCtxRef.current = audioContext
+      const source = audioContext.createMediaStreamSource(stream)
+
+      const analyser = audioContext.createAnalyser()
+      analyser.fftSize = 256
+      analyser.smoothingTimeConstant = 0.6
+      source.connect(analyser)
+      analyserRef.current = analyser
+
+      const processor = audioContext.createScriptProcessor(2048, 1, 1)
+      processorRef.current = processor
+
+      processor.onaudioprocess = (e) => {
+        if (adapterRef.current) {
+          const float32 = e.inputBuffer.getChannelData(0)
+          const int16 = new Int16Array(float32.length)
+          for (let i = 0; i < float32.length; i++) {
+            const s = Math.max(-1, Math.min(1, float32[i]))
+            int16[i] = s < 0 ? s * 0x8000 : s * 0x7FFF
+          }
+          adapterRef.current.sendAudio(int16.buffer)
+        }
+      }
+
+      source.connect(processor)
+      processor.connect(audioContext.destination)
+
+      setTestState('recording')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Test failed'
+      setTestError(message)
+      stopTest()
+    }
+  }, [provider, stopTest])
+
+  const hasContent = segments.length > 0 || interimText
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        {testState === 'recording' ? (
+          <Button size="sm" variant="destructive" onClick={stopTest}>
+            <Square className="h-3 w-3 mr-2" />
+            Stop Test
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={startTest}
+            disabled={testState === 'connecting'}
+          >
+            {testState === 'connecting' ? (
+              <>
+                <Loader2 className="h-3 w-3 mr-2 animate-spin" />
+                Connecting...
+              </>
+            ) : (
+              <>
+                <Volume2 className="h-3 w-3 mr-2" />
+                Test Voice Input
+              </>
+            )}
+          </Button>
+        )}
+      </div>
+
+      {testState === 'recording' && (
+        <div className="rounded-md border bg-muted/30 p-3">
+          <WaveformCanvas analyserRef={analyserRef} />
+        </div>
+      )}
+
+      {(hasContent || testState === 'recording') && (
+        <div className="rounded-md border bg-muted/50 p-3 text-sm min-h-[60px] relative overflow-hidden">
+          {segments.length === 0 && !interimText && testState === 'recording' && (
+            <span className="text-muted-foreground/60 italic animate-pulse">
+              Listening... speak now
+            </span>
+          )}
+          {segments.map((seg) => (
+            <span
+              key={seg.id}
+              className="animate-in fade-in slide-in-from-bottom-1 duration-300 inline"
+            >
+              {seg.text}{' '}
+            </span>
+          ))}
+          {interimText && (
+            <span className="text-muted-foreground animate-in fade-in duration-150 inline">
+              {interimText}
+            </span>
+          )}
+        </div>
+      )}
+
+      {testError && (
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>{testError}</AlertDescription>
+        </Alert>
+      )}
+    </div>
+  )
+}
+
+const VALID_PROVIDERS = new Set(STT_PROVIDERS.map(p => p.value))
+
+export function VoiceTab() {
+  const { data: settings, isLoading } = useSettings()
+  const updateSettings = useUpdateSettings()
+  const rawProvider = settings?.voice?.sttProvider
+  const selectedProvider = rawProvider && VALID_PROVIDERS.has(rawProvider) ? rawProvider : undefined
+
+  const hasKeyConfigured = selectedProvider && (
+    (selectedProvider === 'deepgram' && settings?.apiKeyStatus?.deepgram?.isConfigured) ||
+    (selectedProvider === 'openai' && settings?.apiKeyStatus?.openai?.isConfigured)
+  )
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-4">
+        <h3 className="text-sm font-medium">Speech-to-Text Provider</h3>
+        <div className="space-y-2">
+          <Label htmlFor="stt-provider">Provider</Label>
+          <Select
+            value={selectedProvider ?? ''}
+            onValueChange={(value) => {
+              updateSettings.mutate({ voice: { sttProvider: value as SttProvider } })
+            }}
+            disabled={isLoading}
+          >
+            <SelectTrigger id="stt-provider">
+              <SelectValue placeholder="Select a provider" />
+            </SelectTrigger>
+            <SelectContent>
+              {STT_PROVIDERS.map((provider) => (
+                <SelectItem key={provider.value} value={provider.value}>
+                  {provider.label}
+                  <span className="text-muted-foreground ml-2">({provider.model})</span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Choose which service to use for voice-to-text transcription. A microphone button will appear in the message input once configured.
+          </p>
+        </div>
+      </div>
+
+      {selectedProvider && (
+        <div className="pt-4 border-t space-y-4">
+          <h3 className="text-sm font-medium">API Key</h3>
+          <SttApiKeyInput provider={selectedProvider} disabled={isLoading} />
+        </div>
+      )}
+
+      {hasKeyConfigured && selectedProvider && (
+        <div className="pt-4 border-t space-y-4">
+          <h3 className="text-sm font-medium">Test</h3>
+          <p className="text-xs text-muted-foreground">
+            Verify your microphone and STT provider are working correctly.
+          </p>
+          <VoiceTest provider={selectedProvider} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/hooks/use-settings.ts
+++ b/src/renderer/hooks/use-settings.ts
@@ -7,10 +7,11 @@ import type {
   ModelSettings,
   AgentLimitsSettings,
   AuthSettings,
+  VoiceSettings,
 } from '@shared/lib/config/settings'
 import type { RunnerAvailability } from '@shared/lib/container/client-factory'
 
-export type { GlobalSettingsResponse, ContainerSettings, AppPreferences, ModelSettings, AgentLimitsSettings, AuthSettings, RunnerAvailability }
+export type { GlobalSettingsResponse, ContainerSettings, AppPreferences, ModelSettings, AgentLimitsSettings, AuthSettings, VoiceSettings, RunnerAvailability }
 
 export function useSettings(options?: { enabled?: boolean }) {
   return useQuery<GlobalSettingsResponse>({
@@ -34,11 +35,14 @@ export interface UpdateSettingsParams {
     composioUserId?: string
     browserbaseApiKey?: string
     browserbaseProjectId?: string
+    deepgramApiKey?: string
+    openaiApiKey?: string
   }
   models?: Partial<ModelSettings>
   agentLimits?: Partial<AgentLimitsSettings>
   customEnvVars?: Record<string, string>
   auth?: Partial<AuthSettings>
+  voice?: Partial<VoiceSettings>
 }
 
 export interface UpdateSettingsError {

--- a/src/renderer/hooks/use-voice-input.ts
+++ b/src/renderer/hooks/use-voice-input.ts
@@ -6,6 +6,7 @@ export type VoiceInputState = 'idle' | 'connecting' | 'recording' | 'stopping'
 
 interface UseVoiceInputOptions {
   onTranscriptUpdate: (text: string) => void
+  agentSlug?: string
 }
 
 interface SttCredentials {
@@ -13,7 +14,7 @@ interface SttCredentials {
   token: string
 }
 
-export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
+export function useVoiceInput({ onTranscriptUpdate, agentSlug }: UseVoiceInputOptions) {
   const [state, setState] = useState<VoiceInputState>('idle')
   const [error, setError] = useState<string | null>(null)
 
@@ -26,6 +27,10 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
   const prefixRef = useRef('')
   const finalizedRef = useRef('')
   const interimRef = useRef('')
+
+  // Track recording duration for usage reporting
+  const recordingStartRef = useRef<number>(0)
+  const providerRef = useRef<SttProvider | null>(null)
 
   const isSupported = typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getUserMedia
 
@@ -46,6 +51,22 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
   const stopRecording = useCallback(() => {
     if (state !== 'recording' && state !== 'connecting') return
     setState('stopping')
+
+    // Report usage before cleanup
+    const provider = providerRef.current
+    const durationMs = recordingStartRef.current > 0
+      ? Date.now() - recordingStartRef.current
+      : 0
+    if (provider && durationMs > 0) {
+      apiFetch('/api/stt/usage', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider, durationMs, agentSlug }),
+      }).catch((err) => console.error('Failed to report STT usage:', err))
+    }
+    providerRef.current = null
+    recordingStartRef.current = 0
+
     cleanup()
     // Drop interim text — keep only finalized content in the textarea
     const finalText = prefixRef.current + finalizedRef.current
@@ -54,7 +75,7 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
     interimRef.current = ''
     onTranscriptUpdate(finalText)
     setState('idle')
-  }, [state, cleanup, onTranscriptUpdate])
+  }, [state, cleanup, onTranscriptUpdate, agentSlug])
 
   const startRecording = useCallback(async (existingText: string) => {
     if (state !== 'idle') return
@@ -115,6 +136,9 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
       })
 
       await adapter.connect(apiKey)
+
+      providerRef.current = provider
+      recordingStartRef.current = Date.now()
 
       // 4. Set up audio processing to send PCM chunks
       const audioContext = new AudioContext({ sampleRate })

--- a/src/renderer/hooks/use-voice-input.ts
+++ b/src/renderer/hooks/use-voice-input.ts
@@ -1,0 +1,169 @@
+import { useState, useRef, useCallback, useEffect } from 'react'
+import { apiFetch } from '@renderer/lib/api'
+import { createSttAdapter, type SttAdapter, type SttProvider } from '@renderer/lib/stt'
+
+export type VoiceInputState = 'idle' | 'connecting' | 'recording' | 'stopping'
+
+interface UseVoiceInputOptions {
+  onTranscriptUpdate: (text: string) => void
+}
+
+interface SttCredentials {
+  provider: SttProvider
+  token: string
+}
+
+export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
+  const [state, setState] = useState<VoiceInputState>('idle')
+  const [error, setError] = useState<string | null>(null)
+
+  const adapterRef = useRef<SttAdapter | null>(null)
+  const mediaStreamRef = useRef<MediaStream | null>(null)
+  const processorRef = useRef<ScriptProcessorNode | AudioWorkletNode | null>(null)
+  const audioContextRef = useRef<AudioContext | null>(null)
+
+  // Track text accumulation across interim/final events
+  const prefixRef = useRef('')
+  const finalizedRef = useRef('')
+  const interimRef = useRef('')
+
+  const isSupported = typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getUserMedia
+
+  const cleanup = useCallback(() => {
+    processorRef.current?.disconnect()
+    processorRef.current = null
+
+    audioContextRef.current?.close()
+    audioContextRef.current = null
+
+    mediaStreamRef.current?.getTracks().forEach(t => t.stop())
+    mediaStreamRef.current = null
+
+    adapterRef.current?.close()
+    adapterRef.current = null
+  }, [])
+
+  const stopRecording = useCallback(() => {
+    if (state !== 'recording' && state !== 'connecting') return
+    setState('stopping')
+    cleanup()
+    // Drop interim text — keep only finalized content in the textarea
+    const finalText = prefixRef.current + finalizedRef.current
+    prefixRef.current = ''
+    finalizedRef.current = ''
+    interimRef.current = ''
+    onTranscriptUpdate(finalText)
+    setState('idle')
+  }, [state, cleanup, onTranscriptUpdate])
+
+  const startRecording = useCallback(async (existingText: string) => {
+    if (state !== 'idle') return
+    setError(null)
+
+    // Save prefix (text already in textarea before recording)
+    prefixRef.current = existingText ? existingText + ' ' : ''
+    finalizedRef.current = ''
+    interimRef.current = ''
+
+    setState('connecting')
+
+    try {
+      // 1. Get API key from backend
+      const credRes = await apiFetch('/api/stt/token')
+      const credData: SttCredentials | { error: string } = await credRes.json()
+      if (!credRes.ok) {
+        throw new Error(('error' in credData ? credData.error : null) || 'Failed to get STT credentials')
+      }
+      const { provider, token: apiKey } = credData as SttCredentials
+
+      // 2. Create adapter
+      const adapter = createSttAdapter(provider)
+      adapterRef.current = adapter
+      const sampleRate = adapter.sampleRate ?? 16000
+
+      // 3. Get microphone access
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          sampleRate,
+          echoCancellation: true,
+          noiseSuppression: true,
+        },
+      })
+      mediaStreamRef.current = stream
+
+      adapter.onTranscript((event) => {
+        switch (event.type) {
+          case 'interim':
+            interimRef.current = event.text
+            onTranscriptUpdate(prefixRef.current + finalizedRef.current + interimRef.current)
+            break
+          case 'final':
+            finalizedRef.current += (finalizedRef.current ? ' ' : '') + event.text
+            interimRef.current = ''
+            onTranscriptUpdate(prefixRef.current + finalizedRef.current)
+            break
+          case 'speech_ended':
+            break
+        }
+      })
+
+      adapter.onError((err) => {
+        console.error('STT adapter error:', err)
+        setError(err.message)
+        stopRecording()
+      })
+
+      await adapter.connect(apiKey)
+
+      // 4. Set up audio processing to send PCM chunks
+      const audioContext = new AudioContext({ sampleRate })
+      audioContextRef.current = audioContext
+      const source = audioContext.createMediaStreamSource(stream)
+
+      const processor = audioContext.createScriptProcessor(2048, 1, 1)
+      processorRef.current = processor
+
+      processor.onaudioprocess = (e) => {
+        if (adapterRef.current) {
+          const float32 = e.inputBuffer.getChannelData(0)
+          // Convert Float32 [-1, 1] to Int16 PCM
+          const int16 = new Int16Array(float32.length)
+          for (let i = 0; i < float32.length; i++) {
+            const s = Math.max(-1, Math.min(1, float32[i]))
+            int16[i] = s < 0 ? s * 0x8000 : s * 0x7FFF
+          }
+          adapterRef.current.sendAudio(int16.buffer)
+        }
+      }
+
+      source.connect(processor)
+      processor.connect(audioContext.destination)
+
+      setState('recording')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to start recording'
+      console.error('Voice input error:', err)
+      setError(message)
+      cleanup()
+      setState('idle')
+    }
+  }, [state, cleanup, onTranscriptUpdate, stopRecording])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      cleanup()
+    }
+  }, [cleanup])
+
+  return {
+    state,
+    isRecording: state === 'recording',
+    isConnecting: state === 'connecting',
+    error,
+    isSupported,
+    startRecording,
+    stopRecording,
+  }
+}

--- a/src/renderer/lib/stt.ts
+++ b/src/renderer/lib/stt.ts
@@ -1,0 +1,240 @@
+// --- Types ---
+
+export type SttProvider = 'deepgram' | 'openai'
+
+export interface TranscriptEvent {
+  type: 'interim' | 'final' | 'speech_ended'
+  text: string
+}
+
+export type TranscriptCallback = (event: TranscriptEvent) => void
+export type ErrorCallback = (error: Error) => void
+
+export interface SttAdapter {
+  /** Required audio sample rate in Hz. Defaults to 16000 if not set. */
+  readonly sampleRate?: number
+  connect(token: string): Promise<void>
+  sendAudio(chunk: ArrayBuffer): void
+  onTranscript(cb: TranscriptCallback): void
+  onError(cb: ErrorCallback): void
+  close(): void
+}
+
+// --- Deepgram Adapter ---
+
+const DEEPGRAM_WS_PARAMS = new URLSearchParams({
+  model: 'nova-3',
+  interim_results: 'true',
+  smart_format: 'true',
+  endpointing: '300',
+  vad_events: 'true',
+  utterance_end_ms: '1000',
+  encoding: 'linear16',
+  sample_rate: '16000',
+  channels: '1',
+})
+
+class DeepgramAdapter implements SttAdapter {
+  private ws: WebSocket | null = null
+  private transcriptCb: TranscriptCallback | null = null
+  private errorCb: ErrorCallback | null = null
+
+  async connect(token: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const url = `wss://api.deepgram.com/v1/listen?${DEEPGRAM_WS_PARAMS.toString()}`
+      this.ws = new WebSocket(url, ['token', token])
+
+      this.ws.onopen = () => resolve()
+
+      this.ws.onerror = () => {
+        const err = new Error('Deepgram WebSocket connection failed')
+        reject(err)
+        this.errorCb?.(err)
+      }
+
+      this.ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data as string)
+          if (data.type === 'Results') {
+            const alt = data.channel?.alternatives?.[0]
+            if (!alt) return
+            const text = alt.transcript || ''
+            if (!text) return
+
+            if (data.speech_final) {
+              this.transcriptCb?.({ type: 'final', text })
+            } else if (data.is_final) {
+              this.transcriptCb?.({ type: 'final', text })
+            } else {
+              this.transcriptCb?.({ type: 'interim', text })
+            }
+          } else if (data.type === 'UtteranceEnd') {
+            this.transcriptCb?.({ type: 'speech_ended', text: '' })
+          }
+        } catch {
+          // Ignore non-JSON messages
+        }
+      }
+
+      this.ws.onclose = (event) => {
+        if (event.code !== 1000 && event.code !== 1005) {
+          this.errorCb?.(new Error(`Deepgram connection closed: ${event.code} ${event.reason}`))
+        }
+      }
+    })
+  }
+
+  sendAudio(chunk: ArrayBuffer): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(chunk)
+    }
+  }
+
+  onTranscript(cb: TranscriptCallback): void {
+    this.transcriptCb = cb
+  }
+
+  onError(cb: ErrorCallback): void {
+    this.errorCb = cb
+  }
+
+  close(): void {
+    if (this.ws) {
+      if (this.ws.readyState === WebSocket.OPEN) {
+        this.ws.send(JSON.stringify({ type: 'CloseStream' }))
+      }
+      this.ws.close()
+      this.ws = null
+    }
+  }
+}
+
+// --- OpenAI Adapter ---
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
+class OpenaiAdapter implements SttAdapter {
+  private ws: WebSocket | null = null
+  private transcriptCb: TranscriptCallback | null = null
+  private errorCb: ErrorCallback | null = null
+  readonly sampleRate = 24000
+
+  async connect(token: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const url = 'wss://api.openai.com/v1/realtime?intent=transcription'
+      this.ws = new WebSocket(url, [
+        'realtime',
+        `openai-insecure-api-key.${token}`,
+        'openai-beta.realtime-v1',
+      ])
+
+      this.ws.onopen = () => {
+        this.ws?.send(JSON.stringify({
+          type: 'transcription_session.update',
+          session: {
+            input_audio_format: 'pcm16',
+            input_audio_transcription: {
+              model: 'gpt-4o-mini-transcribe',
+            },
+            turn_detection: {
+              type: 'server_vad',
+              threshold: 0.5,
+              silence_duration_ms: 500,
+              prefix_padding_ms: 300,
+            },
+            input_audio_noise_reduction: {
+              type: 'near_field',
+            },
+          },
+        }))
+        resolve()
+      }
+
+      this.ws.onerror = () => {
+        const err = new Error('OpenAI Realtime WebSocket connection failed')
+        reject(err)
+        this.errorCb?.(err)
+      }
+
+      this.ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data as string)
+
+          switch (data.type) {
+            case 'conversation.item.input_audio_transcription.delta':
+              if (data.delta) {
+                this.transcriptCb?.({ type: 'interim', text: data.delta })
+              }
+              break
+            case 'conversation.item.input_audio_transcription.completed':
+              if (data.transcript) {
+                this.transcriptCb?.({ type: 'final', text: data.transcript })
+              }
+              break
+            case 'input_audio_buffer.speech_stopped':
+              this.transcriptCb?.({ type: 'speech_ended', text: '' })
+              break
+            case 'error':
+              this.errorCb?.(new Error(data.error?.message || 'OpenAI Realtime error'))
+              break
+          }
+        } catch {
+          // Ignore non-JSON messages
+        }
+      }
+
+      this.ws.onclose = (event) => {
+        if (event.code !== 1000 && event.code !== 1005) {
+          this.errorCb?.(new Error(`OpenAI connection closed: ${event.code} ${event.reason}`))
+        }
+      }
+    })
+  }
+
+  sendAudio(chunk: ArrayBuffer): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({
+        type: 'input_audio_buffer.append',
+        audio: arrayBufferToBase64(chunk),
+      }))
+    }
+  }
+
+  onTranscript(cb: TranscriptCallback): void {
+    this.transcriptCb = cb
+  }
+
+  onError(cb: ErrorCallback): void {
+    this.errorCb = cb
+  }
+
+  close(): void {
+    if (this.ws) {
+      if (this.ws.readyState === WebSocket.OPEN) {
+        this.ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }))
+      }
+      this.ws.close()
+      this.ws = null
+    }
+  }
+}
+
+// --- Factory ---
+
+export function createSttAdapter(provider: SttProvider): SttAdapter {
+  switch (provider) {
+    case 'deepgram':
+      return new DeepgramAdapter()
+    case 'openai':
+      return new OpenaiAdapter()
+    default:
+      throw new Error(`Unknown STT provider: ${provider}`)
+  }
+}

--- a/src/renderer/test/test-utils.tsx
+++ b/src/renderer/test/test-utils.tsx
@@ -2,6 +2,7 @@ import { render, type RenderOptions } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ConnectivityProvider } from '@renderer/context/connectivity-context'
 import { UserProvider } from '@renderer/context/user-context'
+import { DialogProvider } from '@renderer/context/dialog-context'
 import type { ReactElement, ReactNode } from 'react'
 
 export { screen, waitFor, within, act } from '@testing-library/react'
@@ -24,7 +25,9 @@ function AllProviders({ children }: { children: ReactNode }) {
     <QueryClientProvider client={queryClient}>
       <ConnectivityProvider>
         <UserProvider>
-          {children}
+          <DialogProvider onOpenWizard={() => {}}>
+            {children}
+          </DialogProvider>
         </UserProvider>
       </ConnectivityProvider>
     </QueryClientProvider>

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -19,6 +19,14 @@ export interface ApiKeySettings {
   composioUserId?: string
   browserbaseApiKey?: string
   browserbaseProjectId?: string
+  deepgramApiKey?: string
+  openaiApiKey?: string
+}
+
+export type SttProvider = 'deepgram' | 'openai'
+
+export interface VoiceSettings {
+  sttProvider?: SttProvider
 }
 
 export interface NotificationSettings {
@@ -110,6 +118,7 @@ export interface AppSettings {
   customEnvVars?: Record<string, string>
   skillsets?: SkillsetConfig[]
   auth?: AuthSettings
+  voice?: VoiceSettings
 }
 
 // API key source types
@@ -146,8 +155,11 @@ export interface GlobalSettingsResponse {
   apiKeyStatus: {
     anthropic: ApiKeyStatus
     composio: ApiKeyStatus
+    deepgram: ApiKeyStatus
+    openai: ApiKeyStatus
   }
   composioUserId?: string
+  voice?: VoiceSettings
   models: ModelSettings
   agentLimits: AgentLimitsSettings
   customEnvVars: Record<string, string>
@@ -246,6 +258,7 @@ export function loadSettings(): AppSettings {
           ...DEFAULT_AUTH_SETTINGS,
           ...loaded.auth,
         },
+        voice: loaded.voice,
       }
     }
   } catch (error) {
@@ -391,6 +404,49 @@ export function getEffectiveAgentLimits(): AgentLimitsSettings {
 export function getCustomEnvVars(): Record<string, string> {
   const settings = getSettings()
   return settings.customEnvVars ?? {}
+}
+
+export function getDeepgramApiKeyStatus(): ApiKeyStatus {
+  const settings = getSettings()
+  if (settings.apiKeys?.deepgramApiKey) {
+    return { isConfigured: true, source: 'settings' }
+  }
+  if (process.env.DEEPGRAM_API_KEY) {
+    return { isConfigured: true, source: 'env' }
+  }
+  return { isConfigured: false, source: 'none' }
+}
+
+export function getEffectiveDeepgramApiKey(): string | undefined {
+  const settings = getSettings()
+  if (settings.apiKeys?.deepgramApiKey) {
+    return settings.apiKeys.deepgramApiKey
+  }
+  return process.env.DEEPGRAM_API_KEY
+}
+
+export function getOpenaiApiKeyStatus(): ApiKeyStatus {
+  const settings = getSettings()
+  if (settings.apiKeys?.openaiApiKey) {
+    return { isConfigured: true, source: 'settings' }
+  }
+  if (process.env.OPENAI_API_KEY) {
+    return { isConfigured: true, source: 'env' }
+  }
+  return { isConfigured: false, source: 'none' }
+}
+
+export function getEffectiveOpenaiApiKey(): string | undefined {
+  const settings = getSettings()
+  if (settings.apiKeys?.openaiApiKey) {
+    return settings.apiKeys.openaiApiKey
+  }
+  return process.env.OPENAI_API_KEY
+}
+
+export function getVoiceSettings(): VoiceSettings {
+  const settings = getSettings()
+  return settings.voice ?? {}
 }
 
 export { DEFAULT_SETTINGS }

--- a/src/shared/lib/db/migrations/0010_amused_sumo.sql
+++ b/src/shared/lib/db/migrations/0010_amused_sumo.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `stt_usage` (
+	`id` text PRIMARY KEY NOT NULL,
+	`provider` text NOT NULL,
+	`model` text NOT NULL,
+	`duration_ms` integer NOT NULL,
+	`cost_micro` integer NOT NULL,
+	`agent_slug` text,
+	`user_id` text,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `stt_usage_created_at_idx` ON `stt_usage` (`created_at`);--> statement-breakpoint
+CREATE INDEX `stt_usage_user_id_idx` ON `stt_usage` (`user_id`);--> statement-breakpoint
+CREATE INDEX `stt_usage_agent_slug_idx` ON `stt_usage` (`agent_slug`);

--- a/src/shared/lib/db/migrations/meta/0010_snapshot.json
+++ b/src/shared/lib/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1462 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "afaa6079-4d08-4f28-a2ab-ac0b95acfeab",
+  "prevId": "1b3abf8e-e10c-4941-9ae7-afdeb239980d",
+  "tables": {
+    "agent_acl": {
+      "name": "agent_acl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_acl_user_agent_unique": {
+          "name": "agent_acl_user_agent_unique",
+          "columns": [
+            "user_id",
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "agent_acl_agent_slug_idx": {
+          "name": "agent_acl_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_acl_user_id_user_id_fk": {
+          "name": "agent_acl_user_id_user_id_fk",
+          "tableFrom": "agent_acl",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_connected_accounts": {
+      "name": "agent_connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_connected_accounts_unique": {
+          "name": "agent_connected_accounts_unique",
+          "columns": [
+            "agent_slug",
+            "connected_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_connected_accounts_connected_account_id_connected_accounts_id_fk": {
+          "name": "agent_connected_accounts_connected_account_id_connected_accounts_id_fk",
+          "tableFrom": "agent_connected_accounts",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "connected_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_remote_mcps": {
+      "name": "agent_remote_mcps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_remote_mcps_unique": {
+          "name": "agent_remote_mcps_unique",
+          "columns": [
+            "agent_slug",
+            "remote_mcp_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "agent_remote_mcps",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "remote_mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connected_accounts": {
+      "name": "connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "composio_connection_id": {
+          "name": "composio_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toolkit_slug": {
+          "name": "toolkit_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connected_accounts_composio_connection_id_unique": {
+          "name": "connected_accounts_composio_connection_id_unique",
+          "columns": [
+            "composio_connection_id"
+          ],
+          "isUnique": true
+        },
+        "connected_accounts_userId_idx": {
+          "name": "connected_accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connected_accounts_user_id_user_id_fk": {
+          "name": "connected_accounts_user_id_user_id_fk",
+          "tableFrom": "connected_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_name": {
+          "name": "remote_mcp_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_agent_slug_is_read_idx": {
+          "name": "notifications_agent_slug_is_read_idx",
+          "columns": [
+            "agent_slug",
+            "is_read"
+          ],
+          "isUnique": false
+        },
+        "notifications_session_id_idx": {
+          "name": "notifications_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_audit_log": {
+      "name": "proxy_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_tokens": {
+      "name": "proxy_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_tokens_agent_slug_unique": {
+          "name": "proxy_tokens_agent_slug_unique",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "proxy_tokens_token_unique": {
+          "name": "proxy_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_mcp_servers": {
+      "name": "remote_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token_endpoint": {
+          "name": "oauth_token_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_resource": {
+          "name": "oauth_resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_discovered_at": {
+          "name": "tools_discovered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "remote_mcp_servers_user_id_user_id_fk": {
+          "name": "remote_mcp_servers_user_id_user_id_fk",
+          "tableFrom": "remote_mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_expression": {
+          "name": "schedule_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "next_execution_at": {
+          "name": "next_execution_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "execution_count": {
+          "name": "execution_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stt_usage": {
+      "name": "stt_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_micro": {
+          "name": "cost_micro",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stt_usage_created_at_idx": {
+          "name": "stt_usage_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "stt_usage_user_id_idx": {
+          "name": "stt_usage_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "stt_usage_agent_slug_idx": {
+          "name": "stt_usage_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stt_usage_user_id_user_id_fk": {
+          "name": "stt_usage_user_id_user_id_fk",
+          "tableFrom": "stt_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/shared/lib/db/migrations/meta/_journal.json
+++ b/src/shared/lib/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1772490382333,
       "tag": "0008_short_ultimatum",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1772660738199,
+      "tag": "0010_amused_sumo",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/lib/db/schema.ts
+++ b/src/shared/lib/db/schema.ts
@@ -278,6 +278,22 @@ export const userSettings = sqliteTable('user_settings', {
   updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
 })
 
+// STT usage - tracks speech-to-text API usage for cost reporting
+export const sttUsage = sqliteTable('stt_usage', {
+  id: text('id').primaryKey(),
+  provider: text('provider', { enum: ['deepgram', 'openai'] }).notNull(),
+  model: text('model').notNull(), // e.g. 'nova-3', 'gpt-4o-mini-transcribe'
+  durationMs: integer('duration_ms').notNull(),
+  cost: integer('cost_micro').notNull(), // cost in micro-dollars (1/1,000,000 USD)
+  agentSlug: text('agent_slug'), // which agent's chat triggered this STT session
+  userId: text('user_id').references(() => user.id, { onDelete: 'set null' }),
+  createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+}, (table) => ({
+  createdAtIdx: index('stt_usage_created_at_idx').on(table.createdAt),
+  userIdIdx: index('stt_usage_user_id_idx').on(table.userId),
+  agentSlugIdx: index('stt_usage_agent_slug_idx').on(table.agentSlug),
+}))
+
 // Type exports for convenience
 export type ConnectedAccount = typeof connectedAccounts.$inferSelect
 export type NewConnectedAccount = typeof connectedAccounts.$inferInsert
@@ -301,6 +317,8 @@ export type AgentAcl = typeof agentAcl.$inferSelect
 export type NewAgentAcl = typeof agentAcl.$inferInsert
 export type UserSettingsRow = typeof userSettings.$inferSelect
 export type NewUserSettingsRow = typeof userSettings.$inferInsert
+export type SttUsageEntry = typeof sttUsage.$inferSelect
+export type NewSttUsageEntry = typeof sttUsage.$inferInsert
 export type User = typeof user.$inferSelect
 export type AuthSession = typeof authSession.$inferSelect
 export type AuthAccount = typeof authAccount.$inferSelect


### PR DESCRIPTION
## Summary

- **BYOK voice input** — users bring their own Deepgram or OpenAI API key, configure in Settings > Voice, and use the mic button to dictate messages with real-time streaming transcription
- **STT adapter layer** with unified interface abstracting Deepgram Nova 3 (16kHz) and OpenAI Realtime Transcribe (24kHz, gpt-4o-mini-transcribe) WebSocket protocols
- **Voice settings tab** with provider selection, API key validation, and live mic test with waveform visualization and streaming transcript preview
- **STT usage tracking** — recording duration and cost are written to a `stt_usage` table and merged into the existing Usage dashboard alongside LLM models (totalCost, byModel, byAgent)

## Changes

### New files (5)
- `src/renderer/lib/stt.ts` — `SttAdapter` interface + `DeepgramAdapter` / `OpenaiAdapter` implementations (direct browser-to-provider WebSocket)
- `src/renderer/hooks/use-voice-input.ts` — React hook managing mic capture, PCM conversion, adapter lifecycle, interim/final transcript accumulation, and usage reporting
- `src/renderer/components/settings/voice-tab.tsx` — Settings UI: provider picker, API key input with validate/save, live test with canvas waveform + animated transcript
- `src/api/routes/stt.ts` — `GET /token` relays stored API key to frontend; `POST /usage` records STT session duration with cost calculation
- `src/shared/lib/db/migrations/0010_amused_sumo.sql` — Creates `stt_usage` table with indexes on created_at, user_id, agent_slug

### Modified files (10)
- `src/shared/lib/db/schema.ts` — Added `sttUsage` table definition (provider, model, durationMs, cost in micro-dollars, agentSlug, userId)
- `src/shared/lib/config/settings.ts` — Added `SttProvider`, `VoiceSettings`, `deepgramApiKey`, `openaiApiKey` to settings schema
- `src/api/routes/settings.ts` — Added Deepgram/OpenAI key save/remove/validate endpoints, voice settings in GET/PUT responses
- `src/api/routes/usage.ts` — Queries `stt_usage` table, merges STT costs into daily aggregation (totalCost + byModel + byAgent)
- `src/api/index.ts` — Mounted `/api/stt` router
- `src/renderer/hooks/use-settings.ts` — Extended `UpdateSettingsParams` with voice + new key fields
- `src/renderer/components/settings/global-settings-dialog.tsx` — Added Voice tab
- `src/renderer/components/messages/message-input.tsx` — Mic button + auto-stop on send + passes agentSlug for usage tracking
- `src/renderer/components/agents/agent-landing.tsx` — Same mic button for initial conversation input + agentSlug

### Test fixes (4)
- `src/api/routes/settings.test.ts` — Added missing mock exports for Deepgram/OpenAI key status and voice settings
- `src/api/routes/usage.test.ts` — Updated drizzle-orm mock with `gte`/`and`/`sql`, added `sttUsage` schema mock and STT query mock chain
- `src/renderer/components/layout/app-sidebar.test.tsx` — Added `DialogProvider` to dialog-context mock
- `src/renderer/test/test-utils.tsx` — Wrapped `AllProviders` with `DialogProvider`

## STT usage tracking design

STT usage can't go through Claude Code's session logs (parsed by `ccusage`) because the WebSocket connection is browser-to-provider. Instead:

1. Frontend records `Date.now()` when recording starts
2. On stop, `POST /api/stt/usage { provider, durationMs, agentSlug }` fires async (non-blocking)
3. Backend calculates cost from a pricing table (Deepgram $4.30/1000min, OpenAI $3.00/1000min) and stores as micro-dollars
4. `GET /api/usage` merges `stt_usage` rows into the same `dateMap` used for LLM data — STT models appear in the Usage chart like any other model

## Test plan

- [ ] Configure Deepgram API key in Settings > Voice, run test, verify waveform + transcript
- [ ] Configure OpenAI API key in Settings > Voice, run test, verify waveform + transcript
- [ ] Click mic in message input, dictate, verify streaming text in textarea
- [ ] Click send while recording — verify recording stops and message sends correctly
- [ ] Click mic without any provider configured — verify it opens Settings > Voice
- [ ] Remove API key — verify mic guides back to settings
- [ ] After a few STT sessions, check Usage tab — verify STT models (nova-3 / gpt-4o-mini-transcribe) appear in By Model view
- [ ] Verify STT cost is included in total cost and in By Agent view for the correct agent


Previews:
<img width="864" height="395" alt="image" src="https://github.com/user-attachments/assets/4b6ceffe-b2d6-4817-bc5c-3f7fc43b0f9a" />
<img width="1193" height="800" alt="image" src="https://github.com/user-attachments/assets/39357164-2d3f-42db-a3c0-699d57ff3a31" />
<img width="793" height="475" alt="image" src="https://github.com/user-attachments/assets/b8d826d6-97c1-4123-bb55-9bb3c41d758c" />
<img width="800" height="486" alt="image" src="https://github.com/user-attachments/assets/d49fb6df-218e-482b-a497-c2d4ea162d4b" />
<img width="804" height="489" alt="image" src="https://github.com/user-attachments/assets/2e1bcd64-e529-47a0-9e7e-5baa6bcc4cc1" />



