### PR TITLE
fix: add proxy usage pitfalls to agent system prompt

### DIFF
--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -176,6 +176,17 @@ if gmail_accounts:
     print(response.json())
 ```
 
+**Using curl with the proxy:**
+```bash
+curl -sf -H "Authorization: Bearer $PROXY_TOKEN" \
+  "$(echo -n $PROXY_BASE_URL)/${ACCOUNT_ID}/api.github.com/user/repos"
+```
+
+**⚠️ Proxy pitfalls:**
+- `$PROXY_TOKEN` only works with the proxy URL — never send it directly to external APIs.
+- Always strip trailing newlines from `$PROXY_BASE_URL` (use `echo -n` or `${var%$'\n'}`).
+- Never use `curl -w` to append to the response body — it breaks JSON parsing.
+
 **Example workflow:**
 1. Call `mcp__user-input__request_connected_account` with `toolkit: "gmail"`
 2. Wait for the tool result confirming access was granted

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -178,14 +178,13 @@ if gmail_accounts:
 
 **Using curl with the proxy:**
 ```bash
+# Fetch repos via proxy
 curl -sf -H "Authorization: Bearer $PROXY_TOKEN" \
-  "$(echo -n $PROXY_BASE_URL)/${ACCOUNT_ID}/api.github.com/user/repos"
+  "$PROXY_BASE_URL/${ACCOUNT_ID}/api.github.com/user/repos"
 ```
 
 **Proxy pitfalls:**
-- `$PROXY_TOKEN` only works with the proxy URL — never send it directly to external APIs.
-- Always strip trailing newlines from `$PROXY_BASE_URL` (use `echo -n` or `${var%$'\n'}`).
-- Never use `curl -w` to append metadata to stdout when piping to a JSON parser — use `-o` to write the body to a file instead.
+- **ALWAYS add a `#` comment line before any bash command that uses `$PROXY_TOKEN` or `$PROXY_BASE_URL`**. There is a known Bash tool bug where `$VAR` expansion silently returns empty strings if the command has no preceding `#` comment. Even an empty `#` on its own line is enough. Without the comment, commands like `curl -H "Authorization: Bearer $PROXY_TOKEN" ...` will send an empty token and fail with auth errors.
 
 **Example workflow:**
 1. Call `mcp__user-input__request_connected_account` with `toolkit: "gmail"`

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -184,7 +184,7 @@ curl -sf -H "Authorization: Bearer $PROXY_TOKEN" \
 ```
 
 **Proxy pitfalls:**
-- **ALWAYS add a `#` comment line before any bash command that uses `$PROXY_TOKEN` or `$PROXY_BASE_URL`**. There is a known Bash tool bug where `$VAR` expansion silently returns empty strings if the command has no preceding `#` comment. Even an empty `#` on its own line is enough. Without the comment, commands like `curl -H "Authorization: Bearer $PROXY_TOKEN" ...` will send an empty token and fail with auth errors.
+- **ALWAYS add a `#` comment line before any bash command that uses environment variables such as `$PROXY_TOKEN` and `$PROXY_BASE_URL`**. There is a known Bash tool bug where `$VAR` expansion silently returns empty strings if the command has no preceding `#` comment. Even an empty `#` on its own line is enough. Without the comment, commands like `curl -H "Authorization: Bearer $PROXY_TOKEN" ...` will send an empty token and fail with auth errors.
 
 **Example workflow:**
 1. Call `mcp__user-input__request_connected_account` with `toolkit: "gmail"`

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -182,7 +182,7 @@ curl -sf -H "Authorization: Bearer $PROXY_TOKEN" \
   "$(echo -n $PROXY_BASE_URL)/${ACCOUNT_ID}/api.github.com/user/repos"
 ```
 
-**⚠️ Proxy pitfalls:**
+**Proxy pitfalls:**
 - `$PROXY_TOKEN` only works with the proxy URL — never send it directly to external APIs.
 - Always strip trailing newlines from `$PROXY_BASE_URL` (use `echo -n` or `${var%$'\n'}`).
 - Never use `curl -w` to append metadata to stdout when piping to a JSON parser — use `-o` to write the body to a file instead.

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -185,7 +185,7 @@ curl -sf -H "Authorization: Bearer $PROXY_TOKEN" \
 **⚠️ Proxy pitfalls:**
 - `$PROXY_TOKEN` only works with the proxy URL — never send it directly to external APIs.
 - Always strip trailing newlines from `$PROXY_BASE_URL` (use `echo -n` or `${var%$'\n'}`).
-- Never use `curl -w` to append to the response body — it breaks JSON parsing.
+- Never use `curl -w` to append metadata to stdout when piping to a JSON parser — use `-o` to write the body to a file instead.
 
 **Example workflow:**
 1. Call `mcp__user-input__request_connected_account` with `toolkit: "gmail"`


### PR DESCRIPTION
## Summary

Workaround for a Claude Code Bash tool bug ([anthropics/claude-code#29298](https://github.com/anthropics/claude-code/issues/29298)) where `$VAR` expansions silently return empty strings when a command has no `#` comment line.

- Add a `# comment` curl example to the proxy usage section in `system-prompt.md`
- Add a **Proxy pitfalls** note: always include a `#` comment line before any bash command that uses `$PROXY_TOKEN` or `$PROXY_BASE_URL`

Linear: [SUP-82](https://linear.app/datawizz/issue/SUP-82/bug-first-proxy-request-always-fails)

## Test plan
- Deploy to a test agent, ask it to call a connected account API via curl
- Verify it includes a `#` comment line before proxy commands
- Verify `$PROXY_TOKEN` and `$PROXY_BASE_URL` expand correctly