### PR TITLE
Feat/browser cmd support

### DIFF
--- a/agent-container/src/cdp-editing-commands.test.ts
+++ b/agent-container/src/cdp-editing-commands.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect } from 'vitest'
+import { getEditingCommands, macEditingCommands } from './cdp-editing-commands'
+
+// CDP modifier bitmask values (matches front-end modifierFlags):
+const ALT = 1
+const CTRL = 2
+const META = 4
+const SHIFT = 8
+
+describe('macEditingCommands map', () => {
+  it('loads a non-empty map', () => {
+    expect(Object.keys(macEditingCommands).length).toBeGreaterThan(0)
+  })
+
+  it('contains known entries from Playwright', () => {
+    expect(macEditingCommands['Meta+KeyA']).toBe('selectAll:')
+    expect(macEditingCommands['Meta+KeyC']).toBe('copy:')
+    expect(macEditingCommands['Meta+KeyV']).toBe('paste:')
+    expect(macEditingCommands['Meta+KeyX']).toBe('cut:')
+    expect(macEditingCommands['Meta+KeyZ']).toBe('undo:')
+    expect(macEditingCommands['Shift+Meta+KeyZ']).toBe('redo:')
+    expect(macEditingCommands['Backspace']).toBe('deleteBackward:')
+    expect(macEditingCommands['Delete']).toBe('deleteForward:')
+  })
+})
+
+describe('getEditingCommands', () => {
+  // --- Single-key (no modifiers) ---
+
+  it('returns command for Backspace with no modifiers', () => {
+    expect(getEditingCommands('Backspace', 0)).toEqual(['deleteBackward'])
+  })
+
+  it('returns command for Delete with no modifiers', () => {
+    expect(getEditingCommands('Delete', 0)).toEqual(['deleteForward'])
+  })
+
+  it('returns command for Enter with no modifiers', () => {
+    // Enter maps to insertNewline: which starts with "insert" → filtered out
+    expect(getEditingCommands('Enter', 0)).toEqual([])
+  })
+
+  it('returns command for ArrowUp with no modifiers', () => {
+    expect(getEditingCommands('ArrowUp', 0)).toEqual(['moveUp'])
+  })
+
+  it('returns command for ArrowDown with no modifiers', () => {
+    expect(getEditingCommands('ArrowDown', 0)).toEqual(['moveDown'])
+  })
+
+  it('returns command for ArrowLeft with no modifiers', () => {
+    expect(getEditingCommands('ArrowLeft', 0)).toEqual(['moveLeft'])
+  })
+
+  it('returns command for ArrowRight with no modifiers', () => {
+    expect(getEditingCommands('ArrowRight', 0)).toEqual(['moveRight'])
+  })
+
+  it('returns empty for unknown key', () => {
+    expect(getEditingCommands('F13', 0)).toEqual([])
+  })
+
+  it('returns empty for a printable character with no modifiers', () => {
+    expect(getEditingCommands('KeyA', 0)).toEqual([])
+  })
+
+  // --- Meta (Cmd) combos ---
+
+  it('Cmd+A → selectAll', () => {
+    expect(getEditingCommands('KeyA', META)).toEqual(['selectAll'])
+  })
+
+  it('Cmd+C → copy', () => {
+    expect(getEditingCommands('KeyC', META)).toEqual(['copy'])
+  })
+
+  it('Cmd+X → cut', () => {
+    expect(getEditingCommands('KeyX', META)).toEqual(['cut'])
+  })
+
+  it('Cmd+V → paste', () => {
+    expect(getEditingCommands('KeyV', META)).toEqual(['paste'])
+  })
+
+  it('Cmd+Z → undo', () => {
+    expect(getEditingCommands('KeyZ', META)).toEqual(['undo'])
+  })
+
+  it('Cmd+Backspace → deleteToBeginningOfLine', () => {
+    expect(getEditingCommands('Backspace', META)).toEqual(['deleteToBeginningOfLine'])
+  })
+
+  it('Cmd+ArrowLeft → moveToLeftEndOfLine', () => {
+    expect(getEditingCommands('ArrowLeft', META)).toEqual(['moveToLeftEndOfLine'])
+  })
+
+  it('Cmd+ArrowRight → moveToRightEndOfLine', () => {
+    expect(getEditingCommands('ArrowRight', META)).toEqual(['moveToRightEndOfLine'])
+  })
+
+  it('Cmd+ArrowUp → moveToBeginningOfDocument', () => {
+    expect(getEditingCommands('ArrowUp', META)).toEqual(['moveToBeginningOfDocument'])
+  })
+
+  it('Cmd+ArrowDown → moveToEndOfDocument', () => {
+    expect(getEditingCommands('ArrowDown', META)).toEqual(['moveToEndOfDocument'])
+  })
+
+  // --- Shift combos ---
+
+  it('Shift+ArrowLeft → moveLeftAndModifySelection', () => {
+    expect(getEditingCommands('ArrowLeft', SHIFT)).toEqual(['moveLeftAndModifySelection'])
+  })
+
+  it('Shift+ArrowRight → moveRightAndModifySelection', () => {
+    expect(getEditingCommands('ArrowRight', SHIFT)).toEqual(['moveRightAndModifySelection'])
+  })
+
+  it('Shift+ArrowUp → moveUpAndModifySelection', () => {
+    expect(getEditingCommands('ArrowUp', SHIFT)).toEqual(['moveUpAndModifySelection'])
+  })
+
+  it('Shift+ArrowDown → moveDownAndModifySelection', () => {
+    expect(getEditingCommands('ArrowDown', SHIFT)).toEqual(['moveDownAndModifySelection'])
+  })
+
+  it('Shift+Home → moveToBeginningOfDocumentAndModifySelection', () => {
+    expect(getEditingCommands('Home', SHIFT)).toEqual(['moveToBeginningOfDocumentAndModifySelection'])
+  })
+
+  it('Shift+End → moveToEndOfDocumentAndModifySelection', () => {
+    expect(getEditingCommands('End', SHIFT)).toEqual(['moveToEndOfDocumentAndModifySelection'])
+  })
+
+  it('Shift+Backspace → deleteBackward', () => {
+    expect(getEditingCommands('Backspace', SHIFT)).toEqual(['deleteBackward'])
+  })
+
+  it('Shift+Delete → deleteForward', () => {
+    expect(getEditingCommands('Delete', SHIFT)).toEqual(['deleteForward'])
+  })
+
+  // --- Shift+Meta combos (two modifiers — tests key ordering) ---
+
+  it('Shift+Cmd+Z → redo', () => {
+    expect(getEditingCommands('KeyZ', SHIFT | META)).toEqual(['redo'])
+  })
+
+  it('Shift+Cmd+ArrowLeft → moveToLeftEndOfLineAndModifySelection', () => {
+    expect(getEditingCommands('ArrowLeft', SHIFT | META)).toEqual(['moveToLeftEndOfLineAndModifySelection'])
+  })
+
+  it('Shift+Cmd+ArrowRight → moveToRightEndOfLineAndModifySelection', () => {
+    expect(getEditingCommands('ArrowRight', SHIFT | META)).toEqual(['moveToRightEndOfLineAndModifySelection'])
+  })
+
+  it('Shift+Cmd+ArrowUp → moveToBeginningOfDocumentAndModifySelection', () => {
+    expect(getEditingCommands('ArrowUp', SHIFT | META)).toEqual(['moveToBeginningOfDocumentAndModifySelection'])
+  })
+
+  it('Shift+Cmd+ArrowDown → moveToEndOfDocumentAndModifySelection', () => {
+    expect(getEditingCommands('ArrowDown', SHIFT | META)).toEqual(['moveToEndOfDocumentAndModifySelection'])
+  })
+
+  it('Shift+Cmd+Backspace → deleteToBeginningOfLine', () => {
+    expect(getEditingCommands('Backspace', SHIFT | META)).toEqual(['deleteToBeginningOfLine'])
+  })
+
+  // --- Control combos ---
+
+  it('Ctrl+A → moveToBeginningOfParagraph', () => {
+    expect(getEditingCommands('KeyA', CTRL)).toEqual(['moveToBeginningOfParagraph'])
+  })
+
+  it('Ctrl+E → moveToEndOfParagraph', () => {
+    expect(getEditingCommands('KeyE', CTRL)).toEqual(['moveToEndOfParagraph'])
+  })
+
+  it('Ctrl+D → deleteForward', () => {
+    expect(getEditingCommands('KeyD', CTRL)).toEqual(['deleteForward'])
+  })
+
+  it('Ctrl+H → deleteBackward', () => {
+    expect(getEditingCommands('KeyH', CTRL)).toEqual(['deleteBackward'])
+  })
+
+  it('Ctrl+K → deleteToEndOfParagraph', () => {
+    expect(getEditingCommands('KeyK', CTRL)).toEqual(['deleteToEndOfParagraph'])
+  })
+
+  it('Ctrl+Backspace → deleteBackwardByDecomposingPreviousCharacter', () => {
+    expect(getEditingCommands('Backspace', CTRL)).toEqual(['deleteBackwardByDecomposingPreviousCharacter'])
+  })
+
+  // --- Shift+Control combos (two modifiers — tests ordering) ---
+
+  it('Shift+Ctrl+A → moveToBeginningOfParagraphAndModifySelection', () => {
+    expect(getEditingCommands('KeyA', SHIFT | CTRL)).toEqual(['moveToBeginningOfParagraphAndModifySelection'])
+  })
+
+  it('Shift+Ctrl+E → moveToEndOfParagraphAndModifySelection', () => {
+    expect(getEditingCommands('KeyE', SHIFT | CTRL)).toEqual(['moveToEndOfParagraphAndModifySelection'])
+  })
+
+  it('Shift+Ctrl+ArrowLeft → moveToLeftEndOfLineAndModifySelection', () => {
+    expect(getEditingCommands('ArrowLeft', SHIFT | CTRL)).toEqual(['moveToLeftEndOfLineAndModifySelection'])
+  })
+
+  it('Shift+Ctrl+ArrowRight → moveToRightEndOfLineAndModifySelection', () => {
+    expect(getEditingCommands('ArrowRight', SHIFT | CTRL)).toEqual(['moveToRightEndOfLineAndModifySelection'])
+  })
+
+  // --- Alt combos ---
+
+  it('Alt+Backspace → deleteWordBackward', () => {
+    expect(getEditingCommands('Backspace', ALT)).toEqual(['deleteWordBackward'])
+  })
+
+  it('Alt+Delete → deleteWordForward', () => {
+    expect(getEditingCommands('Delete', ALT)).toEqual(['deleteWordForward'])
+  })
+
+  it('Alt+ArrowLeft → moveWordLeft', () => {
+    expect(getEditingCommands('ArrowLeft', ALT)).toEqual(['moveWordLeft'])
+  })
+
+  it('Alt+ArrowRight → moveWordRight', () => {
+    expect(getEditingCommands('ArrowRight', ALT)).toEqual(['moveWordRight'])
+  })
+
+  // --- Shift+Alt combos (two modifiers — tests ordering) ---
+
+  it('Shift+Alt+ArrowLeft → moveWordLeftAndModifySelection', () => {
+    expect(getEditingCommands('ArrowLeft', SHIFT | ALT)).toEqual(['moveWordLeftAndModifySelection'])
+  })
+
+  it('Shift+Alt+ArrowRight → moveWordRightAndModifySelection', () => {
+    expect(getEditingCommands('ArrowRight', SHIFT | ALT)).toEqual(['moveWordRightAndModifySelection'])
+  })
+
+  it('Shift+Alt+ArrowUp → moveParagraphBackwardAndModifySelection', () => {
+    expect(getEditingCommands('ArrowUp', SHIFT | ALT)).toEqual(['moveParagraphBackwardAndModifySelection'])
+  })
+
+  it('Shift+Alt+ArrowDown → moveParagraphForwardAndModifySelection', () => {
+    expect(getEditingCommands('ArrowDown', SHIFT | ALT)).toEqual(['moveParagraphForwardAndModifySelection'])
+  })
+
+  // --- Control+Alt combos (two modifiers — tests ordering) ---
+
+  it('Ctrl+Alt+B → moveWordBackward', () => {
+    expect(getEditingCommands('KeyB', CTRL | ALT)).toEqual(['moveWordBackward'])
+  })
+
+  it('Ctrl+Alt+F → moveWordForward', () => {
+    expect(getEditingCommands('KeyF', CTRL | ALT)).toEqual(['moveWordForward'])
+  })
+
+  it('Ctrl+Alt+Backspace → deleteWordBackward', () => {
+    expect(getEditingCommands('Backspace', CTRL | ALT)).toEqual(['deleteWordBackward'])
+  })
+
+  // --- Triple-modifier combos (Shift+Control+Alt — tests full ordering) ---
+
+  it('Shift+Ctrl+Alt+B → moveWordBackwardAndModifySelection', () => {
+    expect(getEditingCommands('KeyB', SHIFT | CTRL | ALT)).toEqual(['moveWordBackwardAndModifySelection'])
+  })
+
+  it('Shift+Ctrl+Alt+F → moveWordForwardAndModifySelection', () => {
+    expect(getEditingCommands('KeyF', SHIFT | CTRL | ALT)).toEqual(['moveWordForwardAndModifySelection'])
+  })
+
+  it('Shift+Ctrl+Alt+Backspace → deleteWordBackward', () => {
+    expect(getEditingCommands('Backspace', SHIFT | CTRL | ALT)).toEqual(['deleteWordBackward'])
+  })
+
+  // --- Multi-command entries ---
+
+  it('Ctrl+O returns multiple commands (filtered)', () => {
+    // macEditingCommands has ["insertNewlineIgnoringFieldEditor:", "moveBackward:"]
+    // "insertNewlineIgnoringFieldEditor:" starts with "insert" → filtered out
+    expect(getEditingCommands('KeyO', CTRL)).toEqual(['moveBackward'])
+  })
+
+  it('Alt+ArrowUp returns multiple commands (filtered)', () => {
+    // macEditingCommands has ["moveBackward:", "moveToBeginningOfParagraph:"]
+    // Neither starts with "insert" → both kept
+    expect(getEditingCommands('ArrowUp', ALT)).toEqual(['moveBackward', 'moveToBeginningOfParagraph'])
+  })
+
+  // --- Insert-filter verification ---
+
+  it('filters out commands starting with "insert"', () => {
+    // Enter → insertNewline: → filtered
+    expect(getEditingCommands('Enter', 0)).toEqual([])
+    // Shift+Enter → insertNewline: → filtered
+    expect(getEditingCommands('Enter', SHIFT)).toEqual([])
+    // Alt+Enter → insertNewlineIgnoringFieldEditor: → filtered
+    expect(getEditingCommands('Enter', ALT)).toEqual([])
+  })
+
+  // --- Colon-stripping verification ---
+
+  it('strips trailing colon from commands', () => {
+    // Verify raw map has colons
+    expect(macEditingCommands['Backspace']).toBe('deleteBackward:')
+    // Verify getEditingCommands strips them
+    expect(getEditingCommands('Backspace', 0)).toEqual(['deleteBackward'])
+  })
+
+  // --- Edge cases ---
+
+  it('returns empty for unrecognized modifier combinations', () => {
+    // Meta+Ctrl+A — not in the map (only Ctrl+A and Meta+KeyA exist separately)
+    expect(getEditingCommands('KeyA', META | CTRL)).toEqual([])
+  })
+
+  it('returns empty for all four modifiers combined', () => {
+    expect(getEditingCommands('KeyA', SHIFT | CTRL | ALT | META)).toEqual([])
+  })
+
+  it('returns empty for modifiers=0 with printable key code', () => {
+    expect(getEditingCommands('KeyZ', 0)).toEqual([])
+    expect(getEditingCommands('KeyC', 0)).toEqual([])
+  })
+
+  // --- Exhaustive: verify every key in macEditingCommands is reachable ---
+
+  it('every entry in macEditingCommands is reachable via getEditingCommands', () => {
+    const modifierNameToBit: Record<string, number> = {
+      'Shift': SHIFT,
+      'Control': CTRL,
+      'Alt': ALT,
+      'Meta': META,
+    }
+
+    for (const [shortcut, rawCmds] of Object.entries(macEditingCommands)) {
+      const parts = shortcut.split('+')
+      const code = parts[parts.length - 1]
+      let modifiers = 0
+      for (let i = 0; i < parts.length - 1; i++) {
+        modifiers |= modifierNameToBit[parts[i]] || 0
+      }
+
+      const result = getEditingCommands(code, modifiers)
+      const expected = (typeof rawCmds === 'string' ? [rawCmds] : rawCmds)
+        .filter(c => !c.startsWith('insert'))
+        .map(c => c.endsWith(':') ? c.slice(0, -1) : c)
+
+      expect(result, `shortcut "${shortcut}" should be reachable`).toEqual(expected)
+    }
+  })
+})

