### PR TITLE
Polish browser preview drawer UI

### DIFF
--- a/src/renderer/components/browser/browser-drawer-panel.tsx
+++ b/src/renderer/components/browser/browser-drawer-panel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { Globe, MousePointerClick, PanelRightClose, PanelRightOpen, Pause, Play, Square, Expand, Shrink } from 'lucide-react'
+import { Eye, EyeOff, Globe, MousePointerClick, PanelRightClose, PanelRightOpen, Pause, Play, Square, Expand, Shrink } from 'lucide-react'
 import { BrowserActivityLog } from './browser-activity-log'
 import { BrowserTabBar } from './browser-tab-bar'
 import { useBrowserStream } from '@renderer/hooks/use-browser-stream'
@@ -8,6 +8,7 @@ import { apiFetch } from '@renderer/lib/api'
 import { removeBrowserInputRequest } from '@renderer/hooks/use-message-stream'
 import { cn } from '@shared/lib/utils/cn'
 import { useSidebar } from '@renderer/components/ui/sidebar'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -215,7 +216,7 @@ export function BrowserDrawerPanel({
     <>
       <div
         className={cn(
-          'h-full border-l bg-background flex flex-col shrink-0 overflow-hidden relative shadow-[-4px_0_16px_rgba(0,0,0,0.08)] dark:shadow-[-4px_0_16px_rgba(0,0,0,0.3)]',
+          'h-full border-l bg-background flex flex-col shrink-0 overflow-hidden relative px-1 shadow-[-4px_0_16px_rgba(0,0,0,0.08)] dark:shadow-[-4px_0_16px_rgba(0,0,0,0.3)]',
           !isResizing && 'transition-[width] duration-300 ease-in-out'
         )}
         style={{ width: isOpen ? drawerWidth : 0, contain: 'layout paint', willChange: 'transform' }}
@@ -257,21 +258,23 @@ export function BrowserDrawerPanel({
           </button>
         </div>
 
-        {/* Tab bar — shown when any tabs are reported */}
-        {stream.tabs.length >= 1 && (
-          <BrowserTabBar
-            tabs={stream.tabs}
-            viewingTargetId={stream.viewingTargetId}
-            autoFollow={stream.autoFollow}
-            loading={stream.pageLoading}
-            onTabClick={stream.handleTabClick}
-            onCloseTab={stream.handleCloseTab}
-            onToggleAutoFollow={stream.toggleAutoFollow}
-          />
-        )}
+        {/* Browser container — tab bar + canvas viewport */}
+        <div className="shrink-0 rounded-lg border border-border overflow-hidden">
+          {/* Tab bar — shown when any tabs are reported */}
+          {stream.tabs.length >= 1 && (
+            <BrowserTabBar
+              tabs={stream.tabs}
+              viewingTargetId={stream.viewingTargetId}
+              autoFollow={stream.autoFollow}
+              loading={stream.pageLoading}
+              onTabClick={stream.handleTabClick}
+              onCloseTab={stream.handleCloseTab}
+              onToggleAutoFollow={stream.toggleAutoFollow}
+            />
+          )}
 
-        {/* Canvas viewport — full width, edge-to-edge. Glow only when agent is actively working */}
-        <div className={cn('relative shrink-0 overflow-hidden bg-black border-y border-border/40', isActive && !stream.needsAttention && 'browser-glow-container')}>
+          {/* Canvas viewport */}
+          <div className={cn('relative overflow-hidden bg-black', isActive && !stream.needsAttention && 'browser-glow-container')}>
           <canvas
             ref={canvasRef}
             className={`w-full block ${stream.isViewOnly ? 'cursor-not-allowed' : 'cursor-default'}`}
@@ -316,46 +319,61 @@ export function BrowserDrawerPanel({
           )}
 
         </div>
+        </div>
 
         {/* Browser controls pill — sticky to bottom of drawer, always visible */}
         <div className="sticky bottom-2 z-20 flex justify-center pointer-events-none shrink-0 -mt-10">
-          <div className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-background px-2 py-1 shadow-md pointer-events-auto">
-            {(isPaused || (isActive && !stream.needsAttention)) && (
-              <button
-                className="p-1.5 rounded-full hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-                onClick={handlePauseResume}
-                title={isPaused ? 'Resume' : 'Pause'}
-              >
-                {isPaused ? <Play className="h-3.5 w-3.5 fill-current" /> : <Pause className="h-3.5 w-3.5 fill-current" />}
-              </button>
-            )}
-            <button
-              className="p-1.5 rounded-full hover:bg-muted transition-colors text-red-500 hover:text-red-600"
-              onClick={stream.handleCloseClick}
-              title="Stop browser"
-            >
-              <Square className="h-3.5 w-3.5 fill-current" />
-            </button>
-            <button
-              className="p-1.5 rounded-full hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-              onClick={() => {
-                if (isExpanded) {
-                  setDrawerWidth(preExpandWidthRef.current ?? DEFAULT_DRAWER_WIDTH)
-                  if (sidebarWasOpenRef.current) setSidebarOpen(true)
-                  setIsExpanded(false)
-                } else {
-                  preExpandWidthRef.current = drawerWidth
-                  sidebarWasOpenRef.current = sidebarOpen
-                  setDrawerWidth(MAX_DRAWER_WIDTH)
-                  setSidebarOpen(false)
-                  setIsExpanded(true)
-                }
-              }}
-              title={isExpanded ? 'Collapse' : 'Expand'}
-            >
-              {isExpanded ? <Shrink className="h-3.5 w-3.5" /> : <Expand className="h-3.5 w-3.5" />}
-            </button>
-          </div>
+          <TooltipProvider delayDuration={300}>
+            <div className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-background px-2 py-1 shadow-md pointer-events-auto">
+              {(isPaused || (isActive && !stream.needsAttention)) && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      className="p-1.5 rounded-full hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
+                      onClick={handlePauseResume}
+                    >
+                      {isPaused ? <Play className="h-3.5 w-3.5 fill-current" /> : <Pause className="h-3.5 w-3.5 fill-current" />}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">{isPaused ? 'Resume Browser' : 'Pause Browser'}</TooltipContent>
+                </Tooltip>
+              )}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    className="p-1.5 rounded-full hover:bg-muted transition-colors text-red-500 hover:text-red-600"
+                    onClick={stream.handleCloseClick}
+                  >
+                    <Square className="h-3.5 w-3.5 fill-current" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top">Stop Browser</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    className="p-1.5 rounded-full hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
+                    onClick={() => {
+                      if (isExpanded) {
+                        setDrawerWidth(preExpandWidthRef.current ?? DEFAULT_DRAWER_WIDTH)
+                        if (sidebarWasOpenRef.current) setSidebarOpen(true)
+                        setIsExpanded(false)
+                      } else {
+                        preExpandWidthRef.current = drawerWidth
+                        sidebarWasOpenRef.current = sidebarOpen
+                        setDrawerWidth(MAX_DRAWER_WIDTH)
+                        setSidebarOpen(false)
+                        setIsExpanded(true)
+                      }
+                    }}
+                  >
+                    {isExpanded ? <Shrink className="h-3.5 w-3.5" /> : <Expand className="h-3.5 w-3.5" />}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top">{isExpanded ? 'Collapse' : 'Expand'}</TooltipContent>
+              </Tooltip>
+            </div>
+          </TooltipProvider>
         </div>
 
         {/* Action bar — shown when browser input is needed */}
@@ -390,7 +408,7 @@ export function BrowserDrawerPanel({
 
         {/* Activity log */}
         <div className="flex items-center gap-1 py-1.5 border-b shrink-0 mx-4 mt-4">
-          <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Activity</span>
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Browser Activity</span>
         </div>
         <BrowserActivityLog sessionId={sessionId} agentSlug={agentSlug} />
       </div>

--- a/src/renderer/components/browser/browser-tab-bar.tsx
+++ b/src/renderer/components/browser/browser-tab-bar.tsx
@@ -1,5 +1,6 @@
-import { Eye, EyeOff, Loader2 } from 'lucide-react'
+import { Eye, EyeOff, Loader2, Lock } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -28,7 +29,8 @@ interface BrowserTabBarProps {
 
 export function BrowserTabBar({ tabs, viewingTargetId, autoFollow, loading, onTabClick, onCloseTab, onToggleAutoFollow }: BrowserTabBarProps) {
   return (
-    <div className="flex items-center gap-0.5 px-1.5 py-1 bg-muted/30 border-b overflow-x-auto shrink-0" style={{ height: 30 }}>
+    <>
+    <div className="flex items-center gap-1 px-1 pt-1.5 pb-0.5 overflow-x-auto shrink-0 bg-white dark:bg-muted" style={{ height: 30 }}>
       {tabs.map((tab) => {
         const isViewing = tab.targetId === viewingTargetId
         const isAgentActive = tab.active
@@ -38,16 +40,26 @@ export function BrowserTabBar({ tabs, viewingTargetId, autoFollow, loading, onTa
             <ContextMenuTrigger asChild>
               <button
                 className={cn(
-                  'relative flex items-center gap-1 px-2 py-1 rounded text-[11px] leading-tight max-w-[120px] truncate transition-colors',
-                  isViewing ? 'bg-background shadow-sm text-foreground' : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+                  'relative flex items-center gap-1 px-2 py-1 text-[11px] leading-tight max-w-[200px] truncate transition-colors',
+                  isViewing
+                    ? 'bg-background text-foreground font-medium rounded-full shadow-sm border border-border/60'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-muted/60 rounded-full',
                 )}
                 onClick={() => onTabClick(tab.targetId)}
                 title={tab.title || tab.url}
               >
-                <span className="truncate">{tab.title || tab.url || `Tab ${tab.index + 1}`}</span>
                 {isAgentActive && (
-                  <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-blue-500 shrink-0" />
+                  <span className="relative flex items-center justify-center h-3 w-3 shrink-0">
+                    {loading && (
+                      <span className="absolute inset-0 dual-arc-spinner" />
+                    )}
+                    <span className={cn(
+                      'rounded-full h-1.5 w-1.5 bg-blue-500',
+                      !loading && 'animate-pulse'
+                    )} />
+                  </span>
                 )}
+                <span className="truncate">{tab.title || tab.url || `Tab ${tab.index + 1}`}</span>
               </button>
             </ContextMenuTrigger>
             <ContextMenuContent>
@@ -61,20 +73,34 @@ export function BrowserTabBar({ tabs, viewingTargetId, autoFollow, loading, onTa
           </ContextMenu>
         )
       })}
-      {loading && (
-        <Loader2 className="h-3 w-3 animate-spin text-muted-foreground shrink-0 ml-auto" />
-      )}
-      <button
-        className={cn(
-          loading ? '' : 'ml-auto',
-          'p-0.5 rounded transition-colors shrink-0',
-          autoFollow ? 'text-blue-500 hover:text-blue-600' : 'text-muted-foreground hover:text-foreground'
-        )}
-        onClick={onToggleAutoFollow}
-        title={autoFollow ? 'Auto-following agent (click to pin)' : 'Not following agent (click to follow)'}
-      >
-        {autoFollow ? <Eye className="h-3 w-3" /> : <EyeOff className="h-3 w-3" />}
-      </button>
     </div>
+    {/* URL bar */}
+    {(() => {
+      const viewingTab = tabs.find(t => t.targetId === viewingTargetId) ?? tabs.find(t => t.active)
+      const url = viewingTab?.url || ''
+      const isHttps = url.startsWith('https://')
+      return (
+        <div className="flex items-center gap-1.5 px-1 mt-0.5 pb-1 bg-background shrink-0" style={{ borderBottom: '1px solid rgba(0,0,0,0.06)' }}>
+          <div className="flex items-center gap-1.5 flex-1 min-w-0 rounded-full bg-muted/50 px-3 py-0.5" style={{ border: '1px solid rgba(0,0,0,0.06)' }}>
+            {isHttps && <Lock className="h-2.5 w-2.5 text-muted-foreground shrink-0" />}
+            <span className="text-[11px] text-muted-foreground truncate">{url}</span>
+          </div>
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  className="p-1 rounded-md shrink-0 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                  onClick={onToggleAutoFollow}
+                >
+                  {autoFollow ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{autoFollow ? 'Auto-follow on' : 'Auto-follow off'}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+      )
+    })()}
+    </>
   )
 }

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -204,6 +204,34 @@
   animation: boink-down 0.35s ease-out;
 }
 
+/* Dual arc spinner for browser tab loading indicator */
+@keyframes dual-arc-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+@keyframes dual-arc-spin-reverse {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(-360deg); }
+}
+.dual-arc-spinner::before,
+.dual-arc-spinner::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  border: 1.5px solid transparent;
+}
+.dual-arc-spinner::before {
+  border-top-color: rgb(59, 130, 246);
+  border-right-color: rgb(59, 130, 246);
+  animation: dual-arc-spin 1s linear infinite;
+}
+.dual-arc-spinner::after {
+  border-bottom-color: rgb(147, 197, 253);
+  border-left-color: rgb(147, 197, 253);
+  animation: dual-arc-spin-reverse 1.5s linear infinite;
+}
+
 /* Browser preview internal glow — GPU-composited opacity animation on a fixed gradient border */
 @keyframes browser-glow-pulse {
   0%, 100% { opacity: 0.6; }


### PR DESCRIPTION
## Summary
- Add Chrome-style floating pill tabs with URL bar showing current page and lock icon for HTTPS
- Add dual-arc loading spinner around active tab indicator
- Add tooltips to all browser control buttons (pause, stop, expand, auto-follow)
- Wrap tab bar + canvas in bordered rounded container with consistent padding
- Move auto-follow toggle to URL bar row
- Rename activity section to "Browser Activity"

## Test plan
- [ ] Verify browser preview drawer opens and displays tabs correctly
- [ ] Confirm URL bar updates when navigating between tabs
- [ ] Check loading spinner animation appears during page loads
- [ ] Verify tooltips appear on hover for all control buttons
- [ ] Test auto-follow toggle in URL bar row
- [ ] Confirm dark mode styling works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)