### PR TITLE
style: reorder agent home cards and polish extras

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -320,7 +320,7 @@ export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHome
           )}
         </div>
 
-        {/* Right Column — Crons + Skills + Volumes */}
+        {/* Right Column — Crons + Connections + Skills + Volumes */}
         {showRightColumn && (
           <div className="space-y-3">
             <HomeCrons
@@ -329,9 +329,9 @@ export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHome
               formatDate={formatDate}
               onSelectTask={selectScheduledTask}
             />
+            <HomeConnections agentSlug={agent.slug} onOpenSettings={onOpenSettings} />
             <HomeSkills agentSlug={agent.slug} />
             <HomeVolumes agentSlug={agent.slug} />
-            <HomeConnections agentSlug={agent.slug} onOpenSettings={onOpenSettings} />
             <HomeExtras agentSlug={agent.slug} onOpenSettings={onOpenSettings} />
           </div>
         )}

--- a/src/renderer/components/agents/agent-home/home-connections.tsx
+++ b/src/renderer/components/agents/agent-home/home-connections.tsx
@@ -130,9 +130,9 @@ export function HomeConnections({ agentSlug, onOpenSettings }: HomeConnectionsPr
         <div className="ml-auto">
           <Popover>
             <PopoverTrigger asChild>
-              <Button type="button" variant="ghost" size="sm" className="h-7 text-xs text-muted-foreground">
-                <Plus className="h-3.5 w-3.5 mr-1.5" />
-                Add connection
+              <Button type="button" variant="ghost" size="sm">
+                <Plus />
+                Add Connection
               </Button>
             </PopoverTrigger>
             <PopoverContent align="end" className="w-56 p-1">

--- a/src/renderer/components/agents/agent-home/home-extras.tsx
+++ b/src/renderer/components/agents/agent-home/home-extras.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from 'react'
-import { ChevronRight, Copy, ExternalLink } from 'lucide-react'
+import { ArrowUpRight, ChevronRight, Copy } from 'lucide-react'
 import { apiFetch } from '@renderer/lib/api'
 import { isElectron } from '@renderer/lib/env'
 
@@ -33,8 +33,8 @@ export function HomeExtras({ agentSlug, onOpenSettings }: HomeExtrasProps) {
     }
   }
 
-  const directoryIcon = isElectron() ? (
-    <ExternalLink className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+  const directoryHoverIcon = isElectron() ? (
+    <ArrowUpRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
   ) : (
     <Copy className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
   )
@@ -44,7 +44,7 @@ export function HomeExtras({ agentSlug, onOpenSettings }: HomeExtrasProps) {
     <div className="rounded-xl border bg-background py-2">
       <div className="divide-y divide-border/50">
         <ExtrasButton label="System Prompt" onClick={() => onOpenSettings?.('system-prompt')} />
-        <ExtrasButton label={directoryLabel} onClick={handleOpenDirectory} icon={directoryIcon} />
+        <ExtrasButton label={directoryLabel} onClick={handleOpenDirectory} hoverIcon={directoryHoverIcon} />
         <ExtrasButton label="Secrets" onClick={() => onOpenSettings?.('secrets')} />
         <ExtrasButton label="API Logs" onClick={() => onOpenSettings?.('audit-log')} />
       </div>
@@ -55,15 +55,27 @@ export function HomeExtras({ agentSlug, onOpenSettings }: HomeExtrasProps) {
   )
 }
 
-function ExtrasButton({ label, onClick, icon }: { label: string; onClick: () => void; icon?: ReactNode }) {
+function ExtrasButton({ label, onClick, hoverIcon }: { label: string; onClick: () => void; hoverIcon?: ReactNode }) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className="flex w-full items-center justify-between py-3 px-4 text-left hover:bg-muted/50 transition-colors"
+      className="group flex w-full items-center justify-between py-3 px-4 text-left hover:bg-muted/50 transition-colors"
     >
       <span className="text-sm font-medium text-muted-foreground">{label}</span>
-      {icon ?? <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />}
+      {hoverIcon ? (
+        <span className="relative h-4 w-4">
+          <ChevronRight
+            className="absolute inset-0 h-4 w-4 text-muted-foreground transition-opacity group-hover:opacity-0"
+            aria-hidden="true"
+          />
+          <span className="absolute inset-0 opacity-0 transition-opacity group-hover:opacity-100">
+            {hoverIcon}
+          </span>
+        </span>
+      ) : (
+        <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+      )}
     </button>
   )
 }


### PR DESCRIPTION
## Summary
- Reorder the right column on the agent home page to Crons → Connections → Skills → Volumes → Extras
- Match the Add Connection button styling to Add Mount (drop the custom size/color overrides, capitalize label)
- Agent Directory row now shows a chevron by default and swaps to ArrowUpRight on hover (Copy on web)

## Test plan
- [ ] Open an agent's home page and confirm the right-column card order
- [ ] Verify the Add Connection button visually matches Add Mount
- [ ] Hover the Agent Directory row and confirm the chevron → ArrowUpRight transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)