### PR TITLE
Keep agent working while background Bash commands run

### DIFF
--- a/e2e/specs/background-bash.spec.ts
+++ b/e2e/specs/background-bash.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+
+test.describe('Background Bash Task Tracking', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+  let testAgentName: string
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+
+    testAgentName = `BgBash Agent ${testInfo.workerIndex}-${Date.now()}`
+    await agentPage.createAgent(testAgentName)
+  })
+
+  test('agent stays working during background bash command', async () => {
+    // "run background" triggers BackgroundBashScenario
+    await sessionPage.sendMessage('run background command')
+
+    // Agent should show working status while the background task runs
+    await agentPage.waitForStatus('working', 15000)
+
+    // Activity indicator should be visible
+    const indicator = sessionPage.getActivityIndicator()
+    await expect(indicator).toBeVisible({ timeout: 10000 })
+
+    // Should show background process count
+    await expect(indicator).toContainText('background process', { timeout: 10000 })
+
+    // Wait for the background task to complete and agent to respond
+    // The BackgroundBashScenario has a 2s delay, then the agent processes the notification
+    await sessionPage.waitForInputEnabled(15000)
+
+    // Agent should go back to idle after everything completes
+    await agentPage.waitForStatus('idle', 15000)
+  })
+
+  test('background process indicator disappears after completion', async ({ page }) => {
+    await sessionPage.sendMessage('run background command')
+
+    // Wait for background process indicator to appear
+    const indicator = sessionPage.getActivityIndicator()
+    await expect(indicator).toContainText('background process', { timeout: 10000 })
+
+    // Wait for completion — the indicator should eventually disappear
+    await sessionPage.waitForInputEnabled(15000)
+
+    // Activity indicator should be gone (session is idle)
+    await expect(indicator).not.toBeVisible({ timeout: 10000 })
+  })
+
+  test('agent responds with final output after background task completes', async () => {
+    await sessionPage.sendMessage('run background command')
+
+    // Wait for the full flow to complete
+    await sessionPage.waitForInputEnabled(15000)
+
+    // Should have the final response mentioning the command output
+    await sessionPage.expectAssistantMessage('Background command completed', 1)
+  })
+
+  test('shows both stop and send buttons while waiting for background task', async ({ page }) => {
+    await sessionPage.sendMessage('run background command')
+
+    // Wait for the background process indicator (agent turn ended, bg task pending)
+    const indicator = sessionPage.getActivityIndicator()
+    await expect(indicator).toContainText('background process', { timeout: 10000 })
+
+    // Both stop and send buttons should be visible
+    const stopButton = page.locator('[data-testid="stop-button"]')
+    const sendButton = page.locator('[data-testid="send-button"]')
+    await expect(stopButton).toBeVisible({ timeout: 5000 })
+    await expect(sendButton).toBeVisible({ timeout: 5000 })
+
+    // Wait for completion
+    await sessionPage.waitForInputEnabled(15000)
+  })
+})

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1648,11 +1648,13 @@ agents.get('/:id/sessions/:sessionId/stream', AgentRead(), async (c) => {
           messagePersister.setSlashCommands(sessionId, slashCommands)
         }
       }
+      const backgroundTasks = messagePersister.getActiveBackgroundTasks(sessionId)
       await stream.writeSSE({
         data: JSON.stringify({
           type: 'connected',
           isActive,
           slashCommands: slashCommands.length > 0 ? slashCommands : undefined,
+          backgroundTasks: backgroundTasks.length > 0 ? backgroundTasks : undefined,
         }),
         event: 'message',
       })

--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -24,6 +24,7 @@ const mockStreamState = {
   activeSubagents: [] as any[],
   completedSubagents: null as Set<string> | null,
   slashCommands: [],
+  backgroundTasks: [] as Array<{ taskId: string; startedAt: number }>,
 }
 
 vi.mock('@renderer/hooks/use-message-stream', () => ({
@@ -63,6 +64,7 @@ describe('AgentActivityIndicator', () => {
       pendingRemoteMcpRequests: [],
       pendingBrowserInputRequests: [],
       isCompacting: false,
+      backgroundTasks: [],
     })
     mockMessages.length = 0
   })
@@ -562,5 +564,37 @@ describe('AgentActivityIndicator', () => {
 
     expect(screen.getByText('New task item')).toBeInTheDocument()
     expect(screen.queryByText('Old todo item')).not.toBeInTheDocument()
+  })
+
+  it('shows background process count when background tasks are running', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockStreamState.backgroundTasks = [
+      { taskId: 'bg-1', startedAt: Date.now() - 5000 },
+    ]
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+    expect(screen.getByText('1 background process')).toBeInTheDocument()
+  })
+
+  it('shows plural "processes" for multiple background tasks', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockStreamState.backgroundTasks = [
+      { taskId: 'bg-1', startedAt: Date.now() - 5000 },
+      { taskId: 'bg-2', startedAt: Date.now() - 3000 },
+    ]
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+    expect(screen.getByText('2 background processes')).toBeInTheDocument()
+  })
+
+  it('does not show background section when no background tasks', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockStreamState.backgroundTasks = []
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+    expect(screen.queryByText(/background process/)).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -25,7 +25,7 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
     isActive, error, apiErrorCode, activeStartTime, isCompacting, activeSubagents, completedSubagents,
     pendingSecretRequests, pendingConnectedAccountRequests, pendingQuestionRequests,
     pendingFileRequests, pendingRemoteMcpRequests, pendingBrowserInputRequests,
-    apiRetry, computerUseApp, computerUseAppIcon,
+    apiRetry, computerUseApp, computerUseAppIcon, backgroundTasks,
   } = useMessageStream(sessionId, agentSlug)
 
   const [revoking, setRevoking] = useState(false)
