### PR TITLE
feat(browser): harden stable-ref system

### DIFF
--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -15,6 +15,10 @@ import { dashboardManager } from './dashboard-manager';
 import { tabManager } from './tab-manager';
 
 import { getEditingCommands } from './cdp-editing-commands';
+import {
+  annotateSnapshot,
+  clearSession as clearStableRefSession,
+} from './snapshot-stable-refs';
 
 // Global error handlers to prevent crashes from AbortError during interrupts
 // The SDK throws AbortError when queries are aborted, which can propagate uncaught
@@ -874,6 +878,10 @@ app.post('/browser/open', async (c) => {
     browserState = { active: true, sessionId: body.sessionId, cdpUrl: cdpUrl || null };
     tabManager.resetTabCount();
     broadcastBrowserEvent(true);
+    // Fresh navigation = fresh sref namespace. Without this, `nextSrefId`
+    // keeps climbing across sites and stale (parentPath, role, name) keys
+    // from the previous page can collide with new elements.
+    clearStableRefSession(body.sessionId);
 
     return c.json({ success: true });
   } catch (error: any) {
@@ -904,6 +912,7 @@ app.post('/browser/close', async (c) => {
 
     cleanupCdpScreencast();
     broadcastBrowserEvent(false);
+    clearStableRefSession(body.sessionId);
     browserState = { active: false, sessionId: null, cdpUrl: null };
     tabManager.resetTabCount();
 
@@ -917,11 +926,13 @@ app.post('/browser/close', async (c) => {
 // POST /browser/notify-closed - Host browser was closed externally, clean up state
 app.post('/browser/notify-closed', (c) => {
   if (browserState.active) {
+    const prevSessionId = browserState.sessionId;
     cleanupAgentBrowserDaemon();
     cleanupCdpScreencast();
     broadcastBrowserEvent(false);
     browserState = { active: false, sessionId: null, cdpUrl: null };
     tabManager.resetTabCount();
+    if (prevSessionId) clearStableRefSession(prevSessionId);
     console.log('[Browser] Browser closed externally, state cleaned up');
   }
   return c.json({ success: true });
@@ -966,7 +977,11 @@ app.post('/browser/snapshot', async (c) => {
       }
     }
 
-    return c.json({ snapshot: result.stdout, tabCount: tabManager.getTabCount() });
+    // Rewrite [ref=eN] → [ref=sN] so the model only ever sees stable refs
+    // that survive page changes between snapshots. The tool layer is
+    // responsible for diffing / promoting baselines — see browserSnapshotTool.
+    const annotated = annotateSnapshot(body.sessionId, result.stdout);
+    return c.json({ snapshot: annotated, tabCount: tabManager.getTabCount() });
   } catch (error: any) {
     console.error('[Browser] Error taking snapshot:', error);
     return c.json({ error: error.message || 'Failed to take snapshot' }, 500);

--- a/agent-container/src/snapshot-stable-refs.ts
+++ b/agent-container/src/snapshot-stable-refs.ts
@@ -1,0 +1,374 @@
+
+import { createHash } from 'crypto';
+
+const LINE_RE =
+  /^(\s*)-\s+([A-Za-z][\w-]*)(?:\s+"((?:[^"\\]|\\.)*)")?([^\n]*)$/;
+// Match `ref=eN`, `ref="eN"`, `ref='eN'` so we survive minor variations in
+// agent-browser's snapshot output formatting.
+const REF_RE = /ref=["']?(e\d+)["']?/;
+const REF_RE_GLOBAL = /ref=["']?(e\d+)["']?/g;
+
+interface StableRefStore {
+  keyToSref: Map<string, string>;
+  srefToCurrentEref: Map<string, string>;
+  srefToCurrentLine: Map<string, string>;
+  srefToBaselineLine: Map<string, string> | null;
+  /** monotonic counter for new sref allocation */
+  nextSrefId: number;
+}
+
+const sessions = new Map<string, StableRefStore>();
+
+function getStore(sessionId: string): StableRefStore {
+  let store = sessions.get(sessionId);
+  if (!store) {
+    store = {
+      keyToSref: new Map(),
+      srefToCurrentEref: new Map(),
+      srefToCurrentLine: new Map(),
+      srefToBaselineLine: null,
+      nextSrefId: 1,
+    };
+    sessions.set(sessionId, store);
+  }
+  return store;
+}
+
+export function clearSession(sessionId: string): void {
+  sessions.delete(sessionId);
+}
+
+/**
+ * Drop every `keyToSref` binding whose key carries an occurrence-disambiguation
+ * suffix (`#1`, `#2`, ...). Returns the number of entries removed.
+ *
+ * Used to recover from occurrence-index drift after a list element is removed:
+ * the remaining identical siblings would otherwise inherit srefs pointing at
+ * the wrong physical element. After this call, those siblings get fresh srefs
+ * on the next annotate pass. Unique-key bindings (occurrence 0) are preserved
+ * because they cannot drift.
+ */
+export function resetDuplicateOccurrences(sessionId: string): number {
+  const store = sessions.get(sessionId);
+  if (!store) return 0;
+  let removed = 0;
+  for (const key of [...store.keyToSref.keys()]) {
+    if (key.includes('#')) {
+      store.keyToSref.delete(key);
+      removed++;
+    }
+  }
+  return removed;
+}
+
+function computeStableKey(
+  role: string,
+  name: string,
+  parentPath: string
+): string {
+  return createHash('sha1')
+    .update(`${parentPath}|${role}|${name}`)
+    .digest('hex')
+    .slice(0, 10);
+}
+
+interface ParsedNode {
+  indent: number;
+  role: string;
+  name: string;
+  attrs: string;
+  raw: string;
+  parentPath: string;
+  eref: string; // ephemeral ref, may be ''
+}
+
+function parseSnapshot(text: string): ParsedNode[] {
+  const nodes: ParsedNode[] = [];
+  /** stack of (indent, role, name) for parent-path computation */
+  const stack: Array<{ indent: number; role: string; name: string }> = [];
+  for (const raw of text.split('\n')) {
+    const m = LINE_RE.exec(raw);
+    if (!m) continue;
+    const indent = m[1].length;
+    const role = m[2];
+    const name = m[3] ?? '';
+    const attrs = m[4] ?? '';
+    while (stack.length > 0 && stack[stack.length - 1].indent >= indent) {
+      stack.pop();
+    }
+    const parentPath = stack
+      .map((s) => `${s.role}:${s.name.slice(0, 20)}`)
+      .join('/');
+    const erefMatch = REF_RE.exec(attrs);
+    const eref = erefMatch ? erefMatch[1] : '';
+    nodes.push({ indent, role, name, attrs, raw, parentPath, eref });
+    stack.push({ indent, role, name });
+  }
+  return nodes;
+}
+
+
+export function annotateSnapshot(sessionId: string, text: string): string {
+  const store = getStore(sessionId);
+
+  store.srefToCurrentEref = new Map();
+  store.srefToCurrentLine = new Map();
+
+  const nodes = parseSnapshot(text);
+  /** per-snapshot counter to disambiguate same-key duplicates */
+  const occCount = new Map<string, number>();
+  /** eref → sref translation table for this snapshot */
+  const erefToSref = new Map<string, string>();
+
+  for (const node of nodes) {
+    if (!node.eref) continue;
+    const baseKey = computeStableKey(node.role, node.name, node.parentPath);
+    const occ = occCount.get(baseKey) ?? 0;
+    occCount.set(baseKey, occ + 1);
+    const fullKey = occ === 0 ? baseKey : `${baseKey}#${occ}`;
+
+    let sref = store.keyToSref.get(fullKey);
+    if (!sref) {
+      sref = `s${store.nextSrefId++}`;
+      store.keyToSref.set(fullKey, sref);
+    }
+    store.srefToCurrentEref.set(sref, node.eref);
+    erefToSref.set(node.eref, sref);
+  }
+
+  // Rewrite each `ref=eN` → `ref=sN` so the model never sees the unstable
+  // ephemeral ref. Works whether the attr stands alone (`[ref=e1]`) or is
+  // merged with others (`[expanded=false, ref=e1]`).
+  const annotated = text.replace(REF_RE_GLOBAL, (whole, eref) => {
+    const sref = erefToSref.get(eref);
+    return sref ? `ref=${sref}` : whole;
+  });
+
+  // Record each sref's current annotated line so we can diff against the
+  // baseline on the next snapshot.
+  for (const line of annotated.split('\n')) {
+    const m = /ref=(s\d+)/.exec(line);
+    if (m) store.srefToCurrentLine.set(m[1], line);
+  }
+
+  return annotated;
+}
+
+/**
+ * Promote the most recently annotated snapshot to the diff baseline. Call
+ * this whenever the model receives a full or differential snapshot, so the
+ * next diff is computed against what the model just saw.
+ */
+export function commitBaseline(sessionId: string): void {
+  const store = sessions.get(sessionId);
+  if (!store) return;
+  // Clone so subsequent annotate calls do not mutate the baseline.
+  store.srefToBaselineLine = new Map(store.srefToCurrentLine);
+}
+
+export interface SnapshotDiff {
+  /** srefs that newly appeared (with their annotated lines). */
+  added: string[];
+  /** srefs that vanished (with the line as it appeared in the baseline). */
+  removed: string[];
+  /** Elements with the same sref but a changed line (e.g. attrs flipped). */
+  changed: Array<{ before: string; after: string }>;
+  /** Count of srefs whose line is byte-identical to the baseline. */
+  unchanged: number;
+  /** True when no baseline exists yet (first snapshot of the session). */
+  noBaseline: boolean;
+}
+
+export function diffAgainstBaseline(sessionId: string): SnapshotDiff {
+  const store = sessions.get(sessionId);
+  if (!store) {
+    return { added: [], removed: [], changed: [], unchanged: 0, noBaseline: true };
+  }
+  const baseline = store.srefToBaselineLine;
+  const current = store.srefToCurrentLine;
+
+  if (!baseline) {
+    return {
+      added: [...current.values()],
+      removed: [],
+      changed: [],
+      unchanged: 0,
+      noBaseline: true,
+    };
+  }
+
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: Array<{ before: string; after: string }> = [];
+  let unchanged = 0;
+
+  for (const [sref, line] of current) {
+    const prior = baseline.get(sref);
+    if (prior === undefined) {
+      added.push(line);
+    } else if (prior !== line) {
+      changed.push({ before: prior, after: line });
+    } else {
+      unchanged++;
+    }
+  }
+  for (const [sref, line] of baseline) {
+    if (!current.has(sref)) removed.push(line);
+  }
+
+  return { added, removed, changed, unchanged, noBaseline: false };
+}
+
+/** Render a SnapshotDiff into model-friendly text. */
+export function formatDiff(diff: SnapshotDiff): string {
+  if (diff.noBaseline) {
+    return (
+      'No previous snapshot to diff against. ' +
+      'Returning the full snapshot below.\n' +
+      diff.added.join('\n')
+    );
+  }
+  const sections: string[] = [];
+  sections.push(
+    `Snapshot diff: +${diff.added.length} added, ` +
+      `-${diff.removed.length} removed, ` +
+      `~${diff.changed.length} changed, ` +
+      `${diff.unchanged} unchanged.`
+  );
+  if (diff.added.length > 0) {
+    sections.push(`\nADDED (${diff.added.length}):`);
+    sections.push(diff.added.map((l) => `+ ${l.trimStart()}`).join('\n'));
+  }
+  if (diff.removed.length > 0) {
+    sections.push(`\nREMOVED (${diff.removed.length}):`);
+    sections.push(diff.removed.map((l) => `- ${l.trimStart()}`).join('\n'));
+  }
+  if (diff.changed.length > 0) {
+    sections.push(`\nCHANGED (${diff.changed.length}):`);
+    sections.push(
+      diff.changed
+        .map((c) => `~ before: ${c.before.trimStart()}\n  after:  ${c.after.trimStart()}`)
+        .join('\n')
+    );
+  }
+  return sections.join('\n');
+}
+
+/**
+ * True when the formatted diff would be at least as long as the full snapshot
+ * — at that point a full tree is unambiguously the better thing to send.
+ *
+ * Line accounting (matches `formatDiff` output):
+ *   - added:     1 line each
+ *   - removed:   1 line each
+ *   - changed:   2 lines each (`before` + `after`)
+ *   - unchanged: 0 lines in diff, 1 line in full
+ *
+ * So full = added + unchanged + changed   (current tree size)
+ *    diff = added + removed + 2 * changed
+ * Fall back when diff >= full. No magic threshold, no buffer — attention
+ * pieces fragmented diffs together fine; the only thing that matters is
+ * whether we're sending more tokens than we have to.
+ */
+export function diffIsLargerThanFull(diff: SnapshotDiff): boolean {
+  if (diff.noBaseline) return false;
+  const fullLines =
+    diff.added.length + diff.unchanged + diff.changed.length;
+  const diffLines =
+    diff.added.length + diff.removed.length + 2 * diff.changed.length;
+  return diffLines >= fullLines;
+}
+
+/**
+ * Translate a ref string from the model into an ephemeral ref usable by
+ * agent-browser. Accepts:
+ *   - "@s14" → current @eN for stable ref s14 (or throws if not found)
+ *   - "@e102" / "e102" → returned as-is (canonicalized with @ prefix)
+ *   - any other shape → returned as-is (let agent-browser report the error)
+ */
+export function resolveRef(sessionId: string, refStr: string): string {
+  if (!refStr) return refStr;
+  const trimmed = refStr.trim();
+  // Stable ref form: @sN or sN
+  const srefMatch = /^@?(s\d+)$/.exec(trimmed);
+  if (srefMatch) {
+    const store = sessions.get(sessionId);
+    const eref = store?.srefToCurrentEref.get(srefMatch[1]);
+    if (!eref) {
+      throw new StableRefNotFoundError(srefMatch[1]);
+    }
+    return `@${eref}`;
+  }
+  // Ephemeral or unknown form: leave alone, just ensure @-prefix is normalized
+  if (/^e\d+$/.test(trimmed)) return `@${trimmed}`;
+  return trimmed;
+}
+
+export class StableRefNotFoundError extends Error {
+  constructor(public sref: string) {
+    super(
+      `Stable ref @${sref} is not present in the most recent snapshot. ` +
+        `Call browser_snapshot to refresh, then use the current ref.`
+    );
+    this.name = 'StableRefNotFoundError';
+  }
+}
+
+/**
+ * Translate any `@sN` tokens embedded in a free-form command string (used by
+ * `browser_run`). Returns the rewritten command. Leaves unknown tokens alone.
+ */
+export function resolveRefsInCommand(
+  sessionId: string,
+  command: string
+): string {
+  return command.replace(/@(s\d+)\b/g, (full, sref) => {
+    const store = sessions.get(sessionId);
+    const eref = store?.srefToCurrentEref.get(sref);
+    return eref ? `@${eref}` : full;
+  });
+}
+
+/**
+ * Rewrite an annotate-mode legend so it uses stable refs (`@sN`) instead of
+ * agent-browser's raw ephemeral refs (`@eN`). Legend lines look like:
+ *
+ *   [1] @e15 button "Submit"
+ *   [2] @e23 link "Sign in"
+ *
+ * We don't have the legend's parentPath info, so we match by (role, name)
+ * against the most recent snapshot. When multiple lines share the same
+ * (role, name) the first match wins — same disambiguation order as the
+ * snapshot's occurrence index, so it lines up in well-behaved pages.
+ *
+ * Lines that can't be matched are kept unchanged (still `@eN`) so the model
+ * sees that something is off rather than silently misleading it.
+ */
+export function rewriteAnnotateLegend(
+  sessionId: string,
+  legend: string
+): string {
+  const store = sessions.get(sessionId);
+  if (!store) return legend;
+
+  // (role + name) → sref, taken from the most recent snapshot. First sref
+  // wins on collisions (matches the occurrence-index ordering).
+  const lookup = new Map<string, string>();
+  for (const [sref, line] of store.srefToCurrentLine) {
+    const m = LINE_RE.exec(line);
+    if (!m) continue;
+    const role = m[2];
+    const name = m[3] ?? '';
+    const key = `${role}\u0000${name}`;
+    if (!lookup.has(key)) lookup.set(key, sref);
+  }
+
+  // Match either `@eN role "name"` or `@eN role` (no name).
+  const LEGEND_LINE = /@e\d+\s+([A-Za-z][\w-]*)(?:\s+"((?:[^"\\]|\\.)*)")?/g;
+  return legend.replace(LEGEND_LINE, (whole, role, name) => {
+    const key = `${role}\u0000${name ?? ''}`;
+    const sref = lookup.get(key);
+    if (!sref) return whole;
+    return name ? `@${sref} ${role} "${name}"` : `@${sref} ${role}`;
+  });
+}

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -1,4 +1,4 @@
-/**
+ /**
  * Browser Automation Tools
  *
  * These tools allow agents to control a headless browser via agent-browser.
@@ -11,6 +11,34 @@ import { readFile } from 'fs/promises'
 import { z } from 'zod'
 import { resizeScreenshot } from '../image-utils'
 import { tabManager } from '../tab-manager'
+import {
+  commitBaseline,
+  diffAgainstBaseline,
+  diffIsLargerThanFull,
+  formatDiff,
+  resetDuplicateOccurrences,
+  resolveRef,
+  resolveRefsInCommand,
+  rewriteAnnotateLegend,
+  StableRefNotFoundError,
+} from '../snapshot-stable-refs'
+
+/** Translate a model-facing `@sN` ref to the current `@eN` understood by
+ *  agent-browser. Returns a typed error result on miss so callers can short-
+ *  circuit cleanly. */
+function resolveRefOrError(ref: string):
+  | { ok: true; ref: string }
+  | { ok: false; error: ReturnType<typeof errorResult> } {
+  if (!currentSessionId) return { ok: true, ref }
+  try {
+    return { ok: true, ref: resolveRef(currentSessionId, ref) }
+  } catch (err) {
+    if (err instanceof StableRefNotFoundError) {
+      return { ok: false, error: errorResult(err.message) }
+    }
+    throw err
+  }
+}
 
 const CONTAINER_URL = `http://localhost:${process.env.PORT || '3000'}`
 
@@ -143,58 +171,124 @@ export const browserCloseTool = tool(
 
 export const browserSnapshotTool = tool(
   'browser_snapshot',
-  `Get an accessibility tree snapshot of the current page. Returns interactive elements with refs (like @e1, @e2) that you can use with browser_click and browser_fill.
+  `Get the current state of the page as an accessibility tree with stable refs (@s1, @s2, ...).
 
-Use interactive=true (default) to get clickable/fillable elements with refs.
-Use compact=true (default) to reduce output size.
-Use json=true to get structured JSON output with a refs dictionary.`,
+The first call (or one after a navigation / full-page replacement) returns the full tree. Subsequent calls return only what changed since the last call — added / removed / changed elements, plus a count of unchanged ones. You always know which one you got from the response header.
+
+Refs persist across calls: a ref you saw earlier still points to the same element as long as that element is still on the page. Reuse refs you already have. Refs are tool-layer identifiers — pass them only to browser_click / browser_fill / browser_hover / browser_select / browser_run's ref argument. They are NOT DOM attributes; do not put @sN inside a CSS selector or eval.
+
+Call this once per new page, and again after any action (click / fill / scroll / hover / press / select / open).
+
+Parameters:
+- fresh=true forces a full tree instead of a diff. Useful when a diff looked wrong or you have lost track of state.
+- include_text=true includes non-interactive text content (addresses, prices, paragraphs, list-item text, descriptions). Default false keeps the tree compact by listing only interactive elements + headings + landmarks. Turn this on when the task requires reading content that the default tree is missing. Returns a full tree (no diff) and is ~3-10× larger, so do not leave it on for routine observations.`,
   {
-    interactive: z
-      .boolean()
-      .optional()
-      .default(true)
-      .describe('Include interactive elements with refs (default: true)'),
-    compact: z
-      .boolean()
-      .optional()
-      .default(true)
-      .describe('Compact output to reduce size (default: true)'),
-    json: z
+    fresh: z
       .boolean()
       .optional()
       .default(false)
-      .describe('Return structured JSON with refs dictionary (default: false)'),
+      .describe('Force a full snapshot instead of a diff (default: false).'),
+    include_text: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        'Include non-interactive text nodes (addresses, prices, paragraphs, etc.). Default false. Forces a full snapshot. Use when the default interactive-only tree is missing the content you need to read.'
+      ),
   },
   async (args) => {
-    const result = await browserFetch('snapshot', {
-      interactive: args.interactive,
-      compact: args.compact,
-      json: args.json,
-    })
+    // Always pull a fresh snapshot — server-side annotates with stable refs.
+    // Default: diff against the committed baseline; fall back to full when the
+    // baseline is missing or the formatted diff would be at least as long as
+    // the full snapshot.
+    // fresh=true or include_text=true: skip the diff entirely and return the
+    // full tree (include_text would otherwise produce a diff that's missing
+    // the text nodes the caller asked for).
+    const fetchSnapshot = () =>
+      browserFetch('snapshot', {
+        interactive: !args.include_text,
+        compact: true,
+      })
+
+    const result = await fetchSnapshot()
     if (!result.success) return errorResult(result.error!)
 
-    const data = result.data as Record<string, unknown>
+    let data = result.data as Record<string, unknown>
     const tabCount = typeof data.tabCount === 'number' ? data.tabCount : 0
-    let text = data.snapshot
-      ? String(data.snapshot)
-      : JSON.stringify(data, null, 2)
+    let fullSnapshot = data.snapshot ? String(data.snapshot) : ''
 
-    text += tabManager.formatTabStatus(tabCount)
+    if (!currentSessionId) {
+      return {
+        content: [{ type: 'text' as const, text: fullSnapshot + tabManager.formatTabStatus(tabCount) }],
+      }
+    }
+
+    let diff = diffAgainstBaseline(currentSessionId)
+
+    // Mutation-driven baseline refresh.
+    // When elements were removed since the last baseline, identical sibling
+    // elements may have shifted occurrence indexes — leaving srefs pointing at
+    // the wrong physical element (Mode D: silent drift). Drop all duplicate-
+    // occurrence keys, re-fetch a clean snapshot, and serve that as a full
+    // tree so the model picks up the refreshed refs. Skipped when the caller
+    // already asked for a full tree or no duplicates exist.
+    let mutationReset = false
+    if (
+      !args.fresh &&
+      !args.include_text &&
+      !diff.noBaseline &&
+      diff.removed.length > 0
+    ) {
+      const dropped = resetDuplicateOccurrences(currentSessionId)
+      if (dropped > 0) {
+        const r2 = await fetchSnapshot()
+        if (r2.success) {
+          mutationReset = true
+          data = r2.data as Record<string, unknown>
+          fullSnapshot = data.snapshot ? String(data.snapshot) : ''
+          // Recompute the diff so srefToCurrentLine reflects the re-annotation.
+          diff = diffAgainstBaseline(currentSessionId)
+        }
+      }
+    }
+
+    commitBaseline(currentSessionId)
+
+    const useFull =
+      args.fresh ||
+      args.include_text ||
+      mutationReset ||
+      diff.noBaseline ||
+      diffIsLargerThanFull(diff)
+    const body = useFull ? fullSnapshot : formatDiff(diff)
+    const header = useFull
+      ? mutationReset
+        ? '(Full snapshot — list elements were removed; sibling refs refreshed to prevent occurrence drift.)\n\n'
+        : args.include_text
+          ? '(Full snapshot — include_text=true; text content included.)\n\n'
+          : args.fresh
+            ? '(Full snapshot — caller requested fresh=true.)\n\n'
+            : diff.noBaseline
+              ? '(Full snapshot — first observation in this session.)\n\n'
+              : '(Full snapshot — page churned enough that a full tree is shorter than the diff.)\n\n'
+      : ''
 
     return {
-      content: [{ type: 'text' as const, text }],
+      content: [{ type: 'text' as const, text: header + body + tabManager.formatTabStatus(tabCount) }],
     }
   }
 )
 
 export const browserClickTool = tool(
   'browser_click',
-  `Click an element on the page by its ref (e.g., @e1). Get refs from browser_snapshot.`,
+  `Click an element on the page by its ref (e.g., @s1). Get refs from browser_snapshot. Refs persist across snapshots — if you remember a ref from an earlier snapshot, it still works as long as the element is still on the page.`,
   {
-    ref: z.string().describe('Element ref from snapshot (e.g., "@e1")'),
+    ref: z.string().describe('Element ref from snapshot (e.g., "@s1")'),
   },
   async (args) => {
-    const result = await browserFetch('click', { ref: args.ref })
+    const resolved = resolveRefOrError(args.ref)
+    if (!resolved.ok) return resolved.error
+    const result = await browserFetch('click', { ref: resolved.ref })
     if (!result.success) return errorResult(result.error!)
     const data = result.data as Record<string, unknown> | undefined
     const tabInfo = data?.tabInfo as { activeIndex: number; activeUrl: string; tabCount: number } | undefined
@@ -214,14 +308,16 @@ export const browserClickTool = tool(
 
 export const browserFillTool = tool(
   'browser_fill',
-  `Fill an input field by its ref (e.g., @e2) with a value. Get refs from browser_snapshot.`,
+  `Fill an input field by its ref (e.g., @s2) with a value. Get refs from browser_snapshot.`,
   {
-    ref: z.string().describe('Input element ref from snapshot (e.g., "@e2")'),
+    ref: z.string().describe('Input element ref from snapshot (e.g., "@s2")'),
     value: z.string().describe('The text to fill into the input'),
   },
   async (args) => {
+    const resolved = resolveRefOrError(args.ref)
+    if (!resolved.ok) return resolved.error
     const result = await browserFetch('fill', {
-      ref: args.ref,
+      ref: resolved.ref,
       value: args.value,
     })
     if (!result.success) return errorResult(result.error!)
@@ -317,7 +413,7 @@ export const browserPressTool = tool(
 
 export const browserScreenshotTool = tool(
   'browser_screenshot',
-  `Take a screenshot of the current page. Returns the screenshot image and the file path where it was saved. Use full=true to capture the entire scrollable page. Use annotate=true to overlay numbered labels on interactive elements — each label [N] corresponds to ref @eN, so you can click elements by their visual label.`,
+  `Take a screenshot for visual verification. Use annotate=true to overlay numbered labels — each label [N] is paired with a stable ref @sN you can pass to browser_click / browser_fill, same as refs from browser_snapshot.`,
   {
     full: z
       .boolean()
@@ -328,7 +424,9 @@ export const browserScreenshotTool = tool(
       .boolean()
       .optional()
       .default(false)
-      .describe('Overlay numbered labels on interactive elements matching snapshot refs (default: false)'),
+      .describe(
+        'Overlay numbered labels [N] @sN on interactive elements (default: false). Useful when you want to pick a target visually.'
+      ),
   },
   async (args) => {
     const result = await browserFetch('screenshot', { full: args.full, annotate: args.annotate })
@@ -344,12 +442,22 @@ export const browserScreenshotTool = tool(
       if (image) {
         content.push({ type: 'image' as const, data: image.data, mimeType: image.mimeType })
       }
-      // For annotated screenshots, include the ref legend after the file path
-      const cleanOutput = stripAnsi(rawOutput).trim()
-      const legendStart = cleanOutput.indexOf('\n')
-      const legend = legendStart > 0 ? cleanOutput.slice(legendStart).trim() : ''
       const textParts = [`Screenshot saved to: ${filePath}`]
-      if (legend) textParts.push(legend)
+      if (args.annotate) {
+        // agent-browser's annotate legend pairs each [N] with its raw @eN ref.
+        // Rewrite those to stable @sN refs by matching (role, name) against
+        // the most recent snapshot — keeps the screenshot path consistent with
+        // browser_click / browser_fill, which only understand @sN.
+        const cleanOutput = stripAnsi(rawOutput).trim()
+        const legendStart = cleanOutput.indexOf('\n')
+        const rawLegend = legendStart > 0 ? cleanOutput.slice(legendStart).trim() : ''
+        if (rawLegend) {
+          const legend = currentSessionId
+            ? rewriteAnnotateLegend(currentSessionId, rawLegend)
+            : rawLegend
+          textParts.push(legend)
+        }
+      }
       content.push({ type: 'text' as const, text: textParts.join('\n') })
     } else {
       content.push({ type: 'text' as const, text: 'Screenshot taken.' })
@@ -363,11 +471,13 @@ export const browserSelectTool = tool(
   'browser_select',
   `Select an option from a <select> dropdown element by its ref. Get refs from browser_snapshot.`,
   {
-    ref: z.string().describe('Select element ref from snapshot (e.g., "@e3")'),
+    ref: z.string().describe('Select element ref from snapshot (e.g., "@s3")'),
     value: z.string().describe('The option value to select'),
   },
   async (args) => {
-    const result = await browserFetch('select', { ref: args.ref, value: args.value })
+    const resolved = resolveRefOrError(args.ref)
+    if (!resolved.ok) return resolved.error
+    const result = await browserFetch('select', { ref: resolved.ref, value: args.value })
     if (!result.success) return errorResult(result.error!)
     return {
       content: [
@@ -381,10 +491,12 @@ export const browserHoverTool = tool(
   'browser_hover',
   `Hover over an element by its ref. Useful for triggering dropdown menus, tooltips, or hover states. Get refs from browser_snapshot.`,
   {
-    ref: z.string().describe('Element ref from snapshot (e.g., "@e1")'),
+    ref: z.string().describe('Element ref from snapshot (e.g., "@s1")'),
   },
   async (args) => {
-    const result = await browserFetch('hover', { ref: args.ref })
+    const resolved = resolveRefOrError(args.ref)
+    if (!resolved.ok) return resolved.error
+    const result = await browserFetch('hover', { ref: resolved.ref })
     if (!result.success) return errorResult(result.error!)
     return {
       content: [
@@ -428,7 +540,12 @@ Available commands:
     command: z.string().describe('The agent-browser command to run (without "agent-browser" prefix)'),
   },
   async (args) => {
-    const result = await browserFetch('run', { command: args.command })
+    // Translate any @sN tokens in the raw command to current @eN refs so
+    // commands like `get text @s5` reach agent-browser with refs it knows.
+    const command = currentSessionId
+      ? resolveRefsInCommand(currentSessionId, args.command)
+      : args.command
+    const result = await browserFetch('run', { command })
     if (!result.success) return errorResult(result.error!)
     const data = result.data as Record<string, unknown>
     let text = data.output ? String(data.output) : 'Command executed.'
@@ -493,6 +610,10 @@ export const browserGetStateTool = tool(
       parts.push(`**Accessibility Snapshot:**\n${snapshot}`)
       const tabStatus = tabManager.formatTabStatus(tabCount)
       if (tabStatus) parts.push(tabStatus.trim())
+      // The model just saw a full annotated snapshot — promote it to the
+      // diff baseline so the next browser_snapshot doesn't re-report changes
+      // already covered here.
+      if (currentSessionId) commitBaseline(currentSessionId)
     } else {
       parts.push(`**Accessibility Snapshot:** Error - ${snapshotResult.error}`)
     }

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -3,11 +3,13 @@ You are a web browser automation agent. You receive high-level objectives and ac
 ## Your Tools
 
 **Core tools:**
-- `browser_snapshot(interactive?, compact?)` — Get accessibility tree with element refs (@e1, @e2, ...)
+- `browser_snapshot()` — Accessibility tree of the page with stable refs (@s1, @s2, ...). Returns the full tree on first call (or after navigation); afterwards returns only what changed. The response tells you which.
+  - `fresh: true` forces a full tree (use when a diff looks off or you have lost track).
+  - `include_text: true` adds non-interactive text content (addresses, prices, descriptions, paragraphs). Default is interactive elements only — fast and compact but missing plain text. Turn this on the **moment** the default tree is missing content you need to read, instead of falling back to `browser_run("eval ...")` to scrape the DOM.
 - `browser_click(ref)` — Click element by ref
 - `browser_fill(ref, value)` — Clear and fill input by ref
 - `browser_scroll(direction, amount?)` — Scroll the page (up/down/left/right)
-- `browser_get_state()` — Get URL + screenshot + snapshot in one call
+- `browser_get_state()` — URL + screenshot + full snapshot in one call. Use to recover when you are lost.
 
 **Interaction tools:**
 - `browser_press(key)` — Press a keyboard key (Enter, Tab, Escape, Control+a, ArrowDown, etc.)
@@ -21,13 +23,13 @@ You are a web browser automation agent. You receive high-level objectives and ac
 
 **Catch-all for advanced commands:**
 - `browser_run(command)` — Run any agent-browser CLI command. Examples:
-  - `browser_run("get text @e1")` — Get text content
+  - `browser_run("get text @s1")` — Get text content
   - `browser_run("get url")` — Get current page URL
   - `browser_run("eval document.title")` — Run JavaScript
   - `browser_run("back")` / `browser_run("forward")` / `browser_run("reload")` — Navigation
-  - `browser_run("type @e1 hello")` — Type text without clearing first
-  - `browser_run("check @e3")` / `browser_run("uncheck @e3")` — Toggle checkboxes
-  - `browser_run("upload @e1 /path/to/file")` — Upload files
+  - `browser_run("type @s1 hello")` — Type text without clearing first
+  - `browser_run("check @s3")` / `browser_run("uncheck @s3")` — Toggle checkboxes
+  - `browser_run("upload @s1 /path/to/file")` — Upload files
   - `browser_run("tab new https://example.com")` — Manage tabs
   - `browser_run("cookies")` — View cookies
 
@@ -36,11 +38,10 @@ You are a web browser automation agent. You receive high-level objectives and ac
 - `Read(file_path)` — Read screenshot files to visually verify pages
 
 ## Core Workflow
-1. Start with `browser_snapshot()` to see the current page state
-2. Interact using refs: `browser_click("@e1")`, `browser_fill("@e2", "text")`
-3. `browser_press("Enter")` to submit forms after filling inputs
-4. Re-snapshot after page changes to get updated refs
-5. After `browser_open()` or `browser_click()` that triggers navigation, just re-snapshot — no need to wait, `browser_open` already waits for the page to load
+1. Observe with `browser_snapshot()`.
+2. Act using refs: `browser_click("@s1")`, `browser_fill("@s2", "text")`, `browser_press("Enter")`. Refs persist across snapshots — reuse refs you saw earlier as long as the element is still on the page. Refs only work as the `ref` argument of browser_* tools; they are **not** DOM attributes, so never write `@sN` inside a CSS selector or eval string.
+3. After any action that could change the page (click / fill / scroll / hover / press / select / `browser_open`) → `browser_snapshot()` again. When elements get removed from a list, the snapshot response will tell you sibling refs were refreshed — trust the new refs.
+4. Recover only when a tool returns "Stable ref not found" or the snapshot contradicts what you expected → `browser_get_state()` to reset, then resume from step 2.
 
 ## Tab Management (MANDATORY)
 
@@ -59,9 +60,8 @@ Tab proliferation causes memory crashes and degrades performance. Follow these r
 - **ALWAYS report the current URL when you finish.** Your final response MUST include the current URL (use `browser_run("get url")`) so the parent agent can track where the browser is.
 - **Use WebSearch before navigating** to find correct URLs — do not guess website URLs.
 - **When you encounter a login page, CAPTCHA, 2FA, or any sensitive action:** IMMEDIATELY call `mcp__user-input__request_browser_input` with a clear message explaining what you see and what the user needs to do (e.g., log in, solve CAPTCHA, complete 2FA). Include specific requirements as a list. Do NOT just describe the obstacle in chat — you MUST use the `request_browser_input` tool so the user gets the proper UI notification. After the user completes, take a snapshot to see the updated state.
-- Use interactive + compact snapshot to reduce output — you usually only need buttons, links, inputs.
 - Use `browser_screenshot()` when you need to visually verify something the accessibility tree cannot tell you.
-- If a page has not fully rendered dynamic content, re-snapshot after a moment.
+- If a page has not fully rendered dynamic content, call `browser_snapshot()` after a moment.
 - The browser preserves cookies/sessions — the user logs in once and you can reuse the session.
 
 ## Response Format


### PR DESCRIPTION
…y diff threshold

Stable refs now survive list deletions without silently re-pointing at the wrong sibling (Mode D fix): when a snapshot diff shows REMOVED elements, the tool layer drops every keyToSref binding with a duplicate-occurrence suffix, re-fetches the snapshot, and serves it as a full tree with a header noting the refresh. Auto-reset replaces the previous prompt-only mitigation that the model frequently ignored.

Other sref lifecycle / correctness fixes:
- browser_open and notify-closed both clear the sref session, so navigation starts a fresh namespace and externally-closed browsers no longer leak state
- browser_get_state now commits the diff baseline so subsequent snapshots do not re-report changes the model already saw
- REF_RE accepts ref=eN / ref="eN" / ref='eN' for robustness against minor agent-browser output variations

Snapshot tool surface:
- New include_text parameter on browser_snapshot exposes the underlying --interactive=false knob (previously hardcoded to true). Forces a full tree so the diff path doesn't strip the text the caller asked for.
- Tool description and prompt clarify that @sN refs are tool-layer identifiers, not DOM attributes — never embed them in CSS selectors / eval.

Diff threshold:
- Replaced the 0.5 churn heuristic with a direct comparison of formatted diff length vs full snapshot length. No magic threshold, and fixes the prior asymmetry where removed elements counted toward churn but not the denominator.