### PR TITLE
feat: timezone-aware frontend UI

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -13,6 +13,7 @@ import { GlobalNotificationHandler } from './components/notifications/global-not
 import { GettingStartedWizard } from './components/wizard/getting-started-wizard'
 import { ErrorBoundary } from './components/ui/error-boundary'
 import { useUserSettings } from './hooks/use-user-settings'
+import { useSettings, useUpdateSettings } from './hooks/use-settings'
 import { useTheme } from './hooks/use-theme'
 import { useUser } from './context/user-context'
 
@@ -20,8 +21,22 @@ function AppContent() {
   useTheme()
   const [wizardOpen, setWizardOpen] = useState(false)
   const { data: userSettings } = useUserSettings()
+  const { data: globalSettings } = useSettings()
+  const updateGlobalSettings = useUpdateSettings()
   const { isAuthMode, isAdmin } = useUser()
   const hasAutoOpened = useRef(false)
+  const hasAutoDetectedTimezone = useRef(false)
+
+  // Auto-detect browser timezone on first load if not configured globally yet
+  useEffect(() => {
+    if (globalSettings && !globalSettings.app?.timezone && !hasAutoDetectedTimezone.current) {
+      hasAutoDetectedTimezone.current = true
+      const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+      if (browserTimezone) {
+        updateGlobalSettings.mutate({ app: { timezone: browserTimezone } })
+      }
+    }
+  }, [globalSettings]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Auto-open wizard on first launch (non-admin auth users skip — they can't configure the server)
   useEffect(() => {

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -49,6 +49,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui
 import { useUser } from '@renderer/context/user-context'
 import { NotificationBell } from '@renderer/components/notifications/notification-bell'
 import { useIsOnline } from '@renderer/context/connectivity-context'
+import { useTimezone, formatDateWithTimezone } from '@renderer/hooks/use-timezone'
 
 // Session sub-item that tracks its streaming state
 function SessionSubItem({
@@ -104,6 +105,7 @@ function ScheduledTaskSubItem({
 }) {
   const { selectedScheduledTaskId, selectAgent, selectScheduledTask } = useSelection()
   const isSelected = task.id === selectedScheduledTaskId
+  const timezone = useTimezone()
 
   const handleClick = () => {
     selectAgent(agentSlug)
@@ -112,7 +114,7 @@ function ScheduledTaskSubItem({
 
   // Format next execution time for tooltip
   const nextExecution = new Date(task.nextExecutionAt)
-  const timeString = nextExecution.toLocaleString()
+  const timeString = formatDateWithTimezone(nextExecution, timezone)
 
   return (
     <SidebarMenuSubItem>

--- a/src/renderer/components/messages/tool-renderers/schedule-task.tsx
+++ b/src/renderer/components/messages/tool-renderers/schedule-task.tsx
@@ -1,6 +1,15 @@
-
 import { Clock, Repeat, CalendarClock } from 'lucide-react'
 import type { ToolRenderer, ToolRendererProps, StreamingToolRendererProps } from './types'
+import { useTimezone } from '@renderer/hooks/use-timezone'
+
+function getTimezoneAbbreviation(timezone: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', { timeZone: timezone, timeZoneName: 'short' }).formatToParts(new Date())
+    return parts.find(p => p.type === 'timeZoneName')?.value || ''
+  } catch {
+    return ''
+  }
+}
 
 interface ScheduleTaskInput {
   scheduleType?: 'at' | 'cron'
@@ -17,20 +26,23 @@ function parseScheduleTaskInput(input: unknown): ScheduleTaskInput {
 }
 
 /**
- * Convert a cron expression to a human-readable string
+ * Convert a cron expression to a human-readable string.
+ * The hour/minute in cron are in the task's creation timezone,
+ * so we display them with that timezone's abbreviation.
  */
-function cronToHuman(cron: string): string {
+function cronToHuman(cron: string, tzAbbr?: string): string {
   const parts = cron.trim().split(/\s+/)
   if (parts.length !== 5) return cron
 
   const [minute, hour, dayOfMonth, month, dayOfWeek] = parts
+  const tzSuffix = tzAbbr ? ` ${tzAbbr}` : ''
 
   // Common patterns
   if (cron === '* * * * *') return 'Every minute'
   if (cron === '0 * * * *') return 'Every hour'
-  if (cron === '0 0 * * *') return 'Daily at midnight'
-  if (cron === '0 0 * * 0') return 'Weekly on Sunday'
-  if (cron === '0 0 1 * *') return 'Monthly on the 1st'
+  if (cron === '0 0 * * *') return `Daily at midnight${tzSuffix}`
+  if (cron === '0 0 * * 0') return `Weekly on Sunday${tzSuffix}`
+  if (cron === '0 0 1 * *') return `Monthly on the 1st${tzSuffix}`
 
   // */N patterns
   if (minute.startsWith('*/') && hour === '*' && dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
@@ -48,9 +60,9 @@ function cronToHuman(cron: string): string {
     const m = parseInt(minute, 10)
     const time = `${h % 12 || 12}:${m.toString().padStart(2, '0')} ${h >= 12 ? 'PM' : 'AM'}`
 
-    if (dayOfWeek === '*') return `Daily at ${time}`
-    if (dayOfWeek === '1-5') return `Weekdays at ${time}`
-    if (dayOfWeek === '0,6') return `Weekends at ${time}`
+    if (dayOfWeek === '*') return `Daily at ${time}${tzSuffix}`
+    if (dayOfWeek === '1-5') return `Weekdays at ${time}${tzSuffix}`
+    if (dayOfWeek === '0,6') return `Weekends at ${time}${tzSuffix}`
   }
 
   return cron
@@ -118,6 +130,7 @@ function ExpandedView({ input, result, isError }: ToolRendererProps) {
   const { scheduleType, scheduleExpression, prompt, name } = parseScheduleTaskInput(input)
   const displayResult = parseResult(result ?? null)
   const isRecurring = scheduleType === 'cron'
+  const tzAbbr = getTimezoneAbbreviation(useTimezone())
 
   return (
     <div className="space-y-3">
@@ -135,7 +148,7 @@ function ExpandedView({ input, result, isError }: ToolRendererProps) {
         </div>
         {scheduleExpression && (
           <div className="text-muted-foreground">
-            {isRecurring ? cronToHuman(scheduleExpression) : scheduleExpression.replace(/^at\s+/i, '')}
+            {isRecurring ? cronToHuman(scheduleExpression, tzAbbr) : scheduleExpression.replace(/^at\s+/i, '')}
           </div>
         )}
       </div>
@@ -182,6 +195,7 @@ function ExpandedView({ input, result, isError }: ToolRendererProps) {
 }
 
 function StreamingView({ partialInput }: StreamingToolRendererProps) {
+  const tzAbbr = getTimezoneAbbreviation(useTimezone())
   let parsed: ScheduleTaskInput = {}
   try {
     parsed = JSON.parse(partialInput)
@@ -207,7 +221,7 @@ function StreamingView({ partialInput }: StreamingToolRendererProps) {
             </span>
             {parsed.scheduleExpression && (
               <span className="text-muted-foreground">
-                {isRecurring ? cronToHuman(parsed.scheduleExpression) : parsed.scheduleExpression.replace(/^at\s+/i, '')}
+                {isRecurring ? cronToHuman(parsed.scheduleExpression, tzAbbr) : parsed.scheduleExpression.replace(/^at\s+/i, '')}
               </span>
             )}
           </>

--- a/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
+++ b/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
@@ -14,6 +14,7 @@ import {
 } from '@renderer/hooks/use-scheduled-tasks'
 import { useSelection } from '@renderer/context/selection-context'
 import { useUser } from '@renderer/context/user-context'
+import { useTimezone, formatDateWithTimezone } from '@renderer/hooks/use-timezone'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -38,6 +39,7 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
   const { handleScheduledTaskDeleted, selectSession } = useSelection()
   const { canUseAgent } = useUser()
   const canCancel = canUseAgent(agentSlug)
+  const timezone = useTimezone()
 
   const handleCancel = async () => {
     try {
@@ -132,7 +134,7 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
           </h3>
           {task.status === 'pending' ? (
             <div className="text-lg">
-              {nextExecution.toLocaleString()}
+              {formatDateWithTimezone(nextExecution, timezone)}
             </div>
           ) : (
             <div className="text-lg capitalize">{task.status}</div>
@@ -160,7 +162,7 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
               <span>
                 This prompt will be sent to the agent{' '}
                 {task.status === 'pending'
-                  ? `on ${nextExecution.toLocaleString()}`
+                  ? `on ${formatDateWithTimezone(nextExecution, timezone)}`
                   : 'when executed'}
               </span>
             </div>
@@ -185,7 +187,7 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
                   <div className="flex-1 min-w-0">
                     <div className="font-medium truncate">{session.name}</div>
                     <div className="text-xs text-muted-foreground">
-                      {new Date(session.createdAt).toLocaleString()}
+                      {formatDateWithTimezone(session.createdAt, timezone)}
                       {session.messageCount > 0 && (
                         <span className="ml-2">• {session.messageCount} messages</span>
                       )}
@@ -204,7 +206,7 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
               Last Executed
             </h3>
             <div className="text-sm">
-              {new Date(task.lastExecutedAt).toLocaleString()}
+              {formatDateWithTimezone(task.lastExecutedAt, timezone)}
               {task.lastSessionId && (
                 <span className="text-muted-foreground ml-2">
                   (Session: {task.lastSessionId.slice(0, 8)}...)
@@ -220,7 +222,7 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
             Created
           </h3>
           <div className="text-sm">
-            {new Date(task.createdAt).toLocaleString()}
+            {formatDateWithTimezone(task.createdAt, timezone)}
           </div>
         </div>
       </div>

--- a/src/renderer/components/settings/general-tab.tsx
+++ b/src/renderer/components/settings/general-tab.tsx
@@ -1,6 +1,8 @@
+import { useState, useMemo, useRef, useCallback, useEffect } from 'react'
 import { Label } from '@renderer/components/ui/label'
 import { Button } from '@renderer/components/ui/button'
 import { Switch } from '@renderer/components/ui/switch'
+import { Input } from '@renderer/components/ui/input'
 import {
   Select,
   SelectContent,
@@ -9,9 +11,43 @@ import {
   SelectValue,
 } from '@renderer/components/ui/select'
 import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user-settings'
+import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
 import { useUser } from '@renderer/context/user-context'
-import { Wand2 } from 'lucide-react'
+import { Wand2, Check, Search, RefreshCw } from 'lucide-react'
 import { UpdateSection } from './update-section'
+import { cn } from '@shared/lib/utils'
+
+const ALL_TIMEZONES = Intl.supportedValuesOf('timeZone')
+
+function formatTimezoneOffset(tz: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', { timeZone: tz, timeZoneName: 'shortOffset' }).formatToParts(new Date())
+    return parts.find(p => p.type === 'timeZoneName')?.value ?? ''
+  } catch {
+    return ''
+  }
+}
+
+type TzEntry = { value: string; label: string; offset: string }
+
+const FLAT_TIMEZONES: TzEntry[] = ALL_TIMEZONES.map(tz => {
+  const slash = tz.indexOf('/')
+  const city = slash > 0 ? tz.substring(slash + 1).replace(/_/g, ' ') : tz
+  const offset = formatTimezoneOffset(tz)
+  return { value: tz, label: `${city} (${offset})`, offset }
+})
+
+const POPULAR_TZ_IDS = new Set([
+  'America/New_York', 'America/Chicago', 'America/Denver', 'America/Los_Angeles',
+  'America/Toronto', 'America/Vancouver', 'America/Sao_Paulo', 'America/Mexico_City',
+  'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Europe/Moscow', 'Europe/Istanbul',
+  'Asia/Shanghai', 'Asia/Tokyo', 'Asia/Seoul', 'Asia/Singapore', 'Asia/Hong_Kong',
+  'Asia/Taipei', 'Asia/Kolkata', 'Asia/Dubai', 'Asia/Bangkok',
+  'Australia/Sydney', 'Australia/Melbourne',
+  'Pacific/Auckland', 'Pacific/Honolulu',
+  'UTC',
+])
+const POPULAR_TIMEZONES = FLAT_TIMEZONES.filter(tz => POPULAR_TZ_IDS.has(tz.value))
 
 interface GeneralTabProps {
   onOpenWizard: () => void
@@ -20,8 +56,51 @@ interface GeneralTabProps {
 export function GeneralTab({ onOpenWizard }: GeneralTabProps) {
   const { data: userSettings, isLoading: isUserSettingsLoading } = useUserSettings()
   const updateUserSettings = useUpdateUserSettings()
+  const { data: globalSettings, isLoading: isGlobalSettingsLoading } = useSettings()
+  const updateGlobalSettings = useUpdateSettings()
   const { isAuthMode, isAdmin } = useUser()
   const showAdminFeatures = !isAuthMode || isAdmin
+  const [tzSearch, setTzSearch] = useState('')
+  const [tzFocused, setTzFocused] = useState(false)
+  const tzInputRef = useRef<HTMLInputElement>(null)
+
+  const filteredTimezones = useMemo(() => {
+    const query = tzSearch.trim().toLowerCase()
+    if (!query) return POPULAR_TIMEZONES
+    return FLAT_TIMEZONES.filter(
+      tz => tz.value.toLowerCase().includes(query) || tz.label.toLowerCase().includes(query)
+    ).slice(0, 30)
+  }, [tzSearch])
+
+  const systemTz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+  const currentTz = globalSettings?.app?.timezone || systemTz
+  const currentTzLabel = useMemo(() => {
+    try {
+      const slash = currentTz.indexOf('/')
+      const city = slash > 0 ? currentTz.substring(slash + 1).replace(/_/g, ' ') : currentTz
+      const abbr = new Intl.DateTimeFormat('en-US', { timeZone: currentTz, timeZoneName: 'short' }).formatToParts(new Date()).find(p => p.type === 'timeZoneName')?.value
+      return abbr ? `${city} (${abbr})` : city
+    } catch {
+      return currentTz
+    }
+  }, [currentTz])
+
+  const [now, setNow] = useState(() => new Date())
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000)
+    return () => clearInterval(id)
+  }, [])
+  const currentTime = useMemo(() =>
+    now.toLocaleTimeString(undefined, { timeZone: currentTz, hour: '2-digit', minute: '2-digit', second: '2-digit' }),
+    [now, currentTz]
+  )
+
+  const selectTimezone = useCallback((tz: string) => {
+    updateGlobalSettings.mutate({ app: { timezone: tz } })
+    setTzSearch('')
+    setTzFocused(false)
+    tzInputRef.current?.blur()
+  }, [updateGlobalSettings])
 
   return (
     <div className="space-y-6">
@@ -46,6 +125,68 @@ export function GeneralTab({ onOpenWizard }: GeneralTabProps) {
         </Select>
         <p className="text-xs text-muted-foreground">
           Choose light or dark theme, or follow your system setting
+        </p>
+      </div>
+
+      {/* Timezone */}
+      <div className="space-y-2">
+        <Label>Timezone</Label>
+        <div className="flex items-center gap-2">
+          <p className="text-sm text-muted-foreground">{currentTzLabel}</p>
+          <span className="text-sm tabular-nums text-muted-foreground">{currentTime}</span>
+          {currentTz !== systemTz && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-xs gap-1"
+              onClick={() => selectTimezone(systemTz)}
+            >
+              <RefreshCw className="h-3 w-3" />
+              Sync with system
+            </Button>
+          )}
+        </div>
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+          <Input
+            ref={tzInputRef}
+            placeholder="Search timezone..."
+            value={tzSearch}
+            onChange={(e) => setTzSearch(e.target.value)}
+            onFocus={() => setTzFocused(true)}
+            onBlur={() => setTimeout(() => setTzFocused(false), 150)}
+            className="h-8 pl-8"
+            disabled={isGlobalSettingsLoading}
+          />
+        </div>
+        {tzFocused && (
+          <div className="border rounded-md max-h-40 overflow-y-auto">
+            {filteredTimezones.length === 0 ? (
+              <div className="px-3 py-4 text-center text-sm text-muted-foreground">No timezone found</div>
+            ) : (
+              filteredTimezones.map((tz) => (
+                <button
+                  key={tz.value}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => selectTimezone(tz.value)}
+                  className={cn(
+                    'w-full px-3 py-1.5 text-left text-sm hover:bg-accent cursor-pointer flex items-center gap-2',
+                    currentTz === tz.value && 'bg-accent'
+                  )}
+                >
+                  <Check className={cn('h-3.5 w-3.5 shrink-0', currentTz === tz.value ? 'opacity-100' : 'opacity-0')} />
+                  <span className="truncate">{tz.value.replace(/_/g, ' ')}</span>
+                  <span className="ml-auto text-xs text-muted-foreground shrink-0">{tz.offset}</span>
+                </button>
+              ))
+            )}
+            {!tzSearch.trim() && (
+              <div className="px-3 py-1.5 text-xs text-muted-foreground border-t">Type to search all {ALL_TIMEZONES.length} timezones</div>
+            )}
+          </div>
+        )}
+        <p className="text-xs text-muted-foreground">
+          Used for scheduled tasks, time displays, and usage reports
         </p>
       </div>
 

--- a/src/renderer/components/settings/users-tab.tsx
+++ b/src/renderer/components/settings/users-tab.tsx
@@ -41,6 +41,7 @@ import { cn } from '@shared/lib/utils/cn'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/components/ui/tooltip'
 import { InviteUserDialog } from './invite-user-dialog'
 import { ResetPasswordDialog } from './reset-password-dialog'
+import { useTimezone, formatDateOnlyWithTimezone } from '@renderer/hooks/use-timezone'
 
 interface AdminUser {
   id: string
@@ -56,6 +57,7 @@ interface AdminUser {
 export function UsersTab() {
   const { user: currentUser } = useUser()
   const queryClient = useQueryClient()
+  const timezone = useTimezone()
   const [search, setSearch] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
 
@@ -321,7 +323,7 @@ export function UsersTab() {
 
                 {/* Joined */}
                 <span className="text-xs text-muted-foreground">
-                  {new Date(user.createdAt).toLocaleDateString()}
+                  {formatDateOnlyWithTimezone(user.createdAt, timezone)}
                 </span>
 
                 {/* Actions */}

--- a/src/renderer/components/wizard/getting-started-wizard.tsx
+++ b/src/renderer/components/wizard/getting-started-wizard.tsx
@@ -415,6 +415,7 @@ function DockerSetupStep() {
           {startRunner.data.message}
         </p>
       )}
+
     </div>
   )
 }

--- a/src/renderer/hooks/use-timezone.ts
+++ b/src/renderer/hooks/use-timezone.ts
@@ -1,0 +1,12 @@
+import { useSettings } from './use-settings'
+
+export { formatDateWithTimezone, formatDateOnlyWithTimezone } from '@shared/lib/utils/timezone'
+
+/**
+ * Returns the globally configured timezone (IANA identifier).
+ * Falls back to the browser's timezone if not set.
+ */
+export function useTimezone(): string {
+  const { data: settings } = useSettings()
+  return settings?.app?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+}


### PR DESCRIPTION
## Summary
- **useTimezone hook**: Reads global `AppSettings.app.timezone`, falls back to browser timezone
- **Settings timezone picker**: Inline searchable picker with popular timezone list, live clock display, and "Sync with system" button
- **Time displays**: Sidebar scheduled tasks, task detail view, and users tab all use `formatDateWithTimezone` for timezone-aware formatting
- **cronToHuman**: Appends current timezone abbreviation (e.g., PST) to recurring task descriptions
- **Auto-detect**: `App.tsx` automatically saves browser timezone to global settings on initial load

## Depends on
- PR #13 (feat/timezone-api)
- PR #12 (feat/timezone-core)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` passes on changed files
- [ ] Manual: open Settings > General, verify timezone picker shows popular timezones
- [ ] Manual: search for a timezone, select it, verify live clock updates
- [ ] Manual: click "Sync with system" button
- [ ] Manual: verify scheduled task times in sidebar show timezone abbreviation
- [ ] Manual: verify task detail view shows timezone-aware next execution time


Made with [Cursor](https://cursor.com)