@@ -274,6 +274,11 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
           </ul>
         )}
 
+        {/* Active background processes */}
+        {backgroundTasks.length > 0 && (
+          <BackgroundTasksSection tasks={backgroundTasks} />
+        )}
+
         {/* Todo list if available and at least one item is not completed */}
         {todos && todos.length > 0 && todos.some((t) => t.status !== 'completed') && (() => {
           const MAX_VISIBLE = 5
@@ -346,6 +351,27 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
             </ul>
           )
         })()}
+      </div>
+    </div>
+  )
+}
+
+function BackgroundTasksSection({ tasks }: { tasks: Array<{ taskId: string; startedAt: number }> }) {
+  const earliest = Math.min(...tasks.map(t => t.startedAt))
+  const elapsed = useElapsedTimer(new Date(earliest))
+  return (
+    <div className="mt-2 text-sm pl-5">
+      <div className="flex items-center gap-2">
+        <span className="relative flex h-2 w-2 shrink-0">
+          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
+          <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {tasks.length} background {tasks.length === 1 ? 'process' : 'processes'}
+        </span>
+        {elapsed && (
+          <span className="text-xs text-muted-foreground tabular-nums">{elapsed}</span>
+        )}
       </div>
     </div>
   )

--- a/src/renderer/components/messages/composer-action-button.test.tsx
+++ b/src/renderer/components/messages/composer-action-button.test.tsx
@@ -7,6 +7,7 @@ import { ComposerActionButton } from './composer-action-button'
 describe('ComposerActionButton', () => {
   const baseProps = {
     isActive: false,
+    isWaitingBackground: false,
     canSubmit: true,
     isSending: false,
     isInterrupting: false,
@@ -46,5 +47,24 @@ describe('ComposerActionButton', () => {
   it('disables the stop button while interrupting', () => {
     render(<ComposerActionButton {...baseProps} isActive isInterrupting />)
     expect(screen.getByTestId('stop-button')).toBeDisabled()
+  })
+
+  it('shows both stop and send buttons when waiting for background tasks', () => {
+    render(<ComposerActionButton {...baseProps} isActive isWaitingBackground />)
+    expect(screen.getByTestId('stop-button')).toBeInTheDocument()
+    expect(screen.getByTestId('send-button')).toBeInTheDocument()
+  })
+
+  it('send button is enabled when waiting for background with canSubmit', () => {
+    render(<ComposerActionButton {...baseProps} isActive isWaitingBackground canSubmit />)
+    expect(screen.getByTestId('send-button')).not.toBeDisabled()
+  })
+
+  it('stop button calls onInterrupt when waiting for background', async () => {
+    const onInterrupt = vi.fn()
+    const user = userEvent.setup()
+    render(<ComposerActionButton {...baseProps} isActive isWaitingBackground onInterrupt={onInterrupt} />)
+    await user.click(screen.getByTestId('stop-button'))
+    expect(onInterrupt).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/components/messages/composer-action-button.tsx
+++ b/src/renderer/components/messages/composer-action-button.tsx
@@ -3,6 +3,7 @@ import { Button } from '@renderer/components/ui/button'
 
 interface ComposerActionButtonProps {
   isActive: boolean
+  isWaitingBackground: boolean
   canSubmit: boolean
   isSending: boolean
   isInterrupting: boolean
@@ -11,11 +12,51 @@ interface ComposerActionButtonProps {
 
 export function ComposerActionButton({
   isActive,
+  isWaitingBackground,
   canSubmit,
   isSending,
   isInterrupting,
   onInterrupt,
 }: ComposerActionButtonProps) {
+  if (isWaitingBackground) {
+    return (
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          className="h-[34px] w-[34px]"
+          onClick={onInterrupt}
+          disabled={isInterrupting}
+          aria-label="Stop background processes"
+          title="Stop background processes"
+          data-testid="stop-button"
+        >
+          {isInterrupting ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Square className="h-3.5 w-3.5 fill-current" />
+          )}
+        </Button>
+        <Button
+          type="submit"
+          size="icon"
+          className="h-[34px] w-[34px]"
+          disabled={!canSubmit || isSending}
+          aria-label="Send message"
+          title="Send message"
+          data-testid="send-button"
+        >
+          {isSending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <ArrowUp className="h-4 w-4" />
+          )}
+        </Button>
+      </div>
+    )
+  }
+
   if (isActive) {
     return (
       <Button

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -40,7 +40,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, initialEffor
   const uploadFile = useUploadFile()
   const uploadFolder = useUploadFolder()
   const interruptSession = useInterruptSession()
-  const { isActive, slashCommands } = useMessageStream(sessionId, agentSlug)
+  const { isActive, slashCommands, isWaitingBackground } = useMessageStream(sessionId, agentSlug)
   const isOnline = useIsOnline()
   const isOffline = !isOnline
   const { track } = useAnalyticsTracking()
@@ -60,7 +60,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, initialEffor
       await sendMessage.mutateAsync({ sessionId, agentSlug, content, ...composerOptions.toRuntimeOptions() })
       track('message_sent')
     }, [onMessageSent, sendMessage, sessionId, agentSlug, track, composerOptions]),
-    submitDisabled: sendMessage.isPending || isActive || isOffline,
+    submitDisabled: sendMessage.isPending || (isActive && !isWaitingBackground) || isOffline,
     draftKey: `session:${sessionId}`,
   })
 
@@ -222,6 +222,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, initialEffor
             />
             <ComposerActionButton
               isActive={isActive}
+              isWaitingBackground={isWaitingBackground}
               canSubmit={composer.canSubmit}
               isSending={sendMessage.isPending || composer.isUploading}
               isInterrupting={interruptSession.isPending}

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -2206,4 +2206,228 @@ describe('useMessageStream', () => {
     const sub = result.current.activeSubagents.find(s => s.parentToolId === 'pt-1')
     expect(sub?.resultText).toBeNull()
   })
+
+  // ============================================================================
+  // Background Bash task events
+  // ============================================================================
+
+  it('tracks background tasks from SSE events', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+    })
+
+    expect(result.current.backgroundTasks).toEqual([])
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'background_task_started',
+        taskId: 'bg-1',
+        startedAt: 1000,
+      })
+    })
+
+    expect(result.current.backgroundTasks).toEqual([{ taskId: 'bg-1', startedAt: 1000 }])
+
+    // Add second task
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'background_task_started',
+        taskId: 'bg-2',
+        startedAt: 2000,
+      })
+    })
+
+    expect(result.current.backgroundTasks).toHaveLength(2)
+
+    // Complete first task
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'background_task_completed',
+        taskId: 'bg-1',
+      })
+    })
+
+    expect(result.current.backgroundTasks).toEqual([{ taskId: 'bg-2', startedAt: 2000 }])
+  })
+
+  it('restores background tasks from connected event', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'connected',
+        isActive: true,
+        backgroundTasks: [{ taskId: 'bg-restore', startedAt: 500 }],
+      })
+    })
+
+    expect(result.current.backgroundTasks).toEqual([{ taskId: 'bg-restore', startedAt: 500 }])
+  })
+
+  it('clears background tasks on session_idle', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+    })
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'background_task_started',
+        taskId: 'bg-1',
+        startedAt: 1000,
+      })
+    })
+
+    expect(result.current.backgroundTasks).toHaveLength(1)
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'session_idle' })
+    })
+
+    expect(result.current.backgroundTasks).toEqual([])
+  })
+
+  it('preserves background tasks across session_active', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+    })
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'background_task_started',
+        taskId: 'bg-1',
+        startedAt: 1000,
+      })
+    })
+
+    expect(result.current.backgroundTasks).toHaveLength(1)
+
+    // New turn starts — background tasks should be preserved
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'session_active' })
+    })
+
+    expect(result.current.backgroundTasks).toEqual([{ taskId: 'bg-1', startedAt: 1000 }])
+  })
+
+  it('sets isWaitingBackground on session_waiting_background event', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+    })
+
+    expect(result.current.isWaitingBackground).toBe(false)
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'session_waiting_background',
+        backgroundTaskCount: 1,
+      })
+    })
+
+    expect(result.current.isWaitingBackground).toBe(true)
+    expect(result.current.isActive).toBe(true)
+  })
+
+  it('clears isWaitingBackground on session_active', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+    })
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'session_waiting_background' })
+    })
+
+    expect(result.current.isWaitingBackground).toBe(true)
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'session_active' })
+    })
+
+    expect(result.current.isWaitingBackground).toBe(false)
+  })
+
+  it('clears isWaitingBackground on stream_start (new turn)', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+    })
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'session_waiting_background' })
+    })
+
+    expect(result.current.isWaitingBackground).toBe(true)
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'stream_start' })
+    })
+
+    expect(result.current.isWaitingBackground).toBe(false)
+  })
+
+  it('restores isWaitingBackground from connected event with backgroundTasks', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'connected',
+        isActive: true,
+        backgroundTasks: [{ taskId: 'bg-1', startedAt: 500 }],
+      })
+    })
+
+    expect(result.current.isWaitingBackground).toBe(true)
+  })
+
+  it('does not set isWaitingBackground from connected event without backgroundTasks', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+    })
+
+    expect(result.current.isWaitingBackground).toBe(false)
+  })
 })

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -109,6 +109,8 @@ interface StreamState {
   typingUser: { id: string; name?: string } | null // User currently typing (auth mode shared agents)
   peerUserMessage: { content: string; sender: { id: string; name?: string; email?: string } } | null // User message from another user
   apiRetry: ApiRetryInfo | null // Non-null while API is retrying a transient error
+  backgroundTasks: Array<{ taskId: string; startedAt: number }> // Active background Bash commands
+  isWaitingBackground: boolean // True when agent turn ended but background tasks are still running
 }
 
 // Upsert a subagent entry in the array by parentToolId (immutable)
