### PR TITLE
perf(messages): incremental streaming markdown (O(N²)→O(N)) + memoization/polling quick wins

### DIFF
--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -99,39 +99,16 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
     return items
   }, [messages, activeSubagents, completedSubagents])
 
-  // Show error if present
-  if (error) {
-    const isProviderError = apiErrorCode != null && PROVIDER_ERROR_CODES.has(apiErrorCode)
-    return (
-      <div className="mx-auto mb-2 w-full max-w-[740px] px-4">
-        {isProviderError ? (
-          <ProviderErrorCard message={error} data-testid="provider-error-card" />
-        ) : (
-          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 select-text" data-testid="error-card">
-            <div className="flex items-center gap-2">
-              <AlertTriangle className="h-4 w-4 text-destructive" />
-              <span className="text-sm font-medium text-destructive">Error</span>
-            </div>
-            <p className="mt-1 text-sm text-destructive/90">{error}</p>
-            <p className="mt-2 text-xs text-muted-foreground">
-              Send another message to retry.
-            </p>
-          </div>
-        )}
-      </div>
-    )
-  }
+  // Derive the todo/task list from TaskCreate/TaskUpdate (newer SDK) or fall back
+  // to TodoWrite (older SDK). Memoized on [messages] so it doesn't re-scan the
+  // whole transcript on every per-delta re-render driven by useMessageStream —
+  // only when the persisted message list actually changes.
+  const { todos, activeItem } = useMemo<{ todos: Todo[] | null; activeItem: Todo | null }>(() => {
+    if (!messages) return { todos: null, activeItem: null }
 
-  // Don't render if not active
-  if (!isActive) {
-    return null
-  }
+    let list: Todo[] | null = null
+    let current: Todo | null = null
 
-  // Build todo list from TaskCreate/TaskUpdate or fall back to TodoWrite
-  let todos: Todo[] | null = null
-  let activeItem: Todo | null = null
-
-  if (messages) {
     // Try TaskCreate/TaskUpdate first (newer SDK format)
     const taskMap = new Map<string, Todo>()
     let taskCounter = 0
@@ -162,12 +139,12 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
     }
 
     if (taskMap.size > 0) {
-      todos = Array.from(taskMap.values())
-      activeItem = todos.find((t) => t.status === 'in_progress') || null
+      list = Array.from(taskMap.values())
+      current = list.find((t) => t.status === 'in_progress') || null
     }
 
     // Fall back to TodoWrite (older SDK format)
-    if (!todos) {
+    if (!list) {
       for (let i = messages.length - 1; i >= 0; i--) {
         const message = messages[i]
         if (message.type === 'compact_boundary' || message.type === 'memory_recall') continue
@@ -178,8 +155,8 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
             try {
               const input = toolCall.input as { todos?: Todo[] }
               if (input?.todos && Array.isArray(input.todos)) {
-                todos = input.todos
-                activeItem = todos.find((t) => t.status === 'in_progress') || null
+                list = input.todos
+                current = list.find((t) => t.status === 'in_progress') || null
                 break
               }
             } catch {
@@ -187,9 +164,39 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
             }
           }
         }
-        if (todos) break
+        if (list) break
       }
     }
+
+    return { todos: list, activeItem: current }
+  }, [messages])
+
+  // Show error if present
+  if (error) {
+    const isProviderError = apiErrorCode != null && PROVIDER_ERROR_CODES.has(apiErrorCode)
+    return (
+      <div className="mx-auto mb-2 w-full max-w-[740px] px-4">
+        {isProviderError ? (
+          <ProviderErrorCard message={error} data-testid="provider-error-card" />
+        ) : (
+          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 select-text" data-testid="error-card">
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4 text-destructive" />
+              <span className="text-sm font-medium text-destructive">Error</span>
+            </div>
+            <p className="mt-1 text-sm text-destructive/90">{error}</p>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Send another message to retry.
+            </p>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // Don't render if not active
+  if (!isActive) {
+    return null
   }
 
   const statusText = isAwaitingInput

--- a/src/renderer/components/messages/message-item.test.tsx
+++ b/src/renderer/components/messages/message-item.test.tsx
@@ -122,6 +122,89 @@ describe('MessageItem', () => {
     })
   })
 
+  describe('streaming markdown splitting', () => {
+    it('renders every block of a multi-block streaming message', () => {
+      const text = '# Heading\n\nSome text\n\n```js\nconsole.log("hi")\n```\n\nMore text'
+      const msg = createAssistantMessage({ content: { text } })
+      render(<MessageItem message={msg} isStreaming />)
+      expect(screen.getByText('Heading')).toBeInTheDocument()
+      expect(screen.getByText('Some text')).toBeInTheDocument()
+      expect(screen.getByText('console.log("hi")')).toBeInTheDocument()
+      expect(screen.getByText('More text')).toBeInTheDocument()
+    })
+
+    it('keeps an in-progress code fence (with an internal blank line) intact while streaming', () => {
+      // Unterminated fence whose body contains a blank line. A naive \n\n split
+      // would freeze a broken open fence, leaving `const y = 2` outside the code
+      // block. The fence-aware split keeps the whole fence in the tail.
+      const text = 'Intro paragraph\n\n```js\nconst x = 1\n\nconst y = 2'
+      const msg = createAssistantMessage({ content: { text } })
+      const { container } = render(<MessageItem message={msg} isStreaming />)
+      expect(screen.getByText('Intro paragraph')).toBeInTheDocument()
+      const pres = container.querySelectorAll('pre')
+      expect(pres.length).toBe(1)
+      // Both lines live inside the SAME code block — the discriminating check.
+      expect(pres[0].textContent).toContain('const x = 1')
+      expect(pres[0].textContent).toContain('const y = 2')
+    })
+
+    it('renders the same text (whitespace-insensitive) while streaming as a single-document parse', () => {
+      const text =
+        '# Title\n\nFirst paragraph with **bold**.\n\n- a\n- b\n\n```ts\nconst n = 1\n```\n\nClosing line.'
+      const msg = createAssistantMessage({ content: { text } })
+      // Per-block rendering adds invisible whitespace text nodes between block
+      // elements (block-level CSS margins handle real spacing), so we compare
+      // visible characters ignoring whitespace: nothing dropped, added, or reordered.
+      const norm = (s: string | null) => (s ?? '').replace(/\s+/g, '')
+
+      const streamed = render(<MessageItem message={msg} isStreaming />)
+      const streamedText = norm(streamed.container.textContent)
+      streamed.unmount()
+
+      const whole = render(<MessageItem message={msg} />)
+      expect(norm(whole.container.textContent)).toBe(streamedText)
+    })
+
+    // The split's accepted trade-off: cross-block markdown constructs (reference-
+    // style links, loose lists) render differently MID-STREAM, then self-heal the
+    // instant the message persists and re-renders as one document. These tests pin
+    // BOTH the transient artifact AND the self-heal, since the self-heal is what
+    // makes the artifact acceptable.
+    it('reference-style link is literal while streaming, resolves once persisted', () => {
+      const text = 'See [the docs][1] for details.\n\n[1]: https://example.com'
+      const msg = createAssistantMessage({ content: { text } })
+
+      // Streaming: usage and its later definition land in separate blocks, so the
+      // link cannot resolve — it shows as literal bracket text, no anchor.
+      const streamed = render(<MessageItem message={msg} isStreaming />)
+      expect(streamed.container.querySelectorAll('a')).toHaveLength(0)
+      expect(streamed.container.textContent).toContain('[the docs][1]')
+      streamed.unmount()
+
+      // Persisted (whole-document parse): the reference resolves to a real link.
+      const whole = render(<MessageItem message={msg} />)
+      const link = whole.container.querySelector('a')
+      expect(link).not.toBeNull()
+      expect(link).toHaveAttribute('href', 'https://example.com')
+      expect(whole.container.textContent).not.toContain('[the docs][1]')
+    })
+
+    it('loose list splits into separate lists while streaming, collapses to one when persisted', () => {
+      const text = '1. a\n\n2. b\n\n3. c'
+      const msg = createAssistantMessage({ content: { text } })
+
+      // Streaming: blank-separated items settle into separate blocks -> separate <ol>.
+      const streamed = render(<MessageItem message={msg} isStreaming />)
+      expect(streamed.container.querySelectorAll('ol').length).toBeGreaterThan(1)
+      streamed.unmount()
+
+      // Persisted: one continuous list.
+      const whole = render(<MessageItem message={msg} />)
+      expect(whole.container.querySelectorAll('ol')).toHaveLength(1)
+      expect(whole.container.querySelectorAll('li')).toHaveLength(3)
+    })
+  })
+
   describe('tool calls', () => {
     it('renders tool calls below assistant message', () => {
       const msg = createAssistantMessage({

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -7,8 +7,9 @@ import { SubAgentBlock } from './subagent-block'
 import { MessageContextMenu } from './message-context-menu'
 import { FileDownloadPill } from '@renderer/components/ui/file-download-pill'
 import { parseAttachedFiles, parseMountedFolders } from '@shared/lib/utils/attached-files'
-import ReactMarkdown from 'react-markdown'
+import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { splitStreamingMarkdown } from './split-streaming-markdown'
 import { PROVIDER_ERROR_CODES } from '@shared/lib/types/api'
 import type { ApiMessage, ApiToolCall } from '@shared/lib/types/api'
 import type { SubagentInfo } from '@renderer/hooks/use-message-stream'
@@ -57,6 +58,78 @@ function extractText(node: ReactNode): string {
   return ''
 }
 
+const REMARK_PLUGINS = [remarkGfm]
+
+// Hoisted to a stable module-level reference. The memoized <MarkdownBlock> below
+// must NOT be handed a fresh `components`/`remarkPlugins` object each render, or
+// its memo would never bail and every settled streaming block would re-parse.
+const MARKDOWN_COMPONENTS: Components = {
+  // Style code blocks
+  pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
+  code: ({ children, className }) => {
+    const isInline = !className
+    return isInline ? (
+      <code className={cn(
+        'rounded px-1.5 py-0.5 text-sm font-medium',
+        'bg-black/[0.05] dark:bg-white/[0.08] text-foreground'
+      )}>
+        {children}
+      </code>
+    ) : (
+      <code className={cn(className, 'text-foreground')}>{children}</code>
+    )
+  },
+  // Style tables with borders and horizontal scroll
+  table: ({ children }) => (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-sm">
+        {children}
+      </table>
+    </div>
+  ),
+  th: ({ children }) => (
+    <th className={cn(
+      'border-b-2 px-3 py-1.5 text-left font-semibold',
+      'border-border'
+    )}>
+      {children}
+    </th>
+  ),
+  td: ({ children }) => (
+    <td className={cn(
+      'border-b px-3 py-1.5',
+      'border-border'
+    )}>
+      {children}
+    </td>
+  ),
+  // Ensure links open in new tab
+  a: ({ children, href }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        'hover:underline',
+        'text-blue-500'
+      )}
+    >
+      {children}
+    </a>
+  ),
+}
+
+// A single markdown block. Memoized so that, while a response streams, each
+// already-settled block parses exactly once even though later deltas keep
+// re-rendering the parent MessageItem. See split-streaming-markdown.ts.
+const MarkdownBlock = memo(function MarkdownBlock({ text }: { text: string }) {
+  return (
+    <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={MARKDOWN_COMPONENTS}>
+      {text}
+    </ReactMarkdown>
+  )
+})
+
 interface MessageItemProps {
   message: ApiMessage
   isStreaming?: boolean
@@ -82,6 +155,11 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
   const toolCalls = message.toolCalls || []
 
   const isSlashCommand = isUser && hasText && text.startsWith('/')
+
+  // While streaming, pre-split the markdown into fence-safe blocks so each
+  // settled block parses once; only the small trailing block re-parses per
+  // delta (O(N) instead of O(N^2)). Persisted messages render as one document.
+  const streamingSplit = isStreaming && text ? splitStreamingMarkdown(text) : null
 
   // Detect assistant messages that failed due to an LLM provider error (from SDK metadata)
   const isProviderErrorMessage = isAssistant && !!message.apiError && PROVIDER_ERROR_CODES.has(message.apiError)
@@ -155,66 +233,16 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
                 <div dir="auto" className={cn(
                   'prose prose-sm max-w-none min-w-0 break-words font-medium dark:prose-invert'
                 )}>
-                  <ReactMarkdown
-                    remarkPlugins={[remarkGfm]}
-                    components={{
-                      // Style code blocks
-                      pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
-                      code: ({ children, className }) => {
-                        const isInline = !className
-                        return isInline ? (
-                          <code className={cn(
-                            'rounded px-1.5 py-0.5 text-sm font-medium',
-                            'bg-black/[0.05] dark:bg-white/[0.08] text-foreground'
-                          )}>
-                            {children}
-                          </code>
-                        ) : (
-                          <code className={cn(className, 'text-foreground')}>{children}</code>
-                        )
-                      },
-                      // Style tables with borders and horizontal scroll
-                      table: ({ children }) => (
-                        <div className="overflow-x-auto">
-                          <table className="w-full border-collapse text-sm">
-                            {children}
-                          </table>
-                        </div>
-                      ),
-                      th: ({ children }) => (
-                        <th className={cn(
-                          'border-b-2 px-3 py-1.5 text-left font-semibold',
-                          'border-border'
-                        )}>
-                          {children}
-                        </th>
-                      ),
-                      td: ({ children }) => (
-                        <td className={cn(
-                          'border-b px-3 py-1.5',
-                          'border-border'
-                        )}>
-                          {children}
-                        </td>
-                      ),
-                      // Ensure links open in new tab
-                      a: ({ children, href }) => (
-                        <a
-                          href={href}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className={cn(
-                            'hover:underline',
-                            'text-blue-500'
-                          )}
-                        >
-                          {children}
-                        </a>
-                      ),
-                    }}
-                  >
-                    {text}
-                  </ReactMarkdown>
+                  {streamingSplit ? (
+                    <>
+                      {streamingSplit.settled.map((block, i) => (
+                        <MarkdownBlock key={i} text={block} />
+                      ))}
+                      {streamingSplit.tail && <MarkdownBlock text={streamingSplit.tail} />}
+                    </>
+                  ) : (
+                    <MarkdownBlock text={text} />
+                  )}
                   {isStreaming && (
                     <span className="inline-block w-2 h-4 bg-current ml-0.5 animate-pulse" />
                   )}

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -264,8 +264,15 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, pendingR
   const isStreamingMessagePersisted = useMemo(() => {
     if (!streamingMessage || !messages?.length) return false
 
-    // Find the last assistant message
-    const lastAssistantMessage = [...messages].reverse().find((m): m is ApiMessage => m.type === 'assistant')
+    // Find the last assistant message (backward scan; avoids copying and
+    // reversing the whole array on every streaming delta).
+    let lastAssistantMessage: ApiMessage | undefined
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].type === 'assistant') {
+        lastAssistantMessage = messages[i] as ApiMessage
+        break
+      }
+    }
     if (!lastAssistantMessage) return false
 
     // Check if the persisted message text contains the streaming content

--- a/src/renderer/components/messages/split-streaming-markdown.test.ts
+++ b/src/renderer/components/messages/split-streaming-markdown.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest'
+import { splitStreamingMarkdown } from './split-streaming-markdown'
+
+// True if `block` contains an unterminated fenced code block (odd/open fence).
+// Settled blocks must NEVER satisfy this — that's the whole point of being
+// fence-aware.
+function hasOpenFence(block: string): boolean {
+  const lines = block.split('\n')
+  let open: { char: string; len: number } | null = null
+  for (const line of lines) {
+    const m = /^ {0,3}(`{3,}|~{3,})/.exec(line)
+    if (!open) {
+      if (m) open = { char: m[1][0], len: m[1].length }
+    } else if (
+      m &&
+      m[1][0] === open.char &&
+      m[1].length >= open.len &&
+      /^ {0,3}(`{3,}|~{3,})[ \t]*$/.test(line)
+    ) {
+      open = null
+    }
+  }
+  return open !== null
+}
+
+describe('splitStreamingMarkdown', () => {
+  it('returns empty for empty input', () => {
+    expect(splitStreamingMarkdown('')).toEqual({ settled: [], tail: '' })
+  })
+
+  it('keeps a single in-progress paragraph entirely in the tail', () => {
+    const { settled, tail } = splitStreamingMarkdown('hello wor')
+    expect(settled).toEqual([])
+    expect(tail).toBe('hello wor')
+  })
+
+  it('settles earlier paragraphs and leaves the last as the tail', () => {
+    const { settled, tail } = splitStreamingMarkdown('para one\n\npara two')
+    expect(settled).toEqual(['para one'])
+    expect(tail).toBe('para two')
+  })
+
+  it('keeps the last non-empty block as the tail even when a blank line follows', () => {
+    // The final block stays in the tail (re-parsing it per delta is cheap) so we
+    // never prematurely commit a block whose siblings — e.g. a loose-list
+    // continuation — might still stream in. Trailing blanks add no empty blocks.
+    const { settled, tail } = splitStreamingMarkdown('para one\n\npara two\n\n')
+    expect(settled).toEqual(['para one'])
+    expect(tail).toBe('para two')
+  })
+
+  it('collapses multiple blank lines into one boundary', () => {
+    const { settled, tail } = splitStreamingMarkdown('a\n\n\n\nb')
+    expect(settled).toEqual(['a'])
+    expect(tail).toBe('b')
+  })
+
+  it('does NOT split inside an open fenced code block with internal blanks', () => {
+    const text = '```python\ndef f():\n\n    return 1'
+    const { settled, tail } = splitStreamingMarkdown(text)
+    expect(settled).toEqual([])
+    expect(tail).toBe(text)
+    expect(hasOpenFence(tail)).toBe(true)
+  })
+
+  it('keeps an in-progress fence in the tail even when a paragraph precedes it', () => {
+    const text = 'intro paragraph\n\n```ts\nconst x = 1\n\nconst y = 2'
+    const { settled, tail } = splitStreamingMarkdown(text)
+    expect(settled).toEqual(['intro paragraph'])
+    expect(tail).toBe('```ts\nconst x = 1\n\nconst y = 2')
+  })
+
+  it('settles a completed fenced block (with internal blank) once a blank follows', () => {
+    const fenced = '```python\ndef f():\n\n    return 1\n```'
+    const { settled, tail } = splitStreamingMarkdown(`${fenced}\n\nnext`)
+    expect(settled).toEqual([fenced])
+    expect(tail).toBe('next')
+    expect(hasOpenFence(settled[0])).toBe(false)
+  })
+
+  it('supports tilde fences', () => {
+    const text = '~~~\nplain\n\ncode\n~~~\n\nafter'
+    const { settled, tail } = splitStreamingMarkdown(text)
+    expect(settled).toEqual(['~~~\nplain\n\ncode\n~~~'])
+    expect(tail).toBe('after')
+  })
+
+  it('does not close a longer opening fence with a shorter delimiter', () => {
+    // Opened with 4 backticks; a 3-backtick line is content, not a close.
+    const text = '````\n```\nstill inside\n\nmore'
+    const { settled, tail } = splitStreamingMarkdown(text)
+    expect(settled).toEqual([])
+    expect(hasOpenFence(tail)).toBe(true)
+  })
+
+  it('does not treat a fence-with-info-string as a closing fence', () => {
+    const text = '```\ncode\n```js\nstill inside\n\nmore'
+    const { settled, tail } = splitStreamingMarkdown(text)
+    // The ```js line has an info string, so it cannot close the block.
+    expect(settled).toEqual([])
+    expect(hasOpenFence(tail)).toBe(true)
+  })
+
+  it('preserves all non-blank lines in order across settled + tail', () => {
+    const text = 'a\n\nb\n\n```\nc\n\nd\n```\n\ne'
+    const { settled, tail } = splitStreamingMarkdown(text)
+    const recombined = [...settled, tail].join('\n')
+    const nonBlank = (s: string) => s.split('\n').filter((l) => l.trim() !== '')
+    expect(nonBlank(recombined)).toEqual(nonBlank(text))
+  })
+
+  // The core safety guarantee: for EVERY prefix of a streaming response, no
+  // block we declare "settled" may contain an unterminated fence.
+  it('never settles an unterminated fence at any streaming prefix', () => {
+    const doc = [
+      '# Heading',
+      '',
+      'Some intro text that explains the code below.',
+      '',
+      '```python',
+      'def compute(n):',
+      '',
+      '    # a blank line lives inside this fence',
+      '    return n * 2',
+      '```',
+      '',
+      'A short paragraph between two code blocks.',
+      '',
+      '| col a | col b |',
+      '| ----- | ----- |',
+      '| 1     | 2     |',
+      '',
+      '```',
+      'plain fence',
+      '```',
+      '',
+      'Final words.',
+    ].join('\n')
+
+    for (let i = 1; i <= doc.length; i++) {
+      const prefix = doc.slice(0, i)
+      const { settled } = splitStreamingMarkdown(prefix)
+      for (const block of settled) {
+        expect(hasOpenFence(block), `prefix len ${i} settled an open fence: ${JSON.stringify(block)}`).toBe(false)
+      }
+    }
+  })
+
+  it('does NOT protect a 4-space-indented fence (documented CommonMark-indent limitation)', () => {
+    // Per CommonMark a fence opener may be indented at most 3 spaces; at 4+ it is an
+    // indented code block, not a fence. The splitter (and hasOpenFence) intentionally
+    // share that rule via the /^ {0,3}.../ FENCE_LINE regex. So a 4-space-indented
+    // fence (e.g. one nested in a list item) with an internal blank line WILL split
+    // mid-stream — a known, transient artifact that self-heals when the message
+    // persists and renders as a single document. This test pins that behavior so the
+    // blind spot is an explicit, reviewed choice rather than a silent surprise.
+    const text = '    ```js\n    const a = 1\n\n    const b = 2'
+    const { settled, tail } = splitStreamingMarkdown(text)
+    expect(settled).toEqual(['    ```js\n    const a = 1'])
+    expect(tail).toBe('    const b = 2')
+    // The 4-space marker is not recognized as a fence, so hasOpenFence agrees.
+    expect(hasOpenFence(settled[0])).toBe(false)
+  })
+
+  it('settled blocks are monotonic: a settled block stays settled as text grows', () => {
+    const doc = 'alpha\n\nbravo\n\ncharlie\n\ndelta'
+    let prevSettled: string[] = []
+    for (let i = 1; i <= doc.length; i++) {
+      const { settled } = splitStreamingMarkdown(doc.slice(0, i))
+      // every previously-settled block is still present, unchanged, as a prefix
+      for (let k = 0; k < prevSettled.length; k++) {
+        expect(settled[k]).toBe(prevSettled[k])
+      }
+      prevSettled = settled
+    }
+  })
+})

--- a/src/renderer/components/messages/split-streaming-markdown.ts
+++ b/src/renderer/components/messages/split-streaming-markdown.ts
@@ -1,0 +1,101 @@
+/**
+ * Split an in-progress streaming markdown string into already-"settled" blocks
+ * and a trailing "tail" block that is still growing.
+ *
+ * A settled block is closed by a blank line that is NOT inside a fenced code
+ * block, so it can never change as more text streams in. The renderer parses
+ * each settled block exactly once (memoized) and only re-parses the small tail
+ * per streaming delta — turning the O(N^2) cost of re-parsing the whole
+ * accumulated markdown on every delta into O(N).
+ *
+ * CRITICAL: the split is fence-aware. A naive split on /\n\n/ would cut inside
+ * fenced code blocks (which legally contain blank lines), freezing an
+ * unterminated fence and rendering broken output mid-stream. We only treat a
+ * blank line as a block boundary when not inside an open ``` / ~~~ fence, and
+ * we never settle a block that still contains an unclosed fence.
+ *
+ * Remaining cross-block imperfections are intentionally NOT handled here because
+ * they are cosmetic and self-correct the instant the message persists and
+ * re-renders as a single document:
+ *   - a "loose" list split across a blank line renders as adjacent lists
+ *   - a reference-style link / footnote whose definition arrives in a later block
+ *   - a 4-space indented code block containing a blank line (rare vs fences)
+ */
+export interface StreamingMarkdownSplit {
+  /** Closed blocks, in order. Each is safe to parse once and memoize forever. */
+  settled: string[]
+  /** The still-growing last block (includes any currently-open code fence). */
+  tail: string
+}
+
+const EMPTY_SPLIT: StreamingMarkdownSplit = { settled: [], tail: '' }
+
+// A fence delimiter line: up to 3 spaces of indent, then 3+ backticks or tildes.
+const FENCE_LINE = /^ {0,3}(`{3,}|~{3,})/
+// A closing fence may only be followed by whitespace (no info string).
+const CLOSING_FENCE_LINE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
+
+interface FenceState {
+  char: string
+  len: number
+}
+
+function fenceDelimiter(line: string): FenceState | null {
+  const m = FENCE_LINE.exec(line)
+  if (!m) return null
+  return { char: m[1][0], len: m[1].length }
+}
+
+export function splitStreamingMarkdown(text: string): StreamingMarkdownSplit {
+  if (text === '') return EMPTY_SPLIT
+
+  const lines = text.split('\n')
+  const blocks: string[] = []
+  let cur: string[] = []
+  let fence: FenceState | null = null
+
+  const flush = () => {
+    if (cur.length > 0) {
+      blocks.push(cur.join('\n'))
+      cur = []
+    }
+  }
+
+  for (const line of lines) {
+    if (fence) {
+      // Inside an open fence: blank lines are content; only a matching closing
+      // delimiter (same char, length >= opening, nothing but whitespace after)
+      // ends it.
+      cur.push(line)
+      const delim = fenceDelimiter(line)
+      if (
+        delim &&
+        delim.char === fence.char &&
+        delim.len >= fence.len &&
+        CLOSING_FENCE_LINE.test(line)
+      ) {
+        fence = null
+      }
+      continue
+    }
+
+    const delim = fenceDelimiter(line)
+    if (delim) {
+      // Opening a new fence — from here blank lines no longer split.
+      fence = delim
+      cur.push(line)
+      continue
+    }
+
+    if (line.trim() === '') {
+      // Blank line outside a fence: close the current block.
+      flush()
+    } else {
+      cur.push(line)
+    }
+  }
+  flush()
+
+  if (blocks.length === 0) return EMPTY_SPLIT
+  return { settled: blocks.slice(0, -1), tail: blocks[blocks.length - 1] }
+}

--- a/src/renderer/components/messages/tool-call-item.tsx
+++ b/src/renderer/components/messages/tool-call-item.tsx
@@ -1,7 +1,7 @@
 
 import { cn } from '@shared/lib/utils/cn'
 import { CheckCircle, XCircle, ChevronDown, ChevronRight, Loader2, Wrench, StopCircle } from 'lucide-react'
-import { useState, useRef } from 'react'
+import { useState, useRef, useMemo, memo } from 'react'
 import { getToolRenderer } from './tool-renderers'
 import { parseToolResult } from '@renderer/lib/parse-tool-result'
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
@@ -38,7 +38,7 @@ function isUserInputTool(name: string): boolean {
   return name === 'AskUserQuestion' || name.startsWith('mcp__user-input__')
 }
 
-export function ToolCallItem({ toolCall, messageCreatedAt, agentSlug, isSessionActive }: ToolCallItemProps) {
+function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessionActive }: ToolCallItemProps) {
   const [expanded, setExpanded] = useState(false)
   const status = getStatus(toolCall, isSessionActive)
   const renderer = getToolRenderer(toolCall.name)
@@ -66,12 +66,13 @@ export function ToolCallItem({ toolCall, messageCreatedAt, agentSlug, isSessionA
   const summary = renderer?.getSummary?.(toolCall.input)
 
   // Format input for display (fallback)
-  const inputStr = typeof toolCall.input === 'string'
-    ? toolCall.input
-    : JSON.stringify(toolCall.input, null, 2)
+  const inputStr = useMemo(
+    () => (typeof toolCall.input === 'string' ? toolCall.input : JSON.stringify(toolCall.input, null, 2)),
+    [toolCall.input]
+  )
 
   // Parse result into text + images
-  const parsed = parseToolResult(toolCall.result)
+  const parsed = useMemo(() => parseToolResult(toolCall.result), [toolCall.result])
   const resultStr = parsed.text
   const resultImages = parsed.images
 
@@ -199,6 +200,11 @@ export function ToolCallItem({ toolCall, messageCreatedAt, agentSlug, isSessionA
   )
 }
 
+// Memoized: a persisted tool call's props are stable across refetches (React
+// Query structural sharing), so collapsed rows don't re-render when the parent
+// MessageItem re-renders (e.g. while a sibling subagent streams).
+export const ToolCallItem = memo(ToolCallItemComponent)
+
 // Component for displaying a tool call while its input is being streamed
 export function StreamingToolCallItem({ name, partialInput }: StreamingToolCallItemProps) {
   const startTimeRef = useRef(new Date())
@@ -211,26 +217,18 @@ export function StreamingToolCallItem({ name, partialInput }: StreamingToolCallI
   // Get custom streaming view if available
   const CustomStreamingView = renderer?.StreamingView
 
-  // Try to get summary from partial input
+  // Parse the partial input at most once and reuse it for both the summary and
+  // the pretty-printed fallback. Skip the parse entirely when nothing consumes
+  // it (a CustomStreamingView renders the body and there's no summary getter).
   let summary: string | null = null
-  if (renderer?.getSummary) {
-    try {
-      const parsed = JSON.parse(partialInput)
-      summary = renderer.getSummary(parsed)
-    } catch {
-      // Can't parse yet, no summary
-    }
-  }
-
-  // Fallback: Try to pretty-print the partial JSON if it's valid
   let displayInput = partialInput
-  if (partialInput) {
+  if (partialInput && (renderer?.getSummary || !CustomStreamingView)) {
     try {
       const parsed = JSON.parse(partialInput)
-      displayInput = JSON.stringify(parsed, null, 2)
+      if (!CustomStreamingView) displayInput = JSON.stringify(parsed, null, 2)
+      if (renderer?.getSummary) summary = renderer.getSummary(parsed)
     } catch {
-      // Show raw partial input as-is
-      displayInput = partialInput
+      // Partial/invalid JSON mid-stream — keep the raw partialInput, no summary.
     }
   }
 

--- a/src/renderer/hooks/poll-cadence.test.ts
+++ b/src/renderer/hooks/poll-cadence.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+// Capture the options object each hook hands to useQuery so we can pin the
+// deliberately-chosen polling cadence. These intervals were lowered from their
+// original values (messages 5s, chat sessions 10s) as a reviewed perf trade-off;
+// this test makes an accidental revert or further drift fail loudly.
+const capturedOptions: Record<string, unknown>[] = []
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>()
+  return {
+    ...actual,
+    useQuery: ((options: Record<string, unknown>) => {
+      capturedOptions.push(options)
+      return { data: undefined, isLoading: false, isError: false }
+    }) as unknown as typeof actual.useQuery,
+  }
+})
+
+import { useMessages } from './use-messages'
+import { useChatIntegrationSessions } from './use-chat-integrations'
+
+describe('polling cadence (reviewed interval constants)', () => {
+  beforeEach(() => {
+    capturedOptions.length = 0
+  })
+
+  it('useMessages polls every 15s as the SSE safety net', () => {
+    renderHook(() => useMessages('session-1', 'agent-1'))
+    expect(capturedOptions.at(-1)?.refetchInterval).toBe(15000)
+  })
+
+  it('useChatIntegrationSessions polls every 20s and not while backgrounded', () => {
+    renderHook(() => useChatIntegrationSessions('integration-1'))
+    const opts = capturedOptions.at(-1)
+    expect(opts?.refetchInterval).toBe(20000)
+    expect(opts?.refetchIntervalInBackground).toBe(false)
+  })
+})

--- a/src/renderer/hooks/use-chat-integrations.ts
+++ b/src/renderer/hooks/use-chat-integrations.ts
@@ -95,7 +95,12 @@ export function useChatIntegrationSessions(integrationId: string | null) {
       return res.json()
     },
     enabled: !!integrationId,
-    refetchInterval: 10_000, // Poll for new sessions (new users DMing the bot)
+    // Poll for new sessions (new users DMing the bot) — these have no SSE
+    // fallback, so keep polling, just less aggressively, and not while backgrounded.
+    // TODO: conservative first step down from the original 10s; can be raised
+    // further (e.g. 60s) once we've confirmed new-session latency is acceptable.
+    refetchInterval: 20_000,
+    refetchIntervalInBackground: false,
   })
 }
 

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -31,8 +31,13 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
     // A missing transcript won't reappear — don't hammer it with retries.
     retry: (failureCount, error) =>
       !(error instanceof TranscriptNotFoundError) && failureCount < 3,
-    // Refetch periodically to catch any messages we might have missed
-    refetchInterval: 5000,
+    // Safety-net poll for any messages the SSE stream missed. The stream
+    // (use-message-stream) is the primary, near-instant path; this only
+    // backstops out-of-band edits / a silently-stalled SSE.
+    // TODO: conservative first step down from the original 5s. Once we've
+    // confirmed nothing relies on tight polling, this can be raised further
+    // (e.g. 30s) or gated on SSE-connection health.
+    refetchInterval: 15000,
   })
 }
 

--- a/src/shared/lib/services/agent-template-service.test.ts
+++ b/src/shared/lib/services/agent-template-service.test.ts
@@ -382,6 +382,9 @@ describe('validateAgentTemplate', () => {
   // Size limits
   // --------------------------------------------------------------------------
 
+  // Each case below builds and zlib-compresses ~500MB in memory, which can run
+  // right up against the 5s default test timeout under `vitest --coverage` on
+  // CI runners (a pre-existing flake). Give these the headroom they need.
   describe('total size limits', () => {
     it('rejects template exceeding 500MB uncompressed', async () => {
       const largeContent = 'x'.repeat(10 * 1024 * 1024)
@@ -395,7 +398,7 @@ describe('validateAgentTemplate', () => {
       expect(result.valid).toBe(false)
       expect(result.error).toContain('too large')
       expect(result.error).toContain('500MB')
-    })
+    }, 30_000)
 
     it('accepts template at exactly the uncompressed size limit', async () => {
       const chunkContent = 'a'.repeat(10 * 1024 * 1024)
@@ -411,7 +414,7 @@ describe('validateAgentTemplate', () => {
       files['data-last.bin'] = 'b'.repeat(remaining)
       const result = await validateAgentTemplate(await makeZip(files))
       expect(result.valid).toBe(true)
-    })
+    }, 30_000)
 
     it('rejects template at exactly one byte over the limit', async () => {
       const chunkContent = 'a'.repeat(10 * 1024 * 1024)
@@ -427,7 +430,7 @@ describe('validateAgentTemplate', () => {
       const result = await validateAgentTemplate(await makeZip(files))
       expect(result.valid).toBe(false)
       expect(result.error).toContain('too large')
-    })
+    }, 30_000)
 
     it('rejects when multiple small files sum to over the limit', async () => {
       const files: Record<string, string> = {
@@ -441,7 +444,7 @@ describe('validateAgentTemplate', () => {
       const result = await validateAgentTemplate(await makeZip(files))
       expect(result.valid).toBe(false)
       expect(result.error).toContain('too large')
-    })
+    }, 30_000)
   })
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Frontend/renderer performance work focused on the chat streaming hot path. The headline fix removes an **O(N²) markdown re-parse** that ran on every assistant response; the rest are low-risk memoization and polling quick wins. All changes are intended to be **behavior-preserving for the final, persisted render**.

Originated from a full renderer perf audit. Two commits:

1. **Incremental streaming markdown** — the real fix.
2. **Memoization + lighter polling quick wins.**

## The problem (commit 1)

While an assistant message streamed, the inline streaming `MessageItem` was rebuilt as a fresh object on every SSE delta (so its `memo` never engaged), and the **entire accumulated markdown string was re-parsed by `react-markdown` on every delta** — `O(N²)` parsing over a response, plus a full markdown-subtree reconcile each delta. For long answers this blows the frame budget on the tail deltas.

### Fix

A fence-aware splitter (`split-streaming-markdown.ts`) breaks the in-progress text into already-**settled** blocks (closed by a blank line *outside* a code fence) + a still-growing **tail**. Each renders via a memoized `MarkdownBlock`, so settled blocks parse **exactly once** and only the small tail re-parses per delta → **O(N)**, independent of delta rate. The markdown components/plugins were hoisted to stable module constants so the memo isn't defeated.

**Gated on `isStreaming`** — only the synthetic streaming bubble takes this path. Persisted/historical messages render the whole document in one pass exactly as before (**byte-identical**), so the split's artifacts are transient and self-heal the instant a message persists.

## Quick wins (commit 2)

- `ToolCallItem` wrapped in `memo()`; `useMemo` its input/result formatting.
- `StreamingToolCallItem` parses `partialInput` once (was twice) and skips the pretty-print when a `CustomStreamingView` renders the body.
- `MessageList`: backward loop instead of `[...messages].reverse().find()` (no per-delta array copy).
- `AgentActivityIndicator`: todo/task derivation hoisted into `useMemo([messages])` so it stops re-scanning the transcript on every per-delta re-render.
- Relaxed over-aggressive polls (SSE is the primary path): `useMessages` 5s→**15s**, chat-integration sessions 10s→**20s** (+ `refetchIntervalInBackground: false`). Both deliberately conservative first steps, marked `TODO` to raise further once validated.

## Risk assessment

Reviewed adversarially (multi-agent) → **zero blockers**. The non-streaming refactors (memo, useMemo, single-parse, backward loop, activity-indicator hoist) were verified **provably output-identical**.

**Residual risks** — all LOW, and split into two kinds:

- **Transient mid-stream visual artifacts (self-heal on persist):** loose/blank-separated lists render as adjacent lists; reference-style links/footnotes show literal `[text][1]` until their definition's block arrives; a 4-space-*indented* fenced block can split. Tight lists and inline `[text](url)` links are unaffected. The final persisted render is byte-identical to before. (A CodeBlock copy-button green-check can also reset once if clicked exactly as a fence settles — negligible.)
- **Data-freshness timing (not visual):** an SSE-missed message in an idle open session now surfaces in ≤15s (was ≤5s); a brand-new inbound chat session appears in ≤20s (was ≤10s). The normal turn flow is covered by SSE invalidation; navigation freshness is unchanged (`staleTime` 5s + refetch-on-mount).

## Test plan

- `split-streaming-markdown.test.ts` — fence-aware split, never settles an open fence (incl. a progressive-prefix property test), documented 4-space-indent limitation.
- `message-item.test.tsx` — multi-block streaming, in-progress fence stays intact, and the reference-link / loose-list **streaming-vs-persisted divergence + self-heal** (pins the property the safety argument rests on).
- `poll-cadence.test.ts` — pins the interval constants (15s / 20s + background off).
- Verified locally: renderer unit suite **1118 passing**, messages+hooks **584 passing**, targeted e2e (chat-flow / tool-rendering / persistence / awaiting-input) **56 passing**, `tsc` and `eslint` clean.

## Follow-ups (not in this PR)

- Promote `render-perf.spec.ts` from logging to a **parse-count assertion** to lock in the streaming win.
- The intervals can be raised further per the `TODO`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
