### PR TITLE
feat(agent): let agents see and manage their scheduled tasks

### DIFF
--- a/agent-container/src/mcp-server.ts
+++ b/agent-container/src/mcp-server.ts
@@ -11,7 +11,13 @@ import { requestConnectedAccountTool } from './tools/request-connected-account'
 import { searchConnectedAccountServicesTool } from './tools/search-connected-account-services'
 import { requestRemoteMcpTool } from './tools/request-remote-mcp'
 import { searchRemoteMcpServicesTool } from './tools/search-remote-mcp-services'
-import { scheduleTaskTool } from './tools/schedule-task'
+import {
+  scheduleTaskTool,
+  listScheduledTasksTool,
+  cancelScheduledTaskTool,
+  pauseScheduledTaskTool,
+  resumeScheduledTaskTool,
+} from './tools/schedule-task'
 import {
   getAvailableTriggersTool,
   listTriggersTool,
@@ -60,7 +66,9 @@ export function createUserInputMcpServer() {
     version: '1.0.0',
     tools: [
       requestSecretTool, requestConnectedAccountTool, searchConnectedAccountServicesTool,
-      requestRemoteMcpTool, searchRemoteMcpServicesTool, scheduleTaskTool,
+      requestRemoteMcpTool, searchRemoteMcpServicesTool,
+      scheduleTaskTool, listScheduledTasksTool, cancelScheduledTaskTool,
+      pauseScheduledTaskTool, resumeScheduledTaskTool,
       deliverFileTool, deliverSessionTool, requestFileTool, requestBrowserInputTool,
       ...(includeScriptRun ? [requestScriptRunTool] : []),
       ...(includeWebhookTriggers ? [getAvailableTriggersTool, listTriggersTool, setupTriggerTool, cancelTriggerTool] : []),

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -485,10 +485,18 @@ prompt: "Remind the user about their 3pm meeting with the design team"
 name: "Meeting Reminder"
 ```
 
+**Managing existing scheduled tasks:**
+You can also inspect and manage tasks you've already scheduled:
+- `mcp__user-input__list_scheduled_tasks` — List the tasks still on the schedule (pending or paused), with their IDs, schedules, next run times, and prompts. Call this first to get the task ID for the tools below.
+- `mcp__user-input__cancel_scheduled_task` — Cancel a task by ID so it no longer runs.
+- `mcp__user-input__pause_scheduled_task` — Pause an active recurring (cron) task; it stays on the schedule but won't execute until resumed.
+- `mcp__user-input__resume_scheduled_task` — Resume a paused recurring task; its next run is recomputed from the cron expression (missed runs are skipped).
+
 **Important:**
 - Scheduled tasks run in new sessions with full access to your skills and tools
-- Users can view and cancel scheduled tasks from the UI
+- You and the user can both view, cancel, pause, and resume scheduled tasks (you via the tools above, the user from the UI)
 - One-time tasks are removed after execution; recurring tasks continue until cancelled
+- Only pending or paused tasks can be cancelled; only recurring tasks can be paused/resumed
 
 ## Webhook Triggers
 

--- a/agent-container/src/tools/schedule-task.ts
+++ b/agent-container/src/tools/schedule-task.ts
@@ -8,6 +8,7 @@
 
 import { tool } from '@anthropic-ai/claude-agent-sdk'
 import { z } from 'zod'
+import { inputManager } from '../input-manager'
 
 /**
  * Basic validation for cron expression (5-6 space-separated fields)
@@ -152,6 +153,167 @@ The task has been registered and will be executed according to the schedule. ${
           }`,
         },
       ],
+    }
+  }
+)
+
+export const listScheduledTasksTool = tool(
+  'list_scheduled_tasks',
+  `List the scheduled tasks for this agent that are still on the schedule (pending or paused).
+
+Returns each task's ID, name, schedule type ("at" for one-time, "cron" for recurring), schedule expression, next execution time, and prompt. Use the returned task ID with cancel_scheduled_task to remove a task.
+
+This only shows tasks that are still scheduled — it does not include tasks that have already executed, failed, or been cancelled.`,
+  {},
+  async () => {
+    console.log('[list_scheduled_tasks] Fetching scheduled tasks')
+
+    const toolUseId = inputManager.consumeCurrentToolUseId()
+    if (!toolUseId) {
+      return {
+        content: [{ type: 'text' as const, text: 'Unable to process request — no tool use ID available.' }],
+        isError: true,
+      }
+    }
+
+    try {
+      const result = await inputManager.createPendingWithType<string>(
+        toolUseId,
+        'list_scheduled_tasks',
+      )
+
+      return {
+        content: [{ type: 'text' as const, text: result }],
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'Unknown error'
+      return {
+        content: [{ type: 'text' as const, text: `Failed to list scheduled tasks: ${msg}` }],
+        isError: true,
+      }
+    }
+  }
+)
+
+export const cancelScheduledTaskTool = tool(
+  'cancel_scheduled_task',
+  `Cancel a scheduled task by ID. This removes the task from the schedule so it will no longer execute.
+
+Use list_scheduled_tasks first to find the task ID. Only pending or paused tasks can be cancelled — tasks that have already executed or been cancelled cannot.`,
+  {
+    task_id: z
+      .string()
+      .describe('The ID of the scheduled task to cancel (from list_scheduled_tasks)'),
+  },
+  async (args) => {
+    console.log(`[cancel_scheduled_task] Cancelling task ${args.task_id}`)
+
+    const toolUseId = inputManager.consumeCurrentToolUseId()
+    if (!toolUseId) {
+      return {
+        content: [{ type: 'text' as const, text: 'Unable to process request — no tool use ID available.' }],
+        isError: true,
+      }
+    }
+
+    try {
+      const result = await inputManager.createPendingWithType<string>(
+        toolUseId,
+        'cancel_scheduled_task',
+        { task_id: args.task_id },
+      )
+
+      return {
+        content: [{ type: 'text' as const, text: result }],
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'Unknown error'
+      return {
+        content: [{ type: 'text' as const, text: `Failed to cancel scheduled task: ${msg}` }],
+        isError: true,
+      }
+    }
+  }
+)
+
+export const pauseScheduledTaskTool = tool(
+  'pause_scheduled_task',
+  `Pause a recurring (cron) scheduled task by ID. A paused task stays on the schedule but does not execute until resumed with resume_scheduled_task.
+
+Use list_scheduled_tasks first to find the task ID. Only active recurring tasks can be paused — one-time ("at") tasks cannot.`,
+  {
+    task_id: z
+      .string()
+      .describe('The ID of the recurring scheduled task to pause (from list_scheduled_tasks)'),
+  },
+  async (args) => {
+    console.log(`[pause_scheduled_task] Pausing task ${args.task_id}`)
+
+    const toolUseId = inputManager.consumeCurrentToolUseId()
+    if (!toolUseId) {
+      return {
+        content: [{ type: 'text' as const, text: 'Unable to process request — no tool use ID available.' }],
+        isError: true,
+      }
+    }
+
+    try {
+      const result = await inputManager.createPendingWithType<string>(
+        toolUseId,
+        'pause_scheduled_task',
+        { task_id: args.task_id },
+      )
+
+      return {
+        content: [{ type: 'text' as const, text: result }],
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'Unknown error'
+      return {
+        content: [{ type: 'text' as const, text: `Failed to pause scheduled task: ${msg}` }],
+        isError: true,
+      }
+    }
+  }
+)
+
+export const resumeScheduledTaskTool = tool(
+  'resume_scheduled_task',
+  `Resume a paused recurring (cron) scheduled task by ID. The next execution time is recomputed from the cron expression, so any executions missed while paused are skipped.
+
+Use list_scheduled_tasks first to find the task ID. Only paused recurring tasks can be resumed.`,
+  {
+    task_id: z
+      .string()
+      .describe('The ID of the paused scheduled task to resume (from list_scheduled_tasks)'),
+  },
+  async (args) => {
+    console.log(`[resume_scheduled_task] Resuming task ${args.task_id}`)
+
+    const toolUseId = inputManager.consumeCurrentToolUseId()
+    if (!toolUseId) {
+      return {
+        content: [{ type: 'text' as const, text: 'Unable to process request — no tool use ID available.' }],
+        isError: true,
+      }
+    }
+
+    try {
+      const result = await inputManager.createPendingWithType<string>(
+        toolUseId,
+        'resume_scheduled_task',
+        { task_id: args.task_id },
+      )
+
+      return {
+        content: [{ type: 'text' as const, text: result }],
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'Unknown error'
+      return {
+        content: [{ type: 'text' as const, text: `Failed to resume scheduled task: ${msg}` }],
+        isError: true,
+      }
     }
   }
 )

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -309,8 +309,10 @@ export function GlobalNotificationHandler() {
             queryClient.invalidateQueries({ queryKey: ['agents'] })
             break
 
-          case 'scheduled_task_created': {
-            // Scheduled task created - update task list and agent card summary
+          case 'scheduled_task_created':
+          case 'scheduled_task_cancelled':
+          case 'scheduled_task_updated': {
+            // Scheduled task created, cancelled, or updated - update task list and agent card summary
             const agentSlug = data.agentSlug as string | undefined
             if (agentSlug) {
               queryClient.invalidateQueries({ queryKey: ['scheduled-tasks', agentSlug] })

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -829,8 +829,8 @@ function getOrCreateEventSource(
         queryClient.invalidateQueries({ queryKey: ['sessions'] })
         queryClient.invalidateQueries({ queryKey: ['session', sessionId] })
       }
-      else if (data.type === 'scheduled_task_created') {
-        // A scheduled task was created - invalidate scheduled tasks cache
+      else if (data.type === 'scheduled_task_created' || data.type === 'scheduled_task_cancelled' || data.type === 'scheduled_task_updated') {
+        // A scheduled task was created, cancelled, or updated - invalidate scheduled tasks cache
         const taskAgentSlug = (data as { agentSlug?: string }).agentSlug
         if (taskAgentSlug) {
           queryClient.invalidateQueries({ queryKey: ['scheduled-tasks', taskAgentSlug] })

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -1,9 +1,22 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type { ContainerClient, StreamMessage } from './types'
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SchedMockFn = (...args: any[]) => any
+const mockListPendingScheduledTasks = vi.fn<SchedMockFn>(() => Promise.resolve([]))
+const mockGetScheduledTask = vi.fn<SchedMockFn>(() => Promise.resolve(null))
+const mockCancelScheduledTask = vi.fn<SchedMockFn>(() => Promise.resolve(true))
+const mockPauseScheduledTask = vi.fn<SchedMockFn>(() => Promise.resolve(true))
+const mockResumeScheduledTask = vi.fn<SchedMockFn>(() => Promise.resolve(true))
+
 // Mock external dependencies before importing
 vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   createScheduledTask: vi.fn(),
+  listPendingScheduledTasks: (...args: unknown[]) => mockListPendingScheduledTasks(...args),
+  getScheduledTask: (...args: unknown[]) => mockGetScheduledTask(...args),
+  cancelScheduledTask: (...args: unknown[]) => mockCancelScheduledTask(...args),
+  pauseScheduledTask: (...args: unknown[]) => mockPauseScheduledTask(...args),
+  resumeScheduledTask: (...args: unknown[]) => mockResumeScheduledTask(...args),
 }))
 vi.mock('@shared/lib/services/session-service', () => ({
   updateSessionMetadata: vi.fn(() => Promise.resolve()),
@@ -2913,6 +2926,324 @@ describe('MessagePersister', () => {
         expect(resolveCall).toBeDefined()
         const body = JSON.parse(resolveCall![1].body)
         expect(body.value).toContain('No webhook triggers available')
+      })
+    })
+  })
+
+  // ============================================================================
+  // Scheduled task tool handling (list_scheduled_tasks / cancel_scheduled_task)
+  // ============================================================================
+
+  describe('scheduled task tool handling', () => {
+    function collectGlobalEvents(): { events: any[]; cleanup: () => void } {
+      const events: any[] = []
+      const cleanup = messagePersister.addGlobalNotificationClient((data) => {
+        events.push(data)
+      })
+      return { events, cleanup }
+    }
+
+    function simulateToolUse(toolName: string, toolId: string, input: Record<string, unknown>) {
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          content_block: { type: 'tool_use', id: toolId, name: toolName },
+        },
+      })
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) },
+        },
+      })
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_stop' },
+      })
+    }
+
+    // Handlers are fire-and-forget via ;(async () => {...})() — let them settle.
+    async function flushHandlers() {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+
+    beforeEach(() => {
+      mockContainerClientFetch.mockClear()
+      mockListPendingScheduledTasks.mockClear()
+      mockGetScheduledTask.mockClear()
+      mockCancelScheduledTask.mockClear()
+      mockPauseScheduledTask.mockClear()
+      mockResumeScheduledTask.mockClear()
+
+      mockContainerClientFetch.mockResolvedValue({ ok: true })
+      mockListPendingScheduledTasks.mockResolvedValue([])
+      mockGetScheduledTask.mockResolvedValue(null)
+      mockCancelScheduledTask.mockResolvedValue(true)
+      mockPauseScheduledTask.mockResolvedValue(true)
+      mockResumeScheduledTask.mockResolvedValue(true)
+    })
+
+    describe('list_scheduled_tasks', () => {
+      it('resolves with a formatted task list', async () => {
+        mockListPendingScheduledTasks.mockResolvedValue([
+          {
+            id: 'task_1', name: 'Daily report', scheduleType: 'cron',
+            scheduleExpression: '0 9 * * 1-5', status: 'pending',
+            nextExecutionAt: new Date('2026-06-04T09:00:00Z'), timezone: 'America/New_York',
+            prompt: 'Send the daily report',
+          },
+          {
+            id: 'task_2', name: null, scheduleType: 'at',
+            scheduleExpression: 'at tomorrow 9am', status: 'paused',
+            nextExecutionAt: new Date('2026-06-04T13:00:00Z'), timezone: null,
+            prompt: 'One-off reminder',
+          },
+        ])
+
+        simulateToolUse('mcp__user-input__list_scheduled_tasks', 'tool-sched-list-1', {})
+
+        await flushHandlers()
+
+        expect(mockListPendingScheduledTasks).toHaveBeenCalledWith(AGENT_SLUG)
+        const resolveCall = mockContainerClientFetch.mock.calls.find(
+          (c) => c[0] === '/inputs/tool-sched-list-1/resolve'
+        )
+        expect(resolveCall).toBeDefined()
+        const body = JSON.parse(resolveCall![1].body)
+        expect(body.value).toContain('task_1')
+        expect(body.value).toContain('Daily report')
+        expect(body.value).toContain('0 9 * * 1-5')
+        expect(body.value).toContain('America/New_York')
+        expect(body.value).toContain('[PAUSED]')
+      })
+
+      it('resolves with empty message when no tasks', async () => {
+        mockListPendingScheduledTasks.mockResolvedValue([])
+
+        simulateToolUse('mcp__user-input__list_scheduled_tasks', 'tool-sched-list-empty', {})
+
+        await flushHandlers()
+
+        const resolveCall = mockContainerClientFetch.mock.calls.find(
+          (c) => c[0] === '/inputs/tool-sched-list-empty/resolve'
+        )
+        expect(resolveCall).toBeDefined()
+        const body = JSON.parse(resolveCall![1].body)
+        expect(body.value).toContain('No scheduled tasks')
+      })
+    })
+
+    describe('cancel_scheduled_task', () => {
+      it('broadcasts scheduled_task_cancelled on success', async () => {
+        const { events: globalEvents, cleanup: globalCleanup } = collectGlobalEvents()
+        sseEvents.length = 0
+        mockGetScheduledTask.mockResolvedValue({ id: 'task_existing', agentSlug: AGENT_SLUG })
+
+        simulateToolUse('mcp__user-input__cancel_scheduled_task', 'tool-sched-cancel-1', {
+          task_id: 'task_existing',
+        })
+
+        await flushHandlers()
+
+        expect(mockCancelScheduledTask).toHaveBeenCalledWith('task_existing')
+
+        const sseCancelled = sseEvents.filter(e => e.type === 'scheduled_task_cancelled')
+        expect(sseCancelled).toHaveLength(1)
+        expect(sseCancelled[0].taskId).toBe('task_existing')
+        expect(sseCancelled[0].agentSlug).toBe(AGENT_SLUG)
+
+        const globalCancelled = globalEvents.filter(e => e.type === 'scheduled_task_cancelled')
+        expect(globalCancelled).toHaveLength(1)
+
+        expect(mockContainerClientFetch).toHaveBeenCalledWith(
+          '/inputs/tool-sched-cancel-1/resolve',
+          expect.objectContaining({ method: 'POST' }),
+        )
+
+        globalCleanup()
+      })
+
+      it('rejects when task belongs to a different agent', async () => {
+        sseEvents.length = 0
+        mockGetScheduledTask.mockResolvedValue({ id: 'task_other', agentSlug: 'someone-else' })
+
+        simulateToolUse('mcp__user-input__cancel_scheduled_task', 'tool-sched-cancel-foreign', {
+          task_id: 'task_other',
+        })
+
+        await flushHandlers()
+
+        expect(mockCancelScheduledTask).not.toHaveBeenCalled()
+        expect(mockContainerClientFetch).toHaveBeenCalledWith(
+          '/inputs/tool-sched-cancel-foreign/reject',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.stringContaining('not found'),
+          }),
+        )
+        const sseCancelled = sseEvents.filter(e => e.type === 'scheduled_task_cancelled')
+        expect(sseCancelled).toHaveLength(0)
+      })
+
+      it('rejects when the task cannot be cancelled (already executed/cancelled)', async () => {
+        mockGetScheduledTask.mockResolvedValue({ id: 'task_done', agentSlug: AGENT_SLUG })
+        mockCancelScheduledTask.mockResolvedValue(false)
+
+        simulateToolUse('mcp__user-input__cancel_scheduled_task', 'tool-sched-cancel-done', {
+          task_id: 'task_done',
+        })
+
+        await flushHandlers()
+
+        expect(mockContainerClientFetch).toHaveBeenCalledWith(
+          '/inputs/tool-sched-cancel-done/reject',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.stringContaining('could not be cancelled'),
+          }),
+        )
+      })
+
+      it('rejects when task_id is missing', async () => {
+        simulateToolUse('mcp__user-input__cancel_scheduled_task', 'tool-sched-cancel-noid', {})
+
+        await flushHandlers()
+
+        expect(mockContainerClientFetch).toHaveBeenCalledWith(
+          '/inputs/tool-sched-cancel-noid/reject',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.stringContaining('Missing required field'),
+          }),
+        )
+      })
+    })
+
+    describe('pause_scheduled_task', () => {
+      it('broadcasts scheduled_task_updated on success', async () => {
+        const { events: globalEvents, cleanup: globalCleanup } = collectGlobalEvents()
+        sseEvents.length = 0
+        mockGetScheduledTask.mockResolvedValue({ id: 'task_cron', agentSlug: AGENT_SLUG })
+
+        simulateToolUse('mcp__user-input__pause_scheduled_task', 'tool-sched-pause-1', {
+          task_id: 'task_cron',
+        })
+
+        await flushHandlers()
+
+        expect(mockPauseScheduledTask).toHaveBeenCalledWith('task_cron')
+
+        const sseUpdated = sseEvents.filter(e => e.type === 'scheduled_task_updated')
+        expect(sseUpdated).toHaveLength(1)
+        expect(sseUpdated[0].taskId).toBe('task_cron')
+        expect(sseUpdated[0].agentSlug).toBe(AGENT_SLUG)
+
+        const globalUpdated = globalEvents.filter(e => e.type === 'scheduled_task_updated')
+        expect(globalUpdated).toHaveLength(1)
+
+        expect(mockContainerClientFetch).toHaveBeenCalledWith(
+          '/inputs/tool-sched-pause-1/resolve',
+          expect.objectContaining({ method: 'POST' }),
+        )
+
+        globalCleanup()
+      })
+
+      it('rejects when the task cannot be paused (not an active recurring task)', async () => {
+        sseEvents.length = 0
+        mockGetScheduledTask.mockResolvedValue({ id: 'task_at', agentSlug: AGENT_SLUG })
+        mockPauseScheduledTask.mockResolvedValue(false)
+
+        simulateToolUse('mcp__user-input__pause_scheduled_task', 'tool-sched-pause-bad', {
+          task_id: 'task_at',
+        })
+
+        await flushHandlers()
+
+        expect(mockContainerClientFetch).toHaveBeenCalledWith(
+          '/inputs/tool-sched-pause-bad/reject',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.stringContaining('could not be paused'),
+          }),
+        )
+        const sseUpdated = sseEvents.filter(e => e.type === 'scheduled_task_updated')
+        expect(sseUpdated).toHaveLength(0)
+      })
+
+      it('rejects when task belongs to a different agent', async () => {
+        mockGetScheduledTask.mockResolvedValue({ id: 'task_other', agentSlug: 'someone-else' })
+
+        simulateToolUse('mcp__user-input__pause_scheduled_task', 'tool-sched-pause-foreign', {
+          task_id: 'task_other',
+        })
+
+        await flushHandlers()
+
+        expect(mockPauseScheduledTask).not.toHaveBeenCalled()
+        expect(mockContainerClientFetch).toHaveBeenCalledWith(
+          '/inputs/tool-sched-pause-foreign/reject',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.stringContaining('not found'),
+          }),
+        )
+      })
+    })
+
+    describe('resume_scheduled_task', () => {
+      it('broadcasts scheduled_task_updated on success', async () => {
+        const { events: globalEvents, cleanup: globalCleanup } = collectGlobalEvents()
+        sseEvents.length = 0
+        mockGetScheduledTask.mockResolvedValue({ id: 'task_paused', agentSlug: AGENT_SLUG })
+
+        simulateToolUse('mcp__user-input__resume_scheduled_task', 'tool-sched-resume-1', {
+          task_id: 'task_paused',
+        })
+
+        await flushHandlers()
+
+        expect(mockResumeScheduledTask).toHaveBeenCalledWith('task_paused')
+
+        const sseUpdated = sseEvents.filter(e => e.type === 'scheduled_task_updated')
+        expect(sseUpdated).toHaveLength(1)
+        expect(sseUpdated[0].taskId).toBe('task_paused')
+        expect(sseUpdated[0].agentSlug).toBe(AGENT_SLUG)
+
+        const globalUpdated = globalEvents.filter(e => e.type === 'scheduled_task_updated')
+        expect(globalUpdated).toHaveLength(1)
+
+        expect(mockContainerClientFetch).toHaveBeenCalledWith(
+          '/inputs/tool-sched-resume-1/resolve',
+          expect.objectContaining({ method: 'POST' }),
+        )
+
+        globalCleanup()
+      })
+
+      it('rejects when the task cannot be resumed (not paused)', async () => {
+        sseEvents.length = 0
+        mockGetScheduledTask.mockResolvedValue({ id: 'task_active', agentSlug: AGENT_SLUG })
+        mockResumeScheduledTask.mockResolvedValue(false)
+
+        simulateToolUse('mcp__user-input__resume_scheduled_task', 'tool-sched-resume-bad', {
+          task_id: 'task_active',
+        })
+
+        await flushHandlers()
+
+        expect(mockContainerClientFetch).toHaveBeenCalledWith(
+          '/inputs/tool-sched-resume-bad/reject',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.stringContaining('could not be resumed'),
+          }),
+        )
+        const sseUpdated = sseEvents.filter(e => e.type === 'scheduled_task_updated')
+        expect(sseUpdated).toHaveLength(0)
       })
     })
   })

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -7,7 +7,14 @@ import type { RequestConnectedAccountInput } from '@shared/lib/tool-definitions/
 import type { RequestRemoteMcpInput } from '@shared/lib/tool-definitions/request-remote-mcp'
 import type { RequestBrowserInputInput } from '@shared/lib/tool-definitions/request-browser-input'
 import type { RequestScriptRunInput } from '@shared/lib/tool-definitions/request-script-run'
