### PR TITLE
feat/autowake-dashboard

### DIFF
--- a/src/renderer/components/dashboards/dashboard-view.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 import { Button } from '@renderer/components/ui/button'
-import { Play, RefreshCw, LayoutDashboard, ExternalLink, Dock } from 'lucide-react'
+import { Play, RefreshCw, LayoutDashboard, ExternalLink, Dock, Loader2 } from 'lucide-react'
 import { useAgent, useStartAgent } from '@renderer/hooks/use-agents'
 import { useArtifacts } from '@renderer/hooks/use-artifacts'
 import { useUser } from '@renderer/context/user-context'
@@ -45,29 +45,37 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
     startAgent.mutate(agentSlug)
   }, [startAgent, agentSlug])
 
+  const autoStartedRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (autoStartedRef.current === agentSlug) return
+    if (!agent || isAgentRunning || !canStart) return
+    if (startAgent.isPending || startAgent.isError) return
+    autoStartedRef.current = agentSlug
+    startAgent.mutate(agentSlug)
+  }, [agent, agentSlug, isAgentRunning, canStart, startAgent])
+
   if (!isAgentRunning || !isDashboardRunning) {
     return (
       <div className="flex-1 flex flex-col items-center justify-center gap-4 text-muted-foreground p-8">
-        <LayoutDashboard className="h-12 w-12 opacity-50" />
-        <div className="text-center">
-          <p className="text-lg font-medium mb-1">
-            {dashboard?.name || dashboardSlug}
-          </p>
-          <p>
+        <div className="flex items-center gap-2">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <p className="text-base">
             {!isAgentRunning
-              ? 'Agent is not running. Start the agent to view this dashboard.'
+              ? startAgent.isError
+                ? 'Agent failed to start.'
+                : 'Starting up...'
               : dashboard?.status === 'starting'
                 ? 'Dashboard is starting up...'
                 : 'Dashboard is not running. It will start automatically when the agent starts.'}
           </p>
         </div>
-        {!isAgentRunning && canStart && (
+        {!isAgentRunning && canStart && startAgent.isError && (
           <Button
             onClick={handleStartAgent}
             disabled={startAgent.isPending}
           >
             <Play className="mr-2 h-4 w-4" />
-            Start Agent
+            Retry
           </Button>
         )}
         {startAgent.isError && (

--- a/src/renderer/components/dashboards/dashboard-view.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.tsx
@@ -26,6 +26,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
 
   const dashboard = artifacts?.find((a) => a.slug === dashboardSlug)
   const isAgentRunning = agent?.status === 'running'
+  const isAgentStarting = startAgent.isPending
   const isDashboardRunning = dashboard?.status === 'running'
 
   const baseUrl = getApiBaseUrl()
@@ -48,26 +49,30 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   const autoStartedRef = useRef<string | null>(null)
   useEffect(() => {
     if (autoStartedRef.current === agentSlug) return
-    if (!agent || isAgentRunning || !canStart) return
-    if (startAgent.isPending || startAgent.isError) return
+    if (!agent || isAgentRunning || isAgentStarting || !canStart) return
+    if (startAgent.isError) return
     autoStartedRef.current = agentSlug
     startAgent.mutate(agentSlug)
-  }, [agent, agentSlug, isAgentRunning, canStart, startAgent])
+  }, [agent, agentSlug, isAgentRunning, isAgentStarting, canStart, startAgent])
 
   if (!isAgentRunning || !isDashboardRunning) {
+    const showSpinner = !isAgentRunning
+      ? !startAgent.isError && canStart
+      : dashboard?.status === 'starting'
+    const message = !isAgentRunning
+      ? startAgent.isError
+        ? 'Agent failed to start.'
+        : !canStart
+          ? 'Agent is not running. Ask an admin to start it.'
+          : 'Starting up...'
+      : dashboard?.status === 'starting'
+        ? 'Dashboard is starting up...'
+        : 'Dashboard is not running. It will start automatically when the agent starts.'
     return (
       <div className="flex-1 flex flex-col items-center justify-center gap-4 text-muted-foreground p-8">
         <div className="flex items-center gap-2">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          <p className="text-base">
-            {!isAgentRunning
-              ? startAgent.isError
-                ? 'Agent failed to start.'
-                : 'Starting up...'
-              : dashboard?.status === 'starting'
-                ? 'Dashboard is starting up...'
-                : 'Dashboard is not running. It will start automatically when the agent starts.'}
-          </p>
+          {showSpinner && <Loader2 className="h-4 w-4 animate-spin" />}
+          <p className="text-base">{message}</p>
         </div>
         {!isAgentRunning && canStart && startAgent.isError && (
           <Button


### PR DESCRIPTION
## Summary
- Auto-triggers the existing start-agent mutation when opening a dashboard whose agent is asleep, removing the redundant second click.
- Replaces the old placeholder (dashboard icon + name + "Start Agent" button) with a compact spinner + "Starting up..." message.
- Keeps a Retry button and error text if the start call fails.

## Test plan
- [ ] Open a dashboard while its agent is stopped — confirm the agent starts without clicking anything and the dashboard loads once ready.
- [ ] Simulate a start failure — confirm "Agent failed to start." and the Retry button appear, and retry works.
- [ ] Open a dashboard while the agent is already running — confirm no extra start call fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)