### PR TITLE
fix: confirm before removing saved API keys

### DIFF
--- a/src/renderer/components/settings/provider-api-key-input.test.tsx
+++ b/src/renderer/components/settings/provider-api-key-input.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ProviderApiKeyInput } from './provider-api-key-input'
+import { renderWithProviders } from '@renderer/test/test-utils'
+
+const mockSettings = {
+  data: {
+    apiKeyStatus: {
+      anthropic: {
+        isConfigured: true,
+        source: 'settings' as const,
+      },
+    },
+  },
+}
+
+const mockUpdateSettings = {
+  mutateAsync: vi.fn().mockResolvedValue({}),
+}
+
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useSettings: () => mockSettings,
+  useUpdateSettings: () => mockUpdateSettings,
+}))
+
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: vi.fn(),
+}))
+
+describe('ProviderApiKeyInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('opens a confirmation dialog before removing a saved key', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(
+      <ProviderApiKeyInput
+        providerId="anthropic"
+        label="Anthropic API Key"
+        apiKeySettingsField="anthropicApiKey"
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Remove Saved Key' }))
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Remove Saved Key' })).toBeInTheDocument()
+    expect(mockUpdateSettings.mutateAsync).not.toHaveBeenCalled()
+  })
+
+  it('does not remove the key when the dialog is cancelled', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(
+      <ProviderApiKeyInput
+        providerId="anthropic"
+        label="Anthropic API Key"
+        apiKeySettingsField="anthropicApiKey"
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Remove Saved Key' }))
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    })
+    expect(mockUpdateSettings.mutateAsync).not.toHaveBeenCalled()
+  })
+
+  it('removes the key after confirmation', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(
+      <ProviderApiKeyInput
+        providerId="anthropic"
+        label="Anthropic API Key"
+        apiKeySettingsField="anthropicApiKey"
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Remove Saved Key' }))
+    await user.click(screen.getByRole('button', { name: 'Remove' }))
+
+    await waitFor(() => {
+      expect(mockUpdateSettings.mutateAsync).toHaveBeenCalledWith({
+        apiKeys: { anthropicApiKey: '' },
+      })
+    })
+  })
+})

--- a/src/renderer/components/settings/provider-api-key-input.tsx
+++ b/src/renderer/components/settings/provider-api-key-input.tsx
@@ -3,6 +3,16 @@ import { Input } from '@renderer/components/ui/input'
 import { Label } from '@renderer/components/ui/label'
 import { Button } from '@renderer/components/ui/button'
 import { Alert, AlertDescription } from '@renderer/components/ui/alert'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@renderer/components/ui/alert-dialog'
 import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
 import { apiFetch } from '@renderer/lib/api'
 import { AlertTriangle, Eye, EyeOff, Check, Loader2 } from 'lucide-react'
@@ -41,6 +51,7 @@ export function ProviderApiKeyInput({
   const [isValidating, setIsValidating] = useState(false)
   const [validationResult, setValidationResult] = useState<{ valid: boolean; error?: string } | null>(null)
   const [isRemoving, setIsRemoving] = useState(false)
+  const [showRemoveConfirm, setShowRemoveConfirm] = useState(false)
 
   const apiKeyStatus: ApiKeyStatus | undefined = settings?.apiKeyStatus?.[providerId]
 
@@ -79,6 +90,7 @@ export function ProviderApiKeyInput({
         apiKeys: { [apiKeySettingsField]: '' },
       })
       setValidationResult(null)
+      setShowRemoveConfirm(false)
     } catch (error) {
       console.error('Failed to remove API key:', error)
     } finally {
@@ -183,13 +195,34 @@ export function ProviderApiKeyInput({
           <Button
             size="sm"
             variant="outline"
-            onClick={handleRemoveApiKey}
+            onClick={() => setShowRemoveConfirm(true)}
             disabled={isBusy}
           >
             {isRemoving ? 'Removing...' : 'Remove Saved Key'}
           </Button>
         )}
       </div>
+
+      <AlertDialog open={showRemoveConfirm} onOpenChange={setShowRemoveConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove Saved Key</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to remove the saved API key? This will disable agent features until a new key is configured.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isRemoving}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleRemoveApiKey}
+              disabled={isRemoving}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isRemoving ? 'Removing...' : 'Remove'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add a confirmation dialog before removing a locally saved API key
- keep the existing remove flow, but require an explicit confirm click before clearing the stored key
- add focused component tests covering open, cancel, and confirm behaviors

<img width="991" height="650" alt="image" src="https://github.com/user-attachments/assets/dbedca3b-a89d-4ace-b72c-ff02d495a5a6" />


## Test plan
- [x] `npm run test:run -- src/renderer/components/settings/provider-api-key-input.test.tsx`
- [x] `npx eslint src/renderer/components/settings/provider-api-key-input.tsx src/renderer/components/settings/provider-api-key-input.test.tsx`
- [x] UI test 

Made with [Cursor](https://cursor.com)