### PR TITLE
Feat/local mode api security

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -23,6 +23,7 @@ import { sql } from 'drizzle-orm'
 import { db } from '@shared/lib/db'
 import { user as userTable } from '@shared/lib/db/schema'
 import { authEnforcementMiddleware, getAuthSettings } from './middleware/auth-enforcement'
+import { LocalModeAuth } from './middleware/local-mode-auth'
 
 const app = new Hono()
 
@@ -37,6 +38,22 @@ if (process.type !== 'browser') {
 // Enable CORS for all routes
 const trustedOrigins = process.env.TRUSTED_ORIGINS?.split(',').map(o => o.trim()).filter(Boolean)
 app.use('*', cors(trustedOrigins?.length ? { origin: trustedOrigins } : undefined))
+
+// Local mode: localhost IP restriction for all API endpoints (except container-facing endpoints)
+if (!isAuthMode()) {
+  const localModeAuth = LocalModeAuth()
+
+  app.use('/api/*', async (c, next) => {
+    const path = c.req.path
+    // Container endpoints: protected by IsAgent() bearer tokens
+    if (path.startsWith('/api/proxy/') ||
+        path.startsWith('/api/mcp-proxy/') ||
+        path.startsWith('/api/browser/')) {
+      return next()
+    }
+    return localModeAuth(c, next)
+  })
+}
 
 // Simple rate limiter for auth endpoints
 const authAttempts = new Map<string, { count: number; resetAt: number }>()

--- a/src/api/middleware/local-mode-auth.ts
+++ b/src/api/middleware/local-mode-auth.ts
@@ -1,0 +1,18 @@
+import type { MiddlewareHandler } from 'hono'
+import { getConnInfo } from '@hono/node-server/conninfo'
+import { isAuthMode } from '@shared/lib/auth/mode'
+
+const LOCALHOST_ADDRS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1'])
+
+export function LocalModeAuth(): MiddlewareHandler {
+  return async (c, next) => {
+    if (isAuthMode()) return next()
+
+    const addr = getConnInfo(c).remote.address
+    if (!addr || !LOCALHOST_ADDRS.has(addr)) {
+      return c.json({ error: 'Forbidden' }, 403)
+    }
+
+    return next()
+  }
+}

--- a/src/api/middleware/local-mode-auth.ts
+++ b/src/api/middleware/local-mode-auth.ts
@@ -8,6 +8,10 @@ export function LocalModeAuth(): MiddlewareHandler {
   return async (c, next) => {
     if (isAuthMode()) return next()
 
+    // Only restrict to localhost in Electron — Docker/web deployments
+    // handle network security at the infrastructure level.
+    if (process.type !== 'browser') return next()
+
     const addr = getConnInfo(c).remote.address
     if (!addr || !LOCALHOST_ADDRS.has(addr)) {
       return c.json({ error: 'Forbidden' }, 403)

--- a/src/main/browser-stream-proxy.ts
+++ b/src/main/browser-stream-proxy.ts
@@ -30,8 +30,11 @@ async function authenticateWs(
   minRole: AgentRole,
 ): Promise<boolean> {
   if (!isAuthMode()) {
-    const addr = request.socket?.remoteAddress
-    if (!addr || !LOCALHOST_ADDRS.has(addr)) return false
+    // Only restrict to localhost in Electron
+    if (process.type === 'browser') {
+      const addr = request.socket?.remoteAddress
+      if (!addr || !LOCALHOST_ADDRS.has(addr)) return false
+    }
     return true
   }
 

--- a/src/main/browser-stream-proxy.ts
+++ b/src/main/browser-stream-proxy.ts
@@ -19,6 +19,8 @@ import { and, eq } from 'drizzle-orm'
 
 const browserWss = new WebSocketServer({ noServer: true })
 
+const LOCALHOST_ADDRS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1'])
+
 type AgentRole = 'owner' | 'user' | 'viewer'
 const ROLE_HIERARCHY: Record<AgentRole, number> = { viewer: 0, user: 1, owner: 2 }
 
@@ -27,7 +29,11 @@ async function authenticateWs(
   agentSlug: string,
   minRole: AgentRole,
 ): Promise<boolean> {
-  if (!isAuthMode()) return true
+  if (!isAuthMode()) {
+    const addr = request.socket?.remoteAddress
+    if (!addr || !LOCALHOST_ADDRS.has(addr)) return false
+    return true
+  }
 
   try {
     // Lazy import to avoid pulling in better-auth ESM at startup

--- a/src/renderer/components/browser/browser-preview.tsx
+++ b/src/renderer/components/browser/browser-preview.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { Globe, ChevronUp, ChevronDown, X, Loader2, MousePointerClick } from 'lucide-react'
 import { getApiBaseUrl } from '@renderer/lib/env'
+import { apiFetch } from '@renderer/lib/api'
 import { clearBrowserActive, useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useUser } from '@renderer/context/user-context'
 import { cn } from '@shared/lib/utils/cn'
@@ -262,7 +263,7 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
     ws.onclose = () => {
       setConnected(false)
       setPageLoading(false)
-      fetch(`${baseUrl}/api/agents/${agentSlug}/browser/status`)
+      apiFetch(`/api/agents/${agentSlug}/browser/status`)
         .then((res) => res.json())
         .then((status: { active?: boolean; sessionId?: string }) => {
           if (!status.active || status.sessionId !== sessionId) {
@@ -401,8 +402,7 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
       parts.push(key)
       const combo = parts.join('+')
 
-      const baseUrl = getApiBaseUrl()
-      fetch(`${baseUrl}/api/agents/${agentSlug}/browser/press`, {
+      apiFetch(`/api/agents/${agentSlug}/browser/press`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ sessionId, key: combo }),
@@ -475,17 +475,16 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
   )
 
   const closeBrowser = useCallback(async () => {
-    const baseUrl = getApiBaseUrl()
     setIsClosing(true)
     try {
       if (isActive) {
         // Interrupt the session first
-        await fetch(`${baseUrl}/api/agents/${agentSlug}/sessions/${sessionId}/interrupt`, {
+        await apiFetch(`/api/agents/${agentSlug}/sessions/${sessionId}/interrupt`, {
           method: 'POST',
         })
       }
       // Close the browser
-      await fetch(`${baseUrl}/api/agents/${agentSlug}/browser/close`, {
+      await apiFetch(`/api/agents/${agentSlug}/browser/close`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ sessionId }),

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -9,10 +9,10 @@ if (isElectron() && getPlatform() === 'darwin') {
   document.documentElement.classList.add('electron-vibrancy')
 }
 
-// Initialize API URL before rendering (needed for Electron where port may vary)
+// Initialize API URL before rendering
 initApiBaseUrl()
   .catch((error) => {
-    console.error('Failed to initialize API URL:', error)
+    console.error('Failed to initialize:', error)
   })
   .finally(() => {
     ReactDOM.createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
- Prevent malicious attackers on LAN from querying app endpoints that are not protected by proxy tokens in non-auth mode.
- Filter out origins that are not 127.0.0.1 (which attackers cannot spoof because of TCP handshake)