### PR TITLE
feat: skill zip export & import

### DIFF
--- a/e2e/helpers/skill-zip.ts
+++ b/e2e/helpers/skill-zip.ts
@@ -1,0 +1,24 @@
+import fs from 'fs'
+import path from 'path'
+import { writeZipFile } from '@shared/lib/utils/zip'
+
+export interface BuildSkillZipOptions {
+  name: string
+  withEnvVars?: boolean
+  extraFiles?: Record<string, string>
+}
+
+export async function buildSkillZip(filePath: string, opts: BuildSkillZipOptions): Promise<string> {
+  const envVarsBlock = opts.withEnvVars
+    ? `  required_env_vars:\n    - name: E2E_TEST_KEY\n      description: A test key\n`
+    : ''
+
+  const files: Record<string, string> = {
+    'SKILL.md': `---\nname: ${opts.name}\nmetadata:\n  version: "1.0.0"\n${envVarsBlock}---\n\nTest skill for E2E.\n`,
+    ...opts.extraFiles,
+  }
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  await writeZipFile(filePath, files)
+  return filePath
+}

--- a/e2e/specs/skill-export-import.spec.ts
+++ b/e2e/specs/skill-export-import.spec.ts
@@ -1,0 +1,162 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { buildSkillZip } from '../helpers/skill-zip'
+
+test.describe('Skill Export & Import', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+  let tmpDir: string
+
+  test.beforeEach(async ({ page }) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-skill-'))
+  })
+
+  test.afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('import a skill via the Import dialog', async ({ page }) => {
+    const skillName = `e2e-imported-${Date.now()}`
+    const zipPath = await buildSkillZip(
+      path.join(tmpDir, 'skill.zip'),
+      { name: skillName },
+    )
+
+    await agentPage.createAgent(`Skill Imp ${Date.now()}`)
+
+    const importButton = page.locator('[data-testid="import-skill-button"]')
+    await expect(importButton).toBeVisible({ timeout: 10000 })
+    await importButton.click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    await dialog.locator('input[type="file"]').setInputFiles(zipPath)
+    await expect(dialog.getByText('skill.zip')).toBeVisible()
+
+    await dialog.locator('button[type="submit"]').click()
+    await expect(dialog).not.toBeVisible({ timeout: 15000 })
+
+    const installedRow = page.locator('[data-testid="installed-skill-row"]').filter({ hasText: skillName })
+    await expect(installedRow).toBeVisible({ timeout: 10000 })
+  })
+
+  test('import shows error for ZIP without SKILL.md', async ({ page }) => {
+    const badZipPath = await buildSkillZip(
+      path.join(tmpDir, 'bad.zip'),
+      { name: 'will-be-replaced' },
+    )
+    // Overwrite with a zip that has no SKILL.md by building one manually
+    // using the same writeZipFile the helper uses
+    const { writeZipFile } = await import('../../src/shared/lib/utils/zip')
+    await writeZipFile(badZipPath, { 'README.md': '# Not a skill' })
+
+    await agentPage.createAgent(`Bad Imp ${Date.now()}`)
+
+    const importButton = page.locator('[data-testid="import-skill-button"]')
+    await expect(importButton).toBeVisible({ timeout: 10000 })
+    await importButton.click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    await dialog.locator('input[type="file"]').setInputFiles(badZipPath)
+    await dialog.locator('button[type="submit"]').click()
+
+    await expect(dialog.locator('.text-destructive')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('export a skill via three-dot menu', async ({ page }) => {
+    await agentPage.createAgent(`Skill Exp ${Date.now()}`)
+
+    const addSkillButton = page.locator('[data-testid="add-skill-button"]')
+    await expect(addSkillButton).toBeVisible({ timeout: 10000 })
+    await addSkillButton.click()
+
+    const browseDialog = page.locator('[data-testid="skills-browse-dialog"]')
+    await expect(browseDialog).toBeVisible()
+    await browseDialog.getByRole('button', { name: 'Install e2e-plain-skill' }).click()
+    await expect(browseDialog.locator('[data-skill-name="e2e-plain-skill"]')).toBeHidden({ timeout: 10000 })
+    await page.keyboard.press('Escape')
+
+    const installedRow = page.locator('[data-testid="installed-skill-row"][data-skill-path="e2e-plain-skill"]')
+    await expect(installedRow).toBeVisible({ timeout: 10000 })
+
+    await installedRow.hover()
+    const moreButton = installedRow.locator('button[aria-label*="Actions"]')
+    await expect(moreButton).toBeVisible()
+    await moreButton.click()
+
+    // Use getByText with exact match to avoid matching the agent name in sidebar
+    const exportButton = page.getByText('Export Skill', { exact: true })
+    await expect(exportButton).toBeVisible()
+
+    const downloadPromise = page.waitForEvent('download')
+    await exportButton.click()
+
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toContain('e2e-plain-skill')
+    expect(download.suggestedFilename()).toMatch(/\.zip$/)
+  })
+
+  test('round-trip: export from one agent, import into another', async ({ page }) => {
+    await agentPage.createAgent(`RT Exp ${Date.now()}`)
+
+    const addSkillButton = page.locator('[data-testid="add-skill-button"]')
+    await expect(addSkillButton).toBeVisible({ timeout: 10000 })
+    await addSkillButton.click()
+
+    const browseDialog = page.locator('[data-testid="skills-browse-dialog"]')
+    await expect(browseDialog).toBeVisible()
+    await browseDialog.getByRole('button', { name: 'Install e2e-plain-skill' }).click()
+    await expect(browseDialog.locator('[data-skill-name="e2e-plain-skill"]')).toBeHidden({ timeout: 10000 })
+    await page.keyboard.press('Escape')
+
+    const installedRow = page.locator('[data-testid="installed-skill-row"][data-skill-path="e2e-plain-skill"]')
+    await expect(installedRow).toBeVisible({ timeout: 10000 })
+    await installedRow.hover()
+    await installedRow.locator('button[aria-label*="Actions"]').click()
+
+    const downloadPromise = page.waitForEvent('download')
+    await page.getByText('Export Skill', { exact: true }).click()
+    const download = await downloadPromise
+
+    const downloadPath = path.join(tmpDir, 'exported-skill.zip')
+    await download.saveAs(downloadPath)
+
+    // Agent 2: import the exported skill
+    await agentPage.clickCreateAgent()
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText('Untitled', { timeout: 10000 })
+
+    await page.locator('[data-testid="home-message-input"]').fill('round trip test')
+    await page.locator('[data-testid="home-send-button"]').click()
+    await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
+    await page.locator('[data-testid="agent-breadcrumb"]').click()
+    await expect(page.locator('[data-testid="agent-settings-button"]')).toBeVisible()
+
+    const importButton = page.locator('[data-testid="import-skill-button"]')
+    await expect(importButton).toBeVisible({ timeout: 10000 })
+    await importButton.click()
+
+    const importDialog = page.getByRole('dialog')
+    await expect(importDialog).toBeVisible()
+    await importDialog.locator('input[type="file"]').setInputFiles(downloadPath)
+    await importDialog.locator('button[type="submit"]').click()
+    await expect(importDialog).not.toBeVisible({ timeout: 15000 })
+
+    const importedRow = page.locator('[data-testid="installed-skill-row"]').filter({ hasText: 'e2e-plain-skill' })
+    await expect(importedRow).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -246,6 +246,9 @@ vi.mock('@shared/lib/services/skillset-service', () => ({
   getSkillPublishInfo: vi.fn(),
   publishSkillToSkillset: vi.fn(),
   refreshAgentSkills: vi.fn(),
+  exportSkill: vi.fn(),
+  importSkillFromZip: vi.fn(),
+  SKILL_MAX_COMPRESSED_SIZE: 100 * 1024 * 1024,
 }))
 
 vi.mock('@shared/lib/services/artifact-service', () => ({
@@ -355,6 +358,10 @@ import {
   hasOnboardingSkill,
   collectAgentRequiredEnvVars,
 } from '@shared/lib/services/agent-template-service'
+import {
+  exportSkill,
+  importSkillFromZip,
+} from '@shared/lib/services/skillset-service'
 import { getAgent, listAgentsWithStatus } from '@shared/lib/services/agent-service'
 import { listSessions, getSessionMessagesWithCompact, getSessionSummary } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks, listPendingScheduledTasksByAgents } from '@shared/lib/services/scheduled-task-service'
@@ -2708,5 +2715,111 @@ describe('POST /api/agents/:id/keep-alive', () => {
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ ok: true })
     expect(mockKeepAlive).toHaveBeenCalledWith('my-agent')
+  })
+})
+
+// ============================================================================
+// Skill ZIP Export / Import Tests
+// ============================================================================
+
+describe('POST /api/agents/:id/skills/:dir/export', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+  })
+
+  it('returns zip binary with correct headers', async () => {
+    const fakeZip = Buffer.from('PK\x03\x04fake-zip-content')
+    vi.mocked(exportSkill).mockResolvedValue(fakeZip)
+
+    const res = await app.request('http://localhost/api/agents/my-agent/skills/my-skill/export', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('application/zip')
+    expect(res.headers.get('Content-Disposition')).toContain('my-skill.zip')
+    expect(exportSkill).toHaveBeenCalledWith('my-agent', 'my-skill')
+  })
+
+  it('returns 500 when service throws', async () => {
+    vi.mocked(exportSkill).mockRejectedValue(new Error('Skill directory not found'))
+
+    const res = await app.request('http://localhost/api/agents/my-agent/skills/bad-skill/export', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toBe('Skill directory not found')
+  })
+})
+
+describe('POST /api/agents/:id/skills/import-zip', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+  })
+
+  it('returns 201 with skill info on success', async () => {
+    vi.mocked(importSkillFromZip).mockResolvedValue({
+      skillDir: 'imported-skill',
+      skillName: 'Imported Skill',
+    })
+
+    const form = new FormData()
+    form.append('file', new File(['zip-data'], 'skill.zip', { type: 'application/zip' }))
+
+    const res = await postFormData(app, '/api/agents/my-agent/skills/import-zip', form)
+    expect(res.status).toBe(201)
+
+    const body = await res.json()
+    expect(body.skillDir).toBe('imported-skill')
+    expect(body.skillName).toBe('Imported Skill')
+    expect(importSkillFromZip).toHaveBeenCalledWith('my-agent', expect.any(Buffer))
+  })
+
+  it('returns required env vars when present', async () => {
+    vi.mocked(importSkillFromZip).mockResolvedValue({
+      skillDir: 'env-skill',
+      skillName: 'Env Skill',
+      requiredEnvVars: [{ name: 'API_KEY', description: 'Key' }],
+    })
+
+    const form = new FormData()
+    form.append('file', new File(['zip-data'], 'skill.zip', { type: 'application/zip' }))
+
+    const res = await postFormData(app, '/api/agents/my-agent/skills/import-zip', form)
+    expect(res.status).toBe(201)
+
+    const body = await res.json()
+    expect(body.requiredEnvVars).toEqual([{ name: 'API_KEY', description: 'Key' }])
+  })
+
+  it('returns 400 when no file provided', async () => {
+    const form = new FormData()
+
+    const res = await postFormData(app, '/api/agents/my-agent/skills/import-zip', form)
+    expect(res.status).toBe(400)
+
+    const body = await res.json()
+    expect(body.error).toBe('No file provided')
+  })
+
+  it('returns 500 when service throws', async () => {
+    vi.mocked(importSkillFromZip).mockRejectedValue(new Error('SKILL.md not found in package'))
+
+    const form = new FormData()
+    form.append('file', new File(['zip-data'], 'skill.zip', { type: 'application/zip' }))
+
+    const res = await postFormData(app, '/api/agents/my-agent/skills/import-zip', form)
+    expect(res.status).toBe(500)
+
+    const body = await res.json()
+    expect(body.error).toBe('SKILL.md not found in package')
   })
 })

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -69,6 +69,9 @@ import {
   getSkillPublishInfo,
   publishSkillToSkillset,
   refreshAgentSkills,
+  exportSkill,
+  importSkillFromZip,
+  SKILL_MAX_COMPRESSED_SIZE,
 } from '@shared/lib/services/skillset-service'
 import { type ArtifactInfo, listArtifactsFromFilesystem, deleteArtifactFromFilesystem, renameArtifactOnFilesystem } from '@shared/lib/services/artifact-service'
 import { getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -3425,6 +3428,57 @@ agents.post('/:id/skills/refresh', AgentUser(), async (c) => {
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to refresh skills'
     console.error('Failed to refresh skills:', error)
+    return c.json({ error: message }, 500)
+  }
+})
+
+// POST /api/agents/:id/skills/:dir/export - Export a skill as ZIP download
+agents.post('/:id/skills/:dir/export', AgentAdmin(), async (c) => {
+  try {
+    const agentSlug = c.req.param('id')
+    const dir = c.req.param('dir')
+    const zipBuffer = await exportSkill(agentSlug, dir)
+
+    logAuditEvent({ userId: getCurrentUserId(c), object: 'skill', objectId: `${agentSlug}/${dir}`, action: 'exported', details: { type: 'zip' } })
+    return new Response(new Uint8Array(zipBuffer), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/zip',
+        'Content-Disposition': `attachment; filename="${dir}.zip"`,
+        'Content-Length': zipBuffer.byteLength.toString(),
+      },
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to export skill'
+    console.error('Failed to export skill:', error)
+    return c.json({ error: message }, 500)
+  }
+})
+
+// POST /api/agents/:id/skills/import-zip - Import a skill from uploaded ZIP
+agents.post('/:id/skills/import-zip', AgentAdmin(), async (c) => {
+  try {
+    const agentSlug = c.req.param('id')
+    const formData = await c.req.formData()
+    const file = formData.get('file') as File | null
+
+    if (!file) {
+      return c.json({ error: 'No file provided' }, 400)
+    }
+
+    const arrayBuffer = await file.arrayBuffer()
+    const zipBuffer = Buffer.from(arrayBuffer)
+
+    if (zipBuffer.length > SKILL_MAX_COMPRESSED_SIZE) {
+      return c.json({ error: `File too large (${(zipBuffer.length / 1024 / 1024).toFixed(1)}MB, max ${SKILL_MAX_COMPRESSED_SIZE / 1024 / 1024}MB)` }, 413)
+    }
+
+    const result = await importSkillFromZip(agentSlug, zipBuffer)
+    logAuditEvent({ userId: getCurrentUserId(c), object: 'skill', objectId: `${agentSlug}/${result.skillDir}`, action: 'created', details: { skillName: result.skillName, source: 'zip-import' } })
+    return c.json(result, 201)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to import skill'
+    console.error('Failed to import skill:', error)
     return c.json({ error: message }, 500)
   }
 })

