### PR TITLE
fix: add common Chrome installation paths for all platforms

### DIFF
--- a/src/main/host-browser/chrome-provider.ts
+++ b/src/main/host-browser/chrome-provider.ts
@@ -13,18 +13,33 @@ interface BrowserCandidate {
   paths: string[]
 }
 
+const WIN_LOCAL_APP_DATA = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local')
+
 const BROWSER_CANDIDATES: Record<string, BrowserCandidate> = {
   darwin: {
     browser: 'chrome',
-    paths: ['/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'],
+    paths: [
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      path.join(os.homedir(), 'Applications', 'Google Chrome.app', 'Contents', 'MacOS', 'Google Chrome'),
+    ],
   },
   linux: {
     browser: 'chrome',
-    paths: ['/usr/bin/google-chrome', '/usr/bin/chromium-browser'],
+    paths: [
+      '/usr/bin/google-chrome-stable',
+      '/usr/bin/google-chrome',
+      '/usr/bin/chromium-browser',
+      '/usr/bin/chromium',
+      '/opt/google/chrome/chrome',
+    ],
   },
   win32: {
     browser: 'chrome',
-    paths: ['C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe'],
+    paths: [
+      path.join(WIN_LOCAL_APP_DATA, 'Google', 'Chrome', 'Application', 'chrome.exe'),
+      'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+      'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+    ],
   },
 }
 

--- a/src/main/host-browser/chrome-provider.ts
+++ b/src/main/host-browser/chrome-provider.ts
@@ -26,18 +26,20 @@ const BROWSER_CANDIDATES: Record<string, BrowserCandidate> = {
   linux: {
     browser: 'chrome',
     paths: [
-      '/usr/bin/google-chrome-stable',
       '/usr/bin/google-chrome',
       '/usr/bin/chromium-browser',
+      '/usr/bin/google-chrome-stable',
       '/usr/bin/chromium',
       '/opt/google/chrome/chrome',
+      '/snap/bin/google-chrome',
+      '/snap/bin/chromium',
     ],
   },
   win32: {
     browser: 'chrome',
     paths: [
-      path.join(WIN_LOCAL_APP_DATA, 'Google', 'Chrome', 'Application', 'chrome.exe'),
       'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+      path.join(WIN_LOCAL_APP_DATA, 'Google', 'Chrome', 'Application', 'chrome.exe'),
       'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
     ],
   },


### PR DESCRIPTION
## Summary
- Add all standard Chrome/Chromium installation paths for macOS, Linux, and Windows
- **macOS**: added `~/Applications/` (user-level install)
- **Linux**: added `google-chrome-stable`, `chromium`, `/opt/google/chrome/chrome`
- **Windows**: added `%LOCALAPPDATA%` (user-level install, most common) and `Program Files (x86)` (32-bit)
- Pure additive/defensive change — existing paths remain in the same priority order

## Test plan
- [ ] Verify Chrome detection still works on macOS (`/Applications/` path)
- [ ] Verify Chrome detection works on Windows with user-level install (`%LOCALAPPDATA%`)
- [ ] Verify Chrome detection works on Linux with `google-chrome-stable`

Made with [Cursor](https://cursor.com)