### PR TITLE
Notify when window isn't focused, even on open sessions

### DIFF
--- a/src/renderer/components/notifications/global-notification-handler.test.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.test.tsx
@@ -31,6 +31,10 @@ vi.mock('@renderer/lib/os-notifications', () => ({
   showOSNotification: vi.fn(),
 }))
 
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: vi.fn(() => Promise.resolve({ ok: true })),
+}))
+
 vi.mock('@renderer/context/selection-context', () => ({
   useSelection: vi.fn(() => ({ view: { kind: 'home' }, setAgent: vi.fn() })),
 }))
@@ -76,15 +80,41 @@ function simulateSSEMessage(es: MockEventSource, data: unknown) {
 describe('GlobalNotificationHandler — proxy review SSE pathway', () => {
   let queryClient: QueryClient
 
-  beforeEach(() => {
+  beforeEach(async () => {
     MockEventSource.instances = []
     queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     })
+
+    // Reset module-level mocks that individual tests override with
+    // `mockReturnValue`. vi.mock factories are NOT reset between tests, so
+    // without this an override (a selected session, `notifyWhenUnfocused`,
+    // etc.) leaks into later tests and makes them order-dependent.
+    const { useSelection } = await import('@renderer/context/selection-context')
+    const { useUserSettings } = await import('@renderer/hooks/use-user-settings')
+    const { apiFetch } = await import('@renderer/lib/api')
+    vi.mocked(useSelection).mockReturnValue({
+      view: { kind: 'home' },
+      setAgent: vi.fn(),
+    } as unknown as ReturnType<typeof useSelection>)
+    vi.mocked(useUserSettings).mockReturnValue({
+      data: undefined,
+    } as unknown as ReturnType<typeof useUserSettings>)
+    // restoreAllMocks (afterEach) wipes the factory implementation, so
+    // re-establish it: the handler does apiFetch(...).then(...) and a bare
+    // undefined return would throw.
+    vi.mocked(apiFetch).mockResolvedValue({ ok: true } as unknown as Response)
   })
 
   afterEach(() => {
     cleanup()
+    // Tests stub OS focus/visibility on `document`; undo so the next test
+    // starts from the real jsdom defaults instead of an inherited
+    // unfocused/visible state. restoreAllMocks restores the `hasFocus` spy;
+    // `visibilityState` is redefined as an own accessor, so delete it to fall
+    // back to the prototype getter.
+    vi.restoreAllMocks()
+    Reflect.deleteProperty(document, 'visibilityState')
   })
 
   it('session_awaiting_input with review data invalidates proxy-reviews query', async () => {
@@ -331,6 +361,48 @@ describe('GlobalNotificationHandler — proxy review SSE pathway', () => {
     })
 
     expect(showOSNotification).not.toHaveBeenCalled()
+  })
+
+  it('marks the DB notification read (no popup) when actively viewing the focused session', async () => {
+    const { showOSNotification } = await import('@renderer/lib/os-notifications')
+    const { apiFetch } = await import('@renderer/lib/api')
+    vi.mocked(showOSNotification).mockClear()
+    vi.mocked(apiFetch).mockClear()
+
+    // Window focused + visible, user is looking at sess-1.
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+
+    const { useSelection } = await import('@renderer/context/selection-context')
+    vi.mocked(useSelection).mockReturnValue({
+      view: { kind: 'session', id: 'sess-1' },
+      setAgent: vi.fn(),
+    } as unknown as ReturnType<typeof useSelection>)
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <GlobalNotificationHandler />
+      </QueryClientProvider>
+    )
+
+    const es = getLatestEventSource()
+    simulateSSEMessage(es, {
+      type: 'os_notification',
+      notificationType: 'session_complete',
+      notificationId: 'notif-9',
+      sessionId: 'sess-1',
+      agentSlug: 'my-agent',
+      title: 'Done',
+      body: 'Session complete',
+    })
+
+    // No OS popup (the user is watching it live), but the backend-created
+    // record is marked read so the unread badge doesn't inflate.
+    expect(showOSNotification).not.toHaveBeenCalled()
+    expect(apiFetch).toHaveBeenCalledWith('/api/notifications/notif-9/read', { method: 'POST' })
   })
 
   it('also invalidates sessions query (for sidebar awaiting_input indicator)', () => {

--- a/src/renderer/components/notifications/global-notification-handler.test.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.test.tsx
@@ -48,7 +48,7 @@ vi.mock('@renderer/hooks/use-notifications', () => ({
 }))
 
 vi.mock('@renderer/hooks/use-user-settings', () => ({
-  useUserSettings: () => ({ data: undefined }),
+  useUserSettings: vi.fn(() => ({ data: undefined })),
 }))
 
 vi.mock('@renderer/hooks/use-mount-warnings', () => ({
@@ -242,6 +242,92 @@ describe('GlobalNotificationHandler — proxy review SSE pathway', () => {
       agentSlug: 'my-agent',
       title: 'Chat Integration Connected',
       body: 'Slack',
+    })
+
+    expect(showOSNotification).not.toHaveBeenCalled()
+  })
+
+  it('session_complete fires when notifyWhenUnfocused is on and window unfocused', async () => {
+    const { showOSNotification } = await import('@renderer/lib/os-notifications')
+    vi.mocked(showOSNotification).mockClear()
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false)
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+
+    const { useSelection } = await import('@renderer/context/selection-context')
+    vi.mocked(useSelection).mockReturnValue({
+      view: { kind: 'session', id: 'sess-1' },
+      setAgent: vi.fn(),
+    } as unknown as ReturnType<typeof useSelection>)
+
+    const { useUserSettings } = await import('@renderer/hooks/use-user-settings')
+    vi.mocked(useUserSettings).mockReturnValue({
+      data: {
+        notifications: {
+          enabled: true,
+          sessionComplete: true,
+          sessionWaiting: true,
+          sessionScheduled: true,
+          notifyWhenUnfocused: true,
+        },
+      },
+    } as unknown as ReturnType<typeof useUserSettings>)
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <GlobalNotificationHandler />
+      </QueryClientProvider>
+    )
+
+    const es = getLatestEventSource()
+    simulateSSEMessage(es, {
+      type: 'os_notification',
+      notificationType: 'session_complete',
+      sessionId: 'sess-1',
+      agentSlug: 'my-agent',
+      title: 'Done',
+      body: 'Session complete',
+    })
+
+    expect(showOSNotification).toHaveBeenCalled()
+  })
+
+  it('session_complete suppressed when notifyWhenUnfocused is off and viewing session', async () => {
+    const { showOSNotification } = await import('@renderer/lib/os-notifications')
+    vi.mocked(showOSNotification).mockClear()
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false)
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+
+    const { useSelection } = await import('@renderer/context/selection-context')
+    vi.mocked(useSelection).mockReturnValue({
+      view: { kind: 'session', id: 'sess-1' },
+      setAgent: vi.fn(),
+    } as unknown as ReturnType<typeof useSelection>)
+
+    const { useUserSettings } = await import('@renderer/hooks/use-user-settings')
+    vi.mocked(useUserSettings).mockReturnValue({
+      data: undefined,
+    } as unknown as ReturnType<typeof useUserSettings>)
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <GlobalNotificationHandler />
+      </QueryClientProvider>
+    )
+
+    const es = getLatestEventSource()
+    simulateSSEMessage(es, {
+      type: 'os_notification',
+      notificationType: 'session_complete',
+      sessionId: 'sess-1',
+      agentSlug: 'my-agent',
+      title: 'Done',
+      body: 'Session complete',
     })
 
     expect(showOSNotification).not.toHaveBeenCalled()

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -211,14 +211,19 @@ export function GlobalNotificationHandler() {
                 ? isTabVisible && document.hasFocus()
                 : isTabVisible
 
+            // The user is actively watching this session right now when the app
+            // is active (focus-aware for actionable / opted-in types) AND this
+            // is the session on screen. The backend always creates the DB
+            // notification record; here we only decide whether to pop an OS
+            // notification on top of it.
+            const typeEnabled = isNotificationTypeEnabled(userSettingsRef.current, notificationType ?? '')
+            const suppressedByActiveView = isAppActive && isViewingNotificationSession
+
             // Show OS notification if:
             // 1. User has access to the notification's agent
             // 2. User's notification settings allow this type
             // 3. App not active OR not viewing the notification's session
-            if (
-              isNotificationTypeEnabled(userSettingsRef.current, notificationType ?? '') &&
-              (!isAppActive || !isViewingNotificationSession)
-            ) {
+            if (typeEnabled && !suppressedByActiveView) {
               const { title, body } = data as { title: string; body: string }
               // Validate actions at the SSE boundary. A malicious / buggy
               // broadcaster can't inject a 1000-button notification with
@@ -241,6 +246,22 @@ export function GlobalNotificationHandler() {
                 notificationId: data.notificationId ?? baseContext.notificationId,
               }
               showOSNotification(title, body, undefined, { actions, context })
+            } else if (suppressedByActiveView && typeof data.notificationId === 'string') {
+              // Popup suppressed because the user is actively viewing this
+              // focused session — but the backend still created the DB record.
+              // Mark it read here, otherwise the unread badge inflates for a
+              // session the user is watching live. main-content's auto-mark-read
+              // only fires on session open / tab refocus, not for notifications
+              // that arrive mid-view. (PR #175 follow-up.)
+              apiFetch(`/api/notifications/${data.notificationId}/read`, { method: 'POST' })
+                .then((res) => {
+                  if (res.ok) {
+                    queryClient.invalidateQueries({ queryKey: ['notifications'] })
+                  }
+                })
+                .catch(() => {
+                  // Best-effort: a stale notificationId is fine to silently ignore.
+                })
             }
             break
           }

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -202,8 +202,12 @@ export function GlobalNotificationHandler() {
             // the prompt. For chattier types (chat-integration, etc.) we
             // keep the visibility-only gate to avoid notification spam
             // for users who keep the window in a side panel. (Review S4.)
+            // `notifyWhenUnfocused` opts the chattier types into the same
+            // focus-aware gate.
+            const notifyWhenUnfocused =
+              userSettingsRef.current?.notifications?.notifyWhenUnfocused === true
             const isAppActive =
-              notificationType === 'session_waiting'
+              notificationType === 'session_waiting' || notifyWhenUnfocused
                 ? isTabVisible && document.hasFocus()
                 : isTabVisible
 

--- a/src/renderer/components/settings/notifications-tab.tsx
+++ b/src/renderer/components/settings/notifications-tab.tsx
@@ -22,6 +22,7 @@ export function NotificationsTab() {
     sessionComplete: boolean
     sessionWaiting: boolean
     sessionScheduled: boolean
+    notifyWhenUnfocused: boolean
   } | null>(null)
 
   // Browser notification permission state
@@ -41,6 +42,7 @@ export function NotificationsTab() {
     sessionComplete: true,
     sessionWaiting: true,
     sessionScheduled: true,
+    notifyWhenUnfocused: false,
   }
 
   const updateNotificationSetting = (key: string, value: boolean) => {
@@ -148,6 +150,28 @@ export function NotificationsTab() {
             id="notify-session-scheduled"
             checked={notificationSettings.sessionScheduled}
             onCheckedChange={(checked) => updateNotificationSetting('sessionScheduled', checked)}
+            disabled={isLoading || !notificationSettings.enabled}
+          />
+        </div>
+      </div>
+
+      {/* Behavior */}
+      <div className="border-t pt-4 space-y-4">
+        <h3 className="text-sm font-medium text-muted-foreground">Behavior</h3>
+
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5 pr-4">
+            <Label htmlFor="notify-when-unfocused">Notify when window isn&apos;t focused</Label>
+            <p className="text-xs text-muted-foreground">
+              Send notifications even while the session is open, as long as the SuperAgent
+              window is behind another app. Useful for long-running sessions you&apos;ve left
+              in the background.
+            </p>
+          </div>
+          <Switch
+            id="notify-when-unfocused"
+            checked={notificationSettings.notifyWhenUnfocused}
+            onCheckedChange={(checked) => updateNotificationSetting('notifyWhenUnfocused', checked)}
             disabled={isLoading || !notificationSettings.enabled}
           />
         </div>

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -49,6 +49,7 @@ export interface NotificationSettings {
   sessionComplete: boolean
   sessionWaiting: boolean
   sessionScheduled: boolean
+  notifyWhenUnfocused?: boolean
 }
 
 export interface ModelSettings {

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -1277,15 +1277,17 @@ describe('MessagePersister', () => {
       expect(mcpRequests).toHaveLength(0)
     })
 
-    it('triggers notification when no active viewers', async () => {
+    // The persister always fires the trigger; the renderer's notification
+    // gate decides whether to actually show the OS popup (it knows focus,
+    // per-user viewing, and the `notifyWhenUnfocused` toggle). An SSE
+    // viewer being attached does NOT suppress the trigger here.
+    it('triggers notification regardless of whether viewers are attached', async () => {
       const { notificationManager } = await import('@shared/lib/notifications/notification-manager')
 
       sseEvents.length = 0
       vi.mocked(notificationManager.triggerSessionWaitingInput).mockClear()
 
-      // Remove SSE client so there are no active viewers
-      sseCleanup()
-
+      // SSE client IS attached — trigger should still fire.
       simulateRemoteMcpToolUse('mcp-notify', {
         url: 'https://mcp.example.com/mcp',
       })
@@ -1295,25 +1297,6 @@ describe('MessagePersister', () => {
         AGENT_SLUG,
         'remote_mcp'
       )
-
-      // Re-attach SSE client for afterEach cleanup
-      const sse = collectSSEEvents(SESSION_ID)
-      sseEvents = sse.events
-      sseCleanup = sse.cleanup
-    })
-
-    it('does not trigger notification when there are active viewers', async () => {
-      const { notificationManager } = await import('@shared/lib/notifications/notification-manager')
-
-      sseEvents.length = 0
-      vi.mocked(notificationManager.triggerSessionWaitingInput).mockClear()
-
-      // SSE client is attached (active viewer) — notification should NOT fire
-      simulateRemoteMcpToolUse('mcp-no-notify', {
-        url: 'https://mcp.example.com/mcp',
-      })
-
-      expect(notificationManager.triggerSessionWaitingInput).not.toHaveBeenCalled()
     })
 
     it('still broadcasts tool_use_ready alongside remote_mcp_request', () => {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -380,12 +380,6 @@ class MessagePersister {
     }
   }
 
-  // Check if a session has active SSE clients (someone is viewing it)
-  hasActiveViewers(sessionId: string): boolean {
-    const clients = this.sseClients.get(sessionId)
-    return (clients?.size ?? 0) > 0
-  }
-
   // Broadcast to global notification clients only (e.g., sidebar updates, Electron main process)
   // Does NOT broadcast to session-specific SSE clients — use broadcastToSSE for that.
   broadcastGlobal(data: unknown): void {
@@ -890,9 +884,12 @@ class MessagePersister {
             agentSlug: state.agentSlug,
             isActive: false,
           })
-          // Trigger session complete notification (only if no one is viewing the session)
-          // Skip for 'resume' exits — the session is pausing for a resume, not truly finished
-          if (content.subtype !== 'resume' && state.agentSlug && !this.hasActiveViewers(sessionId)) {
+          // Trigger session complete notification. Whether to *show* an OS
+          // notification (vs just creating the DB record) is the renderer's
+          // call — it knows about window focus, per-user viewing, and the
+          // `notifyWhenUnfocused` toggle. Skip for 'resume' exits — the
+          // session is pausing for a resume, not truly finished.
+          if (content.subtype !== 'resume' && state.agentSlug) {
             notificationManager.triggerSessionComplete(sessionId, state.agentSlug).catch((err) => {
               console.error('[MessagePersister] Failed to trigger session complete notification:', err)
             })
@@ -1503,8 +1500,9 @@ class MessagePersister {
         agentSlug,
       })
 
-      // Trigger waiting for input notification (only if no one is viewing the session)
-      if (agentSlug && !this.hasActiveViewers(sessionId)) {
+      // Renderer's notification gate decides whether to show the OS popup
+      // based on focus / per-user viewing / `notifyWhenUnfocused` toggle.
+      if (agentSlug) {
         notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'secret').catch((err) => {
           console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
         })
@@ -1545,8 +1543,8 @@ class MessagePersister {
         agentSlug,
       })
 
-      // Trigger waiting for input notification (only if no one is viewing the session)
-      if (agentSlug && !this.hasActiveViewers(sessionId)) {
+      // Renderer-side gate handles suppression; see session_complete trigger.
+      if (agentSlug) {
         notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'connected_account').catch((err) => {
           console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
         })
@@ -1971,8 +1969,8 @@ class MessagePersister {
         agentSlug,
       })
 
-      // Trigger waiting for input notification (only if no one is viewing the session)
-      if (agentSlug && !this.hasActiveViewers(sessionId)) {
+      // Renderer-side gate handles suppression; see session_complete trigger.
+      if (agentSlug) {
         notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'question').catch((err) => {
           console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
         })
@@ -2012,8 +2010,8 @@ class MessagePersister {
         agentSlug,
       })
 
-      // Trigger waiting for input notification (only if no one is viewing the session)
-      if (agentSlug && !this.hasActiveViewers(sessionId)) {
+      // Renderer-side gate handles suppression; see session_complete trigger.
+      if (agentSlug) {
         notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'file').catch((err) => {
           console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
         })
@@ -2055,8 +2053,8 @@ class MessagePersister {
         agentSlug,
       })
 
-      // Trigger waiting for input notification (only if no one is viewing the session)
-      if (agentSlug && !this.hasActiveViewers(sessionId)) {
+      // Renderer-side gate handles suppression; see session_complete trigger.
+      if (agentSlug) {
         notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'remote_mcp').catch((err) => {
           console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
         })
@@ -2095,7 +2093,8 @@ class MessagePersister {
         agentSlug,
       })
 
-      if (agentSlug && !this.hasActiveViewers(sessionId)) {
+      // Renderer-side gate handles suppression; see session_complete trigger.
+      if (agentSlug) {
         notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'browser_input').catch((err) => {
           console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
         })
@@ -2181,7 +2180,8 @@ class MessagePersister {
       // pill in the sidebar / tray) when the user actually has to respond.
       if (!autoApproved) {
         this.markSessionAwaitingInput(sessionId)
-        if (agentSlug && !this.hasActiveViewers(sessionId)) {
+        // Renderer-side gate handles suppression; see session_complete trigger.
+        if (agentSlug) {
           notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'script_run').catch((err) => {
             console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
           })
@@ -2280,7 +2280,8 @@ class MessagePersister {
         agentSlug,
       })
 
-      if (agentSlug && !this.hasActiveViewers(sessionId)) {
+      // Renderer-side gate handles suppression; see session_complete trigger.
+      if (agentSlug) {
         notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'computer_use').catch((err) => {
           console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
         })

--- a/src/shared/lib/proxy/review-manager.ts
+++ b/src/shared/lib/proxy/review-manager.ts
@@ -162,11 +162,10 @@ export class ReviewManager {
       // session of this agent. The proxy call is agent-scoped (no sessionId
       // in the request), so we pick an active session — same attribution
       // heuristic the sidebar uses for its orange dot (agents.ts:
-      // isActive && hasAgentLevelReviews). Do NOT gate on hasActiveViewers
-      // here: an open SSE connection ≠ actively looking at the screen
-      // (the user can have the session open and be alt-tabbed away). The
-      // renderer-side gate (isAppActive && isViewingNotificationSession)
-      // is the only one that knows about real OS focus.
+      // isActive && hasAgentLevelReviews). Whether the OS popup actually
+      // shows is the renderer's call — it knows OS focus + per-user viewing
+      // + `notifyWhenUnfocused`. An open SSE connection ≠ actively looking
+      // at the screen.
       const targetSessionId = messagePersister.getActiveSessionIdsForAgent(details.agentSlug)[0]
       if (targetSessionId) {
         const kind = details.xAgent ? 'agent_action' : 'api_request'

--- a/src/shared/lib/services/user-settings-service.ts
+++ b/src/shared/lib/services/user-settings-service.ts
@@ -11,6 +11,7 @@ const notificationSettingsSchema = z.object({
   sessionComplete: z.boolean().default(true),
   sessionWaiting: z.boolean().default(true),
   sessionScheduled: z.boolean().default(true),
+  notifyWhenUnfocused: z.boolean().default(false),
 })
 
 export const userSettingsSchema = z.object({
@@ -20,6 +21,7 @@ export const userSettingsSchema = z.object({
     sessionComplete: true,
     sessionWaiting: true,
     sessionScheduled: true,
+    notifyWhenUnfocused: false,
   }),
   setupCompleted: z.boolean().default(false),
   showMenuBarIcon: z.boolean().default(true),
@@ -69,6 +71,7 @@ function seedFromAppSettings(): UserSettingsData {
           sessionComplete: appPrefs.notifications.sessionComplete ?? true,
           sessionWaiting: appPrefs.notifications.sessionWaiting ?? true,
           sessionScheduled: appPrefs.notifications.sessionScheduled ?? true,
+          notifyWhenUnfocused: appPrefs.notifications.notifyWhenUnfocused ?? false,
         }
       : undefined,
     setupCompleted: appPrefs.setupCompleted ?? false,


### PR DESCRIPTION
## Summary

- Adds a **Notify when window isn't focused** toggle to Settings → Notifications → Behavior (off by default). When on, OS notifications fire for sessions you have open whenever the SuperAgent window isn't the focused OS app — so you still hear about long-running sessions you've left running in the background while you work in another app.
- Removes a server-side `hasActiveViewers` gate at 9 notification trigger sites in `MessagePersister`. That gate was making the renderer-side toggle a no-op: whenever any client had the session's SSE stream open, the server discarded the notification trigger before it ever reached the renderer. The renderer's gate is strictly more sophisticated (knows OS focus, per-user viewing, and the new toggle) and is the right place to make this call.
- Drive-by improvement: `session_waiting` (Action Required) notifications now also reach you when the session is open but the window isn't focused — previously the server suppressed those too.

## Use case

You start a long agent task, leave its session open in SuperAgent, and switch to your editor / browser / Slack to do other work. Today: no notification when it finishes, so the session sits forgotten. With the toggle on: you get the ping as soon as it's done, regardless of which session is open.

## Test plan

- [ ] **Toggle OFF (default — verify no regression):**
  - [ ] Viewing session, window focused → no notification
  - [ ] Viewing session, window unfocused → no `session_complete` notification (matches current behavior)
  - [ ] Viewing a different session → notification fires
- [ ] **Toggle ON (the new behavior):**
  - [ ] Viewing session, window focused → no notification (don't spam while you're looking)
  - [ ] Viewing session, window unfocused (click another app) → `session_complete` fires ✅
  - [ ] `session_waiting` while viewing and unfocused → fires
- [ ] Toggle state persists across reload
- [ ] "Send Test" button in the same tab still works
- [ ] Master "Enable Notifications" off → toggle disabled, no notifications fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)