@@ -149,6 +151,8 @@ const EMPTY_STREAM_STATE: StreamState = {
   typingUser: null,
   peerUserMessage: null,
   apiRetry: null,
+  backgroundTasks: [],
+  isWaitingBackground: false,
 }
 
 const streamStates = new Map<string, StreamState>()
@@ -230,6 +234,8 @@ function getOrCreateEventSource(
           typingUser: current?.typingUser ?? null,
           peerUserMessage: current?.peerUserMessage ?? null,
           apiRetry: current?.apiRetry ?? null,
+          backgroundTasks: Array.isArray(data.backgroundTasks) ? data.backgroundTasks : (current?.backgroundTasks ?? []),
+          isWaitingBackground: Array.isArray(data.backgroundTasks) && data.backgroundTasks.length > 0,
         })
         // Fetch current browser status to sync state (handles missed events)
         fetch(`${baseUrl}/api/agents/${agentSlug}/browser/status`)
@@ -274,6 +280,8 @@ function getOrCreateEventSource(
           typingUser: null,
           peerUserMessage: current?.peerUserMessage ?? null,
           apiRetry: null,
+          backgroundTasks: current?.backgroundTasks ?? [],
+          isWaitingBackground: false,
         })
         queryClient.invalidateQueries({ queryKey: ['sessions'] })
       }
