### PR TITLE
feat(slack): channel behavior toggles — mention-only, thread replies, per-thread sessions

### DIFF
--- a/src/renderer/components/agents/settings/chat-integrations-tab.tsx
+++ b/src/renderer/components/agents/settings/chat-integrations-tab.tsx
@@ -142,6 +142,9 @@ export function ChatIntegrationsTab({ agentSlug }: ChatIntegrationsTabProps) {
   const [formData, setFormData] = useState<Record<string, string>>({})
   const [integrationName, setIntegrationName] = useState('')
   const [showToolCalls, setShowToolCalls] = useState(false)
+  const [onlyMentioned, setOnlyMentioned] = useState(false)
+  const [answerInThread, setAnswerInThread] = useState(false)
+  const [newSessionPerThread, setNewSessionPerThread] = useState(false)
   const [testResult, setTestResult] = useState<{ valid: boolean; info?: string } | null>(null)
   const [slackSetupMode, setSlackSetupMode] = useState<'manifest' | 'manual'>('manifest')
   const [manifestCopied, setManifestCopied] = useState(false)
@@ -152,6 +155,9 @@ export function ChatIntegrationsTab({ agentSlug }: ChatIntegrationsTabProps) {
     setFormData({})
     setIntegrationName('')
     setShowToolCalls(false)
+    setOnlyMentioned(false)
+    setAnswerInThread(false)
+    setNewSessionPerThread(false)
     setTestResult(null)
     setManifestCopied(false)
   }
@@ -176,11 +182,17 @@ export function ChatIntegrationsTab({ agentSlug }: ChatIntegrationsTabProps) {
   const handleCreate = async () => {
     if (!selectedProvider) return
     try {
+      const config: Record<string, unknown> = { ...formData }
+      if (selectedProvider === 'slack') {
+        if (onlyMentioned) config.onlyMentioned = true
+        if (answerInThread) config.answerInThread = true
+        if (answerInThread && newSessionPerThread) config.newSessionPerThread = true
+      }
       await createIntegration.mutateAsync({
         agentSlug,
         provider: selectedProvider,
         name: integrationName.trim() || undefined,
-        config: formData,
+        config,
         showToolCalls,
       })
       resetForm()
@@ -204,6 +216,29 @@ export function ChatIntegrationsTab({ agentSlug }: ChatIntegrationsTabProps) {
 
   const handleToggleToolCalls = async (id: string, current: boolean) => {
     await updateIntegration.mutateAsync({ id, showToolCalls: !current })
+  }
+
+  const parseSlackFlags = (configStr: string) => {
+    try {
+      const c = JSON.parse(configStr)
+      return {
+        onlyMentioned: c.onlyMentioned ?? false,
+        answerInThread: c.answerInThread ?? false,
+        newSessionPerThread: c.newSessionPerThread ?? false,
+      }
+    } catch {
+      return { onlyMentioned: false, answerInThread: false, newSessionPerThread: false }
+    }
+  }
+
+  const handleToggleSlackFlag = async (integration: { id: string; config: string }, flag: string) => {
+    let config: Record<string, unknown>
+    try { config = JSON.parse(integration.config) } catch { return }
+    config[flag] = !config[flag]
+    if (flag === 'answerInThread' && config[flag] === false) {
+      delete config.newSessionPerThread
+    }
+    await updateIntegration.mutateAsync({ id: integration.id, config })
   }
 
   const statusBadge = (status: string) => {
@@ -287,6 +322,50 @@ export function ChatIntegrationsTab({ agentSlug }: ChatIntegrationsTabProps) {
                       Show tool calls
                     </label>
                   </div>
+                  {integration.provider === 'slack' && (() => {
+                    const flags = parseSlackFlags(integration.config)
+                    return (
+                      <div className="mt-2 space-y-1.5">
+                        <p className="text-2xs text-muted-foreground/70 font-medium">Channel behavior</p>
+                        <div className="flex items-center gap-2">
+                          <Checkbox
+                            id={`only-mentioned-${integration.id}`}
+                            checked={flags.onlyMentioned}
+                            onCheckedChange={() => handleToggleSlackFlag(integration, 'onlyMentioned')}
+                            disabled={updateIntegration.isPending}
+                          />
+                          <label htmlFor={`only-mentioned-${integration.id}`} className="text-xs text-muted-foreground cursor-pointer">
+                            Only trigger on @mention
+                          </label>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Checkbox
+                            id={`answer-thread-${integration.id}`}
+                            checked={flags.answerInThread}
+                            onCheckedChange={() => handleToggleSlackFlag(integration, 'answerInThread')}
+                            disabled={updateIntegration.isPending}
+                          />
+                          <label htmlFor={`answer-thread-${integration.id}`} className="text-xs text-muted-foreground cursor-pointer">
+                            Reply in thread
+                          </label>
+                        </div>
+                        <div className="flex items-center gap-2 pl-5">
+                          <Checkbox
+                            id={`new-session-thread-${integration.id}`}
+                            checked={flags.newSessionPerThread}
+                            onCheckedChange={() => handleToggleSlackFlag(integration, 'newSessionPerThread')}
+                            disabled={updateIntegration.isPending || !flags.answerInThread}
+                          />
+                          <label
+                            htmlFor={`new-session-thread-${integration.id}`}
+                            className={`text-xs cursor-pointer ${flags.answerInThread ? 'text-muted-foreground' : 'text-muted-foreground/40'}`}
+                          >
+                            New session per thread
+                          </label>
+                        </div>
+                      </div>
+                    )
+                  })()}
                 </div>
               </div>
               <div className="flex items-center gap-1 shrink-0 ml-2">
@@ -487,6 +566,49 @@ export function ChatIntegrationsTab({ agentSlug }: ChatIntegrationsTabProps) {
                 Show tool calls in chat
               </label>
             </div>
+
+            {selectedProvider === 'slack' && (
+              <div className="space-y-1.5">
+                <p className="text-2xs text-muted-foreground/70 font-medium">Channel behavior</p>
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="new-only-mentioned"
+                    checked={onlyMentioned}
+                    onCheckedChange={(checked) => setOnlyMentioned(checked === true)}
+                  />
+                  <label htmlFor="new-only-mentioned" className="text-xs text-muted-foreground cursor-pointer">
+                    Only trigger on @mention
+                  </label>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="new-answer-thread"
+                    checked={answerInThread}
+                    onCheckedChange={(checked) => {
+                      setAnswerInThread(checked === true)
+                      if (!checked) setNewSessionPerThread(false)
+                    }}
+                  />
+                  <label htmlFor="new-answer-thread" className="text-xs text-muted-foreground cursor-pointer">
+                    Reply in thread
+                  </label>
+                </div>
+                <div className="flex items-center gap-2 pl-5">
+                  <Checkbox
+                    id="new-session-per-thread"
+                    checked={newSessionPerThread}
+                    onCheckedChange={(checked) => setNewSessionPerThread(checked === true)}
+                    disabled={!answerInThread}
+                  />
+                  <label
+                    htmlFor="new-session-per-thread"
+                    className={`text-xs cursor-pointer ${answerInThread ? 'text-muted-foreground' : 'text-muted-foreground/40'}`}
+                  >
+                    New session per thread
+                  </label>
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Test result */}

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -669,7 +669,18 @@ class ChatIntegrationManager {
   }
 
   private deriveDisplayName(_provider: string, message: IncomingMessage): string | undefined {
-    return deriveDisplayName(message)
+    const baseName = deriveDisplayName(message)
+
+    // Per-thread sessions use composite chatId (channelId|threadTs) — append datetime
+    if (message.chatId.includes('|')) {
+      const d = message.timestamp
+      const date = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+      const time = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+      const label = `${date}, ${time}`
+      return baseName ? `${baseName} — ${label}` : label
+    }
+
+    return baseName
   }
 
   /**

--- a/src/shared/lib/chat-integrations/config-schema.ts
+++ b/src/shared/lib/chat-integrations/config-schema.ts
@@ -15,6 +15,10 @@ export const slackConfigSchema = z.object({
   botToken: z.string().min(1, 'Bot token is required'),
   appToken: z.string().min(1, 'App-level token is required'),
   channelId: z.string().optional(),
+  // Channel behavior toggles (only apply to channels, not DMs)
+  onlyMentioned: z.boolean().optional(),
+  answerInThread: z.boolean().optional(),
+  newSessionPerThread: z.boolean().optional(),
 })
 
 export type TelegramConfig = z.infer<typeof telegramConfigSchema>

--- a/src/shared/lib/chat-integrations/slack-channel-behavior.test.ts
+++ b/src/shared/lib/chat-integrations/slack-channel-behavior.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect } from 'vitest'
+import { routeSlackMessage, resolveSlackChannel, type SlackMessageRoutingParams } from './slack-connector'
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function makeParams(overrides: Partial<SlackMessageRoutingParams> = {}): SlackMessageRoutingParams {
+  return {
+    rawText: 'hello world',
+    chatId: 'C123',
+    ts: '1000.001',
+    channelType: 'channel',
+    botUserId: 'U_BOT',
+    config: {},
+    activeThreads: new Set(),
+    ...overrides,
+  }
+}
+
+// ── routeSlackMessage ──────────────────────────────────────────────────
+
+describe('routeSlackMessage', () => {
+  // ── Mention filtering ─────────────────────────────────────────────
+
+  describe('onlyMentioned filtering', () => {
+    it('processes all channel messages when onlyMentioned is off', () => {
+      const result = routeSlackMessage(makeParams({
+        config: { onlyMentioned: false },
+      }))
+      expect(result.shouldProcess).toBe(true)
+    })
+
+    it('filters out channel messages without bot mention', () => {
+      const result = routeSlackMessage(makeParams({
+        rawText: 'hello everyone',
+        config: { onlyMentioned: true },
+      }))
+      expect(result.shouldProcess).toBe(false)
+    })
+
+    it('processes channel messages that mention the bot', () => {
+      const result = routeSlackMessage(makeParams({
+        rawText: 'hey <@U_BOT> help me',
+        config: { onlyMentioned: true },
+      }))
+      expect(result.shouldProcess).toBe(true)
+    })
+
+    it('never filters DMs regardless of onlyMentioned', () => {
+      const result = routeSlackMessage(makeParams({
+        rawText: 'hello',
+        channelType: 'im',
+        config: { onlyMentioned: true },
+      }))
+      expect(result.shouldProcess).toBe(true)
+    })
+
+    it('never filters group DMs regardless of onlyMentioned', () => {
+      const result = routeSlackMessage(makeParams({
+        rawText: 'hello',
+        channelType: 'mpim',
+        config: { onlyMentioned: true },
+      }))
+      expect(result.shouldProcess).toBe(true)
+    })
+
+    it('filters private channel messages without mention', () => {
+      const result = routeSlackMessage(makeParams({
+        rawText: 'hello',
+        channelType: 'group',
+        config: { onlyMentioned: true },
+      }))
+      expect(result.shouldProcess).toBe(false)
+    })
+
+    it('processes private channel messages with mention', () => {
+      const result = routeSlackMessage(makeParams({
+        rawText: '<@U_BOT> do something',
+        channelType: 'group',
+        config: { onlyMentioned: true },
+      }))
+      expect(result.shouldProcess).toBe(true)
+    })
+  })
+
+  // ── Thread continuity ─────────────────────────────────────────────
+
+  describe('thread continuity (replies in active threads)', () => {
+    it('allows thread replies without mention when thread is active', () => {
+      const activeThreads = new Set(['C123|1000.001'])
+
+      const result = routeSlackMessage(makeParams({
+        rawText: 'follow-up question',
+        threadTs: '1000.001',
+        config: { onlyMentioned: true },
+        activeThreads,
+      }))
+      expect(result.shouldProcess).toBe(true)
+    })
+
+    it('filters thread replies in unknown threads without mention', () => {
+      const result = routeSlackMessage(makeParams({
+        rawText: 'random thread reply',
+        threadTs: '9999.999',
+        config: { onlyMentioned: true },
+        activeThreads: new Set(),
+      }))
+      expect(result.shouldProcess).toBe(false)
+    })
+
+    it('processes thread replies with mention even in unknown threads', () => {
+      const result = routeSlackMessage(makeParams({
+        rawText: '<@U_BOT> new question in thread',
+        threadTs: '9999.999',
+        config: { onlyMentioned: true },
+        activeThreads: new Set(),
+      }))
+      expect(result.shouldProcess).toBe(true)
+    })
+
+    it('returns threadKey so caller can track active threads', () => {
+      const result = routeSlackMessage(makeParams({
+        rawText: '<@U_BOT> start something',
+        ts: '2000.001',
+        config: { onlyMentioned: true, answerInThread: true },
+      }))
+      expect(result.shouldProcess).toBe(true)
+      expect(result.threadKey).toBe('C123|2000.001')
+    })
+
+    it('end-to-end: mention creates thread, follow-up passes filter', () => {
+      const activeThreads = new Set<string>()
+
+      // Step 1: bot is mentioned in a channel message
+      const mention = routeSlackMessage(makeParams({
+        rawText: '<@U_BOT> help me',
+        ts: '2000.001',
+        config: { onlyMentioned: true, answerInThread: true },
+        activeThreads,
+      }))
+      expect(mention.shouldProcess).toBe(true)
+      expect(mention.threadKey).toBe('C123|2000.001')
+
+      // Simulate the connector adding the thread key
+      activeThreads.add(mention.threadKey!)
+
+      // Step 2: user replies in that thread without mentioning the bot
+      const reply = routeSlackMessage(makeParams({
+        rawText: 'thanks, one more thing',
+        ts: '2000.002',
+        threadTs: '2000.001',
+        config: { onlyMentioned: true, answerInThread: true },
+        activeThreads,
+      }))
+      expect(reply.shouldProcess).toBe(true)
+
+      // Step 3: unrelated message in the channel is still filtered
+      const unrelated = routeSlackMessage(makeParams({
+        rawText: 'hey team lunch?',
+        ts: '2000.003',
+        config: { onlyMentioned: true, answerInThread: true },
+        activeThreads,
+      }))
+      expect(unrelated.shouldProcess).toBe(false)
+    })
+  })
+
+  // ── answerInThread / effective chatId ──────────────────────────────
+
+  describe('answerInThread routing', () => {
+    it('returns thread context for channel messages', () => {
+      const result = routeSlackMessage(makeParams({
+        ts: '1000.001',
+        config: { answerInThread: true },
+      }))
+      expect(result.shouldProcess).toBe(true)
+      expect(result.threadContext).toEqual({ channel: 'C123', threadTs: '1000.001' })
+    })
+
+    it('uses thread_ts as anchor for thread replies', () => {
+      const result = routeSlackMessage(makeParams({
+        ts: '2000.002',
+        threadTs: '1000.001',
+        config: { answerInThread: true },
+      }))
+      expect(result.threadContext).toEqual({ channel: 'C123', threadTs: '1000.001' })
+    })
+
+    it('does not set thread context for DMs', () => {
+      const result = routeSlackMessage(makeParams({
+        channelType: 'im',
+        config: { answerInThread: true },
+      }))
+      expect(result.threadContext).toBeUndefined()
+    })
+
+    it('keeps effectiveChatId as channel when newSessionPerThread is off', () => {
+      const result = routeSlackMessage(makeParams({
+        ts: '1000.001',
+        config: { answerInThread: true, newSessionPerThread: false },
+      }))
+      expect(result.effectiveChatId).toBe('C123')
+    })
+  })
+
+  // ── newSessionPerThread ───────────────────────────────────────────
+
+  describe('newSessionPerThread', () => {
+    it('creates composite chatId for top-level messages', () => {
+      const result = routeSlackMessage(makeParams({
+        ts: '1000.001',
+        config: { answerInThread: true, newSessionPerThread: true },
+      }))
+      expect(result.effectiveChatId).toBe('C123|1000.001')
+    })
+
+    it('creates composite chatId using thread_ts for replies', () => {
+      const result = routeSlackMessage(makeParams({
+        ts: '2000.002',
+        threadTs: '1000.001',
+        config: { answerInThread: true, newSessionPerThread: true },
+      }))
+      expect(result.effectiveChatId).toBe('C123|1000.001')
+    })
+
+    it('does not create composite chatId for DMs', () => {
+      const result = routeSlackMessage(makeParams({
+        channelType: 'im',
+        chatId: 'D456',
+        config: { answerInThread: true, newSessionPerThread: true },
+      }))
+      expect(result.effectiveChatId).toBe('D456')
+    })
+
+    it('newSessionPerThread without answerInThread has no effect', () => {
+      const result = routeSlackMessage(makeParams({
+        ts: '1000.001',
+        config: { newSessionPerThread: true },
+      }))
+      expect(result.effectiveChatId).toBe('C123')
+      expect(result.threadContext).toBeUndefined()
+    })
+  })
+})
+
+// ── resolveSlackChannel ────────────────────────────────────────────────
+
+describe('resolveSlackChannel', () => {
+  it('returns plain channel for regular chatId', () => {
+    const result = resolveSlackChannel('C123', new Map())
+    expect(result).toEqual({ channel: 'C123' })
+  })
+
+  it('returns channel + threadTs from threadContextMap', () => {
+    const map = new Map([['C123', { channel: 'C123', threadTs: '1000.001' }]])
+    const result = resolveSlackChannel('C123', map)
+    expect(result).toEqual({ channel: 'C123', threadTs: '1000.001' })
+  })
+
+  it('parses composite chatId when not in map', () => {
+    const result = resolveSlackChannel('C123|1000.001', new Map())
+    expect(result).toEqual({ channel: 'C123', threadTs: '1000.001' })
+  })
+
+  it('prefers threadContextMap over parsing composite chatId', () => {
+    const map = new Map([
+      ['C123|1000.001', { channel: 'C123', threadTs: '2000.002' }],
+    ])
+    const result = resolveSlackChannel('C123|1000.001', map)
+    expect(result).toEqual({ channel: 'C123', threadTs: '2000.002' })
+  })
+
+  it('returns DM channel as-is', () => {
+    const result = resolveSlackChannel('D456', new Map())
+    expect(result).toEqual({ channel: 'D456' })
+  })
+})

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -19,6 +19,9 @@ export interface SlackConfig {
   botToken: string
   appToken: string
   channelId?: string
+  onlyMentioned?: boolean
+  answerInThread?: boolean
+  newSessionPerThread?: boolean
 }
 
 // ── Slack limits ────────────────────────────────────────────────────────
@@ -112,6 +115,73 @@ export function markdownToSlackMrkdwn(md: string): string {
   return result.trim()
 }
 
+// ── Message routing (exported for testing) ──────────────────────────────
+
+export interface SlackMessageRoutingParams {
+  rawText: string
+  chatId: string
+  ts: string
+  channelType: string
+  threadTs?: string
+  botUserId: string | null
+  config: Pick<SlackConfig, 'onlyMentioned' | 'answerInThread' | 'newSessionPerThread'>
+  activeThreads: ReadonlySet<string>
+}
+
+export interface SlackMessageRoutingResult {
+  shouldProcess: boolean
+  effectiveChatId: string
+  threadContext?: { channel: string; threadTs: string }
+  threadKey?: string
+}
+
+export function routeSlackMessage(params: SlackMessageRoutingParams): SlackMessageRoutingResult {
+  const { rawText, chatId, ts, channelType, threadTs, botUserId, config, activeThreads } = params
+  const isChannel = channelType === 'channel' || channelType === 'group'
+
+  if (isChannel && config.onlyMentioned) {
+    const isMentioned = botUserId ? rawText.includes(`<@${botUserId}>`) : false
+    if (!isMentioned) {
+      if (!threadTs || !activeThreads.has(`${chatId}|${threadTs}`)) {
+        return { shouldProcess: false, effectiveChatId: chatId }
+      }
+    }
+  }
+
+  let effectiveChatId = chatId
+  let threadContext: { channel: string; threadTs: string } | undefined
+  let threadKey: string | undefined
+
+  if (isChannel && config.answerInThread) {
+    const threadAnchor = threadTs || ts
+    if (config.newSessionPerThread) {
+      effectiveChatId = `${chatId}|${threadAnchor}`
+    }
+    threadContext = { channel: chatId, threadTs: threadAnchor }
+    threadKey = `${chatId}|${threadAnchor}`
+  }
+
+  return { shouldProcess: true, effectiveChatId, threadContext, threadKey }
+}
+
+export function resolveSlackChannel(
+  effectiveChatId: string,
+  threadContextMap: ReadonlyMap<string, { channel: string; threadTs: string }>,
+): { channel: string; threadTs?: string } {
+  const ctx = threadContextMap.get(effectiveChatId)
+  if (ctx) return ctx
+
+  const pipeIdx = effectiveChatId.indexOf('|')
+  if (pipeIdx > 0) {
+    return {
+      channel: effectiveChatId.slice(0, pipeIdx),
+      threadTs: effectiveChatId.slice(pipeIdx + 1),
+    }
+  }
+
+  return { channel: effectiveChatId }
+}
+
 // ── Connector ───────────────────────────────────────────────────────────
 
 export class SlackConnector extends ChatClientConnector {
@@ -136,7 +206,12 @@ export class SlackConnector extends ChatClientConnector {
   private lastUserMessageTs: Map<string, string> = new Map()
 
   // Track whether we have a thinking reaction active
-  private activeReactions: Set<string> = new Set() // channelId:ts
+  private activeReactions: Set<string> = new Set() // effectiveChatId:ts
+
+  // Thread context: maps effective chatId → real channel + thread anchor ts (for answerInThread)
+  private threadContextMap: Map<string, { channel: string; threadTs: string }> = new Map()
+  // Tracks threads the bot has participated in (for allowing thread replies without re-mention)
+  private activeThreads: Set<string> = new Set() // channelId|threadTs
 
   constructor(private config: SlackConfig) {
     super()
@@ -159,7 +234,6 @@ export class SlackConnector extends ChatClientConnector {
 
     // Handle incoming messages
     this.app.message(async ({ message, say: _say }: { message: any; say: any }) => {
-      // Skip bot messages, edits, etc.
       // Skip bot messages, edits, etc. — but allow file_share (user sent an image/file)
       const subtype = (message as any).subtype
       if (!message || (subtype && subtype !== 'file_share')) return
@@ -169,16 +243,43 @@ export class SlackConnector extends ChatClientConnector {
       const chatId = msg.channel || ''
       const userId = msg.user || ''
       const ts = msg.ts || ''
+      const threadTs = msg.thread_ts as string | undefined
+
+      const routing = routeSlackMessage({
+        rawText,
+        chatId,
+        ts,
+        channelType: msg.channel_type || '',
+        threadTs,
+        botUserId: this.botUserId,
+        config: this.config,
+        activeThreads: this.activeThreads,
+      })
+
+      if (!routing.shouldProcess) return
+
+      // Detect new thread entry before marking it active
+      const isNewThreadEntry = !!(routing.threadKey && !this.activeThreads.has(routing.threadKey) && threadTs)
+
+      const effectiveChatId = routing.effectiveChatId
+      if (routing.threadContext) this.threadContextMap.set(effectiveChatId, routing.threadContext)
+      if (routing.threadKey) this.activeThreads.add(routing.threadKey)
 
       // Track message ts for reaction-based typing
-      this.lastUserMessageTs.set(chatId, ts)
+      this.lastUserMessageTs.set(effectiveChatId, ts)
 
       // Resolve real user and channel names
       const userName = await this.resolveUserName(userId)
       const chatName = await this.resolveChannelName(chatId)
 
       // Resolve <@U123>, <#C123|name>, links, and special mentions in the text
-      const text = await this.resolveMentionsInText(rawText)
+      let text = await this.resolveMentionsInText(rawText)
+
+      // When joining a thread mid-conversation, fetch earlier messages as context
+      if (isNewThreadEntry) {
+        const history = await this.fetchThreadHistory(chatId, threadTs, ts)
+        if (history) text = history + '\n\n' + text
+      }
 
       // Handle file uploads
       const files = msg.files?.map((f: any) => ({
@@ -190,7 +291,7 @@ export class SlackConnector extends ChatClientConnector {
       this.emitMessage({
         externalMessageId: ts,
         text,
-        chatId,
+        chatId: effectiveChatId,
         userId,
         userName,
         chatName,
@@ -276,15 +377,18 @@ export class SlackConnector extends ChatClientConnector {
   async disconnect(): Promise<void> {
     this.connected = false
 
-    // Remove any active reactions
+    // Remove any active reactions (before clearing thread context needed to resolve channels)
     for (const key of this.activeReactions) {
-      const [channel, ts] = key.split(':')
+      const [effectiveChatId, ts] = key.split(':')
+      const { channel } = this.resolveChannel(effectiveChatId)
       this.removeThinkingReaction(channel, ts).catch(() => {})
     }
     this.activeReactions.clear()
     this.actionDataMap.clear()
     this.pendingQuestions.clear()
     this.lastUserMessageTs.clear()
+    this.threadContextMap.clear()
+    this.activeThreads.clear()
     this.userNameCache.clear()
     this.channelNameCache.clear()
 
@@ -304,15 +408,17 @@ export class SlackConnector extends ChatClientConnector {
   async sendMessage(chatId: string, message: OutgoingMessage): Promise<string> {
     if (!this.app) throw new Error('Slack app not connected')
 
+    const { channel, threadTs } = this.resolveChannel(chatId)
     const mrkdwn = markdownToSlackMrkdwn(message.text || '(empty message)')
     const chunks = this.splitMessage(mrkdwn)
 
     let lastTs = ''
     for (const chunk of chunks) {
       const result = await this.app.client.chat.postMessage({
-        channel: chatId,
+        channel,
         text: chunk,
         mrkdwn: true,
+        ...(threadTs ? { thread_ts: threadTs } : {}),
       })
       lastTs = result.ts || ''
     }
@@ -326,21 +432,24 @@ export class SlackConnector extends ChatClientConnector {
   async sendFile(chatId: string, fileData: Buffer, filename: string, caption?: string): Promise<string> {
     if (!this.app) throw new Error('Slack app not connected')
 
+    const { channel, threadTs } = this.resolveChannel(chatId)
     const result = await this.app.client.filesUploadV2({
-      channel_id: chatId,
+      channel_id: channel,
       file: fileData,
       filename,
       initial_comment: caption,
-    })
+      ...(threadTs ? { thread_ts: threadTs } : {}),
+    } as any)
 
     // filesUploadV2 returns files array; extract the message ts if available
     const file = (result as any).files?.[0]
-    return file?.shares?.public?.[chatId]?.[0]?.ts || file?.shares?.private?.[chatId]?.[0]?.ts || ''
+    return file?.shares?.public?.[channel]?.[0]?.ts || file?.shares?.private?.[channel]?.[0]?.ts || ''
   }
 
   async sendStreamingUpdate(chatId: string, text: string, existingMessageId?: string): Promise<string> {
     if (!this.app) throw new Error('Slack app not connected')
 
+    const { channel, threadTs } = this.resolveChannel(chatId)
     const truncated = text.length > MAX_MESSAGE_LENGTH
       ? text.slice(0, MAX_MESSAGE_LENGTH - 20) + '\n\n... (truncated)'
       : text
@@ -348,9 +457,10 @@ export class SlackConnector extends ChatClientConnector {
 
     if (!existingMessageId) {
       const result = await this.app.client.chat.postMessage({
-        channel: chatId,
+        channel,
         text: displayText,
         mrkdwn: true,
+        ...(threadTs ? { thread_ts: threadTs } : {}),
       })
       return result.ts || ''
     }
@@ -358,7 +468,7 @@ export class SlackConnector extends ChatClientConnector {
     // Edit existing message
     try {
       await this.app.client.chat.update({
-        channel: chatId,
+        channel,
         ts: existingMessageId,
         text: displayText,
       })
@@ -375,13 +485,14 @@ export class SlackConnector extends ChatClientConnector {
   async finalizeStreamingMessage(chatId: string, messageId: string, finalText: string): Promise<void> {
     if (!this.app) return
 
+    const { channel } = this.resolveChannel(chatId)
     const truncated = finalText.length > MAX_MESSAGE_LENGTH
       ? finalText.slice(0, MAX_MESSAGE_LENGTH - 20) + '\n\n... (truncated)'
       : finalText
 
     try {
       await this.app.client.chat.update({
-        channel: chatId,
+        channel,
         ts: messageId,
         text: markdownToSlackMrkdwn(truncated || '(empty response)'),
       })
@@ -408,9 +519,10 @@ export class SlackConnector extends ChatClientConnector {
     const key = `${chatId}:${lastTs}`
     if (this.activeReactions.has(key)) return // Already reacting
 
+    const { channel } = this.resolveChannel(chatId)
     try {
       await this.app.client.reactions.add({
-        channel: chatId,
+        channel,
         timestamp: lastTs,
         name: 'thinking_face',
       })
@@ -425,11 +537,15 @@ export class SlackConnector extends ChatClientConnector {
   async sendUserRequestCard(chatId: string, event: UserRequestEvent): Promise<string> {
     if (!this.app) throw new Error('Slack app not connected')
 
+    const { channel, threadTs } = this.resolveChannel(chatId)
+    const threadOpt = threadTs ? { thread_ts: threadTs } : {}
+
     if (isUnsupportedInChat(event)) {
       const result = await this.app.client.chat.postMessage({
-        channel: chatId,
+        channel,
         text: `_${describeUnsupportedRequest(event)}_`,
         mrkdwn: true,
+        ...threadOpt,
       })
       return result.ts || ''
     }
@@ -481,9 +597,10 @@ export class SlackConnector extends ChatClientConnector {
           }
 
           const result = await this.app.client.chat.postMessage({
-            channel: chatId,
+            channel,
             text: q.question, // Fallback text
             blocks,
+            ...threadOpt,
           })
           lastTs = result.ts || ''
         }
@@ -493,18 +610,20 @@ export class SlackConnector extends ChatClientConnector {
 
       case 'secret_request': {
         const result = await this.app.client.chat.postMessage({
-          channel: chatId,
+          channel,
           text: `*Secret requested:* \`${event.secretName}\`${event.reason ? `\nReason: ${event.reason}` : ''}\n\nPlease reply with the secret value.`,
           mrkdwn: true,
+          ...threadOpt,
         })
         return result.ts || ''
       }
 
       case 'file_request': {
         const result = await this.app.client.chat.postMessage({
-          channel: chatId,
+          channel,
           text: `*File requested:*\n${event.description}${event.fileTypes ? `\n\nAccepted types: ${event.fileTypes}` : ''}\n\nPlease upload the file.`,
           mrkdwn: true,
+          ...threadOpt,
         })
         return result.ts || ''
       }
@@ -512,9 +631,10 @@ export class SlackConnector extends ChatClientConnector {
       case 'file_delivery': {
         // File transfer from container to chat is not yet supported — show metadata only
         const result = await this.app.client.chat.postMessage({
-          channel: chatId,
+          channel,
           text: `*File delivered:* \`${event.filePath}\`${event.description ? `\n${event.description}` : ''}\n\n_File download not yet supported — view in the app._`,
           mrkdwn: true,
+          ...threadOpt,
         })
         return result.ts || ''
       }
@@ -525,18 +645,20 @@ export class SlackConnector extends ChatClientConnector {
           : event.status === 'cancelled' ? ':no_entry_sign:'
           : ':hourglass_flowing_sand:'
         const result = await this.app.client.chat.postMessage({
-          channel: chatId,
+          channel,
           text: `:wrench: *${event.toolName}* — \`${event.summary}\` ${emoji}`,
           mrkdwn: true,
+          ...threadOpt,
         })
         return result.ts || ''
       }
 
       default: {
         const result = await this.app.client.chat.postMessage({
-          channel: chatId,
+          channel,
           text: `_${describeUnsupportedRequest(event)}_`,
           mrkdwn: true,
+          ...threadOpt,
         })
         return result.ts || ''
       }
@@ -544,6 +666,43 @@ export class SlackConnector extends ChatClientConnector {
   }
 
   // ── Helpers ─────────────────────────────────────────────────────────
+
+  private resolveChannel(effectiveChatId: string): { channel: string; threadTs?: string } {
+    return resolveSlackChannel(effectiveChatId, this.threadContextMap)
+  }
+
+  /**
+   * Fetch earlier messages from a thread the bot is joining mid-conversation.
+   * Returns formatted history or null on failure (graceful — works without extra scopes).
+   */
+  private async fetchThreadHistory(channel: string, threadTs: string, currentMessageTs: string): Promise<string | null> {
+    if (!this.app) return null
+    try {
+      const result = await this.app.client.conversations.replies({
+        channel,
+        ts: threadTs,
+        limit: 50,
+      })
+      if (!result.ok || !result.messages) return null
+
+      const previous = result.messages.filter(m => m.ts !== currentMessageTs)
+      if (previous.length === 0) return null
+
+      const lines: string[] = []
+      for (const m of previous) {
+        const name = m.user ? (await this.resolveUserName(m.user) || m.user) : 'Unknown'
+        const text = m.text ? await this.resolveMentionsInText(m.text) : ''
+        if (text) lines.push(`${name}: ${text}`)
+      }
+      if (lines.length === 0) return null
+
+      const label = lines.length === 1 ? '1 previous message' : `${lines.length} previous messages`
+      return `[Thread context — ${label}]\n${lines.join('\n')}`
+    } catch (err) {
+      console.warn('[SlackConnector] Failed to fetch thread history (non-critical):', err instanceof Error ? err.message : err)
+      return null
+    }
+  }
 
   private registerAction(toolUseId: string, value: unknown): string {
     // Evict stale action entries to prevent unbounded growth
@@ -564,7 +723,8 @@ export class SlackConnector extends ChatClientConnector {
 
     const key = `${chatId}:${lastTs}`
     if (this.activeReactions.has(key)) {
-      await this.removeThinkingReaction(chatId, lastTs)
+      const { channel } = this.resolveChannel(chatId)
+      await this.removeThinkingReaction(channel, lastTs)
       this.activeReactions.delete(key)
     }
   }
@@ -634,7 +794,7 @@ export class SlackConnector extends ChatClientConnector {
       // For channels/groups use the channel name; for DMs return undefined
       // so that the resolved userName (from users.info) is used instead.
       const channel = result.channel as any
-      const name = channel?.is_im ? undefined : (channel?.name || undefined)
+      const name = channel?.is_im ? undefined : (channel?.name ? `#${channel.name}` : undefined)
       if (name) this.channelNameCache.set(channelId, { value: name, ts: Date.now() })
       return name
     } catch {


### PR DESCRIPTION
## Summary

- Adds three new Slack-specific toggles for channel connections (DMs unaffected):
  - **Only trigger on @mention** — bot ignores channel messages unless `<@bot>` is present; thread replies in active threads pass without re-mentioning
  - **Reply in thread** — responses go as thread replies instead of top-level channel messages
  - **New session per thread** (requires Reply in thread) — each mention starts a separate session, displayed as `#general — May 11, 3:45 PM`
- When the bot is mentioned in an existing thread, it fetches prior messages via `conversations.replies` and prepends them as context (graceful failure if unavailable)
- Channel names now display with `#` prefix throughout the UI
- Core routing logic extracted into pure `routeSlackMessage()` / `resolveSlackChannel()` functions with 25 new tests

## Changed files

- `config-schema.ts` — 3 new optional booleans on `slackConfigSchema`
- `slack-connector.ts` — mention filtering, thread-aware message routing, thread history fetch, all send methods resolve channel + thread_ts
- `chat-integration-manager.ts` — per-thread session display names with datetime
- `chat-integrations-tab.tsx` — UI toggles in both create form and existing integration view
- `slack-channel-behavior.test.ts` — new test file (25 tests)

## Test plan

- [x] TypeScript type check passes
- [x] ESLint passes
- [x] All 229 chat integration tests pass (25 new + 204 existing)
- [ ] Manual: create Slack integration with "Only trigger on @mention" — verify bot ignores non-mention messages in channel
- [ ] Manual: enable "Reply in thread" — verify bot responds as thread reply
- [ ] Manual: mention bot in existing thread — verify thread history is fetched and included
- [ ] Manual: reply in active thread without re-mentioning — verify bot still responds
- [ ] Manual: enable "New session per thread" — verify each mention creates a separate session with datetime in name
- [ ] Manual: toggle settings on existing integration — verify reconnect picks up new config
- [ ] Manual: DMs still work normally regardless of toggle state

🤖 Generated with [Claude Code](https://claude.com/claude-code)