### PR TITLE
fix: skip wizard welcome when platform is connected

### DIFF
--- a/src/renderer/components/wizard/configure-llm-step.test.tsx
+++ b/src/renderer/components/wizard/configure-llm-step.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+const mocks = vi.hoisted(() => ({
+  useSettings: vi.fn(),
+  useUpdateSettings: vi.fn(),
+  usePlatformAuthStatus: vi.fn(),
+}))
+
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useSettings: () => mocks.useSettings(),
+  useUpdateSettings: () => mocks.useUpdateSettings(),
+}))
+
+vi.mock('@renderer/hooks/use-platform-auth', () => ({
+  usePlatformAuthStatus: () => mocks.usePlatformAuthStatus(),
+}))
+
+vi.mock('@renderer/components/settings/provider-api-key-input', () => ({
+  ProviderApiKeyInput: () => <div data-testid="provider-api-key-input" />,
+}))
+
+vi.mock('@renderer/components/settings/bedrock-credentials-input', () => ({
+  BedrockCredentialsInput: () => <div data-testid="bedrock-credentials-input" />,
+}))
+
+import { ConfigureLLMStep } from './configure-llm-step'
+
+beforeEach(() => {
+  mocks.useUpdateSettings.mockReturnValue({ mutate: vi.fn() })
+  mocks.useSettings.mockReturnValue({
+    data: {
+      llmProvider: 'anthropic',
+      apiKeyStatus: {
+        anthropic: { isConfigured: false },
+      },
+    },
+  })
+  mocks.usePlatformAuthStatus.mockReturnValue({
+    data: { connected: false },
+  })
+})
+
+describe('ConfigureLLMStep', () => {
+  it('lets a connected platform provider satisfy the LLM setup step', async () => {
+    const onCanProceedChange = vi.fn()
+    mocks.useSettings.mockReturnValue({
+      data: {
+        llmProvider: 'platform',
+        apiKeyStatus: {
+          anthropic: { isConfigured: false },
+        },
+      },
+    })
+    mocks.usePlatformAuthStatus.mockReturnValue({
+      data: { connected: true },
+    })
+
+    render(<ConfigureLLMStep onCanProceedChange={onCanProceedChange} />)
+
+    expect(screen.getByText('Platform')).toBeInTheDocument()
+    expect(screen.getByText(/platform-managed credentials/i)).toBeInTheDocument()
+    await waitFor(() => expect(onCanProceedChange).toHaveBeenCalledWith(true))
+  })
+
+  it('does not show platform as a manual setup option when disconnected', () => {
+    render(<ConfigureLLMStep onCanProceedChange={vi.fn()} />)
+
+    expect(screen.queryByText('Platform')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/wizard/configure-llm-step.tsx
+++ b/src/renderer/components/wizard/configure-llm-step.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { ProviderApiKeyInput } from '@renderer/components/settings/provider-api-key-input'
 import { BedrockCredentialsInput } from '@renderer/components/settings/bedrock-credentials-input'
 import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
+import { usePlatformAuthStatus } from '@renderer/hooks/use-platform-auth'
 import { ChevronRight } from 'lucide-react'
 import type { LlmProviderId } from '@shared/lib/config/settings'
 
@@ -55,6 +56,11 @@ const LLM_PROVIDER_OPTIONS: Array<{
   description: string
 }> = [
   {
+    id: 'platform',
+    label: 'Platform',
+    description: 'Use the account-managed LLM credentials already connected to SuperAgent.',
+  },
+  {
     id: 'anthropic',
     label: 'Anthropic',
     description: 'Direct API access to Claude models.',
@@ -77,14 +83,21 @@ interface ConfigureLLMStepProps {
 
 export function ConfigureLLMStep({ onCanProceedChange }: ConfigureLLMStepProps) {
   const { data: settings } = useSettings()
+  const { data: platformAuth } = usePlatformAuthStatus()
   const updateSettings = useUpdateSettings()
 
   const activeProvider = (settings?.llmProvider ?? 'anthropic') as LlmProviderId
   const [showInstructions, setShowInstructions] = useState<string | null>(null)
+  const isPlatformConnected = platformAuth?.connected ?? false
+  const providerOptions = isPlatformConnected
+    ? LLM_PROVIDER_OPTIONS
+    : LLM_PROVIDER_OPTIONS.filter((option) => option.id !== 'platform')
 
   // Report to parent whether the selected provider has configured keys
   const apiKeyStatus = (settings?.apiKeyStatus as Record<string, { isConfigured: boolean }> | undefined)
-  const activeProviderConfigured = apiKeyStatus?.[activeProvider]?.isConfigured ?? false
+  const activeProviderConfigured = activeProvider === 'platform'
+    ? isPlatformConnected
+    : apiKeyStatus?.[activeProvider]?.isConfigured ?? false
   useEffect(() => {
     onCanProceedChange?.(activeProviderConfigured)
   }, [activeProviderConfigured, onCanProceedChange])
@@ -99,7 +112,7 @@ export function ConfigureLLMStep({ onCanProceedChange }: ConfigureLLMStepProps) 
       </div>
 
       <div className="space-y-3">
-        {LLM_PROVIDER_OPTIONS.map((option) => {
+        {providerOptions.map((option) => {
           const isSelected = activeProvider === option.id
           const instructions = PROVIDER_INSTRUCTIONS[option.id]
 
@@ -131,7 +144,11 @@ export function ConfigureLLMStep({ onCanProceedChange }: ConfigureLLMStepProps) 
               <div className={`grid transition-all duration-200 ease-in-out ${isSelected ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
                 <div className="overflow-hidden">
                   <div className="px-3 pb-3 pt-2">
-                    {option.id === 'bedrock' ? (
+                    {option.id === 'platform' ? (
+                      <p className="text-xs text-muted-foreground">
+                        Your account is already connected. SuperAgent will use the platform-managed credentials for LLM requests.
+                      </p>
+                    ) : option.id === 'bedrock' ? (
                       <BedrockCredentialsInput
                         key="bedrock"
                         showNotConfiguredAlert={false}

--- a/src/renderer/components/wizard/getting-started-wizard.test.tsx
+++ b/src/renderer/components/wizard/getting-started-wizard.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+const mocks = vi.hoisted(() => ({
+  useUserSettings: vi.fn(),
+  useUpdateUserSettings: vi.fn(),
+  useUpdateSettings: vi.fn(),
+  usePlatformAuthStatus: vi.fn(),
+}))
+
+vi.mock('@renderer/hooks/use-user-settings', () => ({
+  useUserSettings: () => mocks.useUserSettings(),
+  useUpdateUserSettings: () => mocks.useUpdateUserSettings(),
+}))
+
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useUpdateSettings: () => mocks.useUpdateSettings(),
+}))
+
+vi.mock('@renderer/hooks/use-platform-auth', () => ({
+  usePlatformAuthStatus: () => mocks.usePlatformAuthStatus(),
+}))
+
+vi.mock('@renderer/lib/env', () => ({
+  isElectron: () => false,
+  getPlatform: () => 'darwin',
+}))
+
+vi.mock('./welcome-step', () => ({
+  WelcomeStep: () => <div data-testid="welcome-step">Welcome</div>,
+}))
+
+vi.mock('./configure-llm-step', () => ({
+  ConfigureLLMStep: () => <div data-testid="llm-step">LLM</div>,
+}))
+
+vi.mock('./browser-setup-step', () => ({
+  BrowserSetupStep: () => <div data-testid="browser-step">Browser</div>,
+}))
+
+vi.mock('./composio-step', () => ({
+  ComposioStep: () => <div data-testid="composio-step">Composio</div>,
+}))
+
+vi.mock('./docker-setup-step', () => ({
+  DockerSetupStep: () => <div data-testid="runtime-step">Runtime</div>,
+}))
+
+vi.mock('./privacy-step', () => ({
+  PrivacyStep: () => <div data-testid="privacy-step">Privacy</div>,
+}))
+
+vi.mock('./create-agent-step', () => ({
+  CreateAgentStep: () => <div data-testid="agent-step">Agent</div>,
+}))
+
+vi.mock('./ribbon-wave', () => ({
+  RibbonWave: () => <div data-testid="ribbon-wave" />,
+}))
+
+import { GettingStartedWizard } from './getting-started-wizard'
+
+beforeEach(() => {
+  mocks.useUserSettings.mockReturnValue({
+    data: {
+      setupCompleted: false,
+      onboardingProgress: null,
+    },
+  })
+  mocks.useUpdateUserSettings.mockReturnValue({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+  })
+  mocks.useUpdateSettings.mockReturnValue({
+    mutateAsync: vi.fn(),
+  })
+  mocks.usePlatformAuthStatus.mockReturnValue({
+    data: { connected: false },
+    isLoading: false,
+  })
+})
+
+describe('GettingStartedWizard', () => {
+  it('starts on the platform path when platform auth is already connected', () => {
+    mocks.usePlatformAuthStatus.mockReturnValue({
+      data: { connected: true },
+      isLoading: false,
+    })
+
+    render(<GettingStartedWizard onClose={vi.fn()} />)
+
+    expect(screen.queryByTestId('welcome-step')).not.toBeInTheDocument()
+    expect(screen.getByTestId('browser-step')).toBeInTheDocument()
+  })
+
+  it('does not flash the welcome step while checking platform auth', () => {
+    mocks.usePlatformAuthStatus.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    })
+
+    render(<GettingStartedWizard onClose={vi.fn()} />)
+
+    expect(screen.queryByTestId('welcome-step')).not.toBeInTheDocument()
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/wizard/getting-started-wizard.tsx
+++ b/src/renderer/components/wizard/getting-started-wizard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo, useRef } from 'react'
 import { Button } from '@renderer/components/ui/button'
 import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user-settings'
 import { useUpdateSettings } from '@renderer/hooks/use-settings'
+import { usePlatformAuthStatus } from '@renderer/hooks/use-platform-auth'
 import {
   ChevronRight,
   ChevronLeft,
@@ -40,8 +41,12 @@ interface GettingStartedWizardProps {
 }
 
 export function GettingStartedWizard({ agentOnly, onClose }: GettingStartedWizardProps) {
+  const { data: platformAuth, isLoading: isLoadingPlatformAuth } = usePlatformAuthStatus()
+  const shouldUsePlatformPath = !agentOnly && !!platformAuth?.connected
   const [currentStep, setCurrentStep] = useState(0)
-  const [welcomePath, setWelcomePath] = useState<'platform' | 'manual' | null>(null)
+  const [welcomePath, setWelcomePath] = useState<'platform' | 'manual' | null>(
+    shouldUsePlatformPath ? 'platform' : null
+  )
   const [composioCanProceed, setComposioCanProceed] = useState(false)
   const [runtimeCanProceed, setRuntimeCanProceed] = useState(false)
   const [browserCanProceed, setBrowserCanProceed] = useState(true)
@@ -70,6 +75,17 @@ export function GettingStartedWizard({ agentOnly, onClose }: GettingStartedWizar
     if (hasRestoredRef.current) return
     hasRestoredRef.current = true
 
+    if (shouldUsePlatformPath) {
+      const progress = userSettings.onboardingProgress
+      const idx = progress?.path === 'platform'
+        ? PLATFORM_STEPS.findIndex(s => s.id === progress.stepId)
+        : -1
+      isRestoringRef.current = idx >= 0
+      setWelcomePath('platform')
+      setCurrentStep(idx >= 0 ? idx : 0)
+      return
+    }
+
     const progress = userSettings.onboardingProgress
     if (progress) {
       const targetSteps = progress.path === 'platform' ? PLATFORM_STEPS : MANUAL_STEPS
@@ -86,7 +102,14 @@ export function GettingStartedWizard({ agentOnly, onClose }: GettingStartedWizar
       setCurrentStep(0)
       setWelcomePath(null)
     }
-  }, [userSettings])
+  }, [shouldUsePlatformPath, userSettings])
+
+  useEffect(() => {
+    if (!shouldUsePlatformPath) return
+    if (welcomePath !== null && welcomePath !== 'manual') return
+    setWelcomePath('platform')
+    setCurrentStep(0)
+  }, [shouldUsePlatformPath, welcomePath])
 
   // Persist progress on every step change
   useEffect(() => {
@@ -142,6 +165,7 @@ export function GettingStartedWizard({ agentOnly, onClose }: GettingStartedWizar
   }
 
   const isAgentStep = agentOnly || activeStep?.id === 'agent'
+  const isCheckingPlatformPath = !agentOnly && !welcomePath && isLoadingPlatformAuth
 
   if (agentOnly) {
     return (
@@ -184,7 +208,10 @@ export function GettingStartedWizard({ agentOnly, onClose }: GettingStartedWizar
 
           {/* Step content */}
           <div className="min-h-[320px]" data-testid="wizard-step-content" data-step={currentStep}>
-            {!welcomePath && (
+            {isCheckingPlatformPath && (
+              <div className="text-sm text-muted-foreground">Loading...</div>
+            )}
+            {!welcomePath && !isCheckingPlatformPath && (
               <WelcomeStep
                 onChoosePlatform={handleWelcomePlatformPath}
                 onContinueToManualSetup={handleWelcomeManualSetup}
@@ -213,6 +240,7 @@ export function GettingStartedWizard({ agentOnly, onClose }: GettingStartedWizar
               variant="outline"
               onClick={() => {
                 if (currentStep === 0) {
+                  if (shouldUsePlatformPath) return
                   setWelcomePath(null)
                   return
                 }


### PR DESCRIPTION
## Summary
- Skip the wizard welcome/BYOK choice while platform auth is loading or already connected, and enter the platform onboarding path directly once connected.
- Prevent Back from returning connected platform users to the welcome path.
- Show Platform as a valid LLM provider in the wizard when platform auth is connected, allowing the LLM step to pass without BYOK credentials.

## Test plan
- `npx vitest run src/renderer/components/wizard/configure-llm-step.test.tsx src/renderer/components/wizard/getting-started-wizard.test.tsx`
- `ReadLints` on edited wizard files


Made with [Cursor](https://cursor.com)