@@ -315,9 +323,17 @@ function getOrCreateEventSource(
           typingUser: null,
           peerUserMessage: current?.peerUserMessage ?? null,
           apiRetry: current?.apiRetry ?? null,
+          backgroundTasks: [],
+          isWaitingBackground: false,
         })
         queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
         queryClient.invalidateQueries({ queryKey: ['sessions'] })
+      }
+      // Agent turn ended but background tasks are still running — allow sending messages
+      else if (data.type === 'session_waiting_background') {
+        if (current) {
+          streamStates.set(sessionId, { ...current, isWaitingBackground: true })
+        }
       }
       else if (data.type === 'session_error') {
         // Session encountered an error
@@ -349,9 +365,29 @@ function getOrCreateEventSource(
           typingUser: null,
           peerUserMessage: current?.peerUserMessage ?? null,
           apiRetry: current?.apiRetry ?? null,
+          backgroundTasks: [],
+          isWaitingBackground: false,
         })
         queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
         queryClient.invalidateQueries({ queryKey: ['sessions'] })
+      }
+      // Background Bash task events
+      else if (data.type === 'background_task_started') {
+        if (current) {
+          const existing = current.backgroundTasks.filter(t => t.taskId !== data.taskId)
+          streamStates.set(sessionId, {
+            ...current,
+            backgroundTasks: [...existing, { taskId: data.taskId, startedAt: data.startedAt }],
+          })
+        }
+      }
+      else if (data.type === 'background_task_completed') {
+        if (current) {
+          streamStates.set(sessionId, {
+            ...current,
+            backgroundTasks: current.backgroundTasks.filter(t => t.taskId !== data.taskId),
+          })
+        }
       }
       // Streaming events - update streaming state, preserve isActive
       else if (data.type === 'stream_start') {
@@ -390,6 +426,8 @@ function getOrCreateEventSource(
           typingUser: current?.typingUser ?? null,
           peerUserMessage: current?.peerUserMessage ?? null,
           apiRetry: null, // Clear retry state — API call succeeded
+          backgroundTasks: current?.backgroundTasks ?? [],
+          isWaitingBackground: false,
         })
       }
       else if (data.type === 'stream_delta') {
@@ -419,6 +457,8 @@ function getOrCreateEventSource(
           typingUser: current?.typingUser ?? null,
           peerUserMessage: current?.peerUserMessage ?? null,
           apiRetry: current?.apiRetry ?? null,
+          backgroundTasks: current?.backgroundTasks ?? [],
+          isWaitingBackground: current?.isWaitingBackground ?? false,
         })
       }
       else if (data.type === 'stream_api_error') {
@@ -464,6 +504,8 @@ function getOrCreateEventSource(
           typingUser: current?.typingUser ?? null,
           peerUserMessage: current?.peerUserMessage ?? null,
           apiRetry: current?.apiRetry ?? null,
+          backgroundTasks: current?.backgroundTasks ?? [],
+          isWaitingBackground: current?.isWaitingBackground ?? false,
         })
       }
       else if (data.type === 'tool_use_ready') {
@@ -503,6 +545,8 @@ function getOrCreateEventSource(
           typingUser: current?.typingUser ?? null,
           peerUserMessage: current?.peerUserMessage ?? null,
           apiRetry: current?.apiRetry ?? null,
+          backgroundTasks: current?.backgroundTasks ?? [],
+          isWaitingBackground: current?.isWaitingBackground ?? false,
         })
       }
       else if (data.type === 'user_message') {

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -2994,4 +2994,245 @@ describe('MessagePersister', () => {
       expect(subscribeSpy).toHaveBeenCalledTimes(1)
     })
   })
