### PR TITLE
feat(.claude/skills): add claude-prompt-drift skill

### DIFF
--- a/.claude/skills/claude-prompt-drift/.gitignore
+++ b/.claude/skills/claude-prompt-drift/.gitignore
@@ -1,0 +1,2 @@
+# Captured snapshots are local-only build artifacts.
+snapshots/

--- a/.claude/skills/claude-prompt-drift/SKILL.md
+++ b/.claude/skills/claude-prompt-drift/SKILL.md
@@ -1,0 +1,141 @@
+---
+description: Detect drift in the Claude system prompt that agent-container sends to Anthropic. Captures two axes — the bare `claude_code` preset (Anthropic baseline) and agent-container's overlaid wire request — at the SDK version pinned in `agent-container/package-lock.json`, then stores versioned snapshots in `<skill>/snapshots/` (gitignored). Use when bumping `@anthropic-ai/claude-agent-sdk`, debugging unexpected model behavior after an SDK upgrade, previewing what a PR changes in the on-wire prompt, or auditing what Anthropic silently changed in the Claude Code preset.
+---
+
+# Claude Prompt Drift Check
+
+Capture + diff of the `/v1/messages` request body that `claude-agent-sdk` emits, at two layers:
+
+| Axis          | What it captures                                                                              |
+| ------------- | --------------------------------------------------------------------------------------------- |
+| `pure-claude` | Bare `{ type: 'preset', preset: 'claude_code' }` baseline — no MCP, no append, no custom tools |
+| `superagent`  | What `agent-container` actually puts on the wire (skills, MCP, claudeMd, etc.)                |
+
+The diff *between* the two axes in a single snapshot is **our known modifications** — intentional, not interesting. The interesting signal is each axis's drift *across captures*:
+
+- `pure-claude` drift → Anthropic changed the preset.
+- `superagent` drift → our overlay changed (added/removed an MCP server, edited claudeMd, bumped SDK, etc.).
+
+## Files in this skill
+
+```
+.claude/skills/claude-prompt-drift/
+├── SKILL.md
+├── .gitignore                ← ignores `snapshots/`
+├── capture.sh                ← orchestrator (containers + proxy + drive)
+├── diff.sh                   ← cross-snapshot diff
+├── proxy.mjs                 ← pass-through capture proxy (runs in node:20 container)
+├── pure-baseline/run.mjs     ← bare-preset SDK driver (runs inside agent-container image)
+└── snapshots/                ← captured data, local only (gitignored)
+```
+
+`snapshots/` is build output, not source. It lives next to the script so it's trivially discoverable (`ls .claude/skills/claude-prompt-drift/snapshots/`) but never enters git.
+
+## Snapshot layout
+
+Default location: `<this skill>/snapshots/`. Override precedence: `--snapshots-dir <path>` > `$SNAPSHOTS_DIR` env > default.
+
+Layout under the snapshots root:
+
+```
+pure-claude/<sdk-version>/<model>/{system,messages,tools}.md + meta.json
+superagent/<sa-key>/<model>/{system,messages,tools}.md + meta.json
+```
+
+`<sa-key>` shape:
+
+| Source           | Shape                              | Example                       |
+| ---------------- | ---------------------------------- | ----------------------------- |
+| main / release   | `<sdk>+<sa-version>`               | `0.2.118+0.3.24`              |
+| `--pr <num>`     | `<sdk>+pr<num>-<short-sha>`        | `0.2.118+pr73-fef927c2`       |
+| dirty tree       | suffix `-dirty` (needs `--allow-dirty`) | `0.2.118+0.3.24-dirty`   |
+
+The two axes are keyed differently because they depend on different things: `pure-claude` only on the SDK version, `superagent` also on what SuperAgent ships. Mixing them in one key would silently overwrite the superagent axis when SuperAgent changes without an SDK bump.
+
+## When to use
+
+- After bumping `@anthropic-ai/claude-agent-sdk` in `agent-container/package.json`.
+- "Model is behaving weirdly since the SDK upgrade" — diff to see what shifted.
+- Reviewing a PR that touches `agent-container` prompts/tools — capture the PR head and diff against main.
+- Auditing whether Anthropic silently changed the `claude_code` preset.
+
+## Prerequisites
+
+- Docker running.
+- `jq`, `curl`, `git` on PATH.
+- Skill run from inside the SuperAgent repo (so `--superagent-path` can auto-resolve).
+
+## Usage
+
+### Capture the current SDK version (default = working tree)
+
+```bash
+cd /path/to/SuperAgent
+.claude/skills/claude-prompt-drift/capture.sh
+```
+
+### Capture a PR head without touching the working tree
+
+```bash
+.claude/skills/claude-prompt-drift/capture.sh --pr 73
+```
+
+`--pr` fetches `origin/pull/<num>/head`, builds in a detached worktree, captures, removes the worktree on exit.
+
+### Capture against an arbitrary checkout
+
+```bash
+git worktree add --detach /tmp/sa-old origin/main~10
+.claude/skills/claude-prompt-drift/capture.sh --superagent-path /tmp/sa-old
+git worktree remove /tmp/sa-old
+```
+
+### Flags
+
+| Flag                    | Default                                    | Meaning                                                  |
+| ----------------------- | ------------------------------------------ | -------------------------------------------------------- |
+| `--model`               | `claude-opus-4-7`                          | Model id (one snapshot per model)                        |
+| `--axis`                | `both`                                     | `pure-claude`, `superagent`, or `both`                   |
+| `--pr <num>`            | _none_                                     | Capture against a PR head (mutually exclusive with `--superagent-path`) |
+| `--force`               | off                                        | Re-capture even if snapshot exists                       |
+| `--allow-dirty`         | off                                        | Allow `superagent` capture from a dirty working tree. Key gets a `-dirty` suffix. |
+| `--snapshots-dir`       | `$SNAPSHOTS_DIR` or `<skill>/snapshots`    | Where to write snapshots (gitignored at the default location) |
+| `--superagent-path`     | _auto_                                     | Override SuperAgent repo path                            |
+| `--anthropic-api-key`   | `dummy-for-capture`                        | API key passed to the containers. Proxy captures the request body **before** forwarding upstream, so a 401 is fine. Claude Code's CLI does light local validation — pass a real-looking key if it complains. |
+
+### Diff two snapshots
+
+```bash
+.claude/skills/claude-prompt-drift/diff.sh pure-claude <old-sdk> <new-sdk>
+.claude/skills/claude-prompt-drift/diff.sh superagent  <old-key> <new-key>
+```
+
+Exits non-zero on drift (CI-friendly). Diff is per-axis on purpose — the two axes have different key shapes.
+
+## What "known modifications" means
+
+In a single capture, the diff between `pure-claude/<sdk>/<model>/system.md` and `superagent/<key>/<model>/system.md` is everything `agent-container` layers on top: skill listing, MCP instructions, custom claudeMd, etc. **That diff is expected and is not what this skill is for.** This skill tracks how each axis evolves over time.
+
+## Noise handling
+
+`proxy.mjs` redacts two volatile fields before writing the rendered `.md`:
+
+- The capture timestamp is dropped from `.md` (it lives in `meta.json`).
+- `cch=<hex>` in the billing header (system[0]) is replaced with `cch=<redacted>`. Claude Code regenerates this per request even for identical input, so leaving it raw makes every diff flap.
+
+Real signal fields like `cc_version=...` and `cc_entrypoint=` are kept.
+
+## Notes
+
+- One capture per `(axis, key, model)` is intentional — captures are large and the static prefix is stable per session. Use `--force` to redo.
+- `raw.json` and `.seen-models.json` are produced during capture but excluded from diffs.
+- `pure-baseline/run.mjs` uses the SDK that's already installed inside the agent-container image (no separate `npm install`), avoiding the glibc/musl mismatch that broke earlier attempts at running the baseline under `node:20-alpine`.
+- Working tree state matters. When pointing at the working repo directly, the script reads `git rev-parse HEAD` and `git status --porcelain` — make sure that's what you mean to capture (typically `origin/main` or a PR head, not a stale local branch).
+
+## Known caveat: local build ≠ GHCR image
+
+`capture.sh` runs `docker build ./agent-container` locally each invocation; it does **not** pull `ghcr.io/skillfulagents/superagent-agent-container-base:<sha>` (the image users actually run). The two are not byte-identical — different base-image digest resolution, `npm install` transitive-dep timing, build-cache state — so for a strict bit-for-bit integrity audit this skill is not the right tool.
+
+For wire-prompt drift, this is acceptable: `system` / `tools` / `messages` content all originate in `agent-container/src/` (system-prompt.md, MCP registrations, `claude-code.ts` tool wiring), which both the local build and CI bake in the same way. If a finding ever looks suspicious, re-check by pulling the GHCR image at the same SHA and inspecting out-of-band — but the common case doesn't require it.
+
+CI only publishes the base image on push to `main` (see `.github/workflows/build-container.yml`), so for PR captures local build is the only option regardless.

