### PR TITLE
style: add contextual labels to trigger timestamps

### DIFF
--- a/src/renderer/components/agents/agent-home/home-triggers.tsx
+++ b/src/renderer/components/agents/agent-home/home-triggers.tsx
@@ -289,7 +289,10 @@ function CronRow({
       subtitleLeft={<span>cron · {humanizedCron ?? 'One-time'}</span>}
       subtitleRight={
         task.nextExecutionAt && !isPaused ? (
-          <span className="shrink-0">{formatRelativeTime(task.nextExecutionAt)}</span>
+          <span className="shrink-0">
+            <span className="text-muted-foreground">next run </span>
+            {formatRelativeTime(task.nextExecutionAt)}
+          </span>
         ) : null
       }
       isPaused={isPaused}
@@ -333,7 +336,14 @@ function WebhookRow({
       subtitleLeft={<span className="truncate lowercase">webhook · {trigger.triggerType}</span>}
       subtitleRight={
         <span className="shrink-0">
-          {formatRelativeTime(trigger.lastFiredAt) ?? 'Never fired'}
+          {formatRelativeTime(trigger.lastFiredAt) ? (
+            <>
+              <span className="text-muted-foreground">last run </span>
+              {formatRelativeTime(trigger.lastFiredAt)}
+            </>
+          ) : (
+            'No runs yet'
+          )}
         </span>
       }
       isPaused={isPaused}


### PR DESCRIPTION
## Summary
- Adds muted `next run` prefix label to cron card timestamps (e.g. `next run in 1d`)
- Adds muted `last run` prefix label to webhook card timestamps (e.g. `last run 2h ago`)
- Changes `Never fired` → `No runs yet` for webhooks with no history

## Test plan
- [ ] Open an agent with scheduled cron tasks — confirm `next run in Xd/Xh/Xm` appears in the subtitle
- [ ] Open an agent with webhook triggers — confirm `last run Xd/Xh/Xm ago` appears when fired
- [ ] Confirm a webhook with no history shows `No runs yet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)