### PR TITLE
fix(auto-updater): treat missing latest-mac.yml (404) as benign

### DIFF
--- a/src/main/auto-updater.test.ts
+++ b/src/main/auto-updater.test.ts
@@ -506,10 +506,15 @@ describe('silent background checks', () => {
 //
 // electron-updater's checkForUpdates BOTH emits an 'error' event AND rejects,
 // so the same 404 is seen twice: once in the on('error') handler and once in
-// runUpdateCheckBody's catch. Neither path may report it to Sentry or flip the
-// UI to 'error' — it's benign and self-heals once the mac assets finish
-// uploading (ELECTRON-1N / ELECTRON-3S).
+// runUpdateCheckBody's catch. Neither path may report it to Sentry — it's
+// benign and self-heals once the mac assets finish uploading (ELECTRON-1N /
+// ELECTRON-3S). A silent background check stays quiet at 'not-available'; a
+// manual check shows an honest "try again shortly" message (still no Sentry)
+// rather than a misleading "you're up to date".
 // ---------------------------------------------------------------------------
+
+const CHANNEL_FILE_PENDING_MESSAGE =
+  'Could not check for updates right now — the latest release may still be publishing. Please try again shortly.'
 
 describe('channel file not found (latest-mac.yml 404)', () => {
   beforeEach(async () => {
@@ -523,7 +528,7 @@ describe('channel file not found (latest-mac.yml 404)', () => {
     await boot()
   })
 
-  it('manual check: ERR_UPDATER_CHANNEL_FILE_NOT_FOUND is benign (no capture, not error)', async () => {
+  it('manual check: ERR_UPDATER_CHANNEL_FILE_NOT_FOUND is not reported to Sentry and shows a soft retry message', async () => {
     mockAutoUpdater.checkForUpdates.mockImplementation(async () => {
       const err: any = new Error('Cannot find latest-mac.yml in the latest release artifacts ...: HttpError: 404')
       err.code = 'ERR_UPDATER_CHANNEL_FILE_NOT_FOUND'
@@ -533,9 +538,12 @@ describe('channel file not found (latest-mac.yml 404)', () => {
 
     await handlers['check-for-updates']()
 
+    // Benign: never reported to Sentry...
     expect(captureException).not.toHaveBeenCalled()
-    expect(getStatus().state).not.toBe('error')
-    expect(getStatus()).toMatchObject({ state: 'not-available' })
+    // ...but a user who actively checked gets an honest "couldn't verify" message
+    // rather than a misleading "no update available", and NOT the raw 404 text.
+    expect(getStatus()).toMatchObject({ state: 'error', error: CHANNEL_FILE_PENDING_MESSAGE })
+    expect(getStatus().error).not.toMatch(/404/)
   })
 
   it('manual check: a 404 message without the code is still treated as benign', async () => {
@@ -551,7 +559,7 @@ describe('channel file not found (latest-mac.yml 404)', () => {
     await handlers['check-for-updates']()
 
     expect(captureException).not.toHaveBeenCalled()
-    expect(getStatus().state).not.toBe('error')
+    expect(getStatus()).toMatchObject({ state: 'error', error: CHANNEL_FILE_PENDING_MESSAGE })
   })
 
   it('silent check: a channel-file 404 stays quiet (no capture, not error)', async () => {

--- a/src/main/auto-updater.test.ts
+++ b/src/main/auto-updater.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { app, ipcMain, powerMonitor } from 'electron'
 import { getSettings } from '@shared/lib/config/settings'
 import { getUserSettings } from '@shared/lib/services/user-settings-service'
+import { captureException } from '@shared/lib/error-reporting'
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const semver = require('semver')
 
@@ -26,6 +27,11 @@ vi.mock('@shared/lib/config/settings', () => ({
 
 vi.mock('@shared/lib/services/user-settings-service', () => ({
   getUserSettings: vi.fn(() => ({ allowPrereleaseUpdates: false })),
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+  addErrorBreadcrumb: vi.fn(),
 }))
 
 // `mockAutoUpdater.channel` mimics electron-updater's real setter, which
@@ -492,6 +498,93 @@ describe('silent background checks', () => {
     // No check ran — status stays at the initial 'idle'.
     expect(mockAutoUpdater.checkForUpdates).not.toHaveBeenCalled()
     expect(getStatus()).toMatchObject({ state: 'idle' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Benign "channel file not found" (latest-mac.yml 404) filtering
+//
+// electron-updater's checkForUpdates BOTH emits an 'error' event AND rejects,
+// so the same 404 is seen twice: once in the on('error') handler and once in
+// runUpdateCheckBody's catch. Neither path may report it to Sentry or flip the
+// UI to 'error' — it's benign and self-heals once the mac assets finish
+// uploading (ELECTRON-1N / ELECTRON-3S).
+// ---------------------------------------------------------------------------
+
+describe('channel file not found (latest-mac.yml 404)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockAutoUpdater.allowPrerelease = false
+    mockAutoUpdater.allowDowngrade = false
+    _mockChannel = undefined
+    vi.mocked(getSettings).mockReturnValue({ app: {} } as any)
+    vi.mocked(getUserSettings).mockReturnValue({ allowPrereleaseUpdates: false } as any)
+    vi.mocked(app.getVersion).mockReturnValue('0.2.5')
+    await boot()
+  })
+
+  it('manual check: ERR_UPDATER_CHANNEL_FILE_NOT_FOUND is benign (no capture, not error)', async () => {
+    mockAutoUpdater.checkForUpdates.mockImplementation(async () => {
+      const err: any = new Error('Cannot find latest-mac.yml in the latest release artifacts ...: HttpError: 404')
+      err.code = 'ERR_UPDATER_CHANNEL_FILE_NOT_FOUND'
+      events['error']?.(err)
+      throw err
+    })
+
+    await handlers['check-for-updates']()
+
+    expect(captureException).not.toHaveBeenCalled()
+    expect(getStatus().state).not.toBe('error')
+    expect(getStatus()).toMatchObject({ state: 'not-available' })
+  })
+
+  it('manual check: a 404 message without the code is still treated as benign', async () => {
+    mockAutoUpdater.checkForUpdates.mockImplementation(async () => {
+      const err: any = new Error(
+        'HttpError: 404 \n"Cannot find latest-mac.yml in the latest release artifacts (https://github.com/.../latest-mac.yml): HttpError: 404"',
+      )
+      err.statusCode = 404
+      events['error']?.(err)
+      throw err
+    })
+
+    await handlers['check-for-updates']()
+
+    expect(captureException).not.toHaveBeenCalled()
+    expect(getStatus().state).not.toBe('error')
+  })
+
+  it('silent check: a channel-file 404 stays quiet (no capture, not error)', async () => {
+    setupReleases({ currentVersion: '0.2.5', latestRC: null, latestStable: '0.2.5' })
+    await handlers['check-for-updates']()
+    expect(getStatus()).toMatchObject({ state: 'not-available' })
+    vi.mocked(captureException).mockClear()
+
+    mockAutoUpdater.checkForUpdates.mockImplementation(async () => {
+      const err: any = new Error('Cannot find latest-mac.yml in the latest release artifacts ...: HttpError: 404')
+      err.code = 'ERR_UPDATER_CHANNEL_FILE_NOT_FOUND'
+      events['error']?.(err)
+      throw err
+    })
+
+    await powerEvents.resume?.()
+    for (let i = 0; i < 50; i++) await Promise.resolve()
+
+    expect(captureException).not.toHaveBeenCalled()
+    expect(getStatus().state).not.toBe('error')
+  })
+
+  it('a genuine non-404 error is still captured and surfaced', async () => {
+    mockAutoUpdater.checkForUpdates.mockImplementation(async () => {
+      const err = new Error('Some real failure')
+      events['error']?.(err)
+      throw err
+    })
+
+    await handlers['check-for-updates']()
+
+    expect(captureException).toHaveBeenCalled()
+    expect(getStatus()).toMatchObject({ state: 'error' })
   })
 })
 

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { getUserSettings } from '@shared/lib/services/user-settings-service'
-import { captureException } from '@shared/lib/error-reporting'
+import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 
 export interface UpdateStatus {
   state: 'idle' | 'checking' | 'available' | 'not-available' | 'downloading' | 'downloaded' | 'error'
@@ -39,6 +39,27 @@ async function getAutoUpdater() {
 function semverGt(a: string, b: string): boolean {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   return require('semver').gt(a, b)
+}
+
+/**
+ * True for the benign "channel file (latest-mac.yml) is missing" failure.
+ *
+ * This happens when the newest release on the feed has no mac artifacts yet —
+ * e.g. a stable user with allowPrereleaseUpdates picks the newest rc whose
+ * release published before its mac assets (latest-mac.yml) finished uploading,
+ * or a stable release seen mid-publish. electron-updater surfaces it as
+ * ERR_UPDATER_CHANNEL_FILE_NOT_FOUND / an HTTP 404 on latest-mac.yml. There's
+ * nothing the user can do and it self-heals once the assets land, so we treat
+ * it as "no update available" rather than reporting it to Sentry.
+ */
+function isChannelFileNotFoundError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const code = (err as { code?: unknown }).code
+  if (code === 'ERR_UPDATER_CHANNEL_FILE_NOT_FOUND') return true
+  const statusCode = (err as { statusCode?: unknown }).statusCode
+  if (statusCode === 404) return true
+  const message = err instanceof Error ? err.message : String(err)
+  return /Cannot find .*latest-mac\.yml.*404/.test(message)
 }
 
 function sendStatusToRenderer() {
@@ -156,6 +177,18 @@ async function runUpdateCheckBody() {
       setStatus({ state: 'not-available' })
     }
   } catch (err) {
+    // A missing channel file (latest-mac.yml 404) is benign and self-healing —
+    // don't report it to Sentry and don't flip the UI to an error state.
+    if (isChannelFileNotFoundError(err)) {
+      addErrorBreadcrumb({
+        category: 'auto-updater',
+        message: 'Update channel file not yet available (latest-mac.yml 404)',
+        level: 'info',
+        data: { currentVersion: app.getVersion(), operation: 'check' },
+      })
+      setStatus({ state: 'not-available' })
+      return
+    }
     captureException(err, {
       tags: { component: 'auto-updater', operation: 'check' },
       extra: { currentVersion: app.getVersion(), userVisible: runIsUserVisible },
@@ -289,6 +322,19 @@ export async function initAutoUpdater(mainWindow: BrowserWindow) {
 
     autoUpdater.on('error', (err: Error) => {
       if (suppressErrors) return
+      // checkForUpdates both emits 'error' AND rejects, so a channel-file 404 is
+      // seen here too — treat it as benign (no Sentry, no error UI), mirroring
+      // the catch in runUpdateCheckBody.
+      if (isChannelFileNotFoundError(err)) {
+        addErrorBreadcrumb({
+          category: 'auto-updater',
+          message: 'Update channel file not yet available (latest-mac.yml 404)',
+          level: 'info',
+          data: { currentVersion: app.getVersion(), operation: 'runtime' },
+        })
+        setStatus({ state: 'not-available' })
+        return
+      }
       const isTransientNetworkError = /net::ERR_(NETWORK_CHANGED|INTERNET_DISCONNECTED|NAME_NOT_RESOLVED|CONNECTION_TIMED_OUT|CONNECTION_REFUSED|CONNECTION_RESET)\b/.test(err.message)
       if (!isTransientNetworkError) {
         captureException(err, {

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -73,6 +73,25 @@ function setStatus(status: UpdateStatus) {
   sendStatusToRenderer()
 }
 
+// Shown on a manual check when the channel file is missing (latest-mac.yml 404).
+// A user who actively asked deserves an honest "couldn't verify, retry" rather
+// than a false "you're up to date" — there may be a newer release mid-publish.
+const CHANNEL_FILE_PENDING_MESSAGE =
+  'Could not check for updates right now — the latest release may still be publishing. Please try again shortly.'
+
+/**
+ * Apply the benign channel-file-404 status. A silent background check stays
+ * quiet at 'not-available'; a user-initiated check gets the honest, non-Sentry
+ * "try again shortly" message instead of a misleading "no update available".
+ */
+function setChannelFilePendingStatus() {
+  if (runIsUserVisible) {
+    setStatus({ state: 'error', error: CHANNEL_FILE_PENDING_MESSAGE })
+  } else {
+    setStatus({ state: 'not-available' })
+  }
+}
+
 /**
  * Core update-check routine, shared by manual IPC checks and the scheduled
  * background checks. When `silent` is true, errors and the dev-mode-not-ready
@@ -178,7 +197,8 @@ async function runUpdateCheckBody() {
     }
   } catch (err) {
     // A missing channel file (latest-mac.yml 404) is benign and self-healing —
-    // don't report it to Sentry and don't flip the UI to an error state.
+    // never report it to Sentry. Silent checks stay quiet; a manual check gets a
+    // soft "try again shortly" message rather than a misleading "up to date".
     if (isChannelFileNotFoundError(err)) {
       addErrorBreadcrumb({
         category: 'auto-updater',
@@ -186,7 +206,7 @@ async function runUpdateCheckBody() {
         level: 'info',
         data: { currentVersion: app.getVersion(), operation: 'check' },
       })
-      setStatus({ state: 'not-available' })
+      setChannelFilePendingStatus()
       return
     }
     captureException(err, {
@@ -323,8 +343,8 @@ export async function initAutoUpdater(mainWindow: BrowserWindow) {
     autoUpdater.on('error', (err: Error) => {
       if (suppressErrors) return
       // checkForUpdates both emits 'error' AND rejects, so a channel-file 404 is
-      // seen here too — treat it as benign (no Sentry, no error UI), mirroring
-      // the catch in runUpdateCheckBody.
+      // seen here too — treat it as benign (no Sentry), mirroring the catch in
+      // runUpdateCheckBody: quiet for silent checks, soft retry for manual ones.
       if (isChannelFileNotFoundError(err)) {
         addErrorBreadcrumb({
           category: 'auto-updater',
@@ -332,7 +352,7 @@ export async function initAutoUpdater(mainWindow: BrowserWindow) {
           level: 'info',
           data: { currentVersion: app.getVersion(), operation: 'runtime' },
         })
-        setStatus({ state: 'not-available' })
+        setChannelFilePendingStatus()
         return
       }
       const isTransientNetworkError = /net::ERR_(NETWORK_CHANGED|INTERNET_DISCONNECTED|NAME_NOT_RESOLVED|CONNECTION_TIMED_OUT|CONNECTION_REFUSED|CONNECTION_RESET)\b/.test(err.message)


### PR DESCRIPTION
## Sentry issues
- **ELECTRON-1N** (32/38 events): a stable user with `allowPrereleaseUpdates` picks the newest rc (e.g. `v0.3.37-rc.2`) whose release has no mac artifacts yet → `latest-mac.yml` 404.
- **ELECTRON-3S**: `v0.3.36`, a stable release whose `latest-mac.yml` was missing at check time — consistent with a release published before its mac assets finished uploading.

Both surface from electron-updater as `ERR_UPDATER_CHANNEL_FILE_NOT_FOUND` / `HttpError 404`.

## Root cause
`checkForUpdates()` in electron-updater BOTH emits an `'error'` event AND rejects, so the same 404 was reported to Sentry **twice**:
1. `runUpdateCheckBody`'s `catch` (tag `operation=check`)
2. the `autoUpdater.on('error')` handler (tag `operation=runtime`)

The existing transient filter only matched `net::ERR_*`, so the 404 leaked through both paths and also flipped the UI to `state: 'error'`. The condition is benign — there's nothing the user can do, and it self-heals as soon as the mac assets (incl. `latest-mac.yml`) finish uploading to the release.

## What changed (`src/main/auto-updater.ts`)
- Added `isChannelFileNotFoundError(err)` which matches `err.code === 'ERR_UPDATER_CHANNEL_FILE_NOT_FOUND'`, `err.statusCode === 404`, or a `/Cannot find .*latest-mac\.yml.*404/` message.
- In **both** the `catch` and the `on('error')` handler: when it matches, skip `captureException`, add a single `info` breadcrumb instead, and set update state to `not-available` (not `error`). Filtered in both because the error is captured twice.
- The existing `net::ERR_*` transient filter and the silent-vs-user-visible UI logic are unchanged for all other errors.

## Tests (`src/main/auto-updater.test.ts`)
Added a focused `channel file not found (latest-mac.yml 404)` describe block mirroring the silent-check tests (now mocks `@shared/lib/error-reporting` to spy on `captureException`):
- manual check with `ERR_UPDATER_CHANNEL_FILE_NOT_FOUND` → no `captureException`, state `not-available` (not `error`)
- a 404 message without the code (via `statusCode`) → still benign
- silent (resume-triggered) check with the 404 → stays quiet
- a genuine non-404 error → still captured and surfaced as `error` (regression guard)

All 31 tests in the file pass.

## Workflow investigation (publish ordering)
Per the task I reviewed `.github/workflows/release.yml`. The `create-release` job:
- depends on `[prepare, build-agent-container, build-app-container, build-mac, build-win]`, so it only runs after the mac build finishes;
- creates the release with `draft: true` and attaches `files: ./release-artifacts/*` (which includes `latest-mac.yml`) in the same `softprops/action-gh-release@v2` step — uploads complete before that step finishes;
- only then runs `gh release edit --draft=false` to publish.

This is the correct **draft-then-publish** ordering: all platform artifacts (incl. `latest-mac.yml`) are uploaded while the release is still a draft, then it is un-drafted. Drafts are not visible to electron-updater's GitHub provider, so there's no client-side "filter drafts" lever and no obvious publish-ordering bug to fix here. Prerelease marking is also correct: `prerelease: ${{ contains(github.ref_name, '-') }}` flags rc/beta/alpha tags. I therefore made **no workflow change** — the residual ELECTRON-3S window (publishing 404 racing GitHub's asset/CDN availability, or older releases on the feed) is covered defensively by the client-side filter above.

## Validation
- `npx tsc --noEmit` → pass
- `npx eslint src/main/auto-updater.ts src/main/auto-updater.test.ts` → pass
- `npx vitest run src/main/auto-updater.test.ts` → 31 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)