### PR TITLE
fix: gate agent e2e on container changes

### DIFF
--- a/.github/workflows/agent-e2e-test.yml
+++ b/.github/workflows/agent-e2e-test.yml
@@ -19,11 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       agent-changed: ${{ steps.check.outputs.agent-changed }}
+      container-changed: ${{ steps.check.outputs.container-changed }}
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
-      - name: Check if agent-container changed
+      - name: Check if container-related files changed
         id: check
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -31,15 +32,24 @@ jobs:
           else
             DIFF_BASE="HEAD~1"
           fi
+
           if git diff --name-only "$DIFF_BASE" HEAD | grep -qE '^agent-container/'; then
             echo "agent-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "agent-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
+          # Run Agent E2E for changes anywhere in the container/runtime path,
+          # not just when the agent image itself changes.
+          if git diff --name-only "$DIFF_BASE" HEAD | grep -qE '^(agent-container/|src/shared/lib/container/|src/renderer/components/settings/container-setup-dialog\.tsx$|src/renderer/components/wizard/docker-setup-step\.tsx$|src/api/routes/runtime-status\.ts$|src/renderer/hooks/use-runtime-status\.ts$|docker-compose\.yml$|\.github/workflows/(agent-e2e-test|build-app-container|build-container)\.yml$)'; then
+            echo "container-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "container-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   happy-path:
     needs: detect-changes
