### PR TITLE
feat: pre-fill search palette with recent agents

### DIFF
--- a/e2e/specs/search.spec.ts
+++ b/e2e/specs/search.spec.ts
@@ -84,11 +84,81 @@ test.describe('Search palette', () => {
     await expect(page.locator('[data-testid="search-input"]')).toBeVisible()
     await expect(page.locator('[data-testid="search-input"]')).toBeFocused()
 
-    // Empty query: typing nothing shows the empty-state hint
-    await expect(page.locator('[data-testid="search-results"]')).toContainText('Type to search')
+    // Empty query shows recent agents or a "No recent agents" hint
+    const results = page.locator('[data-testid="search-results"]')
+    await expect(results).toBeVisible()
 
     // Close with Escape
     await page.keyboard.press('Escape')
     await expect(page.locator('[data-testid="search-input"]')).not.toBeVisible()
+  })
+
+  test('Empty query shows recent agents with expand/collapse for sessions', async ({ page, request }) => {
+    const stamp = Date.now()
+    const agentName = `Recent Agent ${stamp}`
+    const sessionName = `Deploy Pipeline ${stamp}`
+
+    await agentPage.createAgent(agentName)
+
+    // Look up the slug
+    const agentsRes = await request.get('http://localhost:3000/api/agents')
+    expect(agentsRes.ok()).toBe(true)
+    const agents = (await agentsRes.json()) as Array<{ slug: string; name: string }>
+    const slug = agents.find((a) => a.name === agentName)?.slug
+    expect(slug, `agent ${agentName} not found in API`).toBeDefined()
+
+    // Wait for the session to finish processing before renaming
+    const sessionsRes = await request.get(`http://localhost:3000/api/agents/${slug}/sessions`)
+    expect(sessionsRes.ok()).toBe(true)
+    const sessions = (await sessionsRes.json()) as Array<{ id: string }>
+    expect(sessions.length).toBeGreaterThan(0)
+    const sessionId = sessions[0].id
+
+    // Retry the PATCH in case the session is still being processed
+    await expect(async () => {
+      const res = await request.patch(
+        `http://localhost:3000/api/agents/${slug}/sessions/${sessionId}`,
+        { data: { name: sessionName } }
+      )
+      expect(res.ok()).toBe(true)
+    }).toPass({ timeout: 5000 })
+
+    await appPage.reload()
+
+    // Open the search palette with empty query
+    await page.keyboard.press('ControlOrMeta+k')
+    const searchInput = page.locator('[data-testid="search-input"]')
+    await expect(searchInput).toBeVisible()
+
+    const results = page.locator('[data-testid="search-results"]')
+
+    // The agent should appear in the recent list without typing anything
+    await expect(results.getByText(agentName)).toBeVisible()
+
+    // Sessions should be collapsed (not visible yet)
+    await expect(results.getByText(sessionName)).not.toBeVisible()
+
+    // ArrowRight expands the agent's sessions
+    await page.keyboard.press('ArrowRight')
+    await expect(results.getByText(sessionName)).toBeVisible()
+
+    // ArrowLeft collapses them
+    await page.keyboard.press('ArrowLeft')
+    await expect(results.getByText(sessionName)).not.toBeVisible()
+
+    // Click the chevron to expand
+    const agentRow = results.getByText(agentName).locator('..')
+    await agentRow.locator('svg').first().click()
+    await expect(results.getByText(sessionName)).toBeVisible()
+
+    // Enter on a session navigates to it (dialog closes, lands on the agent)
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('Enter')
+    await expect(page.locator('[data-testid="search-input"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agentName)
+
+    // Cleanup — navigate to agent home before deleting
+    await page.locator('[data-testid="agent-breadcrumb"]').click()
+    await agentPage.deleteAgent()
   })
 })

--- a/src/renderer/components/search/filter.test.ts
+++ b/src/renderer/components/search/filter.test.ts
@@ -1,24 +1,25 @@
 import { describe, it, expect } from 'vitest'
-import { filterAgentsAndSessions, flattenGroups } from './filter'
+import { filterAgentsAndSessions, flattenGroups, getRecentAgents } from './filter'
 import type { ApiAgent, ApiSession } from '@shared/lib/types/api'
 
