### PR TITLE
style: move shared skills into a Browse dialog

### DIFF
--- a/e2e/setup-e2e-data.js
+++ b/e2e/setup-e2e-data.js
@@ -11,6 +11,7 @@
  */
 const fs = require('fs')
 const path = require('path')
+const { execFileSync } = require('child_process')
 
 const dataDir = process.env.SUPERAGENT_DATA_DIR
 if (!dataDir) {
@@ -31,14 +32,20 @@ for (const file of ['superagent.db', 'superagent.db-wal', 'superagent.db-shm']) 
 // Remove agents directory
 try { fs.rmSync(path.join(resolvedDir, 'agents'), { recursive: true }) } catch {}
 
-// Seed a fake skillset on disk so /discoverable-skills returns content without
-// needing a real git remote. The skillset-service treats a directory as a
-// cached skillset whenever it contains a `.git/` subfolder; install copies
-// files locally without invoking git, so this is enough.
+// Seed a fake skillset on disk so /discoverable-skills returns content
+// without needing a real git remote.
+//
+// IMPORTANT: this MUST be a real `git init` repo, not just an empty `.git/`
+// stub. The skillset-service runs `git remote set-url origin …` and
+// `git pull` against this directory — and if `.git/` is malformed, git walks
+// up the directory tree and operates on the project's repo instead, silently
+// rewriting our actual origin URL. Real `git init` keeps git scoped here.
 const SKILLSET_ID = 'e2e-test-skillset'
 const SKILLSET_REPO_DIR = path.join(resolvedDir, 'skillset-cache', SKILLSET_ID)
+const SKILLSET_FAKE_URL = 'https://localhost.invalid/e2e-test-skillset'
 fs.rmSync(SKILLSET_REPO_DIR, { recursive: true, force: true })
-fs.mkdirSync(path.join(SKILLSET_REPO_DIR, '.git'), { recursive: true })
+fs.mkdirSync(SKILLSET_REPO_DIR, { recursive: true })
+execFileSync('git', ['init', '-q'], { cwd: SKILLSET_REPO_DIR })
 
 const SKILLSET_INDEX = {
   skillset_name: 'E2E Test Skillset',
@@ -101,6 +108,14 @@ This skill requires an environment variable to be configured.
 `,
 )
 
+// Commit the seed and add a fake origin. The commit makes this a valid git
+// repo so subsequent `git remote set-url` / `git fetch` calls stay scoped to
+// this directory rather than walking up to the host project.
+const GIT_AUTHOR = ['-c', 'user.email=e2e@local', '-c', 'user.name=E2E Setup', '-c', 'commit.gpgsign=false']
+execFileSync('git', [...GIT_AUTHOR, 'add', '.'], { cwd: SKILLSET_REPO_DIR, stdio: 'pipe' })
+execFileSync('git', [...GIT_AUTHOR, 'commit', '-q', '-m', 'seed'], { cwd: SKILLSET_REPO_DIR, stdio: 'pipe' })
+execFileSync('git', ['remote', 'add', 'origin', SKILLSET_FAKE_URL], { cwd: SKILLSET_REPO_DIR, stdio: 'pipe' })
+
 // Build settings
 const settings = {
   container: {
@@ -112,7 +127,7 @@ const settings = {
   skillsets: [
     {
       id: SKILLSET_ID,
-      url: 'https://github.com/example/e2e-test-skillset',
+      url: SKILLSET_FAKE_URL,
       name: 'E2E Test Skillset',
       description: 'Fake skillset seeded for Playwright tests',
       addedAt: new Date().toISOString(),

--- a/e2e/setup-e2e-data.js
+++ b/e2e/setup-e2e-data.js
@@ -31,6 +31,76 @@ for (const file of ['superagent.db', 'superagent.db-wal', 'superagent.db-shm']) 
 // Remove agents directory
 try { fs.rmSync(path.join(resolvedDir, 'agents'), { recursive: true }) } catch {}
 
+// Seed a fake skillset on disk so /discoverable-skills returns content without
+// needing a real git remote. The skillset-service treats a directory as a
+// cached skillset whenever it contains a `.git/` subfolder; install copies
+// files locally without invoking git, so this is enough.
+const SKILLSET_ID = 'e2e-test-skillset'
+const SKILLSET_REPO_DIR = path.join(resolvedDir, 'skillset-cache', SKILLSET_ID)
+fs.rmSync(SKILLSET_REPO_DIR, { recursive: true, force: true })
+fs.mkdirSync(path.join(SKILLSET_REPO_DIR, '.git'), { recursive: true })
+
+const SKILLSET_INDEX = {
+  skillset_name: 'E2E Test Skillset',
+  description: 'Fake skillset seeded for Playwright tests',
+  version: '1.0.0',
+  skills: [
+    {
+      name: 'e2e-plain-skill',
+      path: 'skills/e2e-plain-skill/SKILL.md',
+      description: 'A plain skill that needs no configuration',
+      version: '1.0.0',
+    },
+    {
+      name: 'e2e-env-skill',
+      path: 'skills/e2e-env-skill/SKILL.md',
+      description: 'A skill that requires an API key to run',
+      version: '1.0.0',
+    },
+  ],
+}
+fs.writeFileSync(
+  path.join(SKILLSET_REPO_DIR, 'index.json'),
+  JSON.stringify(SKILLSET_INDEX, null, 2),
+)
+
+const PLAIN_SKILL_DIR = path.join(SKILLSET_REPO_DIR, 'skills', 'e2e-plain-skill')
+fs.mkdirSync(PLAIN_SKILL_DIR, { recursive: true })
+fs.writeFileSync(
+  path.join(PLAIN_SKILL_DIR, 'SKILL.md'),
+  `---
+name: e2e-plain-skill
+description: A plain skill that needs no configuration
+metadata:
+  version: 1.0.0
+---
+
+# E2E Plain Skill
+
+This skill is seeded for end-to-end tests.
+`,
+)
+
+const ENV_SKILL_DIR = path.join(SKILLSET_REPO_DIR, 'skills', 'e2e-env-skill')
+fs.mkdirSync(ENV_SKILL_DIR, { recursive: true })
+fs.writeFileSync(
+  path.join(ENV_SKILL_DIR, 'SKILL.md'),
+  `---
+name: e2e-env-skill
+description: A skill that requires an API key to run
+metadata:
+  version: 1.0.0
+  required_env_vars:
+    - name: E2E_TEST_API_KEY
+      description: Fake API key for E2E tests
+---
+
+# E2E Env Skill
+
+This skill requires an environment variable to be configured.
+`,
+)
+
 // Build settings
 const settings = {
   container: {
@@ -39,6 +109,16 @@ const settings = {
     resourceLimits: { cpu: 1, memory: '512m' },
   },
   app: { setupCompleted: true },
+  skillsets: [
+    {
+      id: SKILLSET_ID,
+      url: 'https://github.com/example/e2e-test-skillset',
+      name: 'E2E Test Skillset',
+      description: 'Fake skillset seeded for Playwright tests',
+      addedAt: new Date().toISOString(),
+      provider: 'github',
+    },
+  ],
 }
 
 if (process.env.AUTH_MODE === 'true') {
@@ -53,3 +133,4 @@ if (process.env.AUTH_MODE === 'true') {
 
 fs.writeFileSync(path.join(resolvedDir, 'settings.json'), JSON.stringify(settings, null, 2))
 console.log(`[E2E Setup] Data dir prepared: ${resolvedDir}`)
+console.log(`[E2E Setup] Seeded skillset at: ${SKILLSET_REPO_DIR}`)

--- a/e2e/specs/discoverable-skills.spec.ts
+++ b/e2e/specs/discoverable-skills.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+
+test.describe('Discoverable Skills - Browse & Install', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+
+  test.beforeEach(async ({ page }) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+  })
+
+  test('Add Skill button opens browse dialog with the seeded skills', async ({ page }) => {
+    await agentPage.createAgent(`Skills Browse ${Date.now()}`)
+
+    const addSkillButton = page.locator('[data-testid="add-skill-button"]')
+    await expect(addSkillButton).toBeVisible({ timeout: 10000 })
+    await addSkillButton.click()
+
+    const dialog = page.locator('[data-testid="skills-browse-dialog"]')
+    await expect(dialog).toBeVisible()
+
+    // Both seeded skills are listed.
+    await expect(dialog.locator('[data-skill-name="e2e-plain-skill"]')).toBeVisible()
+    await expect(dialog.locator('[data-skill-name="e2e-env-skill"]')).toBeVisible()
+
+    // Search filters down to one card after the debounce settles.
+    await dialog.getByPlaceholder('Search skills...').fill('plain')
+    await expect(dialog.locator('[data-skill-name="e2e-env-skill"]')).toBeHidden()
+    await expect(dialog.locator('[data-skill-name="e2e-plain-skill"]')).toBeVisible()
+  })
+
+  test('installs a skill that requires no env vars', async ({ page }) => {
+    await agentPage.createAgent(`Skills Plain ${Date.now()}`)
+
+    await page.locator('[data-testid="add-skill-button"]').click()
+    const dialog = page.locator('[data-testid="skills-browse-dialog"]')
+    await expect(dialog).toBeVisible()
+
+    // Install button on the card has aria-label "Install <name>".
+    await dialog.getByRole('button', { name: 'Install e2e-plain-skill' }).click()
+
+    // After install, the env-vars dialog should NOT appear (skill has none),
+    // the discoverable list re-renders without the installed skill, and the
+    // installed list shows it.
+    await expect(page.locator('[data-testid="skill-install-dialog"]')).toBeHidden()
+    await expect(dialog.locator('[data-skill-name="e2e-plain-skill"]')).toBeHidden({ timeout: 10000 })
+
+    // Close the browse dialog (Escape) to inspect the agent home list.
+    await page.keyboard.press('Escape')
+    await expect(dialog).toBeHidden()
+
+    const installedRow = page.locator('[data-testid="installed-skill-row"][data-skill-path="e2e-plain-skill"]')
+    await expect(installedRow).toBeVisible({ timeout: 10000 })
+  })
+
+  test('installs a skill that requires env vars via the secrets dialog', async ({ page }) => {
+    await agentPage.createAgent(`Skills Env ${Date.now()}`)
+
+    await page.locator('[data-testid="add-skill-button"]').click()
+    const browseDialog = page.locator('[data-testid="skills-browse-dialog"]')
+    await expect(browseDialog).toBeVisible()
+
+    await browseDialog.getByRole('button', { name: 'Install e2e-env-skill' }).click()
+
+    // The env-vars dialog opens with a field for E2E_TEST_API_KEY.
+    const installDialog = page.locator('[data-testid="skill-install-dialog"]')
+    await expect(installDialog).toBeVisible()
+    await expect(installDialog.getByText('Install e2e-env-skill')).toBeVisible()
+
+    const apiKeyInput = installDialog.locator('#env-E2E_TEST_API_KEY')
+    await expect(apiKeyInput).toBeVisible()
+
+    // Submit is disabled until the field has a value.
+    const submitButton = installDialog.getByRole('button', { name: 'Install', exact: true })
+    await expect(submitButton).toBeDisabled()
+
+    await apiKeyInput.fill('fake-secret-value')
+    await expect(submitButton).toBeEnabled()
+    await submitButton.click()
+
+    // Env-vars dialog closes; the env skill disappears from the browse list.
+    await expect(installDialog).toBeHidden({ timeout: 10000 })
+    await expect(browseDialog.locator('[data-skill-name="e2e-env-skill"]')).toBeHidden({ timeout: 10000 })
+
+    await page.keyboard.press('Escape')
+    await expect(browseDialog).toBeHidden()
+
+    const installedRow = page.locator('[data-testid="installed-skill-row"][data-skill-path="e2e-env-skill"]')
+    await expect(installedRow).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/src/renderer/components/agents/agent-home/home-skills-browse-dialog.test.tsx
+++ b/src/renderer/components/agents/agent-home/home-skills-browse-dialog.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { useState } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HomeSkillsBrowseDialog } from './home-skills-browse-dialog'
+import { renderWithProviders } from '@renderer/test/test-utils'
+import type { ApiDiscoverableSkill } from '@shared/lib/types/api'
+
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: vi.fn(),
+}))
+
+function makeSkill(overrides: Partial<ApiDiscoverableSkill> & { name: string }): ApiDiscoverableSkill {
+  return {
+    skillsetId: 'set-a',
+    skillsetName: 'Set A',
+    description: `${overrides.name} description`,
+    version: '1.0.0',
+    path: `skills/${overrides.name}/SKILL.md`,
+    ...overrides,
+  }
+}
+
+const SKILLS_TWO_SETS: ApiDiscoverableSkill[] = [
+  makeSkill({ name: 'alpha', skillsetId: 'set-a', skillsetName: 'Set A' }),
+  makeSkill({
+    name: 'beta',
+    description: 'queries the beta service',
+    skillsetId: 'set-a',
+    skillsetName: 'Set A',
+  }),
+  makeSkill({ name: 'gamma', skillsetId: 'set-b', skillsetName: 'Set B' }),
+]
+
+function Harness({ skills }: { skills: ApiDiscoverableSkill[] }) {
+  const [open, setOpen] = useState(true)
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>__open</button>
+      <button onClick={() => setOpen(false)}>__close</button>
+      <HomeSkillsBrowseDialog
+        open={open}
+        onOpenChange={setOpen}
+        agentSlug="agent-1"
+        discoverableSkills={skills}
+      />
+    </>
+  )
+}
+
+describe('HomeSkillsBrowseDialog', () => {
+  // Real timers — userEvent + Radix portals + fakeTimers do not play nicely
+  // here. The debounce is only 150ms; we just wait it out.
+  const DEBOUNCE_MS = 150
+
+  function setupUser() {
+    return userEvent.setup()
+  }
+
+  function waitForDebounce() {
+    return new Promise<void>((resolve) => setTimeout(resolve, DEBOUNCE_MS + 20))
+  }
+
+  it('renders every skill on initial open', () => {
+    renderWithProviders(<Harness skills={SKILLS_TWO_SETS} />)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+    expect(screen.getByText('beta')).toBeInTheDocument()
+    expect(screen.getByText('gamma')).toBeInTheDocument()
+  })
+
+  it('debounces search — filter only applies after the debounce window', async () => {
+    const user = setupUser()
+    renderWithProviders(<Harness skills={SKILLS_TWO_SETS} />)
+
+    await user.type(screen.getByPlaceholderText('Search skills...'), 'alp')
+
+    // Right after typing, the filter has not been applied yet.
+    expect(screen.getByText('beta')).toBeInTheDocument()
+    expect(screen.getByText('gamma')).toBeInTheDocument()
+
+    // After the debounce window, only matching skills remain.
+    await waitForDebounce()
+    await waitFor(() => {
+      expect(screen.queryByText('beta')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+    expect(screen.queryByText('gamma')).not.toBeInTheDocument()
+  })
+
+  it('search matches description as well as name', async () => {
+    const user = setupUser()
+    renderWithProviders(<Harness skills={SKILLS_TWO_SETS} />)
+
+    await user.type(screen.getByPlaceholderText('Search skills...'), 'queries')
+    await waitForDebounce()
+
+    await waitFor(() => {
+      expect(screen.queryByText('alpha')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('beta')).toBeInTheDocument()
+  })
+
+  it('empty-state message uses the debounced query, not the typed one', async () => {
+    const user = setupUser()
+    renderWithProviders(<Harness skills={SKILLS_TWO_SETS} />)
+
+    await user.type(screen.getByPlaceholderText('Search skills...'), 'zzz')
+    // Debounce hasn't fired — the empty-state should not yet show "zzz".
+    expect(screen.queryByText(/No skills matching "zzz"/)).not.toBeInTheDocument()
+
+    await waitForDebounce()
+    await waitFor(() => {
+      expect(screen.getByText(/No skills matching "zzz"/)).toBeInTheDocument()
+    })
+  })
+
+  it('skillset filter popover toggles a single set, indicator dot appears for partial selection', async () => {
+    const user = setupUser()
+    renderWithProviders(<Harness skills={SKILLS_TWO_SETS} />)
+
+    // No dot visible while all skillsets are selected (default).
+    const filterButton = screen.getByRole('button', { name: 'Filter by skillset' })
+    expect(filterButton.querySelector('span.bg-primary')).toBeNull()
+
+    await user.click(filterButton)
+    // De-select Set B.
+    await user.click(await screen.findByRole('button', { name: /Set B/ }))
+
+    // Set B's `gamma` is now hidden, Set A skills remain.
+    await waitFor(() => {
+      expect(screen.queryByText('gamma')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+
+    // Indicator dot is now present (size < total).
+    expect(filterButton.querySelector('span.bg-primary')).not.toBeNull()
+  })
+
+  it('shows pagination only when filtered results exceed page size', async () => {
+    const many: ApiDiscoverableSkill[] = Array.from({ length: 31 }, (_, i) =>
+      makeSkill({ name: `skill-${String(i).padStart(2, '0')}` })
+    )
+
+    const { rerender } = renderWithProviders(<Harness skills={many} />)
+    expect(screen.getByText('1 / 2')).toBeInTheDocument()
+
+    rerender(<Harness skills={many.slice(0, 30)} />)
+    await waitFor(() => {
+      expect(screen.queryByText('1 / 2')).not.toBeInTheDocument()
+    })
+  })
+
+  it('resets to page 1 when the search query changes', async () => {
+    const user = setupUser()
+    const many: ApiDiscoverableSkill[] = Array.from({ length: 31 }, (_, i) =>
+      makeSkill({ name: `skill-${String(i).padStart(2, '0')}` })
+    )
+    renderWithProviders(<Harness skills={many} />)
+
+    // Advance to page 2.
+    const nextBtn = screen.getAllByRole('button').find((b) => b.querySelector('.lucide-chevron-right'))
+    expect(nextBtn).toBeDefined()
+    await user.click(nextBtn!)
+    expect(screen.getByText('2 / 2')).toBeInTheDocument()
+
+    // Typing into search should reset to page 1 once debounce settles.
+    await user.type(screen.getByPlaceholderText('Search skills...'), 'skill-0')
+    await waitForDebounce()
+
+    await waitFor(() => {
+      // 10 matches (skill-00..skill-09) -> 1 page total, no pager.
+      expect(screen.queryByText(/^[12] \/ \d/)).not.toBeInTheDocument()
+    })
+  })
+
+  it('clears search, page, and filter when the dialog closes and reopens', async () => {
+    const user = setupUser()
+    renderWithProviders(<Harness skills={SKILLS_TWO_SETS} />)
+
+    await user.type(screen.getByPlaceholderText('Search skills...'), 'alpha')
+    await waitForDebounce()
+    await waitFor(() => {
+      expect(screen.queryByText('beta')).not.toBeInTheDocument()
+    })
+
+    // Close via Escape (the Radix overlay blocks clicks on the harness buttons).
+    await user.keyboard('{Escape}')
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    // Reopen — input is empty, all skills visible again.
+    await user.click(screen.getByText('__open'))
+    expect(screen.getByPlaceholderText('Search skills...')).toHaveValue('')
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+    expect(screen.getByText('beta')).toBeInTheDocument()
+    expect(screen.getByText('gamma')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/agents/agent-home/home-skills-browse-dialog.tsx
+++ b/src/renderer/components/agents/agent-home/home-skills-browse-dialog.tsx
@@ -28,8 +28,14 @@ export function HomeSkillsBrowseDialog({
   discoverableSkills,
 }: HomeSkillsBrowseDialogProps) {
   const [skillSearch, setSkillSearch] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
   const [skillPage, setSkillPage] = useState(0)
   const [selectedSkillsets, setSelectedSkillsets] = useState<Set<string> | null>(null)
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedSearch(skillSearch), 150)
+    return () => clearTimeout(id)
+  }, [skillSearch])
 
   const skillsetList = useMemo(() => {
     const seen = new Map<string, string>()
@@ -47,11 +53,11 @@ export function HomeSkillsBrowseDialog({
   const filteredSkills = useMemo(() => {
     return discoverableSkills.filter((s) => {
       if (!activeSkillsets.has(s.skillsetId)) return false
-      if (!skillSearch.trim()) return true
-      const q = skillSearch.toLowerCase()
+      if (!debouncedSearch.trim()) return true
+      const q = debouncedSearch.toLowerCase()
       return s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q)
     })
-  }, [discoverableSkills, skillSearch, activeSkillsets])
+  }, [discoverableSkills, debouncedSearch, activeSkillsets])
 
   const totalPages = Math.ceil(filteredSkills.length / SKILLS_PER_PAGE)
   const pagedSkills = filteredSkills.slice(
@@ -61,11 +67,12 @@ export function HomeSkillsBrowseDialog({
 
   useEffect(() => {
     setSkillPage(0)
-  }, [skillSearch, selectedSkillsets])
+  }, [debouncedSearch, selectedSkillsets])
 
   useEffect(() => {
     if (!open) {
       setSkillSearch('')
+      setDebouncedSearch('')
       setSkillPage(0)
       setSelectedSkillsets(null)
     }
@@ -73,12 +80,12 @@ export function HomeSkillsBrowseDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl" onOpenAutoFocus={(e) => e.preventDefault()}>
+      <DialogContent className="max-w-3xl" onOpenAutoFocus={(e) => e.preventDefault()} data-testid="skills-browse-dialog">
         <DialogHeader>
           <DialogTitle>Browse & add skills from your team</DialogTitle>
         </DialogHeader>
 
-        <div className="flex items-center gap-2 mt-4">
+        <div className="flex items-center justify-between gap-2 mt-4">
           <div className="relative w-56">
             <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
@@ -95,7 +102,7 @@ export function HomeSkillsBrowseDialog({
                   type="button"
                   size="icon"
                   variant="outline"
-                  className="h-9 w-9 relative ml-auto"
+                  className="h-9 w-9 relative"
                   title="Filter by skillset"
                   aria-label="Filter by skillset"
                 >
@@ -140,8 +147,8 @@ export function HomeSkillsBrowseDialog({
         <div className="min-h-[60vh]">
           {filteredSkills.length === 0 ? (
             <p className="text-xs text-muted-foreground text-center py-6">
-              {skillSearch.trim()
-                ? `No skills matching "${skillSearch}"`
+              {debouncedSearch.trim()
+                ? `No skills matching "${debouncedSearch}"`
                 : 'No skills available'}
             </p>
           ) : (

--- a/src/renderer/components/agents/agent-home/home-skills-browse-dialog.tsx
+++ b/src/renderer/components/agents/agent-home/home-skills-browse-dialog.tsx
@@ -1,0 +1,190 @@
+import { useState, useMemo, useEffect } from 'react'
+import { Button } from '@renderer/components/ui/button'
+import { Input } from '@renderer/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@renderer/components/ui/dialog'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+import { Search, ChevronLeft, ChevronRight, Filter, Check } from 'lucide-react'
+import { DiscoverableSkillCard } from '../discoverable-skill-card'
+import type { ApiDiscoverableSkill } from '@shared/lib/types/api'
+
+const SKILLS_PER_PAGE = 30
+
+interface HomeSkillsBrowseDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  agentSlug: string
+  discoverableSkills: ApiDiscoverableSkill[]
+}
+
+export function HomeSkillsBrowseDialog({
+  open,
+  onOpenChange,
+  agentSlug,
+  discoverableSkills,
+}: HomeSkillsBrowseDialogProps) {
+  const [skillSearch, setSkillSearch] = useState('')
+  const [skillPage, setSkillPage] = useState(0)
+  const [selectedSkillsets, setSelectedSkillsets] = useState<Set<string> | null>(null)
+
+  const skillsetList = useMemo(() => {
+    const seen = new Map<string, string>()
+    for (const s of discoverableSkills) {
+      if (!seen.has(s.skillsetId)) seen.set(s.skillsetId, s.skillsetName)
+    }
+    return Array.from(seen, ([id, name]) => ({ id, name }))
+  }, [discoverableSkills])
+
+  const activeSkillsets = useMemo(
+    () => selectedSkillsets ?? new Set(skillsetList.map((s) => s.id)),
+    [selectedSkillsets, skillsetList]
+  )
+
+  const filteredSkills = useMemo(() => {
+    return discoverableSkills.filter((s) => {
+      if (!activeSkillsets.has(s.skillsetId)) return false
+      if (!skillSearch.trim()) return true
+      const q = skillSearch.toLowerCase()
+      return s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q)
+    })
+  }, [discoverableSkills, skillSearch, activeSkillsets])
+
+  const totalPages = Math.ceil(filteredSkills.length / SKILLS_PER_PAGE)
+  const pagedSkills = filteredSkills.slice(
+    skillPage * SKILLS_PER_PAGE,
+    (skillPage + 1) * SKILLS_PER_PAGE
+  )
+
+  useEffect(() => {
+    setSkillPage(0)
+  }, [skillSearch, selectedSkillsets])
+
+  useEffect(() => {
+    if (!open) {
+      setSkillSearch('')
+      setSkillPage(0)
+      setSelectedSkillsets(null)
+    }
+  }, [open])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl" onOpenAutoFocus={(e) => e.preventDefault()}>
+        <DialogHeader>
+          <DialogTitle>Browse & add skills from your team</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex items-center gap-2 mt-4">
+          <div className="relative w-56">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              value={skillSearch}
+              onChange={(e) => setSkillSearch(e.target.value)}
+              placeholder="Search skills..."
+              className="pl-8"
+            />
+          </div>
+          {skillsetList.length > 0 && (
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="outline"
+                  className="h-9 w-9 relative ml-auto"
+                  title="Filter by skillset"
+                  aria-label="Filter by skillset"
+                >
+                  <Filter className="h-4 w-4 text-muted-foreground" />
+                  {selectedSkillsets && selectedSkillsets.size < skillsetList.length && (
+                    <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-primary" />
+                  )}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-56 p-1 space-y-0.5">
+                {skillsetList.map((ss) => {
+                  const checked = activeSkillsets.has(ss.id)
+                  return (
+                    <button
+                      key={ss.id}
+                      type="button"
+                      onClick={() => {
+                        const next = new Set(activeSkillsets)
+                        if (checked) {
+                          next.delete(ss.id)
+                        } else {
+                          next.add(ss.id)
+                        }
+                        setSelectedSkillsets(
+                          next.size === skillsetList.length ? null : next
+                        )
+                      }}
+                      className={`flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left hover:bg-accent ${
+                        checked ? 'bg-accent' : ''
+                      }`}
+                    >
+                      <span className="text-xs truncate flex-1 min-w-0">{ss.name}</span>
+                      {checked && <Check className="h-3.5 w-3.5 shrink-0 text-foreground" />}
+                    </button>
+                  )
+                })}
+              </PopoverContent>
+            </Popover>
+          )}
+        </div>
+
+        <div className="min-h-[60vh]">
+          {filteredSkills.length === 0 ? (
+            <p className="text-xs text-muted-foreground text-center py-6">
+              {skillSearch.trim()
+                ? `No skills matching "${skillSearch}"`
+                : 'No skills available'}
+            </p>
+          ) : (
+            <div className="grid grid-cols-2 gap-2 items-start py-1">
+              {pagedSkills.map((skill) => (
+                <DiscoverableSkillCard
+                  key={`${skill.skillsetId}/${skill.path}`}
+                  skill={skill}
+                  agentSlug={agentSlug}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-2">
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="h-7 w-7"
+              onClick={() => setSkillPage((p) => p - 1)}
+              disabled={skillPage === 0}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              {skillPage + 1} / {totalPages}
+            </span>
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="h-7 w-7"
+              onClick={() => setSkillPage((p) => p + 1)}
+              disabled={skillPage >= totalPages - 1}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/components/agents/agent-home/home-skills.tsx
+++ b/src/renderer/components/agents/agent-home/home-skills.tsx
@@ -38,7 +38,7 @@ export function HomeSkills({ agentSlug }: HomeSkillsProps) {
           <p className="text-xs mt-1">Skills teach your agent how to do specific tasks, like triaging emails. Your agent builds skills for you as it works.</p>
         </div>
       ) : (
-        <div className="mt-2 divide-y divide-border/50">
+        <div className="mt-2 divide-y divide-border/50" data-testid="installed-skills-list">
           {skills.map((skill) => (
             <SkillRow key={skill.path} skill={skill} agentSlug={agentSlug} />
           ))}
@@ -52,6 +52,7 @@ export function HomeSkills({ agentSlug }: HomeSkillsProps) {
             variant="ghost"
             size="sm"
             onClick={() => setBrowseOpen(true)}
+            data-testid="add-skill-button"
           >
             <Plus />
             Add Skill
@@ -80,7 +81,7 @@ function SkillRow({ skill, agentSlug }: { skill: ApiSkillWithStatus; agentSlug: 
 
   return (
     <>
-      <div role="button" tabIndex={0} className="group relative py-3 px-4 hover:bg-muted/50 transition-colors cursor-pointer" onClick={() => setFilesOpen(true)} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setFilesOpen(true) } }}>
+      <div role="button" tabIndex={0} data-testid="installed-skill-row" data-skill-path={skill.path} className="group relative py-3 px-4 hover:bg-muted/50 transition-colors cursor-pointer" onClick={() => setFilesOpen(true)} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setFilesOpen(true) } }}>
         <div className="flex items-center gap-2">
           <span className="text-xs font-medium truncate">{skill.name ?? skill.path}</span>
           <StatusBadge status={skill.status} />

--- a/src/renderer/components/agents/agent-home/home-skills.tsx
+++ b/src/renderer/components/agents/agent-home/home-skills.tsx
@@ -1,78 +1,43 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo } from 'react'
 import { Button } from '@renderer/components/ui/button'
-import { Input } from '@renderer/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
-import { Checkbox } from '@renderer/components/ui/checkbox'
-import { Search, ChevronLeft, ChevronRight, Filter, MoreVertical, FileCode, CloudUpload, GitPullRequest, Send, RefreshCw, Loader2 } from 'lucide-react'
-import { DiscoverableSkillCard } from '../discoverable-skill-card'
+import { MoreVertical, FileCode, CloudUpload, GitPullRequest, Send, RefreshCw, Loader2, Plus } from 'lucide-react'
 import { StatusBadge } from '../status-badge'
 import { SkillFilesDialog } from '../skill-files-dialog'
 import { SkillPublishDialog } from '../skill-publish-dialog'
 import { SkillPRDialog } from '../skill-pr-dialog'
 import { HomeCollapsible } from './home-collapsible'
+import { HomeSkillsBrowseDialog } from './home-skills-browse-dialog'
 import { useAgentSkills, useDiscoverableSkills, useUpdateSkill } from '@renderer/hooks/use-agent-skills'
 import { useSkillsetPublishMode } from '@renderer/hooks/use-skillsets'
 import { getReviewActionLabel, isPullRequestPublishMode } from '@renderer/lib/skillset-publish-ui'
 import type { ApiSkillWithStatus } from '@shared/lib/types/api'
-
-const SKILLS_PER_PAGE = 6
 
 interface HomeSkillsProps {
   agentSlug: string
 }
 
 export function HomeSkills({ agentSlug }: HomeSkillsProps) {
-  const [skillSearch, setSkillSearch] = useState('')
-  const [skillPage, setSkillPage] = useState(0)
-  const [selectedSkillsets, setSelectedSkillsets] = useState<Set<string> | null>(null)
+  const [browseOpen, setBrowseOpen] = useState(false)
 
   const { data: skillsData } = useAgentSkills(agentSlug)
   const skills = Array.isArray(skillsData) ? skillsData : []
   const { data: discoverableSkillsData } = useDiscoverableSkills(agentSlug)
-  const discoverableSkills = useMemo(() => Array.isArray(discoverableSkillsData) ? discoverableSkillsData : [], [discoverableSkillsData])
-
-  const skillsetList = useMemo(() => {
-    const seen = new Map<string, string>()
-    for (const s of discoverableSkills) {
-      if (!seen.has(s.skillsetId)) seen.set(s.skillsetId, s.skillsetName)
-    }
-    return Array.from(seen, ([id, name]) => ({ id, name }))
-  }, [discoverableSkills])
-
-  const activeSkillsets = useMemo(
-    () => selectedSkillsets ?? new Set(skillsetList.map((s) => s.id)),
-    [selectedSkillsets, skillsetList]
+  const discoverableSkills = useMemo(
+    () => (Array.isArray(discoverableSkillsData) ? discoverableSkillsData : []),
+    [discoverableSkillsData]
   )
 
-  const filteredSkills = useMemo(() => {
-    return discoverableSkills.filter((s) => {
-      if (!activeSkillsets.has(s.skillsetId)) return false
-      if (!skillSearch.trim()) return true
-      const q = skillSearch.toLowerCase()
-      return s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q)
-    })
-  }, [discoverableSkills, skillSearch, activeSkillsets])
-
-  const totalPages = Math.ceil(filteredSkills.length / SKILLS_PER_PAGE)
-  const pagedSkills = filteredSkills.slice(
-    skillPage * SKILLS_PER_PAGE,
-    (skillPage + 1) * SKILLS_PER_PAGE
-  )
-
-  useEffect(() => {
-    setSkillPage(0)
-  }, [skillSearch, selectedSkillsets])
+  const hasDiscoverable = discoverableSkills.length > 0
 
   return (
     <HomeCollapsible title="Skills">
-      {skills.length === 0 && discoverableSkills.length === 0 && (
+      {skills.length === 0 ? (
         <div className="mt-3 mx-4 rounded-lg border border-dashed p-4 text-muted-foreground">
           <p className="text-xs font-medium text-foreground">No skills yet</p>
           <p className="text-xs mt-1">Skills teach your agent how to do specific tasks, like triaging emails. Your agent builds skills for you as it works.</p>
         </div>
-      )}
-
-      {skills.length > 0 && (
+      ) : (
         <div className="mt-2 divide-y divide-border/50">
           {skills.map((skill) => (
             <SkillRow key={skill.path} skill={skill} agentSlug={agentSlug} />
@@ -80,111 +45,26 @@ export function HomeSkills({ agentSlug }: HomeSkillsProps) {
         </div>
       )}
 
-      {discoverableSkills.length > 0 && (
-        <>
-          {skills.length > 0 && (
-            <div className="border-t my-3" />
-          )}
-          <div className="flex items-center gap-1.5 mb-2 px-4">
-            <span className="text-xs text-muted-foreground">Discover</span>
-            <div className="ml-auto flex items-center gap-1.5">
-              {skillsetList.length > 0 && (
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <Button
-                      type="button"
-                      size="icon"
-                      variant="ghost"
-                      className="h-6 w-6 relative"
-                      title="Filter by skillset"
-                      aria-label="Filter by skillset"
-                    >
-                      <Filter className="h-3 w-3 text-muted-foreground" />
-                      {selectedSkillsets && selectedSkillsets.size < skillsetList.length && (
-                        <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-primary" />
-                      )}
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent align="end" className="w-56 p-3">
-                    <p className="text-xs font-medium mb-2">Filter by skillset</p>
-                    <div className="space-y-2">
-                      {skillsetList.map((ss) => (
-                        <label key={ss.id} className="flex items-center gap-2 cursor-pointer">
-                          <Checkbox
-                            checked={activeSkillsets.has(ss.id)}
-                            onCheckedChange={(checked) => {
-                              const next = new Set(activeSkillsets)
-                              if (checked) {
-                                next.add(ss.id)
-                              } else {
-                                next.delete(ss.id)
-                              }
-                              setSelectedSkillsets(
-                                next.size === skillsetList.length ? null : next
-                              )
-                            }}
-                          />
-                          <span className="text-xs truncate">{ss.name}</span>
-                        </label>
-                      ))}
-                    </div>
-                  </PopoverContent>
-                </Popover>
-              )}
-              <div className="relative w-36">
-                <Input
-                  value={skillSearch}
-                  onChange={(e) => setSkillSearch(e.target.value)}
-                  placeholder="Search..."
-                  className="h-6 text-xs pr-6"
-                />
-                <Search className="absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground pointer-events-none" />
-              </div>
-            </div>
-          </div>
-          <div className="divide-y divide-border/50 px-4">
-            {pagedSkills.map((skill) => (
-              <DiscoverableSkillCard
-                key={`${skill.skillsetId}/${skill.path}`}
-                skill={skill}
-                agentSlug={agentSlug}
-              />
-            ))}
-            {filteredSkills.length === 0 && skillSearch.trim() && (
-              <p className="text-xs text-muted-foreground text-center py-3">
-                No skills matching &ldquo;{skillSearch}&rdquo;
-              </p>
-            )}
-          </div>
-          {totalPages > 1 && (
-            <div className="flex items-center justify-center gap-2 mt-3">
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className="h-6 w-6"
-                onClick={() => setSkillPage((p) => p - 1)}
-                disabled={skillPage === 0}
-              >
-                <ChevronLeft className="h-3.5 w-3.5" />
-              </Button>
-              <span className="text-xs text-muted-foreground">
-                {skillPage + 1} / {totalPages}
-              </span>
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className="h-6 w-6"
-                onClick={() => setSkillPage((p) => p + 1)}
-                disabled={skillPage >= totalPages - 1}
-              >
-                <ChevronRight className="h-3.5 w-3.5" />
-              </Button>
-            </div>
-          )}
-        </>
+      {hasDiscoverable && (
+        <div className="flex justify-end mt-3 px-4 pb-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setBrowseOpen(true)}
+          >
+            <Plus />
+            Add Skill
+          </Button>
+        </div>
       )}
+
+      <HomeSkillsBrowseDialog
+        open={browseOpen}
+        onOpenChange={setBrowseOpen}
+        agentSlug={agentSlug}
+        discoverableSkills={discoverableSkills}
+      />
     </HomeCollapsible>
   )
 }

--- a/src/renderer/components/agents/discoverable-skill-card.tsx
+++ b/src/renderer/components/agents/discoverable-skill-card.tsx
@@ -42,14 +42,14 @@ export function DiscoverableSkillCard({ skill, agentSlug }: DiscoverableSkillCar
 
   return (
     <>
-      <div className="rounded-lg border bg-background p-3">
+      <div className="rounded-lg border bg-background p-3" data-testid="discoverable-skill-card" data-skill-name={skill.name}>
         <div className="flex items-start gap-3">
           <div className="min-w-0 flex-1">
             <div className="text-xs font-medium truncate">{skill.name}</div>
             <div className="flex items-center gap-1.5 min-w-0 mt-0.5">
-              <span className="text-[11px] text-muted-foreground truncate">{skill.skillsetName}</span>
-              <span className="text-[11px] text-muted-foreground shrink-0">·</span>
-              <span className="text-[11px] text-muted-foreground shrink-0">v{skill.version}</span>
+              <span className="text-xs text-muted-foreground truncate">{skill.skillsetName}</span>
+              <span className="text-xs text-muted-foreground shrink-0">·</span>
+              <span className="text-xs text-muted-foreground shrink-0">v{skill.version}</span>
             </div>
           </div>
           <Button
@@ -69,7 +69,7 @@ export function DiscoverableSkillCard({ skill, agentSlug }: DiscoverableSkillCar
             )}
           </Button>
         </div>
-        <p className="text-[11px] text-muted-foreground mt-3 line-clamp-2">
+        <p className="text-xs text-muted-foreground mt-3 line-clamp-2">
           {skill.description}
         </p>
       </div>

--- a/src/renderer/components/agents/discoverable-skill-card.tsx
+++ b/src/renderer/components/agents/discoverable-skill-card.tsx
@@ -42,33 +42,36 @@ export function DiscoverableSkillCard({ skill, agentSlug }: DiscoverableSkillCar
 
   return (
     <>
-      <div className="flex items-start gap-3 p-3 rounded-lg bg-muted/50 hover:bg-muted transition-colors">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <p className="text-sm font-medium truncate">{skill.name}</p>
-            <span className="text-xs text-muted-foreground">v{skill.version}</span>
+      <div className="rounded-lg border bg-background p-3">
+        <div className="flex items-start gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="text-xs font-medium truncate">{skill.name}</div>
+            <div className="flex items-center gap-1.5 min-w-0 mt-0.5">
+              <span className="text-[11px] text-muted-foreground truncate">{skill.skillsetName}</span>
+              <span className="text-[11px] text-muted-foreground shrink-0">·</span>
+              <span className="text-[11px] text-muted-foreground shrink-0">v{skill.version}</span>
+            </div>
           </div>
-          <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
-            {skill.description}
-          </p>
-          <p className="text-xs text-muted-foreground mt-1">
-            From: {skill.skillsetName}
-          </p>
+          <Button
+            type="button"
+            size="icon"
+            variant="outline"
+            className="h-7 w-7 shrink-0"
+            onClick={handleInstall}
+            disabled={installSkill.isPending}
+            aria-label={`Install ${skill.name}`}
+            title="Install skill"
+          >
+            {installSkill.isPending ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Plus className="h-3.5 w-3.5" />
+            )}
+          </Button>
         </div>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="h-7 w-7 shrink-0"
-          onClick={handleInstall}
-          disabled={installSkill.isPending}
-          title="Install skill"
-        >
-          {installSkill.isPending ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Plus className="h-4 w-4" />
-          )}
-        </Button>
+        <p className="text-[11px] text-muted-foreground mt-3 line-clamp-2">
+          {skill.description}
+        </p>
       </div>
 
       {showInstallDialog && skill.requiredEnvVars && (

--- a/src/renderer/components/agents/skill-install-dialog.tsx
+++ b/src/renderer/components/agents/skill-install-dialog.tsx
@@ -44,7 +44,7 @@ export function SkillInstallDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent data-testid="skill-install-dialog">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>Install {skillName}</DialogTitle>


### PR DESCRIPTION
## Summary
- Replaces the inline Discover section in the agent home Skills card with an **Add Skill** button that opens a dedicated **Browse & add skills from your team** dialog. Mirrors the placement and styling of the existing Add Connection / Add Mount actions.
- Restyles `DiscoverableSkillCard` to a boxed two-column grid card matching the connections directory layout (clean border + background, name on top, \`skillset · vX.Y.Z\` sub-line, two-line clamped description, outlined \`+\` install button).
- The new dialog includes search, a skillset filter popover (model-picker style row buttons with a check on the right), pagination, and a stable min-height so filtering doesn't reflow the dialog.

## Test plan
- [ ] Open an agent in the home view; with no skillsets connected, the **Add Skill** button does not appear.
- [ ] With at least one skillset connected and discoverable skills available, the **Add Skill** button appears in the Skills card footer and opens the dialog.
- [ ] Search filters skills by name + description.
- [ ] Filter popover allows toggling skillset visibility; the filter indicator dot shows when a subset is selected.
- [ ] Installing a skill from the dialog still triggers the env-var prompt for skills that require it.
- [ ] Closing the dialog resets search/filter/page state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)