### PR TITLE
Add scoped browser snapshots

### DIFF
--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -961,10 +961,10 @@ app.post('/browser/snapshot', async (c) => {
   try {
     const body = await c.req.json<{
       sessionId: string;
+      mode?: 'navigation' | 'detailed';
       interactive?: boolean;
       compact?: boolean;
       json?: boolean;
-      depth?: number;
       scope?: string;
     }>();
 

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -15,6 +15,7 @@ import { dashboardManager } from './dashboard-manager';
 import { tabManager } from './tab-manager';
 
 import { getEditingCommands } from './cdp-editing-commands';
+import { takeSnapshot, invalidate as invalidateSnapshot } from './snapshot';
 
 // Global error handlers to prevent crashes from AbortError during interrupts
 // The SDK throws AbortError when queries are aborted, which can propagate uncaught
@@ -876,6 +877,7 @@ app.post('/browser/open', async (c) => {
     _setBrowserState({ active: true, sessionId: body.sessionId, cdpUrl: cdpUrl || null });
     tabManager.resetTabCount();
     broadcastBrowserEvent(true);
+    invalidateSnapshot(body.sessionId);
 
     return c.json({ success: true });
   } catch (error: any) {
@@ -906,6 +908,7 @@ app.post('/browser/close', async (c) => {
 
     cleanupCdpScreencast();
     broadcastBrowserEvent(false);
+    if (body.sessionId) invalidateSnapshot(body.sessionId);
     _setBrowserState({ active: false, sessionId: null, cdpUrl: null });
     tabManager.resetTabCount();
 
@@ -942,9 +945,11 @@ app.post('/browser/release', async (c) => {
 // POST /browser/notify-closed - Host browser was closed externally, clean up state
 app.post('/browser/notify-closed', (c) => {
   if (browserState.active) {
+    const prevSessionId = browserState.sessionId;
     cleanupAgentBrowserDaemon();
     cleanupCdpScreencast();
     broadcastBrowserEvent(false);
+    if (prevSessionId) invalidateSnapshot(prevSessionId);
     _setBrowserState({ active: false, sessionId: null, cdpUrl: null });
     tabManager.resetTabCount();
     console.log('[Browser] Browser closed externally, state cleaned up');
@@ -952,46 +957,34 @@ app.post('/browser/notify-closed', (c) => {
   return c.json({ success: true });
 });
 
-// POST /browser/snapshot - Get accessibility tree snapshot
 app.post('/browser/snapshot', async (c) => {
   try {
-    const body = await c.req.json<{ sessionId: string; interactive?: boolean; compact?: boolean; json?: boolean }>();
+    const body = await c.req.json<{
+      sessionId: string;
+      interactive?: boolean;
+      compact?: boolean;
+      json?: boolean;
+      depth?: number;
+      scope?: string;
+    }>();
 
-    if (!body.sessionId) {
-      return c.json({ error: 'sessionId is required' }, 400);
-    }
-
+    if (!body.sessionId) return c.json({ error: 'sessionId is required' }, 400);
     const validationError = validateBrowserSession(body.sessionId);
-    if (validationError) {
-      return c.json({ error: validationError }, 409);
-    }
+    if (validationError) return c.json({ error: validationError }, 409);
+    if (!browserState.active) return c.json({ error: 'Browser is not active' }, 400);
 
-    if (!browserState.active) {
-      return c.json({ error: 'Browser is not active' }, 400);
-    }
-
-    const snapshotArgs = ['snapshot'];
-    if (body.json) snapshotArgs.push('--json');
-    if (body.interactive !== false) snapshotArgs.push('-i');
-    if (body.compact !== false) snapshotArgs.push('-c');
-
-    const result = await execBrowser(snapshotArgs, browserState.cdpUrl || undefined);
-
-    if (result.exitCode !== 0) {
-      return c.json({ error: result.stdout, success: false }, 500);
-    }
+    const result = await takeSnapshot(body.sessionId, body, browserState.cdpUrl, execBrowser);
+    if (!result.ok) return c.json({ error: result.error, success: false }, 500);
 
     if (body.json) {
-      // Try to parse JSON output
       try {
-        const parsed = JSON.parse(result.stdout);
+        const parsed = JSON.parse(result.text);
         return c.json({ ...parsed, tabCount: tabManager.getTabCount() });
       } catch {
-        return c.json({ snapshot: result.stdout, tabCount: tabManager.getTabCount() });
+        // fall through
       }
     }
-
-    return c.json({ snapshot: result.stdout, tabCount: tabManager.getTabCount() });
+    return c.json({ snapshot: result.text, tabCount: tabManager.getTabCount() });
   } catch (error: any) {
     console.error('[Browser] Error taking snapshot:', error);
     return c.json({ error: error.message || 'Failed to take snapshot' }, 500);
@@ -1871,8 +1864,8 @@ async function broadcastTabList(prefetched?: { allTargets: PageTarget[]; daemonT
   }
 }
 
-/** After a browser action, check if the active tab changed and switch screencast */
 function notifyBrowserAction() {
+  if (browserState.sessionId) invalidateSnapshot(browserState.sessionId);
   if (!cdpScreencast) return;
   const currentClient = cdpScreencast.clientWs;
   // Brief delay to let agent-browser update its internal state after the action

--- a/agent-container/src/snapshot.test.ts
+++ b/agent-container/src/snapshot.test.ts
@@ -50,43 +50,25 @@ describe('buildScopeCandidates', () => {
     expect(buildScopeCandidates('nav > ul')).toEqual(['nav > ul']);
     expect(buildScopeCandidates('//main')).toEqual(['//main']);
   });
-
-  it('plain names try aria-label first, fall back to bare CSS', () => {
-    expect(buildScopeCandidates('Repository')).toEqual([
-      '[aria-label="Repository"]',
-      '[role][aria-label="Repository"]',
-      'Repository',
-    ]);
-  });
-
-  it('multi-word names', () => {
-    expect(buildScopeCandidates('Personal tools')).toEqual([
-      '[aria-label="Personal tools"]',
-      '[role][aria-label="Personal tools"]',
-      'Personal tools',
-    ]);
-  });
-
-  it('escapes double quotes', () => {
-    expect(buildScopeCandidates('He said "hi"')[0]).toBe('[aria-label="He said \\"hi\\""]');
-  });
 });
 
 describe('takeSnapshot', () => {
-  it('caches full snapshot and serves depth slices locally', async () => {
+  it('caches navigate snapshots and returns a shallow page map', async () => {
     invalidate('s1');
     const exec = vi.fn(async (args: string[]) => ({
       stdout: TREE,
       exitCode: 0,
     }));
 
-    const r1 = await takeSnapshot('s1', { depth: 0 }, null, exec);
-    expect(r1).toEqual({ ok: true, text: '- WebArea "Title"' });
+    const r1 = await takeSnapshot('s1', {}, null, exec);
+    expect(r1).toEqual({
+      ok: true,
+      text: ['- WebArea "Title"', '  - banner', '  - main'].join('\n'),
+    });
     expect(exec).toHaveBeenCalledTimes(1);
 
-    const r2 = await takeSnapshot('s1', { depth: 1 }, null, exec);
-    expect(r2.ok).toBe(true);
-    if (r2.ok) expect(r2.text.split('\n')).toHaveLength(3);
+    const r2 = await takeSnapshot('s1', {}, null, exec);
+    expect(r2).toEqual(r1);
     expect(exec).toHaveBeenCalledTimes(1);
   });
 
@@ -99,11 +81,9 @@ describe('takeSnapshot', () => {
     expect(exec).toHaveBeenCalledTimes(2);
   });
 
-  it('scope tries candidates in order until one succeeds', async () => {
+  it('scope by CSS selector passes the selector through', async () => {
     invalidate('s3');
-    let call = 0;
     const exec = vi.fn(async (args: string[]) => {
-      call++;
       const scopeArg = args[args.indexOf('-s') + 1];
       if (scopeArg === '[aria-label="Repository"]') {
         return { stdout: '- navigation "Repository" [ref=e7]', exitCode: 0 };
@@ -111,12 +91,12 @@ describe('takeSnapshot', () => {
       return { stdout: "Selector didn't match", exitCode: 1 };
     });
 
-    const r = await takeSnapshot('s3', { scope: 'Repository' }, null, exec);
+    const r = await takeSnapshot('s3', { scope: '[aria-label="Repository"]' }, null, exec);
     expect(r).toEqual({ ok: true, text: '- navigation "Repository" [ref=e7]' });
-    expect(call).toBe(1);
+    expect(exec).toHaveBeenCalledTimes(1);
   });
 
-  it('scope falls through candidates when earlier ones miss', async () => {
+  it('scope by plain CSS selector is attempted once', async () => {
     invalidate('s4');
     const exec = vi.fn(async (args: string[]) => {
       const scopeArg = args[args.indexOf('-s') + 1];
@@ -126,7 +106,7 @@ describe('takeSnapshot', () => {
 
     const r = await takeSnapshot('s4', { scope: 'main' }, null, exec);
     expect(r).toEqual({ ok: true, text: '- main' });
-    expect(exec).toHaveBeenCalledTimes(3);
+    expect(exec).toHaveBeenCalledTimes(1);
   });
 
   it('returns error when all scope candidates fail', async () => {
@@ -137,39 +117,62 @@ describe('takeSnapshot', () => {
     expect(r).toEqual({ ok: false, error: 'nope' });
   });
 
-  it('no scope + no depth truncates to default (top-level only)', async () => {
+  it('navigate mode returns a shallow page map', async () => {
     invalidate('s6');
     const exec = vi.fn(async () => ({ stdout: TREE, exitCode: 0 }));
     const r = await takeSnapshot('s6', {}, null, exec);
-    expect(r).toEqual({ ok: true, text: '- WebArea "Title"' });
+    expect(r).toEqual({
+      ok: true,
+      text: ['- WebArea "Title"', '  - banner', '  - main'].join('\n'),
+    });
   });
 
-  it('scope + no depth does NOT pass -d to CLI (returns full subtree)', async () => {
+  it('scoped navigate snapshots stay shallow', async () => {
     invalidate('s7');
-    const exec = vi.fn(async (args: string[]) => ({
-      stdout: args.includes('-d') ? 'truncated' : 'full subtree',
-      exitCode: 0,
-    }));
+    const exec = vi.fn(async (args: string[]) => ({ stdout: TREE, exitCode: 0 }));
     const r = await takeSnapshot('s7', { scope: 'Repository' }, null, exec);
-    expect(r).toEqual({ ok: true, text: 'full subtree' });
+    expect(r).toEqual({
+      ok: true,
+      text: ['- WebArea "Title"', '  - banner', '  - main'].join('\n'),
+    });
     expect(exec).toHaveBeenCalled();
     const calledArgs = exec.mock.calls[0]![0] as string[];
     expect(calledArgs).not.toContain('-d');
   });
 
-  it('depth=-1 returns the full unfiltered snapshot (no truncation)', async () => {
-    invalidate('s9');
+  it('detailed mode requires scope', async () => {
+    invalidate('s10');
     const exec = vi.fn(async () => ({ stdout: TREE, exitCode: 0 }));
-    const r = await takeSnapshot('s9', { depth: -1 }, null, exec);
-    expect(r).toEqual({ ok: true, text: TREE });
+    const r = await takeSnapshot('s10', { mode: 'detailed' }, null, exec);
+    expect(r).toEqual({
+      ok: false,
+      error: 'mode "detailed" requires scope. First use the default navigation snapshot to identify a CSS/XPath selector, then retry with mode "detailed" and scope.',
+    });
+    expect(exec).not.toHaveBeenCalled();
   });
 
-  it('scope + explicit depth passes -d to CLI', async () => {
-    invalidate('s8');
+  it('scoped detailed mode returns the full snapshot without -d', async () => {
+    invalidate('s11');
+    const exec = vi.fn(async (args: string[]) => ({
+      stdout: args.includes('-d') ? '(empty page)' : TREE,
+      exitCode: 0,
+    }));
+    const r = await takeSnapshot('s11', { mode: 'detailed', scope: 'main' }, null, exec);
+    expect(r).toEqual({ ok: true, text: TREE });
+    expect(exec.mock.calls[0]![0]).toEqual(['snapshot', '-c', '-i', '-s', 'main']);
+  });
+
+  it('interactive=false is independent from mode', async () => {
+    invalidate('s12');
     const exec = vi.fn(async (args: string[]) => ({ stdout: args.join(' '), exitCode: 0 }));
-    await takeSnapshot('s8', { scope: 'Repository', depth: 2 }, null, exec);
-    const calledArgs = exec.mock.calls[0]![0] as string[];
-    expect(calledArgs).toContain('-d');
-    expect(calledArgs[calledArgs.indexOf('-d') + 1]).toBe('2');
+    await takeSnapshot('s12', { interactive: false }, null, exec);
+    expect(exec.mock.calls[0]![0]).toEqual(['snapshot', '-c']);
+  });
+
+  it('compact=false is independent from mode', async () => {
+    invalidate('s13');
+    const exec = vi.fn(async (args: string[]) => ({ stdout: args.join(' '), exitCode: 0 }));
+    await takeSnapshot('s13', { compact: false }, null, exec);
+    expect(exec.mock.calls[0]![0]).toEqual(['snapshot', '-i']);
   });
 });

--- a/agent-container/src/snapshot.test.ts
+++ b/agent-container/src/snapshot.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi } from 'vitest';
+import { takeSnapshot, invalidate, buildScopeCandidates, __test } from './snapshot';
+
+const { truncateToDepth } = __test;
+
+const TREE = [
+  '- WebArea "Title"',
+  '  - banner',
+  '    - link "Logo"',
+  '  - main',
+  '    - heading "Welcome"',
+  '      - text "Hello world"',
+  '    - button "Sign in" [ref=e1]',
+].join('\n');
+
+describe('truncateToDepth', () => {
+  it('depth=0 keeps only the root', () => {
+    expect(truncateToDepth(TREE, 0)).toBe('- WebArea "Title"');
+  });
+
+  it('depth=1 keeps root + landmarks', () => {
+    expect(truncateToDepth(TREE, 1)).toBe(
+      ['- WebArea "Title"', '  - banner', '  - main'].join('\n')
+    );
+  });
+
+  it('depth=2 keeps three levels', () => {
+    expect(truncateToDepth(TREE, 2)).toBe(
+      [
+        '- WebArea "Title"',
+        '  - banner',
+        '    - link "Logo"',
+        '  - main',
+        '    - heading "Welcome"',
+        '    - button "Sign in" [ref=e1]',
+      ].join('\n')
+    );
+  });
+
+  it('depth large enough keeps everything', () => {
+    expect(truncateToDepth(TREE, 99)).toBe(TREE);
+  });
+});
+
+describe('buildScopeCandidates', () => {
+  it('passes CSS / XPath through unchanged', () => {
+    expect(buildScopeCandidates('[role=dialog]')).toEqual(['[role=dialog]']);
+    expect(buildScopeCandidates('#login')).toEqual(['#login']);
+    expect(buildScopeCandidates('form.login')).toEqual(['form.login']);
+    expect(buildScopeCandidates('nav > ul')).toEqual(['nav > ul']);
+    expect(buildScopeCandidates('//main')).toEqual(['//main']);
+  });
+
+  it('plain names try aria-label first, fall back to bare CSS', () => {
+    expect(buildScopeCandidates('Repository')).toEqual([
+      '[aria-label="Repository"]',
+      '[role][aria-label="Repository"]',
+      'Repository',
+    ]);
+  });
+
+  it('multi-word names', () => {
+    expect(buildScopeCandidates('Personal tools')).toEqual([
+      '[aria-label="Personal tools"]',
+      '[role][aria-label="Personal tools"]',
+      'Personal tools',
+    ]);
+  });
+
+  it('escapes double quotes', () => {
+    expect(buildScopeCandidates('He said "hi"')[0]).toBe('[aria-label="He said \\"hi\\""]');
+  });
+});
+
+describe('takeSnapshot', () => {
+  it('caches full snapshot and serves depth slices locally', async () => {
+    invalidate('s1');
+    const exec = vi.fn(async (args: string[]) => ({
+      stdout: TREE,
+      exitCode: 0,
+    }));
+
+    const r1 = await takeSnapshot('s1', { depth: 0 }, null, exec);
+    expect(r1).toEqual({ ok: true, text: '- WebArea "Title"' });
+    expect(exec).toHaveBeenCalledTimes(1);
+
+    const r2 = await takeSnapshot('s1', { depth: 1 }, null, exec);
+    expect(r2.ok).toBe(true);
+    if (r2.ok) expect(r2.text.split('\n')).toHaveLength(3);
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidate clears the cache', async () => {
+    invalidate('s2');
+    const exec = vi.fn(async () => ({ stdout: TREE, exitCode: 0 }));
+    await takeSnapshot('s2', {}, null, exec);
+    invalidate('s2');
+    await takeSnapshot('s2', {}, null, exec);
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+
+  it('scope tries candidates in order until one succeeds', async () => {
+    invalidate('s3');
+    let call = 0;
+    const exec = vi.fn(async (args: string[]) => {
+      call++;
+      const scopeArg = args[args.indexOf('-s') + 1];
+      if (scopeArg === '[aria-label="Repository"]') {
+        return { stdout: '- navigation "Repository" [ref=e7]', exitCode: 0 };
+      }
+      return { stdout: "Selector didn't match", exitCode: 1 };
+    });
+
+    const r = await takeSnapshot('s3', { scope: 'Repository' }, null, exec);
+    expect(r).toEqual({ ok: true, text: '- navigation "Repository" [ref=e7]' });
+    expect(call).toBe(1);
+  });
+
+  it('scope falls through candidates when earlier ones miss', async () => {
+    invalidate('s4');
+    const exec = vi.fn(async (args: string[]) => {
+      const scopeArg = args[args.indexOf('-s') + 1];
+      if (scopeArg === 'main') return { stdout: '- main', exitCode: 0 };
+      return { stdout: 'no match', exitCode: 1 };
+    });
+
+    const r = await takeSnapshot('s4', { scope: 'main' }, null, exec);
+    expect(r).toEqual({ ok: true, text: '- main' });
+    expect(exec).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns error when all scope candidates fail', async () => {
+    invalidate('s5');
+    const exec = vi.fn(async () => ({ stdout: 'nope', exitCode: 1 }));
+
+    const r = await takeSnapshot('s5', { scope: 'Nonexistent' }, null, exec);
+    expect(r).toEqual({ ok: false, error: 'nope' });
+  });
+
+  it('no scope + no depth truncates to default (top-level only)', async () => {
+    invalidate('s6');
+    const exec = vi.fn(async () => ({ stdout: TREE, exitCode: 0 }));
+    const r = await takeSnapshot('s6', {}, null, exec);
+    expect(r).toEqual({ ok: true, text: '- WebArea "Title"' });
+  });
+
+  it('scope + no depth does NOT pass -d to CLI (returns full subtree)', async () => {
+    invalidate('s7');
+    const exec = vi.fn(async (args: string[]) => ({
+      stdout: args.includes('-d') ? 'truncated' : 'full subtree',
+      exitCode: 0,
+    }));
+    const r = await takeSnapshot('s7', { scope: 'Repository' }, null, exec);
+    expect(r).toEqual({ ok: true, text: 'full subtree' });
+    expect(exec).toHaveBeenCalled();
+    const calledArgs = exec.mock.calls[0]![0] as string[];
+    expect(calledArgs).not.toContain('-d');
+  });
+
+  it('depth=-1 returns the full unfiltered snapshot (no truncation)', async () => {
+    invalidate('s9');
+    const exec = vi.fn(async () => ({ stdout: TREE, exitCode: 0 }));
+    const r = await takeSnapshot('s9', { depth: -1 }, null, exec);
+    expect(r).toEqual({ ok: true, text: TREE });
+  });
+
+  it('scope + explicit depth passes -d to CLI', async () => {
+    invalidate('s8');
+    const exec = vi.fn(async (args: string[]) => ({ stdout: args.join(' '), exitCode: 0 }));
+    await takeSnapshot('s8', { scope: 'Repository', depth: 2 }, null, exec);
+    const calledArgs = exec.mock.calls[0]![0] as string[];
+    expect(calledArgs).toContain('-d');
+    expect(calledArgs[calledArgs.indexOf('-d') + 1]).toBe('2');
+  });
+});

--- a/agent-container/src/snapshot.ts
+++ b/agent-container/src/snapshot.ts
@@ -10,7 +10,7 @@ interface CacheEntry {
 const cache = new Map<string, CacheEntry>();
 
 export interface SnapshotOptions {
-  depth?: number | null;
+  mode?: 'navigation' | 'detailed' | null;
   scope?: string | null;
   json?: boolean;
   interactive?: boolean;
@@ -40,24 +40,14 @@ function truncateToDepth(text: string, depth: number): string {
   return out.join('\n');
 }
 
-// Plain accessible names (e.g. `"Repository"` from the snapshot) become
-// aria-label lookups; anything else passes through as CSS / XPath.
+// Scope is intentionally simple: a CSS selector or XPath. The model should
+// choose the selector it actually wants to query; we do not guess accessible
+// names or interpret snapshot refs as scope targets.
 export function buildScopeCandidates(scope: string): string[] {
-  if (/[[\]#.>~+*]/.test(scope) || scope.startsWith('//')) return [scope];
-
-  const escaped = scope.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-  return [
-    `[aria-label="${escaped}"]`,
-    `[role][aria-label="${escaped}"]`,
-    scope,
-  ];
+  return [scope];
 }
 
-// When the caller doesn't pin a depth and isn't scoping into a subtree, we
-// truncate to this depth locally so a default `browser_snapshot()` stays cheap
-// (just the top-level clickables). With `scope`, the caller has already
-// narrowed the subtree, so we return it whole unless they pin a depth.
-const DEFAULT_UNSCOPED_DEPTH = 0;
+const NAVIGATE_DEPTH = 1;
 
 export async function takeSnapshot(
   sessionId: string,
@@ -65,15 +55,16 @@ export async function takeSnapshot(
   cdpUrl: string | null,
   execBrowser: ExecBrowser
 ): Promise<SnapshotResult> {
-  // depth semantics: undefined → use default for this mode; -1 → no truncation
-  // (full tree); any non-negative integer → truncate / cap at that depth.
-  const isUnlimited = opts.depth === -1;
-  const explicitDepth =
-    typeof opts.depth === 'number' && Number.isInteger(opts.depth) && opts.depth >= 0
-      ? opts.depth
-      : null;
+  const mode = opts.mode === 'detailed' ? 'detailed' : 'navigation';
   const hasScope = typeof opts.scope === 'string' && opts.scope.length > 0;
+  if (mode === 'detailed' && !hasScope) {
+    return {
+      ok: false,
+      error: 'mode "detailed" requires scope. First use the default navigation snapshot to identify a CSS/XPath selector, then retry with mode "detailed" and scope.',
+    };
+  }
   const canUseCache =
+    mode === 'navigation' &&
     !hasScope &&
     !opts.json &&
     opts.interactive !== false &&
@@ -89,23 +80,23 @@ export async function takeSnapshot(
       full = res.stdout;
       cache.set(sessionId, { text: full, capturedAt: Date.now() });
     }
-    if (isUnlimited) return { ok: true, text: full };
-    const effectiveDepth = explicitDepth ?? DEFAULT_UNSCOPED_DEPTH;
-    return { ok: true, text: truncateToDepth(full, effectiveDepth) };
+    return { ok: true, text: truncateToDepth(full, NAVIGATE_DEPTH) };
   }
 
-  const baseArgs = ['snapshot'];
-  if (opts.json) baseArgs.push('--json');
-  if (opts.interactive !== false) baseArgs.push('-i');
-  if (opts.compact !== false) baseArgs.push('-c');
-  if (explicitDepth != null) baseArgs.push('-d', String(explicitDepth));
+  const snapshotOptions = ['-c'];
+  if (opts.json) snapshotOptions.push('--json');
+  if (opts.interactive !== false) snapshotOptions.push('-i');
+  if (opts.compact === false) snapshotOptions.splice(snapshotOptions.indexOf('-c'), 1);
 
   const selectors = hasScope ? buildScopeCandidates(opts.scope!) : [null];
   let last = { stdout: '', exitCode: 0 };
   for (const sel of selectors) {
-    const args = sel ? [...baseArgs, '-s', sel] : baseArgs;
+    const args = sel ? ['snapshot', ...snapshotOptions, '-s', sel] : ['snapshot', ...snapshotOptions];
     last = await execBrowser(args, cdpUrl ?? undefined);
-    if (last.exitCode === 0) return { ok: true, text: last.stdout };
+    if (last.exitCode === 0) {
+      if (mode === 'detailed' || opts.json) return { ok: true, text: last.stdout };
+      return { ok: true, text: truncateToDepth(last.stdout, NAVIGATE_DEPTH) };
+    }
   }
   return { ok: false, error: last.stdout };
 }

--- a/agent-container/src/snapshot.ts
+++ b/agent-container/src/snapshot.ts
@@ -1,0 +1,113 @@
+const TTL_MS = 5000;
+
+type ExecBrowser = (args: string[], cdpUrl?: string) => Promise<{ stdout: string; exitCode: number }>;
+
+interface CacheEntry {
+  text: string;
+  capturedAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+export interface SnapshotOptions {
+  depth?: number | null;
+  scope?: string | null;
+  json?: boolean;
+  interactive?: boolean;
+  compact?: boolean;
+}
+
+export type SnapshotResult =
+  | { ok: true; text: string }
+  | { ok: false; error: string };
+
+export function invalidate(sessionId: string): void {
+  cache.delete(sessionId);
+}
+
+function truncateToDepth(text: string, depth: number): string {
+  const maxLeadingSpaces = depth * 2;
+  const out: string[] = [];
+  for (const line of text.split('\n')) {
+    const trimmed = line.trimStart();
+    if (trimmed.length === 0) {
+      out.push(line);
+      continue;
+    }
+    const lead = line.length - trimmed.length;
+    if (lead <= maxLeadingSpaces) out.push(line);
+  }
+  return out.join('\n');
+}
+
+// Plain accessible names (e.g. `"Repository"` from the snapshot) become
+// aria-label lookups; anything else passes through as CSS / XPath.
+export function buildScopeCandidates(scope: string): string[] {
+  if (/[[\]#.>~+*]/.test(scope) || scope.startsWith('//')) return [scope];
+
+  const escaped = scope.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return [
+    `[aria-label="${escaped}"]`,
+    `[role][aria-label="${escaped}"]`,
+    scope,
+  ];
+}
+
+// When the caller doesn't pin a depth and isn't scoping into a subtree, we
+// truncate to this depth locally so a default `browser_snapshot()` stays cheap
+// (just the top-level clickables). With `scope`, the caller has already
+// narrowed the subtree, so we return it whole unless they pin a depth.
+const DEFAULT_UNSCOPED_DEPTH = 0;
+
+export async function takeSnapshot(
+  sessionId: string,
+  opts: SnapshotOptions,
+  cdpUrl: string | null,
+  execBrowser: ExecBrowser
+): Promise<SnapshotResult> {
+  // depth semantics: undefined → use default for this mode; -1 → no truncation
+  // (full tree); any non-negative integer → truncate / cap at that depth.
+  const isUnlimited = opts.depth === -1;
+  const explicitDepth =
+    typeof opts.depth === 'number' && Number.isInteger(opts.depth) && opts.depth >= 0
+      ? opts.depth
+      : null;
+  const hasScope = typeof opts.scope === 'string' && opts.scope.length > 0;
+  const canUseCache =
+    !hasScope &&
+    !opts.json &&
+    opts.interactive !== false &&
+    opts.compact !== false;
+
+  if (canUseCache) {
+    const cached = cache.get(sessionId);
+    const fresh = cached && Date.now() - cached.capturedAt <= TTL_MS;
+    let full = fresh ? cached!.text : null;
+    if (full == null) {
+      const res = await execBrowser(['snapshot', '-i', '-c'], cdpUrl ?? undefined);
+      if (res.exitCode !== 0) return { ok: false, error: res.stdout };
+      full = res.stdout;
+      cache.set(sessionId, { text: full, capturedAt: Date.now() });
+    }
+    if (isUnlimited) return { ok: true, text: full };
+    const effectiveDepth = explicitDepth ?? DEFAULT_UNSCOPED_DEPTH;
+    return { ok: true, text: truncateToDepth(full, effectiveDepth) };
+  }
+
+  const baseArgs = ['snapshot'];
+  if (opts.json) baseArgs.push('--json');
+  if (opts.interactive !== false) baseArgs.push('-i');
+  if (opts.compact !== false) baseArgs.push('-c');
+  if (explicitDepth != null) baseArgs.push('-d', String(explicitDepth));
+
+  const selectors = hasScope ? buildScopeCandidates(opts.scope!) : [null];
+  let last = { stdout: '', exitCode: 0 };
+  for (const sel of selectors) {
+    const args = sel ? [...baseArgs, '-s', sel] : baseArgs;
+    last = await execBrowser(args, cdpUrl ?? undefined);
+    if (last.exitCode === 0) return { ok: true, text: last.stdout };
+  }
+  return { ok: false, error: last.stdout };
+}
+
+export const __test = { truncateToDepth };

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -143,30 +143,30 @@ export const browserCloseTool = tool(
 
 export const browserSnapshotTool = tool(
   'browser_snapshot',
-  `Returns the current page's actionable elements with refs (@e1, @e2, ...) for use with browser_click / browser_fill / etc.`,
+  `Get the current page's accessibility tree with refs (@e1, @e2, ...) for use with browser_click / browser_fill / etc.
+
+Call with no arguments first for navigation/interaction. mode controls depth only: navigation (default) is shallow; detailed returns the full tree for a scoped section and requires scope because whole-page detail can be large.`,
   {
-    depth: z
-      .number()
-      .int()
-      .min(-1)
+    mode: z
+      .enum(['navigation', 'detailed'])
       .optional()
-      .describe('How many levels of nested actionable elements to include. Omit (default) to get the sensible default for whichever mode you\'re in: with no `scope`, you get just the top-level clickables (cheap, enough for most tasks); with a `scope`, you get the entire subtree of that container. Pass an explicit number (0, 1, 2, …) to override. Pass `-1` for no limit (full unfiltered tree — expensive, use sparingly).'),
+      .describe('Depth mode. navigation (default) returns a shallow snapshot for finding refs. detailed returns the full tree for the scoped target and requires scope.'),
     scope: z
       .string()
       .optional()
-      .describe('Optional. Limits the snapshot to one section of the page. Accepts ONLY (a) the accessible name of a landmark row in the snapshot — must be one of `navigation` / `main` / `region` / `complementary` / `form` / `search` / `banner` / `contentinfo` (e.g. `scope: "Repository"` when you saw `- navigation "Repository" [ref=e7]`), or (b) a CSS selector (`scope: "#login"`, `scope: "[role=dialog]"`, `scope: "main"`). Do NOT pass the text of a `heading` / `button` / `link` / `cell` row, and do NOT pass free-form phrases — those will fail. If you can\'t find a usable landmark or selector, use `depth` instead.'),
+      .describe('Optional CSS or XPath selector for a known area. Does not accept snapshot refs, visible text, role names, or free-form phrases.'),
     interactive: z
       .boolean()
       .optional()
-      .describe('Default true: only return interactive elements (links, buttons, inputs). Set to `false` to also include non-interactive text content like headings, paragraphs, numbers, and labels. Use `false` when you need to read static text from the page (version numbers, prices, dates, article body, etc.) — those are filtered out by the default.'),
+      .describe('Include interactive elements with refs (default: true)'),
     compact: z
       .boolean()
       .optional()
-      .describe('Default true: collapse empty structural wrappers to reduce output size. Set to `false` only when you specifically need to see the full DOM structure.'),
+      .describe('Compact output to reduce size (default: true)'),
   },
   async (args) => {
     const result = await browserFetch('snapshot', {
-      depth: args.depth,
+      mode: args.mode,
       scope: args.scope,
       interactive: args.interactive,
       compact: args.compact,

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -143,33 +143,33 @@ export const browserCloseTool = tool(
 
 export const browserSnapshotTool = tool(
   'browser_snapshot',
-  `Get an accessibility tree snapshot of the current page. Returns interactive elements with refs (like @e1, @e2) that you can use with browser_click and browser_fill.
-
-Use interactive=true (default) to get clickable/fillable elements with refs.
-Use compact=true (default) to reduce output size.
-Use json=true to get structured JSON output with a refs dictionary.`,
+  `Returns the current page's actionable elements with refs (@e1, @e2, ...) for use with browser_click / browser_fill / etc.`,
   {
+    depth: z
+      .number()
+      .int()
+      .min(-1)
+      .optional()
+      .describe('How many levels of nested actionable elements to include. Omit (default) to get the sensible default for whichever mode you\'re in: with no `scope`, you get just the top-level clickables (cheap, enough for most tasks); with a `scope`, you get the entire subtree of that container. Pass an explicit number (0, 1, 2, …) to override. Pass `-1` for no limit (full unfiltered tree — expensive, use sparingly).'),
+    scope: z
+      .string()
+      .optional()
+      .describe('Optional. Limits the snapshot to one section of the page. Accepts ONLY (a) the accessible name of a landmark row in the snapshot — must be one of `navigation` / `main` / `region` / `complementary` / `form` / `search` / `banner` / `contentinfo` (e.g. `scope: "Repository"` when you saw `- navigation "Repository" [ref=e7]`), or (b) a CSS selector (`scope: "#login"`, `scope: "[role=dialog]"`, `scope: "main"`). Do NOT pass the text of a `heading` / `button` / `link` / `cell` row, and do NOT pass free-form phrases — those will fail. If you can\'t find a usable landmark or selector, use `depth` instead.'),
     interactive: z
       .boolean()
       .optional()
-      .default(true)
-      .describe('Include interactive elements with refs (default: true)'),
+      .describe('Default true: only return interactive elements (links, buttons, inputs). Set to `false` to also include non-interactive text content like headings, paragraphs, numbers, and labels. Use `false` when you need to read static text from the page (version numbers, prices, dates, article body, etc.) — those are filtered out by the default.'),
     compact: z
       .boolean()
       .optional()
-      .default(true)
-      .describe('Compact output to reduce size (default: true)'),
-    json: z
-      .boolean()
-      .optional()
-      .default(false)
-      .describe('Return structured JSON with refs dictionary (default: false)'),
+      .describe('Default true: collapse empty structural wrappers to reduce output size. Set to `false` only when you specifically need to see the full DOM structure.'),
   },
   async (args) => {
     const result = await browserFetch('snapshot', {
+      depth: args.depth,
+      scope: args.scope,
       interactive: args.interactive,
       compact: args.compact,
-      json: args.json,
     })
     if (!result.success) return errorResult(result.error!)
 

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -36,16 +36,11 @@ You are a web browser automation agent. You receive high-level objectives and ac
 - `Read(file_path)` — Read screenshot files to visually verify pages
 
 ## Core Workflow
-1. `browser_snapshot()` — see what you can click. Refs look like `@e1`, `@e2`.
-2. Act with a ref: `browser_click("@e1")`, `browser_fill("@e2", "text")`. Use `browser_press("Enter")` to submit forms.
-3. `browser_snapshot()` again to see the result. `browser_open` and clicks that navigate already wait for load — just snapshot.
-4. Repeat 2-3 until the task is done.
-
-If the default snapshot doesn't show what you need, pick the smallest next step:
-- **Scope:** Use `scope` for one section. Prefer a landmark name from the snapshot (`navigation "X"`, `main`, `region "X"`, `complementary`, `form`, `search`, `banner`, `contentinfo`) or a CSS selector (`#login`, `[role=dialog]`). Do not use text from `heading` / `button` / `link` / `cell` rows as scope.
-- **Static text:** Use `interactive: false` for version numbers, prices, dates, article text, labels, or anything else that isn't a button/link/input.
-- **Depth:** Use `depth: 1`, then `2`, for deeper children. `depth: -1` returns the full tree — last resort.
-- **Visual clarity:** Use `browser_screenshot()` to visually check layout or missing content, then re-snapshot with the right `scope` / `interactive` / `depth`.
+1. Start with `browser_snapshot()` to see the page; re-snapshot with `scope` to zoom into the sections you need
+2. Interact using refs: `browser_click("@e1")`, `browser_fill("@e2", "text")`
+3. `browser_press("Enter")` to submit forms after filling inputs
+4. Re-snapshot after page changes to get updated refs; scope the snapshot when only one section matters
+5. After `browser_open()` or `browser_click()` that triggers navigation, just re-snapshot — no need to wait; use `browser_screenshot()` only to visually confirm layout or missing content
 
 ## Tab Management (MANDATORY)
 

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -3,7 +3,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 ## Your Tools
 
 **Core tools:**
-- `browser_snapshot(depth?, scope?, interactive?, compact?)` — Returns the page's actionable elements with refs (@e1, @e2, ...). Call with no arguments by default; set `depth` (1, 2, …) for nested children, `scope` (landmark name or CSS selector) for one section, or `interactive: false` to also include non-interactive text (version numbers, prices, headings, article text — anything that isn't a button/link/input). See "Core Workflow" below for when each applies.
+- `browser_snapshot(mode?, scope?, interactive?, compact?)` — Get accessibility tree with element refs (@e1, @e2, ...)
 - `browser_click(ref)` — Click element by ref
 - `browser_fill(ref, value)` — Clear and fill input by ref
 - `browser_scroll(direction, amount?)` — Scroll the page (up/down/left/right)
@@ -36,11 +36,11 @@ You are a web browser automation agent. You receive high-level objectives and ac
 - `Read(file_path)` — Read screenshot files to visually verify pages
 
 ## Core Workflow
-1. Start with `browser_snapshot()` to see the page; re-snapshot with `scope` to zoom into the sections you need
+1. Start with `browser_snapshot()` to see the current page state
 2. Interact using refs: `browser_click("@e1")`, `browser_fill("@e2", "text")`
 3. `browser_press("Enter")` to submit forms after filling inputs
-4. Re-snapshot after page changes to get updated refs; scope the snapshot when only one section matters
-5. After `browser_open()` or `browser_click()` that triggers navigation, just re-snapshot — no need to wait; use `browser_screenshot()` only to visually confirm layout or missing content
+4. Re-snapshot after page changes to get updated refs
+5. After `browser_open()` or `browser_click()` that triggers navigation, just re-snapshot — no need to wait, `browser_open` already waits for the page to load
 
 ## Tab Management (MANDATORY)
 
@@ -59,6 +59,7 @@ Tab proliferation causes memory crashes and degrades performance. Follow these r
 - **ALWAYS report the current URL when you finish.** Your final response MUST include the current URL (use `browser_run("get url")`) so the parent agent can track where the browser is.
 - **Use WebSearch before navigating** to find correct URLs — do not guess website URLs.
 - **When you encounter a login page, CAPTCHA, 2FA, or any sensitive action:** IMMEDIATELY call `mcp__user-input__request_browser_input` with a clear message explaining what you see and what the user needs to do (e.g., log in, solve CAPTCHA, complete 2FA). Include specific requirements as a list. Do NOT just describe the obstacle in chat — you MUST use the `request_browser_input` tool so the user gets the proper UI notification. After the user completes, take a snapshot to see the updated state.
+- Use interactive + compact snapshot to reduce output — you usually only need buttons, links, inputs.
 - Use `browser_screenshot()` when you need to visually verify something the accessibility tree cannot tell you.
 - If a page has not fully rendered dynamic content, re-snapshot after a moment.
 - The browser preserves cookies/sessions — the user logs in once and you can reuse the session.

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -3,7 +3,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 ## Your Tools
 
 **Core tools:**
-- `browser_snapshot(interactive?, compact?)` — Get accessibility tree with element refs (@e1, @e2, ...)
+- `browser_snapshot(depth?, scope?, interactive?, compact?)` — Returns the page's actionable elements with refs (@e1, @e2, ...). Call with no arguments by default; set `depth` (1, 2, …) for nested children, `scope` (landmark name or CSS selector) for one section, or `interactive: false` to also include non-interactive text (version numbers, prices, headings, article text — anything that isn't a button/link/input). See "Core Workflow" below for when each applies.
 - `browser_click(ref)` — Click element by ref
 - `browser_fill(ref, value)` — Clear and fill input by ref
 - `browser_scroll(direction, amount?)` — Scroll the page (up/down/left/right)
@@ -36,11 +36,16 @@ You are a web browser automation agent. You receive high-level objectives and ac
 - `Read(file_path)` — Read screenshot files to visually verify pages
 
 ## Core Workflow
-1. Start with `browser_snapshot()` to see the current page state
-2. Interact using refs: `browser_click("@e1")`, `browser_fill("@e2", "text")`
-3. `browser_press("Enter")` to submit forms after filling inputs
-4. Re-snapshot after page changes to get updated refs
-5. After `browser_open()` or `browser_click()` that triggers navigation, just re-snapshot — no need to wait, `browser_open` already waits for the page to load
+1. `browser_snapshot()` — see what you can click. Refs look like `@e1`, `@e2`.
+2. Act with a ref: `browser_click("@e1")`, `browser_fill("@e2", "text")`. Use `browser_press("Enter")` to submit forms.
+3. `browser_snapshot()` again to see the result. `browser_open` and clicks that navigate already wait for load — just snapshot.
+4. Repeat 2-3 until the task is done.
+
+If the default snapshot doesn't show what you need, pick the smallest next step:
+- **Scope:** Use `scope` for one section. Prefer a landmark name from the snapshot (`navigation "X"`, `main`, `region "X"`, `complementary`, `form`, `search`, `banner`, `contentinfo`) or a CSS selector (`#login`, `[role=dialog]`). Do not use text from `heading` / `button` / `link` / `cell` rows as scope.
+- **Static text:** Use `interactive: false` for version numbers, prices, dates, article text, labels, or anything else that isn't a button/link/input.
+- **Depth:** Use `depth: 1`, then `2`, for deeper children. `depth: -1` returns the full tree — last resort.
+- **Visual clarity:** Use `browser_screenshot()` to visually check layout or missing content, then re-snapshot with the right `scope` / `interactive` / `depth`.
 
 ## Tab Management (MANDATORY)
 
@@ -59,7 +64,6 @@ Tab proliferation causes memory crashes and degrades performance. Follow these r
 - **ALWAYS report the current URL when you finish.** Your final response MUST include the current URL (use `browser_run("get url")`) so the parent agent can track where the browser is.
 - **Use WebSearch before navigating** to find correct URLs — do not guess website URLs.
 - **When you encounter a login page, CAPTCHA, 2FA, or any sensitive action:** IMMEDIATELY call `mcp__user-input__request_browser_input` with a clear message explaining what you see and what the user needs to do (e.g., log in, solve CAPTCHA, complete 2FA). Include specific requirements as a list. Do NOT just describe the obstacle in chat — you MUST use the `request_browser_input` tool so the user gets the proper UI notification. After the user completes, take a snapshot to see the updated state.
-- Use interactive + compact snapshot to reduce output — you usually only need buttons, links, inputs.
 - Use `browser_screenshot()` when you need to visually verify something the accessibility tree cannot tell you.
 - If a page has not fully rendered dynamic content, re-snapshot after a moment.
 - The browser preserves cookies/sessions — the user logs in once and you can reuse the session.


### PR DESCRIPTION
## Summary
- Add a snapshot helper that caches default browser snapshots and invalidates them after browser lifecycle/action changes.
- Extend `browser_snapshot` with `depth`, `scope`, `interactive`, and `compact` controls while keeping the default response small.
- Update the browser agent prompt with a concise fallback path for scoped sections, static text, deeper children, and visual confirmation.

## Test plan
- `npx tsc --noEmit`
- `npx vitest run src/snapshot.test.ts`
- Built local Docker image `ghcr.io/skillfulagents/superagent-agent-container-base:local`


Made with [Cursor](https://cursor.com)