### PR TITLE
fix: deliver_file off tool result, not streamed input (ELECTRON-39)

### DIFF
--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -1231,22 +1231,10 @@ export async function processSSEEvent(
     case 'tool_use_ready': {
       const toolName = data.toolName as string
 
-      // Handle file delivery — send the file to the chat client
-      if (toolName === 'mcp__user-input__deliver_file') {
-        try {
-          const toolInput = JSON.parse(managed.currentToolInput || '{}')
-          const filePath = toolInput.filePath as string | undefined
-          const description = toolInput.description as string | undefined
-          if (filePath) {
-            await sendDeliveredFile(managed, filePath, description)
-          }
-        } catch (err) {
-          console.error('[ChatIntegrationManager] Failed to deliver file:', err)
-          reportError(err, 'deliver-file', { integrationId: managed.integration.id, provider: managed.integration.provider })
-        }
-        managed.currentToolInput = ''
-        break
-      }
+      // Note: deliver_file is handled off its tool_result (see 'tool_result_ready'
+      // below), not off the streamed input — so we never read a host-side path
+      // before the in-container tool has validated the file exists. It falls
+      // through to isUserRequestTool() here, which just resets the tool input.
 
       if (isUserRequestTool(toolName)) {
         managed.currentToolInput = ''
@@ -1271,6 +1259,27 @@ export async function processSSEEvent(
         }
       }
       managed.currentToolInput = ''
+      break
+    }
+
+    case 'tool_result_ready': {
+      // Fired once the in-container tool has returned its result. Currently only
+      // deliver_file acts on it: deliver the file to the chat client, but only if
+      // the tool validated the file exists (isError === false). On an error
+      // result we skip host delivery — the agent's text already covers the user.
+      const toolName = data.toolName as string
+      if (toolName === 'mcp__user-input__deliver_file' && !data.isError) {
+        const filePath = data.filePath as string | undefined
+        const description = data.description as string | undefined
+        if (filePath) {
+          try {
+            await sendDeliveredFile(managed, filePath, description)
+          } catch (err) {
+            console.error('[ChatIntegrationManager] Failed to deliver file:', err)
+            reportError(err, 'deliver-file', { integrationId: managed.integration.id, provider: managed.integration.provider })
+          }
+        }
+      }
       break
     }
 
@@ -1369,7 +1378,12 @@ async function sendDeliveredFile(
     await managed.connector.sendFile(managed.chatId, fileData, filename, description)
   } catch (err) {
     console.error('[ChatIntegrationManager] Failed to send delivered file:', err)
-    reportError(err, 'send-delivered-file', { integrationId: managed.integration.id, provider: managed.integration.provider, filePath })
+    // ENOENT is benign: the file isn't host-visible (e.g. a not-yet-flushed
+    // write across the VM file-share). The text fallback below still reaches the
+    // user, so don't page Sentry — log everything else at 'warning'.
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      reportError(err, 'send-delivered-file', { integrationId: managed.integration.id, provider: managed.integration.provider, filePath }, 'warning')
+    }
     // Fall back to a text message with the file path
     await managed.connector.sendMessage(managed.chatId, {
       text: `📎 File ready: \`${filePath}\`${description ? ` — ${description}` : ''}\n(File delivery to chat not available — download from the UI)`,

--- a/src/shared/lib/chat-integrations/sse-event-processing.test.ts
+++ b/src/shared/lib/chat-integrations/sse-event-processing.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { processSSEEvent, finalizeStreaming, resolvePendingToolMessages, type ManagedConnector } from './chat-integration-manager'
 import { MockChatClientConnector } from './mock-connector'
 import type { ChatIntegration } from '@shared/lib/db/schema'
@@ -1039,5 +1039,94 @@ describe('no-streaming connector (iMessage-style)', () => {
 
     const mock = managed.connector as MockChatClientConnector
     expect(mock.typingIndicators.length).toBe(1)
+  })
+})
+
+// ── deliver_file (tool_result_ready) ──────────────────────────────────────
+// Files are delivered off the tool RESULT (which validates existence in the
+// container), not the streamed input — see ELECTRON-39.
+describe('deliver_file delivery', () => {
+  const DELIVER = 'mcp__user-input__deliver_file'
+  let workspaceDir: string
+  let managed: ManagedConnector
+  let prevDataDir: string | undefined
+
+  beforeEach(async () => {
+    const os = await import('os')
+    const fs = await import('fs')
+    const path = await import('path')
+    prevDataDir = process.env.SUPERAGENT_DATA_DIR
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-deliver-'))
+    process.env.SUPERAGENT_DATA_DIR = dataDir
+    managed = createManagedConnector()
+    // getAgentWorkspaceDir resolves to {dataDir}/agents/{agentSlug}/workspace
+    workspaceDir = path.join(dataDir, 'agents', managed.integration.agentSlug, 'workspace')
+    fs.mkdirSync(workspaceDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    if (prevDataDir === undefined) delete process.env.SUPERAGENT_DATA_DIR
+    else process.env.SUPERAGENT_DATA_DIR = prevDataDir
+  })
+
+  it('does NOT deliver the file on tool_use_ready (streamed input)', async () => {
+    await processEvents(managed, [
+      { type: 'tool_use_start', toolId: 't1', toolName: DELIVER },
+      { type: 'tool_use_streaming', partialInput: '{"filePath":"/workspace/out.txt"}' },
+      { type: 'tool_use_ready', toolId: 't1', toolName: DELIVER },
+    ])
+    const mock = getMock(managed)
+    expect(mock.sentFiles.length).toBe(0)
+    expect(mock.sentMessages.length).toBe(0)
+  })
+
+  it('delivers the file on a successful tool_result_ready', async () => {
+    const fs = await import('fs')
+    const path = await import('path')
+    fs.writeFileSync(path.join(workspaceDir, 'out.txt'), 'hello')
+
+    await processSSEEvent(managed, {
+      type: 'tool_result_ready',
+      toolName: DELIVER,
+      toolUseId: 't1',
+      filePath: '/workspace/out.txt',
+      description: 'a report',
+      isError: false,
+    })
+
+    const mock = getMock(managed)
+    expect(mock.sentFiles.length).toBe(1)
+    expect(mock.sentFiles[0].filename).toBe('out.txt')
+    expect(mock.sentFiles[0].caption).toBe('a report')
+  })
+
+  it('does NOT deliver when the tool_result is an error', async () => {
+    await processSSEEvent(managed, {
+      type: 'tool_result_ready',
+      toolName: DELIVER,
+      toolUseId: 't1',
+      filePath: '/workspace/missing.txt',
+      isError: true,
+    })
+
+    const mock = getMock(managed)
+    expect(mock.sentFiles.length).toBe(0)
+    expect(mock.sentMessages.length).toBe(0)
+  })
+
+  it('falls back to a text message (no throw) when a success result points at a missing host file', async () => {
+    // Success result but the file isn't host-visible (benign ENOENT) — graceful fallback.
+    await processSSEEvent(managed, {
+      type: 'tool_result_ready',
+      toolName: DELIVER,
+      toolUseId: 't1',
+      filePath: '/workspace/not-on-host.txt',
+      isError: false,
+    })
+
+    const mock = getMock(managed)
+    expect(mock.sentFiles.length).toBe(0)
+    expect(mock.sentMessages.length).toBe(1)
+    expect(mock.sentMessages[0].message.text).toContain('not-on-host.txt')
   })
 })

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -436,6 +436,85 @@ describe('MessagePersister', () => {
   })
 
   // ============================================================================
+  // deliver_file tool-result correlation (ELECTRON-39)
+  // ============================================================================
+
+  describe('deliver_file tool_result_ready', () => {
+    function streamDeliverFileToolUse(filePath: string, description?: string) {
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          content_block: { type: 'tool_use', id: 'deliver-1', name: 'mcp__user-input__deliver_file' },
+        },
+      })
+      const input = JSON.stringify(description ? { filePath, description } : { filePath })
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: input } },
+      })
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'content_block_stop' } })
+    }
+
+    it('broadcasts tool_result_ready with the validated path on a successful result', () => {
+      streamDeliverFileToolUse('/workspace/out.txt', 'a report')
+      sseEvents.length = 0
+
+      mockClient._sendMessage({
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'deliver-1', content: 'delivered' }] },
+      })
+
+      const ready = sseEvents.filter(e => e.type === 'tool_result_ready')
+      expect(ready).toHaveLength(1)
+      expect(ready[0].toolName).toBe('mcp__user-input__deliver_file')
+      expect(ready[0].filePath).toBe('/workspace/out.txt')
+      expect(ready[0].description).toBe('a report')
+      expect(ready[0].isError).toBe(false)
+    })
+
+    it('marks tool_result_ready as an error when the in-container tool failed', () => {
+      streamDeliverFileToolUse('/workspace/missing.txt')
+      sseEvents.length = 0
+
+      mockClient._sendMessage({
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'deliver-1', content: 'not found', is_error: true }] },
+      })
+
+      const ready = sseEvents.filter(e => e.type === 'tool_result_ready')
+      expect(ready).toHaveLength(1)
+      expect(ready[0].isError).toBe(true)
+    })
+
+    it('does not broadcast tool_result_ready for an untracked tool_result', () => {
+      mockClient._sendMessage({
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'other-tool', content: 'result' }] },
+      })
+
+      const ready = sseEvents.filter(e => e.type === 'tool_result_ready')
+      expect(ready).toHaveLength(0)
+    })
+
+    it('does not re-broadcast tool_result_ready for a duplicate tool_result', () => {
+      streamDeliverFileToolUse('/workspace/out.txt')
+
+      const sendResult = () => mockClient._sendMessage({
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'deliver-1', content: 'delivered' }] },
+      })
+
+      sseEvents.length = 0
+      sendResult()
+      sendResult()
+
+      const ready = sseEvents.filter(e => e.type === 'tool_result_ready')
+      expect(ready).toHaveLength(1)
+    })
+  })
+
+  // ============================================================================
   // Subagent completion detection
   // ============================================================================
 

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -72,6 +72,7 @@ interface StreamingState {
   pendingComputerUseRequests: Map<string, { toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string; agentSlug?: string }> // Pending computer use requests awaiting user approval (keyed by toolUseId)
   lastApiErrorCode: string | null // SDK error code from last assistant message (e.g., 'authentication_failed', 'rate_limit')
   activeBackgroundTasks: Map<string, { startedAt: number }> // Background Bash commands still running (keyed by task ID)
+  pendingDeliverFiles: Map<string, { filePath: string; description?: string }> // deliver_file tool calls awaiting their tool_result, keyed by tool_use ID
 }
 
 // Lazy import to break circular dependency: container-manager -> message-persister
