### PR TITLE
style: increase Tahoe inset radius to match larger window corners

### DIFF
--- a/src/renderer/hooks/use-inset-radius.ts
+++ b/src/renderer/hooks/use-inset-radius.ts
@@ -13,7 +13,7 @@ function pickRadiusForOS(): number {
 
   if (platform === 'darwin') {
     // macOS 26 (Tahoe) ships noticeably larger window corners than 15 (Sequoia) and earlier.
-    if (Number.isFinite(major) && major >= 26) return 10
+    if (Number.isFinite(major) && major >= 26) return 16
     return 7
   }
 


### PR DESCRIPTION
## Summary
- Bumps macOS 26 (Tahoe) inner inset radius from `10px` to `16px` in `useInsetRadius` so the sidebar inset nests cleanly inside Tahoe's visibly larger squircle window corners.
- Sequoia and Windows values unchanged.

## Test plan
- [ ] Launch on macOS 26 (Tahoe) — confirm sidebar inset corners look concentric with the OS window corners (not visibly tighter than the outer radius).
- [ ] Launch on macOS 15 (Sequoia) — confirm radius is unchanged (still 7px).
- [ ] Toggle fullscreen — confirm radius falls back to 16px (no OS corner to match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)