### PR TITLE
Add Connections section to agent home

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -18,6 +18,7 @@ import { useMessageComposer } from '@renderer/hooks/use-message-composer'
 import { ChatComposerBox } from '@renderer/components/messages/chat-composer-box'
 import { HomeCrons } from './home-crons'
 import { HomeSkills } from './home-skills'
+import { HomeConnections } from './home-connections'
 import { HomeBookmarks } from './home-bookmarks'
 import type { ApiAgent } from '@renderer/hooks/use-agents'
 import { useRenderTracker } from '@renderer/lib/perf'
@@ -26,7 +27,7 @@ import { formatDistanceToNow } from 'date-fns'
 interface AgentHomeProps {
   agent: ApiAgent
   onSessionCreated: (sessionId: string, initialMessage: string) => void
-  onOpenSettings?: () => void
+  onOpenSettings?: (tab?: string) => void
 }
 
 export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHomeProps) {
@@ -129,7 +130,7 @@ export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHome
         <div className="space-y-6 w-full min-w-0 xl:min-w-[480px] xl:max-w-[720px]">
           <div className="flex items-center justify-between">
             <h1 className="text-xl font-semibold">{agent.name}</h1>
-            <Button type="button" size="icon" variant="ghost" className="h-8 w-8" onClick={onOpenSettings} aria-label="Agent settings">
+            <Button type="button" size="icon" variant="ghost" className="h-8 w-8" onClick={() => onOpenSettings?.()} aria-label="Agent settings">
               <MoreVertical className="h-4 w-4" />
             </Button>
           </div>
@@ -305,6 +306,7 @@ export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHome
               onSelectTask={selectScheduledTask}
             />
             <HomeSkills agentSlug={agent.slug} />
+            <HomeConnections agentSlug={agent.slug} onOpenSettings={onOpenSettings} />
           </div>
         )}
       </div>

--- a/src/renderer/components/agents/agent-home/home-connections.tsx
+++ b/src/renderer/components/agents/agent-home/home-connections.tsx
@@ -16,11 +16,14 @@ import { ServiceIcon } from '@renderer/components/ui/service-icon'
 import { useAgentConnectedAccounts, useRemoveAgentConnectedAccount } from '@renderer/hooks/use-connected-accounts'
 import { useAgentRemoteMcps, useRemoveMcpFromAgent } from '@renderer/hooks/use-remote-mcps'
 import { HomeCollapsible } from './home-collapsible'
+import { HomeRow } from './home-row'
 import { formatDistanceToNow } from 'date-fns'
