### PR TITLE
feat: volumes section on agent landing page

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -358,6 +358,12 @@ ipcMain.handle('open-directory', async () => {
   return result.canceled ? null : result.filePaths[0]
 })
 
+// IPC handler for revealing a path in the OS file manager
+ipcMain.handle('show-in-folder', async (_event, hostPath: string) => {
+  const errorMessage = await shell.openPath(hostPath)
+  return errorMessage === '' ? null : errorMessage
+})
+
 // --- Recent files infrastructure ---
 
 const MIME_TYPES: Record<string, string> = {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,9 @@ import { execFileSync, exec } from 'child_process'
 import path from 'path'
 import fs from 'fs'
 import os from 'os'
+import { z } from 'zod'
+
+const ShowInFolderPath = z.string().min(1)
 
 // todo huge file - need to break up into multiple modules (tray, menu, auto-updater, host-browser provider, etc.)
 
@@ -358,8 +361,20 @@ ipcMain.handle('open-directory', async () => {
   return result.canceled ? null : result.filePaths[0]
 })
 
-// IPC handler for revealing a path in the OS file manager
-ipcMain.handle('show-in-folder', async (_event, hostPath: string) => {
+// IPC handler for revealing a path in the OS file manager.
+// Only directories are allowed — `shell.openPath` would otherwise launch files
+// with their default app (e.g. .app bundles, .command scripts, .exe).
+ipcMain.handle('show-in-folder', async (_event, rawPath: unknown) => {
+  const hostPath = ShowInFolderPath.parse(rawPath)
+  let stat: fs.Stats
+  try {
+    stat = await fs.promises.stat(hostPath)
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).message
+  }
+  if (!stat.isDirectory()) {
+    return `Not a directory: ${hostPath}`
+  }
   const errorMessage = await shell.openPath(hostPath)
   return errorMessage === '' ? null : errorMessage
 })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -161,6 +161,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return ipcRenderer.invoke('open-directory')
   },
 
+  // Reveal a path in the OS file manager (Finder / Explorer / Files)
+  showInFolder: (hostPath: string): Promise<string | null> => {
+    return ipcRenderer.invoke('show-in-folder', hostPath)
+  },
+
   // Get recently opened files from the OS
   getRecentFiles: (limit?: number): Promise<{ name: string; path: string; thumbnail?: string }[]> => {
     return ipcRenderer.invoke('get-recent-files', limit)
@@ -239,6 +244,7 @@ declare global {
       createDockShortcut: (agentSlug: string, dashboardSlug: string, dashboardName: string, iconPng: Uint8Array) => Promise<void>
       getPathForFile: (file: File) => string
       openDirectory: () => Promise<string | null>
+      showInFolder: (hostPath: string) => Promise<string | null>
       getRecentFiles: (limit?: number) => Promise<{ name: string; path: string; thumbnail?: string }[]>
       readLocalFile: (filePath: string) => Promise<{ buffer: ArrayBuffer; name: string; type: string } | null>
       checkForUpdates: () => Promise<void>

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -18,6 +18,7 @@ import { useMessageComposer } from '@renderer/hooks/use-message-composer'
 import { ChatComposerBox } from '@renderer/components/messages/chat-composer-box'
 import { HomeCrons } from './home-crons'
 import { HomeSkills } from './home-skills'
+import { HomeVolumes } from './home-volumes'
 import { HomeBookmarks } from './home-bookmarks'
 import type { ApiAgent } from '@renderer/hooks/use-agents'
 import { useRenderTracker } from '@renderer/lib/perf'
@@ -295,7 +296,7 @@ export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHome
           )}
         </div>
 
-        {/* Right Column — Crons + Skills */}
+        {/* Right Column — Crons + Skills + Volumes */}
         {showRightColumn && (
           <div className="space-y-3">
             <HomeCrons
@@ -305,6 +306,7 @@ export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHome
               onSelectTask={selectScheduledTask}
             />
             <HomeSkills agentSlug={agent.slug} />
+            <HomeVolumes agentSlug={agent.slug} />
           </div>
         )}
       </div>

--- a/src/renderer/components/agents/agent-home/home-volumes.tsx
+++ b/src/renderer/components/agents/agent-home/home-volumes.tsx
@@ -19,12 +19,11 @@ import {
   Trash2,
   Plus,
   Loader2,
-  AlertTriangle,
   RefreshCw,
 } from 'lucide-react'
 import { HomeCollapsible } from './home-collapsible'
-import { useAgentMounts, useAddMount, useRemoveMount } from '@renderer/hooks/use-mounts'
-import { apiFetch } from '@renderer/lib/api'
+import { useVolumesManager } from '@renderer/hooks/use-mounts'
+import { VolumeStatusBadge } from '../volume-status-badge'
 import type { AgentMountWithHealth } from '@shared/lib/types/mount'
 
 interface HomeVolumesProps {
@@ -32,43 +31,18 @@ interface HomeVolumesProps {
 }
 
 export function HomeVolumes({ agentSlug }: HomeVolumesProps) {
-  const { data: mountsData, refetch } = useAgentMounts(agentSlug)
-  const mounts = Array.isArray(mountsData) ? mountsData : []
-  const addMount = useAddMount()
-  const [pendingRestart, setPendingRestart] = useState(false)
-  const [isRestarting, setIsRestarting] = useState(false)
-
-  const handleAddMount = async () => {
-    const dirPath = await window.electronAPI?.openDirectory()
-    if (!dirPath) return
-    await addMount.mutateAsync({ agentSlug, hostPath: dirPath })
-    setPendingRestart(true)
-  }
-
-  const handleRestart = async () => {
-    setIsRestarting(true)
-    try {
-      await apiFetch(`/api/agents/${agentSlug}/stop`, { method: 'POST' })
-      await apiFetch(`/api/agents/${agentSlug}/start`, { method: 'POST' })
-      setPendingRestart(false)
-      refetch()
-    } catch (error) {
-      console.error('Failed to restart agent:', error)
-    } finally {
-      setIsRestarting(false)
-    }
-  }
+  const vm = useVolumesManager(agentSlug)
 
   return (
     <HomeCollapsible title="Volumes">
-      {mounts.length > 0 ? (
+      {vm.mounts.length > 0 ? (
         <div className="mt-2 divide-y divide-border/50">
-          {mounts.map((mount) => (
+          {vm.mounts.map((mount) => (
             <VolumeRow
               key={mount.id}
               mount={mount}
-              agentSlug={agentSlug}
-              onPendingRestart={() => setPendingRestart(true)}
+              onRemove={() => vm.handleRemove(mount.id)}
+              isRemovingMount={vm.isRemovingMount}
             />
           ))}
         </div>
@@ -80,20 +54,20 @@ export function HomeVolumes({ agentSlug }: HomeVolumesProps) {
       )}
 
       <div className="mt-3 px-4">
-        {pendingRestart ? (
+        {vm.pendingRestart ? (
           <div className="flex items-center gap-2 rounded-lg bg-orange-50 dark:bg-orange-950/30 p-2.5">
             <span className="text-[11px] text-orange-600 dark:text-orange-400 flex-1">
-              Restart your agent for the mount<br />changes to take effect.
+              Restart your agent for mount changes to take effect.
             </span>
             <Button
               size="sm"
               variant="ghost"
               className="text-orange-600 dark:text-orange-400 hover:bg-orange-100 dark:hover:bg-orange-900/40 hover:text-orange-700 dark:hover:text-orange-300"
-              onClick={handleRestart}
-              disabled={isRestarting}
+              onClick={vm.handleRestart}
+              disabled={vm.isRestarting}
             >
-              <RefreshCw className={`${isRestarting ? 'animate-spin' : ''}`} />
-              {isRestarting ? 'Restarting...' : 'Restart'}
+              <RefreshCw className={`${vm.isRestarting ? 'animate-spin' : ''}`} />
+              {vm.isRestarting ? 'Restarting...' : 'Restart'}
             </Button>
           </div>
         ) : (
@@ -101,10 +75,10 @@ export function HomeVolumes({ agentSlug }: HomeVolumesProps) {
             <Button
               variant="ghost"
               size="sm"
-              onClick={handleAddMount}
-              disabled={addMount.isPending}
+              onClick={vm.handleAddMount}
+              disabled={vm.isAddingMount}
             >
-              {addMount.isPending ? (
+              {vm.isAddingMount ? (
                 <Loader2 className="animate-spin" />
               ) : (
                 <Plus />
@@ -120,13 +94,17 @@ export function HomeVolumes({ agentSlug }: HomeVolumesProps) {
 
 interface VolumeRowProps {
   mount: AgentMountWithHealth
-  agentSlug: string
-  onPendingRestart: () => void
+  onRemove: () => void
+  isRemovingMount: boolean
 }
 
-function VolumeRow({ mount, agentSlug, onPendingRestart }: VolumeRowProps) {
-  const removeMount = useRemoveMount()
+const FILE_MANAGER_LABEL =
+  window.electronAPI?.platform === 'win32' ? 'Explorer' :
+  window.electronAPI?.platform === 'darwin' ? 'Finder' : 'Files'
+
+function VolumeRow({ mount, onRemove, isRemovingMount }: VolumeRowProps) {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
 
   const handleOpenInFinder = () => {
     void window.electronAPI?.showInFolder(mount.hostPath)
@@ -136,10 +114,9 @@ function VolumeRow({ mount, agentSlug, onPendingRestart }: VolumeRowProps) {
     void navigator.clipboard.writeText(mount.hostPath)
   }
 
-  const handleDelete = async () => {
-    await removeMount.mutateAsync({ agentSlug, mountId: mount.id })
+  const handleDelete = () => {
+    onRemove()
     setShowDeleteDialog(false)
-    onPendingRestart()
   }
 
   return (
@@ -165,7 +142,7 @@ function VolumeRow({ mount, agentSlug, onPendingRestart }: VolumeRowProps) {
           {mount.hostPath}
         </div>
         <div className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity">
-          <Popover>
+          <Popover open={menuOpen} onOpenChange={setMenuOpen}>
             <PopoverTrigger asChild>
               <Button
                 type="button"
@@ -183,16 +160,18 @@ function VolumeRow({ mount, agentSlug, onPendingRestart }: VolumeRowProps) {
                 onClick={(e) => {
                   e.stopPropagation()
                   handleOpenInFinder()
+                  setMenuOpen(false)
                 }}
               >
                 <FolderOpen className="h-3.5 w-3.5" />
-                Open in Finder
+                Open in {FILE_MANAGER_LABEL}
               </button>
               <button
                 className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
                 onClick={(e) => {
                   e.stopPropagation()
                   handleCopyPath()
+                  setMenuOpen(false)
                 }}
               >
                 <Copy className="h-3.5 w-3.5" />
@@ -203,6 +182,7 @@ function VolumeRow({ mount, agentSlug, onPendingRestart }: VolumeRowProps) {
                 onClick={(e) => {
                   e.stopPropagation()
                   setShowDeleteDialog(true)
+                  setMenuOpen(false)
                 }}
               >
                 <Trash2 className="h-3.5 w-3.5" />
@@ -225,30 +205,14 @@ function VolumeRow({ mount, agentSlug, onPendingRestart }: VolumeRowProps) {
             <AlertDialogCancel>Keep Mount</AlertDialogCancel>
             <AlertDialogAction
               onClick={handleDelete}
-              disabled={removeMount.isPending}
+              disabled={isRemovingMount}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              {removeMount.isPending ? 'Removing...' : 'Remove Mount'}
+              {isRemovingMount ? 'Removing...' : 'Remove Mount'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
     </>
-  )
-}
-
-function VolumeStatusBadge({ health }: { health: 'ok' | 'missing' }) {
-  if (health === 'ok') {
-    return (
-      <span className="text-[10px] px-1.5 py-0 rounded-full bg-green-500/10 text-green-700 dark:text-green-400">
-        OK
-      </span>
-    )
-  }
-  return (
-    <span className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0 rounded-full bg-red-500/10 text-red-700 dark:text-red-400">
-      <AlertTriangle className="h-2.5 w-2.5" />
-      Missing
-    </span>
   )
 }

--- a/src/renderer/components/agents/agent-home/home-volumes.tsx
+++ b/src/renderer/components/agents/agent-home/home-volumes.tsx
@@ -31,18 +31,18 @@ interface HomeVolumesProps {
 }
 
 export function HomeVolumes({ agentSlug }: HomeVolumesProps) {
-  const vm = useVolumesManager(agentSlug)
+  const volumes = useVolumesManager(agentSlug)
 
   return (
     <HomeCollapsible title="Volumes">
-      {vm.mounts.length > 0 ? (
+      {volumes.mounts.length > 0 ? (
         <div className="mt-2 divide-y divide-border/50">
-          {vm.mounts.map((mount) => (
+          {volumes.mounts.map((mount) => (
             <VolumeRow
               key={mount.id}
               mount={mount}
-              onRemove={() => vm.handleRemove(mount.id)}
-              isRemovingMount={vm.isRemovingMount}
+              onRemove={() => volumes.handleRemove(mount.id)}
+              isRemovingMount={volumes.isRemovingMount}
             />
           ))}
         </div>
@@ -54,31 +54,38 @@ export function HomeVolumes({ agentSlug }: HomeVolumesProps) {
       )}
 
       <div className="mt-3 px-4">
-        {vm.pendingRestart ? (
-          <div className="flex items-center gap-2 rounded-lg bg-orange-50 dark:bg-orange-950/30 p-2.5">
-            <span className="text-[11px] text-orange-600 dark:text-orange-400 flex-1">
-              Restart your agent for mount changes to take effect.
-            </span>
-            <Button
-              size="sm"
-              variant="ghost"
-              className="text-orange-600 dark:text-orange-400 hover:bg-orange-100 dark:hover:bg-orange-900/40 hover:text-orange-700 dark:hover:text-orange-300"
-              onClick={vm.handleRestart}
-              disabled={vm.isRestarting}
-            >
-              <RefreshCw className={`${vm.isRestarting ? 'animate-spin' : ''}`} />
-              {vm.isRestarting ? 'Restarting...' : 'Restart'}
-            </Button>
+        {volumes.pendingRestart ? (
+          <div className="flex flex-col gap-1 rounded-lg bg-orange-50 dark:bg-orange-950/30 p-2.5">
+            <div className="flex items-center gap-2">
+              <span className="text-[11px] text-orange-600 dark:text-orange-400 flex-1">
+                Restart your agent for mount changes to take effect.
+              </span>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="text-orange-600 dark:text-orange-400 hover:bg-orange-100 dark:hover:bg-orange-900/40 hover:text-orange-700 dark:hover:text-orange-300"
+                onClick={volumes.handleRestart}
+                disabled={volumes.isRestarting}
+              >
+                <RefreshCw className={`${volumes.isRestarting ? 'animate-spin' : ''}`} />
+                {volumes.isRestarting ? 'Restarting...' : 'Restart'}
+              </Button>
+            </div>
+            {volumes.restartError && (
+              <span className="text-[11px] text-destructive" role="alert">
+                {volumes.restartError}
+              </span>
+            )}
           </div>
         ) : (
           <div className="flex justify-end">
             <Button
               variant="ghost"
               size="sm"
-              onClick={vm.handleAddMount}
-              disabled={vm.isAddingMount}
+              onClick={volumes.handleAddMount}
+              disabled={volumes.isAddingMount}
             >
-              {vm.isAddingMount ? (
+              {volumes.isAddingMount ? (
                 <Loader2 className="animate-spin" />
               ) : (
                 <Plus />
@@ -92,19 +99,23 @@ export function HomeVolumes({ agentSlug }: HomeVolumesProps) {
   )
 }
 
+function getFileManagerLabel(): string {
+  const platform = window.electronAPI?.platform
+  if (platform === 'win32') return 'Explorer'
+  if (platform === 'darwin') return 'Finder'
+  return 'Files'
+}
+
 interface VolumeRowProps {
   mount: AgentMountWithHealth
   onRemove: () => void
   isRemovingMount: boolean
 }
 
-const FILE_MANAGER_LABEL =
-  window.electronAPI?.platform === 'win32' ? 'Explorer' :
-  window.electronAPI?.platform === 'darwin' ? 'Finder' : 'Files'
-
 function VolumeRow({ mount, onRemove, isRemovingMount }: VolumeRowProps) {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
+  const fileManagerLabel = getFileManagerLabel()
 
   const handleOpenInFinder = () => {
     void window.electronAPI?.showInFolder(mount.hostPath)
@@ -127,6 +138,7 @@ function VolumeRow({ mount, onRemove, isRemovingMount }: VolumeRowProps) {
         className="group relative py-3 px-4 hover:bg-muted/50 transition-colors cursor-pointer"
         onClick={handleOpenInFinder}
         onKeyDown={(e) => {
+          if (e.target !== e.currentTarget) return
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault()
             handleOpenInFinder()
@@ -141,7 +153,7 @@ function VolumeRow({ mount, onRemove, isRemovingMount }: VolumeRowProps) {
         <div className="text-[11px] text-muted-foreground mt-0.5 line-clamp-1 font-mono" title={mount.hostPath}>
           {mount.hostPath}
         </div>
-        <div className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity">
+        <div className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
           <Popover open={menuOpen} onOpenChange={setMenuOpen}>
             <PopoverTrigger asChild>
               <Button
@@ -149,6 +161,7 @@ function VolumeRow({ mount, onRemove, isRemovingMount }: VolumeRowProps) {
                 size="icon"
                 variant="outline"
                 className="h-6 w-6"
+                aria-label="Mount actions"
                 onClick={(e) => e.stopPropagation()}
               >
                 <MoreVertical className="h-3.5 w-3.5" />
@@ -164,7 +177,7 @@ function VolumeRow({ mount, onRemove, isRemovingMount }: VolumeRowProps) {
                 }}
               >
                 <FolderOpen className="h-3.5 w-3.5" />
-                Open in {FILE_MANAGER_LABEL}
+                Open in {fileManagerLabel}
               </button>
               <button
                 className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"

--- a/src/renderer/components/agents/agent-home/home-volumes.tsx
+++ b/src/renderer/components/agents/agent-home/home-volumes.tsx
@@ -1,0 +1,253 @@
+import { useState } from 'react'
+import { Button } from '@renderer/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@renderer/components/ui/alert-dialog'
+import {
+  MoreVertical,
+  Folder,
+  FolderOpen,
+  Copy,
+  Trash2,
+  Plus,
+  Loader2,
+  AlertTriangle,
+  RefreshCw,
+} from 'lucide-react'
+import { HomeCollapsible } from './home-collapsible'
+import { useAgentMounts, useAddMount, useRemoveMount } from '@renderer/hooks/use-mounts'
+import { apiFetch } from '@renderer/lib/api'
+import type { AgentMountWithHealth } from '@shared/lib/types/mount'
+
+interface HomeVolumesProps {
+  agentSlug: string
+}
+
+export function HomeVolumes({ agentSlug }: HomeVolumesProps) {
+  const { data: mountsData, refetch } = useAgentMounts(agentSlug)
+  const mounts = Array.isArray(mountsData) ? mountsData : []
+  const addMount = useAddMount()
+  const [pendingRestart, setPendingRestart] = useState(false)
+  const [isRestarting, setIsRestarting] = useState(false)
+
+  const handleAddMount = async () => {
+    const dirPath = await window.electronAPI?.openDirectory()
+    if (!dirPath) return
+    await addMount.mutateAsync({ agentSlug, hostPath: dirPath })
+    setPendingRestart(true)
+  }
+
+  const handleRestart = async () => {
+    setIsRestarting(true)
+    try {
+      await apiFetch(`/api/agents/${agentSlug}/stop`, { method: 'POST' })
+      await apiFetch(`/api/agents/${agentSlug}/start`, { method: 'POST' })
+      setPendingRestart(false)
+      refetch()
+    } catch (error) {
+      console.error('Failed to restart agent:', error)
+    } finally {
+      setIsRestarting(false)
+    }
+  }
+
+  return (
+    <HomeCollapsible title="Volumes">
+      {mounts.length > 0 ? (
+        <div className="mt-2 divide-y divide-border/50">
+          {mounts.map((mount) => (
+            <VolumeRow
+              key={mount.id}
+              mount={mount}
+              agentSlug={agentSlug}
+              onPendingRestart={() => setPendingRestart(true)}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="mt-3 mx-4 rounded-lg border border-dashed p-4 text-muted-foreground">
+          <p className="text-xs font-medium text-foreground">No volumes yet</p>
+          <p className="text-xs mt-1">Mount a folder to give your agent direct access to files on your machine.</p>
+        </div>
+      )}
+
+      <div className="mt-3 px-4">
+        {pendingRestart ? (
+          <div className="flex items-center gap-2 rounded-lg bg-orange-50 dark:bg-orange-950/30 p-2.5">
+            <span className="text-[11px] text-orange-600 dark:text-orange-400 flex-1">
+              Restart your agent for the mount<br />changes to take effect.
+            </span>
+            <Button
+              size="sm"
+              className="bg-orange-600 text-white hover:bg-orange-700"
+              onClick={handleRestart}
+              disabled={isRestarting}
+            >
+              <RefreshCw className={`${isRestarting ? 'animate-spin' : ''}`} />
+              {isRestarting ? 'Restarting...' : 'Restart'}
+            </Button>
+          </div>
+        ) : (
+          <div className="flex justify-end">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleAddMount}
+              disabled={addMount.isPending}
+            >
+              {addMount.isPending ? (
+                <Loader2 className="animate-spin" />
+              ) : (
+                <Plus />
+              )}
+              Add Mount
+            </Button>
+          </div>
+        )}
+      </div>
+    </HomeCollapsible>
+  )
+}
+
+interface VolumeRowProps {
+  mount: AgentMountWithHealth
+  agentSlug: string
+  onPendingRestart: () => void
+}
+
+function VolumeRow({ mount, agentSlug, onPendingRestart }: VolumeRowProps) {
+  const removeMount = useRemoveMount()
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+
+  const handleOpenInFinder = () => {
+    void window.electronAPI?.showInFolder(mount.hostPath)
+  }
+
+  const handleCopyPath = () => {
+    void navigator.clipboard.writeText(mount.hostPath)
+  }
+
+  const handleDelete = async () => {
+    await removeMount.mutateAsync({ agentSlug, mountId: mount.id })
+    setShowDeleteDialog(false)
+    onPendingRestart()
+  }
+
+  return (
+    <>
+      <div
+        role="button"
+        tabIndex={0}
+        className="group relative py-3 px-4 hover:bg-muted/50 transition-colors cursor-pointer"
+        onClick={handleOpenInFinder}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            handleOpenInFinder()
+          }
+        }}
+      >
+        <div className="flex items-center gap-2">
+          <Folder className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          <span className="text-xs font-medium truncate">{mount.folderName}</span>
+          <VolumeStatusBadge health={mount.health} />
+        </div>
+        <div className="text-[11px] text-muted-foreground mt-0.5 line-clamp-1 font-mono" title={mount.hostPath}>
+          {mount.hostPath}
+        </div>
+        <div className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity">
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                size="icon"
+                variant="outline"
+                className="h-6 w-6"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <MoreVertical className="h-3.5 w-3.5" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-40 p-1">
+              <button
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleOpenInFinder()
+                }}
+              >
+                <FolderOpen className="h-3.5 w-3.5" />
+                Open in Finder
+              </button>
+              <button
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleCopyPath()
+                }}
+              >
+                <Copy className="h-3.5 w-3.5" />
+                Copy path
+              </button>
+              <button
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-destructive hover:bg-destructive/10 transition-colors"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setShowDeleteDialog(true)
+                }}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                Remove Mount
+              </button>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove Mount</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to unmount &quot;{mount.folderName}&quot;? The agent will lose access to this folder after restarting.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep Mount</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={removeMount.isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {removeMount.isPending ? 'Removing...' : 'Remove Mount'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}
+
+function VolumeStatusBadge({ health }: { health: 'ok' | 'missing' }) {
+  if (health === 'ok') {
+    return (
+      <span className="text-[10px] px-1.5 py-0 rounded-full bg-green-500/10 text-green-700 dark:text-green-400">
+        OK
+      </span>
+    )
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0 rounded-full bg-red-500/10 text-red-700 dark:text-red-400">
+      <AlertTriangle className="h-2.5 w-2.5" />
+      Missing
+    </span>
+  )
+}

--- a/src/renderer/components/agents/agent-home/home-volumes.tsx
+++ b/src/renderer/components/agents/agent-home/home-volumes.tsx
@@ -75,7 +75,7 @@ export function HomeVolumes({ agentSlug }: HomeVolumesProps) {
       ) : (
         <div className="mt-3 mx-4 rounded-lg border border-dashed p-4 text-muted-foreground">
           <p className="text-xs font-medium text-foreground">No volumes yet</p>
-          <p className="text-xs mt-1">Mount a folder to give your agent direct access to files on your machine.</p>
+          <p className="text-xs mt-1">Mount a folder from your computer to give your agents direct read/write access to the files in it.</p>
         </div>
       )}
 
@@ -87,7 +87,8 @@ export function HomeVolumes({ agentSlug }: HomeVolumesProps) {
             </span>
             <Button
               size="sm"
-              className="bg-orange-600 text-white hover:bg-orange-700"
+              variant="ghost"
+              className="text-orange-600 dark:text-orange-400 hover:bg-orange-100 dark:hover:bg-orange-900/40 hover:text-orange-700 dark:hover:text-orange-300"
               onClick={handleRestart}
               disabled={isRestarting}
             >
@@ -98,7 +99,7 @@ export function HomeVolumes({ agentSlug }: HomeVolumesProps) {
         ) : (
           <div className="flex justify-end">
             <Button
-              variant="outline"
+              variant="ghost"
               size="sm"
               onClick={handleAddMount}
               disabled={addMount.isPending}

--- a/src/renderer/components/agents/settings/volumes-tab.tsx
+++ b/src/renderer/components/agents/settings/volumes-tab.tsx
@@ -1,48 +1,16 @@
-import { useAgentMounts, useAddMount, useRemoveMount } from '@renderer/hooks/use-mounts'
-import { Loader2, HardDrive, Trash2, AlertTriangle, Plus, RefreshCw } from 'lucide-react'
+import { Loader2, HardDrive, Trash2, Plus, RefreshCw } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
-import { useState } from 'react'
-import { apiFetch } from '@renderer/lib/api'
+import { useVolumesManager } from '@renderer/hooks/use-mounts'
+import { VolumeStatusBadge } from '../volume-status-badge'
 
 interface VolumesTabProps {
   agentSlug: string
 }
 
 export function VolumesTab({ agentSlug }: VolumesTabProps) {
-  const { data: mounts, isLoading, refetch } = useAgentMounts(agentSlug)
-  const addMount = useAddMount()
-  const removeMount = useRemoveMount()
-  const [pendingRestart, setPendingRestart] = useState(false)
-  const [isRestarting, setIsRestarting] = useState(false)
+  const vm = useVolumesManager(agentSlug)
 
-  const handleAddMount = async () => {
-    const dirPath = await window.electronAPI?.openDirectory()
-    if (!dirPath) return
-
-    await addMount.mutateAsync({ agentSlug, hostPath: dirPath })
-    setPendingRestart(true)
-  }
-
-  const handleRemove = async (mountId: string) => {
-    await removeMount.mutateAsync({ agentSlug, mountId })
-    setPendingRestart(true)
-  }
-
-  const handleRestart = async () => {
-    setIsRestarting(true)
-    try {
-      await apiFetch(`/api/agents/${agentSlug}/stop`, { method: 'POST' })
-      await apiFetch(`/api/agents/${agentSlug}/start`, { method: 'POST' })
-      setPendingRestart(false)
-      refetch()
-    } catch (error) {
-      console.error('Failed to restart agent:', error)
-    } finally {
-      setIsRestarting(false)
-    }
-  }
-
-  if (isLoading) {
+  if (vm.isLoading) {
     return (
       <div className="flex items-center justify-center py-8">
         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -56,19 +24,19 @@ export function VolumesTab({ agentSlug }: VolumesTabProps) {
         Mounted folders give the agent direct read-write access to directories on your machine.
       </p>
 
-      {pendingRestart && (
+      {vm.pendingRestart && (
         <div className="flex items-center gap-2 rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 p-3">
-          <RefreshCw className={`h-4 w-4 text-amber-600 shrink-0 ${isRestarting ? 'animate-spin' : ''}`} />
+          <RefreshCw className={`h-4 w-4 text-amber-600 shrink-0 ${vm.isRestarting ? 'animate-spin' : ''}`} />
           <span className="text-sm text-amber-800 dark:text-amber-200 flex-1">
             Restart required for mount changes to take effect.
           </span>
-          <Button size="sm" variant="outline" onClick={handleRestart} disabled={isRestarting}>
-            {isRestarting ? 'Restarting...' : 'Restart'}
+          <Button size="sm" variant="outline" onClick={vm.handleRestart} disabled={vm.isRestarting}>
+            {vm.isRestarting ? 'Restarting...' : 'Restart'}
           </Button>
         </div>
       )}
 
-      {(!mounts || mounts.length === 0) ? (
+      {vm.mounts.length === 0 ? (
         <div className="text-center py-8">
           <HardDrive className="h-8 w-8 mx-auto text-muted-foreground mb-3" />
           <p className="text-sm text-muted-foreground">
@@ -80,7 +48,7 @@ export function VolumesTab({ agentSlug }: VolumesTabProps) {
         </div>
       ) : (
         <div className="space-y-2">
-          {mounts.map((mount) => (
+          {vm.mounts.map((mount) => (
             <div
               key={mount.id}
               className="flex items-center gap-3 rounded-lg border p-3"
@@ -89,16 +57,7 @@ export function VolumesTab({ agentSlug }: VolumesTabProps) {
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
                   <span className="font-medium text-sm">{mount.folderName}</span>
-                  {mount.health === 'ok' ? (
-                    <span className="inline-flex items-center rounded-full bg-green-100 dark:bg-green-900/30 px-2 py-0.5 text-[10px] font-medium text-green-700 dark:text-green-300">
-                      OK
-                    </span>
-                  ) : (
-                    <span className="inline-flex items-center gap-1 rounded-full bg-red-100 dark:bg-red-900/30 px-2 py-0.5 text-[10px] font-medium text-red-700 dark:text-red-300">
-                      <AlertTriangle className="h-2.5 w-2.5" />
-                      Missing
-                    </span>
-                  )}
+                  <VolumeStatusBadge health={mount.health} />
                 </div>
                 <div className="text-xs text-muted-foreground font-mono truncate" title={mount.hostPath}>
                   {mount.hostPath}
@@ -111,8 +70,8 @@ export function VolumesTab({ agentSlug }: VolumesTabProps) {
                 variant="ghost"
                 size="icon"
                 className="h-8 w-8 text-muted-foreground hover:text-destructive"
-                onClick={() => handleRemove(mount.id)}
-                disabled={removeMount.isPending}
+                onClick={() => vm.handleRemove(mount.id)}
+                disabled={vm.isRemovingMount}
               >
                 <Trash2 className="h-4 w-4" />
               </Button>
@@ -124,10 +83,10 @@ export function VolumesTab({ agentSlug }: VolumesTabProps) {
       <Button
         variant="outline"
         size="sm"
-        onClick={handleAddMount}
-        disabled={addMount.isPending}
+        onClick={vm.handleAddMount}
+        disabled={vm.isAddingMount}
       >
-        {addMount.isPending ? (
+        {vm.isAddingMount ? (
           <Loader2 className="h-4 w-4 animate-spin mr-2" />
         ) : (
           <Plus className="h-4 w-4 mr-2" />

--- a/src/renderer/components/agents/settings/volumes-tab.tsx
+++ b/src/renderer/components/agents/settings/volumes-tab.tsx
@@ -25,14 +25,21 @@ export function VolumesTab({ agentSlug }: VolumesTabProps) {
       </p>
 
       {vm.pendingRestart && (
-        <div className="flex items-center gap-2 rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 p-3">
-          <RefreshCw className={`h-4 w-4 text-amber-600 shrink-0 ${vm.isRestarting ? 'animate-spin' : ''}`} />
-          <span className="text-sm text-amber-800 dark:text-amber-200 flex-1">
-            Restart required for mount changes to take effect.
-          </span>
-          <Button size="sm" variant="outline" onClick={vm.handleRestart} disabled={vm.isRestarting}>
-            {vm.isRestarting ? 'Restarting...' : 'Restart'}
-          </Button>
+        <div className="flex flex-col gap-1 rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 p-3">
+          <div className="flex items-center gap-2">
+            <RefreshCw className={`h-4 w-4 text-amber-600 shrink-0 ${vm.isRestarting ? 'animate-spin' : ''}`} />
+            <span className="text-sm text-amber-800 dark:text-amber-200 flex-1">
+              Restart required for mount changes to take effect.
+            </span>
+            <Button size="sm" variant="outline" onClick={vm.handleRestart} disabled={vm.isRestarting}>
+              {vm.isRestarting ? 'Restarting...' : 'Restart'}
+            </Button>
+          </div>
+          {vm.restartError && (
+            <span className="text-xs text-destructive pl-6" role="alert">
+              {vm.restartError}
+            </span>
+          )}
         </div>
       )}
 

--- a/src/renderer/components/agents/volume-status-badge.tsx
+++ b/src/renderer/components/agents/volume-status-badge.tsx
@@ -1,0 +1,17 @@
+import { AlertTriangle } from 'lucide-react'
+
+export function VolumeStatusBadge({ health }: { health: 'ok' | 'missing' }) {
+  if (health === 'ok') {
+    return (
+      <span className="text-[10px] px-1.5 py-0 rounded-full bg-green-500/10 text-green-700 dark:text-green-400">
+        OK
+      </span>
+    )
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0 rounded-full bg-red-500/10 text-red-700 dark:text-red-400">
+      <AlertTriangle className="h-2.5 w-2.5" />
+      Missing
+    </span>
+  )
+}

--- a/src/renderer/hooks/use-mounts.ts
+++ b/src/renderer/hooks/use-mounts.ts
@@ -1,6 +1,7 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { apiFetch } from '@renderer/lib/api'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useAgent } from './use-agents'
 import type { AgentMount, AgentMountWithHealth } from '@shared/lib/types/mount'
 
 async function parseErrorMessage(res: Response, fallback: string): Promise<string> {
@@ -61,22 +62,33 @@ export function useRemoveMount() {
 export function useVolumesManager(agentSlug: string) {
   const { data: mountsData, isLoading, refetch } = useAgentMounts(agentSlug)
   const mounts = Array.isArray(mountsData) ? mountsData : []
+  const { data: agent } = useAgent(agentSlug)
+  const isAgentRunning = agent?.status === 'running'
   const addMount = useAddMount()
   const removeMount = useRemoveMount()
   const [pendingRestart, setPendingRestart] = useState(false)
   const [isRestarting, setIsRestarting] = useState(false)
+  const [restartError, setRestartError] = useState<string | null>(null)
+
+  // A stopped agent picks up mount changes on next start — no restart needed.
+  useEffect(() => {
+    if (!isAgentRunning && pendingRestart) {
+      setPendingRestart(false)
+      setRestartError(null)
+    }
+  }, [isAgentRunning, pendingRestart])
 
   const handleAddMount = async () => {
     const dirPath = await window.electronAPI?.openDirectory()
     if (!dirPath) return
     await addMount.mutateAsync({ agentSlug, hostPath: dirPath })
-    setPendingRestart(true)
+    if (isAgentRunning) setPendingRestart(true)
   }
 
   const handleRemove = async (mountId: string) => {
     try {
       await removeMount.mutateAsync({ agentSlug, mountId })
-      setPendingRestart(true)
+      if (isAgentRunning) setPendingRestart(true)
     } catch (error) {
       console.error('Failed to remove mount:', error)
     }
@@ -84,13 +96,19 @@ export function useVolumesManager(agentSlug: string) {
 
   const handleRestart = async () => {
     setIsRestarting(true)
+    setRestartError(null)
     try {
-      await apiFetch(`/api/agents/${agentSlug}/stop`, { method: 'POST' })
-      await apiFetch(`/api/agents/${agentSlug}/start`, { method: 'POST' })
+      const stopRes = await apiFetch(`/api/agents/${agentSlug}/stop`, { method: 'POST' })
+      if (!stopRes.ok) throw new Error(await parseErrorMessage(stopRes, 'Failed to stop agent'))
+      const startRes = await apiFetch(`/api/agents/${agentSlug}/start`, { method: 'POST' })
+      if (!startRes.ok) throw new Error(await parseErrorMessage(startRes, 'Failed to start agent'))
       setPendingRestart(false)
       refetch()
     } catch (error) {
+      // Keep the banner up so the user can retry; surface the error to the caller.
+      const message = error instanceof Error ? error.message : 'Failed to restart agent'
       console.error('Failed to restart agent:', error)
+      setRestartError(message)
     } finally {
       setIsRestarting(false)
     }
@@ -101,6 +119,7 @@ export function useVolumesManager(agentSlug: string) {
     isLoading,
     pendingRestart,
     isRestarting,
+    restartError,
     isAddingMount: addMount.isPending,
     isRemovingMount: removeMount.isPending,
     handleAddMount,

--- a/src/renderer/hooks/use-mounts.ts
+++ b/src/renderer/hooks/use-mounts.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { apiFetch } from '@renderer/lib/api'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { AgentMount, AgentMountWithHealth } from '@shared/lib/types/mount'
@@ -55,4 +56,55 @@ export function useRemoveMount() {
       queryClient.invalidateQueries({ queryKey: ['mounts', agentSlug] })
     },
   })
+}
+
+export function useVolumesManager(agentSlug: string) {
+  const { data: mountsData, isLoading, refetch } = useAgentMounts(agentSlug)
+  const mounts = Array.isArray(mountsData) ? mountsData : []
+  const addMount = useAddMount()
+  const removeMount = useRemoveMount()
+  const [pendingRestart, setPendingRestart] = useState(false)
+  const [isRestarting, setIsRestarting] = useState(false)
+
+  const handleAddMount = async () => {
+    const dirPath = await window.electronAPI?.openDirectory()
+    if (!dirPath) return
+    await addMount.mutateAsync({ agentSlug, hostPath: dirPath })
+    setPendingRestart(true)
+  }
+
+  const handleRemove = async (mountId: string) => {
+    try {
+      await removeMount.mutateAsync({ agentSlug, mountId })
+      setPendingRestart(true)
+    } catch (error) {
+      console.error('Failed to remove mount:', error)
+    }
+  }
+
+  const handleRestart = async () => {
+    setIsRestarting(true)
+    try {
+      await apiFetch(`/api/agents/${agentSlug}/stop`, { method: 'POST' })
+      await apiFetch(`/api/agents/${agentSlug}/start`, { method: 'POST' })
+      setPendingRestart(false)
+      refetch()
+    } catch (error) {
+      console.error('Failed to restart agent:', error)
+    } finally {
+      setIsRestarting(false)
+    }
+  }
+
+  return {
+    mounts,
+    isLoading,
+    pendingRestart,
+    isRestarting,
+    isAddingMount: addMount.isPending,
+    isRemovingMount: removeMount.isPending,
+    handleAddMount,
+    handleRemove,
+    handleRestart,
+  }
 }


### PR DESCRIPTION
## Summary
- Adds a **Volumes** section to the agent landing page, mirroring the Crons and Skills sections (same `HomeCollapsible` wrapper, row layout, hover menu pattern)
- Each row shows the folder name, host path, and an OK/Missing status pill; clicking the row opens the folder in Finder, and the 3-dot menu offers Open in Finder / Copy path / Remove Mount
- Orange restart banner replaces the Add Mount button when there are pending mount changes, with a Restart control that stops and starts the agent inline

## Test plan
- [ ] Open an agent's landing page and confirm the Volumes section renders below Skills
- [ ] With no mounts, confirm the "No volumes yet" empty state shows with the read/write copy
- [ ] Click Add Mount, pick a folder, confirm it appears with an OK pill and the orange restart banner replaces the Add Mount button
- [ ] Click Restart in the banner and confirm the agent restarts and the banner clears
- [ ] Click a mount row and confirm the folder opens in Finder
- [ ] Open the 3-dot menu and exercise Open in Finder, Copy path, and Remove Mount
- [ ] Delete a mounted folder on disk, refresh, and confirm the Missing pill appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)