### PR TITLE
fix: reduce mic-button click-to-listen latency

### DIFF
--- a/src/renderer/components/settings/voice-tab.tsx
+++ b/src/renderer/components/settings/voice-tab.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   Select,
   SelectContent,
@@ -78,6 +79,7 @@ function isApiKeyProvider(provider: SttProvider): provider is ApiKeyProvider {
 function SttApiKeyInput({ provider, disabled }: { provider: ApiKeyProvider; disabled: boolean }) {
   const { data: settings } = useSettings()
   const updateSettings = useUpdateSettings()
+  const queryClient = useQueryClient()
   const config = PROVIDER_CONFIG[provider]
 
   const [apiKeyInput, setApiKeyInput] = useState('')
@@ -107,6 +109,8 @@ function SttApiKeyInput({ provider, disabled }: { provider: ApiKeyProvider; disa
         await updateSettings.mutateAsync({
           apiKeys: { [config.apiKeyField]: apiKeyInput.trim() },
         })
+        // Drop any cached STT token — it was minted against the previous key.
+        queryClient.invalidateQueries({ queryKey: ['stt-token'] })
         setApiKeyInput('')
         setShowApiKey(false)
       }
@@ -123,6 +127,7 @@ function SttApiKeyInput({ provider, disabled }: { provider: ApiKeyProvider; disa
       await updateSettings.mutateAsync({
         apiKeys: { [config.apiKeyField]: '' },
       })
+      queryClient.invalidateQueries({ queryKey: ['stt-token'] })
       setValidationResult(null)
     } catch (error) {
       console.error('Failed to remove API key:', error)
@@ -283,6 +288,7 @@ const VALID_PROVIDERS = new Set(STT_PROVIDERS.map(p => p.value))
 export function VoiceTab() {
   const { data: settings, isLoading } = useSettings()
   const updateSettings = useUpdateSettings()
+  const queryClient = useQueryClient()
   const { data: platformAuth } = usePlatformAuthStatus()
   const isPlatformConnected = platformAuth?.connected ?? false
   const rawProvider = settings?.voice?.sttProvider
@@ -306,6 +312,9 @@ export function VoiceTab() {
             onValueChange={(value) => {
               if (value === 'platform' && !isPlatformConnected) return
               updateSettings.mutate({ voice: { sttProvider: value as SttProvider } })
+              // A new provider means any cached token from the previous one
+              // is unusable; drop it so the next mic click mints a fresh one.
+              queryClient.invalidateQueries({ queryKey: ['stt-token'] })
             }}
             disabled={isLoading}
           >

--- a/src/renderer/hooks/use-voice-input.ts
+++ b/src/renderer/hooks/use-voice-input.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiFetch } from '@renderer/lib/api'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { createSttAdapter, startAudioCapture, type SttAdapter, type SttProvider, type AudioCaptureHandle } from '@renderer/lib/stt'
@@ -18,6 +18,21 @@ interface SttCredentials {
 interface SttConfiguredStatus {
   configured: boolean
   supportsVoiceAgent: boolean
+}
+
+// React Query cache key for the ephemeral STT token. Invalidated on
+// voice-settings changes (provider switch / key save). The backend mints a
+// short-lived token; 5 min stale is comfortably under the typical TTL.
+const STT_TOKEN_QUERY_KEY = ['stt-token'] as const
+const STT_TOKEN_STALE_MS = 300_000
+
+async function fetchSttToken(): Promise<SttCredentials> {
+  const res = await apiFetch('/api/stt/token')
+  const data: SttCredentials | { error: string } = await res.json()
+  if (!res.ok) {
+    throw new Error(('error' in data ? data.error : null) || 'Failed to get STT credentials')
+  }
+  return data as SttCredentials
 }
 
 function useSttConfiguredStatus(): SttConfiguredStatus {
@@ -50,6 +65,8 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
   const [state, setState] = useState<VoiceInputState>('idle')
   const [error, setError] = useState<string | null>(null)
   const { track } = useAnalyticsTracking()
+  const queryClient = useQueryClient()
+  const hasVoiceConfigured = useIsVoiceConfigured()
 
   const adapterRef = useRef<SttAdapter | null>(null)
   const captureRef = useRef<AudioCaptureHandle | null>(null)
@@ -101,6 +118,21 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
     return finalText
   }, [cleanup, onTranscriptUpdate, track])
 
+  /**
+   * Speculatively fetch and cache an STT token. Safe to call repeatedly —
+   * React Query dedupes in-flight requests and skips the network when the
+   * cache is fresh. Call this when the user is likely to click the mic soon
+   * (e.g. on composer focus) so the click path doesn't pay for token minting.
+   */
+  const prefetchToken = useCallback(() => {
+    if (!hasVoiceConfigured) return
+    void queryClient.prefetchQuery({
+      queryKey: STT_TOKEN_QUERY_KEY,
+      queryFn: fetchSttToken,
+      staleTime: STT_TOKEN_STALE_MS,
+    })
+  }, [hasVoiceConfigured, queryClient])
+
   const startRecording = useCallback(async (existingText: string) => {
     if (stateRef.current !== 'idle') return
     setError(null)
@@ -111,17 +143,33 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
     interimRef.current = ''
 
     setState('connecting')
+    const t0 = performance.now()
 
     try {
-      // 1. Get API key from backend
-      const credRes = await apiFetch('/api/stt/token')
-      const credData: SttCredentials | { error: string } = await credRes.json()
-      if (!credRes.ok) {
-        throw new Error(('error' in credData ? credData.error : null) || 'Failed to get STT credentials')
-      }
-      const { provider, token } = credData as SttCredentials
+      // Fire token fetch and mic permission in parallel — they don't depend
+      // on each other, so the combined wait collapses to max(token, mic)
+      // instead of their sum. With a warm token cache (composer-focus
+      // prefetch), this typically resolves in just the getUserMedia time.
+      const tokenPromise = queryClient.ensureQueryData({
+        queryKey: STT_TOKEN_QUERY_KEY,
+        queryFn: fetchSttToken,
+        staleTime: STT_TOKEN_STALE_MS,
+      })
+      // No sampleRate hint — we don't know the provider yet, and the
+      // AudioContext resamples the stream to whatever rate we need.
+      const audioPromise = navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: true,
+        },
+      })
 
-      // 2. Create adapter and wire transcript events
+      const [credData, stream] = await Promise.all([tokenPromise, audioPromise])
+      const { provider, token } = credData
+
+      // Create adapter and wire transcript events before kicking off connect,
+      // so we don't miss any messages.
       const adapter = createSttAdapter(provider)
       adapterRef.current = adapter
 
@@ -147,19 +195,45 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
         stopRecording()
       })
 
-      await adapter.connect(token)
+      // Kick off the WebSocket handshake. Don't await yet — audio capture
+      // starts in parallel and the adapter buffers chunks until the WS opens.
+      const connectPromise = adapter.connect(token)
+      // Prevent unhandled-rejection warnings if we abort before awaiting below.
+      connectPromise.catch(() => {})
 
-      // 3. Start mic capture and pipe audio to the adapter
-      captureRef.current = await startAudioCapture(adapter, { withAnalyser: true })
+      // Pipe the pre-acquired mic stream into the adapter. The first audio
+      // chunks fire immediately and go into the adapter's pre-buffer; they
+      // drain to the WS as soon as it opens.
+      captureRef.current = await startAudioCapture(adapter, { withAnalyser: true, stream })
       analyserRef.current = captureRef.current.analyser
 
-      // Guard against race: if an error callback already triggered stopRecording
-      // while we were awaiting above, don't overwrite the idle state.
-      // Cast needed because TS narrows the ref, but callbacks can mutate it during awaits.
+      // If stopRecording fired during the awaits above, bail without
+      // overwriting the idle/stopping state.
       if ((stateRef.current as VoiceInputState) !== 'connecting') return
 
+      // Optimistic state flip: the mic is live and audio is flowing into the
+      // pre-buffer. The WS may still be handshaking, but the user can start
+      // speaking now — their first words won't be lost.
       setState('recording')
+
+      // Wait for the WS to actually open before considering the start
+      // successful. If it fails, the catch below rolls back state and
+      // surfaces the error.
+      await connectPromise
+
+      track('dictation_start_timing', {
+        click_to_recording_ms: Math.round(performance.now() - t0),
+        provider,
+      })
     } catch (err) {
+      // If the user (or the error callback) already stopped recording during
+      // an await, state is now 'stopping' or 'idle' and cleanup has already
+      // run — don't surface a misleading error.
+      // Cast needed because TS narrows the ref, but callbacks can mutate it during awaits.
+      const currentState = stateRef.current as VoiceInputState
+      if (currentState === 'stopping' || currentState === 'idle') {
+        return
+      }
       const message = err instanceof Error ? err.message : 'Failed to start recording'
       console.error('Voice input error:', err)
       setError(message)
@@ -171,7 +245,7 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
       interimRef.current = ''
       setState('idle')
     }
-  }, [cleanup, onTranscriptUpdate, stopRecording])
+  }, [cleanup, onTranscriptUpdate, queryClient, stopRecording, track])
 
   // Cleanup on unmount
   useEffect(() => {
@@ -179,6 +253,16 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
       cleanup()
     }
   }, [cleanup])
