### PR TITLE
fix: generous stop timeouts for auto-sleep, fix ws.terminate() crash

### DIFF
--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -14,6 +14,7 @@ import type {
   ContainerStats,
   CreateSessionOptions,
   StartOptions,
+  StopOptions,
   StreamMessage,
 } from './types'
 import type { RuntimeOptions } from './runtime-options'
@@ -545,15 +546,21 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     }
   }
 
-  async stop(): Promise<{ forceStopUsed: boolean }> {
+  async stop(options?: StopOptions): Promise<{ forceStopUsed: boolean }> {
     let forceStopUsed = false
+    const stopTimeoutMs = options?.stopTimeoutMs ?? 10_000
+    const killTimeoutMs = options?.killTimeoutMs ?? 5_000
 
     try {
       // Terminate all WebSocket connections immediately (no graceful close handshake)
       // to avoid ECONNRESET errors when the container is stopped
       for (const ws of this.wsConnections.values()) {
         ws.removeAllListeners()
-        ws.terminate()
+        try {
+          ws.terminate()
+        } catch {
+          // ws.terminate() throws if the socket is still in CONNECTING state
+        }
       }
       this.wsConnections.clear()
 
@@ -567,7 +574,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
       const stopped = await Promise.race([
         execWithPathSilent(`${runner} stop -t 5 ${containerName}`).then(() => true),
-        new Promise<false>((resolve) => setTimeout(() => resolve(false), 10000)),
+        new Promise<false>((resolve) => setTimeout(() => resolve(false), stopTimeoutMs)),
       ])
 
       if (!stopped) {
@@ -575,7 +582,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
         addErrorBreadcrumb({ category: 'container', message: 'Graceful stop timed out, escalating to kill', data: { containerName, agentId: this.config.agentId } })
         const killed = await Promise.race([
           execWithPathSilent(`${runner} kill ${containerName}`).then(() => true),
-          new Promise<false>((resolve) => setTimeout(() => resolve(false), 5000)),
+          new Promise<false>((resolve) => setTimeout(() => resolve(false), killTimeoutMs)),
         ])
 
         if (!killed) {
@@ -617,7 +624,11 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       // to avoid ECONNRESET errors when the container is stopped
       for (const ws of this.wsConnections.values()) {
         ws.removeAllListeners()
-        ws.terminate()
+        try {
+          ws.terminate()
+        } catch {
+          // ws.terminate() throws if the socket is still in CONNECTING state
+        }
       }
       this.wsConnections.clear()
 

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { createContainerClient, checkAllRunnersAvailability, checkImageExists, pullImage, canBuildImage, buildImage, startRunner, refreshRunnerAvailability, clearRunnerAvailabilityCache, reconcileRunnerState, getRunnerDisplayName, getContainerClientClass, getCliCommand, type ContainerRunner } from './client-factory'
 import { ensureLimaReady } from './lima-container-client'
-import type { ContainerClient, ContainerConfig, ContainerInfo, HealthCheckResult, ImagePullProgress, RuntimeReadiness } from './types'
+import type { ContainerClient, ContainerConfig, ContainerInfo, HealthCheckResult, ImagePullProgress, RuntimeReadiness, StopOptions } from './types'
 import { healthMonitor } from './health-monitor'
 import { db } from '@shared/lib/db'
 import { agentConnectedAccounts, connectedAccounts, agentRemoteMcps, remoteMcpServers } from '@shared/lib/db/schema'
@@ -134,7 +134,7 @@ class ContainerManager {
    * Marks the agent as "stopping" so health checks, status sync, and connection
    * error handlers stop spawning CLI commands into a potentially overloaded VM.
    */
-  async stopContainer(agentId: string): Promise<void> {
+  async stopContainer(agentId: string, options?: StopOptions): Promise<void> {
     // Mark as stopping immediately to prevent health checks / sync from spawning
     // more CLI processes into an overloaded VM
     this.stoppingAgents.add(agentId)
@@ -151,7 +151,7 @@ class ContainerManager {
       }
 
       const client = this.getClient(agentId)
-      const result = await client.stop()
+      const result = await client.stop(options)
       forceStopUsed = result.forceStopUsed
     } finally {
       this.stoppingAgents.delete(agentId)

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -10,6 +10,7 @@ import type {
   ContainerStats,
   CreateSessionOptions,
   StartOptions,
+  StopOptions,
   StreamMessage,
 } from './types'
 import type { RuntimeOptions } from './runtime-options'
@@ -992,7 +993,7 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     console.log(`[MockContainerClient] Started mock container for agent ${this.config.agentId}`)
   }
 
-  async stop(): Promise<{ forceStopUsed: boolean }> {
+  async stop(_options?: StopOptions): Promise<{ forceStopUsed: boolean }> {
     if (this.activeBrowserSessionId && cleanupBrowserSessionFn) {
       cleanupBrowserSessionFn(this.activeBrowserSessionId)
       this.activeBrowserSessionId = null

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -79,10 +79,15 @@ export interface HealthCheckResult {
   details?: Record<string, unknown>
 }
 
+export interface StopOptions {
+  stopTimeoutMs?: number
+  killTimeoutMs?: number
+}
+
 export interface ContainerClient {
   // Lifecycle management
   start(options?: StartOptions): Promise<void>
-  stop(): Promise<{ forceStopUsed: boolean }>
+  stop(options?: StopOptions): Promise<{ forceStopUsed: boolean }>
   stopSync(): void // Synchronous stop for exit handlers
 
   // Build a -v flag value for a volume mount (hostPath:containerPath with runtime-specific suffix)

--- a/src/shared/lib/scheduler/auto-sleep-monitor.ts
+++ b/src/shared/lib/scheduler/auto-sleep-monitor.ts
@@ -105,7 +105,10 @@ class AutoSleepMonitor {
               `[AutoSleepMonitor] Agent ${agentId} idle for >${timeoutMinutes}m, stopping...`
             )
 
-            await containerManager.stopContainer(agentId)
+            await containerManager.stopContainer(agentId, {
+              stopTimeoutMs: 60_000,
+              killTimeoutMs: 30_000,
+            })
           }
         } catch (error) {
           console.error(


### PR DESCRIPTION
## Summary
- **Per-caller stop timeouts**: `BaseContainerClient.stop()` now accepts `StopOptions` (`stopTimeoutMs`, `killTimeoutMs`) so callers can choose how long to wait before escalating. User-initiated stops (stop button, quit, restart) keep the current tight defaults (10s stop + 5s kill). AutoSleepMonitor uses generous timeouts (60s stop + 30s kill) since nobody is waiting and a false `forceStop` kills *all* running agents.
- **Fix `ws.terminate()` crash (ELECTRON-2R)**: Wrap each `ws.terminate()` call in try/catch — it throws an unhandled fatal exception when the WebSocket is still in CONNECTING state.

## Context
Sentry ELECTRON-E (64 events, 21 users) shows the container stop escalation chain timing out under memory pressure, triggering `forceStop()` which kills the entire Lima/WSL2 VM and stops all running agents. Most events correlate with <0.5 GB free memory on the host, where the OS can't dispatch `nerdctl stop`/`kill` CLI commands within the current 15s window. The auto-sleep monitor is the primary trigger path — it tries to stop an idle agent, times out, and nukes active workflows.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 55 container-manager tests pass
- [ ] Verify user-initiated stop (click Stop button) still uses tight defaults
- [ ] Verify auto-sleep path uses generous timeouts under memory pressure

🤖 Generated with [Claude Code](https://claude.com/claude-code)