### PR TITLE
fix(agent-container): upload via Playwright CDP buffer, not raw path

### DIFF
--- a/agent-container/src/browser-upload.test.ts
+++ b/agent-container/src/browser-upload.test.ts
@@ -1,0 +1,87 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  createUploadFilePayload,
+  guessMimeType,
+  parseBrowserUploadRequest,
+  resolveUploadPath,
+  validateUploadVerification,
+} from './browser-upload'
+
+let tmpDir: string | null = null
+
+afterEach(() => {
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+    tmpDir = null
+  }
+})
+
+describe('browser upload helpers', () => {
+  it('parses upload requests with the default file input selector', () => {
+    expect(parseBrowserUploadRequest({
+      sessionId: 'session-1',
+      filePath: '/workspace/uploads/file.txt',
+    })).toEqual({
+      success: true,
+      data: {
+        sessionId: 'session-1',
+        selector: 'input[type="file"]',
+        filePath: '/workspace/uploads/file.txt',
+      },
+    })
+  })
+
+  it('rejects upload requests missing a file path', () => {
+    const parsed = parseBrowserUploadRequest({ sessionId: 'session-1' })
+
+    expect(parsed.success).toBe(false)
+    if (!parsed.success) {
+      expect(parsed.error).toContain('Invalid input')
+    }
+  })
+
+  it('resolves relative upload paths under /workspace', () => {
+    expect(resolveUploadPath('uploads/file.txt')).toBe('/workspace/uploads/file.txt')
+  })
+
+  it('keeps absolute upload paths unchanged', () => {
+    expect(resolveUploadPath('/tmp/file.txt')).toBe('/tmp/file.txt')
+  })
+
+  it('guesses common mime types', () => {
+    expect(guessMimeType('/tmp/file.txt')).toBe('text/plain')
+    expect(guessMimeType('/tmp/file.PNG')).toBe('image/png')
+    expect(guessMimeType('/tmp/file.bin')).toBe('application/octet-stream')
+  })
+
+  it('creates a Playwright file payload with the real file bytes', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'browser-upload-test-'))
+    const filePath = path.join(tmpDir, 'upload.txt')
+    fs.writeFileSync(filePath, 'hello upload')
+
+    const payload = await createUploadFilePayload(filePath)
+
+    expect(payload.name).toBe('upload.txt')
+    expect(payload.mimeType).toBe('text/plain')
+    expect(payload.size).toBe(12)
+    expect(payload.buffer.toString('utf8')).toBe('hello upload')
+    expect(payload.resolvedPath).toBe(filePath)
+  })
+
+  it('accepts matching upload verification', () => {
+    expect(validateUploadVerification(
+      { name: 'upload.txt', size: 12 },
+      { count: 1, name: 'upload.txt', size: 12 }
+    )).toBeNull()
+  })
+
+  it('rejects zero-byte verification for a non-empty file', () => {
+    expect(validateUploadVerification(
+      { name: 'upload.txt', size: 12 },
+      { count: 1, name: 'upload.txt', size: 0 }
+    )).toContain('size mismatch')
+  })
+})

