### PR TITLE
fix(composio): server-side filter listAuthConfigs by toolkit_slug

### DIFF
--- a/src/shared/lib/composio/client.test.ts
+++ b/src/shared/lib/composio/client.test.ts
@@ -27,6 +27,8 @@ import {
   proxyExecute,
   getAccountDisplayName,
   initiateConnection,
+  getOrCreateAuthConfig,
+  listAuthConfigs,
   ComposioApiError,
   ComposioRedactedTokenError,
 } from './client'
@@ -821,5 +823,173 @@ describe('initiateConnection', () => {
     await expect(
       initiateConnection('ac_x', 'cb://done', 'user-1')
     ).rejects.toThrow()
+  })
+})
+
+describe('listAuthConfigs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetEffectiveComposioApiKey.mockReturnValue('test-api-key')
+  })
+
+  it('omits query params when no toolkitSlug is given (backwards compatible)', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [] }),
+    })
+
+    await listAuthConfigs()
+
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toMatch(/\/auth_configs$/)
+    expect(url).not.toContain('toolkit_slug')
+  })
+
+  it('passes toolkit_slug + limit when slug is given', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [] }),
+    })
+
+    await listAuthConfigs('gmail')
+
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toContain('toolkit_slug=gmail')
+    expect(url).toContain('limit=100')
+  })
+
+  it('url-encodes the slug', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [] }),
+    })
+
+    await listAuthConfigs('weird/slug with space')
+
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toContain('toolkit_slug=weird%2Fslug%20with%20space')
+  })
+})
+
+describe('getOrCreateAuthConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetEffectiveComposioApiKey.mockReturnValue('test-api-key')
+  })
+
+  function mockListResponse(items: Array<{
+    id: string
+    auth_scheme?: string
+    is_composio_managed?: boolean
+    status?: 'ENABLED' | 'DISABLED'
+    created_at?: string
+    toolkit?: { slug: string }
+  }>) {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: items.map((i) => ({
+          id: i.id,
+          auth_scheme: i.auth_scheme ?? 'OAUTH2',
+          is_composio_managed: i.is_composio_managed ?? true,
+          status: i.status ?? 'ENABLED',
+          created_at: i.created_at ?? '2026-05-01T00:00:00Z',
+          toolkit: i.toolkit ?? { slug: 'gmail' },
+        })),
+      }),
+    })
+  }
+
+  function mockCreateResponse(authConfigId: string, slug = 'gmail') {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        toolkit: { slug },
+        auth_config: {
+          id: authConfigId,
+          auth_scheme: 'OAUTH2',
+          is_composio_managed: true,
+        },
+      }),
+    })
+  }
+
+  it('queries Composio with the toolkit_slug filter, not a bare list', async () => {
+    mockListResponse([{ id: 'ac_existing' }])
+
+    await getOrCreateAuthConfig('gmail')
+
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toContain('toolkit_slug=gmail')
+    expect(url).toContain('limit=100')
+  })
+
+  it('reuses an existing ENABLED auth config without POSTing', async () => {
+    mockListResponse([
+      {
+        id: 'ac_existing',
+        status: 'ENABLED',
+        created_at: '2026-05-01T00:00:00Z',
+      },
+    ])
+
+    const result = await getOrCreateAuthConfig('gmail')
+
+    expect(result.id).toBe('ac_existing')
+    expect(mockFetch).toHaveBeenCalledTimes(1) // GET only, no POST
+  })
+
+  it('picks the most recent ENABLED config when multiple exist (the dedup case)', async () => {
+    mockListResponse([
+      { id: 'ac_older', created_at: '2026-03-31T00:00:00Z' },
+      { id: 'ac_newest', created_at: '2026-05-18T00:00:00Z' },
+      { id: 'ac_middle', created_at: '2026-04-23T00:00:00Z' },
+    ])
+
+    const result = await getOrCreateAuthConfig('gmail')
+
+    expect(result.id).toBe('ac_newest')
+    expect(mockFetch).toHaveBeenCalledTimes(1) // GET only
+  })
+
+  it('skips DISABLED configs and reuses the newest ENABLED one', async () => {
+    mockListResponse([
+      { id: 'ac_disabled_newest', status: 'DISABLED', created_at: '2026-05-18T00:00:00Z' },
+      { id: 'ac_enabled_older', status: 'ENABLED', created_at: '2026-05-09T00:00:00Z' },
+    ])
+
+    const result = await getOrCreateAuthConfig('gmail')
+
+    expect(result.id).toBe('ac_enabled_older')
+    expect(mockFetch).toHaveBeenCalledTimes(1) // GET only
+  })
+
+  it('POSTs a new auth config when no ENABLED config exists for the toolkit', async () => {
+    mockListResponse([
+      { id: 'ac_disabled', status: 'DISABLED' },
+    ])
+    mockCreateResponse('ac_new', 'gmail')
+
+    const result = await getOrCreateAuthConfig('gmail')
+
+    expect(result.id).toBe('ac_new')
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    const postCall = mockFetch.mock.calls[1]
+    expect((postCall[1] as { method: string }).method).toBe('POST')
+    const body = JSON.parse((postCall[1] as { body: string }).body)
+    expect(body).toEqual({
+      toolkit: { slug: 'gmail' },
+      auth_config: { type: 'use_composio_managed_auth' },
+    })
+  })
+
+  it('POSTs a new auth config when the list is empty', async () => {
+    mockListResponse([])
+    mockCreateResponse('ac_first', 'gmail')
+
+    const result = await getOrCreateAuthConfig('gmail')
+
+    expect(result.id).toBe('ac_first')
+    expect(mockFetch).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/shared/lib/composio/client.ts
+++ b/src/shared/lib/composio/client.ts
@@ -180,10 +180,19 @@ function mapAuthConfigListItem(item: AuthConfigListItem): AuthConfig {
 }
 
 /**
- * List all auth configs for the current user.
+ * List auth configs for the current user. When `toolkitSlug` is provided,
+ * Composio filters server-side — necessary to avoid pagination cutoff
+ * hiding existing configs for the toolkit (Composio defaults to 20/page).
  */
-export async function listAuthConfigs(): Promise<AuthConfig[]> {
-  const response = await composioFetch<ListAuthConfigsResponse>('/auth_configs')
+export async function listAuthConfigs(
+  toolkitSlug?: string,
+): Promise<AuthConfig[]> {
+  const query = toolkitSlug
+    ? `?toolkit_slug=${encodeURIComponent(toolkitSlug)}&limit=100`
+    : ''
+  const response = await composioFetch<ListAuthConfigsResponse>(
+    `/auth_configs${query}`,
+  )
   return (response.items || []).map(mapAuthConfigListItem)
 }
 
@@ -195,13 +204,9 @@ export async function getOrCreateAuthConfig(
   providerSlug: string
 ): Promise<AuthConfig> {
   // First, check if an enabled auth config already exists for this provider
-  const existing = await listAuthConfigs()
+  const existing = await listAuthConfigs(providerSlug)
   const matchingConfigs = existing
-    .filter(
-      (config) =>
-        config.toolkitSlug.toLowerCase() === providerSlug.toLowerCase() &&
-        config.status !== 'DISABLED'
-    )
+    .filter((config) => config.status !== 'DISABLED')
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
 
   if (matchingConfigs.length > 0) {


### PR DESCRIPTION
## Summary

`getOrCreateAuthConfig` pulled all auth configs from Composio and filtered client-side, but Composio paginates `/auth_configs` at 20 items per page by default. On shared Composio projects (e.g. the platform's `gamut_prod`, used as the fallback when an org hasn't configured its own Composio key), the total auth config count across all toolkits routinely exceeds 20. The most recent auth config for any given toolkit gets pushed off page 1 by churn on other toolkits, so the reuse check sees no matching config and POSTs a duplicate. This silently accumulates orphan auth configs over time.

## Evidence

- `gamut_prod` Composio console shows **6 Gmail managed-auth configs** for the same toolkit (Mar 31, Apr 10 DISABLED, Apr 16, Apr 23, May 9, May 18), connection counts unevenly distributed (47/34/14/12/2/1).
- Empirically verified default page size against `gamut_prod`:
  ```
  GET /auth_configs → { total_items: 88, returned: 20, total_pages: 5, next_cursor: "Mi0yMA==" }
  ```
- ~18 auth configs created per month across all toolkits on `gamut_prod` → Gmail gets pushed off the first page roughly every 2 weeks → matches the new-Gmail cadence in the data.

## Fix

Pass `toolkit_slug=<slug>` so Composio filters server-side. The response now contains only that toolkit's auth configs, comfortably fitting in a single page (`limit=100`) for any realistic per-toolkit count. The redundant client-side `toolkitSlug` filter is dropped (Composio already did it).

## What about the 5 existing orphan Gmail configs?

Left as-is intentionally. Each one owns OAuth credentials for the connections that were created against it; deleting or disabling them would break those existing connections' token refresh. New connections naturally route to the newest ENABLED config going forward. The Composio console looks noisy but functionality is unaffected.

## Test plan

- [x] Unit tests added (`client.test.ts`):
  - URL contains `toolkit_slug=<slug>&limit=100`
  - URL-encodes weird slugs
  - Reuses existing ENABLED config without POSTing
  - Picks newest ENABLED when multiple exist (the dedup behavior)
  - Skips DISABLED, reuses older ENABLED
  - POSTs new when no ENABLED config exists
  - POSTs new when list is empty
- [ ] Manual: connect Gmail in the app → confirm no new auth_config is created in Composio dashboard.

Made with [Cursor](https://cursor.com)