### PR TITLE
feat: timezone-aware API routes and message persister

### DIFF
--- a/src/api/routes/usage.test.ts
+++ b/src/api/routes/usage.test.ts
@@ -60,6 +60,12 @@ vi.mock('drizzle-orm', () => ({
   eq: (col: string, val: string) => ({ col, val }),
 }))
 
+const mockGetSettings = vi.fn()
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: (...args: unknown[]) => mockGetSettings(...args),
+}))
+
 import usage from './usage'
 
 // ---------------------------------------------------------------------------
@@ -103,6 +109,7 @@ describe('usage route', () => {
     mockIsAuthMode.mockReturnValue(false)
     mockListAgents.mockResolvedValue([])
     mockLoadDailyUsageData.mockResolvedValue([])
+    mockGetSettings.mockReturnValue({ app: { timezone: 'UTC' } })
     app = createApp()
   })
 
@@ -546,6 +553,21 @@ describe('usage route', () => {
       expect(dayEntry.totalCost).toBe(2.00)
       expect(dayEntry.byAgent).toHaveLength(1)
       expect(dayEntry.byAgent[0].agentSlug).toBe('agent-1')
+    })
+  })
+
+  // =========================================================================
+  // Timezone support
+  // =========================================================================
+  describe('timezone support', () => {
+    it('uses global settings timezone for date boundaries', async () => {
+      mockGetSettings.mockReturnValue({ app: { timezone: 'America/New_York' } })
+      mockListAgents.mockResolvedValue([])
+      mockLoadDailyUsageData.mockResolvedValue([])
+
+      const res = await getUsage('days=7')
+      expect(res.status).toBe(200)
+      expect(mockGetSettings).toHaveBeenCalled()
     })
   })
 })

--- a/src/api/routes/usage.ts
+++ b/src/api/routes/usage.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { listAgents, getAgent } from '@shared/lib/services/agent-service'
 import { getAgentClaudeConfigDir } from '@shared/lib/utils/file-storage'
-import { subDays, format, addDays } from 'date-fns'
+import { subDays, addDays } from 'date-fns'
 import type { DailyUsageEntry, UsageResponse } from '@shared/lib/types/usage'
 import { Authenticated } from '../middleware/auth'
 import { isAuthMode } from '@shared/lib/auth/mode'
@@ -9,6 +9,8 @@ import { getCurrentUserId } from '@shared/lib/auth/config'
 import { db } from '@shared/lib/db'
 import { agentAcl } from '@shared/lib/db/schema'
 import { eq } from 'drizzle-orm'
+import { getSettings } from '@shared/lib/config/settings'
+import { formatDateKeyInTimezone } from '@shared/lib/utils/timezone'
 
 const usage = new Hono()
 
@@ -22,9 +24,11 @@ usage.get('/', async (c) => {
   const user = isAuthMode() ? c.get('user' as never) as { id: string; role?: string } | undefined : undefined
   const globalView = globalParam && (!isAuthMode() || user?.role === 'admin')
 
+  const timezone = getSettings().app?.timezone || 'UTC'
+
   const now = new Date()
   const sinceDate = subDays(now, days)
-  const since = format(sinceDate, 'yyyyMMdd')
+  const since = formatDateKeyInTimezone(sinceDate, timezone)
 
   // In auth mode, only load agents the user has access to (unless admin requests global view)
   let agents;
@@ -97,9 +101,9 @@ usage.get('/', async (c) => {
     }
   }
 
-  // Fill in missing dates with zero-cost entries
+  // Fill in missing dates with zero-cost entries (using user's timezone for boundaries)
   for (let d = sinceDate; d <= now; d = addDays(d, 1)) {
-    const dateStr = format(d, 'yyyy-MM-dd')
+    const dateStr = formatDateKeyInTimezone(d, timezone, '-')
     if (!dateMap.has(dateStr)) {
       dateMap.set(dateStr, { totalCost: 0, byAgent: new Map(), byModel: new Map() })
     }


### PR DESCRIPTION
## Summary
- **usage.ts**: Uses global `AppSettings.app.timezone` for date boundary calculations instead of hardcoded UTC, ensuring usage reports align with the configured timezone
- **message-persister.ts**: Attaches the global timezone snapshot when creating scheduled tasks and broadcasting SSE events, so each task records its creation timezone
- **usage.test.ts**: Adds timezone support tests with mocked `getSettings`

## Depends on
- PR #12 (feat/timezone-core)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/api/routes/usage.test.ts` — 23 tests pass
- [ ] Manual: verify usage report date boundaries respect timezone setting
- [ ] Manual: create a scheduled task and verify timezone is stored


Made with [Cursor](https://cursor.com)