### PR TITLE
fix: voice agent orb layout and visual polish

### DIFF
--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -614,7 +614,7 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
       </div>
 
       <Dialog open={showVoiceAgent} onOpenChange={(open) => { if (!open) closeVoiceAgent() }}>
-        <DialogContent className="max-w-2xl p-0 overflow-hidden h-[420px]">
+        <DialogContent className="max-w-2xl p-0 overflow-hidden h-[420px] flex flex-col">
           <DialogHeader className="sr-only">
             <DialogTitle>Let&apos;s talk about your agent</DialogTitle>
             <DialogDescription>

--- a/src/renderer/components/ui/voice-agent.tsx
+++ b/src/renderer/components/ui/voice-agent.tsx
@@ -220,7 +220,7 @@ export function VoiceAgent({ config, onResult, onClose, layout = 'vertical', cla
   )
 }
 
-const ORB_BASE = 'flex h-[150px] w-[150px] items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900/30'
+const ORB_BASE = 'voice-agent-orb relative flex h-[150px] w-[150px] items-center justify-center rounded-full'
 
 /** Pulsing / waveform indicator showing who is speaking */
 function SpeakingIndicator({
@@ -234,25 +234,48 @@ function SpeakingIndicator({
   analyserRef: React.RefObject<AnalyserNode | null>
   playbackAnalyserRef: React.RefObject<AnalyserNode | null>
 }) {
-  if (isConnecting) {
-    return (
-      <div className={cn(ORB_BASE, 'shadow-[0_0_28px_rgba(59,130,246,0.28)]')}>
-        <Loader2 className="h-5 w-5 animate-spin text-blue-500/50" />
-      </div>
-    )
-  }
-
   const speakingAnalyser =
-    speakingState === 'user' ? analyserRef :
-    speakingState === 'agent' ? playbackAnalyserRef : null
+    !isConnecting && speakingState === 'user' ? analyserRef :
+    !isConnecting && speakingState === 'agent' ? playbackAnalyserRef : null
+
+  const orbRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const el = orbRef.current
+    if (!el) return
+    let raf = 0
+    let smoothed = 0.15
+    const tick = () => {
+      raf = requestAnimationFrame(tick)
+      const analyser = speakingAnalyser?.current
+      let target: number
+      if (analyser) {
+        const arr = new Uint8Array(analyser.frequencyBinCount)
+        analyser.getByteFrequencyData(arr)
+        let sum = 0
+        for (let i = 0; i < arr.length; i++) sum += arr[i]
+        target = (sum / arr.length) / 255
+      } else {
+        // Idle: slow sinusoidal breath so the orb still feels alive
+        target = 0.12 + (Math.sin(performance.now() / 1600) + 1) * 0.06
+      }
+      smoothed += (target - smoothed) * 0.25
+      el.style.setProperty('--orb-amp', smoothed.toFixed(3))
+    }
+    tick()
+    return () => cancelAnimationFrame(raf)
+  }, [speakingAnalyser])
 
   return (
-    <div className={cn(ORB_BASE, 'voice-agent-breathe')}>
-      {speakingAnalyser ? (
-        <MiniWaveform analyserRef={speakingAnalyser} bars={12} width={45} height={30} color="rgb(59,130,246)" />
-      ) : (
-        <StaticDots count={9} size={2} dotClassName="bg-blue-500/50" />
-      )}
+    <div ref={orbRef} className={ORB_BASE}>
+      <div className="relative z-10 blur-[2px]">
+        {isConnecting ? (
+          <Loader2 className="h-5 w-5 animate-spin text-blue-700/70 dark:text-blue-100/70" />
+        ) : speakingAnalyser ? (
+          <MiniWaveform analyserRef={speakingAnalyser} bars={12} width={45} height={30} color="rgb(30,64,175)" />
+        ) : (
+          <StaticDots count={9} size={2} dotClassName="bg-blue-800/60 dark:bg-blue-100/70" />
+        )}
+      </div>
     </div>
   )
 }