--- a/agent-container/src/cdp-editing-commands.ts
+++ b/agent-container/src/cdp-editing-commands.ts
@@ -1,0 +1,85 @@
+// CDP keyboard shortcut support via Playwright's macEditingCommands map.
+// Chrome's CDP Input.dispatchKeyEvent needs a `commands` array to trigger
+// editing actions (selectAll, cut, undo, etc.) on all platforms.
+
+import * as path from 'path';
+
+/**
+ * Resolve the absolute path to playwright-core's macEditingCommands module.
+ * playwright-core's package.json `exports` field blocks subpath requires,
+ * so we find the package root first, then construct the full path.
+ */
+function resolveMacEditingCommandsPath(): string | null {
+  // Strategy 1: find playwright-core via normal Node resolution, then build the subpath.
+  // require.resolve('playwright-core') gives us the main entry; we derive the package root.
+  try {
+    const mainEntry = require.resolve('playwright-core');
+    // mainEntry is something like .../playwright-core/lib/... or .../playwright-core/index.js
+    const pkgRoot = mainEntry.replace(/([\\/]playwright-core[\\/]).*$/, '$1');
+    return path.join(pkgRoot, 'lib', 'server', 'macEditingCommands');
+  } catch {
+    // playwright-core not in local node_modules
+  }
+
+  // Strategy 2: hardcoded container path (globally-installed agent-browser)
+  const containerPath = '/usr/lib/node_modules/agent-browser/node_modules/playwright-core/lib/server/macEditingCommands';
+  try {
+    require.resolve(containerPath);
+    return containerPath;
+  } catch {
+    // Not in container environment
+  }
+
+  return null;
+}
+
+/**
+ * Load Playwright's macEditingCommands map, trying multiple resolution strategies
+ * so we don't break if the package is hoisted or the container layout changes.
+ */
+function loadMacEditingCommands(): Record<string, string | string[]> {
+  const resolvedPath = resolveMacEditingCommandsPath();
+  if (resolvedPath) {
+    try {
+      const mod = require(resolvedPath);
+      const map = mod.macEditingCommands;
+      if (map && typeof map === 'object' && Object.keys(map).length > 0) {
+        return map;
+      }
+    } catch {
+      // Fall through to warning
+    }
+  }
+
+  console.warn(
+    '[Browser] Could not load macEditingCommands from playwright-core — ' +
+    'keyboard shortcuts in browser preview may not work'
+  );
+  return {};
+}
+
+export const macEditingCommands = loadMacEditingCommands();
+
+/**
+ * Look up CDP editing commands for a key combo.
+ * Matches Playwright's crInput._commandsForCode() — modifier order is
+ * Shift, Control, Alt, Meta (same order Playwright iterates).
+ *
+ * @param code  - The KeyboardEvent.code (e.g. "KeyA", "Backspace")
+ * @param modifiers - CDP modifier bitmask: Alt=1, Ctrl=2, Meta=4, Shift=8
+ */
+export function getEditingCommands(code: string, modifiers: number): string[] {
+  const parts: string[] = [];
+  if (modifiers & 8) parts.push('Shift');
+  if (modifiers & 2) parts.push('Control');
+  if (modifiers & 1) parts.push('Alt');
+  if (modifiers & 4) parts.push('Meta');
+  parts.push(code);
+  const shortcut = parts.join('+');
+  let cmds = macEditingCommands[shortcut];
+  if (!cmds) return [];
+  if (typeof cmds === 'string') cmds = [cmds];
+  return cmds
+    .filter((c: string) => !c.startsWith('insert'))
+    .map((c: string) => c.endsWith(':') ? c.slice(0, -1) : c);
+}

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -14,34 +14,7 @@ import { inputManager } from './input-manager';
 import { dashboardManager } from './dashboard-manager';
 import { tabManager } from './tab-manager';
 
