### PR TITLE
Feat: Add UI + agent tool for requesting user browser input

### DIFF
--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -410,6 +410,7 @@ export class ClaudeCodeProcess extends EventEmitter {
               'mcp__browser__browser_get_state',
               'WebSearch',
               'Read',
+              'mcp__user-input__request_browser_input',
             ],
             prompt: WEB_BROWSER_AGENT_PROMPT,
             maxTurns: 500,
@@ -457,6 +458,13 @@ export class ClaudeCodeProcess extends EventEmitter {
                 message: error instanceof Error ? error.message : 'User declined to answer',
               };
             }
+          }
+
+          // For MCP user-input tools called by subagents, set the toolUseId
+          // so the tool handler can consume it. PreToolUse hooks may not fire
+          // for subagent tool calls, so we set it here as well.
+          if (toolName.startsWith('mcp__user-input__') && options.toolUseID) {
+            inputManager.setCurrentToolUseId(options.toolUseID);
           }
 
           // Auto-approve other tools (we're in bypassPermissions mode)

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -463,6 +463,11 @@ export class ClaudeCodeProcess extends EventEmitter {
           // For MCP user-input tools called by subagents, set the toolUseId
           // so the tool handler can consume it. PreToolUse hooks may not fire
           // for subagent tool calls, so we set it here as well.
+          // TODO: Race condition — if both canUseTool and PreToolUse fire for
+          // the same tool call, the last write wins (setCurrentToolUseId is
+          // not additive). This is acceptable because they write the same ID,
+          // but if two user-input tools fire concurrently the first ID could
+          // be overwritten before consumeCurrentToolUseId is called.
           if (toolName.startsWith('mcp__user-input__') && options.toolUseID) {
             inputManager.setCurrentToolUseId(options.toolUseID);
           }

--- a/agent-container/src/mcp-server.ts
+++ b/agent-container/src/mcp-server.ts
@@ -14,6 +14,7 @@ import { searchRemoteMcpServicesTool } from './tools/search-remote-mcp-services'
 import { scheduleTaskTool } from './tools/schedule-task'
 import { deliverFileTool } from './tools/deliver-file'
 import { requestFileTool } from './tools/request-file'
+import { requestBrowserInputTool } from './tools/request-browser-input'
 import { browserTools } from './tools/browser'
 import { createDashboardTool } from './tools/create-dashboard'
 import { startDashboardTool } from './tools/start-dashboard'
@@ -31,7 +32,7 @@ export function createUserInputMcpServer() {
   return createSdkMcpServer({
     name: 'user-input',
     version: '1.0.0',
-    tools: [requestSecretTool, requestConnectedAccountTool, searchConnectedAccountServicesTool, requestRemoteMcpTool, searchRemoteMcpServicesTool, scheduleTaskTool, deliverFileTool, requestFileTool],
+    tools: [requestSecretTool, requestConnectedAccountTool, searchConnectedAccountServicesTool, requestRemoteMcpTool, searchRemoteMcpServicesTool, scheduleTaskTool, deliverFileTool, requestFileTool, requestBrowserInputTool],
   })
 }
 

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -307,7 +307,7 @@ The web-browser agent:
 - Has full access to all browser interaction tools (click, fill, scroll, screenshot, etc.)
 - Will NOT close the browser — you manage the lifecycle
 - Will ALWAYS report the current URL when it finishes
-- If it encounters a login page or CAPTCHA, it will report the obstacle so you can ask the user to help
+- If it encounters a login page, CAPTCHA, or 2FA, it will automatically call `request_browser_input` to prompt the user — no action needed from you
 
 ### Workflow
 1. **Use WebSearch** if you are unsure about the URL or need to find the correct page (e.g., search for "ExampleCorp contact page" to find the URL for contacting support)
@@ -319,7 +319,7 @@ The web-browser agent:
 
 ### Tips
 - The browser state persists between delegations — you can chain multiple tasks
-- If the agent reports a login/CAPTCHA, ask the user to interact with the browser directly (they can see it live), then re-delegate
+- The web-browser agent will automatically prompt the user via `request_browser_input` if it hits a login/CAPTCHA/2FA. If you're browsing directly (via `browser_get_state()`) and encounter one yourself, call `mcp__user-input__request_browser_input` to prompt the user.
 - Track the URLs reported by the agent so you know where the browser is
 - Remember to close the browser when you're done to free resources
 - Downloads triggered in the browser will be saved to `/workspace/downloads/`

--- a/agent-container/src/tools/request-browser-input.ts
+++ b/agent-container/src/tools/request-browser-input.ts
@@ -15,7 +15,7 @@ Example:
     message: z.string().describe(
       'Informal message explaining what you need the user to do (e.g., "Hey, I need you to enter your password")'
     ),
-    requirements: z.array(z.string()).optional().describe(
+    requirements: z.array(z.string()).default([]).describe(
       'Optional formal list of specific actions the user should complete'
     ),
   },
@@ -35,7 +35,7 @@ Example:
     try {
       await inputManager.createPendingWithType(toolUseId, 'browser_input', {
         message: args.message,
-        requirements: args.requirements || [],
+        requirements: args.requirements,
       })
 
       return {

--- a/agent-container/src/tools/request-browser-input.ts
+++ b/agent-container/src/tools/request-browser-input.ts
@@ -1,0 +1,54 @@
+import { tool } from '@anthropic-ai/claude-agent-sdk'
+import { z } from 'zod'
+import { inputManager } from '../input-manager'
+
+export const requestBrowserInputTool = tool(
+  'request_browser_input',
+  `Request the user to manually interact with the browser. You MUST call this tool whenever you encounter a login page, CAPTCHA, 2FA challenge, password prompt, cookie consent, or any other obstacle that requires manual user interaction. Do NOT just describe the obstacle in chat — always use this tool.
+
+The user will see your message and requirements in the UI alongside the browser preview. The tool blocks until the user clicks "Complete" or chooses to chat with you instead. After the user completes, take a browser snapshot to see the current state.
+
+Example:
+- message: "I need you to log in to your bank account"
+- requirements: ["Navigate to the login page", "Enter your credentials", "Complete 2FA if prompted"]`,
+  {
+    message: z.string().describe(
+      'Informal message explaining what you need the user to do (e.g., "Hey, I need you to enter your password")'
+    ),
+    requirements: z.array(z.string()).optional().describe(
+      'Optional formal list of specific actions the user should complete'
+    ),
+  },
+  async (args) => {
+    console.log(`[request_browser_input] Requesting browser input: ${args.message}`)
+
+    const toolUseId = inputManager.consumeCurrentToolUseId()
+
+    if (!toolUseId) {
+      console.error('[request_browser_input] No toolUseId available')
+      return {
+        content: [{ type: 'text' as const, text: 'Unable to process browser input request - no tool use ID available.' }],
+        isError: true,
+      }
+    }
+
+    try {
+      await inputManager.createPendingWithType(toolUseId, 'browser_input', {
+        message: args.message,
+        requirements: args.requirements || [],
+      })
+
+      return {
+        content: [{ type: 'text' as const, text: 'User has completed the requested browser interaction. Take a browser snapshot to see the current state.' }],
+      }
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      console.log(`[request_browser_input] Request failed: ${errorMessage}`)
+
+      return {
+        content: [{ type: 'text' as const, text: `Browser input request cancelled: ${errorMessage}. The user may want to discuss the task with you.` }],
+        isError: true,
+      }
+    }
+  }
+)

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -46,7 +46,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 - **NEVER close the browser.** You do not have the browser_close tool. The parent agent manages browser lifecycle.
 - **ALWAYS report the current URL when you finish.** Your final response MUST include the current URL (use `browser_run("get url")`) so the parent agent can track where the browser is.
 - **Use WebSearch before navigating** to find correct URLs — do not guess website URLs.
-- **When you encounter a login page, CAPTCHA, or sensitive action:** Stop and clearly explain what you see and what the user needs to do. The user can see and interact with the browser live in their UI.
+- **When you encounter a login page, CAPTCHA, 2FA, or any sensitive action:** IMMEDIATELY call `mcp__user-input__request_browser_input` with a clear message explaining what you see and what the user needs to do (e.g., log in, solve CAPTCHA, complete 2FA). Include specific requirements as a list. Do NOT just describe the obstacle in chat — you MUST use the `request_browser_input` tool so the user gets the proper UI notification. After the user completes, take a snapshot to see the updated state.
 - Use interactive + compact snapshot to reduce output — you usually only need buttons, links, inputs.
 - Use `browser_screenshot()` when you need to visually verify something the accessibility tree cannot tell you.
 - If a page has not fully rendered dynamic content, re-snapshot after a moment.

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1650,6 +1650,15 @@ agents.post('/:id/sessions/:sessionId/complete-browser-input', AgentUser(), asyn
         return c.json({ error: 'Failed to reject browser input request' }, 500)
       }
 
+      // Interrupt the session so the user can chat directly with the agent
+      const sessionId = c.req.param('sessionId')
+      try {
+        await client.interruptSession(sessionId)
+      } catch (e) {
+        console.error(`[complete-browser-input] Failed to interrupt session: ${e}`)
+      }
+      await messagePersister.markSessionInterrupted(sessionId)
+
       trackServerEvent('request_declined', { type: 'browser_input', withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1613,6 +1613,76 @@ agents.post('/:id/sessions/:sessionId/answer-question', AgentUser(), async (c) =
   }
 })
 
+// POST /api/agents/:id/sessions/:sessionId/complete-browser-input - Complete or cancel a browser input request
+agents.post('/:id/sessions/:sessionId/complete-browser-input', AgentUser(), async (c) => {
+  try {
+    const agentSlug = c.req.param('id')
+    const body = await c.req.json()
+    const { toolUseId, decline, declineReason } = body
+
+    if (!toolUseId) {
+      return c.json({ error: 'toolUseId is required' }, 400)
+    }
+
+    const client = containerManager.getClient(agentSlug)
+
+    if (decline) {
+      const reason = declineReason || 'User wants to chat with the agent'
+
+      const rejectResponse = await client.fetch(
+        `/inputs/${encodeURIComponent(toolUseId)}/reject`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reason }),
+        }
+      )
+
+      if (!rejectResponse.ok) {
+        let errorDetails = 'Unknown error'
+        try {
+          const error = await rejectResponse.json()
+          errorDetails = JSON.stringify(error)
+        } catch {
+          errorDetails = await rejectResponse.text()
+        }
+        console.error(`[complete-browser-input] Failed to reject: ${errorDetails}`)
+        return c.json({ error: 'Failed to reject browser input request' }, 500)
+      }
+
+      trackServerEvent('request_declined', { type: 'browser_input', withReason: !!declineReason })
+      return c.json({ success: true, declined: true })
+    }
+
+    // User completed the browser interaction
+    const resolveResponse = await client.fetch(
+      `/inputs/${encodeURIComponent(toolUseId)}/resolve`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: 'completed' }),
+      }
+    )
+
+    if (!resolveResponse.ok) {
+      let errorDetails = 'Unknown error'
+      try {
+        const error = await resolveResponse.json()
+        errorDetails = JSON.stringify(error)
+      } catch {
+        errorDetails = await resolveResponse.text()
+      }
+      console.error(`[complete-browser-input] Failed to resolve: ${errorDetails}`)
+      return c.json({ error: 'Failed to complete browser input request' }, 500)
+    }
+
+    return c.json({ success: true })
+  } catch (error) {
+    console.error('Failed to complete browser input:', error)
+    return c.json({ error: 'Failed to complete browser input' }, 500)
+  }
+})
+
 // GET /api/agents/:id/scheduled-tasks - List scheduled tasks for an agent
 agents.get('/:id/scheduled-tasks', AgentRead(), async (c) => {
   try {

--- a/src/renderer/components/browser/browser-preview.tsx
+++ b/src/renderer/components/browser/browser-preview.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { Globe, ChevronUp, ChevronDown, X } from 'lucide-react'
+import { Globe, ChevronUp, ChevronDown, X, MousePointerClick } from 'lucide-react'
 import { getApiBaseUrl } from '@renderer/lib/env'
-import { clearBrowserActive } from '@renderer/hooks/use-message-stream'
+import { clearBrowserActive, useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useUser } from '@renderer/context/user-context'
+import { cn } from '@shared/lib/utils/cn'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -45,6 +46,15 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
   const [showCloseWarning, setShowCloseWarning] = useState(false)
   const [isClosing, setIsClosing] = useState(false)
   const [aspectRatio, setAspectRatio] = useState('16 / 9')
+  const [overlayDismissedForId, setOverlayDismissedForId] = useState<string | null>(null)
+
+  const { pendingBrowserInputRequests } = useMessageStream(sessionId, agentSlug)
+  const needsAttention = browserActive && pendingBrowserInputRequests.length > 0 && !isViewOnly
+  const latestRequestId = pendingBrowserInputRequests.length > 0
+    ? pendingBrowserInputRequests[pendingBrowserInputRequests.length - 1].toolUseId
+    : null
+  const showOverlay = needsAttention && overlayDismissedForId !== latestRequestId && expanded
+
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const wsRef = useRef<WebSocket | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -272,6 +282,13 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
     }
   }, [browserActive])
 
