### PR TITLE
feat(host-browser): add platform-managed Browserbase provider

### DIFF
--- a/src/main/host-browser/index.ts
+++ b/src/main/host-browser/index.ts
@@ -1,6 +1,7 @@
 import { getSettings } from '@shared/lib/config/settings'
 import { ChromeProvider } from './chrome-provider'
 import { BrowserbaseProvider } from './browserbase-provider'
+import { PlatformBrowserProvider } from './platform-provider'
 import type { HostBrowserProvider, HostBrowserProviderStatus } from './types'
 
 export type { HostBrowserProvider, HostBrowserProviderStatus, BrowserConnectionInfo } from './types'
@@ -9,10 +10,12 @@ export type { HostBrowserProviderId } from './types'
 // Singleton instances
 const chromeProvider = new ChromeProvider()
 const browserbaseProvider = new BrowserbaseProvider()
+const platformBrowserProvider = new PlatformBrowserProvider()
 
 const providerMap: Record<string, HostBrowserProvider> = {
   chrome: chromeProvider,
   browserbase: browserbaseProvider,
+  platform: platformBrowserProvider,
 }
 
 /**
@@ -31,14 +34,18 @@ export function getActiveProvider(): HostBrowserProvider | null {
  * Used by the settings API to populate the provider dropdown.
  */
 export function detectAllProviders(): HostBrowserProviderStatus[] {
-  return [chromeProvider.detect(), browserbaseProvider.detect()]
+  return [chromeProvider.detect(), browserbaseProvider.detect(), platformBrowserProvider.detect()]
 }
 
 /**
  * Stop all provider instances. Used during graceful shutdown.
  */
 export async function stopAllProviders(): Promise<void> {
-  await Promise.all([chromeProvider.stopAll(), browserbaseProvider.stopAll()])
+  await Promise.all([
+    chromeProvider.stopAll(),
+    browserbaseProvider.stopAll(),
+    platformBrowserProvider.stopAll(),
+  ])
 }
 
 /**
@@ -46,6 +53,7 @@ export async function stopAllProviders(): Promise<void> {
  */
 export function setOnExternalClose(callback: (instanceId: string) => void): void {
   chromeProvider.onExternalClose = callback
-  // Browserbase doesn't fire external close events, but wire it up for consistency
+  // Browserbase / platform don't fire external close events, but wire up for consistency
   browserbaseProvider.onExternalClose = callback
+  platformBrowserProvider.onExternalClose = callback
 }

