### PR TITLE
fix(qagent): scope Composio GitHub lookup to configured user

### DIFF
--- a/.qagent/hooks/ensureOAuth.ts
+++ b/.qagent/hooks/ensureOAuth.ts
@@ -15,7 +15,21 @@ export default async function ensureOAuth(ctx: SetupContext): Promise<void> {
     throw new Error('ensureOAuth requires COMPOSIO_API_KEY and COMPOSIO_USER_ID in env')
   }
 
-  const composioUrl = `https://backend.composio.dev/api/v3/connected_accounts?entityId=${encodeURIComponent(composioUserId)}&toolkit=github&status=ACTIVE`
+  // Composio's GET /connected_accounts only honors the *plural* filter names
+  // (`user_ids`, `toolkit_slugs`, `statuses`) per the v3 OpenAPI spec. Older
+  // singular forms (`entityId`, `toolkit`, `status`) are silently ignored and
+  // return every connection in the org across all users — which makes the
+  // subsequent `.find()` pick whichever GitHub connection happens to be first
+  // in the array, regardless of who owns it. That bites CI: a stranger's
+  // GitHub connection whose OAuth token Composio has stopped being able to
+  // refresh comes back ACTIVE-but-broken, and the test fails with a 401
+  // "Bad credentials" from GitHub.
+  const params = new URLSearchParams({
+    user_ids: composioUserId,
+    toolkit_slugs: 'github',
+    statuses: 'ACTIVE',
+  })
+  const composioUrl = `https://backend.composio.dev/api/v3/connected_accounts?${params.toString()}`
   const composioRes = await fetch(composioUrl, {
     headers: { 'x-api-key': composioKey, 'Content-Type': 'application/json' },
   })
@@ -25,15 +39,25 @@ export default async function ensureOAuth(ctx: SetupContext): Promise<void> {
   }
 
   const composioData = (await composioRes.json()) as {
-    items?: Array<{ id: string; toolkit?: { slug?: string } }>
+    items?: Array<{
+      id: string
+      user_id?: string
+      toolkit?: { slug?: string }
+    }>
   }
 
   const connections = composioData.items ?? []
-  const githubConn = connections.find((c) => c.toolkit?.slug === 'github')
+  // Defense in depth: even though the server filter is authoritative, verify
+  // the returned connection actually belongs to our user. If Composio ever
+  // regresses the filter again we want to fail loudly here rather than
+  // silently registering somebody else's GitHub.
+  const githubConn = connections.find(
+    (c) => c.toolkit?.slug === 'github' && c.user_id === composioUserId,
+  )
 
   if (!githubConn) {
     throw new Error(
-      `No active GitHub connection found in Composio for entity "${composioUserId}". ` +
+      `No active GitHub connection found in Composio for user_id "${composioUserId}". ` +
         `Please connect GitHub via Composio first.`,
     )
   }


### PR DESCRIPTION
## Bug

The `github-whoami` happy-path test fails in CI with:

> proxy returned 401 "Bad credentials" when calling the GitHub API

## Root cause

`.qagent/hooks/ensureOAuth.ts` queries Composio with:

```
?entityId=${user}&toolkit=github&status=ACTIVE
```

Per the [Composio v3 OpenAPI spec](https://docs.composio.dev/api-reference/connected-accounts/get-connected-accounts), the connected-accounts list endpoint only honors the **plural** filter names: `user_ids`, `toolkit_slugs`, `statuses`. The singular and the legacy `entityId` form are silently ignored.

Effect: the request returns **every** connection in the org across all users. `.find((c) => c.toolkit?.slug === 'github')` then picks whichever GitHub connection happens to be first in the array. That is frequently somebody else's Composio-managed OAuth, which Composio still reports as `status: ACTIVE` but whose token has been revoked on GitHub's side — yielding 401 even via `proxyExecute`.

Verified against staging org `ak_lActEna0poHrMRx471Tq`:

| connection | user_id | Composio status | GitHub via proxy |
|---|---|---|---|
| `ca__hz1JtyUV3Fn` | sub_fc8b2088-… | ACTIVE | 401 Bad credentials |
| `ca_hXVjJ8BXjoyP` | sub_fc8b2088-… | ACTIVE | 401 Bad credentials |
| `ca_otzNacdn_gt5` | org_71dfb239-… | ACTIVE | 401 Bad credentials |
| **`ca_YSuDWsCNHma6`** | **sub_2eda76ff-…** | ACTIVE | **200 login=yiw190** ✓ |
| **`ca_HR-5RmmTMQqk`** | **sub_2eda76ff-…** | ACTIVE | **200 login=yiw190** ✓ |

Only `sub_2eda76ff-…`'s connections actually work. Old query returned all 10+ org-wide; new query returns the 2 real ones.

## Fix

- Switch to plural filter names (`user_ids`, `toolkit_slugs`, `statuses`).
- Defense in depth: `.find()` also verifies `c.user_id === composioUserId` so a future regression of the server-side filter fails loudly instead of silently registering a stranger's account.

## Test plan

- [x] Verified plural query against staging Composio: scoped to the configured user only.
- [x] Verified `proxyExecute` against the staging user's GitHub connections: returns 200 with expected login.
- [ ] Let the Agent E2E `github-whoami` happy-path run on this PR confirm the end-to-end fix.


Made with [Cursor](https://cursor.com)