--- a/src/renderer/components/agents/agent-home/home-skills.tsx
+++ b/src/renderer/components/agents/agent-home/home-skills.tsx
@@ -1,14 +1,25 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef, useCallback } from 'react'
+import { toast } from 'sonner'
 import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
-import { MoreVertical, FileCode, CloudUpload, GitPullRequest, Send, RefreshCw, Loader2, Plus, Play } from 'lucide-react'
+import { MoreVertical, FileCode, CloudUpload, GitPullRequest, Send, RefreshCw, Loader2, Plus, Play, Upload, Download, FileArchive } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@renderer/components/ui/dialog'
 import { StatusBadge } from '../status-badge'
 import { SkillFilesDialog } from '../skill-files-dialog'
 import { SkillPublishDialog } from '../skill-publish-dialog'
 import { SkillPRDialog } from '../skill-pr-dialog'
+import { SkillInstallDialog } from '../skill-install-dialog'
 import { HomeCollapsible } from './home-collapsible'
 import { HomeSkillsBrowseDialog } from './home-skills-browse-dialog'
-import { useAgentSkills, useDiscoverableSkills, useUpdateSkill } from '@renderer/hooks/use-agent-skills'
+import { apiFetch } from '@renderer/lib/api'
+import { useAgentSkills, useDiscoverableSkills, useUpdateSkill, useExportSkill, useImportSkillZip } from '@renderer/hooks/use-agent-skills'
 import { useSkillsetPublishMode } from '@renderer/hooks/use-skillsets'
 import { getReviewActionLabel, isPullRequestPublishMode } from '@renderer/lib/skillset-publish-ui'
 import type { ApiSkillWithStatus } from '@shared/lib/types/api'
