### PR TITLE
Feat: Agent self-manages tabs

### DIFF
--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -56,6 +56,9 @@ app.post('/sessions', async (c) => {
       return c.json({ error: 'initialMessage is required' }, 400);
     }
 
+    if (body.maxBrowserTabs) {
+      tabManager.setMaxTabs(body.maxBrowserTabs);
+    }
     const session = await sessionManager.createSession(body);
     return c.json(session, 201);
   } catch (error: any) {
@@ -1216,12 +1219,13 @@ app.post('/browser/run', async (c) => {
     }
 
     const cmd = body.command.trim().toLowerCase();
-    if (cmd.startsWith('tab')) {
-      await tabManager.syncTabCount();
+    let tabInfo = null;
+    if (cmd.startsWith('tab') || cmd.includes('.click(') || cmd.startsWith('click') || cmd.startsWith('dblclick')) {
+      tabInfo = await tabManager.detectNewTab();
     }
 
     notifyBrowserAction();
-    return c.json({ success: true, output: result.stdout });
+    return c.json({ success: true, output: result.stdout, ...(tabInfo && { tabInfo }) });
   } catch (error: any) {
     console.error('[Browser] Error running command:', error);
     return c.json({ error: error.message || 'Failed to run browser command' }, 500);

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -9,9 +9,10 @@ import * as path from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import * as dns from 'dns';
-import * as net from 'net';
+
 import { inputManager } from './input-manager';
 import { dashboardManager } from './dashboard-manager';
+import { tabManager } from './tab-manager';
 
 // Global error handlers to prevent crashes from AbortError during interrupts
 // The SDK throws AbortError when queries are aborted, which can propagate uncaught
@@ -780,6 +781,17 @@ app.post('/browser/open', async (c) => {
       return c.json({ error: validationError }, 409);
     }
 
+    // If browser is already active, check for a matching tab before opening a new one
+    if (browserState.active) {
+      const matchingTab = await tabManager.findMatchingTab(body.url);
+      if (matchingTab) {
+        await execBrowser(['tab', String(matchingTab.index)], browserState.cdpUrl || undefined);
+        await tabManager.syncTabCount();
+        notifyBrowserAction();
+        return c.json({ success: true, switchedToExisting: true, tabIndex: matchingTab.index, url: matchingTab.url });
+      }
+    }
+
     const hostBrowser = await launchHostBrowserIfNeeded();
     const cdpUrl = hostBrowser?.cdpUrl;
     const profile = process.env.AGENT_BROWSER_PROFILE || '/workspace/.browser-profile';
@@ -806,6 +818,7 @@ app.post('/browser/open', async (c) => {
     }
 
     browserState = { active: true, sessionId: body.sessionId, cdpUrl: cdpUrl || null };
+    tabManager.resetTabCount();
     broadcastBrowserEvent(true);
 
     return c.json({ success: true });
@@ -837,6 +850,7 @@ app.post('/browser/close', async (c) => {
     cleanupCdpScreencast();
     broadcastBrowserEvent(false);
     browserState = { active: false, sessionId: null, cdpUrl: null };
+    tabManager.resetTabCount();
 
     return c.json({ success: true });
   } catch (error: any) {
@@ -851,6 +865,7 @@ app.post('/browser/notify-closed', (c) => {
     cleanupCdpScreencast();
     broadcastBrowserEvent(false);
     browserState = { active: false, sessionId: null, cdpUrl: null };
+    tabManager.resetTabCount();
     console.log('[Browser] Browser closed externally, state cleaned up');
   }
   return c.json({ success: true });
@@ -887,10 +902,10 @@ app.post('/browser/snapshot', async (c) => {
     // Try to parse JSON output
     try {
       const parsed = JSON.parse(result.stdout);
-      return c.json(parsed);
+      return c.json({ ...parsed, tabCount: tabManager.getTabCount() });
     } catch {
       // Return raw output if not valid JSON
-      return c.json({ snapshot: result.stdout });
+      return c.json({ snapshot: result.stdout, tabCount: tabManager.getTabCount() });
     }
   } catch (error: any) {
     console.error('[Browser] Error taking snapshot:', error);
@@ -922,8 +937,9 @@ app.post('/browser/click', async (c) => {
       return c.json({ error: result.stdout, success: false }, 500);
     }
 
+    const tabInfo = await tabManager.detectNewTab();
     notifyBrowserAction();
-    return c.json({ success: true });
+    return c.json({ success: true, ...(tabInfo && { tabInfo }) });
   } catch (error: any) {
     console.error('[Browser] Error clicking:', error);
     return c.json({ error: error.message || 'Failed to click' }, 500);
@@ -1063,8 +1079,9 @@ app.post('/browser/press', async (c) => {
       return c.json({ error: result.stdout, success: false }, 500);
     }
 
+    const tabInfo = await tabManager.detectNewTab();
     notifyBrowserAction();
-    return c.json({ success: true });
+    return c.json({ success: true, ...(tabInfo && { tabInfo }) });
   } catch (error: any) {
     console.error('[Browser] Error pressing key:', error);
     return c.json({ error: error.message || 'Failed to press key' }, 500);
@@ -1198,12 +1215,22 @@ app.post('/browser/run', async (c) => {
       return c.json({ error: result.stdout, success: false }, 500);
     }
 
+    const cmd = body.command.trim().toLowerCase();
+    if (cmd.startsWith('tab')) {
+      await tabManager.syncTabCount();
+    }
+
     notifyBrowserAction();
     return c.json({ success: true, output: result.stdout });
   } catch (error: any) {
     console.error('[Browser] Error running command:', error);
     return c.json({ error: error.message || 'Failed to run browser command' }, 500);
   }
+});
+
+// GET /browser/tab-status - Return cached tab count (instant, no daemon query)
+app.get('/browser/tab-status', (c) => {
+  return c.json({ tabCount: tabManager.getTabCount() });
 });
 
 async function buildFileTree(
@@ -1373,35 +1400,6 @@ function getCdpHttpEndpoint(): string {
   return 'http://localhost:9222';
 }
 
-/** Query the agent-browser daemon for its tab list via Unix socket */
-async function queryDaemonTabs(): Promise<Array<{ index: number; url: string; title: string; active: boolean }>> {
-  const socketDir = process.env.AGENT_BROWSER_SOCKET_DIR
-    || (process.env.XDG_RUNTIME_DIR ? path.join(process.env.XDG_RUNTIME_DIR, 'agent-browser') : null)
-    || path.join(process.env.HOME || '/home/claude', '.agent-browser');
-  const session = process.env.AGENT_BROWSER_SESSION || 'default';
-  const socketPath = path.join(socketDir, `${session}.sock`);
-
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => { client.destroy(); reject(new Error('Timeout')); }, 3000);
-    const client = net.createConnection(socketPath, () => {
-      client.write(JSON.stringify({ id: 'tab-q', action: 'tab_list' }) + '\n');
-    });
-    let buf = '';
-    client.on('data', (chunk: Buffer) => {
-      buf += chunk.toString();
-      try {
-        const resp = JSON.parse(buf);
-        clearTimeout(timeout);
-        client.end();
-        // Response format: { id, success, data: { tabs, active } }
-        const tabs = resp.data?.tabs;
-        resp.success && tabs ? resolve(tabs) : reject(new Error(resp.error || 'No tabs'));
-      } catch { /* incomplete JSON, wait for more */ }
-    });
-    client.on('error', (err: Error) => { clearTimeout(timeout); reject(err); });
-  });
-}
-
 /** Result from findActivePageTarget */
 interface ActivePageTarget {
   id: string;
@@ -1431,7 +1429,7 @@ async function findActivePageTarget(): Promise<ActivePageTarget | null> {
 
       // Ask agent-browser daemon which tab is active and match to a CDP target
       try {
-        const tabs = await queryDaemonTabs();
+        const tabs = await tabManager.queryTabs();
         const active = tabs.find(t => t.active);
         if (active) {
           const byUrl = pages.find(p => p.url === active.url);

--- a/agent-container/src/tab-manager.ts
+++ b/agent-container/src/tab-manager.ts
@@ -7,7 +7,7 @@
 import * as net from 'net';
 import * as path from 'path';
 
-export const MAX_TABS = 5;
+const DEFAULT_MAX_TABS = 10;
 
 export interface TabInfo {
   index: number;
@@ -25,8 +25,17 @@ export interface NewTabResult {
 
 class TabManager {
   private lastKnownTabCount = 1;
+  private maxTabs = DEFAULT_MAX_TABS;
 
   // --- State ---
+
+  setMaxTabs(n: number): void {
+    this.maxTabs = n;
+  }
+
+  getMaxTabs(): number {
+    return this.maxTabs;
+  }
 
   resetTabCount(): void {
     this.lastKnownTabCount = 1;
@@ -79,8 +88,6 @@ class TabManager {
   /** Check if a new tab was opened since the last check. Returns tab info or null. */
   async detectNewTab(): Promise<NewTabResult | null> {
     try {
-      // Small delay to let the browser settle after the action
-      await new Promise(r => setTimeout(r, 300));
       const tabs = await this.queryTabs();
       const prevCount = this.lastKnownTabCount;
       this.lastKnownTabCount = tabs.length;
@@ -105,13 +112,14 @@ class TabManager {
 
   // --- URL Matching ---
 
-  /** Normalize and compare two URLs (origin + pathname, ignoring trailing slash and query/hash) */
+  /** Normalize and compare two URLs (origin + pathname + search, ignoring trailing slash and hash) */
   urlsMatch(a: string, b: string): boolean {
     try {
       const ua = new URL(a);
       const ub = new URL(b);
       return ua.origin === ub.origin &&
-             ua.pathname.replace(/\/$/, '') === ub.pathname.replace(/\/$/, '');
+             ua.pathname.replace(/\/$/, '') === ub.pathname.replace(/\/$/, '') &&
+             ua.search === ub.search;
     } catch { return false; }
   }
 
@@ -130,8 +138,8 @@ class TabManager {
     const { activeIndex, activeUrl, tabCount } = tabInfo;
     let msg = `\nNew tab opened — you are now on tab ${activeIndex} (${activeUrl}). ${tabCount} tab(s) open.`;
 
-    if (tabCount >= MAX_TABS) {
-      msg += `\n⚠️ WARNING: ${tabCount} tabs open (max ${MAX_TABS}). You MUST close tabs you no longer need IMMEDIATELY. Switch with browser_run("tab <n>") then browser_run("tab close").`;
+    if (tabCount >= this.maxTabs) {
+      msg += `\n⚠️ WARNING: ${tabCount} tabs open (max ${this.maxTabs}). You MUST close tabs you no longer need IMMEDIATELY. Switch with browser_run("tab <n>") then browser_run("tab close").`;
     } else {
       msg += `\nIf you no longer need the tab you came from, close it now: browser_run("tab <prev>") then browser_run("tab close").`;
     }
@@ -141,15 +149,15 @@ class TabManager {
 
   /** Escalating warning appended to tool responses when tabs are high */
   formatTabWarning(tabCount: number): string {
-    if (tabCount >= MAX_TABS) return `\n\n🚨 CRITICAL: ${tabCount} TABS OPEN (limit: ${MAX_TABS}). STOP and close unneeded tabs NOW. Run browser_run("tab") to list, then close extras.`;
-    if (tabCount >= MAX_TABS - 1) return `\n\n[${tabCount} tabs open — close any you no longer need]`;
+    if (tabCount >= this.maxTabs) return `\n\n🚨 CRITICAL: ${tabCount} TABS OPEN (limit: ${this.maxTabs}). STOP and close unneeded tabs NOW. Run browser_run("tab") to list, then close extras.`;
+    if (tabCount >= this.maxTabs - 1) return `\n\n[${tabCount} tabs open — close any you no longer need]`;
     return '';
   }
 
   /** Tab status line appended to snapshot/state responses */
   formatTabStatus(tabCount: number): string {
     if (tabCount <= 1) return '';
-    if (tabCount >= MAX_TABS) return `\n\n[Tabs: ${tabCount} open — OVER LIMIT, close tabs NOW]`;
+    if (tabCount >= this.maxTabs) return `\n\n[Tabs: ${tabCount} open — OVER LIMIT, close tabs NOW]`;
     return `\n\n[Tabs: ${tabCount} open]`;
   }
 }

--- a/agent-container/src/tab-manager.ts
+++ b/agent-container/src/tab-manager.ts
@@ -1,0 +1,157 @@
+/**
+ * Tab Manager — centralized tab state, querying, detection, and message formatting.
+ *
+ * All tab-related logic lives here so server.ts and browser.ts can import shared helpers.
+ */
+
+import * as net from 'net';
+import * as path from 'path';
+
+export const MAX_TABS = 5;
+
+export interface TabInfo {
+  index: number;
+  url: string;
+  title: string;
+  active: boolean;
+}
+
+export interface NewTabResult {
+  newTab: true;
+  activeIndex: number;
+  activeUrl: string;
+  tabCount: number;
+}
+
+class TabManager {
+  private lastKnownTabCount = 1;
+
+  // --- State ---
+
+  resetTabCount(): void {
+    this.lastKnownTabCount = 1;
+  }
+
+  getTabCount(): number {
+    return this.lastKnownTabCount;
+  }
+
+  // --- Daemon Queries ---
+
+  /** Query the agent-browser daemon for its tab list via Unix socket */
+  async queryTabs(): Promise<TabInfo[]> {
+    const socketDir = process.env.AGENT_BROWSER_SOCKET_DIR
+      || (process.env.XDG_RUNTIME_DIR ? path.join(process.env.XDG_RUNTIME_DIR, 'agent-browser') : null)
+      || path.join(process.env.HOME || '/home/claude', '.agent-browser');
+    const session = process.env.AGENT_BROWSER_SESSION || 'default';
+    const socketPath = path.join(socketDir, `${session}.sock`);
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => { client.destroy(); reject(new Error('Timeout')); }, 3000);
+      const client = net.createConnection(socketPath, () => {
+        client.write(JSON.stringify({ id: 'tab-q', action: 'tab_list' }) + '\n');
+      });
+      let buf = '';
+      client.on('data', (chunk: Buffer) => {
+        buf += chunk.toString();
+        try {
+          const resp = JSON.parse(buf);
+          clearTimeout(timeout);
+          client.end();
+          const tabs = resp.data?.tabs;
+          resp.success && tabs ? resolve(tabs) : reject(new Error(resp.error || 'No tabs'));
+        } catch { /* incomplete JSON, wait for more */ }
+      });
+      client.on('error', (err: Error) => { clearTimeout(timeout); reject(err); });
+    });
+  }
+
+  /** Re-query daemon and update the cached tab count */
+  async syncTabCount(): Promise<void> {
+    try {
+      const tabs = await this.queryTabs();
+      this.lastKnownTabCount = tabs.length;
+    } catch { /* best-effort */ }
+  }
+
+  // --- Detection ---
+
+  /** Check if a new tab was opened since the last check. Returns tab info or null. */
+  async detectNewTab(): Promise<NewTabResult | null> {
+    try {
+      // Small delay to let the browser settle after the action
+      await new Promise(r => setTimeout(r, 300));
+      const tabs = await this.queryTabs();
+      const prevCount = this.lastKnownTabCount;
+      this.lastKnownTabCount = tabs.length;
+
+      if (tabs.length > prevCount) {
+        const active = tabs.find(t => t.active);
+        if (active) {
+          return {
+            newTab: true,
+            activeIndex: active.index,
+            activeUrl: active.url,
+            tabCount: tabs.length,
+          };
+        }
+      }
+      return null;
+    } catch {
+      // Tab detection is best-effort — don't fail the action if the daemon is unavailable
+      return null;
+    }
+  }
+
+  // --- URL Matching ---
+
+  /** Normalize and compare two URLs (origin + pathname, ignoring trailing slash and query/hash) */
+  urlsMatch(a: string, b: string): boolean {
+    try {
+      const ua = new URL(a);
+      const ub = new URL(b);
+      return ua.origin === ub.origin &&
+             ua.pathname.replace(/\/$/, '') === ub.pathname.replace(/\/$/, '');
+    } catch { return false; }
+  }
+
+  /** Find a tab whose URL matches the given URL */
+  async findMatchingTab(url: string): Promise<TabInfo | null> {
+    try {
+      const tabs = await this.queryTabs();
+      return tabs.find(t => this.urlsMatch(t.url, url)) ?? null;
+    } catch { return null; }
+  }
+
+  // --- Message Formatting ---
+
+  /** Format a notification about a newly opened tab (appended to click/press responses) */
+  formatTabNotification(tabInfo: { activeIndex: number; activeUrl: string; tabCount: number }): string {
+    const { activeIndex, activeUrl, tabCount } = tabInfo;
+    let msg = `\nNew tab opened — you are now on tab ${activeIndex} (${activeUrl}). ${tabCount} tab(s) open.`;
+
+    if (tabCount >= MAX_TABS) {
+      msg += `\n⚠️ WARNING: ${tabCount} tabs open (max ${MAX_TABS}). You MUST close tabs you no longer need IMMEDIATELY. Switch with browser_run("tab <n>") then browser_run("tab close").`;
+    } else {
+      msg += `\nIf you no longer need the tab you came from, close it now: browser_run("tab <prev>") then browser_run("tab close").`;
+    }
+
+    return msg;
+  }
+
+  /** Escalating warning appended to tool responses when tabs are high */
+  formatTabWarning(tabCount: number): string {
+    if (tabCount >= MAX_TABS) return `\n\n🚨 CRITICAL: ${tabCount} TABS OPEN (limit: ${MAX_TABS}). STOP and close unneeded tabs NOW. Run browser_run("tab") to list, then close extras.`;
+    if (tabCount >= MAX_TABS - 1) return `\n\n[${tabCount} tabs open — close any you no longer need]`;
+    return '';
+  }
+
+  /** Tab status line appended to snapshot/state responses */
+  formatTabStatus(tabCount: number): string {
+    if (tabCount <= 1) return '';
+    if (tabCount >= MAX_TABS) return `\n\n[Tabs: ${tabCount} open — OVER LIMIT, close tabs NOW]`;
+    return `\n\n[Tabs: ${tabCount} open]`;
+  }
+}
+
+export const tabManager = new TabManager();

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -9,6 +9,7 @@
 import { tool } from '@anthropic-ai/claude-agent-sdk'
 import { readFile } from 'fs/promises'
 import { z } from 'zod'
+import { tabManager } from '../tab-manager'
 
 const CONTAINER_URL = `http://localhost:${process.env.PORT || '3000'}`
 
@@ -44,6 +45,17 @@ function errorResult(message: string) {
   return {
     content: [{ type: 'text' as const, text: `Error: ${message}` }],
     isError: true,
+  }
+}
+
+/** Fetch cached tab count from the server (instant, no daemon query) */
+async function getTabWarning(): Promise<string> {
+  try {
+    const response = await fetch(`${CONTAINER_URL}/browser/tab-status`)
+    const data = await response.json() as { tabCount: number }
+    return tabManager.formatTabWarning(data.tabCount)
+  } catch {
+    return ''
   }
 }
 
@@ -83,6 +95,19 @@ Use this to start browsing a website. The browser preserves cookies/sessions via
   async (args) => {
     const result = await browserFetch('open', { url: args.url })
     if (!result.success) return errorResult(result.error!)
+    const data = result.data as Record<string, unknown> | undefined
+
+    if (data?.switchedToExisting) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Switched to existing tab ${data.tabIndex} which already has ${data.url} open. Use browser_snapshot to see the page content.`,
+          },
+        ],
+      }
+    }
+
     return {
       content: [
         {
@@ -135,9 +160,12 @@ Use compact=true (default) to reduce output size.`,
     if (!result.success) return errorResult(result.error!)
 
     const data = result.data as Record<string, unknown>
-    const text = data.snapshot
+    const tabCount = typeof data.tabCount === 'number' ? data.tabCount : 0
+    let text = data.snapshot
       ? String(data.snapshot)
       : JSON.stringify(data, null, 2)
+
+    text += tabManager.formatTabStatus(tabCount)
 
     return {
       content: [{ type: 'text' as const, text }],
@@ -154,13 +182,18 @@ export const browserClickTool = tool(
   async (args) => {
     const result = await browserFetch('click', { ref: args.ref })
     if (!result.success) return errorResult(result.error!)
+    const data = result.data as Record<string, unknown> | undefined
+    const tabInfo = data?.tabInfo as { activeIndex: number; activeUrl: string; tabCount: number } | undefined
+
+    let text = `Clicked ${args.ref}. Use browser_snapshot to see the updated page.`
+    if (tabInfo) {
+      text += tabManager.formatTabNotification(tabInfo)
+    } else {
+      text += await getTabWarning()
+    }
+
     return {
-      content: [
-        {
-          type: 'text' as const,
-          text: `Clicked ${args.ref}. Use browser_snapshot to see the updated page.`,
-        },
-      ],
+      content: [{ type: 'text' as const, text }],
     }
   }
 )
@@ -178,11 +211,13 @@ export const browserFillTool = tool(
       value: args.value,
     })
     if (!result.success) return errorResult(result.error!)
+    let text = `Filled ${args.ref} with "${args.value}".`
+    text += await getTabWarning()
     return {
       content: [
         {
           type: 'text' as const,
-          text: `Filled ${args.ref} with "${args.value}".`,
+          text,
         },
       ],
     }
@@ -207,11 +242,13 @@ export const browserScrollTool = tool(
       amount: args.amount,
     })
     if (!result.success) return errorResult(result.error!)
+    let text = `Scrolled ${args.direction}${args.amount ? ` by ${args.amount}px` : ''}.`
+    text += await getTabWarning()
     return {
       content: [
         {
           type: 'text' as const,
-          text: `Scrolled ${args.direction}${args.amount ? ` by ${args.amount}px` : ''}.`,
+          text,
         },
       ],
     }
@@ -248,10 +285,18 @@ export const browserPressTool = tool(
   async (args) => {
     const result = await browserFetch('press', { key: args.key })
     if (!result.success) return errorResult(result.error!)
+    const data = result.data as Record<string, unknown> | undefined
+    const tabInfo = data?.tabInfo as { activeIndex: number; activeUrl: string; tabCount: number } | undefined
+
+    let text = `Pressed "${args.key}".`
+    if (tabInfo) {
+      text += tabManager.formatTabNotification(tabInfo)
+    } else {
+      text += await getTabWarning()
+    }
+
     return {
-      content: [
-        { type: 'text' as const, text: `Pressed "${args.key}".` },
-      ],
+      content: [{ type: 'text' as const, text }],
     }
   }
 )
@@ -410,10 +455,13 @@ export const browserGetStateTool = tool(
 
     if (snapshotResult.success) {
       const data = snapshotResult.data as Record<string, unknown>
+      const tabCount = typeof data.tabCount === 'number' ? data.tabCount : 0
       const snapshot = data.snapshot
         ? String(data.snapshot)
         : JSON.stringify(data, null, 2)
       parts.push(`**Accessibility Snapshot:**\n${snapshot}`)
+      const tabStatus = tabManager.formatTabStatus(tabCount)
+      if (tabStatus) parts.push(tabStatus.trim())
     } else {
       parts.push(`**Accessibility Snapshot:** Error - ${snapshotResult.error}`)
     }

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -48,15 +48,9 @@ function errorResult(message: string) {
   }
 }
 
-/** Fetch cached tab count from the server (instant, no daemon query) */
-async function getTabWarning(): Promise<string> {
-  try {
-    const response = await fetch(`${CONTAINER_URL}/browser/tab-status`)
-    const data = await response.json() as { tabCount: number }
-    return tabManager.formatTabWarning(data.tabCount)
-  } catch {
-    return ''
-  }
+/** Get tab warning from cached tab count (no network call needed — same process) */
+function getTabWarning(): string {
+  return tabManager.formatTabWarning(tabManager.getTabCount())
 }
 
 export function stripAnsi(str: string): string {
@@ -189,7 +183,7 @@ export const browserClickTool = tool(
     if (tabInfo) {
       text += tabManager.formatTabNotification(tabInfo)
     } else {
-      text += await getTabWarning()
+      text += getTabWarning()
     }
 
     return {
@@ -212,7 +206,7 @@ export const browserFillTool = tool(
     })
     if (!result.success) return errorResult(result.error!)
     let text = `Filled ${args.ref} with "${args.value}".`
-    text += await getTabWarning()
+    text += getTabWarning()
     return {
       content: [
         {
@@ -243,7 +237,7 @@ export const browserScrollTool = tool(
     })
     if (!result.success) return errorResult(result.error!)
     let text = `Scrolled ${args.direction}${args.amount ? ` by ${args.amount}px` : ''}.`
-    text += await getTabWarning()
+    text += getTabWarning()
     return {
       content: [
         {
@@ -292,7 +286,7 @@ export const browserPressTool = tool(
     if (tabInfo) {
       text += tabManager.formatTabNotification(tabInfo)
     } else {
-      text += await getTabWarning()
+      text += getTabWarning()
     }
 
     return {
@@ -406,10 +400,16 @@ Available commands:
     const result = await browserFetch('run', { command: args.command })
     if (!result.success) return errorResult(result.error!)
     const data = result.data as Record<string, unknown>
-    const output = data.output ? String(data.output) : 'Command executed.'
+    let text = data.output ? String(data.output) : 'Command executed.'
+    const tabInfo = data.tabInfo as { activeIndex: number; activeUrl: string; tabCount: number } | undefined
+    if (tabInfo) {
+      text += tabManager.formatTabNotification(tabInfo)
+    } else {
+      text += getTabWarning()
+    }
     return {
       content: [
-        { type: 'text' as const, text: output },
+        { type: 'text' as const, text },
       ],
     }
   }

--- a/agent-container/src/types.ts
+++ b/agent-container/src/types.ts
@@ -60,6 +60,7 @@ export interface CreateSessionRequest {
   maxTurns?: number; // Max conversation turns
   maxBudgetUsd?: number; // Max cost in USD per session
   customEnvVars?: Record<string, string>; // User-defined env vars for the agent process
+  maxBrowserTabs?: number; // Max browser tabs allowed (default 10)
 }
 
 export interface SendMessageRequest {

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -42,6 +42,18 @@ You are a web browser automation agent. You receive high-level objectives and ac
 4. Re-snapshot after page changes to get updated refs
 5. After `browser_open()` or `browser_click()` that triggers navigation, just re-snapshot — no need to wait, `browser_open` already waits for the page to load
 
+## Tab Management (MANDATORY)
+
+Tab proliferation causes memory crashes and degrades performance. Follow these rules strictly:
+
+1. **NEVER exceed 5 tabs.** If you reach 5, STOP your current task and close unneeded tabs before continuing. Failure to do so causes the browser to run out of memory and crash.
+2. **NEVER open a URL you already have open** — use `browser_open()` which automatically switches to existing tabs, or manually switch with `browser_run("tab <n>")`.
+3. **Close tabs immediately when done.** When you navigate away from a page and no longer need it, switch to it and close it: `browser_run("tab <n>")` then `browser_run("tab close")`.
+4. **Check tabs every 5 actions.** Run `browser_run("tab")` to see all open tabs. The snapshot footer also shows your tab count.
+5. **Close duplicate tabs immediately.** If you see the same URL open in multiple tabs, close the extras right away.
+6. **Check tabs after clicking external links.** Links sometimes open in new tabs silently. When a click or press opens a new tab, the tool response will tell you.
+7. **Prefer switching to existing tabs** over opening new ones. It keeps your workspace organized and avoids redundant memory usage.
+
 ## Critical Rules
 - **NEVER close the browser.** You do not have the browser_close tool. The parent agent manages browser lifecycle.
 - **ALWAYS report the current URL when you finish.** Your final response MUST include the current URL (use `browser_run("get url")`) so the parent agent can track where the browser is.

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -46,7 +46,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 
 Tab proliferation causes memory crashes and degrades performance. Follow these rules strictly:
 
-1. **NEVER exceed 5 tabs.** If you reach 5, STOP your current task and close unneeded tabs before continuing. Failure to do so causes the browser to run out of memory and crash.
+1. **NEVER exceed the tab limit.** If tool responses warn you about tab count, STOP your current task and close unneeded tabs before continuing. Failure to do so causes the browser to run out of memory and crash.
 2. **NEVER open a URL you already have open** — use `browser_open()` which automatically switches to existing tabs, or manually switch with `browser_run("tab <n>")`.
 3. **Close tabs immediately when done.** When you navigate away from a page and no longer need it, switch to it and close it: `browser_run("tab <n>")` then `browser_run("tab close")`.
 4. **Check tabs every 5 actions.** Run `browser_run("tab")` to see all open tabs. The snapshot footer also shows your tab count.

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -863,6 +863,7 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
       maxTurns: agentLimits.maxTurns,
       maxBudgetUsd: agentLimits.maxBudgetUsd,
       customEnvVars: Object.keys(customEnvVars).length > 0 ? customEnvVars : undefined,
+      maxBrowserTabs: getSettings().app?.maxBrowserTabs,
     })
     const sessionId = containerSession.id
 

--- a/src/renderer/components/settings/browser-tab.tsx
+++ b/src/renderer/components/settings/browser-tab.tsx
@@ -75,6 +75,28 @@ export function BrowserTab() {
         </p>
       </div>
 
+      {/* Max Browser Tabs */}
+      <div className="space-y-2">
+        <Label htmlFor="max-browser-tabs">Max Browser Tabs</Label>
+        <Input
+          id="max-browser-tabs"
+          type="number"
+          min={1}
+          max={20}
+          value={settings?.app?.maxBrowserTabs ?? 10}
+          onChange={(e) => {
+            const value = parseInt(e.target.value)
+            if (value >= 1 && value <= 20) {
+              updateSettings.mutate({ app: { maxBrowserTabs: value } })
+            }
+          }}
+          disabled={isLoading}
+        />
+        <p className="text-xs text-muted-foreground">
+          Maximum number of browser tabs the agent can have open at once (default: 10)
+        </p>
+      </div>
+
       {/* Browser Host selector */}
       <div className="space-y-2">
         <Label htmlFor="browser-host">Browser Host</Label>

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -64,6 +64,7 @@ export interface AppPreferences {
   chromeProfileId?: string
   allowPrereleaseUpdates?: boolean
   theme?: 'system' | 'light' | 'dark'
+  maxBrowserTabs?: number
 
   // Browserbase session settings
   browserbaseAdvancedStealth?: boolean

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -582,6 +582,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
           maxTurns: options.maxTurns,
           maxBudgetUsd: options.maxBudgetUsd,
           customEnvVars: options.customEnvVars,
+          maxBrowserTabs: options.maxBrowserTabs,
         }),
         signal: controller.signal,
       })

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -46,6 +46,7 @@ export interface CreateSessionOptions {
   maxTurns?: number // Max conversation turns
   maxBudgetUsd?: number // Max cost in USD per session
   customEnvVars?: Record<string, string> // User-defined env vars for the agent process
+  maxBrowserTabs?: number // Max browser tabs allowed (default 10)
 }
 
 export interface StartOptions {


### PR DESCRIPTION
**Problem:** Agents tend to continue to increase tabs, especially when they click on links / buttons that automatically open in new tab. 

**Fix:** Give agent some prompting (in system, and also during runtime) to encourage it to manage its tabs better: 
- Suggestion to manage tabs when 4 tabs open, and critical warning message when 5+ tabs are open
- Automatic syncing of tab count on browser action (when button click / press)
- All browser tool calls will check current tab count, and also return some sort of warning message if thresholds met (see bullet point #1) 
- Create `tab-manager.ts` to cleanly implement helpers