### PR TITLE
feat: voice input configuration and settings backend

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -15,6 +15,7 @@ import remoteMcps from './routes/remote-mcps'
 import commonMcpServers from './routes/common-mcp-servers'
 import userSettingsRouter from './routes/user-settings'
 import runtimeStatusRouter from './routes/runtime-status'
+import sttRouter from './routes/stt'
 import adminUsersRouter from './routes/admin-users'
 import { initializeServices } from '@shared/lib/startup'
 import { isAuthMode } from '@shared/lib/auth/mode'
@@ -128,6 +129,7 @@ app.route('/api/common-mcp-servers', commonMcpServers)
 app.route('/api/user-settings', userSettingsRouter)
 app.route('/api/runtime-status', runtimeStatusRouter)
 app.route('/api/admin/users', adminUsersRouter)
+app.route('/api/stt', sttRouter)
 
 // Global error handler
 app.onError((err, c) => {

--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -14,6 +14,9 @@ const mockGetComposioUserId = vi.fn()
 const mockGetEffectiveModels = vi.fn()
 const mockGetEffectiveAgentLimits = vi.fn()
 const mockGetCustomEnvVars = vi.fn()
+const mockGetDeepgramApiKeyStatus = vi.fn()
+const mockGetOpenaiApiKeyStatus = vi.fn()
+const mockGetVoiceSettings = vi.fn()
 
 vi.mock('@shared/lib/config/settings', () => ({
   getSettings: (...args: unknown[]) => mockGetSettings(...args),
@@ -25,6 +28,9 @@ vi.mock('@shared/lib/config/settings', () => ({
   getEffectiveModels: (...args: unknown[]) => mockGetEffectiveModels(...args),
   getEffectiveAgentLimits: (...args: unknown[]) => mockGetEffectiveAgentLimits(...args),
   getCustomEnvVars: (...args: unknown[]) => mockGetCustomEnvVars(...args),
+  getDeepgramApiKeyStatus: (...args: unknown[]) => mockGetDeepgramApiKeyStatus(...args),
+  getOpenaiApiKeyStatus: (...args: unknown[]) => mockGetOpenaiApiKeyStatus(...args),
+  getVoiceSettings: (...args: unknown[]) => mockGetVoiceSettings(...args),
 }))
 
 const mockHasRunningAgents = vi.fn()
@@ -139,6 +145,9 @@ function setupDefaults() {
   mockGetEffectiveModels.mockReturnValue({ summarizerModel: 'claude-3-haiku', agentModel: 'claude-sonnet-4-20250514', browserModel: 'claude-3-haiku' })
   mockGetEffectiveAgentLimits.mockReturnValue({ maxTurns: 100 })
   mockGetCustomEnvVars.mockReturnValue({ FOO: 'bar' })
+  mockGetDeepgramApiKeyStatus.mockReturnValue({ isConfigured: false, source: 'none' })
+  mockGetOpenaiApiKeyStatus.mockReturnValue({ isConfigured: false, source: 'none' })
+  mockGetVoiceSettings.mockReturnValue({})
   mockGetReadiness.mockReturnValue({ ready: true })
   mockEnsureImageReady.mockResolvedValue(undefined)
   mockClearClients.mockReturnValue(undefined)

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -11,6 +11,9 @@ import {
   getAnthropicApiKeyStatus,
   getComposioApiKeyStatus,
   getComposioUserId,
+  getDeepgramApiKeyStatus,
+  getOpenaiApiKeyStatus,
+  getVoiceSettings,
   getEffectiveModels,
   getEffectiveAgentLimits,
   getCustomEnvVars,
@@ -47,6 +50,8 @@ settings.get('/', async (c) => {
       apiKeyStatus: {
         anthropic: getAnthropicApiKeyStatus(),
         composio: getComposioApiKeyStatus(),
+        deepgram: getDeepgramApiKeyStatus(),
+        openai: getOpenaiApiKeyStatus(),
       },
       models: getEffectiveModels(),
       agentLimits: getEffectiveAgentLimits(),
@@ -56,6 +61,7 @@ settings.get('/', async (c) => {
       hostBrowserStatus: { providers: detectAllProviders() },
       runtimeReadiness: containerManager.getReadiness(),
       auth: currentSettings.auth,
+      voice: getVoiceSettings(),
     }
 
     return c.json(response)
@@ -132,6 +138,9 @@ settings.put('/', async (c) => {
       auth: body.auth !== undefined
         ? { ...currentSettings.auth, ...body.auth }
         : currentSettings.auth,
+      voice: body.voice !== undefined
+        ? { ...currentSettings.voice, ...body.voice }
+        : currentSettings.voice,
     }
 
     // Handle API key updates
@@ -191,6 +200,28 @@ settings.put('/', async (c) => {
         }
       }
 
+      // Handle Deepgram API key
+      if (body.apiKeys.deepgramApiKey === '') {
+        newSettings.apiKeys = { ...newSettings.apiKeys }
+        delete newSettings.apiKeys.deepgramApiKey
+      } else if (body.apiKeys.deepgramApiKey) {
+        newSettings.apiKeys = {
+          ...newSettings.apiKeys,
+          deepgramApiKey: body.apiKeys.deepgramApiKey,
+        }
+      }
+
+      // Handle OpenAI API key
+      if (body.apiKeys.openaiApiKey === '') {
+        newSettings.apiKeys = { ...newSettings.apiKeys }
+        delete newSettings.apiKeys.openaiApiKey
+      } else if (body.apiKeys.openaiApiKey) {
+        newSettings.apiKeys = {
+          ...newSettings.apiKeys,
+          openaiApiKey: body.apiKeys.openaiApiKey,
+        }
+      }
+
       // Clean up empty object
       if (
         newSettings.apiKeys &&
@@ -236,6 +267,8 @@ settings.put('/', async (c) => {
       apiKeyStatus: {
         anthropic: getAnthropicApiKeyStatus(),
         composio: getComposioApiKeyStatus(),
+        deepgram: getDeepgramApiKeyStatus(),
+        openai: getOpenaiApiKeyStatus(),
       },
       models: getEffectiveModels(),
       agentLimits: getEffectiveAgentLimits(),
@@ -245,6 +278,7 @@ settings.put('/', async (c) => {
       hostBrowserStatus: { providers: detectAllProviders() },
       runtimeReadiness: containerManager.getReadiness(),
       auth: newSettings.auth,
+      voice: getVoiceSettings(),
     })
   } catch (error) {
     console.error('Failed to update settings:', error)
@@ -397,6 +431,58 @@ settings.post('/validate-composio-key', async (c) => {
         return c.json({ valid: false, error: 'Invalid API key' })
       }
       return c.json({ valid: false, error: `Composio API error: ${response.status}` })
+    }
+
+    return c.json({ valid: true })
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Validation failed'
+    return c.json({ valid: false, error: message })
+  }
+})
+
+// POST /api/settings/validate-deepgram-key - Validate a Deepgram API key
+settings.post('/validate-deepgram-key', async (c) => {
+  try {
+    const { apiKey } = await c.req.json()
+    if (!apiKey || typeof apiKey !== 'string') {
+      return c.json({ valid: false, error: 'API key is required' }, 400)
+    }
+
+    const response = await fetch('https://api.deepgram.com/v1/projects', {
+      headers: { Authorization: `Token ${apiKey}` },
+    })
+
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        return c.json({ valid: false, error: 'Invalid API key' })
+      }
+      return c.json({ valid: false, error: `Deepgram API error: ${response.status}` })
+    }
+
+    return c.json({ valid: true })
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Validation failed'
+    return c.json({ valid: false, error: message })
+  }
+})
+
+// POST /api/settings/validate-openai-key - Validate an OpenAI API key
+settings.post('/validate-openai-key', async (c) => {
+  try {
+    const { apiKey } = await c.req.json()
+    if (!apiKey || typeof apiKey !== 'string') {
+      return c.json({ valid: false, error: 'API key is required' }, 400)
+    }
+
+    const response = await fetch('https://api.openai.com/v1/models', {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    })
+
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        return c.json({ valid: false, error: 'Invalid API key' })
+      }
+      return c.json({ valid: false, error: `OpenAI API error: ${response.status}` })
     }
 
     return c.json({ valid: true })

--- a/src/api/routes/stt.ts
+++ b/src/api/routes/stt.ts
@@ -1,0 +1,47 @@
+import { Hono } from 'hono'
+import { Authenticated } from '../middleware/auth'
+import {
+  getEffectiveDeepgramApiKey,
+  getEffectiveOpenaiApiKey,
+  getVoiceSettings,
+  type SttProvider,
+} from '@shared/lib/config/settings'
+
+const stt = new Hono()
+
+stt.use('*', Authenticated())
+
+stt.get('/token', async (c) => {
+  try {
+    const voiceSettings = getVoiceSettings()
+    const provider = (c.req.query('provider') as SttProvider) || voiceSettings.sttProvider
+
+    if (!provider) {
+      return c.json({ error: 'No STT provider configured. Set one in Settings > Voice.' }, 400)
+    }
+
+    let apiKey: string | undefined
+    switch (provider) {
+      case 'deepgram':
+        apiKey = getEffectiveDeepgramApiKey()
+        break
+      case 'openai':
+        apiKey = getEffectiveOpenaiApiKey()
+        break
+      default:
+        return c.json({ error: `Unknown STT provider: ${provider}` }, 400)
+    }
+
+    if (!apiKey) {
+      return c.json({ error: `No API key configured for ${provider}. Add one in Settings > Voice.` }, 400)
+    }
+
+    return c.json({ provider, token: apiKey })
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to get STT credentials'
+    console.error('Failed to get STT credentials:', error)
+    return c.json({ error: message }, 500)
+  }
+})
+
+export default stt

--- a/src/renderer/lib/stt.ts
+++ b/src/renderer/lib/stt.ts
@@ -1,0 +1,240 @@
+// --- Types ---
+
+export type SttProvider = 'deepgram' | 'openai'
+
+export interface TranscriptEvent {
+  type: 'interim' | 'final' | 'speech_ended'
+  text: string
+}
+
+export type TranscriptCallback = (event: TranscriptEvent) => void
+export type ErrorCallback = (error: Error) => void
+
+export interface SttAdapter {
+  /** Required audio sample rate in Hz. Defaults to 16000 if not set. */
+  readonly sampleRate?: number
+  connect(token: string): Promise<void>
+  sendAudio(chunk: ArrayBuffer): void
+  onTranscript(cb: TranscriptCallback): void
+  onError(cb: ErrorCallback): void
+  close(): void
+}
+
+// --- Deepgram Adapter ---
+
+const DEEPGRAM_WS_PARAMS = new URLSearchParams({
+  model: 'nova-3',
+  interim_results: 'true',
+  smart_format: 'true',
+  endpointing: '300',
+  vad_events: 'true',
+  utterance_end_ms: '1000',
+  encoding: 'linear16',
+  sample_rate: '16000',
+  channels: '1',
+})
+
+class DeepgramAdapter implements SttAdapter {
+  private ws: WebSocket | null = null
+  private transcriptCb: TranscriptCallback | null = null
+  private errorCb: ErrorCallback | null = null
+
+  async connect(token: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const url = `wss://api.deepgram.com/v1/listen?${DEEPGRAM_WS_PARAMS.toString()}`
+      this.ws = new WebSocket(url, ['token', token])
+
+      this.ws.onopen = () => resolve()
+
+      this.ws.onerror = () => {
+        const err = new Error('Deepgram WebSocket connection failed')
+        reject(err)
+        this.errorCb?.(err)
+      }
+
+      this.ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data as string)
+          if (data.type === 'Results') {
+            const alt = data.channel?.alternatives?.[0]
+            if (!alt) return
+            const text = alt.transcript || ''
+            if (!text) return
+
+            if (data.speech_final) {
+              this.transcriptCb?.({ type: 'final', text })
+            } else if (data.is_final) {
+              this.transcriptCb?.({ type: 'final', text })
+            } else {
+              this.transcriptCb?.({ type: 'interim', text })
+            }
+          } else if (data.type === 'UtteranceEnd') {
+            this.transcriptCb?.({ type: 'speech_ended', text: '' })
+          }
+        } catch {
+          // Ignore non-JSON messages
+        }
+      }
+
+      this.ws.onclose = (event) => {
+        if (event.code !== 1000 && event.code !== 1005) {
+          this.errorCb?.(new Error(`Deepgram connection closed: ${event.code} ${event.reason}`))
+        }
+      }
+    })
+  }
+
+  sendAudio(chunk: ArrayBuffer): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(chunk)
+    }
+  }
+
+  onTranscript(cb: TranscriptCallback): void {
+    this.transcriptCb = cb
+  }
+
+  onError(cb: ErrorCallback): void {
+    this.errorCb = cb
+  }
+
+  close(): void {
+    if (this.ws) {
+      if (this.ws.readyState === WebSocket.OPEN) {
+        this.ws.send(JSON.stringify({ type: 'CloseStream' }))
+      }
+      this.ws.close()
+      this.ws = null
+    }
+  }
+}
+
+// --- OpenAI Adapter ---
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
+class OpenaiAdapter implements SttAdapter {
+  private ws: WebSocket | null = null
+  private transcriptCb: TranscriptCallback | null = null
+  private errorCb: ErrorCallback | null = null
+  readonly sampleRate = 24000
+
+  async connect(token: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const url = 'wss://api.openai.com/v1/realtime?intent=transcription'
+      this.ws = new WebSocket(url, [
+        'realtime',
+        `openai-insecure-api-key.${token}`,
+        'openai-beta.realtime-v1',
+      ])
+
+      this.ws.onopen = () => {
+        this.ws?.send(JSON.stringify({
+          type: 'transcription_session.update',
+          session: {
+            input_audio_format: 'pcm16',
+            input_audio_transcription: {
+              model: 'gpt-4o-mini-transcribe',
+            },
+            turn_detection: {
+              type: 'server_vad',
+              threshold: 0.5,
+              silence_duration_ms: 500,
+              prefix_padding_ms: 300,
+            },
+            input_audio_noise_reduction: {
+              type: 'near_field',
+            },
+          },
+        }))
+        resolve()
+      }
+
+      this.ws.onerror = () => {
+        const err = new Error('OpenAI Realtime WebSocket connection failed')
+        reject(err)
+        this.errorCb?.(err)
+      }
+
+      this.ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data as string)
+
+          switch (data.type) {
+            case 'conversation.item.input_audio_transcription.delta':
+              if (data.delta) {
+                this.transcriptCb?.({ type: 'interim', text: data.delta })
+              }
+              break
+            case 'conversation.item.input_audio_transcription.completed':
+              if (data.transcript) {
+                this.transcriptCb?.({ type: 'final', text: data.transcript })
+              }
+              break
+            case 'input_audio_buffer.speech_stopped':
+              this.transcriptCb?.({ type: 'speech_ended', text: '' })
+              break
+            case 'error':
+              this.errorCb?.(new Error(data.error?.message || 'OpenAI Realtime error'))
+              break
+          }
+        } catch {
+          // Ignore non-JSON messages
+        }
+      }
+
+      this.ws.onclose = (event) => {
+        if (event.code !== 1000 && event.code !== 1005) {
+          this.errorCb?.(new Error(`OpenAI connection closed: ${event.code} ${event.reason}`))
+        }
+      }
+    })
+  }
+
+  sendAudio(chunk: ArrayBuffer): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({
+        type: 'input_audio_buffer.append',
+        audio: arrayBufferToBase64(chunk),
+      }))
+    }
+  }
+
+  onTranscript(cb: TranscriptCallback): void {
+    this.transcriptCb = cb
+  }
+
+  onError(cb: ErrorCallback): void {
+    this.errorCb = cb
+  }
+
+  close(): void {
+    if (this.ws) {
+      if (this.ws.readyState === WebSocket.OPEN) {
+        this.ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }))
+      }
+      this.ws.close()
+      this.ws = null
+    }
+  }
+}
+
+// --- Factory ---
+
+export function createSttAdapter(provider: SttProvider): SttAdapter {
+  switch (provider) {
+    case 'deepgram':
+      return new DeepgramAdapter()
+    case 'openai':
+      return new OpenaiAdapter()
+    default:
+      throw new Error(`Unknown STT provider: ${provider}`)
+  }
+}

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -19,6 +19,14 @@ export interface ApiKeySettings {
   composioUserId?: string
   browserbaseApiKey?: string
   browserbaseProjectId?: string
+  deepgramApiKey?: string
+  openaiApiKey?: string
+}
+
+export type SttProvider = 'deepgram' | 'openai'
+
+export interface VoiceSettings {
+  sttProvider?: SttProvider
 }
 
 export interface NotificationSettings {
@@ -110,6 +118,7 @@ export interface AppSettings {
   customEnvVars?: Record<string, string>
   skillsets?: SkillsetConfig[]
   auth?: AuthSettings
+  voice?: VoiceSettings
 }
 
 // API key source types
@@ -146,8 +155,11 @@ export interface GlobalSettingsResponse {
   apiKeyStatus: {
     anthropic: ApiKeyStatus
     composio: ApiKeyStatus
+    deepgram: ApiKeyStatus
+    openai: ApiKeyStatus
   }
   composioUserId?: string
+  voice?: VoiceSettings
   models: ModelSettings
   agentLimits: AgentLimitsSettings
   customEnvVars: Record<string, string>
@@ -246,6 +258,7 @@ export function loadSettings(): AppSettings {
           ...DEFAULT_AUTH_SETTINGS,
           ...loaded.auth,
         },
+        voice: loaded.voice,
       }
     }
   } catch (error) {
@@ -391,6 +404,49 @@ export function getEffectiveAgentLimits(): AgentLimitsSettings {
 export function getCustomEnvVars(): Record<string, string> {
   const settings = getSettings()
   return settings.customEnvVars ?? {}
+}
+
+export function getDeepgramApiKeyStatus(): ApiKeyStatus {
+  const settings = getSettings()
+  if (settings.apiKeys?.deepgramApiKey) {
+    return { isConfigured: true, source: 'settings' }
+  }
+  if (process.env.DEEPGRAM_API_KEY) {
+    return { isConfigured: true, source: 'env' }
+  }
+  return { isConfigured: false, source: 'none' }
+}
+
+export function getEffectiveDeepgramApiKey(): string | undefined {
+  const settings = getSettings()
+  if (settings.apiKeys?.deepgramApiKey) {
+    return settings.apiKeys.deepgramApiKey
+  }
+  return process.env.DEEPGRAM_API_KEY
+}
+
+export function getOpenaiApiKeyStatus(): ApiKeyStatus {
+  const settings = getSettings()
+  if (settings.apiKeys?.openaiApiKey) {
+    return { isConfigured: true, source: 'settings' }
+  }
+  if (process.env.OPENAI_API_KEY) {
+    return { isConfigured: true, source: 'env' }
+  }
+  return { isConfigured: false, source: 'none' }
+}
+
+export function getEffectiveOpenaiApiKey(): string | undefined {
+  const settings = getSettings()
+  if (settings.apiKeys?.openaiApiKey) {
+    return settings.apiKeys.openaiApiKey
+  }
+  return process.env.OPENAI_API_KEY
+}
+
+export function getVoiceSettings(): VoiceSettings {
+  const settings = getSettings()
+  return settings.voice ?? {}
 }
 
 export { DEFAULT_SETTINGS }


### PR DESCRIPTION
## Summary
- Add `VoiceSettings` type and `SttProvider` (`deepgram` / `openai`) to `AppSettings`
- Add Deepgram and OpenAI API key management functions (get effective key, get status)
- Settings route: voice config CRUD, Deepgram/OpenAI API key validation endpoints

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/api/routes/settings.test.ts` — 30 tests pass
- [x] `npx eslint` passes
- [ ] Manual: PUT /api/settings with voice config, verify persistence
- [ ] Manual: POST /api/settings/validate-deepgram-key with valid/invalid key


Made with [Cursor](https://cursor.com)