### PR TITLE
test(e2e): fix settings + model-selection specs after LLM restyle (#173)

### DIFF
--- a/e2e/specs/model-selection.spec.ts
+++ b/e2e/specs/model-selection.spec.ts
@@ -135,7 +135,7 @@ test.describe('Model selection', () => {
     expect(sendRecord.effort).toBe('low')
   })
 
-  test('switching from Opus+ExtraHigh to Sonnet auto-resets effort to High on the next send', async ({ page }, testInfo) => {
+  test('switching from Opus+ExtraHigh to Sonnet auto-resets effort to Medium on the next send', async ({ page }, testInfo) => {
     const tag = `${testInfo.workerIndex}-${Date.now()}`
     const initialMessage = `xhigh→sonnet auto-reset ${tag}`
 
@@ -149,12 +149,12 @@ test.describe('Model selection', () => {
     await page.locator('[data-testid="effort-option-xhigh"]').click()
 
     // Switch to Sonnet — popover's auto-reset effect should clamp effort back
-    // to High since Sonnet doesn't allow xhigh.
+    // to Medium (the default) since Sonnet doesn't allow xhigh.
     await page.locator('[data-testid="composer-options-trigger"]').click()
     await page.locator('[data-testid="model-option-sonnet"]').click()
 
-    // Trigger should now read "Sonnet · High" (effort was auto-reset).
-    await expect(page.locator('[data-testid="composer-options-trigger"]')).toContainText('High')
+    // Trigger should now read "Sonnet · Medium" (effort was auto-reset).
+    await expect(page.locator('[data-testid="composer-options-trigger"]')).toContainText('Medium')
     await expect(page.locator('[data-testid="composer-options-trigger"]')).not.toContainText('Extra High')
 
     await page.locator('[data-testid="home-message-input"]').fill(initialMessage)
@@ -165,7 +165,7 @@ test.describe('Model selection', () => {
       (r) => r.type === 'createSession' && r.initialMessage === initialMessage
     )
     expect(record.model).toBe('sonnet')
-    expect(record.effort).toBe('high')
+    expect(record.effort).toBe('medium')
   })
 
   test('AgentHome trigger displays the family of the user pinned default model', async ({ page }, testInfo) => {

--- a/e2e/specs/settings.spec.ts
+++ b/e2e/specs/settings.spec.ts
@@ -80,7 +80,7 @@ test.describe('Settings Page', () => {
 
     // Click LLM tab
     await goToTab(page, 'llm')
-    await expect(page.locator('#llm-provider')).toBeVisible()
+    await expect(page.locator('[data-testid="llm-provider-card-anthropic"]')).toBeVisible()
 
     // Click Runtime tab
     await goToTab(page, 'runtime')
@@ -88,7 +88,7 @@ test.describe('Settings Page', () => {
 
     // Click Browser tab
     await goToTab(page, 'browser')
-    await expect(page.locator('#browser-model')).toBeVisible()
+    await expect(page.locator('[data-testid="composer-options-trigger"]')).toBeVisible()
 
     // Click General tab
     await goToTab(page, 'general')
@@ -99,9 +99,10 @@ test.describe('Settings Page', () => {
     await openSettings(page)
     await goToTab(page, 'llm')
 
-    await expect(page.locator('#llm-provider')).toBeVisible()
-    await expect(page.locator('#agent-model')).toBeVisible()
-    await expect(page.locator('#summarizer-model')).toBeVisible()
+    // Provider radio cards replace the old <select>; the active provider's card
+    // expands inline to show its two model selectors (default + summarizer).
+    await expect(page.locator('[data-testid="llm-provider-card-anthropic"]')).toBeVisible()
+    await expect(page.locator('[data-testid="composer-options-trigger"]')).toHaveCount(2)
   })
 
   test('Runtime tab shows container config fields', async ({ page }) => {
@@ -120,7 +121,7 @@ test.describe('Settings Page', () => {
     await openSettings(page)
     await goToTab(page, 'browser')
 
-    await expect(page.locator('#browser-model')).toBeVisible()
+    await expect(page.locator('[data-testid="composer-options-trigger"]')).toBeVisible()
     await expect(page.locator('#max-browser-tabs')).toBeVisible()
     await expect(page.locator('#browser-host')).toBeVisible()
   })


### PR DESCRIPTION
## Summary

`main` is red after #173 merged — the E2E `settings.spec.ts` asserts DOM that the restyle removed, which cascades to skip the rest of the serial block (and the `web-chromium` project that depends on it).

### Root cause
#173 changed the LLM settings UI:
- provider `<select id="llm-provider">` → radio cards (`data-testid="llm-provider-card-*"`)
- `#agent-model` / `#summarizer-model` / `#browser-model` dropdowns → the composer's model/effort popover (`data-testid="composer-options-trigger"`)
- default reasoning effort `high` → `medium`

### Changes
- **settings.spec.ts**: updated the three tests that referenced the removed ids.
- **model-selection.spec.ts**: Opus+xhigh → Sonnet now auto-resets effort to **Medium** (was High). This spec is in the `web-chromium` project which *depends on* `global-state`; it was **skipped** in CI once settings failed, so its medium-default breakage would only surface after settings is fixed — corrected here too.

### Verification
Local `E2E_MOCK=true npx playwright test`:
- `global-state` settings.spec.ts — **34 passed**
- `web-chromium` model-selection.spec.ts — **5 passed** (incl. auto-reset → Medium)

🤖 Generated with [Claude Code](https://claude.com/claude-code)