### PR TITLE
fix(container): capture image-build stderr in ensureImageExists (ELECTRON-6 / ELECTRON-4D)

### DIFF
--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -186,6 +186,15 @@ export const CONTAINER_INTERNAL_PORT = 3000
 const BASE_PORT = 4000
 
 /**
+ * Error thrown by ensureImageExists() when an image build fails, carrying the
+ * captured stderr tail and exit code so start()'s catch can surface them to Sentry.
+ */
+interface ImageBuildError extends Error {
+  imageBuildStderr?: string
+  imageBuildExitCode?: number | null
+}
+
+/**
  * Parse a memory value string (e.g., "231.2MiB", "1.5GiB", "512MB") to bytes.
  */
 export function parseMemoryValue(value: string): number {
@@ -538,6 +547,11 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
             agentId: this.config.agentId,
             containerName: this.getContainerName(),
             runner: getSettings().container.containerRunner,
+            image: getSettings().container.agentImage,
+            // Surface image-build diagnostics when start() failed during
+            // ensureImageExists() (otherwise these are undefined).
+            imageBuildExitCode: error.imageBuildExitCode,
+            imageBuildStderr: error.imageBuildStderr,
           },
         })
       }
@@ -1133,19 +1147,35 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     } catch {
       console.log(`Building container image ${image}...`)
 
+      // Pipe (not inherit) stdout/stderr so we can capture the build output —
+      // a bare exit code is undiagnosable in Sentry. Mirrors buildImage() in
+      // client-factory.ts.
       const buildProcess = spawnWithPath(
         runner,
-        ['build', '-t', image, AGENT_CONTAINER_PATH],
-        { stdio: 'inherit' }
+        ['build', '-t', image, AGENT_CONTAINER_PATH]
       )
+
+      const stderrChunks: string[] = []
+      buildProcess.stdout?.on('data', (data: Buffer) => process.stdout.write(data))
+      buildProcess.stderr?.on('data', (data: Buffer) => {
+        stderrChunks.push(data.toString())
+        process.stderr.write(data)
+      })
 
       await new Promise<void>((resolve, reject) => {
         buildProcess.on('close', (code) => {
-          if (code === 0) {
+          const stderr = stderrChunks.join('').trim()
+          // Treat an "already exists" image as success — a concurrent build
+          // (e.g. ensureImageReady racing the start path) may have created it.
+          if (code === 0 || /already exists/i.test(stderr)) {
             console.log(`Container image ${image} built successfully`)
             resolve()
           } else {
-            reject(new Error(`Container build failed with code ${code}`))
+            const detail = stderr ? `: ${stderr.slice(-500)}` : ''
+            const error = new Error(`Container build failed with code ${code}${detail}`) as ImageBuildError
+            error.imageBuildExitCode = code
+            error.imageBuildStderr = stderr.slice(-2000)
+            reject(error)
           }
         })
         buildProcess.on('error', reject)


### PR DESCRIPTION
## Sentry issues
- **ELECTRON-6** (2572 events, archived-yet-escalating, 122 users)
- **ELECTRON-4D**

## Root cause
`BaseContainerClient.ensureImageExists()` (src/shared/lib/container/base-container-client.ts) spawned the image build with `stdio:'inherit'`, so the child process's `stdout`/`stderr` were `null` and **nothing was captured**. On a non-zero exit it threw a bare `Container build failed with code ${code}`. That propagates to `start()`'s catch, which `captureException`'s with only `agentId` / `containerName` / `runner` — **no stderr** — so the issue is undiagnosable, which is why it stays archived but keeps firing.

By contrast, the modern `buildImage()` in `src/shared/lib/container/client-factory.ts` already pipes the streams, accumulates `stderrChunks`, and includes the stderr tail in both the thrown error and the Sentry extras.

## What changed (`src/shared/lib/container/base-container-client.ts`)
- `ensureImageExists()` now **pipes** (no longer `inherit`) the build process stdout/stderr, accumulates `stderrChunks`, and still mirrors the output to the parent's `process.stdout`/`process.stderr` so console behavior is unchanged.
- On non-zero exit it throws `Container build failed with code ${code}` plus the stderr tail (`: ${stderr.slice(-500)}`), and attaches `imageBuildExitCode` + `imageBuildStderr` (last 2000 chars) to the error via a small `ImageBuildError` interface.
- `start()`'s catch now adds `image`, `imageBuildExitCode`, and `imageBuildStderr` to the Sentry extras (they are `undefined` for non-build failures).
- An `already exists` stderr is treated as **success** (idempotent), to tolerate a concurrent `ensureImageReady()` build racing the start path.

The original error-message prefix is preserved, so any prefix-based matching keeps working.

## Pull-vs-build hypothesis (investigated; left as a follow-up, NOT fixed here)
Review notes suspected the real ELECTRON-6 trigger is that `ensureImageExists()` **always builds and never pulls**, and the relative build context `AGENT_CONTAINER_PATH` (`'./agent-container'`) is **absent in a packaged production app**, so the build exits non-zero.

I confirmed the structural setup:
- `ensureImageExists()` only ever does `image inspect` → `build`; it never pulls.
- `ContainerManager.ensureImageReady()` already does proper pull-vs-build via `canBuildImage()` / `pullImage()` / `buildImage()`, with retry/backoff and `PULLING_IMAGE` readiness.
- **But** `ensureImageReady()` is fire-and-forget at startup (`startup.ts`) and on settings changes — it is **not awaited** before `ensureRunning()` → `doStartContainer()` → `client.start()` → `ensureImageExists()`. So the start path is independent and can build (and fail) in production if the pull hasn't completed.

I did **not** re-route the start path through `ensureImageReady()` / `pullImage()` in this PR because:
1. `pullImage` lives in `client-factory.ts`, which imports `base-container-client.ts` — importing it back would create a **circular dependency**.
2. It is a behavioral change to a path that runs in both dev and prod, and warrants its own focused PR.

The captured stderr added here will **confirm or refute** this hypothesis directly in Sentry (an absent build context surfaces a clear error), which is the right next step before the larger refactor.

## Validation
- `npx tsc --noEmit` — passes (whole project).
- `npx eslint src/shared/lib/container/base-container-client.ts` — passes.
- `npx vitest run src/shared/lib/container/base-container-client.test.ts` — 64/64 pass (no regressions).
- No focused unit test was added: `ensureImageExists()` is private and its `spawnWithPath` / `execWithPath` calls bind to module-local functions in the same file, so they cannot be mocked from that module's own test file (which only covers pure exported helpers). Adding coverage would require refactoring those calls to be injectable — out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)