-// Load Playwright's macEditingCommands for CDP keyboard shortcut support.
-// Chrome's CDP Input.dispatchKeyEvent needs a `commands` array to trigger editing
-// actions (selectAll, cut, undo, etc.) on all platforms.
-let macEditingCommands: Record<string, string | string[]> = {};
-try {
-  // playwright-core is a nested dep of agent-browser (installed globally in the container)
-  const mod = require('/usr/lib/node_modules/agent-browser/node_modules/playwright-core/lib/server/macEditingCommands');
-  macEditingCommands = mod.macEditingCommands || {};
-} catch {
-  console.warn('[Browser] Could not load macEditingCommands from playwright-core — keyboard shortcuts in browser preview may not work');
-}
-
-/** Look up CDP editing commands for a key combo, matching Playwright's crInput._commandsForCode() */
-function getEditingCommands(code: string, modifiers: number): string[] {
-  const parts: string[] = [];
-  if (modifiers & 8) parts.push('Shift');
-  if (modifiers & 2) parts.push('Control');
-  if (modifiers & 1) parts.push('Alt');
-  if (modifiers & 4) parts.push('Meta');
-  parts.push(code);
-  const shortcut = parts.join('+');
-  let cmds = macEditingCommands[shortcut];
-  if (!cmds) return [];
-  if (typeof cmds === 'string') cmds = [cmds];
-  return cmds
-    .filter((c: string) => !c.startsWith('insert'))
-    .map((c: string) => c.endsWith(':') ? c.slice(0, -1) : c);
-}
+import { getEditingCommands } from './cdp-editing-commands';
 
 // Global error handlers to prevent crashes from AbortError during interrupts
 // The SDK throws AbortError when queries are aborted, which can propagate uncaught