-import { createScheduledTask } from '@shared/lib/services/scheduled-task-service'
+import {
+  createScheduledTask,
+  listPendingScheduledTasks,
+  getScheduledTask,
+  cancelScheduledTask,
+  pauseScheduledTask,
+  resumeScheduledTask,
+} from '@shared/lib/services/scheduled-task-service'
 import {
   createWebhookTrigger,
   listActiveWebhookTriggers,
@@ -1396,6 +1403,48 @@ class MessagePersister {
             )
           }
 
+          // List scheduled tasks tool - blocking
+          if (state.currentToolUse.name === 'mcp__user-input__list_scheduled_tasks') {
+            this.handleListScheduledTasksTool(
+              sessionId,
+              state.currentToolUse.id,
+              state.currentToolInput,
+              state.agentSlug
+            )
+          }
+
+          // Cancel scheduled task tool - blocking
+          if (state.currentToolUse.name === 'mcp__user-input__cancel_scheduled_task') {
+            this.handleCancelScheduledTaskTool(
+              sessionId,
+              state.currentToolUse.id,
+              state.currentToolInput,
+              state.agentSlug
+            )
+          }
+
+          // Pause scheduled task tool - blocking
+          if (state.currentToolUse.name === 'mcp__user-input__pause_scheduled_task') {
+            this.handlePauseResumeScheduledTaskTool(
+              'pause',
+              sessionId,
+              state.currentToolUse.id,
+              state.currentToolInput,
+              state.agentSlug
+            )
+          }
+
+          // Resume scheduled task tool - blocking
+          if (state.currentToolUse.name === 'mcp__user-input__resume_scheduled_task') {
+            this.handlePauseResumeScheduledTaskTool(
+              'resume',
+              sessionId,
+              state.currentToolUse.id,
+              state.currentToolInput,
+              state.agentSlug
+            )
+          }
+
           // Webhook trigger tools
           if (state.currentToolUse.name === 'mcp__user-input__get_available_triggers') {
             this.handleGetAvailableTriggersTool(
@@ -1700,6 +1749,185 @@ class MessagePersister {
         })
       } catch (error) {
         console.error('[MessagePersister] Error handling schedule task:', error)
+      }
+    })()
+  }
+
+  // Handle list_scheduled_tasks - blocking: read from SQLite and resolve
+  private handleListScheduledTasksTool(
+    _sessionId: string,
+    toolUseId: string,
+    _toolInput: string,
+    agentSlug?: string
+  ): void {
+    ;(async () => {
+      try {
+        if (!agentSlug) {
+          console.error('[MessagePersister] list_scheduled_tasks missing agentSlug')
+          return
+        }
+
+        const tasks = await listPendingScheduledTasks(agentSlug)
+        const formatted = tasks.length === 0
+          ? 'No scheduled tasks on the schedule for this agent.'
+          : `Scheduled tasks:\n\n${tasks.map((t) => {
+              const kind = t.scheduleType === 'cron' ? 'recurring' : 'one-time'
+              const next = t.nextExecutionAt ? t.nextExecutionAt.toISOString() : 'unknown'
+              const status = t.status === 'paused' ? ' [PAUSED]' : ''
+              return `- **${t.name || 'Scheduled Task'}** (ID: ${t.id})${status}\n  Type: ${kind} (${t.scheduleExpression})\n  Next run: ${next}${t.timezone ? ` (${t.timezone})` : ''}\n  Prompt: ${t.prompt.substring(0, 80)}${t.prompt.length > 80 ? '...' : ''}`
+            }).join('\n\n')}`
+
+        await this.resolveContainerInput(agentSlug, toolUseId, formatted)
+      } catch (error) {
+        console.error('[MessagePersister] Error handling list_scheduled_tasks:', error)
+        if (agentSlug) {
+          await this.rejectContainerInput(agentSlug, toolUseId, String(error)).catch(console.error)
+        }
+      }
+    })()
+  }
+
+  // Handle cancel_scheduled_task - blocking: cancel in SQLite, then resolve
+  private handleCancelScheduledTaskTool(
+    sessionId: string,
+    toolUseId: string,
+    toolInput: string,
+    agentSlug?: string
+  ): void {
+    ;(async () => {
+      try {
+        if (!agentSlug) {
+          console.error('[MessagePersister] cancel_scheduled_task missing agentSlug')
+          return
+        }
+
+        let input: { task_id: string }
+        try {
+          input = JSON.parse(toolInput)
+        } catch {
+          await this.rejectContainerInput(agentSlug, toolUseId, 'Invalid tool input')
+          return
+        }
+
+        if (!input.task_id) {
+          await this.rejectContainerInput(agentSlug, toolUseId, 'Missing required field: task_id')
+          return
+        }
+
+        // Verify the task exists and belongs to this agent before cancelling, so
+        // an agent can't cancel another agent's scheduled tasks by guessing IDs.
+        const task = await getScheduledTask(input.task_id)
+        if (!task || task.agentSlug !== agentSlug) {
+          await this.rejectContainerInput(agentSlug, toolUseId, `Scheduled task ${input.task_id} not found`)
+          return
+        }
+
+        const cancelled = await cancelScheduledTask(input.task_id)
+        if (!cancelled) {
+          await this.rejectContainerInput(agentSlug, toolUseId, `Scheduled task ${input.task_id} could not be cancelled — it may have already executed or been cancelled`)
+          return
+        }
+
+        // Broadcast so the scheduled task list updates in the UI
+        this.broadcastToSSE(sessionId, {
+          type: 'scheduled_task_cancelled',
+          toolUseId,
+          taskId: input.task_id,
+          agentSlug,
+        })
+
+        this.broadcastGlobal({
+          type: 'scheduled_task_cancelled',
+          taskId: input.task_id,
+          agentSlug,
+        })
+
+        await this.resolveContainerInput(agentSlug, toolUseId,
+          `Scheduled task ${input.task_id} has been cancelled. It will no longer execute.`)
+
+        console.log(`[MessagePersister] Scheduled task ${input.task_id} cancelled`)
+      } catch (error) {
+        console.error('[MessagePersister] Error handling cancel_scheduled_task:', error)
+        if (agentSlug) {
+          const msg = error instanceof Error ? error.message : String(error)
+          await this.rejectContainerInput(agentSlug, toolUseId, `Failed to cancel scheduled task: ${msg}`).catch(console.error)
+        }
+      }
+    })()
+  }
+
+  // Handle pause_scheduled_task / resume_scheduled_task - blocking: update SQLite, then resolve
+  private handlePauseResumeScheduledTaskTool(
+    action: 'pause' | 'resume',
+    sessionId: string,
+    toolUseId: string,
+    toolInput: string,
+    agentSlug?: string
+  ): void {
+    ;(async () => {
+      try {
+        if (!agentSlug) {
+          console.error(`[MessagePersister] ${action}_scheduled_task missing agentSlug`)
+          return
+        }
+
+        let input: { task_id: string }
+        try {
+          input = JSON.parse(toolInput)
+        } catch {
+          await this.rejectContainerInput(agentSlug, toolUseId, 'Invalid tool input')
+          return
+        }
+
+        if (!input.task_id) {
+          await this.rejectContainerInput(agentSlug, toolUseId, 'Missing required field: task_id')
+          return
+        }
+
+        // Verify the task exists and belongs to this agent before mutating it.
+        const task = await getScheduledTask(input.task_id)
+        if (!task || task.agentSlug !== agentSlug) {
+          await this.rejectContainerInput(agentSlug, toolUseId, `Scheduled task ${input.task_id} not found`)
+          return
+        }
+
+        const ok = action === 'pause'
+          ? await pauseScheduledTask(input.task_id)
+          : await resumeScheduledTask(input.task_id)
+
+        if (!ok) {
+          const reason = action === 'pause'
+            ? `Scheduled task ${input.task_id} could not be paused — only active recurring tasks can be paused`
+            : `Scheduled task ${input.task_id} could not be resumed — only paused recurring tasks can be resumed`
+          await this.rejectContainerInput(agentSlug, toolUseId, reason)
+          return
+        }
+
+        // Broadcast so the scheduled task list updates in the UI
+        this.broadcastToSSE(sessionId, {
+          type: 'scheduled_task_updated',
+          toolUseId,
+          taskId: input.task_id,
+          agentSlug,
+        })
+
+        this.broadcastGlobal({
+          type: 'scheduled_task_updated',
+          taskId: input.task_id,
+          agentSlug,
+        })
+
+        const verb = action === 'pause' ? 'paused' : 'resumed'
+        await this.resolveContainerInput(agentSlug, toolUseId,
+          `Scheduled task ${input.task_id} has been ${verb}.${action === 'pause' ? ' It will not execute until resumed.' : ' Its next run was recomputed from the schedule.'}`)
+
+        console.log(`[MessagePersister] Scheduled task ${input.task_id} ${verb}`)
+      } catch (error) {
+        console.error(`[MessagePersister] Error handling ${action}_scheduled_task:`, error)
+        if (agentSlug) {
+          const msg = error instanceof Error ? error.message : String(error)
+          await this.rejectContainerInput(agentSlug, toolUseId, `Failed to ${action} scheduled task: ${msg}`).catch(console.error)
+        }
       }
     })()
   }