--- a/.claude/skills/claude-prompt-drift/capture.sh
+++ b/.claude/skills/claude-prompt-drift/capture.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# Capture pure-claude baseline and/or SuperAgent overlay system prompts at the
+# SDK version currently pinned in agent-container.
+#
+# Usage:
+#   capture.sh [--model claude-opus-4-7] \
+#              [--axis both|pure-claude|superagent] \
+#              [--force] \
+#              [--allow-dirty] \
+#              [--pr <number>] \
+#              [--snapshots-dir <path>] \
+#              [--anthropic-api-key <key>] \
+#              [--superagent-path <abs-path>]
+#
+# Snapshots are local-only build artifacts. Default location is `./snapshots/`
+# right next to this script (gitignored). Override precedence:
+#   --snapshots-dir <path>  >  $SNAPSHOTS_DIR env  >  default `<skill>/snapshots`
+#
+# Layout inside the snapshots root (one dir per axis):
+#   pure-claude/<sdk-version>/<model>/{system,messages,tools}.md + meta.json
+#   superagent/<sa-key>/<model>/{system,messages,tools}.md + meta.json
+#
+# superagent key shape depends on the source:
+#   - default       : <sdk-version>+<sa-version>            e.g. 0.2.118+0.3.24
+#   - --pr <num>    : <sdk-version>+pr<num>-<short-sha>     e.g. 0.2.118+pr73-fef927c2
+#   - dirty tree    : key gets a `-dirty` suffix (allowed only with --allow-dirty)
+#
+# Why two roots: pure-claude only depends on (sdk_version, model); superagent
+# also depends on SuperAgent's own version / commit. Sharing a single key
+# would silently overwrite the superagent axis on re-capture.
+#
+# --pr <num> fetches `origin/pull/<num>/head` and captures against that commit
+# without touching the working repo. Useful for previewing on-wire prompt
+# changes a PR would land before merging it.
+#
+# Default --superagent-path is derived from this skill's location
+# (.../<repo>/.claude/skills/claude-prompt-drift/ → <repo>).
+
+set -euo pipefail
+
+MODEL="claude-opus-4-7"
+AXIS="both"
+FORCE="false"
+ALLOW_DIRTY="false"
+PR_NUMBER=""
+API_KEY="dummy-for-capture"
+SUPERAGENT_PATH=""
+PR_WORKTREE=""
+SNAPSHOTS_DIR_FLAG=""
+
+usage() { sed -n '2,33p' "$0" | sed -E 's/^# ?//'; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model)              MODEL="$2"; shift 2 ;;
+    --axis)               AXIS="$2"; shift 2 ;;
+    --force)              FORCE="true"; shift ;;
+    --allow-dirty)        ALLOW_DIRTY="true"; shift ;;
+    --pr)                 PR_NUMBER="$2"; shift 2 ;;
+    --snapshots-dir)      SNAPSHOTS_DIR_FLAG="$2"; shift 2 ;;
+    --anthropic-api-key)  API_KEY="$2"; shift 2 ;;
+    --superagent-path)    SUPERAGENT_PATH="$2"; shift 2 ;;
+    -h|--help)            usage; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+SKILL_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
+
+# Snapshot location precedence: --snapshots-dir > $SNAPSHOTS_DIR > default
+# (skill-local `snapshots/`, gitignored).
+SNAPSHOTS_DIR="${SNAPSHOTS_DIR_FLAG:-${SNAPSHOTS_DIR:-$SKILL_DIR/snapshots}}"
+
+if [[ -n "$PR_NUMBER" && -n "$SUPERAGENT_PATH" ]]; then
+  echo "error: --pr and --superagent-path are mutually exclusive" >&2
+  exit 2
+fi
+
+if [[ -n "$PR_NUMBER" ]]; then
+  [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || { echo "error: --pr expects a number, got '$PR_NUMBER'" >&2; exit 2; }
+
+  PR_WORKTREE="/tmp/superagent-pr-$PR_NUMBER"
+  echo "[capture] fetching pull/$PR_NUMBER/head from origin..."
+  git -C "$REPO_ROOT" fetch origin "pull/$PR_NUMBER/head:refs/cprompt-drift/pr/$PR_NUMBER" --force >/dev/null 2>&1 \
+    || { echo "error: failed to fetch origin pull/$PR_NUMBER/head" >&2; exit 2; }
+
+  if [[ -d "$PR_WORKTREE" ]]; then
+    git -C "$REPO_ROOT" worktree remove --force "$PR_WORKTREE" >/dev/null 2>&1 || rm -rf "$PR_WORKTREE"
+  fi
+  git -C "$REPO_ROOT" worktree add --detach "$PR_WORKTREE" "refs/cprompt-drift/pr/$PR_NUMBER" >/dev/null \
+    || { echo "error: failed to create worktree at $PR_WORKTREE" >&2; exit 2; }
+
+  SUPERAGENT_PATH="$PR_WORKTREE"
+fi
+
+if [[ -z "$SUPERAGENT_PATH" ]]; then
+  SUPERAGENT_PATH="$REPO_ROOT"
+fi
+
+if [[ ! -d "$SUPERAGENT_PATH/agent-container" ]]; then
+  echo "error: $SUPERAGENT_PATH/agent-container not found — pass --superagent-path explicitly" >&2
+  exit 2
+fi
+
+for bin in docker jq curl; do
+  command -v "$bin" >/dev/null || { echo "error: $bin not on PATH" >&2; exit 2; }
+done
+
+LOCKFILE="$SUPERAGENT_PATH/agent-container/package-lock.json"
+[[ -f "$LOCKFILE" ]] || { echo "error: missing $LOCKFILE" >&2; exit 2; }
+
+SDK_VERSION=$(jq -r '.packages["node_modules/@anthropic-ai/claude-agent-sdk"].version // empty' "$LOCKFILE")
+if [[ -z "$SDK_VERSION" ]]; then
+  echo "error: could not extract @anthropic-ai/claude-agent-sdk version from $LOCKFILE" >&2
+  exit 2
+fi
+
+SA_VERSION=$(jq -r '.version // empty' "$SUPERAGENT_PATH/package.json" 2>/dev/null)
+if [[ -z "$SA_VERSION" ]]; then
+  echo "error: could not read .version from $SUPERAGENT_PATH/package.json" >&2
+  exit 2
+fi
+SA_COMMIT=$(git -C "$SUPERAGENT_PATH" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+SA_DIRTY="false"
+if [[ -n "$(git -C "$SUPERAGENT_PATH" status --porcelain 2>/dev/null || true)" ]]; then
+  SA_DIRTY="true"
+fi
+
+SA_KEY_SUFFIX=""
+if [[ "$SA_DIRTY" == "true" ]]; then
+  SA_KEY_SUFFIX="-dirty"
+fi
+
+if [[ -n "$PR_NUMBER" ]]; then
+  SA_KEY="${SDK_VERSION}+pr${PR_NUMBER}-${SA_COMMIT}${SA_KEY_SUFFIX}"
+else
+  SA_KEY="${SDK_VERSION}+${SA_VERSION}${SA_KEY_SUFFIX}"
+fi
+
+mkdir -p "$SNAPSHOTS_DIR"
+SNAPSHOTS_DIR="$(cd "$SNAPSHOTS_DIR" && pwd)"
+PURE_ROOT="$SNAPSHOTS_DIR/pure-claude/$SDK_VERSION"
+SA_ROOT="$SNAPSHOTS_DIR/superagent/$SA_KEY"
+
+IMAGE_TAG="superagent-container:drift-check"
+
+echo "[capture] SDK version  : $SDK_VERSION"
+echo "[capture] SA version   : $SA_VERSION"
+echo "[capture] SA commit    : $SA_COMMIT (dirty=$SA_DIRTY)"
+[[ -n "$PR_NUMBER" ]] && echo "[capture] source       : PR #$PR_NUMBER (worktree $PR_WORKTREE)"
+echo "[capture] snapshots    : $SNAPSHOTS_DIR"
+echo "[capture] model        : $MODEL"
+echo "[capture] axis         : $AXIS"
+echo "[capture] pure-claude  : $PURE_ROOT"
+echo "[capture] superagent   : $SA_ROOT"
+
+if [[ "$SA_DIRTY" == "true" && "$ALLOW_DIRTY" != "true" ]]; then
+  if [[ "$AXIS" == "superagent" || "$AXIS" == "both" ]]; then
+    echo "error: SuperAgent working tree is dirty — refuse to capture superagent axis." >&2
+    echo "       commit/stash changes, or pass --allow-dirty (snapshot key gets a '-dirty' suffix and should NOT be committed)." >&2
+    exit 2
+  fi
+fi
+
+NET_NAME="claude-drift-$$"
+PROXY_NAME="proxy-$$"
+SA_NAME="superagent-$$"
+BASELINE_NAME="baseline-$$"
+
+cleanup() {
+  local rc=$?
+  set +e
+  docker rm -f "$PROXY_NAME" "$SA_NAME" "$BASELINE_NAME" >/dev/null 2>&1
+  docker network rm "$NET_NAME" >/dev/null 2>&1
+  if [[ -n "$PR_WORKTREE" && -d "$PR_WORKTREE" ]]; then
+    git -C "$REPO_ROOT" worktree remove --force "$PR_WORKTREE" >/dev/null 2>&1 || rm -rf "$PR_WORKTREE"
+  fi
+  exit $rc
+}
+trap cleanup EXIT INT TERM
+
+docker network create "$NET_NAME" >/dev/null
+
+sanitize_model() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'; }
+MODEL_DIR=$(sanitize_model "$MODEL")
+
+build_image_once() {
+  # Always invoke docker build — image tag is not content-addressed, so a stale
+  # tag from an earlier capture (different branch / different --superagent-path)
+  # would otherwise be silently reused. Docker's own layer cache makes this fast
+  # when the build context hasn't changed.
+  echo "[capture] building $IMAGE_TAG from $SUPERAGENT_PATH/agent-container ..."
+  docker build -q -t "$IMAGE_TAG" "$SUPERAGENT_PATH/agent-container" >/dev/null
+}
+
+start_proxy() {
+  local out_dir="$1"
+  mkdir -p "$out_dir"
+  rm -f "$out_dir/.seen-models.json"
+
+  docker run -d --rm \
+    --name "$PROXY_NAME" \
+    --network "$NET_NAME" \
+    -v "$SKILL_DIR/proxy.mjs:/proxy.mjs:ro" \
+    -v "$out_dir:/out" \
+    node:20 \
+    node /proxy.mjs --port 9876 --upstream https://api.anthropic.com --out /out >/dev/null
+
+  for _ in $(seq 1 20); do
+    if docker logs "$PROXY_NAME" 2>&1 | grep -q '\[proxy\] listening'; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "[capture] proxy failed to start within 10s" >&2
+  docker logs "$PROXY_NAME" >&2 || true
+  exit 1
+}
+
+stop_proxy() { docker rm -f "$PROXY_NAME" >/dev/null 2>&1 || true; }
+
+wait_for_capture() {
+  local out_dir="$1" timeout_s="${2:-60}"
+  local target="$out_dir/$MODEL_DIR/raw.json"
+  for _ in $(seq 1 $((timeout_s * 2))); do
+    [[ -f "$target" ]] && return 0
+    sleep 0.5
+  done
+  echo "[capture] timeout waiting for $target" >&2
+  echo "[capture] proxy logs:" >&2
+  docker logs "$PROXY_NAME" 2>&1 | tail -50 >&2 || true
+  return 1
+}
+
+axis_already_captured() {
+  local out_dir="$1"
+  [[ -f "$out_dir/$MODEL_DIR/system.md" ]]
+}
+
+write_pure_meta() {
+  cat > "$PURE_ROOT/meta.json" <<EOF
+{
+  "sdk_version": "$SDK_VERSION",
+  "model": "$MODEL",
+  "captured_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+}
+
+write_sa_meta() {
+  local source_json='"main"'
+  if [[ -n "$PR_NUMBER" ]]; then
+    source_json="\"pr/$PR_NUMBER\""
+  fi
+  cat > "$SA_ROOT/meta.json" <<EOF
+{
+  "sdk_version": "$SDK_VERSION",
+  "superagent_version": "$SA_VERSION",
+  "superagent_commit": "$SA_COMMIT",
+  "superagent_dirty": $SA_DIRTY,
+  "source": $source_json,
+  "model": "$MODEL",
+  "captured_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+}
+
+capture_superagent() {
+  if axis_already_captured "$SA_ROOT" && [[ "$FORCE" != "true" ]]; then
+    echo "[skip] superagent/$SA_KEY/$MODEL already captured (use --force to redo)"
+    return
+  fi
+  rm -rf "$SA_ROOT"
+  mkdir -p "$SA_ROOT"
+
+  start_proxy "$SA_ROOT"
+
+  echo "[capture] running agent-container..."
+  docker run -d --rm \
+    --name "$SA_NAME" \
+    --network "$NET_NAME" \
+    -e ANTHROPIC_API_KEY="$API_KEY" \
+    -e ANTHROPIC_BASE_URL="http://$PROXY_NAME:9876" \
+    -p 3099:3000 \
+    "$IMAGE_TAG" >/dev/null
+
+  echo "[capture] waiting for agent-container HTTP API..."
+  for _ in $(seq 1 60); do
+    if curl -fsS -o /dev/null -X POST "http://localhost:3099/sessions" \
+         -H 'content-type: application/json' -d '{}' 2>/dev/null; then
+      break
+    fi
+    sleep 1
+  done
+
+  echo "[capture] firing model call..."
+  local create_body
+  create_body=$(jq -n --arg m "$MODEL" '{
+    initialMessage: "hi",
+    model: $m,
+    metadata: { name: "drift-check" }
+  }')
+
+  if ! curl -fsS -X POST "http://localhost:3099/sessions" \
+       -H 'content-type: application/json' \
+       -d "$create_body" -o /dev/null; then
+    echo "[capture] failed to create session" >&2
+    docker logs "$SA_NAME" 2>&1 | tail -80 >&2 || true
+    exit 1
+  fi
+
+  wait_for_capture "$SA_ROOT" 60
+  rm -f "$SA_ROOT/.seen-models.json"
+  write_sa_meta
+  echo "[capture] superagent capture done → $SA_ROOT/$MODEL_DIR"
+
+  docker rm -f "$SA_NAME" >/dev/null 2>&1 || true
+  stop_proxy
+}
+
+capture_pure_claude() {
+  if axis_already_captured "$PURE_ROOT" && [[ "$FORCE" != "true" ]]; then
+    echo "[skip] pure-claude/$SDK_VERSION/$MODEL already captured (use --force to redo)"
+    return
+  fi
+  rm -rf "$PURE_ROOT"
+  mkdir -p "$PURE_ROOT"
+
+  start_proxy "$PURE_ROOT"
+
+  echo "[capture] running pure-claude baseline (inside agent-container image, CMD overridden)..."
+  docker run --rm \
+    --name "$BASELINE_NAME" \
+    --network "$NET_NAME" \
+    -v "$SKILL_DIR/pure-baseline/run.mjs:/app/baseline-driver.mjs:ro" \
+    -e ANTHROPIC_API_KEY="$API_KEY" \
+    -e ANTHROPIC_BASE_URL="http://$PROXY_NAME:9876" \
+    --entrypoint node \
+    "$IMAGE_TAG" \
+    /app/baseline-driver.mjs >/dev/null 2>&1 || true
+
+  wait_for_capture "$PURE_ROOT" 30
+  rm -f "$PURE_ROOT/.seen-models.json"
+  write_pure_meta
+  echo "[capture] pure-claude capture done → $PURE_ROOT/$MODEL_DIR"
+
+  stop_proxy
+}
+
+build_image_once
+
+case "$AXIS" in
+  superagent)  capture_superagent ;;
+  pure-claude) capture_pure_claude ;;
+  both)        capture_pure_claude; capture_superagent ;;
+  *) echo "invalid --axis: $AXIS (expected: pure-claude | superagent | both)" >&2; exit 2 ;;
+esac
+
+echo
+echo "[done] diff against an older snapshot with:"
+echo "       $SKILL_DIR/diff.sh pure-claude <old-sdk-version> $SDK_VERSION"
+echo "       $SKILL_DIR/diff.sh superagent <old-key> $SA_KEY"
+echo "       (snapshots dir: $SNAPSHOTS_DIR)"

--- a/.claude/skills/claude-prompt-drift/diff.sh
+++ b/.claude/skills/claude-prompt-drift/diff.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Compare two captured snapshots within a single axis.
+#
+# Usage:
+#   diff.sh <axis> <old-key> <new-key> [--model <model>] [--snapshots-dir <path>]
+#
+#   axis     pure-claude | superagent
+#   old-key  for pure-claude: <sdk-version>               (e.g. 0.2.118)
+#            for superagent : <sdk-version>+<sa-version>  (e.g. 0.2.118+0.3.24)
+#                          or <sdk-version>+pr<num>-<sha> (e.g. 0.2.118+pr73-fef927c2)
+#   new-key  same format as old-key
+#
+# Snapshots default to `<skill>/snapshots/`. Override with --snapshots-dir
+# or the SNAPSHOTS_DIR env var.
+#
+# Exits non-zero if any drift is found (CI-friendly).
+
+set -euo pipefail
+
+AXIS=""
+OLD=""
+NEW=""
+MODEL=""
+SNAPSHOTS_DIR_FLAG=""
+
+usage() { sed -n '2,16p' "$0" | sed -E 's/^# ?//'; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model)          MODEL="$2"; shift 2 ;;
+    --snapshots-dir)  SNAPSHOTS_DIR_FLAG="$2"; shift 2 ;;
+    -h|--help)        usage; exit 0 ;;
+    *) if   [[ -z "$AXIS" ]]; then AXIS="$1"
+       elif [[ -z "$OLD"  ]]; then OLD="$1"
+       elif [[ -z "$NEW"  ]]; then NEW="$1"
+       else echo "extra arg: $1" >&2; usage >&2; exit 2
+       fi; shift ;;
+  esac
+done
+
+if [[ -z "$AXIS" || -z "$OLD" || -z "$NEW" ]]; then
+  echo "error: need <axis> <old-key> <new-key>" >&2
+  usage >&2
+  exit 2
+fi
+
+case "$AXIS" in
+  pure-claude|superagent) ;;
+  *) echo "invalid axis: $AXIS (expected: pure-claude | superagent)" >&2; exit 2 ;;
+esac
+
+SKILL_DIR="$(cd "$(dirname "$0")" && pwd)"
+SNAPSHOTS_DIR="${SNAPSHOTS_DIR_FLAG:-${SNAPSHOTS_DIR:-$SKILL_DIR/snapshots}}"
+
+OLD_DIR="$SNAPSHOTS_DIR/$AXIS/$OLD"
+NEW_DIR="$SNAPSHOTS_DIR/$AXIS/$NEW"
+
+[[ -d "$OLD_DIR" ]] || { echo "missing snapshot: $OLD_DIR" >&2; exit 2; }
+[[ -d "$NEW_DIR" ]] || { echo "missing snapshot: $NEW_DIR" >&2; exit 2; }
+
+sanitize_model() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'; }
+
+echo "===================================================================="
+echo " axis: $AXIS    $OLD  →  $NEW"
+echo " from: $SNAPSHOTS_DIR"
+echo "===================================================================="
+
+exit_code=0
+if [[ -n "$MODEL" ]]; then
+  m=$(sanitize_model "$MODEL")
+  diff -ruN -x 'raw.json' -x '.seen-models.json' \
+    --label "$AXIS/$OLD/$m" "$OLD_DIR/$m" \
+    --label "$AXIS/$NEW/$m" "$NEW_DIR/$m" || exit_code=$?
+else
+  diff -ruN -x 'raw.json' -x '.seen-models.json' \
+    --label "$AXIS/$OLD" "$OLD_DIR" \
+    --label "$AXIS/$NEW" "$NEW_DIR" || exit_code=$?
+fi
+
+echo
+if [[ $exit_code -eq 0 ]]; then
+  echo "[diff] no drift in $AXIS between $OLD and $NEW"
+else
+  echo "[diff] drift detected in $AXIS between $OLD and $NEW (see above)"
+fi
+exit $exit_code