--- a/src/main/host-browser/platform-provider.ts
+++ b/src/main/host-browser/platform-provider.ts
@@ -1,0 +1,302 @@
+import fs from 'fs'
+import path from 'path'
+import { getSettings } from '@shared/lib/config/settings'
+import { getDataDir } from '@shared/lib/config/data-dir'
+import { getPlatformAccessToken } from '@shared/lib/services/platform-auth-service'
+import { getPlatformProxyBaseUrl } from '@shared/lib/platform-auth/config'
+import type { HostBrowserProvider, HostBrowserProviderStatus, BrowserConnectionInfo, BrowserDebugInfo } from './types'
+
+/**
+ * Platform-managed Browserbase provider.
+ *
+ * Logically a separate provider — the user is signed in to the platform and
+ * the platform's proxy holds the Browserbase API key + project id. The user
+ * does NOT configure any Browserbase credentials themselves; they just need
+ * a valid platform session.
+ *
+ * Wire-protocol notes (intentionally different from `BrowserbaseProvider`):
+ *  - Base URL is `${platformProxy}/v1/browserbase/*`, not `api.browserbase.com`.
+ *  - Auth header is `Authorization: Bearer <platformToken>`, not `X-BB-API-Key`.
+ *  - `projectId` is omitted from request bodies; the proxy injects the real
+ *    project id server-side from its env, so clients can't pin a project.
+ *  - Context map is persisted to a separate file (`platform-browserbase-contexts.json`)
+ *    so it never collides with the BYOK BrowserbaseProvider's map.
+ *
+ * Note: the Browserbase debug `wsUrl` returned by the proxy still points at
+ * `wss://connect.browserbase.com/...`. CDP traffic flows directly to
+ * Browserbase, not through the platform proxy — the proxy only mediates the
+ * REST control plane (create / inspect / release session, create context).
+ */
+const CONTEXTS_FILE = 'platform-browserbase-contexts.json'
+
+interface BrowserbaseSession {
+  id: string
+  connectUrl: string
+  status: string
+  keepAlive: boolean
+}
+
+interface BrowserbaseDebugResponse {
+  wsUrl?: string
+  pages?: Array<{
+    id: string
+    url: string
+    debuggerUrl?: string
+    debuggerFullscreenUrl?: string
+  }>
+}
+
+export class PlatformBrowserProvider implements HostBrowserProvider {
+  readonly id = 'platform' as const
+  readonly name = 'Platform'
+
+  /** Maps instanceId → Browserbase session ID (proxied through platform) */
+  private sessions: Map<string, string> = new Map()
+
+  onExternalClose: ((instanceId: string) => void) | null = null
+
+  detect(): HostBrowserProviderStatus {
+    if (!getPlatformAccessToken()) {
+      return {
+        id: this.id,
+        name: this.name,
+        available: false,
+        reason: 'Sign in to Platform to use this provider',
+      }
+    }
+    return { id: this.id, name: this.name, available: true }
+  }
+
+  async launch(instanceId: string, _options?: Record<string, string>, agentId?: string): Promise<BrowserConnectionInfo> {
+    const token = getPlatformAccessToken()
+    if (!token) {
+      throw new Error('Not signed in to Platform — cannot use platform-managed Browserbase')
+    }
+
+    // Reuse a still-running session if we have one
+    const existingSessionId = this.sessions.get(instanceId)
+    if (existingSessionId) {
+      try {
+        const session = await this.fetchSession(existingSessionId, token)
+        if (session.status === 'RUNNING') {
+          const debugUrl = await this.getDebugBrowserUrl(existingSessionId, token)
+          if (debugUrl) {
+            console.log(`[PlatformBrowserProvider] Reusing session ${existingSessionId} for instance ${instanceId}`)
+            return { cdpUrl: debugUrl }
+          }
+        }
+      } catch {
+        // Session no longer valid — drop and create a fresh one below
+      }
+      this.sessions.delete(instanceId)
+    }
+
+    // Persistent context per agent (cookies / storage carried across sessions)
+    const contextKey = agentId || instanceId
+    const contextId = await this.getOrCreateContext(contextKey, token)
+
+    const settings = getSettings()
+    const browserSettings: Record<string, unknown> = {
+      context: { id: contextId, persist: true },
+    }
+
+    if (settings.app?.browserbaseAdvancedStealth) {
+      browserSettings.advancedStealth = true
+      if (settings.app.browserbaseStealthOs) {
+        browserSettings.os = settings.app.browserbaseStealthOs
+      }
+    }
+
+    // No `projectId` here — the platform proxy injects it server-side.
+    const sessionPayload: Record<string, unknown> = { keepAlive: true, browserSettings }
+
+    if (settings.app?.browserbaseProxies) {
+      const { browserbaseProxyCountry, browserbaseProxyCity, browserbaseProxyState } = settings.app
+      if (browserbaseProxyCountry || browserbaseProxyCity || browserbaseProxyState) {
+        const geolocation: Record<string, string> = {}
+        if (browserbaseProxyCountry) geolocation.country = browserbaseProxyCountry
+        if (browserbaseProxyState) geolocation.state = browserbaseProxyState
+        if (browserbaseProxyCity) geolocation.city = browserbaseProxyCity
+        sessionPayload.proxies = [{ type: 'browserbase', geolocation }]
+      } else {
+        sessionPayload.proxies = true
+      }
+    }
+
+    const response = await fetch(`${this.proxyBase()}/sessions`, {
+      method: 'POST',
+      headers: this.authHeaders(token, true),
+      body: JSON.stringify(sessionPayload),
+    })
+
+    if (!response.ok) {
+      const body = await response.text()
+      throw new Error(`Failed to create platform Browserbase session: ${response.status} ${body}`)
+    }
+
+    const session = await response.json() as BrowserbaseSession
+    this.sessions.set(instanceId, session.id)
+    console.log(`[PlatformBrowserProvider] Created session ${session.id} for instance ${instanceId} (keepAlive: ${session.keepAlive})`)
+
+    const debugUrl = await this.getDebugBrowserUrl(session.id, token)
+    if (debugUrl) {
+      return { cdpUrl: debugUrl }
+    }
+
+    // Fallback to single-use connectUrl if the debug endpoint didn't yield one
+    return { cdpUrl: session.connectUrl }
+  }
+
+  async getDebugInfo(instanceId: string): Promise<BrowserDebugInfo | null> {
+    const sessionId = this.sessions.get(instanceId)
+    if (!sessionId) return null
+
+    const token = getPlatformAccessToken()
+    if (!token) return null
+
+    const response = await fetch(`${this.proxyBase()}/sessions/${sessionId}/debug`, {
+      headers: this.authHeaders(token),
+    })
+
+    if (!response.ok) {
+      console.error(`[PlatformBrowserProvider] Debug endpoint returned ${response.status} for session ${sessionId}`)
+      return null
+    }
+
+    const debug = await response.json() as BrowserbaseDebugResponse
+    if (!debug.pages || debug.pages.length === 0) return null
+
+    // Page-level CDP wsUrls connect directly to Browserbase, not through the proxy.
+    const pages = debug.pages.map((page) => ({
+      id: page.id,
+      url: page.url,
+      wsUrl: `wss://connect.browserbase.com/debug/${sessionId}/devtools/page/${page.id}`,
+    }))
+
+    return { pages }
+  }
+
+  async stop(instanceId: string): Promise<void> {
+    const sessionId = this.sessions.get(instanceId)
+    if (!sessionId) return
+
+    this.sessions.delete(instanceId)
+
+    const token = getPlatformAccessToken()
+    if (!token) return
+
+    try {
+      await fetch(`${this.proxyBase()}/sessions/${sessionId}`, {
+        method: 'POST',
+        headers: this.authHeaders(token, true),
+        // No projectId — the proxy injects it server-side.
+        body: JSON.stringify({ status: 'REQUEST_RELEASE' }),
+      })
+      console.log(`[PlatformBrowserProvider] Released session ${sessionId}`)
+    } catch (error) {
+      console.error(`[PlatformBrowserProvider] Error releasing session ${sessionId}:`, error)
+    }
+  }
+
+  async stopAll(): Promise<void> {
+    const instanceIds = Array.from(this.sessions.keys())
+    await Promise.all(instanceIds.map((id) => this.stop(id)))
+  }
+
+  isRunning(instanceId?: string): boolean {
+    if (instanceId) {
+      return this.sessions.has(instanceId)
+    }
+    return this.sessions.size > 0
+  }
+
+  /**
+   * Resolve the platform proxy URL for Browserbase routes.
+   * Read fresh on every call so users that switch platform endpoints (e.g.
+   * staging ↔ production) don't need to restart the app.
+   */
+  private proxyBase(): string {
+    const base = getPlatformProxyBaseUrl()
+    if (!base) {
+      throw new Error('Platform proxy URL is not configured')
+    }
+    return `${base}/v1/browserbase`
+  }
+
+  private authHeaders(token: string, json = false): Record<string, string> {
+    const headers: Record<string, string> = { Authorization: `Bearer ${token}` }
+    if (json) headers['Content-Type'] = 'application/json'
+    return headers
+  }
+
+  private loadContextMap(): Record<string, string> {
+    try {
+      const filePath = path.join(getDataDir(), CONTEXTS_FILE)
+      return JSON.parse(fs.readFileSync(filePath, 'utf-8'))
+    } catch {
+      return {}
+    }
+  }
+
+  private saveContextMap(map: Record<string, string>): void {
+    const filePath = path.join(getDataDir(), CONTEXTS_FILE)
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, JSON.stringify(map, null, 2))
+  }
+
+  private async getOrCreateContext(contextKey: string, token: string): Promise<string> {
+    const map = this.loadContextMap()
+    if (map[contextKey]) {
+      return map[contextKey]
+    }
+
+    const response = await fetch(`${this.proxyBase()}/contexts`, {
+      method: 'POST',
+      headers: this.authHeaders(token, true),
+      // No projectId in body — proxy fills it.
+      body: JSON.stringify({}),
+    })
+
+    if (!response.ok) {
+      const body = await response.text()
+      throw new Error(`Failed to create platform Browserbase context: ${response.status} ${body}`)
+    }
+
+    const context = await response.json() as { id: string }
+    map[contextKey] = context.id
+    this.saveContextMap(map)
+    console.log(`[PlatformBrowserProvider] Created context ${context.id} for ${contextKey}`)
+    return context.id
+  }
+
+  private async getDebugBrowserUrl(sessionId: string, token: string): Promise<string | null> {
+    try {
+      const response = await fetch(`${this.proxyBase()}/sessions/${sessionId}/debug`, {
+        headers: this.authHeaders(token),
+      })
+
+      if (!response.ok) {
+        console.error(`[PlatformBrowserProvider] Debug endpoint returned ${response.status} for session ${sessionId}`)
+        return null
+      }
+
+      const debug = await response.json() as BrowserbaseDebugResponse
+      return debug.wsUrl || null
+    } catch (err) {
+      console.error('[PlatformBrowserProvider] Failed to get debug URL:', err)
+      return null
+    }
+  }
+
+  private async fetchSession(sessionId: string, token: string): Promise<BrowserbaseSession> {
+    const response = await fetch(`${this.proxyBase()}/sessions/${sessionId}`, {
+      headers: this.authHeaders(token),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to get session: ${response.status}`)
+    }
+
+    return response.json() as Promise<BrowserbaseSession>
+  }
+}

--- a/src/main/host-browser/platform-provider.ts
+++ b/src/main/host-browser/platform-provider.ts
@@ -6,27 +6,6 @@ import { getPlatformAccessToken } from '@shared/lib/services/platform-auth-servi
 import { getPlatformProxyBaseUrl } from '@shared/lib/platform-auth/config'
 import type { HostBrowserProvider, HostBrowserProviderStatus, BrowserConnectionInfo, BrowserDebugInfo } from './types'
 
-/**
- * Platform-managed Browserbase provider.
- *
- * Logically a separate provider — the user is signed in to the platform and
- * the platform's proxy holds the Browserbase API key + project id. The user
- * does NOT configure any Browserbase credentials themselves; they just need
- * a valid platform session.
- *
- * Wire-protocol notes (intentionally different from `BrowserbaseProvider`):
- *  - Base URL is `${platformProxy}/v1/browserbase/*`, not `api.browserbase.com`.
- *  - Auth header is `Authorization: Bearer <platformToken>`, not `X-BB-API-Key`.
- *  - `projectId` is omitted from request bodies; the proxy injects the real
- *    project id server-side from its env, so clients can't pin a project.
- *  - Context map is persisted to a separate file (`platform-browserbase-contexts.json`)
- *    so it never collides with the BYOK BrowserbaseProvider's map.
- *
- * Note: the Browserbase debug `wsUrl` returned by the proxy still points at
- * `wss://connect.browserbase.com/...`. CDP traffic flows directly to
- * Browserbase, not through the platform proxy — the proxy only mediates the
- * REST control plane (create / inspect / release session, create context).
- */
 const CONTEXTS_FILE = 'platform-browserbase-contexts.json'
 
 interface BrowserbaseSession {
@@ -86,12 +65,11 @@ export class PlatformBrowserProvider implements HostBrowserProvider {
           }
         }
       } catch {
-        // Session no longer valid — drop and create a fresh one below
+        // Session no longer valid
       }
       this.sessions.delete(instanceId)
     }
 
-    // Persistent context per agent (cookies / storage carried across sessions)
     const contextKey = agentId || instanceId
     const contextId = await this.getOrCreateContext(contextKey, token)
 
@@ -107,7 +85,6 @@ export class PlatformBrowserProvider implements HostBrowserProvider {
       }
     }
 