--- a/src/renderer/components/ui/voice-agent.tsx
+++ b/src/renderer/components/ui/voice-agent.tsx
@@ -238,22 +238,31 @@ function SpeakingIndicator({
     !isConnecting && speakingState === 'user' ? analyserRef :
     !isConnecting && speakingState === 'agent' ? playbackAnalyserRef : null
 
+  const isDark = useIsDark()
   const orbRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     const el = orbRef.current
     if (!el) return
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (reduceMotion) {
+      el.style.setProperty('--orb-amp', '0.15')
+      return
+    }
     let raf = 0
     let smoothed = 0.15
+    let freqBuf: Uint8Array<ArrayBuffer> | null = null
     const tick = () => {
       raf = requestAnimationFrame(tick)
       const analyser = speakingAnalyser?.current
       let target: number
       if (analyser) {
-        const arr = new Uint8Array(analyser.frequencyBinCount)
-        analyser.getByteFrequencyData(arr)
+        if (!freqBuf || freqBuf.length !== analyser.frequencyBinCount) {
+          freqBuf = new Uint8Array(analyser.frequencyBinCount)
+        }
+        analyser.getByteFrequencyData(freqBuf)
         let sum = 0
-        for (let i = 0; i < arr.length; i++) sum += arr[i]
-        target = (sum / arr.length) / 255
+        for (let i = 0; i < freqBuf.length; i++) sum += freqBuf[i]
+        target = (sum / freqBuf.length) / 255
       } else {
         // Idle: slow sinusoidal breath so the orb still feels alive
         target = 0.12 + (Math.sin(performance.now() / 1600) + 1) * 0.06
@@ -271,13 +280,35 @@ function SpeakingIndicator({
         {isConnecting ? (
           <Loader2 className="h-5 w-5 animate-spin text-blue-700/70 dark:text-blue-100/70" />
         ) : speakingAnalyser ? (
-          <MiniWaveform analyserRef={speakingAnalyser} bars={12} width={45} height={30} color="rgb(30,64,175)" />
+          <MiniWaveform
+            analyserRef={speakingAnalyser}
+            bars={12}
+            width={45}
+            height={30}
+            color={isDark ? 'rgb(191,219,254)' : 'rgb(30,64,175)'}
+          />
         ) : (
           <StaticDots count={9} size={2} dotClassName="bg-blue-800/60 dark:bg-blue-100/70" />
         )}
       </div>
     </div>
   )
+}
+
+/** Tracks whether the `dark` class is applied to <html>. */
+function useIsDark() {
+  const [isDark, setIsDark] = useState(() =>
+    typeof document !== 'undefined' && document.documentElement.classList.contains('dark')
+  )
+  useEffect(() => {
+    const el = document.documentElement
+    const observer = new MutationObserver(() => {
+      setIsDark(el.classList.contains('dark'))
+    })
+    observer.observe(el, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+  return isDark
 }
 
 /** Row of small static dots — used for the Ready state */

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -259,8 +259,13 @@
     inset 0 -14px 30px rgba(30, 64, 175, 0.3),
     inset 0 12px 24px rgba(255, 255, 255, 0.4);
   transform: scale(calc(1 + var(--orb-amp) * 0.09));
-  transition: transform 120ms ease-out;
   will-change: transform, box-shadow;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .voice-agent-orb {
+    transform: none;
+  }
 }
 
 .dark .voice-agent-orb {

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -241,14 +241,41 @@
   animation: browser-glow-pulse 4s ease-in-out infinite;
 }
 
-@keyframes voice-agent-breathe {
-  0%, 100% { box-shadow: 0 0 18px rgba(59, 130, 246, 0.22); }
-  50% { box-shadow: 0 0 36px rgba(59, 130, 246, 0.45); }
+/* Voice agent orb — glowing sphere with radial depth and amp-driven reactivity.
+   --orb-amp (0..1) is set on the element via JS, driven by the active analyser
+   when speaking or a slow sinusoidal breath when idle. */
+.voice-agent-orb {
+  --orb-amp: 0.15;
+  background:
+    radial-gradient(
+      circle at 30% 28%,
+      rgba(219, 234, 254, 0.95) 0%,
+      rgba(96, 165, 250, 0.55) 42%,
+      rgba(37, 99, 235, 0.4) 78%,
+      rgba(30, 58, 138, 0.45) 100%
+    );
+  box-shadow:
+    0 0 calc(20px + var(--orb-amp) * 80px) rgba(59, 130, 246, calc(0.25 + var(--orb-amp) * 0.55)),
+    inset 0 -14px 30px rgba(30, 64, 175, 0.3),
+    inset 0 12px 24px rgba(255, 255, 255, 0.4);
+  transform: scale(calc(1 + var(--orb-amp) * 0.09));
+  transition: transform 120ms ease-out;
+  will-change: transform, box-shadow;
 }
 
-.voice-agent-breathe {
-  animation: voice-agent-breathe 3.6s ease-in-out infinite;
-  will-change: box-shadow;
+.dark .voice-agent-orb {
+  background:
+    radial-gradient(
+      circle at 30% 28%,
+      rgba(147, 197, 253, 0.75) 0%,
+      rgba(59, 130, 246, 0.4) 42%,
+      rgba(30, 64, 175, 0.4) 78%,
+      rgba(15, 23, 42, 0.6) 100%
+    );
+  box-shadow:
+    0 0 calc(20px + var(--orb-amp) * 80px) rgba(96, 165, 250, calc(0.3 + var(--orb-amp) * 0.6)),
+    inset 0 -14px 30px rgba(15, 23, 42, 0.5),
+    inset 0 12px 24px rgba(147, 197, 253, 0.25);
 }
 
 /* Create-agent screen intro: items fade down from the top with a brief blur.


### PR DESCRIPTION
## Summary
- Pin the voice agent's button bar inside its dialog (was being pushed off-screen as the transcript grew) by forcing the DialogContent to `flex flex-col` so the `h-[420px]` height actually propagates to VoiceAgent's `h-full`.
- Add a subtle blur to the waveform bars/dots for a softer, more atmospheric look.
- Replace the flat blue orb with a radial-gradient sphere whose glow radius and scale are driven in real time by the active analyser's amplitude; falls back to a slow sinusoidal breath when idle so it always feels alive.

## Test plan
- [ ] Open "Create Agent" voice flow — orb stays centered, transcript scrolls independently, button bar stays pinned
- [ ] Orb pulses/scales in time with user speaking and agent speaking
- [ ] When idle, orb breathes slowly (no jittery jumps)
- [ ] Dark mode looks right
- [ ] Connecting spinner state still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)