@@ -21,6 +32,7 @@ interface HomeSkillsProps {
 
 export function HomeSkills({ agentSlug, className, onRunSkill }: HomeSkillsProps) {
   const [browseOpen, setBrowseOpen] = useState(false)
+  const [importOpen, setImportOpen] = useState(false)
 
   const { data: skillsData } = useAgentSkills(agentSlug)
   const skills = Array.isArray(skillsData) ? skillsData : []
@@ -47,8 +59,18 @@ export function HomeSkills({ agentSlug, className, onRunSkill }: HomeSkillsProps
         </div>
       )}
 
-      {hasDiscoverable && (
-        <div className="flex justify-end mt-3 px-4 pb-1">
+      <div className="flex justify-end mt-3 px-4 pb-1 gap-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => setImportOpen(true)}
+          data-testid="import-skill-button"
+        >
+          <Download className="h-3.5 w-3.5" />
+          Import
+        </Button>
+        {hasDiscoverable && (
           <Button
             type="button"
             variant="ghost"
@@ -59,14 +81,19 @@ export function HomeSkills({ agentSlug, className, onRunSkill }: HomeSkillsProps
             <Plus />
             Add Skill
           </Button>
-        </div>
-      )}
+        )}
+      </div>
 
       <HomeSkillsBrowseDialog
         open={browseOpen}
         onOpenChange={setBrowseOpen}
         agentSlug={agentSlug}
         discoverableSkills={discoverableSkills}
+      />
+      <SkillImportDialog
+        open={importOpen}
+        onOpenChange={setImportOpen}
+        agentSlug={agentSlug}
       />
     </HomeCollapsible>
   )
@@ -77,6 +104,7 @@ function SkillRow({ skill, agentSlug, onRunSkill }: { skill: ApiSkillWithStatus;
   const [publishOpen, setPublishOpen] = useState(false)
   const [reviewOpen, setReviewOpen] = useState(false)
   const updateSkill = useUpdateSkill()
+  const exportSkill = useExportSkill()
   const publishMode = useSkillsetPublishMode(skill.status.skillsetId)
   const ReviewIcon = isPullRequestPublishMode(publishMode) ? GitPullRequest : Send
   const actionLabel = getReviewActionLabel(publishMode)
@@ -124,6 +152,24 @@ function SkillRow({ skill, agentSlug, onRunSkill }: { skill: ApiSkillWithStatus;
               >
                 <FileCode className="h-3.5 w-3.5" />
                 View Files
+              </button>
+              <button
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
+                disabled={exportSkill.isPending}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  exportSkill.mutate(
+                    { agentSlug, skillDir: skill.path, skillName: skill.name ?? skill.path },
+                    { onError: (err) => toast.error('Export failed', { description: err.message }) },
+                  )
+                }}
+              >
+                {exportSkill.isPending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Upload className="h-3.5 w-3.5" />
+                )}
+                Export Skill
               </button>
               {skill.status.type === 'local' && skill.status.publishable !== false && publishMode !== 'none' && (
                 <button
@@ -184,6 +230,186 @@ function SkillRow({ skill, agentSlug, onRunSkill }: { skill: ApiSkillWithStatus;
         skillDir={skill.path}
         publishMode={publishMode}
       />
+    </>
+  )
+}
+
+function SkillImportDialog({ open, onOpenChange, agentSlug }: { open: boolean; onOpenChange: (open: boolean) => void; agentSlug: string }) {
+  const [importFile, setImportFile] = useState<File | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const importSkill = useImportSkillZip()
+  const [secretsPrompt, setSecretsPrompt] = useState<{
+    requiredEnvVars: Array<{ name: string; description: string }>
+    skillDir: string
+  } | null>(null)
+
+  const acceptFile = useCallback((file: File | null | undefined) => {
+    if (!file) return
+    if (!file.name.toLowerCase().endsWith('.zip')) {
+      toast.error('Only .zip files are supported')
+      return
+    }
+    setImportFile(file)
+  }, [])
+
+  const resetImport = useCallback(() => {
+    setImportFile(null)
+    importSkill.reset()
+  }, [importSkill])
+
+  const closeDialog = useCallback(() => {
+    onOpenChange(false)
+    resetImport()
+  }, [onOpenChange, resetImport])
+
+  const handleImport = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!importFile) return
+
+    try {
+      const result = await importSkill.mutateAsync({ agentSlug, file: importFile })
+
+      if (result.requiredEnvVars && result.requiredEnvVars.length > 0) {
+        setSecretsPrompt({ requiredEnvVars: result.requiredEnvVars, skillDir: result.skillDir })
+        return
+      }
+
+      closeDialog()
+      toast.success(`Imported skill "${result.skillName}"`)
+    } catch {
+      // Error is shown by the mutation's error state
+    }
+  }, [importFile, importSkill, agentSlug, closeDialog])
+
+  const handleFileDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    acceptFile(e.dataTransfer.files[0])
+  }
+
+  return (
+    <>
+      <Dialog open={open && !secretsPrompt} onOpenChange={(o) => { if (!o) closeDialog() }}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="font-medium">Import a Skill</DialogTitle>
+            <DialogDescription className="sr-only">
+              Upload a .zip file to import a skill.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleImport}>
+            <div className="py-4 space-y-4">
+              <div
+                className={`border border-dashed rounded-lg p-6 text-center transition-colors bg-muted/50 ${
+                  importSkill.isPending ? 'opacity-50 pointer-events-none' : 'cursor-pointer'
+                }`}
+                role="button"
+                tabIndex={0}
+                onClick={() => !importSkill.isPending && fileInputRef.current?.click()}
+                onKeyDown={(e) => {
+                  if ((e.key === 'Enter' || e.key === ' ') && !importSkill.isPending) {
+                    e.preventDefault()
+                    fileInputRef.current?.click()
+                  }
+                }}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={importSkill.isPending ? undefined : handleFileDrop}
+              >
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".zip"
+                  className="hidden"
+                  disabled={importSkill.isPending}
+                  onChange={(e) => {
+                    acceptFile(e.target.files?.[0])
+                    e.target.value = ''
+                  }}
+                />
+                {importFile ? (
+                  <div className="flex items-center justify-center gap-2">
+                    <FileArchive className="h-5 w-5 text-primary" />
+                    <span className="text-sm font-medium">{importFile.name}</span>
+                    {!importSkill.isPending && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 text-xs"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          setImportFile(null)
+                        }}
+                      >
+                        Remove
+                      </Button>
+                    )}
+                  </div>
+                ) : (
+                  <>
+                    <Download className="h-5 w-5 mx-auto text-muted-foreground mb-2" />
+                    <p className="text-sm text-muted-foreground">
+                      Drop a .zip skill file here<br />
+                      or click to browse
+                    </p>
+                  </>
+                )}
+              </div>
+
+              {importSkill.error && (
+                <p className="text-sm text-destructive">{importSkill.error.message}</p>
+              )}
+            </div>
+
+            <DialogFooter className="mt-4">
+              <Button type="button" variant="outline" onClick={closeDialog} disabled={importSkill.isPending}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={!importFile || importSkill.isPending}>
+                {importSkill.isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Importing...
+                  </>
+                ) : (
+                  'Import'
+                )}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {secretsPrompt && (
+        <SkillInstallDialog
+          open={!!secretsPrompt}
+          onOpenChange={(o) => {
+            if (!o) {
+              setSecretsPrompt(null)
+              closeDialog()
+            }
+          }}
+          skillName="imported skill"
+          requiredEnvVars={secretsPrompt.requiredEnvVars}
+          onInstall={async (envVars) => {
+            for (const [key, value] of Object.entries(envVars)) {
+              if (value && typeof value === 'string') {
+                try {
+                  await apiFetch(`/api/agents/${encodeURIComponent(agentSlug)}/secrets`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ key, value }),
+                  })
+                } catch (error) {
+                  console.error(`Failed to save secret ${key}:`, error)
+                }
+              }
+            }
+            setSecretsPrompt(null)
+            closeDialog()
+            toast.success('Skill imported successfully')
+          }}
+        />
+      )}
     </>
   )
 }

