### PR TITLE
fix(triggers): poll webhook events in local mode with opaque platform…

### DIFF
--- a/src/shared/lib/scheduler/trigger-manager.test.ts
+++ b/src/shared/lib/scheduler/trigger-manager.test.ts
@@ -74,6 +74,33 @@ vi.mock('@shared/lib/services/webhook-events-client', () => ({
   acknowledgeEvents: (...args: unknown[]) => mockAcknowledgeEvents(...args),
 }))
 
+const mockGetPlatformAccessToken = vi.fn<() => string | null>(() => 'opaque_test_token')
+vi.mock('@shared/lib/services/platform-auth-service', () => ({
+  getPlatformAccessToken: () => mockGetPlatformAccessToken(),
+}))
+
+const mockDecodeOrgIdFromToken = vi.fn<(token: string) => string | null>(() => null)
+vi.mock('@shared/lib/platform-attribution', () => ({
+  runWithOptionalUser: (_userId: string | null, fn: () => unknown) => fn(),
+  decodeOrgIdFromToken: (token: string) => mockDecodeOrgIdFromToken(token),
+}))
+
+vi.mock('@shared/lib/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => ({ all: () => [] }),
+        }),
+      }),
+    }),
+  },
+}))
+
+vi.mock('@shared/lib/db/schema', () => ({
+  connectedAccounts: {},
+}))
+
 vi.mock('@shared/lib/services/supabase-realtime-client', () => ({
   SupabaseRealtimeClient: vi.fn().mockImplementation(() => ({
     connect: vi.fn().mockResolvedValue(undefined),
@@ -91,6 +118,8 @@ describe('TriggerManager', () => {
     vi.clearAllMocks()
     mockCreateSession.mockResolvedValue({ id: 'session_123' })
     mockGetDistinctMemberIds.mockReturnValue(['sub_test_member'])
+    mockGetPlatformAccessToken.mockReturnValue('opaque_test_token')
+    mockDecodeOrgIdFromToken.mockReturnValue(null)
   })
 
   describe('start', () => {
@@ -234,6 +263,47 @@ describe('TriggerManager', () => {
 
       triggerManager.stop()
       mockAgentExists.mockResolvedValue(true) // restore for other tests
+    })
+  })
+
+  describe('pollAndProcess fallback when memberIds is empty', () => {
+    it('opaque key mode: polls with "local" placeholder', async () => {
+      mockGetDistinctMemberIds.mockReturnValue([])
+      mockGetPlatformAccessToken.mockReturnValue('opaque_test_token')
+      mockDecodeOrgIdFromToken.mockReturnValue(null)
+      mockPollAndClaimEvents.mockResolvedValue({ events: [], realtime: null })
+
+      await triggerManager.start()
+
+      expect(mockPollAndClaimEvents).toHaveBeenCalledTimes(1)
+      expect(mockPollAndClaimEvents).toHaveBeenCalledWith('local')
+
+      triggerManager.stop()
+    })
+
+    it('org JWT mode: skips poll to avoid bogus `::local` bearer', async () => {
+      mockGetDistinctMemberIds.mockReturnValue([])
+      mockGetPlatformAccessToken.mockReturnValue('org_jwt_token')
+      mockDecodeOrgIdFromToken.mockReturnValue('org_123')
+      mockPollAndClaimEvents.mockResolvedValue({ events: [], realtime: null })
+
+      await triggerManager.start()
+
+      expect(mockPollAndClaimEvents).not.toHaveBeenCalled()
+
+      triggerManager.stop()
+    })
+
+    it('no platform token: skips poll', async () => {
+      mockGetDistinctMemberIds.mockReturnValue([])
+      mockGetPlatformAccessToken.mockReturnValue(null)
+      mockPollAndClaimEvents.mockResolvedValue({ events: [], realtime: null })
+
+      await triggerManager.start()
+
+      expect(mockPollAndClaimEvents).not.toHaveBeenCalled()
+
+      triggerManager.stop()
     })
   })
 })

--- a/src/shared/lib/scheduler/trigger-manager.ts
+++ b/src/shared/lib/scheduler/trigger-manager.ts
@@ -12,7 +12,8 @@ import { containerManager } from '@shared/lib/container/container-manager'
 import { getEffectiveModels } from '@shared/lib/config/settings'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
-import { runWithOptionalUser } from '@shared/lib/platform-attribution'
+import { runWithOptionalUser, decodeOrgIdFromToken } from '@shared/lib/platform-attribution'
+import { getPlatformAccessToken } from '@shared/lib/services/platform-auth-service'
 import { db } from '@shared/lib/db'
 import { connectedAccounts } from '@shared/lib/db/schema'
 import { eq } from 'drizzle-orm'
@@ -120,10 +121,16 @@ class TriggerManager {
     this.isProcessing = true
 
     try {
-      // Poll once per distinct trigger owner; first realtime config wins
-      // (other members are picked up on the next pollAndProcess()).
-      const memberIds = getDistinctPlatformMemberIdsForActiveTriggers()
-      if (memberIds.length === 0) return
+      // Poll once per distinct trigger owner; first realtime config wins.
+      // Opaque-key mode has no authAccount rows, so fall back to a placeholder
+      // (buildBearer ignores it). Org JWT mode returns early to avoid a bogus
+      // `${token}::local` bearer.
+      let memberIds = getDistinctPlatformMemberIdsForActiveTriggers()
+      if (memberIds.length === 0) {
+        const token = getPlatformAccessToken()
+        if (!token || decodeOrgIdFromToken(token)) return
+        memberIds = ['local']
+      }
 
       for (const memberId of memberIds) {
         try {


### PR DESCRIPTION
## What's broken

In opaque-key (local single-user) mode, the platform access token is not an org JWT and `authAccount` has no `providerId='platform'` row. As a result:

- `getDistinctPlatformMemberIdsForActiveTriggers()` returns `[]`
- `pollAndProcess()` early-returns
- Webhook events sitting in the platform proxy never get claimed or fired

## Repro

1. Run SuperAgent locally with `PLATFORM_PROXY_URL` set and an opaque platform key (no OAuth login)
2. Create a webhook trigger (e.g. `GMAIL_NEW_EMAIL`) — the Composio subscription is created on the platform side
3. Send a matching event — the row lands in the `webhook_events` table but the local agent never fires
4. `[TriggerManager] Starting...` prints, but no `Processing N event(s)` log ever follows

## Fix

When `memberIds` is empty, branch on the token shape:

- **No token** → early return (nothing we can do)
- **Org JWT** (`decodeOrgIdFromToken(token) !== null`) → early return; an empty list here means the org genuinely has no active triggers
- **Opaque key** → use `['local']` placeholder; `buildBearer` ignores the memberId in this mode

## Tests

Added 3 cases to `trigger-manager.test.ts`:

- opaque key + empty memberIds → polls with `'local'`
- org JWT + empty memberIds → does not poll
- no token + empty memberIds → does not poll

All 8 tests in the file pass.