### PR TITLE
style(new-agent): simplify creation aids to chip row

### DIFF
--- a/src/renderer/components/agents/agent-creation-aids.tsx
+++ b/src/renderer/components/agents/agent-creation-aids.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from 'react'
-import { AudioLines, Upload, ArrowDownToLine, FileArchive, Loader2 } from 'lucide-react'
+import { AudioLines, Upload, ArrowUpToLine, FileArchive, Loader2, Shapes } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@renderer/components/ui/button'
 import { OptionCard } from '@renderer/components/ui/option-card'
@@ -14,9 +14,10 @@ import {
 } from '@renderer/components/ui/dialog'
 import { VoiceAgent } from '@renderer/components/ui/voice-agent'
 import { SkillInstallDialog } from '@renderer/components/agents/skill-install-dialog'
+import { AgentTemplateBrowseDialog } from '@renderer/components/agents/agent-template-browse-dialog'
 import { apiFetch } from '@renderer/lib/api'
 import { useDeleteAgent } from '@renderer/hooks/use-agents'
-import { useImportAgentTemplate, type ImportProgress } from '@renderer/hooks/use-agent-templates'
+import { useImportAgentTemplate, useDiscoverableAgents, type ImportProgress } from '@renderer/hooks/use-agent-templates'
 import { useIsVoiceAgentConfigured } from '@renderer/hooks/use-voice-input'
 import type { VoiceAgentConfig } from '@renderer/lib/voice-agent'
 import type { ApiAgent } from '@shared/lib/types/api'
@@ -44,6 +45,9 @@ export interface AgentCreationAidsProps {
 export function AgentCreationAids({ onVoiceResult, onImportComplete, className }: AgentCreationAidsProps) {
   const hasVoiceConfigured = useIsVoiceAgentConfigured()
   const deleteAgent = useDeleteAgent()
+  const { data: discoverableAgents } = useDiscoverableAgents()
+  const hasMarketplace = !!(discoverableAgents && discoverableAgents.length > 0)
+  const [showTemplatesDialog, setShowTemplatesDialog] = useState(false)
 
   // --- Voice agent flow ---
   const [showVoiceAgent, setShowVoiceAgent] = useState(false)
@@ -209,27 +213,32 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
 
   return (
     <div className={className}>
-      <div className="space-y-3">
+      <p className="mb-3 text-xs text-muted-foreground">Other ways to get started</p>
+      <div className="flex flex-wrap gap-3">
+        {hasMarketplace && (
+          <OptionCard
+            title="Browse Templates"
+            icon={<Shapes className="h-4 w-4" />}
+            onClick={() => setShowTemplatesDialog(true)}
+          />
+        )}
+
         {hasVoiceConfigured && (
           <OptionCard
-            title="Talk to SuperAgent for Ideas"
-            description="Answer a few questions about your job — get a detailed prompt for your agent."
-            icon={<AudioLines className="h-3 w-3" />}
-            pill="5 min"
-            buttonLabel="Start"
+            title="Brainstorm with Voice"
+            icon={<AudioLines className="h-4 w-4" />}
             onClick={startVoiceAgent}
           />
         )}
 
         <OptionCard
           title="Import an Agent"
-          description="Import an agent via a .zip file with bundled skills and optional env. variables."
-          icon={<ArrowDownToLine className="h-3 w-3" />}
-          pill="30 sec"
-          buttonLabel="Import"
+          icon={<ArrowUpToLine className="h-4 w-4" />}
           onClick={() => setShowImportDialog(true)}
         />
       </div>
+
+      <AgentTemplateBrowseDialog open={showTemplatesDialog} onOpenChange={setShowTemplatesDialog} />
 
       <Dialog open={showVoiceAgent} onOpenChange={(open) => { if (!open) closeVoiceAgent() }}>
         <DialogContent className="max-w-2xl p-0 overflow-hidden h-[420px] [grid-template-rows:minmax(0,1fr)] gap-0">

--- a/src/renderer/components/agents/agent-creation-aids.tsx
+++ b/src/renderer/components/agents/agent-creation-aids.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from 'react'
-import { AudioLines, Upload, ArrowUpToLine, FileArchive, Loader2, Shapes } from 'lucide-react'
+import { AudioLines, Upload, ArrowDownToLine, FileArchive, Loader2, Shapes } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@renderer/components/ui/button'
 import { OptionCard } from '@renderer/components/ui/option-card'
@@ -219,6 +219,7 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
           <OptionCard
             title="Browse Templates"
             icon={<Shapes className="h-4 w-4" />}
+            ariaDescription="Opens the agent template marketplace"
             onClick={() => setShowTemplatesDialog(true)}
           />
         )}
@@ -227,13 +228,15 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
           <OptionCard
             title="Brainstorm with Voice"
             icon={<AudioLines className="h-4 w-4" />}
+            ariaDescription="Start a voice interview to draft your agent prompt"
             onClick={startVoiceAgent}
           />
         )}
 
         <OptionCard
           title="Import an Agent"
