### PR TITLE
style: redesign agent creation aid cards

### DIFF
--- a/e2e/helpers/agent-template-zip.ts
+++ b/e2e/helpers/agent-template-zip.ts
@@ -1,0 +1,41 @@
+import AdmZip from 'adm-zip'
+import fs from 'fs'
+import path from 'path'
+
+export interface BuildAgentTemplateZipOptions {
+  /** Agent display name written into CLAUDE.md frontmatter. */
+  name: string
+  /** When true, include `.claude/skills/agent-onboarding/SKILL.md` so the import is detected as an onboarding template. */
+  withOnboardingSkill?: boolean
+}
+
+/**
+ * Build a minimal agent template .zip on disk and return its path.
+ * Caller is responsible for cleanup (write to a tmp dir).
+ *
+ * Layout when `withOnboardingSkill` is true:
+ *   CLAUDE.md
+ *   .claude/skills/agent-onboarding/SKILL.md
+ */
+export function buildAgentTemplateZip(filePath: string, opts: BuildAgentTemplateZipOptions): string {
+  const zip = new AdmZip()
+
+  zip.addFile(
+    'CLAUDE.md',
+    Buffer.from(`---\nname: ${opts.name}\n---\n\nTest agent template for E2E.\n`, 'utf-8'),
+  )
+
+  if (opts.withOnboardingSkill) {
+    zip.addFile(
+      '.claude/skills/agent-onboarding/SKILL.md',
+      Buffer.from(
+        `---\nname: agent-onboarding\ndescription: Helps the user configure a freshly-imported agent.\n---\n\nOnboard the agent.\n`,
+        'utf-8',
+      ),
+    )
+  }
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  zip.writeZip(filePath)
+  return filePath
+}

--- a/e2e/specs/agent-import.spec.ts
+++ b/e2e/specs/agent-import.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+import { buildAgentTemplateZip } from '../helpers/agent-template-zip'
+
+const ONBOARDING_MESSAGE =
+  'This agent was just set up from a template. Please run the agent-onboarding skill to help me configure it.'
+
+/**
+ * Covers the AgentHome → import → onboarding-session flow refactored to use
+ * `useStartOnboardingSession`. The wizard's CreateAgentForm uses the same
+ * hook + AgentCreationAids component, so this test exercises both call sites'
+ * shared behavior.
+ */
+test.describe('Agent Import Onboarding', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+  let tmpDir: string
+
+  test.beforeEach(async ({ page }) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-import-'))
+  })
+
+  test.afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('importing a template with the onboarding skill creates an onboarding session', async ({ page }) => {
+    const agentName = `Imported Onboarding ${Date.now()}`
+    const zipPath = buildAgentTemplateZip(
+      path.join(tmpDir, 'with-onboarding.zip'),
+      { name: agentName, withOnboardingSkill: true },
+    )
+
+    // Land on a fresh Untitled agent's AgentHome — this is where the import card lives.
+    await agentPage.clickCreateAgent()
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText('Untitled', { timeout: 10000 })
+
+    // Open the Import dialog via the AgentCreationAids card.
+    await page.getByRole('button', { name: 'Import an Agent — Import' }).click()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    // Upload the fixture zip into the dialog's hidden file input, then submit.
+    await dialog.locator('input[type="file"]').setInputFiles(zipPath)
+    await expect(dialog.getByText('with-onboarding.zip')).toBeVisible()
+    await dialog.locator('button[type="submit"]').click()
+
+    // Dialog closes, then `useStartOnboardingSession` creates the onboarding
+    // session and `selectSession` routes to it — the message list renders.
+    await expect(dialog).not.toBeVisible({ timeout: 15000 })
+    await expect(sessionPage.getMessageList()).toBeVisible({ timeout: 15000 })
+
+    // The first user message in the new session is the onboarding prompt.
+    await sessionPage.expectUserMessage(ONBOARDING_MESSAGE)
+
+    // The imported agent is now selected in the sidebar.
+    await expect(agentPage.getAgentItem(agentName)).toBeVisible()
+  })
+
+  test('importing a template without the onboarding skill skips session creation', async ({ page }) => {
+    const agentName = `Imported Plain ${Date.now()}`
+    const zipPath = buildAgentTemplateZip(
+      path.join(tmpDir, 'plain.zip'),
+      { name: agentName, withOnboardingSkill: false },
+    )
+
+    await agentPage.clickCreateAgent()
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText('Untitled', { timeout: 10000 })
+
+    await page.getByRole('button', { name: 'Import an Agent — Import' }).click()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    await dialog.locator('input[type="file"]').setInputFiles(zipPath)
+    await dialog.locator('button[type="submit"]').click()
+    await expect(dialog).not.toBeVisible({ timeout: 15000 })
+
+    // No onboarding skill → the imported agent's AgentHome stays put. The
+    // breadcrumb updates to the imported agent's name and the home composer
+    // (not a session message list) is what's visible.
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agentName, { timeout: 15000 })
+    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
+    await expect(sessionPage.getMessageList()).not.toBeVisible()
+    await expect(agentPage.getAgentItem(agentName)).toBeVisible()
+  })
+})

