### PR TITLE
feat: support TaskCreate/TaskUpdate in activity indicator

### DIFF
--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
 import { AgentActivityIndicator } from './agent-activity-indicator'
 
 // Mock useMessageStream
@@ -324,5 +324,243 @@ describe('AgentActivityIndicator', () => {
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
     expect(screen.getByText('Waiting for input...')).toBeInTheDocument()
     expect(screen.queryByText('Setting things up')).not.toBeInTheDocument()
+  })
+
+  // --- TaskCreate / TaskUpdate support ---
+
+  it('builds todo list from TaskCreate tool calls', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockMessages.push({
+      id: 'msg-1',
+      type: 'assistant',
+      content: { text: '' },
+      toolCalls: [
+        {
+          id: 'tc-1',
+          name: 'TaskCreate',
+          input: { subject: 'Set up database', activeForm: 'Setting up database' },
+          result: 'Task #1 created successfully: Set up database',
+        },
+        {
+          id: 'tc-2',
+          name: 'TaskCreate',
+          input: { subject: 'Write API routes', activeForm: 'Writing API routes' },
+          result: 'Task #2 created successfully: Write API routes',
+        },
+        {
+          id: 'tc-3',
+          name: 'TaskCreate',
+          input: { subject: 'Add tests', activeForm: 'Adding tests' },
+          result: 'Task #3 created successfully: Add tests',
+        },
+      ],
+      createdAt: new Date(),
+    })
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+
+    expect(screen.getByText('Set up database')).toBeInTheDocument()
+    expect(screen.getByText('Write API routes')).toBeInTheDocument()
+    expect(screen.getByText('Add tests')).toBeInTheDocument()
+    expect(screen.getAllByText('○')).toHaveLength(3)
+  })
+
+  it('applies TaskUpdate status changes to task list', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockMessages.push(
+      {
+        id: 'msg-1',
+        type: 'assistant',
+        content: { text: '' },
+        toolCalls: [
+          {
+            id: 'tc-1',
+            name: 'TaskCreate',
+            input: { subject: 'Set up database', activeForm: 'Setting up database' },
+            result: 'Task #1 created successfully',
+          },
+          {
+            id: 'tc-2',
+            name: 'TaskCreate',
+            input: { subject: 'Write API routes', activeForm: 'Writing API routes' },
+            result: 'Task #2 created successfully',
+          },
+        ],
+        createdAt: new Date(),
+      },
+      {
+        id: 'msg-2',
+        type: 'assistant',
+        content: { text: '' },
+        toolCalls: [
+          {
+            id: 'tc-3',
+            name: 'TaskUpdate',
+            input: { taskId: '1', status: 'completed' },
+            result: 'Updated task #1 status',
+          },
+          {
+            id: 'tc-4',
+            name: 'TaskUpdate',
+            input: { taskId: '2', status: 'in_progress' },
+            result: 'Updated task #2 status',
+          },
+        ],
+        createdAt: new Date(),
+      },
+    )
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+
+    // Task 1 completed, task 2 in progress
+    expect(screen.getByText('✓')).toBeInTheDocument()
+    expect(screen.getByText('→')).toBeInTheDocument()
+    // Shows activeForm of in_progress task as status text
+    expect(screen.getByText('Writing API routes')).toBeInTheDocument()
+  })
+
+  it('hides task list when all TaskCreate tasks are completed', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockMessages.push({
+      id: 'msg-1',
+      type: 'assistant',
+      content: { text: '' },
+      toolCalls: [
+        {
+          id: 'tc-1',
+          name: 'TaskCreate',
+          input: { subject: 'Task A', activeForm: 'Doing A' },
+          result: 'Task #1 created successfully',
+        },
+        {
+          id: 'tc-2',
+          name: 'TaskUpdate',
+          input: { taskId: '1', status: 'completed' },
+          result: 'Updated task #1 status',
+        },
+      ],
+      createdAt: new Date(),
+    })
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+
+    expect(screen.getByText('Working...')).toBeInTheDocument()
+    expect(screen.queryByText('Task A')).not.toBeInTheDocument()
+  })
+
+  it('truncates to 5 visible tasks, prioritizing not-done', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockMessages.push({
+      id: 'msg-1',
+      type: 'assistant',
+      content: { text: '' },
+      toolCalls: [
+        // 7 tasks: 3 completed, 4 pending
+        ...[1, 2, 3, 4, 5, 6, 7].map((n) => ({
+          id: `tc-create-${n}`,
+          name: 'TaskCreate',
+          input: { subject: `Task ${n}` },
+          result: `Task #${n} created successfully`,
+        })),
+        ...[1, 2, 3].map((n) => ({
+          id: `tc-update-${n}`,
+          name: 'TaskUpdate',
+          input: { taskId: String(n), status: 'completed' },
+          result: `Updated task #${n} status`,
+        })),
+      ],
+      createdAt: new Date(),
+    })
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+
+    // All 4 pending tasks should be visible
+    expect(screen.getByText('Task 4')).toBeInTheDocument()
+    expect(screen.getByText('Task 5')).toBeInTheDocument()
+    expect(screen.getByText('Task 6')).toBeInTheDocument()
+    expect(screen.getByText('Task 7')).toBeInTheDocument()
+    // 1 completed task fills the remaining slot (Task 3 is newest completed)
+    expect(screen.getByText('Task 3')).toBeInTheDocument()
+    // The other 2 completed tasks are hidden
+    expect(screen.queryByText('Task 1')).not.toBeInTheDocument()
+    expect(screen.queryByText('Task 2')).not.toBeInTheDocument()
+    // Shows the overflow indicator
+    expect(screen.getByText(/2 more.*2 done/)).toBeInTheDocument()
+  })
+
+  it('shows all tasks when toggle is clicked', async () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockMessages.push({
+      id: 'msg-1',
+      type: 'assistant',
+      content: { text: '' },
+      toolCalls: [
+        ...[1, 2, 3, 4, 5, 6].map((n) => ({
+          id: `tc-create-${n}`,
+          name: 'TaskCreate',
+          input: { subject: `Task ${n}` },
+          result: `Task #${n} created successfully`,
+        })),
+      ],
+      createdAt: new Date(),
+    })
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+
+    // 1 task hidden
+    expect(screen.queryByText('Task 6')).not.toBeInTheDocument()
+    expect(screen.getByText(/1 more.*1 pending/)).toBeInTheDocument()
+
+    // Click toggle
+    act(() => { screen.getByText(/1 more/).click() })
+
+    // All tasks now visible
+    expect(screen.getByText('Task 6')).toBeInTheDocument()
+    expect(screen.queryByText(/1 more/)).not.toBeInTheDocument()
+    // "Show fewer" button appears
+    expect(screen.getByText('Show fewer')).toBeInTheDocument()
+  })
+
+  it('prefers TaskCreate/TaskUpdate over TodoWrite when both exist', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockMessages.push(
+      {
+        id: 'msg-1',
+        type: 'assistant',
+        content: { text: '' },
+        toolCalls: [{
+          id: 'tc-1',
+          name: 'TodoWrite',
+          input: {
+            todos: [{ content: 'Old todo item', status: 'in_progress', activeForm: 'Old active form' }],
+          },
+          result: 'ok',
+        }],
+        createdAt: new Date(),
+      },
+      {
+        id: 'msg-2',
+        type: 'assistant',
+        content: { text: '' },
+        toolCalls: [{
+          id: 'tc-2',
+          name: 'TaskCreate',
+          input: { subject: 'New task item', activeForm: 'New active form' },
+          result: 'Task #1 created successfully',
+        }],
+        createdAt: new Date(),
+      },
+    )
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+
+    expect(screen.getByText('New task item')).toBeInTheDocument()
+    expect(screen.queryByText('Old todo item')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -30,6 +30,7 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
 
   const [revoking, setRevoking] = useState(false)
   const [revokeError, setRevokeError] = useState(false)
+  const [showAllTodos, setShowAllTodos] = useState(false)
   const handleRevokeComputerUse = useCallback(async () => {
     setRevoking(true)
     setRevokeError(false)
@@ -122,33 +123,68 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
     return null
   }
 
-  // Find the most recent TodoWrite tool call
+  // Build todo list from TaskCreate/TaskUpdate or fall back to TodoWrite
   let todos: Todo[] | null = null
   let activeItem: Todo | null = null
 
   if (messages) {
-    // Iterate through messages in reverse to find the most recent TodoWrite
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const message = messages[i]
+    // Try TaskCreate/TaskUpdate first (newer SDK format)
+    const taskMap = new Map<string, Todo>()
+    let taskCounter = 0
+
+    for (const message of messages) {
       if (message.type === 'compact_boundary' || message.type === 'memory_recall') continue
-      // Use the toolCalls array from the API message
-      const toolCalls = message.toolCalls || []
-      for (let j = toolCalls.length - 1; j >= 0; j--) {
-        const toolCall = toolCalls[j]
-        if (toolCall.name === 'TodoWrite') {
-          try {
-            const input = toolCall.input as { todos?: Todo[] }
-            if (input?.todos && Array.isArray(input.todos)) {
-              todos = input.todos
-              activeItem = todos.find((t) => t.status === 'in_progress') || null
-              break
+      for (const tc of message.toolCalls || []) {
+        if (tc.name === 'TaskCreate') {
+          taskCounter++
+          const input = tc.input as { subject?: string; activeForm?: string }
+          if (input?.subject) {
+            taskMap.set(String(taskCounter), {
+              content: input.subject,
+              status: 'pending',
+              activeForm: input.activeForm || input.subject,
+            })
+          }
+        } else if (tc.name === 'TaskUpdate') {
+          const input = tc.input as { taskId?: string; status?: string }
+          if (input?.taskId && taskMap.has(input.taskId)) {
+            const task = taskMap.get(input.taskId)!
+            if (input.status === 'completed' || input.status === 'in_progress' || input.status === 'pending') {
+              task.status = input.status
             }
-          } catch {
-            // Invalid input format, skip
           }
         }
       }
-      if (todos) break
+    }
+
+    if (taskMap.size > 0) {
+      todos = Array.from(taskMap.values())
+      activeItem = todos.find((t) => t.status === 'in_progress') || null
+    }
+
+    // Fall back to TodoWrite (older SDK format)
+    if (!todos) {
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const message = messages[i]
+        if (message.type === 'compact_boundary' || message.type === 'memory_recall') continue
+        const toolCalls = message.toolCalls || []
+        for (let j = toolCalls.length - 1; j >= 0; j--) {
+          const toolCall = toolCalls[j]
+          if (toolCall.name === 'TodoWrite') {
+            try {
+              const input = toolCall.input as { todos?: Todo[] }
+              if (input?.todos && Array.isArray(input.todos)) {
+                todos = input.todos
+                activeItem = todos.find((t) => t.status === 'in_progress') || null
+                break
+              }
+            } catch {
+              // Invalid input format, skip
+            }
+          }
+        }
+        if (todos) break
+      }
     }
   }
 
@@ -239,27 +275,77 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
         )}
 
         {/* Todo list if available and at least one item is not completed */}
-        {todos && todos.length > 0 && todos.some((t) => t.status !== 'completed') && (
-          <ul className="mt-2 space-y-1 text-sm">
-            {todos.map((todo, index) => (
-              <li
-                key={index}
-                className={cn(
-                  'flex items-center gap-2',
-                  todo.status === 'completed' && 'text-muted-foreground line-through',
-                  todo.status === 'in_progress' && 'font-semibold'
-                )}
-              >
-                <span className="text-xs">
-                  {todo.status === 'completed' && '✓'}
-                  {todo.status === 'in_progress' && '→'}
-                  {todo.status === 'pending' && '○'}
-                </span>
-                {todo.content}
-              </li>
-            ))}
-          </ul>
-        )}
+        {todos && todos.length > 0 && todos.some((t) => t.status !== 'completed') && (() => {
+          const MAX_VISIBLE = 5
+          const needsTruncation = todos.length > MAX_VISIBLE && !showAllTodos
+
+          const notDone = todos.filter(t => t.status !== 'completed')
+          const doneReversed = todos.filter(t => t.status === 'completed').reverse()
+
+          let visibleTodos: Todo[]
+          let hiddenTodos: Todo[]
+
+          if (!needsTruncation) {
+            visibleTodos = [...notDone, ...doneReversed]
+            hiddenTodos = []
+          } else {
+            const visibleNotDone = notDone.slice(0, MAX_VISIBLE)
+            const remainingSlots = MAX_VISIBLE - visibleNotDone.length
+            const visibleDone = doneReversed.slice(0, remainingSlots)
+            visibleTodos = [...visibleNotDone, ...visibleDone]
+            const visibleSet = new Set(visibleTodos)
+            hiddenTodos = todos.filter(t => !visibleSet.has(t))
+          }
+
+          const hiddenPending = hiddenTodos.filter(t => t.status !== 'completed').length
+          const hiddenDone = hiddenTodos.filter(t => t.status === 'completed').length
+
+          return (
+            <ul className="mt-2 space-y-1 text-sm">
+              {hiddenTodos.length > 0 && (
+                <li>
+                  <button
+                    onClick={() => setShowAllTodos(true)}
+                    className="text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                  >
+                    {hiddenTodos.length} more{': '}
+                    {[
+                      hiddenPending > 0 && `${hiddenPending} pending`,
+                      hiddenDone > 0 && `${hiddenDone} done`,
+                    ].filter(Boolean).join(', ')}
+                  </button>
+                </li>
+              )}
+              {showAllTodos && todos.length > MAX_VISIBLE && (
+                <li>
+                  <button
+                    onClick={() => setShowAllTodos(false)}
+                    className="text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                  >
+                    Show fewer
+                  </button>
+                </li>
+              )}
+              {visibleTodos.map((todo, index) => (
+                <li
+                  key={index}
+                  className={cn(
+                    'flex items-center gap-2',
+                    todo.status === 'completed' && 'text-muted-foreground line-through',
+                    todo.status === 'in_progress' && 'font-semibold'
+                  )}
+                >
+                  <span className="text-xs">
+                    {todo.status === 'completed' && '✓'}
+                    {todo.status === 'in_progress' && '→'}
+                    {todo.status === 'pending' && '○'}
+                  </span>
+                  {todo.content}
+                </li>
+              ))}
+            </ul>
+          )
+        })()}
       </div>
     </div>
   )

--- a/src/renderer/components/messages/tool-renderers/index.ts
+++ b/src/renderer/components/messages/tool-renderers/index.ts
@@ -44,6 +44,11 @@ import {
   getAgentSessionsRenderer,
   getAgentSessionTranscriptRenderer,
 } from './x-agent-tools'
+import {
+  taskCreateRenderer,
+  taskUpdateRenderer,
+  taskListRenderer,
+} from './task-management'
 
 export type { ToolRenderer, ToolRendererProps, StreamingToolRendererProps, CollapsedContentProps } from './types'
 
@@ -70,6 +75,9 @@ const toolRenderers: Record<string, ToolRenderer> = {
 
   // Task management
   TodoWrite: todoWriteRenderer,
+  TaskCreate: taskCreateRenderer,
+  TaskUpdate: taskUpdateRenderer,
+  TaskList: taskListRenderer,
 
   // User interaction
   AskUserQuestion: askUserQuestionRenderer,

--- a/src/renderer/components/messages/tool-renderers/task-management.test.tsx
+++ b/src/renderer/components/messages/tool-renderers/task-management.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { taskCreateRenderer, taskUpdateRenderer, taskListRenderer } from './task-management'
+
+describe('taskCreateRenderer', () => {
+  describe('metadata', () => {
+    it('has correct displayName', () => {
+      expect(taskCreateRenderer.displayName).toBe('Create Task')
+    })
+
+    it('has an icon', () => {
+      expect(taskCreateRenderer.icon).toBeDefined()
+    })
+  })
+
+  describe('getSummary', () => {
+    it('returns subject text', () => {
+      expect(taskCreateRenderer.getSummary!({ subject: 'Set up database' }))
+        .toBe('Set up database')
+    })
+
+    it('returns null for empty input', () => {
+      expect(taskCreateRenderer.getSummary!({})).toBeNull()
+    })
+  })
+
+  describe('ExpandedView', () => {
+    const ExpandedView = taskCreateRenderer.ExpandedView!
+
+    it('renders subject and description', () => {
+      render(
+        <ExpandedView
+          input={{ subject: 'Set up database', description: 'Initialize PostgreSQL and run migrations' }}
+        />
+      )
+      expect(screen.getByText('Set up database')).toBeInTheDocument()
+      expect(screen.getByText('Initialize PostgreSQL and run migrations')).toBeInTheDocument()
+    })
+
+    it('renders subject only when no description', () => {
+      render(<ExpandedView input={{ subject: 'Write tests' }} />)
+      expect(screen.getByText('Write tests')).toBeInTheDocument()
+    })
+
+    it('handles empty input gracefully', () => {
+      const { container } = render(<ExpandedView input={{}} />)
+      expect(container.textContent).toBe('')
+    })
+  })
+})
+
+describe('taskUpdateRenderer', () => {
+  describe('metadata', () => {
+    it('has correct displayName', () => {
+      expect(taskUpdateRenderer.displayName).toBe('Update Task')
+    })
+
+    it('has an icon', () => {
+      expect(taskUpdateRenderer.icon).toBeDefined()
+    })
+  })
+
+  describe('getSummary', () => {
+    it('returns task id and status', () => {
+      expect(taskUpdateRenderer.getSummary!({ taskId: '2', status: 'completed' }))
+        .toBe('Task #2 completed')
+    })
+
+    it('returns null when no taskId', () => {
+      expect(taskUpdateRenderer.getSummary!({})).toBeNull()
+    })
+  })
+
+  describe('ExpandedView', () => {
+    const ExpandedView = taskUpdateRenderer.ExpandedView!
+
+    it('renders completed status with checkmark', () => {
+      render(<ExpandedView input={{ taskId: '1', status: 'completed' }} />)
+      expect(screen.getByText('Task #1')).toBeInTheDocument()
+      expect(screen.getByText('✓')).toBeInTheDocument()
+    })
+
+    it('renders in_progress status with arrow', () => {
+      render(<ExpandedView input={{ taskId: '2', status: 'in_progress' }} />)
+      expect(screen.getByText('Task #2')).toBeInTheDocument()
+      expect(screen.getByText('→')).toBeInTheDocument()
+    })
+
+    it('renders pending status with circle', () => {
+      render(<ExpandedView input={{ taskId: '3', status: 'pending' }} />)
+      expect(screen.getByText('Task #3')).toBeInTheDocument()
+      expect(screen.getByText('○')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('taskListRenderer', () => {
+  it('has correct displayName', () => {
+    expect(taskListRenderer.displayName).toBe('List Tasks')
+  })
+
+  it('has an icon', () => {
+    expect(taskListRenderer.icon).toBeDefined()
+  })
+})

--- a/src/renderer/components/messages/tool-renderers/task-management.tsx
+++ b/src/renderer/components/messages/tool-renderers/task-management.tsx
@@ -1,0 +1,49 @@
+import { ListPlus, ListChecks, ListTodo } from 'lucide-react'
+import { cn } from '@shared/lib/utils/cn'
+import { taskCreateDef, taskUpdateDef, taskListDef } from '@shared/lib/tool-definitions/task-management'
+import type { ToolRenderer, ToolRendererProps } from './types'
+
+function TaskCreateExpandedView({ input }: ToolRendererProps) {
+  const { subject, description } = taskCreateDef.parseInput(input)
+  return (
+    <div className="space-y-1 text-sm">
+      {subject && <div className="font-medium">{subject}</div>}
+      {description && <div className="text-muted-foreground text-xs">{description}</div>}
+    </div>
+  )
+}
+
+function TaskUpdateExpandedView({ input }: ToolRendererProps) {
+  const { taskId, status } = taskUpdateDef.parseInput(input)
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <span className="text-xs">
+        {status === 'completed' && <span className="text-green-500">✓</span>}
+        {status === 'in_progress' && <span className="text-blue-500">→</span>}
+        {status === 'pending' && <span className="text-muted-foreground">○</span>}
+      </span>
+      <span className={cn(status === 'completed' && 'text-muted-foreground')}>
+        Task #{taskId}
+      </span>
+    </div>
+  )
+}
+
+export const taskCreateRenderer: ToolRenderer = {
+  displayName: taskCreateDef.displayName,
+  icon: ListPlus,
+  getSummary: taskCreateDef.getSummary,
+  ExpandedView: TaskCreateExpandedView,
+}
+
+export const taskUpdateRenderer: ToolRenderer = {
+  displayName: taskUpdateDef.displayName,
+  icon: ListChecks,
+  getSummary: taskUpdateDef.getSummary,
+  ExpandedView: TaskUpdateExpandedView,
+}
+
+export const taskListRenderer: ToolRenderer = {
+  displayName: taskListDef.displayName,
+  icon: ListTodo,
+}

--- a/src/shared/lib/tool-definitions/registry.ts
+++ b/src/shared/lib/tool-definitions/registry.ts
@@ -52,6 +52,11 @@ import {
   getAgentSessionsDef,
   getAgentSessionTranscriptDef,
 } from './x-agent-tools'
+import {
+  taskCreateDef,
+  taskUpdateDef,
+  taskListDef,
+} from './task-management'
 
 const definitions: Record<string, ToolDefinition> = {
   // Agent tools
@@ -72,6 +77,9 @@ const definitions: Record<string, ToolDefinition> = {
 
   // Task management
   TodoWrite: todoWriteDef,
+  TaskCreate: taskCreateDef,
+  TaskUpdate: taskUpdateDef,
+  TaskList: taskListDef,
 
   // User interaction
   AskUserQuestion: askUserQuestionDef,

--- a/src/shared/lib/tool-definitions/task-management.test.ts
+++ b/src/shared/lib/tool-definitions/task-management.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { taskCreateDef, taskUpdateDef, taskListDef } from './task-management'
+
+describe('taskCreateDef', () => {
+  it('has correct displayName', () => {
+    expect(taskCreateDef.displayName).toBe('Create Task')
+  })
+
+  describe('parseInput', () => {
+    it('parses valid input', () => {
+      const result = taskCreateDef.parseInput({
+        subject: 'Set up database',
+        description: 'Initialize PostgreSQL',
+        activeForm: 'Setting up database',
+      })
+      expect(result).toEqual({
+        subject: 'Set up database',
+        description: 'Initialize PostgreSQL',
+        activeForm: 'Setting up database',
+      })
+    })
+
+    it('returns empty object for non-object input', () => {
+      expect(taskCreateDef.parseInput(null)).toEqual({})
+      expect(taskCreateDef.parseInput(undefined)).toEqual({})
+      expect(taskCreateDef.parseInput('string')).toEqual({})
+    })
+  })
+
+  describe('getSummary', () => {
+    it('returns subject', () => {
+      expect(taskCreateDef.getSummary({ subject: 'Write tests' })).toBe('Write tests')
+    })
+
+    it('returns null when no subject', () => {
+      expect(taskCreateDef.getSummary({})).toBeNull()
+      expect(taskCreateDef.getSummary({ description: 'only desc' })).toBeNull()
+    })
+  })
+})
+
+describe('taskUpdateDef', () => {
+  it('has correct displayName', () => {
+    expect(taskUpdateDef.displayName).toBe('Update Task')
+  })
+
+  describe('parseInput', () => {
+    it('parses valid input', () => {
+      const result = taskUpdateDef.parseInput({ taskId: '3', status: 'completed' })
+      expect(result).toEqual({ taskId: '3', status: 'completed' })
+    })
+
+    it('returns empty object for non-object input', () => {
+      expect(taskUpdateDef.parseInput(null)).toEqual({})
+    })
+  })
+
+  describe('getSummary', () => {
+    it('returns task id and status', () => {
+      expect(taskUpdateDef.getSummary({ taskId: '2', status: 'completed' }))
+        .toBe('Task #2 completed')
+    })
+
+    it('falls back to "updated" when no status', () => {
+      expect(taskUpdateDef.getSummary({ taskId: '1' })).toBe('Task #1 updated')
+    })
+
+    it('returns null when no taskId', () => {
+      expect(taskUpdateDef.getSummary({})).toBeNull()
+      expect(taskUpdateDef.getSummary({ status: 'completed' })).toBeNull()
+    })
+  })
+})
+
+describe('taskListDef', () => {
+  it('has correct displayName', () => {
+    expect(taskListDef.displayName).toBe('List Tasks')
+  })
+
+  it('returns fixed summary', () => {
+    expect(taskListDef.getSummary({})).toBe('Listed tasks')
+  })
+})

--- a/src/shared/lib/tool-definitions/task-management.ts
+++ b/src/shared/lib/tool-definitions/task-management.ts
@@ -1,0 +1,53 @@
+export interface TaskCreateInput {
+  subject?: string
+  description?: string
+  activeForm?: string
+}
+
+export interface TaskUpdateInput {
+  taskId?: string
+  status?: string
+}
+
+function parseTaskCreateInput(input: unknown): TaskCreateInput {
+  return typeof input === 'object' && input !== null ? (input as TaskCreateInput) : {}
+}
+
+function parseTaskUpdateInput(input: unknown): TaskUpdateInput {
+  return typeof input === 'object' && input !== null ? (input as TaskUpdateInput) : {}
+}
+
+function getTaskCreateSummary(input: unknown): string | null {
+  const { subject } = parseTaskCreateInput(input)
+  return subject || null
+}
+
+function getTaskUpdateSummary(input: unknown): string | null {
+  const { taskId, status } = parseTaskUpdateInput(input)
+  if (!taskId) return null
+  return `Task #${taskId} ${status || 'updated'}`
+}
+
+function getTaskListSummary(_input: unknown): string | null {
+  return 'Listed tasks'
+}
+
+export const taskCreateDef = {
+  displayName: 'Create Task',
+  iconName: 'ListPlus',
+  parseInput: parseTaskCreateInput,
+  getSummary: getTaskCreateSummary,
+} as const
+
+export const taskUpdateDef = {
+  displayName: 'Update Task',
+  iconName: 'ListChecks',
+  parseInput: parseTaskUpdateInput,
+  getSummary: getTaskUpdateSummary,
+} as const
+
+export const taskListDef = {
+  displayName: 'List Tasks',
+  iconName: 'ListTodo',
+  getSummary: getTaskListSummary,
+} as const


### PR DESCRIPTION
## Summary
- The Claude SDK now uses `TaskCreate`/`TaskUpdate`/`TaskList` tools instead of `TodoWrite` for task management. The activity indicator and tool renderers were only wired up for `TodoWrite`, so the todo list in the working indicator stopped appearing.
- Adds tool definitions and renderers for the three new task tools, with backward-compatible `TodoWrite` fallback.
- Caps the visible task list at 5 items (prioritizing not-done tasks, oldest-first for pending, newest-first for done), with a collapsible "N more" overflow indicator.

## Test plan
- [x] Unit tests for tool definitions (`task-management.test.ts` — 13 tests)
- [x] Component tests for tool renderers (`task-management.test.tsx` — 16 tests)
- [x] Activity indicator tests for TaskCreate/TaskUpdate building, truncation, and toggle (`agent-activity-indicator.test.tsx` — 25 tests)
- [x] Registry completeness test passes (`registry.test.ts` — 43 tests)
- [x] TypeScript compiles cleanly
- [x] Manually verified working indicator shows task list with real agent session

🤖 Generated with [Claude Code](https://claude.com/claude-code)