### PR TITLE
fix(triggers): kick TriggerManager after creating webhook trigger

### DIFF
--- a/src/shared/lib/scheduler/trigger-manager.ts
+++ b/src/shared/lib/scheduler/trigger-manager.ts
@@ -111,7 +111,7 @@ class TriggerManager {
     return this.isRunning
   }
 
-  private async pollAndProcess(): Promise<void> {
+  async pollAndProcess(): Promise<void> {
     if (this.isProcessing) return
     this.isProcessing = true
 

--- a/src/shared/lib/scheduler/trigger-manager.ts
+++ b/src/shared/lib/scheduler/trigger-manager.ts
@@ -111,6 +111,10 @@ class TriggerManager {
     return this.isRunning
   }
 
+  isRealtimeActive(): boolean {
+    return this.realtimeClient?.isActive() ?? false
+  }
+
   async pollAndProcess(): Promise<void> {
     if (this.isProcessing) return
     this.isProcessing = true

--- a/src/shared/lib/services/webhook-trigger-service.ts
+++ b/src/shared/lib/services/webhook-trigger-service.ts
@@ -108,6 +108,8 @@ export async function createWebhookTrigger(params: CreateWebhookTriggerParams): 
     agentSlug: params.agentSlug,
   })
 
+  // Cold-start fix: a host that booted with 0 active triggers never
+  // subscribed Realtime. Lazy import avoids the circular dep.
   void import('@shared/lib/scheduler/trigger-manager').then(({ triggerManager }) => {
     if (!triggerManager.isRealtimeActive()) {
       void triggerManager.pollAndProcess()

--- a/src/shared/lib/services/webhook-trigger-service.ts
+++ b/src/shared/lib/services/webhook-trigger-service.ts
@@ -108,6 +108,12 @@ export async function createWebhookTrigger(params: CreateWebhookTriggerParams): 
     agentSlug: params.agentSlug,
   })
 
+  // Re-poll so a host that booted with 0 active triggers subscribes to
+  // Realtime now. Lazy import avoids circular dependency.
+  void import('@shared/lib/scheduler/trigger-manager').then(({ triggerManager }) =>
+    triggerManager.pollAndProcess(),
+  )
+
   return id
 }
 

--- a/src/shared/lib/services/webhook-trigger-service.ts
+++ b/src/shared/lib/services/webhook-trigger-service.ts
@@ -108,11 +108,6 @@ export async function createWebhookTrigger(params: CreateWebhookTriggerParams): 
     agentSlug: params.agentSlug,
   })
 
-  // If the host booted with 0 active triggers, TriggerManager early-returned
-  // without subscribing to Realtime. Kick it now so this trigger actually
-  // fires. Skip when Realtime is already active — events will be pushed in
-  // through the existing subscription, no need for an extra poll.
-  // Lazy import avoids the trigger-manager <-> webhook-trigger-service cycle.
   void import('@shared/lib/scheduler/trigger-manager').then(({ triggerManager }) => {
     if (!triggerManager.isRealtimeActive()) {
       void triggerManager.pollAndProcess()

--- a/src/shared/lib/services/webhook-trigger-service.ts
+++ b/src/shared/lib/services/webhook-trigger-service.ts
@@ -108,11 +108,16 @@ export async function createWebhookTrigger(params: CreateWebhookTriggerParams): 
     agentSlug: params.agentSlug,
   })
 
-  // Re-poll so a host that booted with 0 active triggers subscribes to
-  // Realtime now. Lazy import avoids circular dependency.
-  void import('@shared/lib/scheduler/trigger-manager').then(({ triggerManager }) =>
-    triggerManager.pollAndProcess(),
-  )
+  // If the host booted with 0 active triggers, TriggerManager early-returned
+  // without subscribing to Realtime. Kick it now so this trigger actually
+  // fires. Skip when Realtime is already active — events will be pushed in
+  // through the existing subscription, no need for an extra poll.
+  // Lazy import avoids the trigger-manager <-> webhook-trigger-service cycle.
+  void import('@shared/lib/scheduler/trigger-manager').then(({ triggerManager }) => {
+    if (!triggerManager.isRealtimeActive()) {
+      void triggerManager.pollAndProcess()
+    }
+  })
 
   return id
 }


### PR DESCRIPTION
## Problem

A SuperAgent host that booted with **zero active webhook triggers in SQLite** permanently ignored every webhook trigger created afterwards, until the host process restarted.

Confirmed in production: a fresh cloud deployment had 2 active triggers in SQLite for Composio trigger \`ti_5_mPIG08ZVZb\`, both with \`fire_count=0\`. \`webhook_events\` had unclaimed rows. The host's logs showed exactly one \`[TriggerManager] Starting...\` line, no \`Realtime subscription active\`, no \`Processing N event(s)\`. Restarting the container immediately resolved it (boot saw 2 active triggers, subscribed Realtime, claimed queued events).

## Root cause

\`TriggerManager.start()\` is called once at boot from \`startup.ts\`. It calls \`pollAndProcess()\` exactly once. \`pollAndProcess()\` early-returns when \`getDistinctPlatformMemberIdsForActiveTriggers()\` returns an empty array (line 122):

\`\`\`typescript
const memberIds = getDistinctPlatformMemberIdsForActiveTriggers()
if (memberIds.length === 0) return
\`\`\`

So Realtime is never subscribed. Subsequent \`createWebhookTrigger()\` calls insert into SQLite but never re-trigger the manager → events stack up in \`webhook_events\` with no consumer.

## Fix

After \`createWebhookTrigger()\` inserts the row, fire-and-forget a \`triggerManager.pollAndProcess()\`. The manager re-evaluates state, finds the new trigger, claims pending events, and subscribes to Realtime.

- \`pollAndProcess()\` already guards re-entry via \`isProcessing\` and only subscribes when \`!this.realtimeClient?.isActive()\`, so concurrent creations are safe.
- Lazy \`import()\` avoids the \`trigger-manager.ts\` ↔ \`webhook-trigger-service.ts\` circular dependency.
- \`pollAndProcess\` flipped from \`private\` to \`public\` for the external caller.

## Diff

2 files, 7 insertions, 1 deletion.

\`\`\`
src/shared/lib/scheduler/trigger-manager.ts        |  2 +-
src/shared/lib/services/webhook-trigger-service.ts |  6 ++++++
\`\`\`

## Test plan

- [ ] On a fresh host (empty \`webhook_triggers\`), create a trigger via the agent → verify host log shows \`[TriggerManager] Realtime subscription active\` and trigger fires on next event without restart.
- [ ] On a host with existing triggers, behavior unchanged (boot subscribes, second \`createWebhookTrigger\` is a no-op kick due to \`isProcessing\` / active client guards).
- [ ] Existing \`trigger-manager.test.ts\` and \`webhook-trigger-service.test.ts\` still pass.

## Note for ops

The currently stuck cloud host can be unblocked with \`docker compose restart superagent\` (no need to wait for this PR). After this PR ships, no manual restart needed for future cold-start cases.


Made with [Cursor](https://cursor.com)