### PR TITLE
feat: redesign onboarding wizard

### DIFF
--- a/e2e/pages/app.page.ts
+++ b/e2e/pages/app.page.ts
@@ -14,21 +14,23 @@ export class AppPage {
   }
 
   /**
-   * Wait for the sidebar to be visible (indicates app is loaded)
+   * Wait for the app to be loaded (sidebar visible or wizard visible)
    */
   async waitForAppLoaded() {
-    await expect(this.page.locator('[data-testid="app-sidebar"]')).toBeVisible()
+    await expect(
+      this.page.locator('[data-testid="app-sidebar"], [data-testid="wizard-container"]').first()
+    ).toBeVisible()
   }
 
   /**
    * Dismiss the getting started wizard if it's open.
-   * Clicks through all steps using Next/Skip/Finish to close it.
+   * Navigates through all steps using Next/Skip to close it.
+   * Requires E2E mock mode (mock API key configured, runtime available).
    */
   async dismissWizardIfVisible() {
-    const wizard = this.page.locator('[data-testid="wizard-dialog"]')
+    const wizard = this.page.locator('[data-testid="wizard-container"]')
     if (await wizard.isVisible({ timeout: 1000 }).catch(() => false)) {
       const stepContent = this.page.locator('[data-testid="wizard-step-content"]')
-      // The welcome screen now branches into Platform or manual setup.
       // Use the manual path so generic app tests can dismiss the wizard
       // without relying on platform auth state.
       await this.page.locator('[data-testid="wizard-manual-setup"]').click()
@@ -39,19 +41,23 @@ export class AppPage {
       await expect(stepContent).toHaveAttribute('data-step', '1')
 
       // Browser -> Composio
-      await this.page.locator('[data-testid="wizard-skip"]').click()
+      await this.page.locator('[data-testid="wizard-next"]').click()
       await expect(stepContent).toHaveAttribute('data-step', '2')
 
       // Composio -> Runtime
       await this.page.locator('[data-testid="wizard-skip"]').click()
       await expect(stepContent).toHaveAttribute('data-step', '3')
 
-      // Runtime -> Agent
-      await this.page.locator('[data-testid="wizard-skip"]').click()
+      // Runtime -> Privacy
+      await this.page.locator('[data-testid="wizard-next"]').click()
       await expect(stepContent).toHaveAttribute('data-step', '4')
 
-      // Finish on the Agent step
-      await this.page.locator('[data-testid="wizard-finish"]').click()
+      // Privacy -> Agent
+      await this.page.locator('[data-testid="wizard-next"]').click()
+      await expect(stepContent).toHaveAttribute('data-step', '5')
+
+      // Skip on Agent step finishes the wizard
+      await this.page.locator('[data-testid="wizard-skip"]').click()
       await expect(wizard).not.toBeVisible()
     }
   }

--- a/e2e/pages/wizard.page.ts
+++ b/e2e/pages/wizard.page.ts
@@ -2,13 +2,19 @@ import { Page, expect } from '@playwright/test'
 
 /**
  * Page object for the Getting Started Wizard
+ *
+ * Manual flow steps (0-indexed):
+ *   0: LLM  |  1: Browser  |  2: Composio  |  3: Runtime  |  4: Privacy  |  5: Agent
+ *
+ * Skippable steps: Composio (2), Agent (5)
+ * Non-skippable steps with gating: LLM (needs key), Browser (default ok), Runtime (needs available runner)
  */
 export class WizardPage {
   constructor(private page: Page) {}
 
-  /** Get the wizard dialog locator */
+  /** Get the wizard container locator */
   getDialog() {
-    return this.page.locator('[data-testid="wizard-dialog"]')
+    return this.page.locator('[data-testid="wizard-container"]')
   }
 
   /** Get the step content container */
@@ -51,14 +57,9 @@ export class WizardPage {
     await this.page.locator('[data-testid="wizard-back"]').click()
   }
 
-  /** Click the Skip button (available on optional steps) */
+  /** Click the Skip button (available on optional steps: Composio, Agent) */
   async clickSkip() {
     await this.page.locator('[data-testid="wizard-skip"]').click()
-  }
-
-  /** Click the Finish button (available on the last step) */
-  async clickFinish() {
-    await this.page.locator('[data-testid="wizard-finish"]').click()
   }
 
   /** Check if the Back button is disabled */
@@ -71,14 +72,27 @@ export class WizardPage {
     await expect(this.page.locator('[data-testid="wizard-back"]')).toBeEnabled()
   }
 
-  /** Fill in the agent name on the Create Agent step */
-  async fillAgentName(name: string) {
-    await this.page.locator('[data-testid="wizard-agent-name-input"]').fill(name)
-  }
-
-  /** Click the Create Agent button on the last step */
-  async clickCreateAgent() {
-    await this.page.locator('[data-testid="wizard-create-agent"]').click()
+  /**
+   * Navigate through the full manual wizard flow to completion.
+   * Requires a mock API key to be configured (LLM step gating)
+   * and a runtime to be available (Runtime step gating).
+   *
+   * Steps: LLM(Next) -> Browser(Next) -> Composio(Skip) -> Runtime(Next) -> Privacy(Next) -> Agent(Skip=Finish)
+   */
+  async dismissManualFlow() {
+    await this.chooseManualSetup()
+    await this.expectStep(0)
+    await this.clickNext()    // LLM -> Browser
+    await this.expectStep(1)
+    await this.clickNext()    // Browser -> Composio
+    await this.expectStep(2)
+    await this.clickSkip()    // Composio -> Runtime
+    await this.expectStep(3)
+    await this.clickNext()    // Runtime -> Privacy
+    await this.expectStep(4)
+    await this.clickNext()    // Privacy -> Agent
+    await this.expectStep(5)
+    await this.clickSkip()    // Agent (skip = finish)
   }
 
   /**

--- a/e2e/specs/getting-started-wizard.spec.ts
+++ b/e2e/specs/getting-started-wizard.spec.ts
@@ -5,21 +5,40 @@ import { WizardPage } from '../pages/wizard.page'
 
 test.describe.configure({ mode: 'serial' })
 
+/**
+ * Manual wizard steps (0-indexed):
+ *   0: LLM  |  1: Browser  |  2: Composio  |  3: Runtime  |  4: Privacy  |  5: Agent
+ *
+ * Skippable: Composio (2), Agent (5)
+ * Gated (Next disabled until configured): LLM (needs key), Runtime (needs available runner)
+ *
+ * In E2E mock mode the mock API key is pre-configured and the runtime reports READY,
+ * so Next is enabled on LLM, Browser, Runtime, and Privacy steps.
+ */
 test.describe('Getting Started Wizard', () => {
   let appPage: AppPage
   let wizardPage: WizardPage
   let agentPage: AgentPage
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, request }) => {
     appPage = new AppPage(page)
     wizardPage = new WizardPage(page)
     agentPage = new AgentPage(page)
+
+    // Set a mock API key so the LLM step's Next button is enabled
+    await request.put('http://localhost:3000/api/settings', {
+      data: { apiKeys: { anthropicApiKey: 'sk-ant-test-key-for-e2e' } },
+    })
   })
 
   test.afterEach(async ({ request }) => {
     // Restore setupCompleted to true so subsequent test files don't see the wizard
     await request.put('http://localhost:3000/api/user-settings', {
       data: { setupCompleted: true },
+    })
+    // Clean up mock API key
+    await request.put('http://localhost:3000/api/settings', {
+      data: { apiKeys: { anthropicApiKey: '' } },
     })
   })
 
@@ -32,18 +51,19 @@ test.describe('Getting Started Wizard', () => {
     await appPage.goto()
     await appPage.waitForAppLoaded()
 
-    // Wizard should auto-open
+    // Wizard should auto-open on the welcome screen
     await wizardPage.expectVisible()
     await wizardPage.expectStep(0)
     await wizardPage.chooseManualSetup()
     await wizardPage.expectStep(0)
 
     // Dismiss it for cleanup
-    await wizardPage.clickNext()  // -> Browser
-    await wizardPage.clickSkip()  // -> Composio
-    await wizardPage.clickSkip()  // -> Runtime
-    await wizardPage.clickSkip()  // -> Agent
-    await wizardPage.clickFinish()
+    await wizardPage.clickNext()  // LLM -> Browser
+    await wizardPage.clickNext()  // Browser -> Composio
+    await wizardPage.clickSkip()  // Composio -> Runtime
+    await wizardPage.clickNext()  // Runtime -> Privacy
+    await wizardPage.clickNext()  // Privacy -> Agent
+    await wizardPage.clickSkip()  // Agent (skip = finish)
     await wizardPage.expectNotVisible()
   })
 
@@ -70,51 +90,56 @@ test.describe('Getting Started Wizard', () => {
     await appPage.waitForAppLoaded()
     await wizardPage.expectVisible()
 
-    // Step 0: Welcome (no Back button rendered on this screen)
+    // Welcome screen (no Back button)
     await wizardPage.expectStep(0)
-    await expect(page.getByText('Welcome to Superagent')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Build your agent workforce' })).toBeVisible()
     await expect(page.locator('[data-testid="wizard-platform-login"]')).toBeVisible()
     await expect(page.locator('[data-testid="wizard-manual-setup"]')).toBeVisible()
     await expect(page.locator('[data-testid="wizard-back"]')).not.toBeVisible()
 
-    // Choose the manual path and land on Step 0: LLM
+    // Choose manual path -> Step 0: LLM
     await wizardPage.chooseManualSetup()
     await wizardPage.expectStep(0)
-    await expect(page.getByText('Configure LLM Provider')).toBeVisible()
+    await expect(page.getByText('Connect an LLM provider')).toBeVisible()
     await wizardPage.expectBackEnabled()
 
-    // Go to Step 1: Browser
+    // Step 1: Browser
     await wizardPage.clickNext()
     await wizardPage.expectStep(1)
-    await expect(page.getByText('Set Up Browser')).toBeVisible()
+    await expect(page.getByText('Give your agents browser access')).toBeVisible()
 
     // Go back to Step 0: LLM
     await wizardPage.clickBack()
     await wizardPage.expectStep(0)
-    await expect(page.getByText('Configure LLM Provider')).toBeVisible()
+    await expect(page.getByText('Connect an LLM provider')).toBeVisible()
 
-    // Go forward again to Step 1: Browser
+    // Forward again to Step 1: Browser
     await wizardPage.clickNext()
     await wizardPage.expectStep(1)
-    await expect(page.getByText('Set Up Browser')).toBeVisible()
+    await expect(page.getByText('Give your agents browser access')).toBeVisible()
 
-    // Go to Step 2: Composio (optional)
-    await wizardPage.clickSkip()
+    // Step 2: Composio (skippable)
+    await wizardPage.clickNext()
     await wizardPage.expectStep(2)
-    await expect(page.getByText('Set Up Composio')).toBeVisible()
+    await expect(page.getByText('Let your agents connect to your apps')).toBeVisible()
 
-    // Go to Step 3: Runtime
+    // Step 3: Runtime
     await wizardPage.clickSkip()
     await wizardPage.expectStep(3)
-    await expect(page.getByText('Set Up Container Runtime')).toBeVisible()
+    await expect(page.getByText('Choose a container runtime')).toBeVisible()
 
-    // Go to Step 4: Create Agent (optional)
-    await wizardPage.clickSkip()
+    // Step 4: Privacy
+    await wizardPage.clickNext()
     await wizardPage.expectStep(4)
-    await expect(page.getByRole('heading', { name: 'Create Your First Agent' })).toBeVisible()
+    await expect(page.getByText('Help improve Superagent')).toBeVisible()
 
-    // Finish
-    await wizardPage.clickFinish()
+    // Step 5: Create Agent (skippable)
+    await wizardPage.clickNext()
+    await wizardPage.expectStep(5)
+    await expect(page.getByRole('heading', { name: /create your first agent/i })).toBeVisible()
+
+    // Skip on last step finishes
+    await wizardPage.clickSkip()
     await wizardPage.expectNotVisible()
   })
 
@@ -127,22 +152,24 @@ test.describe('Getting Started Wizard', () => {
     await appPage.waitForAppLoaded()
     await wizardPage.expectVisible()
 
-    // Choose manual setup, then navigate to Browser (step 1)
+    // Choose manual setup, navigate to Composio (step 2) — first skippable step
     await wizardPage.chooseManualSetup()
-    await wizardPage.clickNext() // -> Browser
+    await wizardPage.clickNext() // LLM -> Browser
     await wizardPage.expectStep(1)
-
-    // Skip should advance to Composio
-    await wizardPage.clickSkip()
+    await wizardPage.clickNext() // Browser -> Composio
     await wizardPage.expectStep(2)
 
     // Skip should advance to Runtime
     await wizardPage.clickSkip()
     await wizardPage.expectStep(3)
 
-    // Skip should advance to Agent
-    await wizardPage.clickSkip()
+    // Runtime is not skippable — use Next to advance to Privacy
+    await wizardPage.clickNext()
     await wizardPage.expectStep(4)
+
+    // Privacy is not skippable — use Next to advance to Agent
+    await wizardPage.clickNext()
+    await wizardPage.expectStep(5)
 
     // Skip on last step should finish
     await wizardPage.clickSkip()
@@ -160,11 +187,12 @@ test.describe('Getting Started Wizard', () => {
     await wizardPage.chooseManualSetup()
 
     // Navigate through and finish
-    await wizardPage.clickNext()  // -> Browser
-    await wizardPage.clickSkip()  // -> Composio
-    await wizardPage.clickSkip()  // -> Runtime
-    await wizardPage.clickSkip()  // -> Agent
-    await wizardPage.clickFinish()
+    await wizardPage.clickNext()  // LLM -> Browser
+    await wizardPage.clickNext()  // Browser -> Composio
+    await wizardPage.clickSkip()  // Composio -> Runtime
+    await wizardPage.clickNext()  // Runtime -> Privacy
+    await wizardPage.clickNext()  // Privacy -> Agent
+    await wizardPage.clickSkip()  // Agent (skip = finish)
     await wizardPage.expectNotVisible()
 
     // Verify setupCompleted is now true via API
@@ -175,43 +203,6 @@ test.describe('Getting Started Wizard', () => {
     // Reload - wizard should not reappear
     await appPage.reload()
     await wizardPage.expectNotVisible()
-  })
-
-  test('can create an agent in the wizard', async ({ page, request }) => {
-    await request.put('http://localhost:3000/api/user-settings', {
-      data: { setupCompleted: false },
-    })
-
-    await appPage.goto()
-    await appPage.waitForAppLoaded()
-    await wizardPage.expectVisible()
-    await wizardPage.chooseManualSetup()
-
-    // Navigate to Create Agent step
-    await wizardPage.clickNext()  // -> Browser
-    await wizardPage.clickSkip()  // -> Composio
-    await wizardPage.clickSkip()  // -> Runtime
-    await wizardPage.clickSkip()  // -> Agent
-    await wizardPage.expectStep(4)
-
-    // Create an agent
-    const agentName = `Wizard Agent ${Date.now()}`
-    await wizardPage.fillAgentName(agentName)
-    await wizardPage.clickCreateAgent()
-
-    // Wait for success message
-    await expect(page.getByText('Agent created successfully')).toBeVisible()
-
-    // Finish
-    await wizardPage.clickFinish()
-    await wizardPage.expectNotVisible()
-
-    // Verify agent appears in sidebar
-    await expect(agentPage.getAgentItem(agentName)).toBeVisible()
-
-    // Clean up
-    await agentPage.selectAgent(agentName)
-    await agentPage.deleteAgent()
   })
 
   test('re-run wizard button opens wizard from settings', async ({ page, request }) => {
@@ -230,11 +221,12 @@ test.describe('Getting Started Wizard', () => {
     await wizardPage.expectStep(0)
 
     // Dismiss it
-    await wizardPage.clickNext()  // -> Browser
-    await wizardPage.clickSkip()  // -> Composio
-    await wizardPage.clickSkip()  // -> Runtime
-    await wizardPage.clickSkip()  // -> Agent
-    await wizardPage.clickFinish()
+    await wizardPage.clickNext()  // LLM -> Browser
+    await wizardPage.clickNext()  // Browser -> Composio
+    await wizardPage.clickSkip()  // Composio -> Runtime
+    await wizardPage.clickNext()  // Runtime -> Privacy
+    await wizardPage.clickNext()  // Privacy -> Agent
+    await wizardPage.clickSkip()  // Agent (skip = finish)
     await wizardPage.expectNotVisible()
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@hono/node-server": "^1.13.7",
+        "@hono/zod-validator": "^0.7.6",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -4336,6 +4337,16 @@
         "wrangler": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@hono/zod-validator": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.7.6.tgz",
+      "integrity": "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "hono": ">=3.9.0",
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@hookform/resolvers": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@hono/node-server": "^1.13.7",
+    "@hono/zod-validator": "^0.7.6",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,6 +14,25 @@ try {
   // Chromium not installed (e.g., `npx playwright install` hasn't been run yet)
 }
 
+// Build a cross-platform webServer command.
+// Unix uses inline `VAR=val cmd`, Windows needs `set VAR=val && cmd`.
+const isWindows = process.platform === 'win32'
+function buildWebServerCommand() {
+  const env: Record<string, string> = {
+    SUPERAGENT_DATA_DIR: e2eDataDir,
+    E2E_MOCK: 'true',
+    PORT: '3000',
+  }
+  if (chromiumPath) env.E2E_CHROMIUM_PATH = chromiumPath
+
+  if (isWindows) {
+    const setVars = Object.entries(env).map(([k, v]) => `set "${k}=${v}"`).join(' && ')
+    return `${setVars} && node e2e/setup-e2e-data.js && npm run dev:web`
+  }
+  const inlineVars = Object.entries(env).map(([k, v]) => `${k}="${v}"`).join(' ')
+  return `${inlineVars} node e2e/setup-e2e-data.js && ${inlineVars} npm run dev:web`
+}
+
 export default defineConfig({
   testDir: './e2e',
   testIgnore: ['**/auth/**'],  // Auth tests use separate config (playwright.auth.config.ts)
@@ -64,7 +83,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: `SUPERAGENT_DATA_DIR="${e2eDataDir}" node e2e/setup-e2e-data.js && SUPERAGENT_DATA_DIR="${e2eDataDir}" E2E_MOCK=true PORT=3000${chromiumPath ? ` E2E_CHROMIUM_PATH='${chromiumPath}'` : ''} npm run dev:web`,
+    command: buildWebServerCommand(),
     url: 'http://localhost:3000/api/settings',  // Wait for API to be ready, not just Vite
     reuseExistingServer: false,  // Always start fresh for E2E tests
     timeout: 120000,

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2,6 +2,8 @@ import { Hono, type Context } from 'hono'
 import { streamSSE } from 'hono/streaming'
 import type Anthropic from '@anthropic-ai/sdk'
 import { randomUUID } from 'crypto'
+import { z } from 'zod'
+import { zValidator } from '@hono/zod-validator'
 import { Authenticated, AgentRead, AgentUser, AgentAdmin } from '../middleware/auth'
 import {
   listAgentsWithStatus,
@@ -578,6 +580,47 @@ agents.post('/', async (c) => {
   } catch (error) {
     console.error('Failed to create agent:', error)
     return c.json({ error: 'Failed to create agent' }, 500)
+  }
+})
+
+// POST /api/agents/generate-name - Generate an agent name from a prompt using a lightweight LLM
+// TODO: Migrate remaining route handlers to use zValidator for consistent request validation
+const generateNameBodySchema = z.object({
+  prompt: z.string().min(1, 'Prompt is required'),
+})
+
+agents.post('/generate-name', zValidator('json', generateNameBodySchema), async (c) => {
+  try {
+    const { prompt } = c.req.valid('json')
+    const truncatedPrompt = prompt.trim().substring(0, 10_000)
+
+    const anthropic = getLlmClient()
+    const response = await withRetry(() =>
+      anthropic.messages.create({
+        model: getSummarizerModel(),
+        max_tokens: 50,
+        messages: [
+          {
+            role: 'user',
+            content: `Generate a short, descriptive agent name (2-4 words max) based on what the user wants the agent to do. The user's description is:
+
+"${truncatedPrompt}"
+
+Respond with ONLY the agent name, nothing else. No quotes, no explanation.`,
+          },
+        ],
+      })
+    )
+
+    const name = extractTextFromLlmResponse(response)?.trim()
+    if (!name) {
+      return c.json({ error: 'Failed to generate name' }, 500)
+    }
+
+    return c.json({ name })
+  } catch (error) {
+    console.error('Failed to generate agent name:', error)
+    return c.json({ error: 'Failed to generate name' }, 500)
   }
 })
 

--- a/src/main/host-browser/types.ts
+++ b/src/main/host-browser/types.ts
@@ -1,3 +1,5 @@
+import type { ChromeProfile } from '@shared/lib/browser/chrome-profile'
+
 export type HostBrowserProviderId = 'chrome' | 'browserbase'
 
 export interface BrowserConnectionInfo {
@@ -21,7 +23,7 @@ export interface HostBrowserProviderStatus {
   available: boolean
   reason?: string
   /** Chrome-specific: detected browser profiles */
-  profiles?: Array<{ id: string; name: string; avatarUrl?: string }>
+  profiles?: ChromeProfile[]
 }
 
 export interface HostBrowserProvider {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -62,20 +62,19 @@ function AppContent() {
 
   return (
     <DialogProvider onOpenWizard={() => setWizardOpen(true)}>
-      <TrayNavigationHandler>
-        <GlobalNotificationHandler />
-        <SidebarProvider className="h-screen">
-          <AppSidebar />
-          <SidebarInset className="min-w-0 h-full">
-            <MainContent />
-          </SidebarInset>
-        </SidebarProvider>
-      </TrayNavigationHandler>
-
-      <GettingStartedWizard
-        open={wizardOpen}
-        onOpenChange={setWizardOpen}
-      />
+      {wizardOpen ? (
+        <GettingStartedWizard onClose={() => setWizardOpen(false)} />
+      ) : (
+        <TrayNavigationHandler>
+          <GlobalNotificationHandler />
+          <SidebarProvider className="h-screen">
+            <AppSidebar />
+            <SidebarInset className="min-w-0 h-full">
+              <MainContent />
+            </SidebarInset>
+          </SidebarProvider>
+        </TrayNavigationHandler>
+      )}
     </DialogProvider>
   )
 }

--- a/src/renderer/components/settings/bedrock-credentials-input.tsx
+++ b/src/renderer/components/settings/bedrock-credentials-input.tsx
@@ -4,9 +4,10 @@ import { Label } from '@renderer/components/ui/label'
 import { Button } from '@renderer/components/ui/button'
 import { Alert, AlertDescription } from '@renderer/components/ui/alert'
 import { PasswordInput } from '@renderer/components/ui/password-input'
+import { RequestError } from '@renderer/components/messages/request-error'
 import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
 import { apiFetch } from '@renderer/lib/api'
-import { AlertTriangle, Check, Loader2, ChevronRight } from 'lucide-react'
+import { AlertTriangle, Check, Loader2 } from 'lucide-react'
 import type { ApiKeyStatus } from '@shared/lib/config/settings'
 
 interface BedrockCredentialsInputProps {
@@ -122,10 +123,9 @@ export function BedrockCredentialsInput({
 
   return (
     <div className="space-y-3">
-      <Label>AWS Bedrock Credentials</Label>
-
-      {apiKeyStatus?.isConfigured && (
-        <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2">
+        <Label>AWS Bedrock Credentials</Label>
+        {apiKeyStatus?.isConfigured && (
           <span
             className={`text-xs px-2 py-0.5 rounded-full ${
               apiKeyStatus.source === 'settings'
@@ -137,8 +137,8 @@ export function BedrockCredentialsInput({
               ? 'Using saved setting'
               : 'Using environment variable'}
           </span>
-        </div>
-      )}
+        )}
+      </div>
 
       {showNotConfiguredAlert && !apiKeyStatus?.isConfigured && (
         <Alert variant="destructive">
@@ -149,120 +149,124 @@ export function BedrockCredentialsInput({
         </Alert>
       )}
 
-      {/* Region (always shown) */}
-      <div className="space-y-1">
-        <Label htmlFor="bedrock-region" className="text-xs">AWS Region</Label>
-        <Input
-          id="bedrock-region"
-          value={region}
-          onChange={(e) => setRegion(e.target.value)}
-          placeholder="us-east-1"
-          disabled={disabled || isBusy}
-        />
+      {/* Tab bar */}
+      <div className="flex gap-4 border-b mt-2">
+        <button
+          type="button"
+          onClick={() => setShowAdvanced(false)}
+          className={`pb-1.5 text-xs transition-colors ${!showAdvanced ? 'border-b-2 border-primary text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+        >
+          API key
+        </button>
+        <button
+          type="button"
+          onClick={() => setShowAdvanced(true)}
+          className={`pb-1.5 text-xs transition-colors ${showAdvanced ? 'border-b-2 border-primary text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+        >
+          Access key
+        </button>
       </div>
 
-      {!showAdvanced ? (
-        <>
-          {/* Simple: Bedrock API Key */}
-          <div className="space-y-1">
-            <Label htmlFor="bedrock-api-key" className="text-xs">Bedrock API Key</Label>
-            <PasswordInput
-              id="bedrock-api-key"
-              value={apiKeyInput}
-              onChange={(e) => { setApiKeyInput(e.target.value); setValidationResult(null) }}
-              placeholder={apiKeyStatus?.isConfigured ? '••••••••••••••••' : 'Enter Bedrock API key...'}
-              disabled={disabled || isBusy}
-            />
-          </div>
+      {/* Fields container — no space-y so collapsed tab panels don't add gaps */}
+      <div className="mt-3">
+        {/* Region (shared) */}
+        <div className="space-y-1 mb-3">
+          <Label htmlFor="bedrock-region" className="font-normal text-muted-foreground">AWS Region</Label>
+          <Input
+            id="bedrock-region"
+            value={region}
+            onChange={(e) => setRegion(e.target.value)}
+            placeholder="us-east-1"
+            disabled={disabled || isBusy}
+            className="bg-background"
+          />
+        </div>
 
-          <button
-            type="button"
-            onClick={() => setShowAdvanced(true)}
-            className="text-xs text-primary hover:underline flex items-center gap-1"
-          >
-            <ChevronRight className="h-3 w-3" />
-            Use AWS Access Key credentials instead
-          </button>
+        {/* API key tab panel */}
+      <div className={`grid transition-all duration-200 ease-in-out ${!showAdvanced ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+        <div className="overflow-hidden">
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <Label htmlFor="bedrock-api-key" className="font-normal text-muted-foreground">Bedrock API Key</Label>
+              <PasswordInput
+                id="bedrock-api-key"
+                value={apiKeyInput}
+                onChange={(e) => { setApiKeyInput(e.target.value); setValidationResult(null) }}
+                placeholder={apiKeyStatus?.isConfigured ? '••••••••••••••••' : 'br-api-...'}
+                disabled={disabled || isBusy}
+                className="bg-background"
+              />
+            </div>
 
-          <div className="flex gap-2">
-            {apiKeyInput.trim() && (
-              <Button size="sm" onClick={handleValidateSimple} disabled={isBusy}>
-                {isValidating ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Validating...</> : 'Validate & Save'}
-              </Button>
-            )}
-            {apiKeyStatus?.source === 'settings' && (
-              <Button size="sm" variant="outline" onClick={handleRemove} disabled={isBusy}>
-                {isRemoving ? 'Removing...' : 'Remove Saved Credentials'}
-              </Button>
-            )}
+            <div className="flex gap-2">
+              {apiKeyInput.trim() && (
+                <Button size="sm" onClick={handleValidateSimple} disabled={isBusy}>
+                  {isValidating ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Validating...</> : 'Validate & Save'}
+                </Button>
+              )}
+              {apiKeyStatus?.source === 'settings' && (
+                <Button size="sm" variant="outline" onClick={handleRemove} disabled={isBusy}>
+                  {isRemoving ? 'Removing...' : 'Remove Saved Credentials'}
+                </Button>
+              )}
+            </div>
           </div>
-        </>
-      ) : (
-        <>
-          {/* Advanced: AWS Access Key + Secret */}
-          <div className="space-y-1">
-            <Label htmlFor="bedrock-access-key" className="text-xs">AWS Access Key ID</Label>
-            <Input
-              id="bedrock-access-key"
-              value={accessKeyId}
-              onChange={(e) => { setAccessKeyId(e.target.value); setValidationResult(null) }}
-              placeholder={apiKeyStatus?.isConfigured ? '••••••••••••••••' : 'AKIA...'}
-              disabled={disabled || isBusy}
-            />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="bedrock-secret-key" className="text-xs">AWS Secret Access Key</Label>
-            <PasswordInput
-              id="bedrock-secret-key"
-              value={secretAccessKey}
-              onChange={(e) => { setSecretAccessKey(e.target.value); setValidationResult(null) }}
-              placeholder={apiKeyStatus?.isConfigured ? '••••••••••••••••' : 'Enter secret key...'}
-              disabled={disabled || isBusy}
-            />
-          </div>
+        </div>
+      </div>
 
-          <button
-            type="button"
-            onClick={() => setShowAdvanced(false)}
-            className="text-xs text-primary hover:underline flex items-center gap-1"
-          >
-            <ChevronRight className="h-3 w-3 rotate-180" />
-            Use Bedrock API Key instead
-          </button>
+      {/* Access key tab panel */}
+      <div className={`grid transition-all duration-200 ease-in-out ${showAdvanced ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+        <div className="overflow-hidden">
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <Label htmlFor="bedrock-access-key" className="font-normal text-muted-foreground">AWS Access Key ID</Label>
+              <Input
+                id="bedrock-access-key"
+                value={accessKeyId}
+                onChange={(e) => { setAccessKeyId(e.target.value); setValidationResult(null) }}
+                placeholder={apiKeyStatus?.isConfigured ? '••••••••••••••••' : 'AKIA...'}
+                disabled={disabled || isBusy}
+                className="bg-background"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="bedrock-secret-key" className="font-normal text-muted-foreground">AWS Secret Access Key</Label>
+              <PasswordInput
+                id="bedrock-secret-key"
+                value={secretAccessKey}
+                onChange={(e) => { setSecretAccessKey(e.target.value); setValidationResult(null) }}
+                placeholder={apiKeyStatus?.isConfigured ? '••••••••••••••••' : 'wJalr...'}
+                disabled={disabled || isBusy}
+                className="bg-background"
+              />
+            </div>
 
-          <div className="flex gap-2">
-            {accessKeyId.trim() && secretAccessKey.trim() && (
-              <Button size="sm" onClick={handleValidateAdvanced} disabled={isBusy}>
-                {isValidating ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Validating...</> : 'Validate & Save'}
-              </Button>
-            )}
-            {apiKeyStatus?.source === 'settings' && (
-              <Button size="sm" variant="outline" onClick={handleRemove} disabled={isBusy}>
-                {isRemoving ? 'Removing...' : 'Remove Saved Credentials'}
-              </Button>
-            )}
+            <div className="flex gap-2">
+              {accessKeyId.trim() && secretAccessKey.trim() && (
+                <Button size="sm" onClick={handleValidateAdvanced} disabled={isBusy}>
+                  {isValidating ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Validating...</> : 'Validate & Save'}
+                </Button>
+              )}
+              {apiKeyStatus?.source === 'settings' && (
+                <Button size="sm" variant="outline" onClick={handleRemove} disabled={isBusy}>
+                  {isRemoving ? 'Removing...' : 'Remove Saved Credentials'}
+                </Button>
+              )}
+            </div>
           </div>
-        </>
+        </div>
+      </div>
+      </div>
+
+      {validationResult && !validationResult.valid && (
+        <RequestError message={validationResult.error || 'Invalid credentials'} />
       )}
-
-      {validationResult && (
-        <Alert variant={validationResult.valid ? 'default' : 'destructive'}>
-          {validationResult.valid ? <Check className="h-4 w-4" /> : <AlertTriangle className="h-4 w-4" />}
-          <AlertDescription>
-            {validationResult.valid
-              ? 'Credentials are valid and have been saved.'
-              : validationResult.error || 'Invalid credentials'}
-          </AlertDescription>
-        </Alert>
+      {validationResult?.valid && (
+        <p className="text-xs text-green-600 dark:text-green-400 flex items-center gap-1">
+          <Check className="h-3 w-3" />
+          Credentials are valid and have been saved.
+        </p>
       )}
-
-      <p className="text-xs text-muted-foreground">
-        {apiKeyStatus?.source === 'settings'
-          ? 'Your credentials are saved locally. Enter new ones to replace them.'
-          : apiKeyStatus?.source === 'env'
-            ? 'Save credentials here to override the environment variables.'
-            : 'Credentials will be saved locally in ~/.superagent/settings.json'}
-      </p>
     </div>
   )
 }

--- a/src/renderer/components/settings/browser-tab.tsx
+++ b/src/renderer/components/settings/browser-tab.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import { Label } from '@renderer/components/ui/label'
 import { Input } from '@renderer/components/ui/input'
 import { Button } from '@renderer/components/ui/button'
-import { Alert, AlertDescription } from '@renderer/components/ui/alert'
 import {
   Select,
   SelectContent,
@@ -14,7 +13,8 @@ import { Switch } from '@renderer/components/ui/switch'
 import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { apiFetch } from '@renderer/lib/api'
-import { AlertTriangle, Check, Loader2 } from 'lucide-react'
+import { Check, Loader2 } from 'lucide-react'
+import { RequestError } from '@renderer/components/messages/request-error'
 import type { HostBrowserProviderId, BrowserbaseStealthOs, LlmProviderId } from '@shared/lib/config/settings'
 import { ChromeProfileSelect } from '@renderer/components/settings/chrome-profile-select'
 
@@ -440,51 +440,32 @@ export function BrowserbaseSettings({
       )}
 
       <div className="space-y-2">
-        <Label htmlFor="browserbase-api-key">Browserbase API Key</Label>
+        <Label htmlFor="browserbase-api-key" className="font-normal text-muted-foreground">Browserbase API Key</Label>
         <Input
           id="browserbase-api-key"
           type="password"
-          placeholder={hasSavedCredentials ? '••••••••••••••••' : 'Enter your Browserbase API key'}
+          placeholder={hasSavedCredentials ? '••••••••••••••••' : 'bb-api-...'}
           value={apiKey}
           onChange={(e) => onApiKeyChange(e.target.value)}
           disabled={disabled || isValidating}
+          className="bg-background"
         />
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="browserbase-project-id">Browserbase Project ID</Label>
+        <Label htmlFor="browserbase-project-id" className="font-normal text-muted-foreground">Browserbase Project ID</Label>
         <Input
           id="browserbase-project-id"
           type="text"
-          placeholder={hasSavedCredentials ? '••••••••••••••••' : 'Enter your Browserbase project ID'}
+          placeholder={hasSavedCredentials ? '••••••••••••••••' : 'bb-proj-...'}
           value={projectId}
           onChange={(e) => onProjectIdChange(e.target.value)}
           disabled={disabled || isValidating}
+          className="bg-background"
         />
       </div>
 
-      {validationResult && (
-        <Alert variant={validationResult.valid ? 'default' : 'destructive'}>
-          {validationResult.valid ? (
-            <Check className="h-4 w-4" />
-          ) : (
-            <AlertTriangle className="h-4 w-4" />
-          )}
-          <AlertDescription>
-            {validationResult.valid
-              ? 'Credentials are valid and have been saved.'
-              : validationResult.error || 'Invalid credentials'}
-          </AlertDescription>
-        </Alert>
-      )}
-
-      <p className="text-xs text-muted-foreground">
-        {hasSavedCredentials
-          ? 'Your credentials are saved locally. Enter new values to replace them.'
-          : 'Get your API key and project ID from the Browserbase dashboard.'}
-      </p>
-
-      <div className="flex gap-2">
+      <div className="flex justify-end gap-2">
         {hasInput && (
           <Button size="sm" onClick={onValidateAndSave} disabled={isValidating}>
             {isValidating ? (
@@ -493,7 +474,7 @@ export function BrowserbaseSettings({
                 Validating...
               </>
             ) : (
-              'Save & Validate'
+              'Connect'
             )}
           </Button>
         )}
@@ -508,6 +489,16 @@ export function BrowserbaseSettings({
           </Button>
         )}
       </div>
+
+      {validationResult && !validationResult.valid && (
+        <RequestError message={validationResult.error || 'Invalid credentials'} />
+      )}
+      {validationResult?.valid && (
+        <p className="text-xs text-green-600 dark:text-green-400 flex items-center gap-1">
+          <Check className="h-3 w-3" />
+          Credentials saved
+        </p>
+      )}
     </div>
   )
 }

--- a/src/renderer/components/settings/chrome-profile-select.tsx
+++ b/src/renderer/components/settings/chrome-profile-select.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Label } from '@renderer/components/ui/label'
+import { UserRound } from 'lucide-react'
 import {
   Select,
   SelectContent,
@@ -7,9 +7,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@renderer/components/ui/select'
+import type { ChromeProfile } from '@shared/lib/browser/chrome-profile'
 
 interface ChromeProfileSelectProps {
-  profiles: Array<{ id: string; name: string; avatarUrl?: string }>
+  profiles: ChromeProfile[]
   value: string
   onValueChange: (profileId: string) => void
   idPrefix?: string
@@ -47,30 +48,41 @@ export function ChromeProfileSelect({
 }: ChromeProfileSelectProps) {
   return (
     <div className="space-y-2">
-      <Label htmlFor={`${idPrefix}-select`}>Chrome Profile</Label>
       <Select
         value={value || '__none__'}
         onValueChange={(v) => onValueChange(v === '__none__' ? '' : v)}
         disabled={disabled}
       >
-        <SelectTrigger id={`${idPrefix}-select`}>
+        <SelectTrigger id={`${idPrefix}-select`} className="bg-background">
           <SelectValue placeholder="Select a Chrome profile" />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="__none__">None (clean profile)</SelectItem>
+          <SelectItem value="__none__">
+            <span className="flex items-center gap-2">
+              <span className="h-5 w-5 rounded-full shrink-0 bg-muted flex items-center justify-center">
+                <UserRound className="h-3 w-3 text-muted-foreground/40" />
+              </span>
+              <span>
+                None
+                <span className="text-muted-foreground/70 text-xs ml-2">Fresh profile</span>
+              </span>
+            </span>
+          </SelectItem>
           {profiles.map((profile) => (
             <SelectItem key={profile.id} value={profile.id}>
               <span className="flex items-center gap-2">
                 <ProfileAvatar name={profile.name} avatarUrl={profile.avatarUrl} />
-                {profile.name}
+                <span>
+                  {profile.name}
+                  {profile.email && (
+                    <span className="text-muted-foreground/70 text-xs ml-2">{profile.email}</span>
+                  )}
+                </span>
               </span>
             </SelectItem>
           ))}
         </SelectContent>
       </Select>
-      <p className="text-xs text-muted-foreground">
-        Use cookies and login sessions from a Chrome profile. Data is copied fresh each time the browser launches.
-      </p>
     </div>
   )
 }

--- a/src/renderer/components/settings/composio-api-key-input.tsx
+++ b/src/renderer/components/settings/composio-api-key-input.tsx
@@ -4,6 +4,7 @@ interface ComposioApiKeyInputProps {
   showSourceIndicator?: boolean
   showHelpText?: boolean
   showRemoveButton?: boolean
+  validateButtonLabel?: string
   disabled?: boolean
 }
 
@@ -11,6 +12,7 @@ export function ComposioApiKeyInput({
   showSourceIndicator = true,
   showHelpText = true,
   showRemoveButton = true,
+  validateButtonLabel,
   disabled = false,
 }: ComposioApiKeyInputProps) {
   return (
@@ -27,6 +29,7 @@ export function ComposioApiKeyInput({
       showHelpText={showHelpText}
       showRemoveButton={showRemoveButton}
       showRemoveConfirm={false}
+      validateButtonLabel={validateButtonLabel}
       helpText={
         <>
           Get your API key from{' '}

--- a/src/renderer/components/settings/manual-access-key-input.tsx
+++ b/src/renderer/components/settings/manual-access-key-input.tsx
@@ -1,41 +1,44 @@
 import { useState } from 'react'
-import { KeyRound, Loader2 } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
 
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
-import { Label } from '@renderer/components/ui/label'
+import { RequestError } from '@renderer/components/messages/request-error'
 import { useSavePlatformAccessKey } from '@renderer/hooks/use-platform-auth'
 
-export function ManualAccessKeyInput({ className }: { className?: string }) {
+export function ManualAccessKeyInput({ className, prefixText }: { className?: string; prefixText?: string }) {
   const [showInput, setShowInput] = useState(false)
   const [key, setKey] = useState('')
   const saveKey = useSavePlatformAccessKey()
 
   if (!showInput) {
     return (
-      <button
-        type="button"
-        className={`text-xs text-muted-foreground hover:text-foreground hover:underline ${className ?? ''}`}
-        onClick={() => setShowInput(true)}
-      >
-        <KeyRound className="inline mr-1 h-3 w-3" />
-        Add access key manually
-      </button>
+      <div className={className ?? ''}>
+        {prefixText && <>{prefixText}{' '}</>}
+        <button
+          type="button"
+          className="text-sm underline underline-offset-2 hover:text-foreground transition-colors"
+          onClick={() => setShowInput(true)}
+        >
+          Add access key
+        </button>
+      </div>
     )
   }
 
   return (
-    <div className={`space-y-2 ${className ?? ''}`}>
-      <Label className="text-xs">Paste access key</Label>
-      <div className="flex gap-2">
+    <div className={className ?? ''}>
+      <div className="flex items-center gap-2">
         <Input
           value={key}
           onChange={(e) => setKey(e.target.value)}
-          placeholder="plat_sa_..."
-          className="font-mono text-xs"
+          placeholder="Paste account key"
+          className="font-mono text-xs h-8 flex-1"
+          autoFocus
         />
         <Button
           size="sm"
+          className="h-8"
           disabled={!key.trim() || saveKey.isPending}
           onClick={() => {
             saveKey.mutate(key.trim(), {
@@ -46,12 +49,10 @@ export function ManualAccessKeyInput({ className }: { className?: string }) {
             })
           }}
         >
-          {saveKey.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Save'}
+          {saveKey.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Submit'}
         </Button>
       </div>
-      {saveKey.isError && (
-        <p className="text-xs text-destructive">{saveKey.error.message}</p>
-      )}
+      <RequestError message={saveKey.isError ? saveKey.error.message : null} className="mt-2" />
     </div>
   )
 }

--- a/src/renderer/components/settings/provider-api-key-input.tsx
+++ b/src/renderer/components/settings/provider-api-key-input.tsx
@@ -13,6 +13,7 @@ import {
   AlertDialogTitle,
 } from '@renderer/components/ui/alert-dialog'
 import { PasswordInput } from '@renderer/components/ui/password-input'
+import { RequestError } from '@renderer/components/messages/request-error'
 import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
 import { apiFetch } from '@renderer/lib/api'
 import { AlertTriangle, Check, Loader2 } from 'lucide-react'
@@ -38,6 +39,8 @@ interface ProviderApiKeyInputProps {
   showRemoveConfirm?: boolean
   /** Custom help text node. When provided, replaces the default help text. */
   helpText?: ReactNode
+  /** Custom label for the validate button. Defaults to "Validate & Save". */
+  validateButtonLabel?: string
   disabled?: boolean
 }
 
@@ -56,6 +59,7 @@ export function ProviderApiKeyInput({
   showRemoveButton = true,
   showRemoveConfirm = true,
   helpText,
+  validateButtonLabel = 'Validate & Save',
   disabled = false,
 }: ProviderApiKeyInputProps) {
   const { data: settings } = useSettings()
@@ -126,10 +130,9 @@ export function ProviderApiKeyInput({
 
   return (
     <div className="space-y-2">
-      <Label htmlFor={idPrefix}>{label}</Label>
-
-      {showSourceIndicator && apiKeyStatus?.isConfigured && (
-        <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2">
+        <Label htmlFor={idPrefix} className="font-normal text-muted-foreground">{label}</Label>
+        {showSourceIndicator && apiKeyStatus?.isConfigured && (
           <span
             className={`text-xs px-2 py-0.5 rounded-full ${
               apiKeyStatus.source === 'settings'
@@ -141,8 +144,8 @@ export function ProviderApiKeyInput({
               ? 'Using saved setting'
               : 'Using environment variable'}
           </span>
-        </div>
-      )}
+        )}
+      </div>
 
       {showNotConfiguredAlert && !apiKeyStatus?.isConfigured && (
         <Alert variant="destructive">
@@ -162,21 +165,17 @@ export function ProviderApiKeyInput({
         }}
         placeholder={apiKeyStatus?.isConfigured ? '••••••••••••••••' : placeholder}
         disabled={disabled || isBusy}
+        className="bg-background"
       />
 
-      {validationResult && (
-        <Alert variant={validationResult.valid ? 'default' : 'destructive'}>
-          {validationResult.valid ? (
-            <Check className="h-4 w-4" />
-          ) : (
-            <AlertTriangle className="h-4 w-4" />
-          )}
-          <AlertDescription>
-            {validationResult.valid
-              ? 'API key is valid and has been saved.'
-              : validationResult.error || 'Invalid API key'}
-          </AlertDescription>
-        </Alert>
+      {validationResult && !validationResult.valid && (
+        <RequestError message={validationResult.error || 'Invalid API key'} />
+      )}
+      {validationResult?.valid && (
+        <p className="text-xs text-green-600 dark:text-green-400 flex items-center gap-1">
+          <Check className="h-3 w-3" />
+          API key is valid and has been saved.
+        </p>
       )}
 
       {showHelpText && (
@@ -185,7 +184,7 @@ export function ProviderApiKeyInput({
         </p>
       )}
 
-      <div className="flex gap-2">
+      <div className="flex justify-end gap-2">
         {apiKeyInput.trim() && (
           <Button size="sm" onClick={handleValidateAndSave} disabled={isBusy}>
             {isValidating ? (
@@ -194,7 +193,7 @@ export function ProviderApiKeyInput({
                 Validating...
               </>
             ) : (
-              'Validate & Save'
+              validateButtonLabel
             )}
           </Button>
         )}

--- a/src/renderer/components/wizard/browser-setup-step.tsx
+++ b/src/renderer/components/wizard/browser-setup-step.tsx
@@ -1,67 +1,100 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
 import { apiFetch } from '@renderer/lib/api'
 import { ChromeProfileSelect } from '@renderer/components/settings/chrome-profile-select'
 import { BrowserbaseSettings } from '@renderer/components/settings/browser-tab'
-import {
-  Check,
-  Globe,
-  Monitor,
-  Cloud,
-} from 'lucide-react'
 import type { HostBrowserProviderId } from '@shared/lib/config/settings'
 
 const CONTAINER_VALUE = '__container__'
 
-const BROWSER_HOST_OPTIONS = [
-  {
-    id: CONTAINER_VALUE,
-    label: 'Container (built-in)',
-    description: 'Use the built-in browser inside the agent container. No extra setup needed.',
-    icon: Monitor,
-  },
+const BROWSER_HOST_OPTIONS: Array<{
+  id: string
+  label: string
+  recommended?: boolean
+  isDefault?: boolean
+  isAdvanced?: boolean
+  description: string
+  subdescription?: string
+}> = [
   {
     id: 'chrome' as HostBrowserProviderId,
     label: 'Google Chrome',
-    description: 'Use Chrome installed on your machine. Supports profiles for logged-in sessions.',
-    icon: Globe,
+    recommended: true,
+    description: 'Your agents can use sites you\'re already logged into Chrome.',
+    subdescription: 'Just pick a Chrome profile.',
+  },
+  {
+    id: CONTAINER_VALUE,
+    label: 'Built-in Browser',
+    recommended: false,
+    isDefault: true,
+    description: 'Your agents will need you to log in before they can use a site.',
+    subdescription: 'No stored passwords or cookies.',
   },
   {
     id: 'browserbase' as HostBrowserProviderId,
     label: 'Browserbase',
-    description: 'Use a remote cloud browser. Requires a Browserbase account with API credentials.',
-    icon: Cloud,
+    recommended: false,
+    isAdvanced: true,
+    description: 'Remote cloud browser. Requires a Browserbase account.',
   },
 ]
 
-export function BrowserSetupStep() {
+interface BrowserSetupStepProps {
+  onCanProceedChange?: (canProceed: boolean) => void
+}
+
+export function BrowserSetupStep({ onCanProceedChange }: BrowserSetupStepProps) {
   const { data: settings } = useSettings()
   const updateSettings = useUpdateSettings()
 
   const [hostProvider, setHostProvider] = useState<string | null>(null)
+  const [showAdvancedBrowsers, setShowAdvancedBrowsers] = useState(false)
   const [chromeProfileId, setChromeProfileId] = useState<string | null>(null)
   const [browserbaseApiKey, setBrowserbaseApiKey] = useState('')
   const [browserbaseProjectId, setBrowserbaseProjectId] = useState('')
   const [isValidating, setIsValidating] = useState(false)
   const [validationResult, setValidationResult] = useState<{ valid: boolean; error?: string } | null>(null)
 
-  const effectiveProvider = hostProvider ?? settings?.app?.hostBrowserProvider ?? CONTAINER_VALUE
   const providers = settings?.hostBrowserStatus?.providers ?? []
   const chromeProvider = providers.find((p) => p.id === 'chrome')
+  const isChromeAvailable = !!chromeProvider?.available
+  const smartDefault = isChromeAvailable ? 'chrome' : CONTAINER_VALUE
+  const effectiveProvider = hostProvider ?? settings?.app?.hostBrowserProvider ?? smartDefault
   const chromeProfiles = chromeProvider?.profiles ?? []
   const effectiveChromeProfileId = chromeProfileId ?? settings?.app?.chromeProfileId ?? ''
 
   const browserbaseProvider = providers.find((p) => p.id === 'browserbase')
   const hasSavedBrowserbaseCredentials = !!browserbaseProvider?.available
 
+  // If Browserbase is selected, can only proceed with valid credentials
+  useEffect(() => {
+    if (effectiveProvider === 'browserbase') {
+      onCanProceedChange?.(hasSavedBrowserbaseCredentials)
+    } else {
+      onCanProceedChange?.(true)
+    }
+  }, [effectiveProvider, hasSavedBrowserbaseCredentials, onCanProceedChange])
+
   const handleSelectProvider = (id: string) => {
-    const providerId = id === CONTAINER_VALUE ? null : id as HostBrowserProviderId
+    const providerId = id === CONTAINER_VALUE ? undefined : id as HostBrowserProviderId
     setHostProvider(id)
-    updateSettings.mutate({ app: { hostBrowserProvider: providerId as HostBrowserProviderId | undefined } })
+    updateSettings.mutate({ app: { hostBrowserProvider: providerId } })
   }
 
   const handleValidateBrowserbase = async () => {
-    if (!browserbaseApiKey.trim() || !browserbaseProjectId.trim()) return
+    if (!browserbaseApiKey.trim() && !browserbaseProjectId.trim()) {
+      setValidationResult({ valid: false, error: 'Enter your API key and project ID.' })
+      return
+    }
+    if (!browserbaseApiKey.trim()) {
+      setValidationResult({ valid: false, error: 'Enter your API key.' })
+      return
+    }
+    if (!browserbaseProjectId.trim()) {
+      setValidationResult({ valid: false, error: 'Enter your project ID.' })
+      return
+    }
     setIsValidating(true)
     setValidationResult(null)
     try {
@@ -73,7 +106,11 @@ export function BrowserSetupStep() {
           projectId: browserbaseProjectId.trim(),
         }),
       })
-      const result = await res.json()
+      if (!res.ok) {
+        setValidationResult({ valid: false, error: 'Failed to validate credentials' })
+        return
+      }
+      const result = await res.json() as { valid: boolean; error?: string }
       setValidationResult(result)
       if (result.valid) {
         await updateSettings.mutateAsync({
@@ -93,97 +130,134 @@ export function BrowserSetupStep() {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <div>
-        <h2 className="text-xl font-bold">Set Up Browser</h2>
+        <h2 className="text-2xl font-normal max-w-sm">Give your agents browser access</h2>
         <p className="text-sm text-muted-foreground mt-1">
-          Choose how your agents browse the web. The default container browser works out of the box.
-          This step is optional.
+          Your agents can use the internet on your behalf.<br />Choose the browser you want them to use by default.
         </p>
       </div>
 
       <div className="space-y-3">
         {BROWSER_HOST_OPTIONS.map((option) => {
+          if (option.isAdvanced && !showAdvancedBrowsers) return null
           const provider = providers.find((p) => p.id === option.id)
           const isSelected = effectiveProvider === option.id
-          const Icon = option.icon
+          const isDisabled = option.id === 'chrome' && provider && !provider.available
           return (
-            <button
+            <div
               key={option.id}
-              type="button"
-              className={`w-full flex items-start gap-3 p-3 rounded-lg border bg-card text-left transition-colors ${
-                isSelected ? 'border-primary bg-primary/5' : 'hover:border-muted-foreground/50'
+              className={`rounded-lg border text-left transition-colors ${
+                isDisabled ? 'opacity-40' : isSelected ? 'border-primary bg-muted/50' : 'hover:border-muted-foreground/50'
               }`}
-              onClick={() => handleSelectProvider(option.id)}
             >
-              <Icon className="h-5 w-5 mt-0.5 shrink-0 text-muted-foreground" />
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="font-medium text-sm">{option.label}</span>
-                  {provider && provider.available && (
-                    <span className="text-xs bg-green-500/10 text-green-600 dark:text-green-400 px-2 py-0.5 rounded-full flex items-center gap-1">
-                      <Check className="h-3 w-3" />
-                      Available
-                    </span>
-                  )}
-                  {provider && !provider.available && provider.reason && (
-                    <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full">
-                      {provider.reason}
-                    </span>
-                  )}
+              <button
+                type="button"
+                disabled={!!isDisabled}
+                className="w-full flex items-start gap-3 p-3 text-left disabled:cursor-not-allowed"
+                onClick={() => handleSelectProvider(option.id)}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-sm">{option.label}</span>
+                    {option.recommended && (
+                      <span className="text-xs text-muted-foreground">recommended</span>
+                    )}
+                  {option.isDefault && (
+                      <span className="text-xs text-muted-foreground">default</span>
+                    )}
+                  {option.isAdvanced && (
+                      <span className="text-xs text-muted-foreground">advanced</span>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    {option.description}
+                    {option.subdescription && (<><br />{option.subdescription}</>)}
+                  </p>
                 </div>
-                <p className="text-xs text-muted-foreground mt-1">{option.description}</p>
-              </div>
-              <div className={`mt-1 h-4 w-4 rounded-full border-2 shrink-0 flex items-center justify-center ${
-                isSelected ? 'border-primary' : 'border-muted-foreground/40'
-              }`}>
-                {isSelected && <div className="h-2 w-2 rounded-full bg-primary" />}
-              </div>
-            </button>
+                <div className={`mt-1 h-4 w-4 rounded-full border-2 shrink-0 flex items-center justify-center ${
+                  isSelected ? 'border-primary' : 'border-muted-foreground/40'
+                }`}>
+                  {isSelected && <div className="h-2 w-2 rounded-full bg-primary" />}
+                </div>
+              </button>
+
+              {option.id === 'chrome' && chromeProfiles.length > 0 && (
+                <div className={`grid transition-all duration-200 ease-in-out ${isSelected ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+                  <div className="overflow-hidden">
+                    <div className="px-3 pb-3 pt-2">
+                      <ChromeProfileSelect
+                        profiles={chromeProfiles}
+                        value={effectiveChromeProfileId}
+                        onValueChange={(profileId) => {
+                          setChromeProfileId(profileId)
+                          updateSettings.mutate({ app: { chromeProfileId: profileId } })
+                        }}
+                        idPrefix="wizard-chrome-profile"
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {option.id === 'browserbase' && (
+                <div className={`grid transition-all duration-200 ease-in-out ${isSelected ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+                  <div className="overflow-hidden">
+                <div className="px-3 pb-3 pt-0">
+                  <BrowserbaseSettings
+                    apiKey={browserbaseApiKey}
+                    projectId={browserbaseProjectId}
+                    onApiKeyChange={(v) => { setBrowserbaseApiKey(v); setValidationResult(null) }}
+                    onProjectIdChange={(v) => { setBrowserbaseProjectId(v); setValidationResult(null) }}
+                    isValidating={isValidating}
+                    validationResult={validationResult}
+                    hasSavedCredentials={hasSavedBrowserbaseCredentials}
+                    disabled={false}
+                    onValidateAndSave={handleValidateBrowserbase}
+                    onRemove={async () => {
+                      setIsValidating(true)
+                      try {
+                        await updateSettings.mutateAsync({
+                          apiKeys: {
+                            browserbaseApiKey: '',
+                            browserbaseProjectId: '',
+                          },
+                        })
+                        setBrowserbaseApiKey('')
+                        setBrowserbaseProjectId('')
+                        setValidationResult(null)
+                      } finally {
+                        setIsValidating(false)
+                      }
+                    }}
+                  />
+                </div>
+                  </div>
+                </div>
+              )}
+            </div>
           )
         })}
       </div>
 
-      {effectiveProvider === 'chrome' && chromeProfiles.length > 0 && (
-        <ChromeProfileSelect
-          profiles={chromeProfiles}
-          value={effectiveChromeProfileId}
-          onValueChange={(profileId) => {
-            setChromeProfileId(profileId)
-            updateSettings.mutate({ app: { chromeProfileId: profileId } })
-          }}
-          idPrefix="wizard-chrome-profile"
-        />
-      )}
-
-      {effectiveProvider === 'browserbase' && (
-        <BrowserbaseSettings
-          apiKey={browserbaseApiKey}
-          projectId={browserbaseProjectId}
-          onApiKeyChange={(v) => { setBrowserbaseApiKey(v); setValidationResult(null) }}
-          onProjectIdChange={(v) => { setBrowserbaseProjectId(v); setValidationResult(null) }}
-          isValidating={isValidating}
-          validationResult={validationResult}
-          hasSavedCredentials={hasSavedBrowserbaseCredentials}
-          disabled={false}
-          onValidateAndSave={handleValidateBrowserbase}
-          onRemove={async () => {
-            setIsValidating(true)
-            try {
-              await updateSettings.mutateAsync({
-                apiKeys: {
-                  browserbaseApiKey: '',
-                  browserbaseProjectId: '',
-                },
-              })
-              setBrowserbaseApiKey('')
-              setBrowserbaseProjectId('')
-              setValidationResult(null)
-            } finally {
-              setIsValidating(false)
-            }
-          }}
-        />
+      {!showAdvancedBrowsers ? (
+        <div className="flex justify-start">
+          <button
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            onClick={() => setShowAdvancedBrowsers(true)}
+          >
+            Show advanced options
+          </button>
+        </div>
+      ) : (
+        <div className="flex justify-start">
+          <button
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            onClick={() => setShowAdvancedBrowsers(false)}
+          >
+            Show less
+          </button>
+        </div>
       )}
     </div>
   )

--- a/src/renderer/components/wizard/composio-step.tsx
+++ b/src/renderer/components/wizard/composio-step.tsx
@@ -1,14 +1,10 @@
 import { useState, useEffect } from 'react'
 import { Input } from '@renderer/components/ui/input'
 import { Label } from '@renderer/components/ui/label'
-import { Alert, AlertDescription } from '@renderer/components/ui/alert'
 import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
-import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user-settings'
 import { ComposioApiKeyInput } from '@renderer/components/settings/composio-api-key-input'
-import { Check } from 'lucide-react'
-import { ConnectedAccountsSection } from '@renderer/components/connected-accounts-section'
+import { CircleCheckBig, ChevronRight } from 'lucide-react'
 import { useUser } from '@renderer/context/user-context'
-import { PolicyDecisionToggle } from '@renderer/components/ui/policy-decision-toggle'
 
 export interface ComposioStepProps {
   onCanProceedChange: (canProceed: boolean) => void
@@ -22,6 +18,7 @@ export function ComposioStep({ onCanProceedChange, saveRef }: ComposioStepProps)
 
   const [composioUserIdInput, setComposioUserIdInput] = useState('')
   const [isSaving, setIsSaving] = useState(false)
+  const [showInstructions, setShowInstructions] = useState(false)
 
   const composioApiKeyStatus = settings?.apiKeyStatus?.composio
   // In auth mode, user ID is automatic (from the logged-in user)
@@ -47,86 +44,84 @@ export function ComposioStep({ onCanProceedChange, saveRef }: ComposioStepProps)
   // Keep save ref in sync for parent to call on Next
   saveRef.current = (hasUserIdInput && !isComposioConfigured) ? handleSaveUserId : null
 
-  const { data: userSettings } = useUserSettings()
-  const updateUserSettings = useUpdateUserSettings()
-  const currentPolicy = userSettings?.defaultApiPolicy ?? 'review'
-
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <div>
-        <h2 className="text-xl font-bold">Set Up Composio</h2>
+        <h2 className="text-2xl font-normal max-w-sm">Let your agents connect to your apps</h2>
         <p className="text-sm text-muted-foreground mt-1">
-          Composio lets your agents connect to external services via OAuth (Gmail, Slack, GitHub, etc.).
-          This step is optional.
+          Composio lets your agents use apps like Gmail, Slack, and GitHub on your behalf by handling authentication securely.
         </p>
       </div>
 
-      {isComposioConfigured && (
-        <Alert>
-          <Check className="h-4 w-4 text-green-600" />
-          <AlertDescription className="text-green-700 dark:text-green-400">
-            Composio is configured. You can connect accounts below or skip to the next step.
-          </AlertDescription>
-        </Alert>
-      )}
+      <div className={`rounded-lg border p-3 transition-colors ${isComposioConfigured ? 'border-green-500 bg-green-50' : 'border-primary'}`}>
+        <div className="flex items-center gap-2">
+          {isComposioConfigured && <CircleCheckBig className="h-4 w-4 text-green-600" />}
+          <span className={`font-medium text-sm ${isComposioConfigured ? 'text-green-700 dark:text-green-400' : ''}`}>
+            {isComposioConfigured ? 'Composio connected' : 'Connect to Composio'}
+          </span>
+        </div>
+        {isComposioConfigured && (
+          <p className="text-xs text-green-700/80 dark:text-green-400/80 mt-2">
+            You&apos;ll be able to connect your apps when you build your agents.<br />You can manage app connections in settings.
+          </p>
+        )}
 
-      {!isComposioConfigured && (
-        <>
-          <ComposioApiKeyInput
-            showRemoveButton={false}
-            showSourceIndicator={false}
-          />
+        <div className={`grid transition-all duration-300 ease-in-out ${!isComposioConfigured ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+          <div className="overflow-hidden">
+            <div className="space-y-3 pt-3">
+              <div className="space-y-1">
+                <Label htmlFor="wizard-composio-userid">Composio User ID</Label>
+                <Input
+                  id="wizard-composio-userid"
+                  type="text"
+                  value={isAuthMode ? (user?.id ?? '') : composioUserIdInput}
+                  onChange={(e) => setComposioUserIdInput(e.target.value)}
+                  placeholder="Enter your Composio user ID (e.g., your email)"
+                  disabled={isAuthMode}
+                />
+              </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="wizard-composio-userid">Composio User ID</Label>
-            <Input
-              id="wizard-composio-userid"
-              type="text"
-              value={isAuthMode ? (user?.id ?? '') : composioUserIdInput}
-              onChange={(e) => setComposioUserIdInput(e.target.value)}
-              placeholder="Enter your Composio user ID (e.g., your email)"
-              disabled={isAuthMode}
-            />
-            <p className="text-xs text-muted-foreground">
-              {isAuthMode
-                ? 'Automatically set from your account.'
-                : 'Your unique identifier in Composio. Can be any string.'}
-            </p>
-          </div>
-        </>
-      )}
-
-      {isComposioConfigured && (
-        <>
-          <div className="rounded-md border p-3 space-y-2">
-            <div>
-              <Label className="text-sm font-medium">Default API Request Policy</Label>
-              <p className="text-xs text-muted-foreground mt-0.5">
-                When agents make API calls or use MCP tools, this policy determines what happens by default.
-                You can override this per-account or per-tool later in Settings.
-              </p>
-            </div>
-            <div className="flex items-center gap-3">
-              <PolicyDecisionToggle
-                value={currentPolicy}
-                onChange={(value) => {
-                  if (value === 'default') return // Global default must be set
-                  updateUserSettings.mutate({ defaultApiPolicy: value })
-                }}
-                size="md"
+              <ComposioApiKeyInput
+                showRemoveButton={false}
+                showSourceIndicator={false}
+                showHelpText={false}
+                validateButtonLabel="Connect"
               />
-              <span className="text-xs text-muted-foreground">
-                {currentPolicy === 'allow' && 'Agents can make API calls without asking.'}
-                {currentPolicy === 'review' && 'You\'ll be prompted to approve each new type of request.'}
-                {currentPolicy === 'block' && 'All API calls are blocked until you add explicit allow rules.'}
-              </span>
+
+              <div className="mt-3">
+                <button
+                  type="button"
+                  onClick={() => setShowInstructions(!showInstructions)}
+                  className="text-sm text-primary hover:underline flex items-center gap-1"
+                >
+                  <ChevronRight className={`h-3 w-3 transition-transform ${showInstructions ? 'rotate-90' : ''}`} />
+                  How to get your API key
+                </button>
+
+                {showInstructions && (
+                  <div className="mt-2 p-2.5 rounded-md border bg-muted/30">
+                    <ol className="list-decimal list-inside space-y-1 text-xs text-muted-foreground">
+                      <li>Go to the{' '}
+                        <a
+                          href="https://app.composio.dev/settings"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary underline underline-offset-4"
+                        >
+                          Composio Dashboard
+                        </a>
+                      </li>
+                      <li>Navigate to Settings and copy your API key</li>
+                      <li>Paste it in the field above</li>
+                    </ol>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
-          <div className="pt-2 border-t">
-            <ConnectedAccountsSection />
-          </div>
-        </>
-      )}
+        </div>
+      </div>
+
     </div>
   )
 }

--- a/src/renderer/components/wizard/configure-llm-step.tsx
+++ b/src/renderer/components/wizard/configure-llm-step.tsx
@@ -1,30 +1,11 @@
-import { useState } from 'react'
-import { Alert, AlertDescription } from '@renderer/components/ui/alert'
-import { Button } from '@renderer/components/ui/button'
-import { Label } from '@renderer/components/ui/label'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@renderer/components/ui/select'
+import { useState, useEffect } from 'react'
 import { ProviderApiKeyInput } from '@renderer/components/settings/provider-api-key-input'
 import { BedrockCredentialsInput } from '@renderer/components/settings/bedrock-credentials-input'
 import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
-import { usePlatformConnect } from '@renderer/hooks/use-platform-auth'
-import { ManualAccessKeyInput } from '@renderer/components/settings/manual-access-key-input'
-import { ChevronRight, Loader2, LogIn } from 'lucide-react'
+import { ChevronRight } from 'lucide-react'
 import type { LlmProviderId } from '@shared/lib/config/settings'
 
 const PROVIDER_INSTRUCTIONS: Record<string, { steps: { text: string; link?: { href: string; label: string } }[] }> = {
-  platform: {
-    steps: [
-      { text: 'Choose Platform as your provider' },
-      { text: 'Connect your account from the Platform settings tab' },
-      { text: 'SuperAgent will use your platform token and the hosted proxy automatically' },
-    ],
-  },
   anthropic: {
     steps: [
       { text: 'Sign up for an account at', link: { href: 'https://console.anthropic.com/login', label: 'console.anthropic.com' } },
@@ -68,196 +49,150 @@ const SIMPLE_PROVIDER_KEY_CONFIG: Record<string, {
   },
 }
 
+const LLM_PROVIDER_OPTIONS: Array<{
+  id: LlmProviderId
+  label: string
+  description: string
+}> = [
+  {
+    id: 'anthropic',
+    label: 'Anthropic (Claude)',
+    description: 'Direct API access to Claude models.',
+  },
+  {
+    id: 'openrouter',
+    label: 'OpenRouter',
+    description: 'Multi-model access through a single API key.',
+  },
+  {
+    id: 'bedrock',
+    label: 'Amazon Bedrock',
+    description: 'AWS managed Claude inference with IAM or API key credentials.',
+  },
+]
+
 interface ConfigureLLMStepProps {
-  mode?: 'manual' | 'platform'
-  onPlatformConnected?: () => void
+  onCanProceedChange?: (canProceed: boolean) => void
 }
 
-export function ConfigureLLMStep({ mode = 'manual', onPlatformConnected }: ConfigureLLMStepProps) {
-  const [showInstructions, setShowInstructions] = useState(false)
+export function ConfigureLLMStep({ onCanProceedChange }: ConfigureLLMStepProps) {
   const { data: settings } = useSettings()
   const updateSettings = useUpdateSettings()
-  const {
-    handleConnect,
-    isLaunching,
-    error: platformError,
-    isConnected,
-    platformAuth,
-  } = usePlatformConnect({
-    successMessage: null,
-    onSuccess: () => {
-      if (mode === 'platform') {
-        onPlatformConnected?.()
-      }
-    },
-  })
 
   const activeProvider = (settings?.llmProvider ?? 'anthropic') as LlmProviderId
-  const providerStatus = settings?.llmProviderStatus ?? []
-  const instructions = PROVIDER_INSTRUCTIONS[activeProvider]
+  const [showInstructions, setShowInstructions] = useState<string | null>(null)
 
-  if (mode === 'platform') {
-    return (
-      <div className="space-y-4">
-        <div>
-          <h2 className="text-xl font-bold">Connect to Platform</h2>
-          <p className="text-sm text-muted-foreground mt-1">
-            Sign in to Platform to use your subscription and hosted proxy.
-          </p>
-        </div>
-
-        <div className="rounded-lg border bg-muted/30 p-4 space-y-3">
-          <p className="text-sm text-muted-foreground">
-            {isConnected
-              ? `Connected to ${platformAuth?.email ?? 'Platform'}. SuperAgent will use your Platform subscription automatically.`
-              : 'Connect your account to continue with the Platform setup flow.'}
-          </p>
-
-          <Button
-            type="button"
-            variant="default"
-            onClick={() => {
-              void handleConnect()
-            }}
-            disabled={isLaunching}
-          >
-            {isLaunching ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <LogIn className="mr-2 h-4 w-4" />
-            )}
-            Connect
-          </Button>
-
-          {platformError ? (
-            <Alert variant="destructive">
-              <AlertDescription>{platformError}</AlertDescription>
-            </Alert>
-          ) : null}
-        </div>
-
-        <ManualAccessKeyInput />
-      </div>
-    )
-  }
+  // Report to parent whether the selected provider has configured keys
+  const apiKeyStatus = (settings?.apiKeyStatus as Record<string, { isConfigured: boolean }> | undefined)
+  const activeProviderConfigured = apiKeyStatus?.[activeProvider]?.isConfigured ?? false
+  useEffect(() => {
+    onCanProceedChange?.(activeProviderConfigured)
+  }, [activeProviderConfigured, onCanProceedChange])
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <div>
-        <h2 className="text-xl font-bold">Configure LLM Provider</h2>
+        <h2 className="text-2xl font-normal max-w-sm">Connect an LLM provider</h2>
         <p className="text-sm text-muted-foreground mt-1">
-          Superagent needs either an API key or a Platform connection to communicate with AI models.
+          Keys will be saved locally. Enter a new key to override previously set environment variables or saved keys. Manage saved keys in settings.
         </p>
       </div>
 
-      <div className="space-y-2">
-        <Label>Provider</Label>
-        <Select
-          value={activeProvider}
-          onValueChange={(value) => {
-            updateSettings.mutate({ llmProvider: value as LlmProviderId })
-          }}
-        >
-          <SelectTrigger>
-            <SelectValue placeholder="Select a provider" />
-          </SelectTrigger>
-          <SelectContent>
-            {providerStatus.map((provider) => (
-              <SelectItem key={provider.id} value={provider.id}>
-                {provider.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+      <div className="space-y-3">
+        {LLM_PROVIDER_OPTIONS.map((option) => {
+          const isSelected = activeProvider === option.id
+          const instructions = PROVIDER_INSTRUCTIONS[option.id]
 
-      {activeProvider === 'bedrock' ? (
-        <BedrockCredentialsInput
-          key="bedrock"
-          showNotConfiguredAlert={false}
-        />
-      ) : activeProvider === 'platform' ? (
-        <div className="space-y-3">
-          <p className="text-sm text-muted-foreground">
-            {isConnected
-              ? `Connected to ${platformAuth?.email ?? 'Platform'}. SuperAgent will use your Platform subscription automatically.`
-              : 'Platform not connected yet. Connect now to use your Platform subscription.'}
-          </p>
-          {!isConnected ? (
-            <>
-              <Button
+          return (
+            <div
+              key={option.id}
+              className={`rounded-lg border text-left transition-colors ${
+                isSelected ? 'border-primary bg-muted/50' : 'hover:border-muted-foreground/50'
+              }`}
+            >
+              <button
                 type="button"
-                variant="outline"
-                onClick={() => {
-                  void handleConnect()
-                }}
-                disabled={isLaunching}
+                className="w-full flex items-start gap-3 p-3 text-left"
+                onClick={() => updateSettings.mutate({ llmProvider: option.id })}
               >
-                {isLaunching ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : (
-                  <LogIn className="mr-2 h-4 w-4" />
-                )}
-                Connect Platform
-              </Button>
-              {platformError ? (
-                <Alert variant="destructive">
-                  <AlertDescription>{platformError}</AlertDescription>
-                </Alert>
-              ) : null}
-            </>
-          ) : null}
-        </div>
-      ) : (
-        <ProviderApiKeyInput
-          key={activeProvider}
-          providerId={activeProvider}
-          label={SIMPLE_PROVIDER_KEY_CONFIG[activeProvider].label}
-          placeholder={SIMPLE_PROVIDER_KEY_CONFIG[activeProvider].placeholder}
-          envVarName={SIMPLE_PROVIDER_KEY_CONFIG[activeProvider].envVarName}
-          apiKeySettingsField={SIMPLE_PROVIDER_KEY_CONFIG[activeProvider].apiKeySettingsField}
-          showNotConfiguredAlert={false}
-          showHelpText={false}
-          showRemoveButton={false}
-        />
-      )}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-sm">{option.label}</span>
+                  </div>
+                </div>
+                <div className={`mt-1 h-4 w-4 rounded-full border-2 shrink-0 flex items-center justify-center ${
+                  isSelected ? 'border-primary' : 'border-muted-foreground/40'
+                }`}>
+                  {isSelected && <div className="h-2 w-2 rounded-full bg-primary" />}
+                </div>
+              </button>
 
-      {instructions && (
-        <div className="pt-2">
-          <button
-            type="button"
-            onClick={() => setShowInstructions(!showInstructions)}
-            className="text-sm text-primary hover:underline flex items-center gap-1"
-          >
-            <ChevronRight className={`h-3 w-3 transition-transform ${showInstructions ? 'rotate-90' : ''}`} />
-            How to get started
-          </button>
-
-          {showInstructions && (
-            <div className="mt-2 p-3 rounded-md border bg-muted/30 text-sm space-y-2">
-              <ol className="list-decimal list-inside space-y-1.5 text-muted-foreground">
-                {instructions.steps.map((step, i) => (
-                  <li key={i}>
-                    {step.text}{step.link && (
-                      <>
-                        {' '}
-                        <a
-                          href={step.link.href}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-primary underline underline-offset-4"
-                        >
-                          {step.link.label}
-                        </a>
-                      </>
+              {/* Expanded settings area when selected */}
+              <div className={`grid transition-all duration-200 ease-in-out ${isSelected ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+                <div className="overflow-hidden">
+                  <div className="px-3 pb-3 pt-2">
+                    {option.id === 'bedrock' ? (
+                      <BedrockCredentialsInput
+                        key="bedrock"
+                        showNotConfiguredAlert={false}
+                      />
+                    ) : (
+                      <ProviderApiKeyInput
+                        key={option.id}
+                        providerId={option.id}
+                        label={SIMPLE_PROVIDER_KEY_CONFIG[option.id].label}
+                        placeholder={SIMPLE_PROVIDER_KEY_CONFIG[option.id].placeholder}
+                        envVarName={SIMPLE_PROVIDER_KEY_CONFIG[option.id].envVarName}
+                        apiKeySettingsField={SIMPLE_PROVIDER_KEY_CONFIG[option.id].apiKeySettingsField}
+                        showNotConfiguredAlert={false}
+                        showHelpText={false}
+                        showRemoveButton={false}
+                      />
                     )}
-                  </li>
-                ))}
-              </ol>
+
+                    {instructions && (
+                      <div className="mt-3">
+                        <button
+                          type="button"
+                          onClick={() => setShowInstructions(showInstructions === option.id ? null : option.id)}
+                          className="text-sm text-primary hover:underline flex items-center gap-1"
+                        >
+                          <ChevronRight className={`h-3 w-3 transition-transform ${showInstructions === option.id ? 'rotate-90' : ''}`} />
+                          How to get your API key
+                        </button>
+
+                        {showInstructions === option.id && (
+                          <div className="mt-2 p-2.5 rounded-md border bg-muted/30">
+                            <ol className="list-decimal list-inside space-y-1 text-xs text-muted-foreground">
+                              {instructions.steps.map((step, i) => (
+                                <li key={i}>
+                                  {step.text}{step.link && (
+                                    <>
+                                      {' '}
+                                      <a
+                                        href={step.link.href}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-primary underline underline-offset-4"
+                                      >
+                                        {step.link.label}
+                                      </a>
+                                    </>
+                                  )}
+                                </li>
+                              ))}
+                            </ol>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
             </div>
-          )}
-        </div>
-      )}
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/src/renderer/components/wizard/create-agent-step.tsx
+++ b/src/renderer/components/wizard/create-agent-step.tsx
@@ -1,127 +1,220 @@
-import { useState, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { Button } from '@renderer/components/ui/button'
-import { Input } from '@renderer/components/ui/input'
-import { Label } from '@renderer/components/ui/label'
-import { Alert, AlertDescription } from '@renderer/components/ui/alert'
-import { Checkbox } from '@renderer/components/ui/checkbox'
+import { ChatComposerBox } from '@renderer/components/messages/chat-composer-box'
+import { AttachmentPicker } from '@renderer/components/ui/attachment-picker'
+import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
 import { useCreateAgent } from '@renderer/hooks/use-agents'
+import { useCreateSession } from '@renderer/hooks/use-sessions'
 import { useSelection } from '@renderer/context/selection-context'
-import { useUpdateSettings } from '@renderer/hooks/use-settings'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
-import { Loader2, Check } from 'lucide-react'
+import { useMessageComposer } from '@renderer/hooks/use-message-composer'
+import { apiFetch } from '@renderer/lib/api'
+import { Loader2 } from 'lucide-react'
 
-export function CreateAgentStep() {
-  const [name, setName] = useState('')
-  const [created, setCreated] = useState(false)
-  const [shareAnalytics, setShareAnalytics] = useState(true)
-  const [shareErrorReports, setShareErrorReports] = useState(true)
+const PLACEHOLDER_EXAMPLES = [
+  // HR recruiter — one-shot
+  'Search LinkedIn for senior backend engineers in NYC with 5+ years of Python experience. Reach out to the top 10 candidates with personalized intro messages.',
+  // CEO — recurring weekly
+  'Every Monday morning, pull highlights from my Granola meetings, Linear issues, and Slack DMs. Send me a briefing of key decisions and blockers from last week.',
+  // Financial ops — recurring monthly
+  'At the end of every month, reconcile expenses from my Gmail receipts against our QuickBooks ledger. Flag anything missing, duplicated, or out of policy.',
+  // Product manager — recurring daily
+  'Every morning, scan new Linear issues and customer feedback from our support inbox. Cluster them into themes and post a daily summary in our #product Slack channel.',
+]
+
+interface CreateAgentStepProps {
+  onAgentCreated?: () => Promise<void> | void
+}
+
+export function CreateAgentStep({ onAgentCreated }: CreateAgentStepProps) {
+  const [pendingAgentSlug, setPendingAgentSlug] = useState<string | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Typewriter placeholder cycle
+  const [displayedPlaceholder, setDisplayedPlaceholder] = useState('')
+  useEffect(() => {
+    let cancelled = false
+    let timeoutId: ReturnType<typeof setTimeout>
+
+    const TYPE_MS = 25
+    const DELETE_MS = 12
+    const HOLD_FULL_MS = 2000
+    const HOLD_EMPTY_MS = 350
+
+    const run = (exampleIdx: number, charIdx: number, deleting: boolean) => {
+      if (cancelled) return
+      const fullText = PLACEHOLDER_EXAMPLES[exampleIdx]
+
+      if (!deleting && charIdx <= fullText.length) {
+        setDisplayedPlaceholder(fullText.slice(0, charIdx))
+        if (charIdx === fullText.length) {
+          timeoutId = setTimeout(() => run(exampleIdx, charIdx, true), HOLD_FULL_MS)
+        } else {
+          timeoutId = setTimeout(() => run(exampleIdx, charIdx + 1, false), TYPE_MS)
+        }
+      } else if (deleting && charIdx >= 0) {
+        setDisplayedPlaceholder(fullText.slice(0, charIdx))
+        if (charIdx === 0) {
+          timeoutId = setTimeout(
+            () => run((exampleIdx + 1) % PLACEHOLDER_EXAMPLES.length, 0, false),
+            HOLD_EMPTY_MS
+          )
+        } else {
+          timeoutId = setTimeout(() => run(exampleIdx, charIdx - 1, true), DELETE_MS)
+        }
+      }
+    }
+
+    run(0, 0, false)
+
+    return () => {
+      cancelled = true
+      clearTimeout(timeoutId)
+    }
+  }, [])
   const createAgent = useCreateAgent()
-  const { selectAgent } = useSelection()
-  const updateSettings = useUpdateSettings()
+  const createSession = useCreateSession()
+  const { selectAgent, selectSession } = useSelection()
   const { track } = useAnalyticsTracking()
 
-  // Persist the analytics and error reporting preferences when they change
-  useEffect(() => {
-    updateSettings.mutate({ shareAnalytics })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shareAnalytics])
+  const composer = useMessageComposer({
+    agentSlug: pendingAgentSlug ?? '',
+    uploadFile: useCallback(async ({ file }: { file: File }) => {
+      if (!pendingAgentSlug) throw new Error('No agent yet')
+      const formData = new FormData()
+      formData.append('file', file)
+      const res = await apiFetch(
+        `/api/agents/${pendingAgentSlug}/upload-file`,
+        { method: 'POST', body: formData }
+      )
+      if (!res.ok) throw new Error('Failed to upload file')
+      return res.json() as Promise<{ path: string }>
+    }, [pendingAgentSlug]),
+    uploadFolder: useCallback(async ({ sourcePath }: { sourcePath: string }) => {
+      if (!pendingAgentSlug) throw new Error('No agent yet')
+      const res = await apiFetch(
+        `/api/agents/${pendingAgentSlug}/upload-folder`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sourcePath }),
+        }
+      )
+      if (!res.ok) throw new Error('Failed to upload folder')
+      return res.json() as Promise<{ path: string }>
+    }, [pendingAgentSlug]),
+    onSubmit: useCallback(async (content: string) => {
+      try {
+        // Ask the backend to generate a descriptive name from the prompt using the summarizer model
+        let generatedName = ''
+        try {
+          const res = await apiFetch('/api/agents/generate-name', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ prompt: content.trim() }),
+          })
+          if (res.ok) {
+            const data = await res.json() as { name?: string }
+            generatedName = data.name?.trim() ?? ''
+          }
+        } catch {
+          // Fall back to simple truncation if the generate endpoint fails
+        }
+        const fallbackName = content.trim().split(/\s+/).slice(0, 5).join(' ').slice(0, 50)
+        const agentName = generatedName || fallbackName || 'My First Agent'
+        const newAgent = await createAgent.mutateAsync({ name: agentName })
+        track('agent_created', { source: 'new', num_skills_added_at_creation: 0 })
+        setPendingAgentSlug(newAgent.slug)
+        selectAgent(newAgent.slug)
 
-  useEffect(() => {
-    updateSettings.mutate({ shareErrorReports })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shareErrorReports])
+        const session = await createSession.mutateAsync({
+          agentSlug: newAgent.slug,
+          message: content,
+        })
+        selectSession(session.id)
 
-  const handleCreate = async () => {
-    if (!name.trim()) return
-    try {
-      const newAgent = await createAgent.mutateAsync({ name: name.trim() })
-      track('agent_created', { source: 'new', num_skills_added_at_creation: 0 })
-      selectAgent(newAgent.slug)
-      setCreated(true)
-    } catch (error) {
-      console.error('Failed to create agent:', error)
+        await onAgentCreated?.()
+      } catch (error) {
+        console.error('Failed to create agent:', error)
+      }
+    }, [createAgent, createSession, selectAgent, selectSession, track, onAgentCreated]),
+  })
+
+  // Auto-resize textarea based on content, capped at 240px
+  useEffect(() => {
+    const textarea = textareaRef.current
+    if (textarea) {
+      textarea.style.height = 'auto'
+      textarea.style.height = `${Math.min(textarea.scrollHeight, 240)}px`
+    }
+  }, [composer.message])
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      e.currentTarget.closest('form')?.requestSubmit()
     }
   }
 
+  const isDisabled = createAgent.isPending || createSession.isPending
+
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <div>
-        <h2 className="text-xl font-bold">Create Your First Agent</h2>
-        <p className="text-sm text-muted-foreground mt-1">
-          Create an AI agent to get started. Each agent runs in its own container and can be customized with instructions and tools.
-          This step is optional.
-        </p>
+        <h2 className="text-2xl font-normal max-w-sm">Let&apos;s create your first agent</h2>
       </div>
 
-      {created ? (
-        <Alert>
-          <Check className="h-4 w-4 text-green-600" />
-          <AlertDescription className="text-green-700 dark:text-green-400">
-            Agent created successfully! Click <strong>Finish</strong> to start using Superagent.
-          </AlertDescription>
-        </Alert>
-      ) : (
-        <div className="space-y-3">
-          <div className="space-y-2">
-            <Label htmlFor="wizard-agent-name">Agent Name</Label>
-            <Input
-              id="wizard-agent-name"
-              placeholder="My First Agent"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handleCreate()
-              }}
-              data-testid="wizard-agent-name-input"
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          void composer.handleSubmit(e)
+        }}
+      >
+        <ChatComposerBox
+          textareaRef={textareaRef}
+          attachments={composer.attachments}
+          onRemoveAttachment={composer.removeAttachment}
+          value={composer.message}
+          onChange={(e) => composer.setMessage(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onPaste={composer.handlePaste}
+          placeholder={displayedPlaceholder}
+          disabled={isDisabled}
+          rows={3}
+          autoFocus
+          dataTestId="wizard-agent-prompt"
+          leftActions={(
+            <AttachmentPicker
+              onFileSelect={composer.handleFileSelect}
+              onFolderSelect={composer.handleFolderSelect}
+              disabled={isDisabled}
             />
-          </div>
+          )}
+          rightActions={(
+            <>
+              <VoiceInputButton voiceInput={composer.voiceInput} message={composer.message} disabled={isDisabled} />
+              <Button
+                type="submit"
+                size="sm"
+                data-testid="wizard-create-agent"
+              >
+                {isDisabled ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                    Creating...
+                  </>
+                ) : (
+                  'Create Agent'
+                )}
+              </Button>
+            </>
+          )}
+          footer={(
+            <VoiceInputError error={composer.voiceInput.error} onDismiss={composer.voiceInput.clearError} className="mt-2 justify-center" />
+          )}
+        />
+      </form>
 
-          <Button
-            onClick={handleCreate}
-            disabled={!name.trim() || createAgent.isPending}
-            data-testid="wizard-create-agent"
-          >
-            {createAgent.isPending ? (
-              <>
-                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                Creating...
-              </>
-            ) : (
-              'Create Agent'
-            )}
-          </Button>
-        </div>
-      )}
-
-      {/* Error reporting & analytics opt-in */}
-      <div className="pt-4 border-t space-y-3">
-        <div className="flex items-center gap-3">
-          <Checkbox
-            id="wizard-share-error-reports"
-            checked={shareErrorReports}
-            onCheckedChange={(checked) => setShareErrorReports(!!checked)}
-          />
-          <div className="space-y-0.5">
-            <Label htmlFor="wizard-share-error-reports" className="cursor-pointer">Share error reports</Label>
-            <p className="text-xs text-muted-foreground">
-              Send error reports to help us diagnose and fix issues faster. You can change this later in Settings.
-            </p>
-          </div>
-        </div>
-        <div className="flex items-center gap-3">
-          <Checkbox
-            id="wizard-share-analytics"
-            checked={shareAnalytics}
-            onCheckedChange={(checked) => setShareAnalytics(!!checked)}
-          />
-          <div className="space-y-0.5">
-            <Label htmlFor="wizard-share-analytics" className="cursor-pointer">Share anonymous analytics</Label>
-            <p className="text-xs text-muted-foreground">
-              Help improve Superagent by sharing anonymous usage data. You can change this later in Settings.
-            </p>
-          </div>
-        </div>
-      </div>
     </div>
   )
 }

--- a/src/renderer/components/wizard/docker-setup-step.tsx
+++ b/src/renderer/components/wizard/docker-setup-step.tsx
@@ -1,59 +1,57 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { Button } from '@renderer/components/ui/button'
-import { Alert, AlertDescription } from '@renderer/components/ui/alert'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@renderer/components/ui/collapsible'
 import { useSettings, useStartRunner, useRefreshAvailability } from '@renderer/hooks/use-settings'
 import { useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
 import { getPlatform } from '@renderer/lib/env'
 import { Wsl2InstallGuide } from './wsl2-install-guide'
+import { RequestError } from '@renderer/components/messages/request-error'
 import {
   Loader2,
   Check,
-  Play,
-  ExternalLink,
+  Power,
+  ArrowUpRight,
   RefreshCw,
-  ChevronDown,
 } from 'lucide-react'
 
-const RUNTIME_INFO: Record<string, { name: string; description: string; installUrl: string; icon: string }> = {
+const RUNTIME_INFO: Record<string, { name: string; description: string; installUrl: string }> = {
   'apple-container': {
     name: 'macOS Container',
     description: 'Native container runtime built into macOS. Fast and lightweight with no extra software needed.',
     installUrl: 'https://github.com/apple/container',
-    icon: '🍎',
   },
   docker: {
     name: 'Docker Desktop',
-    description: 'The most popular container runtime. Easy to use with a graphical interface.',
+    description: 'The most popular third-party container runtime. Easy to use with a graphical interface.',
     installUrl: 'https://www.docker.com/products/docker-desktop/',
-    icon: '🐳',
   },
   podman: {
     name: 'Podman',
-    description: 'A lightweight, daemonless container engine. Great alternative to Docker.',
+    description: 'A lightweight, daemonless container engine. Great alternative to Docker for more technical users.',
     installUrl: 'https://podman.io/getting-started/installation',
-    icon: '🦭',
   },
   lima: {
     name: 'Built-in Runtime',
     description: 'Bundled lightweight container runtime. No extra software needed — just works.',
     installUrl: '',
-    icon: '📦',
   },
   wsl2: {
     name: 'Built-in Runtime',
-    description: 'Lightweight container runtime using WSL2. Run "wsl --install" in PowerShell as Administrator, then restart your computer.',
+    description: 'Bundled lightweight container runtime using WSL2. No extra software needed — just works.',
     installUrl: 'https://learn.microsoft.com/en-us/windows/wsl/install',
-    icon: '📦',
   },
 }
 
-export function DockerSetupStep() {
+interface DockerSetupStepProps {
+  onCanProceedChange?: (canProceed: boolean) => void
+}
+
+export function DockerSetupStep({ onCanProceedChange }: DockerSetupStepProps) {
   const { data: settings } = useSettings()
   const { data: runtimeStatus } = useRuntimeStatus()
   const startRunner = useStartRunner()
   const refreshAvailability = useRefreshAvailability()
-  const [othersOpen, setOthersOpen] = useState(false)
+  const [selectedRunner, setSelectedRunner] = useState<string | null>(null)
+  const [showMoreOptions, setShowMoreOptions] = useState(false)
 
   // Detect if the built-in runtime (Lima on macOS, WSL2 on Windows) is actively starting
   const isBuiltinStarting = runtimeStatus?.runtimeReadiness?.status === 'CHECKING' &&
@@ -61,26 +59,39 @@ export function DockerSetupStep() {
 
   const runtimeStatuses = useMemo(() => {
     if (!settings?.runnerAvailability) return []
-    return settings.runnerAvailability.map((r) => ({
+    const statuses = settings.runnerAvailability.map((r) => ({
       ...r,
-      info: RUNTIME_INFO[r.runner] || { name: r.runner, description: '', installUrl: '', icon: '📦' },
-      // Built-in runtimes count as "effectively available" while starting
+      info: RUNTIME_INFO[r.runner] || { name: r.runner, description: '', installUrl: '' },
       effectivelyAvailable: r.available || ((r.runner === 'lima' || r.runner === 'wsl2') && isBuiltinStarting),
     }))
+    // Built-in runtime (lima/wsl2) should always appear first
+    return statuses.sort((a, b) => {
+      const aBuiltin = a.runner === 'lima' || a.runner === 'wsl2' ? 0 : 1
+      const bBuiltin = b.runner === 'lima' || b.runner === 'wsl2' ? 0 : 1
+      return aBuiltin - bBuiltin
+    })
   }, [settings?.runnerAvailability, isBuiltinStarting])
 
-  // Split into primary (available/starting) and others — prefer built-in runtimes
-  const primaryRuntime =
-    runtimeStatuses.find((r) => r.effectivelyAvailable && (r.runner === 'lima' || r.runner === 'wsl2'))
-    || runtimeStatuses.find((r) => r.effectivelyAvailable)
-  const otherRuntimes = runtimeStatuses.filter((r) => r !== primaryRuntime)
+  // Default selection: always prefer built-in runtime, then any available, then first in list
+  const defaultRunner = useMemo(() => {
+    return (
+      runtimeStatuses.find((r) => r.runner === 'lima' || r.runner === 'wsl2')
+      || runtimeStatuses.find((r) => r.effectivelyAvailable)
+      || runtimeStatuses[0]
+    )?.runner ?? null
+  }, [runtimeStatuses])
 
-  // On Windows, check if WSL2 needs to be installed
+  const effectiveSelected = selectedRunner ?? defaultRunner
+
   const isWindows = getPlatform() === 'win32'
   const wsl2Runtime = runtimeStatuses.find((r) => r.runner === 'wsl2')
   const showWsl2Guide = isWindows && wsl2Runtime && !wsl2Runtime.installed
 
-  const hasAvailableRunner = primaryRuntime != null
+  // Report to parent whether the selected runtime is available and running
+  const selectedRuntime = runtimeStatuses.find((r) => r.runner === effectiveSelected)
+  useEffect(() => {
+    onCanProceedChange?.(selectedRuntime?.available ?? false)
+  }, [selectedRuntime?.available, onCanProceedChange])
 
   const handleStartRunner = async (runner: string) => {
     try {
@@ -98,161 +109,158 @@ export function DockerSetupStep() {
     }
   }
 
-  const renderRuntime = (runtime: typeof runtimeStatuses[number]) => {
-    const isStarting = (runtime.runner === 'lima' || runtime.runner === 'wsl2') && isBuiltinStarting && !runtime.available
-
-    return (
-      <div
-        key={runtime.runner}
-        className="flex items-start gap-3 p-3 rounded-lg border bg-card"
-      >
-        <span className="text-2xl">{runtime.info.icon}</span>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <span className="font-medium">{runtime.info.name}</span>
-            {runtime.available && (
-              <span className="text-xs bg-green-500/10 text-green-600 dark:text-green-400 px-2 py-0.5 rounded-full flex items-center gap-1">
-                <Check className="h-3 w-3" />
-                Running
-              </span>
-            )}
-            {isStarting && (
-              <span className="text-xs bg-blue-500/10 text-blue-600 dark:text-blue-400 px-2 py-0.5 rounded-full flex items-center gap-1">
-                <Loader2 className="h-3 w-3 animate-spin" />
-                Starting...
-              </span>
-            )}
-            {!runtime.available && !isStarting && runtime.installed && !runtime.running && (
-              <span className="text-xs bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 px-2 py-0.5 rounded-full">
-                Installed (not running)
-              </span>
-            )}
-            {!runtime.installed && (
-              <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full">
-                Not installed
-              </span>
-            )}
-          </div>
-          <p className="text-xs text-muted-foreground mt-1">
-            {runtime.info.description}
-          </p>
-          <div className="mt-2">
-            {runtime.available ? (
-              <Button size="sm" variant="outline" className="h-7 text-xs" disabled>
-                <Check className="h-3 w-3 mr-1" />
-                Ready to use
-              </Button>
-            ) : isStarting ? (
-              <Button size="sm" variant="outline" className="h-7 text-xs" disabled>
-                <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-                Starting...
-              </Button>
-            ) : runtime.installed && runtime.canStart ? (
-              <Button
-                size="sm"
-                className="h-7 text-xs"
-                onClick={() => handleStartRunner(runtime.runner)}
-                disabled={startRunner.isPending}
-              >
-                {startRunner.isPending ? (
-                  <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-                ) : (
-                  <Play className="h-3 w-3 mr-1" />
-                )}
-                Start {runtime.info.name}
-              </Button>
-            ) : (
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7 text-xs"
-                onClick={() => handleOpenInstallLink(runtime.info.installUrl)}
-              >
-                <ExternalLink className="h-3 w-3 mr-1" />
-                Install {runtime.info.name}
-              </Button>
-            )}
-          </div>
-        </div>
-      </div>
-    )
-  }
-
   return (
-    <div className="space-y-4">
-      <div className="flex items-start justify-between">
-        <div>
-          <h2 className="text-xl font-bold">Set Up Container Runtime</h2>
-          <p className="text-sm text-muted-foreground mt-1">
-            Superagent runs AI agents in isolated containers. You need a container runtime installed and running.
-          </p>
-        </div>
-        <Button
-          size="sm"
-          variant="ghost"
-          className="h-7 text-xs shrink-0"
-          onClick={() => refreshAvailability.mutate()}
-          disabled={refreshAvailability.isPending}
-        >
-          <RefreshCw className={`h-3 w-3 mr-1 ${refreshAvailability.isPending ? 'animate-spin' : ''}`} />
-          Recheck
-        </Button>
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-normal max-w-sm">Choose a container runtime</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          For security, every agent runs in its own isolated workspace called a &apos;container&apos;. Choose the runtime software that manages them.
+        </p>
       </div>
 
-      {hasAvailableRunner && !isBuiltinStarting && (
-        <Alert>
-          <Check className="h-4 w-4 text-green-600" />
-          <AlertDescription className="text-green-700 dark:text-green-400">
-            Container runtime is available. You&apos;re good to go!
-          </AlertDescription>
-        </Alert>
-      )}
-
-      {isBuiltinStarting && (
-        <Alert>
-          <Loader2 className="h-4 w-4 animate-spin" />
-          <AlertDescription>
-            {runtimeStatus?.runtimeReadiness?.message || 'Starting container runtime...'}
-          </AlertDescription>
-        </Alert>
-      )}
-
-      {/* WSL2 install guide for Windows users who don't have WSL2 yet */}
-      {showWsl2Guide && (
-        <div className="p-3 rounded-lg border bg-card">
-          <Wsl2InstallGuide
-            onRefresh={() => refreshAvailability.mutate()}
-            isRefreshing={refreshAvailability.isPending}
-          />
-        </div>
-      )}
 
       <div className="space-y-3">
-        {/* Primary runtime (available or starting) shown at top */}
-        {primaryRuntime && renderRuntime(primaryRuntime)}
+        {runtimeStatuses.map((runtime) => {
+          const isBuiltin = runtime.runner === 'lima' || runtime.runner === 'wsl2'
+          if (!isBuiltin && !showMoreOptions) return null
 
-        {/* Other runtimes collapsed if there's a primary */}
-        {primaryRuntime && otherRuntimes.length > 0 ? (
-          <Collapsible open={othersOpen} onOpenChange={setOthersOpen}>
-            <CollapsibleTrigger asChild>
-              <button className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors py-1">
-                <ChevronDown className={`h-3 w-3 transition-transform ${othersOpen ? 'rotate-180' : ''}`} />
-                Other runtimes
+          const isSelected = effectiveSelected === runtime.runner
+          const isStarting = isBuiltin && isBuiltinStarting && !runtime.available
+
+          return (
+            <div
+              key={runtime.runner}
+              className={`rounded-lg border text-left transition-colors ${
+                isSelected ? 'border-primary bg-muted/50' : 'hover:border-muted-foreground/50'
+              }`}
+            >
+              <button
+                type="button"
+                className="w-full flex items-start gap-3 p-3 text-left"
+                onClick={() => setSelectedRunner(runtime.runner)}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-sm">{runtime.info.name}</span>
+                    {runtime.available && (
+                      <span className="text-xs bg-green-500/10 text-green-600 dark:text-green-400 px-2 py-0.5 rounded-full flex items-center gap-1.5">
+                        <span className="relative flex h-1.5 w-1.5">
+                          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+                          <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-green-500" />
+                        </span>
+                        Running
+                      </span>
+                    )}
+                    {isStarting && (
+                      <span className="text-xs bg-blue-500/10 text-blue-600 dark:text-blue-400 px-2 py-0.5 rounded-full flex items-center gap-1">
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                        Starting...
+                      </span>
+                    )}
+                    {!runtime.available && !isStarting && runtime.installed && !runtime.running && (
+                      <span className="text-xs bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 px-2 py-0.5 rounded-full flex items-center gap-1.5">
+                        <span className="inline-flex rounded-full h-1.5 w-1.5 bg-yellow-500" />
+                        Installed (not running)
+                      </span>
+                    )}
+                    {!runtime.installed && (
+                      <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full flex items-center gap-1.5">
+                        <span className="inline-flex rounded-full h-1.5 w-1.5 bg-muted-foreground/40" />
+                        Not installed
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">{isBuiltin && 'Recommended option. '}{runtime.info.description}</p>
+                </div>
+                <div className={`mt-1 h-4 w-4 rounded-full border-2 shrink-0 flex items-center justify-center ${
+                  isSelected ? 'border-primary' : 'border-muted-foreground/40'
+                }`}>
+                  {isSelected && <div className="h-2 w-2 rounded-full bg-primary" />}
+                </div>
               </button>
-            </CollapsibleTrigger>
-            <CollapsibleContent className="space-y-3 pt-1">
-              {otherRuntimes.map(renderRuntime)}
-            </CollapsibleContent>
-          </Collapsible>
-        ) : (
-          /* No primary — show all runtimes flat */
-          otherRuntimes.map(renderRuntime)
-        )}
+
+              {/* Expanded action area when selected */}
+              <div className={`grid transition-all duration-200 ease-in-out ${isSelected ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+                <div className="overflow-hidden">
+                  <div className="px-3 pb-3">
+                    {runtime.runner === 'wsl2' && showWsl2Guide ? (
+                      <Wsl2InstallGuide
+                        onRefresh={() => refreshAvailability.mutate()}
+                        isRefreshing={refreshAvailability.isPending}
+                      />
+                    ) : runtime.available ? (
+                      null
+                    ) : isStarting ? (
+                      <p className="text-xs flex items-center gap-1.5">
+                        <span className="relative flex h-2 w-2">
+                          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-black/40 opacity-75" />
+                          <span className="relative inline-flex rounded-full h-2 w-2 bg-black" />
+                        </span>
+                        Starting up...
+                      </p>
+                    ) : runtime.installed && runtime.canStart ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7 text-xs pl-[8px]"
+                        onClick={() => handleStartRunner(runtime.runner)}
+                        disabled={startRunner.isPending}
+                      >
+                        {startRunner.isPending ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : (
+                          <Power className="!h-3 !w-3" />
+                        )}
+                        Start {runtime.info.name}
+                      </Button>
+                    ) : runtime.info.installUrl ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7 text-xs"
+                        onClick={() => handleOpenInstallLink(runtime.info.installUrl)}
+                      >
+                        Install {runtime.info.name}
+                        <ArrowUpRight className="h-3 w-3" />
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )
+        })}
       </div>
 
-      {startRunner.error && (
-        <p className="text-sm text-destructive">{startRunner.error.message}</p>
+      {!showMoreOptions ? (
+        <div className="flex justify-start">
+          <button
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            onClick={() => setShowMoreOptions(true)}
+          >
+            Show advanced options
+          </button>
+        </div>
+      ) : (
+        <div className="flex justify-between">
+          <button
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            onClick={() => setShowMoreOptions(false)}
+          >
+            Show less
+          </button>
+          <button
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+            onClick={() => refreshAvailability.mutate()}
+            disabled={refreshAvailability.isPending}
+          >
+            <RefreshCw className={`h-3 w-3 ${refreshAvailability.isPending ? 'animate-spin' : ''}`} />
+            Refresh runtime options
+          </button>
+        </div>
       )}
+
+      <RequestError message={startRunner.error?.message ?? null} />
 
       {startRunner.isSuccess && startRunner.data?.message && (
         <p className="text-sm text-green-600 dark:text-green-400">

--- a/src/renderer/components/wizard/getting-started-wizard.tsx
+++ b/src/renderer/components/wizard/getting-started-wizard.tsx
@@ -1,50 +1,49 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogTitle,
-} from '@renderer/components/ui/dialog'
 import { Button } from '@renderer/components/ui/button'
 import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user-settings'
 import {
-  Check,
   ChevronRight,
   ChevronLeft,
 } from 'lucide-react'
+import { isElectron, getPlatform } from '@renderer/lib/env'
 import { WelcomeStep } from './welcome-step'
 import { ConfigureLLMStep } from './configure-llm-step'
 import { DockerSetupStep } from './docker-setup-step'
 import { BrowserSetupStep } from './browser-setup-step'
 import { ComposioStep } from './composio-step'
 import { CreateAgentStep } from './create-agent-step'
+import { PrivacyStep } from './privacy-step'
+import { RibbonWave } from './ribbon-wave'
 
-type WizardStepId = 'llm' | 'browser' | 'composio' | 'runtime' | 'agent'
+type WizardStepId = 'llm' | 'browser' | 'composio' | 'runtime' | 'privacy' | 'agent'
 
 const MANUAL_STEPS: { id: WizardStepId; label: string; skippable: boolean }[] = [
   { id: 'llm', label: 'LLM', skippable: false },
-  { id: 'browser', label: 'Browser', skippable: true },
+  { id: 'browser', label: 'Browser', skippable: false },
   { id: 'composio', label: 'Composio', skippable: true },
-  { id: 'runtime', label: 'Runtime', skippable: true },
+  { id: 'runtime', label: 'Runtime', skippable: false },
+  { id: 'privacy', label: 'Privacy', skippable: false },
   { id: 'agent', label: 'Agent', skippable: true },
 ]
 
 const PLATFORM_STEPS: { id: WizardStepId; label: string; skippable: boolean }[] = [
-  { id: 'llm', label: 'Platform', skippable: false },
-  { id: 'browser', label: 'Browser', skippable: true },
-  { id: 'runtime', label: 'Runtime', skippable: true },
+  { id: 'browser', label: 'Browser', skippable: false },
+  { id: 'runtime', label: 'Runtime', skippable: false },
+  { id: 'privacy', label: 'Privacy', skippable: false },
   { id: 'agent', label: 'Agent', skippable: true },
 ]
 
 interface GettingStartedWizardProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
+  onClose: () => void
 }
 
-export function GettingStartedWizard({ open, onOpenChange }: GettingStartedWizardProps) {
+export function GettingStartedWizard({ onClose }: GettingStartedWizardProps) {
   const [currentStep, setCurrentStep] = useState(0)
   const [welcomePath, setWelcomePath] = useState<'platform' | 'manual' | null>(null)
   const [composioCanProceed, setComposioCanProceed] = useState(false)
+  const [runtimeCanProceed, setRuntimeCanProceed] = useState(false)
+  const [browserCanProceed, setBrowserCanProceed] = useState(true)
+  const [llmCanProceed, setLlmCanProceed] = useState(false)
   const composioSaveRef = useRef<(() => Promise<void>) | null>(null)
   // Track whether we're restoring progress to avoid a redundant persist on resume
   const isRestoringRef = useRef(false)
@@ -59,18 +58,12 @@ export function GettingStartedWizard({ open, onOpenChange }: GettingStartedWizar
 
   const activeStep = welcomePath ? steps[currentStep] : null
 
-  // Resume at last known step on open, or reset to beginning.
-  // Depends on both `open` and `userSettings` so that if settings load after
-  // the dialog is already open, we still resume correctly.
+  // Resume at last known step on mount, or reset to beginning.
   const hasRestoredRef = useRef(false)
   useEffect(() => {
-    if (!open) {
-      hasRestoredRef.current = false
-      return
-    }
     // Wait for settings to load before deciding where to start
     if (!userSettings) return
-    // Only restore once per open
+    // Only restore once per mount
     if (hasRestoredRef.current) return
     hasRestoredRef.current = true
 
@@ -83,7 +76,6 @@ export function GettingStartedWizard({ open, onOpenChange }: GettingStartedWizar
         setWelcomePath(progress.path)
         setCurrentStep(idx)
       } else {
-        // stepId not found (e.g., removed across versions) — start fresh
         setCurrentStep(0)
         setWelcomePath(null)
       }
@@ -91,7 +83,7 @@ export function GettingStartedWizard({ open, onOpenChange }: GettingStartedWizar
       setCurrentStep(0)
       setWelcomePath(null)
     }
-  }, [open, userSettings])
+  }, [userSettings])
 
   // Persist progress on every step change
   useEffect(() => {
@@ -110,7 +102,7 @@ export function GettingStartedWizard({ open, onOpenChange }: GettingStartedWizar
   const handleFinish = async () => {
     // Use null (not undefined) so it survives JSON serialization and actually clears the field
     await updateUserSettings.mutateAsync({ setupCompleted: true, onboardingProgress: null })
-    onOpenChange(false)
+    onClose()
   }
 
   const handleComposioNext = async () => {
@@ -144,76 +136,78 @@ export function GettingStartedWizard({ open, onOpenChange }: GettingStartedWizar
     setCurrentStep(0)
   }
 
-  const handlePlatformConnected = () => {
-    setCurrentStep((s) => {
-      if (welcomePath !== 'platform') return s
-      return Math.min(s + 1, steps.length - 1)
-    })
-  }
+  const isAgentStep = activeStep?.id === 'agent'
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[600px] p-0 gap-0 [&>button]:hidden" data-testid="wizard-dialog" onPointerDownOutside={(e) => e.preventDefault()}>
-        <DialogTitle className="sr-only">Getting Started</DialogTitle>
-        <DialogDescription className="sr-only">
-          Set up Superagent for the first time
-        </DialogDescription>
+    <div className="flex h-svh bg-background overflow-hidden" data-testid="wizard-container">
+      {/* Draggable title bar region for Electron */}
+      {isElectron() && <div className="absolute top-0 left-0 right-0 h-12 app-drag-region z-10" />}
 
-        {/* Progress indicator */}
-        {welcomePath && (
-          <div className="flex items-center justify-center gap-0 px-8 pt-6 pb-2">
-            {steps.map((step, i) => (
-              <div key={i} className="flex items-center">
-                <div className="flex flex-col items-center">
-                  <div
-                    className={`flex items-center justify-center w-8 h-8 rounded-full text-xs font-medium border-2 transition-colors ${
-                      i < currentStep
-                        ? 'bg-primary border-primary text-primary-foreground'
-                        : i === currentStep
-                          ? 'border-primary text-primary bg-primary/10'
-                          : 'border-muted-foreground/30 text-muted-foreground'
-                    }`}
-                  >
-                    {i < currentStep ? <Check className="h-4 w-4" /> : i + 1}
-                  </div>
-                  <span className={`text-[10px] mt-1 ${i === currentStep ? 'text-foreground font-medium' : 'text-muted-foreground'}`}>
-                    {step.label}
-                  </span>
-                </div>
-                {i < steps.length - 1 && (
-                  <div
-                    className={`w-12 h-0.5 mx-1 mb-4 ${
-                      i < currentStep ? 'bg-primary' : 'bg-muted-foreground/30'
-                    }`}
-                  />
-                )}
+      {/* Left column: wizard content */}
+      <div className={`relative flex flex-col h-svh transition-[width] duration-500 ease-in-out ${isAgentStep ? 'w-full' : 'w-full lg:w-1/2'}`}>
+        <h1 className="sr-only">Getting Started</h1>
+
+        {/* TEMP: debug step controller — remove before merging */}
+        <div className="absolute top-2 right-2 z-20 flex gap-1 items-center opacity-30 hover:opacity-100 transition-opacity app-no-drag">
+          {(['manual', 'platform'] as const).map(flow => {
+            const flowSteps = flow === 'platform' ? PLATFORM_STEPS : MANUAL_STEPS
+            const isActive = welcomePath === flow
+            return (
+              <div key={flow} className="flex items-center gap-0.5">
+                <button
+                  className="px-1.5 py-0.5 rounded text-xs hover:bg-black/10"
+                  onClick={() => {
+                    if (isActive && currentStep === 0) { setWelcomePath(null) }
+                    else if (isActive) { setCurrentStep(s => s - 1) }
+                    else { setWelcomePath(flow); setCurrentStep(0) }
+                  }}
+                >
+                  ‹
+                </button>
+                <span className="text-[10px] tabular-nums w-20 text-center select-none">
+                  {isActive ? `${flow} ${currentStep + 1}/${flowSteps.length}` : flow}
+                </span>
+                <button
+                  className="px-1.5 py-0.5 rounded text-xs hover:bg-black/10"
+                  onClick={() => {
+                    if (!isActive) { setWelcomePath(flow); setCurrentStep(0) }
+                    else { setCurrentStep(s => Math.min(s + 1, flowSteps.length - 1)) }
+                  }}
+                >
+                  ›
+                </button>
               </div>
-            ))}
-          </div>
-        )}
-
-        {/* Step content */}
-        <div className="px-6 py-4 min-h-[320px]" data-testid="wizard-step-content" data-step={currentStep}>
-          {!welcomePath && (
-            <WelcomeStep
-              onChoosePlatform={handleWelcomePlatformPath}
-              onContinueToManualSetup={handleWelcomeManualSetup}
-            />
-          )}
-          {activeStep?.id === 'llm' && (
-            <ConfigureLLMStep
-              mode={welcomePath === 'platform' ? 'platform' : 'manual'}
-              onPlatformConnected={handlePlatformConnected}
-            />
-          )}
-          {activeStep?.id === 'browser' && <BrowserSetupStep />}
-          {activeStep?.id === 'composio' && <ComposioStep onCanProceedChange={setComposioCanProceed} saveRef={composioSaveRef} />}
-          {activeStep?.id === 'runtime' && <DockerSetupStep />}
-          {activeStep?.id === 'agent' && <CreateAgentStep />}
+            )
+          })}
         </div>
 
-        {/* Navigation buttons */}
-        <div className="flex items-center justify-between px-6 py-4 border-t">
+        <div className={`flex flex-1 flex-col justify-center py-10 w-full mx-auto transition-[max-width] duration-500 ${isAgentStep ? 'max-w-[560px]' : 'max-w-[480px]'}`}>
+          <div className="w-full">
+
+          {/* Step content */}
+          <div className="min-h-[320px]" data-testid="wizard-step-content" data-step={currentStep}>
+            {!welcomePath && (
+              <WelcomeStep
+                onChoosePlatform={handleWelcomePlatformPath}
+                onContinueToManualSetup={handleWelcomeManualSetup}
+              />
+            )}
+            {activeStep?.id === 'llm' && (
+              <ConfigureLLMStep
+                onCanProceedChange={setLlmCanProceed}
+              />
+            )}
+            {activeStep?.id === 'browser' && <BrowserSetupStep onCanProceedChange={setBrowserCanProceed} />}
+            {activeStep?.id === 'composio' && <ComposioStep onCanProceedChange={setComposioCanProceed} saveRef={composioSaveRef} />}
+            {activeStep?.id === 'runtime' && <DockerSetupStep onCanProceedChange={setRuntimeCanProceed} />}
+            {activeStep?.id === 'privacy' && <PrivacyStep />}
+            {activeStep?.id === 'agent' && <CreateAgentStep onAgentCreated={handleFinish} />}
+          </div>
+          </div>
+        </div>
+
+        {/* Navigation buttons — hidden on welcome page */}
+        <div className={`flex items-center justify-between pb-10 w-full mx-auto transition-[max-width] duration-500 ${isAgentStep ? 'max-w-[560px]' : 'max-w-[480px]'} ${!welcomePath ? 'hidden' : ''}`}>
           {!welcomePath ? (
             <div />
           ) : (
@@ -236,7 +230,7 @@ export function GettingStartedWizard({ open, onOpenChange }: GettingStartedWizar
           <div className="flex gap-2">
             {canSkipStep && (
               <Button
-                variant="ghost"
+                variant="outline"
                 onClick={() => {
                   if (isLastStep) {
                     handleFinish()
@@ -247,16 +241,13 @@ export function GettingStartedWizard({ open, onOpenChange }: GettingStartedWizar
                 data-testid="wizard-skip"
               >
                 Skip
+                <ChevronRight className="h-4 w-4 ml-1" />
               </Button>
             )}
-            {!welcomePath ? null : isLastStep ? (
-              <Button onClick={handleFinish} data-testid="wizard-finish">
-                Finish
-              </Button>
-            ) : (
+            {!welcomePath || isLastStep ? null : (
               <Button
                 onClick={activeStep?.id === 'composio' ? handleComposioNext : () => setCurrentStep((s) => s + 1)}
-                disabled={activeStep?.id === 'composio' && !composioCanProceed}
+                disabled={(activeStep?.id === 'llm' && !llmCanProceed) || (activeStep?.id === 'composio' && !composioCanProceed) || (activeStep?.id === 'runtime' && !runtimeCanProceed) || (activeStep?.id === 'browser' && !browserCanProceed)}
                 data-testid="wizard-next"
               >
                 Next
@@ -265,7 +256,12 @@ export function GettingStartedWizard({ open, onOpenChange }: GettingStartedWizar
             )}
           </div>
         </div>
-      </DialogContent>
-    </Dialog>
+      </div>
+
+      {/* Right column: cover image — slides out on the agent step */}
+      <div className={`hidden lg:block p-4 shrink-0 transition-all duration-500 ease-in-out ${isAgentStep ? 'w-0 translate-x-full opacity-0 p-0' : 'w-1/2 translate-x-0 opacity-100'} ${getPlatform() === 'win32' ? 'pt-12' : ''}`}>
+        <RibbonWave className="h-full w-full rounded-xl" />
+      </div>
+    </div>
   )
 }

--- a/src/renderer/components/wizard/privacy-step.tsx
+++ b/src/renderer/components/wizard/privacy-step.tsx
@@ -1,0 +1,82 @@
+import { useState, useEffect, useRef } from 'react'
+import { Switch } from '@renderer/components/ui/switch'
+import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
+
+export function PrivacyStep() {
+  const { data: settings } = useSettings()
+  const updateSettings = useUpdateSettings()
+  const [shareErrorReports, setShareErrorReports] = useState(true)
+  const [shareAnalytics, setShareAnalytics] = useState(true)
+  const initializedRef = useRef(false)
+
+  // Initialize from current settings on first load (defaults to true for fresh installs)
+  useEffect(() => {
+    if (!settings || initializedRef.current) return
+    initializedRef.current = true
+    setShareErrorReports(settings.shareErrorReports ?? true)
+    setShareAnalytics(settings.shareAnalytics ?? true)
+  }, [settings])
+
+  // Only persist after the user interacts (skip the initialization render)
+  const userHasInteracted = useRef(false)
+  useEffect(() => {
+    if (!initializedRef.current) return
+    if (!userHasInteracted.current) { userHasInteracted.current = true; return }
+    updateSettings.mutate({ shareErrorReports })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shareErrorReports])
+
+  useEffect(() => {
+    if (!initializedRef.current) return
+    if (!userHasInteracted.current) { userHasInteracted.current = true; return }
+    updateSettings.mutate({ shareAnalytics })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shareAnalytics])
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-normal max-w-sm">Help improve Superagent</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Choose what data you share with us. Error reports and anonymous analytics help us improve Superagent faster for everyone.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <label
+          htmlFor="privacy-error-reports"
+          className="rounded-lg border p-3 cursor-pointer block"
+        >
+          <div className="flex items-center justify-between">
+            <span className="font-medium text-sm">Share error reports</span>
+            <Switch
+              id="privacy-error-reports"
+              checked={shareErrorReports}
+              onCheckedChange={setShareErrorReports}
+            />
+          </div>
+          <p className="text-xs text-muted-foreground mt-1 max-w-sm">
+            Allow Superagent to send error reports when something goes wrong. Change anytime in settings.
+          </p>
+        </label>
+
+        <label
+          htmlFor="privacy-analytics"
+          className="rounded-lg border p-3 cursor-pointer block"
+        >
+          <div className="flex items-center justify-between">
+            <span className="font-medium text-sm">Share anonymous analytics</span>
+            <Switch
+              id="privacy-analytics"
+              checked={shareAnalytics}
+              onCheckedChange={setShareAnalytics}
+            />
+          </div>
+          <p className="text-xs text-muted-foreground mt-1 max-w-sm">
+            Share anonymous usage data to help us improve Superagent. Change anytime in settings.
+          </p>
+        </label>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/wizard/ribbon-wave.tsx
+++ b/src/renderer/components/wizard/ribbon-wave.tsx
@@ -1,0 +1,238 @@
+import { useRef, useEffect } from 'react'
+
+const STRIPE_COLORS = [
+  '#c0392b', '#e74c3c', '#e67e22', '#f39c12', '#d4ac0d', '#8b6914',
+  '#f1c40f', '#2980b9', '#3498db', '#8e44ad', '#9b59b6', '#1a5276',
+  '#154360', '#c0392b', '#cb4335', '#f0b27a', '#f8c471', '#f9e79f',
+  '#fdfefe', '#d5d8dc', '#aab7b8', '#808b96', '#1c2833', '#212f3d',
+  '#e74c3c', '#e91e63', '#ff5722', '#ff9800', '#ffc107', '#cddc39',
+  '#8bc34a', '#4caf50', '#009688', '#00bcd4', '#03a9f4', '#2196f3',
+  '#3f51b5', '#673ab7', '#9c27b0', '#795548', '#607d8b', '#ff6f61',
+  '#c0392b', '#e74c3c', '#e67e22', '#d4ac0d', '#2980b9', '#8e44ad',
+  '#f1c40f', '#3498db', '#9b59b6', '#1a5276', '#c0392b', '#f0b27a',
+  '#fdfefe', '#aab7b8', '#1c2833', '#e74c3c', '#ff5722', '#2196f3',
+  '#4caf50', '#ff9800',
+]
+
+const CFG = {
+  stripeCount: 91,
+  stripeSize: 8,
+  waveAmplitude: 67,
+  waveFrequency: 4,
+  ribbonWidth: 343,
+  cornerRadius: 80,
+  waveSpeed: 2.49,
+  scrollSpeed: 5,
+  morphSpeed: 0,
+  mouseInfluence: 200,
+  bgColor: '#000000',
+  colorShift: 0,
+  shadowDepth: 0,
+}
+
+function hueShift(hex: string, deg: number): string {
+  if (deg === 0) return hex
+  let r = parseInt(hex.slice(1, 3), 16) / 255
+  let g = parseInt(hex.slice(3, 5), 16) / 255
+  let b = parseInt(hex.slice(5, 7), 16) / 255
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  let h = 0
+  let s = 0
+  const l = (max + min) / 2
+  if (max !== min) {
+    const d = max - min
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+    switch (max) {
+      case r: h = ((g - b) / d + (g < b ? 6 : 0)) / 6; break
+      case g: h = ((b - r) / d + 2) / 6; break
+      case b: h = ((r - g) / d + 4) / 6; break
+    }
+  }
+  h = ((h * 360 + deg) % 360 + 360) % 360 / 360
+  function hue2rgb(p: number, q: number, t: number) {
+    if (t < 0) t += 1
+    if (t > 1) t -= 1
+    if (t < 1 / 6) return p + (q - p) * 6 * t
+    if (t < 1 / 2) return q
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6
+    return p
+  }
+  const q2 = l < 0.5 ? l * (1 + s) : l + s - l * s
+  const p2 = 2 * l - q2
+  r = hue2rgb(p2, q2, h + 1 / 3)
+  g = hue2rgb(p2, q2, h)
+  b = hue2rgb(p2, q2, h - 1 / 3)
+  return '#' + [r, g, b].map(v => ('0' + Math.round(v * 255).toString(16)).slice(-2)).join('')
+}
+
+function drawRoundedRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number) {
+  r = Math.min(r, w / 2, h / 2)
+  ctx.beginPath()
+  ctx.moveTo(x + r, y)
+  ctx.lineTo(x + w - r, y)
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r)
+  ctx.lineTo(x + w, y + h - r)
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h)
+  ctx.lineTo(x + r, y + h)
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r)
+  ctx.lineTo(x, y + r)
+  ctx.quadraticCurveTo(x, y, x + r, y)
+  ctx.closePath()
+}
+
+interface RibbonWaveProps {
+  className?: string
+}
+
+export function RibbonWave({ className }: RibbonWaveProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    let W = 0
+    let H = 0
+    let mx = -9999
+    let my = -9999
+    let smoothMx = -9999
+    let smoothMy = -9999
+    let t = 0
+    let stripeOffset = 0
+    let animId = 0
+
+    function resize() {
+      const dpr = window.devicePixelRatio || 1
+      const rect = canvas!.getBoundingClientRect()
+      W = rect.width
+      H = rect.height
+      canvas!.width = W * dpr
+      canvas!.height = H * dpr
+      ctx!.setTransform(dpr, 0, 0, dpr, 0, 0)
+    }
+
+    function getWaveX(y: number, time: number) {
+      const norm = y / H
+      let wave = Math.sin(norm * Math.PI * CFG.waveFrequency * 2 + time) * CFG.waveAmplitude * 0.5
+      wave += Math.sin(norm * Math.PI * CFG.waveFrequency + time * 0.7) * CFG.waveAmplitude * 0.3
+      if (smoothMx > -999 && CFG.mouseInfluence > 0) {
+        const dist = Math.abs(y - smoothMy)
+        const radius = H * 0.25
+        if (dist < radius) {
+          const strength = (1 - dist / radius) * CFG.mouseInfluence
+          wave += (smoothMx - W / 2) * strength * 0.008
+        }
+      }
+      return W * 0.5 + wave
+    }
+
+    function draw() {
+      ctx!.fillStyle = CFG.bgColor
+      ctx!.fillRect(0, 0, W, H)
+
+      const count = CFG.stripeCount
+      const stripeH = CFG.stripeSize
+      const totalH = count * stripeH
+      const startY = (H - totalH) / 2
+
+      for (let i = 0; i < count; i++) {
+        let fi = (i + stripeOffset) % count
+        if (fi < 0) fi += count
+
+        const y = startY + i * stripeH
+        const cx = getWaveX(y + stripeH * 0.5, t * CFG.waveSpeed)
+        const x = cx - CFG.ribbonWidth * 0.5
+
+        let colorIdx = Math.floor(fi + t * CFG.morphSpeed * 10) % STRIPE_COLORS.length
+        if (colorIdx < 0) colorIdx += STRIPE_COLORS.length
+        const col = hueShift(STRIPE_COLORS[colorIdx], CFG.colorShift)
+
+        if (CFG.shadowDepth > 0) {
+          ctx!.save()
+          ctx!.shadowColor = 'rgba(0,0,0,0.18)'
+          ctx!.shadowBlur = CFG.shadowDepth
+          ctx!.shadowOffsetY = CFG.shadowDepth * 0.4
+        }
+
+        ctx!.fillStyle = col
+        const gap = stripeH > 3 ? 1 : 0
+        drawRoundedRect(ctx!, x, y + gap * 0.5, CFG.ribbonWidth, stripeH - gap, CFG.cornerRadius)
+        ctx!.fill()
+
+        if (CFG.shadowDepth > 0) ctx!.restore()
+      }
+    }
+
+    const LERP = 0.08
+    // Spring physics for bounce-back
+    let velX = 0
+    let velY = 0
+    const SPRING = 0.05
+    const DAMPING = 0.82
+
+    function loop() {
+      t += 0.016
+      stripeOffset = (stripeOffset + CFG.scrollSpeed * 0.05) % CFG.stripeCount
+
+      // Ease mouse influence toward cursor, spring back with overshoot on leave
+      if (mx > -999) {
+        if (smoothMx < -999) { smoothMx = mx; smoothMy = my; velX = 0; velY = 0 }
+        else { smoothMx += (mx - smoothMx) * LERP; smoothMy += (my - smoothMy) * LERP; velX = 0; velY = 0 }
+      } else if (smoothMx > -999) {
+        velX += (W / 2 - smoothMx) * SPRING
+        velY += (H / 2 - smoothMy) * SPRING
+        velX *= DAMPING
+        velY *= DAMPING
+        smoothMx += velX
+        smoothMy += velY
+        if (Math.abs(smoothMx - W / 2) < 0.3 && Math.abs(velX) < 0.1) {
+          smoothMx = -9999; smoothMy = -9999; velX = 0; velY = 0
+        }
+      }
+
+      draw()
+      animId = requestAnimationFrame(loop)
+    }
+
+    function onMouseMove(e: MouseEvent) {
+      const rect = canvas!.getBoundingClientRect()
+      mx = e.clientX - rect.left
+      my = e.clientY - rect.top
+    }
+
+    function onMouseLeave() {
+      mx = -9999
+      my = -9999
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      resize()
+    })
+    resizeObserver.observe(canvas)
+
+    canvas.addEventListener('mousemove', onMouseMove)
+    canvas.addEventListener('mouseleave', onMouseLeave)
+
+    resize()
+    animId = requestAnimationFrame(loop)
+
+    return () => {
+      cancelAnimationFrame(animId)
+      resizeObserver.disconnect()
+      canvas.removeEventListener('mousemove', onMouseMove)
+      canvas.removeEventListener('mouseleave', onMouseLeave)
+    }
+  }, [])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={className}
+      style={{ width: '100%', height: '100%', display: 'block' }}
+    />
+  )
+}

--- a/src/renderer/components/wizard/welcome-step.tsx
+++ b/src/renderer/components/wizard/welcome-step.tsx
@@ -1,7 +1,10 @@
-import { ChevronRight, Loader2 } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
 
 import { Button } from '@renderer/components/ui/button'
+import { RequestError } from '@renderer/components/messages/request-error'
+import { ManualAccessKeyInput } from '@renderer/components/settings/manual-access-key-input'
 import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
+import { usePlatformConnect } from '@renderer/hooks/use-platform-auth'
 
 interface WelcomeStepProps {
   onChoosePlatform?: () => void
@@ -11,6 +14,16 @@ interface WelcomeStepProps {
 export function WelcomeStep({ onChoosePlatform, onContinueToManualSetup }: WelcomeStepProps) {
   const { data: settings } = useSettings()
   const updateSettings = useUpdateSettings()
+  const {
+    handleConnect,
+    isLaunching,
+    error: platformError,
+  } = usePlatformConnect({
+    successMessage: null,
+    onSuccess: () => {
+      onChoosePlatform?.()
+    },
+  })
 
   async function handleManualSetup() {
     try {
@@ -24,81 +37,54 @@ export function WelcomeStep({ onChoosePlatform, onContinueToManualSetup }: Welco
     }
   }
 
-  async function handlePlatformPath() {
-    try {
-      onChoosePlatform?.()
-    } catch {
-      // Keep the welcome page lightweight. Subsequent steps handle recovery.
-    }
-  }
-
   return (
-    <div className="space-y-5">
-      <div className="space-y-2">
-        <h2 className="text-2xl font-bold">Welcome to Superagent</h2>
-        <p className="text-muted-foreground">
-          Superagent lets you create and manage AI agents that run in isolated containers.
-          Each agent has its own environment, tools, and can connect to external services.
+    <div className="space-y-8">
+      <div className="space-y-4">
+        <h2 className="text-4xl font-normal">Build your<br />agent workforce</h2>
+        <p className="text-sm text-muted-foreground mt-1 max-w-sm">
+          Superagent is the most powerful and secure way to build and manage AI teammates that actually get the job done.
         </p>
       </div>
 
-      <div className="grid gap-4">
-        <div className="rounded-lg border bg-muted/30 p-4 space-y-3">
-          <div className="flex items-center justify-between gap-4">
-            <div className="space-y-1">
-              <h3 className="text-sm font-medium">Connect to Platform</h3>
-              <p className="text-sm text-muted-foreground">
-                Use your Platform subscription and hosted proxy.
-              </p>
-            </div>
-
+      <div className="flex flex-col gap-8">
+        <div className="space-y-3">
+          <div className="flex items-center gap-3">
             <Button
               type="button"
               variant="default"
-              onClick={() => {
-                void handlePlatformPath()
-              }}
+              size="lg"
+              onClick={() => void handleConnect()}
               data-testid="wizard-platform-login"
-              className="shrink-0"
+              disabled={isLaunching}
+              className="w-full max-w-[380px]"
             >
-              Next
-              <ChevronRight className="ml-2 h-4 w-4" />
-            </Button>
-          </div>
-        </div>
-
-        <div className="rounded-lg border bg-muted/30 p-4">
-          <div className="flex items-center justify-between gap-4">
-            <div className="space-y-1">
-              <h3 className="text-sm font-medium">Bring your own keys</h3>
-              <p className="text-sm text-muted-foreground">
-                Bring your own keys for providers like Anthropic, Deepgram, and Composio.
-              </p>
-            </div>
-
-            <Button
-              type="button"
-              variant="default"
-              onClick={() => {
-                void handleManualSetup()
-              }}
-              data-testid="wizard-manual-setup"
-              className="shrink-0"
-              disabled={updateSettings.isPending}
-            >
-              {updateSettings.isPending ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              {isLaunching ? (
+                <><Loader2 className="h-4 w-4 animate-spin mr-2" />Logging in...</>
               ) : (
-                <>
-                  Next
-                  <ChevronRight className="ml-2 h-4 w-4" />
-                </>
+                'Get Started'
               )}
-              {updateSettings.isPending ? 'Next' : null}
             </Button>
           </div>
+          {isLaunching && (
+            <ManualAccessKeyInput prefixText="Log in issues?" className="text-sm text-muted-foreground" />
+          )}
         </div>
+        <RequestError message={platformError ?? null} />
+        <p className="text-sm text-muted-foreground">
+          Need to bring your own keys?{' '}
+          <button
+            type="button"
+            onClick={() => void handleManualSetup()}
+            data-testid="wizard-manual-setup"
+            disabled={updateSettings.isPending}
+            className="underline underline-offset-2 hover:text-foreground transition-colors disabled:opacity-50"
+          >
+            {updateSettings.isPending ? <Loader2 className="inline h-3 w-3 animate-spin mr-1" /> : null}
+            Start BYOK setup
+          </button>
+        </p>
       </div>
+
     </div>
   )
 }

--- a/src/renderer/components/wizard/wsl2-install-guide.tsx
+++ b/src/renderer/components/wizard/wsl2-install-guide.tsx
@@ -1,13 +1,8 @@
 import { useState } from 'react'
 import { Button } from '@renderer/components/ui/button'
-import { Alert, AlertDescription } from '@renderer/components/ui/alert'
-import {
-  Terminal,
-  RefreshCw,
-  ExternalLink,
-  Copy,
-  Check,
-} from 'lucide-react'
+import { RequestError } from '@renderer/components/messages/request-error'
+import { RefreshCw, MoveRight } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
 
 interface Wsl2InstallGuideProps {
   onRefresh: () => void
@@ -18,17 +13,15 @@ const WSL_INSTALL_COMMAND = 'wsl --install'
 
 export function Wsl2InstallGuide({ onRefresh, isRefreshing }: Wsl2InstallGuideProps) {
   const [copied, setCopied] = useState(false)
-  const [launched, setLaunched] = useState(false)
   const [launchError, setLaunchError] = useState<string | null>(null)
 
   const handleLaunchInstall = async () => {
     setLaunchError(null)
     try {
       await window.electronAPI?.launchPowershellAdmin(WSL_INSTALL_COMMAND)
-      setLaunched(true)
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Failed to launch PowerShell:', error)
-      setLaunchError(error?.message || 'Failed to launch PowerShell. Try running the command manually.')
+      setLaunchError(error instanceof Error ? error.message : 'Failed to launch PowerShell. Try running the command manually.')
     }
   }
 
@@ -51,94 +44,77 @@ export function Wsl2InstallGuide({ onRefresh, isRefreshing }: Wsl2InstallGuidePr
   }
 
   return (
-    <div className="space-y-4">
-      <div>
-        <h3 className="text-sm font-semibold">Set Up Windows Subsystem for Linux (WSL2)</h3>
-        <p className="text-xs text-muted-foreground mt-1">
-          The built-in runtime requires WSL2, which is a one-time setup on Windows.
+    <div className="space-y-3">
+      <hr className="border-border" />
+      <p className="text-sm text-foreground/70">
+        WSL2 required. Follow these steps to set up.
+      </p>
+
+      <ol className="list-decimal list-inside space-y-2 text-sm text-muted-foreground">
+        <li>
+          Click this <MoveRight className="h-3 w-3 inline -mt-0.5" />{' '}
+          <TooltipProvider delayDuration={0}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-6 text-xs"
+                  onClick={handleLaunchInstall}
+                >
+                  Open PowerShell
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Opens PowerShell in admin mode</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </li>
+        <li>If prompted by Windows Security, click Yes to allow.</li>
+        <li>
+          Paste this <MoveRight className="h-3 w-3 inline -mt-0.5" />{' '}
+          <TooltipProvider delayDuration={0}>
+            <Tooltip open={copied || undefined}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  className="inline-flex items-center rounded-md border border-input bg-background px-3 py-0.5 text-xs font-mono cursor-pointer hover:bg-accent hover:text-accent-foreground transition-colors"
+                  onClick={handleCopyCommand}
+                >
+                  {WSL_INSTALL_COMMAND}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{copied ? 'Copied!' : 'Click to copy'}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          {' '}into PowerShell. Then press Enter.
+        </li>
+        <li>Restart your computer, then reopen Superagent.</li>
+      </ol>
+
+      <RequestError message={launchError ?? null} />
+
+      <div className="flex items-center justify-between text-xs text-muted-foreground pt-3">
+        <p>
+          Having issues?{' '}
+          <button
+            className="underline underline-offset-2 hover:text-foreground transition-colors"
+            onClick={handleOpenDocs}
+          >
+            View Microsoft Docs
+          </button>
         </p>
-      </div>
-
-      <div className="space-y-3 text-sm">
-        <div className="flex gap-3">
-          <span className="flex-shrink-0 w-5 h-5 rounded-full bg-primary/10 text-primary text-xs flex items-center justify-center font-medium">1</span>
-          <div className="flex-1">
-            <p>Click below to open an Administrator PowerShell that will install WSL2.</p>
-            <div className="mt-2 flex items-center gap-2">
-              <Button
-                size="sm"
-                className="h-8 text-xs"
-                onClick={handleLaunchInstall}
-              >
-                <Terminal className="h-3 w-3 mr-1" />
-                {launched ? 'Open PowerShell Again' : 'Open PowerShell (Admin)'}
-              </Button>
-            </div>
-            <p className="text-xs text-muted-foreground mt-1.5">
-              You may see a Windows security prompt (UAC) — click Yes to allow.
-            </p>
-            {launchError && (
-              <p className="text-xs text-destructive mt-1.5">{launchError}</p>
-            )}
-          </div>
-        </div>
-
-        <div className="flex gap-3">
-          <span className="flex-shrink-0 w-5 h-5 rounded-full bg-primary/10 text-primary text-xs flex items-center justify-center font-medium">2</span>
-          <div className="flex-1">
-            <p>After the installation completes, <strong>restart your computer</strong>.</p>
-          </div>
-        </div>
-
-        <div className="flex gap-3">
-          <span className="flex-shrink-0 w-5 h-5 rounded-full bg-primary/10 text-primary text-xs flex items-center justify-center font-medium">3</span>
-          <div className="flex-1">
-            <p>Reopen Superagent — setup will resume from here.</p>
-          </div>
-        </div>
-      </div>
-
-      {/* Manual command fallback */}
-      <div className="rounded-md bg-muted px-3 py-2 flex items-center justify-between gap-2">
-        <code className="text-xs font-mono">{WSL_INSTALL_COMMAND}</code>
-        <Button
-          size="sm"
-          variant="ghost"
-          className="h-6 w-6 p-0 shrink-0"
-          onClick={handleCopyCommand}
-        >
-          {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-        </Button>
-      </div>
-
-      {launched && (
-        <Alert>
-          <AlertDescription className="text-xs">
-            After the install finishes in PowerShell and you restart your computer, click Recheck below.
-          </AlertDescription>
-        </Alert>
-      )}
-
-      <div className="flex items-center gap-2">
-        <Button
-          size="sm"
-          variant="outline"
-          className="h-8 text-xs"
+        <button
+          className="inline-flex items-center gap-1 hover:text-foreground transition-colors disabled:opacity-50"
           onClick={onRefresh}
           disabled={isRefreshing}
         >
-          <RefreshCw className={`h-3 w-3 mr-1 ${isRefreshing ? 'animate-spin' : ''}`} />
-          Recheck WSL2 Status
-        </Button>
-        <Button
-          size="sm"
-          variant="ghost"
-          className="h-8 text-xs"
-          onClick={handleOpenDocs}
-        >
-          <ExternalLink className="h-3 w-3 mr-1" />
-          Microsoft Docs
-        </Button>
+          <RefreshCw className={`h-3 w-3 ${isRefreshing ? 'animate-spin' : ''}`} />
+          Recheck WSL2 status
+        </button>
       </div>
     </div>
   )

--- a/src/shared/lib/browser/chrome-profile.ts
+++ b/src/shared/lib/browser/chrome-profile.ts
@@ -2,6 +2,13 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 
+export interface ChromeProfile {
+  id: string
+  name: string
+  avatarUrl?: string
+  email?: string
+}
+
 const PROFILE_FILES = ['Cookies', 'Cookies-journal', 'Login Data', 'Login Data-journal', 'Web Data', 'Web Data-journal']
 const PROFILE_DIRS = ['Local Storage', 'Session Storage']
 
@@ -26,7 +33,7 @@ export function getChromeUserDataDir(): string | null {
 /**
  * Lists Chrome profiles by reading Local State JSON.
  */
-export function listChromeProfiles(): Array<{ id: string; name: string; avatarUrl?: string }> {
+export function listChromeProfiles(): ChromeProfile[] {
   const dataDir = getChromeUserDataDir()
   if (!dataDir) return []
 
@@ -38,11 +45,15 @@ export function listChromeProfiles(): Array<{ id: string; name: string; avatarUr
     const infoCache = localState?.profile?.info_cache
     if (!infoCache || typeof infoCache !== 'object') return []
 
-    return Object.entries(infoCache).map(([id, info]) => ({
-      id,
-      name: (info as { name?: string }).name || id,
-      avatarUrl: (info as { last_downloaded_gaia_picture_url_with_size?: string }).last_downloaded_gaia_picture_url_with_size || undefined,
-    }))
+    return Object.entries(infoCache).map(([id, info]) => {
+      const typed = info as { name?: string; user_name?: string; last_downloaded_gaia_picture_url_with_size?: string }
+      return {
+        id,
+        name: typed.name || id,
+        avatarUrl: typed.last_downloaded_gaia_picture_url_with_size || undefined,
+        email: typed.user_name || undefined,
+      }
+    })
   } catch {
     return []
   }

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -195,13 +195,14 @@ export interface ApiKeyStatus {
 // Note: This creates a type-only dependency, avoiding circular imports
 import type { RunnerAvailability } from '@shared/lib/container/client-factory'
 import type { RuntimeReadiness } from '@shared/lib/container/types'
+import type { ChromeProfile } from '@shared/lib/browser/chrome-profile'
 
 export interface HostBrowserProviderInfo {
   id: string
   name: string
   available: boolean
   reason?: string
-  profiles?: Array<{ id: string; name: string; avatarUrl?: string }>
+  profiles?: ChromeProfile[]
 }
 
 export interface HostBrowserStatus {


### PR DESCRIPTION
## Summary

Full redesign of the getting-started wizard from a modal dialog into a two-column full-page flow, with a new set of steps, consistent card-based selection UI, and an animated ribbon-wave cover in the right column.

## What's new

**Layout & navigation**
- Wizard is now a full-page two-column layout (`grid min-h-svh lg:grid-cols-2`) instead of a modal dialog
- Right column shows an animated ribbon-wave canvas loaded via iframe (slides out when the user reaches the create-agent step so the content column takes the full width)
- Nav bar matches content width (`max-w-[480px]` / `max-w-[560px]` on the agent step), Back is a ghost button, Finish is removed, and Skip gains a chevron on the last step
- Welcome page has no nav bar; the "Trouble creating your account or signing in?" link lives at the bottom of the platform account step

**New steps**
- **Welcome** — "Build your agent workforce" with a "Get Started" button that routes to the platform flow, and a "Need to bring your own keys?" secondary CTA for the manual BYOK flow
- **Let's create your account** (platform flow only) — name + email form fields, "Create Account" button (OAuth redirect), and a "Need to link your account manually? Add access key" fallback
- **Connect an LLM provider** (manual flow) — radio card UI for Anthropic, OpenRouter, and Amazon Bedrock, with tabbed Bedrock input (API key vs. AWS access key) and a collapsible "How to get your API key" helper per provider
- **Give your agents browser access** — radio cards for Chrome (with profile picker + email detection), Built-in Browser, and Browserbase (advanced)
- **Let your agents connect to your apps** (Composio) — single card with an animated row of service icons that hover-scale, auto-collapsing animation when connected
- **Choose how Superagent isolates your agents** (runtime) — radio cards with Show advanced options toggle, Power/start button for installed runtimes, ArrowUpRight icon for install links, and an inline WSL2 install guide (decluttered from the old version)
- **Help improve Superagent** (new privacy step) — two toggle cards for error reports and anonymous analytics, replacing the opt-ins that used to live on the final create-agent step
- **Let's create your first agent** — now uses the same \`ChatComposerBox\` used elsewhere in the app, with attachment picker, voice input, auto-resizing textarea, cycling typewriter placeholders (HR recruiter, CEO, financial ops, PM examples), and a Phone-icon "Start conversation" CTA (unwired) for a future voice agent flow

**Backend**
- New \`POST /api/agents/generate-name\` endpoint uses the summarizer model (same pattern as session naming) to generate a 2-4 word agent name from the user's prompt before creating the agent

**Consistency pass**
- All error states across both sign-up flows now use the shared \`RequestError\` component (red background, smaller size)
- Normalized status badges (\`Saved locally\` / \`Via env. variable\`) and help text across all credential inputs
- Center-aligned card header rows across all radio card steps
- Newsreader font at weight 200 for all wizard headings

**Typography**
- Newsreader font loaded for headings at weight 200 (via \`src/renderer/index.html\`)

## Still to do before merging

- [ ] Remove the debug manual/platform forward-back nav controls from \`getting-started-wizard.tsx\` (TODO block is marked near line 158)
- [ ] Wire the "Start conversation" button on the create-agent step to an ElevenLabs voice agent dialog

## Test plan

- [ ] Run through the manual BYOK flow end-to-end (welcome → BYOK link → LLM cards → browser → composio → runtime → privacy → agent)
- [ ] Run through the platform flow end-to-end (welcome → Get Started → account step → browser → runtime → privacy → agent)
- [ ] Verify Anthropic, OpenRouter, and Bedrock API key validation shows correct success and error states
- [ ] Verify Chrome profile selection populates the email correctly
- [ ] Verify Browserbase validation shows the normalized error style
- [ ] Verify the built-in runtime starts on macOS and the Power start button shows for other runtimes when applicable
- [ ] Windows-only: verify the WSL2 install guide renders inside the built-in runtime card when WSL2 isn't installed
- [ ] Verify the cover image slides out when reaching the create-agent step and the content column expands smoothly
- [ ] Verify create-agent step generates a descriptive agent name (e.g. "Tokyo Trip Planner") instead of the first 5 words of the prompt
- [ ] Verify creating an agent also creates a session with the prompt as the first message and drops the user into that session

🤖 Generated with [Claude Code](https://claude.com/claude-code)