### PR TITLE
fix(container): bound the isHealthy /health probe with a timeout

### DIFF
--- a/src/shared/lib/container/base-container-client.test.ts
+++ b/src/shared/lib/container/base-container-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
@@ -614,5 +614,47 @@ describe('BaseContainerClient.isPortConflictError', () => {
 
   it('base extractInaccessibleMountPath returns null (no VM filesystem)', () => {
     expect(client.testExtractInaccessibleMountPath(new Error('operation not permitted'))).toBe(null)
+  })
+})
+
+// ============================================================================
+// isHealthy — the /health probe must be bounded (it gates the request hot path
+// via ensureRunning's stale-cache liveness check; an unresponsive port-forward
+// would otherwise hang the caller indefinitely).
+// ============================================================================
+
+describe('BaseContainerClient.isHealthy', () => {
+  const client = new TestContainerClient({ agentId: 'test-agent' })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('passes an AbortSignal to the /health fetch (bounded probe)', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true }) as Response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    await client.isHealthy(4001)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:4001/health',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('returns true when the probe responds ok', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true }) as Response))
+    await expect(client.isHealthy(4001)).resolves.toBe(true)
+  })
+
+  it('returns false (not throw) when the probe aborts/times out', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new DOMException('The operation was aborted', 'AbortError')
+    }))
+    await expect(client.isHealthy(4001)).resolves.toBe(false)
+  })
+
+  it('returns false when no port is known', async () => {
+    await expect(client.isHealthy(0)).resolves.toBe(false)
   })
 })

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -184,6 +184,9 @@ export function isConnectionError(err: Error): boolean {
 export const AGENT_CONTAINER_PATH = './agent-container'
 export const CONTAINER_INTERNAL_PORT = 3000
 const BASE_PORT = 4000
+// Max time for a single /health probe (isHealthy). Kept short because it gates
+// the request hot path via ensureRunning's stale-cache liveness check.
+const HEALTH_PROBE_TIMEOUT_MS = 2000
 
 /**
  * Error thrown by ensureImageExists() when an image build fails, carrying the
@@ -846,9 +849,16 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     const port = knownPort ?? (await this.getInfo()).port
     if (!port) return false
     try {
-      const response = await fetch(`http://127.0.0.1:${port}/health`)
+      // Bound the probe: this runs on the request hot path (ensureRunning's
+      // stale-cache liveness check), and a container that died with its port
+      // forward left half-open would accept the TCP connect but never respond,
+      // hanging the fetch — and the caller — indefinitely without this.
+      const response = await fetch(`http://127.0.0.1:${port}/health`, {
+        signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+      })
       return response.ok
     } catch {
+      // Includes AbortError on timeout — treat an unresponsive probe as unhealthy.
       return false
     }
   }


### PR DESCRIPTION
## What

`isHealthy()` does `fetch('http://127.0.0.1:<port>/health')` with **no timeout**. #198 (merged) put it on the **request hot path** — `ContainerManager.ensureRunning` now calls it as a stale-cache liveness probe before every message send once the cached status ages past the TTL.

If a container died with its Lima port-forward left half-open (accepts the TCP connect but never responds), the fetch hangs with no bound → `ensureRunning` hangs → the user's next message hangs indefinitely. The #198 unit tests mock `isHealthy` to resolve instantly, so this couldn't surface there.

## Fix

`fetch(url, { signal: AbortSignal.timeout(2000) })`. An aborted/timed-out probe is treated as unhealthy (the existing `catch` already returns `false`, so the liveness check falls through to a restart, which is the right behavior for a dead container).

## Testing

- `npx tsc --noEmit` clean, eslint clean.
- Added 4 fast regression tests: signal is passed to fetch, `ok→true`, `abort→false`, `no-port→false`.
- Found while doing a real-runtime validation pass on #198 against a live Lima VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)