### PR TITLE
fix(skillset): make cache refresh swap atomic and non-destructive (ELECTRON-4G)

### DIFF
--- a/src/shared/lib/skillset-provider/atomic-cache-swap.ts
+++ b/src/shared/lib/skillset-provider/atomic-cache-swap.ts
@@ -1,0 +1,97 @@
+import fs from 'fs'
+
+/**
+ * Atomic, non-destructive cache swap.
+ *
+ * The naive refresh (rm(cacheDir) then rename(tmpDir, cacheDir)) destroys the
+ * working cache *before* the new one is in place. On Windows the rename can fail
+ * with EPERM/EBUSY when antivirus or another handle briefly locks the directory,
+ * leaving the user with NO cache at all rather than a merely-failed refresh
+ * (Sentry ELECTRON-4G).
+ *
+ * This helper preserves the old cache until the new dir is fully in place:
+ *   1. move the existing cache aside to a backup path,
+ *   2. move the freshly-populated tmp dir into place (with bounded retries, then
+ *      a copy fallback for stubborn Windows locks),
+ *   3. delete the backup on success.
+ * On ANY failure the backup is restored so the user keeps a working cache.
+ */
+export async function atomicSwapCacheDir(cacheDir: string, tmpDir: string): Promise<void> {
+  const backupDir = cacheDir + '.bak-' + Date.now()
+  let movedAside = false
+
+  try {
+    // Step aside the old cache only if it exists. force:true makes rm a no-op
+    // when missing, but we must know whether a restore is needed on failure.
+    if (await pathExists(cacheDir)) {
+      await moveDir(cacheDir, backupDir)
+      movedAside = true
+    }
+
+    // Promote the new cache into place. If this throws after the old cache was
+    // moved aside, the catch restores the backup so the user is never left
+    // cacheless.
+    await moveDir(tmpDir, cacheDir)
+  } catch (err) {
+    // Restore the previous cache if we had moved it aside but failed to install
+    // the new one. Best-effort: a restore failure must not mask the original.
+    if (movedAside && !(await pathExists(cacheDir))) {
+      await moveDir(backupDir, cacheDir).catch(() => {})
+    }
+    await fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+    throw err
+  }
+
+  // New cache is committed — drop the backup. A leftover backup is harmless, so
+  // swallow errors here rather than failing an otherwise-successful refresh.
+  await fs.promises.rm(backupDir, { recursive: true, force: true }).catch(() => {})
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.promises.access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Move a directory with a bounded retry around transient Windows locks
+ * (EPERM/EBUSY/EACCES from AV or open handles), falling back to a recursive
+ * copy + delete if rename keeps failing.
+ */
+async function moveDir(src: string, dest: string): Promise<void> {
+  const MAX_ATTEMPTS = 5
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    try {
+      await fs.promises.rename(src, dest)
+      return
+    } catch (err) {
+      if (attempt === MAX_ATTEMPTS - 1 || !isTransientLockError(err)) {
+        // Last resort: copy-into-place. rename can also fail with EXDEV when
+        // src and dest straddle filesystems, which a copy handles too.
+        if (isTransientLockError(err) || isCrossDeviceError(err)) {
+          await fs.promises.cp(src, dest, { recursive: true, force: true })
+          await fs.promises.rm(src, { recursive: true, force: true }).catch(() => {})
+          return
+        }
+        throw err
+      }
+      await delay(100 * (attempt + 1))
+    }
+  }
+}
+
+function isTransientLockError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException)?.code
+  return code === 'EPERM' || code === 'EBUSY' || code === 'EACCES'
+}
+
+function isCrossDeviceError(err: unknown): boolean {
+  return (err as NodeJS.ErrnoException)?.code === 'EXDEV'
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/src/shared/lib/skillset-provider/platform-provider.test.ts
+++ b/src/shared/lib/skillset-provider/platform-provider.test.ts
@@ -315,6 +315,40 @@ describe('PlatformSkillsetProvider archive cache (no-git path)', () => {
       .toEqual({ fresh: true })
     expect(await provider.isCacheReady(destDir)).toBe(true)
   })
+
+  it('refreshCache preserves the existing cache when the swap fails (ELECTRON-4G)', async () => {
+    const destDir = path.join(tmpDir, 'cache')
+    await fs.promises.mkdir(destDir, { recursive: true })
+    await fs.promises.writeFile(path.join(destDir, 'stale.txt'), 'old')
+    await fs.promises.writeFile(path.join(destDir, '.skillset-cache-meta.json'), '{}')
+
+    mockArchiveFetch(await buildTarGz({ 'index.json': '{"fresh":true}' }))
+
+    // Persistent Windows EPERM lock on the swap moves, plus a failing copy
+    // fallback, so the new cache can't be installed. The old cache must be
+    // restored intact rather than left destroyed.
+    const realRename = fs.promises.rename
+    const renameSpy = vi.spyOn(fs.promises, 'rename').mockImplementation(async (from, to) => {
+      if (String(from) === destDir || String(to) === destDir) {
+        const e = new Error('EPERM: operation not permitted, rename') as NodeJS.ErrnoException
+        e.code = 'EPERM'
+        throw e
+      }
+      return realRename(from, to)
+    })
+    const cpSpy = vi.spyOn(fs.promises, 'cp').mockRejectedValue(
+      Object.assign(new Error('EPERM: operation not permitted, copyfile'), { code: 'EPERM' }),
+    )
+
+    await expect(provider.refreshCache(destDir, makeRef())).rejects.toThrow(/EPERM/)
+
+    expect(fs.existsSync(path.join(destDir, 'stale.txt'))).toBe(true)
+    expect(await fs.promises.readFile(path.join(destDir, 'stale.txt'), 'utf-8')).toBe('old')
+    expect(await provider.isCacheReady(destDir)).toBe(true)
+
+    renameSpy.mockRestore()
+    cpSpy.mockRestore()
+  })
 })
 
 describe('PlatformSkillsetProvider.getQueueItemStatuses', () => {

--- a/src/shared/lib/skillset-provider/platform-provider.ts
+++ b/src/shared/lib/skillset-provider/platform-provider.ts
@@ -17,6 +17,7 @@ import { ensureDirectory } from '@shared/lib/utils/file-storage'
 import { validateSafeCloneUrl } from '@shared/lib/utils/url-safety'
 import { withRetry, NonRetryableError } from '@shared/lib/utils/retry'
 import { captureException } from '@shared/lib/error-reporting'
+import { atomicSwapCacheDir } from './atomic-cache-swap'
 import {
   BaseSkillsetProvider,
   type SkillsetHostedUpdateInput,
@@ -260,12 +261,13 @@ export class PlatformSkillsetProvider extends BaseSkillsetProvider {
     const tmpDir = cacheDir + '.tmp-' + Date.now()
     try {
       await this.populateCache(tmpDir, ref)
-      await fs.promises.rm(cacheDir, { recursive: true, force: true })
-      await fs.promises.rename(tmpDir, cacheDir)
     } catch (err) {
       await fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
       throw err
     }
+    // Swap atomically so a failed rename (Windows EPERM/EBUSY) can never leave
+    // the user with a destroyed cache instead of a working one.
+    await atomicSwapCacheDir(cacheDir, tmpDir)
   }
 
   override async publishUpdate(input: SkillsetPublishInput): Promise<SkillsetPublishResult> {

--- a/src/shared/lib/skillset-provider/public-provider.test.ts
+++ b/src/shared/lib/skillset-provider/public-provider.test.ts
@@ -295,4 +295,43 @@ describe('PublicSkillsetProvider.refreshCache', () => {
     expect(JSON.parse(await fs.promises.readFile(path.join(destDir, 'index.json'), 'utf-8'))).toEqual({ fresh: true })
     expect(await provider.isCacheReady(destDir)).toBe(true)
   })
+
+  it('preserves the existing cache when the swap rename fails (ELECTRON-4G)', async () => {
+    const destDir = path.join(tmpDir, 'cache')
+    await fs.promises.mkdir(destDir, { recursive: true })
+    await fs.promises.writeFile(path.join(destDir, 'old-file.txt'), 'stale')
+    await fs.promises.writeFile(path.join(destDir, '.skillset-cache-meta.json'), '{}')
+
+    mockFetchResponse(await buildTestZip({ 'index.json': '{"fresh":true}' }))
+
+    // Simulate a persistent Windows EPERM lock on every rename so even the
+    // copy-fallback's source rename + the swap-in both fail. cp also fails so
+    // the new cache can't be installed — the old one must be restored intact.
+    const realRename = fs.promises.rename
+    const renameSpy = vi.spyOn(fs.promises, 'rename').mockImplementation(async (from, to) => {
+      // Allow renaming the freshly-populated tmp dir during populateCache, but
+      // block the atomic swap moves (which target/originate the real cacheDir).
+      if (String(from) === destDir || String(to) === destDir) {
+        const e = new Error('EPERM: operation not permitted, rename') as NodeJS.ErrnoException
+        e.code = 'EPERM'
+        throw e
+      }
+      return realRename(from, to)
+    })
+    const cpSpy = vi.spyOn(fs.promises, 'cp').mockRejectedValue(
+      Object.assign(new Error('EPERM: operation not permitted, copyfile'), { code: 'EPERM' }),
+    )
+
+    await expect(
+      provider.refreshCache(destDir, makeRef('https://github.com/Org/repo')),
+    ).rejects.toThrow(/EPERM/)
+
+    // The old cache must still be there and usable — not destroyed.
+    expect(fs.existsSync(path.join(destDir, 'old-file.txt'))).toBe(true)
+    expect(await fs.promises.readFile(path.join(destDir, 'old-file.txt'), 'utf-8')).toBe('stale')
+    expect(await provider.isCacheReady(destDir)).toBe(true)
+
+    renameSpy.mockRestore()
+    cpSpy.mockRestore()
+  })
 })

--- a/src/shared/lib/skillset-provider/public-provider.ts
+++ b/src/shared/lib/skillset-provider/public-provider.ts
@@ -4,6 +4,7 @@ import { ensureDirectory } from '@shared/lib/utils/file-storage'
 import { openZipFromBuffer, detectZipPrefix } from '@shared/lib/utils/zip'
 import { validateSafeCloneUrl } from '@shared/lib/utils/url-safety'
 import { withRetry, NonRetryableError } from '@shared/lib/utils/retry'
+import { atomicSwapCacheDir } from './atomic-cache-swap'
 import {
   BaseSkillsetProvider,
   type SkillsetPublishInput,
@@ -46,12 +47,13 @@ export class PublicSkillsetProvider extends BaseSkillsetProvider {
     const tmpDir = cacheDir + '.tmp-' + Date.now()
     try {
       await this.populateCache(tmpDir, ref)
-      await fs.promises.rm(cacheDir, { recursive: true, force: true })
-      await fs.promises.rename(tmpDir, cacheDir)
     } catch (err) {
       await fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
       throw err
     }
+    // Swap atomically so a failed rename (Windows EPERM/EBUSY) can never leave
+    // the user with a destroyed cache instead of a working one.
+    await atomicSwapCacheDir(cacheDir, tmpDir)
   }
 
   override async publishUpdate(_input: SkillsetPublishInput): Promise<SkillsetPublishResult> {


### PR DESCRIPTION
## Sentry issue
**ELECTRON-4G** — Windows EPERM during skillset cache refresh.

(The other 3 issues bucketed into this triage group — **3E** rate-limit, **3Q** not-authorized, **1P** ECONNRESET — are external/transient and already handled by existing `NonRetryableError`/`withRetry` logic. They are intentionally left untouched; this PR does not broadly suppress them.)

## Root cause
`refreshCache` in both `src/shared/lib/skillset-provider/public-provider.ts` and `src/shared/lib/skillset-provider/platform-provider.ts` did:

```
await this.populateCache(tmpDir, ref)
await fs.promises.rm(cacheDir, { recursive: true, force: true })  // destroys live cache first
await fs.promises.rename(tmpDir, cacheDir)                        // can fail on Windows
```

The `rm(cacheDir)` ran **before** the `rename`, and the `catch` only removed `tmpDir`. On Windows the rename can fail with `EPERM`/`EBUSY` when antivirus or another handle briefly locks the directory. When that happens, the user is left with a **destroyed cache** — strictly worse than a merely-failed refresh. This is the real latent data-loss bug.

## What changed
- New helper `src/shared/lib/skillset-provider/atomic-cache-swap.ts` exporting `atomicSwapCacheDir(cacheDir, tmpDir)`:
  1. move the existing cache aside to a `*.bak-<ts>` backup,
  2. move the freshly-populated tmp dir into place,
  3. delete the backup on success.
  On **any** failure it restores the backup so a working cache always survives. `moveDir` adds a bounded retry (5 attempts, escalating backoff) around transient Windows lock errors (`EPERM`/`EBUSY`/`EACCES`) and a recursive `fs.cp` copy-into-place fallback (which also covers `EXDEV` cross-device renames).
- Both providers' `refreshCache` now populate `tmpDir`, then delegate the swap to `atomicSwapCacheDir`. The old cache is no longer `rm`'d up front.

## Validation
- `npx tsc --noEmit` — passes.
- `npx eslint` on all changed files — clean.
- Added focused tests in `public-provider.test.ts` and `platform-provider.test.ts` that stub `fs.promises.rename` to throw a persistent `EPERM` on the swap moves **and** make the `fs.cp` fallback reject, then assert the original cache files survive and `isCacheReady` stays true. Existing "replaces stale cache atomically" tests still pass. 49 tests pass across both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)