+
+  // Speculatively warm the STT token as soon as voice is known to be
+  // configured — i.e. as soon as the composer (or anything that mounts this
+  // hook) appears. By the time the user clicks the mic, the token round-trip
+  // is usually already done. prefetchToken itself no-ops when not configured.
+  useEffect(() => {
+    if (hasVoiceConfigured) {
+      prefetchToken()
+    }
+  }, [hasVoiceConfigured, prefetchToken])
 
   const clearError = useCallback(() => setError(null), [])
 
@@ -192,5 +276,6 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
     analyserRef,
     startRecording,
     stopRecording,
+    prefetchToken,
   }
 }

--- a/src/renderer/lib/stt.ts
+++ b/src/renderer/lib/stt.ts
@@ -5,6 +5,12 @@ export type { SttProvider }
 
 const CONNECT_TIMEOUT_MS = 10_000
 
+// Max audio chunks buffered before the WS is open. At ~128ms per chunk
+// (2048 samples @ 16kHz), 50 chunks ≈ 6.4s of audio. Beyond this, oldest
+// chunks are dropped; in practice the WS opens in <1s so the buffer rarely
+// holds more than a handful of chunks.
+const MAX_PENDING_CHUNKS = 50
+
 export interface TranscriptEvent {
   type: 'interim' | 'final' | 'speech_ended'
   text: string
@@ -42,6 +48,7 @@ class DeepgramAdapter implements SttAdapter {
   private transcriptCb: TranscriptCallback | null = null
   private errorCb: ErrorCallback | null = null
   private connected = false
+  private pendingChunks: ArrayBuffer[] = []
 
   async connect(token: string): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -56,6 +63,11 @@ class DeepgramAdapter implements SttAdapter {
       this.ws.onopen = () => {
         clearTimeout(timeout)
         this.connected = true
+        // Drain any audio captured before the WS opened.
+        for (const chunk of this.pendingChunks) {
+          this.ws?.send(chunk)
+        }
+        this.pendingChunks = []
         resolve()
       }
 
@@ -94,7 +106,14 @@ class DeepgramAdapter implements SttAdapter {
       }
 
       this.ws.onclose = (event) => {
-        if (event.code !== 1000 && event.code !== 1005) {
+        clearTimeout(timeout)
+        if (!this.connected) {
+          // Closed before open — happens when the caller aborts mid-handshake
+          // (user clicked stop) or the server rejected. Reject so callers
+          // don't hang awaiting connect().
+          this.pendingChunks = []
+          reject(new Error(`Deepgram connection closed before open: ${event.code} ${event.reason}`))
+        } else if (event.code !== 1000 && event.code !== 1005) {
           this.errorCb?.(new Error(`Deepgram connection closed: ${event.code} ${event.reason}`))
         }
       }
@@ -104,6 +123,11 @@ class DeepgramAdapter implements SttAdapter {
   sendAudio(chunk: ArrayBuffer): void {
     if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(chunk)
+    } else if (this.ws?.readyState === WebSocket.CONNECTING) {
+      if (this.pendingChunks.length >= MAX_PENDING_CHUNKS) {
+        this.pendingChunks.shift()
+      }
+      this.pendingChunks.push(chunk)
     }
   }
 
@@ -154,7 +178,15 @@ class OpenaiAdapter implements SttAdapter {
   private errorCb: ErrorCallback | null = null
   private pendingDelta = ''
   private connected = false
+  private pendingChunks: ArrayBuffer[] = []
   readonly sampleRate = 24000
+
+  private sendChunk(chunk: ArrayBuffer): void {
+    this.ws?.send(JSON.stringify({
+      type: 'input_audio_buffer.append',
+      audio: arrayBufferToBase64(chunk),
+    }))
+  }
 
   async connect(token: string): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -193,6 +225,11 @@ class OpenaiAdapter implements SttAdapter {
             },
           },
         }))
+        // Drain any audio captured before the WS opened.
+        for (const chunk of this.pendingChunks) {
+          this.sendChunk(chunk)
+        }
+        this.pendingChunks = []
         resolve()
       }
 