--- a/.claude/skills/claude-prompt-drift/proxy.mjs
+++ b/.claude/skills/claude-prompt-drift/proxy.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// Pass-through proxy for capturing the first /v1/messages request per model
+// emitted by SuperAgent's agent-container (or any anthropic-sdk client).
+// On first sighting of each model, dump body.tools / body.system / body.messages
+// as readable .md files. Subsequent calls for the same model are forwarded
+// without capture.
+
+import http from 'node:http';
+import https from 'node:https';
+import { mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { URL } from 'node:url';
+
+const args = Object.fromEntries(
+  process.argv.slice(2).reduce((acc, cur, i, arr) => {
+    if (cur.startsWith('--')) acc.push([cur.slice(2), arr[i + 1]]);
+    return acc;
+  }, [])
+);
+
+const PORT = Number(args.port || process.env.PORT || 9876);
+const UPSTREAM = (args.upstream || process.env.UPSTREAM || 'https://api.anthropic.com').replace(/\/$/, '');
+const OUT_DIR = resolve(args.out || process.env.OUT_DIR || './captures');
+const RESET = args.reset === 'true' || args.reset === '';
+
+mkdirSync(OUT_DIR, { recursive: true });
+const seenFile = join(OUT_DIR, '.seen-models.json');
+let seen = new Set();
+if (!RESET && existsSync(seenFile)) {
+  try { seen = new Set(JSON.parse(readFileSync(seenFile, 'utf8'))); } catch {}
+}
+
+const upstreamUrl = new URL(UPSTREAM);
+const httpLib = upstreamUrl.protocol === 'https:' ? https : http;
+
+function fence(lang, s) { return '```' + lang + '\n' + s + '\n```\n'; }
+
+// Per-request volatile fields that change between identical builds and would
+// otherwise pollute every cross-snapshot diff. `cch=<hex>` is Claude Code's
+// per-request cache hash (header inside system[0]); it differs across every
+// run for the same input. The capture timestamp lives in meta.json, never in
+// the rendered .md.
+function redact(text) {
+  return String(text).replace(/cch=[0-9a-f]+/gi, 'cch=<redacted>');
+}
+
+function dumpCapture(model, body, ts) {
+  const dir = join(OUT_DIR, sanitize(model));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'raw.json'), JSON.stringify(body, null, 2));
+
+  const note = `> Model: \`${model}\`\n> Source: agent-container intercept proxy\n> Volatile fields redacted: \`cch=<redacted>\`; capture timestamp lives in meta.json.\n\n---\n\n`;
+
+  // system.md
+  const sys = body.system;
+  let sysMd = `# System Prompts\n\n${note}`;
+  if (typeof sys === 'string') {
+    sysMd += sys + '\n';
+  } else if (Array.isArray(sys)) {
+    sysMd += `\`body.system\` is an array of ${sys.length} blocks.\n\n`;
+    sys.forEach((blk, i) => {
+      sysMd += `## system[${i}] — type: \`${blk.type ?? '?'}\`\n`;
+      if (blk.cache_control) sysMd += `_cache_control_: \`${JSON.stringify(blk.cache_control)}\`\n\n`;
+      sysMd += redact(blk.text ?? JSON.stringify(blk, null, 2)) + '\n\n---\n\n';
+    });
+  } else {
+    sysMd += '_(no system block)_\n';
+  }
+  writeFileSync(join(dir, 'system.md'), sysMd);
+
+  // messages.md
+  const msgs = body.messages || [];
+  let msgMd = `# Messages\n\n${note}\`body.messages\` has ${msgs.length} message(s).\n\n`;
+  msgs.forEach((m, i) => {
+    msgMd += `## messages[${i}] — role: \`${m.role}\`\n\n`;
+    const c = m.content;
+    if (typeof c === 'string') { msgMd += c + '\n\n'; return; }
+    if (!Array.isArray(c)) { msgMd += fence('json', JSON.stringify(c, null, 2)); return; }
+    c.forEach((blk, j) => {
+      msgMd += `### content[${j}] — type: \`${blk.type}\`\n`;
+      if (blk.cache_control) msgMd += `_cache_control_: \`${JSON.stringify(blk.cache_control)}\`\n\n`;
+      if (blk.type === 'text') msgMd += redact(blk.text ?? '') + '\n\n';
+      else if (blk.type === 'tool_use') {
+        msgMd += `**tool**: \`${blk.name}\` **id**: \`${blk.id}\`\n\n**input**:\n\n` + fence('json', JSON.stringify(blk.input ?? {}, null, 2));
+      } else if (blk.type === 'tool_result') {
+        msgMd += `**tool_use_id**: \`${blk.tool_use_id}\` **is_error**: \`${blk.is_error ?? false}\`\n\n`;
+        const tc = blk.content;
+        if (typeof tc === 'string') msgMd += fence('', tc);
+        else if (Array.isArray(tc)) tc.forEach(x => msgMd += x.type === 'text' ? fence('', x.text ?? '') : fence('json', JSON.stringify(x, null, 2)));
+      } else {
+        msgMd += fence('json', JSON.stringify(blk, null, 2));
+      }
+    });
+    msgMd += '\n---\n\n';
+  });
+  writeFileSync(join(dir, 'messages.md'), msgMd);
+
+  // tools.md
+  const tools = body.tools || [];
+  let toolsMd = `# Tools\n\n${note}\`body.tools\` has **${tools.length}** definitions.\n\n## Index\n\n`;
+  tools.forEach((t, i) => toolsMd += `- [${i + 1}. ${t.name}](#${i + 1}-${slugify(t.name)})\n`);
+  toolsMd += '\n---\n\n';
+  tools.forEach((t, i) => {
+    toolsMd += `## ${i + 1}. ${t.name}\n\n`;
+    if (t.description) toolsMd += t.description.trim() + '\n\n';
+    toolsMd += `**input_schema**:\n\n` + fence('json', JSON.stringify(t.input_schema ?? {}, null, 2)) + '\n---\n\n';
+  });
+  writeFileSync(join(dir, 'tools.md'), toolsMd);
+
+  console.log(`[capture] ${model} → ${dir} (system ${sys?.length ?? 0}, messages ${msgs.length}, tools ${tools.length})`);
+}
+
+function sanitize(s) { return String(s).replace(/[^A-Za-z0-9._-]+/g, '_').slice(0, 80); }
+function slugify(s) { return String(s).toLowerCase().replace(/[^a-z0-9]+/g, '-'); }
+
+const server = http.createServer((req, res) => {
+  const chunks = [];
+  req.on('data', c => chunks.push(c));
+  req.on('end', () => {
+    const raw = Buffer.concat(chunks);
+
+    // Try to capture; failures must not block forwarding
+    if (req.method === 'POST' && req.url.startsWith('/v1/messages')) {
+      try {
+        const body = JSON.parse(raw.toString('utf8'));
+        const model = body.model || 'unknown';
+        if (!seen.has(model)) {
+          seen.add(model);
+          writeFileSync(seenFile, JSON.stringify([...seen], null, 2));
+          dumpCapture(model, body, new Date().toISOString());
+        } else {
+          console.log(`[skip] ${model} already captured`);
+        }
+      } catch (e) {
+        console.error('[capture-error]', e.message);
+      }
+    }
+
+    // Forward to upstream
+    const headers = { ...req.headers };
+    delete headers.host;
+    delete headers['content-length'];
+    headers.host = upstreamUrl.host;
+
+    const fwd = httpLib.request({
+      protocol: upstreamUrl.protocol,
+      host: upstreamUrl.hostname,
+      port: upstreamUrl.port || (upstreamUrl.protocol === 'https:' ? 443 : 80),
+      method: req.method,
+      path: req.url,
+      headers,
+    }, (upRes) => {
+      res.writeHead(upRes.statusCode || 502, upRes.headers);
+      upRes.pipe(res);
+    });
+
+    fwd.on('error', (e) => {
+      console.error('[upstream-error]', e.message);
+      if (!res.headersSent) res.writeHead(502, { 'content-type': 'text/plain' });
+      res.end('upstream error: ' + e.message);
+    });
+
+    if (raw.length) fwd.write(raw);
+    fwd.end();
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`[proxy] listening on http://localhost:${PORT}`);
+  console.log(`[proxy] upstream  ${UPSTREAM}`);
+  console.log(`[proxy] out dir   ${OUT_DIR}`);
+  console.log(`[proxy] seen so far: ${[...seen].join(', ') || '(none)'}`);
+});

--- a/.claude/skills/claude-prompt-drift/pure-baseline/run.mjs
+++ b/.claude/skills/claude-prompt-drift/pure-baseline/run.mjs
@@ -1,0 +1,30 @@
+// Minimal driver: invoke @anthropic-ai/claude-agent-sdk with the bare
+// `claude_code` preset and nothing else (no append, no mcpServers, no custom
+// tools). Sends one prompt so the SDK builds + emits its outbound /v1/messages
+// payload, which the capture proxy at ANTHROPIC_BASE_URL records.
+//
+// The SDK version is pinned in this folder's package.json. Keep it in sync
+// with SuperAgent/agent-container/package.json before running, then:
+//   npm install
+//   ANTHROPIC_API_KEY=dummy ANTHROPIC_BASE_URL=http://localhost:9876 \
+//     node run.mjs
+
+import { query } from '@anthropic-ai/claude-agent-sdk';
+
+const q = query({
+  prompt: 'say hi',
+  options: {
+    systemPrompt: { type: 'preset', preset: 'claude_code' },
+    model: 'claude-opus-4-7',
+    permissionMode: 'bypassPermissions',
+    cwd: '/tmp',
+  },
+});
+
+try {
+  for await (const msg of q) {
+    if (msg.type === 'result') break;
+  }
+} catch (err) {
+  console.error('[driver] expected error after capture:', err?.message ?? err);
+}


### PR DESCRIPTION
## Summary

Adds a `.claude/skills/claude-prompt-drift/` skill that snapshots and diffs the `/v1/messages` request body that `claude-agent-sdk` emits, at two independent layers:

| Axis          | What it captures                                                                              |
| ------------- | --------------------------------------------------------------------------------------------- |
| `pure-claude` | The bare `{ type: 'preset', preset: 'claude_code' }` baseline — no MCP, no append, no custom tools |
| `superagent`  | What `agent-container` actually puts on the wire (skills, MCP, claudeMd, etc.)                |

Cross-version diff on each axis catches two separate kinds of drift:

- **`pure-claude` drift** → Anthropic silently changed the Claude Code preset (new skill_listing entry, new `<system-reminder>`, tool description rewritten, etc.).
- **`superagent` drift** → our overlay changed (added/removed an MCP server, edited `claudeMd`, bumped SDK without realizing it touched something else).

The diff *between* the two axes inside a single snapshot is our **known modifications** — intentional, not noise. This skill does not try to subtract them; it just tracks each axis's evolution over time.

For the captured 0.2.118 baseline, the cross-axis delta is:

```
                       pure-claude   superagent   delta
system.md  lines:           245          725       +480
tools.md   lines:          1871         2952      +1081
tools      count:            26           58       +32   (mcp__agents__*, mcp__browser__*, mcp__dashboards__*, mcp__user-input__*)
```

## How it works

`capture.sh` is a one-shot orchestrator that:

1. Reads the pinned SDK version from `agent-container/package-lock.json`.
2. Builds (or reuses) the `superagent-container` image.
3. Spins up a private Docker network with three containers:
   - `proxy-*`: `node:20` running `proxy.mjs`, a pass-through HTTP proxy that dumps `body.system` / `body.messages` / `body.tools` as Markdown on first sight of each model, then forwards to `api.anthropic.com`.
   - `superagent-*`: the agent-container image, pointed at the proxy via `ANTHROPIC_BASE_URL`.
   - `baseline-*`: the **same** agent-container image, but with CMD overridden to run `pure-baseline/run.mjs` (a bare `query({ preset: 'claude_code' })` driver). Reusing this image is critical — it has the right `claude` native binary on PATH (glibc, not musl) so the SDK's spawned subprocess actually issues the wire request.
4. Fires one model call per axis.
5. Tears everything down (trap-based cleanup, verified).

Output lands in `snapshots/<sdk-version>/{pure-claude,superagent}/<model>/{system,messages,tools}.md` plus a `meta.json` recording SDK version, model, SuperAgent commit, capture timestamp.

`diff.sh <old> <new>` runs `diff -ruN` per axis (excluding `raw.json`) and exits non-zero if drift is detected — CI-friendly.

## Why this design (notes from testing)

Two non-obvious traps that bit during testing and informed the implementation:

1. **Alpine/musl vs glibc**: my first attempt ran the baseline driver in `node:20-alpine` with `npm install`. The SDK's spawned `claude` subprocess immediately failed because `agent-container`'s own Dockerfile explicitly strips the musl variant of the native binary; the musl/glibc mismatch makes the binary unusable. Fix: use the agent-container image itself as the runtime for both axes.
2. **Local API-key validation**: current `claude-agent-sdk@0.2.118` does light local key validation before issuing the request, so dummy keys + a synthetic install path never reach the proxy. Inside the agent-container image this path doesn't bite — the SDK proceeds and the proxy captures the body.

## What's included

- `SKILL.md` — frontmatter + full usage docs (matches the `update-claude-deps` neighbor style).
- `capture.sh`, `diff.sh` — orchestrator + diff (both `bash -n` clean, `--help` flags).
- `proxy.mjs` — pass-through capture proxy.
- `pure-baseline/run.mjs` — bare-preset SDK driver.
- `snapshots/0.2.118/` — a captured baseline for the currently-pinned SDK so the very next SDK bump has something to diff against. `raw.json` and `.seen-models.json` are `.gitignore`d (large / proxy-internal).
- `snapshots/README.md` — explains the snapshot layout and commit policy.

## Test plan

- [x] Fresh end-to-end run: `rm -rf snapshots/0.2.118 && ./capture.sh --axis both` — exit 0 in ~66s, both axes produce non-empty captures (pure-claude system 245 lines, superagent system 725 lines; tools 1871 vs 2952; messages 51 each).
- [x] `./diff.sh 0.2.118 0.2.118` reports no drift (sanity).
- [x] Cleanup trap: no leftover proxy / baseline / superagent containers; port 9876 free; private network removed.
- [x] `.gitignore` correctly excludes `raw.json` and `.seen-models.json` from the staged tree.
- [ ] Reviewer: please skim `snapshots/0.2.118/{pure-claude,superagent}/claude-opus-4-7/system.md` to confirm the captured content looks correct.

## Notes

- Skill is co-located with other SuperAgent-engineering skills (`update-claude-deps`, `update-models`, etc.) under `.claude/skills/`, not under the broader DatawizzAI/skills registry, because it is tightly tied to agent-container's Dockerfile and SDK pinning.
- No production code is touched. Adding files only.

Made with [Cursor](https://cursor.com)