### PR TITLE
Fix: Add multi-session browser check

### DIFF
--- a/src/renderer/components/browser/browser-preview.tsx
+++ b/src/renderer/components/browser/browser-preview.tsx
@@ -254,8 +254,8 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
       setPageLoading(false)
       fetch(`${baseUrl}/api/agents/${agentSlug}/browser/status`)
         .then((res) => res.json())
-        .then((status: { active?: boolean }) => {
-          if (!status.active) {
+        .then((status: { active?: boolean; sessionId?: string }) => {
+          if (!status.active || status.sessionId !== sessionId) {
             clearBrowserActive(sessionId)
           } else {
             // Browser still active but stream dropped (e.g. tab switch disrupted

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -144,10 +144,12 @@ function getOrCreateEventSource(
         // Fetch current browser status to sync state (handles missed events)
         fetch(`${baseUrl}/api/agents/${agentSlug}/browser/status`)
           .then((res) => res.json())
-          .then((status: { active?: boolean }) => {
+          .then((status: { active?: boolean; sessionId?: string }) => {
             const latest = streamStates.get(sessionId)
-            if (latest && latest.browserActive !== (status.active ?? false)) {
-              streamStates.set(sessionId, { ...latest, browserActive: status.active ?? false })
+            // Only mark browser active if it belongs to THIS session
+            const activeForThisSession = (status.active ?? false) && status.sessionId === sessionId
+            if (latest && latest.browserActive !== activeForThisSession) {
+              streamStates.set(sessionId, { ...latest, browserActive: activeForThisSession })
               streamListeners.get(sessionId)?.forEach((listener) => listener())
             }
           })


### PR DESCRIPTION
- Before: Frontend only checks if browser is active in container, but does not check whether it belongs to open session
- After: Frontend checks if browser is active **AND** belongs to current session --> does not show browser window for another session. Makes UI less confusing for user.