### PR TITLE
style: redesign runtime banners and chat-top status toast

### DIFF
--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -1,5 +1,5 @@
 
-import { Bell, ChevronDown, ChevronRight, Plus, Search, Settings, AlertTriangle, LayoutGrid, Loader2, SquareMousePointer, WifiOff, LogOut, User, Users, Compass } from 'lucide-react'
+import { Bell, ChevronDown, ChevronRight, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, User, Users, Compass } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
 import { Skeleton } from '@renderer/components/ui/skeleton'
 import { ErrorBoundary } from '@renderer/components/ui/error-boundary'
@@ -30,6 +30,13 @@ import {
   SidebarRail,
 } from '@renderer/components/ui/sidebar'
 import { Alert, AlertDescription } from '@renderer/components/ui/alert'
+import {
+  OfflineSidebarBanner,
+  RuntimeUnavailableSidebarBanner,
+  RuntimeCheckingSidebarBanner,
+  RuntimePullingSidebarBanner,
+  SidebarBannerStack,
+} from '@renderer/components/runtime/runtime-status-banners'
 import { useAgents, type ApiAgent } from '@renderer/hooks/use-agents'
 import { useSessions, type ApiSession } from '@renderer/hooks/use-sessions'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
@@ -898,57 +905,27 @@ export function AppSidebar() {
             </div>
 
             {/* Status banners — render under the wordmark so they sit inside the
-                sidebar's content area rather than pushing the wordmark down. */}
-            {!isOnline && (
-              <div className="px-2 pb-2">
-                <Alert variant="destructive" className="py-2 [&>svg]:top-2.5">
-                  <WifiOff className="h-4 w-4" />
-                  <AlertDescription className="text-xs">
-                    No internet connection. Some features may be unavailable.
-                  </AlertDescription>
-                </Alert>
-              </div>
-            )}
-
-            {isRuntimeUnavailable && (
-              <div className="px-2 pb-2">
-                <Alert
-                  variant="destructive"
-                  className="py-2 [&>svg]:top-2.5 cursor-pointer hover:bg-destructive/20 transition-colors"
-                  onClick={() => openSettings('runtime')}
-                >
-                  <AlertTriangle className="h-4 w-4" />
-                  <AlertDescription className="text-xs">
-                    {readiness?.message || 'Container runtime not available.'}{' '}
-                    <span className="underline">Open settings</span>
-                  </AlertDescription>
-                </Alert>
-              </div>
-            )}
-
-            {isChecking && (
-              <div className="px-2 pb-2">
-                <Alert className="py-2 [&>svg]:top-2.5">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  <AlertDescription className="text-xs">
-                    {readiness?.message || 'Starting runtime...'}
-                  </AlertDescription>
-                </Alert>
-              </div>
-            )}
-
-            {isPullingOrBuilding && (
-              <div className="px-2 pb-2">
-                <Alert className="py-2 [&>svg]:top-2.5">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  <AlertDescription className="text-xs">
-                    {readiness?.message || 'Preparing agent image...'}
-                    {readiness?.pullProgress?.percent != null && (
-                      <span className="ml-1">({readiness.pullProgress.percent}%)</span>
-                    )}
-                  </AlertDescription>
-                </Alert>
-              </div>
+                sidebar's content area rather than pushing the wordmark down. The
+                SidebarBannerStack wrapper owns horizontal padding, inter-banner
+                gap, and trailing space; render it only when at least one banner
+                is visible to avoid a stray padded div. */}
+            {(!isOnline || isRuntimeUnavailable || isChecking || isPullingOrBuilding) && (
+              <SidebarBannerStack>
+                {!isOnline && <OfflineSidebarBanner />}
+                {isRuntimeUnavailable && (
+                  <RuntimeUnavailableSidebarBanner
+                    message={readiness?.message}
+                    onOpenSettings={() => openSettings('runtime')}
+                  />
+                )}
+                {isChecking && <RuntimeCheckingSidebarBanner message={readiness?.message} />}
+                {isPullingOrBuilding && (
+                  <RuntimePullingSidebarBanner
+                    message={readiness?.message}
+                    percent={readiness?.pullProgress?.percent}
+                  />
+                )}
+              </SidebarBannerStack>
             )}
 
             <ApiKeyWarning onOpenSettings={() => openSettings('llm')} />

--- a/src/renderer/components/runtime/runtime-status-banners.tsx
+++ b/src/renderer/components/runtime/runtime-status-banners.tsx
@@ -1,0 +1,115 @@
+import { AlertTriangle, Loader2, WifiOff } from 'lucide-react'
+import { cn } from '@shared/lib/utils/cn'
+import { splitMessageSentences } from './sentence-split'
+
+// Sidebar banners — sit above the SuperAgent wordmark, full sidebar width.
+
+/**
+ * Wraps any combination of sidebar banners with consistent horizontal padding,
+ * a small inter-banner gap (so stacked banners don't compound their margins),
+ * and a trailing space below the group before the wordmark.
+ *
+ * Render only when at least one banner is visible to avoid a stray padded div.
+ */
+export function SidebarBannerStack({ children }: { children: React.ReactNode }) {
+  return <div className="px-2 pb-6 flex flex-col gap-2">{children}</div>
+}
+
+// Destructive banner shell — two flex columns (icon circle + text), both
+// vertically centered in the row. Built without the Alert primitive so we
+// don't fight its grid layout when we need a non-svg icon wrapper.
+function DestructiveBannerCard({
+  icon,
+  children,
+  onClick,
+}: {
+  icon: React.ReactNode
+  children: React.ReactNode
+  onClick?: () => void
+}) {
+  return (
+    <div
+      role={onClick ? 'button' : 'alert'}
+      tabIndex={onClick ? 0 : undefined}
+      onClick={onClick}
+      onKeyDown={onClick ? (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onClick()
+        }
+      } : undefined}
+      className={cn(
+        'flex items-center gap-3 rounded-lg shadow-md bg-background pl-3 pr-4 py-2 text-destructive',
+        onClick && 'cursor-pointer hover:bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+      )}
+    >
+      <div className="flex items-center justify-center h-7 w-7 rounded-full bg-destructive/10 shrink-0">
+        {icon}
+      </div>
+      <div className="text-xs flex-1 min-w-0">{children}</div>
+    </div>
+  )
+}
+
+export function OfflineSidebarBanner() {
+  return (
+    <DestructiveBannerCard icon={<WifiOff className="h-4 w-4" />}>
+      <div>No internet connection.</div>
+      <div>Some features may be unavailable.</div>
+    </DestructiveBannerCard>
+  )
+}
+
+export function RuntimeUnavailableSidebarBanner({
+  message,
+  onOpenSettings,
+}: {
+  message?: string
+  onOpenSettings?: () => void
+}) {
+  // Render one sentence per line; splitter is abbreviation/decimal-aware so it
+  // doesn't break inside "e.g.", version numbers, etc. (see sentence-split.ts).
+  const sentences = splitMessageSentences(message || 'Container runtime not available.')
+  return (
+    <DestructiveBannerCard
+      icon={<AlertTriangle className="h-4 w-4" />}
+      onClick={onOpenSettings}
+    >
+      {sentences.map((sentence, i) => (
+        <div key={i}>{sentence}</div>
+      ))}
+      <div className="underline">Open settings →</div>
+    </DestructiveBannerCard>
+  )
+}
+
+// Loading banner shell — text on the left, spinner on the right, both
+// vertically centered. Built without the Alert primitive so the icon can
+// trail the text (Alert's grid forces the svg into column 1).
+function LoadingBannerCard({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg shadow-md bg-background pl-4 pr-3 py-2">
+      <div className="text-xs flex-1 min-w-0">{children}</div>
+      <Loader2 className="h-4 w-4 animate-spin shrink-0 text-muted-foreground" />
+    </div>
+  )
+}
+
+export function RuntimeCheckingSidebarBanner({ message }: { message?: string }) {
+  return <LoadingBannerCard>{message || 'Starting runtime...'}</LoadingBannerCard>
+}
+
+export function RuntimePullingSidebarBanner({
+  message,
+  percent,
+}: {
+  message?: string
+  percent?: number | null
+}) {
+  return (
+    <LoadingBannerCard>
+      {message || 'Preparing agent image...'}
+      {percent != null && <span className="ml-1">({percent}%)</span>}
+    </LoadingBannerCard>
+  )
+}

--- a/src/renderer/components/runtime/sentence-split.test.ts
+++ b/src/renderer/components/runtime/sentence-split.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { splitMessageSentences } from './sentence-split'
+
+describe('splitMessageSentences', () => {
+  it('splits a plain multi-sentence message one line per sentence', () => {
+    expect(
+      splitMessageSentences('Insufficient disk space: 5 GB required. Free up space and try again.'),
+    ).toEqual([
+      'Insufficient disk space: 5 GB required.',
+      'Free up space and try again.',
+    ])
+  })
+
+  it('keeps a single sentence on one line', () => {
+    expect(splitMessageSentences('Container runtime not available.')).toEqual([
+      'Container runtime not available.',
+    ])
+  })
+
+  it('does not break after abbreviations followed by a capitalised word', () => {
+    expect(
+      splitMessageSentences('Runtime is down, e.g. Docker is not running. Open settings.'),
+    ).toEqual([
+      'Runtime is down, e.g. Docker is not running.',
+      'Open settings.',
+    ])
+    expect(
+      splitMessageSentences('Several runtimes work, i.e. Docker, Podman, etc. Pick one.'),
+    ).toEqual(['Several runtimes work, i.e. Docker, Podman, etc. Pick one.'])
+  })
+
+  it('does not break version numbers or decimals (no space after the dot)', () => {
+    expect(splitMessageSentences('Docker 4.2 needs 5.5 GB free. Update Docker.')).toEqual([
+      'Docker 4.2 needs 5.5 GB free.',
+      'Update Docker.',
+    ])
+  })
+
+  it('does not break on a period followed by a lowercase word', () => {
+    expect(splitMessageSentences('failed at step 3. retrying now')).toEqual([
+      'failed at step 3. retrying now',
+    ])
+  })
+
+  it('does not break after a single capitalised initial (e.g. a drive letter)', () => {
+    expect(splitMessageSentences('No space on drive C. Free up space.')).toEqual([
+      'No space on drive C. Free up space.',
+    ])
+  })
+
+  it('handles ! and ? terminators', () => {
+    expect(splitMessageSentences('Runtime crashed! Restart it. Need help?')).toEqual([
+      'Runtime crashed!',
+      'Restart it.',
+      'Need help?',
+    ])
+  })
+
+  it('returns the trimmed whole string when there is nothing to split', () => {
+    expect(splitMessageSentences('  just one line  ')).toEqual(['just one line'])
+  })
+})

--- a/src/renderer/components/runtime/sentence-split.ts
+++ b/src/renderer/components/runtime/sentence-split.ts
@@ -1,0 +1,42 @@
+// Abbreviations that end with a period but do NOT terminate a sentence. Lowercase;
+// matched case-insensitively against the token preceding a candidate break so
+// "e.g. Foo" / "etc. Bar" stay on one line instead of breaking after them.
+const NON_TERMINAL_ABBR = new Set([
+  'e.g', 'i.e', 'etc', 'vs', 'approx', 'cf', 'al', 'no', 'fig',
+  'min', 'max', 'sec', 'vol', 'mr', 'mrs', 'ms', 'dr', 'st',
+])
+
+/**
+ * Split a short status/error message into one line per sentence for display.
+ *
+ * Tuned for narrow sidebar banners: it breaks on sentence-ending punctuation
+ * (`.`, `!`, `?`) followed by whitespace and the start of a new sentence
+ * (capital letter, digit, or opening quote/paren). A break is suppressed when
+ * the preceding token is a known abbreviation (e.g., i.e., etc.) or a single
+ * capitalised initial, so inline abbreviations stay intact. Version numbers and
+ * decimals ("v1.2", "5.5 GB") never break because their dots aren't followed by
+ * whitespace.
+ *
+ * Returns the trimmed whole string as a single-element array when there's
+ * nothing to split, and never yields empty segments.
+ */
+export function splitMessageSentences(text: string): string[] {
+  const lines: string[] = []
+  const boundary = /[.!?]\s+(?=[A-Z0-9"'(])/g
+  let start = 0
+  let match: RegExpExecArray | null
+  while ((match = boundary.exec(text)) !== null) {
+    const end = match.index + 1 // keep the punctuation with its sentence
+    const segment = text.slice(start, end)
+    const lastToken = segment.slice(0, -1).split(/\s+/).pop() ?? ''
+    const isFalseBoundary =
+      NON_TERMINAL_ABBR.has(lastToken.toLowerCase()) ||
+      /^[A-Z]$/.test(lastToken) // single capitalised initial, e.g. drive "C."
+    if (isFalseBoundary) continue // keep scanning past this dot
+    lines.push(segment.trim())
+    start = boundary.lastIndex
+  }
+  const tail = text.slice(start).trim()
+  if (tail) lines.push(tail)
+  return lines.length ? lines : [text.trim()]
+}


### PR DESCRIPTION
## Summary
- Extracts the sidebar runtime banners (offline, runtime-unavailable, checking, pulling) and the chat-top status indicators into a shared `runtime-status-banners.tsx` module.
- Sidebar banners now sit **above** the SuperAgent wordmark and stack with a consistent inter-banner gap + trailing space via a new `SidebarBannerStack` wrapper.
- Destructive cards get a borderless `shadow-md` shell with a light-red icon-circle column and the message on its own row; loading cards reuse the same shell with the spinner trailing the text.
- The chat-top banner becomes a **floating toast** (Sonner-styled chrome, absolute-positioned at the top of the chat). `ContentShell`'s children area is now `relative` so the toast can position inside the chat without escaping into the header. Pull progress is conveyed via a two-line layout (headline + `"X of Y layers"` sub-detail) and a thin linear progress bar along the bottom edge of the card.

## Test plan
- [ ] In dev, stop Docker Desktop — sidebar shows the runtime-unavailable card with `Open settings →` row, click navigates to runtime settings.
- [ ] Disconnect from the network — sidebar shows the offline card stacked above the wordmark.
- [ ] Delete the agent image (`docker rmi superagent-container`) and start an agent — sidebar pulling banner + chat-top floating toast appear in sync, progress bar fills along the bottom of the toast as layers complete.
- [ ] Start an agent while Docker is stopped — chat-top error toast appears with the dismiss × clearing the mutation state.
- [ ] Resize the window with the toast visible — toast stays centered, doesn't push chat content down.
- [ ] Open Settings or another non-session view — no toast renders, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)