### PR TITLE
Refine chat UI and unify composer layouts

### DIFF
--- a/src/renderer/components/agents/agent-landing.test.tsx
+++ b/src/renderer/components/agents/agent-landing.test.tsx
@@ -138,7 +138,7 @@ describe('AgentLanding', () => {
       <AgentLanding agent={testAgent} onSessionCreated={onSessionCreated} />
     )
     expect(screen.getByTestId('landing-message-input')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('Type your message...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument()
   })
 
   it('renders send button', () => {
@@ -243,35 +243,15 @@ describe('AgentLanding', () => {
     expect(screen.getByTestId('landing-message-input')).toBeDisabled()
   })
 
-  // --- Expand/Collapse ---
+  // --- Auto-expand ---
 
-  it('has expand button', () => {
-    renderWithProviders(
-      <AgentLanding agent={testAgent} onSessionCreated={onSessionCreated} />
-    )
-    expect(screen.getByTitle('Expand input')).toBeInTheDocument()
-  })
-
-  it('toggles expand/collapse on button click', async () => {
-    const user = userEvent.setup()
+  it('auto-expands when the message is very long', () => {
+    mockComposer.message = 'one\ntwo\nthree\nfour\nfive'
     renderWithProviders(
       <AgentLanding agent={testAgent} onSessionCreated={onSessionCreated} />
     )
 
-    // Initially collapsed
-    const textarea = screen.getByTestId('landing-message-input')
-    expect(textarea.className).toContain('min-h-[120px]')
-
-    // Click expand
-    await user.click(screen.getByTitle('Expand input'))
-
-    expect(textarea.className).toContain('min-h-[50vh]')
-    expect(screen.getByTitle('Collapse input')).toBeInTheDocument()
-
-    // Click collapse
-    await user.click(screen.getByTitle('Collapse input'))
-
-    expect(textarea.className).toContain('min-h-[120px]')
+    expect(screen.getByTestId('landing-message-input').className).toContain('min-h-[50vh]')
   })
 
   // --- View-only mode ---
@@ -389,7 +369,7 @@ describe('AgentLanding', () => {
     renderWithProviders(
       <AgentLanding agent={testAgent} onSessionCreated={onSessionCreated} />
     )
-    expect(screen.getByTitle('Attach')).toBeInTheDocument()
+    expect(screen.getByTitle('Add files')).toBeInTheDocument()
   })
 
   it('disables attachment picker when disabled', () => {
@@ -397,6 +377,6 @@ describe('AgentLanding', () => {
     renderWithProviders(
       <AgentLanding agent={testAgent} onSessionCreated={onSessionCreated} />
     )
-    expect(screen.getByTitle('Attach')).toBeDisabled()
+    expect(screen.getByTitle('Add files')).toBeDisabled()
   })
 })

--- a/src/renderer/components/agents/agent-landing.tsx
+++ b/src/renderer/components/agents/agent-landing.tsx
@@ -2,10 +2,9 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
-import { Textarea } from '@renderer/components/ui/textarea'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { Checkbox } from '@renderer/components/ui/checkbox'
-import { Send, Loader2, Sparkles, Search, RefreshCw, ChevronLeft, ChevronRight, Filter, Eye, Maximize2, Minimize2 } from 'lucide-react'
+import { ArrowUp, Loader2, Sparkles, Search, RefreshCw, ChevronLeft, ChevronRight, Filter, Eye } from 'lucide-react'
 import { useCreateSession } from '@renderer/hooks/use-sessions'
 import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
 import { useAgentSkills, useDiscoverableSkills, useRefreshAgentSkills } from '@renderer/hooks/use-agent-skills'
@@ -14,10 +13,10 @@ import { DiscoverableSkillCard } from './discoverable-skill-card'
 import { useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
 import { useUser } from '@renderer/context/user-context'
 import { apiFetch } from '@renderer/lib/api'
-import { AttachmentPreview } from '@renderer/components/messages/attachment-preview'
 import { AttachmentPicker } from '@renderer/components/ui/attachment-picker'
 import { MountChoiceDialog } from '@renderer/components/ui/mount-choice-dialog'
 import { useMessageComposer } from '@renderer/hooks/use-message-composer'
+import { ChatComposerBox } from '@renderer/components/messages/chat-composer-box'
 import type { ApiAgent } from '@renderer/hooks/use-agents'
 
 interface AgentLandingProps {
@@ -30,7 +29,6 @@ export function AgentLanding({ agent, onSessionCreated }: AgentLandingProps) {
   const isViewOnly = !canUseAgent(agent.slug)
   const isOwner = canAdminAgent(agent.slug)
   const [isExpanded, setIsExpanded] = useState(false)
-  const [manuallyCollapsed, setManuallyCollapsed] = useState(false)
   const [skillSearch, setSkillSearch] = useState('')
   const [skillPage, setSkillPage] = useState(0)
   const [selectedSkillsets, setSelectedSkillsets] = useState<Set<string> | null>(null)
@@ -85,10 +83,10 @@ export function AgentLanding({ agent, onSessionCreated }: AgentLandingProps) {
   // Auto-expand when message gets long (5+ lines)
   useEffect(() => {
     const lineCount = composer.message.split('\n').length
-    if (lineCount >= 5 && !isExpanded && !manuallyCollapsed) {
+    if (lineCount >= 5 && !isExpanded) {
       setIsExpanded(true)
     }
-  }, [composer.message, isExpanded, manuallyCollapsed])
+  }, [composer.message, isExpanded])
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
@@ -177,65 +175,53 @@ export function AgentLanding({ agent, onSessionCreated }: AgentLandingProps) {
             />
             <form
               onSubmit={composer.handleSubmit}
-              className={`space-y-4 ${composer.isDragOver ? 'ring-2 ring-primary rounded-lg' : ''}`}
+              className={composer.isDragOver ? 'rounded-2xl ring-2 ring-primary ring-inset' : ''}
               {...composer.dragHandlers}
             >
-              <div className="relative">
-                <Textarea
-                  placeholder="Type your message..."
-                  value={composer.message}
-                  onChange={(e) => composer.setMessage(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  onPaste={composer.handlePaste}
-                  className={`pr-12 resize-none text-base transition-[min-height] duration-300 ease-in-out ${isExpanded ? 'min-h-[50vh]' : 'min-h-[120px]'}`}
-                  disabled={isDisabled}
-                  autoFocus
-                  data-testid="landing-message-input"
-                />
-                <div className="absolute bottom-3 right-3 flex gap-1">
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    className="h-8 w-8"
-                    onClick={() => {
-                      setIsExpanded((v) => {
-                        if (v) setManuallyCollapsed(true)
-                        else setManuallyCollapsed(false)
-                        return !v
-                      })
-                    }}
-                    title={isExpanded ? 'Collapse input' : 'Expand input'}
-                  >
-                    {isExpanded ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
-                  </Button>
+              <ChatComposerBox
+                attachments={composer.attachments}
+                onRemoveAttachment={composer.removeAttachment}
+                value={composer.message}
+                onChange={(e) => composer.setMessage(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onPaste={composer.handlePaste}
+                placeholder="Type a message..."
+                disabled={isDisabled}
+                rows={2}
+                autoFocus
+                dataTestId="landing-message-input"
+                textareaClassName={`transition-[min-height] duration-300 ease-in-out ${isExpanded ? 'min-h-[50vh]' : 'min-h-[60px]'}`}
+                leftActions={(
                   <AttachmentPicker
                     onFileSelect={composer.handleFileSelect}
                     onFolderSelect={composer.handleFolderSelect}
                     disabled={isDisabled}
-                    buttonClassName="h-8 w-8"
-                    popoverAlign="end"
                   />
-                  <VoiceInputButton voiceInput={composer.voiceInput} message={composer.message} disabled={isDisabled} size="sm" />
-                  <Button
-                    type="submit"
-                    size="icon"
-                    className="h-8 w-8"
-                    disabled={!composer.canSubmit}
-                    data-testid="landing-send-button"
-                    aria-label="Send message"
-                  >
-                    {isDisabled ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Send className="h-4 w-4" />
-                    )}
-                  </Button>
-                </div>
-              </div>
-              <AttachmentPreview attachments={composer.attachments} onRemove={composer.removeAttachment} />
-              <VoiceInputError error={composer.voiceInput.error} onDismiss={composer.voiceInput.clearError} className="justify-center" />
-              <p className="text-xs text-muted-foreground text-center">
+                )}
+                rightActions={(
+                  <>
+                    <VoiceInputButton voiceInput={composer.voiceInput} message={composer.message} disabled={isDisabled} />
+                    <Button
+                      type="submit"
+                      size="icon"
+                      className="h-[34px] w-[34px]"
+                      disabled={!composer.canSubmit}
+                      data-testid="landing-send-button"
+                      aria-label="Send message"
+                    >
+                      {isDisabled ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <ArrowUp className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </>
+                )}
+                footer={(
+                  <VoiceInputError error={composer.voiceInput.error} onDismiss={composer.voiceInput.clearError} className="mt-2 justify-center" />
+                )}
+              />
+              <p className="mt-2 text-center text-xs text-muted-foreground">
                 Press Cmd+Enter to send
               </p>
             </form>

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -95,15 +95,17 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
   // Show error if present
   if (error) {
     return (
-      <div className="mx-4 mb-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3">
-        <div className="flex items-center gap-2">
-          <AlertTriangle className="h-4 w-4 text-destructive" />
-          <span className="text-sm font-medium text-destructive">Error</span>
+      <div className="mx-auto mb-2 w-full max-w-[740px] px-4">
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-3">
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-destructive" />
+            <span className="text-sm font-medium text-destructive">Error</span>
+          </div>
+          <p className="mt-1 text-sm text-destructive/90">{error}</p>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Send another message to retry.
+          </p>
         </div>
-        <p className="mt-1 text-sm text-destructive/90">{error}</p>
-        <p className="mt-2 text-xs text-muted-foreground">
-          Send another message to retry.
-        </p>
       </div>
     )
   }
@@ -152,104 +154,106 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
         : (activeItem?.activeForm || 'Working...')
 
   return (
-    <div className="mx-4 mb-2 rounded-lg border bg-muted/50 p-3" data-testid="activity-indicator">
-      {/* Header with pulsing indicator */}
-      <div className="flex items-center gap-2">
-        <span className="relative flex h-3 w-3">
-          <span className={cn(
-            "animate-ping absolute inline-flex h-full w-full rounded-full opacity-75",
-            (isAwaitingInput || apiRetry) ? "bg-orange-500" : "bg-primary"
-          )}></span>
-          <span className={cn(
-            "relative inline-flex rounded-full h-3 w-3",
-            (isAwaitingInput || apiRetry) ? "bg-orange-500" : "bg-primary"
-          )}></span>
-        </span>
-        <span className="text-sm font-medium">{statusText}</span>
-        {computerUseApp && (
-          <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300">
-            {computerUseAppIcon ? (
-              <img src={`data:image/png;base64,${computerUseAppIcon}`} alt="" className="h-4 w-4" />
-            ) : (
-              <Monitor className="h-3 w-3" />
-            )}
-            {computerUseApp}
-            <button
-              onClick={handleRevokeComputerUse}
-              disabled={revoking}
-              className={cn(
-                "ml-0.5 rounded-full p-0.5 transition-colors cursor-pointer",
-                revokeError ? "bg-red-200 dark:bg-red-800" : "hover:bg-blue-200 dark:hover:bg-blue-800"
-              )}
-              title={revokeError ? "Failed to revoke — click to retry" : "Release app and revoke permission"}
-            >
-              <X className={cn("h-3 w-3", revokeError && "text-red-600 dark:text-red-400")} />
-            </button>
+    <div className="mx-auto mb-2 w-full max-w-[740px] px-4">
+      <div className="rounded-lg border bg-muted/50 p-3" data-testid="activity-indicator">
+        {/* Header with pulsing indicator */}
+        <div className="flex items-center gap-2">
+          <span className="relative flex h-3 w-3">
+            <span className={cn(
+              "animate-ping absolute inline-flex h-full w-full rounded-full opacity-75",
+              (isAwaitingInput || apiRetry) ? "bg-orange-500" : "bg-primary"
+            )}></span>
+            <span className={cn(
+              "relative inline-flex rounded-full h-3 w-3",
+              (isAwaitingInput || apiRetry) ? "bg-orange-500" : "bg-primary"
+            )}></span>
           </span>
+          <span className="text-sm font-medium">{statusText}</span>
+          {computerUseApp && (
+            <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300">
+              {computerUseAppIcon ? (
+                <img src={`data:image/png;base64,${computerUseAppIcon}`} alt="" className="h-4 w-4" />
+              ) : (
+                <Monitor className="h-3 w-3" />
+              )}
+              {computerUseApp}
+              <button
+                onClick={handleRevokeComputerUse}
+                disabled={revoking}
+                className={cn(
+                  "ml-0.5 rounded-full p-0.5 transition-colors cursor-pointer",
+                  revokeError ? "bg-red-200 dark:bg-red-800" : "hover:bg-blue-200 dark:hover:bg-blue-800"
+                )}
+                title={revokeError ? "Failed to revoke — click to retry" : "Release app and revoke permission"}
+              >
+                <X className={cn("h-3 w-3", revokeError && "text-red-600 dark:text-red-400")} />
+              </button>
+            </span>
+          )}
+          {elapsed && (
+            <span className="text-xs text-muted-foreground tabular-nums">{elapsed}</span>
+          )}
+        </div>
+
+        {/* Active subagents */}
+        {subagentItems.length > 0 && (
+          <ul className="mt-2 space-y-1 text-sm pl-5">
+            {subagentItems.map((item) => (
+              <li key={item.id} className="flex flex-col gap-0.5">
+                <div className="flex items-center gap-2">
+                  {item.status === 'running' ? (
+                    <span className="relative flex h-2 w-2 shrink-0">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
+                      <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500"></span>
+                    </span>
+                  ) : (
+                    <span className="text-xs text-green-500 shrink-0">✓</span>
+                  )}
+                  <span className={cn(
+                    'font-mono text-xs',
+                    item.status === 'completed' && 'text-muted-foreground'
+                  )}>
+                    {item.name}
+                  </span>
+                  {item.description && (
+                    <span className="text-xs text-muted-foreground truncate">
+                      {item.description}
+                    </span>
+                  )}
+                </div>
+                {item.progressSummary && item.status === 'running' && (
+                  <span className="text-xs text-muted-foreground ml-4 italic">
+                    {item.progressSummary}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
         )}
-        {elapsed && (
-          <span className="text-xs text-muted-foreground tabular-nums">{elapsed}</span>
+
+        {/* Todo list if available and at least one item is not completed */}
+        {todos && todos.length > 0 && todos.some((t) => t.status !== 'completed') && (
+          <ul className="mt-2 space-y-1 text-sm">
+            {todos.map((todo, index) => (
+              <li
+                key={index}
+                className={cn(
+                  'flex items-center gap-2',
+                  todo.status === 'completed' && 'text-muted-foreground line-through',
+                  todo.status === 'in_progress' && 'font-semibold'
+                )}
+              >
+                <span className="text-xs">
+                  {todo.status === 'completed' && '✓'}
+                  {todo.status === 'in_progress' && '→'}
+                  {todo.status === 'pending' && '○'}
+                </span>
+                {todo.content}
+              </li>
+            ))}
+          </ul>
         )}
       </div>
-
-      {/* Active subagents */}
-      {subagentItems.length > 0 && (
-        <ul className="mt-2 space-y-1 text-sm pl-5">
-          {subagentItems.map((item) => (
-            <li key={item.id} className="flex flex-col gap-0.5">
-              <div className="flex items-center gap-2">
-                {item.status === 'running' ? (
-                  <span className="relative flex h-2 w-2 shrink-0">
-                    <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
-                    <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500"></span>
-                  </span>
-                ) : (
-                  <span className="text-xs text-green-500 shrink-0">✓</span>
-                )}
-                <span className={cn(
-                  'font-mono text-xs',
-                  item.status === 'completed' && 'text-muted-foreground'
-                )}>
-                  {item.name}
-                </span>
-                {item.description && (
-                  <span className="text-xs text-muted-foreground truncate">
-                    {item.description}
-                  </span>
-                )}
-              </div>
-              {item.progressSummary && item.status === 'running' && (
-                <span className="text-xs text-muted-foreground ml-4 italic">
-                  {item.progressSummary}
-                </span>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
-
-      {/* Todo list if available and at least one item is not completed */}
-      {todos && todos.length > 0 && todos.some((t) => t.status !== 'completed') && (
-        <ul className="mt-2 space-y-1 text-sm">
-          {todos.map((todo, index) => (
-            <li
-              key={index}
-              className={cn(
-                'flex items-center gap-2',
-                todo.status === 'completed' && 'text-muted-foreground line-through',
-                todo.status === 'in_progress' && 'font-semibold'
-              )}
-            >
-              <span className="text-xs">
-                {todo.status === 'completed' && '✓'}
-                {todo.status === 'in_progress' && '→'}
-                {todo.status === 'pending' && '○'}
-              </span>
-              {todo.content}
-            </li>
-          ))}
-        </ul>
-      )}
     </div>
   )
 }

--- a/src/renderer/components/messages/chat-composer-box.tsx
+++ b/src/renderer/components/messages/chat-composer-box.tsx
@@ -1,0 +1,81 @@
+import type { ChangeEventHandler, ClipboardEventHandler, FocusEventHandler, KeyboardEventHandler, ReactNode, Ref } from 'react'
+import { cn } from '@shared/lib/utils'
+import { AttachmentPreview, type Attachment } from './attachment-preview'
+
+interface ChatComposerBoxProps {
+  attachments: Attachment[]
+  onRemoveAttachment: (id: string) => void
+  textareaRef?: Ref<HTMLTextAreaElement>
+  value: string
+  onChange: ChangeEventHandler<HTMLTextAreaElement>
+  onKeyDown?: KeyboardEventHandler<HTMLTextAreaElement>
+  onPaste?: ClipboardEventHandler<HTMLTextAreaElement>
+  onFocus?: FocusEventHandler<HTMLTextAreaElement>
+  onBlur?: FocusEventHandler<HTMLTextAreaElement>
+  placeholder: string
+  disabled?: boolean
+  rows?: number
+  autoFocus?: boolean
+  dataTestId?: string
+  leftActions?: ReactNode
+  rightActions?: ReactNode
+  footer?: ReactNode
+  className?: string
+  textareaClassName?: string
+}
+
+export function ChatComposerBox({
+  attachments,
+  onRemoveAttachment,
+  textareaRef,
+  value,
+  onChange,
+  onKeyDown,
+  onPaste,
+  onFocus,
+  onBlur,
+  placeholder,
+  disabled,
+  rows = 2,
+  autoFocus,
+  dataTestId,
+  leftActions,
+  rightActions,
+  footer,
+  className,
+  textareaClassName,
+}: ChatComposerBoxProps) {
+  return (
+    <div className={cn(
+      'mx-auto w-full max-w-[740px] rounded-2xl border border-border/60 bg-background/95 px-3 py-3 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/80',
+      className
+    )}>
+      <AttachmentPreview attachments={attachments} onRemove={onRemoveAttachment} />
+      <div className={attachments.length > 0 ? 'mt-2' : ''}>
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={onChange}
+          onKeyDown={onKeyDown}
+          onPaste={onPaste}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          placeholder={placeholder}
+          disabled={disabled}
+          rows={rows}
+          autoFocus={autoFocus}
+          data-testid={dataTestId}
+          className={cn(
+            'w-full resize-none rounded-md bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 min-h-[60px] max-h-[200px] overflow-y-auto',
+            textareaClassName
+          )}
+        />
+      </div>
+      <div className="mt-2 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1">{leftActions}</div>
+        <div className="flex items-center gap-2">{rightActions}</div>
+      </div>
+      {footer}
+    </div>
+  )
+}

--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -57,11 +57,11 @@ describe('MessageInput', () => {
     expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument()
   })
 
-  it('shows send button when not active', () => {
+  it('shows a disabled send button when idle and empty', () => {
     renderWithProviders(
       <MessageInput sessionId="s-1" agentSlug="agent-1" />
     )
-    expect(screen.getByTestId('send-button')).toBeInTheDocument()
+    expect(screen.getByTestId('send-button')).toBeDisabled()
   })
 
   it('shows stop button when session is active', () => {
@@ -139,12 +139,35 @@ describe('MessageInput', () => {
     })
   })
 
-  it('send button is disabled when input is empty', () => {
+  it('enables the send button after the user types', async () => {
+    const user = userEvent.setup()
     renderWithProviders(
       <MessageInput sessionId="s-1" agentSlug="agent-1" />
     )
-    const sendButton = screen.getByTestId('send-button')
-    expect(sendButton).toBeDisabled()
+
+    const input = screen.getByTestId('message-input')
+    await user.type(input, 'Hello')
+
+    expect(screen.getByTestId('send-button')).toBeEnabled()
+  })
+
+  it('submits message on send button click', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <MessageInput sessionId="s-1" agentSlug="agent-1" />
+    )
+
+    const input = screen.getByTestId('message-input')
+    await user.type(input, 'Hello by button')
+    await user.click(screen.getByTestId('send-button'))
+
+    await waitFor(() => {
+      expect(mockSendMessage.mutateAsync).toHaveBeenCalledWith({
+        sessionId: 's-1',
+        agentSlug: 'agent-1',
+        content: 'Hello by button',
+      })
+    })
   })
 
   it('calls interrupt on stop button click', async () => {
@@ -271,7 +294,7 @@ describe('MessageInput', () => {
     renderWithProviders(
       <MessageInput sessionId="s-1" agentSlug="agent-1" />
     )
-    expect(screen.getByTitle('Attach')).toBeInTheDocument()
+    expect(screen.getByTitle('Add files')).toBeInTheDocument()
   })
 
   // ---- Offline state ----
@@ -315,7 +338,7 @@ describe('MessageInput', () => {
       renderWithProviders(
         <MessageInput sessionId="s-1" agentSlug="agent-1" />
       )
-      expect(screen.getByTitle('Attach')).toBeDisabled()
+      expect(screen.getByTitle('Add files')).toBeDisabled()
     })
   })
 

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -4,16 +4,16 @@ import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import { getApiBaseUrl } from '@renderer/lib/env'
 import { useSendMessage, useUploadFile, useUploadFolder, useInterruptSession } from '@renderer/hooks/use-messages'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
-import { Send, Loader2, StopCircle, WifiOff } from 'lucide-react'
+import { ArrowUp, Loader2, StopCircle, WifiOff } from 'lucide-react'
 import { useIsOnline } from '@renderer/context/connectivity-context'
 import { useUser } from '@renderer/context/user-context'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
-import { AttachmentPreview } from './attachment-preview'
 import { SlashCommandMenu } from './slash-command-menu'
 import { AttachmentPicker } from '@renderer/components/ui/attachment-picker'
 import { MountChoiceDialog } from '@renderer/components/ui/mount-choice-dialog'
 import { useMessageComposer } from '@renderer/hooks/use-message-composer'
+import { ChatComposerBox } from './chat-composer-box'
 
 interface MessageInputProps {
   sessionId: string
@@ -158,6 +158,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent }: MessageInp
   }
 
   const isDisabled = sendMessage.isPending || isActive || composer.isUploading || isOffline
+  const hasTypedMessage = composer.message.trim().length > 0
 
   if (isViewOnly) {
     return null
@@ -166,7 +167,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent }: MessageInp
   return (
     <form
       onSubmit={composer.handleSubmit}
-      className={`relative pl-2 pr-4 py-[18px] border-t bg-background ${composer.isDragOver ? 'ring-2 ring-primary ring-inset' : ''}`}
+      className={`relative px-4 pb-10 pt-3 ${composer.isDragOver ? 'ring-2 ring-primary ring-inset' : ''}`}
       {...composer.dragHandlers}
     >
       <MountChoiceDialog
@@ -181,40 +182,38 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent }: MessageInp
         visible={slashMenuOpen}
         filter={slashFilter ?? ''}
       />
-      <AttachmentPreview attachments={composer.attachments} onRemove={composer.removeAttachment} />
-      <div className={`flex items-center gap-1 ${composer.attachments.length > 0 ? 'mt-2' : ''}`}>
-        <AttachmentPicker
-          onFileSelect={composer.handleFileSelect}
-          onFolderSelect={composer.handleFolderSelect}
-          disabled={isDisabled}
-        />
-        <VoiceInputButton voiceInput={composer.voiceInput} message={composer.message} disabled={isDisabled} />
-        <textarea
-          ref={textareaRef}
-          value={composer.message}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          onPaste={composer.handlePaste}
-          onFocus={() => { if (slashFilter !== null && slashCommands.length > 0) setSlashMenuOpen(true) }}
-          onBlur={() => setSlashMenuOpen(false)}
-          placeholder={
-            isOffline
-              ? 'No internet connection...'
-              : isActive
-                ? 'Agent is responding...'
-                : 'Type a message...'
-          }
-          disabled={isDisabled}
-          className="flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 min-h-9 max-h-[200px] overflow-y-auto"
-          rows={1}
-          data-testid="message-input"
-        />
-        {isActive ? (
+      <ChatComposerBox
+        attachments={composer.attachments}
+        onRemoveAttachment={composer.removeAttachment}
+        textareaRef={textareaRef}
+        value={composer.message}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onPaste={composer.handlePaste}
+        onFocus={() => { if (slashFilter !== null && slashCommands.length > 0) setSlashMenuOpen(true) }}
+        onBlur={() => setSlashMenuOpen(false)}
+        placeholder={
+          isOffline
+            ? 'No internet connection...'
+            : isActive
+              ? 'Agent is responding...'
+              : 'Type a message...'
+        }
+        disabled={isDisabled}
+        rows={2}
+        dataTestId="message-input"
+        leftActions={(
+          <AttachmentPicker
+            onFileSelect={composer.handleFileSelect}
+            onFolderSelect={composer.handleFolderSelect}
+            disabled={isDisabled}
+          />
+        )}
+        rightActions={isActive ? (
           <Button
             type="button"
-            size="icon"
             variant="destructive"
-            className="h-[34px] w-[34px]"
+            className="h-[34px] px-3"
             onClick={handleInterrupt}
             disabled={interruptSession.isPending}
             data-testid="stop-button"
@@ -222,32 +221,46 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent }: MessageInp
             {interruptSession.isPending ? (
               <Loader2 className="h-4 w-4 animate-spin" />
             ) : (
-              <StopCircle className="h-4 w-4" />
+              <>
+                <StopCircle className="mr-2 h-4 w-4" />
+                Stop
+              </>
             )}
           </Button>
         ) : (
-          <Button
-            type="submit"
-            size="icon"
-            className="h-[34px] w-[34px]"
-            disabled={!composer.canSubmit || sendMessage.isPending}
-            data-testid="send-button"
-          >
-            {sendMessage.isPending || composer.isUploading ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Send className="h-4 w-4" />
-            )}
-          </Button>
+          <>
+            <VoiceInputButton
+              voiceInput={composer.voiceInput}
+              message={composer.message}
+              disabled={isDisabled}
+            />
+            <Button
+              type="submit"
+              size="icon"
+              className="h-[34px] w-[34px]"
+              disabled={!hasTypedMessage || sendMessage.isPending || composer.isUploading}
+              data-testid="send-button"
+            >
+              {sendMessage.isPending || composer.isUploading ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <ArrowUp className="h-4 w-4" />
+              )}
+            </Button>
+          </>
         )}
-      </div>
-      {isOffline && !isActive && (
-        <div className="flex items-center gap-1.5 mt-2 text-xs text-destructive">
-          <WifiOff className="h-3 w-3 shrink-0" />
-          <span>No internet connection. Messages cannot be sent.</span>
-        </div>
-      )}
-      <VoiceInputError error={composer.voiceInput.error} onDismiss={composer.voiceInput.clearError} className="mt-2" />
+        footer={(
+          <>
+            {isOffline && !isActive && (
+              <div className="mt-2 flex items-center gap-1.5 text-xs text-destructive">
+                <WifiOff className="h-3 w-3 shrink-0" />
+                <span>No internet connection. Messages cannot be sent.</span>
+              </div>
+            )}
+            <VoiceInputError error={composer.voiceInput.error} onDismiss={composer.voiceInput.clearError} className="mt-2" />
+          </>
+        )}
+      />
     </form>
   )
 }

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -67,6 +67,11 @@ export function MessageItem({ message, isStreaming, agentSlug, sessionId, isSess
           isUser && 'items-end'
         )}
       >
+        {/* Sender name for shared agent sessions */}
+        {isUser && message.sender?.name && (
+          <span className="text-xs text-muted-foreground">{message.sender.name}</span>
+        )}
+
         {/* Message bubble - only show if there's text content */}
         {showMessageBubble && (
           <MessageContextMenu text={text || ''} onRemove={onRemoveMessage ? () => onRemoveMessage(message.id) : undefined}>

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -1,7 +1,5 @@
-
 import { cn } from '@shared/lib/utils/cn'
-import { User, Bot, Terminal, Link2 } from 'lucide-react'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
+import { Link2 } from 'lucide-react'
 import { ToolCallItem } from './tool-call-item'
 import { SubAgentBlock } from './subagent-block'
 import { MessageContextMenu } from './message-context-menu'
@@ -38,16 +36,7 @@ export function MessageItem({ message, isStreaming, agentSlug, sessionId, isSess
   const hasText = text && text.length > 0
   const toolCalls = message.toolCalls || []
 
-  // Detect slash commands (user messages starting with /)
   const isSlashCommand = isUser && hasText && text.startsWith('/')
-
-  // Compute sender initials for the avatar
-  const senderInitials = message.sender?.name
-    ?.split(' ')
-    .map((w) => w[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 2)
 
   // Don't render assistant messages that have no text and no tool calls
   // (and aren't streaming). These are transient empty entries from partially-
@@ -63,20 +52,6 @@ export function MessageItem({ message, isStreaming, agentSlug, sessionId, isSess
     ? (hasText || attachedFiles.length === 0)
     : (hasText || isStreaming)
 
-  const avatarContent = (
-    <div
-      className={cn(
-        'h-8 w-8 rounded-full items-center justify-center shrink-0 hidden md:flex',
-        isUser && 'bg-primary text-primary-foreground',
-        isAssistant && 'bg-muted'
-      )}
-    >
-      {isSlashCommand && <Terminal className="h-4 w-4" />}
-      {isUser && !isSlashCommand && (senderInitials ? <span className="text-xs font-medium">{senderInitials}</span> : <User className="h-4 w-4" />)}
-      {isAssistant && <Bot className="h-4 w-4" />}
-    </div>
-  )
-
   return (
     <div
       className={cn(
@@ -85,16 +60,6 @@ export function MessageItem({ message, isStreaming, agentSlug, sessionId, isSess
       )}
       data-testid={isUser ? 'message-user' : isAssistant ? 'message-assistant' : undefined}
     >
-      {/* Avatar */}
-      {message.sender ? (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>{avatarContent}</TooltipTrigger>
-            <TooltipContent>{message.sender.name}</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      ) : avatarContent}
-
       {/* Message content */}
       <div
         className={cn(
@@ -107,9 +72,9 @@ export function MessageItem({ message, isStreaming, agentSlug, sessionId, isSess
           <MessageContextMenu text={text || ''} onRemove={onRemoveMessage ? () => onRemoveMessage(message.id) : undefined}>
             <div
               className={cn(
-                'rounded-lg px-4 py-2 max-w-full overflow-hidden',
-                isUser && 'bg-primary text-primary-foreground',
-                isAssistant && 'bg-muted'
+                'rounded-lg max-w-full overflow-hidden text-foreground',
+                isUser && 'bg-zinc-100 dark:bg-zinc-800/70 px-4 py-2',
+                isAssistant && 'py-1'
               )}
             >
               {/* Slash command display */}
@@ -129,10 +94,7 @@ export function MessageItem({ message, isStreaming, agentSlug, sessionId, isSess
               {/* Text content */}
               {hasText && !isSlashCommand && (
                 <div className={cn(
-                  'prose prose-sm max-w-none min-w-0 break-words',
-                  // Use inverted (light) text for user messages (dark bg) and dark mode
-                  // prose-user-message resets prose-invert in dark mode where primary bg is light
-                  isUser ? 'prose-invert prose-user-message' : 'dark:prose-invert'
+                  'prose prose-sm max-w-none min-w-0 break-words font-medium dark:prose-invert'
                 )}>
                   <ReactMarkdown
                     remarkPlugins={[remarkGfm]}
@@ -141,7 +103,7 @@ export function MessageItem({ message, isStreaming, agentSlug, sessionId, isSess
                       pre: ({ children }) => (
                         <pre className={cn(
                           'rounded-md p-3 overflow-x-auto text-[13px] leading-relaxed border',
-                          isUser ? 'bg-black/20 text-inherit border-white/10' : 'bg-black/[0.03] dark:bg-white/[0.06] border-border/60 text-foreground'
+                          'bg-black/[0.03] dark:bg-white/[0.06] border-border/60 text-foreground'
                         )}>
                           {children}
                         </pre>
@@ -151,12 +113,12 @@ export function MessageItem({ message, isStreaming, agentSlug, sessionId, isSess
                         return isInline ? (
                           <code className={cn(
                             'rounded px-1.5 py-0.5 text-[13px] font-medium',
-                            isUser ? 'bg-black/20 text-inherit' : 'bg-black/[0.05] dark:bg-white/[0.08] text-foreground'
+                            'bg-black/[0.05] dark:bg-white/[0.08] text-foreground'
                           )}>
                             {children}
                           </code>
                         ) : (
-                          <code className={cn(className, isUser ? 'text-inherit' : 'text-foreground')}>{children}</code>
+                          <code className={cn(className, 'text-foreground')}>{children}</code>
                         )
                       },
                       // Style tables with borders and horizontal scroll
@@ -170,7 +132,7 @@ export function MessageItem({ message, isStreaming, agentSlug, sessionId, isSess
                       th: ({ children }) => (
                         <th className={cn(
                           'border-b-2 px-3 py-1.5 text-left font-semibold',
-                          isUser ? 'border-white/30 dark:border-black/20' : 'border-border'
+                          'border-border'
                         )}>
                           {children}
                         </th>
@@ -178,7 +140,7 @@ export function MessageItem({ message, isStreaming, agentSlug, sessionId, isSess
                       td: ({ children }) => (
                         <td className={cn(
                           'border-b px-3 py-1.5',
-                          isUser ? 'border-white/20 dark:border-black/10' : 'border-border'
+                          'border-border'
                         )}>
                           {children}
                         </td>
@@ -191,7 +153,7 @@ export function MessageItem({ message, isStreaming, agentSlug, sessionId, isSess
                           rel="noopener noreferrer"
                           className={cn(
                             'hover:underline',
-                            isUser ? 'text-blue-200 dark:text-blue-600' : 'text-blue-500'
+                            'text-blue-500'
                           )}
                         >
                           {children}

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -655,7 +655,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, onPendin
   return (
     <div className="relative flex-1 min-h-0">
       <div className="overflow-y-auto h-full" ref={scrollRef} onScroll={handleScroll} data-testid="message-list">
-        <div className="p-4 space-y-4">
+        <div className="mx-auto w-full max-w-[720px] px-4 pb-4 pt-14 space-y-4">
         {messages?.filter((item) => {
           // Hide system-injected user messages (e.g., MCP registration continuation)
           if (item.type === 'user') {
@@ -674,8 +674,9 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, onPendin
                   <DeliveredFiles files={turnDeliveredFiles.get(item.id)!} agentSlug={agentSlug} />
                 )}
                 {turnElapsedTimes.has(item.id) && item.id !== deferredElapsedMessageId && (
-                  <div className="text-xs text-muted-foreground pb-1 -mt-1 tabular-nums ml-11 italic">
-                    Agent took {formatElapsed(turnElapsedTimes.get(item.id)!)}
+                  <div className="flex items-center gap-3 pb-1 -mt-3 text-xs text-muted-foreground tabular-nums italic">
+                    <span>Worked for {formatElapsed(turnElapsedTimes.get(item.id)!)}</span>
+                    <div className="h-px flex-1 bg-border" />
                   </div>
                 )}
               </>
@@ -765,8 +766,9 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, onPendin
           <DeliveredFiles files={turnDeliveredFiles.get(deferredElapsedMessageId)!} agentSlug={agentSlug} />
         )}
         {deferredElapsedMessageId && turnElapsedTimes.has(deferredElapsedMessageId) && (
-          <div className="text-xs text-muted-foreground pb-1 -mt-1 tabular-nums ml-11 italic">
-            Agent took {formatElapsed(turnElapsedTimes.get(deferredElapsedMessageId)!)}
+          <div className="flex items-center gap-3 pb-1 -mt-3 text-xs text-muted-foreground tabular-nums italic">
+            <span>Worked for {formatElapsed(turnElapsedTimes.get(deferredElapsedMessageId)!)}</span>
+            <div className="h-px flex-1 bg-border" />
           </div>
         )}
 

--- a/src/renderer/components/ui/attachment-picker.tsx
+++ b/src/renderer/components/ui/attachment-picker.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react'
 import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
-import { Paperclip, FileIcon, FolderOpen } from 'lucide-react'
+import { Plus, FileIcon, FolderOpen } from 'lucide-react'
 
 interface AttachmentPickerProps {
   onFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void
@@ -15,7 +15,7 @@ export function AttachmentPicker({
   onFileSelect,
   onFolderSelect,
   disabled,
-  buttonClassName = 'h-[34px] w-[34px]',
+  buttonClassName = 'h-[34px] px-3',
   popoverAlign = 'start',
 }: AttachmentPickerProps) {
   const [open, setOpen] = useState(false)
@@ -42,13 +42,13 @@ export function AttachmentPicker({
         <PopoverTrigger asChild>
           <Button
             type="button"
-            size="icon"
             variant="ghost"
             className={buttonClassName}
             disabled={disabled}
-            title="Attach"
+            title="Add files"
           >
-            <Paperclip className="h-4 w-4" />
+            <Plus className="mr-1 h-4 w-4" />
+            Add files
           </Button>
         </PopoverTrigger>
         <PopoverContent side="top" align={popoverAlign} className="w-40 p-1">

--- a/src/renderer/components/ui/voice-input-button.tsx
+++ b/src/renderer/components/ui/voice-input-button.tsx
@@ -1,18 +1,19 @@
 import { useCallback } from 'react'
-import { Button } from '@renderer/components/ui/button'
+import { Button, buttonVariants } from '@renderer/components/ui/button'
 import { MiniWaveform } from '@renderer/components/ui/mini-waveform'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
 import { Loader2, Mic, MicOff, Square, X } from 'lucide-react'
 import { useDialogs } from '@renderer/context/dialog-context'
 import { useUser } from '@renderer/context/user-context'
 import { useIsVoiceConfigured } from '@renderer/hooks/use-voice-input'
+import { cn } from '@shared/lib/utils'
 import type { useVoiceInput } from '@renderer/hooks/use-voice-input'
 
 type VoiceInputSize = 'default' | 'sm'
 
 const SIZE_CONFIG = {
-  default: { button: 'h-[34px] w-[34px]', pill: 'h-[34px]', waveform: { width: 56, height: 18 } },
-  sm: { button: 'h-8 w-8', pill: 'h-8', waveform: { width: 48, height: 16 } },
+  default: { button: 'h-[34px] w-[34px]', pill: 'h-[34px] w-[102px]', waveform: { width: 56, height: 18 } },
+  sm: { button: 'h-8 w-8', pill: 'h-8 w-[92px]', waveform: { width: 48, height: 16 } },
 } as const
 
 interface VoiceInputButtonProps {
@@ -83,32 +84,42 @@ export function VoiceInputButton({ voiceInput, message, disabled, size = 'defaul
     )
   }
 
-  return isRecording ? (
+  return (
     <button
       type="button"
       onClick={handleToggle}
-      className={`flex items-center gap-1.5 ${config.pill} px-2 rounded-full bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors`}
-      title="Stop recording"
-    >
-      <Square className="h-3 w-3 fill-current" />
-      <MiniWaveform analyserRef={voiceInput.analyserRef} {...config.waveform} />
-    </button>
-  ) : (
-    <Button
-      type="button"
-      size="icon"
-      variant="ghost"
-      className={config.button}
-      onClick={handleToggle}
-      disabled={disabled}
-      title={!hasVoiceConfigured ? 'Set up voice input' : 'Voice input'}
-    >
-      {isConnecting ? (
-        <Loader2 className="h-4 w-4 animate-spin" />
-      ) : (
-        <Mic className="h-4 w-4" />
+      disabled={disabled && !isRecording && !isConnecting}
+      className={cn(
+        buttonVariants({ variant: 'outline', size: 'icon' }),
+        'overflow-hidden px-0 transition-[width,padding,background-color,border-color,color,border-radius] duration-200 ease-out',
+        isRecording || isConnecting
+          ? `${config.pill} gap-2 justify-between rounded-md border-input bg-background px-2 text-foreground hover:bg-zinc-100`
+          : `gap-0 rounded-md ${config.button}`
       )}
-    </Button>
+      title={
+        isRecording || isConnecting
+          ? 'Stop recording'
+          : !hasVoiceConfigured
+            ? 'Set up voice input'
+            : 'Voice input'
+      }
+    >
+      <span
+        className={cn(
+          'overflow-hidden transition-[max-width,opacity] duration-200 ease-out',
+          isRecording || isConnecting ? 'max-w-[64px] opacity-100' : 'max-w-0 opacity-0'
+        )}
+      >
+        <MiniWaveform analyserRef={voiceInput.analyserRef} color="black" {...config.waveform} />
+      </span>
+      {isConnecting ? (
+        <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+      ) : isRecording ? (
+        <Square className="h-3 w-3 shrink-0 fill-current" />
+      ) : (
+        <Mic className="h-4 w-4 shrink-0" />
+      )}
+    </button>
   )
 }
 


### PR DESCRIPTION
## Summary

- refine the chat transcript layout, widths, bubble styling, and metadata treatment
- update the main chat composer layout and controls, including the revised voice and send actions
- extract a shared composer shell and reuse it on the agent landing page
- simplify the landing page input so it auto-expands for large text without a manual expand/collapse control

## Verification

- npm test -- --run src/renderer/components/messages/message-input.test.tsx src/renderer/components/agents/agent-landing.test.tsx
- npm run typecheck