### PR TITLE
feat: add Device Info dialog with system diagnostics

### DIFF
--- a/src/api/routes/debug.ts
+++ b/src/api/routes/debug.ts
@@ -5,9 +5,53 @@ import { checkAllRunnersAvailability, type ContainerRunner } from '@shared/lib/c
 import { getSettings } from '@shared/lib/config/settings'
 import { execWithPath } from '@shared/lib/container/base-container-client'
 import { getLimaHome, getLimactlPath } from '@shared/lib/container/lima-container-client'
-import { platform } from 'os'
+import { APP_VERSION } from '@shared/lib/config/version'
+import os, { platform } from 'os'
+import fs from 'fs'
 
 const debug = new Hono()
+
+// GET /api/debug/system-info — lightweight system diagnostics (available to all authenticated users)
+debug.get('/system-info', Authenticated(), (c) => {
+  const cpus = os.cpus()
+
+  let disk: { totalBytes: number; freeBytes: number } | null = null
+  try {
+    const stats = fs.statfsSync(os.homedir())
+    disk = {
+      totalBytes: stats.bsize * stats.blocks,
+      freeBytes: stats.bsize * stats.bavail,
+    }
+  } catch {
+    // statfsSync may fail on some platforms/configurations
+  }
+
+  return c.json({
+    app: {
+      version: APP_VERSION,
+      electronVersion: process.versions.electron || null,
+      chromeVersion: process.versions.chrome || null,
+      nodeVersion: process.version,
+    },
+    os: {
+      platform: platform(),
+      type: os.type(),
+      release: os.release(),
+      version: os.version(),
+      arch: process.arch,
+    },
+    hardware: {
+      cpuModel: cpus[0]?.model || null,
+      cpuCores: cpus.length,
+      totalMemoryBytes: os.totalmem(),
+      freeMemoryBytes: os.freemem(),
+    },
+    disk,
+    runtime: {
+      uptime: os.uptime(),
+    },
+  })
+})
 
 debug.use('*', Authenticated(), IsAdmin())
 

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -49,6 +49,7 @@ import { useScheduledTasks, type ApiScheduledTask } from '@renderer/hooks/use-sc
 import { useWebhookTriggers } from '@renderer/hooks/use-webhook-triggers'
 import { useArtifacts, type ArtifactInfo } from '@renderer/hooks/use-artifacts'
 import { GlobalSettingsDialog } from '@renderer/components/settings/global-settings-dialog'
+import { DeviceInfoDialog } from '@renderer/components/settings/device-info-dialog'
 import { ContainerSetupDialog } from '@renderer/components/settings/container-setup-dialog'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { useUser } from '@renderer/context/user-context'