+
+type SettingsTab = 'connected-accounts' | 'remote-mcps'
 
 interface HomeConnectionsProps {
   agentSlug: string
-  onOpenSettings?: (tab?: string) => void
+  onOpenSettings?: (tab?: SettingsTab) => void
 }
 
 interface ConnectionRow {
@@ -28,13 +31,15 @@ interface ConnectionRow {
   rawId: string
   name: string
   subtitle?: string
-  iconSlug: string
+  iconSlug?: string
   type: 'oauth' | 'mcp'
   date: string | number
-  settingsTab: string
+  settingsTab: SettingsTab
 }
 
-/** Parse a date value that may be an ISO string, numeric string, or number (ms epoch). */
+// MCP's `mappedAt` can be a numeric-string epoch in ms, not an ISO date.
+// Accounts store `createdAt` as a real ISO string, so the numeric branch
+// only protects the MCP case.
 function safeDate(value: string | number): Date {
   if (typeof value === 'number') return new Date(value)
   const num = Number(value)
@@ -70,7 +75,7 @@ export function HomeConnections({ agentSlug, onOpenSettings }: HomeConnectionsPr
           rawId: mcp.id,
           name: mcp.name,
           subtitle: mcp.url,
-          iconSlug: '',
+          iconSlug: undefined,
           type: 'mcp',
           date: mcp.mappedAt,
           settingsTab: 'remote-mcps',
@@ -106,7 +111,7 @@ export function HomeConnections({ agentSlug, onOpenSettings }: HomeConnectionsPr
       )}
       <div className="flex items-center justify-between mt-3 px-4 pb-1">
         {connections.length === 0 && (
-          <div className="flex items-center">
+          <div className="flex items-center" aria-hidden="true">
             {['gmail', 'slack', 'notion', 'github', 'linear', 'figma', 'jira', 'salesforce'].map((slug, i) => (
               <div
                 key={slug}
@@ -123,35 +128,35 @@ export function HomeConnections({ agentSlug, onOpenSettings }: HomeConnectionsPr
           </div>
         )}
         <div className="ml-auto">
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button type="button" variant="ghost" size="sm" className="h-7 text-xs text-muted-foreground">
-              <Plus className="h-3.5 w-3.5 mr-1.5" />
-              Add connection
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent align="end" className="w-56 p-1">
-            <button
-              className="flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
-              onClick={() => onOpenSettings?.('connected-accounts')}
-            >
-              OAuth Account
-              <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
-            </button>
-            <button
-              className="flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
-              onClick={() => onOpenSettings?.('remote-mcps')}
-            >
-              MCP Server
-              <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
-            </button>
-            <div className="border-t mt-1 pt-1.5 px-2 pb-1.5">
-              <p className="text-[11px] text-muted-foreground leading-snug">
-                Your agent will also prompt you to add connections while chatting.
-              </p>
-            </div>
-          </PopoverContent>
-        </Popover>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button type="button" variant="ghost" size="sm" className="h-7 text-xs text-muted-foreground">
+                <Plus className="h-3.5 w-3.5 mr-1.5" />
+                Add connection
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-56 p-1">
+              <button
+                className="flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
+                onClick={() => onOpenSettings?.('connected-accounts')}
+              >
+                OAuth Account
+                <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+              </button>
+              <button
+                className="flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
+                onClick={() => onOpenSettings?.('remote-mcps')}
+              >
+                MCP Server
+                <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+              </button>
+              <div className="border-t mt-1 pt-1.5 px-2 pb-1.5">
+                <p className="text-[11px] text-muted-foreground leading-snug">
+                  Your agent will also prompt you to add connections while chatting.
+                </p>
+              </div>
+            </PopoverContent>
+          </Popover>
         </div>
       </div>
     </HomeCollapsible>
@@ -170,42 +175,30 @@ function ConnectionRowItem({
   const removeAccount = useRemoveAgentConnectedAccount()
   const removeMcp = useRemoveMcpFromAgent()
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+  const [removeError, setRemoveError] = useState<string | null>(null)
 
   const isRemoving = removeAccount.isPending || removeMcp.isPending
 
-  const handleRemove = () => {
-    if (conn.type === 'oauth') {
-      removeAccount.mutate({ agentSlug, accountId: conn.rawId })
-    } else {
-      removeMcp.mutate({ agentSlug, mcpId: conn.rawId })
+  const handleRemove = async () => {
+    setRemoveError(null)
+    try {
+      if (conn.type === 'oauth') {
+        await removeAccount.mutateAsync({ agentSlug, accountId: conn.rawId })
+      } else {
+        await removeMcp.mutateAsync({ agentSlug, mcpId: conn.rawId })
+      }
+      setShowDeleteDialog(false)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to remove connection'
+      setRemoveError(message)
     }
   }
 
   return (
     <>
-      <button
-        onClick={onConfigure}
-        className="group relative w-full py-3 px-4 text-left hover:bg-muted/50 transition-colors"
-      >
-        <div className="flex items-center gap-3">
-          <div className="h-7 w-7 rounded-md bg-muted flex items-center justify-center shrink-0">
-            <ServiceIcon
-              slug={conn.iconSlug}
-              fallback="blocks"
-              className="h-4 w-4 text-muted-foreground/60"
-            />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="text-xs font-medium truncate">{conn.name}</div>
-            <div className="flex items-center justify-between text-[11px] text-muted-foreground mt-0.5">
-              <span className="truncate">{conn.type}{conn.subtitle ? ` · ${conn.subtitle}` : ''}</span>
-              <span className="whitespace-nowrap shrink-0 ml-2">
-                {formatDistanceToNow(safeDate(conn.date), { addSuffix: true })}
-              </span>
-            </div>
-          </div>
-        </div>
-        <div className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity">
+      <HomeRow
+        onActivate={onConfigure}
+        actions={
           <Popover>
             <PopoverTrigger asChild>
               <Button
@@ -213,6 +206,7 @@ function ConnectionRowItem({
                 size="icon"
                 variant="outline"
                 className="h-6 w-6"
+                aria-label={`Actions for ${conn.name}`}
                 onClick={(e) => e.stopPropagation()}
               >
                 <MoreVertical className="h-3.5 w-3.5" />
@@ -241,10 +235,43 @@ function ConnectionRowItem({
               </button>
             </PopoverContent>
           </Popover>
+        }
+      >
+        <div className="flex items-center gap-3">
+          <div className="h-7 w-7 rounded-md bg-muted flex items-center justify-center shrink-0">
+            <ServiceIcon
+              slug={conn.iconSlug}
+              fallback="blocks"
+              className="h-4 w-4 text-muted-foreground/60"
+            />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-xs font-medium truncate">{conn.name}</div>
+            <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground mt-0.5">
+              <span className="flex min-w-0 items-center gap-1">
+                <span className="shrink-0">{conn.type}</span>
+                {conn.subtitle && (
+                  <>
+                    <span className="shrink-0">·</span>
+                    <span className="truncate">{conn.subtitle}</span>
+                  </>
+                )}
+              </span>
+              <span className="whitespace-nowrap shrink-0">
+                {formatDistanceToNow(safeDate(conn.date), { addSuffix: true })}
+              </span>
+            </div>
+          </div>
         </div>
-      </button>
+      </HomeRow>
 
-      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+      <AlertDialog
+        open={showDeleteDialog}
+        onOpenChange={(open) => {
+          setShowDeleteDialog(open)
+          if (!open) setRemoveError(null)
+        }}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Remove Connection</AlertDialogTitle>
@@ -252,10 +279,16 @@ function ConnectionRowItem({
               Are you sure you want to remove &quot;{conn.name}&quot; from this agent? The connection itself will not be deleted.
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {removeError && (
+            <p className="text-xs text-destructive" role="alert">{removeError}</p>
+          )}
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={isRemoving}>Cancel</AlertDialogCancel>
             <AlertDialogAction
-              onClick={handleRemove}
+              onClick={(e) => {
+                e.preventDefault()
+                void handleRemove()
+              }}
               disabled={isRemoving}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >

--- a/src/renderer/components/agents/agent-home/home-connections.tsx
+++ b/src/renderer/components/agents/agent-home/home-connections.tsx
@@ -1,0 +1,269 @@
+import { useMemo, useState } from 'react'
+import { Button } from '@renderer/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+import { ChevronRight, MoreVertical, Plus, Settings, Trash2 } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@renderer/components/ui/alert-dialog'
+import { ServiceIcon } from '@renderer/components/ui/service-icon'
+import { useAgentConnectedAccounts, useRemoveAgentConnectedAccount } from '@renderer/hooks/use-connected-accounts'
+import { useAgentRemoteMcps, useRemoveMcpFromAgent } from '@renderer/hooks/use-remote-mcps'
+import { HomeCollapsible } from './home-collapsible'
+import { formatDistanceToNow } from 'date-fns'
+
+interface HomeConnectionsProps {
+  agentSlug: string
+  onOpenSettings?: (tab?: string) => void
+}
+
+interface ConnectionRow {
+  id: string
+  rawId: string
+  name: string
+  subtitle?: string
+  iconSlug: string
+  type: 'oauth' | 'mcp'
+  date: string | number
+  settingsTab: string
+}
+
+/** Parse a date value that may be an ISO string, numeric string, or number (ms epoch). */
+function safeDate(value: string | number): Date {
+  if (typeof value === 'number') return new Date(value)
+  const num = Number(value)
+  return Number.isFinite(num) ? new Date(num) : new Date(value)
+}
+
+export function HomeConnections({ agentSlug, onOpenSettings }: HomeConnectionsProps) {
+  const { data: accountsData } = useAgentConnectedAccounts(agentSlug)
+  const { data: mcpsData } = useAgentRemoteMcps(agentSlug)
+
+  const connections = useMemo<ConnectionRow[]>(() => {
+    const rows: ConnectionRow[] = []
+
+    if (accountsData?.accounts) {
+      for (const account of accountsData.accounts) {
+        rows.push({
+          id: `account-${account.id}`,
+          rawId: account.id,
+          name: account.provider?.displayName ?? account.toolkitSlug,
+          subtitle: account.displayName,
+          iconSlug: account.toolkitSlug,
+          type: 'oauth',
+          date: account.createdAt,
+          settingsTab: 'connected-accounts',
+        })
+      }
+    }
+
+    if (mcpsData?.mcps) {
+      for (const mcp of mcpsData.mcps) {
+        rows.push({
+          id: `mcp-${mcp.id}`,
+          rawId: mcp.id,
+          name: mcp.name,
+          subtitle: mcp.url,
+          iconSlug: '',
+          type: 'mcp',
+          date: mcp.mappedAt,
+          settingsTab: 'remote-mcps',
+        })
+      }
+    }
+
+    rows.sort((a, b) => safeDate(b.date).getTime() - safeDate(a.date).getTime())
+
+    return rows
+  }, [accountsData, mcpsData])
+
+  return (
+    <HomeCollapsible title="Connections">
+      {connections.length > 0 ? (
+        <div className="mt-2 divide-y divide-border/50">
+          {connections.map((conn) => (
+            <ConnectionRowItem
+              key={conn.id}
+              conn={conn}
+              agentSlug={agentSlug}
+              onConfigure={() => onOpenSettings?.(conn.settingsTab)}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="mt-3 mx-4 rounded-lg border border-dashed p-4 text-muted-foreground">
+          <p className="text-xs font-medium text-foreground">No connections yet</p>
+          <p className="text-xs mt-1">
+            Connect OAuth accounts or MCP servers to give your agent access to external services like Gmail or Slack.
+          </p>
+        </div>
+      )}
+      <div className="flex items-center justify-between mt-3 px-4 pb-1">
+        {connections.length === 0 && (
+          <div className="flex items-center">
+            {['gmail', 'slack', 'notion', 'github', 'linear', 'figma', 'jira', 'salesforce'].map((slug, i) => (
+              <div
+                key={slug}
+                className="h-8 w-8 rounded-lg border border-border bg-background flex items-center justify-center shadow-sm transition-transform duration-100 ease-out hover:scale-110 hover:z-10"
+                style={{ marginLeft: i === 0 ? 0 : -8, zIndex: i }}
+              >
+                <img
+                  src={`${import.meta.env.BASE_URL}service-icons/${slug}.svg`}
+                  alt=""
+                  className="h-4 w-4 object-contain"
+                />
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="ml-auto">
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button type="button" variant="ghost" size="sm" className="h-7 text-xs text-muted-foreground">
+              <Plus className="h-3.5 w-3.5 mr-1.5" />
+              Add connection
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="end" className="w-56 p-1">
+            <button
+              className="flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
+              onClick={() => onOpenSettings?.('connected-accounts')}
+            >
+              OAuth Account
+              <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+            </button>
+            <button
+              className="flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
+              onClick={() => onOpenSettings?.('remote-mcps')}
+            >
+              MCP Server
+              <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+            </button>
+            <div className="border-t mt-1 pt-1.5 px-2 pb-1.5">
+              <p className="text-[11px] text-muted-foreground leading-snug">
+                Your agent will also prompt you to add connections while chatting.
+              </p>
+            </div>
+          </PopoverContent>
+        </Popover>
+        </div>
+      </div>
+    </HomeCollapsible>
+  )
+}
+
+function ConnectionRowItem({
+  conn,
+  agentSlug,
+  onConfigure,
+}: {
+  conn: ConnectionRow
+  agentSlug: string
+  onConfigure: () => void
+}) {
+  const removeAccount = useRemoveAgentConnectedAccount()
+  const removeMcp = useRemoveMcpFromAgent()
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+
+  const isRemoving = removeAccount.isPending || removeMcp.isPending
+
+  const handleRemove = () => {
+    if (conn.type === 'oauth') {
+      removeAccount.mutate({ agentSlug, accountId: conn.rawId })
+    } else {
+      removeMcp.mutate({ agentSlug, mcpId: conn.rawId })
+    }
+  }
+
+  return (
+    <>
+      <button
+        onClick={onConfigure}
+        className="group relative w-full py-3 px-4 text-left hover:bg-muted/50 transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <div className="h-7 w-7 rounded-md bg-muted flex items-center justify-center shrink-0">
+            <ServiceIcon
+              slug={conn.iconSlug}
+              fallback="blocks"
+              className="h-4 w-4 text-muted-foreground/60"
+            />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-xs font-medium truncate">{conn.name}</div>
+            <div className="flex items-center justify-between text-[11px] text-muted-foreground mt-0.5">
+              <span className="truncate">{conn.type}{conn.subtitle ? ` · ${conn.subtitle}` : ''}</span>
+              <span className="whitespace-nowrap shrink-0 ml-2">
+                {formatDistanceToNow(safeDate(conn.date), { addSuffix: true })}
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity">
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                size="icon"
+                variant="outline"
+                className="h-6 w-6"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <MoreVertical className="h-3.5 w-3.5" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-36 p-1">
+              <button
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onConfigure()
+                }}
+              >
+                <Settings className="h-3.5 w-3.5" />
+                Configure
+              </button>
+              <button
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-destructive hover:bg-destructive/10 transition-colors"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setShowDeleteDialog(true)
+                }}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                Remove
+              </button>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </button>
+
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove Connection</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to remove &quot;{conn.name}&quot; from this agent? The connection itself will not be deleted.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleRemove}
+              disabled={isRemoving}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isRemoving ? 'Removing...' : 'Remove'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/src/renderer/components/agents/agent-home/home-row.tsx
+++ b/src/renderer/components/agents/agent-home/home-row.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react'
+
+// TODO: migrate home-crons, home-skills, home-volumes, home-bookmarks rows to use HomeRow.
+// home-crons currently uses a <button> outer which nests buttons (invalid HTML + breaks Radix focus).
+
+interface HomeRowProps {
+  onActivate: () => void
+  children: ReactNode
+  actions?: ReactNode
+}
+
+export function HomeRow({ onActivate, children, actions }: HomeRowProps) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className="group relative py-3 px-4 hover:bg-muted/50 transition-colors cursor-pointer"
+      onClick={onActivate}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onActivate()
+        }
+      }}
+    >
+      {children}
+      {actions && (
+        <div className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+          {actions}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/layout/main-content.tsx
+++ b/src/renderer/components/layout/main-content.tsx
@@ -48,6 +48,7 @@ export function MainContent() {
     selectWebhookTrigger,
   } = useSelection()
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [settingsTab, setSettingsTab] = useState<string | undefined>(undefined)
   const [contextBarExpanded, setContextBarExpanded] = useState(false)
   // Pending user messages per session — survives navigation between sessions
   const pendingMessagesRef = useRef(new Map<string, { text: string; sentAt: number; sender?: { id: string; name: string; email: string } }>())
@@ -473,7 +474,7 @@ export function MainContent() {
             <AgentHome
               agent={agent}
               onSessionCreated={handleSessionCreated}
-              onOpenSettings={() => setSettingsOpen(true)}
+              onOpenSettings={(tab?: string) => { setSettingsTab(tab); setSettingsOpen(true) }}
             />
           )
         )}
@@ -483,7 +484,8 @@ export function MainContent() {
         <AgentSettingsDialog
           agent={agent}
           open={settingsOpen}
-          onOpenChange={setSettingsOpen}
+          onOpenChange={(open) => { setSettingsOpen(open); if (!open) setSettingsTab(undefined) }}
+          initialTab={settingsTab}
         />
       )}
     </div>

--- a/src/renderer/components/ui/service-icon.tsx
+++ b/src/renderer/components/ui/service-icon.tsx
@@ -12,8 +12,8 @@ const FALLBACK_ICONS: Record<FallbackType, LucideIcon> = {
 }
 
 interface ServiceIconProps {
-  /** The service slug (e.g., 'gmail', 'slack', 'github') */
-  slug: string
+  /** The service slug (e.g., 'gmail', 'slack', 'github'). Omit/empty to render the fallback. */
+  slug?: string
   /** Which generic icon to show when no service icon is found */
   fallback?: FallbackType
   /** CSS classes applied to the icon element */

--- a/src/renderer/components/ui/service-icon.tsx
+++ b/src/renderer/components/ui/service-icon.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
-import { ExternalLink, Plug, Link2, type LucideIcon } from 'lucide-react'
+import { ExternalLink, Plug, Link2, Blocks, type LucideIcon } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
 
-type FallbackType = 'oauth' | 'mcp' | 'request'
+type FallbackType = 'oauth' | 'mcp' | 'blocks' | 'request'
 
 const FALLBACK_ICONS: Record<FallbackType, LucideIcon> = {
   oauth: ExternalLink,
   mcp: Plug,
+  blocks: Blocks,
   request: Link2,
 }
 

--- a/src/renderer/hooks/use-connected-accounts.ts
+++ b/src/renderer/hooks/use-connected-accounts.ts
@@ -15,6 +15,11 @@ export interface ConnectedAccount {
   provider?: Provider
 }
 
+export interface AgentConnectedAccount extends ConnectedAccount {
+  mappingId: string
+  mappedAt: string
+}
+
 interface ConnectedAccountsResponse {
   accounts: ConnectedAccount[]
 }
@@ -36,6 +41,21 @@ export function useConnectedAccounts() {
       if (!res.ok) throw new Error('Failed to fetch connected accounts')
       return res.json()
     },
+  })
+}
+
+/**
+ * Hook to fetch connected accounts assigned to a specific agent
+ */
+export function useAgentConnectedAccounts(agentSlug: string) {
+  return useQuery<{ accounts: AgentConnectedAccount[] }>({
+    queryKey: ['agent-connected-accounts', agentSlug],
+    queryFn: async () => {
+      const res = await apiFetch(`/api/agents/${agentSlug}/connected-accounts`)
+      if (!res.ok) throw new Error('Failed to fetch agent connected accounts')
+      return res.json()
+    },
+    enabled: !!agentSlug,
   })
 }
 
@@ -128,6 +148,25 @@ export function useRenameConnectedAccount() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['connected-accounts'] })
       queryClient.invalidateQueries({ queryKey: ['agent-connected-accounts'] })
+    },
+  })
+}
+
+/**
+ * Hook to remove a connected account from an agent
+ */
+export function useRemoveAgentConnectedAccount() {
+  const queryClient = useQueryClient()
+
+  return useMutation<void, Error, { agentSlug: string; accountId: string }>({
+    mutationFn: async ({ agentSlug, accountId }) => {
+      const res = await apiFetch(`/api/agents/${agentSlug}/connected-accounts/${accountId}`, {
+        method: 'DELETE',
+      })
+      if (!res.ok) throw new Error('Failed to remove account from agent')
+    },
+    onSuccess: (_, { agentSlug }) => {
+      queryClient.invalidateQueries({ queryKey: ['agent-connected-accounts', agentSlug] })
     },
   })
 }

--- a/src/renderer/hooks/use-connected-accounts.ts
+++ b/src/renderer/hooks/use-connected-accounts.ts
@@ -167,6 +167,7 @@ export function useRemoveAgentConnectedAccount() {
     },
     onSuccess: (_, { agentSlug }) => {
       queryClient.invalidateQueries({ queryKey: ['agent-connected-accounts', agentSlug] })
+      queryClient.invalidateQueries({ queryKey: ['connected-accounts'] })
     },
   })
 }


### PR DESCRIPTION
## Summary
- Adds a **Connections** section to the right column of the agent landing page, aggregating both OAuth connected accounts and remote MCP servers into a unified list
- Each row displays a service icon, provider name, connection type (`oauth`/`mcp`), subtitle (account email or MCP URL), and relative timestamp
- Rows are clickable and open the agent settings dialog to the relevant tab (Accounts or MCPs)
- 3-dot hover menu with **Configure** and **Remove** actions (with confirmation dialog)
- **Add connection** dropdown button with options for OAuth Account or MCP Server
- Decorative overlapping service icon stack in the empty state

## Changes
- **New:** `src/renderer/components/agents/agent-home/home-connections.tsx`
- **Modified:** `agent-home.tsx` — added `HomeConnections` to right column, updated `onOpenSettings` to accept optional tab param
- **Modified:** `main-content.tsx` — threads `initialTab` to `AgentSettingsDialog`
- **Modified:** `service-icon.tsx` — added `blocks` fallback icon type
- **Modified:** `use-connected-accounts.ts` — added `AgentConnectedAccount` type, `useAgentConnectedAccounts` and `useRemoveAgentConnectedAccount` hooks

## Test plan
- [ ] Verify Connections section renders in the right column below Skills
- [ ] With OAuth accounts and MCP servers assigned, verify rows show correct icons, names, subtitles, and timestamps
- [ ] Verify empty state with icon stack and help text
- [ ] Click a row → agent settings opens to correct tab
- [ ] 3-dot menu: Configure → opens settings; Remove → confirmation dialog → removes connection
- [ ] Add connection dropdown: OAuth Account / MCP Server → opens correct settings tab
- [ ] Collapsible behavior works (expand/collapse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)