+
+  // ============================================================================
+  // Background Bash task tracking
+  // ============================================================================
+
+  describe('background Bash task tracking', () => {
+    it('detects backgroundTaskId from tool_use_result and broadcasts start event', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      sseEvents.length = 0
+
+      mockClient._sendMessage({
+        type: 'user',
+        tool_use_result: { backgroundTaskId: 'abc123' },
+        message: {
+          content: [{
+            type: 'tool_result',
+            tool_use_id: 'tool-bash-1',
+            content: 'Command running in background with ID: abc123.',
+          }],
+        },
+      })
+
+      const startEvents = sseEvents.filter(e => e.type === 'background_task_started')
+      expect(startEvents).toHaveLength(1)
+      expect(startEvents[0].taskId).toBe('abc123')
+      expect(startEvents[0].startedAt).toBeTypeOf('number')
+    })
+
+    it('keeps isActive true when result arrives with pending background tasks', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+
+      // Inject a background task
+      mockClient._sendMessage({
+        type: 'user',
+        tool_use_result: { backgroundTaskId: 'bg-1' },
+        message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running in background' }] },
+      })
+
+      // Agent turn ends
+      mockClient._sendMessage({
+        type: 'result',
+        subtype: 'success',
+      })
+
+      // Session should still be active
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+    })
+
+    it('broadcasts session_waiting_background instead of session_idle when bg tasks pending', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+
+      mockClient._sendMessage({
+        type: 'user',
+        tool_use_result: { backgroundTaskId: 'bg-1' },
+        message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
+      })
+
+      sseEvents.length = 0
+
+      mockClient._sendMessage({
+        type: 'result',
+        subtype: 'success',
+      })
+
+      const waitingEvents = sseEvents.filter(e => e.type === 'session_waiting_background')
+      expect(waitingEvents).toHaveLength(1)
+      expect(waitingEvents[0].backgroundTaskCount).toBe(1)
+
+      // Should NOT have session_idle
+      expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(0)
+    })
+
+    it('clears background task on system task-completion and goes idle', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+
+      // Start background task
+      mockClient._sendMessage({
+        type: 'user',
+        tool_use_result: { backgroundTaskId: 'bg-1' },
+        message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
+      })
+
+      // Agent turn ends (stays active due to bg task)
+      mockClient._sendMessage({
+        type: 'result',
+        subtype: 'success',
+      })
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+
+      sseEvents.length = 0
+
+      // SDK delivers task completion as a system message with task_id and status
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'task_completed',
+        task_id: 'bg-1',
+        tool_use_id: 'tool-1',
+        status: 'completed',
+        summary: 'Background command completed (exit code 0)',
+      })
+
+      const completedEvents = sseEvents.filter(e => e.type === 'background_task_completed')
+      expect(completedEvents).toHaveLength(1)
+      expect(completedEvents[0].taskId).toBe('bg-1')
+
+      // Now when the next result arrives, session should go idle
+      mockClient._sendMessage({
+        type: 'result',
+        subtype: 'success',
+      })
+
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
+    })
+
+    it('tracks multiple concurrent background tasks', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+
+      mockClient._sendMessage({
+        type: 'user',
+        tool_use_result: { backgroundTaskId: 'bg-1' },
+        message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
+      })
+      mockClient._sendMessage({
+        type: 'user',
+        tool_use_result: { backgroundTaskId: 'bg-2' },
+        message: { content: [{ type: 'tool_result', tool_use_id: 'tool-2', content: 'Running' }] },
+      })
+
+      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(2)
+
+      // Complete first task via system message
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'task_completed',
+        task_id: 'bg-1',
+        status: 'completed',
+      })
+
+      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
+      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)[0].taskId).toBe('bg-2')
+    })
+
+    it('clears background tasks on session interrupt', async () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+
+      mockClient._sendMessage({
+        type: 'user',
+        tool_use_result: { backgroundTaskId: 'bg-1' },
+        message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
+      })
+
+      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
+
+      await messagePersister.markSessionInterrupted(SESSION_ID)
+
+      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(0)
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+    })
+
+    it('does not duplicate background task on repeated tool_use_result', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+
+      // Same backgroundTaskId twice
+      mockClient._sendMessage({
+        type: 'user',
+        tool_use_result: { backgroundTaskId: 'bg-dup' },
+        message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
+      })
+      mockClient._sendMessage({
+        type: 'user',
+        tool_use_result: { backgroundTaskId: 'bg-dup' },
+        message: { content: [{ type: 'tool_result', tool_use_id: 'tool-2', content: 'Running' }] },
+      })
+
+      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
+    })
+
+    it('preserves background tasks across re-subscribe', async () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+
+      mockClient._sendMessage({
+        type: 'user',
+        tool_use_result: { backgroundTaskId: 'bg-persist' },
+        message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
+      })
+
+      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
+
+      // Re-subscribe (simulates reconnection)
+      const newClient = createMockClient()
+      await messagePersister.subscribeToSession(SESSION_ID, newClient, SESSION_ID, AGENT_SLUG)
+
+      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+
+      // Clean up the new subscription
+      messagePersister.unsubscribeFromSession(SESSION_ID)
+    })
+
+    it('returns empty array for unknown session', () => {
+      expect(messagePersister.getActiveBackgroundTasks('nonexistent')).toEqual([])
+    })
+
+    it('ignores system messages with task_id that do not match active bg tasks', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+
+      mockClient._sendMessage({
+        type: 'user',
+        tool_use_result: { backgroundTaskId: 'bg-real' },
+        message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
+      })
+
+      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
+
+      // System message with non-matching task_id
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'task_completed',
+        task_id: 'bg-nonexistent',
+        status: 'completed',
+      })
+
+      // Should NOT have cleared our task
+      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
+    })
+
+    it('also detects snake_case background_task_id', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      sseEvents.length = 0
+
+      mockClient._sendMessage({
+        type: 'user',
+        tool_use_result: { background_task_id: 'snake-1' },
+        message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
+      })
+
+      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
+      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)[0].taskId).toBe('snake-1')
+    })
+  })
 })

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -63,6 +63,7 @@ interface StreamingState {
   isAwaitingInput: boolean // True when session is waiting for user input (e.g., secret, file, question)
   pendingComputerUseRequests: Map<string, { toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string; agentSlug?: string }> // Pending computer use requests awaiting user approval (keyed by toolUseId)
   lastApiErrorCode: string | null // SDK error code from last assistant message (e.g., 'authentication_failed', 'rate_limit')
+  activeBackgroundTasks: Map<string, { startedAt: number }> // Background Bash commands still running (keyed by task ID)
 }
 
 // Lazy import to break circular dependency: container-manager -> message-persister
