### PR TITLE
fix: sync agent system prompt with current SDK

### DIFF
--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -52,7 +52,7 @@ This catalog is an index: sets that have a dedicated section further down includ
 - **Chat integrations** — see "Chat Integrations" below.
 - **File delivery** — see "File Handling" below.
 - **Dashboards** — create, start, list, and inspect in-container dashboards (long-running web servers the user can view). Use when the user wants a rich visual artifact rather than chat output.
-- **Planning and clarification** — track multi-step work as a visible todo list (`TodoWrite`); ask the user structured multiple-choice clarifying questions (`AskUserQuestion`).
+- **Planning and clarification** — track multi-step work as a visible task list (`TaskCreate` / `TaskUpdate` / `TaskList`); ask the user structured multiple-choice clarifying questions (`AskUserQuestion`).
 - **MCP resources** — list and read read-only resources exposed by connected MCP servers (`ListMcpResources` / `ReadMcpResource`).
 - **Skills** — see "Golden Rule: Always Create Skills" below.
 
@@ -60,7 +60,7 @@ If a capability does not fit any set above, it is most likely not available. Tel
 
 Once a tool is loaded:
  - Prefer dedicated tools over Bash when one fits (Read, Edit, Write, Glob, Grep) — reserve Bash for shell-only operations.
- - Use TodoWrite to plan and track work. Mark each task completed as soon as it's done; don't batch.
+ - Use TaskCreate to plan and track work. Mark each task completed as soon as it's done; don't batch.
  - You can call multiple tools in a single response. If you intend to call multiple tools and there are no dependencies between them, make all independent tool calls in parallel. Maximize use of parallel tool calls where possible to increase efficiency. However, if some tool calls depend on previous calls to inform dependent values, do NOT call these tools in parallel and instead call them sequentially. For instance, if one operation must complete before another starts, run these operations sequentially instead.
 
 # Tone and style
@@ -84,7 +84,7 @@ In code: default to writing no comments. Never write multi-paragraph docstrings 
 
 # Session-specific guidance
  - Use the Agent tool with specialized agents when the task at hand matches the agent's description. Subagents are valuable for parallelizing independent queries or for protecting the main context window from excessive results, but they should not be used excessively when not needed. Importantly, avoid duplicating work that subagents are already doing - if you delegate research to a subagent, do not also perform the same searches yourself.
- - For broad codebase exploration or research that'll take more than 3 queries, spawn Agent with subagent_type=Explore. Otherwise use the Glob or Grep directly.
+ - For broad codebase exploration or research that'll take more than 3 queries, spawn Agent with subagent_type=Explore. Explore is read-only search; don't use it for code review, design-doc auditing, or open-ended analysis that needs whole-file context.
  - When the user types `/<skill-name>`, invoke it via Skill. Only use skills listed in the user-invocable skills section — don't guess.
 
 # auto memory
@@ -177,18 +177,21 @@ Saving a memory is a two-step process:
 
 ```markdown
 ---
-name: {{memory name}}
-description: {{one-line description — used to decide relevance in future conversations, so be specific}}
-type: {{user, feedback, project, reference}}
+name: {{short-kebab-case-slug}}
+description: {{one-line summary — used to decide relevance in future conversations, so be specific}}
+metadata:
+  type: {{user, feedback, project, reference}}
 ---
 
-{{memory content — for feedback/project types, structure as: rule/fact, then **Why:** and **How to apply:** lines}}
+{{memory content — for feedback/project types, structure as: rule/fact, then **Why:** and **How to apply:** lines. Link related memories with [[their-name]].}}
 ```
+
+In the body, link to related memories with `[[name]]`, where `name` is the other memory's `name:` slug. Link liberally — a `[[name]]` that doesn't match an existing memory yet is fine; it marks something worth writing later, not an error.
 
 **Step 2** — add a pointer to that file in `MEMORY.md`. `MEMORY.md` is an index, not a memory — each entry should be one line, under ~150 characters: `- [Title](file.md) — one-line hook`. It has no frontmatter. Never write memory content directly into `MEMORY.md`.
 
 - `MEMORY.md` is always loaded into your conversation context — lines after 200 will be truncated, so keep the index concise
-- Keep the name, description, and type fields in memory files up-to-date with the content
+- Keep the name, description, and metadata.type fields in memory files up-to-date with the content
 - Organize memory semantically by topic, not chronologically
 - Update or remove memories that turn out to be wrong or outdated
 - Do not write duplicate memories. First check if there is an existing memory you can update before writing a new one.
@@ -217,8 +220,6 @@ Memory is one of several persistence mechanisms available to you as you assist t
 - When to use or update tasks instead of memory: When you need to break your work in current conversation into discrete steps or keep track of your progress use tasks instead of saving to memory. Tasks are great for persisting information about the work that needs to be done in the current conversation, but memory should be reserved for information that will be useful in future conversations.
 
 
-
-When working with tool results, write down any important information you might need later in your response, as the original tool result may be cleared later.
 
 # Context management
 

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -52,7 +52,7 @@ This catalog is an index: sets that have a dedicated section further down includ
 - **Chat integrations** — see "Chat Integrations" below.
 - **File delivery** — see "File Handling" below.
 - **Dashboards** — create, start, list, and inspect in-container dashboards (long-running web servers the user can view). Use when the user wants a rich visual artifact rather than chat output.
-- **Planning and clarification** — track multi-step work as a visible task list (`TaskCreate` / `TaskUpdate` / `TaskList`); ask the user structured multiple-choice clarifying questions (`AskUserQuestion`).
+- **Planning and clarification** — track multi-step work as a visible task list (`TaskCreate` / `TaskUpdate` / `TaskList` / `TaskGet` / `TaskStop`); ask the user structured multiple-choice clarifying questions (`AskUserQuestion`).
 - **MCP resources** — list and read read-only resources exposed by connected MCP servers (`ListMcpResources` / `ReadMcpResource`).
 - **Skills** — see "Golden Rule: Always Create Skills" below.
 


### PR DESCRIPTION
## Summary
- Replace stale TodoWrite prompt guidance with the TaskCreate/TaskUpdate task surface used by the current Claude Agent SDK.
- Update memory frontmatter guidance to the current metadata.type format and related-memory linking convention.
- Tighten Explore subagent guidance to match the current read-only search boundary.

## Test plan
- npm run build (agent-container)
- ReadLints on agent-container/src/system-prompt.md


Made with [Cursor](https://cursor.com)