### PR TITLE
style: consolidate send and stop into one composer button

### DIFF
--- a/src/renderer/components/messages/composer-action-button.test.tsx
+++ b/src/renderer/components/messages/composer-action-button.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ComposerActionButton } from './composer-action-button'
+
+describe('ComposerActionButton', () => {
+  const baseProps = {
+    isActive: false,
+    canSubmit: true,
+    isSending: false,
+    isInterrupting: false,
+    onInterrupt: vi.fn(),
+  }
+
+  it('renders the send button when idle', () => {
+    render(<ComposerActionButton {...baseProps} />)
+    expect(screen.getByTestId('send-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('stop-button')).not.toBeInTheDocument()
+  })
+
+  it('renders the stop button when active', () => {
+    render(<ComposerActionButton {...baseProps} isActive />)
+    expect(screen.getByTestId('stop-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('send-button')).not.toBeInTheDocument()
+  })
+
+  it('disables the send button when canSubmit is false', () => {
+    render(<ComposerActionButton {...baseProps} canSubmit={false} />)
+    expect(screen.getByTestId('send-button')).toBeDisabled()
+  })
+
+  it('disables the send button while sending', () => {
+    render(<ComposerActionButton {...baseProps} isSending />)
+    expect(screen.getByTestId('send-button')).toBeDisabled()
+  })
+
+  it('calls onInterrupt when the stop button is clicked', async () => {
+    const onInterrupt = vi.fn()
+    const user = userEvent.setup()
+    render(<ComposerActionButton {...baseProps} isActive onInterrupt={onInterrupt} />)
+    await user.click(screen.getByTestId('stop-button'))
+    expect(onInterrupt).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the stop button while interrupting', () => {
+    render(<ComposerActionButton {...baseProps} isActive isInterrupting />)
+    expect(screen.getByTestId('stop-button')).toBeDisabled()
+  })
+})

--- a/src/renderer/components/messages/composer-action-button.tsx
+++ b/src/renderer/components/messages/composer-action-button.tsx
@@ -45,6 +45,7 @@ export function ComposerActionButton({
       className="h-[34px] w-[34px]"
       disabled={!canSubmit || isSending}
       aria-label="Send message"
+      title="Send message"
       data-testid="send-button"
     >
       {isSending ? (

--- a/src/renderer/components/messages/composer-action-button.tsx
+++ b/src/renderer/components/messages/composer-action-button.tsx
@@ -1,0 +1,57 @@
+import { ArrowUp, Loader2, Square } from 'lucide-react'
+import { Button } from '@renderer/components/ui/button'
+
+interface ComposerActionButtonProps {
+  isActive: boolean
+  canSubmit: boolean
+  isSending: boolean
+  isInterrupting: boolean
+  onInterrupt: () => void
+}
+
+export function ComposerActionButton({
+  isActive,
+  canSubmit,
+  isSending,
+  isInterrupting,
+  onInterrupt,
+}: ComposerActionButtonProps) {
+  if (isActive) {
+    return (
+      <Button
+        type="button"
+        size="icon"
+        variant="outline"
+        className="h-[34px] w-[34px]"
+        onClick={onInterrupt}
+        disabled={isInterrupting}
+        aria-label="Stop the agent"
+        title="Stop the agent"
+        data-testid="stop-button"
+      >
+        {isInterrupting ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Square className="h-3.5 w-3.5 fill-current" />
+        )}
+      </Button>
+    )
+  }
+
+  return (
+    <Button
+      type="submit"
+      size="icon"
+      className="h-[34px] w-[34px]"
+      disabled={!canSubmit || isSending}
+      aria-label="Send message"
+      data-testid="send-button"
+    >
+      {isSending ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : (
+        <ArrowUp className="h-4 w-4" />
+      )}
+    </Button>
+  )
+}

--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -113,14 +113,13 @@ describe('MessageInput', () => {
     expect(screen.getByTestId('message-input')).not.toBeDisabled()
   })
 
-  it('shows both send and stop buttons when active, with send disabled', () => {
+  it('shows only the stop button when active', () => {
     mockStreamState.isActive = true
     renderWithProviders(
       <MessageInput sessionId="s-1" agentSlug="agent-1" />
     )
     expect(screen.getByTestId('stop-button')).toBeInTheDocument()
-    expect(screen.getByTestId('send-button')).toBeInTheDocument()
-    expect(screen.getByTestId('send-button')).toBeDisabled()
+    expect(screen.queryByTestId('send-button')).not.toBeInTheDocument()
   })
 
   it('does not submit message while agent is active', async () => {

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -1,4 +1,3 @@
-
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import { getApiBaseUrl } from '@renderer/lib/env'
 import { useSendMessage, useUploadFile, useUploadFolder, useInterruptSession } from '@renderer/hooks/use-messages'

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -1,15 +1,14 @@
 
-import { Button } from '@renderer/components/ui/button'
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import { getApiBaseUrl } from '@renderer/lib/env'
 import { useSendMessage, useUploadFile, useUploadFolder, useInterruptSession } from '@renderer/hooks/use-messages'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
-import { ArrowUp, Loader2, Square, WifiOff } from 'lucide-react'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
+import { WifiOff } from 'lucide-react'
 import { useIsOnline } from '@renderer/context/connectivity-context'
 import { useUser } from '@renderer/context/user-context'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
+import { ComposerActionButton } from './composer-action-button'
 import { SlashCommandMenu } from './slash-command-menu'
 import { AttachmentPicker } from '@renderer/components/ui/attachment-picker'
 import { MountChoiceDialog } from '@renderer/components/ui/mount-choice-dialog'
@@ -217,56 +216,18 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, initialEffor
         )}
         rightActions={(
           <>
-            {isActive && (
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                className="h-[34px] w-[34px]"
-                onClick={handleInterrupt}
-                disabled={interruptSession.isPending}
-                data-testid="stop-button"
-                aria-label="Stop message"
-              >
-                {interruptSession.isPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Square className="h-3.5 w-3.5 fill-current" />
-                )}
-              </Button>
-            )}
             <VoiceInputButton
               voiceInput={composer.voiceInput}
               message={composer.message}
               disabled={isDisabled}
             />
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span>
-                    <Button
-                      type="submit"
-                      size="icon"
-                      className="h-[34px] w-[34px]"
-                      disabled={!composer.canSubmit || sendMessage.isPending}
-                      data-testid="send-button"
-                      aria-label="Send message"
-                    >
-                      {sendMessage.isPending || composer.isUploading ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <ArrowUp className="h-4 w-4" />
-                      )}
-                    </Button>
-                  </span>
-                </TooltipTrigger>
-                {isActive && (
-                  <TooltipContent>
-                    <p>Wait for the agent to finish</p>
-                  </TooltipContent>
-                )}
-              </Tooltip>
-            </TooltipProvider>
+            <ComposerActionButton
+              isActive={isActive}
+              canSubmit={composer.canSubmit}
+              isSending={sendMessage.isPending || composer.isUploading}
+              isInterrupting={interruptSession.isPending}
+              onInterrupt={handleInterrupt}
+            />
           </>
         )}
         footer={(


### PR DESCRIPTION
## Summary
- Replaces the two separate Send and Stop buttons with a single 34×34 morphing icon button that swaps between `ArrowUp` (idle) and a filled `Square` (active).
- Stable dimensions across states — no horizontal layout shift when the agent starts or finishes. Matches the convention used by Cursor / v0 / ChatGPT.
- Extracts the state-based morph into `ComposerActionButton` so `message-input.tsx` stays focused on composer wiring.

## Test plan
- [ ] Type a message — Send button is enabled (blue, ArrowUp).
- [ ] Click Send — button transitions to Stop state (outline, filled Square) without layout shift.
- [ ] While the agent is responding, type a follow-up — Enter is still a no-op (existing guard).
- [ ] Hover the active button — native title "Stop the agent" appears.
- [ ] Click Stop — button returns to Send state.
- [ ] Tab to the button — focus ring visible; Enter activates (sends idle, stops active).
- [ ] Screen reader announces "Send message, button" idle and "Stop the agent, button" active.
- [ ] Offline (no active session) — button stays as disabled Send.
- [ ] Visual: 34×34 height aligns cleanly with the voice button to its left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)