### PR TITLE
fix(auth): verify org_id at OIDC callback + stop polluting account_id

### DIFF
--- a/src/shared/lib/auth/provider-config.test.ts
+++ b/src/shared/lib/auth/provider-config.test.ts
@@ -7,10 +7,18 @@ vi.mock('@shared/lib/error-reporting', () => ({
 
 import { getGenericOAuthProviderConfigs, getPublicAuthProviders } from './provider-config'
 
+// Build an unsigned org access JWT (header.payload.sig) carrying { orgId } so
+// decodeOrgIdFromToken(process.env.PLATFORM_TOKEN) resolves the deployment org.
+function makeOrgToken(orgId: string): string {
+  const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString('base64url')
+  return `${b64({ alg: 'RS256', typ: 'JWT' })}.${b64({ orgId })}.sig`
+}
+
 describe('getPublicAuthProviders', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     delete process.env.AUTH_PROVIDERS_JSON
+    delete process.env.PLATFORM_TOKEN
   })
 
   it('returns enabled providers with readiness details', () => {
@@ -185,7 +193,7 @@ describe('getPublicAuthProviders', () => {
     ])
   })
 
-  it('mapProfileToUser extracts platform user_id claim as id', () => {
+  it('mapProfileToUser never overrides id, so account.accountId stays the OIDC sub', () => {
     process.env.AUTH_PROVIDERS_JSON = JSON.stringify([
       { id: 'platform', type: 'oidc', issuer: 'https://auth.example.com', clientId: 'c' },
     ])
@@ -194,18 +202,60 @@ describe('getPublicAuthProviders', () => {
       sub: 'sub_member_123',
       email: 'user@example.com',
       'https://platform.skillfulagents.dev/claims/user_id': 'uuid-user-456',
-    })).toEqual({ id: 'uuid-user-456' })
+    })).toEqual({})
   })
 