-          icon={<ArrowUpToLine className="h-4 w-4" />}
+          icon={<ArrowDownToLine className="h-4 w-4" />}
+          ariaDescription="Import an agent from a .zip template file"
           onClick={() => setShowImportDialog(true)}
         />
       </div>

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -8,10 +8,8 @@ import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice
 import { AgentCreationAids, type ImportResult } from '@renderer/components/agents/agent-creation-aids'
 import { useStartOnboardingSession } from '@renderer/hooks/use-start-onboarding-session'
 import { TemplateInstallDialog } from '@renderer/components/agents/template-install-dialog'
-import { AgentTemplateBrowseContent } from '@renderer/components/agents/agent-template-browse-content'
 import { useCreateAgent } from '@renderer/hooks/use-agents'
 import { useCreateSession } from '@renderer/hooks/use-sessions'
-import { useDiscoverableAgents } from '@renderer/hooks/use-agent-templates'
 import { useSelection } from '@renderer/context/selection-context'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { useMessageComposer } from '@renderer/hooks/use-message-composer'
@@ -108,9 +106,6 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
     }
   }, [composer.message])
 
-  // --- Template install flow (inline name step + required env vars) ---
-  const { data: discoverableAgents } = useDiscoverableAgents()
-  const hasTemplates = !!(discoverableAgents && discoverableAgents.length > 0)
   const [templateToInstall, setTemplateToInstall] = useState<ApiDiscoverableAgent | null>(initialTemplate ?? null)
 
   useEffect(() => {
@@ -203,29 +198,6 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
             onImportComplete={handleImportComplete}
           />
         </div>
-
-        {hasTemplates && (
-          <>
-            <div
-              {...itemProps(300, 30)}
-              className={`flex items-center gap-4 pt-2 px-6 ${itemProps(300, 30).className}`}
-            >
-              <div className="h-px flex-1 bg-border" />
-              <span className="text-xs text-muted-foreground">OR START FROM A TEMPLATE</span>
-              <div className="h-px flex-1 bg-border" />
-            </div>
-
-            <div
-              {...itemProps(360, 0)}
-              className={itemProps(360, 0).className}
-            >
-              <AgentTemplateBrowseContent
-                discoverableAgents={discoverableAgents!}
-                onSelect={setTemplateToInstall}
-              />
-            </div>
-          </>
-        )}
       </div>
 
       <TemplateInstallDialog

--- a/src/renderer/components/ui/option-card.tsx
+++ b/src/renderer/components/ui/option-card.tsx
@@ -4,15 +4,17 @@ export interface OptionCardProps {
   title: string
   icon: ReactNode
   onClick: () => void
+  /** Accessible description appended after the title in the aria-label (e.g. "Opens the template marketplace"). */
+  ariaDescription?: string
   className?: string
 }
 
-export function OptionCard({ title, icon, onClick, className }: OptionCardProps) {
+export function OptionCard({ title, icon, onClick, ariaDescription, className }: OptionCardProps) {
   return (
     <button
       type="button"
       onClick={onClick}
-      aria-label={title}
+      aria-label={ariaDescription ? `${title} — ${ariaDescription}` : title}
       className={`text-left rounded-xl bg-muted px-4 py-2 flex items-center gap-2 cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors text-foreground ${className ?? ''}`}
     >
       {icon}

--- a/src/renderer/components/ui/option-card.tsx
+++ b/src/renderer/components/ui/option-card.tsx
@@ -1,67 +1,22 @@
 import type { ReactNode } from 'react'
-import { ArrowRight } from 'lucide-react'
 
 export interface OptionCardProps {
   title: string
-  description: ReactNode
   icon: ReactNode
-  /** CTA label rendered next to the arrow and used for the button's aria-label. */
-  buttonLabel: string
-  /** Optional metadata chip displayed at the bottom of the card. */
-  pill?: ReactNode
   onClick: () => void
   className?: string
 }
 
-const ANIM = '[transition-duration:750ms] [transition-timing-function:cubic-bezier(0.16,1,0.3,1)]'
-
-export function OptionCard({
-  title,
-  description,
-  icon,
-  buttonLabel,
-  pill,
-  onClick,
-  className,
-}: OptionCardProps) {
+export function OptionCard({ title, icon, onClick, className }: OptionCardProps) {
   return (
     <button
       type="button"
       onClick={onClick}
-      aria-label={`${title} — ${buttonLabel}`}
-      className={`group w-full text-left rounded-2xl border border-border/50 p-4 flex flex-col items-stretch cursor-pointer hover:border-foreground/30 hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors ${className ?? ''}`}
+      aria-label={title}
+      className={`text-left rounded-xl bg-muted px-4 py-2 flex items-center gap-2 cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors text-foreground ${className ?? ''}`}
     >
-      <div className="flex items-center gap-2">
-        <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-muted text-foreground">
-          {icon}
-        </span>
-        <span className="text-xs font-medium">{title}</span>
-      </div>
-      <div className={`grid grid-rows-[0fr] group-hover:grid-rows-[1fr] group-focus-visible:grid-rows-[1fr] mt-0 group-hover:mt-1.5 group-focus-visible:mt-1.5 transition-[grid-template-rows,margin] ${ANIM}`}>
-        <div className="overflow-hidden">
-          <p className={`text-xs text-muted-foreground opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity ${ANIM}`}>
-            {description}
-          </p>
-        </div>
-      </div>
-      <div className={`grid grid-rows-[0fr] group-hover:grid-rows-[1fr] group-focus-visible:grid-rows-[1fr] mt-0 group-hover:mt-4 group-focus-visible:mt-4 transition-[grid-template-rows,margin] ${ANIM}`}>
-        <div className="overflow-hidden">
-          <div className={`flex items-center justify-between gap-2 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity ${ANIM}`}>
-            {pill ? (
-              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[11px] text-foreground">
-                {pill}
-              </span>
-            ) : (
-              // Empty placeholder keeps the CTA right-aligned via justify-between when no pill is provided.
-              <span />
-            )}
-            <span className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-foreground hover:bg-accent hover:text-accent-foreground transition-colors">
-              {buttonLabel}
-              <ArrowRight className="h-3 w-3" />
-            </span>
-          </div>
-        </div>
-      </div>
+      {icon}
+      <span className="text-xs font-medium">{title}</span>
     </button>
   )
 }

--- a/src/renderer/components/wizard/getting-started-wizard.tsx
+++ b/src/renderer/components/wizard/getting-started-wizard.tsx
@@ -147,7 +147,7 @@ export function GettingStartedWizard({ onClose }: GettingStartedWizardProps) {
       <div className={`relative flex flex-col h-svh transition-[width] duration-500 ease-in-out ${isAgentStep ? 'w-full' : 'w-full lg:w-1/2'}`}>
         <h1 className="sr-only">Getting Started</h1>
 
-        <div className={`flex flex-1 min-h-0 flex-col py-10 w-full mx-auto transition-[max-width] duration-500 ${isAgentStep ? 'max-w-[640px] justify-start overflow-y-auto' : 'max-w-[480px] justify-center'}`}>
+        <div className={`flex flex-1 min-h-0 flex-col py-10 w-full mx-auto transition-[max-width] duration-500 justify-center ${isAgentStep ? 'max-w-[640px]' : 'max-w-[480px]'}`}>
           <div className="w-full">
 
           {/* Step content */}


### PR DESCRIPTION
## Summary
- Strip the hover-expand option cards under the composer down to compact chips (icon + label) and lay them out in a single row
- Add a **Browse Templates** chip that opens the marketplace modal (gated on `useDiscoverableAgents`, matching the sidebar)
- Drop the inline "OR START FROM A TEMPLATE" grid from the wizard create-agent step now that templates are reachable from the chip row
- Vertically center the wizard agent step to match the other steps

## Test plan
- [ ] Fresh install → wizard reaches "Let's create your first agent" → composer + 3 chips render centered on the page (no template grid)
- [ ] **Browse Templates** chip opens the Agent Marketplace dialog and an install works end-to-end
- [ ] **Brainstorm with Voice** chip starts the voice-agent interview (only visible when voice agent is configured)
- [ ] **Import an Agent** chip opens the import dialog and a `.zip` import works end-to-end
- [ ] Existing agent's empty home state shows the same chip row below the composer
- [ ] `initialTemplate` prop on `CreateAgentForm` still jumps straight to `TemplateInstallDialog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)