+  // Reset overlay dismiss state when attention state ends (agent resumed)
+  useEffect(() => {
+    if (!needsAttention) {
+      setOverlayDismissedForId(null)
+    }
+  }, [needsAttention])
+
   // --- Canvas input handlers ---
   const mapCoordinates = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -483,7 +500,10 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
     <div
       ref={containerRef}
       style={floatStyle}
-      className="flex flex-col rounded-lg border bg-background shadow-lg overflow-visible"
+      className={cn(
+        "flex flex-col rounded-lg border bg-background shadow-lg overflow-visible",
+        needsAttention && "ring-2 ring-blue-400 dark:ring-blue-500"
+      )}
     >
       {/* Drag handle / header bar */}
       <div
@@ -493,9 +513,19 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
         onPointerMove={handleDragMove}
         onPointerUp={handleDragEnd}
       >
+        {needsAttention && (
+          <span className="relative flex h-2 w-2">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500"></span>
+          </span>
+        )}
         <Globe className="h-3.5 w-3.5 shrink-0" />
         <span className="flex-1 text-xs truncate">
-          Browser{connected ? '' : ' (connecting...)'}
+          {needsAttention ? (
+            <span className="text-blue-600 dark:text-blue-400 font-medium">Input needed</span>
+          ) : (
+            <>Browser{connected ? '' : ' (connecting...)'}</>
+          )}
         </span>
         <button
           className="p-0.5 rounded hover:bg-muted transition-colors"