-  it('mapProfileToUser returns empty object when user_id claim is absent', () => {
+  it('mapProfileToUser rejects an id_token whose org_id differs from the deployment org', () => {
     process.env.AUTH_PROVIDERS_JSON = JSON.stringify([
       { id: 'platform', type: 'oidc', issuer: 'https://auth.example.com', clientId: 'c' },
     ])
+    process.env.PLATFORM_TOKEN = makeOrgToken('org_AAA')
     const [config] = getGenericOAuthProviderConfigs()
-    expect(config.mapProfileToUser!({
-      sub: 'sub_member_123',
-      email: 'user@example.com',
-    })).toEqual({})
+    expect(() =>
+      config.mapProfileToUser!({
+        sub: 'sub_member_123',
+        'https://platform.skillfulagents.dev/claims/org_id': 'org_BBB',
+      }),
+    ).toThrow(/different organization/i)
+  })
+
+  it('mapProfileToUser passes when the id_token org_id matches the deployment org', () => {
+    process.env.AUTH_PROVIDERS_JSON = JSON.stringify([
+      { id: 'platform', type: 'oidc', issuer: 'https://auth.example.com', clientId: 'c' },
+    ])
+    process.env.PLATFORM_TOKEN = makeOrgToken('org_AAA')
+    const [config] = getGenericOAuthProviderConfigs()
+    expect(
+      config.mapProfileToUser!({
+        sub: 'sub_member_123',
+        'https://platform.skillfulagents.dev/claims/org_id': 'org_AAA',
+      }),
+    ).toEqual({})
+  })
+
+  it('mapProfileToUser rejects an id_token with no org_id claim on an org-pinned deployment', () => {
+    process.env.AUTH_PROVIDERS_JSON = JSON.stringify([
+      { id: 'platform', type: 'oidc', issuer: 'https://auth.example.com', clientId: 'c' },
+    ])
+    process.env.PLATFORM_TOKEN = makeOrgToken('org_AAA')
+    const [config] = getGenericOAuthProviderConfigs()
+    expect(() =>
+      config.mapProfileToUser!({ sub: 'sub_member_123', email: 'user@example.com' }),
+    ).toThrow(/different organization/i)
+  })
+
+  it('mapProfileToUser skips the org check when no PLATFORM_TOKEN is configured', () => {
+    process.env.AUTH_PROVIDERS_JSON = JSON.stringify([
+      { id: 'platform', type: 'oidc', issuer: 'https://auth.example.com', clientId: 'c' },
+    ])
+    delete process.env.PLATFORM_TOKEN
+    const [config] = getGenericOAuthProviderConfigs()
+    expect(
+      config.mapProfileToUser!({
+        sub: 'sub_member_123',
+        'https://platform.skillfulagents.dev/claims/org_id': 'org_BBB',
+      }),
+    ).toEqual({})
   })
 
   it('reports invalid AUTH_PROVIDERS_JSON to error reporting instead of silently dropping', () => {

--- a/src/shared/lib/auth/provider-config.ts
+++ b/src/shared/lib/auth/provider-config.ts
@@ -1,4 +1,5 @@
 import { captureException } from '@shared/lib/error-reporting'
+import { decodeOrgIdFromToken } from '@shared/lib/platform-auth/decode-org-id'
 import { z } from 'zod'
 
 // Shape of each entry in the AUTH_PROVIDERS_JSON env bundle. Provider
@@ -54,7 +55,7 @@ export interface GenericOAuthProviderConfig {
   mapProfileToUser?: (profile: Record<string, unknown>) => Record<string, unknown>
 }
 
-const PLATFORM_USER_ID_CLAIM = 'https://platform.skillfulagents.dev/claims/user_id'
+const PLATFORM_ORG_ID_CLAIM = 'https://platform.skillfulagents.dev/claims/org_id'
 
 abstract class AuthProviderDefinition {
   constructor(protected readonly config: AuthProviderSettings) {}
@@ -119,8 +120,17 @@ class OidcAuthProviderDefinition extends AuthProviderDefinition {
       requireIssuerValidation: true,
       overrideUserInfo: true,
       mapProfileToUser: (profile: Record<string, unknown>) => {
-        const val = profile[PLATFORM_USER_ID_CLAIM]
-        return val ? { id: String(val) } : {}
+        // org-pinned deployment: id_token org_id must match; throw aborts
+        // before Better Auth creates the user/account/session.
+        const deploymentOrg = decodeOrgIdFromToken(process.env.PLATFORM_TOKEN ?? '')
+        if (deploymentOrg) {
+          const tokenOrg = profile[PLATFORM_ORG_ID_CLAIM]
+          if (typeof tokenOrg !== 'string' || tokenOrg !== deploymentOrg) {
+            throw new Error('Account belongs to a different organization')
+          }
+        }
+        // Never override id: account.accountId must stay the OIDC sub.
+        return {}
       },
     }
   }

--- a/src/shared/lib/platform-attribution/index.ts
+++ b/src/shared/lib/platform-attribution/index.ts
@@ -5,26 +5,12 @@ import { and, desc, eq } from 'drizzle-orm'
 import { db } from '@shared/lib/db'
 import { authAccount } from '@shared/lib/db/schema'
 import { getPlatformAccessToken, getStoredPlatformMemberId } from '@shared/lib/services/platform-auth-service'
+import { decodeOrgIdFromToken } from '@shared/lib/platform-auth/decode-org-id'
+
+// Re-export so existing consumers keep importing from here.
+export { decodeOrgIdFromToken }
 
 const PLATFORM_PROVIDER_ID = 'platform'
-
-/** Unverified `orgId` claim, or null for opaque access keys. Used only for routing. */
-export function decodeOrgIdFromToken(token: string): string | null {
-  const segments = token.split('.')
-  if (segments.length !== 3) return null
-  try {
-    const claims = JSON.parse(decodeBase64Url(segments[1])) as { orgId?: unknown }
-    return typeof claims.orgId === 'string' && claims.orgId.length > 0 ? claims.orgId : null
-  } catch {
-    return null
-  }
-}
-
-function decodeBase64Url(value: string): string {
-  const normalized = value.replace(/-/g, '+').replace(/_/g, '/')
-  const padded = normalized + '='.repeat((4 - (normalized.length % 4 || 4)) % 4)
-  return Buffer.from(padded, 'base64').toString('utf8')
-}
 
 function getPlatformAccountIdForUserId(userId: string): string | null {
   const rows = db

--- a/src/shared/lib/platform-auth/decode-org-id.ts
+++ b/src/shared/lib/platform-auth/decode-org-id.ts
@@ -1,0 +1,20 @@
+// Dependency-free org-id decode, standalone to avoid an import cycle
+// (provider-config <- platform-attribution <- platform-auth-service).
+
+function decodeBase64Url(value: string): string {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = normalized + '='.repeat((4 - (normalized.length % 4 || 4)) % 4)
+  return Buffer.from(padded, 'base64').toString('utf8')
+}
+
+/** Unverified `orgId` claim, or null for opaque access keys. Used only for routing. */
+export function decodeOrgIdFromToken(token: string): string | null {
+  const segments = token.split('.')
+  if (segments.length !== 3) return null
+  try {
+    const claims = JSON.parse(decodeBase64Url(segments[1])) as { orgId?: unknown }
+    return typeof claims.orgId === 'string' && claims.orgId.length > 0 ? claims.orgId : null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

Two fixes in the platform `genericOAuth` callback mapping (`src/shared/lib/auth/provider-config.ts`), both in auth mode:

- **Bug 1 — org_id defense-in-depth check at the callback.** A SuperAgent deployment is pinned to a single org via `PLATFORM_TOKEN`. `mapProfileToUser` now rejects any `id_token` whose `org_id` claim disagrees with the deployment org. The throw happens **before** Better Auth creates the user / account / session, so a validly-signed but foreign-org token cannot create a user or sign in here (currently surfaces as a failed sign-in / 500; no DB writes).

- **Bug 2 — stop overriding `id`, keep analytics.** The previous `mapProfileToUser` returned `{ id: user_id_claim }`, which made Better Auth persist `account.accountId` as the platform `user_id` instead of the OIDC `sub`. The platform proxy expects the `sub` as the `<token>::<memberId>` bearer suffix, so every member hit `403 "Member does not belong to this organization"`. Returning `{}` restores `account.accountId = OIDC sub`. **Analytics is preserved** — the global `user_id` still comes from `getPlatformOidcUserId()` reading the `user_id` claim off `authAccount.idToken`, independent of `account.accountId`.

Also extracts the dependency-free `decodeOrgIdFromToken` into `src/shared/lib/platform-auth/decode-org-id.ts` to break the `provider-config -> platform-attribution -> platform-auth-service -> provider-config` import cycle. `platform-attribution` re-exports it, so existing consumers (`startup`, `trigger-manager`, `webhook-events-client`) are unchanged. No duplicated decode logic.

## Root cause (Bug 2)

Reproduced locally against staging `org_459af371`: after login the DB had `account.account_id = f1510415-... (user_id claim)` while `id_token.sub = sub_8eaf79d4-...`. Attribution sent `::f1510415...` to the proxy, which expects `sub_8eaf79d4...` -> 403. Introduced by the `mapProfileToUser` override added in `db6dbc8c`.

## Test plan

- [x] `vitest run` for `provider-config.test.ts` + `platform-attribution` (35 passed): no-id-override, org mismatch rejected, org match passes, no-PLATFORM_TOKEN skips.
- [x] `tsc --noEmit` clean for these changes (only pre-existing unrelated `react-pdf` errors remain).
- [ ] E2E via `run-org459.sh` on :3001: after login, `account.account_id == id_token.sub` and a platform proxy call returns 200.

## Out of scope

- The upstream IdP-side cross-org sign-in bypass (consent-prompt session reuse) is a separate `platform/apps/auth` change and is not in this PR.

Made with [Cursor](https://cursor.com)