--- a/src/renderer/components/agents/agent-creation-aids.tsx
+++ b/src/renderer/components/agents/agent-creation-aids.tsx
@@ -26,6 +26,8 @@ export interface ImportResult {
   hasOnboarding?: boolean
 }
 
+export const ONBOARDING_MESSAGE = 'This agent was just set up from a template. Please run the agent-onboarding skill to help me configure it.'
+
 export interface AgentCreationAidsProps {
   /** Called after the voice agent interview completes with its tool-call args. */
   onVoiceResult: (args: { name: string; prompt: string }) => void

--- a/src/renderer/components/agents/agent-creation-aids.tsx
+++ b/src/renderer/components/agents/agent-creation-aids.tsx
@@ -3,7 +3,6 @@ import { AudioLines, Upload, ArrowUpFromLine, FileArchive, Loader2 } from 'lucid
 import { toast } from 'sonner'
 import { Button } from '@renderer/components/ui/button'
 import { OptionCard } from '@renderer/components/ui/option-card'
-import { Input } from '@renderer/components/ui/input'
 import { Checkbox } from '@renderer/components/ui/checkbox'
 import {
   Dialog,
@@ -103,7 +102,6 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
   // --- Import flow ---
   const [showImportDialog, setShowImportDialog] = useState(false)
   const [importFile, setImportFile] = useState<File | null>(null)
-  const [importName, setImportName] = useState('')
   const [importFull, setImportFull] = useState(false)
   const [uploadProgress, setUploadProgress] = useState<ImportProgress | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -126,7 +124,6 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
 
   const resetImport = useCallback(() => {
     setImportFile(null)
-    setImportName('')
     setImportFull(false)
     setUploadProgress(null)
     importTemplate.reset()
@@ -153,7 +150,6 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
         setUploadProgress({ phase: 'uploading', percent: 0 })
         const result = await importTemplate.mutateAsync({
           file: importFile,
-          nameOverride: importName.trim() || undefined,
           mode: importFull ? 'full' : 'template',
           onProgress: setUploadProgress,
         })
@@ -176,7 +172,7 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
         console.error('Failed to import template:', error)
       }
     },
-    [importFile, importName, importFull, importTemplate, resetImport, finishImport],
+    [importFile, importFull, importTemplate, resetImport, finishImport],
   )
 
   const handleTemplateSecretsSubmit = useCallback(
@@ -221,18 +217,18 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
             icon={<AudioLines className="h-3 w-3" />}
             iconTone="neutral"
             pill="5 min"
-            buttonLabel="Start talking"
+            buttonLabel="Start"
             onClick={startVoiceAgent}
           />
         )}
 
         <OptionCard
           title="Import an Agent"
-          description="Bring in a pre-built agent from a .zip template, including skills and optional environment variables."
+          description="Import an agent via a .zip file with bundled skills and optional env. variables."
           icon={<ArrowUpFromLine className="h-3 w-3" />}
           iconTone="neutral"
           pill="30 sec"
-          buttonLabel="Import agent"
+          buttonLabel="Import"
           onClick={() => setShowImportDialog(true)}
         />
       </div>
@@ -259,18 +255,18 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
       <Dialog open={showImportDialog} onOpenChange={(open) => { if (!open) closeImportDialog() }}>
         <DialogContent className="max-w-lg">
           <DialogHeader>
-            <DialogTitle>Import an agent</DialogTitle>
-            <DialogDescription>
+            <DialogTitle className="font-medium">Import an agent</DialogTitle>
+            <DialogDescription className="sr-only">
               Upload a .zip template to create a new agent.
             </DialogDescription>
           </DialogHeader>
           <form onSubmit={handleImport}>
             <div className="py-4 space-y-4">
               <div
