### PR TITLE
fix(subagent): deterministic parent tool_use_id → agentId mapping via marker injection

### DIFF
--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -28,6 +28,15 @@ import { sanitizeMcpName } from './sanitize-mcp-name';
 // Keep in sync with SYSTEM_MESSAGE_PREFIX in src/renderer/components/messages/message-list.tsx
 const SYSTEM_MESSAGE_PREFIX = '[SYSTEM] ';
 
+// Tracking marker appended to Agent/Task subagent prompts via PreToolUse hook.
+// Lets message-persister deterministically map parent tool_use_id → subagent agentId
+// by reading the first message of each subagent jsonl (much more reliable than
+// the previous mtime-based FIFO guessing, especially for parallel subagents).
+// Format: <!-- sa-track:<tool_use_id> -->
+// Keep SA_TRACK_MARKER_REGEX in sync in src/shared/lib/container/message-persister.ts
+const SA_TRACK_MARKER_PREFIX = '<!-- sa-track:';
+const SA_TRACK_MARKER_SUFFIX = ' -->';
+
 // Load platform system prompt from file
 const PLATFORM_SYSTEM_PROMPT = fs.readFileSync(
   path.join(__dirname, 'system-prompt.md'),
@@ -551,6 +560,29 @@ export class ClaudeCodeProcess extends EventEmitter {
                     }
                   }
                   return {};
+                },
+              ],
+            },
+            // Inject a tracking marker into every subagent prompt so the host can
+            // deterministically map parent tool_use_id → subagent agentId when
+            // reading the resulting subagent jsonl transcript. The marker is an
+            // HTML comment, invisible to the subagent's behavior.
+            {
+              matcher: '^(Agent|Task)$',
+              hooks: [
+                async (input, toolUseId) => {
+                  if (!toolUseId) return {};
+                  const toolInput = (input as any).tool_input as Record<string, unknown> | undefined;
+                  if (!toolInput || typeof toolInput !== 'object') return {};
+                  const prompt = typeof toolInput.prompt === 'string' ? toolInput.prompt : '';
+                  const marker = `${SA_TRACK_MARKER_PREFIX}${toolUseId}${SA_TRACK_MARKER_SUFFIX}`;
+                  if (prompt.includes(marker)) return {};
+                  return {
+                    hookSpecificOutput: {
+                      hookEventName: 'PreToolUse' as const,
+                      updatedInput: { ...toolInput, prompt: `${prompt}\n\n${marker}` },
+                    },
+                  };
                 },
               ],
             },

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -28,12 +28,7 @@ import { sanitizeMcpName } from './sanitize-mcp-name';
 // Keep in sync with SYSTEM_MESSAGE_PREFIX in src/renderer/components/messages/message-list.tsx
 const SYSTEM_MESSAGE_PREFIX = '[SYSTEM] ';
 
-// Tracking marker appended to Agent/Task subagent prompts via PreToolUse hook.
-// Lets message-persister deterministically map parent tool_use_id → subagent agentId
-// by reading the first message of each subagent jsonl (much more reliable than
-// the previous mtime-based FIFO guessing, especially for parallel subagents).
-// Format: <!-- sa-track:<tool_use_id> -->
-// Keep SA_TRACK_MARKER_REGEX in sync in src/shared/lib/container/message-persister.ts
+// Keep in sync with SA_TRACK_MARKER_REGEX in message-persister.ts
 const SA_TRACK_MARKER_PREFIX = '<!-- sa-track:';
 const SA_TRACK_MARKER_SUFFIX = ' -->';
 
@@ -563,10 +558,6 @@ export class ClaudeCodeProcess extends EventEmitter {
                 },
               ],
             },
