### PR TITLE
fix(agent-container): disable Claude Code attribution prompt block

### DIFF
--- a/agent-container/Dockerfile
+++ b/agent-container/Dockerfile
@@ -171,6 +171,7 @@ EXPOSE 3000
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOME=/home/claude
+ENV CLAUDE_CODE_ATTRIBUTION_HEADER=0
 ENV AGENT_BROWSER_STREAM_PORT=9223
 # Point agent-browser at the chromium binary installed under PLAYWRIGHT_BROWSERS_PATH.
 # agent-browser's built-in discovery only finds Playwright's chromium at the old

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -278,6 +278,15 @@ describe('containerManager.ensureRunning — env var construction', () => {
     const startOpts = mockStart.mock.calls[0][0]
     expect(startOpts.envVars.TZ).toBe('America/New_York')
   })
+
+  it('disables Claude Code attribution header injection for stable prompt caching', async () => {
+    setupAccountMocks([])
+
+    await containerManager.ensureRunning('test-agent')
+
+    const startOpts = mockStart.mock.calls[0][0]
+    expect(startOpts.envVars.CLAUDE_CODE_ATTRIBUTION_HEADER).toBe('0')
+  })
 })
 
 // ============================================================================

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -560,6 +560,8 @@ class ContainerManager {
         Object.assign(envVars, settings.customEnvVars)
       }
 
+      envVars['CLAUDE_CODE_ATTRIBUTION_HEADER'] = '0'
+
       // Load mounts and build volume flags for healthy ones
       const mountsWithHealth = getMountsWithHealth(agentId)
       const healthyMounts = mountsWithHealth.filter((m) => m.health === 'ok')


### PR DESCRIPTION
## Summary

- Set `CLAUDE_CODE_ATTRIBUTION_HEADER=0` in the agent-container image so direct image runs do not inject the volatile Claude Code billing/attribution prompt block.
- Set the same env var in app-managed container startup to keep runtime launches stable even if the image/env changes.
- Add a container-manager test to assert the env var is injected.

## Why

Claude Code SDK currently injects this as the first system block:

```text
x-anthropic-billing-header: cc_version=...; cc_entrypoint=sdk-ts; cch=<random>;
```

The random `cch` value changes the prompt prefix on otherwise identical requests, which breaks prompt cache reuse through our proxy. Setting `CLAUDE_CODE_ATTRIBUTION_HEADER=0` removes the whole block at the source.

## Verification

- `npm test -- container-manager.test.ts`
- claude-prompt-drift skill capture:
  - default env: `system` has 3 blocks and `raw.json` includes `x-anthropic-billing-header ... cch=...`
  - with this branch / Dockerfile env: `system` has 2 blocks and no `x-anthropic-billing-header` in `raw.json`


Made with [Cursor](https://cursor.com)