@@ -128,6 +129,7 @@ class MessagePersister {
     const prior = this.streamingStates.get(sessionId)
     const priorIsActive = prior?.isActive ?? false
     const priorIsAwaitingInput = prior?.isAwaitingInput ?? false
+    const priorBackgroundTasks = prior?.activeBackgroundTasks ?? new Map()
 
     // Unsubscribe if already subscribed (this also clears state, which is why
     // we captured the flags above)
@@ -151,6 +153,7 @@ class MessagePersister {
       isAwaitingInput: priorIsAwaitingInput,
       pendingComputerUseRequests: new Map(),
       lastApiErrorCode: null,
+      activeBackgroundTasks: priorBackgroundTasks,
     })
 
     // Store container client for reconnection checks
@@ -310,6 +313,15 @@ class MessagePersister {
     }
   }
 
+  getActiveBackgroundTasks(sessionId: string): Array<{ taskId: string; startedAt: number }> {
+    const state = this.streamingStates.get(sessionId)
+    if (!state) return []
+    return Array.from(state.activeBackgroundTasks.entries()).map(([taskId, info]) => ({
+      taskId,
+      startedAt: info.startedAt,
+    }))
+  }
+
   // Check if a session has an active subscription
   isSubscribed(sessionId: string): boolean {
     return this.subscriptions.has(sessionId)
@@ -420,6 +432,7 @@ class MessagePersister {
       state.currentToolUse = null
       state.currentToolInput = ''
       state.activeSubagents.clear()
+      state.activeBackgroundTasks.clear()
     }
 
     // Broadcast to session-specific clients
@@ -480,6 +493,7 @@ class MessagePersister {
         isAwaitingInput: false,
         pendingComputerUseRequests: new Map(),
         lastApiErrorCode: null,
+        activeBackgroundTasks: new Map(),
       }
       this.streamingStates.set(sessionId, state)
       if (this.capture && agentSlug) {
@@ -585,6 +599,18 @@ class MessagePersister {
 
     const content = message.content
 
+    // Detect background task completion from system messages BEFORE the sidechain
+    // filter. The SDK delivers task completions as system events with task_id and
+    // status fields, not as user messages.
+    if (content.type === 'system' && state.activeBackgroundTasks.size > 0) {
+      const taskId = content.task_id as string | undefined
+      if (taskId && content.status && state.activeBackgroundTasks.has(taskId)) {
+        state.activeBackgroundTasks.delete(taskId)
+        this.broadcastToSSE(sessionId, { type: 'background_task_completed', taskId })
+        this.broadcastGlobal({ type: 'background_task_completed', sessionId, agentSlug: state.agentSlug, taskId })
+      }
+    }
+
     // Filter sidechain (subagent) messages — they should not affect main streaming state
     // SDK emitted format uses parent_tool_use_id (non-null for subagent messages)
     if (content.parent_tool_use_id != null) {
@@ -670,6 +696,27 @@ class MessagePersister {
                 }
               }
             }
+          }
+        }
+
+        // Detect background Bash task from tool_use_result metadata
+        {
+          const tur = content.tool_use_result as Record<string, unknown> | undefined
+          const bgId = (tur?.backgroundTaskId ?? tur?.background_task_id) as string | undefined
+          if (bgId && typeof bgId === 'string' && !state.activeBackgroundTasks.has(bgId)) {
+            const startedAt = Date.now()
+            state.activeBackgroundTasks.set(bgId, { startedAt })
+            this.broadcastToSSE(sessionId, {
+              type: 'background_task_started',
+              taskId: bgId,
+              startedAt,
+            })
+            this.broadcastGlobal({
+              type: 'background_task_started',
+              sessionId,
+              agentSlug: state.agentSlug,
+              taskId: bgId,
+            })
           }
         }
 