-function agent(slug: string, name: string): ApiAgent {
+function agent(slug: string, name: string, lastActivityAt?: Date): ApiAgent {
   return {
     slug,
     name,
     createdAt: new Date(0),
     status: 'stopped',
     containerPort: null,
+    lastActivityAt: lastActivityAt ?? undefined,
   }
 }
 
-function session(id: string, agentSlug: string, name: string): ApiSession {
+function session(id: string, agentSlug: string, name: string, lastActivityAt?: Date): ApiSession {
   return {
     id,
     agentSlug,
     name,
     createdAt: new Date(0),
-    lastActivityAt: new Date(0),
+    lastActivityAt: lastActivityAt ?? new Date(0),
     messageCount: 0,
     isActive: false,
     isAwaitingInput: false,
@@ -27,18 +28,16 @@ function session(id: string, agentSlug: string, name: string): ApiSession {
 }
 
 describe('filterAgentsAndSessions', () => {
-  const alpha = agent('alpha', 'Alpha Bot')
-  const beta = agent('beta', 'Beta Worker')
+  const alpha = agent('alpha', 'Alpha Bot', new Date('2025-01-01'))
+  const beta = agent('beta', 'Beta Worker', new Date('2025-01-02'))
   const sessions = {
     alpha: [session('s1', 'alpha', 'Refactor login'), session('s2', 'alpha', 'Database backup')],
     beta: [session('s3', 'beta', 'Login analytics'), session('s4', 'beta', 'Daily report')],
   }
 
-  it('empty query returns every agent with no nested sessions', () => {
+  it('empty query returns empty array', () => {
     const groups = filterAgentsAndSessions([alpha, beta], sessions, '')
-    expect(groups).toHaveLength(2)
-    expect(groups[0]).toEqual({ agent: alpha, matchedAgent: true, sessions: [] })
-    expect(groups[1]).toEqual({ agent: beta, matchedAgent: true, sessions: [] })
+    expect(groups).toHaveLength(0)
   })
 
   it('matches agent name case-insensitively', () => {
@@ -51,7 +50,6 @@ describe('filterAgentsAndSessions', () => {
 
   it('surfaces a non-matching agent because one of its sessions matches', () => {
     const groups = filterAgentsAndSessions([alpha, beta], sessions, 'login')
-    // Both agents appear: alpha has "Refactor login", beta has "Login analytics"
     expect(groups).toHaveLength(2)
     const alphaGroup = groups.find((g) => g.agent.slug === 'alpha')!
     expect(alphaGroup.matchedAgent).toBe(false)
@@ -67,7 +65,6 @@ describe('filterAgentsAndSessions', () => {
     expect(groups).toHaveLength(1)
     expect(groups[0].agent.slug).toBe('alpha')
     expect(groups[0].matchedAgent).toBe(true)
-    // None of alpha's sessions contain "alpha"
     expect(groups[0].sessions).toEqual([])
   })
 
@@ -78,18 +75,71 @@ describe('filterAgentsAndSessions', () => {
 
   it('whitespace-only query is treated as empty', () => {
     const groups = filterAgentsAndSessions([alpha, beta], sessions, '   ')
-    expect(groups).toHaveLength(2)
-    expect(groups.every((g) => g.matchedAgent && g.sessions.length === 0)).toBe(true)
+    expect(groups).toHaveLength(0)
+  })
+})
+
+describe('getRecentAgents', () => {
+  it('returns agents sorted by lastActivityAt descending, limited to 10', () => {
+    const agents = Array.from({ length: 12 }, (_, i) =>
+      agent(`a${i}`, `Agent ${i}`, new Date(2025, 0, i + 1))
+    )
+    const sessions: Record<string, ApiSession[]> = {}
+    const result = getRecentAgents(agents, sessions)
+    expect(result).toHaveLength(10)
+    expect(result[0].agent.slug).toBe('a11')
+    expect(result[9].agent.slug).toBe('a2')
+  })
+
+  it('excludes agents without lastActivityAt', () => {
+    const agents = [
+      agent('active', 'Active', new Date('2025-03-01')),
+      agent('inactive', 'Inactive'),
+    ]
+    const result = getRecentAgents(agents, {})
+    expect(result).toHaveLength(1)
+    expect(result[0].agent.slug).toBe('active')
+  })
+
+  it('sorts sessions by lastActivityAt descending and limits to 10', () => {
+    const a = agent('a', 'Agent A', new Date('2025-01-01'))
+    const allSessions = Array.from({ length: 12 }, (_, i) =>
+      session(`s${i}`, 'a', `Session ${i}`, new Date(2025, 0, i + 1))
+    )
+    const result = getRecentAgents([a], { a: allSessions })
+    expect(result[0].sessions).toHaveLength(10)
+    expect(result[0].sessions[0].id).toBe('s11')
+    expect(result[0].sessions[9].id).toBe('s2')
   })
 })
 
 describe('flattenGroups', () => {
-  const alpha = agent('alpha', 'Alpha')
+  const alpha = agent('alpha', 'Alpha', new Date('2025-01-01'))
   const s1 = session('s1', 'alpha', 'one')
   const s2 = session('s2', 'alpha', 'two')
 
-  it('emits agent first, then its sessions in order', () => {
+  it('without expandedSlugs, emits agent and all sessions', () => {
     const flat = flattenGroups([{ agent: alpha, matchedAgent: true, sessions: [s1, s2] }])
+    expect(flat).toEqual([
+      { kind: 'agent', agent: alpha },
+      { kind: 'session', agent: alpha, session: s1 },
+      { kind: 'session', agent: alpha, session: s2 },
+    ])
+  })
+
+  it('with expandedSlugs, only emits sessions for expanded agents', () => {
+    const flat = flattenGroups(
+      [{ agent: alpha, matchedAgent: true, sessions: [s1, s2] }],
+      new Set()
+    )
+    expect(flat).toEqual([{ kind: 'agent', agent: alpha }])
+  })
+
+  it('with expandedSlugs containing the agent, emits sessions', () => {
+    const flat = flattenGroups(
+      [{ agent: alpha, matchedAgent: true, sessions: [s1, s2] }],
+      new Set(['alpha'])
+    )
     expect(flat).toEqual([
       { kind: 'agent', agent: alpha },
       { kind: 'session', agent: alpha, session: s1 },

--- a/src/renderer/components/search/filter.ts
+++ b/src/renderer/components/search/filter.ts
@@ -12,9 +12,33 @@ export type FlatItem =
   | { kind: 'session'; agent: ApiAgent; session: ApiSession }
 
 /**
+ * Return the top N most recently used agents with their sessions sorted by recency.
+ */
+export function getRecentAgents(
+  agents: ApiAgent[],
+  sessionsByAgent: Record<string, ApiSession[]>,
+  limit = 10
+): AgentGroup[] {
+  return [...agents]
+    .filter((a) => a.lastActivityAt)
+    .sort((a, b) => {
+      const ta = new Date(a.lastActivityAt!).getTime()
+      const tb = new Date(b.lastActivityAt!).getTime()
+      return tb - ta
+    })
+    .slice(0, limit)
+    .map((agent) => {
+      const sessions = (sessionsByAgent[agent.slug] ?? [])
+        .slice()
+        .sort((a, b) => new Date(b.lastActivityAt).getTime() - new Date(a.lastActivityAt).getTime())
+        .slice(0, 10)
+      return { agent, matchedAgent: true, sessions }
+    })
+}
+
+/**
  * Filter agents and sessions by a substring query. Case-insensitive.
  *
- * - Empty query returns every agent with `matchedAgent: true` and no sessions.
  * - An agent is included if its name matches OR if any of its sessions match.
  * - Only matching sessions are returned within an agent group.
  */
@@ -24,28 +48,30 @@ export function filterAgentsAndSessions(
   query: string
 ): AgentGroup[] {
   const trimmed = query.trim().toLowerCase()
+  if (!trimmed) return []
   const groups = agents.map<AgentGroup>((agent) => {
     const sessions = sessionsByAgent[agent.slug] ?? []
-    if (!trimmed) {
-      return { agent, matchedAgent: true, sessions: [] }
-    }
     const matchedAgent = agent.name.toLowerCase().includes(trimmed)
     const matchedSessions = sessions.filter((s) =>
       s.name.toLowerCase().includes(trimmed)
     )
     return { agent, matchedAgent, sessions: matchedSessions }
   })
-  if (!trimmed) return groups
   return groups.filter((g) => g.matchedAgent || g.sessions.length > 0)
 }
 
 /** Flatten visible groups into the linear list used for keyboard navigation. */
-export function flattenGroups(groups: AgentGroup[]): FlatItem[] {
+export function flattenGroups(
+  groups: AgentGroup[],
+  expandedSlugs?: Set<string>
+): FlatItem[] {
   const items: FlatItem[] = []
   for (const g of groups) {
     items.push({ kind: 'agent', agent: g.agent })
-    for (const s of g.sessions) {
-      items.push({ kind: 'session', agent: g.agent, session: s })
+    if (!expandedSlugs || expandedSlugs.has(g.agent.slug)) {
+      for (const s of g.sessions) {
+        items.push({ kind: 'session', agent: g.agent, session: s })
+      }
     }
   }
   return items

--- a/src/renderer/components/search/search-dialog.tsx
+++ b/src/renderer/components/search/search-dialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQueries } from '@tanstack/react-query'
-import { Bot, MessageSquare, Search } from 'lucide-react'
+import { Bot, ChevronRight, MessageSquare, Search } from 'lucide-react'
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@renderer/components/ui/dialog'
 import { HighlightMatch } from '@renderer/components/ui/highlight-match'
 import { useAgents } from '@renderer/hooks/use-agents'
@@ -8,7 +8,13 @@ import { useSelection } from '@renderer/context/selection-context'
 import { apiFetch } from '@renderer/lib/api'
 import type { ApiSession } from '@shared/lib/types/api'
 import { cn } from '@shared/lib/utils/cn'
-import { filterAgentsAndSessions, flattenGroups, type FlatItem } from './filter'
+import { formatDistanceToNow } from 'date-fns'
+import { filterAgentsAndSessions, flattenGroups, getRecentAgents, type FlatItem } from './filter'
+
+function formatLastRun(date: Date | string | null | undefined): string | null {
+  if (!date) return null
+  return `Last run ${formatDistanceToNow(new Date(date), { addSuffix: true })}`
+}
 
 interface SearchDialogProps {
   open: boolean
@@ -18,6 +24,7 @@ interface SearchDialogProps {
 export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
   const [query, setQuery] = useState('')
   const [activeIndex, setActiveIndex] = useState(0)
+  const [expandedSlugs, setExpandedSlugs] = useState<Set<string>>(new Set())
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
   const { setAgent } = useSelection()
@@ -41,21 +48,36 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
     if (open) {
       setQuery('')
       setActiveIndex(0)
-      // Focus the input after the dialog mounts
+      setExpandedSlugs(new Set())
       requestAnimationFrame(() => inputRef.current?.focus())
     }
   }, [open])
 
+  const sessionsByAgent = useMemo(() => {
+    if (!agents) return {}
+    const map: Record<string, ApiSession[]> = {}
+    agents.forEach((a, i) => {
+      map[a.slug] = sessionQueries[i]?.data ?? []
+    })
+    return map
+  }, [agents, sessionQueries])
+
+  const isSearchMode = query.trim().length > 0
+
   const visibleGroups = useMemo(() => {
     if (!agents) return []
-    const sessionsByAgent: Record<string, ApiSession[]> = {}
-    agents.forEach((a, i) => {
-      sessionsByAgent[a.slug] = sessionQueries[i]?.data ?? []
-    })
-    return filterAgentsAndSessions(agents, sessionsByAgent, query)
-  }, [agents, sessionQueries, query])
+    if (isSearchMode) {
+      return filterAgentsAndSessions(agents, sessionsByAgent, query)
+    }
+    return getRecentAgents(agents, sessionsByAgent)
+  }, [agents, sessionsByAgent, query, isSearchMode])
 
-  const flatItems = useMemo<FlatItem[]>(() => flattenGroups(visibleGroups), [visibleGroups])
+  const flatItems = useMemo<FlatItem[]>(() => {
+    if (isSearchMode) {
+      return flattenGroups(visibleGroups)
+    }
+    return flattenGroups(visibleGroups, expandedSlugs)
+  }, [visibleGroups, isSearchMode, expandedSlugs])
 
   // Clamp activeIndex when result list shrinks
   useEffect(() => {
@@ -71,6 +93,18 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
     )
     el?.scrollIntoView({ block: 'nearest' })
   }, [activeIndex])
+
+  const toggleExpand = (slug: string) => {
+    setExpandedSlugs((prev) => {
+      const next = new Set(prev)
+      if (next.has(slug)) {
+        next.delete(slug)
+      } else {
+        next.add(slug)
+      }
+      return next
+    })
+  }
 
   const handleSelect = (item: FlatItem) => {
     if (item.kind === 'agent') {
@@ -90,6 +124,25 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
       setActiveIndex((i) =>
         flatItems.length === 0 ? 0 : (i - 1 + flatItems.length) % flatItems.length
       )
+    } else if (e.key === 'ArrowRight' && !isSearchMode) {
+      e.preventDefault()
+      const item = flatItems[activeIndex]
+      if (item?.kind === 'agent' && !expandedSlugs.has(item.agent.slug)) {
+        toggleExpand(item.agent.slug)
+      }
+    } else if (e.key === 'ArrowLeft' && !isSearchMode) {
+      e.preventDefault()
+      const item = flatItems[activeIndex]
+      if (item?.kind === 'agent' && expandedSlugs.has(item.agent.slug)) {
+        toggleExpand(item.agent.slug)
+      } else if (item?.kind === 'session') {
+        // Collapse the parent agent and move focus to it
+        toggleExpand(item.agent.slug)
+        const agentIdx = flatItems.findIndex(
+          (fi) => fi.kind === 'agent' && fi.agent.slug === item.agent.slug
+        )
+        if (agentIdx >= 0) setActiveIndex(agentIdx)
+      }
     } else if (e.key === 'Enter') {
       e.preventDefault()
       const item = flatItems[activeIndex]
@@ -126,15 +179,17 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
           className="max-h-[60vh] overflow-y-auto py-1"
           data-testid="search-results"
         >
-          {!query.trim() || flatItems.length === 0 ? (
+          {flatItems.length === 0 ? (
             <div className="px-4 py-6 text-center text-sm text-muted-foreground">
-              {query.trim() ? 'No matches found' : 'Type to search...'}
+              {isSearchMode ? 'No matches found' : 'No recent agents'}
             </div>
           ) : (
             (() => {
               let idx = 0
               return visibleGroups.map((g) => {
                 const agentIdx = idx++
+                const isExpanded = isSearchMode || expandedSlugs.has(g.agent.slug)
+                const hasSessions = g.sessions.length > 0
                 return (
                   <div key={g.agent.slug} className="py-1">
                     <button
@@ -147,12 +202,32 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
                         activeIndex === agentIdx ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50'
                       )}
                     >
+                      {!isSearchMode && hasSessions && (
+                        <ChevronRight
+                          className={cn(
+                            'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform',
+                            isExpanded && 'rotate-90'
+                          )}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            toggleExpand(g.agent.slug)
+                          }}
+                        />
+                      )}
+                      {!isSearchMode && !hasSessions && (
+                        <span className="w-3.5 shrink-0" />
+                      )}
                       <Bot className="h-4 w-4 shrink-0 text-muted-foreground" />
                       <span className="truncate font-medium">
                         <HighlightMatch text={g.agent.name} query={query} />
                       </span>
+                      {!isSearchMode && g.agent.lastActivityAt && (
+                        <span className="ml-auto shrink-0 text-xs italic text-muted-foreground">
+                          {formatLastRun(g.agent.lastActivityAt)}
+                        </span>
+                      )}
                     </button>
-                    {g.sessions.map((s) => {
+                    {isExpanded && g.sessions.map((s) => {
                       const sessionIdx = idx++
                       return (
                         <button
@@ -170,6 +245,11 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
                           <span className="truncate text-muted-foreground">
                             <HighlightMatch text={s.name} query={query} />
                           </span>
+                          {!isSearchMode && s.lastActivityAt && (
+                            <span className="ml-auto shrink-0 text-xs italic text-muted-foreground">
+                              {formatLastRun(s.lastActivityAt)}
+                            </span>
+                          )}
                         </button>
                       )
                     })}


### PR DESCRIPTION
## Summary
- Cmd-K search palette now shows the 10 most recently used agents (by `lastActivityAt`) when opened with an empty query, instead of a blank "Type to search" state
- Each agent row has a collapsible chevron to reveal its most recent sessions (up to 10, sorted by recency). Toggle via click, Right arrow to expand, Left arrow to collapse
- Both agent and session rows display an italic muted "Last run X ago" timestamp (using `date-fns` `formatDistanceToNow`)
- Typing a search query switches to the existing filter behavior with all sessions expanded inline

## Test plan
- [x] Unit tests: 13 tests in `filter.test.ts` covering `getRecentAgents`, `filterAgentsAndSessions`, and `flattenGroups` with `expandedSlugs`
- [x] E2E test: new test verifying recent agents appear on empty query, expand/collapse via keyboard and chevron click, and session selection navigates correctly
- [x] TypeScript and ESLint pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)