### PR TITLE
fix(a11y): theme picker is a radiogroup, not dangling Radix tabs

### DIFF
--- a/src/renderer/components/settings/general-tab.tsx
+++ b/src/renderer/components/settings/general-tab.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useState, type ReactNode } from 'react'
 import { Button } from '@renderer/components/ui/button'
 import { Switch } from '@renderer/components/ui/switch'
-import { Tabs, TabsList, TabsTrigger } from '@renderer/components/ui/tabs'
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from '@renderer/components/ui/tooltip'
+import { cn } from '@shared/lib/utils/cn'
 import { TimezonePicker } from '@renderer/components/ui/timezone-picker'
 import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user-settings'
 import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
@@ -137,38 +137,45 @@ export function GeneralTab({ onOpenWizard }: GeneralTabProps) {
             subtitle="Choose light or dark theme, or follow your system setting"
             right={
               <TooltipProvider delayDuration={0}>
-                <Tabs
-                  value={userSettings?.theme ?? 'system'}
-                  onValueChange={(value) => {
-                    updateUserSettings.mutate({ theme: value as 'system' | 'light' | 'dark' })
-                  }}
+                {/* Single-select segmented control. Intentionally NOT Radix Tabs:
+                    a theme picker has no tab panels, so TabsTrigger's aria-controls
+                    would dangle (critical aria-valid-attr-value violation). */}
+                <div
+                  role="radiogroup"
+                  aria-label="Appearance"
+                  className="inline-flex h-8 items-center justify-center rounded-lg bg-muted p-0.5 text-muted-foreground"
                 >
-                  <TabsList className="h-8 p-0.5">
-                    {(
-                      [
-                        { value: 'system', label: 'System', Icon: Monitor },
-                        { value: 'light', label: 'Light', Icon: Sun },
-                        { value: 'dark', label: 'Dark', Icon: Moon },
-                      ] as const
-                    ).map(({ value, label, Icon }) => (
+                  {(
+                    [
+                      { value: 'system', label: 'System', Icon: Monitor },
+                      { value: 'light', label: 'Light', Icon: Sun },
+                      { value: 'dark', label: 'Dark', Icon: Moon },
+                    ] as const
+                  ).map(({ value, label, Icon }) => {
+                    const selected = (userSettings?.theme ?? 'system') === value
+                    return (
                       <Tooltip key={value}>
                         <TooltipTrigger asChild>
-                          <span className="inline-flex">
-                            <TabsTrigger
-                              value={value}
-                              className="h-7 w-8 px-0"
-                              disabled={isUserSettingsLoading}
-                              aria-label={`${label} theme`}
-                            >
-                              <Icon className="h-3.5 w-3.5" />
-                            </TabsTrigger>
-                          </span>
+                          <button
+                            type="button"
+                            role="radio"
+                            aria-checked={selected}
+                            aria-label={`${label} theme`}
+                            disabled={isUserSettingsLoading}
+                            onClick={() => updateUserSettings.mutate({ theme: value })}
+                            className={cn(
+                              'inline-flex h-7 w-8 items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+                              selected && 'bg-background text-foreground shadow',
+                            )}
+                          >
+                            <Icon className="h-3.5 w-3.5" />
+                          </button>
                         </TooltipTrigger>
                         <TooltipContent>{label}</TooltipContent>
                       </Tooltip>
-                    ))}
-                  </TabsList>
-                </Tabs>
+                    )
+                  })}
+                </div>
               </TooltipProvider>
             }
           />


### PR DESCRIPTION
## Summary

`main`'s `e2e-tests` job is red on a **critical** axe-core violation, surfaced in `a11y-audit.spec.ts › global settings page has no critical a11y violations`:

```
[CRITICAL] aria-valid-attr-value: Ensure all ARIA attributes have valid values
HTML: <button role="tab" aria-controls="radix-…-content-…" aria-label="System theme" …>
```

## Root cause

The Appearance **theme picker** (`general-tab.tsx`, from the General settings restyle) used Radix `Tabs`/`TabsTrigger` as a segmented control but rendered **no `TabsContent`**. Radix still puts `aria-controls="…-content-…"` on each trigger, so it points at a panel that doesn't exist → critical `aria-valid-attr-value`. It's also semantically wrong (a theme picker is single-select, not a tabset).

This was **masked, not introduced, by the LLM restyle wave**: `a11y-audit.spec.ts` runs in the `web-chromium` project, which depends on `global-state` (`settings.spec.ts`). While settings was red the audit was skipped; fixing settings in #183 un-masked this pre-existing violation.

## Fix

Replace the misused `Tabs` with an accessible segmented control — `role="radiogroup"` wrapping `role="radio"` + `aria-checked` buttons — styled identically. No dangling `aria-controls`, no new dependency, same look/behavior (tooltips preserved).

## Verification

`E2E_MOCK=true npx playwright test --project=web-chromium a11y-audit.spec.ts` → **5 passed**, zero critical violations on the global settings page. `tsc` clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)