### PR TITLE
Feat/multi tab preview

### DIFF
--- a/agent-container/src/browser-command-args.ts
+++ b/agent-container/src/browser-command-args.ts
@@ -44,3 +44,13 @@ export function buildRunCommandArgs(command: string): string[] {
 
   return commandArgs;
 }
+
+// Workaround: agent-browser@0.12.0 newTab() fails with --profile (persistent context).
+// Rewrite "tab new [url]" to use window.open() which works in any context.
+export function rewriteTabNewCommand(args: string[]): string[] {
+  if (args[0] === 'tab' && args[1] === 'new') {
+    const url = args[2] || 'about:blank';
+    return ['eval', `(() => { window.open('${url.replace(/'/g, "\\'")}', '_blank'); return 'opened'; })()`];
+  }
+  return args;
+}

--- a/agent-container/src/browser-command-args.ts
+++ b/agent-container/src/browser-command-args.ts
@@ -50,7 +50,7 @@ export function buildRunCommandArgs(command: string): string[] {
 export function rewriteTabNewCommand(args: string[]): string[] {
   if (args[0] === 'tab' && args[1] === 'new') {
     const url = args[2] || 'about:blank';
-    return ['eval', `(() => { window.open('${url.replace(/'/g, "\\'")}', '_blank'); return 'opened'; })()`];
+    return ['eval', `(() => { window.open(${JSON.stringify(url)}, '_blank'); return 'opened'; })()`];
   }
   return args;
 }

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -1718,17 +1718,18 @@ function switchScreencastTarget(target: PageTarget, clientWs: WebSocket): void {
   }
 }
 