@@ -1946,11 +1919,12 @@ function handleBrowserStreamConnection(ws: WebSocket) {
             text: data.text,
           }));
         } else if (data.type === 'get_selection') {
+          // Capture the message ID before cdpMsg increments it, to avoid re-parsing
+          const msgId = cdpScreencast.msgId + 1;
           const msgStr = cdpMsg(cdpScreencast, 'Runtime.evaluate', {
             expression: 'window.getSelection().toString()',
             returnByValue: true,
           });
-          const msgId = JSON.parse(msgStr).id;
           cdpScreencast.pendingSelections.add(msgId);
           cdpScreencast.cdpWs.send(msgStr);
         }

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -14,6 +14,35 @@ import { inputManager } from './input-manager';
 import { dashboardManager } from './dashboard-manager';
 import { tabManager } from './tab-manager';
 
+// Load Playwright's macEditingCommands for CDP keyboard shortcut support.
+// Chrome's CDP Input.dispatchKeyEvent needs a `commands` array to trigger editing
+// actions (selectAll, cut, undo, etc.) on all platforms.
+let macEditingCommands: Record<string, string | string[]> = {};
+try {
+  // playwright-core is a nested dep of agent-browser (installed globally in the container)
+  const mod = require('/usr/lib/node_modules/agent-browser/node_modules/playwright-core/lib/server/macEditingCommands');
+  macEditingCommands = mod.macEditingCommands || {};
+} catch {
+  console.warn('[Browser] Could not load macEditingCommands from playwright-core — keyboard shortcuts in browser preview may not work');
+}
+
+/** Look up CDP editing commands for a key combo, matching Playwright's crInput._commandsForCode() */
+function getEditingCommands(code: string, modifiers: number): string[] {
+  const parts: string[] = [];
+  if (modifiers & 8) parts.push('Shift');
+  if (modifiers & 2) parts.push('Control');
+  if (modifiers & 1) parts.push('Alt');
+  if (modifiers & 4) parts.push('Meta');
+  parts.push(code);
+  const shortcut = parts.join('+');
+  let cmds = macEditingCommands[shortcut];
+  if (!cmds) return [];
+  if (typeof cmds === 'string') cmds = [cmds];
+  return cmds
+    .filter((c: string) => !c.startsWith('insert'))
+    .map((c: string) => c.endsWith(':') ? c.slice(0, -1) : c);
+}
+
 // Global error handlers to prevent crashes from AbortError during interrupts
 // The SDK throws AbortError when queries are aborted, which can propagate uncaught
 process.on('uncaughtException', (error: Error) => {
@@ -1883,7 +1912,34 @@ function handleBrowserStreamConnection(ws: WebSocket) {
             key: data.key,
             code: data.code,
             text: data.text,
+            windowsVirtualKeyCode: data.keyCode || 0,
+            nativeVirtualKeyCode: data.keyCode || 0,
             modifiers: data.modifiers || 0,
+          }));
+        } else if (data.type === 'input_press') {
+          // Playwright-style key press: look up editing commands from Playwright's
+          // macEditingCommands map and include them in the CDP event. This is required
+          // for Chrome to trigger keyboard shortcuts (selectAll, cut, undo, etc.) via CDP.
+          const mods = data.modifiers || 0;
+          const isPrintable = data.key && data.key.length === 1;
+          const commands = getEditingCommands(data.code, mods);
+
+          cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Input.dispatchKeyEvent', {
+            type: isPrintable ? 'keyDown' : 'rawKeyDown',
+            key: data.key, code: data.code,
+            text: isPrintable ? data.key : '',
+            unmodifiedText: isPrintable ? data.key : '',
+            windowsVirtualKeyCode: data.keyCode || 0,
+            nativeVirtualKeyCode: data.keyCode || 0,
+            modifiers: mods,
+            commands,
+          }));
+
+          cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Input.dispatchKeyEvent', {
+            type: 'keyUp', key: data.key, code: data.code,
+            windowsVirtualKeyCode: data.keyCode || 0,
+            nativeVirtualKeyCode: data.keyCode || 0,
+            modifiers: mods,
           }));
         } else if (data.type === 'input_paste' && data.text) {
           cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Input.insertText', {
@@ -1899,7 +1955,7 @@ function handleBrowserStreamConnection(ws: WebSocket) {
           cdpScreencast.cdpWs.send(msgStr);
         }
       }
