### PR TITLE
fix: stop setTitleBarOverlay crash on Windows theme change

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -875,14 +875,10 @@ ipcMain.handle('create-dock-shortcut', (_event, { agentSlug, dashboardSlug, dash
 ipcMain.handle('set-native-theme', (_event, theme: string) => {
   nativeTheme.themeSource = theme as 'system' | 'light' | 'dark'
 
-  // Update Windows title bar overlay symbol color to match theme
-  if (process.platform === 'win32' && mainWindow) {
-    const isDark = nativeTheme.shouldUseDarkColors
-    mainWindow.setTitleBarOverlay({
-      symbolColor: isDark ? '#cccccc' : '#333333',
-      color: '#00000000',
-    })
-  }
+  // Windows uses titleBarStyle: 'hidden' WITHOUT a native overlay (see window
+  // creation above) and draws its own title-bar buttons in the renderer, which
+  // recolor via CSS. Calling setTitleBarOverlay here would throw
+  // "Titlebar overlay is not enabled", so there is nothing native to recolor.
 })
 
 // IPC handler for popping up the full app menu at a position (Windows custom title bar)


### PR DESCRIPTION
## Sentry issue

ELECTRON-1S (306 events, Windows): `TypeError: Titlebar overlay is not enabled`.

## Root cause

The `set-native-theme` IPC handler in `src/main/index.ts` unconditionally called `mainWindow.setTitleBarOverlay({...})` when `process.platform === 'win32'`. But the Windows `BrowserWindow` is created with `titleBarStyle: 'hidden'` and **no** `titleBarOverlay` option. Electron throws `TypeError: Titlebar overlay is not enabled` when `setTitleBarOverlay` is called on a window that wasn't created with an overlay.

The renderer's `use-theme.ts` calls `window.electronAPI.setNativeTheme(...)` on every theme change, so this fired (and threw an unhandled rejection) repeatedly — 306 events.

As documented by the comment near the custom Windows title-bar IPC handlers, Windows intentionally uses `titleBarStyle: 'hidden'` **without** a native overlay and draws its own title-bar buttons in the renderer, which recolor via CSS. There is therefore nothing native to recolor.

## What changed

- Removed the `if (process.platform === 'win32' && mainWindow) { ... setTitleBarOverlay(...) }` block from the `set-native-theme` handler and replaced it with an explanatory comment.
- The handler still sets `nativeTheme.themeSource = theme` for all platforms (controls macOS vibrancy appearance).
- The macOS path was never in this handler and is untouched.

No remaining `setTitleBarOverlay` calls exist in the file, and the now-unused `shouldUseDarkColors` read was removed along with the block.

## Validation

- `npx tsc --noEmit` passes.
- `npx eslint src/main/index.ts` passes.
- No unit-test file exists for the Electron main entry point (`src/main/index.ts`); only `auto-updater.test.ts` and `find-port.test.ts` are present, neither touched. Adding a focused test would require mocking the full Electron app lifecycle, which is out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)