### PR TITLE
fix: clean up connector on connect failure to prevent unhandled rejections

### DIFF
--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -271,7 +271,13 @@ class ChatIntegrationManager {
 
     this.connections.set(integration.id, conn)
 
-    await connector.connect()
+    try {
+      await connector.connect()
+    } catch (err) {
+      this.disconnectConnection(conn)
+      this.connections.delete(integration.id)
+      throw err
+    }
     this.disconnectedSince.delete(integration.id)
     breadcrumb('Integration connected', { integrationId: integration.id, provider: integration.provider })
     this.emitNotification(integration, 'connected')

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -274,8 +274,7 @@ class ChatIntegrationManager {
     try {
       await connector.connect()
     } catch (err) {
-      this.disconnectConnection(conn)
-      this.connections.delete(integration.id)
+      await this.removeIntegration(integration.id)
       throw err
     }
     this.disconnectedSince.delete(integration.id)


### PR DESCRIPTION
## Summary
- When `connector.connect()` fails (e.g. invalid Slack bot token), the connector and its event listeners were left registered in the `connections` map. The Slack SDK could then fire error events through those dangling listeners, causing unhandled promise rejections that crash the entire app.
- Now on `connect()` failure, we disconnect the connector and remove it from the map before re-throwing, so the existing `start()` catch handler works cleanly with no leftover state.

## Test plan
- Configure a Slack chat integration with an invalid bot token
- Verify the app logs the error but does not crash with an unhandled rejection
- Verify valid integrations still connect normally

Made with [Cursor](https://cursor.com)