@@ -242,7 +279,11 @@ class OpenaiAdapter implements SttAdapter {
       }
 
       this.ws.onclose = (event) => {
-        if (event.code !== 1000 && event.code !== 1005) {
+        clearTimeout(timeout)
+        if (!this.connected) {
+          this.pendingChunks = []
+          reject(new Error(`OpenAI connection closed before open: ${event.code} ${event.reason}`))
+        } else if (event.code !== 1000 && event.code !== 1005) {
           this.errorCb?.(new Error(`OpenAI connection closed: ${event.code} ${event.reason}`))
         }
       }
@@ -251,10 +292,12 @@ class OpenaiAdapter implements SttAdapter {
 
   sendAudio(chunk: ArrayBuffer): void {
     if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({
-        type: 'input_audio_buffer.append',
-        audio: arrayBufferToBase64(chunk),
-      }))
+      this.sendChunk(chunk)
+    } else if (this.ws?.readyState === WebSocket.CONNECTING) {
+      if (this.pendingChunks.length >= MAX_PENDING_CHUNKS) {
+        this.pendingChunks.shift()
+      }
+      this.pendingChunks.push(chunk)
     }
   }
 
@@ -315,15 +358,20 @@ export interface AudioCaptureHandle {
  * Set up microphone capture and pipe PCM audio chunks to an SttAdapter.
  * Returns handles for the resources and a cleanup function.
  *
+ * If `options.stream` is provided, it is used as-is (the caller retains no
+ * other reference — cleanup stops its tracks). Otherwise, `getUserMedia` is
+ * called internally. Pre-acquiring the stream lets callers parallelize the
+ * mic-permission prompt with other async work.
+ *
  * TODO: Migrate from deprecated createScriptProcessor to AudioWorkletNode.
  */
 export async function startAudioCapture(
   adapter: SttAdapter,
-  options?: { withAnalyser?: boolean },
+  options?: { withAnalyser?: boolean; stream?: MediaStream },
 ): Promise<AudioCaptureHandle> {
   const sampleRate = adapter.sampleRate ?? 16000
 
-  const stream = await navigator.mediaDevices.getUserMedia({
+  const stream = options?.stream ?? await navigator.mediaDevices.getUserMedia({
     audio: {
       channelCount: 1,
       sampleRate,
@@ -332,6 +380,9 @@ export async function startAudioCapture(
     },
   })
 
+  // AudioContext resamples the stream to its own sampleRate as it flows
+  // through the MediaStreamSource, so a pre-acquired stream at a different
+  // hardware rate is fine.
   const audioContext = new AudioContext({ sampleRate })
   // The context may start suspended if created outside a synchronous user-gesture
   // handler (e.g. after awaiting network requests). Explicitly resume it.


### PR DESCRIPTION
## Summary

The Chat Composer's mic button felt laggy. Two issues:

1. **Click → ready-to-listen lag (~300–1300ms).** The click path serially awaited token fetch, WebSocket handshake, then `getUserMedia` + AudioContext setup.
2. **First-word loss.** Audio didn't start flowing to the STT provider until the WebSocket was open, so words spoken immediately after click were lost during the handshake.

This PR collapses the click path and adds an audio pre-buffer so first words aren't lost.

## Changes

- **Token prefetch.** Token fetch now goes through React Query (`['stt-token']`, 5min stale). An auto-prefetch fires when `useVoiceInput` mounts, so as soon as the composer is on screen the token starts warming. By the time the user clicks the mic, the token round-trip is almost always already complete.
- **Parallelized click path.** `startRecording` runs the token fetch and `getUserMedia` in parallel via `Promise.all`. `adapter.connect()` is kicked off without awaiting; audio capture starts in parallel.
- **Optimistic state flip.** State flips to `'recording'` (pill + waveform) as soon as `getUserMedia` resolves, not after the WebSocket opens. The WS handshake continues in the background.
- **Audio pre-buffer.** Both `DeepgramAdapter` and `OpenaiAdapter` now buffer audio chunks captured while the WS is still handshaking (cap ~50 chunks ≈ 6s) and drain them in order on `onopen`. First words spoken on click are preserved.
- **Robust mid-handshake abort.** Adapters now reject the connect promise on `onclose-before-open`, so user-initiated stops mid-handshake don't leave a dangling promise. The catch in `startRecording` differentiates user-stop from real failure via `stateRef`.
- **Cache invalidation.** `['stt-token']` is invalidated on provider change, API-key save, and API-key remove in the voice settings tab so a stale token from the previous provider/key isn't reused.
- **Telemetry.** A `dictation_start_timing` event captures `click_to_recording_ms` and provider, so real-world impact is measurable.

## Test plan

- [ ] **Manual A/B (cold).** On `main`: click composer, immediately click mic, time to "pill appears" and to "first interim text." Repeat 5×. Repeat on this branch. Expect noticeable improvement from parallelization.
- [ ] **Manual A/B (warm).** Click composer, wait ~1s (lets prefetch settle), then click mic. Should feel essentially instant.
- [ ] **First-word fidelity.** Click mic and immediately say "the quick brown fox" with no pause. Confirm "the" appears in the transcript (pre-buffer working).
- [ ] **Failure rollback.** Temporarily force `DeepgramAdapter.connect` to reject. Confirm the recording pill appears briefly then collapses to idle with an error toast, and the textarea text isn't corrupted.
- [ ] **Provider switch.** Switch STT provider in Settings → Voice; confirm next mic click mints a fresh token (cache invalidation).
- [ ] Typecheck + lint clean (verified).

## Follow-ups (not in this PR)

- Migrate deprecated `ScriptProcessorNode` → `AudioWorkletNode` (TODO in `stt.ts:318`). Reduces audio-chunk cadence from ~128ms to ~8ms — the biggest remaining win on the "speaking → first text in composer" pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)