### PR TITLE
fix: require agent image in runtime settings

### DIFF
--- a/src/renderer/components/settings/runtime-tab.test.tsx
+++ b/src/renderer/components/settings/runtime-tab.test.tsx
@@ -119,7 +119,7 @@ describe('RuntimeTab', () => {
 
     renderWithProviders(<RuntimeTab />)
 
-    await user.click(screen.getByRole('button', { name: 'Back to latest' }))
+    await user.click(screen.getByRole('button', { name: 'Use default' }))
 
     expect(screen.getByLabelText('Agent Image')).toHaveValue(getDefaultAgentImage())
   })

--- a/src/renderer/components/settings/runtime-tab.test.tsx
+++ b/src/renderer/components/settings/runtime-tab.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RuntimeTab } from './runtime-tab'
+import { renderWithProviders } from '@renderer/test/test-utils'
+
+const mockSettings = {
+  data: {
+    container: {
+      containerRunner: 'docker',
+      agentImage: 'ghcr.io/skillfulagents/superagent-agent-container-base:latest',
+      resourceLimits: {
+        cpu: 1,
+        memory: '1g',
+      },
+      runtimeSettings: {},
+    },
+    runnerAvailability: [
+      {
+        runner: 'docker',
+        installed: true,
+        running: true,
+        available: true,
+        canStart: false,
+      },
+    ],
+    runtimeReadiness: { status: 'READY', message: 'Ready' },
+    hasRunningAgents: false,
+    customEnvVars: {},
+    dataDir: '/tmp/superagent',
+    app: { autoSleepTimeoutMinutes: 30 },
+    agentLimits: {},
+  },
+  isLoading: false,
+}
+
+const mockUpdateSettings = {
+  mutateAsync: vi.fn().mockResolvedValue({}),
+  mutate: vi.fn(),
+  isPending: false,
+  error: null as { error: string } | null,
+}
+
+const mockStartRunner = {
+  mutateAsync: vi.fn(),
+  isPending: false,
+  isSuccess: false,
+  data: undefined as { message?: string } | undefined,
+  error: null as Error | null,
+}
+
+const mockRestartRunner = {
+  mutateAsync: vi.fn(),
+  isPending: false,
+  isSuccess: false,
+  data: undefined as { message?: string } | undefined,
+  error: null as Error | null,
+}
+
+const mockRefreshAvailability = {
+  mutate: vi.fn(),
+  isPending: false,
+}
+
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useSettings: () => mockSettings,
+  useUpdateSettings: () => mockUpdateSettings,
+  useStartRunner: () => mockStartRunner,
+  useRestartRunner: () => mockRestartRunner,
+  useRefreshAvailability: () => mockRefreshAvailability,
+}))
+
+describe('RuntimeTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSettings.data.container.agentImage = 'ghcr.io/skillfulagents/superagent-agent-container-base:latest'
+    mockUpdateSettings.isPending = false
+    mockUpdateSettings.error = null
+  })
+
+  it('disables save when agent image is blank', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<RuntimeTab />)
+
+    const agentImageInput = screen.getByLabelText('Agent Image')
+    await user.clear(agentImageInput)
+    await user.type(agentImageInput, '   ')
+
+    expect(screen.getByText('Agent image is required.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('trims agent image before saving', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<RuntimeTab />)
+
+    const agentImageInput = screen.getByLabelText('Agent Image')
+    await user.clear(agentImageInput)
+    await user.type(agentImageInput, '  ghcr.io/custom/image:latest  ')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(mockUpdateSettings.mutateAsync).toHaveBeenCalledWith({
+      container: {
+        containerRunner: 'docker',
+        agentImage: 'ghcr.io/custom/image:latest',
+        resourceLimits: {
+          cpu: 1,
+          memory: '1g',
+        },
+      },
+    })
+  })
+})

--- a/src/renderer/components/settings/runtime-tab.test.tsx
+++ b/src/renderer/components/settings/runtime-tab.test.tsx
@@ -4,6 +4,7 @@ import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { RuntimeTab } from './runtime-tab'
 import { renderWithProviders } from '@renderer/test/test-utils'
+import { getDefaultAgentImage } from '@shared/lib/config/version'
 
 const mockSettings = {
   data: {
@@ -110,5 +111,16 @@ describe('RuntimeTab', () => {
         },
       },
     })
+  })
+
+  it('resets agent image to the latest default', async () => {
+    const user = userEvent.setup()
+    mockSettings.data.container.agentImage = 'ghcr.io/custom/image:latest'
+
+    renderWithProviders(<RuntimeTab />)
+
+    await user.click(screen.getByRole('button', { name: 'Back to latest' }))
+
+    expect(screen.getByLabelText('Agent Image')).toHaveValue(getDefaultAgentImage())
   })
 })

--- a/src/renderer/components/settings/runtime-tab.tsx
+++ b/src/renderer/components/settings/runtime-tab.tsx
@@ -186,14 +186,16 @@ export function RuntimeTab() {
   }, [containerRunner, agentImage, cpuLimit, memoryLimit, settings])
 
   const memoryTooLow = parseMemoryToBytes(memoryLimit) > 0 && parseMemoryToBytes(memoryLimit) < MIN_MEMORY_BYTES
