### PR TITLE
Enforce consistent language guidelines across approval/request cards

### DIFF
--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -361,6 +361,30 @@ The computer-use agent:
 - Menu actions (`computer_menu("File > Save")`) are often more reliable than clicking toolbar buttons
 - Always ungrab the app window when you're done to remove the halo and free resources - only keep it after responding if you are still mid task (like waiting for user input or in the middle of a multi-step interaction)
 
+## Language Guidelines for User-Facing Requests
+
+When using request tools (request_secret, request_file, request_connected_account, request_browser_input, request_script_run, request_remote_mcp), follow these rules for the reason/explanation/message/description text:
+
+1. **Always phrase as a question ending with "?"** The text is shown to the user as a confirmation prompt.
+
+2. **Never use first person.** Do not write "I need", "I want", "I'm going to". Use "the agent" if you need a subject.
+   - BAD: "I need your GitHub token to access the repository"
+   - GOOD: "Add GITHUB_TOKEN so the agent can read pull request data?"
+
+3. **Be concise.** One sentence. No greetings, no "please", no "Hey!".
+
+4. **Focus on the 'why'.** Explain what will be accomplished, not the mechanical steps.
+   - BAD: "Need to call the Gmail API to list messages?"
+   - GOOD: "Allow access to Gmail to search for the invoice from last week?"
+
+5. **Use the framing pattern for each tool:**
+   - request_connected_account reason: "Allow access to {service} to {purpose}?"
+   - request_remote_mcp reason: "Allow access to {server} to {purpose}?"
+   - request_file description: "Upload your {file description} so the agent can {purpose}."
+   - request_secret reason: "Add {secretName} so the agent can {purpose}?"
+   - request_script_run explanation: "Allow {plain english description of what the script does}?"
+   - request_browser_input message: "Complete {what needs to be done} to {purpose}."
+
 ## Other Guidelines
 
 - Use UV to run Python code: `uv run --env-file .env --with <packages> script.py`