@@ -540,7 +570,20 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
               <span className="text-white text-xs">Connecting to browser stream...</span>
             </div>
           )}
-
+          {showOverlay && (
+            <div
+              className="absolute inset-0 flex flex-col items-center justify-center bg-black/40 backdrop-blur-sm cursor-pointer z-10 transition-opacity duration-300"
+              onClick={() => setOverlayDismissedForId(latestRequestId)}
+            >
+              <span className="relative flex h-3 w-3 mb-2">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
+                <span className="relative inline-flex rounded-full h-3 w-3 bg-blue-500"></span>
+              </span>
+              <span className="text-white text-sm font-medium mb-3">Your input needed</span>
+              <MousePointerClick className="h-6 w-6 text-white animate-pulse" />
+              <span className="text-white/70 text-xs mt-1">Click to interact</span>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/renderer/components/messages/browser-input-request-item.tsx
+++ b/src/renderer/components/messages/browser-input-request-item.tsx
@@ -14,6 +14,7 @@ interface BrowserInputRequestItemProps {
   onComplete: () => void
 }
 
+type SubmittingAction = 'completing' | 'declining'
 type RequestStatus = 'pending' | 'submitting' | 'completed' | 'declined'
 
 export function BrowserInputRequestItem({
@@ -26,10 +27,12 @@ export function BrowserInputRequestItem({
   onComplete,
 }: BrowserInputRequestItemProps) {
   const [status, setStatus] = useState<RequestStatus>('pending')
+  const [submittingAction, setSubmittingAction] = useState<SubmittingAction | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  const submitBrowserInput = async (body: object, successStatus: RequestStatus) => {
+  const submitBrowserInput = async (body: object, successStatus: RequestStatus, action: SubmittingAction) => {
     setStatus('submitting')
+    setSubmittingAction(action)
     setError(null)
 
     try {
@@ -52,15 +55,17 @@ export function BrowserInputRequestItem({
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Request failed')
       setStatus('pending')
+      setSubmittingAction(null)
     }
   }
 
-  const handleComplete = () => submitBrowserInput({ toolUseId }, 'completed')
+  const handleComplete = () => submitBrowserInput({ toolUseId }, 'completed', 'completing')
 
   const handleChatWithAgent = () =>
     submitBrowserInput(
       { toolUseId, decline: true, declineReason: 'User wants to chat with the agent' },
-      'declined'
+      'declined',
+      'declining'
     )
 
   if (status === 'completed' || status === 'declined') {
@@ -138,7 +143,7 @@ export function BrowserInputRequestItem({
               className="bg-blue-600 hover:bg-blue-700 text-white"
               data-testid="browser-input-complete-btn"
             >
-              {status === 'submitting' ? (
+              {submittingAction === 'completing' ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
                 <Check className="h-4 w-4" />
@@ -154,7 +159,11 @@ export function BrowserInputRequestItem({
               className="border-blue-200 dark:border-blue-700 text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900"
               data-testid="browser-input-chat-btn"
             >
-              <MessageSquare className="h-4 w-4" />
+              {submittingAction === 'declining' ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <MessageSquare className="h-4 w-4" />
+              )}
               <span className="ml-1">Chat with agent</span>
             </Button>
           </div>

--- a/src/renderer/components/messages/browser-input-request-item.tsx
+++ b/src/renderer/components/messages/browser-input-request-item.tsx
@@ -1,0 +1,167 @@
+import { apiFetch } from '@renderer/lib/api'
+import { useState } from 'react'
+import { Globe, Check, Loader2, MessageSquare } from 'lucide-react'
+import { Button } from '@renderer/components/ui/button'
+import { cn } from '@shared/lib/utils/cn'
+
+interface BrowserInputRequestItemProps {
+  toolUseId: string
+  message: string
+  requirements: string[]
+  sessionId: string
+  agentSlug: string
+  readOnly?: boolean
+  onComplete: () => void
+}
+
+type RequestStatus = 'pending' | 'submitting' | 'completed' | 'declined'
+
+export function BrowserInputRequestItem({
+  toolUseId,
+  message,
+  requirements,
+  sessionId,
+  agentSlug,
+  readOnly,
+  onComplete,
+}: BrowserInputRequestItemProps) {
+  const [status, setStatus] = useState<RequestStatus>('pending')
+  const [error, setError] = useState<string | null>(null)
+
+  const submitBrowserInput = async (body: object, successStatus: RequestStatus) => {
+    setStatus('submitting')
+    setError(null)
+
+    try {
+      const response = await apiFetch(
+        `/api/agents/${agentSlug}/sessions/${sessionId}/complete-browser-input`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        }
+      )
+
+      if (!response.ok) {
+        const data = await response.json()
+        throw new Error(data.error || 'Request failed')
+      }
+
+      setStatus(successStatus)
+      onComplete()
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Request failed')
+      setStatus('pending')
+    }
+  }
+
+  const handleComplete = () => submitBrowserInput({ toolUseId }, 'completed')
+
+  const handleChatWithAgent = () =>
+    submitBrowserInput(
+      { toolUseId, decline: true, declineReason: 'User wants to chat with the agent' },
+      'declined'
+    )
+
+  if (status === 'completed' || status === 'declined') {
+    return (
+      <div className="border rounded-md bg-muted/30 text-sm" data-testid="browser-input-request-completed" data-status={status}>
+        <div className="flex items-center gap-2 px-3 py-2">
+          <Globe
+            className={cn(
+              'h-4 w-4 shrink-0',
+              status === 'completed' ? 'text-green-500' : 'text-red-500'
+            )}
+          />
+          <span className="text-sm">Browser Input</span>
+          <span
+            className={cn(
+              'ml-auto text-xs',
+              status === 'completed' ? 'text-green-600' : 'text-red-600'
+            )}
+          >
+            {status === 'completed' ? 'Completed' : 'Cancelled'}
+          </span>
+        </div>
+      </div>
+    )
+  }
+
+  if (readOnly) {
+    return (
+      <div className="border rounded-md bg-blue-50 dark:bg-blue-950/50 border-blue-200 dark:border-blue-800 text-sm">
+        <div className="flex items-center gap-3 p-3">
+          <div className="h-8 w-8 rounded-full bg-blue-100 dark:bg-blue-900 flex items-center justify-center shrink-0">
+            <Globe className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="font-medium text-blue-900 dark:text-blue-100">Browser Input Needed</div>
+            <div className="text-xs text-blue-700 dark:text-blue-300 mt-0.5">{message}</div>
+          </div>
+          <span className="text-xs text-blue-600 dark:text-blue-400 shrink-0">Waiting for input</span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="border rounded-md bg-blue-50 dark:bg-blue-950/50 border-blue-200 dark:border-blue-800 text-sm" data-testid="browser-input-request">
+      <div className="flex items-start gap-3 p-3">
+        <div className="h-8 w-8 rounded-full bg-blue-100 dark:bg-blue-900 flex items-center justify-center shrink-0">
+          <Globe className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+        </div>
+
+        <div className="flex-1 min-w-0 space-y-3">
+          <div className="font-medium text-blue-900 dark:text-blue-100">Browser Input Needed</div>
+
+          <p className="text-blue-800 dark:text-blue-200">{message}</p>
+
+          {requirements.length > 0 && (
+            <div className="rounded-md bg-blue-100/50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 p-3 space-y-2">
+              <div className="text-xs font-medium text-blue-700 dark:text-blue-300 uppercase tracking-wide">Requirements</div>
+              <ul className="space-y-1.5">
+                {requirements.map((req, i) => (
+                  <li key={i} className="flex items-start gap-2 text-blue-800 dark:text-blue-200">
+                    <span className="text-blue-500 mt-0.5 shrink-0 text-xs">{i + 1}.</span>
+                    <span>{req}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            <Button
+              onClick={handleComplete}
+              disabled={status === 'submitting'}
+              size="sm"
+              className="bg-blue-600 hover:bg-blue-700 text-white"
+              data-testid="browser-input-complete-btn"
+            >
+              {status === 'submitting' ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Check className="h-4 w-4" />
+              )}
+              <span className="ml-1">Complete</span>
+            </Button>
+
+            <Button
+              onClick={handleChatWithAgent}
+              disabled={status === 'submitting'}
+              size="sm"
+              variant="outline"
+              className="border-blue-200 dark:border-blue-700 text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900"
+              data-testid="browser-input-chat-btn"
+            >
+              <MessageSquare className="h-4 w-4" />
+              <span className="ml-1">Chat with agent</span>
+            </Button>
+          </div>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -28,12 +28,14 @@ const mockStreamState = {
   streamingMessage: null as string | null,
   streamingToolUse: null as { id: string; name: string; partialInput: string } | null,
   isCompacting: false,
-  activeSubagent: null,
+  activeSubagents: new Map(),
+  completedSubagents: new Map(),
   pendingSecretRequests: [] as Array<{ toolUseId: string; secretName: string; reason?: string }>,
   pendingConnectedAccountRequests: [] as any[],
   pendingRemoteMcpRequests: [] as any[],
   pendingQuestionRequests: [] as any[],
   pendingFileRequests: [] as any[],
+  pendingBrowserInputRequests: [] as any[],
 }
 
 const mockClearCompacting = vi.fn()
@@ -45,6 +47,7 @@ vi.mock('@renderer/hooks/use-message-stream', () => ({
   removeRemoteMcpRequest: vi.fn(),
   removeQuestionRequest: vi.fn(),
   removeFileRequest: vi.fn(),
+  removeBrowserInputRequest: vi.fn(),
   clearCompacting: (...args: unknown[]) => mockClearCompacting(...args),
 }))
 
@@ -114,12 +117,14 @@ describe('MessageList', () => {
       streamingMessage: null,
       streamingToolUse: null,
       isCompacting: false,
-      activeSubagent: null,
+      activeSubagents: new Map(),
+      completedSubagents: new Map(),
       pendingSecretRequests: [],
       pendingConnectedAccountRequests: [],
       pendingRemoteMcpRequests: [],
       pendingQuestionRequests: [],
       pendingFileRequests: [],
+      pendingBrowserInputRequests: [],
     })
   })
 

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -7,6 +7,7 @@ import {
   removeRemoteMcpRequest,
   removeQuestionRequest,
   removeFileRequest,
+  removeBrowserInputRequest,
   clearCompacting,
 } from '@renderer/hooks/use-message-stream'
 import { MessageItem } from './message-item'
@@ -17,6 +18,7 @@ import { ConnectedAccountRequestItem } from './connected-account-request-item'
 import { RemoteMcpRequestItem } from './remote-mcp-request-item'
 import { QuestionRequestItem } from './question-request-item'
 import { FileRequestItem } from './file-request-item'
+import { BrowserInputRequestItem } from './browser-input-request-item'
 import { Loader2, Wrench, WifiOff } from 'lucide-react'
 import { FileDownloadPill } from '@renderer/components/ui/file-download-pill'
 import { useIsOnline } from '@renderer/context/connectivity-context'
@@ -101,6 +103,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, onPendin
     pendingRemoteMcpRequests: sseRemoteMcpRequests,
     pendingQuestionRequests: sseQuestionRequests,
     pendingFileRequests: sseFileRequests,
+    pendingBrowserInputRequests: sseBrowserInputRequests,
   } = useMessageStream(sessionId, agentSlug)
   const isOnline = useIsOnline()
 
@@ -121,8 +124,9 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, onPendin
     }[] = []
     const fileRequests: { toolUseId: string; description: string; fileTypes?: string }[] = []
     const remoteMcpRequests: { toolUseId: string; url: string; name?: string; reason?: string; authHint?: 'oauth' | 'bearer' }[] = []
+    const browserInputRequests: { toolUseId: string; message: string; requirements: string[] }[] = []
 
-    if (!messages) return { secretRequests, connectedAccountRequests, questionRequests, fileRequests, remoteMcpRequests }
+    if (!messages) return { secretRequests, connectedAccountRequests, questionRequests, fileRequests, remoteMcpRequests, browserInputRequests }
 
     for (let i = 0; i < messages.length; i++) {
       const message = messages[i]
@@ -191,11 +195,20 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, onPendin
               fileTypes: input.fileTypes,
             })
           }
+        } else if (toolCall.name === 'mcp__user-input__request_browser_input') {
+          const input = toolCall.input as { message?: string; requirements?: string[] }
+          if (input.message) {
+            browserInputRequests.push({
+              toolUseId: toolCall.id,
+              message: input.message,
+              requirements: input.requirements || [],
+            })
+          }
         }
       }
     }
 
-    return { secretRequests, connectedAccountRequests, questionRequests, fileRequests, remoteMcpRequests }
+    return { secretRequests, connectedAccountRequests, questionRequests, fileRequests, remoteMcpRequests, browserInputRequests }
   }, [messages, pendingUserMessage])
 
   // Track toolUseIds the user has already answered, so that the message-based
@@ -293,6 +306,20 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, onPendin
     return merged
   }, [sseRemoteMcpRequests, messagesBasedPendingRequests.remoteMcpRequests, isActive])
 
+  const pendingBrowserInputRequests = useMemo(() => {
+    const seen = new Set<string>()
+    const merged: { toolUseId: string; message: string; requirements: string[] }[] = []
+
+    const messageBased = isActive ? messagesBasedPendingRequests.browserInputRequests : []
+    for (const req of [...sseBrowserInputRequests, ...messageBased]) {
+      if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
+        seen.add(req.toolUseId)
+        merged.push(req)
+      }
+    }
+    return merged
+  }, [sseBrowserInputRequests, messagesBasedPendingRequests.browserInputRequests, isActive])
+
   const scrollRef = useRef<HTMLDivElement>(null)
   const isScrolledToBottomRef = useRef(true)
 
@@ -363,6 +390,15 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, onPendin
     (toolUseId: string) => {
       dismissedRequestIds.current.add(toolUseId)
       removeFileRequest(sessionId, toolUseId)
+    },
+    [sessionId]
+  )
+
+  // Handler to remove a completed browser input request
+  const handleBrowserInputRequestComplete = useCallback(
+    (toolUseId: string) => {
+      dismissedRequestIds.current.add(toolUseId)
+      removeBrowserInputRequest(sessionId, toolUseId)
     },
     [sessionId]
   )
@@ -516,7 +552,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, onPendin
     if (scrollRef.current && isScrolledToBottomRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight
     }
-  }, [messages, pendingUserMessage, streamingMessage, streamingToolUse, isCompacting, pendingSecretRequests, pendingConnectedAccountRequests, pendingQuestionRequests, pendingFileRequests, pendingRemoteMcpRequests, activeSubagent])
+  }, [messages, pendingUserMessage, streamingMessage, streamingToolUse, isCompacting, pendingSecretRequests, pendingConnectedAccountRequests, pendingQuestionRequests, pendingFileRequests, pendingRemoteMcpRequests, pendingBrowserInputRequests, activeSubagent])
 
   if (isLoading && !pendingUserMessage) {
     return (
@@ -690,6 +726,18 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, onPendin
             agentSlug={agentSlug}
             readOnly={isViewOnly}
             onComplete={() => handleFileRequestComplete(request.toolUseId)}
+          />
+        ))}
+        {pendingBrowserInputRequests.map((request) => (
+          <BrowserInputRequestItem
+            key={request.toolUseId}
+            toolUseId={request.toolUseId}
+            message={request.message}
+            requirements={request.requirements}
+            sessionId={sessionId}
+            agentSlug={agentSlug}
+            readOnly={isViewOnly}
+            onComplete={() => handleBrowserInputRequestComplete(request.toolUseId)}
           />
         ))}
       </div>

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -464,12 +464,13 @@ function getOrCreateEventSource(
         }
       }
       else if (data.type === 'browser_input_request') {
-        const newRequest: BrowserInputRequest = {
-          toolUseId: data.toolUseId,
-          message: data.message,
-          requirements: data.requirements || [],
-        }
-        if (current) {
+        // Dedupe: the server may broadcast the same toolUseId from multiple detection points
+        if (current && !current.pendingBrowserInputRequests.some(r => r.toolUseId === data.toolUseId)) {
+          const newRequest: BrowserInputRequest = {
+            toolUseId: data.toolUseId,
+            message: data.message,
+            requirements: data.requirements || [],
+          }
           streamStates.set(sessionId, {
             ...current,
             pendingBrowserInputRequests: [...current.pendingBrowserInputRequests, newRequest],

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -41,6 +41,12 @@ interface RemoteMcpRequest {
   authHint?: 'oauth' | 'bearer'
 }
 
+interface BrowserInputRequest {
+  toolUseId: string
+  message: string
+  requirements: string[]
+}
+
 export interface SubagentInfo {
   parentToolId: string | null
   agentId: string | null
@@ -58,6 +64,7 @@ interface StreamState {
   pendingQuestionRequests: QuestionRequest[]
   pendingFileRequests: FileRequest[]
   pendingRemoteMcpRequests: RemoteMcpRequest[]
+  pendingBrowserInputRequests: BrowserInputRequest[]
   error: string | null // Error message if session encountered an error
   browserActive: boolean // Whether browser is running for this session
   activeStartTime: number | null // Timestamp when session became active (for elapsed timer)
@@ -120,6 +127,7 @@ function getOrCreateEventSource(
           pendingQuestionRequests: current?.pendingQuestionRequests ?? [],
           pendingFileRequests: current?.pendingFileRequests ?? [],
           pendingRemoteMcpRequests: current?.pendingRemoteMcpRequests ?? [],
+          pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           error: null,
           browserActive: current?.browserActive ?? false,
           activeStartTime: current?.activeStartTime ?? null,
@@ -151,6 +159,7 @@ function getOrCreateEventSource(
           pendingQuestionRequests: current?.pendingQuestionRequests ?? [],
           pendingFileRequests: current?.pendingFileRequests ?? [],
           pendingRemoteMcpRequests: current?.pendingRemoteMcpRequests ?? [],
+          pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           error: null, // Clear any previous error when starting new request
           browserActive: current?.browserActive ?? false,
           activeStartTime: Date.now(),
@@ -176,6 +185,7 @@ function getOrCreateEventSource(
           pendingQuestionRequests: [],
           pendingFileRequests: [],
           pendingRemoteMcpRequests: [],
+          pendingBrowserInputRequests: [],
           error: null,
           browserActive: current?.browserActive ?? false,
           activeStartTime: null,
@@ -198,6 +208,7 @@ function getOrCreateEventSource(
           pendingQuestionRequests: [],
           pendingFileRequests: [],
           pendingRemoteMcpRequests: [],
+          pendingBrowserInputRequests: [],
           error: data.error || 'An unknown error occurred',
           browserActive: current?.browserActive ?? false,
           activeStartTime: null,
@@ -229,6 +240,7 @@ function getOrCreateEventSource(
           pendingQuestionRequests: current?.pendingQuestionRequests ?? [],
           pendingFileRequests: current?.pendingFileRequests ?? [],
           pendingRemoteMcpRequests: current?.pendingRemoteMcpRequests ?? [],
+          pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           error: null,
           browserActive: current?.browserActive ?? false,
           activeStartTime: current?.activeStartTime ?? null,
@@ -248,6 +260,7 @@ function getOrCreateEventSource(
           pendingQuestionRequests: current?.pendingQuestionRequests ?? [],
           pendingFileRequests: current?.pendingFileRequests ?? [],
           pendingRemoteMcpRequests: current?.pendingRemoteMcpRequests ?? [],
+          pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           error: current?.error ?? null,
           browserActive: current?.browserActive ?? false,
           activeStartTime: current?.activeStartTime ?? null,
@@ -271,6 +284,7 @@ function getOrCreateEventSource(
           pendingQuestionRequests: current?.pendingQuestionRequests ?? [],
           pendingFileRequests: current?.pendingFileRequests ?? [],
           pendingRemoteMcpRequests: current?.pendingRemoteMcpRequests ?? [],
+          pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           error: current?.error ?? null,
           browserActive: current?.browserActive ?? false,
           activeStartTime: current?.activeStartTime ?? null,
@@ -291,6 +305,7 @@ function getOrCreateEventSource(
           pendingQuestionRequests: current?.pendingQuestionRequests ?? [],
           pendingFileRequests: current?.pendingFileRequests ?? [],
           pendingRemoteMcpRequests: current?.pendingRemoteMcpRequests ?? [],
+          pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           error: current?.error ?? null,
           browserActive: current?.browserActive ?? false,
           activeStartTime: current?.activeStartTime ?? null,
@@ -310,6 +325,7 @@ function getOrCreateEventSource(
           pendingQuestionRequests: current?.pendingQuestionRequests ?? [],
           pendingFileRequests: current?.pendingFileRequests ?? [],
           pendingRemoteMcpRequests: current?.pendingRemoteMcpRequests ?? [],
+          pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           error: current?.error ?? null,
           browserActive: current?.browserActive ?? false,
           activeStartTime: current?.activeStartTime ?? null,
@@ -417,6 +433,19 @@ function getOrCreateEventSource(
           streamStates.set(sessionId, {
             ...current,
             pendingRemoteMcpRequests: [...current.pendingRemoteMcpRequests, newRequest],
+          })
+        }
+      }
+      else if (data.type === 'browser_input_request') {
+        const newRequest: BrowserInputRequest = {
+          toolUseId: data.toolUseId,
+          message: data.message,
+          requirements: data.requirements || [],
+        }
+        if (current) {
+          streamStates.set(sessionId, {
+            ...current,
+            pendingBrowserInputRequests: [...current.pendingBrowserInputRequests, newRequest],
           })
         }
       }
@@ -670,6 +699,20 @@ export function removeRemoteMcpRequest(sessionId: string, toolUseId: string): vo
   }
 }
 
+// Helper function to remove a browser input request from a session
+export function removeBrowserInputRequest(sessionId: string, toolUseId: string): void {
+  const current = streamStates.get(sessionId)
+  if (current) {
+    streamStates.set(sessionId, {
+      ...current,
+      pendingBrowserInputRequests: current.pendingBrowserInputRequests.filter(
+        (r) => r.toolUseId !== toolUseId
+      ),
+    })
+    streamListeners.get(sessionId)?.forEach((listener) => listener())
+  }
+}
+
 // Helper to clear isCompacting state (used when persisted messages already show the boundary)
 export function clearCompacting(sessionId: string): void {
   const current = streamStates.get(sessionId)
@@ -699,6 +742,7 @@ export function useMessageStream(sessionId: string | null, agentSlug: string | n
     pendingQuestionRequests: [],
     pendingFileRequests: [],
     pendingRemoteMcpRequests: [],
+    pendingBrowserInputRequests: [],
     error: null,
     browserActive: false,
     activeStartTime: null,
@@ -743,6 +787,7 @@ export function useMessageStream(sessionId: string | null, agentSlug: string | n
         pendingQuestionRequests: [],
         pendingFileRequests: [],
         pendingRemoteMcpRequests: [],
+        pendingBrowserInputRequests: [],
         error: null,
         browserActive: false,
         activeStartTime: null,

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -571,6 +571,21 @@ class MessagePersister {
       // Clear streaming text since it's now persisted
       if (content.type === 'assistant') {
         state.subagentCurrentText = ''
+        // Subagent messages arrive as complete messages (not stream events),
+        // so detect browser input requests from the finished tool_use blocks.
+        const messageContent = content.message?.content
+        if (Array.isArray(messageContent)) {
+          for (const block of messageContent) {
+            if (block.type === 'tool_use' && block.name === 'mcp__user-input__request_browser_input') {
+              this.handleBrowserInputRequestTool(
+                sessionId,
+                block.id,
+                JSON.stringify(block.input || {}),
+                state.agentSlug
+              )
+            }
+          }
+        }
       }
       this.broadcastToSSE(sessionId, {
         type: 'subagent_updated',
@@ -705,6 +720,16 @@ class MessagePersister {
 
       case 'content_block_stop':
         if (state.subagentCurrentToolUse) {
+          // Safety net: detect browser input if stream events arrive for subagents
+          if (state.subagentCurrentToolUse.name === 'mcp__user-input__request_browser_input') {
+            this.handleBrowserInputRequestTool(
+              sessionId,
+              state.subagentCurrentToolUse.id,
+              state.subagentCurrentToolInput,
+              state.agentSlug
+            )
+          }
+
           this.broadcastToSSE(sessionId, {
             type: 'subagent_tool_use_ready',
             parentToolId: state.pendingTaskToolId,
@@ -839,6 +864,15 @@ class MessagePersister {
           // Check if this is a remote MCP request tool
           if (state.currentToolUse.name === 'mcp__user-input__request_remote_mcp') {
             this.handleRemoteMcpRequestTool(
+              sessionId,
+              state.currentToolUse.id,
+              state.currentToolInput,
+              state.agentSlug
+            )
+          }
+
+          if (state.currentToolUse.name === 'mcp__user-input__request_browser_input') {
+            this.handleBrowserInputRequestTool(
               sessionId,
               state.currentToolUse.id,
               state.currentToolInput,
@@ -1155,6 +1189,45 @@ class MessagePersister {
       }
     } catch (error) {
       console.error('[MessagePersister] Error handling remote MCP request:', error)
+    }
+  }
+
+  // Handle browser input request tool - broadcast to SSE clients so they can show the UI
+  private handleBrowserInputRequestTool(
+    sessionId: string,
+    toolUseId: string,
+    toolInput: string,
+    agentSlug?: string
+  ): void {
+    try {
+      let input: { message: string; requirements?: string[] } = { message: '' }
+      try {
+        input = JSON.parse(toolInput)
+      } catch {
+        console.error('[MessagePersister] Failed to parse browser input request:', toolInput)
+        return
+      }
+
+      if (!input.message) {
+        console.error('[MessagePersister] Browser input request missing message')
+        return
+      }
+
+      this.broadcastToSSE(sessionId, {
+        type: 'browser_input_request',
+        toolUseId,
+        message: input.message,
+        requirements: input.requirements || [],
+        agentSlug,
+      })
+
+      if (agentSlug && !this.hasActiveViewers(sessionId)) {
+        notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'browser_input').catch((err) => {
+          console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
+        })
+      }
+    } catch (error) {
+      console.error('[MessagePersister] Error handling browser input request:', error)
     }
   }
 

--- a/src/shared/lib/notifications/notification-manager.ts
+++ b/src/shared/lib/notifications/notification-manager.ts
@@ -125,7 +125,7 @@ class NotificationManager {
   async triggerSessionWaitingInput(
     sessionId: string,
     agentSlug: string,
-    waitingFor: 'secret' | 'connected_account' | 'question' | 'file' | 'remote_mcp',
+    waitingFor: 'secret' | 'connected_account' | 'question' | 'file' | 'remote_mcp' | 'browser_input',
     agentName?: string
   ): Promise<void> {
     const displayName = agentName || await this.getAgentDisplayName(agentSlug)
@@ -145,6 +145,9 @@ class NotificationManager {
         break
       case 'remote_mcp':
         waitingMessage = 'needs access to an MCP server'
+        break
+      case 'browser_input':
+        waitingMessage = 'needs your browser input'
         break
     }
 


### PR DESCRIPTION
- Add browser input request tool for model (both browser subagent and main agent): Agent can formally request user to enter browser input instead of using ask question tool
- Add UI browser overlay + card UI by which model request user browser input is surfaced
- User can explicitly confirm that they have completed steps / follow-up chat with agent
<img width="1501" height="946" alt="Screenshot 2026-03-09 at 12 49 29 PM" src="https://github.com/user-attachments/assets/786b9350-5729-4f3b-8828-30bb1378636b" />