@@ -664,36 +665,56 @@ if (__RENDER_TRACKING__) {
 
 function UserFooter() {
   const { isAuthMode, user, signOut } = useUser()
+  const [deviceInfoOpen, setDeviceInfoOpen] = useState(false)
 
   if (!isAuthMode || !user) {
     return (
-      <div className="px-2 text-xs text-muted-foreground">
-        Version: {__APP_VERSION__}
+      <div className="px-2 flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">Version: {__APP_VERSION__}</span>
+        <button
+          onClick={() => setDeviceInfoOpen(true)}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Device Info
+        </button>
+        <DeviceInfoDialog open={deviceInfoOpen} onOpenChange={setDeviceInfoOpen} />
       </div>
     )
   }
 
   return (
-    <div className="px-2 flex items-center justify-between">
-      <Popover>
-        <PopoverTrigger asChild>
-          <button className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors" data-testid="user-menu-trigger">
-            <User className="h-3 w-3" />
-            <span className="truncate max-w-[140px]">{user.name}</span>
-          </button>
-        </PopoverTrigger>
-        <PopoverContent align="start" className="w-48 p-1">
+    <div className="px-2 space-y-1">
+      <div className="flex items-center justify-between">
+        <Popover>
+          <PopoverTrigger asChild>
+            <button className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors" data-testid="user-menu-trigger">
+              <User className="h-3 w-3" />
+              <span className="truncate max-w-[140px]">{user.name}</span>
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-48 p-1">
+            <button
+              onClick={signOut}
+              className="flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded-sm hover:bg-accent transition-colors"
+              data-testid="sign-out-button"
+            >
+              <LogOut className="h-4 w-4" />
+              Sign out
+            </button>
+          </PopoverContent>
+        </Popover>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">v{__APP_VERSION__}</span>
+          <span className="text-xs text-muted-foreground">·</span>
           <button
-            onClick={signOut}
-            className="flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded-sm hover:bg-accent transition-colors"
-            data-testid="sign-out-button"
+            onClick={() => setDeviceInfoOpen(true)}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
           >
-            <LogOut className="h-4 w-4" />
-            Sign out
+            Device Info
           </button>
-        </PopoverContent>
-      </Popover>
-      <span className="text-xs text-muted-foreground">v{__APP_VERSION__}</span>
+        </div>
+      </div>
+      <DeviceInfoDialog open={deviceInfoOpen} onOpenChange={setDeviceInfoOpen} />
     </div>
   )
 }

--- a/src/renderer/components/settings/device-info-dialog.tsx
+++ b/src/renderer/components/settings/device-info-dialog.tsx
@@ -1,0 +1,183 @@
+import { useState, useCallback, useEffect } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@renderer/components/ui/dialog'
+import { Button } from '@renderer/components/ui/button'
+import { Label } from '@renderer/components/ui/label'
+import { Loader2, Copy, Check } from 'lucide-react'
+import { apiFetch } from '@renderer/lib/api'
+
+interface SystemInfo {
+  app: {
+    version: string
+    electronVersion: string | null
+    chromeVersion: string | null
+    nodeVersion: string
+  }
+  os: {
+    platform: string
+    type: string
+    release: string
+    version: string
+    arch: string
+  }
+  hardware: {
+    cpuModel: string | null
+    cpuCores: number
+    totalMemoryBytes: number
+    freeMemoryBytes: number
+  }
+  disk: {
+    totalBytes: number
+    freeBytes: number
+  } | null
+  runtime: {
+    uptime: number
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`
+}
+
+function formatUptime(seconds: number): string {
+  const days = Math.floor(seconds / 86400)
+  const hours = Math.floor((seconds % 86400) / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  const parts: string[] = []
+  if (days > 0) parts.push(`${days}d`)
+  if (hours > 0) parts.push(`${hours}h`)
+  parts.push(`${minutes}m`)
+  return parts.join(' ')
+}
+
+function formatPlainText(info: SystemInfo): string {
+  const lines = [
+    `App Version: ${info.app.version}`,
+  ]
+  if (info.app.electronVersion) lines.push(`Electron: ${info.app.electronVersion}`)
+  if (info.app.chromeVersion) lines.push(`Chrome: ${info.app.chromeVersion}`)
+  lines.push(`Node: ${info.app.nodeVersion}`)
+  lines.push(`Platform: ${info.os.platform} (${info.os.arch})`)
+  lines.push(`OS: ${info.os.type} ${info.os.release}`)
+  if (info.hardware.cpuModel) {
+    lines.push(`CPU: ${info.hardware.cpuModel} (${info.hardware.cpuCores} cores)`)
+  }
+  lines.push(`Memory: ${formatBytes(info.hardware.freeMemoryBytes)} / ${formatBytes(info.hardware.totalMemoryBytes)} free`)
+  if (info.disk) {
+    lines.push(`Disk: ${formatBytes(info.disk.freeBytes)} / ${formatBytes(info.disk.totalBytes)} free`)
+  }
+  lines.push(`Uptime: ${formatUptime(info.runtime.uptime)}`)
+  return lines.join('\n')
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <Label className="text-muted-foreground">{label}</Label>
+      <span>{value}</span>
+    </>
+  )
+}
+
+interface DeviceInfoDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function DeviceInfoDialog({ open, onOpenChange }: DeviceInfoDialogProps) {
+  const [info, setInfo] = useState<SystemInfo | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const fetchInfo = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await apiFetch('/api/debug/system-info')
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setInfo(await res.json())
+    } catch (e: any) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (open) {
+      fetchInfo()
+    }
+  }, [open, fetchInfo])
+
+  const handleCopy = useCallback(() => {
+    if (!info) return
+    navigator.clipboard.writeText(formatPlainText(info))
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }, [info])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>Device Info</DialogTitle>
+          <DialogDescription className="sr-only">System and hardware information for debugging</DialogDescription>
+        </DialogHeader>
+        {loading && (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        )}
+        {error && (
+          <p className="text-xs text-destructive py-4">Failed to load system info: {error}</p>
+        )}
+        {info && (
+          <div className="space-y-4">
+            <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-xs">
+              <InfoRow label="App Version" value={info.app.version} />
+              {info.app.electronVersion && (
+                <InfoRow label="Electron" value={info.app.electronVersion} />
+              )}
+              {info.app.chromeVersion && (
+                <InfoRow label="Chrome" value={info.app.chromeVersion} />
+              )}
+              <InfoRow label="Node" value={info.app.nodeVersion} />
+              <InfoRow label="Platform" value={`${info.os.platform} (${info.os.arch})`} />
+              <InfoRow label="OS" value={`${info.os.type} ${info.os.release}`} />
+              {info.hardware.cpuModel && (
+                <InfoRow label="CPU" value={`${info.hardware.cpuModel} (${info.hardware.cpuCores} cores)`} />
+              )}
+              <InfoRow
+                label="Memory"
+                value={`${formatBytes(info.hardware.freeMemoryBytes)} / ${formatBytes(info.hardware.totalMemoryBytes)} free`}
+              />
+              {info.disk && (
+                <InfoRow
+                  label="Disk"
+                  value={`${formatBytes(info.disk.freeBytes)} / ${formatBytes(info.disk.totalBytes)} free`}
+                />
+              )}
+              <InfoRow label="Uptime" value={formatUptime(info.runtime.uptime)} />
+            </div>
+            <div className="flex justify-end">
+              <Button variant="outline" size="sm" onClick={handleCopy}>
+                {copied ? <Check className="h-3.5 w-3.5 mr-1.5" /> : <Copy className="h-3.5 w-3.5 mr-1.5" />}
+                {copied ? 'Copied' : 'Copy to Clipboard'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds a `GET /api/debug/system-info` endpoint that collects app version, OS, CPU architecture, CPU model, RAM, disk usage, and system uptime using cross-platform Node.js APIs (no shell commands)
- Adds a "Device Info" button to the sidebar footer (next to the version text) that opens a modal displaying all system diagnostics
- Includes a "Copy to Clipboard" button for easy attachment to bug reports

## Test plan
- [ ] Restart Electron dev server to pick up the new API route
- [ ] Verify "Device Info" button appears in sidebar footer next to version
- [ ] Click button and verify modal shows correct system info (OS, arch, CPU, RAM, disk, uptime)
- [ ] Click "Copy to Clipboard" and paste — verify clean formatted output
- [ ] Verify modal works in both auth and non-auth modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)