### PR TITLE
Fix/better dashboard agent browser limitation prompt

### DIFF
--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -95,7 +95,12 @@ Use this to start browsing a website. The browser preserves cookies/sessions via
       : ''
 
     const result = await browserFetch('open', { url: args.url })
-    if (!result.success) return errorResult(result.error!)
+    if (!result.success) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${result.error}${localhostWarning}` }],
+        isError: true,
+      }
+    }
     const data = result.data as Record<string, unknown> | undefined
 
     if (data?.switchedToExisting) {

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -87,6 +87,13 @@ Use this to start browsing a website. The browser preserves cookies/sessions via
     url: z.string().describe('The URL to navigate to'),
   },
   async (args) => {
+    // Warn if the agent is trying to open a localhost URL — the browser runs outside
+    // the container and cannot reach servers running inside it (e.g. dashboards).
+    const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/i.test(args.url)
+    const localhostWarning = isLocalhost
+      ? '\n\nWARNING: This is a localhost URL. The browser runs outside the container and cannot access servers running inside it. If you are trying to view a dashboard, stop — the user can already see dashboards through the Superagent UI. Use get_dashboard_logs to debug any issues instead.'
+      : ''
+
     const result = await browserFetch('open', { url: args.url })
     if (!result.success) return errorResult(result.error!)
     const data = result.data as Record<string, unknown> | undefined
@@ -96,7 +103,7 @@ Use this to start browsing a website. The browser preserves cookies/sessions via
         content: [
           {
             type: 'text' as const,
-            text: `Switched to existing tab ${data.tabIndex} which already has ${data.url} open. Use browser_snapshot to see the page content.`,
+            text: `Switched to existing tab ${data.tabIndex} which already has ${data.url} open. Use browser_snapshot to see the page content.${localhostWarning}`,
           },
         ],
       }
@@ -106,7 +113,7 @@ Use this to start browsing a website. The browser preserves cookies/sessions via
       content: [
         {
           type: 'text' as const,
-          text: `Browser opened and navigating to ${args.url}. The user can see the browser live. Use browser_snapshot to see the page content.`,
+          text: `Browser opened and navigating to ${args.url}. The user can see the browser live. Use browser_snapshot to see the page content.${localhostWarning}`,
         },
       ],
     }

--- a/agent-container/src/tools/start-dashboard.ts
+++ b/agent-container/src/tools/start-dashboard.ts
@@ -18,6 +18,8 @@ The dashboard must exist at /workspace/artifacts/<slug>/ with a valid package.js
 
       if (info.status === 'running') {
         text += '\n\nThe dashboard is accessible to the user through the Superagent UI.'
+        text +=
+          '\n\nDo NOT use the browser tool to view this dashboard. The browser runs outside the container and cannot access localhost URLs served inside it. The user can already see it through the Superagent UI — use get_dashboard_logs to debug any issues.'
       } else if (info.status === 'crashed' || info.status === 'stopped') {
         // Include recent logs so the agent can debug without a separate tool call
         const logs = await dashboardManager.getDashboardLogs(args.slug)


### PR DESCRIPTION
Three flows:
- When dashboard is created, agent receives warning, preventing it from trying to use `open_browser` tool to access dashboard through `localhost` (1)
- If dashboard was created by another session, agent won't see the above warning. So, we add the cue to the `open_browser` tool as well in case it tries to open `localhost` URL. This is handled in both the error case and non-error case (2, 3)