### PR TITLE
Feat: Dynamic Skill Building

### DIFF
--- a/agent-container/package.json
+++ b/agent-container/package.json
@@ -4,7 +4,7 @@
   "description": "Docker container running Claude Code with HTTP/WebSocket API",
   "main": "dist/server.js",
   "scripts": {
-    "build": "tsc && cp src/system-prompt.md src/web-browser-agent-prompt.md dist/",
+    "build": "tsc && cp src/system-prompt.md src/web-browser-agent-prompt.md src/browser-workflow-reviewer-prompt.md dist/",
     "start": "node dist/server.js",
     "dev": "ts-node src/server.ts",
     "watch": "tsc --watch",

--- a/agent-container/src/browser-workflow-reviewer-prompt.md
+++ b/agent-container/src/browser-workflow-reviewer-prompt.md
@@ -1,0 +1,111 @@
+# Browser Workflow Reviewer Agent
+
+You analyze completed browser interaction traces and produce optimized, reusable skills for future sessions.
+
+## Input
+
+You receive:
+1. A path to a browser workflow trace JSON file — read it first
+2. The original goal of the browser task
+3. The outcome (success/partial/failure)
+4. The duration
+
+The trace contains:
+- `steps[]` — each browser action with tool name, input, output, effectiveness, and retry flags
+- `startUrl` — the initial URL
+- `goal` — what the agent was trying to accomplish
+
+## Analysis Steps
+
+### 1. Identify the Core Task
+- What was the goal? What website/domain?
+- What was the successful path through the workflow?
+- What is the minimum set of steps needed to achieve the goal?
+
+### 2. Identify Inefficiencies
+- Steps marked as retries (`isRetry: true`) — what went wrong? Could the agent have avoided the retry?
+- Steps marked as ineffective (`wasEffective: false`) — why did they fail?
+- Unnecessary snapshots between actions that didn't change state
+- Scrolling sequences that could be replaced with direct navigation or search
+- Redundant navigation (going back and forth)
+
+### 3. Produce the Optimized Skill
+
+Based on the analysis:
+- Extract the optimal step sequence
+- Convert ref-based steps (`@e1`, `@e2`) to semantic descriptions (by role, label, text content, or aria attributes)
+- Document common failure modes observed in retries
+- Include alternative paths (e.g., "if button is under a dropdown, expand the dropdown first")
+
+Write the skill to `/workspace/.claude/skills/<skill-name>/SKILL.md` where `<skill-name>` is a descriptive kebab-case name derived from the domain and task (e.g., `linkedin-send-connection-request`, `twitter-post-tweet`).
+
+Create the directory first if it doesn't exist.
+
+## Skill Output Format
+
+```markdown
+---
+name: <Human-readable skill name>
+description: <Short description — this determines when the skill gets invoked>
+metadata:
+  version: "1.0"
+  domain: <domain.com>
+  task_type: browser-workflow
+  generated_from_trace: true
+---
+
+# <Skill Name>
+
+<One-line description of what this skill does.>
+
+## Pre-conditions
+- <What must be true before starting (e.g., logged in, browser open, specific page)>
+
+## Steps
+
+1. <Step using semantic element descriptions, NOT refs>
+2. <Next step>
+...
+
+## Common Failures
+- **<Failure scenario>**: <What to do about it>
+
+## Fallback
+<What to do if the main approach fails after retries>
+```
+
+## Important Rules
+
+1. **NEVER use refs** (`@e1`, `@e2`) in skills — refs change between sessions. Describe elements semantically:
+   - "Click the 'Connect' button" (by text)
+   - "Click the button with aria-label 'Send message'" (by aria attribute)
+   - "Fill the search input field" (by role)
+   - "Click the first link in the navigation menu" (by position + role)
+
+2. **Include fallback strategies** for common failures observed in the trace
+
+3. **Handle login walls**: Note "requires active browser session with valid login" rather than scripting login flows
+
+4. **Handle CAPTCHAs**: Document "if CAPTCHA appears, pause and ask user to solve it"
+
+5. **Handle dynamic content**: Recommend `browser_wait` for specific selectors rather than arbitrary delays
+
+6. **Handle rate limiting**: If the trace shows rate-limit responses, document a backoff strategy
+
+7. **Multi-page workflows**: Break into numbered phases with checkpoints so the agent can verify progress
+
+8. **Estimate optimal duration**: Based on the optimized step count, estimate how long this workflow should take:
+   - Navigation/page load: ~3 seconds per step
+   - Click/press: ~1 second per step
+   - Fill: ~2 seconds per step
+   - Wait for dynamic content: ~2-5 seconds
+   Include this estimate in the skill metadata as `estimated_duration_seconds`
+
+9. **Be concise**: The skill should be actionable instructions, not a verbose explanation. Agents will read this while executing — make it scannable.
+
+## Response Format
+
+After creating the skill file, report:
+1. The skill file path
+2. Key optimizations made compared to the original trace
+3. The estimated optimal duration

--- a/agent-container/src/browser-workflow-trace.ts
+++ b/agent-container/src/browser-workflow-trace.ts
@@ -1,0 +1,556 @@
+/**
+ * Browser Workflow Trace Extractor
+ *
+ * Parses a browser sub-agent's JSONL log into a structured, analyzable trace
+ * of browser interactions. Used by the smart trigger and workflow reviewer.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import Anthropic from '@anthropic-ai/sdk';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface BrowserWorkflowTrace {
+  sessionId: string
+  subagentId: string
+  startUrl: string
+  goal: string
+  steps: BrowserWorkflowStep[]
+  outcome: 'success' | 'partial' | 'failure'
+  totalDurationMs: number
+  totalTokens: number
+  totalToolUseCount: number
+}
+
+export interface BrowserWorkflowStep {
+  index: number
+  tool: string
+  input: Record<string, unknown>
+  output: string
+  wasEffective: boolean
+  isRetry: boolean
+  accessibilityContext?: string
+  timestampMs: number
+  durationMs: number
+}
+
+export interface ReviewTriggerResult {
+  shouldReview: boolean
+  reason: string
+}
+
+export interface ReviewConfig {
+  retryRateThreshold: number       // default 0.3
+  ineffectivenessThreshold: number // default 0.4
+  minStepsForReview: number        // default 5
+}
+
+interface Skill {
+  name: string
+  description: string
+  domain?: string
+}
+
+// Internal types for JSONL parsing
+interface ContentBlock {
+  type: string
+  id?: string
+  name?: string
+  input?: Record<string, unknown>
+  text?: string
+  tool_use_id?: string
+  content?: string
+  is_error?: boolean
+}
+
+interface JsonlEntry {
+  uuid: string
+  type: 'user' | 'assistant' | 'system' | 'file-history-snapshot'
+  timestamp: string
+  message?: {
+    role: string
+    content: string | ContentBlock[]
+  }
+  toolUseResult?: {
+    stdout: string
+    stderr: string
+    interrupted: boolean
+    agentId?: string
+    status?: string
+    totalDurationMs?: number
+    totalTokens?: number
+    totalToolUseCount?: number
+  }
+  isCompactSummary?: boolean
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const BROWSER_TOOLS = new Set([
+  'mcp__browser__browser_open',
+  'mcp__browser__browser_snapshot',
+  'mcp__browser__browser_click',
+  'mcp__browser__browser_fill',
+  'mcp__browser__browser_scroll',
+  'mcp__browser__browser_wait',
+  'mcp__browser__browser_press',
+  'mcp__browser__browser_screenshot',
+  'mcp__browser__browser_select',
+  'mcp__browser__browser_hover',
+  'mcp__browser__browser_run',
+  'mcp__browser__browser_get_state',
+])
+
+const SNAPSHOT_TOOLS = new Set([
+  'mcp__browser__browser_snapshot',
+  'mcp__browser__browser_get_state',
+  'mcp__browser__browser_screenshot',
+])
+
+const DEFAULT_REVIEW_CONFIG: ReviewConfig = {
+  retryRateThreshold: 0.3,
+  ineffectivenessThreshold: 0.4,
+  minStepsForReview: 5,
+}
+
+// ============================================================================
+// Trace Extraction
+// ============================================================================
+
+/**
+ * Parse a browser sub-agent's JSONL log into a structured workflow trace.
+ */
+export function extractBrowserWorkflowTrace(
+  jsonlPath: string,
+  goal: string
+): BrowserWorkflowTrace {
+  const content = fs.readFileSync(jsonlPath, 'utf-8')
+  const lines = content.split('\n').filter(line => line.trim())
+
+  const entries: JsonlEntry[] = []
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line) as JsonlEntry
+      // Skip compact summaries, system entries, and file-history-snapshot entries
+      if (entry.isCompactSummary) continue
+      if (entry.type === 'system' || entry.type === 'file-history-snapshot') continue
+      entries.push(entry)
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  // Extract session/subagent IDs from the file path
+  const pathParts = jsonlPath.split('/')
+  const fileName = pathParts[pathParts.length - 1] || ''
+  const subagentId = fileName.replace('agent-', '').replace('.jsonl', '')
+  const sessionIdx = pathParts.indexOf('sessions')
+  const sessionId = sessionIdx >= 0 && sessionIdx + 1 < pathParts.length
+    ? pathParts[sessionIdx + 1]
+    : ''
+
+  // Pair tool_use blocks with their tool_result blocks
+  const steps = extractSteps(entries)
+
+  // Detect retries
+  detectRetries(steps)
+
+  // Determine start URL
+  const startUrl = findStartUrl(steps)
+
+  // Determine outcome from the last entry or tool result metadata
+  const outcome = determineOutcome(entries, steps)
+
+  // Calculate totals from entries
+  const firstTimestamp = entries.length > 0 ? new Date(entries[0].timestamp).getTime() : 0
+  const lastTimestamp = entries.length > 0 ? new Date(entries[entries.length - 1].timestamp).getTime() : 0
+  const totalDurationMs = lastTimestamp - firstTimestamp
+
+  // Find subagent completion metadata if available
+  const completionEntry = entries.find(e => e.toolUseResult?.agentId)
+  const totalTokens = completionEntry?.toolUseResult?.totalTokens ?? 0
+  const totalToolUseCount = completionEntry?.toolUseResult?.totalToolUseCount ?? steps.length
+
+  return {
+    sessionId,
+    subagentId,
+    startUrl,
+    goal,
+    steps,
+    outcome,
+    totalDurationMs,
+    totalTokens,
+    totalToolUseCount,
+  }
+}
+
+/**
+ * Extract browser interaction steps by pairing tool_use with tool_result blocks.
+ */
+function extractSteps(entries: JsonlEntry[]): BrowserWorkflowStep[] {
+  const steps: BrowserWorkflowStep[] = []
+
+  // Collect all tool_use and tool_result blocks across entries
+  const toolUseMap = new Map<string, { name: string; input: Record<string, unknown>; timestamp: string }>()
+  const toolResults: Array<{ toolUseId: string; output: string; isError: boolean; timestamp: string }> = []
+
+  for (const entry of entries) {
+    if (!entry.message?.content || typeof entry.message.content === 'string') continue
+
+    for (const block of entry.message.content) {
+      if (block.type === 'tool_use' && block.id && block.name && BROWSER_TOOLS.has(block.name)) {
+        toolUseMap.set(block.id, {
+          name: block.name,
+          input: block.input || {},
+          timestamp: entry.timestamp,
+        })
+      }
+
+      if (block.type === 'tool_result' && block.tool_use_id && toolUseMap.has(block.tool_use_id)) {
+        toolResults.push({
+          toolUseId: block.tool_use_id,
+          output: typeof block.content === 'string' ? block.content : '',
+          isError: block.is_error ?? false,
+          timestamp: entry.timestamp,
+        })
+      }
+    }
+  }
+
+  // Build steps from paired tool_use + tool_result
+  let index = 0
+  for (const result of toolResults) {
+    const use = toolUseMap.get(result.toolUseId)
+    if (!use) continue
+
+    const timestampMs = new Date(use.timestamp).getTime()
+    const resultTimestampMs = new Date(result.timestamp).getTime()
+
+    steps.push({
+      index,
+      tool: use.name,
+      input: use.input,
+      output: result.output,
+      wasEffective: true, // Will be refined below
+      isRetry: false,     // Will be refined by detectRetries
+      timestampMs,
+      durationMs: resultTimestampMs - timestampMs,
+    })
+    index++
+  }
+
+  // Classify step effectiveness
+  classifyAllStepEffectiveness(steps)
+
+  return steps
+}
+
+/**
+ * Classify effectiveness for all steps by comparing surrounding snapshots.
+ */
+function classifyAllStepEffectiveness(steps: BrowserWorkflowStep[]): void {
+  // Track the last snapshot output to compare against
+  let lastSnapshotOutput: string | null = null
+
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i]
+    const toolName = step.tool.replace('mcp__browser__', '')
+
+    // Snapshots are always "effective" (informational, not actions)
+    if (SNAPSHOT_TOOLS.has(step.tool)) {
+      lastSnapshotOutput = step.output
+      step.wasEffective = true
+      continue
+    }
+
+    // browser_open is effective if no error in output
+    if (toolName === 'browser_open') {
+      step.wasEffective = !step.output.toLowerCase().includes('error')
+        && !step.output.toLowerCase().includes('failed')
+      lastSnapshotOutput = null // Page changed, invalidate snapshot
+      continue
+    }
+
+    // For actions (click, fill, press, hover, select), check if next snapshot differs
+    const nextSnapshotStep = steps.slice(i + 1).find(s => SNAPSHOT_TOOLS.has(s.tool))
+    if (lastSnapshotOutput && nextSnapshotStep) {
+      step.wasEffective = nextSnapshotStep.output !== lastSnapshotOutput
+    } else if (step.output.toLowerCase().includes('error') || step.output.toLowerCase().includes('failed')) {
+      step.wasEffective = false
+    }
+    // else keep default true
+
+    // For scroll sequences: only the last scroll before a non-scroll action is effective
+    if (toolName === 'browser_scroll') {
+      const nextNonScroll = steps.slice(i + 1).find(s =>
+        !s.tool.endsWith('browser_scroll') && !SNAPSHOT_TOOLS.has(s.tool)
+      )
+      const nextStep = steps[i + 1]
+      if (nextStep && nextStep.tool.endsWith('browser_scroll')) {
+        // Not the last scroll in a sequence
+        step.wasEffective = false
+      } else if (nextNonScroll) {
+        step.wasEffective = true
+      }
+    }
+
+    // Update last snapshot if this step produced a snapshot-like result
+    if (SNAPSHOT_TOOLS.has(step.tool)) {
+      lastSnapshotOutput = step.output
+    }
+  }
+}
+
+/**
+ * Mark steps that repeat similar actions after a failure (retries).
+ */
+function detectRetries(steps: BrowserWorkflowStep[]): void {
+  for (let i = 1; i < steps.length; i++) {
+    const current = steps[i]
+    // Skip non-action tools
+    if (SNAPSHOT_TOOLS.has(current.tool)) continue
+
+    // Look back at recent steps (within last 5 action steps)
+    const lookback = steps.slice(Math.max(0, i - 5), i)
+      .filter(s => !SNAPSHOT_TOOLS.has(s.tool))
+
+    for (const prev of lookback) {
+      if (prev.tool === current.tool && !prev.wasEffective && isSimilarInput(prev.input, current.input)) {
+        current.isRetry = true
+        break
+      }
+    }
+  }
+}
+
+/**
+ * Check if two tool inputs are similar (same tool, similar target).
+ */
+function isSimilarInput(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  // Same ref
+  if (a.ref && b.ref && a.ref === b.ref) return true
+
+  // Same URL
+  if (a.url && b.url && a.url === b.url) return true
+
+  // Same value being filled
+  if (a.value && b.value && a.value === b.value) return true
+
+  // Same direction for scroll
+  if (a.direction && b.direction && a.direction === b.direction) return true
+
+  // Same key for press
+  if (a.key && b.key && a.key === b.key) return true
+
+  return false
+}
+
+/**
+ * Find the first URL navigated to in the workflow.
+ */
+function findStartUrl(steps: BrowserWorkflowStep[]): string {
+  for (const step of steps) {
+    if (step.tool.endsWith('browser_open') && typeof step.input.url === 'string') {
+      return step.input.url
+    }
+  }
+  return ''
+}
+
+/**
+ * Determine the workflow outcome based on the trace.
+ */
+function determineOutcome(
+  entries: JsonlEntry[],
+  steps: BrowserWorkflowStep[]
+): 'success' | 'partial' | 'failure' {
+  // Check for subagent completion metadata
+  for (const entry of entries) {
+    if (entry.toolUseResult?.status) {
+      if (entry.toolUseResult.status === 'cancelled' || entry.toolUseResult.interrupted) {
+        return 'partial'
+      }
+    }
+  }
+
+  if (steps.length === 0) return 'failure'
+
+  // Check if the last few action steps were effective
+  const actionSteps = steps.filter(s => !SNAPSHOT_TOOLS.has(s.tool))
+  if (actionSteps.length === 0) return 'partial'
+
+  const lastActions = actionSteps.slice(-3)
+  const allFailed = lastActions.every(s => !s.wasEffective)
+  if (allFailed) return 'failure'
+
+  // Check overall retry/failure rate
+  const retryRate = actionSteps.filter(s => s.isRetry).length / actionSteps.length
+  const ineffectiveRate = actionSteps.filter(s => !s.wasEffective).length / actionSteps.length
+
+  if (retryRate > 0.5 || ineffectiveRate > 0.6) return 'partial'
+
+  return 'success'
+}
+
+// ============================================================================
+// Smart Trigger
+// ============================================================================
+
+/**
+ * Decide whether a completed browser workflow warrants review.
+ */
+export async function shouldTriggerReview(
+  trace: BrowserWorkflowTrace,
+  existingSkills: Skill[],
+  config: Partial<ReviewConfig> = {}
+): Promise<ReviewTriggerResult> {
+  const cfg = { ...DEFAULT_REVIEW_CONFIG, ...config }
+
+  // Skip if too few steps to learn from
+  if (trace.totalToolUseCount < cfg.minStepsForReview) {
+    return { shouldReview: false, reason: `Too few steps (${trace.totalToolUseCount} < ${cfg.minStepsForReview})` }
+  }
+
+  // Condition 4: Failure outcome
+  if (trace.outcome === 'failure') {
+    return { shouldReview: true, reason: 'Workflow failed' }
+  }
+
+  const actionSteps = trace.steps.filter(s => !SNAPSHOT_TOOLS.has(s.tool))
+  if (actionSteps.length === 0) {
+    return { shouldReview: false, reason: 'No action steps found' }
+  }
+
+  // Condition 1: High retry rate
+  const retryRate = actionSteps.filter(s => s.isRetry).length / actionSteps.length
+  if (retryRate > cfg.retryRateThreshold) {
+    return { shouldReview: true, reason: `High retry rate: ${(retryRate * 100).toFixed(0)}%` }
+  }
+
+  // Condition 2: Low effectiveness ratio
+  const ineffectiveRate = actionSteps.filter(s => !s.wasEffective).length / actionSteps.length
+  if (ineffectiveRate > cfg.ineffectivenessThreshold) {
+    return { shouldReview: true, reason: `Low effectiveness: ${((1 - ineffectiveRate) * 100).toFixed(0)}% effective` }
+  }
+
+  // Condition 3: No matching skill for this domain + task
+  if (existingSkills.length === 0) {
+    return { shouldReview: true, reason: 'No existing skills' }
+  }
+
+  const matchingSkill = await findMatchingSkill(existingSkills, trace)
+  if (!matchingSkill) {
+    return { shouldReview: true, reason: 'No existing skill covers this domain + task' }
+  }
+
+  // All healthy and skill exists — skip review
+  return { shouldReview: false, reason: `Workflow succeeded with existing skill "${matchingSkill}", metrics healthy` }
+}
+
+/**
+ * Use haiku to determine if any existing skill covers the trace's task.
+ * Returns the matching skill name, or null if none match.
+ */
+async function findMatchingSkill(
+  skills: Skill[],
+  trace: BrowserWorkflowTrace
+): Promise<string | null> {
+  const client = new Anthropic()
+
+  const skillList = skills
+    .map(s => `- "${s.name}": ${s.description}${s.domain ? ` (domain: ${s.domain})` : ''}`)
+    .join('\n')
+
+  let domain = ''
+  try {
+    domain = new URL(trace.startUrl).hostname.replace('www.', '')
+  } catch {
+    // Invalid URL
+  }
+
+  const response = await client.messages.create({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 100,
+    messages: [{
+      role: 'user',
+      content: `Does any of these skills cover this exact task? A skill matches only if it describes the same specific workflow — same domain AND same type of action (not just the same website).
+
+Task: "${trace.goal}"
+Domain: ${domain || 'unknown'}
+
+Skills:
+${skillList}
+
+Reply with ONLY the skill name if one matches, or "none" if no skill covers this specific task.`,
+    }],
+  })
+
+  const answer = (response.content[0] as { type: string; text: string }).text.trim().toLowerCase()
+
+  if (answer === 'none') return null
+
+  // Verify the response matches an actual skill name
+  const matched = skills.find(s => s.name.toLowerCase() === answer)
+  return matched ? matched.name : null
+}
+
+// ============================================================================
+// Helpers for code-driven review trigger
+// ============================================================================
+
+/**
+ * Scan existing skills from .claude/skills/<name>/SKILL.md frontmatter.
+ * Returns an array of skill metadata for use in shouldTriggerReview().
+ */
+export function scanExistingSkills(
+  workDir: string
+): Array<{ name: string; description: string; domain?: string }> {
+  const skillsDir = path.join(workDir, '.claude', 'skills')
+  if (!fs.existsSync(skillsDir)) return []
+
+  const skills: Array<{ name: string; description: string; domain?: string }> = []
+
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(skillsDir)
+  } catch {
+    return []
+  }
+
+  for (const entry of entries) {
+    const skillMdPath = path.join(skillsDir, entry, 'SKILL.md')
+    if (!fs.existsSync(skillMdPath)) continue
+
+    try {
+      const content = fs.readFileSync(skillMdPath, 'utf-8')
+
+      // Parse YAML frontmatter between --- delimiters
+      const fmMatch = content.match(/^---\n([\s\S]*?)\n---/)
+      if (!fmMatch) continue
+
+      const frontmatter = fmMatch[1]
+
+      // Simple regex extraction (avoids YAML parser dependency)
+      const nameMatch = frontmatter.match(/^name:\s*(.+)$/m)
+      const descMatch = frontmatter.match(/^description:\s*(.+)$/m)
+      const domainMatch = frontmatter.match(/^\s*domain:\s*(.+)$/m)
+
+      if (nameMatch && descMatch) {
+        skills.push({
+          name: nameMatch[1].trim().replace(/^["']|["']$/g, ''),
+          description: descMatch[1].trim().replace(/^["']|["']$/g, ''),
+          domain: domainMatch ? domainMatch[1].trim().replace(/^["']|["']$/g, '') : undefined,
+        })
+      }
+    } catch {
+      // Skip unreadable skill files
+    }
+  }
+
+  return skills
+}

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -6,6 +6,11 @@ import { createUserInputMcpServer, createBrowserMcpServer, createDashboardsMcpSe
 import { inputManager } from './input-manager';
 import { setCurrentBrowserSessionId } from './tools/browser';
 import { sanitizeMcpName } from './sanitize-mcp-name';
+import {
+  extractBrowserWorkflowTrace,
+  scanExistingSkills,
+  shouldTriggerReview,
+} from './browser-workflow-trace';
 
 // Prefix for system-injected user messages that should be hidden in the UI.
 // Keep in sync with SYSTEM_MESSAGE_PREFIX in src/renderer/components/messages/message-list.tsx
@@ -20,6 +25,12 @@ const PLATFORM_SYSTEM_PROMPT = fs.readFileSync(
 // Load web-browser subagent prompt from file
 const WEB_BROWSER_AGENT_PROMPT = fs.readFileSync(
   path.join(__dirname, 'web-browser-agent-prompt.md'),
+  'utf-8'
+);
+
+// Load browser workflow reviewer subagent prompt from file
+const BROWSER_WORKFLOW_REVIEWER_PROMPT = fs.readFileSync(
+  path.join(__dirname, 'browser-workflow-reviewer-prompt.md'),
   'utf-8'
 );
 
@@ -282,6 +293,8 @@ export class ClaudeCodeProcess extends EventEmitter {
   private customEnvVars: Record<string, string> | undefined;
   private isReady: boolean = false;
   private isProcessing: boolean = false;
+  private lastBrowserTaskPrompt: string | null = null;
+  private browserAgentPrompts: Map<string, string> = new Map();
   public slashCommands: { name: string; description: string; argumentHint: string }[] = [];
 
   constructor(options: ClaudeCodeProcessOptions) {
@@ -414,6 +427,17 @@ export class ClaudeCodeProcess extends EventEmitter {
             prompt: WEB_BROWSER_AGENT_PROMPT,
             maxTurns: 500,
           },
+          'browser-workflow-reviewer': {
+            description: 'Browser workflow optimization specialist. Analyzes completed browser workflow traces to identify inefficiencies and produce optimized reusable browser skills. Delegate to this agent after a browser task completes when the smart trigger conditions are met.',
+            model: 'sonnet',
+            tools: [
+              'Read',
+              'Write',
+              'Bash',
+            ],
+            prompt: BROWSER_WORKFLOW_REVIEWER_PROMPT,
+            maxTurns: 50,
+          },
         },
         // Handle AskUserQuestion via canUseTool callback (per SDK docs)
         canUseTool: async (toolName: string, toolInput: Record<string, unknown>, options: { toolUseID: string; signal: AbortSignal }) => {
@@ -470,6 +494,54 @@ export class ClaudeCodeProcess extends EventEmitter {
                 async (_input, toolUseId) => {
                   if (toolUseId) {
                     inputManager.setCurrentToolUseId(toolUseId);
+                  }
+                  return {};
+                },
+              ],
+            },
+            {
+              matcher: 'Task',
+              hooks: [
+                async (input: any) => {
+                  if (input.tool_input?.subagent_type === 'web-browser') {
+                    this.lastBrowserTaskPrompt = input.tool_input.prompt || '';
+                    console.log(`[Workflow Review] PreToolUse: captured web-browser Task prompt`);
+                  }
+                  return {};
+                },
+              ],
+            },
+          ],
+          SubagentStart: [
+            {
+              hooks: [
+                async (input: any) => {
+                  if (input.agent_type === 'web-browser' && this.lastBrowserTaskPrompt !== null) {
+                    this.browserAgentPrompts.set(input.agent_id, this.lastBrowserTaskPrompt);
+                    this.lastBrowserTaskPrompt = null;
+                    console.log(`[Workflow Review] SubagentStart: associated prompt with agent ${input.agent_id}`);
+                  }
+                  return {};
+                },
+              ],
+            },
+          ],
+          SubagentStop: [
+            {
+              hooks: [
+                async (input: any) => {
+                  if (input.agent_type === 'web-browser') {
+                    const prompt = this.browserAgentPrompts.get(input.agent_id) || '';
+                    this.browserAgentPrompts.delete(input.agent_id);
+                    console.log(`[Workflow Review] SubagentStop: web-browser agent ${input.agent_id} completed`);
+
+                    this.handleBrowserWorkflowCompletion(
+                      input.agent_id,
+                      prompt,
+                      input.agent_transcript_path,
+                    ).catch(err => {
+                      console.error(`[Workflow Review] Error handling completion:`, err);
+                    });
                   }
                   return {};
                 },
@@ -545,8 +617,6 @@ export class ClaudeCodeProcess extends EventEmitter {
         // Emit the SDK message
         console.log(`[Session ${this.sessionId}] SDK message:`, message.type,
           'subtype' in message ? (message as any).subtype : '');
-
-
 
 
         // Check for result message to know when processing is complete
@@ -702,5 +772,50 @@ export class ClaudeCodeProcess extends EventEmitter {
     console.log(`[Session ${this.sessionId}] Restarting query after interrupt`);
     this.initializeQuery();
     this.processMessages();
+  }
+
+  /**
+   * Handle a completed web-browser Task: extract trace, evaluate trigger, inject system message.
+   * Called from the SubagentStop hook when agent_type === 'web-browser'.
+   */
+  private async handleBrowserWorkflowCompletion(
+    agentId: string,
+    prompt: string,
+    transcriptPath: string,
+  ): Promise<void> {
+    // 1. Verify transcript exists
+    if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+      console.log(`[Workflow Review] Transcript not found: ${transcriptPath}`);
+      return;
+    }
+
+    // 2. Extract trace
+    const trace = extractBrowserWorkflowTrace(transcriptPath, prompt);
+
+    // 3. Scan existing skills
+    const existingSkills = scanExistingSkills(this.workingDirectory);
+
+    // 4. Evaluate trigger
+    const result = await shouldTriggerReview(trace, existingSkills);
+    console.log(`[Workflow Review] ${result.reason} → ${result.shouldReview ? 'REVIEW' : 'SKIP'}`);
+
+    if (!result.shouldReview) return;
+
+    // 5. Write trace to temp file for reviewer to read
+    const claudeDir = path.join(this.workingDirectory, '.claude');
+    if (!fs.existsSync(claudeDir)) {
+      fs.mkdirSync(claudeDir, { recursive: true });
+    }
+    const tracePath = path.join(claudeDir, `workflow-trace-${agentId}.json`);
+    fs.writeFileSync(tracePath, JSON.stringify(trace, null, 2));
+
+    // 6. Inject system message instructing parent to spawn reviewer
+    await this.sendMessage(
+      `${SYSTEM_MESSAGE_PREFIX}A browser workflow just completed and needs review. ` +
+      `EXECUTE NOW: Spawn the browser-workflow-reviewer agent to analyze the trace and create an optimized skill. ` +
+      `Use: Task(subagent_type="browser-workflow-reviewer", prompt="Review the browser workflow trace at ${tracePath}. ` +
+      `The goal was: ${prompt}. Outcome: ${trace.outcome}. Duration: ${trace.totalDurationMs}ms. ` +
+      `Tool uses: ${trace.totalToolUseCount}. Create an optimized skill in /workspace/.claude/skills/.")`
+    );
   }
 }

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -323,6 +323,7 @@ The web-browser agent:
 - Track the URLs reported by the agent so you know where the browser is
 - Remember to close the browser when you're done to free resources
 - Downloads triggered in the browser will be saved to `/workspace/downloads/`
+- Before delegating a browser task, check if an existing skill covers it (browser workflow skills have `task_type: browser-workflow` in metadata). If one exists, include its instructions in the web-browser agent's prompt for faster execution.
 
 ## Other Guidelines
 


### PR DESCRIPTION
- Browser agent automatically generates workflow traces when completing long-horizon tasks
- Reviewer LLM call used to go through trace (in combination with heuristics) --> If "flagged," use strong model to improve + create skill

Still need: 
- More testing
- Currently, the LLM claims that the skill "helped it", but I think the overhead of actually identifying the skill matches the task + reading through it offsets any efficiency advantages. Most likely need to test on even longer-horizon tasks (currently just have it sending linkedin messages, looking for people with XYZ background, etc.). 

- Nothing is broken currently, and this would "work" if merged as-is, but isn't offering substantial improvement ATM. 