### PR TITLE
feat: add pause/resume for scheduled tasks

### DIFF
--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -38,6 +38,7 @@ import {
 import {
   listScheduledTasks,
   listPendingScheduledTasks,
+  listActiveScheduledTasks,
 } from '@shared/lib/services/scheduled-task-service'
 import { db } from '@shared/lib/db'
 import { connectedAccounts, agentConnectedAccounts, proxyAuditLog, remoteMcpServers, agentRemoteMcps, mcpAuditLog, agentAcl, user as userTable } from '@shared/lib/db/schema'
@@ -1619,6 +1620,8 @@ agents.get('/:id/scheduled-tasks', AgentRead(), async (c) => {
     let tasks
     if (status === 'pending') {
       tasks = await listPendingScheduledTasks(slug)
+    } else if (status === 'active') {
+      tasks = await listActiveScheduledTasks(slug)
     } else {
       tasks = await listScheduledTasks(slug)
     }

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -100,14 +100,14 @@ scheduledTasksRouter.delete('/:taskId', TaskAgentRole('user'), async (c) => {
   }
 })
 
-// POST /api/scheduled-tasks/:taskId/pause - Pause a pending scheduled task
+// POST /api/scheduled-tasks/:taskId/pause - Pause a pending recurring task
 scheduledTasksRouter.post('/:taskId/pause', TaskAgentRole('user'), async (c) => {
   try {
     const task = c.get('scheduledTask' as never) as Awaited<ReturnType<typeof getScheduledTask>>
-    const paused = await pauseScheduledTask(task!.id)
+    const result = await pauseScheduledTask(task!.id)
 
-    if (!paused) {
-      return c.json({ error: 'Scheduled task not found or not in pending state' }, 404)
+    if (!result.success) {
+      return c.json({ error: result.error }, 400)
     }
 
     const updated = await getScheduledTask(task!.id)
@@ -118,14 +118,14 @@ scheduledTasksRouter.post('/:taskId/pause', TaskAgentRole('user'), async (c) => 
   }
 })
 
-// POST /api/scheduled-tasks/:taskId/resume - Resume a paused scheduled task
+// POST /api/scheduled-tasks/:taskId/resume - Resume a paused recurring task
 scheduledTasksRouter.post('/:taskId/resume', TaskAgentRole('user'), async (c) => {
   try {
     const task = c.get('scheduledTask' as never) as Awaited<ReturnType<typeof getScheduledTask>>
-    const resumed = await resumeScheduledTask(task!.id)
+    const result = await resumeScheduledTask(task!.id)
 
-    if (!resumed) {
-      return c.json({ error: 'Scheduled task not found or not in paused state' }, 404)
+    if (!result.success) {
+      return c.json({ error: result.error }, 400)
     }
 
     const updated = await getScheduledTask(task!.id)

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -11,6 +11,8 @@ import { and, eq } from 'drizzle-orm'
 import {
   getScheduledTask,
   cancelScheduledTask,
+  pauseScheduledTask,
+  resumeScheduledTask,
   resetScheduledTask,
 } from '@shared/lib/services/scheduled-task-service'
 import { getSessionsByScheduledTask } from '@shared/lib/services/session-service'
@@ -95,6 +97,42 @@ scheduledTasksRouter.delete('/:taskId', TaskAgentRole('user'), async (c) => {
   } catch (error) {
     console.error('Failed to cancel scheduled task:', error)
     return c.json({ error: 'Failed to cancel scheduled task' }, 500)
+  }
+})
+
+// POST /api/scheduled-tasks/:taskId/pause - Pause a pending scheduled task
+scheduledTasksRouter.post('/:taskId/pause', TaskAgentRole('user'), async (c) => {
+  try {
+    const task = c.get('scheduledTask' as never) as Awaited<ReturnType<typeof getScheduledTask>>
+    const paused = await pauseScheduledTask(task!.id)
+
+    if (!paused) {
+      return c.json({ error: 'Scheduled task not found or not in pending state' }, 404)
+    }
+
+    const updated = await getScheduledTask(task!.id)
+    return c.json(updated)
+  } catch (error) {
+    console.error('Failed to pause scheduled task:', error)
+    return c.json({ error: 'Failed to pause scheduled task' }, 500)
+  }
+})
+
+// POST /api/scheduled-tasks/:taskId/resume - Resume a paused scheduled task
+scheduledTasksRouter.post('/:taskId/resume', TaskAgentRole('user'), async (c) => {
+  try {
+    const task = c.get('scheduledTask' as never) as Awaited<ReturnType<typeof getScheduledTask>>
+    const resumed = await resumeScheduledTask(task!.id)
+
+    if (!resumed) {
+      return c.json({ error: 'Scheduled task not found or not in paused state' }, 404)
+    }
+
+    const updated = await getScheduledTask(task!.id)
+    return c.json(updated)
+  } catch (error) {
+    console.error('Failed to resume scheduled task:', error)
+    return c.json({ error: 'Failed to resume scheduled task' }, 500)
   }
 })
 

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -1,5 +1,5 @@
 
-import { ChevronRight, Plus, Settings, AlertTriangle, Clock, LayoutDashboard, Loader2, WifiOff, LogOut, User, Users } from 'lucide-react'
+import { ChevronRight, Plus, Settings, AlertTriangle, Clock, Pause, LayoutDashboard, Loader2, WifiOff, LogOut, User, Users } from 'lucide-react'
 import { ErrorBoundary } from '@renderer/components/ui/error-boundary'
 import { useState, useEffect, useRef } from 'react'
 import { isElectron, getPlatform } from '@renderer/lib/env'
@@ -113,19 +113,20 @@ function ScheduledTaskSubItem({
   // Format next execution time for tooltip
   const nextExecution = new Date(task.nextExecutionAt)
   const timeString = nextExecution.toLocaleString()
+  const isPaused = task.status === 'paused'
 
   return (
     <SidebarMenuSubItem>
       <SidebarMenuSubButton
         asChild
         isActive={isSelected}
-        title={`Scheduled for: ${timeString}`}
+        title={isPaused ? 'Paused' : `Scheduled for: ${timeString}`}
       >
         <button
           onClick={handleClick}
-          className="flex items-center gap-2 w-full text-muted-foreground opacity-70"
+          className={`flex items-center gap-2 w-full text-muted-foreground ${isPaused ? 'opacity-50' : 'opacity-70'}`}
         >
-          <Clock className="h-3 w-3 shrink-0" />
+          {isPaused ? <Pause className="h-3 w-3 shrink-0" /> : <Clock className="h-3 w-3 shrink-0" />}
           <span className="truncate">{task.name || 'Scheduled Task'}</span>
         </button>
       </SidebarMenuSubButton>
@@ -173,7 +174,7 @@ function AgentMenuItem({ agent }: { agent: ApiAgent }) {
   const { selectedAgentSlug, selectAgent } = useSelection()
   const { agentMemberCount } = useUser()
   const { data: sessions } = useSessions(agent.slug)
-  const { data: scheduledTasks } = useScheduledTasks(agent.slug, 'pending')
+  const { data: scheduledTasks } = useScheduledTasks(agent.slug, 'active')
   const { data: artifacts } = useArtifacts(agent.slug)
   const isSelected = agent.slug === selectedAgentSlug
   const [isOpen, setIsOpen] = useState(isSelected)
@@ -182,7 +183,7 @@ function AgentMenuItem({ agent }: { agent: ApiAgent }) {
 
   const visibleSessions = showAll ? sessions : sessions?.slice(0, 5)
   const hasMore = (sessions?.length ?? 0) > 5
-  const pendingTasks = scheduledTasks || []
+  const activeTasks = scheduledTasks || []
   const dashboards = Array.isArray(artifacts) ? artifacts : []
 
   const handleClick = () => {
@@ -210,7 +211,7 @@ function AgentMenuItem({ agent }: { agent: ApiAgent }) {
             />
           </SidebarMenuButton>
         </AgentContextMenu>
-        {(sessions?.length || pendingTasks.length || dashboards.length) ? (
+        {(sessions?.length || activeTasks.length || dashboards.length) ? (
           <>
             <CollapsibleTrigger asChild>
               <SidebarMenuAction className="data-[state=open]:rotate-90">
@@ -229,7 +230,7 @@ function AgentMenuItem({ agent }: { agent: ApiAgent }) {
                   />
                 ))}
                 {/* Pending scheduled tasks */}
-                {pendingTasks.map((task) => (
+                {activeTasks.map((task) => (
                   <ScheduledTaskSubItem
                     key={task.id}
                     task={task}

--- a/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
+++ b/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
@@ -5,11 +5,13 @@
  * that will be executed and options to cancel the task.
  */
 
-import { Clock, Calendar, Repeat, Trash2, MessageSquare } from 'lucide-react'
+import { Clock, Calendar, Repeat, Trash2, Pause, Play, MessageSquare } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import {
   useScheduledTask,
   useCancelScheduledTask,
+  usePauseScheduledTask,
+  useResumeScheduledTask,
   useScheduledTaskSessions,
 } from '@renderer/hooks/use-scheduled-tasks'
 import { useSelection } from '@renderer/context/selection-context'
@@ -35,9 +37,27 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
   const { data: task, isLoading, error } = useScheduledTask(taskId)
   const { data: sessions = [] } = useScheduledTaskSessions(taskId)
   const cancelTask = useCancelScheduledTask()
+  const pauseTask = usePauseScheduledTask()
+  const resumeTask = useResumeScheduledTask()
   const { handleScheduledTaskDeleted, selectSession } = useSelection()
   const { canUseAgent } = useUser()
   const canCancel = canUseAgent(agentSlug)
+
+  const handlePause = async () => {
+    try {
+      await pauseTask.mutateAsync({ taskId, agentSlug })
+    } catch (err) {
+      console.error('Failed to pause scheduled task:', err)
+    }
+  }
+
+  const handleResume = async () => {
+    try {
+      await resumeTask.mutateAsync({ taskId, agentSlug })
+    } catch (err) {
+      console.error('Failed to resume scheduled task:', err)
+    }
+  }
 
   const handleCancel = async () => {
     try {
@@ -92,33 +112,59 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
             </div>
           </div>
 
-          {task.status === 'pending' && canCancel && (
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button variant="destructive" size="sm">
-                  <Trash2 className="h-4 w-4 mr-2" />
-                  Cancel Task
+          {canCancel && (
+            <div className="flex items-center gap-2">
+              {task.status === 'pending' && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handlePause}
+                  disabled={pauseTask.isPending}
+                >
+                  <Pause className="h-4 w-4 mr-2" />
+                  {pauseTask.isPending ? 'Pausing...' : 'Pause'}
                 </Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Cancel Scheduled Task</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    Are you sure you want to cancel this scheduled task? This action cannot be undone.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Keep Task</AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={handleCancel}
-                    disabled={cancelTask.isPending}
-                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                  >
-                    {cancelTask.isPending ? 'Cancelling...' : 'Cancel Task'}
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
+              )}
+              {task.status === 'paused' && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleResume}
+                  disabled={resumeTask.isPending}
+                >
+                  <Play className="h-4 w-4 mr-2" />
+                  {resumeTask.isPending ? 'Resuming...' : 'Resume'}
+                </Button>
+              )}
+              {(task.status === 'pending' || task.status === 'paused') && (
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button variant="destructive" size="sm">
+                      <Trash2 className="h-4 w-4 mr-2" />
+                      Cancel Task
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Cancel Scheduled Task</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Are you sure you want to cancel this scheduled task? This action cannot be undone.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Keep Task</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={handleCancel}
+                        disabled={cancelTask.isPending}
+                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                      >
+                        {cancelTask.isPending ? 'Cancelling...' : 'Cancel Task'}
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              )}
+            </div>
           )}
         </div>
       </div>
@@ -133,6 +179,10 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
           {task.status === 'pending' ? (
             <div className="text-lg">
               {nextExecution.toLocaleString()}
+            </div>
+          ) : task.status === 'paused' ? (
+            <div className="text-lg text-yellow-600">
+              Paused
             </div>
           ) : (
             <div className="text-lg capitalize">{task.status}</div>
@@ -161,7 +211,9 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
                 This prompt will be sent to the agent{' '}
                 {task.status === 'pending'
                   ? `on ${nextExecution.toLocaleString()}`
-                  : 'when executed'}
+                  : task.status === 'paused'
+                    ? 'when resumed'
+                    : 'when executed'}
               </span>
             </div>
             <div className="whitespace-pre-wrap text-sm">{task.prompt}</div>

--- a/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
+++ b/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
@@ -114,7 +114,7 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
 
           {canCancel && (
             <div className="flex items-center gap-2">
-              {task.status === 'pending' && (
+              {task.status === 'pending' && isRecurring && (
                 <Button
                   variant="outline"
                   size="sm"

--- a/src/renderer/hooks/use-scheduled-tasks.ts
+++ b/src/renderer/hooks/use-scheduled-tasks.ts
@@ -14,7 +14,7 @@ export type { ApiScheduledTask }
 /**
  * Fetch all scheduled tasks for an agent
  */
-export function useScheduledTasks(agentSlug: string | null, status?: 'pending') {
+export function useScheduledTasks(agentSlug: string | null, status?: 'pending' | 'active') {
   return useQuery<ApiScheduledTask[]>({
     queryKey: ['scheduled-tasks', agentSlug, status],
     queryFn: async () => {
@@ -61,6 +61,44 @@ export function useCancelScheduledTask() {
       // Invalidate all scheduled tasks queries for this agent
       queryClient.invalidateQueries({ queryKey: ['scheduled-tasks', variables.agentSlug] })
       // Invalidate the specific task query
+      queryClient.invalidateQueries({ queryKey: ['scheduled-task', variables.taskId] })
+    },
+  })
+}
+
+/**
+ * Pause a scheduled task
+ */
+export function usePauseScheduledTask() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ taskId, agentSlug }: { taskId: string; agentSlug: string }) => {
+      const res = await apiFetch(`/api/scheduled-tasks/${taskId}/pause`, { method: 'POST' })
+      if (!res.ok) throw new Error('Failed to pause scheduled task')
+      return { taskId, agentSlug }
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['scheduled-tasks', variables.agentSlug] })
+      queryClient.invalidateQueries({ queryKey: ['scheduled-task', variables.taskId] })
+    },
+  })
+}
+
+/**
+ * Resume a paused scheduled task
+ */
+export function useResumeScheduledTask() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ taskId, agentSlug }: { taskId: string; agentSlug: string }) => {
+      const res = await apiFetch(`/api/scheduled-tasks/${taskId}/resume`, { method: 'POST' })
+      if (!res.ok) throw new Error('Failed to resume scheduled task')
+      return { taskId, agentSlug }
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['scheduled-tasks', variables.agentSlug] })
       queryClient.invalidateQueries({ queryKey: ['scheduled-task', variables.taskId] })
     },
   })

--- a/src/shared/lib/db/schema.ts
+++ b/src/shared/lib/db/schema.ts
@@ -142,8 +142,8 @@ export const scheduledTasks = sqliteTable('scheduled_tasks', {
   prompt: text('prompt').notNull(),
   name: text('name'),
 
-  // Status: pending, executed, cancelled, failed
-  status: text('status', { enum: ['pending', 'executed', 'cancelled', 'failed'] })
+  // Status: pending, paused, executed, cancelled, failed
+  status: text('status', { enum: ['pending', 'paused', 'executed', 'cancelled', 'failed'] })
     .notNull()
     .default('pending'),
 

--- a/src/shared/lib/services/scheduled-task-service.test.ts
+++ b/src/shared/lib/services/scheduled-task-service.test.ts
@@ -30,8 +30,11 @@ import {
   getScheduledTask,
   listScheduledTasks,
   listPendingScheduledTasks,
+  listActiveScheduledTasks,
   getDueTasks,
   cancelScheduledTask,
+  pauseScheduledTask,
+  resumeScheduledTask,
   markTaskExecuted,
   updateNextExecution,
   markTaskFailed,
@@ -201,6 +204,64 @@ describe('scheduled-task-service', () => {
   })
 
   // ============================================================================
+  // listActiveScheduledTasks Tests
+  // ============================================================================
+
+  describe('listActiveScheduledTasks', () => {
+    it('returns pending and paused tasks', async () => {
+      const id1 = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Pending',
+      })
+
+      const id2 = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 2 hours',
+        prompt: 'Will be paused',
+      })
+
+      const id3 = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 3 hours',
+        prompt: 'Will be cancelled',
+      })
+
+      await pauseScheduledTask(id2)
+      await cancelScheduledTask(id3)
+
+      const active = await listActiveScheduledTasks('test-agent')
+      expect(active).toHaveLength(2)
+      const ids = active.map(t => t.id)
+      expect(ids).toContain(id1)
+      expect(ids).toContain(id2)
+    })
+
+    it('excludes tasks from other agents', async () => {
+      await createScheduledTask({
+        agentSlug: 'agent-a',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Agent A task',
+      })
+
+      await createScheduledTask({
+        agentSlug: 'agent-b',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Agent B task',
+      })
+
+      const active = await listActiveScheduledTasks('agent-a')
+      expect(active).toHaveLength(1)
+      expect(active[0].agentSlug).toBe('agent-a')
+    })
+  })
+
+  // ============================================================================
   // getDueTasks Tests
   // ============================================================================
 
@@ -236,6 +297,23 @@ describe('scheduled-task-service', () => {
       })
 
       await cancelScheduledTask(taskId)
+
+      // Advance time
+      vi.setSystemTime(new Date('2024-06-15T13:00:00.000Z'))
+
+      const dueTasks = await getDueTasks()
+      expect(dueTasks).toHaveLength(0)
+    })
+
+    it('does not return paused tasks', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 30 minutes',
+        prompt: 'Paused task',
+      })
+
+      await pauseScheduledTask(taskId)
 
       // Advance time
       vi.setSystemTime(new Date('2024-06-15T13:00:00.000Z'))
@@ -299,8 +377,133 @@ describe('scheduled-task-service', () => {
       expect(result).toBe(false)
     })
 
+    it('cancels a paused task', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Test',
+      })
+
+      await pauseScheduledTask(taskId)
+      const result = await cancelScheduledTask(taskId)
+      expect(result).toBe(true)
+
+      const task = await getScheduledTask(taskId)
+      expect(task!.status).toBe('cancelled')
+    })
+
     it('returns false for nonexistent tasks', async () => {
       const result = await cancelScheduledTask('nonexistent-id')
+      expect(result).toBe(false)
+    })
+  })
+
+  // ============================================================================
+  // pauseScheduledTask Tests
+  // ============================================================================
+
+  describe('pauseScheduledTask', () => {
+    it('sets status to paused', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Test',
+      })
+
+      const result = await pauseScheduledTask(taskId)
+      expect(result).toBe(true)
+
+      const task = await getScheduledTask(taskId)
+      expect(task!.status).toBe('paused')
+    })
+
+    it('returns false for already paused tasks', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Test',
+      })
+
+      await pauseScheduledTask(taskId)
+      const result = await pauseScheduledTask(taskId)
+      expect(result).toBe(false)
+    })
+
+    it('returns false for cancelled tasks', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Test',
+      })
+
+      await cancelScheduledTask(taskId)
+      const result = await pauseScheduledTask(taskId)
+      expect(result).toBe(false)
+    })
+
+    it('returns false for nonexistent tasks', async () => {
+      const result = await pauseScheduledTask('nonexistent-id')
+      expect(result).toBe(false)
+    })
+  })
+
+  // ============================================================================
+  // resumeScheduledTask Tests
+  // ============================================================================
+
+  describe('resumeScheduledTask', () => {
+    it('sets status back to pending', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Test',
+      })
+
+      await pauseScheduledTask(taskId)
+      const result = await resumeScheduledTask(taskId)
+      expect(result).toBe(true)
+
+      const task = await getScheduledTask(taskId)
+      expect(task!.status).toBe('pending')
+    })
+
+    it('preserves original nextExecutionAt', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 2 hours',
+        prompt: 'Test',
+      })
+
+      const original = await getScheduledTask(taskId)
+      await pauseScheduledTask(taskId)
+
+      vi.setSystemTime(new Date('2024-06-15T13:00:00.000Z'))
+
+      await resumeScheduledTask(taskId)
+      const resumed = await getScheduledTask(taskId)
+      expect(resumed!.nextExecutionAt.getTime()).toBe(original!.nextExecutionAt.getTime())
+    })
+
+    it('returns false for pending tasks', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Test',
+      })
+
+      const result = await resumeScheduledTask(taskId)
+      expect(result).toBe(false)
+    })
+
+    it('returns false for nonexistent tasks', async () => {
+      const result = await resumeScheduledTask('nonexistent-id')
       expect(result).toBe(false)
     })
   })