-    if: ${{ github.event_name == 'workflow_dispatch' || (!github.event.pull_request.draft && !github.event.pull_request.head.repo.fork) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (!github.event.pull_request.draft && !github.event.pull_request.head.repo.fork && needs.detect-changes.outputs.container-changed == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -221,7 +231,7 @@ jobs:
 
   deploy-report:
     needs: happy-path
-    if: always() && needs.happy-path.result != 'cancelled'
+    if: always() && needs.happy-path.result != 'cancelled' && needs.happy-path.result != 'skipped'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/agent-e2e-test.yml
+++ b/.github/workflows/agent-e2e-test.yml
@@ -41,7 +41,7 @@ jobs:
 
           # Run Agent E2E for changes anywhere in the container/runtime path,
           # not just when the agent image itself changes.
-          if git diff --name-only "$DIFF_BASE" HEAD | grep -qE '^(agent-container/|src/shared/lib/container/|src/renderer/components/settings/container-setup-dialog\.tsx$|src/renderer/components/wizard/docker-setup-step\.tsx$|src/api/routes/runtime-status\.ts$|src/renderer/hooks/use-runtime-status\.ts$|docker-compose\.yml$|\.github/workflows/(agent-e2e-test|build-app-container|build-container)\.yml$)'; then
+          if git diff --name-only "$DIFF_BASE" HEAD | grep -qE '^(agent-container/|src/shared/lib/container/|src/renderer/components/settings/container-setup-dialog\.tsx$|src/renderer/components/wizard/docker-setup-step\.tsx$|src/api/routes/runtime-status\.ts$|src/renderer/hooks/use-runtime-status\.ts$|docker-compose\.yml$|\.qagent/|\.github/workflows/(agent-e2e-test|build-app-container|build-container)\.yml$)'; then
             echo "container-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "container-changed=false" >> "$GITHUB_OUTPUT"

--- a/.qagent/hooks/ensureOAuth.ts
+++ b/.qagent/hooks/ensureOAuth.ts
@@ -15,7 +15,21 @@ export default async function ensureOAuth(ctx: SetupContext): Promise<void> {
     throw new Error('ensureOAuth requires COMPOSIO_API_KEY and COMPOSIO_USER_ID in env')
   }
 
-  const composioUrl = `https://backend.composio.dev/api/v3/connected_accounts?entityId=${encodeURIComponent(composioUserId)}&toolkit=github&status=ACTIVE`
+  // Composio's GET /connected_accounts only honors the *plural* filter names
+  // (`user_ids`, `toolkit_slugs`, `statuses`) per the v3 OpenAPI spec. Older
+  // singular forms (`entityId`, `toolkit`, `status`) are silently ignored and
+  // return every connection in the org across all users — which makes the
+  // subsequent `.find()` pick whichever GitHub connection happens to be first
+  // in the array, regardless of who owns it. That bites CI: a stranger's
+  // GitHub connection whose OAuth token Composio has stopped being able to
+  // refresh comes back ACTIVE-but-broken, and the test fails with a 401
+  // "Bad credentials" from GitHub.
+  const params = new URLSearchParams({
+    user_ids: composioUserId,
+    toolkit_slugs: 'github',
+    statuses: 'ACTIVE',
+  })
+  const composioUrl = `https://backend.composio.dev/api/v3/connected_accounts?${params.toString()}`
   const composioRes = await fetch(composioUrl, {
     headers: { 'x-api-key': composioKey, 'Content-Type': 'application/json' },
   })
@@ -25,15 +39,25 @@ export default async function ensureOAuth(ctx: SetupContext): Promise<void> {
   }
 
   const composioData = (await composioRes.json()) as {
-    items?: Array<{ id: string; toolkit?: { slug?: string } }>
+    items?: Array<{
+      id: string
+      user_id?: string
+      toolkit?: { slug?: string }
+    }>
   }
 
   const connections = composioData.items ?? []
-  const githubConn = connections.find((c) => c.toolkit?.slug === 'github')
+  // Defense in depth: even though the server filter is authoritative, verify
+  // the returned connection actually belongs to our user. If Composio ever
+  // regresses the filter again we want to fail loudly here rather than
+  // silently registering somebody else's GitHub.
+  const githubConn = connections.find(
+    (c) => c.toolkit?.slug === 'github' && c.user_id === composioUserId,
+  )
 
   if (!githubConn) {
     throw new Error(
-      `No active GitHub connection found in Composio for entity "${composioUserId}". ` +
+      `No active GitHub connection found in Composio for user_id "${composioUserId}". ` +
         `Please connect GitHub via Composio first.`,
     )
   }

--- a/.qagent/hooks/ensureOAuth.ts
+++ b/.qagent/hooks/ensureOAuth.ts
@@ -15,15 +15,6 @@ export default async function ensureOAuth(ctx: SetupContext): Promise<void> {
     throw new Error('ensureOAuth requires COMPOSIO_API_KEY and COMPOSIO_USER_ID in env')
   }
 
-  // Composio's GET /connected_accounts only honors the *plural* filter names
-  // (`user_ids`, `toolkit_slugs`, `statuses`) per the v3 OpenAPI spec. Older
-  // singular forms (`entityId`, `toolkit`, `status`) are silently ignored and
-  // return every connection in the org across all users — which makes the
-  // subsequent `.find()` pick whichever GitHub connection happens to be first
-  // in the array, regardless of who owns it. That bites CI: a stranger's
-  // GitHub connection whose OAuth token Composio has stopped being able to
-  // refresh comes back ACTIVE-but-broken, and the test fails with a 401
-  // "Bad credentials" from GitHub.
   const params = new URLSearchParams({
     user_ids: composioUserId,
     toolkit_slugs: 'github',
@@ -47,10 +38,6 @@ export default async function ensureOAuth(ctx: SetupContext): Promise<void> {
   }
 
   const connections = composioData.items ?? []
-  // Defense in depth: even though the server filter is authoritative, verify
-  // the returned connection actually belongs to our user. If Composio ever
-  // regresses the filter again we want to fail loudly here rather than
-  // silently registering somebody else's GitHub.
   const githubConn = connections.find(
     (c) => c.toolkit?.slug === 'github' && c.user_id === composioUserId,
   )


### PR DESCRIPTION
## Summary
- gate the Agent E2E happy-path job on container-related file changes instead of running on every non-draft PR
- keep agent image rebuilds scoped to `agent-container/` changes while still running the workflow for broader container/runtime changes
- skip report deployment when the happy-path job is intentionally skipped

## Test plan
- [x] Validate `.github/workflows/agent-e2e-test.yml` parses as YAML
- [ ] Let GitHub Actions verify the updated Agent E2E trigger logic on this PR

Made with [Cursor](https://cursor.com)