### PR TITLE
feat: add cross-session chat search via search-chats subagent

### DIFF
--- a/agent-container/package.json
+++ b/agent-container/package.json
@@ -4,7 +4,7 @@
   "description": "Docker container running Claude Code with HTTP/WebSocket API",
   "main": "dist/server.js",
   "scripts": {
-    "build": "tsc && cp src/system-prompt.md src/web-browser-agent-prompt.md src/computer-use-agent-prompt.md dist/",
+    "build": "tsc && cp src/system-prompt.md src/web-browser-agent-prompt.md src/computer-use-agent-prompt.md src/search-chats-agent-prompt.md dist/",
     "start": "node dist/server.js",
     "dev": "ts-node src/server.ts",
     "watch": "tsc --watch",

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -21,6 +21,7 @@ function mcpToolNames(
 import { inputManager } from './input-manager';
 import { setCurrentBrowserSessionId } from './tools/browser';
 import { sanitizeMcpName } from './sanitize-mcp-name';
+import { generateSessionSummary, writeSessionSummary, shouldGenerateSummary } from './session-summary';
 
 // Prefix for system-injected user messages that should be hidden in the UI.
 // Keep in sync with SYSTEM_MESSAGE_PREFIX in src/renderer/components/messages/message-list.tsx
@@ -41,6 +42,12 @@ const WEB_BROWSER_AGENT_PROMPT = fs.readFileSync(
 // Load computer-use subagent prompt from file
 const COMPUTER_USE_AGENT_PROMPT = fs.readFileSync(
   path.join(__dirname, 'computer-use-agent-prompt.md'),
+  'utf-8'
+);
+
+// Load search-chats subagent prompt from file
+const SEARCH_CHATS_AGENT_PROMPT = fs.readFileSync(
+  path.join(__dirname, 'search-chats-agent-prompt.md'),
   'utf-8'
 );
 
@@ -305,6 +312,7 @@ export class ClaudeCodeProcess extends EventEmitter {
   private customEnvVars: Record<string, string> | undefined;
   private isReady: boolean = false;
   private isProcessing: boolean = false;
+  private turnCount: number = 0;
   public slashCommands: { name: string; description: string; argumentHint: string }[] = [];
 
   constructor(options: ClaudeCodeProcessOptions) {
@@ -441,6 +449,13 @@ export class ClaudeCodeProcess extends EventEmitter {
               maxTurns: 500,
             },
           } : {}),
+          'search-chats': {
+            description: 'Chat history search specialist. Delegate when you need to find information from previous conversations — searching for topics discussed, decisions made, past instructions, or reviewing what was done in earlier sessions. This agent searches through chat logs efficiently and returns relevant excerpts.',
+            model: 'haiku' as const,
+            tools: ['Bash', 'Grep', 'Read', 'Glob'],
+            prompt: SEARCH_CHATS_AGENT_PROMPT,
+            maxTurns: 20,
+          },
         },
         // Handle AskUserQuestion via canUseTool callback (per SDK docs)
         canUseTool: async (toolName: string, toolInput: Record<string, unknown>, options: { toolUseID: string; signal: AbortSignal }) => {
@@ -610,6 +625,16 @@ export class ClaudeCodeProcess extends EventEmitter {
             }
           }
           console.log(`[Session ${this.sessionId}] Query completed`);
+
+          // Fire-and-forget: generate session summary on turn 1, then every N turns
+          this.turnCount++;
+          if (shouldGenerateSummary(this.turnCount)) {
+            generateSessionSummary(this.sessionId)
+              .then(summary => {
+                if (summary) return writeSessionSummary(this.sessionId, summary);
+              })
+              .catch(err => console.error(`[Session ${this.sessionId}] Summary generation failed:`, err));
+          }
         }
 
         this.emit('message', message);

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -627,13 +627,17 @@ export class ClaudeCodeProcess extends EventEmitter {
           console.log(`[Session ${this.sessionId}] Query completed`);
 
           // Fire-and-forget: generate session summary on turn 1, then every N turns
-          this.turnCount++;
-          if (shouldGenerateSummary(this.turnCount)) {
-            generateSessionSummary(this.sessionId)
-              .then(summary => {
-                if (summary) return writeSessionSummary(this.sessionId, summary);
-              })
-              .catch(err => console.error(`[Session ${this.sessionId}] Summary generation failed:`, err));
+          // Skip error/resume results — no meaningful new content to summarize
+          const resultSubtype = (message as any).subtype;
+          if (resultSubtype !== 'error' && resultSubtype !== 'error_during_execution' && resultSubtype !== 'resume') {
+            this.turnCount++;
+            if (shouldGenerateSummary(this.turnCount)) {
+              generateSessionSummary(this.sessionId)
+                .then(summary => {
+                  if (summary) return writeSessionSummary(this.sessionId, summary);
+                })
+                .catch(err => console.error(`[Session ${this.sessionId}] Summary generation failed:`, err));
+            }
           }
         }
 

--- a/agent-container/src/search-chats-agent-prompt.md
+++ b/agent-container/src/search-chats-agent-prompt.md
@@ -1,0 +1,74 @@
+You are a chat history search agent. You search through past conversation logs to find relevant information for the main agent.
+
+## File Locations
+
+- **Chat logs**: `/workspace/.claude/projects/-workspace/{sessionId}.jsonl` — one JSON object per line
+- **Session metadata**: `/workspace/session-metadata.json` — maps sessionId to `{name, createdAt, summary, summaryGeneratedAt, ...}`
+- **Session persistence**: `/workspace/.superagent-sessions.json` — maps sessionId to `{claudeSessionId, createdAt, lastActivity, ...}`
+
+## JSONL Format
+
+Each line is a JSON object. The key fields for search:
+
+**User messages** (`"type": "user"`):
+- Content is at `.message.content` — an array of content blocks
+- Each block has `"type": "text"` and `"text": "the actual message"`
+- `.uuid` and `.timestamp` identify the message
+
+**Assistant messages** (`"type": "assistant"`):
+- Content is at `.message.content` — an array of content blocks
+- Text blocks: `{"type": "text", "text": "..."}`
+- Tool use blocks: `{"type": "tool_use", "name": "...", "input": {...}}`
+- Thinking blocks: `{"type": "thinking", "thinking": "..."}` — skip these in search results
+- `.uuid` and `.timestamp` identify the message
+
+**Other types to ignore for content search**: `queue-operation`, `result`, `system`
+
+## Search Strategy
+
+1. **Start with session summaries**: Read `/workspace/session-metadata.json` to get session names, dates, and **summaries**. Most sessions have an auto-generated 2-4 sentence summary describing what was discussed. Use these summaries to quickly identify which sessions are likely relevant before grepping JSONL files.
+
+2. **For broad topic searches**: If summaries narrow it down, drill directly into those sessions. Otherwise, use `grep -rl "keyword"` across the JSONL directory to identify which sessions mention the topic.
+
+3. **For content extraction**: Use `grep -n "keyword" file.jsonl` to find matching lines, then parse them with `jq` or read them to extract the human-readable text content.
+
+4. **For large files**: Check file size first with `wc -l`. Use grep to narrow down before reading entire files. Never cat an entire large JSONL file.
+
+5. **For date-based queries**: Use the session metadata `createdAt` / `lastActivity` fields to filter, or grep for timestamp patterns in the JSONL.
+
+## Useful Commands
+
+```bash
+# List all sessions with names and summaries
+cat /workspace/session-metadata.json | jq -r 'to_entries[] | "\(.key) — \(.value.name) — \(.value.summary // "no summary") (\(.value.createdAt))"'
+
+# Find sessions mentioning a keyword
+grep -rl "keyword" /workspace/.claude/projects/-workspace/*.jsonl
+
+# Extract user message text from a matching line
+echo '<jsonl_line>' | jq -r '.message.content[] | select(.type == "text") | .text'
+
+# Search for keyword with context in a specific session
+grep -n "keyword" /workspace/.claude/projects/-workspace/{sessionId}.jsonl
+
+# Count messages in a session
+wc -l /workspace/.claude/projects/-workspace/{sessionId}.jsonl
+```
+
+## Output Format
+
+Return a concise, well-organized summary of your findings:
+
+- **Always include**: session name, session ID, and timestamp for each relevant excerpt
+- **Quote actual message content**, not raw JSON
+- **Organize by session** if multiple sessions match
+- **Be selective** — return only the most relevant excerpts, not everything that matched
+- **If nothing found**, say so clearly and suggest alternative search terms if possible
+
+## Constraints
+
+- Do NOT dump entire conversations — extract only relevant portions
+- Do NOT read thinking blocks — they are internal reasoning, not useful content
+- Keep your output focused and concise — the main agent needs actionable information, not a data dump
+- If a file is very large (>1000 lines), use grep to narrow down before reading
+- You have a limited number of turns — be efficient with your searches

--- a/agent-container/src/search-chats-agent-prompt.md
+++ b/agent-container/src/search-chats-agent-prompt.md
@@ -1,74 +1,54 @@
 You are a chat history search agent. You search through past conversation logs to find relevant information for the main agent.
 
-## File Locations
+## Your Tools
+
+**Grep** — Search across chat log files for keywords or patterns.
+- `Grep(pattern, path, output_mode)` to find which sessions mention a topic
+- Use `files_with_matches` mode first to identify relevant session files, then `content` mode with context lines to extract matches
+
+**Read** — Read files to get session metadata or specific portions of chat logs.
+- Read `/workspace/session-metadata.json` to get session names, dates, and summaries
+- Read specific JSONL files to extract full conversation context around a match
+
+**Bash** — Run shell commands for advanced parsing.
+- `jq` for structured JSON extraction from JSONL lines
+- `wc -l` to check file sizes before reading
+- `cat /workspace/session-metadata.json | jq -r 'to_entries[] | "\(.key) — \(.value.name) — \(.value.summary // "no summary")"'` to list all sessions
+
+**Glob** — Find session files by pattern.
+- `Glob("*.jsonl", path="/workspace/.claude/projects/-workspace")` to list all session files
+
+## Data Layout
 
 - **Chat logs**: `/workspace/.claude/projects/-workspace/{sessionId}.jsonl` — one JSON object per line
 - **Session metadata**: `/workspace/session-metadata.json` — maps sessionId to `{name, createdAt, summary, summaryGeneratedAt, ...}`
-- **Session persistence**: `/workspace/.superagent-sessions.json` — maps sessionId to `{claudeSessionId, createdAt, lastActivity, ...}`
 
-## JSONL Format
+**JSONL message types** (only `user` and `assistant` are relevant for search):
+- `type: "user"` → text content at `.message.content` (string or array of `{type: "text", text: "..."}` blocks)
+- `type: "assistant"` → text content at `.message.content` (array of content blocks — use `text` blocks, skip `thinking` and `tool_use` blocks)
+- Ignore: `queue-operation`, `result`, `system`
 
-Each line is a JSON object. The key fields for search:
+## Core Workflow
 
-**User messages** (`"type": "user"`):
-- Content is at `.message.content` — an array of content blocks
-- Each block has `"type": "text"` and `"text": "the actual message"`
-- `.uuid` and `.timestamp` identify the message
+1. **Read session summaries** — Read `/workspace/session-metadata.json`. Most sessions have a 2-4 sentence `summary` field. Use these to quickly identify which sessions are likely relevant.
+2. **Narrow down sessions** — Based on summaries, pick the most relevant sessions. If summaries aren't enough, use Grep with `files_with_matches` mode across the JSONL directory.
+3. **Search within sessions** — Use Grep with `content` mode and context lines (`-C 2`) on specific JSONL files to find matching messages.
+4. **Extract readable content** — Parse matching JSONL lines to extract the actual message text (strip JSON wrappers). Use `jq` via Bash if needed.
+5. **Return findings** — Summarize what you found in a clean, organized format.
 
-**Assistant messages** (`"type": "assistant"`):
-- Content is at `.message.content` — an array of content blocks
-- Text blocks: `{"type": "text", "text": "..."}`
-- Tool use blocks: `{"type": "tool_use", "name": "...", "input": {...}}`
-- Thinking blocks: `{"type": "thinking", "thinking": "..."}` — skip these in search results
-- `.uuid` and `.timestamp` identify the message
+## Critical Rules
 
-**Other types to ignore for content search**: `queue-operation`, `result`, `system`
+- **NEVER dump entire conversations.** Extract only the relevant portions.
+- **NEVER read thinking blocks** — they are internal reasoning, not useful content.
+- **Check file size before reading.** If a JSONL file is >1000 lines, use Grep to narrow down before reading.
+- **Start with summaries, not grep.** Reading metadata is one tool call; grepping all files is expensive.
+- **Be efficient with your turns.** You have a limited turn budget — don't waste turns on exploratory reads when Grep can pinpoint matches.
+- **Quote actual message content**, not raw JSON, when reporting findings.
 
-## Search Strategy
+## Response Format
 
-1. **Start with session summaries**: Read `/workspace/session-metadata.json` to get session names, dates, and **summaries**. Most sessions have an auto-generated 2-4 sentence summary describing what was discussed. Use these summaries to quickly identify which sessions are likely relevant before grepping JSONL files.
-
-2. **For broad topic searches**: If summaries narrow it down, drill directly into those sessions. Otherwise, use `grep -rl "keyword"` across the JSONL directory to identify which sessions mention the topic.
-
-3. **For content extraction**: Use `grep -n "keyword" file.jsonl` to find matching lines, then parse them with `jq` or read them to extract the human-readable text content.
-
-4. **For large files**: Check file size first with `wc -l`. Use grep to narrow down before reading entire files. Never cat an entire large JSONL file.
-
-5. **For date-based queries**: Use the session metadata `createdAt` / `lastActivity` fields to filter, or grep for timestamp patterns in the JSONL.
-
-## Useful Commands
-
-```bash
-# List all sessions with names and summaries
-cat /workspace/session-metadata.json | jq -r 'to_entries[] | "\(.key) — \(.value.name) — \(.value.summary // "no summary") (\(.value.createdAt))"'
-
-# Find sessions mentioning a keyword
-grep -rl "keyword" /workspace/.claude/projects/-workspace/*.jsonl
-
-# Extract user message text from a matching line
-echo '<jsonl_line>' | jq -r '.message.content[] | select(.type == "text") | .text'
-
-# Search for keyword with context in a specific session
-grep -n "keyword" /workspace/.claude/projects/-workspace/{sessionId}.jsonl
-
-# Count messages in a session
-wc -l /workspace/.claude/projects/-workspace/{sessionId}.jsonl
-```
-
-## Output Format
-
-Return a concise, well-organized summary of your findings:
-
-- **Always include**: session name, session ID, and timestamp for each relevant excerpt
-- **Quote actual message content**, not raw JSON
-- **Organize by session** if multiple sessions match
-- **Be selective** — return only the most relevant excerpts, not everything that matched
-- **If nothing found**, say so clearly and suggest alternative search terms if possible
-
-## Constraints
-
-- Do NOT dump entire conversations — extract only relevant portions
-- Do NOT read thinking blocks — they are internal reasoning, not useful content
-- Keep your output focused and concise — the main agent needs actionable information, not a data dump
-- If a file is very large (>1000 lines), use grep to narrow down before reading
-- You have a limited number of turns — be efficient with your searches
+When you complete your search, always include:
+1. A concise summary of what you found (or didn't find)
+2. For each relevant result: **session name**, **session ID**, **timestamp**, and **quoted message content**
+3. Results organized by session if multiple sessions match
+4. If nothing was found, suggest alternative search terms

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -13,6 +13,7 @@ import * as dns from 'dns';
 import { inputManager } from './input-manager';
 import { dashboardManager } from './dashboard-manager';
 import { tabManager } from './tab-manager';
+import { backfillMissingSummaries, BACKFILL_STARTUP_DELAY_MS } from './session-summary';
 
 import { getEditingCommands } from './cdp-editing-commands';
 
@@ -1339,6 +1340,13 @@ const server = serve({
   fetch: app.fetch,
   port,
 });
+
+// Backfill session summaries for any sessions that don't have one yet
+setTimeout(() => {
+  backfillMissingSummaries().catch(err => {
+    console.error('[Server] Session summary backfill failed:', err);
+  });
+}, BACKFILL_STARTUP_DELAY_MS);
 
 // Create WebSocket server
 const wss = new WebSocketServer({ noServer: true });

--- a/agent-container/src/session-summary.ts
+++ b/agent-container/src/session-summary.ts
@@ -1,0 +1,235 @@
+import Anthropic from '@anthropic-ai/sdk';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ─── Configuration ──────────────────────────────────────────────────────────
+
+/** Number of turns between summary regenerations (first turn always generates) */
+const SUMMARY_TURN_INTERVAL = 10;
+
+/** Model to use for summary generation */
+const SUMMARY_MODEL = 'claude-haiku-4-5-20251001';
+
+/** Max characters of conversation to include in the summary prompt */
+const SUMMARY_MAX_CONTEXT_CHARS = 8000;
+
+/** Delay between backfill calls (ms) to avoid API hammering */
+const BACKFILL_DELAY_MS = 500;
+
+/** Delay before starting backfill on container startup (ms) */
+export const BACKFILL_STARTUP_DELAY_MS = 10_000;
+
+// ─── Paths ──────────────────────────────────────────────────────────────────
+
+const SESSIONS_DIR = '/workspace/.claude/projects/-workspace';
+const SESSION_METADATA_PATH = '/workspace/session-metadata.json';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Generate a summary on turn 1, then every SUMMARY_TURN_INTERVAL turns */
+export function shouldGenerateSummary(turnCount: number): boolean {
+  return turnCount === 1 || turnCount % SUMMARY_TURN_INTERVAL === 0;
+}
+
+interface SessionMetadataEntry {
+  name?: string;
+  summary?: string;
+  summaryGeneratedAt?: string;
+  [key: string]: unknown;
+}
+
+function readMetadataFile(): Record<string, SessionMetadataEntry> {
+  try {
+    if (fs.existsSync(SESSION_METADATA_PATH)) {
+      return JSON.parse(fs.readFileSync(SESSION_METADATA_PATH, 'utf-8'));
+    }
+  } catch (err) {
+    console.error('[SessionSummary] Failed to read session-metadata.json:', err);
+  }
+  return {};
+}
+
+/**
+ * Extract readable conversation text from a JSONL file.
+ * Returns user and assistant messages, truncated to SUMMARY_MAX_CONTEXT_CHARS.
+ */
+function extractConversationText(jsonlPath: string): { text: string; messageCount: number } {
+  const content = fs.readFileSync(jsonlPath, 'utf-8');
+  const lines = content.split('\n').filter(Boolean);
+
+  const messages: string[] = [];
+  let messageCount = 0;
+
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line);
+
+      if (entry.type === 'user' && entry.message?.content) {
+        const text = extractTextContent(entry.message.content);
+        if (text) {
+          messages.push(`User: ${text}`);
+          messageCount++;
+        }
+      } else if (entry.type === 'assistant' && entry.message?.content) {
+        const text = extractTextContent(entry.message.content);
+        if (text) {
+          messages.push(`Assistant: ${text}`);
+          messageCount++;
+        }
+      }
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  // Truncate from the end to fit within max chars
+  let combined = '';
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const candidate = messages[i] + '\n\n' + combined;
+    if (candidate.length > SUMMARY_MAX_CONTEXT_CHARS) break;
+    combined = candidate;
+  }
+
+  return { text: combined.trim(), messageCount };
+}
+
+/**
+ * Extract plain text from message content (handles both string and content block array formats).
+ */
+function extractTextContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((block: any) => block.type === 'text' && block.text)
+      .map((block: any) => block.text)
+      .join('\n');
+  }
+  return '';
+}
+
+// ─── Anthropic Client (lazy singleton) ──────────────────────────────────────
+
+let anthropicClient: Anthropic | null = null;
+
+function getAnthropicClient(): Anthropic | null {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return null;
+  if (!anthropicClient) {
+    anthropicClient = new Anthropic({ apiKey });
+  }
+  return anthropicClient;
+}
+
+// ─── Core Functions ─────────────────────────────────────────────────────────
+
+/**
+ * Generate a summary for a session by reading its JSONL and calling Haiku.
+ * Returns the summary string, or null if generation should be skipped or fails.
+ */
+export async function generateSessionSummary(sessionId: string): Promise<string | null> {
+  const client = getAnthropicClient();
+  if (!client) {
+    console.warn('[SessionSummary] No ANTHROPIC_API_KEY, skipping summary generation');
+    return null;
+  }
+
+  const jsonlPath = path.join(SESSIONS_DIR, `${sessionId}.jsonl`);
+  if (!fs.existsSync(jsonlPath)) {
+    return null;
+  }
+
+  const { text, messageCount } = extractConversationText(jsonlPath);
+
+  // Skip very short sessions
+  if (messageCount < 2 || !text) {
+    return null;
+  }
+
+  try {
+    const response = await client.messages.create({
+      model: SUMMARY_MODEL,
+      max_tokens: 256,
+      messages: [
+        {
+          role: 'user',
+          content: `Summarize this conversation in 2-4 sentences. Focus on: what the user asked for, what was accomplished, and any key decisions or outcomes. Be specific about technologies, files, or topics discussed.\n\n<conversation>\n${text}\n</conversation>`,
+        },
+      ],
+    });
+
+    const summary = response.content
+      .filter((block) => block.type === 'text')
+      .map((block) => (block as { type: 'text'; text: string }).text)
+      .join('');
+
+    return summary || null;
+  } catch (err) {
+    console.error(`[SessionSummary] Haiku API call failed for session ${sessionId}:`, err);
+    return null;
+  }
+}
+
+/**
+ * Write a summary to session-metadata.json atomically.
+ */
+export async function writeSessionSummary(sessionId: string, summary: string): Promise<void> {
+  const metadata = readMetadataFile();
+
+  if (!metadata[sessionId]) {
+    metadata[sessionId] = {};
+  }
+
+  metadata[sessionId].summary = summary;
+  metadata[sessionId].summaryGeneratedAt = new Date().toISOString();
+
+  const tmpPath = SESSION_METADATA_PATH + '.tmp';
+  fs.writeFileSync(tmpPath, JSON.stringify(metadata, null, 2));
+  fs.renameSync(tmpPath, SESSION_METADATA_PATH);
+
+  console.log(`[SessionSummary] Summary written for session ${sessionId}`);
+}
+
+/**
+ * Backfill summaries for all sessions that are missing one.
+ */
+export async function backfillMissingSummaries(): Promise<void> {
+  console.log('[SessionSummary] Starting backfill of missing summaries...');
+
+  if (!getAnthropicClient()) {
+    console.warn('[SessionSummary] No ANTHROPIC_API_KEY, skipping backfill');
+    return;
+  }
+
+  const metadata = readMetadataFile();
+
+  let jsonlFiles: string[];
+  try {
+    jsonlFiles = fs.readdirSync(SESSIONS_DIR).filter((f) => f.endsWith('.jsonl'));
+  } catch {
+    console.log('[SessionSummary] No sessions directory found, skipping backfill');
+    return;
+  }
+
+  let generated = 0;
+  for (const file of jsonlFiles) {
+    const sessionId = path.basename(file, '.jsonl');
+
+    // Skip if already has a summary
+    if (metadata[sessionId]?.summary) continue;
+
+    try {
+      const summary = await generateSessionSummary(sessionId);
+      if (summary) {
+        await writeSessionSummary(sessionId, summary);
+        generated++;
+      }
+    } catch (err) {
+      console.error(`[SessionSummary] Backfill failed for ${sessionId}:`, err);
+    }
+
+    // Rate limit
+    await new Promise((resolve) => setTimeout(resolve, BACKFILL_DELAY_MS));
+  }
+
+  console.log(`[SessionSummary] Backfill complete: ${generated} summaries generated`);
+}