-            // Inject a tracking marker into every subagent prompt so the host can
-            // deterministically map parent tool_use_id → subagent agentId when
-            // reading the resulting subagent jsonl transcript. The marker is an
-            // HTML comment, invisible to the subagent's behavior.
             {
               matcher: '^(Agent|Task)$',
               hooks: [

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -27,12 +27,24 @@ vi.mock('@shared/lib/config/settings', () => ({
 
 const mockReaddir = vi.fn()
 const mockStat = vi.fn()
-vi.mock('fs', () => ({
-  promises: {
-    readdir: (...args: unknown[]) => mockReaddir(...args),
-    stat: (...args: unknown[]) => mockStat(...args),
-  },
-}))
+// Maps a file path to the first-line content that createReadStream should emit.
+// Tests that exercise marker-based subagent discovery populate this before sending messages.
+const mockFirstLineByPath = new Map<string, string>()
+vi.mock('fs', () => {
+  // Use Node's real Readable so readline.createInterface works against the mock stream.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Readable } = require('stream') as typeof import('stream')
+  return {
+    promises: {
+      readdir: (...args: unknown[]) => mockReaddir(...args),
+      stat: (...args: unknown[]) => mockStat(...args),
+    },
+    createReadStream: (filePath: string) => {
+      const line = mockFirstLineByPath.get(filePath) ?? ''
+      return Readable.from([line + '\n'])
+    },
+  }
+})
 vi.mock('@shared/lib/utils/file-storage', () => ({
   getAgentSessionsDir: vi.fn(() => '/mock/sessions'),
 }))
@@ -640,6 +652,104 @@ describe('MessagePersister', () => {
       const events = sseEvents.filter(e => e.type === 'subagent_updated')
       expect(events.length).toBeGreaterThanOrEqual(1)
       expect(events[0].agentId).toBeNull()
+    })
+
+    it('maps parent tool_use_id to agentId deterministically via the sa-track marker, even when mtime order would mismatch', async () => {
+      // Two subagents created in REVERSE mtime order relative to registration:
+      // tool-A is registered first, but its subagent jsonl (abc123) has a
+      // NEWER mtime than tool-B's (def456). Without the marker, the old FIFO
+      // logic would misassign (tool-A → def456, tool-B → abc123).
+      mockReaddir.mockResolvedValue(['agent-abc123.jsonl', 'agent-def456.jsonl'])
+      mockStat.mockImplementation((filePath: string) => {
+        if (filePath.includes('abc123')) return Promise.resolve({ mtimeMs: 2000 }) // newer
+        if (filePath.includes('def456')) return Promise.resolve({ mtimeMs: 1000 }) // older
+        return Promise.reject(new Error('ENOENT'))
+      })
+
+      // Wire the first-line marker content for each subagent jsonl.
+      // In production this line is written by the SDK as the subagent's
+      // initial user message after the claude-code.ts PreToolUse hook
+      // appended the marker to the prompt.
+      mockFirstLineByPath.set(
+        `/mock/sessions/${SESSION_ID}/subagents/agent-abc123.jsonl`,
+        JSON.stringify({ type: 'user', message: { content: 'do A\n\n<!-- sa-track:tool-A -->' } })
+      )
+      mockFirstLineByPath.set(
+        `/mock/sessions/${SESSION_ID}/subagents/agent-def456.jsonl`,
+        JSON.stringify({ type: 'user', message: { content: 'do B\n\n<!-- sa-track:tool-B -->' } })
+      )
+
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_start', content_block: { type: 'tool_use', id: 'tool-A', name: 'Task' } },
+      })
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'content_block_stop' } })
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_start', content_block: { type: 'tool_use', id: 'tool-B', name: 'Task' } },
+      })
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'content_block_stop' } })
+
+      sseEvents.length = 0
+
+      mockClient._sendMessage({
+        type: 'assistant',
+        parent_tool_use_id: 'tool-A',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'working' }] },
+      })
+
+      await vi.waitFor(() => {
+        // Marker-based matching: tool-A → abc123, tool-B → def456,
+        // even though mtime order would have flipped these under FIFO.
+        const eventsA = sseEvents.filter(e => e.type === 'subagent_updated' && e.parentToolId === 'tool-A' && e.agentId === 'abc123')
+        expect(eventsA.length).toBeGreaterThanOrEqual(1)
+        const eventsB = sseEvents.filter(e => e.type === 'subagent_updated' && e.parentToolId === 'tool-B' && e.agentId === 'def456')
+        expect(eventsB.length).toBeGreaterThanOrEqual(1)
+      })
+
+      // Confirm no cross-wired mappings leaked.
+      const wrongA = sseEvents.filter(e => e.type === 'subagent_updated' && e.parentToolId === 'tool-A' && e.agentId === 'def456')
+      const wrongB = sseEvents.filter(e => e.type === 'subagent_updated' && e.parentToolId === 'tool-B' && e.agentId === 'abc123')
+      expect(wrongA).toHaveLength(0)
+      expect(wrongB).toHaveLength(0)
+    })
+
+    it('falls back to mtime FIFO for files without the sa-track marker (legacy transcripts)', async () => {
+      mockReaddir.mockResolvedValue(['agent-legacy1.jsonl', 'agent-legacy2.jsonl'])
+      mockStat.mockImplementation((filePath: string) => {
+        if (filePath.includes('legacy1')) return Promise.resolve({ mtimeMs: 1000 })
+        if (filePath.includes('legacy2')) return Promise.resolve({ mtimeMs: 2000 })
+        return Promise.reject(new Error('ENOENT'))
+      })
+
+      // No markers set → mockFirstLineByPath returns empty string for both files.
+
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_start', content_block: { type: 'tool_use', id: 'tool-A', name: 'Task' } },
+      })
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'content_block_stop' } })
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_start', content_block: { type: 'tool_use', id: 'tool-B', name: 'Task' } },
+      })
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'content_block_stop' } })
+
+      sseEvents.length = 0
+
+      mockClient._sendMessage({
+        type: 'assistant',
+        parent_tool_use_id: 'tool-A',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'working' }] },
+      })
+
+      await vi.waitFor(() => {
+        // Fallback to mtime FIFO: tool-A (first registered) gets legacy1 (oldest).
+        const eventsA = sseEvents.filter(e => e.type === 'subagent_updated' && e.parentToolId === 'tool-A' && e.agentId === 'legacy1')
+        expect(eventsA.length).toBeGreaterThanOrEqual(1)
+        const eventsB = sseEvents.filter(e => e.type === 'subagent_updated' && e.parentToolId === 'tool-B' && e.agentId === 'legacy2')
+        expect(eventsB.length).toBeGreaterThanOrEqual(1)
+      })
     })
   })
 

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -57,12 +57,8 @@ export function seedKnownSubagentIds(agentSlug: string | undefined, sessionId: s
   return seeded
 }
 
