### PR TITLE
fix: stop dashboard process in container before deleting files

### DIFF
--- a/agent-container/src/dashboard-manager.ts
+++ b/agent-container/src/dashboard-manager.ts
@@ -310,6 +310,27 @@ class DashboardManager {
     return result
   }
 
+  async stopDashboard(slug: string): Promise<boolean> {
+    const info = this.dashboards.get(slug)
+    if (!info) return false
+
+    if (info.process) {
+      info.process.kill('SIGTERM')
+      await new Promise<void>((resolve) => {
+        if (info.process) {
+          info.process.on('exit', () => resolve())
+          setTimeout(resolve, 5000)
+        } else {
+          resolve()
+        }
+      })
+    }
+
+    info.logStream?.end()
+    this.dashboards.delete(slug)
+    return true
+  }
+
   getDashboardPort(slug: string): number | null {
     const info = this.dashboards.get(slug)
     if (!info || info.status !== 'running') return null

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -451,6 +451,18 @@ app.post('/artifacts/:slug/start', async (c) => {
   }
 });
 
+// DELETE /artifacts/:slug - Stop dashboard process and clean up
+app.delete('/artifacts/:slug', async (c) => {
+  try {
+    const slug = c.req.param('slug');
+    await dashboardManager.stopDashboard(slug);
+    return c.json({ success: true });
+  } catch (error: any) {
+    console.error('[Artifacts] Error deleting dashboard:', error);
+    return c.json({ error: error.message || 'Failed to delete dashboard' }, 500);
+  }
+});
+
 // GET /artifacts/:slug/logs - Get dashboard logs
 app.get('/artifacts/:slug/logs', async (c) => {
   try {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2860,6 +2860,17 @@ agents.delete('/:id/artifacts/:artifactSlug', AgentAdmin(), async (c) => {
     const agentSlug = c.req.param('id')
     const artifactSlug = c.req.param('artifactSlug')
 
+    // Stop the dashboard process in the container (if running), then delete files
+    try {
+      const client = containerManager.getClient(agentSlug)
+      const info = containerManager.getCachedInfo(agentSlug)
+      if (info.status === 'running') {
+        await client.fetch(`/artifacts/${encodeURIComponent(artifactSlug)}`, { method: 'DELETE' })
+      }
+    } catch {
+      // Container not running — just delete files
+    }
+
     await deleteArtifactFromFilesystem(agentSlug, artifactSlug)
     return c.body(null, 204)
   } catch (error) {


### PR DESCRIPTION
## Summary
- Dashboard deletion now first sends a `DELETE` request to the running container to gracefully stop the dashboard process (`SIGTERM` + 5s timeout), close its log stream, and remove it from memory
- Then proceeds to delete files from the host filesystem as before
- Fixes the bug where a deleted dashboard would reappear in the UI because the container still held it in memory

## Test plan
- [x] Create a dashboard via an agent
- [x] Right-click the dashboard → Delete → Confirm
- [x] Verify the dashboard disappears from the sidebar and does not reappear on refresh
- [x] Verify deleting a dashboard while the agent container is stopped also works (falls back to file-only deletion)


Made with [Cursor](https://cursor.com)