--- a/src/renderer/components/agents/skill-context-menu.tsx
+++ b/src/renderer/components/agents/skill-context-menu.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { FileCode } from 'lucide-react'
+import { FileCode, Upload } from 'lucide-react'
+import { toast } from 'sonner'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -7,6 +8,7 @@ import {
   ContextMenuTrigger,
 } from '@renderer/components/ui/context-menu'
 import { SkillFilesDialog } from './skill-files-dialog'
+import { useExportSkill } from '@renderer/hooks/use-agent-skills'
 import type { ApiSkillWithStatus } from '@shared/lib/types/api'
 
 interface SkillContextMenuProps {
@@ -17,6 +19,7 @@ interface SkillContextMenuProps {
 
 export function SkillContextMenu({ skill, agentSlug, children }: SkillContextMenuProps) {
   const [filesDialogOpen, setFilesDialogOpen] = useState(false)
+  const exportSkill = useExportSkill()
 
   return (
     <>
@@ -28,6 +31,18 @@ export function SkillContextMenu({ skill, agentSlug, children }: SkillContextMen
           <ContextMenuItem onClick={() => setFilesDialogOpen(true)}>
             <FileCode className="h-4 w-4 mr-2" />
             View Files
+          </ContextMenuItem>
+          <ContextMenuItem
+            disabled={exportSkill.isPending}
+            onClick={() => {
+              exportSkill.mutate(
+                { agentSlug, skillDir: skill.path, skillName: skill.name ?? skill.path },
+                { onError: (err) => toast.error('Export failed', { description: err.message }) },
+              )
+            }}
+          >
+            <Upload className="h-4 w-4 mr-2" />
+            Export Skill
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>

--- a/src/renderer/hooks/use-agent-skills.ts
+++ b/src/renderer/hooks/use-agent-skills.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { apiFetch } from '@renderer/lib/api'
+import { downloadBlob } from '@renderer/lib/download'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiSkillWithStatus, ApiDiscoverableSkill } from '@shared/lib/types/api'
 
@@ -236,6 +237,50 @@ export function usePublishSkill() {
     onSuccess: (_, vars) => {
       queryClient.invalidateQueries({ queryKey: ['agent-skills', vars.agentSlug] })
       queryClient.invalidateQueries({ queryKey: ['discoverable-skills', vars.agentSlug] })
+    },
+  })
+}
+
+export function useExportSkill() {
+  return useMutation<void, Error, { agentSlug: string; skillDir: string; skillName: string }>({
+    mutationFn: async ({ agentSlug, skillDir, skillName }) => {
+      const res = await apiFetch(
+        `/api/agents/${encodeURIComponent(agentSlug)}/skills/${encodeURIComponent(skillDir)}/export`,
+        { method: 'POST' },
+      )
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Failed to export skill')
+      }
+      await downloadBlob(res, `${skillName || skillDir}.zip`)
+    },
+  })
+}
+
+export function useImportSkillZip() {
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    { skillDir: string; skillName: string; requiredEnvVars?: Array<{ name: string; description: string }> },
+    Error,
+    { agentSlug: string; file: File }
+  >({
+    mutationFn: async ({ agentSlug, file }) => {
+      const formData = new FormData()
+      formData.append('file', file)
+
+      const res = await apiFetch(
+        `/api/agents/${encodeURIComponent(agentSlug)}/skills/import-zip`,
+        { method: 'POST', body: formData },
+      )
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Failed to import skill')
+      }
+      return res.json()
+    },
+    onSuccess: (_, vars) => {
+      queryClient.invalidateQueries({ queryKey: ['agent-skills', vars.agentSlug] })
     },
   })
 }