-    } catch { /* ignore */ }
+    } catch { /* ignore parse errors for non-JSON frames */ }
   });
 
   ws.on('close', () => {

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -1448,6 +1448,8 @@ let cdpScreencast: {
   cdpSessionId: string | null;
   /** Whether the viewer auto-follows the agent's active tab */
   autoFollow: boolean;
+  /** Pending CDP message IDs for get_selection requests */
+  pendingSelections: Set<number>;
 } | null = null;
 
 /** Derive the CDP HTTP endpoint from the current browser state */
@@ -1610,7 +1612,7 @@ function cdpMsg(state: NonNullable<typeof cdpScreencast>, method: string, params
 function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket, requiresSession = false) {
   const cdpWs = new WebSocket(wsUrl);
   const prevAutoFollow = cdpScreencast?.autoFollow ?? true;
-  cdpScreencast = { clientWs, cdpWs, currentTargetId: targetId, msgId: 0, lastDeviceWidth: 0, lastDeviceHeight: 0, cdpSessionId: null, autoFollow: prevAutoFollow };
+  cdpScreencast = { clientWs, cdpWs, currentTargetId: targetId, msgId: 0, lastDeviceWidth: 0, lastDeviceHeight: 0, cdpSessionId: null, autoFollow: prevAutoFollow, pendingSelections: new Set() };
   const state = cdpScreencast;
 
   cdpWs.on('open', () => {
@@ -1671,6 +1673,12 @@ function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket
             type: 'page_loading',
             loading: msg.method === 'Page.frameStartedLoading',
           }));
+        }
+      } else if (msg.id && state.pendingSelections.has(msg.id)) {
+        state.pendingSelections.delete(msg.id);
+        const text = msg.result?.result?.value;
+        if (typeof text === 'string' && text && clientWs.readyState === WebSocket.OPEN) {
+          clientWs.send(JSON.stringify({ type: 'selection_result', text }));
         }
       }
     } catch { /* ignore */ }
