### PR TITLE
Rename SuperAgent → Gamut (display strings only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
   <img src="build/icon.png" height="128">
-  <h1 align="center">SuperAgent - AI Agent Platform</h1>
+  <h1 align="center">Gamut - AI Agent Platform</h1>
 </p>
 
-SuperAgent is a super app for building and running personal agents. You can create custom agents, let them develop the skills they need to do task for you, and have them run automatocally in the background for you.
+Gamut is a super app for building and running personal agents. You can create custom agents, let them develop the skills they need to do task for you, and have them run automatocally in the background for you.
 
 | Windows | Mac |
 |:-------:|:---:|
@@ -11,7 +11,7 @@ SuperAgent is a super app for building and running personal agents. You can crea
 
 **Features:**
 
-- **Containerized Agents** - SuperAgents spins up a containerized sandbox per agent - keeping your computer secure. 
+- **Containerized Agents** - Gamut spins up a containerized sandbox per agent - keeping your computer secure. 
 - **Connected Accounts** - easily connect 100s of accounts your agent can use.
 - **Secure Integrations** - API calls are proxied outside your agent and the agent never sees Auth Tokens, keeping your account secure and giving you an audit trail of agent actions.
 - **Recurring and Scheduled Tasks** - agents can schedule recurring tasks and future work so they can serve you autonomously in the background.
@@ -21,19 +21,19 @@ SuperAgent is a super app for building and running personal agents. You can crea
 
 **Run as:**
 
-- **Web App** - you can run super agent in server mode and access it via the web. Great if you have a computer that can run it 24/7
-- **Desktop App** - you can download and run superagent locally in your machine as a desktop app.
+- **Web App** - you can run Gamut in server mode and access it via the web. Great if you have a computer that can run it 24/7
+- **Desktop App** - you can download and run Gamut locally in your machine as a desktop app.
 
 ## Pre-Reqs
 
-To get strated with Superagent, you need:
+To get strated with Gamut, you need:
 
-1. **A container runtime** -> this is where SuperAgent will run it’s agent containers. Our recommendations:
+1. **A container runtime** -> this is where Gamut will run it’s agent containers. Our recommendations:
   1. [Docker Desktop](https://docs.docker.com/desktop/setup/install/mac-install/)
   2. [OrbStack](https://orbstack.dev/download)
   3. [Podman](https://podman.io/get-started)
 2. **An Anthropic API Key** -> we currently only support Anthropic models, more coming soon. Get your API key from the [Anthropic Console](https://platform.claude.com/settings/keys).
-3. **[Optional] A Composio API key** -> SuperAgent uses Composio to generate OAuth Tokens for you for different acocunts. You can get one on [Composio](https://platform.composio.dev).
+3. **[Optional] A Composio API key** -> Gamut uses Composio to generate OAuth Tokens for you for different acocunts. You can get one on [Composio](https://platform.composio.dev).
 
 
 # Getting Started
@@ -43,7 +43,7 @@ Download the latest release from the links above, or visit the [releases page](h
 
 ## Running with Docker
 
-You can run Superagent in a Docker container using Docker-outside-of-Docker (DooD) to spawn agent containers.
+You can run Gamut in a Docker container using Docker-outside-of-Docker (DooD) to spawn agent containers.
 
 ### Using the published image
 
@@ -113,7 +113,7 @@ The image is published to `ghcr.io/iddogino/superagent` on every push to main an
 
 ## Auth Mode (Multi-User)
 
-Superagent can run in **auth mode** for multi-user deployments with role-based access control. When enabled, users sign up and sign in with email/password, and agents are isolated per user via ACLs.
+Gamut can run in **auth mode** for multi-user deployments with role-based access control. When enabled, users sign up and sign in with email/password, and agents are isolated per user via ACLs.
 
 ### How it works
 
@@ -186,14 +186,14 @@ The runtime variables (`TRUSTED_ORIGINS`, `BETTER_AUTH_SECRET`, etc.) are passed
 
 ### Optional: Composio OAuth setup
 
-If you connect accounts through Composio (Slack/Gmail/GitHub, etc.), make sure token masking is disabled in your Composio project settings, otherwise SuperAgent cannot read usable access tokens and proxy calls may fail.
+If you connect accounts through Composio (Slack/Gmail/GitHub, etc.), make sure token masking is disabled in your Composio project settings, otherwise Gamut cannot read usable access tokens and proxy calls may fail.
 
 In the Composio dashboard, go to:
 - `Project Settings`
 - `Project Configuration`
 - Disable `Mask Connected Account Secrets`
 
-After changing this setting, reconnect the account in SuperAgent.
+After changing this setting, reconnect the account in Gamut.
 
 Create a `.env.local` file in the project root:
 

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -93,7 +93,7 @@ function parseConnectedAccounts(): Map<string, Array<{ name: string; id: string 
 }
 
 /**
- * Generates the full system prompt from the SuperAgent prompt plus dynamic
+ * Generates the full system prompt from the Gamut prompt plus dynamic
  * sections (connected accounts, env vars, user instructions).
  */
 function generateSystemPrompt(

--- a/agent-container/src/dashboard-builder-agent-prompt.md
+++ b/agent-container/src/dashboard-builder-agent-prompt.md
@@ -1,4 +1,4 @@
-You are a dashboard builder agent. You receive high-level objectives and build or edit interactive dashboards (artifacts) that run inside the Superagent platform.
+You are a dashboard builder agent. You receive high-level objectives and build or edit interactive dashboards (artifacts) that run inside the Gamut platform.
 
 ## Your Tools
 

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -89,7 +89,7 @@ In code: default to writing no comments. Never write multi-paragraph docstrings 
 
 # auto memory
 
-You have a persistent, file-based memory system at `${CLAUDE_CONFIG_DIR}/projects/-workspace/memory/`. This directory lives inside the agent's persistent workspace volume, so memories survive across container restarts and SuperAgent sessions. Write to it directly with the Write tool — the tool will create the directory on first write, so do not run mkdir or check for its existence.
+You have a persistent, file-based memory system at `${CLAUDE_CONFIG_DIR}/projects/-workspace/memory/`. This directory lives inside the agent's persistent workspace volume, so memories survive across container restarts and Gamut sessions. Write to it directly with the Write tool — the tool will create the directory on first write, so do not run mkdir or check for its existence.
 
 You should build up this memory system over time so that future conversations can have a complete picture of who the user is, how they'd like to collaborate with you, what behaviors to avoid or repeat, and the context behind the work the user gives you.
 
@@ -225,9 +225,9 @@ Memory is one of several persistence mechanisms available to you as you assist t
 
 When the conversation grows long, some or all of the current context is summarized; the summary, along with any remaining unsummarized context, is provided in the next context window so work can continue — you don't need to wrap up early or hand off mid-task.
 
-# Super Agent Platform
+# Gamut Platform
 
-You operate inside a Super Agent container — a long-running, autonomous runtime that persists across sessions, with the platform capabilities described below.
+You operate inside a Gamut container — a long-running, autonomous runtime that persists across sessions, with the platform capabilities described below.
 
 ## Standing Instructions — CLAUDE.md
 

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -92,7 +92,7 @@ Use this to start browsing a website. The browser preserves cookies/sessions via
     // the container and cannot reach servers running inside it (e.g. dashboards).
     const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/i.test(args.url)
     const localhostWarning = isLocalhost
-      ? '\n\nWARNING: This is a localhost URL. The browser runs outside the container and cannot access servers running inside it. If you are trying to view a dashboard, stop — the user can already see dashboards through the Superagent UI. Use get_dashboard_logs to debug any issues instead.'
+      ? '\n\nWARNING: This is a localhost URL. The browser runs outside the container and cannot access servers running inside it. If you are trying to view a dashboard, stop — the user can already see dashboards through the Gamut UI. Use get_dashboard_logs to debug any issues instead.'
       : ''
 
     const result = await browserFetch('open', { url: args.url })

--- a/agent-container/src/tools/start-dashboard.ts
+++ b/agent-container/src/tools/start-dashboard.ts
@@ -25,9 +25,9 @@ The dashboard must exist at /workspace/artifacts/<slug>/ with a valid package.js
       const content: ToolContentBlock[] = []
 
       if (info.status === 'running') {
-        text += '\n\nThe dashboard is accessible to the user through the Superagent UI.'
+        text += '\n\nThe dashboard is accessible to the user through the Gamut UI.'
         text +=
-          '\n\nDo NOT use the browser tool to view this dashboard. The browser runs outside the container and cannot access localhost URLs served inside it. The user can already see it through the Superagent UI — use get_dashboard_logs to debug any issues.'
+          '\n\nDo NOT use the browser tool to view this dashboard. The browser runs outside the container and cannot access localhost URLs served inside it. The user can already see it through the Gamut UI — use get_dashboard_logs to debug any issues.'
 
         // Await screenshot so the agent can sanity-check rendering in the same
         // tool result. Best-effort: if capture fails we still return success.

--- a/release.md
+++ b/release.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Superagent uses a tag-based release process. Pushing a `v*` tag triggers the release pipeline which builds and publishes all three components:
+Gamut uses a tag-based release process. Pushing a `v*` tag triggers the release pipeline which builds and publishes all three components:
 
 1. **Electron desktop app** (macOS DMG + ZIP) — attached to a GitHub Release
 2. **App container** (`ghcr.io/skillfulagents/superagent`) — pushed to GHCR

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -4163,7 +4163,7 @@ agents.get('/:id/artifacts/:artifactSlug/view', AgentRead(), async (c) => {
     const loadingEl = document.getElementById('loading');
 
     function setTitle(name) {
-      document.title = (name || artifactSlug) + ' \\u2014 SuperAgent';
+      document.title = (name || artifactSlug) + ' \\u2014 Gamut';
     }
 
     async function fetchDashboardName() {

--- a/src/api/routes/llm.ts
+++ b/src/api/routes/llm.ts
@@ -75,7 +75,7 @@ llm.post('/v1/messages', async (c) => {
   try {
     client = getConfiguredLlmClient()
   } catch {
-    return c.json({ error: 'LLM provider not configured. Check Superagent settings.' }, 503)
+    return c.json({ error: 'LLM provider not configured. Check Gamut settings.' }, 503)
   }
 
   try {

--- a/src/api/speech-recognition-polyfill.ts
+++ b/src/api/speech-recognition-polyfill.ts
@@ -294,7 +294,7 @@ const POLYFILL_SOURCE = /* js */ `(function () {
       this._speechDetected = false;
       var self = this;
 
-      // Absolute path intentional — reaches the Superagent API, not the dashboard's own server
+      // Absolute path intentional — reaches the Gamut API, not the dashboard's own server
       fetch("/api/stt/token")
         .then(function (res) {
           if (!res.ok) {

--- a/src/main/app-menu.ts
+++ b/src/main/app-menu.ts
@@ -111,9 +111,9 @@ async function buildAppMenu(): Promise<void> {
   const template: Electron.MenuItemConstructorOptions[] = [
     // App menu (macOS only — on macOS, the first menu becomes the "app" menu)
     ...(isMac ? [{
-      label: 'SuperAgent',
+      label: 'Gamut',
       submenu: [
-        { role: 'about' as const, label: 'About SuperAgent' },
+        { role: 'about' as const, label: 'About Gamut' },
         { type: 'separator' as const },
         {
           label: 'Settings...',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -210,7 +210,7 @@ function openDashboardWindow(agentSlug: string, dashboardSlug: string) {
   const win = new BrowserWindow({
     width: 1000,
     height: 700,
-    title: 'SuperAgent Dashboard',
+    title: 'Gamut Dashboard',
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
@@ -1044,7 +1044,7 @@ function handleDeepLinkUrl(url: string, fromQueue = false) {
       }
 
       const email = callbackUrl.searchParams.get('email')
-      const label = callbackUrl.searchParams.get('label') || 'SuperAgent'
+      const label = callbackUrl.searchParams.get('label') || 'Gamut'
       const orgId = callbackUrl.searchParams.get('org_id')
       const orgName = callbackUrl.searchParams.get('org_name')
       const role = callbackUrl.searchParams.get('role')

--- a/src/main/keep-awake.ts
+++ b/src/main/keep-awake.ts
@@ -161,7 +161,7 @@ export async function restoreKeepAwakeOnStartup(enabled: boolean): Promise<void>
     const { response } = await dialog.showMessageBox({
       type: 'warning',
       title: 'Keep Awake Cleanup',
-      message: 'Superagent previously prevented your Mac from sleeping, but that setting is still active from a prior session. Would you like to restore normal sleep behavior?',
+      message: 'Gamut previously prevented your Mac from sleeping, but that setting is still active from a prior session. Would you like to restore normal sleep behavior?',
       buttons: ['Restore Sleep', 'Leave As-Is'],
       defaultId: 0,
     })

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -21,7 +21,7 @@ export function createTray(
   const icon = createTrayIcon()
 
   tray = new Tray(icon)
-  tray.setToolTip('Superagent')
+  tray.setToolTip('Gamut')
 
   // On Windows, clicking the tray icon should show/focus the window
   if (process.platform === 'win32') {
@@ -69,7 +69,7 @@ export function setTrayVisible(visible: boolean): void {
     if (apiPortRef > 0) {
       const icon = createTrayIcon()
       tray = new Tray(icon)
-      tray.setToolTip('Superagent')
+      tray.setToolTip('Gamut')
 
       // On Windows, clicking the tray icon should show/focus the window
       if (process.platform === 'win32') {
@@ -78,7 +78,7 @@ export function setTrayVisible(visible: boolean): void {
 
       // Set initial simple menu, then update async
       const initialMenu = Menu.buildFromTemplate([
-        { label: 'Open Superagent', click: () => showWindow() },
+        { label: 'Open Gamut', click: () => showWindow() },
         { type: 'separator' },
         { label: 'Loading...', enabled: false },
         { type: 'separator' },
@@ -198,7 +198,7 @@ async function updateTrayMenu(): Promise<void> {
   // Build menu template
   const menuTemplate: Electron.MenuItemConstructorOptions[] = [
     {
-      label: 'Open Superagent',
+      label: 'Open Gamut',
       click: () => showWindow(),
     },
     { type: 'separator' },

--- a/src/renderer/components/agents/agent-creation-aids.tsx
+++ b/src/renderer/components/agents/agent-creation-aids.tsx
@@ -203,7 +203,7 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
           <DialogHeader className="sr-only">
             <DialogTitle>Let&apos;s talk about your agent</DialogTitle>
             <DialogDescription>
-              Answer a few quick questions and Superagent will draft a detailed prompt for you to review.
+              Answer a few quick questions and Gamut will draft a detailed prompt for you to review.
             </DialogDescription>
           </DialogHeader>
           {voiceAgentConfig && (

--- a/src/renderer/components/auth/auth-page.test.tsx
+++ b/src/renderer/components/auth/auth-page.test.tsx
@@ -90,7 +90,7 @@ describe('AuthPage', () => {
       expect(screen.getByTestId('auth-provider-platform')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('SuperAgent')).toBeInTheDocument()
+    expect(screen.getByText('Gamut')).toBeInTheDocument()
     expect(screen.getByText('Continue with SSO')).toBeInTheDocument()
     expect(screen.getByText('or')).toBeInTheDocument()
 

--- a/src/renderer/components/auth/auth-page.tsx
+++ b/src/renderer/components/auth/auth-page.tsx
@@ -392,7 +392,7 @@ export function AuthPage({ onPendingApproval }: { onPendingApproval?: (pending?:
     <div className="flex items-center justify-center h-screen bg-background" data-testid="auth-page">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <h1 className="text-2xl font-bold">SuperAgent</h1>
+          <h1 className="text-2xl font-bold">Gamut</h1>
         </CardHeader>
         <CardContent className="space-y-4">
           {isLoading ? (

--- a/src/renderer/components/chat-integrations/chat-integration-setup-dialog.tsx
+++ b/src/renderer/components/chat-integrations/chat-integration-setup-dialog.tsx
@@ -294,7 +294,7 @@ function SetupForm({
                     size="sm"
                     className="h-7 px-2 text-xs"
                     onClick={async () => {
-                      await navigator.clipboard.writeText(generateSlackManifest(integrationName.trim() || 'SuperAgent Bot'))
+                      await navigator.clipboard.writeText(generateSlackManifest(integrationName.trim() || 'Gamut Bot'))
                       setManifestCopied(true)
                       setTimeout(() => setManifestCopied(false), 2000)
                     }}
@@ -312,7 +312,7 @@ function SetupForm({
                 </div>
                 {manifestPreview && (
                   <pre className="mt-2 text-2xs leading-relaxed bg-background border rounded-md p-2 overflow-x-auto max-h-40 select-all">
-                    {generateSlackManifest(integrationName.trim() || 'SuperAgent Bot')}
+                    {generateSlackManifest(integrationName.trim() || 'Gamut Bot')}
                   </pre>
                 )}
               </li>

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -304,9 +304,9 @@ beforeEach(() => {
 })
 
 describe('AppSidebar — layout & top nav', () => {
-  it('renders the SuperAgent wordmark', () => {
+  it('renders the Gamut wordmark', () => {
     renderWithProviders(<AppSidebar />)
-    expect(screen.getByText('SuperAgent')).toBeInTheDocument()
+    expect(screen.getByText('Gamut')).toBeInTheDocument()
   })
 
   it('renders Home, Notifications, and New Agent in the top nav', () => {

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -864,7 +864,7 @@ export function AppSidebar() {
               )}
               style={{ marginTop: showHeaderBar ? '-8px' : '8px' }}
             >
-              <span>SuperAgent</span>
+              <span>Gamut</span>
               {isWindowsElectron && (
                 <button
                   className="app-no-drag p-0.5 rounded hover:bg-foreground/10 transition-colors cursor-default"

--- a/src/renderer/components/settings/analytics-tab.tsx
+++ b/src/renderer/components/settings/analytics-tab.tsx
@@ -91,7 +91,7 @@ export function AnalyticsTab() {
         <div className="space-y-0.5">
           <Label htmlFor="share-analytics">Share Anonymous Analytics</Label>
           <p className="text-xs text-muted-foreground">
-            Help improve Superagent by sharing anonymous usage data
+            Help improve Gamut by sharing anonymous usage data
           </p>
         </div>
         <Switch

--- a/src/renderer/components/settings/container-setup-dialog.tsx
+++ b/src/renderer/components/settings/container-setup-dialog.tsx
@@ -88,8 +88,8 @@ export function ContainerSetupDialog({ open, onOpenChange }: ContainerSetupDialo
         <DialogHeader>
           <DialogTitle>Container Runtime Required</DialogTitle>
           <DialogDescription>
-            Superagent runs AI agents in isolated containers for security and consistency.
-            You need a container runtime installed and running to use Superagent.
+            Gamut runs AI agents in isolated containers for security and consistency.
+            You need a container runtime installed and running to use Gamut.
           </DialogDescription>
         </DialogHeader>
 

--- a/src/renderer/components/settings/general-tab.tsx
+++ b/src/renderer/components/settings/general-tab.tsx
@@ -242,7 +242,7 @@ export function GeneralTab({ onOpenWizard }: GeneralTabProps) {
             />
             <SettingRow
               name="Share Anonymous Analytics"
-              subtitle="Help improve Superagent by sharing anonymous usage data"
+              subtitle="Help improve Gamut by sharing anonymous usage data"
               htmlFor="share-analytics"
               right={
                 <Switch

--- a/src/renderer/components/settings/llm-tab.tsx
+++ b/src/renderer/components/settings/llm-tab.tsx
@@ -33,7 +33,7 @@ const PROVIDER_DESCRIPTIONS: Partial<Record<LlmProviderId, string>> = {
   anthropic: 'Direct API access to Claude models.',
   openrouter: 'Multi-model access through a single API key.',
   bedrock: 'AWS-managed Claude inference with IAM or API key credentials.',
-  platform: 'Use credentials provided by your Superagent account.',
+  platform: 'Use credentials provided by your Gamut account.',
 }
 
 const CARD_CLASS = 'rounded-xl border bg-background divide-y divide-border/50 overflow-hidden'

--- a/src/renderer/components/settings/notifications-tab.tsx
+++ b/src/renderer/components/settings/notifications-tab.tsx
@@ -163,7 +163,7 @@ export function NotificationsTab() {
           <div className="space-y-0.5 pr-4">
             <Label htmlFor="notify-when-unfocused">Notify when window isn&apos;t focused</Label>
             <p className="text-xs text-muted-foreground">
-              Send notifications even while the session is open, as long as the SuperAgent
+              Send notifications even while the session is open, as long as the Gamut
               window is behind another app. Useful for long-running sessions you&apos;ve left
               in the background.
             </p>

--- a/src/renderer/components/settings/platform-tab.tsx
+++ b/src/renderer/components/settings/platform-tab.tsx
@@ -263,7 +263,7 @@ function NotConnectedEmptyState({ readOnly, isLaunching, onConnect }: NotConnect
         <div className="rounded-full bg-muted p-3">
           <BadgeX className="h-5 w-5 text-muted-foreground" />
         </div>
-        <h3 className="text-sm font-normal">No Superagent account connected to this workspace</h3>
+        <h3 className="text-sm font-normal">No Gamut account connected to this workspace</h3>
         {!readOnly && (
           <div className="w-full max-w-sm mt-3 space-y-2">
             {showKeyInput ? (

--- a/src/renderer/components/settings/runtime-tab.tsx
+++ b/src/renderer/components/settings/runtime-tab.tsx
@@ -352,7 +352,7 @@ export function RuntimeTab() {
               </div>
             )}
             {!hasStartableRunner && (
-              <p className="text-xs">Please install a container runtime to use Superagent.</p>
+              <p className="text-xs">Please install a container runtime to use Gamut.</p>
             )}
           </AlertDescription>
         </Alert>

--- a/src/renderer/components/update-toast-notifier.tsx
+++ b/src/renderer/components/update-toast-notifier.tsx
@@ -20,7 +20,7 @@ export function UpdateToastNotifier() {
       // toastIdRef is null after dismissal, so a fresh toast is created.
       toastIdRef.current = toast(`Version ${status.version} is available`, {
         id: toastIdRef.current ?? undefined,
-        description: 'A new version of Superagent is ready to download.',
+        description: 'A new version of Gamut is ready to download.',
         duration: Infinity,
         closeButton: true,
         onDismiss,
@@ -48,7 +48,7 @@ export function UpdateToastNotifier() {
     } else if (status.state === 'downloaded') {
       toast(`Version ${status.version ?? ''} is ready to install`, {
         id: toastIdRef.current,
-        description: 'Restart Superagent to apply the update.',
+        description: 'Restart Gamut to apply the update.',
         duration: Infinity,
         closeButton: true,
         onDismiss,

--- a/src/renderer/components/wizard/privacy-step.tsx
+++ b/src/renderer/components/wizard/privacy-step.tsx
@@ -36,9 +36,9 @@ export function PrivacyStep() {
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-2xl font-normal max-w-sm">Help improve Superagent</h2>
+        <h2 className="text-2xl font-normal max-w-sm">Help improve Gamut</h2>
         <p className="text-sm text-muted-foreground mt-1">
-          Choose what data you share with us. Error reports and anonymous analytics help us improve Superagent faster for everyone.
+          Choose what data you share with us. Error reports and anonymous analytics help us improve Gamut faster for everyone.
         </p>
       </div>
 
@@ -56,7 +56,7 @@ export function PrivacyStep() {
             />
           </div>
           <p className="text-xs text-muted-foreground mt-1 max-w-sm">
-            Allow Superagent to send error reports when something goes wrong. Change anytime in settings.
+            Allow Gamut to send error reports when something goes wrong. Change anytime in settings.
           </p>
         </label>
 
@@ -73,7 +73,7 @@ export function PrivacyStep() {
             />
           </div>
           <p className="text-xs text-muted-foreground mt-1 max-w-sm">
-            Share anonymous usage data to help us improve Superagent. Change anytime in settings.
+            Share anonymous usage data to help us improve Gamut. Change anytime in settings.
           </p>
         </label>
       </div>

--- a/src/renderer/components/wizard/welcome-step.tsx
+++ b/src/renderer/components/wizard/welcome-step.tsx
@@ -60,7 +60,7 @@ export function WelcomeStep({ onChoosePlatform, onContinueToManualSetup }: Welco
       <div className="space-y-4">
         <h2 className="text-4xl font-normal">Build your<br />agent workforce</h2>
         <p className="text-sm text-muted-foreground mt-1 max-w-sm">
-          Superagent is the most powerful and secure way to build and manage AI teammates that actually get the job done.
+          Gamut is the most powerful and secure way to build and manage AI teammates that actually get the job done.
         </p>
       </div>
 

--- a/src/renderer/components/wizard/wsl2-install-guide.tsx
+++ b/src/renderer/components/wizard/wsl2-install-guide.tsx
@@ -92,7 +92,7 @@ export function Wsl2InstallGuide({ onRefresh, isRefreshing }: Wsl2InstallGuidePr
           </TooltipProvider>
           {' '}into PowerShell. Then press Enter.
         </li>
-        <li>Restart your computer, then reopen Superagent.</li>
+        <li>Restart your computer, then reopen Gamut.</li>
       </ol>
 
       <RequestError message={launchError ?? null} />

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Super Agent</title>
+  <title>Gamut</title>
   <meta name="description" content="Run sophisticated AI code agents powered by Claude Code" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/shared/lib/chat-integrations/imessage-connector.test.ts
+++ b/src/shared/lib/chat-integrations/imessage-connector.test.ts
@@ -850,7 +850,7 @@ describe('IMessageConnector', () => {
 
       const text = (parseSent(ws)[0].data as any).parts[0].value as string
       expect(text).toContain("isn't supported in chat")
-      expect(text).toContain('Open Superagent on your desktop')
+      expect(text).toContain('Open Gamut on your desktop')
     })
   })
 

--- a/src/shared/lib/chat-integrations/utils.ts
+++ b/src/shared/lib/chat-integrations/utils.ts
@@ -70,7 +70,7 @@ export function splitChatMessage(text: string, maxLength: number): string[] {
  * Connectors wrap this in their own formatting (Telegram HTML, Slack mrkdwn).
  */
 export function describeUnsupportedRequest(event: UserRequestEvent): string {
-  const tail = ' Open Superagent on your desktop to continue.'
+  const tail = ' Open Gamut on your desktop to continue.'
   switch (event.type) {
     case 'connected_account_request':
       return `The agent wants to connect your ${event.toolkit} account, which isn't supported in chat.${tail}`

--- a/src/shared/lib/config/data-dir.ts
+++ b/src/shared/lib/config/data-dir.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import os from 'os'
 
 /**
- * Get the data directory for Superagent.
+ * Get the data directory for Gamut.
  *
  * The data directory contains:
  * - The SQLite database (superagent.db)

--- a/src/shared/lib/container/lima-container-client.ts
+++ b/src/shared/lib/container/lima-container-client.ts
@@ -545,7 +545,7 @@ async function ensureLimaReadyImpl(): Promise<void> {
   }
 
   if (!vmExists) {
-    console.log('Creating Lima VM for Superagent...')
+    console.log('Creating Lima VM for Gamut...')
     addErrorBreadcrumb({ category: 'lima', message: 'Creating new Lima VM', data: { explicitMemory } })
     try {
       await createLimaVm()
@@ -649,7 +649,7 @@ async function createLimaVm(): Promise<void> {
   }
 
   const lines = [
-    '# Lima VM for Superagent container runtime',
+    '# Lima VM for Gamut container runtime',
     'vmType: vz',
     'mountType: virtiofs',
     'mounts:',

--- a/src/shared/lib/container/wsl2-container-client.ts
+++ b/src/shared/lib/container/wsl2-container-client.ts
@@ -492,7 +492,7 @@ async function ensureWSL2ReadyImpl(isRetry: boolean): Promise<void> {
   }
 
   if (!distroExists) {
-    console.log('Creating WSL2 distro for Superagent...')
+    console.log('Creating WSL2 distro for Gamut...')
     addErrorBreadcrumb({ category: 'wsl2', message: 'Creating new WSL2 distro' })
     try {
       await createWSL2Distro()

--- a/src/shared/lib/container/wsl2-setup-errors.ts
+++ b/src/shared/lib/container/wsl2-setup-errors.ts
@@ -196,11 +196,11 @@ export function classifyWSL2Stderr(stderrRaw: string): RunnerSetupRemediation | 
       kind: 'access-denied',
       title: 'Access denied while creating WSL2 distro',
       remediation:
-        'Windows blocked writing to the Superagent data directory. This is usually caused by antivirus software or Windows Controlled Folder Access.',
+        'Windows blocked writing to the Gamut data directory. This is usually caused by antivirus software or Windows Controlled Folder Access.',
       steps: [
         { label: 'Open Windows Security → Virus & threat protection → Ransomware protection → Manage Controlled folder access.' },
-        { label: 'Allow Superagent through Controlled Folder Access, or temporarily disable it to confirm it is the cause.' },
-        { label: 'Whitelist the Superagent data folder in your antivirus: %APPDATA%\\superagent' },
+        { label: 'Allow Gamut through Controlled Folder Access, or temporarily disable it to confirm it is the cause.' },
+        { label: 'Whitelist the Gamut data folder in your antivirus: %APPDATA%\\superagent' },
         { label: 'Retry starting the runtime.' },
       ],
       docsUrl: null,
@@ -219,11 +219,11 @@ export function classifyWSL2Stderr(stderrRaw: string): RunnerSetupRemediation | 
       kind: 'rootfs-missing',
       title: 'WSL2 could not read the Alpine rootfs',
       remediation:
-        'Windows reported that the path to the bundled Alpine rootfs could not be found. Your Superagent install may be corrupt, or %APPDATA% may be redirected to OneDrive.',
+        'Windows reported that the path to the bundled Alpine rootfs could not be found. Your Gamut install may be corrupt, or %APPDATA% may be redirected to OneDrive.',
       steps: [
         { label: 'Check whether your AppData is redirected to OneDrive:', command: '[Environment]::GetFolderPath("ApplicationData")' },
         { label: 'If the path is inside OneDrive, pause OneDrive sync and retry.' },
-        { label: 'Otherwise, reinstall Superagent to restore the bundled Alpine rootfs.' },
+        { label: 'Otherwise, reinstall Gamut to restore the bundled Alpine rootfs.' },
       ],
       docsUrl: null,
       originalStderr: stderr,
@@ -261,7 +261,7 @@ export function unknownRunnerSetupError(stderr: string): RunnerSetupRemediation 
     kind: 'unknown',
     title: 'Failed to set up WSL2 runtime',
     remediation:
-      'An unexpected error occurred while setting up the WSL2 runtime. The error details have been reported to Superagent.',
+      'An unexpected error occurred while setting up the WSL2 runtime. The error details have been reported to Gamut.',
     steps: [
       { label: 'Try shutting down WSL and retrying:', command: 'wsl --shutdown' },
       { label: 'If the error persists, reboot your computer.' },

--- a/src/shared/lib/services/platform-device-service.ts
+++ b/src/shared/lib/services/platform-device-service.ts
@@ -25,7 +25,7 @@ export function getPlatformDeviceName(): string {
       // fall through
     }
   }
-  return os.hostname().trim() || 'SuperAgent Device'
+  return os.hostname().trim() || 'Gamut Device'
 }
 
 export function getOrCreatePlatformClientInstanceId() {

--- a/src/shared/lib/services/secrets-service.test.ts
+++ b/src/shared/lib/services/secrets-service.test.ts
@@ -138,7 +138,7 @@ describe('serializeEnvFile', () => {
     const secrets = [{ key: 'KEY', envVar: 'KEY', value: 'value' }]
     const result = serializeEnvFile(secrets)
 
-    expect(result).toContain('# Superagent Secrets')
+    expect(result).toContain('# Gamut Secrets')
     expect(result).toContain('# Format: ENV_VAR=value  # Display Name')
   })
 
@@ -181,7 +181,7 @@ describe('serializeEnvFile', () => {
   it('handles empty secrets array', () => {
     const result = serializeEnvFile([])
 
-    expect(result).toContain('# Superagent Secrets')
+    expect(result).toContain('# Gamut Secrets')
     expect(result.split('\n').filter((l) => l && !l.startsWith('#')).length).toBe(0)
   })
 })

--- a/src/shared/lib/services/secrets-service.ts
+++ b/src/shared/lib/services/secrets-service.ts
@@ -83,7 +83,7 @@ export function parseEnvFile(content: string): Map<string, { value: string; comm
  */
 export function serializeEnvFile(secrets: AgentSecret[]): string {
   const lines: string[] = [
-    '# Superagent Secrets',
+    '# Gamut Secrets',
     '# Format: ENV_VAR=value  # Display Name',
     '',
   ]
@@ -206,7 +206,7 @@ export async function deleteSecret(agentSlug: string, envVar: string): Promise<b
 
   if (filtered.length === 0) {
     // No secrets left, could delete file or leave empty
-    await writeFile(envPath, '# Superagent Secrets\n', { mode: 0o666 })
+    await writeFile(envPath, '# Gamut Secrets\n', { mode: 0o666 })
   } else {
     const content = serializeEnvFile(filtered)
     await writeFile(envPath, content, { mode: 0o666 })

--- a/src/shared/lib/skillset-provider/default-public-skillset.ts
+++ b/src/shared/lib/skillset-provider/default-public-skillset.ts
@@ -3,8 +3,8 @@ import type { SkillsetConfig } from '@shared/lib/types/skillset'
 export const DEFAULT_PUBLIC_SKILLSET: SkillsetConfig = {
   id: 'github-com-skillfulagents-public-skillset',
   url: 'https://github.com/SkillfulAgents/public-skillset',
-  name: 'Super Agent Public Skillset',
-  description: 'A public collection of agent templates for the Super Agent app.',
+  name: 'Gamut Public Skillset',
+  description: 'A public collection of agent templates for the Gamut app.',
   addedAt: new Date(0).toISOString(),
   provider: 'public',
 }

--- a/superagent.md
+++ b/superagent.md
@@ -1,10 +1,10 @@
-# Super Agent
+# Gamut
 
-Super Agent is an open-source application that allows users to run sophisticated, code based AI agents. The one thing AI models are already pretty good at is agentically writing code. Thankfully, many general purpose tasks can be reduced into code wrriting tasks. Super Agent leverages this with general purpose code based agents.
+Gamut is an open-source application that allows users to run sophisticated, code based AI agents. The one thing AI models are already pretty good at is agentically writing code. Thankfully, many general purpose tasks can be reduced into code wrriting tasks. Gamut leverages this with general purpose code based agents.
 
-The agents are powered by Claude Code itself, running in headless mode inside a docker container where it can run wild. The docker container exposes an API that the Super Agent can send messages to and get responses from, including a websocket interface for streaming responses.
+The agents are powered by Claude Code itself, running in headless mode inside a docker container where it can run wild. The docker container exposes an API that the Gamut can send messages to and get responses from, including a websocket interface for streaming responses.
 
-The Super Agent application itself is a NextJS application that provides a user interface for managing agents, creating new agents, and running them. It uses a SQLite database to store agent configurations, message histories, and other data.
+The Gamut application itself is a NextJS application that provides a user interface for managing agents, creating new agents, and running them. It uses a SQLite database to store agent configurations, message histories, and other data.
 
 ## Architecture
 


### PR DESCRIPTION
## What

Cosmetic branding pass: replaces the **SuperAgent** name (any casing, including spaced *Super Agent*) with **Gamut** in **user-visible text only** — UI labels, macOS menu/tray, dialogs, error messages, window/tab titles, README + docs, agent prompt prose, and brand mentions in comments. Coupled test assertions were updated to match.

**43 files, 81 substitutions.**

## Why

The rebrand to Gamut is already partly underway in the repo (e.g. `gamutagents.com` URLs, `Gamut` Windows code-signing). This PR moves the user-facing brand text over without touching anything functional.

## Scope — cosmetic only

These are **naming-only** changes. All functional identifiers were **intentionally left untouched** to avoid breaking existing installs and auto-update:

- Data dir (`~/.superagent`) and DB filename (`superagent.db`)
- `SUPERAGENT_*` env vars
- `superagent://` URL scheme
- App identity: `appId` (`com.superagent.app`), `productName`, artifact names, and the GitHub publish repo (`SkillfulAgents/SuperAgent`)
- GHCR image names, Lima VM / WSL distro names, localStorage keys, analytics IDs, the `SuperagentSpeechRecognition` class
- Brand-as-identifier values presented externally: MCP `clientInfo.name`, OAuth client name, and the `Superagent-App` User-Agent

A **follow-up pass** can rename these identifiers once the corresponding runtime/migration concerns (data migration, repo rename, re-signing, scheme registration) are decided.

## Verification

- **Typecheck**: passes for all changed files. (2 pre-existing errors in `pdf-renderer.tsx` for a missing `react-pdf` module exist on clean `main` — unrelated.)
- **Lint**: no new errors; one pre-existing `exhaustive-deps` warning in `runtime-tab.tsx`, unrelated to the edit.
- **Tests**: the 4 coupled test files pass (116/116).

## Reviewer notes

- Edits were applied via asserted scripts (each replacement's occurrence count was verified) and confirmed not to touch any of the must-keep identifiers above.
- `eslint src` reports "no files" in this worktree because it lives under `.claude/` (eslint default-ignores dot dirs); changed files were linted with `--no-ignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)