-                className={`border-2 border-dashed rounded-lg p-6 text-center transition-colors ${
+                className={`border border-dashed rounded-lg p-6 text-center transition-colors bg-muted/50 ${
                   importTemplate.isPending
                     ? 'opacity-50 pointer-events-none'
-                    : 'cursor-pointer hover:bg-muted/50'
+                    : 'cursor-pointer'
                 }`}
                 role="button"
                 tabIndex={0}
@@ -316,20 +312,14 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
                   </div>
                 ) : (
                   <>
-                    <Upload className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
+                    <Upload className="h-5 w-5 mx-auto text-muted-foreground mb-2" />
                     <p className="text-sm text-muted-foreground">
-                      Drop a .zip template file here or click to browse
+                      Drop a .zip template file here<br />
+                      or click to browse
                     </p>
                   </>
                 )}
               </div>
-
-              <Input
-                placeholder="Name override (optional)"
-                value={importName}
-                onChange={(e) => setImportName(e.target.value)}
-                disabled={importTemplate.isPending}
-              />
 
               <div className="flex items-center gap-2">
                 <Checkbox
@@ -342,7 +332,7 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
                   htmlFor="creation-aids-import-full"
                   className="text-sm text-muted-foreground cursor-pointer select-none"
                 >
-                  Full import (includes environment variables and data)
+                  Import includes env. variables and session data
                 </label>
               </div>
 
@@ -377,7 +367,7 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
               )}
             </div>
 
-            <DialogFooter>
+            <DialogFooter className="mt-4">
               <Button
                 type="button"
                 variant="outline"
@@ -386,7 +376,7 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={!importFile || importTemplate.isPending}>
+              <Button type="submit" disabled={importTemplate.isPending}>
                 {importTemplate.isPending ? (
                   <>
                     <Loader2 className="h-4 w-4 mr-2 animate-spin" />

--- a/src/renderer/components/agents/agent-creation-aids.tsx
+++ b/src/renderer/components/agents/agent-creation-aids.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from 'react'
-import { Phone, Upload, FileArchive, Loader2 } from 'lucide-react'
+import { AudioLines, Upload, ArrowUpFromLine, FileArchive, Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@renderer/components/ui/button'
 import { OptionCard } from '@renderer/components/ui/option-card'
@@ -213,36 +213,25 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
 
   return (
     <div className={className}>
-      <div className="flex items-center gap-4 pt-2 px-6 mb-4">
-        <div className="h-px flex-1 bg-border" />
-        <span className="text-xs text-muted-foreground">OR</span>
-        <div className="h-px flex-1 bg-border" />
-      </div>
-      <div className="space-y-4">
+      <div className="flex flex-wrap items-start gap-3">
         {hasVoiceConfigured && (
           <OptionCard
-            title="Try Talking to SuperAgent for Ideas."
-            description={(
-              <>
-                Answer a few questions about your job — get a detailed<br />
-                prompt for your agent. Takes less than five minutes.
-              </>
-            )}
-            icon={<Phone className="h-4 w-4" />}
+            title="Talk to SuperAgent for Ideas"
+            description="Answer a few questions about your job — get a detailed prompt for your agent."
+            icon={<AudioLines className="h-3 w-3" />}
+            iconTone="neutral"
+            pill="5 min"
             buttonLabel="Start talking"
             onClick={startVoiceAgent}
           />
         )}
 
         <OptionCard
-          title="Import an agent or agent template."
-          description={(
-            <>
-              Bring in a pre-built agent from a .zip template,<br />
-              including skills and optional environment variables.
-            </>
-          )}
-          icon={<Upload className="h-4 w-4" />}
+          title="Import an Agent"
+          description="Bring in a pre-built agent from a .zip template, including skills and optional environment variables."
+          icon={<ArrowUpFromLine className="h-3 w-3" />}
+          iconTone="neutral"
+          pill="30 sec"
           buttonLabel="Import agent"
           onClick={() => setShowImportDialog(true)}
         />

--- a/src/renderer/components/agents/agent-creation-aids.tsx
+++ b/src/renderer/components/agents/agent-creation-aids.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from 'react'
-import { AudioLines, Upload, ArrowUpFromLine, FileArchive, Loader2 } from 'lucide-react'
+import { AudioLines, Upload, ArrowDownToLine, FileArchive, Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@renderer/components/ui/button'
 import { OptionCard } from '@renderer/components/ui/option-card'
@@ -25,8 +25,6 @@ export interface ImportResult {
   agent: ApiAgent
   hasOnboarding?: boolean
 }
-
-export const ONBOARDING_MESSAGE = 'This agent was just set up from a template. Please run the agent-onboarding skill to help me configure it.'
 
 export interface AgentCreationAidsProps {
   /** Called after the voice agent interview completes with its tool-call args. */
@@ -211,13 +209,12 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
 
   return (
     <div className={className}>
-      <div className="flex flex-wrap items-start gap-3">
+      <div className="space-y-3">
         {hasVoiceConfigured && (
           <OptionCard
             title="Talk to SuperAgent for Ideas"
             description="Answer a few questions about your job — get a detailed prompt for your agent."
             icon={<AudioLines className="h-3 w-3" />}
-            iconTone="neutral"
             pill="5 min"
             buttonLabel="Start"
             onClick={startVoiceAgent}
@@ -227,8 +224,7 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
         <OptionCard
           title="Import an Agent"
           description="Import an agent via a .zip file with bundled skills and optional env. variables."
-          icon={<ArrowUpFromLine className="h-3 w-3" />}
-          iconTone="neutral"
+          icon={<ArrowDownToLine className="h-3 w-3" />}
           pill="30 sec"
           buttonLabel="Import"
           onClick={() => setShowImportDialog(true)}
@@ -257,7 +253,7 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
       <Dialog open={showImportDialog} onOpenChange={(open) => { if (!open) closeImportDialog() }}>
         <DialogContent className="max-w-lg">
           <DialogHeader>
-            <DialogTitle className="font-medium">Import an agent</DialogTitle>
+            <DialogTitle className="font-medium">Import an Agent</DialogTitle>
             <DialogDescription className="sr-only">
               Upload a .zip template to create a new agent.
             </DialogDescription>
@@ -378,7 +374,7 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={importTemplate.isPending}>
+              <Button type="submit" disabled={!importFile || importTemplate.isPending}>
                 {importTemplate.isPending ? (
                   <>
                     <Loader2 className="h-4 w-4 mr-2 animate-spin" />

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -26,7 +26,7 @@ import { HomeConnections } from './home-connections'
 import { HomeVolumes } from './home-volumes'
 import { HomeBookmarks } from './home-bookmarks'
 import { useUpdateAgent, useDeleteAgent, type ApiAgent } from '@renderer/hooks/use-agents'
-import { AgentCreationAids } from '@renderer/components/agents/agent-creation-aids'
+import { AgentCreationAids, ONBOARDING_MESSAGE, type ImportResult } from '@renderer/components/agents/agent-creation-aids'
 import {
   useTypewriterPlaceholder,
   DEFAULT_AGENT_PROMPT_EXAMPLES,
@@ -45,7 +45,7 @@ interface AgentHomeProps {
 
 export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHomeProps) {
   useRenderTracker('AgentHome')
-  const { selectScheduledTask, selectAgent, consumePendingDraft } = useSelection()
+  const { selectScheduledTask, selectAgent, selectSession, consumePendingDraft } = useSelection()
   const { canUseAgent, canAdminAgent } = useUser()
   const isViewOnly = !canUseAgent(agent.slug)
   const isOwner = canAdminAgent(agent.slug)
@@ -206,13 +206,24 @@ export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHome
   )
 
   const handleImportComplete = useCallback(
-    async ({ agent: imported }: { agent: ApiAgent }) => {
+    async ({ agent: imported, hasOnboarding }: ImportResult) => {
       selectAgent(imported.slug)
       if (agent.name === UNTITLED_AGENT_NAME && sessions.length === 0 && agent.slug !== imported.slug) {
         deleteAgent.mutate(agent.slug)
       }
+      if (hasOnboarding) {
+        try {
+          const session = await createSession.mutateAsync({
+            agentSlug: imported.slug,
+            message: ONBOARDING_MESSAGE,
+          })
+          selectSession(session.id)
+        } catch {
+          // Onboarding session creation failed — user can still use agent normally
+        }
+      }
     },
-    [selectAgent, agent.slug, agent.name, sessions.length, deleteAgent],
+    [selectAgent, selectSession, agent.slug, agent.name, sessions.length, deleteAgent, createSession],
   )
 
   const formatDate = useCallback(

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -400,7 +400,7 @@ export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHome
               <HomeBookmarks agentSlug={agent.slug} isOwner={isOwner} />
 
               {/* Sessions list / creation aids */}
-              <div className="pt-2">
+              <div className={sessions.length > 0 ? 'pt-2' : '-mt-5'}>
                 {sessions.length > 0 ? (
                   <>
                     <div className="flex items-center gap-2">

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -26,7 +26,8 @@ import { HomeConnections } from './home-connections'
 import { HomeVolumes } from './home-volumes'
 import { HomeBookmarks } from './home-bookmarks'
 import { useUpdateAgent, useDeleteAgent, type ApiAgent } from '@renderer/hooks/use-agents'
-import { AgentCreationAids, ONBOARDING_MESSAGE, type ImportResult } from '@renderer/components/agents/agent-creation-aids'
+import { AgentCreationAids, type ImportResult } from '@renderer/components/agents/agent-creation-aids'
+import { useStartOnboardingSession } from '@renderer/hooks/use-start-onboarding-session'
 import {
   useTypewriterPlaceholder,
   DEFAULT_AGENT_PROMPT_EXAMPLES,
@@ -45,7 +46,8 @@ interface AgentHomeProps {
 
 export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHomeProps) {
   useRenderTracker('AgentHome')
-  const { selectScheduledTask, selectAgent, selectSession, consumePendingDraft } = useSelection()
+  const { selectScheduledTask, selectAgent, consumePendingDraft } = useSelection()
+  const startOnboardingSession = useStartOnboardingSession()
   const { canUseAgent, canAdminAgent } = useUser()
   const isViewOnly = !canUseAgent(agent.slug)
   const isOwner = canAdminAgent(agent.slug)
@@ -212,18 +214,10 @@ export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHome
         deleteAgent.mutate(agent.slug)
       }
       if (hasOnboarding) {
-        try {
-          const session = await createSession.mutateAsync({
-            agentSlug: imported.slug,
-            message: ONBOARDING_MESSAGE,
-          })
-          selectSession(session.id)
-        } catch {
-          // Onboarding session creation failed — user can still use agent normally
-        }
+        await startOnboardingSession(imported.slug)
       }
     },
-    [selectAgent, selectSession, agent.slug, agent.name, sessions.length, deleteAgent, createSession],
+    [selectAgent, agent.slug, agent.name, sessions.length, deleteAgent, startOnboardingSession],
   )
 
   const formatDate = useCallback(

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -5,7 +5,7 @@ import { Button } from '@renderer/components/ui/button'
 import { ChatComposerBox } from '@renderer/components/messages/chat-composer-box'
 import { AttachmentPicker } from '@renderer/components/ui/attachment-picker'
 import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
-import { AgentCreationAids, type ImportResult } from '@renderer/components/agents/agent-creation-aids'
+import { AgentCreationAids, ONBOARDING_MESSAGE, type ImportResult } from '@renderer/components/agents/agent-creation-aids'
 import { TemplateInstallDialog } from '@renderer/components/agents/template-install-dialog'
 import { TemplateCard } from '@renderer/components/agents/template-card'
 import { useCreateAgent } from '@renderer/hooks/use-agents'
@@ -20,8 +20,6 @@ import {
 } from '@renderer/hooks/use-typewriter-placeholder'
 import { deriveAgentName } from '@renderer/lib/derive-agent-name'
 import type { ApiAgent, ApiDiscoverableAgent } from '@shared/lib/types/api'
-
-const ONBOARDING_MESSAGE = 'This agent was just set up from a template. Please run the agent-onboarding skill to help me configure it.'
 
 export interface CreateAgentFormProps {
   /** Fires after an agent is successfully created (via any path). Parent uses this to close the overlay/wizard. */

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -5,7 +5,8 @@ import { Button } from '@renderer/components/ui/button'
 import { ChatComposerBox } from '@renderer/components/messages/chat-composer-box'
 import { AttachmentPicker } from '@renderer/components/ui/attachment-picker'
 import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
-import { AgentCreationAids, ONBOARDING_MESSAGE, type ImportResult } from '@renderer/components/agents/agent-creation-aids'
+import { AgentCreationAids, type ImportResult } from '@renderer/components/agents/agent-creation-aids'
+import { useStartOnboardingSession } from '@renderer/hooks/use-start-onboarding-session'
 import { TemplateInstallDialog } from '@renderer/components/agents/template-install-dialog'
 import { TemplateCard } from '@renderer/components/agents/template-card'
 import { useCreateAgent } from '@renderer/hooks/use-agents'
@@ -54,25 +55,18 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
   const createSession = useCreateSession()
   const { selectAgent, selectSession } = useSelection()
   const { track } = useAnalyticsTracking()
+  const startOnboardingSession = useStartOnboardingSession()
 
   const finishCreatedAgent = useCallback(
     async (agent: ApiAgent, source: 'new' | 'import' | 'skillset', hasOnboarding?: boolean) => {
       track('agent_created', { source, num_skills_added_at_creation: 0 })
       selectAgent(agent.slug)
       if (hasOnboarding) {
-        try {
-          const session = await createSession.mutateAsync({
-            agentSlug: agent.slug,
-            message: ONBOARDING_MESSAGE,
-          })
-          selectSession(session.id)
-        } catch {
-          // Onboarding session creation failed — user can still use agent normally
-        }
+        await startOnboardingSession(agent.slug)
       }
       await onAgentCreated?.()
     },
-    [track, selectAgent, selectSession, createSession, onAgentCreated],
+    [track, selectAgent, startOnboardingSession, onAgentCreated],
   )
 
   const composer = useMessageComposer({

--- a/src/renderer/components/ui/option-card.tsx
+++ b/src/renderer/components/ui/option-card.tsx
@@ -1,30 +1,70 @@
 import type { ReactNode } from 'react'
+import { ArrowRight } from 'lucide-react'
 
 export interface OptionCardProps {
   title: string
   description: ReactNode
   icon: ReactNode
+  /** Color treatment for the circular icon badge. */
+  iconTone?: 'blue' | 'neutral'
+  /** Action label kept for accessibility — not rendered visibly. */
   buttonLabel: string
+  /** Optional metadata chip displayed at the bottom of the card. */
+  pill?: ReactNode
   onClick: () => void
   className?: string
 }
 
-export function OptionCard({ title, description, icon, buttonLabel, onClick, className }: OptionCardProps) {
+const ICON_TONES = {
+  blue: 'bg-blue-100 text-blue-600 dark:bg-blue-500/15 dark:text-blue-400',
+  neutral: 'bg-muted text-foreground dark:bg-muted dark:text-foreground',
+} as const
+
+export function OptionCard({
+  title,
+  description,
+  icon,
+  iconTone = 'blue',
+  buttonLabel,
+  pill,
+  onClick,
+  className,
+}: OptionCardProps) {
   return (
     <button
       type="button"
       onClick={onClick}
       aria-label={`${title} — ${buttonLabel}`}
-      className={`w-full text-left rounded-lg border p-5 flex items-center justify-between gap-4 cursor-pointer opacity-60 hover:opacity-100 focus-visible:opacity-100 hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-all ${className ?? ''}`}
+      className={`group text-left rounded-2xl border border-border/50 p-4 flex flex-col items-stretch cursor-pointer w-fit hover:w-[280px] focus-visible:w-[280px] hover:border-foreground/30 hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-[width,background-color,border-color] duration-200 ease-out ${className ?? ''}`}
     >
-      <div className="space-y-1">
-        <p className="text-sm font-medium">{title}</p>
-        <p className="text-sm text-muted-foreground">{description}</p>
+      <div className="flex items-center gap-2">
+        <span className={`inline-flex h-6 w-6 items-center justify-center rounded-full ${ICON_TONES[iconTone]}`}>
+          {icon}
+        </span>
+        <span className="text-xs font-medium whitespace-nowrap">{title}</span>
       </div>
-      <span className="inline-flex items-center gap-2 shrink-0 text-sm text-muted-foreground">
-        {icon}
-        {buttonLabel}
-      </span>
+      <div className="w-0 min-w-full grid grid-rows-[0fr] group-hover:grid-rows-[1fr] group-focus-visible:grid-rows-[1fr] mt-0 group-hover:mt-1.5 group-focus-visible:mt-1.5 transition-[grid-template-rows,margin] duration-200 ease-out">
+        <div className="overflow-hidden">
+          <p className="text-xs text-muted-foreground opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-200">
+            {description}
+          </p>
+        </div>
+      </div>
+      <div className="w-0 min-w-full grid grid-rows-[0fr] group-hover:grid-rows-[1fr] group-focus-visible:grid-rows-[1fr] mt-0 group-hover:mt-4 group-focus-visible:mt-4 transition-[grid-template-rows,margin] duration-200 ease-out">
+        <div className="overflow-hidden">
+          <div className="flex items-center justify-between gap-2 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-200">
+            {pill ? (
+              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[11px] text-foreground">
+                {pill}
+              </span>
+            ) : <span />}
+            <span className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-foreground hover:bg-accent hover:text-accent-foreground transition-colors">
+              {buttonLabel}
+              <ArrowRight className="h-3 w-3" />
+            </span>
+          </div>
+        </div>
+      </div>
     </button>
   )
 }

--- a/src/renderer/components/ui/option-card.tsx
+++ b/src/renderer/components/ui/option-card.tsx
@@ -20,6 +20,11 @@ const ICON_TONES = {
   neutral: 'bg-muted text-foreground dark:bg-muted dark:text-foreground',
 } as const
 
+const animStyle = {
+  transitionDuration: '750ms',
+  transitionTimingFunction: 'cubic-bezier(0.16, 1, 0.3, 1)',
+} as const
+
 export function OptionCard({
   title,
   description,
@@ -35,7 +40,8 @@ export function OptionCard({
       type="button"
       onClick={onClick}
       aria-label={`${title} — ${buttonLabel}`}
-      className={`group text-left rounded-2xl border border-border/50 p-4 flex flex-col items-stretch cursor-pointer w-fit hover:w-[280px] focus-visible:w-[280px] hover:border-foreground/30 hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-[width,background-color,border-color] duration-200 ease-out ${className ?? ''}`}
+      style={animStyle}
+      className={`group text-left rounded-2xl border border-border/50 p-4 flex flex-col items-stretch cursor-pointer w-fit hover:w-[280px] focus-visible:w-[280px] hover:border-foreground/30 hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-[width,background-color,border-color] ${className ?? ''}`}
     >
       <div className="flex items-center gap-2">
         <span className={`inline-flex h-6 w-6 items-center justify-center rounded-full ${ICON_TONES[iconTone]}`}>
@@ -43,16 +49,16 @@ export function OptionCard({
         </span>
         <span className="text-xs font-medium whitespace-nowrap">{title}</span>
       </div>
-      <div className="w-0 min-w-full grid grid-rows-[0fr] group-hover:grid-rows-[1fr] group-focus-visible:grid-rows-[1fr] mt-0 group-hover:mt-1.5 group-focus-visible:mt-1.5 transition-[grid-template-rows,margin] duration-200 ease-out">
+      <div style={animStyle} className="w-0 min-w-full grid grid-rows-[0fr] group-hover:grid-rows-[1fr] group-focus-visible:grid-rows-[1fr] mt-0 group-hover:mt-1.5 group-focus-visible:mt-1.5 transition-[grid-template-rows,margin]">
         <div className="overflow-hidden">
-          <p className="text-xs text-muted-foreground opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-200">
+          <p style={animStyle} className="text-xs text-muted-foreground opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity">
             {description}
           </p>
         </div>
       </div>
-      <div className="w-0 min-w-full grid grid-rows-[0fr] group-hover:grid-rows-[1fr] group-focus-visible:grid-rows-[1fr] mt-0 group-hover:mt-4 group-focus-visible:mt-4 transition-[grid-template-rows,margin] duration-200 ease-out">
+      <div style={animStyle} className="w-0 min-w-full grid grid-rows-[0fr] group-hover:grid-rows-[1fr] group-focus-visible:grid-rows-[1fr] mt-0 group-hover:mt-4 group-focus-visible:mt-4 transition-[grid-template-rows,margin]">
         <div className="overflow-hidden">
-          <div className="flex items-center justify-between gap-2 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-200">
+          <div style={animStyle} className="flex items-center justify-between gap-2 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity">
             {pill ? (
               <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[11px] text-foreground">
                 {pill}

--- a/src/renderer/components/ui/option-card.tsx
+++ b/src/renderer/components/ui/option-card.tsx
@@ -5,9 +5,7 @@ export interface OptionCardProps {
   title: string
   description: ReactNode
   icon: ReactNode
-  /** Color treatment for the circular icon badge. */
-  iconTone?: 'blue' | 'neutral'
-  /** Action label kept for accessibility — not rendered visibly. */
+  /** CTA label rendered next to the arrow and used for the button's aria-label. */
   buttonLabel: string
   /** Optional metadata chip displayed at the bottom of the card. */
   pill?: ReactNode
@@ -15,21 +13,12 @@ export interface OptionCardProps {
   className?: string
 }
 
-const ICON_TONES = {
-  blue: 'bg-blue-100 text-blue-600 dark:bg-blue-500/15 dark:text-blue-400',
-  neutral: 'bg-muted text-foreground dark:bg-muted dark:text-foreground',
-} as const
-
-const animStyle = {
-  transitionDuration: '750ms',
-  transitionTimingFunction: 'cubic-bezier(0.16, 1, 0.3, 1)',
-} as const
+const ANIM = '[transition-duration:750ms] [transition-timing-function:cubic-bezier(0.16,1,0.3,1)]'
 
 export function OptionCard({
   title,
   description,
   icon,
-  iconTone = 'blue',
   buttonLabel,
   pill,
   onClick,
@@ -40,30 +29,32 @@ export function OptionCard({
       type="button"
       onClick={onClick}
       aria-label={`${title} — ${buttonLabel}`}
-      style={animStyle}
-      className={`group text-left rounded-2xl border border-border/50 p-4 flex flex-col items-stretch cursor-pointer w-fit hover:w-[280px] focus-visible:w-[280px] hover:border-foreground/30 hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-[width,background-color,border-color] ${className ?? ''}`}
+      className={`group w-full text-left rounded-2xl border border-border/50 p-4 flex flex-col items-stretch cursor-pointer hover:border-foreground/30 hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors ${className ?? ''}`}
     >
       <div className="flex items-center gap-2">
-        <span className={`inline-flex h-6 w-6 items-center justify-center rounded-full ${ICON_TONES[iconTone]}`}>
+        <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-muted text-foreground">
           {icon}
         </span>
-        <span className="text-xs font-medium whitespace-nowrap">{title}</span>
+        <span className="text-xs font-medium">{title}</span>
       </div>
-      <div style={animStyle} className="w-0 min-w-full grid grid-rows-[0fr] group-hover:grid-rows-[1fr] group-focus-visible:grid-rows-[1fr] mt-0 group-hover:mt-1.5 group-focus-visible:mt-1.5 transition-[grid-template-rows,margin]">
+      <div className={`grid grid-rows-[0fr] group-hover:grid-rows-[1fr] group-focus-visible:grid-rows-[1fr] mt-0 group-hover:mt-1.5 group-focus-visible:mt-1.5 transition-[grid-template-rows,margin] ${ANIM}`}>
         <div className="overflow-hidden">
-          <p style={animStyle} className="text-xs text-muted-foreground opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity">
+          <p className={`text-xs text-muted-foreground opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity ${ANIM}`}>
             {description}
           </p>
         </div>
       </div>
-      <div style={animStyle} className="w-0 min-w-full grid grid-rows-[0fr] group-hover:grid-rows-[1fr] group-focus-visible:grid-rows-[1fr] mt-0 group-hover:mt-4 group-focus-visible:mt-4 transition-[grid-template-rows,margin]">
+      <div className={`grid grid-rows-[0fr] group-hover:grid-rows-[1fr] group-focus-visible:grid-rows-[1fr] mt-0 group-hover:mt-4 group-focus-visible:mt-4 transition-[grid-template-rows,margin] ${ANIM}`}>
         <div className="overflow-hidden">
-          <div style={animStyle} className="flex items-center justify-between gap-2 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity">
+          <div className={`flex items-center justify-between gap-2 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity ${ANIM}`}>
             {pill ? (
               <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[11px] text-foreground">
                 {pill}
               </span>
-            ) : <span />}
+            ) : (
+              // Empty placeholder keeps the CTA right-aligned via justify-between when no pill is provided.
+              <span />
+            )}
             <span className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-foreground hover:bg-accent hover:text-accent-foreground transition-colors">
               {buttonLabel}
               <ArrowRight className="h-3 w-3" />

--- a/src/renderer/hooks/use-agent-templates.ts
+++ b/src/renderer/hooks/use-agent-templates.ts
@@ -99,14 +99,13 @@ export function useImportAgentTemplate() {
   return useMutation<
     ApiAgent & { hasOnboarding?: boolean; requiredEnvVars?: Array<{ name: string; description: string }> },
     Error,
-    { file: File; nameOverride?: string; mode?: 'template' | 'full'; onProgress?: (p: ImportProgress) => void }
+    { file: File; mode?: 'template' | 'full'; onProgress?: (p: ImportProgress) => void }
   >({
-    mutationFn: async ({ file, nameOverride, mode, onProgress }) => {
+    mutationFn: async ({ file, mode, onProgress }) => {
       if (file.size <= CHUNK_SIZE) {
         // Small file — single request (existing behavior)
         const formData = new FormData()
         formData.append('file', file)
-        if (nameOverride) formData.append('name', nameOverride)
         if (mode) formData.append('mode', mode)
 
         onProgress?.({ phase: 'uploading', percent: 100 })
@@ -137,7 +136,6 @@ export function useImportAgentTemplate() {
         formData.append('chunkIndex', String(i))
         formData.append('totalChunks', String(totalChunks))
         formData.append('mode', mode || 'template')
-        if (nameOverride) formData.append('name', nameOverride)
 
         onProgress?.({ phase: 'uploading', percent: (i / totalChunks) * 100 })
 

--- a/src/renderer/hooks/use-start-onboarding-session.ts
+++ b/src/renderer/hooks/use-start-onboarding-session.ts
@@ -1,0 +1,30 @@
+import { useCallback } from 'react'
+import { useCreateSession } from '@renderer/hooks/use-sessions'
+import { useSelection } from '@renderer/context/selection-context'
+
+const ONBOARDING_MESSAGE =
+  'This agent was just set up from a template. Please run the agent-onboarding skill to help me configure it.'
+
+/**
+ * Kicks off the onboarding session for a freshly imported agent.
+ * Failures are swallowed — the agent is still usable without it.
+ */
+export function useStartOnboardingSession() {
+  const createSession = useCreateSession()
+  const { selectSession } = useSelection()
+
+  return useCallback(
+    async (agentSlug: string) => {
+      try {
+        const session = await createSession.mutateAsync({
+          agentSlug,
+          message: ONBOARDING_MESSAGE,
+        })
+        selectSession(session.id)
+      } catch {
+        // Onboarding session creation failed — user can still use agent normally
+      }
+    },
+    [createSession, selectSession],
+  )
+}


### PR DESCRIPTION
## Summary
- Compact, content-hugging cards with circular icon badges (neutral tone)
- Title-only at rest; description, pill, and ghost CTA reveal on hover with a grid-row + opacity animation
- Side-by-side layout via flex-wrap with independent card heights (one expanding no longer stretches the other)
- Tightened spacing between the chat composer and the cards on the empty home state

## Test plan
- [ ] Open a fresh agent with no sessions — both cards render side-by-side, hugging their title widths
- [ ] Hover each card — description, pill, and ghost CTA reveal with smooth animation; other card does not grow
- [ ] Keyboard tab to each card — same expansion fires on focus-visible
- [ ] Click each card — Voice agent dialog / Import dialog opens as before
- [ ] Verify spacing between composer area and cards is tight on the empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)