@@ -1881,6 +1889,14 @@ function handleBrowserStreamConnection(ws: WebSocket) {
           cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Input.insertText', {
             text: data.text,
           }));
+        } else if (data.type === 'get_selection') {
+          const msgStr = cdpMsg(cdpScreencast, 'Runtime.evaluate', {
+            expression: 'window.getSelection().toString()',
+            returnByValue: true,
+          });
+          const msgId = JSON.parse(msgStr).id;
+          cdpScreencast.pendingSelections.add(msgId);
+          cdpScreencast.cdpWs.send(msgStr);
         }
       }
     } catch { /* ignore */ }

--- a/src/renderer/components/browser/browser-preview.tsx
+++ b/src/renderer/components/browser/browser-preview.tsx
@@ -474,8 +474,12 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLCanvasElement>) => {
-      // Let paste shortcut through so the native paste event fires
+      // Cmd+V / Ctrl+V: read host clipboard and paste into remote browser
       if (e.key === 'v' && (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey) {
+        e.preventDefault()
+        navigator.clipboard.readText().then(text => {
+          if (text) sendMessage({ type: 'input_paste', text })
+        }).catch(() => {})
         return
       }
 

--- a/src/renderer/components/browser/browser-preview.tsx
+++ b/src/renderer/components/browser/browser-preview.tsx
@@ -461,28 +461,6 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
     [mapCoordinates, sendMessage, modifierFlags]
   )
 
-  const pressKeyViaHttp = useCallback(
-    (key: string, mods: number) => {
-      // Build Playwright-style combo: "Meta+Shift+ArrowLeft", "Control+a", etc.
-      const parts: string[] = []
-      if (mods & 2) parts.push('Control')
-      if (mods & 1) parts.push('Alt')
-      if (mods & 4) parts.push('Meta')
-      if (mods & 8) parts.push('Shift')
-      parts.push(key)
-      const combo = parts.join('+')
-
-      apiFetch(`/api/agents/${agentSlug}/browser/press`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sessionId, key: combo }),
-      }).catch(() => {
-        // Ignore errors — fire-and-forget for responsiveness
-      })
-    },
-    [agentSlug, sessionId]
-  )
-
   const handlePaste = useCallback(
     (e: React.ClipboardEvent<HTMLCanvasElement>) => {
       e.preventDefault()
@@ -508,7 +486,19 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
         return
       }
 
+      // Cmd+X / Ctrl+X: copy selection to host clipboard, then cut in remote browser
+      if (e.key === 'x' && (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey) {
+        e.preventDefault()
+        sendMessage({ type: 'get_selection' })
+        sendMessage({ type: 'input_press', key: e.key, code: e.code, keyCode: e.keyCode, modifiers: modifierFlags(e) })
+        return
+      }
+
       e.preventDefault()
+
+      // Pure modifier keys alone: skip — they're communicated via the modifiers bitmask
+      if (MODIFIER_KEYS.has(e.key)) return
+
       const printable = e.key.length === 1
       const hasCommandModifier = e.metaKey || e.ctrlKey
 
@@ -520,34 +510,37 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
           key: e.key,
           code: e.code,
           text: e.key,
+          keyCode: e.keyCode,
           modifiers: modifierFlags(e),
         })
