### PR TITLE
feat: actionable billing card for insufficient-balance errors

### DIFF
--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -47,6 +47,13 @@ vi.mock('@shared/lib/utils', () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
 }))
 
+// Mock the platform billing card — its usePlatformBillingUrl hook uses React Query,
+// which these tests don't provide. Default to no billing error (returns null).
+vi.mock('./insufficient-balance-card', () => ({
+  usePlatformBillingUrl: () => null,
+  InsufficientBalanceCard: () => <div data-testid="insufficient-balance-card" />,
+}))
+
 describe('AgentActivityIndicator', () => {
   beforeEach(() => {
     // Reset to defaults

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -4,6 +4,7 @@ import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
 import { apiFetch } from '@renderer/lib/api'
 import { ProviderErrorCard } from '@renderer/components/ui/provider-error-card'
+import { InsufficientBalanceCard, usePlatformBillingUrl } from './insufficient-balance-card'
 import { PROVIDER_ERROR_CODES } from '@shared/lib/types/api'
 import { cn } from '@shared/lib/utils'
 import { AlertTriangle, Monitor, X } from 'lucide-react'
@@ -32,6 +33,9 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
   const [revoking, setRevoking] = useState(false)
   const [revokeError, setRevokeError] = useState(false)
   const [showAllTodos, setShowAllTodos] = useState(false)
+
+  // Non-null only for a platform billing 402 the workspace can act on (see hook).
+  const billingUrl = usePlatformBillingUrl(error ?? '')
 
   // Rough token estimate for the streamed reasoning (~4 chars/token). UI-only.
   const thinkingTokens = thinkingText ? Math.ceil(thinkingText.length / 4) : 0
@@ -176,7 +180,9 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
     const isProviderError = apiErrorCode != null && PROVIDER_ERROR_CODES.has(apiErrorCode)
     return (
       <div className="mx-auto mb-2 w-full max-w-[740px] px-4">
-        {isProviderError ? (
+        {billingUrl ? (
+          <InsufficientBalanceCard billingUrl={billingUrl} data-testid="insufficient-balance-card" />
+        ) : isProviderError ? (
           <ProviderErrorCard message={error} data-testid="provider-error-card" />
         ) : (
           <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 select-text" data-testid="error-card">

--- a/src/renderer/components/messages/insufficient-balance-card.test.tsx
+++ b/src/renderer/components/messages/insufficient-balance-card.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, renderHook, screen, fireEvent } from '@testing-library/react'
+
+import { InsufficientBalanceCard, usePlatformBillingUrl } from './insufficient-balance-card'
+
+const platformAuth = {
+  connected: true as boolean,
+  platformBaseUrl: 'https://platform.example.com' as string | null,
+  orgId: 'org_123' as string | null,
+}
+const settings = { llmProvider: 'platform' as string | null }
+
+vi.mock('@renderer/hooks/use-platform-auth', () => ({
+  usePlatformAuthStatus: () => ({ data: platformAuth }),
+}))
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useSettings: () => ({ data: settings }),
+}))
+
+const BILLING_MESSAGE = 'API Error: 402 Workspace has insufficient balance. Top up to continue.'
+
+beforeEach(() => {
+  platformAuth.connected = true
+  platformAuth.platformBaseUrl = 'https://platform.example.com'
+  platformAuth.orgId = 'org_123'
+  settings.llmProvider = 'platform'
+})
+
+describe('usePlatformBillingUrl', () => {
+  it('returns the org billing URL for a platform insufficient-balance error', () => {
+    const { result } = renderHook(() => usePlatformBillingUrl(BILLING_MESSAGE))
+    expect(result.current).toBe(
+      'https://platform.example.com/dashboard/organizations/org_123?tab=billing',
+    )
+  })
+
+  it('returns null when the error is not insufficient-balance', () => {
+    const { result } = renderHook(() => usePlatformBillingUrl('API Error: 500 server error'))
+    expect(result.current).toBeNull()
+  })
+
+  it('returns null for a BYOK provider (llmProvider is not platform)', () => {
+    settings.llmProvider = 'anthropic'
+    const { result } = renderHook(() => usePlatformBillingUrl(BILLING_MESSAGE))
+    expect(result.current).toBeNull()
+  })
+
+  it('returns null when the platform account is not connected', () => {
+    platformAuth.connected = false
+    const { result } = renderHook(() => usePlatformBillingUrl(BILLING_MESSAGE))
+    expect(result.current).toBeNull()
+  })
+
+  it('returns null when orgId is missing', () => {
+    platformAuth.orgId = null
+    const { result } = renderHook(() => usePlatformBillingUrl(BILLING_MESSAGE))
+    expect(result.current).toBeNull()
+  })
+})
+
+describe('InsufficientBalanceCard', () => {
+  it('renders the actionable card and opens billing externally on click', async () => {
+    const openExternal = vi.fn().mockResolvedValue(undefined)
+    ;(window as unknown as { electronAPI?: unknown }).electronAPI = { openExternal }
+
+    render(<InsufficientBalanceCard billingUrl="https://platform.example.com/billing" />)
+
+    expect(screen.getByText('Insufficient balance')).toBeInTheDocument()
+    const button = screen.getByRole('button', { name: /go to billing/i })
+    fireEvent.click(button)
+    expect(openExternal).toHaveBeenCalledWith('https://platform.example.com/billing')
+  })
+})

--- a/src/renderer/components/messages/insufficient-balance-card.tsx
+++ b/src/renderer/components/messages/insufficient-balance-card.tsx
@@ -1,0 +1,74 @@
+import { ArrowUpRight, Wallet } from 'lucide-react'
+
+import { Button } from '@renderer/components/ui/button'
+import { usePlatformAuthStatus } from '@renderer/hooks/use-platform-auth'
+import { useSettings } from '@renderer/hooks/use-settings'
+
+// A platform billing 402 is the only provider error we can resolve in-product
+// (subscribe / top up the org wallet).
+function isInsufficientBalanceError(message: string): boolean {
+  const lower = message.toLowerCase()
+  return (
+    lower.includes('insufficient balance') ||
+    lower.includes('insufficient_balance') ||
+    (lower.includes('402') && lower.includes('top up'))
+  )
+}
+
+// Returns the org billing URL when `message` is a platform billing 402 the
+// workspace can act on (platform LLM in use, connected, org known); otherwise
+// null. Callers use null to fall through to the generic provider-error card —
+// e.g. a BYOK provider returning a 402 must not surface a platform billing CTA.
+export function usePlatformBillingUrl(message: string): string | null {
+  const { data: platformAuth } = usePlatformAuthStatus()
+  const { data: settings } = useSettings()
+
+  if (!isInsufficientBalanceError(message)) return null
+  if (settings?.llmProvider !== 'platform') return null
+  if (!platformAuth?.connected) return null
+
+  const platformBaseUrl = platformAuth.platformBaseUrl
+  const orgId = platformAuth.orgId
+  if (!platformBaseUrl || !orgId) return null
+
+  return `${platformBaseUrl}/dashboard/organizations/${orgId}?tab=billing`
+}
+
+export function InsufficientBalanceCard({
+  billingUrl,
+  'data-testid': testId,
+}: {
+  billingUrl: string
+  'data-testid'?: string
+}) {
+  async function handleGoToBilling() {
+    if (window.electronAPI?.openExternal) {
+      await window.electronAPI.openExternal(billingUrl)
+      return
+    }
+    window.open(billingUrl, '_blank', 'noopener,noreferrer')
+  }
+
+  return (
+    <div
+      className="rounded-[12px] border bg-muted/30 shadow-md p-4"
+      data-testid={testId ?? 'insufficient-balance-card'}
+    >
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-amber-500/15">
+          <Wallet className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h4 className="text-sm font-medium text-foreground">Insufficient balance</h4>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Subscribe or top up to continue running agents.
+          </p>
+          <Button size="sm" className="mt-3 gap-1.5" onClick={() => void handleGoToBilling()}>
+            Go to billing
+            <ArrowUpRight className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/messages/message-item.test.tsx
+++ b/src/renderer/components/messages/message-item.test.tsx
@@ -33,6 +33,13 @@ vi.mock('@renderer/components/ui/tooltip', () => ({
   TooltipContent: ({ children }: { children: React.ReactNode }) => <span data-testid="tooltip-content">{children}</span>,
 }))
 
+// Mock the platform billing card — its usePlatformBillingUrl hook uses React Query,
+// which these tests don't provide. Default to no billing error (returns null).
+vi.mock('./insufficient-balance-card', () => ({
+  usePlatformBillingUrl: () => null,
+  InsufficientBalanceCard: () => <div data-testid="insufficient-balance-card" />,
+}))
+
 describe('MessageItem', () => {
   describe('user messages', () => {
     it('renders with user data-testid', () => {

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -2,6 +2,7 @@ import { cn } from '@shared/lib/utils/cn'
 import { useState, useCallback, memo, type ReactNode } from 'react'
 import { Check, Copy, Link2 } from 'lucide-react'
 import { ProviderErrorCard } from '@renderer/components/ui/provider-error-card'
+import { InsufficientBalanceCard, usePlatformBillingUrl } from './insufficient-balance-card'
 import { ToolCallItem } from './tool-call-item'
 import { SubAgentBlock } from './subagent-block'
 import { MessageContextMenu } from './message-context-menu'
@@ -163,6 +164,8 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
 
   // Detect assistant messages that failed due to an LLM provider error (from SDK metadata)
   const isProviderErrorMessage = isAssistant && !!message.apiError && PROVIDER_ERROR_CODES.has(message.apiError)
+  const billingUrl = usePlatformBillingUrl(rawText ?? '')
+  const showBillingCard = isAssistant && !!message.apiError && !!billingUrl
 
   // Don't render assistant messages that have no text and no tool calls
   // (and aren't streaming). These are transient empty entries from partially-
@@ -223,13 +226,18 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
                 </div>
               )}
 
+              {/* Actionable platform billing error */}
+              {hasText && !isSlashCommand && showBillingCard && (
+                <InsufficientBalanceCard billingUrl={billingUrl!} />
+              )}
+
               {/* LLM provider error display */}
-              {hasText && !isSlashCommand && isProviderErrorMessage && (
+              {hasText && !isSlashCommand && !showBillingCard && isProviderErrorMessage && (
                 <ProviderErrorCard message={text} />
               )}
 
               {/* Text content */}
-              {hasText && !isSlashCommand && !isProviderErrorMessage && (
+              {hasText && !isSlashCommand && !showBillingCard && !isProviderErrorMessage && (
                 <div dir="auto" className={cn(
                   'prose prose-sm max-w-none min-w-0 break-words font-medium dark:prose-invert'
                 )}>


### PR DESCRIPTION
## Summary

When an agent run ends with a `402 insufficient_balance` error (`API Error: 402 Workspace has insufficient balance. Top up to continue.`), the chat now shows a dedicated, actionable card instead of raw provider error text:

- **Title**: Insufficient balance
- **Body**: Subscribe or top up to continue running agents.
- **Button**: Go to billing → opens the org billing page

The billing URL is built from `platformBaseUrl` + `orgId` via `usePlatformAuthStatus()`, reusing the exact pattern already used by `handleManageBilling` in `platform-tab.tsx`:
`${platformBaseUrl}/dashboard/organizations/${orgId}?tab=billing`

## What changed

- `provider-error-card.tsx`: added `isInsufficientBalanceError()` detector + a new `InsufficientBalanceCard` rendered when the error is a 402 insufficient-balance. Styled to match the standard card convention (`rounded-[12px] border bg-muted/30 shadow-md`).
- `message-item.tsx` / `agent-activity-indicator.tsx`: widened the provider-error gate so the card also renders when the error **text** signals insufficient balance — the SDK's category for a 402 is not guaranteed to be in `PROVIDER_ERROR_CODES`, so we don't rely solely on the code.

## Why

A bare error message is a dead end for the user. This routes them straight to the place where they can resolve it (subscribe / top up).

## Test plan

- [ ] Trigger a 402 insufficient-balance on an agent run and confirm the card renders with a working "Go to billing" button.
- [ ] Confirm non-billing provider errors still render the standard provider-error card.
- [ ] `typecheck` clean (verified locally; only pre-existing `tools/` errors remain).

Made with [Cursor](https://cursor.com)