--- a/src/shared/lib/services/skillset-service.test.ts
+++ b/src/shared/lib/services/skillset-service.test.ts
@@ -103,7 +103,11 @@ import {
   getSkillsetRepoDir,
   isCacheReady,
   isGitAvailable,
+  exportSkill,
+  validateSkillZip,
+  importSkillFromZip,
 } from './skillset-service'
+import { createZipBuffer, openZipFromBuffer } from '@shared/lib/utils/zip'
 
 // ============================================================================
 // Test Suite
@@ -2240,6 +2244,338 @@ metadata:
     it('returns false when git --version fails', async () => {
       mockExecFile.mockImplementation(() => { throw new Error('not found') })
       expect(await isGitAvailable()).toBe(false)
+    })
+  })
+
+  // ==========================================================================
+  // Skill ZIP Export / Import
+  // ==========================================================================
+
+  const MINIMAL_SKILL_MD = `---
+name: Test Skill
+metadata:
+  version: "1.0.0"
+---
+# Test Skill
+
+Do something useful.
+`
+
+  const SKILL_MD_WITH_ENV = `---
+name: Env Skill
+metadata:
+  version: "1.0.0"
+  required_env_vars:
+    - name: API_KEY
+      description: The API key
+    - name: SECRET
+      description: A secret value
+---
+# Env Skill
+
+Needs env vars.
+`
+
+  const SKILL_MD_NO_NAME = `---
+metadata:
+  version: "1.0.0"
+---
+# A Skill
+`
+
+  async function makeSkillZip(files: Record<string, string>): Promise<Buffer> {
+    return createZipBuffer(files)
+  }
+
+  function makeSkillDir(agentSlug: string, skillDirName: string): string {
+    const skillsDir = path.join(testDir, 'agents', agentSlug, 'workspace', '.claude', 'skills', skillDirName)
+    fs.mkdirSync(skillsDir, { recursive: true })
+    return skillsDir
+  }
+
+  describe('exportSkill', () => {
+    it('exports a single-file skill', async () => {
+      const agentSlug = 'test-agent'
+      const skillDir = makeSkillDir(agentSlug, 'my-skill')
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), MINIMAL_SKILL_MD)
+
+      const zipBuffer = await exportSkill(agentSlug, 'my-skill')
+      expect(zipBuffer).toBeInstanceOf(Buffer)
+
+      const reader = await openZipFromBuffer(zipBuffer)
+      try {
+        const fileNames = reader.entries.map(e => e.fileName)
+        expect(fileNames).toContain('SKILL.md')
+        expect(reader.entries.length).toBe(1)
+      } finally {
+        reader.close()
+      }
+    })
+
+    it('exports a multi-file skill', async () => {
+      const agentSlug = 'test-agent'
+      const skillDir = makeSkillDir(agentSlug, 'multi-skill')
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), MINIMAL_SKILL_MD)
+      fs.writeFileSync(path.join(skillDir, 'helper.py'), 'print("hello")')
+      fs.mkdirSync(path.join(skillDir, 'lib'))
+      fs.writeFileSync(path.join(skillDir, 'lib', 'utils.py'), 'x = 1')
+
+      const zipBuffer = await exportSkill(agentSlug, 'multi-skill')
+      const reader = await openZipFromBuffer(zipBuffer)
+      try {
+        const fileNames = reader.entries.map(e => e.fileName).sort()
+        expect(fileNames).toEqual(['SKILL.md', 'helper.py', expect.stringContaining('utils.py')])
+      } finally {
+        reader.close()
+      }
+    })
+
+    it('excludes .skillset-metadata.json and .skillset-original.md', async () => {
+      const agentSlug = 'test-agent'
+      const skillDir = makeSkillDir(agentSlug, 'meta-skill')
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), MINIMAL_SKILL_MD)
+      fs.writeFileSync(path.join(skillDir, '.skillset-metadata.json'), '{}')
+      fs.writeFileSync(path.join(skillDir, '.skillset-original.md'), '# original')
+
+      const zipBuffer = await exportSkill(agentSlug, 'meta-skill')
+      const reader = await openZipFromBuffer(zipBuffer)
+      try {
+        const fileNames = reader.entries.map(e => e.fileName)
+        expect(fileNames).toContain('SKILL.md')
+        expect(fileNames).not.toContain('.skillset-metadata.json')
+        expect(fileNames).not.toContain('.skillset-original.md')
+      } finally {
+        reader.close()
+      }
+    })
+
+    it('throws when skill directory does not exist', async () => {
+      await expect(exportSkill('test-agent', 'nonexistent')).rejects.toThrow('Skill directory not found')
+    })
+
+    it('throws when SKILL.md is missing', async () => {
+      const agentSlug = 'test-agent'
+      const skillDir = makeSkillDir(agentSlug, 'no-skillmd')
+      fs.writeFileSync(path.join(skillDir, 'helper.py'), 'x = 1')
+
+      await expect(exportSkill(agentSlug, 'no-skillmd')).rejects.toThrow('SKILL.md not found')
+    })
+
+    it('rejects path traversal in skillDirName', async () => {
+      await expect(exportSkill('test-agent', '../etc')).rejects.toThrow('Invalid directory name')
+    })
+  })
+
+  describe('validateSkillZip', () => {
+    it('accepts a valid zip with SKILL.md and extracts name', async () => {
+      const buf = await makeSkillZip({ 'SKILL.md': MINIMAL_SKILL_MD })
+      const result = await validateSkillZip(buf)
+      expect(result.valid).toBe(true)
+      expect(result.skillName).toBe('Test Skill')
+      expect(result.fileCount).toBe(1)
+      expect(result.stripPrefix).toBe('')
+    })
+
+    it('returns skillName undefined when frontmatter has no name', async () => {
+      const buf = await makeSkillZip({ 'SKILL.md': SKILL_MD_NO_NAME })
+      const result = await validateSkillZip(buf)
+      expect(result.valid).toBe(true)
+      expect(result.skillName).toBeUndefined()
+    })
+
+    it('rejects zip without SKILL.md', async () => {
+      const buf = await makeSkillZip({ 'README.md': '# Readme' })
+      const result = await validateSkillZip(buf)
+      expect(result.valid).toBe(false)
+      expect(result.error).toContain('SKILL.md not found')
+    })
+
+    it('handles macOS wrapper directory prefix', async () => {
+      const buf = await makeSkillZip({
+        'my-skill/SKILL.md': MINIMAL_SKILL_MD,
+        'my-skill/helper.py': 'x = 1',
+      })
+      const result = await validateSkillZip(buf)
+      expect(result.valid).toBe(true)
+      expect(result.skillName).toBe('Test Skill')
+      expect(result.stripPrefix).toBe('my-skill/')
+    })
+
+    it('filters __MACOSX entries', async () => {
+      const buf = await makeSkillZip({
+        'SKILL.md': MINIMAL_SKILL_MD,
+        '__MACOSX/._SKILL.md': 'junk',
+      })
+      const result = await validateSkillZip(buf)
+      expect(result.valid).toBe(true)
+      expect(result.fileCount).toBe(1)
+    })
+
+    it('rejects path traversal in entries', async () => {
+      // yazl rejects `..` in paths, so we must patch the buffer directly
+      const buf = Buffer.from(await makeSkillZip({
+        'SKILL.md': MINIMAL_SKILL_MD,
+        'safe/evil.txt': 'bad content',
+      }))
+      const searchStr = Buffer.from('safe/evil.txt')
+      const replaceStr = Buffer.from('../evil..txt')
+      let idx = buf.indexOf(searchStr)
+      while (idx !== -1) {
+        replaceStr.copy(buf, idx)
+        idx = buf.indexOf(searchStr, idx + 1)
+      }
+      const result = await validateSkillZip(buf)
+      expect(result.valid).toBe(false)
+      expect(result.error?.toLowerCase()).toMatch(/invalid.*path/)
+    })
+
+    it('handles invalid/corrupt buffer gracefully', async () => {
+      const result = await validateSkillZip(Buffer.from('not a zip'))
+      expect(result.valid).toBe(false)
+      expect(result.error).toBeDefined()
+      expect(result.fileCount).toBe(0)
+    })
+  })
+
+  describe('importSkillFromZip', () => {
+    it('imports a valid zip and returns skill info', async () => {
+      const agentSlug = 'import-agent'
+      // Create the agent workspace dir
+      const agentDir = path.join(testDir, 'agents', agentSlug, 'workspace')
+      fs.mkdirSync(agentDir, { recursive: true })
+
+      const buf = await makeSkillZip({ 'SKILL.md': MINIMAL_SKILL_MD })
+      const result = await importSkillFromZip(agentSlug, buf)
+
+      expect(result.skillDir).toBe('test-skill')
+      expect(result.skillName).toBe('Test Skill')
+      expect(result.requiredEnvVars).toBeUndefined()
+
+      // Verify file was extracted
+      const skillMdPath = path.join(agentDir, '.claude', 'skills', 'test-skill', 'SKILL.md')
+      expect(fs.existsSync(skillMdPath)).toBe(true)
+      expect(fs.readFileSync(skillMdPath, 'utf-8')).toBe(MINIMAL_SKILL_MD)
+    })
+
+    it('returns required env vars from frontmatter', async () => {
+      const agentSlug = 'env-agent'
+      fs.mkdirSync(path.join(testDir, 'agents', agentSlug, 'workspace'), { recursive: true })
+
+      const buf = await makeSkillZip({ 'SKILL.md': SKILL_MD_WITH_ENV })
+      const result = await importSkillFromZip(agentSlug, buf)
+
+      expect(result.skillName).toBe('Env Skill')
+      expect(result.requiredEnvVars).toEqual([
+        { name: 'API_KEY', description: 'The API key' },
+        { name: 'SECRET', description: 'A secret value' },
+      ])
+    })
+
+    it('derives safe directory name from skill name', async () => {
+      const agentSlug = 'safe-name-agent'
+      fs.mkdirSync(path.join(testDir, 'agents', agentSlug, 'workspace'), { recursive: true })
+
+      const skillMd = `---\nname: My Fancy Skill!\n---\n# Skill\n`
+      const buf = await makeSkillZip({ 'SKILL.md': skillMd })
+      const result = await importSkillFromZip(agentSlug, buf)
+
+      expect(result.skillDir).toBe('my-fancy-skill')
+    })
+
+    it('appends suffix when directory name collides', async () => {
+      const agentSlug = 'collision-agent'
+      const agentDir = path.join(testDir, 'agents', agentSlug, 'workspace')
+      fs.mkdirSync(agentDir, { recursive: true })
+
+      // Pre-create the target directory
+      const existingDir = path.join(agentDir, '.claude', 'skills', 'test-skill')
+      fs.mkdirSync(existingDir, { recursive: true })
+
+      const buf = await makeSkillZip({ 'SKILL.md': MINIMAL_SKILL_MD })
+      const result = await importSkillFromZip(agentSlug, buf)
+
+      expect(result.skillDir).toBe('test-skill-1')
+    })
+
+    it('strips wrapper directory prefix', async () => {
+      const agentSlug = 'prefix-agent'
+      fs.mkdirSync(path.join(testDir, 'agents', agentSlug, 'workspace'), { recursive: true })
+
+      const buf = await makeSkillZip({
+        'wrapper/SKILL.md': MINIMAL_SKILL_MD,
+        'wrapper/helper.py': 'x = 1',
+      })
+      const result = await importSkillFromZip(agentSlug, buf)
+
+      expect(result.skillDir).toBe('test-skill')
+      const skillDir = path.join(testDir, 'agents', agentSlug, 'workspace', '.claude', 'skills', result.skillDir)
+      expect(fs.existsSync(path.join(skillDir, 'SKILL.md'))).toBe(true)
+      expect(fs.existsSync(path.join(skillDir, 'helper.py'))).toBe(true)
+    })
+
+    it('skips .skillset-metadata.json and .skillset-original.md from source', async () => {
+      const agentSlug = 'skip-meta-agent'
+      fs.mkdirSync(path.join(testDir, 'agents', agentSlug, 'workspace'), { recursive: true })
+
+      const buf = await makeSkillZip({
+        'SKILL.md': MINIMAL_SKILL_MD,
+        '.skillset-metadata.json': '{"skillsetId": "old"}',
+        '.skillset-original.md': '# old',
+      })
+      const result = await importSkillFromZip(agentSlug, buf)
+
+      const skillDir = path.join(testDir, 'agents', agentSlug, 'workspace', '.claude', 'skills', result.skillDir)
+      expect(fs.existsSync(path.join(skillDir, 'SKILL.md'))).toBe(true)
+      expect(fs.existsSync(path.join(skillDir, '.skillset-metadata.json'))).toBe(false)
+      expect(fs.existsSync(path.join(skillDir, '.skillset-original.md'))).toBe(false)
+    })
+
+    it('throws when SKILL.md is missing', async () => {
+      const agentSlug = 'no-skill-agent'
+      fs.mkdirSync(path.join(testDir, 'agents', agentSlug, 'workspace'), { recursive: true })
+
+      const buf = await makeSkillZip({ 'README.md': '# Hi' })
+      await expect(importSkillFromZip(agentSlug, buf)).rejects.toThrow('SKILL.md not found')
+    })
+
+    it('filters __MACOSX entries during import', async () => {
+      const agentSlug = 'macosx-agent'
+      fs.mkdirSync(path.join(testDir, 'agents', agentSlug, 'workspace'), { recursive: true })
+
+      const buf = await makeSkillZip({
+        'SKILL.md': MINIMAL_SKILL_MD,
+        '__MACOSX/._SKILL.md': 'resource fork junk',
+      })
+      const result = await importSkillFromZip(agentSlug, buf)
+
+      const skillDir = path.join(testDir, 'agents', agentSlug, 'workspace', '.claude', 'skills', result.skillDir)
+      expect(fs.existsSync(path.join(skillDir, '__MACOSX'))).toBe(false)
+    })
+  })
+
+  describe('skill zip round-trip', () => {
+    it('export then import preserves files', async () => {
+      const agentSlug = 'roundtrip-agent'
+      const agentDir = path.join(testDir, 'agents', agentSlug, 'workspace')
+      fs.mkdirSync(agentDir, { recursive: true })
+
+      // Create a skill to export
+      const sourceDir = makeSkillDir(agentSlug, 'source-skill')
+      fs.writeFileSync(path.join(sourceDir, 'SKILL.md'), MINIMAL_SKILL_MD)
+      fs.writeFileSync(path.join(sourceDir, 'tool.py'), 'def run(): pass')
+
+      // Export it
+      const zipBuffer = await exportSkill(agentSlug, 'source-skill')
+
+      // Import into a different agent
+      const importAgentSlug = 'roundtrip-import'
+      fs.mkdirSync(path.join(testDir, 'agents', importAgentSlug, 'workspace'), { recursive: true })
+      const result = await importSkillFromZip(importAgentSlug, zipBuffer)
+
+      // Verify files match
+      const importedDir = path.join(testDir, 'agents', importAgentSlug, 'workspace', '.claude', 'skills', result.skillDir)
+      expect(fs.readFileSync(path.join(importedDir, 'SKILL.md'), 'utf-8')).toBe(MINIMAL_SKILL_MD)
+      expect(fs.readFileSync(path.join(importedDir, 'tool.py'), 'utf-8')).toBe('def run(): pass')
     })
   })
 })

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -1672,4 +1672,191 @@ export async function publishSkillToSkillset(
   return { prUrl: result.prUrl, successMessage: result.successMessage }
 }
 