-// Regex matching the tracking marker injected into subagent prompts by the
-// PreToolUse hook in agent-container/src/claude-code.ts.
-// Keep in sync with SA_TRACK_MARKER_PREFIX/SUFFIX in that file.
+// Keep in sync with SA_TRACK_MARKER_PREFIX/SUFFIX in claude-code.ts
 const SA_TRACK_MARKER_REGEX = /<!-- sa-track:([A-Za-z0-9_-]+) -->/
-
-// Read only the first line of a JSONL file without loading the whole file.
 async function readFirstJsonlLine(filePath: string): Promise<string | null> {
   let stream: ReturnType<typeof createReadStream> | null = null
   try {
@@ -917,8 +913,7 @@ class MessagePersister {
         }
       }
 
-      // Marker-based matching: read the first line of each unclaimed file and
-      // look for a sa-track marker that encodes the parent tool_use_id.
+      // Marker-based matching (preferred over FIFO below)
       const matchedIds = new Set<string>()
       await Promise.all(
         unclaimed.map(async ({ id }) => {
@@ -940,14 +935,14 @@ class MessagePersister {
         })
       )
 
-      // Rebuild needingIds after marker pass; skip FIFO if all matched.
+      // Skip FIFO if all matched
       const stillNeeding: string[] = []
       for (const [parentToolId, sub] of state.activeSubagents) {
         if (!sub.agentId) stillNeeding.push(parentToolId)
       }
       if (stillNeeding.length === 0) return
 
-      // FIFO fallback: match oldest unclaimed file → first registered parentToolId.
+      // FIFO fallback for containers without marker injection
       const unclaimedLeft = unclaimed
         .filter(u => !matchedIds.has(u.id))
         .sort((a, b) => a.mtimeMs - b.mtimeMs)

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -33,7 +33,8 @@ import { getRequiredPermissionLevel, resolveTargetApp, type ComputerUsePermissio
 import { getAgentSessionsDir } from '@shared/lib/utils/file-storage'
 import { SubagentCapture } from './subagent-capture'
 import * as path from 'path'
-import { promises as fsPromises, readdirSync } from 'fs'
+import { createReadStream, promises as fsPromises, readdirSync } from 'fs'
+import { createInterface } from 'readline'
 
 // Seed completedSubagentIds with every agent-*.jsonl already on disk for this
 // session. Called when StreamingState is (re)created so the FIFO live-discovery
@@ -54,6 +55,30 @@ export function seedKnownSubagentIds(agentSlug: string | undefined, sessionId: s
     // Directory missing / unreadable — nothing to seed, which is fine.
   }
   return seeded
+}
+
+// Regex matching the tracking marker injected into subagent prompts by the
+// PreToolUse hook in agent-container/src/claude-code.ts.
+// Keep in sync with SA_TRACK_MARKER_PREFIX/SUFFIX in that file.
+const SA_TRACK_MARKER_REGEX = /<!-- sa-track:([A-Za-z0-9_-]+) -->/
+
+// Read only the first line of a JSONL file without loading the whole file.
+async function readFirstJsonlLine(filePath: string): Promise<string | null> {
+  let stream: ReturnType<typeof createReadStream> | null = null
+  try {
+    stream = createReadStream(filePath, { encoding: 'utf-8' })
+    const rl = createInterface({ input: stream, crlfDelay: Infinity })
+    for await (const line of rl) {
+      rl.close()
+      stream.destroy()
+      return line
+    }
+  } catch {
+    // file may be missing or unreadable
+  } finally {
+    stream?.destroy()
+  }
+  return null
 }
 
 // Per-subagent streaming state (supports multiple concurrent background agents)
@@ -891,15 +916,47 @@ class MessagePersister {
           }
         }
       }
