### PR TITLE
Bind Hono to ipv4 instead of ipv6 interface

### DIFF
--- a/src/main/find-port.test.ts
+++ b/src/main/find-port.test.ts
@@ -36,7 +36,7 @@ describe('findAvailablePort', () => {
     const port = await findAvailablePort(3000)
 
     expect(port).toBe(3000)
-    expect(mockServer.listen).toHaveBeenCalledWith(3000)
+    expect(mockServer.listen).toHaveBeenCalledWith(3000, '0.0.0.0')
   })
 
   it('skips unavailable ports and returns the first available one', async () => {
@@ -105,7 +105,7 @@ describe('findAvailablePort', () => {
     expect(port).toBe(3001)
   })
 
-  it('listens without specifying host to match serve() binding', async () => {
+  it('listens on 0.0.0.0 to match serve() IPv4 binding', async () => {
     mockServer.once.mockImplementation((event: string, callback: () => void) => {
       if (event === 'listening') {
         mockServer.close.mockImplementation((cb: () => void) => cb())
@@ -116,7 +116,7 @@ describe('findAvailablePort', () => {
 
     await findAvailablePort(8080)
 
-    expect(mockServer.listen).toHaveBeenCalledWith(8080)
+    expect(mockServer.listen).toHaveBeenCalledWith(8080, '0.0.0.0')
   })
 
   it('properly closes the server after checking availability', async () => {

--- a/src/main/find-port.ts
+++ b/src/main/find-port.ts
@@ -36,6 +36,6 @@ function isPortAvailable(port: number): Promise<boolean> {
       })
     })
 
-    server.listen(port)
+    server.listen(port, '0.0.0.0')
   })
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -362,7 +362,7 @@ async function startApp() {
   }
 
   // Start the API server
-  apiServer = serve({ fetch: api.fetch, port: actualApiPort }, () => {
+  apiServer = serve({ fetch: api.fetch, port: actualApiPort, hostname: '0.0.0.0' }, () => {
     console.log(`API server running on http://localhost:${actualApiPort}`)
 
     // Initialize all background services


### PR DESCRIPTION
## Browser Unauthorized Bug

### Root Cause

A stale Vite dev server occupying `0.0.0.0:47891` (IPv4) caused the packaged app's backend to silently bind to the wrong interface, resulting in Docker requests hitting the wrong server with invalid proxy tokens.

#### The Conflict

| Process | Interface | Address |
|---|---|---|
| Stale Vite dev server | IPv4 | `0.0.0.0:47891` |
| Packaged app (Hono) | IPv6 | `:::47891` |

#### Why This Happens

1. The stale Vite dev server holds `0.0.0.0:47891` (IPv4)
2. On startup, `checkAvailablePorts` checks IPv6 — sees port 47891 free — binds to it
3. `Hono.serve()` launches the backend via Node, which defaults to IPv6 (`:::47891`)
4. Docker container tries to reach `host.docker.internal:47891`
5. Docker resolves `host.docker.internal` → `192.168.65.254` (IPv4)
6. **The stale dev server is hit instead of the packaged app**
7. Proxy tokens created by the packaged app are invalid against the stale dev DB → `Unauthorized`

---

### Why `npm run dev:electron` Works

- `npm run dev` uses Vite for both frontend and backend (`/api/*`)
- Vite binds to `0.0.0.0` (IPv4) per config — finds 47891 occupied, falls back to **47892**
- Docker makes its IPv4 request to `:47892`, correctly hits Vite's Hono API ✅

---

### Fix

Make the packaged app behave consistently with the dev workflow:

- **Bind Hono server to `0.0.0.0`** (IPv4) instead of defaulting to Node's IPv6
- **Update `findAvailablePorts`** to check IPv4 availability, not IPv6