@@ -162,6 +163,7 @@ class MessagePersister {
       pendingComputerUseRequests: new Map(),
       lastApiErrorCode: null,
       activeBackgroundTasks: priorBackgroundTasks,
+      pendingDeliverFiles: new Map(),
     })
 
     // Store container client for reconnection checks
@@ -496,6 +498,7 @@ class MessagePersister {
         pendingComputerUseRequests: new Map(),
         lastApiErrorCode: null,
         activeBackgroundTasks: new Map(),
+        pendingDeliverFiles: new Map(),
       }
       this.streamingStates.set(sessionId, state)
       if (this.capture && agentSlug) {
@@ -1537,6 +1540,23 @@ class MessagePersister {
               state.currentToolUse.name !== 'mcp__user-input__request_script_run')
           ) {
             this.markSessionAwaitingInput(sessionId)
+          }
+
+          // Track deliver_file tool calls so the matching tool_result can be
+          // correlated. We deliver the file to chat clients off the tool RESULT
+          // (which validates the file exists in-container) rather than off the
+          // streamed input, so a path that doesn't exist never reaches host-side
+          // delivery. Keyed by tool_use ID; resolved in handleToolResults.
+          if (state.currentToolUse.name === 'mcp__user-input__deliver_file') {
+            try {
+              const parsed = JSON.parse(state.currentToolInput)
+              if (parsed && typeof parsed.filePath === 'string') {
+                state.pendingDeliverFiles.set(state.currentToolUse.id, {
+                  filePath: parsed.filePath,
+                  description: typeof parsed.description === 'string' ? parsed.description : undefined,
+                })
+              }
+            } catch { /* partial or invalid JSON — nothing to deliver */ }
           }
 
           // Track Task/Agent tool for subagent correlation