-    // No `projectId` here — the platform proxy injects it server-side.
     const sessionPayload: Record<string, unknown> = { keepAlive: true, browserSettings }
 
     if (settings.app?.browserbaseProxies) {
@@ -143,7 +120,6 @@ export class PlatformBrowserProvider implements HostBrowserProvider {
       return { cdpUrl: debugUrl }
     }
 
-    // Fallback to single-use connectUrl if the debug endpoint didn't yield one
     return { cdpUrl: session.connectUrl }
   }
 
@@ -166,7 +142,6 @@ export class PlatformBrowserProvider implements HostBrowserProvider {
     const debug = await response.json() as BrowserbaseDebugResponse
     if (!debug.pages || debug.pages.length === 0) return null
 
-    // Page-level CDP wsUrls connect directly to Browserbase, not through the proxy.
     const pages = debug.pages.map((page) => ({
       id: page.id,
       url: page.url,
@@ -189,7 +164,6 @@ export class PlatformBrowserProvider implements HostBrowserProvider {
       await fetch(`${this.proxyBase()}/sessions/${sessionId}`, {
         method: 'POST',
         headers: this.authHeaders(token, true),
-        // No projectId — the proxy injects it server-side.
         body: JSON.stringify({ status: 'REQUEST_RELEASE' }),
       })
       console.log(`[PlatformBrowserProvider] Released session ${sessionId}`)
@@ -210,11 +184,6 @@ export class PlatformBrowserProvider implements HostBrowserProvider {
     return this.sessions.size > 0
   }
 
-  /**
-   * Resolve the platform proxy URL for Browserbase routes.
-   * Read fresh on every call so users that switch platform endpoints (e.g.
-   * staging ↔ production) don't need to restart the app.
-   */
   private proxyBase(): string {
     const base = getPlatformProxyBaseUrl()
     if (!base) {
@@ -253,7 +222,6 @@ export class PlatformBrowserProvider implements HostBrowserProvider {
     const response = await fetch(`${this.proxyBase()}/contexts`, {
       method: 'POST',
       headers: this.authHeaders(token, true),
-      // No projectId in body — proxy fills it.
       body: JSON.stringify({}),
     })
 

--- a/src/main/host-browser/platform-provider.ts
+++ b/src/main/host-browser/platform-provider.ts
@@ -35,6 +35,14 @@ export class PlatformBrowserProvider implements HostBrowserProvider {
   onExternalClose: ((instanceId: string) => void) | null = null
 
   detect(): HostBrowserProviderStatus {
+    if (!getPlatformProxyBaseUrl()) {
+      return {
+        id: this.id,
+        name: this.name,
+        available: false,
+        reason: 'Platform proxy URL is not configured',
+      }
+    }
     if (!getPlatformAccessToken()) {
       return {
         id: this.id,

--- a/src/main/host-browser/types.ts
+++ b/src/main/host-browser/types.ts
@@ -1,6 +1,6 @@
 import type { ChromeProfile } from '@shared/lib/browser/chrome-profile'
 
-export type HostBrowserProviderId = 'chrome' | 'browserbase'
+export type HostBrowserProviderId = 'chrome' | 'browserbase' | 'platform'
 
 export interface BrowserConnectionInfo {
   /** Full CDP WebSocket URL (for remote providers like Browserbase) */

--- a/src/renderer/components/settings/browser-tab.tsx
+++ b/src/renderer/components/settings/browser-tab.tsx
@@ -115,18 +115,20 @@ export function BrowserTab() {
             <SelectItem value={CONTAINER_VALUE}>
               Container (built-in)
             </SelectItem>
-            {providers.map((provider) => (
-              <SelectItem
-                key={provider.id}
-                value={provider.id}
-                disabled={!provider.available && provider.id === 'chrome'}
-              >
-                {provider.name}
-                {!provider.available && provider.id === 'chrome' && provider.reason
-                  ? ` (${provider.reason})`
-                  : ''}
-              </SelectItem>
-            ))}
+            {providers.map((provider) => {
+              const showReason =
+                !provider.available && (provider.id === 'chrome' || provider.id === 'platform')
+              return (
+                <SelectItem
+                  key={provider.id}
+                  value={provider.id}
+                  disabled={showReason}
+                >
+                  {provider.name}
+                  {showReason && provider.reason ? ` (${provider.reason})` : ''}
+                </SelectItem>
+              )
+            })}
           </SelectContent>
         </Select>
         <p className="text-xs text-muted-foreground">
@@ -237,6 +239,30 @@ export function BrowserTab() {
               }
             }}
           />
+
+          <BrowserbaseSessionSettings
+            advancedStealth={settings?.app?.browserbaseAdvancedStealth ?? false}
+            stealthOs={settings?.app?.browserbaseStealthOs}
+            proxies={settings?.app?.browserbaseProxies ?? false}
+            proxyCountry={settings?.app?.browserbaseProxyCountry ?? ''}
+            proxyState={settings?.app?.browserbaseProxyState ?? ''}
+            proxyCity={settings?.app?.browserbaseProxyCity ?? ''}
+            disabled={isLoading}
+            onUpdate={(updates) => updateSettings.mutate({ app: updates })}
+          />
+        </>
+      )}
+
+      {/* Platform-managed Browserbase: no credentials needed, just show session settings */}
+      {effectiveProvider === 'platform' && (
+        <>
+          <div className="rounded-lg border p-4 space-y-1 bg-muted/30">
+            <p className="text-sm font-medium">Managed by Platform</p>
+            <p className="text-xs text-muted-foreground">
+              Browser sessions run on Browserbase using your Platform account&apos;s
+              credentials — no API key configuration needed.
+            </p>
+          </div>
 
           <BrowserbaseSessionSettings
             advancedStealth={settings?.app?.browserbaseAdvancedStealth ?? false}

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -61,7 +61,7 @@ export interface AgentLimitsSettings {
   maxBudgetUsd?: number
 }
 
-export type HostBrowserProviderId = 'chrome' | 'browserbase'
+export type HostBrowserProviderId = 'chrome' | 'browserbase' | 'platform'
 
 export type BrowserbaseStealthOs = 'linux' | 'windows' | 'mac' | 'mobile' | 'tablet'
 


### PR DESCRIPTION
## Summary

Adds a third host-browser provider — `platform` — that runs Browserbase sessions through the platform proxy instead of requiring the user to configure their own Browserbase API key + project id. The user just signs in to platform; platform pays.

## What's in this PR

- **`PlatformBrowserProvider`** (`src/main/host-browser/platform-provider.ts`) — implements `HostBrowserProvider`; calls `${platformProxy}/v1/browserbase/*` with `Authorization: Bearer <platformToken>`.
  - Persists context map to `~/.superagent/platform-browserbase-contexts.json` (separate file from the BYOK `BrowserbaseProvider` so the two modes don't collide).
  - Reuses the existing `app.browserbase*` settings (advanced stealth, proxies, geolocation) — those get forwarded to the proxy and applied server-side.
- `HostBrowserProviderId` widened to `'chrome' | 'browserbase' | 'platform'` in both `types.ts` and `settings.ts`.
- `host-browser/index.ts` — register the singleton; included in `detectAllProviders` / `stopAllProviders` / `setOnExternalClose`.
- `browser-tab.tsx`:
  - Dropdown shows "Platform" with reason text when unavailable (e.g. not signed in, proxy URL not configured).
  - Selecting "Platform" surfaces a "Managed by Platform" hint card + the existing stealth/proxy session settings (no API-key inputs).

`detect()` checks both `getPlatformProxyBaseUrl()` and `getPlatformAccessToken()` so users get a clear failure reason in the dropdown instead of an exception out of `launch()`.

## Cross-repo dependency

Requires platform proxy support for `/v1/browserbase/*` (separate change in the platform repo, already deployed to `platform-proxy-staging`). The proxy:
- accepts `Bearer <platformToken>`,
- injects platform-managed `BROWSERBASE_API_KEY` (`X-BB-API-Key`) + `BROWSERBASE_PROJECT_ID` (request body),
- forwards to `api.browserbase.com/v1/*`.

CDP traffic itself does **not** flow through the proxy — the proxy only mediates the REST control plane (create / inspect / release session, create context). The agent container connects to `wss://connect.browserbase.com/...` directly, exactly as in BYOK mode.

**Deploy order**: platform proxy first (with `BROWSERBASE_API_KEY` + `BROWSERBASE_PROJECT_ID` secrets set), then SuperAgent. Otherwise users who pick "Platform" hit 404s on `/v1/browserbase/*`.

## Test plan

- [ ] Sign in to staging platform → settings → Browser Host = Platform → run an agent that opens a browser → verify a Browserbase session shows up under the platform-managed project.
- [ ] Sign out → dropdown shows Platform disabled with "Sign in to Platform to use this provider".
- [ ] Build without `PLATFORM_PROXY_URL` → dropdown shows Platform disabled with "Platform proxy URL is not configured".
- [ ] Switch to BYOK Browserbase → confirm `~/.superagent/browserbase-contexts.json` and `platform-browserbase-contexts.json` stay separate.