--- a/agent-container/src/browser-upload.ts
+++ b/agent-container/src/browser-upload.ts
@@ -1,0 +1,287 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { chromium, type Browser, type Page } from 'playwright-core'
+import { z } from 'zod'
+
+const BrowserUploadRequestSchema = z.object({
+  sessionId: z.string().min(1),
+  selector: z.string().min(1).default('input[type="file"]'),
+  filePath: z.string().min(1),
+})
+
+export type BrowserUploadRequest = z.infer<typeof BrowserUploadRequestSchema>
+
+export interface BrowserUploadFilePayload {
+  name: string
+  mimeType: string
+  buffer: Buffer
+  size: number
+  resolvedPath: string
+}
+
+export interface UploadVerification {
+  count: number
+  name: string | null
+  size: number | null
+}
+
+interface UploadToFileInputOptions {
+  connectionUrl: string
+  activeTargetUrl: string | null
+  selector: string
+  file: BrowserUploadFilePayload
+  urlsMatch: (left: string, right: string) => boolean
+}
+
+interface RunBrowserUploadOptions {
+  validateSession: (sessionId: string) => string | null
+  isBrowserActive: () => boolean
+  getConnectionUrl: () => string
+  getActiveTargetUrl: () => Promise<string | null>
+  urlsMatch: (left: string, right: string) => boolean
+}
+
+type BrowserUploadResponse =
+  | {
+    success: true
+    body: {
+      success: true
+      selector: string
+      file: { name: string; size: number; mimeType: string; path: string }
+      verification: UploadVerification | null
+    }
+  }
+  | {
+    success: false
+    status: 400 | 409 | 500
+    body: {
+      error: string
+      expected?: { name: string; size: number }
+      verification?: UploadVerification | null
+    }
+  }
+
+const MIME_TYPES: Record<string, string> = {
+  '.csv': 'text/csv',
+  '.gif': 'image/gif',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.json': 'application/json',
+  '.pdf': 'application/pdf',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.txt': 'text/plain',
+  '.webp': 'image/webp',
+  '.zip': 'application/zip',
+}
+
+export function parseBrowserUploadRequest(rawBody: unknown):
+  | { success: true; data: BrowserUploadRequest }
+  | { success: false; error: string } {
+  const parsed = BrowserUploadRequestSchema.safeParse(rawBody)
+  if (parsed.success) {
+    return { success: true, data: parsed.data }
+  }
+
+  return {
+    success: false,
+    error: parsed.error.issues.map(issue => issue.message).join(', '),
+  }
+}
+
+export function resolveUploadPath(filePath: string): string {
+  return path.isAbsolute(filePath) ? filePath : path.resolve('/workspace', filePath)
+}
+
+export function guessMimeType(filePath: string): string {
+  return MIME_TYPES[path.extname(filePath).toLowerCase()] || 'application/octet-stream'
+}
+
+export async function createUploadFilePayload(filePath: string): Promise<BrowserUploadFilePayload> {
+  const resolvedPath = resolveUploadPath(filePath)
+  const stat = await fs.promises.stat(resolvedPath)
+  if (!stat.isFile()) {
+    throw new Error(`Upload path is not a file: ${resolvedPath}`)
+  }
+
+  return {
+    name: path.basename(resolvedPath),
+    mimeType: guessMimeType(resolvedPath),
+    buffer: await fs.promises.readFile(resolvedPath),
+    size: stat.size,
+    resolvedPath,
+  }
+}
+
+export function validateUploadVerification(
+  expected: { name: string; size: number },
+  verification: UploadVerification | null
+): string | null {
+  if (!verification) {
+    return 'File input did not emit a change event after upload'
+  }
+  if (verification.count < 1) {
+    return 'File input has no files after upload'
+  }
+  if (verification.name !== expected.name) {
+    return `Uploaded file name mismatch: expected ${expected.name}, got ${verification.name || 'none'}`
+  }
+  if (verification.size !== expected.size) {
+    return `Uploaded file size mismatch: expected ${expected.size} bytes, got ${verification.size ?? 'unknown'}`
+  }
+  return null
+}
+
+export async function runBrowserUpload(
+  rawBody: unknown,
+  options: RunBrowserUploadOptions
+): Promise<BrowserUploadResponse> {
+  const parsed = parseBrowserUploadRequest(rawBody)
+  if (!parsed.success) {
+    return { success: false, status: 400, body: { error: parsed.error } }
+  }
+
+  const body = parsed.data
+  const validationError = options.validateSession(body.sessionId)
+  if (validationError) {
+    return { success: false, status: 409, body: { error: validationError } }
+  }
+
+  if (!options.isBrowserActive()) {
+    return { success: false, status: 400, body: { error: 'Browser is not active' } }
+  }
+
+  const file = await createUploadFilePayload(body.filePath)
+  const verification = (await uploadToFileInput({
+    connectionUrl: options.getConnectionUrl(),
+    activeTargetUrl: await options.getActiveTargetUrl(),
+    selector: body.selector,
+    file,
+    urlsMatch: options.urlsMatch,
+  })).verification
+
+  const verificationError = validateUploadVerification(
+    { name: file.name, size: file.size },
+    verification
+  )
+
+  if (verificationError) {
+    return {
+      success: false,
+      status: 500,
+      body: {
+        error: verificationError,
+        expected: { name: file.name, size: file.size },
+        verification,
+      },
+    }
+  }
+
+  return {
+    success: true,
+    body: {
+      success: true,
+      selector: body.selector,
+      file: {
+        name: file.name,
+        size: file.size,
+        mimeType: file.mimeType,
+        path: file.resolvedPath,
+      },
+      verification,
+    },
+  }
+}
+
+export async function uploadToFileInput({
+  connectionUrl,
+  activeTargetUrl,
+  selector,
+  file,
+  urlsMatch,
+}: UploadToFileInputOptions): Promise<{ verification: UploadVerification | null }> {
+  const browser = await chromium.connectOverCDP(connectionUrl)
+  try {
+    const page = getActivePage(browser, activeTargetUrl, urlsMatch)
+    const locator = page.locator(selector).first()
+    if (await locator.count() === 0) {
+      throw new Error(`No file input matched selector: ${selector}`)
+    }
+
+    const verificationKey = `__superagentUpload_${Date.now()}_${Math.random().toString(36).slice(2)}`
+    await locator.evaluate((element: any, key: string) => {
+      ;(globalThis as typeof globalThis & Record<string, UploadVerification | null>)[key] = null
+      element.addEventListener('change', () => {
+        const uploadedFile = element.files?.[0] ?? null
+        ;(globalThis as typeof globalThis & Record<string, UploadVerification | null>)[key] = {
+          count: element.files?.length ?? 0,
+          name: uploadedFile?.name ?? null,
+          size: uploadedFile?.size ?? null,
+        }
+      }, { once: true })
+    }, verificationKey)
+
+    await locator.setInputFiles({
+      name: file.name,
+      mimeType: file.mimeType,
+      buffer: file.buffer,
+    })
+
+    return {
+      verification: await readUploadVerification(page, selector, verificationKey),
+    }
+  } finally {
+    await browser.close({ reason: 'browser_upload complete' }).catch((error) => {
+      console.warn('[Browser] Failed to close Playwright CDP connection:', error)
+    })
+  }
+}
+
+function getActivePage(
+  browser: Browser,
+  activeTargetUrl: string | null,
+  urlsMatch: (left: string, right: string) => boolean
+): Page {
+  const pages = browser.contexts().flatMap(context => context.pages())
+  if (pages.length === 0) {
+    throw new Error('No browser pages available for upload')
+  }
+
+  const activePage = activeTargetUrl
+    ? pages.find(page => urlsMatch(page.url(), activeTargetUrl))
+    : null
+
+  return activePage || pages[0]
+}
+
+async function readUploadVerification(
+  page: Page,
+  selector: string,
+  verificationKey: string
+): Promise<UploadVerification | null> {
+  try {
+    await page.waitForFunction(
+      key => (globalThis as typeof globalThis & Record<string, UploadVerification | null>)[key] !== null,
+      verificationKey,
+      { timeout: 3000 }
+    )
+    return await page.evaluate(
+      key => (globalThis as typeof globalThis & Record<string, UploadVerification | null>)[key],
+      verificationKey
+    )
+  } catch {
+    try {
+      return await page.locator(selector).first().evaluate((element: any) => {
+        const uploadedFile = element.files?.[0] ?? null
+        return {
+          count: element.files?.length ?? 0,
+          name: uploadedFile?.name ?? null,
+          size: uploadedFile?.size ?? null,
+        }
+      })
+    } catch (error) {
+      console.warn('[Browser] Failed to read upload verification fallback:', error)
+      return null
+    }
+  }
+}

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -443,6 +443,7 @@ export class ClaudeCodeProcess extends EventEmitter {
               ...mcpToolNames('browser', browserTools),
               'WebSearch',
               'Read',
+              'mcp__user-input__request_file',
               'mcp__user-input__request_browser_input',
             ],
             prompt: WEB_BROWSER_AGENT_PROMPT,

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -13,6 +13,7 @@ import * as dns from 'dns';
 import { inputManager } from './input-manager';
 import { dashboardManager } from './dashboard-manager';
 import { tabManager } from './tab-manager';
