### PR TITLE
fix: hide active toggle and delete action for deleted triggers

### DIFF
--- a/src/renderer/components/agents/agent-home/home-triggers.tsx
+++ b/src/renderer/components/agents/agent-home/home-triggers.tsx
@@ -175,6 +175,8 @@ interface TriggerRowProps {
   // Cron-only Run Now action.
   onRunNow?: () => void
   runNowPending?: boolean
+  // When true, the trigger is already deleted — only the View Details action is shown.
+  isDeleted?: boolean
 }
 
 function TriggerRow({
@@ -191,6 +193,7 @@ function TriggerRow({
   kind,
   onRunNow,
   runNowPending,
+  isDeleted = false,
 }: TriggerRowProps) {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const label = kind === 'cron' ? 'Cron' : 'Webhook'
@@ -232,7 +235,7 @@ function TriggerRow({
               </Button>
             </PopoverTrigger>
             <PopoverContent align="end" className="w-36 p-1">
-              {canTogglePause && (
+              {canTogglePause && !isDeleted && (
                 <>
                   <div className="flex w-full items-center justify-between px-2 py-1.5">
                     <div
@@ -271,7 +274,7 @@ function TriggerRow({
                 <Info className="h-3.5 w-3.5" />
                 View Details
               </button>
-              {onRunNow && (
+              {onRunNow && !isDeleted && (
                 <button
                   className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
                   disabled={runNowPending}
@@ -284,16 +287,18 @@ function TriggerRow({
                   {runNowPending ? 'Running...' : 'Run Now'}
                 </button>
               )}
-              <button
-                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-destructive hover:bg-destructive/10 transition-colors"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  setShowDeleteDialog(true)
-                }}
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-                Delete {label}
-              </button>
+              {!isDeleted && (
+                <button
+                  className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-destructive hover:bg-destructive/10 transition-colors"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setShowDeleteDialog(true)
+                  }}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Delete {label}
+                </button>
+              )}
             </PopoverContent>
           </Popover>
         </div>
@@ -338,10 +343,12 @@ function CronRow({
   const resumeTask = useResumeScheduledTask()
   const humanizedCron = useHumanizedCron(task.isRecurring ? task.scheduleExpression : null)
   const isPaused = task.status === 'paused'
+  const isDeleted = task.status === 'cancelled'
 
   return (
     <TriggerRow
       kind="cron"
+      isDeleted={isDeleted}
       name={task.name ?? 'Scheduled Task'}
       subtitleLeft={<span>cron · {humanizedCron ?? 'One-time'}</span>}
       subtitleRight={
@@ -384,11 +391,13 @@ function WebhookRow({
   const pauseTrigger = usePauseWebhookTrigger()
   const resumeTrigger = useResumeWebhookTrigger()
   const isPaused = trigger.status === 'paused'
+  const isDeleted = trigger.status === 'cancelled'
   const displayName = trigger.name ?? trigger.triggerType
 
   return (
     <TriggerRow
       kind="webhook"
+      isDeleted={isDeleted}
       name={displayName}
       subtitleLeft={<span className="truncate lowercase">webhook · {trigger.triggerType}</span>}
       subtitleRight={


### PR DESCRIPTION
## Summary
- In the agent home triggers list, deleted (cancelled) crons and webhooks were still showing the Active/Paused toggle and the Delete action in their popover menu, which has no effect since the item is already deleted.
- Now, when a trigger's status is `cancelled`, the popover only shows **View Details**. The Active toggle, Run Now (cron), and Delete actions are hidden.

## Test plan
- [ ] Open an agent with at least one deleted webhook trigger and one deleted cron
- [ ] Expand "Show N deleted" under Triggers
- [ ] Hover a deleted row → click the ⋮ menu → only "View Details" appears
- [ ] Hover an active row → ⋮ menu still shows Active toggle, View Details, Run Now (cron), Delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)