### PR TITLE
feat: cloud workspace layout for remote runtime

### DIFF
--- a/src/shared/lib/config/data-dir.ts
+++ b/src/shared/lib/config/data-dir.ts
@@ -39,6 +39,11 @@ export function getAgentsDataDir(): string {
  * Get the workspace directory for a specific agent.
  */
 export function getAgentWorkspaceDir(agentId: string): string {
+  const cloudWorkspaceRoot = process.env.GAMUT_CLOUD_WORKSPACE_ROOT
+  if (cloudWorkspaceRoot) {
+    return path.join(path.resolve(cloudWorkspaceRoot), agentId)
+  }
+
   return path.join(getAgentsDataDir(), agentId, 'workspace')
 }
 

--- a/src/shared/lib/services/agent-service.ts
+++ b/src/shared/lib/services/agent-service.ts
@@ -5,6 +5,7 @@
  * Agents are stored as directories with CLAUDE.md files.
  */
 
+import path from 'path'
 import {
   getAgentsDir,
   getAgentDir,
@@ -54,6 +55,7 @@ function toApiAgent(
     createdAt: new Date(agent.frontmatter.createdAt),
     status,
     containerPort,
+    runtime: process.env.REMOTE_RUNTIME === 'kubernetes' || process.env.GAMUT_CLOUD_WORKSPACE_ROOT ? 'cloud' : 'local',
     ...(healthWarnings.length > 0 ? { healthWarnings } : {}),
   }
 }
@@ -213,6 +215,9 @@ export async function createAgent(input: CreateAgentInput): Promise<ApiAgent> {
 
   // Create CLAUDE.md
   const claudeMdPath = getAgentClaudeMdPath(slug)
+  // In cloud mode the workspace lives on /data while CLAUDE.md lives on the
+  // metadata PVC, so the parent of claudeMdPath is a separate directory.
+  await ensureDirectory(path.dirname(claudeMdPath))
   const frontmatter: AgentFrontmatter = {
     name,
     createdAt: new Date().toISOString(),
@@ -325,6 +330,7 @@ export async function createAgentFromExistingWorkspace(rawName: string): Promise
 
   // Create a basic CLAUDE.md (may be overwritten by template)
   const claudeMdPath = getAgentClaudeMdPath(slug)
+  await ensureDirectory(path.dirname(claudeMdPath))
   const frontmatter: AgentFrontmatter = {
     name,
     createdAt: new Date().toISOString(),

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -158,12 +158,9 @@ function parseSessionInfo(
   // Generate name from first user message if no custom name
   let name = metadata?.name || 'New Session'
   if (!metadata?.name && messages.length > 0) {
-    const firstUserMessage = messages.find(
-      (m) => m.type === 'user' && typeof m.message.content === 'string'
-    )
-    if (firstUserMessage && typeof firstUserMessage.message.content === 'string') {
-      // Use first 50 chars of first message as name
-      const content = firstUserMessage.message.content
+    const firstUserMessage = messages.find((m) => m.type === 'user')
+    const content = firstUserMessage ? getMessageText(firstUserMessage) : ''
+    if (content) {
       name = content.substring(0, 50).trim()
       if (content.length > 50) {
         name += '...'
@@ -179,6 +176,16 @@ function parseSessionInfo(
     lastActivityAt,
     messageCount: messages.length,
   }
+}
+
+function getMessageText(entry: JsonlMessageEntry): string {
+  const content = entry.message.content
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  return content
+    .map((block) => block.type === 'text' ? block.text : '')
+    .join('')
+    .trim()
 }
 
 // ============================================================================
@@ -282,14 +289,28 @@ export async function listSessions(
         continue
       }
 
-      sessions.push({
-        id: sessionId,
-        agentSlug,
-        name: metadata[sessionId]?.name || 'New Session',
-        createdAt: stat.birthtime,
-        lastActivityAt: new Date(stat.mtimeMs),
-        messageCount: 0,
-      })
+      // Cloud has no metadata sidecar, so parse the JSONL to recover name and
+      // timestamps; locally the lightweight stat-based info is enough.
+      let info: SessionInfo
+      if (process.env.GAMUT_CLOUD_WORKSPACE_ROOT) {
+        const entries = await readJsonlFile<JsonlEntry>(path.join(sessionsDir, `${sessionId}.jsonl`))
+        const parsed = parseSessionInfo(sessionId, agentSlug, entries, metadata[sessionId])
+        info = {
+          ...parsed,
+          createdAt: parsed.createdAt.getTime() > 0 ? parsed.createdAt : new Date(stat.mtimeMs),
+          lastActivityAt: parsed.lastActivityAt.getTime() > 0 ? parsed.lastActivityAt : new Date(stat.mtimeMs),
+        }
+      } else {
+        info = {
+          id: sessionId,
+          agentSlug,
+          name: metadata[sessionId]?.name || 'New Session',
+          createdAt: stat.birthtime,
+          lastActivityAt: new Date(stat.mtimeMs),
+          messageCount: 0,
+        }
+      }
+      sessions.push(info)
     }
   }
 
@@ -328,12 +349,23 @@ export async function getSession(
   sessionId: string
 ): Promise<SessionInfo | null> {
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
+  const metadata = await getSessionMetadata(agentSlug, sessionId)
 
   if (!(await fileExists(jsonlPath))) {
+    if (metadata?.createdAt) {
+      const createdAt = new Date(metadata.createdAt)
+      return {
+        id: sessionId,
+        agentSlug,
+        name: metadata.name || 'New Session',
+        createdAt,
+        lastActivityAt: createdAt,
+        messageCount: 0,
+      }
+    }
     return null
   }
 
-  const metadata = await getSessionMetadata(agentSlug, sessionId)
   const entries = await readJsonlFile<JsonlEntry>(jsonlPath)
 
   return parseSessionInfo(sessionId, agentSlug, entries, metadata || undefined)

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -23,6 +23,7 @@ export interface ApiAgent {
   createdAt: Date
   status: 'running' | 'stopped'
   containerPort: number | null
+  runtime?: 'local' | 'cloud'
   healthWarnings?: HealthCheckResult[]
   templateStatus?: ApiAgentTemplateStatus
   // Summary fields (included in list response)

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -381,6 +381,15 @@ export function getAgentDir(slug: string): string {
  * ~/.superagent/agents/{slug}/workspace/
  */
 export function getAgentWorkspaceDir(slug: string): string {
+  const cloudWorkspaceRoot = process.env.GAMUT_CLOUD_WORKSPACE_ROOT
+  if (cloudWorkspaceRoot) {
+    return path.join(path.resolve(cloudWorkspaceRoot), slug)
+  }
+
+  return getLocalAgentWorkspaceDir(slug)
+}
+
+function getLocalAgentWorkspaceDir(slug: string): string {
   return path.join(getAgentDir(slug), 'workspace')
 }
 
@@ -389,7 +398,7 @@ export function getAgentWorkspaceDir(slug: string): string {
  * ~/.superagent/agents/{slug}/workspace/CLAUDE.md
  */
 export function getAgentClaudeMdPath(slug: string): string {
-  return path.join(getAgentWorkspaceDir(slug), 'CLAUDE.md')
+  return path.join(getLocalAgentWorkspaceDir(slug), 'CLAUDE.md')
 }
 
 /**


### PR DESCRIPTION
## What this adds
Host-side workspace and session handling for cloud deployments, where agent workspaces live on a shared PVC root instead of under `~/.superagent`. Complements the Kubernetes remote runtime (#177) but is independent: gated on `GAMUT_CLOUD_WORKSPACE_ROOT` / `REMOTE_RUNTIME`, so local behavior is unchanged when unset.

## Changes
- **`data-dir.ts` / `file-storage.ts`**: resolve the agent workspace under `GAMUT_CLOUD_WORKSPACE_ROOT/<slug>` when set; `CLAUDE.md` stays on the local metadata path (`getLocalAgentWorkspaceDir`).
- **`session-service.ts`**: under the cloud workspace root there is no metadata sidecar, so parse the session JSONL to recover name/timestamps; `getSession` falls back to metadata-only when the JSONL doesn't exist yet. Also handles array (multimodal) message content when deriving the session name.
- **`agent-service.ts`**: expose `runtime` (`'cloud' | 'local'`) on `ApiAgent` and ensure the `CLAUDE.md` parent dir exists (cloud splits the workspace and metadata directories).
- **`types/api.ts`**: add optional `runtime?: 'local' | 'cloud'` to `ApiAgent`.

## Relationship to other PRs
Touches a disjoint set of files from #177 (K8s runtime) and #176 (per-member account sync). Each merges to main independently without breaking the others.

## Test plan
- [x] `tsc --noEmit` clean (only the pre-existing unrelated `pdf-renderer.tsx`/`react-pdf` error)
- [x] `eslint` clean
- [x] `vitest run` — session-service (80), file-storage (67), agent-service (32) green
- [ ] Manual: set `GAMUT_CLOUD_WORKSPACE_ROOT`, verify session list names/timestamps and `runtime: 'cloud'` on the agent API

Made with [Cursor](https://cursor.com)