--- a/agent-container/src/tools/request-browser-input.ts
+++ b/agent-container/src/tools/request-browser-input.ts
@@ -13,7 +13,7 @@ Example:
 - requirements: ["Navigate to the login page", "Enter your credentials", "Complete 2FA if prompted"]`,
   {
     message: z.string().describe(
-      'Informal message explaining what you need the user to do (e.g., "Hey, I need you to enter your password")'
+      "A short statement describing what the user needs to do. Never use first person or greetings. Must end with a period. Example: 'Log in to the bank account to continue the data export.'"
     ),
     requirements: z.array(z.string()).default([]).describe(
       'Optional formal list of specific actions the user should complete'

--- a/agent-container/src/tools/request-connected-account.ts
+++ b/agent-container/src/tools/request-connected-account.ts
@@ -32,7 +32,7 @@ Common toolkits include gmail, slack, github, notion, linear, salesforce, and ma
       .string()
       .optional()
       .describe(
-        'Explain why you need access to this service - what you will use it for. This helps the user understand the request.'
+        "A question for the user following the pattern 'Allow access to {service} to {purpose}?'. Never use first person. Must end with '?'. Example: 'Allow access to Gmail to search for the shipping confirmation?'"
       ),
   },
   async (args) => {

--- a/agent-container/src/tools/request-file.ts
+++ b/agent-container/src/tools/request-file.ts
@@ -27,7 +27,7 @@ Example usage:
     description: z
       .string()
       .describe(
-        'Description of the file you need from the user (e.g., "Please upload the CSV file with sales data")'
+        "A short statement following the pattern 'Upload your {file description} so the agent can {purpose}.'. Never use first person. Must end with a period. Example: 'Upload your sales CSV so the agent can generate the quarterly report.'"
       ),
     fileTypes: z
       .string()

--- a/agent-container/src/tools/request-remote-mcp.ts
+++ b/agent-container/src/tools/request-remote-mcp.ts
@@ -28,7 +28,7 @@ Use this when you need to interact with an MCP server that hasn't been configure
     reason: z
       .string()
       .optional()
-      .describe('Explain why you need access to this MCP server'),
+      .describe("A question for the user following the pattern 'Allow access to {server} to {purpose}?'. Never use first person. Must end with '?'. Example: 'Allow access to Slack MCP to post the weekly summary?'"),
     authHint: z
       .enum(['oauth', 'bearer'])
       .optional()

--- a/agent-container/src/tools/request-script-run.ts
+++ b/agent-container/src/tools/request-script-run.ts
@@ -18,7 +18,7 @@ Examples:
 - PowerShell on Windows: scriptType "powershell", script: 'Get-Process | Select-Object -First 5'`,
   {
     script: z.string().describe('The script code to execute on the host machine'),
-    explanation: z.string().describe('A clear, human-readable explanation of what this script does and why'),
+    explanation: z.string().describe("A question for the user following the pattern 'Allow {what the script does}?'. Plain English, never use first person. Must end with '?'. Example: 'Allow opening the project URL in the default browser?'"),
     scriptType: z.enum(['applescript', 'shell', 'powershell']).describe(
       'The type of script to execute. Check HOST_PLATFORM env var: darwin → applescript or shell, win32 → powershell'
     ),

--- a/agent-container/src/tools/request-secret.ts
+++ b/agent-container/src/tools/request-secret.ts
@@ -31,7 +31,7 @@ Always check your available environment variables first (listed at the start of 
       .string()
       .optional()
       .describe(
-        'Explain why you need this secret - what you will use it for. This helps the user understand the request.'
+        "A question for the user following the pattern 'Add {secretName} so the agent can {purpose}?'. Never use first person. Must end with '?'. Example: 'Add GITHUB_TOKEN so the agent can authenticate with the GitHub API?'"
       ),
   },
   async (args) => {

--- a/src/renderer/components/dashboards/pending-agent-reviews.tsx
+++ b/src/renderer/components/dashboards/pending-agent-reviews.tsx
@@ -36,6 +36,7 @@ export function PendingAgentReviews({ agentSlug, readOnly, onReviewResolved }: P
           targetPath={review.targetPath}
           matchedScopes={review.matchedScopes}
           scopeDescriptions={review.scopeDescriptions}
+          displayText={review.displayText}
           agentSlug={agentSlug}
           readOnly={readOnly}
           onComplete={() => {

--- a/src/renderer/components/messages/browser-input-request-item.tsx
+++ b/src/renderer/components/messages/browser-input-request-item.tsx
@@ -102,7 +102,7 @@ export function BrowserInputRequestItem({
                 <>
                   <div className="pt-6 whitespace-pre-line text-sm font-medium leading-5 text-foreground">{message}</div>
                   <p className="pt-2 text-xs text-muted-foreground">
-                    Click &apos;Done&apos; when you have completed the suggested step(s).
+                    Click &apos;Done&apos; when you have completed the suggested steps.
                   </p>
                 </>
               ),
@@ -115,7 +115,7 @@ export function BrowserInputRequestItem({
     >
       <p className="pt-6 whitespace-pre-line text-sm font-medium leading-5 text-foreground">{message}</p>
       <p className="mt-2 text-xs text-muted-foreground">
-        Click &apos;Done&apos; when you have completed the suggested step(s).
+        Click &apos;Done&apos; when you have completed the suggested steps.
       </p>
 
       {requirements.length > 0 && (

--- a/src/renderer/components/messages/computer-use-request-item.tsx
+++ b/src/renderer/components/messages/computer-use-request-item.tsx
@@ -173,7 +173,7 @@ export function ComputerUseRequestItem({
     <RequestItemShell
       title="Computer Use Request"
       icon={<Monitor />}
-      theme="blue"
+      theme="orange"
       waitingText="Waiting for approval"
       error={error}
       data-testid={isCompleted ? 'computer-use-request-completed' : 'computer-use-request'}
@@ -237,7 +237,7 @@ export function ComputerUseRequestItem({
             onClick={() => handleApprove('timed')}
             loading={status === 'submitting'}
             size="sm"
-            className="min-w-28 rounded-r-none border-r-0 bg-blue-600 text-white hover:bg-blue-700"
+            className="min-w-28 rounded-r-none border-r-0 bg-orange-600 text-white hover:bg-orange-700"
             data-testid="computer-use-allow-timed-btn"
           >
             Allow 15 min
@@ -247,7 +247,7 @@ export function ComputerUseRequestItem({
               <Button
                 disabled={status === 'submitting'}
                 size="sm"
-                className="rounded-l-none border-l border-l-blue-500 bg-blue-600 px-1.5 text-white hover:bg-blue-700"
+                className="rounded-l-none border-l border-l-orange-500 bg-orange-600 px-1.5 text-white hover:bg-orange-700"
                 data-testid="computer-use-allow-timed-btn-chevron"
               >
                 <ChevronDown className="h-3.5 w-3.5" />

--- a/src/renderer/components/messages/proxy-review-request-item.tsx
+++ b/src/renderer/components/messages/proxy-review-request-item.tsx
@@ -16,6 +16,7 @@ interface ProxyReviewRequestItemProps {
   targetPath: string
   matchedScopes: string[]
   scopeDescriptions: Record<string, string>
+  displayText?: string
   agentSlug: string
   readOnly?: boolean
   onComplete: () => void
@@ -31,6 +32,7 @@ export function ProxyReviewRequestItem({
   targetPath,
   matchedScopes,
   scopeDescriptions,
+  displayText,
   agentSlug,
   readOnly,
   onComplete,
@@ -156,8 +158,15 @@ export function ProxyReviewRequestItem({
       data-testid={isCompleted ? 'proxy-review-completed' : 'proxy-review-request'}
       data-status={isCompleted ? status : undefined}
     >
+      {/* Display text (human-readable description of the request) */}
+      {displayText && (
+        <p className="mt-6 whitespace-pre-line text-sm font-medium leading-5 text-foreground">
+          {displayText}
+        </p>
+      )}
+
       {/* Code block showing method/path + toolkit */}
-      <div className="mt-5">
+      <div className={displayText ? 'mt-3' : 'mt-5'}>
         <div className="rounded-md border border-border bg-white px-3 py-2 dark:bg-background">
           <span className="mr-2 inline-flex h-7 items-center rounded-md bg-muted px-2.5 text-xs font-medium text-foreground/80 capitalize">
             {toolkit}

--- a/src/renderer/components/messages/secret-request-item.tsx
+++ b/src/renderer/components/messages/secret-request-item.tsx
@@ -28,12 +28,7 @@ function formatSecretReason(secretName: string, reason: string): string {
     return `Provide ${secretName}`
   }
 
-  const normalizedReason =
-    trimmedReason[0] === trimmedReason[0]?.toUpperCase()
-      ? trimmedReason[0].toLowerCase() + trimmedReason.slice(1)
-      : trimmedReason
-
-  return `Provide ${secretName} ${normalizedReason}`
+  return trimmedReason
 }
 
 export function SecretRequestItem({

--- a/src/renderer/hooks/use-proxy-reviews.ts
+++ b/src/renderer/hooks/use-proxy-reviews.ts
@@ -10,6 +10,7 @@ export interface PendingReview {
   targetPath: string
   matchedScopes: string[]
   scopeDescriptions: Record<string, string>
+  displayText?: string
 }
 
 export function usePendingProxyReviews(agentSlug: string) {

--- a/src/shared/lib/proxy/review-manager.ts
+++ b/src/shared/lib/proxy/review-manager.ts
@@ -13,6 +13,62 @@ export interface ReviewDetails {
   scopeDescriptions: Record<string, string>
 }
 
+/**
+ * Convert a snake_case or kebab-case tool/action name into a gerund phrase.
+ * e.g. "list_meetings" → "listing meetings", "get_user_profile" → "getting user profile",
+ *      "send_message" → "sending message", "search_contacts" → "searching contacts"
+ */
+function humanizeActionName(name: string): string {
+  const words = name.replace(/[_-]/g, ' ').trim().split(' ')
+  if (words.length === 0) return name
+
+  // Convert first word (the verb) to gerund form
+  const verb = words[0]
+  let gerund: string
+  if (verb.endsWith('e') && !verb.endsWith('ee')) {
+    gerund = verb.slice(0, -1) + 'ing' // e.g. "create" → "creating"
+  } else if (/^[a-z]+[bcdfghlmnprstvwz]$/.test(verb) && verb.length <= 4) {
+    gerund = verb + verb[verb.length - 1] + 'ing' // e.g. "get" → "getting"
+  } else {
+    gerund = verb + 'ing' // e.g. "list" → "listing", "search" → "searching"
+  }
+
+  return [gerund, ...words.slice(1)].join(' ')
+}
+
+/**
+ * Generate a human-readable display text for a proxy review request.
+ * Uses scope descriptions when available, otherwise builds from the
+ * structured fields — with special handling for MCP tool call paths.
+ */
+export function generateReviewDisplayText(
+  toolkit: string,
+  method: string,
+  targetPath: string,
+  scopeDescriptions: Record<string, string>
+): string {
+  // Use the first scope description if available — it's usually the best
+  // human-readable summary of what the request does.
+  const descriptions = Object.values(scopeDescriptions)
+  if (descriptions.length > 0) {
+    const desc = descriptions[0]
+    // Ensure it ends with '?'
+    return desc.endsWith('?') ? desc : `Allow ${desc.charAt(0).toLowerCase()}${desc.slice(1)}?`
+  }
+
+  const toolkitDisplay = toolkit.charAt(0).toUpperCase() + toolkit.slice(1)
+
+  // MCP tool call pattern: "tools/call: <tool_name>" or "tools/call:<tool_name>"
+  const mcpMatch = targetPath.match(/tools\/call:\s*(.+)/)
+  if (mcpMatch) {
+    const action = humanizeActionName(mcpMatch[1])
+    return `Allow ${action} via ${toolkitDisplay}?`
+  }
+
+  // Fallback: generic description using toolkit name
+  return `Allow ${method} request to ${toolkitDisplay}?`
+}
+
 interface PendingReview {
   id: string
   details: ReviewDetails
@@ -54,6 +110,13 @@ export class ReviewManager {
 
       this.pending.set(id, { id, details, resolve, reject, timer })
 
+      const displayText = generateReviewDisplayText(
+        details.toolkit,
+        details.method,
+        details.targetPath,
+        details.scopeDescriptions
+      )
+
       // Broadcast review request to agent's active sessions
       broadcastReview(details.agentSlug, {
         type: 'proxy_review_request',
@@ -64,6 +127,7 @@ export class ReviewManager {
         targetPath: details.targetPath,
         matchedScopes: details.matchedScopes,
         scopeDescriptions: details.scopeDescriptions,
+        displayText,
       })
     })
   }
@@ -111,11 +175,17 @@ export class ReviewManager {
 
   getPendingReviewsForAgent(
     agentSlug: string
-  ): Array<{ id: string } & ReviewDetails> {
-    const results: Array<{ id: string } & ReviewDetails> = []
+  ): Array<{ id: string; displayText: string } & ReviewDetails> {
+    const results: Array<{ id: string; displayText: string } & ReviewDetails> = []
     for (const review of this.pending.values()) {
       if (review.details.agentSlug === agentSlug) {
-        results.push({ id: review.id, ...review.details })
+        const displayText = generateReviewDisplayText(
+          review.details.toolkit,
+          review.details.method,
+          review.details.targetPath,
+          review.details.scopeDescriptions
+        )
+        results.push({ id: review.id, displayText, ...review.details })
       }
     }
     return results


### PR DESCRIPTION
## Summary
- Add language guidelines to the system prompt and update all 6 tool parameter descriptions to guide the LLM toward consistent, third-person, question-formatted body text (no first person, no greetings, concise)
- Add `displayText` to proxy review cards — generates human-readable text from structured API data (e.g. "Allow listing meetings via Granola?" instead of raw method/path)
- Remove hardcoded "Provide {secretName}" prefix from secret card so LLM-generated text displays directly
- Switch computer use card to orange theme (header + buttons)
- Fix "step(s)" → "steps" on browser input card

## Test plan
- [ ] Rebuild agent container (`npm run build:container`) and start a new session
- [ ] Trigger connected account, secret, file, script, and MCP requests — verify body text ends with `?`, uses no first person
- [ ] Trigger a proxy review (e.g. via Granola MCP call) — verify displayText renders above the method/path code block
- [ ] Verify computer use card renders with orange theme and orange buttons
- [ ] Verify browser input card says "steps" not "step(s)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)