@@ -2761,6 +2781,7 @@ class MessagePersister {
     try {
       const messageContent = content.message?.content || []
 
+      const state = this.streamingStates.get(sessionId)
       for (const block of messageContent) {
         if (block.type === 'tool_result' && block.tool_use_id) {
           // Broadcast update to SSE clients
@@ -2770,6 +2791,22 @@ class MessagePersister {
             result: block.content,
             isError: block.is_error || false,
           })
+
+          // If this is the result of a tracked deliver_file call, surface a
+          // dedicated event so chat integrations deliver the file only now that
+          // the in-container tool has validated it exists (isError === false).
+          const pendingDeliver = state?.pendingDeliverFiles.get(block.tool_use_id)
+          if (pendingDeliver) {
+            state!.pendingDeliverFiles.delete(block.tool_use_id)
+            this.broadcastToSSE(sessionId, {
+              type: 'tool_result_ready',
+              toolName: 'mcp__user-input__deliver_file',
+              toolUseId: block.tool_use_id,
+              filePath: pendingDeliver.filePath,
+              description: pendingDeliver.description,
+              isError: block.is_error || false,
+            })
+          }
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Sentry issue
- **ELECTRON-39** — `sendDeliveredFile` ENOENT, captured at error level.

## Root cause
The host fired `sendDeliveredFile(...)` from the `case 'tool_use_ready'` handler in `chat-integration-manager.ts`. But `tool_use_ready` is broadcast by `message-persister.ts` at `content_block_stop` — i.e. when the **model finishes streaming the tool-call input**, NOT when the in-container `deliver_file` MCP tool actually executes. The in-container tool (`agent-container/src/tools/deliver-file.ts`) does an `fs.stat` and only returns success (`isError: false`) if the file exists.

So the host read its mount **before** the tool had validated existence. A path the model emitted that doesn't actually exist (or a not-yet-host-visible write across the VM file-share) surfaced as ENOENT and was captured at **error** level — even though the user still received the graceful text fallback.

## What changed
**Deliver off the tool RESULT, not the streamed input:**
- `message-persister.ts`: track `deliver_file` tool calls by `tool_use` ID at `content_block_stop` (new `pendingDeliverFiles` map on `StreamingState`), and on the matching `tool_result` broadcast a new **`tool_result_ready`** SSE event carrying `toolName`, `filePath`, `description`, and `isError`. The entry is deleted on first match so a duplicate `tool_result` can't double-fire.
- `chat-integration-manager.ts`: `tool_use_ready` no longer delivers `deliver_file` (it now falls through to `isUserRequestTool()`, which just resets the tool input). A new `tool_result_ready` case delivers the file **only when `isError === false`** — on an error result host delivery is skipped entirely (the agent's text already covers the user).
- `chat-integration-manager.ts`: the `sendDeliveredFile` failure report is downgraded from `error` to `warning`, and **skips Sentry entirely** on `err.code === 'ENOENT'` (benign — the text fallback covers the user).

Diff is confined to the deliver-file path, since this file is slated for later chat-connector lifecycle work.

## Validation
- `npx tsc --noEmit` — passes.
- `npx eslint` on all 4 changed files — passes.
- Added focused tests (all green):
  - `src/shared/lib/container/message-persister.test.ts` → `deliver_file tool_result_ready`: broadcasts `tool_result_ready` with the validated path on success, marks `isError` on a failed in-container result, does not fire for untracked tool_results, and does not re-fire on a duplicate tool_result.
  - `src/shared/lib/chat-integrations/sse-event-processing.test.ts` → `deliver_file delivery`: no delivery on `tool_use_ready`; delivers on a successful `tool_result_ready`; no delivery on an error result; graceful text-message fallback (no throw) when a success result points at a host-missing file (benign ENOENT).
- Full runs: `message-persister.test.ts` (153 tests) and `sse-event-processing.test.ts` (66 tests) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)