### PR TITLE
fix: surface compaction state from SDK status

### DIFF
--- a/.qagent/features/session-chat.md
+++ b/.qagent/features/session-chat.md
@@ -22,7 +22,7 @@ This feature covers new session creation, ongoing chat behavior, and sidebar-bas
 - **Message list** (`data-testid='message-list'`) - chronological conversation history.
 - **Message input** (`data-testid='message-input'`) - follow-up message input.
 - **Send button** (`data-testid='send-button'`) - submits follow-up message.
-- **Activity indicator** (`data-testid='activity-indicator'`) - shown while agent responds.
+- **Activity indicator** (`data-testid='activity-indicator'`) - shown while agent responds. Displays "Working..." during normal processing, "Compacting conversation..." (violet pulse) when SDK signals compaction in progress, or "Waiting for input..." (orange pulse) when awaiting user input.
 - **Stop button** (`data-testid='stop-button'`) - interrupts active response.
 - **Tool call cards** - inline tool usage indicators.
 - **Attachment button** - opens native file picker.
@@ -31,6 +31,7 @@ This feature covers new session creation, ongoing chat behavior, and sidebar-bas
 - Send follow-up message and verify activity indicator appears then disappears.
 - Verify assistant response is appended to list.
 - Interrupt response with stop button and verify input is re-enabled.
+- During context compaction, verify activity indicator shows "Compacting conversation..." instead of generic "Working...".
 
 ## Sidebar - Session Management
 

