### PR TITLE
style: restyle global Account (Platform) settings

### DIFF
--- a/src/renderer/components/settings/global-settings-page.tsx
+++ b/src/renderer/components/settings/global-settings-page.tsx
@@ -1,4 +1,4 @@
-import { Settings, Container, Bell, Globe, Library, BarChart3, Plug, Brain, Users, Shield, ShieldEllipsis, User, Mic, Activity, Terminal, Waypoints, ClipboardList } from 'lucide-react'
+import { Settings, Container, Bell, Globe, Library, BarChart3, Plug, Brain, Users, Shield, ShieldEllipsis, User, Mic, Activity, Terminal, BadgeCheck, ClipboardList } from 'lucide-react'
 import { SettingsPage, type SettingsPageSection, type SettingsPageSectionGroup } from '@renderer/components/settings/settings-page'
 import { ProfileTab } from './profile-tab'
 import { GeneralTab } from './general-tab'
@@ -38,7 +38,7 @@ export function GlobalSettingsPage({ onClose, onOpenWizard, initialSection }: Gl
     ...(isAuthMode ? [{ id: 'profile', label: 'Profile & Login', icon: <User className="h-4 w-4" />, render: () => <ProfileTab /> }] : []),
     { id: 'general', label: 'General', icon: <Settings className="h-4 w-4" />, render: () => <GeneralTab onOpenWizard={onOpenWizard} /> },
     { id: 'notifications', label: 'Notifications', icon: <Bell className="h-4 w-4" />, render: () => <NotificationsTab /> },
-    { id: 'platform', label: 'Platform', icon: <Waypoints className="h-4 w-4" />, render: () => <PlatformTab readOnly={isAuthMode} /> },
+    { id: 'platform', label: 'Account', icon: <BadgeCheck className="h-4 w-4" />, render: () => <PlatformTab readOnly={isAuthMode} /> },
     { id: 'connections', label: 'Connections', icon: <Plug className="h-4 w-4" />, render: () => <ConnectionsTab />, headerActions: <NewIntegrationButton /> },
     { id: 'usage', label: 'Usage', icon: <BarChart3 className="h-4 w-4" />, render: () => <UsageTab /> },
   ]

--- a/src/renderer/components/settings/platform-tab.tsx
+++ b/src/renderer/components/settings/platform-tab.tsx
@@ -1,14 +1,213 @@
-import { useMemo } from 'react'
-import { ExternalLink, Loader2, LogIn, RefreshCw } from 'lucide-react'
+import { useMemo, useState, type ReactNode } from 'react'
+import { ArrowUpRight, BadgeX, Loader2 } from 'lucide-react'
 
 import { Alert, AlertDescription } from '@renderer/components/ui/alert'
 import { Button } from '@renderer/components/ui/button'
