### PR TITLE
feat: add browser use permission system

### DIFF
--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -494,7 +494,7 @@ export class ClaudeCodeProcess extends EventEmitter {
           // not additive). This is acceptable because they write the same ID,
           // but if two user-input tools fire concurrently the first ID could
           // be overwritten before consumeCurrentToolUseId is called.
-          if ((toolName.startsWith('mcp__user-input__') || toolName.startsWith('mcp__computer-use__')) && options.toolUseID) {
+          if ((toolName.startsWith('mcp__user-input__') || toolName.startsWith('mcp__computer-use__') || toolName.startsWith('mcp__browser__browser_')) && options.toolUseID) {
             inputManager.setCurrentToolUseId(options.toolUseID);
           }
 
@@ -516,6 +516,17 @@ export class ClaudeCodeProcess extends EventEmitter {
             },
             {
               matcher: 'mcp__computer-use__.*',
+              hooks: [
+                async (_input, toolUseId) => {
+                  if (toolUseId) {
+                    inputManager.setCurrentToolUseId(toolUseId);
+                  }
+                  return {};
+                },
+              ],
+            },
+            {
+              matcher: 'mcp__browser__browser_.*',
               hooks: [
                 async (_input, toolUseId) => {
                   if (toolUseId) {

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -2,7 +2,8 @@
  * Browser Automation Tools
  *
  * These tools allow agents to control a headless browser via agent-browser.
- * Each tool calls the container's own HTTP browser endpoints internally.
+ * Each tool call blocks via InputManager until the host approves the permission,
+ * then calls the container's own HTTP browser endpoints internally.
  * The user can see the browser live and interact with it directly.
  */
 
@@ -10,6 +11,7 @@ import { tool } from '@anthropic-ai/claude-agent-sdk'
 import { readFile } from 'fs/promises'
 import { z } from 'zod'
 import { tabManager } from '../tab-manager'
+import { inputManager } from '../input-manager'
 
 const CONTAINER_URL = `http://localhost:${process.env.PORT || '3000'}`
 
@@ -78,6 +80,56 @@ async function readScreenshotAsBase64(filePath: string): Promise<{ data: string;
   }
 }
 
+/**
+ * Get the current page domain from the browser.
+ * Returns undefined if the browser isn't running or URL can't be determined.
+ */
+async function getCurrentPageDomain(): Promise<string | undefined> {
+  try {
+    const result = await browserFetch('run', { command: 'get url' })
+    if (!result.success) return undefined
+    const data = result.data as Record<string, unknown>
+    const raw = data.output ? String(data.output).trim() : undefined
+    if (!raw) return undefined
+    return new URL(raw).hostname || undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Request permission from the host before executing a browser action.
+ * Blocks via InputManager until the host approves or denies.
+ * On approval, resolves with undefined. On denial, throws.
+ */
+async function browserUseRequest(
+  method: string,
+  params: Record<string, unknown>,
+  permissionLevel: 'browse_read' | 'browse_interact' | 'browse_navigate' | 'browse_manage',
+  domain?: string,
+): Promise<void> {
+  const toolUseId = inputManager.consumeCurrentToolUseId()
+
+  if (!toolUseId) {
+    console.error(`[browser_use:${method}] No toolUseId available`)
+    throw new Error('Unable to process browser use request - no tool use ID available.')
+  }
+
+  try {
+    await inputManager.createPendingWithType<string>(toolUseId, 'browser_use', {
+      method,
+      params,
+      permissionLevel,
+      domain,
+    })
+    // Host approved — proceed with execution
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    console.log(`[browser_use:${method}] Request denied: ${errorMessage}`)
+    throw new Error(`Browser use request denied: ${errorMessage}`)
+  }
+}
+
 export const browserOpenTool = tool(
   'browser_open',
   `Open a headless browser and navigate to a URL. The user can see the browser live in their interface and interact with it directly.
@@ -87,6 +139,18 @@ Use this to start browsing a website. The browser preserves cookies/sessions via
     url: z.string().describe('The URL to navigate to'),
   },
   async (args) => {
+    // Extract domain from URL for permission check
+    let domain: string | undefined
+    try {
+      domain = new URL(args.url).hostname || undefined
+    } catch { /* invalid URL, permission manager will handle */ }
+
+    try {
+      await browserUseRequest('open', { url: args.url }, 'browse_navigate', domain)
+    } catch (error: unknown) {
+      return errorResult(error instanceof Error ? error.message : 'Permission denied')
+    }
+
     // Warn if the agent is trying to open a localhost URL — the browser runs outside
     // the container and cannot reach servers running inside it (e.g. dashboards).
     const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/i.test(args.url)
@@ -130,6 +194,12 @@ export const browserCloseTool = tool(
   `Close the browser and free resources. Call this when you're done browsing.`,
   {},
   async () => {
+    try {
+      await browserUseRequest('close', {}, 'browse_manage')
+    } catch (error: unknown) {
+      return errorResult(error instanceof Error ? error.message : 'Permission denied')
+    }
+
     const result = await browserFetch('close', {})
     if (!result.success) return errorResult(result.error!)
     return {
@@ -159,6 +229,13 @@ Use compact=true (default) to reduce output size.`,
       .describe('Compact output to reduce size (default: true)'),
   },
   async (args) => {
+    // Domain will be resolved by the host from the current page URL
+    try {
+      await browserUseRequest('snapshot', { interactive: args.interactive, compact: args.compact }, 'browse_read', await getCurrentPageDomain())
+    } catch (error: unknown) {
+      return errorResult(error instanceof Error ? error.message : 'Permission denied')
+    }
+
     const result = await browserFetch('snapshot', {
       interactive: args.interactive,
       compact: args.compact,
@@ -186,6 +263,12 @@ export const browserClickTool = tool(
     ref: z.string().describe('Element ref from snapshot (e.g., "@e1")'),
   },
   async (args) => {
+    try {
+      await browserUseRequest('click', { ref: args.ref }, 'browse_interact', await getCurrentPageDomain())
+    } catch (error: unknown) {
+      return errorResult(error instanceof Error ? error.message : 'Permission denied')
+    }
+
     const result = await browserFetch('click', { ref: args.ref })
     if (!result.success) return errorResult(result.error!)
     const data = result.data as Record<string, unknown> | undefined
@@ -212,6 +295,12 @@ export const browserFillTool = tool(
     value: z.string().describe('The text to fill into the input'),
   },
   async (args) => {
+    try {
+      await browserUseRequest('fill', { ref: args.ref, value: args.value }, 'browse_interact', await getCurrentPageDomain())
+    } catch (error: unknown) {
+      return errorResult(error instanceof Error ? error.message : 'Permission denied')
+    }
+
     const result = await browserFetch('fill', {
       ref: args.ref,
       value: args.value,
@@ -243,6 +332,12 @@ export const browserScrollTool = tool(
       .describe('Scroll amount in pixels (default: browser default)'),
   },
   async (args) => {
+    try {
+      await browserUseRequest('scroll', { direction: args.direction, amount: args.amount }, 'browse_interact', await getCurrentPageDomain())
+    } catch (error: unknown) {
+      return errorResult(error instanceof Error ? error.message : 'Permission denied')
+    }
+
     const result = await browserFetch('scroll', {
       direction: args.direction,
       amount: args.amount,
@@ -272,6 +367,12 @@ export const browserWaitTool = tool(
       ),
   },
   async (args) => {
+    try {
+      await browserUseRequest('wait', { for: args.for }, 'browse_read', await getCurrentPageDomain())
+    } catch (error: unknown) {
+      return errorResult(error instanceof Error ? error.message : 'Permission denied')
+    }
+
     const result = await browserFetch('wait', { for: args.for })
     if (!result.success) return errorResult(result.error!)
     return {
@@ -289,6 +390,12 @@ export const browserPressTool = tool(
     key: z.string().describe('Key to press (e.g., "Enter", "Tab", "Escape", "Control+a", "ArrowDown")'),
   },
   async (args) => {
+    try {
+      await browserUseRequest('press', { key: args.key }, 'browse_interact', await getCurrentPageDomain())
+    } catch (error: unknown) {
+      return errorResult(error instanceof Error ? error.message : 'Permission denied')
+    }
+
     const result = await browserFetch('press', { key: args.key })
     if (!result.success) return errorResult(result.error!)
     const data = result.data as Record<string, unknown> | undefined
@@ -318,6 +425,12 @@ export const browserScreenshotTool = tool(
       .describe('Capture full scrollable page (default: false, viewport only)'),
   },
   async (args) => {
+    try {
+      await browserUseRequest('screenshot', { full: args.full }, 'browse_read', await getCurrentPageDomain())
+    } catch (error: unknown) {
+      return errorResult(error instanceof Error ? error.message : 'Permission denied')
+    }
+
     const result = await browserFetch('screenshot', { full: args.full })
     if (!result.success) return errorResult(result.error!)
     const data = result.data as Record<string, unknown>
@@ -348,6 +461,12 @@ export const browserSelectTool = tool(
     value: z.string().describe('The option value to select'),
   },
   async (args) => {
+    try {
+      await browserUseRequest('select', { ref: args.ref, value: args.value }, 'browse_interact', await getCurrentPageDomain())
+    } catch (error: unknown) {
+      return errorResult(error instanceof Error ? error.message : 'Permission denied')
+    }
+
     const result = await browserFetch('select', { ref: args.ref, value: args.value })
     if (!result.success) return errorResult(result.error!)
     return {
@@ -365,6 +484,12 @@ export const browserHoverTool = tool(
     ref: z.string().describe('Element ref from snapshot (e.g., "@e1")'),
   },
   async (args) => {
+    try {
+      await browserUseRequest('hover', { ref: args.ref }, 'browse_interact', await getCurrentPageDomain())
+    } catch (error: unknown) {
+      return errorResult(error instanceof Error ? error.message : 'Permission denied')
+    }
+
     const result = await browserFetch('hover', { ref: args.ref })
     if (!result.success) return errorResult(result.error!)
     return {
@@ -409,6 +534,12 @@ Available commands:
     command: z.string().describe('The agent-browser command to run (without "agent-browser" prefix)'),
   },
   async (args) => {
+    try {
+      await browserUseRequest('run', { command: args.command }, 'browse_manage')
+    } catch (error: unknown) {
+      return errorResult(error instanceof Error ? error.message : 'Permission denied')
+    }
+
     const result = await browserFetch('run', { command: args.command })
     if (!result.success) return errorResult(result.error!)
     const data = result.data as Record<string, unknown>
@@ -432,6 +563,13 @@ export const browserGetStateTool = tool(
   `Get the current state of the browser in one call. Returns the current URL, a screenshot image, and an accessibility snapshot. Use this to quickly check what the browser is showing without needing multiple tool calls.`,
   {},
   async () => {
+    // browse_read permission — domain resolved by host from current page
+    try {
+      await browserUseRequest('get_state', {}, 'browse_read', await getCurrentPageDomain())
+    } catch (error: unknown) {
+      return errorResult(error instanceof Error ? error.message : 'Permission denied')
+    }
+
     const [urlResult, screenshotResult, snapshotResult] = await Promise.all([
       browserFetch('run', { command: 'get url' }),
       browserFetch('screenshot', { full: false }),

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1454,6 +1454,15 @@ agents.get('/:id/sessions/:sessionId/stream', AgentRead(), async (c) => {
         })
       }
 
+      // Replay any pending browser use requests (survives SSE reconnection)
+      const pendingBU = messagePersister.getPendingBrowserUseRequests(sessionId)
+      for (const req of pendingBU) {
+        await stream.writeSSE({
+          data: JSON.stringify({ type: 'browser_use_request', ...req }),
+          event: 'message',
+        })
+      }
+
       // Replay current computer use grab state (with icon if cached)
       const agentSlugForStream = c.req.param('id')
       const { computerUsePermissionManager: cuPermMgr } = await import('@shared/lib/computer-use/permission-manager')
@@ -2317,6 +2326,104 @@ agents.post('/:id/sessions/:sessionId/computer-use/revoke', AgentUser(), async (
   } catch (error) {
     console.error('Failed to revoke computer use:', error)
     return c.json({ error: 'Failed to revoke computer use' }, 500)
+  }
+})
+
+// POST /api/agents/:id/sessions/:sessionId/browser-use - Approve or deny a browser use request
+agents.post('/:id/sessions/:sessionId/browser-use', AgentUser(), async (c) => {
+  try {
+    const agentSlug = c.req.param('id')
+    const sessionId = c.req.param('sessionId')
+    const body = await c.req.json()
+    const { toolUseId, method, params, permissionLevel, domain, grantType, decline, declineReason } = body
+
+    if (!toolUseId) {
+      return c.json({ error: 'toolUseId is required' }, 400)
+    }
+
+    // Validate session belongs to this agent (skip for _auto internal calls)
+    if (sessionId !== '_auto') {
+      const session = await getSession(agentSlug, sessionId)
+      if (!session) {
+        return c.json({ error: 'Session not found' }, 404)
+      }
+    }
+
+    const client = containerManager.getClient(agentSlug)
+
+    if (decline) {
+      const reason = declineReason || 'User denied browser use request'
+
+      const rejectResponse = await client.fetch(
+        `/inputs/${encodeURIComponent(toolUseId)}/reject`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reason }),
+        }
+      )
+
+      if (!rejectResponse.ok) {
+        let errorDetails = 'Unknown error'
+        try {
+          const error = await rejectResponse.json()
+          errorDetails = JSON.stringify(error)
+        } catch {
+          errorDetails = await rejectResponse.text()
+        }
+        console.error(`[browser-use] Failed to reject: ${errorDetails}`)
+        return c.json({ error: 'Failed to reject browser use request' }, 500)
+      }
+
+      messagePersister.clearPendingBrowserUseRequest(sessionId, toolUseId)
+      trackServerEvent('request_declined', { type: 'browser_use', method, withReason: !!declineReason })
+      return c.json({ success: true, declined: true })
+    }
+
+    // Approve path: grant permission, then resolve the pending input so the container tool proceeds
+    if (!method) {
+      return c.json({ error: 'method is required for execution' }, 400)
+    }
+
+    // Record the permission grant
+    const { browserUsePermissionManager } = await import('@shared/lib/browser-use/permission-manager')
+    if (grantType && ['once', 'timed', 'always'].includes(grantType)) {
+      browserUsePermissionManager.grantPermission(agentSlug, permissionLevel || 'browse_read', grantType, domain)
+    }
+
+    // Resolve the pending input — the container tool will then execute browserFetch
+    const resolveResponse = await client.fetch(
+      `/inputs/${encodeURIComponent(toolUseId)}/resolve`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: 'approved' }),
+      }
+    )
+
+    if (!resolveResponse.ok) {
+      let errorDetails = 'Unknown error'
+      try {
+        const error = await resolveResponse.json()
+        errorDetails = JSON.stringify(error)
+      } catch {
+        errorDetails = await resolveResponse.text()
+      }
+      console.error(`[browser-use] Failed to resolve: ${errorDetails}`)
+      return c.json({ error: 'Failed to resolve browser use request' }, 500)
+    }
+
+    // Consume "once" grant after approval
+    if (grantType === 'once') {
+      browserUsePermissionManager.consumeOnceGrant(agentSlug, permissionLevel || 'browse_read', domain)
+    }
+
+    messagePersister.clearPendingBrowserUseRequest(sessionId, toolUseId)
+    trackServerEvent('browser_use_approved', { method, permissionLevel, grantType })
+    return c.json({ success: true })
+  } catch (error) {
+    console.error('Failed to handle browser use request:', error)
+    return c.json({ error: 'Failed to handle browser use request' }, 500)
   }
 })
 

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -85,6 +85,7 @@ function buildSettingsResponse(
     voice: getVoiceSettings(),
     tenantId: getTenantId(),
     computerUse: appSettings.computerUse,
+    browserUse: appSettings.browserUse,
     shareAnalytics: !!appSettings.shareAnalytics,
     analyticsTargets: appSettings.analyticsTargets,
   }
@@ -178,6 +179,9 @@ settings.put('/', async (c) => {
       computerUse: body.computerUse !== undefined
         ? { ...currentSettings.computerUse, ...body.computerUse }
         : currentSettings.computerUse,
+      browserUse: body.browserUse !== undefined
+        ? { ...currentSettings.browserUse, ...body.browserUse }
+        : currentSettings.browserUse,
       analyticsTargets: body.analyticsTargets !== undefined ? body.analyticsTargets : currentSettings.analyticsTargets,
     }
 

--- a/src/renderer/components/messages/browser-use-request-item.tsx
+++ b/src/renderer/components/messages/browser-use-request-item.tsx
@@ -1,0 +1,195 @@
+import { apiFetch } from '@renderer/lib/api'
+import { useState, useRef } from 'react'
+import { Globe } from 'lucide-react'
+import { Input } from '@renderer/components/ui/input'
+import {
+  BLUE_THEME,
+  CompletedRequestCard,
+  ReadOnlyRequestCard,
+  PermissionRequestCard,
+} from './permission-request-card'
+import { DOMAIN_SCOPED_LEVELS, type BrowserUsePermissionLevel } from '@shared/lib/browser-use/types'
+
+interface BrowserUseRequestItemProps {
+  toolUseId: string
+  method: string
+  params: Record<string, unknown>
+  permissionLevel: string
+  domain?: string
+  sessionId: string
+  agentSlug: string
+  readOnly?: boolean
+  onComplete: () => void
+}
+
+const PERMISSION_LABELS: Record<string, string> = {
+  browse_read: 'Read Page',
+  browse_interact: 'Interact with Page',
+  browse_navigate: 'Navigate',
+  browse_manage: 'Browser Control',
+}
+
+export function BrowserUseRequestItem({
+  toolUseId,
+  method,
+  params,
+  permissionLevel,
+  domain,
+  sessionId,
+  agentSlug,
+  readOnly,
+  onComplete,
+}: BrowserUseRequestItemProps) {
+  const [status, setStatus] = useState<'pending' | 'submitting' | 'executed' | 'denied'>('pending')
+  const [error, setError] = useState<string | null>(null)
+  const [editingDomain, setEditingDomain] = useState<string | null>(null)
+  const domainInputRef = useRef<HTMLInputElement>(null)
+
+  const isDomainScoped = DOMAIN_SCOPED_LEVELS.has(permissionLevel as BrowserUsePermissionLevel)
+
+  const startEditingDomain = () => {
+    setEditingDomain(domain || '')
+    setTimeout(() => domainInputRef.current?.focus(), 0)
+  }
+
+  const handleApprove = async (grantType: 'once' | 'timed' | 'always') => {
+    // For timed/always on domain-scoped levels, open the editor first so the user can adjust
+    if (grantType !== 'once' && isDomainScoped && editingDomain === null) {
+      startEditingDomain()
+      return
+    }
+
+    setStatus('submitting')
+    setError(null)
+
+    const grantDomain = grantType === 'once'
+      ? domain
+      : (editingDomain !== null ? (editingDomain || undefined) : domain)
+
+    try {
+      const response = await apiFetch(
+        `/api/agents/${agentSlug}/sessions/${sessionId}/browser-use`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            toolUseId,
+            method,
+            params,
+            permissionLevel,
+            domain: grantDomain,
+            grantType,
+          }),
+        }
+      )
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || `Request failed (${response.status})`)
+      }
+
+      setStatus('executed')
+      onComplete()
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to execute command')
+      setStatus('pending')
+    }
+  }
+
+  const handleDeny = async (reason?: string) => {
+    setStatus('submitting')
+    setError(null)
+
+    try {
+      const response = await apiFetch(
+        `/api/agents/${agentSlug}/sessions/${sessionId}/browser-use`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            toolUseId,
+            decline: true,
+            declineReason: reason || 'User denied browser use request',
+          }),
+        }
+      )
+
+      if (!response.ok) {
+        const data = await response.json()
+        throw new Error(data.error || 'Failed to deny request')
+      }
+
+      setStatus('denied')
+      onComplete()
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to deny request')
+      setStatus('pending')
+    }
+  }
+
+  if (status === 'executed' || status === 'denied') {
+    return (
+      <CompletedRequestCard
+        icon={Globe}
+        method={method}
+        scopeLabel={domain}
+        status={status}
+        testIdPrefix="browser-use"
+      />
+    )
+  }
+
+  if (readOnly) {
+    return (
+      <ReadOnlyRequestCard
+        icon={Globe}
+        title="Browser Use Request"
+        method={method}
+        scopeLabel={domain}
+        theme={BLUE_THEME}
+      />
+    )
+  }
+
+  return (
+    <PermissionRequestCard
+      title="Browser Use Request"
+      icon={Globe}
+      theme={BLUE_THEME}
+      testIdPrefix="browser-use"
+      permissionLabel={PERMISSION_LABELS[permissionLevel] || permissionLevel}
+      scopeLabel={domain}
+      method={method}
+      params={params}
+      warningText="This will allow the agent to use the browser. Review carefully before approving."
+      status={status}
+      error={error}
+      onApprove={handleApprove}
+      onDeny={handleDeny}
+      extraContent={
+        isDomainScoped && editingDomain !== null ? (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-blue-600 dark:text-blue-400">Domain:</span>
+            <Input
+              ref={domainInputRef}
+              value={editingDomain}
+              onChange={(e) => setEditingDomain(e.target.value)}
+              placeholder="* (any domain)"
+              className="h-7 text-xs max-w-[200px]"
+            />
+          </div>
+        ) : undefined
+      }
+      extraActions={
+        isDomainScoped && editingDomain === null ? (
+          <button
+            onClick={startEditingDomain}
+            className="text-xs text-blue-600 dark:text-blue-400 underline hover:no-underline"
+          >
+            Edit domain scope for timed/always grants
+          </button>
+        ) : undefined
+      }
+    />
+  )
+}

--- a/src/renderer/components/messages/computer-use-request-item.tsx
+++ b/src/renderer/components/messages/computer-use-request-item.tsx
@@ -1,6 +1,6 @@
 import { apiFetch } from '@renderer/lib/api'
 import { useState } from 'react'
-import { Monitor, Check, Loader2, Clock, ShieldCheck, ShieldAlert, ExternalLink } from 'lucide-react'
+import { Monitor, ShieldAlert, ExternalLink } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import {
   Dialog,
@@ -10,8 +10,12 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@renderer/components/ui/dialog'
-import { cn } from '@shared/lib/utils/cn'
-import { DeclineButton } from './decline-button'
+import {
+  BLUE_THEME,
+  CompletedRequestCard,
+  ReadOnlyRequestCard,
+  PermissionRequestCard,
+} from './permission-request-card'
 
 interface ComputerUseRequestItemProps {
   toolUseId: string
@@ -25,22 +29,10 @@ interface ComputerUseRequestItemProps {
   onComplete: () => void
 }
 
-type RequestStatus = 'pending' | 'submitting' | 'executed' | 'denied'
-
 const PERMISSION_LABELS: Record<string, string> = {
   list_apps_windows: 'List Apps & Windows',
   use_application: 'Use Application',
   use_host_shell: 'Host Shell',
-}
-
-function formatParams(params: Record<string, unknown>): string {
-  const parts: string[] = []
-  for (const [key, val] of Object.entries(params)) {
-    if (val !== undefined && val !== null && val !== '') {
-      parts.push(`${key}: ${typeof val === 'string' ? val : JSON.stringify(val)}`)
-    }
-  }
-  return parts.join(', ')
 }
 
 export function ComputerUseRequestItem({
@@ -54,7 +46,7 @@ export function ComputerUseRequestItem({
   readOnly,
   onComplete,
 }: ComputerUseRequestItemProps) {
-  const [status, setStatus] = useState<RequestStatus>('pending')
+  const [status, setStatus] = useState<'pending' | 'submitting' | 'executed' | 'denied'>('pending')
   const [error, setError] = useState<string | null>(null)
   const [missingPermissions, setMissingPermissions] = useState<{ accessibility: boolean; screen_recording: boolean } | null>(null)
   const [pendingGrantType, setPendingGrantType] = useState<'once' | 'timed' | 'always' | null>(null)
@@ -143,138 +135,47 @@ export function ComputerUseRequestItem({
     }
   }
 
-  // Completed state
   if (status === 'executed' || status === 'denied') {
     return (
-      <div className="border rounded-md bg-muted/30 text-sm" data-testid="computer-use-request-completed" data-status={status}>
-        <div className="flex items-center gap-2 px-3 py-2">
-          <Monitor
-            className={cn(
-              'h-4 w-4 shrink-0',
-              status === 'executed' ? 'text-green-500' : 'text-red-500'
-            )}
-          />
-          <span className="text-sm">{method}{appName ? ` (${appName})` : ''}</span>
-          <span
-            className={cn(
-              'ml-auto text-xs',
-              status === 'executed' ? 'text-green-600' : 'text-red-600'
-            )}
-          >
-            {status === 'executed' ? 'Executed' : 'Denied'}
-          </span>
-        </div>
-      </div>
+      <CompletedRequestCard
+        icon={Monitor}
+        method={method}
+        scopeLabel={appName}
+        status={status}
+        testIdPrefix="computer-use"
+      />
     )
   }
 
-  // Read-only state for viewers
   if (readOnly) {
     return (
-      <div className="border rounded-md bg-blue-50 dark:bg-blue-950/50 border-blue-200 dark:border-blue-800 text-sm">
-        <div className="flex items-center gap-3 p-3">
-          <div className="h-8 w-8 rounded-full bg-blue-100 dark:bg-blue-900 flex items-center justify-center shrink-0">
-            <Monitor className="h-4 w-4 text-blue-600 dark:text-blue-400" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="font-medium text-blue-900 dark:text-blue-100">
-              Computer Use Request
-            </div>
-            <p className="text-sm text-blue-700 dark:text-blue-300 mt-0.5">
-              {method}{appName ? ` — ${appName}` : ''}
-            </p>
-          </div>
-          <span className="text-xs text-blue-600 dark:text-blue-400 shrink-0">Waiting for approval</span>
-        </div>
-      </div>
+      <ReadOnlyRequestCard
+        icon={Monitor}
+        title="Computer Use Request"
+        method={method}
+        scopeLabel={appName}
+        theme={BLUE_THEME}
+      />
     )
   }
 
-  const paramStr = formatParams(params)
-
-  // Pending/submitting state
   return (
-    <div className="border rounded-md bg-blue-50 dark:bg-blue-950/50 border-blue-200 dark:border-blue-800 text-sm" data-testid="computer-use-request">
-      <div className="flex items-start gap-3 p-3">
-        <div className="h-8 w-8 rounded-full bg-blue-100 dark:bg-blue-900 flex items-center justify-center shrink-0">
-          <Monitor className="h-4 w-4 text-blue-600 dark:text-blue-400" />
-        </div>
-
-        <div className="flex-1 min-w-0 space-y-3">
-          <div>
-            <div className="flex items-center gap-2">
-              <span className="font-medium text-blue-900 dark:text-blue-100">
-                Computer Use Request
-              </span>
-              <span className="text-xs px-1.5 py-0.5 rounded bg-blue-200 dark:bg-blue-800 text-blue-700 dark:text-blue-300">
-                {PERMISSION_LABELS[permissionLevel] || permissionLevel}
-              </span>
-              {appName && (
-                <span className="text-xs px-1.5 py-0.5 rounded bg-blue-200 dark:bg-blue-800 text-blue-700 dark:text-blue-300">
-                  {appName}
-                </span>
-              )}
-            </div>
-            <p className="text-sm text-blue-800 dark:text-blue-200 mt-1 font-mono">
-              {method}{paramStr ? `(${paramStr})` : '()'}
-            </p>
-          </div>
-
-          <div className="flex flex-wrap gap-2">
-            <Button
-              onClick={() => handleApprove('once')}
-              disabled={status === 'submitting'}
-              size="sm"
-              variant="outline"
-              className="border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900"
-              data-testid="computer-use-allow-once-btn"
-            >
-              {status === 'submitting' ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Check className="h-4 w-4" />
-              )}
-              <span className="ml-1">Allow Once</span>
-            </Button>
-
-            <Button
-              onClick={() => handleApprove('timed')}
-              disabled={status === 'submitting'}
-              size="sm"
-              className="bg-blue-600 hover:bg-blue-700 text-white"
-              data-testid="computer-use-allow-timed-btn"
-            >
-              <Clock className="h-4 w-4" />
-              <span className="ml-1">Allow 15 min</span>
-            </Button>
-
-            <Button
-              onClick={() => handleApprove('always')}
-              disabled={status === 'submitting'}
-              size="sm"
-              variant="outline"
-              className="border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900"
-              data-testid="computer-use-allow-always-btn"
-            >
-              <ShieldCheck className="h-4 w-4" />
-              <span className="ml-1">Always Allow</span>
-            </Button>
-
-            <DeclineButton
-              onDecline={handleDeny}
-              disabled={status === 'submitting'}
-              className="border-blue-200 dark:border-blue-700 text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900"
-              data-testid="computer-use-deny-btn"
-            />
-          </div>
-
-          {error && <p className="text-sm text-red-600">{error}</p>}
-
-          <p className="text-xs text-blue-600 dark:text-blue-400">
-            This will control your computer. Review carefully before approving.
-          </p>
-        </div>
-      </div>
+    <>
+      <PermissionRequestCard
+        title="Computer Use Request"
+        icon={Monitor}
+        theme={BLUE_THEME}
+        testIdPrefix="computer-use"
+        permissionLabel={PERMISSION_LABELS[permissionLevel] || permissionLevel}
+        scopeLabel={appName}
+        method={method}
+        params={params}
+        warningText="This will control your computer. Review carefully before approving."
+        status={status}
+        error={error}
+        onApprove={handleApprove}
+        onDeny={handleDeny}
+      />
 
       <Dialog open={!!missingPermissions} onOpenChange={(open) => { if (!open) setMissingPermissions(null) }}>
         <DialogContent>
@@ -334,6 +235,6 @@ export function ComputerUseRequestItem({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </>
   )
 }

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -38,6 +38,7 @@ const mockStreamState = {
   pendingBrowserInputRequests: [] as any[],
   pendingScriptRunRequests: [] as any[],
   pendingComputerUseRequests: [] as any[],
+  pendingBrowserUseRequests: [] as any[],
   typingUser: null as { id: string; name?: string } | null,
   peerUserMessage: null as { content: string; sender: { id: string; name?: string; email?: string } } | null,
 }
@@ -54,6 +55,7 @@ vi.mock('@renderer/hooks/use-message-stream', () => ({
   removeBrowserInputRequest: vi.fn(),
   removeScriptRunRequest: vi.fn(),
   removeComputerUseRequest: vi.fn(),
+  removeBrowserUseRequest: vi.fn(),
   clearCompacting: (...args: unknown[]) => mockClearCompacting(...args),
 }))
 

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -10,6 +10,7 @@ import {
   removeBrowserInputRequest,
   removeScriptRunRequest,
   removeComputerUseRequest,
+  removeBrowserUseRequest,
   clearCompacting,
 } from '@renderer/hooks/use-message-stream'
 import { MessageItem } from './message-item'
@@ -23,6 +24,7 @@ import { FileRequestItem } from './file-request-item'
 import { BrowserInputRequestItem } from './browser-input-request-item'
 import { ScriptRunRequestItem } from './script-run-request-item'
 import { ComputerUseRequestItem } from './computer-use-request-item'
+import { BrowserUseRequestItem } from './browser-use-request-item'
 import { PendingAgentReviews } from '@renderer/components/dashboards/pending-agent-reviews'
 import { ArrowDown, Loader2, WifiOff } from 'lucide-react'
 import { FileDownloadPill } from '@renderer/components/ui/file-download-pill'
@@ -132,6 +134,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, onPendin
     pendingBrowserInputRequests: sseBrowserInputRequests,
     pendingScriptRunRequests: sseScriptRunRequests,
     pendingComputerUseRequests: sseComputerUseRequests,
+    pendingBrowserUseRequests: sseBrowserUseRequests,
   } = useMessageStream(sessionId, agentSlug)
   const isOnline = useIsOnline()
 
@@ -386,6 +389,19 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, onPendin
     return merged
   }, [sseComputerUseRequests])
 
+  const pendingBrowserUseRequests = useMemo(() => {
+    const seen = new Set<string>()
+    const merged: { toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; domain?: string }[] = []
+
+    for (const req of sseBrowserUseRequests) {
+      if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
+        seen.add(req.toolUseId)
+        merged.push(req)
+      }
+    }
+    return merged
+  }, [sseBrowserUseRequests])
+
   const scrollRef = useRef<HTMLDivElement>(null)
   const isScrolledToBottomRef = useRef(true)
   const [showScrollToBottom, setShowScrollToBottom] = useState(false)
@@ -483,6 +499,15 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, onPendin
     (toolUseId: string) => {
       dismissedRequestIds.current.add(toolUseId)
       removeComputerUseRequest(sessionId, toolUseId)
+    },
+    [sessionId]
+  )
+
+  // Handler to remove a completed browser use request
+  const handleBrowserUseRequestComplete = useCallback(
+    (toolUseId: string) => {
+      dismissedRequestIds.current.add(toolUseId)
+      removeBrowserUseRequest(sessionId, toolUseId)
     },
     [sessionId]
   )
@@ -646,7 +671,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, onPendin
     if (scrollRef.current && isScrolledToBottomRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight
     }
-  }, [messages, pendingUserMessage, streamingMessage, streamingToolUse, isCompacting, pendingSecretRequests, pendingConnectedAccountRequests, pendingQuestionRequests, pendingFileRequests, pendingRemoteMcpRequests, pendingBrowserInputRequests, pendingScriptRunRequests, sseComputerUseRequests, activeSubagents])
+  }, [messages, pendingUserMessage, streamingMessage, streamingToolUse, isCompacting, pendingSecretRequests, pendingConnectedAccountRequests, pendingQuestionRequests, pendingFileRequests, pendingRemoteMcpRequests, pendingBrowserInputRequests, pendingScriptRunRequests, sseComputerUseRequests, sseBrowserUseRequests, activeSubagents])
 
   if (isLoading && !pendingUserMessage) {
     return (
@@ -893,6 +918,20 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, onPendin
             agentSlug={agentSlug}
             readOnly={isViewOnly}
             onComplete={() => handleComputerUseRequestComplete(request.toolUseId)}
+          />
+        ))}
+        {pendingBrowserUseRequests.map((request) => (
+          <BrowserUseRequestItem
+            key={request.toolUseId}
+            toolUseId={request.toolUseId}
+            method={request.method}
+            params={request.params}
+            permissionLevel={request.permissionLevel}
+            domain={request.domain}
+            sessionId={sessionId}
+            agentSlug={agentSlug}
+            readOnly={isViewOnly}
+            onComplete={() => handleBrowserUseRequestComplete(request.toolUseId)}
           />
         ))}
         </div>

--- a/src/renderer/components/messages/permission-request-card.tsx
+++ b/src/renderer/components/messages/permission-request-card.tsx
@@ -1,0 +1,262 @@
+import { type ReactNode } from 'react'
+import { Check, Loader2, Clock, ShieldCheck, type LucideIcon } from 'lucide-react'
+import { Button } from '@renderer/components/ui/button'
+import { cn } from '@shared/lib/utils/cn'
+import { DeclineButton } from './decline-button'
+
+type RequestStatus = 'pending' | 'submitting' | 'executed' | 'denied'
+
+/** Color theme tokens — all Tailwind classes keyed by usage */
+export interface ColorTheme {
+  bg: string                   // e.g. 'bg-blue-50 dark:bg-blue-950/50'
+  border: string               // e.g. 'border-blue-200 dark:border-blue-800'
+  iconBg: string               // e.g. 'bg-blue-100 dark:bg-blue-900'
+  iconText: string             // e.g. 'text-blue-600 dark:text-blue-400'
+  titleText: string            // e.g. 'text-blue-900 dark:text-blue-100'
+  subtitleText: string         // e.g. 'text-blue-700 dark:text-blue-300'
+  bodyText: string             // e.g. 'text-blue-800 dark:text-blue-200'
+  badgeBg: string              // e.g. 'bg-blue-200 dark:bg-blue-800'
+  badgeText: string            // e.g. 'text-blue-700 dark:text-blue-300'
+  mutedText: string            // e.g. 'text-blue-600 dark:text-blue-400'
+  btnOutlineBorder: string     // e.g. 'border-blue-300 dark:border-blue-700'
+  btnOutlineText: string       // e.g. 'text-blue-700 dark:text-blue-300'
+  btnOutlineHover: string      // e.g. 'hover:bg-blue-100 dark:hover:bg-blue-900'
+  btnPrimaryBg: string         // e.g. 'bg-blue-600 hover:bg-blue-700'
+  declineBorder: string        // e.g. 'border-blue-200 dark:border-blue-700'
+}
+
+export const BLUE_THEME: ColorTheme = {
+  bg: 'bg-blue-50 dark:bg-blue-950/50',
+  border: 'border-blue-200 dark:border-blue-800',
+  iconBg: 'bg-blue-100 dark:bg-blue-900',
+  iconText: 'text-blue-600 dark:text-blue-400',
+  titleText: 'text-blue-900 dark:text-blue-100',
+  subtitleText: 'text-blue-700 dark:text-blue-300',
+  bodyText: 'text-blue-800 dark:text-blue-200',
+  badgeBg: 'bg-blue-200 dark:bg-blue-800',
+  badgeText: 'text-blue-700 dark:text-blue-300',
+  mutedText: 'text-blue-600 dark:text-blue-400',
+  btnOutlineBorder: 'border-blue-300 dark:border-blue-700',
+  btnOutlineText: 'text-blue-700 dark:text-blue-300',
+  btnOutlineHover: 'hover:bg-blue-100 dark:hover:bg-blue-900',
+  btnPrimaryBg: 'bg-blue-600 hover:bg-blue-700',
+  declineBorder: 'border-blue-200 dark:border-blue-700',
+}
+
+export function formatParams(params: Record<string, unknown>): string {
+  const parts: string[] = []
+  for (const [key, val] of Object.entries(params)) {
+    if (val !== undefined && val !== null && val !== '') {
+      parts.push(`${key}: ${typeof val === 'string' ? val : JSON.stringify(val)}`)
+    }
+  }
+  return parts.join(', ')
+}
+
+interface PermissionRequestCardProps {
+  /** Display config */
+  title: string
+  icon: LucideIcon
+  theme: ColorTheme
+  testIdPrefix: string
+  permissionLabel: string
+  scopeLabel?: string                // e.g. appName or domain
+  method: string
+  params: Record<string, unknown>
+  warningText: string
+
+  /** State */
+  status: RequestStatus
+  error: string | null
+  readOnly?: boolean
+
+  /** Handlers */
+  onApprove: (grantType: 'once' | 'timed' | 'always') => void
+  onDeny: (reason?: string) => void
+
+  /** Optional extra content rendered between the header and the buttons */
+  extraContent?: ReactNode
+  /** Optional extra content rendered between buttons and warning */
+  extraActions?: ReactNode
+}
+
+/** Completed state — shared by all permission request types */
+export function CompletedRequestCard({
+  icon: Icon,
+  method,
+  scopeLabel,
+  status,
+  testIdPrefix,
+}: {
+  icon: LucideIcon
+  method: string
+  scopeLabel?: string
+  status: 'executed' | 'denied'
+  testIdPrefix: string
+}) {
+  return (
+    <div className="border rounded-md bg-muted/30 text-sm" data-testid={`${testIdPrefix}-request-completed`} data-status={status}>
+      <div className="flex items-center gap-2 px-3 py-2">
+        <Icon
+          className={cn(
+            'h-4 w-4 shrink-0',
+            status === 'executed' ? 'text-green-500' : 'text-red-500'
+          )}
+        />
+        <span className="text-sm">{method}{scopeLabel ? ` (${scopeLabel})` : ''}</span>
+        <span
+          className={cn(
+            'ml-auto text-xs',
+            status === 'executed' ? 'text-green-600' : 'text-red-600'
+          )}
+        >
+          {status === 'executed' ? 'Executed' : 'Denied'}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+/** Read-only state — shared by all permission request types */
+export function ReadOnlyRequestCard({
+  icon: Icon,
+  title,
+  method,
+  scopeLabel,
+  theme,
+}: {
+  icon: LucideIcon
+  title: string
+  method: string
+  scopeLabel?: string
+  theme: ColorTheme
+}) {
+  return (
+    <div className={cn('border rounded-md text-sm', theme.bg, theme.border)}>
+      <div className="flex items-center gap-3 p-3">
+        <div className={cn('h-8 w-8 rounded-full flex items-center justify-center shrink-0', theme.iconBg)}>
+          <Icon className={cn('h-4 w-4', theme.iconText)} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className={cn('font-medium', theme.titleText)}>
+            {title}
+          </div>
+          <p className={cn('text-sm mt-0.5', theme.subtitleText)}>
+            {method}{scopeLabel ? ` — ${scopeLabel}` : ''}
+          </p>
+        </div>
+        <span className={cn('text-xs shrink-0', theme.mutedText)}>Waiting for approval</span>
+      </div>
+    </div>
+  )
+}
+
+/** Pending/submitting state — the full interactive card */
+export function PermissionRequestCard({
+  title,
+  icon: Icon,
+  theme,
+  testIdPrefix,
+  permissionLabel,
+  scopeLabel,
+  method,
+  params,
+  warningText,
+  status,
+  error,
+  onApprove,
+  onDeny,
+  extraContent,
+  extraActions,
+}: PermissionRequestCardProps) {
+  const paramStr = formatParams(params)
+
+  return (
+    <div className={cn('border rounded-md text-sm', theme.bg, theme.border)} data-testid={`${testIdPrefix}-request`}>
+      <div className="flex items-start gap-3 p-3">
+        <div className={cn('h-8 w-8 rounded-full flex items-center justify-center shrink-0', theme.iconBg)}>
+          <Icon className={cn('h-4 w-4', theme.iconText)} />
+        </div>
+
+        <div className="flex-1 min-w-0 space-y-3">
+          <div>
+            <div className="flex items-center gap-2">
+              <span className={cn('font-medium', theme.titleText)}>
+                {title}
+              </span>
+              <span className={cn('text-xs px-1.5 py-0.5 rounded', theme.badgeBg, theme.badgeText)}>
+                {permissionLabel}
+              </span>
+              {scopeLabel && (
+                <span className={cn('text-xs px-1.5 py-0.5 rounded', theme.badgeBg, theme.badgeText)}>
+                  {scopeLabel}
+                </span>
+              )}
+            </div>
+            <p className={cn('text-sm mt-1 font-mono', theme.bodyText)}>
+              {method}{paramStr ? `(${paramStr})` : '()'}
+            </p>
+          </div>
+
+          {extraContent}
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              onClick={() => onApprove('once')}
+              disabled={status === 'submitting'}
+              size="sm"
+              variant="outline"
+              className={cn(theme.btnOutlineBorder, theme.btnOutlineText, theme.btnOutlineHover)}
+              data-testid={`${testIdPrefix}-allow-once-btn`}
+            >
+              {status === 'submitting' ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Check className="h-4 w-4" />
+              )}
+              <span className="ml-1">Allow Once</span>
+            </Button>
+
+            <Button
+              onClick={() => onApprove('timed')}
+              disabled={status === 'submitting'}
+              size="sm"
+              className={cn(theme.btnPrimaryBg, 'text-white')}
+              data-testid={`${testIdPrefix}-allow-timed-btn`}
+            >
+              <Clock className="h-4 w-4" />
+              <span className="ml-1">Allow 15 min</span>
+            </Button>
+
+            <Button
+              onClick={() => onApprove('always')}
+              disabled={status === 'submitting'}
+              size="sm"
+              variant="outline"
+              className={cn(theme.btnOutlineBorder, theme.btnOutlineText, theme.btnOutlineHover)}
+              data-testid={`${testIdPrefix}-allow-always-btn`}
+            >
+              <ShieldCheck className="h-4 w-4" />
+              <span className="ml-1">Always Allow</span>
+            </Button>
+
+            <DeclineButton
+              onDecline={onDeny}
+              disabled={status === 'submitting'}
+              className={cn(theme.declineBorder, theme.btnOutlineText, theme.btnOutlineHover)}
+              data-testid={`${testIdPrefix}-deny-btn`}
+            />
+          </div>
+
+          {extraActions}
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <p className={cn('text-xs', theme.mutedText)}>
+            {warningText}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/settings/browser-tab.tsx
+++ b/src/renderer/components/settings/browser-tab.tsx
@@ -1,3 +1,4 @@
+import { BrowserUsePermissionsSection } from './browser-use-permissions-section'
 import { useState } from 'react'
 import { Label } from '@renderer/components/ui/label'
 import { Input } from '@renderer/components/ui/input'
@@ -229,6 +230,10 @@ export function BrowserTab() {
           />
         </>
       )}
+
+      <hr className="my-4" />
+
+      <BrowserUsePermissionsSection />
     </div>
   )
 }

--- a/src/renderer/components/settings/browser-use-permissions-section.tsx
+++ b/src/renderer/components/settings/browser-use-permissions-section.tsx
@@ -1,0 +1,116 @@
+import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
+import { useAgents } from '@renderer/hooks/use-agents'
+import { Button } from '@renderer/components/ui/button'
+import { Globe, Trash2 } from 'lucide-react'
+import type { BrowserUseSettings } from '@shared/lib/browser-use/types'
+
+const PERMISSION_LABELS: Record<string, string> = {
+  browse_read: 'Read Page',
+  browse_interact: 'Interact with Page',
+  browse_navigate: 'Navigate',
+  browse_manage: 'Browser Control',
+}
+
+export function BrowserUsePermissionsSection() {
+  const { data: settings } = useSettings()
+  const { data: agents } = useAgents()
+  const updateSettings = useUpdateSettings()
+
+  const browserUse = settings?.browserUse as BrowserUseSettings | undefined
+  const agentPermissions = browserUse?.agentPermissions || {}
+  const hasGrants = Object.keys(agentPermissions).length > 0
+
+  const agentNameMap = new Map(agents?.map((a) => [a.slug, a.name]) ?? [])
+
+  const handleRevokeAll = (agentSlug: string) => {
+    const newPerms = { ...agentPermissions }
+    delete newPerms[agentSlug]
+    updateSettings.mutate({
+      browserUse: { agentPermissions: newPerms },
+    })
+  }
+
+  const handleRevokeGrant = (agentSlug: string, grantIndex: number) => {
+    const agentGrants = agentPermissions[agentSlug]?.grants || []
+    const newGrants = agentGrants.filter((_, i) => i !== grantIndex)
+    const newPerms = { ...agentPermissions }
+    if (newGrants.length === 0) {
+      delete newPerms[agentSlug]
+    } else {
+      newPerms[agentSlug] = { grants: newGrants }
+    }
+    updateSettings.mutate({
+      browserUse: { agentPermissions: newPerms },
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h4 className="text-sm font-medium flex items-center gap-2">
+          <Globe className="h-4 w-4" />
+          Browser Permissions
+        </h4>
+        <p className="text-sm text-muted-foreground mt-1">
+          Agents request permission before using the browser. Permissions are granted per-agent and can be scoped to specific domains.
+        </p>
+      </div>
+
+      <div>
+        <h4 className="text-sm font-medium mb-2">Permission Levels</h4>
+        <ul className="text-sm text-muted-foreground space-y-1">
+          <li><strong>Read Page</strong> — Observe page content: snapshot, screenshot, get state.</li>
+          <li><strong>Interact with Page</strong> — Click, fill, scroll, press, select, hover on a page.</li>
+          <li><strong>Navigate</strong> — Open/navigate to a URL.</li>
+          <li><strong>Browser Control</strong> — Close browser, run arbitrary commands.</li>
+        </ul>
+      </div>
+
+      <div>
+        <h4 className="text-sm font-medium mb-2">Persistent Permissions (&quot;Always Allow&quot;)</h4>
+        {!hasGrants ? (
+          <p className="text-sm text-muted-foreground">
+            No persistent permissions granted. Permissions will be requested when agents need browser access.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {Object.entries(agentPermissions).map(([agentSlug, agentPerms]) => (
+              <div key={agentSlug} className="border rounded-md p-3">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="font-medium text-sm">{agentNameMap.get(agentSlug) || agentSlug}</span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleRevokeAll(agentSlug)}
+                    className="text-destructive hover:text-destructive"
+                  >
+                    <Trash2 className="h-3.5 w-3.5 mr-1" />
+                    Revoke All
+                  </Button>
+                </div>
+                <div className="space-y-1">
+                  {agentPerms.grants.map((grant, i) => (
+                    <div key={i} className="flex items-center justify-between text-sm text-muted-foreground">
+                      <span>
+                        {PERMISSION_LABELS[grant.level] || grant.level}
+                        {grant.domain ? ` — ${grant.domain}` : ' — any domain'}
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleRevokeGrant(agentSlug, i)}
+                        className="h-6 px-2 text-muted-foreground hover:text-destructive"
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -62,6 +62,14 @@ export interface ComputerUseRequest {
   appName?: string
 }
 
+export interface BrowserUseRequest {
+  toolUseId: string
+  method: string
+  params: Record<string, unknown>
+  permissionLevel: string
+  domain?: string
+}
+
 export interface SubagentInfo {
   parentToolId: string | null
   agentId: string | null
@@ -90,6 +98,7 @@ interface StreamState {
   pendingBrowserInputRequests: BrowserInputRequest[]
   pendingScriptRunRequests: ScriptRunRequest[]
   pendingComputerUseRequests: ComputerUseRequest[]
+  pendingBrowserUseRequests: BrowserUseRequest[]
   error: string | null // Error message if session encountered an error
   /** SDK error code from the LLM provider (e.g., 'authentication_failed', 'rate_limit', 'server_error') */
   apiErrorCode: string | null
@@ -175,6 +184,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
           pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
+          pendingBrowserUseRequests: current?.pendingBrowserUseRequests ?? [],
           error: null,
           apiErrorCode: null,
           browserActive: current?.browserActive ?? false,
@@ -219,6 +229,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
           pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
+          pendingBrowserUseRequests: current?.pendingBrowserUseRequests ?? [],
           error: null, // Clear any previous error when starting new request
           apiErrorCode: null,
           browserActive: current?.browserActive ?? false,
@@ -255,6 +266,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: [],
           pendingScriptRunRequests: [],
           pendingComputerUseRequests: [],
+          pendingBrowserUseRequests: [],
           error: null,
           // Preserve apiErrorCode — it was set from the assistant message's error field
           // and is still valid context for the last turn. Cleared on next session_active.
@@ -294,6 +306,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: [],
           pendingScriptRunRequests: [],
           pendingComputerUseRequests: [],
+          pendingBrowserUseRequests: [],
           error: data.error || 'An unknown error occurred',
           apiErrorCode: data.apiErrorCode || null,
           browserActive: current?.browserActive ?? false,
@@ -335,6 +348,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
           pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
+          pendingBrowserUseRequests: current?.pendingBrowserUseRequests ?? [],
           error: null,
           apiErrorCode: null,
           browserActive: current?.browserActive ?? false,
@@ -364,6 +378,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
           pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
+          pendingBrowserUseRequests: current?.pendingBrowserUseRequests ?? [],
           error: current?.error ?? null,
           apiErrorCode: data.apiErrorCode || current?.apiErrorCode || null,
           browserActive: current?.browserActive ?? false,
@@ -407,6 +422,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
           pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
+          pendingBrowserUseRequests: current?.pendingBrowserUseRequests ?? [],
           error: current?.error ?? null,
           apiErrorCode: current?.apiErrorCode ?? null,
           browserActive: current?.browserActive ?? false,
@@ -437,6 +453,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
           pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
+          pendingBrowserUseRequests: current?.pendingBrowserUseRequests ?? [],
           error: current?.error ?? null,
           apiErrorCode: current?.apiErrorCode ?? null,
           browserActive: current?.browserActive ?? false,
@@ -466,6 +483,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
           pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
+          pendingBrowserUseRequests: current?.pendingBrowserUseRequests ?? [],
           error: current?.error ?? null,
           apiErrorCode: current?.apiErrorCode ?? null,
           browserActive: current?.browserActive ?? false,
@@ -660,6 +678,23 @@ function getOrCreateEventSource(
           streamStates.set(sessionId, {
             ...current,
             pendingComputerUseRequests: [...current.pendingComputerUseRequests, newRequest],
+          })
+          queryClient.invalidateQueries({ queryKey: ['sessions'] })
+        }
+      }
+      else if (data.type === 'browser_use_request') {
+        // Agent is requesting browser use permission
+        if (current && !current.pendingBrowserUseRequests.some(r => r.toolUseId === data.toolUseId)) {
+          const newRequest: BrowserUseRequest = {
+            toolUseId: data.toolUseId,
+            method: data.method,
+            params: data.params || {},
+            permissionLevel: data.permissionLevel,
+            domain: data.domain,
+          }
+          streamStates.set(sessionId, {
+            ...current,
+            pendingBrowserUseRequests: [...current.pendingBrowserUseRequests, newRequest],
           })
           queryClient.invalidateQueries({ queryKey: ['sessions'] })
         }
@@ -1023,6 +1058,20 @@ export function removeComputerUseRequest(sessionId: string, toolUseId: string): 
   }
 }
 
+// Helper function to remove a browser use request from a session
+export function removeBrowserUseRequest(sessionId: string, toolUseId: string): void {
+  const current = streamStates.get(sessionId)
+  if (current) {
+    streamStates.set(sessionId, {
+      ...current,
+      pendingBrowserUseRequests: current.pendingBrowserUseRequests.filter(
+        (r) => r.toolUseId !== toolUseId
+      ),
+    })
+    streamListeners.get(sessionId)?.forEach((listener) => listener())
+  }
+}
+
 // Helper to clear isCompacting state (used when persisted messages already show the boundary)
 export function clearCompacting(sessionId: string): void {
   const current = streamStates.get(sessionId)
@@ -1055,6 +1104,7 @@ export function useMessageStream(sessionId: string | null, agentSlug: string | n
     pendingBrowserInputRequests: [],
     pendingScriptRunRequests: [],
     pendingComputerUseRequests: [],
+    pendingBrowserUseRequests: [],
     error: null,
     apiErrorCode: null,
     browserActive: false,
@@ -1109,6 +1159,7 @@ export function useMessageStream(sessionId: string | null, agentSlug: string | n
         pendingBrowserInputRequests: [],
         pendingScriptRunRequests: [],
         pendingComputerUseRequests: [],
+        pendingBrowserUseRequests: [],
         error: null,
         apiErrorCode: null,
         browserActive: false,

--- a/src/renderer/hooks/use-settings.ts
+++ b/src/renderer/hooks/use-settings.ts
@@ -12,6 +12,7 @@ import type {
   LlmProviderId,
 } from '@shared/lib/config/settings'
 import type { ComputerUseSettings } from '@shared/lib/computer-use/types'
+import type { BrowserUseSettings } from '@shared/lib/browser-use/types'
 import type { RunnerAvailability } from '@shared/lib/container/client-factory'
 
 export type { GlobalSettingsResponse, ContainerSettings, AppPreferences, ModelSettings, AgentLimitsSettings, AuthSettings, VoiceSettings, AnalyticsTarget, LlmProviderId, RunnerAvailability }
@@ -53,6 +54,7 @@ export interface UpdateSettingsParams {
   auth?: Partial<AuthSettings>
   voice?: Partial<VoiceSettings>
   computerUse?: Partial<ComputerUseSettings>
+  browserUse?: Partial<BrowserUseSettings>
   shareAnalytics?: boolean
   analyticsTargets?: AnalyticsTarget[]
 }

--- a/src/renderer/test/mock-stream.ts
+++ b/src/renderer/test/mock-stream.ts
@@ -19,6 +19,7 @@ export interface MockStreamState {
   pendingBrowserInputRequests: Array<{ toolUseId: string; message: string; requirements: string[] }>
   pendingScriptRunRequests: Array<{ toolUseId: string; script: string; explanation: string; scriptType: 'applescript' | 'shell' | 'powershell' }>
   pendingComputerUseRequests: Array<{ toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string }>
+  pendingBrowserUseRequests: Array<{ toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; domain?: string }>
   error: string | null
   browserActive: boolean
   activeStartTime: number | null
@@ -41,6 +42,7 @@ export const DEFAULT_STREAM_STATE: MockStreamState = {
   pendingBrowserInputRequests: [],
   pendingScriptRunRequests: [],
   pendingComputerUseRequests: [],
+  pendingBrowserUseRequests: [],
   error: null,
   browserActive: false,
   activeStartTime: null,

--- a/src/shared/lib/browser-use/permission-manager.ts
+++ b/src/shared/lib/browser-use/permission-manager.ts
@@ -1,0 +1,90 @@
+/**
+ * BrowserUsePermissionManager
+ *
+ * Manages per-agent browser use permissions. Extends BasePermissionManager
+ * with domain subdomain matching for domain-scoped levels.
+ */
+
+import { getSettings, updateSettings } from '@shared/lib/config/settings'
+import { BasePermissionManager } from '@shared/lib/permissions/base-permission-manager'
+import type { PermissionGrant } from '@shared/lib/permissions/types'
+import type { BrowserUsePermissionLevel, BrowserUseSettings } from './types'
+import { DOMAIN_SCOPED_LEVELS, domainMatches } from './types'
+
+export class BrowserUsePermissionManager extends BasePermissionManager<BrowserUsePermissionLevel> {
+  constructor() {
+    super('BrowserUsePermissions')
+  }
+
+  // --- Settings serialization (maps scope ↔ domain) ---
+
+  loadFromSettings(): void {
+    try {
+      const settings = getSettings()
+      const bu = settings.browserUse as BrowserUseSettings | undefined
+      if (!bu?.agentPermissions) return
+
+      for (const [agentSlug, agentPerms] of Object.entries(bu.agentPermissions)) {
+        const existingGrants = this.grants.get(agentSlug) || []
+        for (const g of agentPerms.grants) {
+          existingGrants.push({
+            level: g.level,
+            scope: g.domain,
+            grantType: 'always',
+            grantedAt: Date.now(),
+          })
+        }
+        this.grants.set(agentSlug, existingGrants)
+      }
+    } catch (error) {
+      console.error(`[${this.logPrefix}] Failed to load from settings:`, error)
+    }
+  }
+
+  persistToSettings(): void {
+    try {
+      const settings = getSettings()
+      const agentPermissions: BrowserUseSettings['agentPermissions'] = {}
+
+      for (const [agentSlug, agentGrants] of this.grants) {
+        const alwaysGrants = agentGrants.filter((g) => g.grantType === 'always')
+        if (alwaysGrants.length > 0) {
+          agentPermissions[agentSlug] = {
+            grants: alwaysGrants.map((g) => ({
+              level: g.level,
+              domain: g.scope,
+              grantType: 'always' as const,
+            })),
+          }
+        }
+      }
+
+      updateSettings({
+        ...settings,
+        browserUse: {
+          ...settings.browserUse,
+          agentPermissions,
+        },
+      })
+    } catch (error) {
+      console.error(`[${this.logPrefix}] Failed to persist to settings:`, error)
+    }
+  }
+
+  // --- Grant matching ---
+
+  protected grantMatches(
+    grant: PermissionGrant<BrowserUsePermissionLevel>,
+    level: BrowserUsePermissionLevel,
+    scope?: string,
+  ): boolean {
+    if (grant.level !== level) return false
+    if (DOMAIN_SCOPED_LEVELS.has(level)) {
+      return domainMatches(grant.scope, scope)
+    }
+    return true
+  }
+}
+
+/** Singleton instance */
+export const browserUsePermissionManager = new BrowserUsePermissionManager()

--- a/src/shared/lib/browser-use/types.ts
+++ b/src/shared/lib/browser-use/types.ts
@@ -1,0 +1,112 @@
+/**
+ * Browser Use Permission & Request Types
+ *
+ * Four permission levels control what agents can do in the browser:
+ * - browse_read: passive observation (snapshot, screenshot, get_state, wait) — domain-scoped
+ * - browse_interact: page interaction (click, fill, scroll, press, select, hover) — domain-scoped
+ * - browse_navigate: open/navigate to URLs — domain-scoped (target URL)
+ * - browse_manage: lifecycle & advanced (close, run arbitrary commands) — global (not domain-scoped)
+ */
+
+export type { PermissionGrantType } from '@shared/lib/permissions/types'
+export { TIMED_GRANT_DURATION_MS } from '@shared/lib/permissions/types'
+
+export type BrowserUsePermissionLevel =
+  | 'browse_read'
+  | 'browse_interact'
+  | 'browse_navigate'
+  | 'browse_manage'
+
+/** Persisted in settings.json — only 'always' grants are stored */
+export interface BrowserUseSettings {
+  agentPermissions?: Record<string, {
+    grants: Array<{
+      level: BrowserUsePermissionLevel
+      domain?: string
+      grantType: 'always'
+    }>
+  }>
+}
+
+/** SSE event broadcast when a browser use request needs user approval */
+export interface BrowserUseRequestEvent {
+  type: 'browser_use_request'
+  toolUseId: string
+  method: string
+  params: Record<string, unknown>
+  permissionLevel: BrowserUsePermissionLevel
+  domain?: string
+  agentSlug?: string
+}
+
+/** Browser methods that only need browse_read permission */
+export const READ_ONLY_BROWSER_METHODS = new Set([
+  'snapshot', 'screenshot', 'get_state', 'wait',
+])
+
+/** Browser methods that need browse_interact permission */
+export const INTERACT_BROWSER_METHODS = new Set([
+  'click', 'fill', 'scroll', 'press', 'select', 'hover',
+])
+
+/** Browser methods that need browse_navigate permission */
+export const NAVIGATE_BROWSER_METHODS = new Set([
+  'open',
+])
+
+/** Browser methods that need browse_manage permission (not domain-scoped) */
+export const MANAGE_BROWSER_METHODS = new Set([
+  'close', 'run',
+])
+
+/** Permission levels that are scoped to a domain */
+export const DOMAIN_SCOPED_LEVELS = new Set<BrowserUsePermissionLevel>([
+  'browse_read', 'browse_interact', 'browse_navigate',
+])
+
+/**
+ * Determine the permission level required for a browser method.
+ */
+export function getRequiredBrowserPermissionLevel(method: string): BrowserUsePermissionLevel {
+  if (READ_ONLY_BROWSER_METHODS.has(method)) return 'browse_read'
+  if (INTERACT_BROWSER_METHODS.has(method)) return 'browse_interact'
+  if (NAVIGATE_BROWSER_METHODS.has(method)) return 'browse_navigate'
+  return 'browse_manage'
+}
+
+/**
+ * Extract the domain from a URL string.
+ * Returns undefined if the URL is invalid or has no hostname.
+ */
+export function extractDomainFromUrl(url: string): string | undefined {
+  try {
+    const parsed = new URL(url)
+    return parsed.hostname || undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Check if a requested domain matches a grant domain.
+ *
+ * - Wildcard grant (undefined, '*', or '') matches any domain.
+ * - Exact match: 'github.com' matches 'github.com'
+ * - Subdomain match: grant for 'github.com' also matches 'docs.github.com'
+ */
+export function domainMatches(grantDomain: string | undefined, requestedDomain: string | undefined): boolean {
+  // Wildcard grant matches anything
+  if (!grantDomain || grantDomain === '*') return true
+  // No requested domain — only wildcard grants match
+  if (!requestedDomain) return false
+
+  const grantLower = grantDomain.toLowerCase()
+  const requestedLower = requestedDomain.toLowerCase()
+
+  // Exact match
+  if (requestedLower === grantLower) return true
+  // Subdomain match: requested ends with ".grantDomain"
+  if (requestedLower.endsWith('.' + grantLower)) return true
+
+  return false
+}

--- a/src/shared/lib/computer-use/permission-manager.ts
+++ b/src/shared/lib/computer-use/permission-manager.ts
@@ -1,161 +1,82 @@
 /**
  * ComputerUsePermissionManager
  *
- * Manages per-agent computer use permissions with three grant types:
- * - "once": in-memory only, consumed after single use
- * - "timed": in-memory with 15-min expiry
- * - "always": persisted to settings.json + in-memory
+ * Manages per-agent computer use permissions. Extends BasePermissionManager
+ * with exact app-name matching for 'use_application' level.
+ *
+ * Also tracks per-agent "grabbed app" state.
  */
 
 import { getSettings, updateSettings } from '@shared/lib/config/settings'
+import { BasePermissionManager } from '@shared/lib/permissions/base-permission-manager'
+import type { PermissionGrant } from '@shared/lib/permissions/types'
 import type {
   ComputerUsePermissionLevel,
-  PermissionGrant,
+  PermissionGrant as LegacyPermissionGrant,
   PermissionGrantType,
   ComputerUseSettings,
 } from './types'
-import { TIMED_GRANT_DURATION_MS } from './types'
 
-export class ComputerUsePermissionManager {
-  /** In-memory grants: agentSlug → grants[] */
-  private grants = new Map<string, PermissionGrant[]>()
-
-  /** Per-agent grabbed app tracking: agentSlug → app name */
+export class ComputerUsePermissionManager extends BasePermissionManager<ComputerUsePermissionLevel> {
   private grabbedApps = new Map<string, string>()
 
-  /** Whether persisted grants have been loaded from settings.json yet. */
-  private loaded = false
-
-  /** Lazily load persisted grants on first access. */
-  private ensureLoaded(): void {
-    if (!this.loaded) {
-      this.loaded = true
-      this.loadFromSettings()
-    }
+  constructor() {
+    super('ComputerUsePermissions')
   }
 
-  /**
-   * Check if a permission is currently granted.
-   * Returns 'granted' if an active (non-expired, non-consumed) grant exists.
-   * Returns 'prompt_needed' if the user must be prompted.
-   */
   checkPermission(
     agentSlug: string,
     level: ComputerUsePermissionLevel,
     appName?: string,
   ): 'granted' | 'prompt_needed' {
-    this.ensureLoaded()
-    const agentGrants = this.grants.get(agentSlug)
-    if (!agentGrants) return 'prompt_needed'
-
-    const now = Date.now()
-    for (const grant of agentGrants) {
-      if (!this.grantMatches(grant, level, appName)) continue
-      // Check expiry for timed grants
-      if (grant.grantType === 'timed' && grant.expiresAt && grant.expiresAt < now) continue
-      return 'granted'
-    }
-
-    return 'prompt_needed'
+    return super.checkPermission(agentSlug, level, appName)
   }
 
-  /**
-   * Record a permission grant. For "always" grants, also persists to settings.
-   */
   grantPermission(
     agentSlug: string,
     level: ComputerUsePermissionLevel,
     grantType: PermissionGrantType,
     appName?: string,
   ): void {
-    this.ensureLoaded()
-    const now = Date.now()
-    const grant: PermissionGrant = {
-      level,
-      grantType,
-      grantedAt: now,
-      ...(appName && { appName }),
-      ...(grantType === 'timed' && { expiresAt: now + TIMED_GRANT_DURATION_MS }),
-    }
-
-    if (!this.grants.has(agentSlug)) {
-      this.grants.set(agentSlug, [])
-    }
-
-    // For 'timed' and 'always': remove existing matching grants before adding new one
-    if (grantType !== 'once') {
-      this.removeMatchingGrants(agentSlug, level, appName)
-    }
-
-    this.grants.get(agentSlug)!.push(grant)
-    console.log(`[ComputerUsePermissions] Granted ${grantType} ${level}${appName ? ` for ${appName}` : ''} to ${agentSlug}`)
-
-    if (grantType === 'always') {
-      this.persistToSettings()
-    }
+    super.grantPermission(agentSlug, level, grantType, appName)
   }
 
-  /**
-   * Consume a "once" grant after use. Removes the first matching "once" grant.
-   */
   consumeOnceGrant(
     agentSlug: string,
     level: ComputerUsePermissionLevel,
     appName?: string,
   ): void {
-    const agentGrants = this.grants.get(agentSlug)
-    if (!agentGrants) return
-
-    const idx = agentGrants.findIndex(
-      (g) => g.grantType === 'once' && this.grantMatches(g, level, appName),
-    )
-    if (idx >= 0) {
-      agentGrants.splice(idx, 1)
-      console.log(`[ComputerUsePermissions] Consumed once grant ${level}${appName ? ` for ${appName}` : ''} from ${agentSlug}`)
-    }
+    super.consumeOnceGrant(agentSlug, level, appName)
   }
 
-  /**
-   * Revoke all permissions for an agent.
-   */
-  revokeAllForAgent(agentSlug: string): void {
-    console.log(`[ComputerUsePermissions] Revoking all grants for ${agentSlug}`)
-    this.grants.delete(agentSlug)
-    this.grabbedApps.delete(agentSlug)
-    this.persistToSettings()
-  }
-
-  /**
-   * Revoke a specific "always" grant for an agent.
-   */
   revokeGrant(
     agentSlug: string,
     level: ComputerUsePermissionLevel,
     appName?: string,
   ): void {
-    console.log(`[ComputerUsePermissions] Revoking ${level}${appName ? ` for ${appName}` : ''} from ${agentSlug}`)
-    this.removeMatchingGrants(agentSlug, level, appName)
-    this.persistToSettings()
+    super.revokeGrant(agentSlug, level, appName)
   }
 
-  /**
-   * Get all active (non-expired) grants for an agent.
-   */
-  getGrantsForAgent(agentSlug: string): PermissionGrant[] {
-    this.ensureLoaded()
-    const agentGrants = this.grants.get(agentSlug)
-    if (!agentGrants) return []
+  revokeAllForAgent(agentSlug: string): void {
+    this.grabbedApps.delete(agentSlug)
+    super.revokeAllForAgent(agentSlug)
+  }
 
-    const now = Date.now()
-    return agentGrants.filter((g) => {
-      if (g.grantType === 'timed' && g.expiresAt && g.expiresAt < now) return false
-      return true
+  getGrantsForAgent(agentSlug: string): LegacyPermissionGrant[] {
+    return super.getGrantsForAgent(agentSlug).map((g) => {
+      const result: LegacyPermissionGrant = {
+        level: g.level,
+        grantType: g.grantType,
+        grantedAt: g.grantedAt,
+      }
+      if (g.scope) result.appName = g.scope
+      if (g.expiresAt) result.expiresAt = g.expiresAt
+      return result
     })
   }
 
-  /**
-   * Track which app is currently grabbed by an agent session.
-   */
+  // --- Grabbed app tracking ---
+
   setGrabbedApp(agentSlug: string, appName: string): void {
     this.grabbedApps.set(agentSlug, appName)
   }
@@ -168,13 +89,12 @@ export class ComputerUsePermissionManager {
     return this.grabbedApps.get(agentSlug)
   }
 
-  /**
-   * Load persisted "always" grants from settings.json on startup.
-   */
+  // --- Settings serialization (maps scope ↔ appName) ---
+
   loadFromSettings(): void {
     try {
       const settings = getSettings()
-      const cu = settings.computerUse
+      const cu = settings.computerUse as ComputerUseSettings | undefined
       if (!cu?.agentPermissions) return
 
       for (const [agentSlug, agentPerms] of Object.entries(cu.agentPermissions)) {
@@ -182,7 +102,7 @@ export class ComputerUsePermissionManager {
         for (const g of agentPerms.grants) {
           existingGrants.push({
             level: g.level,
-            appName: g.appName,
+            scope: g.appName,
             grantType: 'always',
             grantedAt: Date.now(),
           })
@@ -190,13 +110,10 @@ export class ComputerUsePermissionManager {
         this.grants.set(agentSlug, existingGrants)
       }
     } catch (error) {
-      console.error('[ComputerUsePermissionManager] Failed to load from settings:', error)
+      console.error(`[${this.logPrefix}] Failed to load from settings:`, error)
     }
   }
 
-  /**
-   * Persist all "always" grants to settings.json.
-   */
   persistToSettings(): void {
     try {
       const settings = getSettings()
@@ -208,7 +125,7 @@ export class ComputerUsePermissionManager {
           agentPermissions[agentSlug] = {
             grants: alwaysGrants.map((g) => ({
               level: g.level,
-              appName: g.appName,
+              appName: g.scope,
               grantType: 'always' as const,
             })),
           }
@@ -223,35 +140,22 @@ export class ComputerUsePermissionManager {
         },
       })
     } catch (error) {
-      console.error('[ComputerUsePermissionManager] Failed to persist to settings:', error)
+      console.error(`[${this.logPrefix}] Failed to persist to settings:`, error)
     }
   }
 
-  // --- Private helpers ---
+  // --- Grant matching ---
 
-  private grantMatches(
-    grant: PermissionGrant,
+  protected grantMatches(
+    grant: PermissionGrant<ComputerUsePermissionLevel>,
     level: ComputerUsePermissionLevel,
-    appName?: string,
+    scope?: string,
   ): boolean {
     if (grant.level !== level) return false
-    // For 'use_application', appName must match
     if (level === 'use_application') {
-      return grant.appName === appName
+      return grant.scope === scope
     }
     return true
-  }
-
-  private removeMatchingGrants(
-    agentSlug: string,
-    level: ComputerUsePermissionLevel,
-    appName?: string,
-  ): void {
-    const agentGrants = this.grants.get(agentSlug)
-    if (!agentGrants) return
-
-    const filtered = agentGrants.filter((g) => !this.grantMatches(g, level, appName))
-    this.grants.set(agentSlug, filtered)
   }
 }
 

--- a/src/shared/lib/computer-use/types.ts
+++ b/src/shared/lib/computer-use/types.ts
@@ -7,18 +7,20 @@
  * - use_host_shell: shell commands / AppleScript (replaces old hostShellUse toggle)
  */
 
+// Re-export shared permission types for backward compatibility
+export type { PermissionGrantType } from '@shared/lib/permissions/types'
+export { TIMED_GRANT_DURATION_MS } from '@shared/lib/permissions/types'
+
 export type ComputerUsePermissionLevel =
   | 'list_apps_windows'
   | 'use_application'
   | 'use_host_shell'
 
-export type PermissionGrantType = 'once' | 'timed' | 'always'
-
 export interface PermissionGrant {
   level: ComputerUsePermissionLevel
   /** Only for 'use_application' — the specific app name */
   appName?: string
-  grantType: PermissionGrantType
+  grantType: 'once' | 'timed' | 'always'
   grantedAt: number
   /** Only for 'timed' grants (15 min) */
   expiresAt?: number
@@ -58,9 +60,6 @@ export function getRequiredPermissionLevel(method: string): ComputerUsePermissio
   if (READ_ONLY_METHODS.has(method)) return 'list_apps_windows'
   return 'use_application'
 }
-
-/** Duration of "timed" permission grants in milliseconds (15 minutes) */
-export const TIMED_GRANT_DURATION_MS = 15 * 60 * 1000
 
 /**
  * Resolve which app an AC method call targets, for permission checks.

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -5,6 +5,7 @@ import { getDataDir } from './data-dir'
 import { getDefaultAgentImage, AGENT_IMAGE_REGISTRY } from './version'
 import type { SkillsetConfig } from '@shared/lib/types/skillset'
 import type { ComputerUseSettings } from '@shared/lib/computer-use/types'
+import type { BrowserUseSettings } from '@shared/lib/browser-use/types'
 
 export interface ContainerSettings {
   containerRunner: string
@@ -165,6 +166,7 @@ export interface AppSettings {
   auth?: AuthSettings
   voice?: VoiceSettings
   computerUse?: ComputerUseSettings
+  browserUse?: BrowserUseSettings
   shareAnalytics?: boolean
   analyticsTargets?: AnalyticsTarget[]
 }
@@ -229,6 +231,7 @@ export interface GlobalSettingsResponse {
   auth?: AuthSettings
   tenantId: string
   computerUse?: ComputerUseSettings
+  browserUse?: BrowserUseSettings
   shareAnalytics: boolean
   analyticsTargets?: AnalyticsTarget[]
 }
@@ -339,6 +342,7 @@ export function loadSettings(): AppSettings {
         },
         voice: loaded.voice,
         computerUse: loaded.computerUse,
+        browserUse: loaded.browserUse,
         shareAnalytics: loaded.shareAnalytics ?? false,
         analyticsTargets: loaded.analyticsTargets,
       }

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -41,6 +41,7 @@ interface StreamingState {
   slashCommands: SlashCommandInfo[] // Available slash commands from SDK
   isAwaitingInput: boolean // True when session is waiting for user input (e.g., secret, file, question)
   pendingComputerUseRequests: Map<string, { toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string; agentSlug?: string }> // Pending computer use requests awaiting user approval (keyed by toolUseId)
+  pendingBrowserUseRequests: Map<string, { toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; domain?: string; agentSlug?: string }> // Pending browser use requests awaiting user approval (keyed by toolUseId)
   lastApiErrorCode: string | null // SDK error code from last assistant message (e.g., 'authentication_failed', 'rate_limit')
 }
 
@@ -93,6 +94,7 @@ class MessagePersister {
       slashCommands: [],
       isAwaitingInput: false,
       pendingComputerUseRequests: new Map(),
+      pendingBrowserUseRequests: new Map(),
       lastApiErrorCode: null,
     })
 
@@ -150,6 +152,28 @@ class MessagePersister {
       // Don't clear isAwaitingInput here — other input types (secrets, questions, etc.)
       // may still be pending. The flag is cleared when the tool result arrives in the stream.
       if (state.pendingComputerUseRequests.size === 0) {
+        this.broadcastGlobal({
+          type: 'session_input_provided',
+          sessionId,
+          agentSlug: state.agentSlug,
+        })
+      }
+    }
+  }
+
+  // Get pending browser use requests for a session (for SSE replay on reconnect)
+  getPendingBrowserUseRequests(sessionId: string): Array<{ toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; domain?: string; agentSlug?: string }> {
+    const state = this.streamingStates.get(sessionId)
+    if (!state) return []
+    return Array.from(state.pendingBrowserUseRequests.values())
+  }
+
+  // Clear a pending browser use request (after approval/rejection)
+  clearPendingBrowserUseRequest(sessionId: string, toolUseId: string): void {
+    const state = this.streamingStates.get(sessionId)
+    if (state) {
+      state.pendingBrowserUseRequests.delete(toolUseId)
+      if (state.pendingBrowserUseRequests.size === 0) {
         this.broadcastGlobal({
           type: 'session_input_provided',
           sessionId,
@@ -317,6 +341,7 @@ class MessagePersister {
         slashCommands: [],
         isAwaitingInput: false,
         pendingComputerUseRequests: new Map(),
+        pendingBrowserUseRequests: new Map(),
         lastApiErrorCode: null,
       }
       this.streamingStates.set(sessionId, state)
@@ -767,6 +792,15 @@ class MessagePersister {
                 state.agentSlug
               )
             }
+            if (block.type === 'tool_use' && block.name.startsWith('mcp__browser__browser_')) {
+              this.handleBrowserUseRequestTool(
+                sessionId,
+                block.id,
+                block.name,
+                JSON.stringify(block.input || {}),
+                state.agentSlug
+              )
+            }
           }
         }
       }
@@ -962,6 +996,16 @@ class MessagePersister {
             )
           }
 
+          if (sub.currentToolUse.name.startsWith('mcp__browser__browser_')) {
+            this.handleBrowserUseRequestTool(
+              sessionId,
+              sub.currentToolUse.id,
+              sub.currentToolUse.name,
+              sub.currentToolInput,
+              state.agentSlug
+            )
+          }
+
           this.broadcastToSSE(sessionId, {
             type: 'subagent_tool_use_ready',
             parentToolId,
@@ -1131,10 +1175,20 @@ class MessagePersister {
             )
           }
 
+          if (state.currentToolUse.name.startsWith('mcp__browser__browser_')) {
+            this.handleBrowserUseRequestTool(
+              sessionId,
+              state.currentToolUse.id,
+              state.currentToolUse.name,
+              state.currentToolInput,
+              state.agentSlug
+            )
+          }
+
           // Mark session as awaiting input when a blocking user-input tool fires
           // Only tools with 'request_' prefix actually block waiting for user response
           // (schedule_task, deliver_file, search_* resolve immediately and don't block)
-          // Note: computer-use tools are handled by handleComputerUseRequestTool which
+          // Note: computer-use and browser-use tools are handled by their respective handlers which
           // only marks awaiting input when user approval is actually needed (not auto-executed)
           if (
             state.currentToolUse.name === 'AskUserQuestion' ||
@@ -1690,6 +1744,129 @@ class MessagePersister {
       }
     } catch (error) {
       console.error('[MessagePersister] Error handling computer use request:', error)
+    }
+  }
+
+  /**
+   * Handle browser use request tools — check permissions and either auto-approve or prompt user.
+   * Unlike computer use (where the host executes the command), browser use execution
+   * happens in the container. We just need to approve/reject the pending input.
+   */
+  private async handleBrowserUseRequestTool(
+    sessionId: string,
+    toolUseId: string,
+    toolName: string,
+    toolInput: string,
+    agentSlug?: string,
+  ): Promise<void> {
+    try {
+      const method = toolName.replace('mcp__browser__browser_', '')
+
+      let params: Record<string, unknown>
+      try {
+        params = toolInput.trim() ? JSON.parse(toolInput) : {}
+      } catch {
+        console.error('[MessagePersister] Failed to parse browser use request:', toolInput)
+        return
+      }
+
+      const { getRequiredBrowserPermissionLevel, extractDomainFromUrl, DOMAIN_SCOPED_LEVELS } = await import('@shared/lib/browser-use/types')
+      const permissionLevel = getRequiredBrowserPermissionLevel(method)
+
+      // Resolve domain for domain-scoped levels
+      let domain: string | undefined
+      if (DOMAIN_SCOPED_LEVELS.has(permissionLevel)) {
+        if (method === 'open' && params.url && typeof params.url === 'string') {
+          domain = extractDomainFromUrl(params.url)
+        } else {
+          domain = await this.getBrowserCurrentDomain(sessionId, extractDomainFromUrl)
+        }
+      }
+
+      // Check cached permissions
+      if (agentSlug) {
+        const { browserUsePermissionManager } = await import('@shared/lib/browser-use/permission-manager')
+        if (browserUsePermissionManager.checkPermission(agentSlug, permissionLevel, domain) === 'granted') {
+          this.autoApproveBrowserUseRequest(sessionId, agentSlug, toolUseId, permissionLevel, domain)
+          return
+        }
+      }
+
+      // Permission needed — track and broadcast to UI for user approval
+      const state = this.streamingStates.get(sessionId)
+      if (state && !state.pendingBrowserUseRequests.has(toolUseId)) {
+        state.pendingBrowserUseRequests.set(toolUseId, { toolUseId, method, params, permissionLevel, domain, agentSlug })
+      }
+      this.markSessionAwaitingInput(sessionId)
+
+      this.broadcastToSSE(sessionId, {
+        type: 'browser_use_request',
+        toolUseId, method, params, permissionLevel, domain, agentSlug,
+      })
+
+      if (agentSlug && !this.hasActiveViewers(sessionId)) {
+        notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'browser_use').catch(() => {})
+      }
+    } catch (error) {
+      console.error('[MessagePersister] Error handling browser use request:', error)
+    }
+  }
+
+  /** Get the current page domain from the container's browser. */
+  private async getBrowserCurrentDomain(
+    sessionId: string,
+    extractDomainFromUrl: (url: string) => string | undefined,
+  ): Promise<string | undefined> {
+    try {
+      const client = this.containerClients.get(sessionId)
+      if (!client) return undefined
+
+      const statusResponse = await client.fetch('/browser/status')
+      if (!statusResponse.ok) return undefined
+      const browserStatus = await statusResponse.json() as { active?: boolean; sessionId?: string }
+      if (!browserStatus.active || !browserStatus.sessionId) return undefined
+
+      const urlResponse = await client.fetch('/browser/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: browserStatus.sessionId, command: 'get url' }),
+      })
+      if (!urlResponse.ok) return undefined
+
+      const urlData = await urlResponse.json() as { output?: string }
+      const currentUrl = urlData.output ? String(urlData.output).trim() : undefined
+      return currentUrl ? extractDomainFromUrl(currentUrl) : undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  /** Auto-approve a browser use request when permission is already cached. */
+  private async autoApproveBrowserUseRequest(
+    sessionId: string,
+    agentSlug: string,
+    toolUseId: string,
+    permissionLevel: string,
+    domain?: string,
+  ): Promise<void> {
+    try {
+      const client = this.containerClients.get(sessionId)
+      if (!client) return
+
+      const resolveResponse = await client.fetch(
+        `/inputs/${encodeURIComponent(toolUseId)}/resolve`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ value: 'approved' }),
+        }
+      )
+      if (!resolveResponse.ok) return
+
+      const { browserUsePermissionManager } = await import('@shared/lib/browser-use/permission-manager')
+      browserUsePermissionManager.consumeOnceGrant(agentSlug, permissionLevel as Parameters<typeof browserUsePermissionManager.consumeOnceGrant>[1], domain)
+    } catch (error) {
+      console.error('[MessagePersister] Error auto-approving browser use request:', error)
     }
   }
 

--- a/src/shared/lib/notifications/notification-manager.ts
+++ b/src/shared/lib/notifications/notification-manager.ts
@@ -125,7 +125,7 @@ class NotificationManager {
   async triggerSessionWaitingInput(
     sessionId: string,
     agentSlug: string,
-    waitingFor: 'secret' | 'connected_account' | 'question' | 'file' | 'remote_mcp' | 'browser_input' | 'script_run' | 'computer_use',
+    waitingFor: 'secret' | 'connected_account' | 'question' | 'file' | 'remote_mcp' | 'browser_input' | 'script_run' | 'computer_use' | 'browser_use',
     agentName?: string
   ): Promise<void> {
     const displayName = agentName || await this.getAgentDisplayName(agentSlug)
@@ -154,6 +154,9 @@ class NotificationManager {
         break
       case 'computer_use':
         waitingMessage = 'wants to control your computer'
+        break
+      case 'browser_use':
+        waitingMessage = 'wants to use the browser'
         break
     }
 

--- a/src/shared/lib/permissions/base-permission-manager.ts
+++ b/src/shared/lib/permissions/base-permission-manager.ts
@@ -1,0 +1,143 @@
+/**
+ * BasePermissionManager
+ *
+ * Shared logic for per-agent permission management with three grant types:
+ * - "once": in-memory only, consumed after single use
+ * - "timed": in-memory with 15-min expiry
+ * - "always": persisted to settings.json + in-memory
+ *
+ * Subclasses implement grant matching and settings serialization.
+ */
+
+import type { PermissionGrant, PermissionGrantType } from './types'
+import { TIMED_GRANT_DURATION_MS } from './types'
+
+export abstract class BasePermissionManager<TLevel extends string> {
+  protected grants = new Map<string, PermissionGrant<TLevel>[]>()
+  protected loaded = false
+
+  constructor(protected readonly logPrefix: string) {}
+
+  protected ensureLoaded(): void {
+    if (!this.loaded) {
+      this.loaded = true
+      this.loadFromSettings()
+    }
+  }
+
+  checkPermission(
+    agentSlug: string,
+    level: TLevel,
+    scope?: string,
+  ): 'granted' | 'prompt_needed' {
+    this.ensureLoaded()
+    const agentGrants = this.grants.get(agentSlug)
+    if (!agentGrants) return 'prompt_needed'
+
+    const now = Date.now()
+    for (const grant of agentGrants) {
+      if (!this.grantMatches(grant, level, scope)) continue
+      if (grant.grantType === 'timed' && grant.expiresAt && grant.expiresAt < now) continue
+      return 'granted'
+    }
+
+    return 'prompt_needed'
+  }
+
+  grantPermission(
+    agentSlug: string,
+    level: TLevel,
+    grantType: PermissionGrantType,
+    scope?: string,
+  ): void {
+    this.ensureLoaded()
+    const now = Date.now()
+    const grant: PermissionGrant<TLevel> = {
+      level,
+      grantType,
+      grantedAt: now,
+      ...(scope && { scope }),
+      ...(grantType === 'timed' && { expiresAt: now + TIMED_GRANT_DURATION_MS }),
+    }
+
+    if (!this.grants.has(agentSlug)) {
+      this.grants.set(agentSlug, [])
+    }
+
+    if (grantType !== 'once') {
+      this.removeMatchingGrants(agentSlug, level, scope)
+    }
+
+    this.grants.get(agentSlug)!.push(grant)
+    console.log(`[${this.logPrefix}] Granted ${grantType} ${level}${scope ? ` for ${scope}` : ''} to ${agentSlug}`)
+
+    if (grantType === 'always') {
+      this.persistToSettings()
+    }
+  }
+
+  consumeOnceGrant(
+    agentSlug: string,
+    level: TLevel,
+    scope?: string,
+  ): void {
+    const agentGrants = this.grants.get(agentSlug)
+    if (!agentGrants) return
+
+    const idx = agentGrants.findIndex(
+      (g) => g.grantType === 'once' && this.grantMatches(g, level, scope),
+    )
+    if (idx >= 0) {
+      agentGrants.splice(idx, 1)
+    }
+  }
+
+  revokeAllForAgent(agentSlug: string): void {
+    this.grants.delete(agentSlug)
+    this.persistToSettings()
+  }
+
+  revokeGrant(
+    agentSlug: string,
+    level: TLevel,
+    scope?: string,
+  ): void {
+    this.removeMatchingGrants(agentSlug, level, scope)
+    this.persistToSettings()
+  }
+
+  getGrantsForAgent(agentSlug: string): PermissionGrant<TLevel>[] {
+    this.ensureLoaded()
+    const agentGrants = this.grants.get(agentSlug)
+    if (!agentGrants) return []
+
+    const now = Date.now()
+    return agentGrants.filter((g) => {
+      if (g.grantType === 'timed' && g.expiresAt && g.expiresAt < now) return false
+      return true
+    })
+  }
+
+  // --- Abstract methods ---
+
+  protected abstract grantMatches(
+    grant: PermissionGrant<TLevel>,
+    level: TLevel,
+    scope?: string,
+  ): boolean
+
+  abstract loadFromSettings(): void
+  abstract persistToSettings(): void
+
+  // --- Private helpers ---
+
+  private removeMatchingGrants(
+    agentSlug: string,
+    level: TLevel,
+    scope?: string,
+  ): void {
+    const agentGrants = this.grants.get(agentSlug)
+    if (!agentGrants) return
+    this.grants.set(agentSlug, agentGrants.filter((g) => !this.grantMatches(g, level, scope)))
+  }
+}

--- a/src/shared/lib/permissions/types.ts
+++ b/src/shared/lib/permissions/types.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared Permission Types
+ *
+ * Common types used by both computer use and browser use permission systems.
+ */
+
+export type PermissionGrantType = 'once' | 'timed' | 'always'
+
+/** Duration of "timed" permission grants in milliseconds (15 minutes) */
+export const TIMED_GRANT_DURATION_MS = 15 * 60 * 1000
+
+export interface PermissionGrant<TLevel extends string> {
+  level: TLevel
+  /** Scope identifier — appName for computer use, domain for browser use */
+  scope?: string
+  grantType: PermissionGrantType
+  grantedAt: number
+  /** Only for 'timed' grants */
+  expiresAt?: number
+}


### PR DESCRIPTION
Add domain-scoped permission prompts for browser tools, mirroring the existing computer use permission flow. Agents must now request approval before using browser tools (read, interact, navigate, manage).

- Extract shared BasePermissionManager from ComputerUsePermissionManager
- Add BrowserUsePermissionManager with subdomain matching
- Add browser_use_request SSE events and approval API route
- Modify agent-container browser tools to block via InputManager
- Add shared PermissionRequestCard component used by both systems
- Add BrowserUsePermissionsSection to settings UI