-      unclaimed.sort((a, b) => a.mtimeMs - b.mtimeMs)
 
-      // FIFO: match oldest unclaimed file → first registered parentToolId, etc.
-      const count = Math.min(needingIds.length, unclaimed.length)
+      // Marker-based matching: read the first line of each unclaimed file and
+      // look for a sa-track marker that encodes the parent tool_use_id.
+      const matchedIds = new Set<string>()
+      await Promise.all(
+        unclaimed.map(async ({ id }) => {
+          const filePath = path.join(subagentsDir, `agent-${id}.jsonl`)
+          const firstLine = await readFirstJsonlLine(filePath)
+          if (!firstLine) return
+          const match = firstLine.match(SA_TRACK_MARKER_REGEX)
+          if (!match) return
+          const trackedToolId = match[1]
+          const sub = state.activeSubagents.get(trackedToolId)
+          if (!sub || sub.agentId) return
+          sub.agentId = id
+          matchedIds.add(id)
+          this.broadcastToSSE(sessionId, {
+            type: 'subagent_updated',
+            parentToolId: trackedToolId,
+            agentId: id,
+          })
+        })
+      )
+
+      // Rebuild needingIds after marker pass; skip FIFO if all matched.
+      const stillNeeding: string[] = []
+      for (const [parentToolId, sub] of state.activeSubagents) {
+        if (!sub.agentId) stillNeeding.push(parentToolId)
+      }
+      if (stillNeeding.length === 0) return
+
+      // FIFO fallback: match oldest unclaimed file → first registered parentToolId.
+      const unclaimedLeft = unclaimed
+        .filter(u => !matchedIds.has(u.id))
+        .sort((a, b) => a.mtimeMs - b.mtimeMs)
+      const count = Math.min(stillNeeding.length, unclaimedLeft.length)
       for (let i = 0; i < count; i++) {
-        const parentToolId = needingIds[i]
+        const parentToolId = stillNeeding[i]
         const sub = state.activeSubagents.get(parentToolId)
         if (sub && !sub.agentId) {
-          sub.agentId = unclaimed[i].id
+          sub.agentId = unclaimedLeft[i].id
           this.broadcastToSSE(sessionId, {
             type: 'subagent_updated',
             parentToolId,


### PR DESCRIPTION
## Summary

- Adds a `PreToolUse` hook in `claude-code.ts` that injects an HTML comment marker (`<!-- sa-track:<tool_use_id> -->`) into every `Agent/Task` subagent prompt
- `message-persister.ts` reads the first line of each unclaimed subagent jsonl and extracts the marker to deterministically map `parentToolId → agentId`, eliminating mtime-based FIFO guessing for parallel subagents
- FIFO matching is preserved as a fallback for older containers without marker injection

## Test plan

- [x] Verified locally: marker injection logged in container (`docker logs`), marker match confirmed in Electron console
- [ ] Test with multiple parallel subagents to confirm no cross-mapping
- [ ] Verify FIFO fallback still works when marker is absent (e.g. old container image)

Tested local with logs
```
[sa-track:discover] ✓ MARKER MATCH: parentToolId=toolu_01Vv6eZXopHbq2qMbZkz5t67 → agentId=a953a43a35a37e834
[sa-track:discover] all matched by marker, skipping FIFO fallback
[ContainerManager] Syncing container statuses with Docker...
[ContainerManager] Synced 7 container statuses
[sa-track:discover] START needingIds=[toolu_01BZTsAypQNvByTEziC9ckeo] unclaimed=[a66c9ae9a91452772]
[sa-track:discover] ✓ MARKER MATCH: parentToolId=toolu_01BZTsAypQNvByTEziC9ckeo → agentId=a66c9ae9a91452772
[sa-track:discover] all matched by marker, skipping FIFO fallback
[sa-track:discover] START needingIds=[toolu_01QAiUa3NMozWPdwLrbhqbBq] unclaimed=[]
[sa-track:discover] FIFO FALLBACK for remaining needingIds=[toolu_01QAiUa3NMozWPdwLrbhqbBq]
[sa-track:discover] START needingIds=[toolu_01QAiUa3NMozWPdwLrbhqbBq] unclaimed=[a599d3a994ded65e3]
[sa-track:discover] ✓ MARKER MATCH: parentToolId=toolu_01QAiUa3NMozWPdwLrbhqbBq → agentId=a599d3a994ded65e3
[sa-track:discover] all matched by marker, skipping FIFO fallback

```
Made with [Cursor](https://cursor.com)