--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -52,7 +52,6 @@ describe('AgentActivityIndicator', () => {
       isActive: false,
       error: null,
       activeStartTime: null,
-      isCompacting: false,
       activeSubagents: [],
       completedSubagents: null,
       pendingSecretRequests: [],
@@ -243,51 +242,6 @@ describe('AgentActivityIndicator', () => {
     )
     // Component should return null when not active
     expect(container.innerHTML).toBe('')
-  })
-
-  it('shows "Compacting conversation..." when isCompacting is true', () => {
-    mockStreamState.isActive = true
-    mockStreamState.activeStartTime = Date.now()
-    mockStreamState.isCompacting = true
-
-    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
-    expect(screen.getByText('Compacting conversation...')).toBeInTheDocument()
-    expect(screen.queryByText('Working...')).not.toBeInTheDocument()
-  })
-
-  it('"Compacting conversation..." takes priority over TodoWrite activeForm', () => {
-    mockStreamState.isActive = true
-    mockStreamState.activeStartTime = Date.now()
-    mockStreamState.isCompacting = true
-    mockMessages.push({
-      id: 'msg-1',
-      type: 'assistant',
-      content: { text: '' },
-      toolCalls: [{
-        id: 'tc-1',
-        name: 'TodoWrite',
-        input: {
-          todos: [{ content: 'Doing work', status: 'in_progress', activeForm: 'Setting things up' }],
-        },
-        result: 'ok',
-      }],
-      createdAt: new Date(),
-    })
-
-    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
-    expect(screen.getByText('Compacting conversation...')).toBeInTheDocument()
-    expect(screen.queryByText('Setting things up')).not.toBeInTheDocument()
-  })
-
-  it('"Waiting for input..." takes priority over compacting', () => {
-    mockStreamState.isActive = true
-    mockStreamState.activeStartTime = Date.now()
-    mockStreamState.isCompacting = true
-    mockStreamState.pendingSecretRequests = [{ toolUseId: 't1', secretName: 'KEY' }]
-
-    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
-    expect(screen.getByText('Waiting for input...')).toBeInTheDocument()
-    expect(screen.queryByText('Compacting conversation...')).not.toBeInTheDocument()
   })
 
   it('"Waiting for input..." takes priority over TodoWrite activeForm', () => {

--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -52,6 +52,7 @@ describe('AgentActivityIndicator', () => {
       isActive: false,
       error: null,
       activeStartTime: null,
+      isCompacting: false,
       activeSubagents: [],
       completedSubagents: null,
       pendingSecretRequests: [],
@@ -242,6 +243,51 @@ describe('AgentActivityIndicator', () => {
     )
     // Component should return null when not active
     expect(container.innerHTML).toBe('')
+  })
+
+  it('shows "Compacting conversation..." when isCompacting is true', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockStreamState.isCompacting = true
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+    expect(screen.getByText('Compacting conversation...')).toBeInTheDocument()
+    expect(screen.queryByText('Working...')).not.toBeInTheDocument()
+  })
+
+  it('"Compacting conversation..." takes priority over TodoWrite activeForm', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockStreamState.isCompacting = true
+    mockMessages.push({
+      id: 'msg-1',
+      type: 'assistant',
+      content: { text: '' },
+      toolCalls: [{
+        id: 'tc-1',
+        name: 'TodoWrite',
+        input: {
+          todos: [{ content: 'Doing work', status: 'in_progress', activeForm: 'Setting things up' }],
+        },
+        result: 'ok',
+      }],
+      createdAt: new Date(),
+    })
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+    expect(screen.getByText('Compacting conversation...')).toBeInTheDocument()
+    expect(screen.queryByText('Setting things up')).not.toBeInTheDocument()
+  })
+
+  it('"Waiting for input..." takes priority over compacting', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockStreamState.isCompacting = true
+    mockStreamState.pendingSecretRequests = [{ toolUseId: 't1', secretName: 'KEY' }]
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+    expect(screen.getByText('Waiting for input...')).toBeInTheDocument()
+    expect(screen.queryByText('Compacting conversation...')).not.toBeInTheDocument()
   })
 
   it('"Waiting for input..." takes priority over TodoWrite activeForm', () => {

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -127,7 +127,7 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
   const statusText = isAwaitingInput
     ? 'Waiting for input...'
     : isCompacting
-      ? 'Compacting conversation...'
+      ? 'Compacting...'
       : (activeItem?.activeForm || 'Working...')
 
   return (

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -19,7 +19,7 @@ interface AgentActivityIndicatorProps {
 
 export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIndicatorProps) {
   const {
-    isActive, error, activeStartTime, isCompacting, activeSubagents, completedSubagents,
+    isActive, error, activeStartTime, activeSubagents, completedSubagents,
     pendingSecretRequests, pendingConnectedAccountRequests, pendingQuestionRequests,
     pendingFileRequests, pendingRemoteMcpRequests, pendingBrowserInputRequests,
   } = useMessageStream(sessionId, agentSlug)
@@ -126,9 +126,7 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
 
   const statusText = isAwaitingInput
     ? 'Waiting for input...'
-    : isCompacting
-      ? 'Compacting conversation...'
-      : (activeItem?.activeForm || 'Working...')
+    : (activeItem?.activeForm || 'Working...')
 
   return (
     <div className="mx-4 mb-2 rounded-lg border bg-muted/50 p-3" data-testid="activity-indicator">
@@ -137,11 +135,11 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
         <span className="relative flex h-3 w-3">
           <span className={cn(
             "animate-ping absolute inline-flex h-full w-full rounded-full opacity-75",
-            isAwaitingInput ? "bg-orange-500" : isCompacting ? "bg-violet-500" : "bg-primary"
+            isAwaitingInput ? "bg-orange-500" : "bg-primary"
           )}></span>
           <span className={cn(
             "relative inline-flex rounded-full h-3 w-3",
-            isAwaitingInput ? "bg-orange-500" : isCompacting ? "bg-violet-500" : "bg-primary"
+            isAwaitingInput ? "bg-orange-500" : "bg-primary"
           )}></span>
         </span>
         <span className="text-sm font-medium">{statusText}</span>

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -19,7 +19,7 @@ interface AgentActivityIndicatorProps {
 
 export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIndicatorProps) {
   const {
-    isActive, error, activeStartTime, activeSubagents, completedSubagents,
+    isActive, error, activeStartTime, isCompacting, activeSubagents, completedSubagents,
     pendingSecretRequests, pendingConnectedAccountRequests, pendingQuestionRequests,
     pendingFileRequests, pendingRemoteMcpRequests, pendingBrowserInputRequests,
   } = useMessageStream(sessionId, agentSlug)
@@ -126,7 +126,9 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
 
   const statusText = isAwaitingInput
     ? 'Waiting for input...'
-    : (activeItem?.activeForm || 'Working...')
+    : isCompacting
+      ? 'Compacting conversation...'
+      : (activeItem?.activeForm || 'Working...')
 
   return (
     <div className="mx-4 mb-2 rounded-lg border bg-muted/50 p-3" data-testid="activity-indicator">
@@ -135,11 +137,11 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
         <span className="relative flex h-3 w-3">
           <span className={cn(
             "animate-ping absolute inline-flex h-full w-full rounded-full opacity-75",
-            isAwaitingInput ? "bg-orange-500" : "bg-primary"
+            isAwaitingInput ? "bg-orange-500" : isCompacting ? "bg-violet-500" : "bg-primary"
           )}></span>
           <span className={cn(
             "relative inline-flex rounded-full h-3 w-3",
-            isAwaitingInput ? "bg-orange-500" : "bg-primary"
+            isAwaitingInput ? "bg-orange-500" : isCompacting ? "bg-violet-500" : "bg-primary"
           )}></span>
         </span>
         <span className="text-sm font-medium">{statusText}</span>

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -19,7 +19,7 @@ interface AgentActivityIndicatorProps {
 
 export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIndicatorProps) {
   const {
-    isActive, error, activeStartTime, activeSubagents, completedSubagents,
+    isActive, error, activeStartTime, isCompacting, activeSubagents, completedSubagents,
     pendingSecretRequests, pendingConnectedAccountRequests, pendingQuestionRequests,
     pendingFileRequests, pendingRemoteMcpRequests, pendingBrowserInputRequests,
   } = useMessageStream(sessionId, agentSlug)
@@ -126,7 +126,9 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
 
   const statusText = isAwaitingInput
     ? 'Waiting for input...'
-    : (activeItem?.activeForm || 'Working...')
+    : isCompacting
+      ? 'Compacting conversation...'
+      : (activeItem?.activeForm || 'Working...')
 
   return (
     <div className="mx-4 mb-2 rounded-lg border bg-muted/50 p-3" data-testid="activity-indicator">

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -198,6 +198,47 @@ describe('MessagePersister', () => {
     })
   })
 
+  describe('compaction status events', () => {
+    it('broadcasts compact_start on early compacting status', () => {
+      sseEvents.length = 0
+
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'status',
+        status: 'compacting',
+        session_id: SESSION_ID,
+        uuid: 'status-1',
+      })
+
+      const compactStarts = sseEvents.filter(e => e.type === 'compact_start')
+      expect(compactStarts).toHaveLength(1)
+    })
+
+    it('does not broadcast duplicate compact_start when boundary follows status', () => {
+      sseEvents.length = 0
+
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'status',
+        status: 'compacting',
+        session_id: SESSION_ID,
+        uuid: 'status-1',
+      })
+
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'compact_boundary',
+        content: 'Conversation compacted',
+        session_id: SESSION_ID,
+        uuid: 'boundary-1',
+        compactMetadata: { trigger: 'auto', preTokens: 170000 },
+      })
+
+      const compactStarts = sseEvents.filter(e => e.type === 'compact_start')
+      expect(compactStarts).toHaveLength(1)
+    })
+  })
+
   // ============================================================================
   // Task tool tracking
   // ============================================================================

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -29,7 +29,7 @@ interface StreamingState {
   currentToolInput: string // Accumulated partial JSON input for current tool
   isActive: boolean // True from user message until result received
   isInterrupted: boolean // True after user interrupts, prevents race conditions
-  isCompacting: boolean // True after compact_boundary, cleared on next user message (compact summary)
+  isCompacting: boolean // True while compaction is in progress, cleared on compact completion
   agentSlug?: string // The agent slug for this session
   lastContextWindow: number // Last known context window size (default 200k)
   lastAssistantUsage: SessionUsage | null // Per-call usage from most recent assistant message
@@ -419,7 +419,9 @@ class MessagePersister {
           }
         }
 
-        // After a compact_boundary, the next user message is always the compact summary.
+        // After SDK compaction starts, the next relevant user message is the compact summary.
+        // This can follow either automatic compaction or a manual /compact path,
+        // depending on which compact-related events the SDK emits.
         // Use position-based detection (state.isCompacting flag) as primary check,
         // with content.isCompactSummary as fallback, since the WebSocket payload
         // may not always carry the isCompactSummary metadata flag.
@@ -461,10 +463,18 @@ class MessagePersister {
             type: 'stream_start',
             slashCommands: state.slashCommands.length > 0 ? state.slashCommands : undefined,
           })
+        } else if (content.subtype === 'status') {
+          // Prefer the SDK's explicit compacting status when available.
+          if (content.status === 'compacting' && !state.isCompacting) {
+            state.isCompacting = true
+            this.broadcastToSSE(sessionId, { type: 'compact_start' })
+          }
         } else if (content.subtype === 'compact_boundary') {
-          // Compaction has started — set flag so we recognize the next user message as compact summary
-          state.isCompacting = true
-          this.broadcastToSSE(sessionId, { type: 'compact_start' })
+          // Fallback for SDK paths that surface compaction via boundary without an earlier status.
+          if (!state.isCompacting) {
+            state.isCompacting = true
+            this.broadcastToSSE(sessionId, { type: 'compact_start' })
+          }
         }
         break
 


### PR DESCRIPTION
## Summary
- start the compacting UI state from the SDK's `status = \"compacting\"` event instead of waiting for `compact_boundary`
- keep `compact_boundary` only as a fallback so SDK paths without the earlier status still surface compaction
- add regression coverage for the new status handling and compacting activity indicator UI

## Test plan
- [x] `npm run test:run -- src/shared/lib/container/message-persister.test.ts src/renderer/components/messages/agent-activity-indicator.test.tsx`
- [x] manually verify the UI switches from `Working...` to `Compacting conversation...` when the SDK emits `status = \"compacting\"`

Made with [Cursor](https://cursor.com)