@@ -787,14 +834,26 @@ class MessagePersister {
         break
 
       case 'result': {
-        // Query completed - session is no longer active
+        // Query completed
         state.isStreaming = false
-        state.isActive = false
         state.isAwaitingInput = false
         state.currentText = ''
 
         // Extract and persist context usage from result event
         this.handleResultUsage(sessionId, state, content)
+
+        // If background tasks are still running, keep the session active so
+        // the UI stays in "working" state and auto-sleep is prevented.
+        if (state.activeBackgroundTasks.size > 0) {
+          this.broadcastToSSE(sessionId, {
+            type: 'session_waiting_background',
+            backgroundTaskCount: state.activeBackgroundTasks.size,
+          })
+          break
+        }
+
+        // No pending background tasks — session is no longer active
+        state.isActive = false
 
         // Check if this is an error result
         if (content.subtype === 'error_during_execution' || content.subtype === 'error') {
@@ -924,6 +983,7 @@ class MessagePersister {
     state.currentToolUse = null
     state.currentToolInput = ''
     state.activeSubagents.clear()
+    state.activeBackgroundTasks.clear()
     this.broadcastToSSE(sessionId, { type: 'session_idle', isActive: false })
     this.broadcastGlobal({
       type: 'session_idle',

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -684,6 +684,231 @@ export class XAgentReviewScenario implements MockScenario {
 }
 
 /**
+ * Background Bash scenario — simulates a Bash tool call with run_in_background: true.
+ * The SDK returns an immediate tool result with backgroundTaskId, the agent finishes
+ * its turn, then after a delay a task-notification arrives and the agent responds.
+ */
+export class BackgroundBashScenario implements MockScenario {
+  constructor(
+    private delayMs: number = 2000,
+    private commandOutput: string = 'done sleeping',
+  ) {}
+
+  execute(sessionId: string, client: MockContainerClient, userMessage: string): void {
+    let delay = 10
+    const toolId = `tool_bash_${Date.now()}`
+    const bgTaskId = `bg_${Date.now().toString(36)}`
+
+    // Start assistant message
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'message_start' } },
+      })
+    }, delay)
+    delay += 10
+
+    // Tool use start: Bash
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_start',
+            content_block: { type: 'tool_use', id: toolId, name: 'Bash' },
+          },
+        },
+      })
+    }, delay)
+    delay += 10
+
+    // Tool input delta
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            delta: { type: 'input_json_delta', partial_json: JSON.stringify({ command: 'sleep 10 && echo done', run_in_background: true }) },
+          },
+        },
+      })
+    }, delay)
+    delay += 20
+
+    // Tool use stop
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_stop' } },
+      })
+    }, delay)
+    delay += 10
+
+    // Tool result with backgroundTaskId
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'user',
+        content: {
+          type: 'user',
+          tool_use_result: { backgroundTaskId: bgTaskId, stdout: '', stderr: '', interrupted: false, isImage: false },
+          message: {
+            content: [{
+              type: 'tool_result',
+              tool_use_id: toolId,
+              content: `Command running in background with ID: ${bgTaskId}. Output is being written to: /tmp/tasks/${bgTaskId}.output.`,
+            }],
+          },
+        },
+      })
+    }, delay)
+    delay += 20
+
+    // Agent streams a text response
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'text' } } },
+      })
+    }, delay)
+    delay += 10
+
+    const responseText = `Started background task ${bgTaskId}.`
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: responseText } } },
+      })
+    }, delay)
+    delay += 10
+
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_stop' } },
+      })
+    }, delay)
+    delay += 10
+
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'message_stop' } },
+      })
+    }, delay)
+    delay += 10
+
+    // Write JSONL and emit result (agent turn ends, but bg task is still running)
+    const firstResultDelay = delay
+    setTimeout(() => {
+      client.writeJsonlEntry(sessionId, {
+        type: 'user',
+        message: { content: userMessage },
+        timestamp: new Date().toISOString(),
+      })
+      client.writeJsonlEntry(sessionId, {
+        type: 'assistant',
+        message: { content: [
+          { type: 'tool_use', id: toolId, name: 'Bash', input: { command: 'sleep 10 && echo done', run_in_background: true } },
+          { type: 'text', text: responseText },
+        ] },
+        timestamp: new Date().toISOString(),
+      })
+      client.writeJsonlEntry(sessionId, {
+        type: 'user',
+        toolUseResult: { backgroundTaskId: bgTaskId, stdout: '', stderr: '', interrupted: false, isImage: false },
+        message: { content: [{ type: 'tool_result', tool_use_id: toolId, content: `Command running in background with ID: ${bgTaskId}.` }] },
+        timestamp: new Date().toISOString(),
+      })
+
+      client.emitStreamMessage(sessionId, {
+        type: 'result',
+        content: { type: 'result', subtype: 'success' },
+      })
+    }, firstResultDelay)
+
+    // After delay, task-notification arrives (background command finished)
+    // The SDK delivers this as a system message with task_id and status fields.
+    const notificationDelay = firstResultDelay + this.delayMs
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'system',
+        content: {
+          type: 'system',
+          subtype: 'task_completed',
+          task_id: bgTaskId,
+          tool_use_id: toolId,
+          status: 'completed',
+          output_file: `/tmp/tasks/${bgTaskId}.output`,
+          summary: 'Background command completed (exit code 0)',
+          session_id: sessionId,
+        },
+      })
+    }, notificationDelay)
+
+    // Agent processes the notification — reads the output and responds
+    const finalDelay = notificationDelay + 50
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'message_start' } },
+      })
+    }, finalDelay)
+
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'text' } } },
+      })
+    }, finalDelay + 10)
+
+    const finalText = `Background command completed. Output: ${this.commandOutput}`
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: finalText } } },
+      })
+    }, finalDelay + 20)
+
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_stop' } },
+      })
+    }, finalDelay + 30)
+
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'message_stop' } },
+      })
+    }, finalDelay + 40)
+
+    // Write JSONL and final result
+    setTimeout(() => {
+      client.writeJsonlEntry(sessionId, {
+        type: 'user',
+        origin: { kind: 'task-notification' },
+        message: { content: `<task-notification>\n<task-id>${bgTaskId}</task-id>\n<status>completed</status>\n</task-notification>` },
+        timestamp: new Date().toISOString(),
+      })
+      client.writeJsonlEntry(sessionId, {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: finalText }] },
+        timestamp: new Date().toISOString(),
+      })
+
+      client.emitStreamMessage(sessionId, {
+        type: 'result',
+        content: { type: 'result', subtype: 'success' },
+      })
+    }, finalDelay + 50)
+  }
+}
+
+/**
  * Mock implementation of ContainerClient for E2E testing.
  * Simulates container behavior without requiring Docker/Podman.
  */