--- a/src/shared/lib/services/scheduled-task-service.test.ts
+++ b/src/shared/lib/services/scheduled-task-service.test.ts
@@ -211,22 +211,22 @@ describe('scheduled-task-service', () => {
     it('returns pending and paused tasks', async () => {
       const id1 = await createScheduledTask({
         agentSlug: 'test-agent',
-        scheduleType: 'at',
-        scheduleExpression: 'at now + 1 hour',
+        scheduleType: 'cron',
+        scheduleExpression: '0 * * * *',
         prompt: 'Pending',
       })
 
       const id2 = await createScheduledTask({
         agentSlug: 'test-agent',
-        scheduleType: 'at',
-        scheduleExpression: 'at now + 2 hours',
+        scheduleType: 'cron',
+        scheduleExpression: '30 * * * *',
         prompt: 'Will be paused',
       })
 
       const id3 = await createScheduledTask({
         agentSlug: 'test-agent',
-        scheduleType: 'at',
-        scheduleExpression: 'at now + 3 hours',
+        scheduleType: 'cron',
+        scheduleExpression: '45 * * * *',
         prompt: 'Will be cancelled',
       })
 
@@ -308,15 +308,15 @@ describe('scheduled-task-service', () => {
     it('does not return paused tasks', async () => {
       const taskId = await createScheduledTask({
         agentSlug: 'test-agent',
-        scheduleType: 'at',
-        scheduleExpression: 'at now + 30 minutes',
+        scheduleType: 'cron',
+        scheduleExpression: '30 12 * * *',
         prompt: 'Paused task',
       })
 
       await pauseScheduledTask(taskId)
 
-      // Advance time
-      vi.setSystemTime(new Date('2024-06-15T13:00:00.000Z'))
+      // Advance time past next execution
+      vi.setSystemTime(new Date('2024-06-16T13:00:00.000Z'))
 
       const dueTasks = await getDueTasks()
       expect(dueTasks).toHaveLength(0)
@@ -380,8 +380,8 @@ describe('scheduled-task-service', () => {
     it('cancels a paused task', async () => {
       const taskId = await createScheduledTask({
         agentSlug: 'test-agent',
-        scheduleType: 'at',
-        scheduleExpression: 'at now + 1 hour',
+        scheduleType: 'cron',
+        scheduleExpression: '0 * * * *',
         prompt: 'Test',
       })
 
@@ -404,50 +404,66 @@ describe('scheduled-task-service', () => {
   // ============================================================================
 
   describe('pauseScheduledTask', () => {
-    it('sets status to paused', async () => {
+    it('pauses a recurring task', async () => {
       const taskId = await createScheduledTask({
         agentSlug: 'test-agent',
-        scheduleType: 'at',
-        scheduleExpression: 'at now + 1 hour',
+        scheduleType: 'cron',
+        scheduleExpression: '0 * * * *',
         prompt: 'Test',
       })
 
       const result = await pauseScheduledTask(taskId)
-      expect(result).toBe(true)
+      expect(result.success).toBe(true)
 
       const task = await getScheduledTask(taskId)
       expect(task!.status).toBe('paused')
     })
 
-    it('returns false for already paused tasks', async () => {
+    it('rejects pausing a one-time task', async () => {
       const taskId = await createScheduledTask({
         agentSlug: 'test-agent',
         scheduleType: 'at',
         scheduleExpression: 'at now + 1 hour',
+        prompt: 'Test',
+      })
+
+      const result = await pauseScheduledTask(taskId)
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('one-time')
+
+      const task = await getScheduledTask(taskId)
+      expect(task!.status).toBe('pending')
+    })
+
+    it('returns error for already paused tasks', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'cron',
+        scheduleExpression: '0 * * * *',
         prompt: 'Test',
       })
 
       await pauseScheduledTask(taskId)
       const result = await pauseScheduledTask(taskId)
-      expect(result).toBe(false)
+      expect(result.success).toBe(false)
     })
 
-    it('returns false for cancelled tasks', async () => {
+    it('returns error for cancelled tasks', async () => {
       const taskId = await createScheduledTask({
         agentSlug: 'test-agent',
-        scheduleType: 'at',
-        scheduleExpression: 'at now + 1 hour',
+        scheduleType: 'cron',
+        scheduleExpression: '0 * * * *',
         prompt: 'Test',
       })
 
       await cancelScheduledTask(taskId)
       const result = await pauseScheduledTask(taskId)
-      expect(result).toBe(false)
+      expect(result.success).toBe(false)
     })
 
-    it('returns false for nonexistent tasks', async () => {
+    it('returns error for nonexistent tasks', async () => {
       const result = await pauseScheduledTask('nonexistent-id')
-      expect(result).toBe(false)
+      expect(result.success).toBe(false)
     })
   })
 
@@ -456,17 +472,17 @@ describe('scheduled-task-service', () => {
   // ============================================================================
 
   describe('resumeScheduledTask', () => {
-    it('sets status back to pending', async () => {
+    it('resumes a paused recurring task back to pending', async () => {
       const taskId = await createScheduledTask({
         agentSlug: 'test-agent',
-        scheduleType: 'at',
-        scheduleExpression: 'at now + 1 hour',
+        scheduleType: 'cron',
+        scheduleExpression: '0 * * * *',
         prompt: 'Test',
       })
 
       await pauseScheduledTask(taskId)
       const result = await resumeScheduledTask(taskId)
-      expect(result).toBe(true)
+      expect(result.success).toBe(true)
 
       const task = await getScheduledTask(taskId)
       expect(task!.status).toBe('pending')
@@ -475,8 +491,8 @@ describe('scheduled-task-service', () => {
     it('preserves original nextExecutionAt', async () => {
       const taskId = await createScheduledTask({
         agentSlug: 'test-agent',
-        scheduleType: 'at',
-        scheduleExpression: 'at now + 2 hours',
+        scheduleType: 'cron',
+        scheduleExpression: '0 * * * *',
         prompt: 'Test',
       })
 
@@ -490,7 +506,7 @@ describe('scheduled-task-service', () => {
       expect(resumed!.nextExecutionAt.getTime()).toBe(original!.nextExecutionAt.getTime())
     })
 
-    it('returns false for pending tasks', async () => {
+    it('rejects resuming a one-time task', async () => {
       const taskId = await createScheduledTask({
         agentSlug: 'test-agent',
         scheduleType: 'at',
@@ -499,12 +515,25 @@ describe('scheduled-task-service', () => {
       })
 
       const result = await resumeScheduledTask(taskId)
-      expect(result).toBe(false)
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('one-time')
     })
 
-    it('returns false for nonexistent tasks', async () => {
+    it('returns error for pending tasks', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'cron',
+        scheduleExpression: '0 * * * *',
+        prompt: 'Test',
+      })
+
+      const result = await resumeScheduledTask(taskId)
+      expect(result.success).toBe(false)
+    })
+
+    it('returns error for nonexistent tasks', async () => {
       const result = await resumeScheduledTask('nonexistent-id')
-      expect(result).toBe(false)
+      expect(result.success).toBe(false)
     })
   })
 

--- a/src/shared/lib/services/scheduled-task-service.ts
+++ b/src/shared/lib/services/scheduled-task-service.ts
@@ -175,9 +175,15 @@ export async function cancelScheduledTask(taskId: string): Promise<boolean> {
 }
 
 /**
- * Pause a scheduled task (keeps schedule, stops execution until resumed)
+ * Pause a recurring scheduled task (keeps schedule, stops execution until resumed).
+ * One-time tasks cannot be paused — use cancel instead.
  */
-export async function pauseScheduledTask(taskId: string): Promise<boolean> {
+export async function pauseScheduledTask(taskId: string): Promise<{ success: boolean; error?: string }> {
+  const task = await getScheduledTask(taskId)
+  if (!task) return { success: false, error: 'Task not found' }
+  if (!task.isRecurring) return { success: false, error: 'Cannot pause a one-time task. Use cancel instead.' }
+  if (task.status !== 'pending') return { success: false, error: `Task is ${task.status}, only pending tasks can be paused` }
+
   const result = await db
     .update(scheduledTasks)
     .set({
@@ -190,15 +196,18 @@ export async function pauseScheduledTask(taskId: string): Promise<boolean> {
       )
     )
 
-  return (result.changes ?? 0) > 0
+  return { success: (result.changes ?? 0) > 0 }
 }
 
 /**
- * Resume a paused scheduled task back to pending
+ * Resume a paused recurring task back to pending.
+ * One-time tasks cannot be resumed — use cancel instead.
  */
-export async function resumeScheduledTask(taskId: string): Promise<boolean> {
+export async function resumeScheduledTask(taskId: string): Promise<{ success: boolean; error?: string }> {
   const task = await getScheduledTask(taskId)
-  if (!task || task.status !== 'paused') return false
+  if (!task) return { success: false, error: 'Task not found' }
+  if (!task.isRecurring) return { success: false, error: 'Cannot resume a one-time task. Use cancel instead.' }
+  if (task.status !== 'paused') return { success: false, error: `Task is ${task.status}, only paused tasks can be resumed` }
 
   const result = await db
     .update(scheduledTasks)
@@ -210,7 +219,7 @@ export async function resumeScheduledTask(taskId: string): Promise<boolean> {
       )
     )
 
-  return (result.changes ?? 0) > 0
+  return { success: (result.changes ?? 0) > 0 }
 }
 
 /**

--- a/src/shared/lib/services/scheduled-task-service.ts
+++ b/src/shared/lib/services/scheduled-task-service.ts
@@ -7,7 +7,7 @@
 
 import { db } from '@shared/lib/db'
 import { scheduledTasks, type ScheduledTask, type NewScheduledTask } from '@shared/lib/db/schema'
-import { eq, and, lte } from 'drizzle-orm'
+import { eq, and, or, lte } from 'drizzle-orm'
 import { getNextCronTime, parseAtSyntax } from './schedule-parser'
 
 // Re-export the ScheduledTask type for external use
@@ -114,6 +114,24 @@ export async function listPendingScheduledTasks(agentSlug: string): Promise<Sche
 }
 
 /**
+ * List active scheduled tasks for an agent (pending + paused)
+ */
+export async function listActiveScheduledTasks(agentSlug: string): Promise<ScheduledTask[]> {
+  return db
+    .select()
+    .from(scheduledTasks)
+    .where(
+      and(
+        eq(scheduledTasks.agentSlug, agentSlug),
+        or(
+          eq(scheduledTasks.status, 'pending'),
+          eq(scheduledTasks.status, 'paused')
+        )
+      )
+    )
+}
+
+/**
  * Get all tasks that are due for execution
  * (nextExecutionAt <= now and status = 'pending')
  */
@@ -146,7 +164,49 @@ export async function cancelScheduledTask(taskId: string): Promise<boolean> {
     .where(
       and(
         eq(scheduledTasks.id, taskId),
+        or(
+          eq(scheduledTasks.status, 'pending'),
+          eq(scheduledTasks.status, 'paused')
+        )
+      )
+    )
+
+  return (result.changes ?? 0) > 0
+}
+
+/**
+ * Pause a scheduled task (keeps schedule, stops execution until resumed)
+ */
+export async function pauseScheduledTask(taskId: string): Promise<boolean> {
+  const result = await db
+    .update(scheduledTasks)
+    .set({
+      status: 'paused',
+    })
+    .where(
+      and(
+        eq(scheduledTasks.id, taskId),
         eq(scheduledTasks.status, 'pending')
+      )
+    )
+
+  return (result.changes ?? 0) > 0
+}
+
+/**
+ * Resume a paused scheduled task back to pending
+ */
+export async function resumeScheduledTask(taskId: string): Promise<boolean> {
+  const task = await getScheduledTask(taskId)
+  if (!task || task.status !== 'paused') return false
+
+  const result = await db
+    .update(scheduledTasks)
+    .set({ status: 'pending' })
+    .where(
+      and(
+        eq(scheduledTasks.id, taskId),
+        eq(scheduledTasks.status, 'paused')
       )
     )
 

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -229,7 +229,7 @@ export interface ApiScheduledTask {
   scheduleExpression: string
   prompt: string
   name: string | null
-  status: 'pending' | 'executed' | 'cancelled' | 'failed'
+  status: 'pending' | 'paused' | 'executed' | 'cancelled' | 'failed'
   nextExecutionAt: Date
   lastExecutedAt: Date | null
   isRecurring: boolean


### PR DESCRIPTION
## Summary
- Add `paused` status to scheduled tasks schema
- Add `pauseScheduledTask`, `resumeScheduledTask`, `listActiveScheduledTasks` service functions
- Add `POST /api/scheduled-tasks/:taskId/pause` and `/resume` API endpoints
- Update sidebar to show paused tasks with Pause icon and reduced opacity
- Add pause/resume buttons to scheduled task detail view
- Add unit tests for pause, resume, cancel-paused, listActive

## Test plan
- [x] 33 unit tests passing
- [ ] Verify pause button appears for pending tasks in task detail view
- [ ] Verify resume button appears for paused tasks
- [ ] Verify paused tasks show with Pause icon in sidebar


Made with [Cursor](https://cursor.com)