### PR TITLE
fix: wait for Chrome process to exit before removing from instance map

### DIFF
--- a/src/main/host-browser/chrome-provider.ts
+++ b/src/main/host-browser/chrome-provider.ts
@@ -204,6 +204,19 @@ export class ChromeProvider implements HostBrowserProvider {
       instance.proxyServer?.close()
       if (!instance.process.killed) {
         instance.process.kill()
+        // Wait for process to actually exit before removing from map.
+        // Without this, the next launch() won't see the existing instance
+        // and will spawn a new Chrome while this one is still dying.
+        await new Promise<void>((resolve) => {
+          const timeout = setTimeout(() => {
+            try { instance.process.kill('SIGKILL') } catch { /* ignore */ }
+            resolve()
+          }, 5000)
+          instance.process.on('exit', () => {
+            clearTimeout(timeout)
+            resolve()
+          })
+        })
       }
     }
     this.instances.delete(instanceId)


### PR DESCRIPTION
title
- does not 100% solve the window-megadon, as it's difficult to reproduce in the first place
- is a good sanity fix and should lead to safer and more consistent chrome window process kills