### PR TITLE
fix: crash opening sessions with a stringified AskUserQuestion arg

### DIFF
--- a/src/renderer/components/messages/tool-renderers/ask-user-question.tsx
+++ b/src/renderer/components/messages/tool-renderers/ask-user-question.tsx
@@ -3,11 +3,11 @@ import { MessageCircleQuestion } from 'lucide-react'
 import type { ToolRenderer, ToolRendererProps } from './types'
 import { askUserQuestionDef, type AskUserQuestionInput } from '@shared/lib/tool-definitions/ask-user-question'
 
+// Use the shared parser, which coerces a JSON-string `questions` argument back
+// into an array (some models stringify complex tool args). Casting the raw
+// input here instead would let a string reach `questions.map(...)` and crash.
 function parseInput(input: unknown): AskUserQuestionInput {
-  if (typeof input === 'object' && input !== null) {
-    return input as AskUserQuestionInput
-  }
-  return {}
+  return askUserQuestionDef.parseInput(input)
 }
 
 function getSummary(input: unknown): string | null {

--- a/src/shared/lib/tool-definitions/ask-user-question.test.ts
+++ b/src/shared/lib/tool-definitions/ask-user-question.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { askUserQuestionDef } from './ask-user-question'
+
+const arrayQuestions = [
+  { question: 'Which database should we use?', header: 'Database', options: [{ label: 'Postgres' }, { label: 'SQLite' }] },
+  { question: 'Deploy now?', header: 'Deploy' },
+]
+
+describe('askUserQuestionDef.parseInput', () => {
+  it('passes through an array of questions', () => {
+    expect(askUserQuestionDef.parseInput({ questions: arrayQuestions })).toEqual({ questions: arrayQuestions })
+  })
+
+  // Regression: some models emit `questions` as a JSON-encoded string rather than
+  // an array. Left uncoerced, this crashed the whole message thread when the
+  // collapsed tool header called getSummary (string[0].question -> undefined.length).
+  it('coerces a JSON-stringified questions array back into an array', () => {
+    const result = askUserQuestionDef.parseInput({ questions: JSON.stringify(arrayQuestions) })
+    expect(result.questions).toEqual(arrayQuestions)
+  })
+
+  it('returns undefined questions for an unparseable string', () => {
+    expect(askUserQuestionDef.parseInput({ questions: 'not json' }).questions).toBeUndefined()
+  })
+
+  it('returns undefined questions when the string parses to a non-array', () => {
+    expect(askUserQuestionDef.parseInput({ questions: '{"question":"x"}' }).questions).toBeUndefined()
+  })
+
+  it('returns empty object for non-object input', () => {
+    expect(askUserQuestionDef.parseInput(null)).toEqual({})
+    expect(askUserQuestionDef.parseInput('string')).toEqual({})
+  })
+})
+
+describe('askUserQuestionDef.getSummary', () => {
+  it('summarizes a single question', () => {
+    expect(askUserQuestionDef.getSummary({ questions: [{ question: 'Deploy now?' }] })).toBe('Deploy now?')
+  })
+
+  it('appends a (+ N more) suffix for multiple questions', () => {
+    expect(askUserQuestionDef.getSummary({ questions: arrayQuestions })).toBe('Which database should we use? (+ 1 more)')
+  })
+
+  it('does not throw and summarizes when questions arrives as a JSON string', () => {
+    expect(askUserQuestionDef.getSummary({ questions: JSON.stringify(arrayQuestions) })).toBe(
+      'Which database should we use? (+ 1 more)'
+    )
+  })
+
+  it('returns null for missing or empty questions', () => {
+    expect(askUserQuestionDef.getSummary({})).toBeNull()
+    expect(askUserQuestionDef.getSummary({ questions: [] })).toBeNull()
+    expect(askUserQuestionDef.getSummary({ questions: 'garbage' })).toBeNull()
+  })
+})

--- a/src/shared/lib/tool-definitions/ask-user-question.ts
+++ b/src/shared/lib/tool-definitions/ask-user-question.ts
@@ -4,14 +4,38 @@ export interface AskUserQuestionInput {
   questions?: Question[]
 }
 
+/**
+ * Coerce the `questions` argument into an array.
+ *
+ * Models occasionally emit complex tool arguments as a JSON-encoded string
+ * instead of a structured value (e.g. `questions: "[{...}]"` rather than
+ * `questions: [{...}]`). Left as-is, a string passes the `?.length` truthiness
+ * guard but indexing it (`questions[0]`) yields a character, so `.question`
+ * is undefined and downstream `.length`/`.map` access throws — crashing the
+ * whole message thread. Normalize here so every consumer sees an array.
+ */
+function coerceQuestions(raw: unknown): Question[] | undefined {
+  let value = raw
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value)
+    } catch {
+      return undefined
+    }
+  }
+  return Array.isArray(value) ? (value as Question[]) : undefined
+}
+
 function parseInput(input: unknown): AskUserQuestionInput {
-  return typeof input === 'object' && input !== null ? (input as AskUserQuestionInput) : {}
+  if (typeof input !== 'object' || input === null) return {}
+  return { questions: coerceQuestions((input as { questions?: unknown }).questions) }
 }
 
 function getSummary(input: unknown): string | null {
   const { questions } = parseInput(input)
   if (!questions?.length) return null
-  const first = questions[0].question
+  const first = questions[0]?.question
+  if (!first) return null
   const truncated = first.length > 50 ? first.slice(0, 47) + '...' : first
   return questions.length > 1 ? `${truncated} (+ ${questions.length - 1} more)` : truncated
 }


### PR DESCRIPTION
## What

A user could not open a session — the whole renderer crashed to the top-level "Something went wrong — Cannot read properties of undefined (reading 'length')" screen.

## Root cause

One `AskUserQuestion` tool call in the session had its `questions` argument persisted as a **JSON-encoded string** instead of an array:

```jsonc
"input": { "questions": "[{\"question\": \"How should the Monday report look...\" }]" }
```

This is a model-side serialization quirk — the model occasionally stringifies complex tool arguments (the other three `AskUserQuestion` calls in the same session sent proper arrays).

The collapsed tool-call header runs `getSummary` for **every** tool call on render (`tool-call-item.tsx`). With a string:

```js
if (!questions?.length) return null      // string length is truthy → passes
const first = questions[0].question       // questions[0] is the char "[", .question is undefined
const truncated = first.length > 50 ...   // undefined.length → 💥
```

There is no error boundary around the message thread, so this single bad render takes down the entire app and the session can't be opened. (A follow-up PR adds per-message/per-tool-call error boundaries so this class of bug is contained.)

## Fix

- `tool-definitions/ask-user-question.ts` — `parseInput` now JSON-parses a string `questions` and only accepts an array (else `undefined`); `getSummary` guards the first question.
- `tool-renderers/ask-user-question.tsx` — `ExpandedView` now routes through the shared `parseInput`, so expanding the call no longer hits `questions.map is not a function`.
- Added regression tests covering the stringified-array, unparseable-string, and non-array-string cases.

## Verification

Reproduced by running the real `transformMessages` + `MessageItem` render over the actual session log: it threw on the offending message before the fix and renders all 115 messages after. `tsc --noEmit` and eslint are clean; the 92 tool-definition/tool-renderer tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)