--- a/agent-container/src/session-summary.ts
+++ b/agent-container/src/session-summary.ts
@@ -200,8 +200,6 @@ export async function backfillMissingSummaries(): Promise<void> {
     return;
   }
 
-  const metadata = readMetadataFile();
-
   let jsonlFiles: string[];
   try {
     jsonlFiles = fs.readdirSync(SESSIONS_DIR).filter((f) => f.endsWith('.jsonl'));
@@ -213,6 +211,10 @@ export async function backfillMissingSummaries(): Promise<void> {
   let generated = 0;
   for (const file of jsonlFiles) {
     const sessionId = path.basename(file, '.jsonl');
+
+    // Re-read metadata each iteration to see writes from previous iterations
+    // and avoid clobbering concurrent webapp writes
+    const metadata = readMetadataFile();
 
     // Skip if already has a summary
     if (metadata[sessionId]?.summary) continue;

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -360,6 +360,29 @@ The computer-use agent:
 - The computer-use agent will re-snapshot after every interaction to stay in sync with the UI
 - Menu actions (`computer_menu("File > Save")`) are often more reliable than clicking toolbar buttons
 
+## Searching Past Conversations
+
+You can search through your previous chat sessions to recall past discussions, find decisions, or review earlier work. This acts as a form of memory across sessions.
+
+### Search Chat Agent
+For any search over past conversations, **delegate to the search-chats agent** using the Task tool. This agent runs on a cheaper model and efficiently searches your chat logs.
+
+### Workflow
+1. Delegate: `Task(subagent_type="search-chats", prompt="<describe what you're looking for>")`
+2. The agent searches through past session logs and returns relevant excerpts
+3. Use the results to inform your current task
+
+### When to Use
+- When the user references something from a previous conversation
+- When you need to recall past decisions, instructions, or preferences
+- When the user asks "did we discuss..." or "what did we do about..."
+- When you want to check if a topic was covered in an earlier session
+
+### Tips
+- Be specific in your search queries for better results
+- You can search for: topics, specific messages, date ranges, decisions, code discussed, etc.
+- The search agent handles all file parsing — you don't need to read JSONL files directly
+
 ## Other Guidelines
 
 - Use UV to run Python code: `uv run --env-file .env --with <packages> script.py`

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
     __AUTH_MODE__: JSON.stringify(process.env.AUTH_MODE === 'true'),
+    __RENDER_TRACKING__: 'false',
   },
   test: {
     globals: true,


### PR DESCRIPTION
Agents can now search across their past chat sessions as a form of memory. A new `search-chats` Haiku subagent greps JSONL chat logs and returns relevant excerpts without polluting the main agent's context. Session summaries are auto-generated via Haiku after turn 1 and every 10 turns, with backfill on container startup for existing sessions.