### PR TITLE
fix: preserve local Composio API key when connected to Platform

### DIFF
--- a/src/renderer/components/settings/composio-tab.tsx
+++ b/src/renderer/components/settings/composio-tab.tsx
@@ -47,29 +47,7 @@ export function ComposioTab() {
     }
   }
 
-  if (isPlatformConnected) {
-    return (
-      <div className="space-y-6">
-        <div>
-          <h3 className="text-sm font-medium">Composio Integration</h3>
-          <p className="text-xs text-muted-foreground mt-1">
-            Configure the Composio account provider for OAuth connections (Gmail, Slack, GitHub, etc.).
-          </p>
-        </div>
-
-        <div className="flex items-center gap-2">
-          <span className="text-xs px-2 py-0.5 rounded-full bg-green-500/10 text-green-700 dark:text-green-400">
-            Connected via Platform
-          </span>
-        </div>
-
-        <p className="text-sm text-muted-foreground">
-          Composio is managed by your organization on the platform.
-          {platformAuth?.orgName && <> ({platformAuth.orgName})</>}
-        </p>
-      </div>
-    )
-  }
+  const hasLocalComposioKey = settings?.apiKeyStatus?.composio?.isConfigured ?? false
 
   return (
     <div className="space-y-6">
@@ -79,6 +57,27 @@ export function ComposioTab() {
           Configure the Composio account provider for OAuth connections (Gmail, Slack, GitHub, etc.).
         </p>
       </div>
+
+      {isPlatformConnected && (
+        <div className={`rounded-md border px-3 py-2 ${
+          hasLocalComposioKey
+            ? 'border-blue-200 bg-blue-50 dark:border-blue-900 dark:bg-blue-950/30'
+            : 'border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950/30'
+        }`}>
+          {hasLocalComposioKey ? (
+            <p className="text-xs text-blue-700 dark:text-blue-400">
+              Using your local Composio API key. Your existing OAuth connections are preserved.
+              Remove the key below to switch to platform-managed Composio.
+            </p>
+          ) : (
+            <p className="text-xs text-green-700 dark:text-green-400">
+              Composio is managed by your organization on the platform.
+              {platformAuth?.orgName && <> ({platformAuth.orgName})</>}
+              {' '}Set your own API key below to use a personal Composio account instead.
+            </p>
+          )}
+        </div>
+      )}
 
       <ComposioApiKeyInput disabled={isLoading} />
 

--- a/src/shared/lib/composio/client.ts
+++ b/src/shared/lib/composio/client.ts
@@ -38,11 +38,16 @@ function getPlatformComposioToken(): string | null {
 /**
  * Make a request to the Composio API.
  */
+function shouldUseLocalComposioKey(): boolean {
+  return Boolean(getEffectiveComposioApiKey())
+}
+
 async function composioFetch<T>(
   endpoint: string,
   options: RequestInit = {}
 ): Promise<T> {
-  const platformToken = getPlatformComposioToken()
+  const localApiKey = getEffectiveComposioApiKey()
+  const platformToken = localApiKey ? null : getPlatformComposioToken()
   const headers = new Headers(options.headers)
   headers.set('Content-Type', 'application/json')
 
@@ -51,13 +56,11 @@ async function composioFetch<T>(
     url = `${getPlatformComposioBaseUrl()}${endpoint}`
     headers.set('Authorization', `Bearer ${platformToken}`)
     headers.delete('x-api-key')
-  } else {
-    const apiKey = getEffectiveComposioApiKey()
-    if (!apiKey) {
-      throw new ComposioApiError('Composio API key is not configured', 401)
-    }
+  } else if (localApiKey) {
     url = `${COMPOSIO_BASE_URL}${endpoint}`
-    headers.set('x-api-key', apiKey)
+    headers.set('x-api-key', localApiKey)
+  } else {
+    throw new ComposioApiError('Composio API key is not configured', 401)
   }
 
   const response = await fetch(url, {
@@ -235,9 +238,9 @@ export async function listConnections(
   toolkit?: string,
   userIdOverride?: string
 ): Promise<ComposioConnection[]> {
-  const platformToken = getPlatformComposioToken()
+  const useLocal = shouldUseLocalComposioKey()
   let endpoint = '/connected_accounts'
-  if (!platformToken) {
+  if (useLocal || !getPlatformComposioToken()) {
     const userId = userIdOverride || getComposioUserId()
     if (!userId) {
       throw new ComposioApiError('Composio User ID is not configured', 401)
@@ -271,9 +274,10 @@ export async function initiateConnection(
   callbackUrl: string,
   userIdOverride?: string
 ): Promise<InitiateConnectionResponse> {
-  const platformToken = getPlatformComposioToken()
-  const userId = platformToken ? null : (userIdOverride || getComposioUserId())
-  if (!platformToken && !userId) {
+  const useLocal = shouldUseLocalComposioKey()
+  const needsUserId = useLocal || !getPlatformComposioToken()
+  const userId = needsUserId ? (userIdOverride || getComposioUserId()) : null
+  if (needsUserId && !userId) {
     throw new ComposioApiError('Composio User ID is not configured', 401)
   }
 


### PR DESCRIPTION
## Summary
- Local Composio API key now takes priority over Platform proxy, so existing users' OAuth connections (Gmail, Slack, GitHub, etc.) are not disrupted when they connect to Platform
- Settings UI always shows the Composio API key input — no longer hidden behind "Connected via Platform" screen
- Status banner indicates whether local key or Platform-managed Composio is active, with guidance on how to switch

## Changes
- `src/shared/lib/composio/client.ts`: `composioFetch`, `listConnections`, `initiateConnection` all check for local key first
- `src/renderer/components/settings/composio-tab.tsx`: removed early-return that hid the config UI when Platform was connected

## Test plan
- [ ] Connect to Platform **without** a local Composio key → should show green banner "managed by platform" + API key input visible
- [ ] Connect to Platform **with** an existing local Composio key → should show blue banner "using your local key" + existing OAuth connections still work
- [ ] Add a local Composio key while connected to Platform → Composio requests should go direct (not through proxy)
- [ ] Remove local Composio key while connected to Platform → should fall back to Platform proxy
- [ ] Without Platform connection, Composio settings page works as before

Made with [Cursor](https://cursor.com)