### PR TITLE
fix: clean up all eslint warnings

### DIFF
--- a/src/api/middleware/auth.ts
+++ b/src/api/middleware/auth.ts
@@ -17,7 +17,7 @@ async function getAuthLazy() {
 
 // Re-export from shared types so existing consumers (webhook-triggers.ts etc.) keep working
 export { type AgentRole, ROLE_HIERARCHY, hasMinRole } from '@shared/lib/types/agent'
-import { type AgentRole, ROLE_HIERARCHY, hasMinRole } from '@shared/lib/types/agent'
+import { type AgentRole, hasMinRole } from '@shared/lib/types/agent'
 
 /**
  * Authenticated — verifies user session and attaches user to context.

--- a/src/api/routes/policies.test.ts
+++ b/src/api/routes/policies.test.ts
@@ -9,7 +9,6 @@ const mockAll = vi.fn()
 const mockWhere = vi.fn()
 const mockDbFrom = vi.fn()
 const mockInsertValues = vi.fn()
-const mockOnConflictDoUpdate = vi.fn()
 
 const mockDeleteWhere = vi.fn()
 const mockDeleteRun = vi.fn()

--- a/src/renderer/components/settings/scope-policy-editor.tsx
+++ b/src/renderer/components/settings/scope-policy-editor.tsx
@@ -56,24 +56,31 @@ export function ScopePolicyEditor({
 
   // Get scopes from the scope map for this toolkit
   const provider = SCOPE_MAPS[toolkit]
-  const allScopes = provider
-    ? Array.isArray(provider.allScopes)
-      ? provider.allScopes
-      : Object.values(provider.allScopes).flat()
-    : []
+  const allScopes = useMemo(
+    () =>
+      provider
+        ? Array.isArray(provider.allScopes)
+          ? provider.allScopes
+          : Object.values(provider.allScopes).flat()
+        : [],
+    [provider],
+  )
 
   // For each scope, prefer the curated description; otherwise borrow the
   // first endpoint description that mentions this scope.
-  const curated = SCOPE_DESCRIPTIONS[toolkit] ?? {}
-  const scopeDescriptions: Record<string, string> = {}
-  for (const scope of allScopes) {
-    const desc =
-      curated[scope] ??
-      provider?.scopeMap.find(
-        (e) => e.description && e.sufficientScopes.includes(scope),
-      )?.description
-    if (desc) scopeDescriptions[scope] = desc
-  }
+  const scopeDescriptions = useMemo(() => {
+    const curated = SCOPE_DESCRIPTIONS[toolkit] ?? {}
+    const descs: Record<string, string> = {}
+    for (const scope of allScopes) {
+      const desc =
+        curated[scope] ??
+        provider?.scopeMap.find(
+          (e) => e.description && e.sufficientScopes.includes(scope),
+        )?.description
+      if (desc) descs[scope] = desc
+    }
+    return descs
+  }, [allScopes, toolkit, provider])
 
   // Fetch existing policies
   useEffect(() => {
@@ -111,7 +118,7 @@ export function ScopePolicyEditor({
         setPolicies(allScopes.map((scope) => ({ scope, decision: 'default' })))
         setLoading(false)
       })
-  }, [open, accountId, toolkit])
+  }, [open, accountId, allScopes])
 
   // Filtered policies
   const filteredPolicies = useMemo(() => {

--- a/src/renderer/components/settings/tool-policy-editor.tsx
+++ b/src/renderer/components/settings/tool-policy-editor.tsx
@@ -79,7 +79,7 @@ export function ToolPolicyEditor({
         setPolicies(tools.map((tool) => ({ toolName: tool.name, decision: 'default' })))
         setLoading(false)
       })
-  }, [open, mcpId])
+  }, [open, mcpId, tools])
 
   // Filtered policies
   const filteredPolicies = useMemo(() => {


### PR DESCRIPTION
## Summary
- Remove unused `ROLE_HIERARCHY` import in `auth.ts` (re-export on prior line covers it)
- Remove unused `mockOnConflictDoUpdate` mock in `policies.test.ts`
- Memoize `allScopes` and `scopeDescriptions` in `scope-policy-editor.tsx` to fix `react-hooks/exhaustive-deps` warnings
- Add missing `tools` dependency to useEffect in `tool-policy-editor.tsx`

Lint now passes with 0 warnings.

## Test plan
- [x] `npx eslint 'src/**/*.{ts,tsx}'` — 0 warnings, 0 errors
- [x] `npx tsc --noEmit` — clean
- [x] Verified all `ToolPolicyEditor` call sites pass stable `tools` references (no re-render loop risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)