### PR TITLE
fix: restore active timer on reconnect

### DIFF
--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -149,6 +149,44 @@ describe('useMessageStream', () => {
     expect(result.current.activeStartTime).not.toBeNull()
   })
 
+  it('sets activeStartTime on connected when session is already active (page refresh recovery)', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    const before = Date.now()
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'connected',
+        isActive: true,
+      })
+    })
+
+    expect(result.current.isActive).toBe(true)
+    expect(result.current.activeStartTime).not.toBeNull()
+    expect(result.current.activeStartTime).toBeGreaterThanOrEqual(before)
+  })
+
+  it('does not set activeStartTime on connected when session is inactive', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'connected',
+        isActive: false,
+      })
+    })
+
+    expect(result.current.isActive).toBe(false)
+    expect(result.current.activeStartTime).toBeNull()
+  })
+
   it('handles streaming: stream_start → stream_delta → stream_end', async () => {
     const { useMessageStream } = await getHookModule()
     const { result } = renderHook(

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -180,7 +180,7 @@ function getOrCreateEventSource(
           browserActive: current?.browserActive ?? false,
           computerUseApp: current?.computerUseApp ?? null,
           computerUseAppIcon: current?.computerUseAppIcon ?? null,
-          activeStartTime: current?.activeStartTime ?? null,
+          activeStartTime: current?.activeStartTime ?? (data.isActive ? Date.now() : null),
           isCompacting: current?.isCompacting ?? false,
           contextUsage: current?.contextUsage ?? null,
           activeSubagents: current?.activeSubagents ?? [],


### PR DESCRIPTION
## Summary
- restore `activeStartTime` when an already-active session reconnects so the Working timer does not fall back to stale message timestamps
- keep inactive reconnects unchanged and add regression coverage for both reconnect paths
- verify the message stream hook and activity indicator tests still pass

## Test plan
- [x] `npx vitest run src/renderer/hooks/use-message-stream.test.ts`
- [x] `npx vitest run src/renderer/components/messages/agent-activity-indicator.test.tsx`

Made with [Cursor](https://cursor.com)