-/** Broadcast tab list to the connected frontend viewer */
-async function broadcastTabList(): Promise<void> {
+/** Broadcast tab list to the connected frontend viewer.
+ *  Accepts pre-fetched data to avoid redundant calls when used alongside findActivePageTarget. */
+async function broadcastTabList(prefetched?: { allTargets: PageTarget[]; daemonTabs: Awaited<ReturnType<typeof tabManager.queryTabs>> }): Promise<void> {
   if (!cdpScreencast) return;
   const clientWs = cdpScreencast.clientWs;
   if (clientWs.readyState !== WebSocket.OPEN) return;
 
   try {
-    const [allTargets, daemonTabs] = await Promise.all([
-      getAllPageTargets(),
-      tabManager.queryTabs(),
-    ]);
+    const { allTargets, daemonTabs } = prefetched ?? {
+      allTargets: await getAllPageTargets(),
+      daemonTabs: await tabManager.queryTabs(),
+    };
 
     const claimedTargetIds = new Set<string>();
     const tabs: BrowserTabInfo[] = [];
@@ -1766,16 +1767,27 @@ function notifyBrowserAction() {
     if (!cdpScreencast || cdpScreencast.clientWs !== currentClient) return;
 
     try {
-      const target = await findActivePageTarget();
+      // Fetch once and share across both operations
+      const [allTargets, daemonTabs] = await Promise.all([
+        getAllPageTargets(),
+        tabManager.queryTabs(),
+      ]);
+
+      // Resolve the active target from daemon info
+      const activeDaemonTab = daemonTabs.find(t => t.active);
+      let activeTarget: PageTarget | null = allTargets[0] ?? null;
+      if (activeDaemonTab && allTargets.length > 1) {
+        activeTarget = allTargets.find(p => tabManager.urlsMatch(p.url, activeDaemonTab.url)) ?? activeTarget;
+      }
 
       // Switch screencast only if auto-following and target changed
-      if (target && target.id !== cdpScreencast.currentTargetId && viewerAutoFollow) {
-        console.log(`[CDP] Auto-following to target ${target.id}`);
-        switchScreencastTarget(target, currentClient);
+      if (activeTarget && activeTarget.id !== cdpScreencast.currentTargetId && viewerAutoFollow) {
+        console.log(`[CDP] Auto-following to target ${activeTarget.id}`);
+        switchScreencastTarget(activeTarget, currentClient);
       }
 
       // Always broadcast updated tab list (so frontend sees agent's active tab move)
-      broadcastTabList();
+      broadcastTabList({ allTargets, daemonTabs });
     } catch (err) {
       console.error('[CDP] notifyBrowserAction failed:', err);
     }

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -1747,6 +1747,15 @@ async function broadcastTabList(prefetched?: { allTargets: PageTarget[]; daemonT
     }
 
     const activeEntry = tabs.find(t => t.active);
+    const activeTargetId = activeEntry?.targetId;
+
+    // Auto-follow: switch screencast if active target changed (e.g. user clicked a link that opened a new tab)
+    if (viewerAutoFollow && activeTargetId && activeTargetId !== cdpScreencast?.currentTargetId) {
+      const target = allTargets.find(t => t.id === activeTargetId);
+      if (target) {
+        switchScreencastTarget(target, clientWs);
+      }
+    }
 
     clientWs.send(JSON.stringify({
       type: 'tab_list',

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -546,7 +546,7 @@ let browserState: BrowserState = { active: false, sessionId: null, cdpUrl: null 
 
 const execFileAsync = promisify(execFile);
 
-import { splitCommandArgs, buildRunCommandArgs } from './browser-command-args';
+import { splitCommandArgs, buildRunCommandArgs, rewriteTabNewCommand } from './browser-command-args';
 
 // Ensure Chrome download preferences are set in the browser profile directory.
 // Merges with existing preferences to avoid overwriting other settings.
@@ -1263,13 +1263,7 @@ app.post('/browser/run', async (c) => {
       return c.json({ error: 'Empty command' }, 400);
     }
 
-    // Workaround: agent-browser@0.12.0 newTab() fails with --profile (persistent context).
-    // Rewrite "tab new [url]" to use window.open() which works in any context.
-    let actualArgs = commandArgs;
-    if (commandArgs[0] === 'tab' && commandArgs[1] === 'new') {
-      const url = commandArgs[2] || 'about:blank';
-      actualArgs = ['eval', `(() => { window.open('${url.replace(/'/g, "\\'")}', '_blank'); return 'opened'; })()`];
-    }
+    const actualArgs = rewriteTabNewCommand(commandArgs);
 
     const result = await execBrowser(actualArgs, browserState.cdpUrl || undefined);
 

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -1446,6 +1446,8 @@ let cdpScreencast: {
   lastDeviceHeight: number;
   /** CDP session ID for flattened session mode (remote providers like Browserbase) */
   cdpSessionId: string | null;
+  /** Whether the viewer auto-follows the agent's active tab */
+  autoFollow: boolean;
 } | null = null;
 
 /** Derive the CDP HTTP endpoint from the current browser state */
@@ -1476,8 +1478,6 @@ interface BrowserTabInfo {
   active: boolean;
 }
 
-// Viewer tab-selection state — persists across CDP target switches
-let viewerAutoFollow = true;
 let tabPollInterval: NodeJS.Timeout | null = null;
 
 /** Get ALL CDP page targets across all strategies */
@@ -1609,7 +1609,8 @@ function cdpMsg(state: NonNullable<typeof cdpScreencast>, method: string, params
 /** Connect CDP screencast to a page target and forward frames to the client */
 function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket, requiresSession = false) {
   const cdpWs = new WebSocket(wsUrl);
-  cdpScreencast = { clientWs, cdpWs, currentTargetId: targetId, msgId: 0, lastDeviceWidth: 0, lastDeviceHeight: 0, cdpSessionId: null };
+  const prevAutoFollow = cdpScreencast?.autoFollow ?? true;
+  cdpScreencast = { clientWs, cdpWs, currentTargetId: targetId, msgId: 0, lastDeviceWidth: 0, lastDeviceHeight: 0, cdpSessionId: null, autoFollow: prevAutoFollow };
   const state = cdpScreencast;
 
   cdpWs.on('open', () => {
@@ -1683,7 +1684,7 @@ function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket
     findActivePageTarget().then(target => {
       if (target && cdpScreencast?.clientWs === clientWs && clientWs.readyState === WebSocket.OPEN) {
         console.log('[CDP] Recovering from closed target, switching to', target.id);
-        viewerAutoFollow = true;
+        cdpScreencast.autoFollow = true;
         switchScreencastTarget(target, clientWs);
         broadcastTabList();
       } else if (clientWs.readyState === WebSocket.OPEN) {
@@ -1752,7 +1753,7 @@ async function broadcastTabList(prefetched?: { allTargets: PageTarget[]; daemonT
     const activeTargetId = activeEntry?.targetId;
 
     // Auto-follow: switch screencast if active target changed (e.g. user clicked a link that opened a new tab)
-    if (viewerAutoFollow && activeTargetId && activeTargetId !== cdpScreencast?.currentTargetId) {
+    if (cdpScreencast?.autoFollow && activeTargetId && activeTargetId !== cdpScreencast?.currentTargetId) {
       const target = allTargets.find(t => t.id === activeTargetId);
       if (target) {
         switchScreencastTarget(target, clientWs);
@@ -1792,7 +1793,7 @@ function notifyBrowserAction() {
       }
 
       // Switch screencast only if auto-following and target changed
-      if (activeTarget && activeTarget.id !== cdpScreencast.currentTargetId && viewerAutoFollow) {
+      if (activeTarget && activeTarget.id !== cdpScreencast.currentTargetId && cdpScreencast.autoFollow) {
         console.log(`[CDP] Auto-following to target ${activeTarget.id}`);
         switchScreencastTarget(activeTarget, currentClient);
       }
@@ -1810,12 +1811,12 @@ function handleBrowserStreamConnection(ws: WebSocket) {
   // If there's an existing screencast, close it (single viewer)
   cleanupCdpScreencast();
 
-  // Reset viewer state for new connection
-  viewerAutoFollow = true;
-
   findActivePageTarget().then((target) => {
     if (!target) {
       console.error('[CDP] No active page target found');
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'error', message: 'No browser tab found — the page may still be loading' }));
+      }
       ws.close();
       return;
     }
@@ -1823,6 +1824,9 @@ function handleBrowserStreamConnection(ws: WebSocket) {
     broadcastTabList();
   }).catch((err) => {
     console.error('[CDP] Failed to start screencast:', err);
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'error', message: 'Failed to connect to browser' }));
+    }
     ws.close();
   });
 
@@ -1841,12 +1845,12 @@ function handleBrowserStreamConnection(ws: WebSocket) {
         const allTargets = await getAllPageTargets();
         const target = allTargets.find(t => t.id === data.targetId);
         if (target && cdpScreencast && cdpScreencast.cdpWs.readyState === WebSocket.OPEN) {
-          viewerAutoFollow = false;
+          cdpScreencast.autoFollow = false;
           switchScreencastTarget(target, ws);
         }
       } else if (data.type === 'follow_agent') {
-        viewerAutoFollow = data.enabled !== false;
-        if (viewerAutoFollow) {
+        if (cdpScreencast) cdpScreencast.autoFollow = data.enabled !== false;
+        if (cdpScreencast?.autoFollow) {
           // Snap to agent's active tab immediately
           const target = await findActivePageTarget();
           if (target && cdpScreencast && target.id !== cdpScreencast.currentTargetId) {

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -1455,21 +1455,36 @@ function getCdpHttpEndpoint(): string {
   return 'http://localhost:9222';
 }
 
-/** Result from findActivePageTarget */
-interface ActivePageTarget {
+/** A discovered CDP page target */
+interface PageTarget {
   id: string;
+  url: string;
+  title: string;
   wsUrl: string;
   /** If true, wsUrl is a browser-level URL; connectCdpToTarget must use Target.attachToTarget */
   requiresSession: boolean;
 }
 
-/** Find the CDP page target that corresponds to agent-browser's active page */
-async function findActivePageTarget(): Promise<ActivePageTarget | null> {
+// Protocol: see src/renderer/components/browser/browser-preview.tsx
+interface BrowserTabInfo {
+  targetId: string;
+  index: number;
+  url: string;
+  title: string;
+  active: boolean;
+}
+
+// Viewer tab-selection state — persists across CDP target switches
+let viewerAutoFollow = true;
+let tabPollInterval: NodeJS.Timeout | null = null;
+
+/** Get ALL CDP page targets across all strategies */
+async function getAllPageTargets(): Promise<PageTarget[]> {
   // Try Chrome's HTTP /json endpoint first (works for local Chrome)
   const endpoint = getCdpHttpEndpoint();
   try {
     const res = await fetch(`${endpoint}/json`);
-    const targets = await res.json() as Array<{ id: string; type: string; url: string; webSocketDebuggerUrl: string }>;
+    const targets = await res.json() as Array<{ id: string; type: string; url: string; title?: string; webSocketDebuggerUrl: string }>;
 
     const pages = targets.filter(t => t.type === 'page');
     if (pages.length > 0) {
@@ -1480,31 +1495,19 @@ async function findActivePageTarget(): Promise<ActivePageTarget | null> {
         page.webSocketDebuggerUrl = page.webSocketDebuggerUrl.replace(/^ws:\/\/[^/]+/, `ws://${cdpHost}`);
       }
 
-      if (pages.length === 1) return { id: pages[0].id, wsUrl: pages[0].webSocketDebuggerUrl, requiresSession: false };
-
-      // Ask agent-browser daemon which tab is active and match to a CDP target
-      try {
-        const tabs = await tabManager.queryTabs();
-        const active = tabs.find(t => t.active);
-        if (active) {
-          const byUrl = pages.find(p => p.url === active.url);
-          if (byUrl) return { id: byUrl.id, wsUrl: byUrl.webSocketDebuggerUrl, requiresSession: false };
-          if (active.index < pages.length) return { id: pages[active.index].id, wsUrl: pages[active.index].webSocketDebuggerUrl, requiresSession: false };
-        }
-      } catch (err) {
-        console.error('[CDP] Daemon tab query failed:', err);
-      }
-
-      // Fallback: last page (most recently created)
-      const last = pages[pages.length - 1];
-      return { id: last.id, wsUrl: last.webSocketDebuggerUrl, requiresSession: false };
+      return pages.map(p => ({
+        id: p.id,
+        url: p.url,
+        title: p.title || '',
+        wsUrl: p.webSocketDebuggerUrl,
+        requiresSession: false,
+      }));
     }
   } catch {
     // HTTP /json not available — fall through to WebSocket CDP approach
   }
 
   // For remote CDP providers (e.g. Browserbase), try the host API debug endpoint first.
-  // This returns fresh page-level debug URLs that can be connected to directly.
   const hostAppUrl = process.env.HOST_APP_URL;
   const agentId = process.env.AGENT_ID;
   if (hostAppUrl && agentId) {
@@ -1519,11 +1522,16 @@ async function findActivePageTarget(): Promise<ActivePageTarget | null> {
         body: JSON.stringify({ agentId }),
       });
       if (debugRes.ok) {
-        const debugInfo = await debugRes.json() as { pages?: Array<{ id: string; url: string; wsUrl: string }> };
+        const debugInfo = await debugRes.json() as { pages?: Array<{ id: string; url: string; title?: string; wsUrl: string }> };
         const pages = debugInfo.pages || [];
         if (pages.length > 0) {
-          const page = pages[pages.length - 1];
-          return { id: page.id, wsUrl: page.wsUrl, requiresSession: false };
+          return pages.map(p => ({
+            id: p.id,
+            url: p.url,
+            title: p.title || '',
+            wsUrl: p.wsUrl,
+            requiresSession: false,
+          }));
         }
       }
     } catch (err) {
@@ -1531,13 +1539,35 @@ async function findActivePageTarget(): Promise<ActivePageTarget | null> {
     }
   }
 
-  // Fallback: try CDP Target.getTargets over WebSocket (may not work for single-use URLs)
-  if (!browserState.cdpUrl) return null;
-  return findPageTargetViaCdp(browserState.cdpUrl);
+  // Fallback: try CDP Target.getTargets over WebSocket
+  if (!browserState.cdpUrl) return [];
+  const target = await findPageTargetViaCdp(browserState.cdpUrl);
+  return target ? [target] : [];
+}
+
+/** Find the CDP page target that corresponds to agent-browser's active page */
+async function findActivePageTarget(): Promise<PageTarget | null> {
+  const allTargets = await getAllPageTargets();
+  if (allTargets.length === 0) return null;
+  if (allTargets.length === 1) return allTargets[0];
+
+  // Use daemon to find which is active
+  try {
+    const tabs = await tabManager.queryTabs();
+    const active = tabs.find(t => t.active);
+    if (active) {
+      const byUrl = allTargets.find(p => tabManager.urlsMatch(p.url, active.url));
+      if (byUrl) return byUrl;
+    }
+  } catch (err) {
+    console.error('[CDP] Daemon tab query failed:', err);
+  }
+
+  return allTargets[0]; // fallback: first target (most recently active per Chrome's /json ordering)
 }
 
 /** Discover page targets via CDP WebSocket protocol (for remote providers) */
-function findPageTargetViaCdp(browserWsUrl: string): Promise<ActivePageTarget | null> {
+function findPageTargetViaCdp(browserWsUrl: string): Promise<PageTarget | null> {
   return new Promise((resolve) => {
     const ws = new WebSocket(browserWsUrl);
     const timeout = setTimeout(() => { ws.close(); resolve(null); }, 5000);
@@ -1557,7 +1587,7 @@ function findPageTargetViaCdp(browserWsUrl: string): Promise<ActivePageTarget | 
           );
           if (pages.length === 0) { resolve(null); return; }
           const target = pages[pages.length - 1];
-          resolve({ id: target.targetId, wsUrl: browserWsUrl, requiresSession: true });
+          resolve({ id: target.targetId, url: target.url || '', title: target.title || '', wsUrl: browserWsUrl, requiresSession: true });
         }
       } catch { /* wait for next message */ }
     });
@@ -1644,10 +1674,22 @@ function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket
   });
 
   cdpWs.on('close', () => {
-    // If this was our active connection, close the client so the frontend reconnects
-    if (cdpScreencast?.cdpWs === cdpWs && clientWs.readyState === WebSocket.OPEN) {
-      clientWs.close();
-    }
+    // If this wasn't our active connection (already replaced by a tab switch), ignore
+    if (cdpScreencast?.cdpWs !== cdpWs) return;
+
+    // Unexpected close — try to recover by switching to agent's active tab
+    findActivePageTarget().then(target => {
+      if (target && cdpScreencast?.clientWs === clientWs && clientWs.readyState === WebSocket.OPEN) {
+        console.log('[CDP] Recovering from closed target, switching to', target.id);
+        viewerAutoFollow = true;
+        switchScreencastTarget(target, clientWs);
+        broadcastTabList();
+      } else if (clientWs.readyState === WebSocket.OPEN) {
+        clientWs.close();
+      }
+    }).catch(() => {
+      if (clientWs.readyState === WebSocket.OPEN) clientWs.close();
+    });
   });
 
   cdpWs.on('error', (err) => {
@@ -1664,23 +1706,79 @@ function cleanupCdpScreencast() {
   cdpScreencast = null;
 }
 
+/** Switch the CDP screencast to a different target, keeping the client WS alive */
+function switchScreencastTarget(target: PageTarget, clientWs: WebSocket): void {
+  if (cdpScreencast?.cdpWs.readyState === WebSocket.OPEN) {
+    cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Page.stopScreencast'));
+    cdpScreencast.cdpWs.close();
+  }
+  connectCdpToTarget(target.id, target.wsUrl, clientWs, target.requiresSession);
+  if (clientWs.readyState === WebSocket.OPEN) {
+    clientWs.send(JSON.stringify({ type: 'tab_switched', targetId: target.id }));
+  }
+}
+
+/** Broadcast tab list to the connected frontend viewer */
+async function broadcastTabList(): Promise<void> {
+  if (!cdpScreencast) return;
+  const clientWs = cdpScreencast.clientWs;
+  if (clientWs.readyState !== WebSocket.OPEN) return;
+
+  try {
+    const [allTargets, daemonTabs] = await Promise.all([
+      getAllPageTargets(),
+      tabManager.queryTabs(),
+    ]);
+
+    const claimedTargetIds = new Set<string>();
+    const tabs: BrowserTabInfo[] = [];
+    for (const dt of daemonTabs) {
+      const target = allTargets.find(t => tabManager.urlsMatch(t.url, dt.url) && !claimedTargetIds.has(t.id));
+      if (!target) continue; // skip tabs with no CDP match (timing edge case, resolves on next poll)
+      claimedTargetIds.add(target.id);
+      tabs.push({
+        targetId: target.id,
+        index: dt.index,
+        url: dt.url,
+        title: dt.title || target.title || '',
+        active: dt.active,
+      });
+    }
+
+    const activeEntry = tabs.find(t => t.active);
+
+    clientWs.send(JSON.stringify({
+      type: 'tab_list',
+      tabs,
+      activeTargetId: activeEntry?.targetId ?? cdpScreencast?.currentTargetId ?? '',
+    }));
+  } catch (err) {
+    console.error('[CDP] Failed to broadcast tab list:', err);
+  }
+}
+
 /** After a browser action, check if the active tab changed and switch screencast */
 function notifyBrowserAction() {
   if (!cdpScreencast) return;
   const currentClient = cdpScreencast.clientWs;
   // Brief delay to let agent-browser update its internal state after the action
-  setTimeout(() => {
+  setTimeout(async () => {
     if (!cdpScreencast || cdpScreencast.clientWs !== currentClient) return;
-    findActivePageTarget().then((target) => {
-      if (!target || !cdpScreencast || target.id === cdpScreencast.currentTargetId) return;
-      console.log(`[CDP] Switching screencast to target ${target.id}`);
-      // Stop old screencast and connect to the new target
-      if (cdpScreencast.cdpWs.readyState === WebSocket.OPEN) {
-        cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Page.stopScreencast'));
-        cdpScreencast.cdpWs.close();
+
+    try {
+      const target = await findActivePageTarget();
+
+      // Switch screencast only if auto-following and target changed
+      if (target && target.id !== cdpScreencast.currentTargetId && viewerAutoFollow) {
+        console.log(`[CDP] Auto-following to target ${target.id}`);
+        switchScreencastTarget(target, currentClient);
       }
-      connectCdpToTarget(target.id, target.wsUrl, currentClient, target.requiresSession);
-    }).catch(err => console.error('[CDP] Recheck failed:', err));
+
+      // Always broadcast updated tab list (so frontend sees agent's active tab move)
+      broadcastTabList();
+    } catch (err) {
+      console.error('[CDP] notifyBrowserAction failed:', err);
+    }
   }, 300);
 }
 
@@ -1689,6 +1787,9 @@ function handleBrowserStreamConnection(ws: WebSocket) {
   // If there's an existing screencast, close it (single viewer)
   cleanupCdpScreencast();
 
+  // Reset viewer state for new connection
+  viewerAutoFollow = true;
+
   findActivePageTarget().then((target) => {
     if (!target) {
       console.error('[CDP] No active page target found');
@@ -1696,50 +1797,75 @@ function handleBrowserStreamConnection(ws: WebSocket) {
       return;
     }
     connectCdpToTarget(target.id, target.wsUrl, ws, target.requiresSession);
+    broadcastTabList();
   }).catch((err) => {
     console.error('[CDP] Failed to start screencast:', err);
     ws.close();
   });
 
-  // Forward input events from client to the active page via CDP
-  ws.on('message', (rawData) => {
+  // Start tab list polling
+  tabPollInterval = setInterval(() => broadcastTabList(), 2000);
+
+  // Forward input events and handle tab control messages from client
+  // Protocol: see src/renderer/components/browser/browser-preview.tsx
+  ws.on('message', async (rawData) => {
     try {
       const data = JSON.parse(rawData.toString());
-      if (!cdpScreencast || cdpScreencast.cdpWs.readyState !== WebSocket.OPEN) return;
+      if (!cdpScreencast) return;
 
-      if (data.type === 'input_mouse') {
-        cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Input.dispatchMouseEvent', {
-          type: data.eventType,
-          x: Math.round(data.x),
-          y: Math.round(data.y),
-          button: data.button,
-          clickCount: data.clickCount || 0,
-          deltaX: data.deltaX || 0,
-          deltaY: data.deltaY || 0,
-          modifiers: data.modifiers || 0,
-        }));
-      } else if (data.type === 'input_keyboard') {
-        cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Input.dispatchKeyEvent', {
-          type: data.eventType,
-          key: data.key,
-          code: data.code,
-          text: data.text,
-          modifiers: data.modifiers || 0,
-        }));
-      } else if (data.type === 'input_paste' && data.text) {
-        // Paste: inject clipboard text from the client into the remote page
-        cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Input.insertText', {
-          text: data.text,
-        }));
+      if (data.type === 'switch_tab' && data.targetId) {
+        // User wants to view a specific tab
+        const allTargets = await getAllPageTargets();
+        const target = allTargets.find(t => t.id === data.targetId);
+        if (target && cdpScreencast && cdpScreencast.cdpWs.readyState === WebSocket.OPEN) {
+          viewerAutoFollow = false;
+          switchScreencastTarget(target, ws);
+        }
+      } else if (data.type === 'follow_agent') {
+        viewerAutoFollow = data.enabled !== false;
+        if (viewerAutoFollow) {
+          // Snap to agent's active tab immediately
+          const target = await findActivePageTarget();
+          if (target && cdpScreencast && target.id !== cdpScreencast.currentTargetId) {
+            switchScreencastTarget(target, ws);
+          }
+        }
+      } else if (cdpScreencast.cdpWs.readyState === WebSocket.OPEN) {
+        if (data.type === 'input_mouse') {
+          cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Input.dispatchMouseEvent', {
+            type: data.eventType,
+            x: Math.round(data.x),
+            y: Math.round(data.y),
+            button: data.button,
+            clickCount: data.clickCount || 0,
+            deltaX: data.deltaX || 0,
+            deltaY: data.deltaY || 0,
+            modifiers: data.modifiers || 0,
+          }));
+        } else if (data.type === 'input_keyboard') {
+          cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Input.dispatchKeyEvent', {
+            type: data.eventType,
+            key: data.key,
+            code: data.code,
+            text: data.text,
+            modifiers: data.modifiers || 0,
+          }));
+        } else if (data.type === 'input_paste' && data.text) {
+          cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Input.insertText', {
+            text: data.text,
+          }));
+        }
       }
     } catch { /* ignore */ }
   });
 
   ws.on('close', () => {
+    if (tabPollInterval) { clearInterval(tabPollInterval); tabPollInterval = null; }
     if (cdpScreencast?.clientWs === ws) cleanupCdpScreencast();
   });
 
   ws.on('error', () => {
+    if (tabPollInterval) { clearInterval(tabPollInterval); tabPollInterval = null; }
     if (cdpScreencast?.clientWs === ws) cleanupCdpScreencast();
   });
 }

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -1263,7 +1263,15 @@ app.post('/browser/run', async (c) => {
       return c.json({ error: 'Empty command' }, 400);
     }
 
-    const result = await execBrowser(commandArgs, browserState.cdpUrl || undefined);
+    // Workaround: agent-browser@0.12.0 newTab() fails with --profile (persistent context).
+    // Rewrite "tab new [url]" to use window.open() which works in any context.
+    let actualArgs = commandArgs;
+    if (commandArgs[0] === 'tab' && commandArgs[1] === 'new') {
+      const url = commandArgs[2] || 'about:blank';
+      actualArgs = ['eval', `(() => { window.open('${url.replace(/'/g, "\\'")}', '_blank'); return 'opened'; })()`];
+    }
+
+    const result = await execBrowser(actualArgs, browserState.cdpUrl || undefined);
 
     if (result.exitCode !== 0) {
       return c.json({ error: result.stdout, success: false }, 500);

--- a/agent-container/src/tab-new-rewrite.test.ts
+++ b/agent-container/src/tab-new-rewrite.test.ts
@@ -6,7 +6,7 @@ describe('rewriteTabNewCommand', () => {
     const result = rewriteTabNewCommand(['tab', 'new', 'https://example.com'])
     expect(result).toEqual([
       'eval',
-      "(() => { window.open('https://example.com', '_blank'); return 'opened'; })()",
+      '(() => { window.open("https://example.com", \'_blank\'); return \'opened\'; })()',
     ])
   })
 
@@ -14,16 +14,22 @@ describe('rewriteTabNewCommand', () => {
     const result = rewriteTabNewCommand(['tab', 'new'])
     expect(result).toEqual([
       'eval',
-      "(() => { window.open('about:blank', '_blank'); return 'opened'; })()",
+      '(() => { window.open("about:blank", \'_blank\'); return \'opened\'; })()',
     ])
   })
 
-  it('escapes single quotes in url', () => {
-    const result = rewriteTabNewCommand(['tab', 'new', "url'with'quotes"])
-    expect(result).toEqual([
-      'eval',
-      "(() => { window.open('url\\'with\\'quotes', '_blank'); return 'opened'; })()",
-    ])
+  it('escapes special characters in url safely', () => {
+    const result = rewriteTabNewCommand(['tab', 'new', "url'with\"quotes"])
+    expect(result[0]).toBe('eval')
+    // JSON.stringify handles all escaping — no breakout possible
+    expect(result[1]).toContain('window.open("url\'with\\"quotes"')
+  })
+
+  it('handles backslash-quote sequences safely', () => {
+    // This input would break the old single-quote escaping approach
+    const result = rewriteTabNewCommand(['tab', 'new', "test\\'breakout"])
+    expect(result[0]).toBe('eval')
+    expect(result[1]).toContain('window.open("test\\\\\'breakout"')
   })
 
   it('passes non-tab commands through unchanged', () => {

--- a/agent-container/src/tab-new-rewrite.test.ts
+++ b/agent-container/src/tab-new-rewrite.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { rewriteTabNewCommand } from './browser-command-args'
+
+describe('rewriteTabNewCommand', () => {
+  it('rewrites tab new <url> to eval with window.open', () => {
+    const result = rewriteTabNewCommand(['tab', 'new', 'https://example.com'])
+    expect(result).toEqual([
+      'eval',
+      "(() => { window.open('https://example.com', '_blank'); return 'opened'; })()",
+    ])
+  })
+
+  it('uses about:blank as default when no url provided', () => {
+    const result = rewriteTabNewCommand(['tab', 'new'])
+    expect(result).toEqual([
+      'eval',
+      "(() => { window.open('about:blank', '_blank'); return 'opened'; })()",
+    ])
+  })
+
+  it('escapes single quotes in url', () => {
+    const result = rewriteTabNewCommand(['tab', 'new', "url'with'quotes"])
+    expect(result).toEqual([
+      'eval',
+      "(() => { window.open('url\\'with\\'quotes', '_blank'); return 'opened'; })()",
+    ])
+  })
+
+  it('passes non-tab commands through unchanged', () => {
+    expect(rewriteTabNewCommand(['click', '@e1'])).toEqual(['click', '@e1'])
+    expect(rewriteTabNewCommand(['tab', '2'])).toEqual(['tab', '2'])
+    expect(rewriteTabNewCommand(['eval', 'document.title'])).toEqual(['eval', 'document.title'])
+  })
+})

--- a/src/renderer/components/browser/browser-preview.test.tsx
+++ b/src/renderer/components/browser/browser-preview.test.tsx
@@ -1,0 +1,259 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// --- Mocks (must be before component import) ---
+
+vi.mock('@renderer/lib/env', () => ({
+  getApiBaseUrl: () => 'http://localhost:3000',
+}))
+
+vi.mock('@renderer/hooks/use-message-stream', () => ({
+  useMessageStream: () => ({ pendingBrowserInputRequests: [] }),
+  clearBrowserActive: vi.fn(),
+}))
+
+vi.mock('@renderer/context/user-context', () => ({
+  useUser: () => ({ canUseAgent: () => true }),
+}))
+
+// Mock lucide-react icons to simple spans
+vi.mock('lucide-react', () => ({
+  Globe: (props: any) => <span data-testid="icon-globe" {...props} />,
+  ChevronUp: (props: any) => <span data-testid="icon-chevron-up" {...props} />,
+  ChevronDown: (props: any) => <span data-testid="icon-chevron-down" {...props} />,
+  X: (props: any) => <span data-testid="icon-x" {...props} />,
+  MousePointerClick: (props: any) => <span data-testid="icon-mouse" {...props} />,
+  Eye: (props: any) => <span data-testid="icon-eye" {...props} />,
+  EyeOff: (props: any) => <span data-testid="icon-eye-off" {...props} />,
+}))
+
+// Mock alert dialog to avoid Radix DOM issues
+vi.mock('@renderer/components/ui/alert-dialog', () => ({
+  AlertDialog: ({ children }: any) => <div>{children}</div>,
+  AlertDialogContent: ({ children }: any) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: any) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: any) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: any) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: any) => <div>{children}</div>,
+  AlertDialogAction: (props: any) => <button {...props} />,
+  AlertDialogCancel: (props: any) => <button {...props} />,
+}))
+
+// Track WebSocket instances
+let wsInstances: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CLOSED = 3
+  readyState = MockWebSocket.OPEN
+  url: string
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: any }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  send = vi.fn()
+  close = vi.fn(() => { this.readyState = MockWebSocket.CLOSED })
+  addEventListener = vi.fn()
+  removeEventListener = vi.fn()
+
+  constructor(url: string) {
+    this.url = url
+    wsInstances.push(this)
+    // Auto-fire onopen in next tick
+    setTimeout(() => this.onopen?.(), 0)
+  }
+}
+
+// Also mock global fetch for the status check on ws close
+const mockFetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ active: false }) }))
+
+beforeEach(() => {
+  wsInstances = []
+  vi.stubGlobal('WebSocket', MockWebSocket)
+  vi.stubGlobal('fetch', mockFetch)
+  // Mock canvas getContext
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+    drawImage: vi.fn(),
+    clearRect: vi.fn(),
+  })) as any
+})
+
+import { BrowserPreview } from './browser-preview'
+
+const defaultProps = {
+  agentSlug: 'test-agent',
+  sessionId: 'session-1',
+  browserActive: true,
+  isActive: true,
+}
+
+function getLatestWs(): MockWebSocket {
+  return wsInstances[wsInstances.length - 1]
+}
+
+function simulateWsMessage(ws: MockWebSocket, data: Record<string, unknown>) {
+  ws.onmessage?.({ data: JSON.stringify(data) })
+}
+
+describe('BrowserPreview multi-tab', () => {
+  it('shows tab bar when tab_list message is received', async () => {
+    render(<BrowserPreview {...defaultProps} />)
+    // Wait for WS to connect
+    await act(async () => { await new Promise(r => setTimeout(r, 10)) })
+
+    const ws = getLatestWs()
+    act(() => {
+      simulateWsMessage(ws, {
+        type: 'tab_list',
+        tabs: [
+          { targetId: 't1', index: 0, url: 'https://a.com', title: 'A', active: true },
+          { targetId: 't2', index: 1, url: 'https://b.com', title: 'B', active: false },
+        ],
+        activeTargetId: 't1',
+      })
+    })
+
+    expect(screen.getByText('A')).toBeInTheDocument()
+    expect(screen.getByText('B')).toBeInTheDocument()
+  })
+
+  it('auto-follow updates viewingTargetId from tab_list activeTargetId', async () => {
+    render(<BrowserPreview {...defaultProps} />)
+    await act(async () => { await new Promise(r => setTimeout(r, 10)) })
+
+    const ws = getLatestWs()
+    act(() => {
+      simulateWsMessage(ws, {
+        type: 'tab_list',
+        tabs: [
+          { targetId: 't1', index: 0, url: 'https://a.com', title: 'A', active: false },
+          { targetId: 't2', index: 1, url: 'https://b.com', title: 'B', active: true },
+        ],
+        activeTargetId: 't2',
+      })
+    })
+
+    // The viewing tab should be t2 (the active one) — it gets bg-background class
+    const bButton = screen.getByText('B').closest('button')!
+    expect(bButton.className).toContain('bg-background')
+  })
+
+  it('tab_switched message updates viewingTargetId', async () => {
+    render(<BrowserPreview {...defaultProps} />)
+    await act(async () => { await new Promise(r => setTimeout(r, 10)) })
+
+    const ws = getLatestWs()
+    // First, send tab_list to populate tabs
+    act(() => {
+      simulateWsMessage(ws, {
+        type: 'tab_list',
+        tabs: [
+          { targetId: 't1', index: 0, url: 'https://a.com', title: 'A', active: true },
+          { targetId: 't2', index: 1, url: 'https://b.com', title: 'B', active: false },
+        ],
+        activeTargetId: 't1',
+      })
+    })
+
+    // Then switch to t2
+    act(() => {
+      simulateWsMessage(ws, { type: 'tab_switched', targetId: 't2' })
+    })
+
+    const bButton = screen.getByText('B').closest('button')!
+    expect(bButton.className).toContain('bg-background')
+  })
+
+  it('tab click sends switch_tab WS message and disables auto-follow', async () => {
+    const user = userEvent.setup()
+    render(<BrowserPreview {...defaultProps} />)
+    await act(async () => { await new Promise(r => setTimeout(r, 10)) })
+
+    const ws = getLatestWs()
+    act(() => {
+      simulateWsMessage(ws, {
+        type: 'tab_list',
+        tabs: [
+          { targetId: 't1', index: 0, url: 'https://a.com', title: 'A', active: true },
+          { targetId: 't2', index: 1, url: 'https://b.com', title: 'B', active: false },
+        ],
+        activeTargetId: 't1',
+      })
+    })
+
+    await user.click(screen.getByText('B'))
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'switch_tab', targetId: 't2' })
+    )
+
+    // Auto-follow should be disabled — look for the EyeOff icon title
+    expect(screen.getByTitle('Not following agent (click to follow)')).toBeInTheDocument()
+  })
+
+  it('toggle auto-follow sends follow_agent WS message', async () => {
+    const user = userEvent.setup()
+    render(<BrowserPreview {...defaultProps} />)
+    await act(async () => { await new Promise(r => setTimeout(r, 10)) })
+
+    const ws = getLatestWs()
+    act(() => {
+      simulateWsMessage(ws, {
+        type: 'tab_list',
+        tabs: [
+          { targetId: 't1', index: 0, url: 'https://a.com', title: 'A', active: true },
+        ],
+        activeTargetId: 't1',
+      })
+    })
+
+    // Initially autoFollow is true, click to disable
+    await user.click(screen.getByTitle('Auto-following agent (click to pin)'))
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'follow_agent', enabled: false })
+    )
+  })
+
+  it('falls back to agent active tab when viewed tab is closed', async () => {
+    render(<BrowserPreview {...defaultProps} />)
+    await act(async () => { await new Promise(r => setTimeout(r, 10)) })
+
+    const ws = getLatestWs()
+
+    // Set up 2 tabs, manually switch to t2
+    act(() => {
+      simulateWsMessage(ws, {
+        type: 'tab_list',
+        tabs: [
+          { targetId: 't1', index: 0, url: 'https://a.com', title: 'A', active: true },
+          { targetId: 't2', index: 1, url: 'https://b.com', title: 'B', active: false },
+        ],
+        activeTargetId: 't1',
+      })
+    })
+
+    // Switch to t2 via tab_switched
+    act(() => {
+      simulateWsMessage(ws, { type: 'tab_switched', targetId: 't2' })
+    })
+
+    // Now t2 is closed — new tab_list without t2
+    act(() => {
+      simulateWsMessage(ws, {
+        type: 'tab_list',
+        tabs: [
+          { targetId: 't1', index: 0, url: 'https://a.com', title: 'A', active: true },
+        ],
+        activeTargetId: 't1',
+      })
+    })
+
+    // Should fall back to t1 (agent's active tab) and re-enable auto-follow
+    const aButton = screen.getByText('A').closest('button')!
+    expect(aButton.className).toContain('bg-background')
+    expect(screen.getByTitle('Auto-following agent (click to pin)')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/browser/browser-preview.test.tsx
+++ b/src/renderer/components/browser/browser-preview.test.tsx
@@ -24,6 +24,7 @@ vi.mock('lucide-react', () => ({
   ChevronUp: (props: any) => <span data-testid="icon-chevron-up" {...props} />,
   ChevronDown: (props: any) => <span data-testid="icon-chevron-down" {...props} />,
   X: (props: any) => <span data-testid="icon-x" {...props} />,
+  Loader2: (props: any) => <span data-testid="icon-loader" {...props} />,
   MousePointerClick: (props: any) => <span data-testid="icon-mouse" {...props} />,
   Eye: (props: any) => <span data-testid="icon-eye" {...props} />,
   EyeOff: (props: any) => <span data-testid="icon-eye-off" {...props} />,
@@ -255,5 +256,39 @@ describe('BrowserPreview multi-tab', () => {
     const aButton = screen.getByText('A').closest('button')!
     expect(aButton.className).toContain('bg-background')
     expect(screen.getByTitle('Auto-following agent (click to pin)')).toBeInTheDocument()
+  })
+
+  it('shows loading spinner when page_loading is true', async () => {
+    render(<BrowserPreview {...defaultProps} />)
+    await act(async () => { await new Promise(r => setTimeout(r, 10)) })
+
+    const ws = getLatestWs()
+    // Send tabs first so tab bar is visible
+    act(() => {
+      simulateWsMessage(ws, {
+        type: 'tab_list',
+        tabs: [
+          { targetId: 't1', index: 0, url: 'https://a.com', title: 'A', active: true },
+        ],
+        activeTargetId: 't1',
+      })
+    })
+
+    // No spinner before page_loading
+    expect(screen.queryByTestId('icon-loader')).not.toBeInTheDocument()
+
+    // Send page_loading = true
+    act(() => {
+      simulateWsMessage(ws, { type: 'page_loading', loading: true })
+    })
+
+    expect(screen.getByTestId('icon-loader')).toBeInTheDocument()
+
+    // Send page_loading = false
+    act(() => {
+      simulateWsMessage(ws, { type: 'page_loading', loading: false })
+    })
+
+    expect(screen.queryByTestId('icon-loader')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/components/browser/browser-preview.tsx
+++ b/src/renderer/components/browser/browser-preview.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { Globe, ChevronUp, ChevronDown, X, Loader2, MousePointerClick } from 'lucide-react'
+import { BrowserTabBar, type BrowserTabInfo } from './browser-tab-bar'
 import { getApiBaseUrl } from '@renderer/lib/env'
 import { clearBrowserActive, useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useUser } from '@renderer/context/user-context'
@@ -48,6 +49,14 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
   const [isClosing, setIsClosing] = useState(false)
   const [aspectRatio, setAspectRatio] = useState('16 / 9')
   const [overlayDismissedForId, setOverlayDismissedForId] = useState<string | null>(null)
+
+  // Multi-tab state — Protocol: see agent-container/src/server.ts
+  const [tabs, setTabs] = useState<BrowserTabInfo[]>([])
+  const [agentActiveTargetId, setAgentActiveTargetId] = useState<string | null>(null)
+  const [viewingTargetId, setViewingTargetId] = useState<string | null>(null)
+  const [autoFollow, setAutoFollow] = useState(true)
+  const autoFollowRef = useRef(autoFollow)
+  autoFollowRef.current = autoFollow
 
   const { pendingBrowserInputRequests } = useMessageStream(sessionId, agentSlug)
   const needsAttention = browserActive && pendingBrowserInputRequests.length > 0 && !isViewOnly
@@ -253,6 +262,14 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
               deviceHeight: data.metadata.deviceHeight || 720,
             }
           }
+        } else if (data.type === 'tab_list') {
+          setTabs(data.tabs)
+          setAgentActiveTargetId(data.activeTargetId)
+          if (autoFollowRef.current) {
+            setViewingTargetId(data.activeTargetId)
+          }
+        } else if (data.type === 'tab_switched') {
+          setViewingTargetId(data.targetId)
         }
       } catch {
         // Ignore parse errors for binary frames
@@ -305,6 +322,14 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
     }
   }, [needsAttention])
 
+  // Fallback when the tab the user is viewing gets closed
+  useEffect(() => {
+    if (viewingTargetId && tabs.length > 0 && !tabs.find(t => t.targetId === viewingTargetId)) {
+      setViewingTargetId(agentActiveTargetId)
+      setAutoFollow(true)
+    }
+  }, [tabs, viewingTargetId, agentActiveTargetId])
+
   // --- Canvas input handlers ---
   const mapCoordinates = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -322,7 +347,7 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
     []
   )
 
-  const sendInput = useCallback(
+  const sendMessage = useCallback(
     (message: Record<string, unknown>) => {
       if (wsRef.current?.readyState === WebSocket.OPEN) {
         wsRef.current.send(JSON.stringify(message))
@@ -352,31 +377,31 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
   const handleMouseDown = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
       const { x, y } = mapCoordinates(e)
-      sendInput({ type: 'input_mouse', eventType: 'mousePressed', x, y, button: buttonName(e.button), clickCount: 1, modifiers: modifierFlags(e) })
+      sendMessage({ type: 'input_mouse', eventType: 'mousePressed', x, y, button: buttonName(e.button), clickCount: 1, modifiers: modifierFlags(e) })
     },
-    [mapCoordinates, sendInput, buttonName, modifierFlags]
+    [mapCoordinates, sendMessage, buttonName, modifierFlags]
   )
 
   const handleMouseUp = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
       const { x, y } = mapCoordinates(e)
-      sendInput({ type: 'input_mouse', eventType: 'mouseReleased', x, y, button: buttonName(e.button), modifiers: modifierFlags(e) })
+      sendMessage({ type: 'input_mouse', eventType: 'mouseReleased', x, y, button: buttonName(e.button), modifiers: modifierFlags(e) })
     },
-    [mapCoordinates, sendInput, buttonName, modifierFlags]
+    [mapCoordinates, sendMessage, buttonName, modifierFlags]
   )
 
   const handleMouseMove = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
       const { x, y } = mapCoordinates(e)
-      sendInput({ type: 'input_mouse', eventType: 'mouseMoved', x, y, button: 'none', modifiers: modifierFlags(e) })
+      sendMessage({ type: 'input_mouse', eventType: 'mouseMoved', x, y, button: 'none', modifiers: modifierFlags(e) })
     },
-    [mapCoordinates, sendInput, modifierFlags]
+    [mapCoordinates, sendMessage, modifierFlags]
   )
 
   const handleWheel = useCallback(
     (e: React.WheelEvent<HTMLCanvasElement>) => {
       const { x, y } = mapCoordinates(e)
-      sendInput({
+      sendMessage({
         type: 'input_mouse',
         eventType: 'mouseWheel',
         x,
@@ -387,7 +412,7 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
         modifiers: modifierFlags(e),
       })
     },
-    [mapCoordinates, sendInput, modifierFlags]
+    [mapCoordinates, sendMessage, modifierFlags]
   )
 
   const pressKeyViaHttp = useCallback(
@@ -418,10 +443,10 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
       e.preventDefault()
       const text = e.clipboardData.getData('text/plain')
       if (text) {
-        sendInput({ type: 'input_paste', text })
+        sendMessage({ type: 'input_paste', text })
       }
     },
-    [sendInput]
+    [sendMessage]
   )
 
   const handleKeyDown = useCallback(
@@ -436,7 +461,7 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
 
       if (printable) {
         // Printable characters: send via WebSocket stream (low latency, works via CDP text field)
-        sendInput({
+        sendMessage({
           type: 'input_keyboard',
           eventType: 'keyDown',
           key: e.key,
@@ -453,7 +478,7 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
       // Pure modifier keys (Shift, Ctrl, etc.) alone: ignore — they're included
       // in the combo string when a non-modifier key is pressed with them.
     },
-    [sendInput, modifierFlags, pressKeyViaHttp]
+    [sendMessage, modifierFlags, pressKeyViaHttp]
   )
 
   const handleKeyUp = useCallback(
@@ -462,7 +487,7 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
       // Only send keyUp for printable characters via stream.
       // Non-printable keys use press (which sends both down+up).
       if (e.key.length === 1) {
-        sendInput({
+        sendMessage({
           type: 'input_keyboard',
           eventType: 'keyUp',
           key: e.key,
@@ -471,8 +496,24 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
         })
       }
     },
-    [sendInput, modifierFlags]
+    [sendMessage, modifierFlags]
   )
+
+  const handleTabClick = useCallback((targetId: string) => {
+    if (targetId === viewingTargetId) return
+    setAutoFollow(false)
+    setViewingTargetId(targetId)
+    sendMessage({ type: 'switch_tab', targetId })
+  }, [viewingTargetId, sendMessage])
+
+  const toggleAutoFollow = useCallback(() => {
+    const next = !autoFollow
+    setAutoFollow(next)
+    sendMessage({ type: 'follow_agent', enabled: next })
+    if (next && agentActiveTargetId) {
+      setViewingTargetId(agentActiveTargetId)
+    }
+  }, [autoFollow, agentActiveTargetId, sendMessage])
 
   const closeBrowser = useCallback(async () => {
     const baseUrl = getApiBaseUrl()
@@ -576,6 +617,17 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
           </button>
         )}
       </div>
+
+      {/* Tab bar — shown when any tabs are reported */}
+      {expanded && tabs.length >= 1 && (
+        <BrowserTabBar
+          tabs={tabs}
+          viewingTargetId={viewingTargetId}
+          autoFollow={autoFollow}
+          onTabClick={handleTabClick}
+          onToggleAutoFollow={toggleAutoFollow}
+        />
+      )}
 
       {/* Canvas viewport */}
       {expanded && (

--- a/src/renderer/components/browser/browser-preview.tsx
+++ b/src/renderer/components/browser/browser-preview.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { Globe, ChevronUp, ChevronDown, X, Loader2, MousePointerClick } from 'lucide-react'
+import { Globe, ChevronUp, ChevronDown, X, MousePointerClick } from 'lucide-react'
 import { BrowserTabBar, type BrowserTabInfo } from './browser-tab-bar'
 import { getApiBaseUrl } from '@renderer/lib/env'
 import { clearBrowserActive, useMessageStream } from '@renderer/hooks/use-message-stream'
@@ -43,7 +43,7 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
   const isViewOnly = !canUseAgent(agentSlug)
   const [expanded, setExpanded] = useState(false)
   const [connected, setConnected] = useState(false)
-  const [pageLoading, setPageLoading] = useState(false)
+  const [, setPageLoading] = useState(false)
   const [reconnectKey, setReconnectKey] = useState(0)
   const [showCloseWarning, setShowCloseWarning] = useState(false)
   const [isClosing, setIsClosing] = useState(false)

--- a/src/renderer/components/browser/browser-preview.tsx
+++ b/src/renderer/components/browser/browser-preview.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { Globe, ChevronUp, ChevronDown, X, MousePointerClick } from 'lucide-react'
+import { Globe, ChevronUp, ChevronDown, X, Loader2, MousePointerClick } from 'lucide-react'
 import { BrowserTabBar, type BrowserTabInfo } from './browser-tab-bar'
 import { getApiBaseUrl } from '@renderer/lib/env'
 import { clearBrowserActive, useMessageStream } from '@renderer/hooks/use-message-stream'
@@ -43,7 +43,7 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
   const isViewOnly = !canUseAgent(agentSlug)
   const [expanded, setExpanded] = useState(false)
   const [connected, setConnected] = useState(false)
-  const [, setPageLoading] = useState(false)
+  const [pageLoading, setPageLoading] = useState(false)
   const [reconnectKey, setReconnectKey] = useState(0)
   const [showCloseWarning, setShowCloseWarning] = useState(false)
   const [isClosing, setIsClosing] = useState(false)
@@ -269,6 +269,7 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
             setViewingTargetId(data.activeTargetId)
           }
         } else if (data.type === 'tab_switched') {
+          setAgentActiveTargetId(data.targetId)
           setViewingTargetId(data.targetId)
         }
       } catch {
@@ -624,6 +625,7 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
           tabs={tabs}
           viewingTargetId={viewingTargetId}
           autoFollow={autoFollow}
+          loading={pageLoading}
           onTabClick={handleTabClick}
           onToggleAutoFollow={toggleAutoFollow}
         />

--- a/src/renderer/components/browser/browser-tab-bar.test.tsx
+++ b/src/renderer/components/browser/browser-tab-bar.test.tsx
@@ -95,4 +95,16 @@ describe('BrowserTabBar', () => {
     await user.click(screen.getByTitle('Auto-following agent (click to pin)'))
     expect(onToggleAutoFollow).toHaveBeenCalledOnce()
   })
+
+  it('shows loading spinner when loading is true', () => {
+    const { container } = render(<BrowserTabBar {...defaultProps} loading={true} />)
+    const spinner = container.querySelector('.animate-spin')
+    expect(spinner).toBeInTheDocument()
+  })
+
+  it('does not show loading spinner when loading is false', () => {
+    const { container } = render(<BrowserTabBar {...defaultProps} loading={false} />)
+    const spinner = container.querySelector('.animate-spin')
+    expect(spinner).not.toBeInTheDocument()
+  })
 })

--- a/src/renderer/components/browser/browser-tab-bar.test.tsx
+++ b/src/renderer/components/browser/browser-tab-bar.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BrowserTabBar, type BrowserTabInfo } from './browser-tab-bar'
+
+const makeTabs = (count: number): BrowserTabInfo[] =>
+  Array.from({ length: count }, (_, i) => ({
+    targetId: `target-${i}`,
+    index: i,
+    url: `https://example.com/${i}`,
+    title: `Tab ${i}`,
+    active: i === 0,
+  }))
+
+describe('BrowserTabBar', () => {
+  const defaultProps = {
+    tabs: makeTabs(3),
+    viewingTargetId: 'target-0',
+    autoFollow: true,
+    onTabClick: vi.fn(),
+    onToggleAutoFollow: vi.fn(),
+  }
+
+  it('renders all tabs', () => {
+    render(<BrowserTabBar {...defaultProps} />)
+    expect(screen.getByText('Tab 0')).toBeInTheDocument()
+    expect(screen.getByText('Tab 1')).toBeInTheDocument()
+    expect(screen.getByText('Tab 2')).toBeInTheDocument()
+  })
+
+  it('falls back to url when title is empty', () => {
+    const tabs: BrowserTabInfo[] = [
+      { targetId: 't1', index: 0, url: 'https://foo.com', title: '', active: false },
+    ]
+    render(<BrowserTabBar {...defaultProps} tabs={tabs} />)
+    expect(screen.getByText('https://foo.com')).toBeInTheDocument()
+  })
+
+  it('falls back to Tab N+1 when both title and url are empty', () => {
+    const tabs: BrowserTabInfo[] = [
+      { targetId: 't1', index: 2, url: '', title: '', active: false },
+    ]
+    render(<BrowserTabBar {...defaultProps} tabs={tabs} />)
+    expect(screen.getByText('Tab 3')).toBeInTheDocument()
+  })
+
+  it('highlights the viewing tab with bg-background class', () => {
+    render(<BrowserTabBar {...defaultProps} viewingTargetId="target-1" />)
+    const viewingButton = screen.getByText('Tab 1').closest('button')!
+    expect(viewingButton.className).toContain('bg-background')
+
+    const otherButton = screen.getByText('Tab 2').closest('button')!
+    expect(otherButton.className).not.toContain('bg-background')
+  })
+
+  it('shows agent-active indicator (blue dot) on active tab', () => {
+    render(<BrowserTabBar {...defaultProps} />)
+    // Tab 0 is active — should have a bg-blue-500 dot
+    const activeButton = screen.getByText('Tab 0').closest('button')!
+    const dot = activeButton.querySelector('.bg-blue-500')
+    expect(dot).toBeInTheDocument()
+
+    // Tab 1 is not active — no dot
+    const inactiveButton = screen.getByText('Tab 1').closest('button')!
+    expect(inactiveButton.querySelector('.bg-blue-500')).toBeNull()
+  })
+
+  it('calls onTabClick with correct targetId', async () => {
+    const onTabClick = vi.fn()
+    const user = userEvent.setup()
+    render(<BrowserTabBar {...defaultProps} onTabClick={onTabClick} />)
+
+    await user.click(screen.getByText('Tab 2'))
+    expect(onTabClick).toHaveBeenCalledWith('target-2')
+  })
+
+  it('shows Eye icon and blue text when autoFollow is true', () => {
+    render(<BrowserTabBar {...defaultProps} autoFollow={true} />)
+    const toggleButton = screen.getByTitle('Auto-following agent (click to pin)')
+    expect(toggleButton.className).toContain('text-blue-500')
+  })
+
+  it('shows EyeOff icon when autoFollow is false', () => {
+    render(<BrowserTabBar {...defaultProps} autoFollow={false} />)
+    const toggleButton = screen.getByTitle('Not following agent (click to follow)')
+    expect(toggleButton).toBeInTheDocument()
+  })
+
+  it('calls onToggleAutoFollow when toggle button is clicked', async () => {
+    const onToggleAutoFollow = vi.fn()
+    const user = userEvent.setup()
+    render(<BrowserTabBar {...defaultProps} onToggleAutoFollow={onToggleAutoFollow} />)
+
+    await user.click(screen.getByTitle('Auto-following agent (click to pin)'))
+    expect(onToggleAutoFollow).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/components/browser/browser-tab-bar.tsx
+++ b/src/renderer/components/browser/browser-tab-bar.tsx
@@ -1,4 +1,4 @@
-import { Eye, EyeOff } from 'lucide-react'
+import { Eye, EyeOff, Loader2 } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
 
 // Protocol: see agent-container/src/server.ts
@@ -14,11 +14,12 @@ interface BrowserTabBarProps {
   tabs: BrowserTabInfo[]
   viewingTargetId: string | null
   autoFollow: boolean
+  loading?: boolean
   onTabClick: (targetId: string) => void
   onToggleAutoFollow: () => void
 }
 
-export function BrowserTabBar({ tabs, viewingTargetId, autoFollow, onTabClick, onToggleAutoFollow }: BrowserTabBarProps) {
+export function BrowserTabBar({ tabs, viewingTargetId, autoFollow, loading, onTabClick, onToggleAutoFollow }: BrowserTabBarProps) {
   return (
     <div className="flex items-center gap-0.5 px-1 py-0.5 bg-muted/30 border-b overflow-x-auto shrink-0" style={{ height: 24 }}>
       {tabs.map((tab) => {
@@ -42,9 +43,13 @@ export function BrowserTabBar({ tabs, viewingTargetId, autoFollow, onTabClick, o
           </button>
         )
       })}
+      {loading && (
+        <Loader2 className="h-3 w-3 animate-spin text-muted-foreground shrink-0 ml-auto" />
+      )}
       <button
         className={cn(
-          'ml-auto p-0.5 rounded transition-colors shrink-0',
+          loading ? '' : 'ml-auto',
+          'p-0.5 rounded transition-colors shrink-0',
           autoFollow ? 'text-blue-500 hover:text-blue-600' : 'text-muted-foreground hover:text-foreground'
         )}
         onClick={onToggleAutoFollow}

--- a/src/renderer/components/browser/browser-tab-bar.tsx
+++ b/src/renderer/components/browser/browser-tab-bar.tsx
@@ -1,0 +1,57 @@
+import { Eye, EyeOff } from 'lucide-react'
+import { cn } from '@shared/lib/utils/cn'
+
+// Protocol: see agent-container/src/server.ts
+export interface BrowserTabInfo {
+  targetId: string
+  index: number
+  url: string
+  title: string
+  active: boolean // true = agent's active tab
+}
+
+interface BrowserTabBarProps {
+  tabs: BrowserTabInfo[]
+  viewingTargetId: string | null
+  autoFollow: boolean
+  onTabClick: (targetId: string) => void
+  onToggleAutoFollow: () => void
+}
+
+export function BrowserTabBar({ tabs, viewingTargetId, autoFollow, onTabClick, onToggleAutoFollow }: BrowserTabBarProps) {
+  return (
+    <div className="flex items-center gap-0.5 px-1 py-0.5 bg-muted/30 border-b overflow-x-auto shrink-0" style={{ height: 24 }}>
+      {tabs.map((tab) => {
+        const isViewing = tab.targetId === viewingTargetId
+        const isAgentActive = tab.active
+
+        return (
+          <button
+            key={tab.targetId}
+            className={cn(
+              'relative flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] leading-tight max-w-[100px] truncate transition-colors',
+              isViewing ? 'bg-background shadow-sm text-foreground' : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+            )}
+            onClick={() => onTabClick(tab.targetId)}
+            title={tab.title || tab.url}
+          >
+            <span className="truncate">{tab.title || tab.url || `Tab ${tab.index + 1}`}</span>
+            {isAgentActive && (
+              <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-blue-500 shrink-0" />
+            )}
+          </button>
+        )
+      })}
+      <button
+        className={cn(
+          'ml-auto p-0.5 rounded transition-colors shrink-0',
+          autoFollow ? 'text-blue-500 hover:text-blue-600' : 'text-muted-foreground hover:text-foreground'
+        )}
+        onClick={onToggleAutoFollow}
+        title={autoFollow ? 'Auto-following agent (click to pin)' : 'Not following agent (click to follow)'}
+      >
+        {autoFollow ? <Eye className="h-3 w-3" /> : <EyeOff className="h-3 w-3" />}
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
- Support for multi-tab preview
- Allow user to click through tabs (especially useful in container mode, when user input causes new tab to open)
- Allow user to "follow" agent and see which tab is currently being viewed by agent
- **Bug Fix:** In container mode, `tab new [url]` was not working due to bug in agent browser. Quick fix: Route to custom JS instead of using agent browser. Long term TODO is to upgrade agent browser, but due to major refactoring on their end, this would require a more significant effort on our part as well. Leaving this for another PR. 
<img width="1485" height="888" alt="Screenshot 2026-03-17 at 4 33 14 PM" src="https://github.com/user-attachments/assets/cb7987d9-f459-434f-8fa7-0ec6daf2cff1" />