-      } else if (printable && hasCommandModifier) {
-        // Modifier+key combos (Cmd+A, Cmd+Z, etc.): route through Playwright's keyboard API
-        // Pass targetId so the press targets the user's viewed tab, not the agent's
-        pressKeyViaHttp(e.key, modifierFlags(e))
-      } else if (!MODIFIER_KEYS.has(e.key)) {
-        // Non-printable, non-modifier keys (Backspace, Arrow, Enter, Tab, Escape, etc.):
-        // Use Playwright's keyboard API (properly handles virtual key codes)
-        pressKeyViaHttp(e.key, modifierFlags(e))
+      } else {
+        // Modifier combos (Cmd+A, Ctrl+Z) and non-printable keys (Backspace, Delete, arrows):
+        // Send via input_press which includes Playwright's editing commands in the CDP event
+        // (e.g. 'selectAll' for Cmd+A). Goes through WebSocket so it targets the viewed tab.
+        sendMessage({
+          type: 'input_press',
+          key: e.key,
+          code: e.code,
+          keyCode: e.keyCode,
+          modifiers: modifierFlags(e),
+        })
       }
-      // Pure modifier keys (Shift, Ctrl, etc.) alone: ignore — they're included
-      // in the combo string when a non-modifier key is pressed with them.
     },
-    [sendMessage, modifierFlags, pressKeyViaHttp]
+    [sendMessage, modifierFlags]
   )
 
   const handleKeyUp = useCallback(
     (e: React.KeyboardEvent<HTMLCanvasElement>) => {
       e.preventDefault()
-      // Only send keyUp for printable characters via stream.
-      // Non-printable keys and modifier combos use input_press (which sends both down+up).
+      // Only send keyUp for printable characters without modifiers (stream path).
+      // Modifier combos and non-printable keys use input_press which sends its own keyUp.
       if (e.key.length === 1 && !e.metaKey && !e.ctrlKey) {
         sendMessage({
           type: 'input_keyboard',
           eventType: 'keyUp',
           key: e.key,
           code: e.code,
+          keyCode: e.keyCode,
           modifiers: modifierFlags(e),
         })
       }

--- a/src/renderer/components/browser/browser-preview.tsx
+++ b/src/renderer/components/browser/browser-preview.tsx
@@ -297,6 +297,8 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
         } else if (data.type === 'tab_switched') {
           setAgentActiveTargetId(data.targetId)
           setViewingTargetId(data.targetId)
+        } else if (data.type === 'selection_result' && data.text) {
+          navigator.clipboard.writeText(data.text).catch(() => {})
         }
       } catch {
         // Ignore parse errors for binary frames
@@ -357,6 +359,18 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
     }
   }, [tabs, viewingTargetId, agentActiveTargetId])
 