+// ============================================================================
+// ZIP Export / Import
+// ============================================================================
+
+const SKILL_MAX_UNCOMPRESSED_SIZE = 100 * 1024 * 1024 // 100MB
+export const SKILL_MAX_COMPRESSED_SIZE = 100 * 1024 * 1024 // 100MB
+const SKILL_MAX_FILE_COUNT = 500
+
+/**
+ * Export a single skill directory as a ZIP buffer.
+ */
+export async function exportSkill(agentSlug: string, skillDirName: string): Promise<Buffer> {
+  sanitizeDirName(skillDirName)
+  const skillDir = path.join(getAgentSkillsDir(agentSlug), skillDirName)
+
+  if (!(await directoryExists(skillDir))) {
+    throw new Error('Skill directory not found')
+  }
+
+  const skillMdPath = path.join(skillDir, 'SKILL.md')
+  const skillContent = await readFileOrNull(skillMdPath)
+  if (!skillContent) {
+    throw new Error('SKILL.md not found in skill directory')
+  }
+
+  const packageFiles = await readSkillPackageFiles(skillDir)
+  const files: Record<string, string> = {}
+  for (const f of packageFiles) {
+    files[f.relativePath] = f.content
+  }
+
+  const { createZipBuffer } = await import('@shared/lib/utils/zip')
+  return createZipBuffer(files)
+}
+
+export interface SkillValidationResult {
+  valid: boolean
+  error?: string
+  skillName?: string
+  fileCount: number
+  stripPrefix: string
+}
+
+/**
+ * Validate a ZIP buffer as a skill package.
+ * Checks for SKILL.md, file count, size limits, and path traversal.
+ */
+export async function validateSkillZip(zipBuffer: Buffer): Promise<SkillValidationResult> {
+  const { openZipFromBuffer, detectZipPrefix } = await import('@shared/lib/utils/zip')
+  let reader: Awaited<ReturnType<typeof openZipFromBuffer>> | undefined
+  try {
+    reader = await openZipFromBuffer(zipBuffer)
+
+    const realEntries = reader.entries.filter((e) => !e.fileName.startsWith('__MACOSX/'))
+
+    if (realEntries.length > SKILL_MAX_FILE_COUNT) {
+      return { valid: false, error: `Too many files (${realEntries.length}, max ${SKILL_MAX_FILE_COUNT})`, fileCount: realEntries.length, stripPrefix: '' }
+    }
+
+    let totalSize = 0
+    for (const entry of realEntries) {
+      totalSize += entry.uncompressedSize
+      if (totalSize > SKILL_MAX_UNCOMPRESSED_SIZE) {
+        return { valid: false, error: `Skill package too large (exceeds ${SKILL_MAX_UNCOMPRESSED_SIZE / 1024 / 1024}MB)`, fileCount: realEntries.length, stripPrefix: '' }
+      }
+    }
+
+    for (const entry of realEntries) {
+      if (entry.fileName.split('/').includes('..') || path.isAbsolute(entry.fileName)) {
+        return { valid: false, error: `Invalid path in package: ${entry.fileName}`, fileCount: realEntries.length, stripPrefix: '' }
+      }
+    }
+
+    const stripPrefix = detectZipPrefix(reader.entries)
+
+    const skillMdEntry = realEntries.find((e) => {
+      const name = stripPrefix ? e.fileName.replace(stripPrefix, '') : e.fileName
+      const normalized = name.replace(/^\.\//, '')
+      return normalized === 'SKILL.md'
+    })
+    if (!skillMdEntry) {
+      return { valid: false, error: 'SKILL.md not found in package', fileCount: realEntries.length, stripPrefix }
+    }
+
+    const skillMdBuf = await reader.readEntry(skillMdEntry.fileName)
+    const frontmatter = parseSkillFrontmatter(skillMdBuf.toString('utf-8'))
+    const skillName = frontmatter.name || undefined
+
+    return { valid: true, skillName, fileCount: realEntries.length, stripPrefix }
+  } catch (error) {
+    return {
+      valid: false,
+      error: error instanceof Error ? error.message : 'Failed to read ZIP file',
+      fileCount: 0,
+      stripPrefix: '',
+    }
+  } finally {
+    reader?.close()
+  }
+}
+
+/**
+ * Import a skill from a ZIP buffer into an agent's workspace.
+ * Validates the ZIP upfront (file count, size, path traversal, SKILL.md presence)
+ * then extracts into `.claude/skills/<dir>`.
+ */
+export async function importSkillFromZip(
+  agentSlug: string,
+  zipBuffer: Buffer,
+): Promise<{ skillDir: string; skillName: string; requiredEnvVars?: Array<{ name: string; description: string }> }> {
+  const validation = await validateSkillZip(zipBuffer)
+  if (!validation.valid) {
+    throw new Error(validation.error || 'Invalid skill package')
+  }
+
+  const { openZipFromBuffer } = await import('@shared/lib/utils/zip')
+  const reader = await openZipFromBuffer(zipBuffer)
+  try {
+    const { stripPrefix } = validation
+
+    // Read SKILL.md to get skill name and env vars
+    const realEntries = reader.entries.filter((e) => !e.fileName.startsWith('__MACOSX/'))
+    const skillMdEntry = realEntries.find((e) => {
+      const name = stripPrefix ? e.fileName.replace(stripPrefix, '') : e.fileName
+      return name.replace(/^\.\//, '') === 'SKILL.md'
+    })!
+    const skillMdBuf = await reader.readEntry(skillMdEntry.fileName)
+    const skillMdContent = skillMdBuf.toString('utf-8')
+    const frontmatter = parseSkillFrontmatter(skillMdContent)
+    const skillName = frontmatter.name || 'imported-skill'
+
+    // Derive a safe directory name from the skill name
+    const baseDirName = skillName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'imported-skill'
+
+    // Ensure unique directory name
+    const skillsDir = getAgentSkillsDir(agentSlug)
+    await ensureDirectory(skillsDir)
+    let dirName = baseDirName
+    let suffix = 1
+    while (await directoryExists(path.join(skillsDir, dirName))) {
+      dirName = `${baseDirName}-${suffix}`
+      suffix++
+    }
+
+    const destDir = path.join(skillsDir, dirName)
+    await ensureDirectory(destDir)
+
+    let totalExtracted = 0
+    for (const entry of reader.entries) {
+      if (entry.isDirectory) continue
+      if (entry.fileName.startsWith('__MACOSX/')) continue
+
+      let entryName = stripPrefix
+        ? entry.fileName.replace(stripPrefix, '')
+        : entry.fileName
+      entryName = entryName.replace(/^\.\//, '')
+
+      if (!entryName) continue
+
+      const baseName = path.basename(entryName)
+      if (baseName === '.skillset-metadata.json' || baseName === '.skillset-original.md') continue
+
+      const destPath = path.resolve(destDir, entryName)
+      if (!destPath.startsWith(destDir)) continue
+
+      await ensureDirectory(path.dirname(destPath))
+      const bytesWritten = await reader.extractEntry(
+        entry.fileName,
+        destPath,
+        SKILL_MAX_UNCOMPRESSED_SIZE - totalExtracted,
+      )
+      totalExtracted += bytesWritten
+    }
+
+    return {
+      skillDir: dirName,
+      skillName: frontmatter.name || getDisplayName(dirName),
+      requiredEnvVars: frontmatter.required_env_vars,
+    }
+  } finally {
+    reader.close()
+  }
+}
+
 export { copyDirectoryFiltered as copyDirectory } from '@shared/lib/utils/file-storage'


### PR DESCRIPTION
## Summary
- **Export**: skills can be exported as `.zip` files via the three-dot menu (popover) and right-click context menu on any installed skill
- **Import**: new Import button in the Skills section opens a modal with drag-and-drop zone + file picker; imported skills with `required_env_vars` in SKILL.md frontmatter trigger the secrets prompt
- Follows all ZIP safety patterns from agent template export/import: path traversal protection, `__MACOSX` filtering, `detectZipPrefix` for wrapper directories, file count/size limits, SKILL.md required, metadata files stripped on import

## Changes
- **Service** (`skillset-service.ts`): `exportSkill`, `validateSkillZip`, `importSkillFromZip` — import calls validate upfront before extraction
- **API** (`agents.ts`): `POST /:id/skills/:dir/export` (ZIP download), `POST /:id/skills/import-zip` (multipart upload)
- **Hooks** (`use-agent-skills.ts`): `useExportSkill`, `useImportSkillZip`
- **UI** (`home-skills.tsx`): Import button + `SkillImportDialog` component, Export Skill in three-dot menu
- **UI** (`skill-context-menu.tsx`): Export Skill in right-click menu

## Test plan
- [x] Unit tests for `exportSkill`, `validateSkillZip`, `importSkillFromZip` (21 tests including round-trip)
- [x] API route tests for both endpoints (7 tests)
- [x] E2E tests: import via dialog, invalid zip error, export via menu, round-trip export→import (4 tests)
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)