### PR TITLE
fix: scheduled task locks input box across all sessions

### DIFF
--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -141,6 +141,7 @@ function getOrCreateEventSource(
       }
       else if (data.type === 'session_active') {
         // Session became active - user sent a message
+        if (data.sessionId && data.sessionId !== sessionId) return
         streamStates.set(sessionId, {
           isActive: true,
           isStreaming: current?.isStreaming ?? false,
@@ -166,6 +167,7 @@ function getOrCreateEventSource(
         // (isStreamingMessagePersisted in MessageList handles deduplication)
         // Clear streamingToolUse - if the tool was persisted, ToolCallItem renders it;
         // if it wasn't (interrupted mid-stream), it should disappear.
+        if (data.sessionId && data.sessionId !== sessionId) return
         streamStates.set(sessionId, {
           isActive: false,
           isStreaming: false,


### PR DESCRIPTION
## Summary

When a scheduled task fires, `session_active` is broadcast globally via SSE. The frontend didn't filter by `sessionId`, so every open session's input box got locked — even across different agents.

**Fix:** Skip `session_active` / `session_idle` events when `data.sessionId` doesn't match the current session. One file, two lines.


Made with [Cursor](https://cursor.com)