-import { Label } from '@renderer/components/ui/label'
-import { usePlatformConnect } from '@renderer/hooks/use-platform-auth'
-import { ManualAccessKeyInput } from '@renderer/components/settings/manual-access-key-input'
+import { Input } from '@renderer/components/ui/input'
+import { RequestError } from '@renderer/components/messages/request-error'
+import { usePlatformConnect, useSavePlatformAccessKey } from '@renderer/hooks/use-platform-auth'
 
 interface PlatformTabProps {
   readOnly?: boolean
+}
+
+interface SettingRowProps {
+  name: string
+  subtitle?: ReactNode
+  right: ReactNode
+}
+
+function SettingRow({ name, subtitle, right }: SettingRowProps) {
+  return (
+    <div className="py-3 px-4">
+      <div className="flex items-center gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-medium truncate">{name}</div>
+          {subtitle && (
+            <div className="text-[11px] text-muted-foreground mt-0.5">{subtitle}</div>
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">{right}</div>
+      </div>
+    </div>
+  )
+}
+
+const CARD_CLASS = 'rounded-xl border bg-background divide-y divide-border/50 overflow-hidden'
+
+interface NotConnectedEmptyStateProps {
+  readOnly: boolean
+  isLaunching: boolean
+  onConnect: () => void
+}
+
+function NotConnectedEmptyState({ readOnly, isLaunching, onConnect }: NotConnectedEmptyStateProps) {
+  const [showKeyInput, setShowKeyInput] = useState(false)
+  const [key, setKey] = useState('')
+  const saveKey = useSavePlatformAccessKey()
+
+  return (
+    <div className="rounded-xl border border-dashed bg-background px-6 py-10">
+      <div className="flex flex-col items-center text-center gap-3">
+        <div className="rounded-full bg-muted p-3">
+          <BadgeX className="h-5 w-5 text-muted-foreground" />
+        </div>
+        <h3 className="text-sm font-normal">No Superagent account connected to this workspace</h3>
+        {!readOnly && (
+          <div className="w-full max-w-sm mt-3 space-y-2">
+            {showKeyInput ? (
+              <>
+                <div className="flex items-center gap-2">
+                  <Input
+                    value={key}
+                    onChange={(e) => setKey(e.target.value)}
+                    placeholder="Paste account key"
+                    className="font-mono text-xs h-8 flex-1"
+                    autoFocus
+                  />
+                  <Button
+                    size="sm"
+                    className="h-8"
+                    disabled={!key.trim() || saveKey.isPending}
+                    onClick={() => {
+                      saveKey.mutate(key.trim(), {
+                        onSuccess: () => {
+                          setKey('')
+                          setShowKeyInput(false)
+                        },
+                      })
+                    }}
+                  >
+                    {saveKey.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Submit'}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-8"
+                    onClick={() => {
+                      setShowKeyInput(false)
+                      setKey('')
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+                <RequestError message={saveKey.isError ? saveKey.error.message : null} />
+              </>
+            ) : (
+              <div className="flex items-center justify-center gap-2">
+                <Button size="sm" onClick={onConnect} disabled={isLaunching} className="group gap-0">
+                  {isLaunching ? 'Opening browser…' : 'Connect Account'}
+                  {isLaunching ? (
+                    <Loader2 className="ml-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <span className="inline-flex overflow-hidden w-0 ml-0 opacity-0 transition-all duration-150 group-hover:w-4 group-hover:ml-2 group-hover:opacity-100 group-focus-visible:w-4 group-focus-visible:ml-2 group-focus-visible:opacity-100">
+                      <ArrowUpRight className="h-4 w-4 shrink-0" />
+                    </span>
+                  )}
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => setShowKeyInput(true)}>
+                  Add access key
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface ReconnectRowProps {
+  readOnly: boolean
+  isLaunching: boolean
+  connectLabel: string
+  onReconnect: () => void
+}
+
+function ReconnectRow({ readOnly, isLaunching, connectLabel, onReconnect }: ReconnectRowProps) {
+  const [showInput, setShowInput] = useState(false)
+  const [key, setKey] = useState('')
+  const saveKey = useSavePlatformAccessKey()
+
+  if (showInput) {
+    return (
+      <div className="py-3 px-4 space-y-2">
+        <div className="flex items-center gap-2">
+          <Input
+            value={key}
+            onChange={(e) => setKey(e.target.value)}
+            placeholder="Paste account key"
+            className="font-mono text-xs h-8 flex-1"
+            autoFocus
+          />
+          <Button
+            size="sm"
+            className="h-8"
+            disabled={!key.trim() || saveKey.isPending}
+            onClick={() => {
+              saveKey.mutate(key.trim(), {
+                onSuccess: () => {
+                  setKey('')
+                  setShowInput(false)
+                },
+              })
+            }}
+          >
+            {saveKey.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Submit'}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-8"
+            onClick={() => {
+              setShowInput(false)
+              setKey('')
+            }}
+          >
+            Cancel
+          </Button>
+        </div>
+        <RequestError message={saveKey.isError ? saveKey.error.message : null} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="py-3 px-4">
+      <div className="flex items-center gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-medium truncate">Issues? Try reconnecting</div>
+          <div className="text-[11px] text-muted-foreground mt-0.5">
+            Sign in to your account on the web or add an access key.
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={onReconnect}
+            disabled={readOnly || isLaunching}
+            className="group gap-0"
+          >
+            {connectLabel}
+            {isLaunching ? (
+              <Loader2 className="ml-2 h-4 w-4 animate-spin" />
+            ) : (
+              <span className="inline-flex overflow-hidden w-0 ml-0 opacity-0 transition-all duration-150 group-hover:w-4 group-hover:ml-2 group-hover:opacity-100 group-focus-visible:w-4 group-focus-visible:ml-2 group-focus-visible:opacity-100">
+                <ArrowUpRight className="h-4 w-4 shrink-0" />
+              </span>
+            )}
+          </Button>
+          {!readOnly && (
+            <Button size="sm" variant="outline" onClick={() => setShowInput(true)}>
+              Add key
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 function formatTimestamp(value: string | null): string {
@@ -56,41 +255,66 @@ export function PlatformTab({ readOnly = false }: PlatformTabProps) {
     )
   }
 
+  const valueClass = 'text-xs text-muted-foreground truncate max-w-[260px]'
+
   return (
     <div className="space-y-6">
-      {/* Status */}
-      <div className="space-y-2">
-        <Label>Status</Label>
-        <p className={`text-sm ${isConnected ? 'text-foreground font-medium' : 'text-muted-foreground'}`}>
-          {isConnected ? 'Connected' : 'Not connected'}
-        </p>
-      </div>
+      {isConnected && (
+        <div className={CARD_CLASS}>
+          <SettingRow
+            name="Email"
+            right={<span className={valueClass}>{data?.email ?? '—'}</span>}
+          />
+          <SettingRow
+            name="Organization"
+            right={<span className={valueClass}>{data?.orgName ?? '—'}</span>}
+          />
+          <SettingRow
+            name="Role"
+            right={<span className={`${valueClass} capitalize`}>{data?.role ?? '—'}</span>}
+          />
+          <SettingRow
+            name="Last updated"
+            right={<span className={valueClass}>{formatTimestamp(data?.updatedAt ?? null)}</span>}
+          />
+          <SettingRow
+            name="Manage your account and organization on the web"
+            right={
+              <Button
+                size="sm"
+                className="group gap-0"
+                onClick={() => {
+                  void handleOpenPlatform()
+                }}
+                disabled={!data?.platformBaseUrl}
+              >
+                Go to Account
+                <span className="inline-flex overflow-hidden w-0 ml-0 opacity-0 transition-all duration-150 group-hover:w-4 group-hover:ml-2 group-hover:opacity-100 group-focus-visible:w-4 group-focus-visible:ml-2 group-focus-visible:opacity-100">
+                  <ArrowUpRight className="h-4 w-4 shrink-0" />
+                </span>
+              </Button>
+            }
+          />
+        </div>
+      )}
 
-      {/* Account */}
-      <div className="space-y-2">
-        <Label>Account</Label>
-        <p className="text-sm">{data?.email ?? '—'}</p>
-      </div>
+      {isConnected ? (
+        <div className={CARD_CLASS}>
+          <ReconnectRow
+            readOnly={readOnly}
+            isLaunching={isLaunching}
+            connectLabel={connectLabel}
+            onReconnect={handleConnect}
+          />
+        </div>
+      ) : (
+        <NotConnectedEmptyState
+          readOnly={readOnly}
+          isLaunching={isLaunching}
+          onConnect={handleConnect}
+        />
+      )}
 
-      {/* Organization */}
-      <div className="space-y-2">
-        <Label>Organization</Label>
-        <p className="text-sm">{data?.orgName ?? '—'}</p>
-      </div>
-
-      {/* Role */}
-      <div className="space-y-2">
-        <Label>Role</Label>
-        <p className="text-sm capitalize">{data?.role ?? '—'}</p>
-      </div>
-
-      {/* Last updated */}
-      <div className="space-y-2">
-        <Label>Last updated</Label>
-        <p className="text-sm">{formatTimestamp(data?.updatedAt ?? null)}</p>
-      </div>
-
-      {/* Feedback */}
       {readOnly && (
         <Alert>
           <AlertDescription>
@@ -104,38 +328,11 @@ export function PlatformTab({ readOnly = false }: PlatformTabProps) {
         </Alert>
       )}
       {error && (
-        <Alert variant="destructive">
-          <AlertDescription>
-            {error}
-            {error.includes('membership') ? ' Create or join an organization in Platform, then try again.' : ''}
-          </AlertDescription>
-        </Alert>
+        <div className="rounded-md bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-950/30 dark:text-red-300">
+          {error}
+          {error.includes('membership') ? ' Create or join an organization in Platform, then try again.' : ''}
+        </div>
       )}
-
-      {/* Actions */}
-      <div className="flex flex-wrap gap-2 pt-2">
-        <Button size="sm" onClick={handleConnect} disabled={readOnly || isLaunching}>
-          {isLaunching ? (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-          ) : isConnected ? (
-            <RefreshCw className="mr-2 h-4 w-4" />
-          ) : (
-            <LogIn className="mr-2 h-4 w-4" />
-          )}
-          {connectLabel}
-        </Button>
-
-        <Button size="sm" variant="outline" onClick={() => { void handleOpenPlatform() }}>
-          <ExternalLink className="mr-2 h-4 w-4" />
-          Open Platform
-        </Button>
-      </div>
-
-      <ManualAccessKeyInput
-        className="pt-1"
-        disabled={readOnly}
-        disabledReason="Manual access keys are disabled while Platform auth is managed by AUTH_MODE."
-      />
     </div>
   )
 }

--- a/src/renderer/components/settings/platform-tab.tsx
+++ b/src/renderer/components/settings/platform-tab.tsx
@@ -35,6 +35,52 @@ function SettingRow({ name, subtitle, right }: SettingRowProps) {
 
 const CARD_CLASS = 'rounded-xl border bg-background divide-y divide-border/50 overflow-hidden'
 
+function HoverArrow() {
+  return (
+    <span className="inline-flex overflow-hidden w-0 ml-0 opacity-0 transition-all duration-150 group-hover:w-4 group-hover:ml-2 group-hover:opacity-100 group-focus-visible:w-4 group-focus-visible:ml-2 group-focus-visible:opacity-100">
+      <ArrowUpRight className="h-4 w-4 shrink-0" />
+    </span>
+  )
+}
+
+function AccessKeyInput({ onClose }: { onClose: () => void }) {
+  const [key, setKey] = useState('')
+  const saveKey = useSavePlatformAccessKey()
+
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <Input
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          placeholder="Paste account key"
+          className="font-mono text-xs h-8 flex-1"
+          autoFocus
+        />
+        <Button
+          size="sm"
+          className="h-8"
+          disabled={!key.trim() || saveKey.isPending}
+          onClick={() => {
+            saveKey.mutate(key.trim(), { onSuccess: onClose })
+          }}
+        >
+          {saveKey.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Submit'}
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-8"
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+      </div>
+      <RequestError message={saveKey.isError ? saveKey.error.message : null} />
+    </>
+  )
+}
+
 interface NotConnectedEmptyStateProps {
   readOnly: boolean
   isLaunching: boolean
@@ -43,8 +89,6 @@ interface NotConnectedEmptyStateProps {
 
 function NotConnectedEmptyState({ readOnly, isLaunching, onConnect }: NotConnectedEmptyStateProps) {
   const [showKeyInput, setShowKeyInput] = useState(false)
-  const [key, setKey] = useState('')
-  const saveKey = useSavePlatformAccessKey()
 
   return (
     <div className="rounded-xl border border-dashed bg-background px-6 py-10">
@@ -56,44 +100,7 @@ function NotConnectedEmptyState({ readOnly, isLaunching, onConnect }: NotConnect
         {!readOnly && (
           <div className="w-full max-w-sm mt-3 space-y-2">
             {showKeyInput ? (
-              <>
-                <div className="flex items-center gap-2">
-                  <Input
-                    value={key}
-                    onChange={(e) => setKey(e.target.value)}
-                    placeholder="Paste account key"
-                    className="font-mono text-xs h-8 flex-1"
-                    autoFocus
-                  />
-                  <Button
-                    size="sm"
-                    className="h-8"
-                    disabled={!key.trim() || saveKey.isPending}
-                    onClick={() => {
-                      saveKey.mutate(key.trim(), {
-                        onSuccess: () => {
-                          setKey('')
-                          setShowKeyInput(false)
-                        },
-                      })
-                    }}
-                  >
-                    {saveKey.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Submit'}
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    className="h-8"
-                    onClick={() => {
-                      setShowKeyInput(false)
-                      setKey('')
-                    }}
-                  >
-                    Cancel
-                  </Button>
-                </div>
-                <RequestError message={saveKey.isError ? saveKey.error.message : null} />
-              </>
+              <AccessKeyInput onClose={() => setShowKeyInput(false)} />
             ) : (
               <div className="flex items-center justify-center gap-2">
                 <Button size="sm" onClick={onConnect} disabled={isLaunching} className="group gap-0">
@@ -101,9 +108,7 @@ function NotConnectedEmptyState({ readOnly, isLaunching, onConnect }: NotConnect
                   {isLaunching ? (
                     <Loader2 className="ml-2 h-4 w-4 animate-spin" />
                   ) : (
-                    <span className="inline-flex overflow-hidden w-0 ml-0 opacity-0 transition-all duration-150 group-hover:w-4 group-hover:ml-2 group-hover:opacity-100 group-focus-visible:w-4 group-focus-visible:ml-2 group-focus-visible:opacity-100">
-                      <ArrowUpRight className="h-4 w-4 shrink-0" />
-                    </span>
+                    <HoverArrow />
                   )}
                 </Button>
                 <Button size="sm" variant="outline" onClick={() => setShowKeyInput(true)}>
@@ -127,48 +132,11 @@ interface ReconnectRowProps {
 
 function ReconnectRow({ readOnly, isLaunching, connectLabel, onReconnect }: ReconnectRowProps) {
   const [showInput, setShowInput] = useState(false)
-  const [key, setKey] = useState('')
-  const saveKey = useSavePlatformAccessKey()
 
   if (showInput) {
     return (
       <div className="py-3 px-4 space-y-2">
-        <div className="flex items-center gap-2">
-          <Input
-            value={key}
-            onChange={(e) => setKey(e.target.value)}
-            placeholder="Paste account key"
-            className="font-mono text-xs h-8 flex-1"
-            autoFocus
-          />
-          <Button
-            size="sm"
-            className="h-8"
-            disabled={!key.trim() || saveKey.isPending}
-            onClick={() => {
-              saveKey.mutate(key.trim(), {
-                onSuccess: () => {
-                  setKey('')
-                  setShowInput(false)
-                },
-              })
-            }}
-          >
-            {saveKey.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Submit'}
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            className="h-8"
-            onClick={() => {
-              setShowInput(false)
-              setKey('')
-            }}
-          >
-            Cancel
-          </Button>
-        </div>
-        <RequestError message={saveKey.isError ? saveKey.error.message : null} />
+        <AccessKeyInput onClose={() => setShowInput(false)} />
       </div>
     )
   }
@@ -194,9 +162,7 @@ function ReconnectRow({ readOnly, isLaunching, connectLabel, onReconnect }: Reco
             {isLaunching ? (
               <Loader2 className="ml-2 h-4 w-4 animate-spin" />
             ) : (
-              <span className="inline-flex overflow-hidden w-0 ml-0 opacity-0 transition-all duration-150 group-hover:w-4 group-hover:ml-2 group-hover:opacity-100 group-focus-visible:w-4 group-focus-visible:ml-2 group-focus-visible:opacity-100">
-                <ArrowUpRight className="h-4 w-4 shrink-0" />
-              </span>
+              <HoverArrow />
             )}
           </Button>
           {!readOnly && (
@@ -289,9 +255,7 @@ export function PlatformTab({ readOnly = false }: PlatformTabProps) {
                 disabled={!data?.platformBaseUrl}
               >
                 Go to Account
-                <span className="inline-flex overflow-hidden w-0 ml-0 opacity-0 transition-all duration-150 group-hover:w-4 group-hover:ml-2 group-hover:opacity-100 group-focus-visible:w-4 group-focus-visible:ml-2 group-focus-visible:opacity-100">
-                  <ArrowUpRight className="h-4 w-4 shrink-0" />
-                </span>
+                <HoverArrow />
               </Button>
             }
           />
@@ -328,10 +292,12 @@ export function PlatformTab({ readOnly = false }: PlatformTabProps) {
         </Alert>
       )}
       {error && (
-        <div className="rounded-md bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-950/30 dark:text-red-300">
-          {error}
-          {error.includes('membership') ? ' Create or join an organization in Platform, then try again.' : ''}
-        </div>
+        <Alert variant="destructive" className="py-2 text-xs">
+          <AlertDescription className="text-xs">
+            {error}
+            {error.includes('membership') ? ' Create or join an organization in Platform, then try again.' : ''}
+          </AlertDescription>
+        </Alert>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

- Restyle the global **Settings → Platform** tab to match the agent-level connections aesthetic introduced for [Notifications](https://github.com/SkillfulAgents/SuperAgent/pull/166) and extended in [General](https://github.com/SkillfulAgents/SuperAgent/pull/167): rows grouped in `rounded-xl` bordered cards, `text-xs` name + `text-[11px]` muted subtitle, right-aligned control. A local `SettingRow` mirrors the agent-level `IntegrationRow` minus the leading service icon.
- Rename the sidebar entry and page title from **"Platform"** → **"Account"** and swap the `Waypoints` icon for `BadgeCheck`. "Platform" was internal brand jargon — "Account" reads coherently to a user landing on the page cold.
- **Connected state**: a single Account card with Email / Organization / Role / Last updated rows (info-only, value rendered muted in the right slot) and a "Manage your account and organization on the web" row with a primary **Go to Account** button (hover-reveal `ArrowUpRight` that slides in via a `w-0 → w-4 ml-0 → ml-2` transition; `gap-0` on the Button defeats the default `gap-1`). Below that, an "Issues? Try reconnecting" row pairs an outline **Reconnect** button (matching hover-reveal arrow) with an outline **Add key** button. Clicking Add key replaces the row contents with an inline access-key form (Input / Submit / Cancel + `RequestError` for failures), reusing `useSavePlatformAccessKey`.
- **Not-connected empty state**: dashed-border card with a `BadgeX` hero, "No Superagent account connected to this workspace" heading, and a **Connect Account** (primary, hover-reveal arrow) + **Add access key** (outline) pair. The same inline access-key form surfaces here on demand — one place to choose between the browser flow and a pre-issued key.
- **Read-only (AUTH_MODE)**: hides the Connect / Add key buttons in the empty state and disables the Reconnect button in the connected state. The existing deployment-managed Alert moves to the bottom of the tab alongside the success message and a borderless red error banner that matches the `RequestError` treatment used by the inline key form.
- The standalone `ManualAccessKeyInput` is no longer used on this page (the wizard still imports it). No changes to `usePlatformConnect` / `useSavePlatformAccessKey` hook contracts or to the underlying auth flow.

Light mode works for free — everything uses semantic tokens (`bg-background`, `border-dashed`, `text-muted-foreground`, `bg-red-50` / `dark:bg-red-950/30`, etc.).

## Test plan

- [ ] Open Settings → Account in dark mode while signed out — confirm the dashed empty-state card renders with the `BadgeX` hero, heading, and Connect Account + Add access key buttons centered.
- [ ] Switch to light mode — verify contrast on the empty-state card, the Connect Account primary button, the outline Add access key button, and the muted heading.
- [ ] Hover (and tab-focus) **Connect Account** — arrow should slide in from `w-0 → w-4` without expanding the button's resting width.
- [ ] Click **Add access key** — the two buttons should be swapped in-place by an Input / Submit / Cancel row. Submit a bad key and confirm the borderless red error banner renders below. Cancel restores the buttons.
- [ ] Successfully connect via the browser flow — confirm the empty state is replaced by the Account card (Email / Organization / Role / Last updated / Go to Account) and the "Issues? Try reconnecting" card below.
- [ ] Hover the **Reconnect** and **Go to Account** buttons — both should reveal the trailing `ArrowUpRight` with the same animation.
- [ ] Click **Add key** in the connected state — the entire Reconnect row contents (title, subtitle, buttons) should be replaced by the inline Input / Submit / Cancel form. Cancel restores the row.
- [ ] In AUTH_MODE: confirm the empty state heading still renders without buttons, the Reconnect button is disabled, and the deployment-managed Alert appears at the bottom of the tab.
- [ ] Trigger a membership-flavored error (or any error) — confirm it lands at the bottom of the tab as a borderless red banner, with the "Create or join an organization in Platform, then try again." suffix when the message includes "membership".

🤖 Generated with [Claude Code](https://claude.com/claude-code)