+  const trimmedAgentImage = agentImage.trim()
+  const agentImageMissing = trimmedAgentImage.length === 0
 
   const handleSave = async () => {
-    if (memoryTooLow) return
+    if (memoryTooLow || agentImageMissing) return
     try {
       await updateSettings.mutateAsync({
         container: {
           containerRunner,
-          agentImage,
+          agentImage: trimmedAgentImage,
           resourceLimits: {
             cpu: parseFloat(cpuLimit) || 1,
             memory: memoryLimit,
@@ -523,6 +525,9 @@ export function RuntimeTab() {
         <p className="text-xs text-muted-foreground">
           Docker image to use for agent containers.
         </p>
+        {agentImageMissing && (
+          <p className="text-xs text-destructive">Agent image is required.</p>
+        )}
       </div>
 
       <div className="grid grid-cols-2 gap-4">
@@ -792,7 +797,7 @@ export function RuntimeTab() {
           </Button>
           <Button
             onClick={handleSave}
-            disabled={updateSettings.isPending || saveBlocked || memoryTooLow}
+            disabled={updateSettings.isPending || saveBlocked || memoryTooLow || agentImageMissing}
           >
             {updateSettings.isPending ? 'Saving...' : 'Save'}
           </Button>

--- a/src/renderer/components/settings/runtime-tab.tsx
+++ b/src/renderer/components/settings/runtime-tab.tsx
@@ -13,6 +13,7 @@ import { Alert, AlertDescription, AlertTitle } from '@renderer/components/ui/ale
 import { useSettings, useUpdateSettings, useStartRunner, useRestartRunner, useRefreshAvailability } from '@renderer/hooks/use-settings'
 import { AlertCircle, AlertTriangle, Play, Loader2, RefreshCw, Plus, X } from 'lucide-react'
 import { DEFAULT_LIMA_VM_MEMORY, VALID_LIMA_VM_MEMORY_OPTIONS } from '@shared/lib/container/types'
+import { getDefaultAgentImage } from '@shared/lib/config/version'
 
 const MIN_MEMORY_BYTES = 512 * 1024 * 1024 // 512 MiB
 
@@ -186,8 +187,10 @@ export function RuntimeTab() {
   }, [containerRunner, agentImage, cpuLimit, memoryLimit, settings])
 
   const memoryTooLow = parseMemoryToBytes(memoryLimit) > 0 && parseMemoryToBytes(memoryLimit) < MIN_MEMORY_BYTES
+  const latestAgentImage = getDefaultAgentImage()
   const trimmedAgentImage = agentImage.trim()
   const agentImageMissing = trimmedAgentImage.length === 0
+  const isLatestAgentImage = trimmedAgentImage === latestAgentImage
 
   const handleSave = async () => {
     if (memoryTooLow || agentImageMissing) return
@@ -525,6 +528,16 @@ export function RuntimeTab() {
         <p className="text-xs text-muted-foreground">
           Docker image to use for agent containers.
         </p>
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          className="h-auto px-0 text-xs"
+          onClick={() => setAgentImage(latestAgentImage)}
+          disabled={isLoading || isLatestAgentImage}
+        >
+          Back to latest
+        </Button>
         {agentImageMissing && (
           <p className="text-xs text-destructive">Agent image is required.</p>
         )}

--- a/src/renderer/components/settings/runtime-tab.tsx
+++ b/src/renderer/components/settings/runtime-tab.tsx
@@ -536,7 +536,7 @@ export function RuntimeTab() {
           onClick={() => setAgentImage(latestAgentImage)}
           disabled={isLoading || isLatestAgentImage}
         >
-          Back to latest
+          Use default
         </Button>
         {agentImageMissing && (
           <p className="text-xs text-destructive">Agent image is required.</p>

--- a/src/renderer/components/settings/runtime-tab.tsx
+++ b/src/renderer/components/settings/runtime-tab.tsx
@@ -91,10 +91,16 @@ export function RuntimeTab() {
   const [hasChanges, setHasChanges] = useState(false)
 
   // Get saved runtime settings for the current runner
-  const savedRuntimeSettings = settings?.container.runtimeSettings?.[containerRunner] ?? {}
+  const savedRuntimeSettings = useMemo(
+    () => settings?.container.runtimeSettings?.[containerRunner] ?? {},
+    [settings, containerRunner]
+  )
 
   // Get the field definitions for the current runner
-  const currentRunnerFields = RUNTIME_SETTINGS[containerRunner] ?? []
+  const currentRunnerFields = useMemo(
+    () => RUNTIME_SETTINGS[containerRunner] ?? [],
+    [containerRunner]
+  )
 
   // Check if runtime-specific settings have changed
   const runtimeSettingsChanged = useMemo(() => {


### PR DESCRIPTION
## Summary
- block saving runtime settings when `Agent Image` is blank or whitespace-only
- trim the configured image before persisting it so accidental surrounding whitespace is not saved
- add a lightweight `Use default` action to restore the app's default agent image
- memoize runner field definitions and saved runtime settings to keep the runtime settings change detection stable without hook dependency warnings
- add focused component tests covering blank validation, trimmed saves, and restoring the default image

## Test plan
- [x] `npm run test:run -- src/renderer/components/settings/runtime-tab.test.tsx`
- [x] `npx eslint src/renderer/components/settings/runtime-tab.tsx src/renderer/components/settings/runtime-tab.test.tsx`