### PR DESCRIPTION
## Summary

Agents could already create cron jobs via `schedule_task`, but had no way to **see** or **manage** the ones they'd created. This adds four blocking tools to the `user-input` MCP server, modeled on the existing webhook-trigger tools:

| Tool | Args | Behavior |
|------|------|----------|
| `list_scheduled_tasks` | — | Lists pending/paused tasks: id, name, schedule, next run, prompt |
| `cancel_scheduled_task` | `task_id` | Removes a task from the schedule |
| `pause_scheduled_task` | `task_id` | Pauses an active recurring (cron) task |
| `resume_scheduled_task` | `task_id` | Resumes a paused task (next run recomputed from cron, missed runs skipped) |

All four are **blocking** (the agent waits for a real result), unlike fire-and-forget `schedule_task`. They reuse the existing `scheduled-task-service` functions and the `inputManager.createPendingWithType` → `resolveContainerInput`/`rejectContainerInput` plumbing.

## Implementation notes

- **Ownership-checked:** every mutating handler verifies `task.agentSlug === agentSlug` before acting, so an agent can't cancel/pause/resume another agent's tasks by guessing IDs. (This is stricter than the webhook-trigger handler it's based on, which skips the ownership check — worth back-porting separately.)
- **Live UI sync:** handlers broadcast new `scheduled_task_cancelled` / `scheduled_task_updated` SSE events; `use-message-stream` and `global-notification-handler` invalidate the `scheduled-tasks` and `agents` query caches on them.
- **Always-on:** registered unconditionally like `schedule_task` (no platform gating — scheduling has no Composio-style dependency).
- **System prompt:** the Scheduling section now documents the management tools and corrects the note that implied only the user could manage tasks.

## Tests

11 new tests in `message-persister.test.ts` covering: formatted list, empty list, successful cancel/pause/resume with SSE broadcast, cross-agent rejection, missing `task_id`, and the can't-pause / can't-resume guard paths. Full suite green (231 tests across the two affected files); root typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)