+import { runBrowserUpload } from './browser-upload';
 
 import { getEditingCommands } from './cdp-editing-commands';
 
@@ -1269,6 +1270,30 @@ app.post('/browser/hover', async (c) => {
   } catch (error: any) {
     console.error('[Browser] Error hovering:', error);
     return c.json({ error: error.message || 'Failed to hover' }, 500);
+  }
+});
+
+// POST /browser/upload - Upload a local file into an <input type="file">
+app.post('/browser/upload', async (c) => {
+  try {
+    const rawBody = await c.req.json().catch(() => ({}));
+    const result = await runBrowserUpload(rawBody, {
+      validateSession: validateBrowserSession,
+      isBrowserActive: () => browserState.active,
+      getConnectionUrl: () => browserState.cdpUrl || getCdpHttpEndpoint(),
+      getActiveTargetUrl: async () => (await findActivePageTarget())?.url ?? null,
+      urlsMatch: (left, right) => tabManager.urlsMatch(left, right),
+    });
+
+    if (!result.success) {
+      return c.json(result.body, result.status);
+    }
+
+    notifyBrowserAction();
+    return c.json(result.body);
+  } catch (error: any) {
+    console.error('[Browser] Error uploading file:', error);
+    return c.json({ error: error.message || 'Failed to upload file' }, 500);
   }
 });
 

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -557,7 +557,7 @@ const browserState: BrowserState = new Proxy({} as BrowserState, {
 
 const execFileAsync = promisify(execFile);
 
-import { buildRunCommandArgs } from './browser-command-args';
+import { buildRunCommandArgs, splitCommandArgs } from './browser-command-args';
 
 // Ensure Chrome download preferences are set in the browser profile directory.
 // Merges with existing preferences to avoid overwriting other settings.
@@ -1313,6 +1313,16 @@ app.post('/browser/run', async (c) => {
 
     if (!browserState.active) {
       return c.json({ error: 'Browser is not active' }, 400);
+    }
+
+    // The agent-browser CLI `upload` command does not work reliably in this
+    // environment — refuse it and steer the model to `browser_upload`, which
+    // routes through the buffer-based path with size verification.
+    if (splitCommandArgs(body.command)[0] === 'upload') {
+      return c.json({
+        error: 'Use the `browser_upload(filePath, selector)` MCP tool for file uploads instead of `browser_run("upload …")`.',
+        success: false,
+      }, 400);
     }
 
     const commandArgs = buildRunCommandArgs(body.command);

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -394,6 +394,41 @@ export const browserHoverTool = tool(
   }
 )
 
+export const browserUploadTool = tool(
+  'browser_upload',
+  `Upload a local file into a web page <input type="file"> using Playwright setInputFiles.
+
+Use this instead of browser_run("upload ..."). The agent-browser upload command is known to create zero-byte uploads on some sites.
+
+The selector must target the actual file input element, such as input[type="file"] or input.dz-hidden-input. Hidden file inputs are supported.`,
+  {
+    filePath: z.string().describe('Path to the local file to upload, usually under /workspace/uploads/...'),
+    selector: z
+      .string()
+      .optional()
+      .default('input[type="file"]')
+      .describe('CSS selector for the target <input type="file"> element. Defaults to input[type="file"].'),
+  },
+  async (args) => {
+    const result = await browserFetch('upload', {
+      filePath: args.filePath,
+      selector: args.selector,
+    })
+    if (!result.success) return errorResult(result.error!)
+
+    const data = result.data as Record<string, any>
+    const file = data.file as { name?: string; size?: number } | undefined
+    let text = file?.name
+      ? `Uploaded ${file.name} (${file.size ?? 'unknown'} bytes) to ${args.selector}.`
+      : `Uploaded file to ${args.selector}.`
+    text += getTabWarning()
+
+    return {
+      content: [{ type: 'text' as const, text }],
+    }
+  }
+)
+
 export const browserRunTool = tool(
   'browser_run',
   `Run any agent-browser CLI command. Use this for advanced browser operations not covered by the dedicated tools.
@@ -408,7 +443,6 @@ Available commands:
 - check/uncheck <ref> — Toggle checkbox
 - scrollintoview <ref> — Scroll element into view
 - drag <srcRef> <tgtRef> — Drag and drop
-- upload <ref> <files> — Upload files
 - eval <js> — Run JavaScript
 - get text/html/value/attr/title/url/count/box <ref> — Get element info
 - is visible/enabled/checked <ref> — Check element state
@@ -515,6 +549,7 @@ export const browserTools = [
   browserScreenshotTool,
   browserSelectTool,
   browserHoverTool,
+  browserUploadTool,
   browserRunTool,
   browserGetStateTool,
 ]

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -13,6 +13,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 - `browser_press(key)` — Press a keyboard key (Enter, Tab, Escape, Control+a, ArrowDown, etc.)
 - `browser_hover(ref)` — Hover over an element (triggers dropdown menus, tooltips)
 - `browser_select(ref, value)` — Select an option from a `<select>` dropdown
+- `browser_upload(filePath, selector?)` — Upload a local file into an `<input type="file">`. Use this for Dropbox, Box, Dropzone, and any file picker flow.
 - `browser_wait(for)` — Wait for a CSS selector to appear on the page. Do NOT use for load states — `browser_open` already waits for the page to load.
 - `browser_screenshot(full?)` — Take a screenshot (returns file path; use Read to see the image)
 
@@ -27,13 +28,13 @@ You are a web browser automation agent. You receive high-level objectives and ac
   - `browser_run("back")` / `browser_run("forward")` / `browser_run("reload")` — Navigation
   - `browser_run("type @e1 hello")` — Type text without clearing first
   - `browser_run("check @e3")` / `browser_run("uncheck @e3")` — Toggle checkboxes
-  - `browser_run("upload @e1 /path/to/file")` — Upload files
   - `browser_run("tab new https://example.com")` — Manage tabs
   - `browser_run("cookies")` — View cookies
 
 **Research:**
 - `WebSearch(query)` — Search the web to find correct URLs or information
 - `Read(file_path)` — Read screenshot files to visually verify pages
+- `request_file(description, fileTypes?)` — Open an upload prompt for the user when you need a file but don't have one available locally. Returns a `/workspace/...` path you can pass to `browser_upload`.
 
 ## Core Workflow
 1. Start with `browser_snapshot()` to see the current page state
@@ -61,6 +62,8 @@ Tab proliferation causes memory crashes and degrades performance. Follow these r
 - **When you encounter a login page, CAPTCHA, 2FA, or any sensitive action:** IMMEDIATELY call `mcp__user-input__request_browser_input` with a clear message explaining what you see and what the user needs to do (e.g., log in, solve CAPTCHA, complete 2FA). Include specific requirements as a list. Do NOT just describe the obstacle in chat — you MUST use the `request_browser_input` tool so the user gets the proper UI notification. After the user completes, take a snapshot to see the updated state.
 - Use interactive + compact snapshot to reduce output — you usually only need buttons, links, inputs.
 - Use `browser_screenshot()` when you need to visually verify something the accessibility tree cannot tell you.
+- For file uploads, target the actual `<input type="file">` with `browser_upload(filePath, selector)`. Do not click "Upload" buttons to trigger a file picker.
+- If you need to upload a file but don't have one available locally (e.g. the user mentioned an upload but didn't attach anything), call `request_file` first, then pass the returned `/workspace/...` path to `browser_upload`.
 - If a page has not fully rendered dynamic content, re-snapshot after a moment.
 - The browser preserves cookies/sessions — the user logs in once and you can reuse the session.
 


### PR DESCRIPTION
## 1. Bug

`mcp__browser__browser_run` with `upload <selector> <path>` returns `✓ Done`, but the file attached to the page's `<input type="file">` ends up at 0 bytes instead of its real size. Reproduced on file.io: a 100 KB source file becomes a `File` object with the right `name`, an extension-guessed `type` (`application/macbinary`), and `size === 0`. Injecting the same file via in-page JS (`DataTransfer` → `File`) on the same input uploads correctly, so the page, the input, and the network path are all fine.

## 2. Cause

agent-browser 0.25.3 forwards the path as an opaque string through CDP. cli/src/native/browser.rs calls DOM.setFileInputFiles({ files: [path], backendNodeId }) and propagates errors with ?, so ✓ Done means Chrome returned success. With AGENT_BROWSER_USE_HOST on, agent-browser is in the container and Chrome is on the host — the container path is meaningless to Chrome's filesystem. Chrome produces a File with the basename as name, a type guessed from the extension, and size === 0. The exact swallow point doesn't matter: path resolution is delegated to the wrong filesystem, and the failure has no channel back to the caller.

## 3. Fix

New MCP tool `browser_upload(filePath, selector)` that never sends a path across CDP. The agent-container reads the file locally with `fs.readFile`, connects to Chrome via Playwright's `chromium.connectOverCDP`, and calls `setInputFiles({ name, mimeType, buffer })`. The bytes travel through CDP into Chrome's memory, so Chrome never has to find the file on its own filesystem. We then read `input.files[0]` back via `locator.evaluate` and verify `count`, `name`, and `size` against the source — any future silent 0-byte regression throws with expected/actual instead of reporting success. Because nothing depends on a shared filesystem, the same code path works identically in container-local mode, host mode (`AGENT_BROWSER_USE_HOST`), and remote-CDP mode (Browserbase and similar). The agent prompt is also updated so the model targets the actual `<input type="file">` with `browser_upload` instead of clicking an "Upload" button, which under headless triggers a programmatic file-chooser open that no-ops silently — a separate path to the same 0-byte symptom.

## Test plan

- [x] `npm test -- browser-upload.test.ts` — 8 tests pass (parse, path resolve, MIME guess, real-bytes payload, size-mismatch detection, …)
- [x] `npm run build` — tsc clean
- [x] Manual repro on file.io with 100KB random file → upload succeeds at 102400 bytes, 100% progress
- [ ] Manual repro on Dropzone-style page (catbox.moe) → upload should succeed
- [ ] Manual repro with Browserbase / remote CDP mode

Made with [Cursor](https://cursor.com)