### PR TITLE
fix: copy Web Data when cloning Chrome profile to prevent session logout

### DIFF
--- a/src/shared/lib/browser/chrome-profile.ts
+++ b/src/shared/lib/browser/chrome-profile.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 
-const PROFILE_FILES = ['Cookies', 'Cookies-journal', 'Login Data', 'Login Data-journal']
+const PROFILE_FILES = ['Cookies', 'Cookies-journal', 'Login Data', 'Login Data-journal', 'Web Data', 'Web Data-journal']
 const PROFILE_DIRS = ['Local Storage', 'Session Storage']
 
 /**


### PR DESCRIPTION
Chrome's AccountReconcilor was detecting GAIA session cookies without matching OAuth tokens in the Token Service (stored in Web Data), treating them as orphaned, and sending a GAIA logout request to Google's servers — which revoked sessions for all holders of those tokens, including the user's real Chrome.