@@ -709,6 +934,8 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
       'file1.txt\nfile2.txt\nfolder/',
       'I found the following files in the current directory.'
     )],
+    // Register a background bash scenario for testing background task tracking
+    ['run background', new BackgroundBashScenario(2000, 'done sleeping')],
     // Register a slow response scenario for cross-session tests
     ['slow response', new DelayedTextResponseScenario(
       'This is a delayed mock response.',

--- a/src/shared/lib/types/agent.ts
+++ b/src/shared/lib/types/agent.ts
@@ -152,6 +152,7 @@ export interface JsonlMessageEntry {
     stderr: string
     interrupted: boolean
     isImage: boolean
+    backgroundTaskId?: string
     // Subagent-specific (present only on Task tool results)
     agentId?: string
     status?: string


### PR DESCRIPTION
## Summary
- When Claude calls `Bash` with `run_in_background: true`, the agent now stays in "working" state with a background process indicator and elapsed timer until the command completes
- During the background wait, both stop and send buttons are shown — stop cancels the background processes, send lets the user queue a new message
- Auto-sleep is prevented while background tasks are pending
- Background task state survives SSE reconnection

## How it works
- **Detection**: `backgroundTaskId` from `tool_use_result` metadata on Bash tool results
- **Completion**: SDK delivers task completions as `system` messages with `task_id` + `status` fields (not user messages); detected before the sidechain filter
- **State**: `isActive` stays `true` while `activeBackgroundTasks` is non-empty; `isWaitingBackground` flag enables message input during the wait
- **Cleanup**: Background tasks cleared on interrupt, disconnect, and session teardown

## Test plan
- [ ] 12 message-persister unit tests (detection, keepalive, completion, multi-task, interrupt, dedup, reconnect, snake_case)
- [ ] 9 use-message-stream hook tests (task lifecycle, isWaitingBackground set/clear on 5 event types, connected restore)
- [ ] 3 activity indicator component tests (singular/plural/empty)
- [ ] 3 composer button tests (both-buttons visible, send enabled, stop clickable)
- [ ] 4 E2E tests with BackgroundBashScenario (working-during-wait, indicator-disappears, final-output, both-buttons-visible)
- [ ] Manual test: send a background bash command, verify working indicator shows, both buttons appear, agent goes idle after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)