+  // Prevent wheel events from bubbling to parent (must use native listener with passive: false)
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas || isViewOnly) return
+    const handler = (e: WheelEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+    }
+    canvas.addEventListener('wheel', handler, { passive: false })
+    return () => canvas.removeEventListener('wheel', handler)
+  }, [isViewOnly])
+
   // --- Canvas input handlers ---
   const mapCoordinates = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -401,10 +415,14 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
     return flags
   }, [])
 
+  const pressedButtonRef = useRef<string>('none')
+
   const handleMouseDown = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
       const { x, y } = mapCoordinates(e)
-      sendMessage({ type: 'input_mouse', eventType: 'mousePressed', x, y, button: buttonName(e.button), clickCount: 1, modifiers: modifierFlags(e) })
+      const btn = buttonName(e.button)
+      pressedButtonRef.current = btn
+      sendMessage({ type: 'input_mouse', eventType: 'mousePressed', x, y, button: btn, clickCount: 1, modifiers: modifierFlags(e) })
     },
     [mapCoordinates, sendMessage, buttonName, modifierFlags]
   )
@@ -412,6 +430,7 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
   const handleMouseUp = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
       const { x, y } = mapCoordinates(e)
+      pressedButtonRef.current = 'none'
       sendMessage({ type: 'input_mouse', eventType: 'mouseReleased', x, y, button: buttonName(e.button), modifiers: modifierFlags(e) })
     },
     [mapCoordinates, sendMessage, buttonName, modifierFlags]
@@ -420,7 +439,7 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
   const handleMouseMove = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
       const { x, y } = mapCoordinates(e)
-      sendMessage({ type: 'input_mouse', eventType: 'mouseMoved', x, y, button: 'none', modifiers: modifierFlags(e) })
+      sendMessage({ type: 'input_mouse', eventType: 'mouseMoved', x, y, button: pressedButtonRef.current, modifiers: modifierFlags(e) })
     },
     [mapCoordinates, sendMessage, modifierFlags]
   )
@@ -482,11 +501,19 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
         return
       }
 
+      // Cmd+C / Ctrl+C: copy selected text from remote browser to host clipboard
+      if (e.key === 'c' && (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey) {
+        e.preventDefault()
+        sendMessage({ type: 'get_selection' })
+        return
+      }
+
       e.preventDefault()
       const printable = e.key.length === 1
+      const hasCommandModifier = e.metaKey || e.ctrlKey
 
-      if (printable) {
-        // Printable characters: send via WebSocket stream (low latency, works via CDP text field)
+      if (printable && !hasCommandModifier) {
+        // Printable characters without modifiers: send via WebSocket stream (low latency)
         sendMessage({
           type: 'input_keyboard',
           eventType: 'keyDown',
@@ -495,10 +522,13 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
           text: e.key,
           modifiers: modifierFlags(e),
         })
+      } else if (printable && hasCommandModifier) {
+        // Modifier+key combos (Cmd+A, Cmd+Z, etc.): route through Playwright's keyboard API
+        // Pass targetId so the press targets the user's viewed tab, not the agent's
+        pressKeyViaHttp(e.key, modifierFlags(e))
       } else if (!MODIFIER_KEYS.has(e.key)) {
         // Non-printable, non-modifier keys (Backspace, Arrow, Enter, Tab, Escape, etc.):
-        // Use HTTP press endpoint which goes through Playwright's keyboard API
-        // (properly sets windowsVirtualKeyCode in CDP, unlike the stream path)
+        // Use Playwright's keyboard API (properly handles virtual key codes)
         pressKeyViaHttp(e.key, modifierFlags(e))
       }
       // Pure modifier keys (Shift, Ctrl, etc.) alone: ignore — they're included
@@ -511,8 +541,8 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
     (e: React.KeyboardEvent<HTMLCanvasElement>) => {
       e.preventDefault()
       // Only send keyUp for printable characters via stream.
-      // Non-printable keys use press (which sends both down+up).
-      if (e.key.length === 1) {
+      // Non-printable keys and modifier combos use input_press (which sends both down+up).
+      if (e.key.length === 1 && !e.metaKey && !e.ctrlKey) {
         sendMessage({
           type: 'input_keyboard',
           eventType: 'keyUp',
@@ -671,6 +701,7 @@ export function BrowserPreview({ agentSlug, sessionId, browserActive, isActive }
             onKeyDown={isViewOnly ? undefined : handleKeyDown}
             onKeyUp={isViewOnly ? undefined : handleKeyUp}
             onPaste={isViewOnly ? undefined : handlePaste}
+            onContextMenu={(e) => e.preventDefault()}
           />
           {!connected && (
             <div className="absolute inset-0 flex items-center justify-center bg-black/50">


### PR DESCRIPTION
User can now use keyboard shorcuts (copy + paste, cmd + a, cmd + x, ctrl + a, etc.) in browser. Works even when not following the agent's tab (outside of agent-browser).