### PR TITLE
fix: improve task pause/resume reliability and code quality

### DIFF
--- a/agent-container/src/tools/manage-scheduled-tasks.ts
+++ b/agent-container/src/tools/manage-scheduled-tasks.ts
@@ -38,35 +38,53 @@ Use "list" first to see available tasks and their IDs before performing other ac
       .describe('The ID of the task to act on. Required for pause, resume, and cancel actions.'),
   },
   async (args) => {
+    const text = (t: string) => ({ content: [{ type: 'text' as const, text: t }] })
+    const fail = (t: string) => ({ content: [{ type: 'text' as const, text: t }], isError: true as const })
+
     if (args.action !== 'list' && !args.taskId) {
-      return {
-        content: [{ type: 'text' as const, text: `Action "${args.action}" requires a taskId. Use "list" first.` }],
-        isError: true,
-      }
+      return fail(`Action "${args.action}" requires a taskId. Use "list" first.`)
     }
 
     const agentId = process.env.AGENT_ID
-    if (!agentId) {
-      return { content: [{ type: 'text' as const, text: 'AGENT_ID not configured.' }], isError: true }
-    }
+    if (!agentId) return fail('AGENT_ID not configured.')
 
     try {
       if (args.action === 'list') {
         const res = await hostFetch(`/api/agents/${agentId}/scheduled-tasks?status=active`)
-        if (!res.ok) return { content: [{ type: 'text' as const, text: `Failed to list tasks: ${res.statusText}` }], isError: true }
-        const tasks = await res.json() as Array<{ id: string; name: string; scheduleType: string; scheduleExpression: string; status: string; executionCount: number; nextExecutionAt: string | null }>
-        if (tasks.length === 0) return { content: [{ type: 'text' as const, text: 'No active scheduled tasks.' }] }
-        const lines = tasks.map(t => `- ${t.name} (ID: ${t.id}) [${t.status}] ${t.scheduleType}="${t.scheduleExpression}" executions=${t.executionCount}${t.nextExecutionAt ? ` next=${t.nextExecutionAt}` : ''}`)
-        return { content: [{ type: 'text' as const, text: lines.join('\n') }] }
+        if (!res.ok) return fail(`Failed to list tasks: ${res.statusText}`)
+
+        interface TaskSummary {
+          id: string; name: string; scheduleType: string
+          scheduleExpression: string; status: string
+          executionCount: number; nextExecutionAt: string | null
+        }
+        const tasks = await res.json() as TaskSummary[]
+        if (tasks.length === 0) return text('No active scheduled tasks.')
+
+        const lines = tasks.map(t =>
+          `- ${t.name} (ID: ${t.id}) [${t.status}] ` +
+          `${t.scheduleType}="${t.scheduleExpression}" executions=${t.executionCount}` +
+          (t.nextExecutionAt ? ` next=${t.nextExecutionAt}` : '')
+        )
+        return text(lines.join('\n'))
       }
 
-      const actionMap = { pause: ['POST', `/api/scheduled-tasks/${args.taskId}/pause`], resume: ['POST', `/api/scheduled-tasks/${args.taskId}/resume`], cancel: ['DELETE', `/api/scheduled-tasks/${args.taskId}`] } as const
-      const [method, path] = actionMap[args.action as keyof typeof actionMap]
+      let method: string
+      let path: string
+      switch (args.action) {
+        case 'pause':
+          method = 'POST'; path = `/api/scheduled-tasks/${args.taskId}/pause`; break
+        case 'resume':
+          method = 'POST'; path = `/api/scheduled-tasks/${args.taskId}/resume`; break
+        case 'cancel':
+          method = 'DELETE'; path = `/api/scheduled-tasks/${args.taskId}`; break
+      }
+
       const res = await hostFetch(path, method)
-      if (!res.ok) return { content: [{ type: 'text' as const, text: `Failed to ${args.action} task: ${res.statusText}` }], isError: true }
-      return { content: [{ type: 'text' as const, text: `Successfully ${args.action}d task ${args.taskId}.` }] }
+      if (!res.ok) return fail(`Failed to ${args.action} task: ${res.statusText}`)
+      return text(`Successfully ${args.action}d task ${args.taskId}.`)
     } catch (err) {
-      return { content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : err}` }], isError: true }
+      return fail(`Error: ${err instanceof Error ? err.message : err}`)
     }
   }
 )

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -24,6 +24,7 @@ interface StreamingState {
   lastContextWindow: number // Last known context window size (default 200k)
   lastAssistantUsage: SessionUsage | null // Per-call usage from most recent assistant message
   pendingTaskToolId: string | null // tool_use ID of the currently executing Task tool
+  pendingManageTasksToolIds: Map<string, { action: string; taskId?: string }> // tool_use IDs for manage_scheduled_tasks awaiting result
   activeSubagentId: string | null // agentId of the running subagent
   completedSubagentIds: Set<string> // agentIds of subagents that have completed (to avoid re-discovery)
   // Subagent streaming state (separate from main agent to avoid corruption)
@@ -68,6 +69,7 @@ class MessagePersister {
       lastContextWindow: 200_000,
       lastAssistantUsage: null,
       pendingTaskToolId: null,
+      pendingManageTasksToolIds: new Map(),
       activeSubagentId: null,
       completedSubagentIds: new Set(),
       subagentCurrentText: '',
@@ -212,6 +214,7 @@ class MessagePersister {
       state.currentToolUse = null
       state.currentToolInput = ''
       state.pendingTaskToolId = null
+      state.pendingManageTasksToolIds.clear()
       state.activeSubagentId = null
       state.subagentCurrentText = ''
       state.subagentCurrentToolUse = null
@@ -269,6 +272,7 @@ class MessagePersister {
         lastContextWindow: 200_000,
         lastAssistantUsage: null,
         pendingTaskToolId: null,
+        pendingManageTasksToolIds: new Map(),
         activeSubagentId: null,
         completedSubagentIds: new Set(),
         subagentCurrentText: '',
@@ -375,7 +379,7 @@ class MessagePersister {
           break
         }
         // Tool results come as 'user' type messages
-        this.handleToolResults(sessionId, content)
+        this.handleToolResults(sessionId, content, state)
         break
 
       case 'system':
@@ -531,6 +535,7 @@ class MessagePersister {
     state.currentToolUse = null
     state.currentToolInput = ''
     state.pendingTaskToolId = null
+    state.pendingManageTasksToolIds.clear()
     state.activeSubagentId = null
     state.subagentCurrentText = ''
     state.subagentCurrentToolUse = null
@@ -813,7 +818,7 @@ class MessagePersister {
           }
 
           if (state.currentToolUse.name === 'mcp__user-input__manage_scheduled_tasks') {
-            this.handleManageScheduledTasksTool(state.currentToolInput, state.agentSlug)
+            this.trackManageScheduledTasksTool(state, state.currentToolInput)
           }
 
           // Check if this is an AskUserQuestion tool
@@ -1022,11 +1027,11 @@ class MessagePersister {
   }
 
   /**
-   * The tool calls the host API directly for DB operations.
-   * Here we only broadcast a global SSE event so the frontend UI refreshes.
+   * Record pending manage_scheduled_tasks tool call so we can broadcast the
+   * SSE event once the tool_result arrives (guaranteeing the DB write is done).
    */
-  private handleManageScheduledTasksTool(toolInput: string, agentSlug?: string): void {
-    if (!agentSlug) return
+  private trackManageScheduledTasksTool(state: StreamingState, toolInput: string): void {
+    if (!state.currentToolUse) return
 
     let input: { action: string; taskId?: string }
     try {
@@ -1037,14 +1042,10 @@ class MessagePersister {
 
     if (input.action === 'list') return
 
-    // Delay so the tool's API call completes before frontend refetches
-    setTimeout(() => {
-      this.broadcastGlobal({
-        type: 'scheduled_task_updated',
-        taskId: input.taskId,
-        agentSlug,
-      })
-    }, 1000)
+    state.pendingManageTasksToolIds.set(state.currentToolUse.id, {
+      action: input.action,
+      taskId: input.taskId,
+    })
   }
 
   // Handle AskUserQuestion tool - broadcast to SSE clients so they can show the UI
@@ -1238,23 +1239,32 @@ class MessagePersister {
     }
   }
 
-  // Handle tool results - broadcast to SSE clients
   private handleToolResults(
     sessionId: string,
-    content: { message?: { content?: Array<{ type: string; tool_use_id?: string; content?: unknown; is_error?: boolean }> } }
+    content: { message?: { content?: Array<{ type: string; tool_use_id?: string; content?: unknown; is_error?: boolean }> } },
+    state: StreamingState
   ): void {
     try {
       const messageContent = content.message?.content || []
 
       for (const block of messageContent) {
         if (block.type === 'tool_result' && block.tool_use_id) {
-          // Broadcast update to SSE clients
           this.broadcastToSSE(sessionId, {
             type: 'tool_result',
             toolUseId: block.tool_use_id,
             result: block.content,
             isError: block.is_error || false,
           })
+
+          const pending = state.pendingManageTasksToolIds.get(block.tool_use_id)
+          if (pending && state.agentSlug && !block.is_error) {
+            state.pendingManageTasksToolIds.delete(block.tool_use_id)
+            this.broadcastGlobal({
+              type: 'scheduled_task_updated',
+              taskId: pending.taskId,
+              agentSlug: state.agentSlug,
+            })
+          }
         }
       }
     } catch (error) {

--- a/src/shared/lib/services/scheduled-task-service.test.ts
+++ b/src/shared/lib/services/scheduled-task-service.test.ts
@@ -30,6 +30,7 @@ import {
   getScheduledTask,
   listScheduledTasks,
   listPendingScheduledTasks,
+  listActiveScheduledTasks,
   getDueTasks,
   cancelScheduledTask,
   pauseScheduledTask,
@@ -203,6 +204,64 @@ describe('scheduled-task-service', () => {
   })
 
   // ============================================================================
+  // listActiveScheduledTasks Tests
+  // ============================================================================
+
+  describe('listActiveScheduledTasks', () => {
+    it('returns pending and paused tasks', async () => {
+      const id1 = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Pending',
+      })
+
+      const id2 = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 2 hours',
+        prompt: 'Will be paused',
+      })
+
+      const id3 = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 3 hours',
+        prompt: 'Will be cancelled',
+      })
+
+      await pauseScheduledTask(id2)
+      await cancelScheduledTask(id3)
+
+      const active = await listActiveScheduledTasks('test-agent')
+      expect(active).toHaveLength(2)
+      const ids = active.map(t => t.id)
+      expect(ids).toContain(id1)
+      expect(ids).toContain(id2)
+    })
+
+    it('excludes tasks from other agents', async () => {
+      await createScheduledTask({
+        agentSlug: 'agent-a',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Agent A task',
+      })
+
+      await createScheduledTask({
+        agentSlug: 'agent-b',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Agent B task',
+      })
+
+      const active = await listActiveScheduledTasks('agent-a')
+      expect(active).toHaveLength(1)
+      expect(active[0].agentSlug).toBe('agent-a')
+    })
+  })
+
+  // ============================================================================
   // getDueTasks Tests
   // ============================================================================
 
@@ -318,6 +377,22 @@ describe('scheduled-task-service', () => {
       expect(result).toBe(false)
     })
 
+    it('cancels a paused task', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Test',
+      })
+
+      await pauseScheduledTask(taskId)
+      const result = await cancelScheduledTask(taskId)
+      expect(result).toBe(true)
+
+      const task = await getScheduledTask(taskId)
+      expect(task!.status).toBe('cancelled')
+    })
+
     it('returns false for nonexistent tasks', async () => {
       const result = await cancelScheduledTask('nonexistent-id')
       expect(result).toBe(false)
@@ -397,7 +472,7 @@ describe('scheduled-task-service', () => {
       expect(task!.status).toBe('pending')
     })
 
-    it('keeps the original nextExecutionAt if it has not passed', async () => {
+    it('preserves original nextExecutionAt', async () => {
       const taskId = await createScheduledTask({
         agentSlug: 'test-agent',
         scheduleType: 'at',
@@ -408,31 +483,11 @@ describe('scheduled-task-service', () => {
       const original = await getScheduledTask(taskId)
       await pauseScheduledTask(taskId)
 
-      // Advance time but not past the execution time
       vi.setSystemTime(new Date('2024-06-15T13:00:00.000Z'))
 
       await resumeScheduledTask(taskId)
       const resumed = await getScheduledTask(taskId)
       expect(resumed!.nextExecutionAt.getTime()).toBe(original!.nextExecutionAt.getTime())
-    })
-
-    it('recalculates nextExecutionAt for cron tasks if time has passed', async () => {
-      const taskId = await createScheduledTask({
-        agentSlug: 'test-agent',
-        scheduleType: 'cron',
-        scheduleExpression: '0 * * * *',
-        prompt: 'Test',
-      })
-
-      const original = await getScheduledTask(taskId)
-      await pauseScheduledTask(taskId)
-
-      // Advance time past the original execution time
-      vi.setSystemTime(new Date('2024-06-15T14:30:00.000Z'))
-
-      await resumeScheduledTask(taskId)
-      const resumed = await getScheduledTask(taskId)
-      expect(resumed!.nextExecutionAt.getTime()).toBeGreaterThan(original!.nextExecutionAt.getTime())
     })
 
     it('returns false for pending tasks', async () => {

--- a/src/shared/lib/services/scheduled-task-service.ts
+++ b/src/shared/lib/services/scheduled-task-service.ts
@@ -200,24 +200,9 @@ export async function resumeScheduledTask(taskId: string): Promise<boolean> {
   const task = await getScheduledTask(taskId)
   if (!task || task.status !== 'paused') return false
 
-  // Recalculate next execution time if the original one has passed
-  let nextExecutionAt = task.nextExecutionAt
-  const now = new Date()
-  if (new Date(nextExecutionAt) < now) {
-    if (task.scheduleType === 'cron') {
-      nextExecutionAt = getNextCronTime(task.scheduleExpression)
-    } else {
-      // For 'at' tasks, recalculate from the expression
-      nextExecutionAt = parseAtSyntax(task.scheduleExpression)
-    }
-  }
-
   const result = await db
     .update(scheduledTasks)
-    .set({
-      status: 'pending',
-      nextExecutionAt,
-    })
+    .set({ status: 'pending' })
     .where(
       and(
         eq(scheduledTasks.id, taskId),


### PR DESCRIPTION
## Summary
- Fix SSE broadcast race condition: emit `scheduled_task_updated` on tool_result instead of fragile setTimeout(1000)
- Simplify `resumeScheduledTask` to only flip status without time recalculation
- Improve `manage-scheduled-tasks` tool readability (switch statement + typed TaskSummary interface)
- Add missing test coverage for `listActiveScheduledTasks` and cancelling paused tasks

## Test plan
- [x] 33 unit tests passing
- [ ] Verify SSE events trigger UI refresh on pause/resume from agent tool


Made with [Cursor](https://cursor.com)