### PR TITLE
feat: isolate message/tool-call render errors behind a boundary

### DIFF
--- a/src/renderer/components/messages/message-error-boundary.test.tsx
+++ b/src/renderer/components/messages/message-error-boundary.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+const captureRendererException = vi.fn()
+vi.mock('@renderer/lib/error-reporting', () => ({
+  captureRendererException: (...args: unknown[]) => captureRendererException(...args),
+}))
+
+import { MessageErrorBoundary } from './message-error-boundary'
+import { MessageItem } from './message-item'
+import type { ApiMessage } from '@shared/lib/types/api'
+
+function Boom(): never {
+  throw new Error('kaboom while rendering')
+}
+
+describe('MessageErrorBoundary', () => {
+  beforeEach(() => {
+    captureRendererException.mockClear()
+  })
+
+  it('renders children when they do not throw', () => {
+    render(
+      <MessageErrorBoundary kind="message" raw={{ id: 'm1' }}>
+        <div>healthy child</div>
+      </MessageErrorBoundary>
+    )
+    expect(screen.getByText('healthy child')).toBeInTheDocument()
+    expect(screen.queryByTestId('message-error-boundary')).not.toBeInTheDocument()
+  })
+
+  it('shows an error box (not a crash) when a child throws', () => {
+    // Suppress React's expected error log for the thrown render.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(
+      <MessageErrorBoundary kind="tool call" raw={{ id: 't1' }}>
+        <Boom />
+      </MessageErrorBoundary>
+    )
+    expect(screen.getByTestId('message-error-boundary')).toBeInTheDocument()
+    expect(screen.getByText('Failed to display this tool call')).toBeInTheDocument()
+    spy.mockRestore()
+  })
+
+  it('reports the error to Sentry with kind + item id', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(
+      <MessageErrorBoundary kind="tool call" raw={{ id: 't1' }} itemId="t1">
+        <Boom />
+      </MessageErrorBoundary>
+    )
+    expect(captureRendererException).toHaveBeenCalledTimes(1)
+    const [error, context] = captureRendererException.mock.calls[0] as [Error, { tags: Record<string, string>; extra: Record<string, unknown> }]
+    expect(error).toBeInstanceOf(Error)
+    expect(context.tags).toMatchObject({ feature: 'message-render', item_kind: 'tool call' })
+    expect(context.extra).toMatchObject({ itemId: 't1' })
+    spy.mockRestore()
+  })
+
+  it('reveals the raw payload behind a "View raw" toggle', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(
+      <MessageErrorBoundary kind="message" raw={{ id: 'm1', secret: 'raw-payload-marker' }}>
+        <Boom />
+      </MessageErrorBoundary>
+    )
+    // Raw hidden by default
+    expect(screen.queryByText(/raw-payload-marker/)).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('View raw'))
+    expect(screen.getByText(/raw-payload-marker/)).toBeInTheDocument()
+    // Toggle back
+    fireEvent.click(screen.getByText('Hide raw'))
+    expect(screen.queryByText(/raw-payload-marker/)).not.toBeInTheDocument()
+    spy.mockRestore()
+  })
+
+  // End-to-end: a real MessageItem containing a tool call that crashes the
+  // renderer (AskUserQuestion with a stringified `questions` arg — the exact bug
+  // this branch does NOT fix) must degrade to the inline error box, not take the
+  // thread down. The healthy text in the same message still renders.
+  it('contains a crashing tool call inside a real MessageItem', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const message = {
+      id: 'assistant-1',
+      type: 'assistant',
+      content: { text: 'Here is my question:' },
+      toolCalls: [
+        {
+          id: 'toolu_bad',
+          name: 'AskUserQuestion',
+          input: { questions: '[{"question":"Pick one","options":[{"label":"A"}]}]' },
+        },
+      ],
+      createdAt: new Date(),
+    } as unknown as ApiMessage
+
+    render(<MessageItem message={message} sessionId="s1" agentSlug="agent" isSessionActive={false} />)
+
+    expect(screen.getByText('Failed to display this tool call')).toBeInTheDocument()
+    expect(screen.getByText('Here is my question:')).toBeInTheDocument()
+    expect(captureRendererException).toHaveBeenCalledTimes(1)
+    spy.mockRestore()
+  })
+})

--- a/src/renderer/components/messages/message-error-boundary.tsx
+++ b/src/renderer/components/messages/message-error-boundary.tsx
@@ -1,0 +1,98 @@
+import { Component, useMemo, useState, type ErrorInfo, type ReactNode } from 'react'
+import { AlertTriangle } from 'lucide-react'
+import { cn } from '@shared/lib/utils/cn'
+import { captureRendererException } from '@renderer/lib/error-reporting'
+
+/** What kind of item failed to render — drives the copy and the Sentry tags. */
+type RenderItemKind = 'message' | 'tool call'
+
+interface MessageErrorBoundaryProps {
+  children: ReactNode
+  kind: RenderItemKind
+  /** The raw payload for this item, shown verbatim under "View raw". */
+  raw: unknown
+  /** Stable id (message id / tool-call id) for Sentry correlation. */
+  itemId?: string
+}
+
+interface MessageErrorBoundaryState {
+  error: Error | null
+}
+
+/**
+ * Isolates a single message or tool call so a render error in one item can't
+ * crash the whole thread. On error it swaps the item for an inline notice with
+ * a "View raw" escape hatch, and reports the error to Sentry.
+ */
+export class MessageErrorBoundary extends Component<MessageErrorBoundaryProps, MessageErrorBoundaryState> {
+  state: MessageErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): MessageErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    captureRendererException(error, {
+      tags: { feature: 'message-render', item_kind: this.props.kind },
+      extra: {
+        itemId: this.props.itemId,
+        componentStack: info.componentStack,
+      },
+    })
+  }
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return <RenderErrorNotice kind={this.props.kind} raw={this.props.raw} error={this.state.error} />
+    }
+    return this.props.children
+  }
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function RenderErrorNotice({ kind, raw, error }: { kind: RenderItemKind; raw: unknown; error: Error }) {
+  const [showRaw, setShowRaw] = useState(false)
+  const rawText = useMemo(() => safeStringify(raw), [raw])
+
+  return (
+    <div
+      className="border border-amber-300/70 dark:border-amber-700/60 rounded-md bg-amber-50 dark:bg-amber-950/30 text-sm"
+      data-testid="message-error-boundary"
+    >
+      <div className="flex items-center gap-2 px-3 py-2 text-amber-800 dark:text-amber-200">
+        <AlertTriangle className="h-4 w-4 shrink-0" />
+        <span className="font-medium">Failed to display this {kind}</span>
+        <button
+          type="button"
+          onClick={() => setShowRaw((v) => !v)}
+          className="ml-auto shrink-0 text-xs underline underline-offset-2 hover:no-underline"
+        >
+          {showRaw ? 'Hide raw' : 'View raw'}
+        </button>
+      </div>
+      {showRaw && (
+        <div className="px-3 pb-3 space-y-2">
+          {error.message && (
+            <div className="text-xs text-amber-700/90 dark:text-amber-300/80 font-mono break-words">
+              {error.message}
+            </div>
+          )}
+          <pre
+            className={cn(
+              'bg-background/70 rounded p-2 text-xs overflow-auto max-h-64 whitespace-pre-wrap break-words'
+            )}
+          >
+            {rawText}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -5,6 +5,7 @@ import { ProviderErrorCard } from '@renderer/components/ui/provider-error-card'
 import { ToolCallItem } from './tool-call-item'
 import { SubAgentBlock } from './subagent-block'
 import { MessageContextMenu } from './message-context-menu'
+import { MessageErrorBoundary } from './message-error-boundary'
 import { FileDownloadPill } from '@renderer/components/ui/file-download-pill'
 import { parseAttachedFiles, parseMountedFolders } from '@shared/lib/utils/attached-files'
 import ReactMarkdown, { type Components } from 'react-markdown'
@@ -289,18 +290,20 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
             {toolCalls.map((toolCall) => (
               <MessageContextMenu key={toolCall.id} text={toolCall.name} onRemove={onRemoveToolCall ? () => onRemoveToolCall(toolCall.id) : undefined}>
                 <div>
-                  {(toolCall.name === 'Task' || toolCall.name === 'Agent') && sessionId ? (
-                    <SubAgentBlock
-                      toolCall={toolCall}
-                      sessionId={sessionId}
-                      agentSlug={agentSlug!}
-                      isSessionActive={isSessionActive}
-                      activeSubagent={activeSubagents?.find(s => s.parentToolId === toolCall.id) ?? null}
-                      isCompleted={completedSubagents?.has(toolCall.id) ?? false}
-                    />
-                  ) : (
-                    <ToolCallItem toolCall={toolCall} messageCreatedAt={message.createdAt} agentSlug={agentSlug} isSessionActive={isSessionActive} />
-                  )}
+                  <MessageErrorBoundary kind="tool call" raw={toolCall} itemId={toolCall.id}>
+                    {(toolCall.name === 'Task' || toolCall.name === 'Agent') && sessionId ? (
+                      <SubAgentBlock
+                        toolCall={toolCall}
+                        sessionId={sessionId}
+                        agentSlug={agentSlug!}
+                        isSessionActive={isSessionActive}
+                        activeSubagent={activeSubagents?.find(s => s.parentToolId === toolCall.id) ?? null}
+                        isCompleted={completedSubagents?.has(toolCall.id) ?? false}
+                      />
+                    ) : (
+                      <ToolCallItem toolCall={toolCall} messageCreatedAt={message.createdAt} agentSlug={agentSlug} isSessionActive={isSessionActive} />
+                    )}
+                  </MessageErrorBoundary>
                 </div>
               </MessageContextMenu>
             ))}

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -12,13 +12,14 @@ import { ToolCallItem, StreamingToolCallItem } from './tool-call-item'
 import { SubAgentBlock } from './subagent-block'
 import { CompactBoundaryItem } from './compact-boundary-item'
 import { MemoryRecallItem } from './memory-recall-item'
+import { MessageErrorBoundary } from './message-error-boundary'
 import { ArrowDown, FileX2, Loader2, MessageSquarePlus, WifiOff } from 'lucide-react'
 import { FileDownloadPill } from '@renderer/components/ui/file-download-pill'
 import { useIsOnline } from '@renderer/context/connectivity-context'
 import { useUser } from '@renderer/context/user-context'
 import { useDraft } from '@renderer/context/drafts-context'
 import { useRenderTracker } from '@renderer/lib/perf'
-import { useEffect, useLayoutEffect, useRef, useState, useCallback, useMemo, Fragment } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, useCallback, useMemo, Fragment, type ReactNode } from 'react'
 import { formatElapsed } from '@renderer/hooks/use-elapsed-timer'
 import type { ApiMessage, ApiCompactBoundary, ApiMemoryRecall } from '@shared/lib/types/api'
 
@@ -464,7 +465,9 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, pendingR
               <CompactBoundaryItem boundary={item as ApiCompactBoundary} />
             ) : (
               <>
-                <MessageItem message={item as ApiMessage} agentSlug={agentSlug} sessionId={sessionId} isSessionActive={canHaveRunningToolCalls.has(item.id)} activeSubagents={activeSubagents} completedSubagents={completedSubagents} onRemoveMessage={handleRemoveMessage} onRemoveToolCall={handleRemoveToolCall} />
+                <MessageErrorBoundary kind="message" raw={item} itemId={item.id}>
+                  <MessageItem message={item as ApiMessage} agentSlug={agentSlug} sessionId={sessionId} isSessionActive={canHaveRunningToolCalls.has(item.id)} activeSubagents={activeSubagents} completedSubagents={completedSubagents} onRemoveMessage={handleRemoveMessage} onRemoveToolCall={handleRemoveToolCall} />
+                </MessageErrorBoundary>
                 {turnDeliveredFiles.has(item.id) && item.id !== deferredElapsedMessageId && (
                   <DeliveredFiles files={turnDeliveredFiles.get(item.id)!} agentSlug={agentSlug} />
                 )}
@@ -495,32 +498,36 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, pendingR
         {peerUserMessage &&
           peerUserMessage.sender.id !== user?.id &&
           !messages?.some((m) => m.type === 'user' && (m.content as { text?: string }).text?.trim() === peerUserMessage.content.trim()) && (
-          <MessageItem
-            message={{
-              id: 'peer-user-message',
-              type: 'user',
-              content: { text: peerUserMessage.content },
-              toolCalls: [],
-              createdAt: new Date(),
-              ...(peerUserMessage.sender.name ? { sender: { id: peerUserMessage.sender.id, name: peerUserMessage.sender.name, email: peerUserMessage.sender.email || '' } } : {}),
-            }}
-            agentSlug={agentSlug}
-          />
+          <MessageErrorBoundary kind="message" raw={peerUserMessage} itemId="peer-user-message">
+            <MessageItem
+              message={{
+                id: 'peer-user-message',
+                type: 'user',
+                content: { text: peerUserMessage.content },
+                toolCalls: [],
+                createdAt: new Date(),
+                ...(peerUserMessage.sender.name ? { sender: { id: peerUserMessage.sender.id, name: peerUserMessage.sender.name, email: peerUserMessage.sender.email || '' } } : {}),
+              }}
+              agentSlug={agentSlug}
+            />
+          </MessageErrorBoundary>
         )}
 
         {/* Pending user message - shown immediately after sending */}
         {pendingUserMessage && (
-          <MessageItem
-            message={{
-              id: 'pending-user-message',
-              type: 'user',
-              content: { text: pendingUserMessage.text },
-              toolCalls: [],
-              createdAt: new Date(),
-              sender: pendingUserMessage.sender,
-            }}
-            agentSlug={agentSlug}
-          />
+          <MessageErrorBoundary kind="message" raw={pendingUserMessage} itemId="pending-user-message">
+            <MessageItem
+              message={{
+                id: 'pending-user-message',
+                type: 'user',
+                content: { text: pendingUserMessage.text },
+                toolCalls: [],
+                createdAt: new Date(),
+                sender: pendingUserMessage.sender,
+              }}
+              agentSlug={agentSlug}
+            />
+          </MessageErrorBoundary>
         )}
 
         {/* Typing indicator - shown when another user is typing */}
@@ -539,29 +546,31 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, pendingR
 
         {/* Streaming text message - keep visible until persisted data arrives */}
         {streamingMessage && !isStreamingMessagePersisted && (
-          <MessageItem
-            message={{
-              id: 'streaming',
-              type: 'assistant',
-              content: { text: streamingMessage },
-              toolCalls: [],
-              createdAt: new Date(),
-              ...(apiErrorCode && { apiError: apiErrorCode }),
-            }}
-            isStreaming={isStreaming}
-          />
+          <MessageErrorBoundary kind="message" raw={streamingMessage} itemId="streaming">
+            <MessageItem
+              message={{
+                id: 'streaming',
+                type: 'assistant',
+                content: { text: streamingMessage },
+                toolCalls: [],
+                createdAt: new Date(),
+                ...(apiErrorCode && { apiError: apiErrorCode }),
+              }}
+              isStreaming={isStreaming}
+            />
+          </MessageErrorBoundary>
         )}
 
         {/* Tool use streaming - keep visible until persisted data arrives */}
         {unpersistedStreamingToolUses.map(tool => {
+          let inner: ReactNode
           if (tool.ready) {
             let input: Record<string, unknown> = {}
             try { input = JSON.parse(tool.partialInput) } catch { /* use empty */ }
             const syntheticToolCall = { id: tool.id, name: tool.name, input }
             if ((tool.name === 'Task' || tool.name === 'Agent') && sessionId) {
-              return (
+              inner = (
                 <SubAgentBlock
-                  key={tool.id}
                   toolCall={syntheticToolCall}
                   sessionId={sessionId}
                   agentSlug={agentSlug}
@@ -570,20 +579,27 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessage, pendingR
                   isCompleted={completedSubagents?.has(tool.id) ?? false}
                 />
               )
+            } else {
+              inner = (
+                <div className="max-w-[80%]">
+                  <ToolCallItem toolCall={syntheticToolCall} agentSlug={agentSlug} isSessionActive={isActive} />
+                </div>
+              )
             }
-            return (
-              <div key={tool.id} className="max-w-[80%]">
-                <ToolCallItem toolCall={syntheticToolCall} agentSlug={agentSlug} isSessionActive={isActive} />
+          } else {
+            inner = (
+              <div className="max-w-[80%]">
+                <StreamingToolCallItem
+                  name={tool.name}
+                  partialInput={tool.partialInput}
+                />
               </div>
             )
           }
           return (
-            <div key={tool.id} className="max-w-[80%]">
-              <StreamingToolCallItem
-                name={tool.name}
-                partialInput={tool.partialInput}
-              />
-            </div>
+            <MessageErrorBoundary key={tool.id} kind="tool call" raw={tool} itemId={tool.id}>
+              {inner}
+            </MessageErrorBoundary>
           )
         })}
 

--- a/src/renderer/lib/error-reporting.ts
+++ b/src/renderer/lib/error-reporting.ts
@@ -48,3 +48,21 @@ export function setRendererErrorReportingUser(user: ErrorReportingUser | null): 
     }
   } catch { /* never crash */ }
 }
+
+/**
+ * Report a caught exception to Sentry from the renderer.
+ *
+ * Safe to call from anywhere (including error-boundary lifecycles) — it never
+ * throws, and is a no-op in dev where Sentry is intentionally not initialized.
+ */
+export function captureRendererException(
+  error: unknown,
+  context?: { tags?: Record<string, string>; extra?: Record<string, unknown> }
+): void {
+  try {
+    Sentry.captureException(error, {
+      tags: context?.tags,
+      extra: context?.extra,
+    })
+  } catch { /* never crash */ }
+}


### PR DESCRIPTION
## What

Wraps every `MessageItem` and `ToolCallItem`/`SubAgentBlock` in a `MessageErrorBoundary` so a render error in one item can no longer crash the entire message thread.

Today the thread has **no** error boundary — a single throwing render (e.g. a tool call whose `getSummary` chokes on a malformed argument) takes down the whole renderer and the user can't open the session at all. That's exactly the failure mode behind #202.

## Behavior on error

When a wrapped item throws during render, the boundary swaps it for an inline notice instead of unmounting the thread:

- **Error box** — "Failed to display this message" / "Failed to display this tool call".
- **View raw** — a toggle that reveals the raw payload (the message or tool-call JSON) plus the error message, so the content is never lost and the user/support can inspect it.
- **Sentry** — the error (with `feature: message-render`, `item_kind`, item id, and the React component stack) is reported via a new renderer-side `captureRendererException`. `@sentry/browser` stays confined to `error-reporting.ts`; the helper never throws and is a no-op in dev.

Healthy siblings keep rendering — one bad tool call degrades to a box while the rest of the message (and the rest of the thread) renders normally.

## Scope of wrapping

- Persisted messages (the main list), plus the pending / peer / streaming `MessageItem`s.
- Persisted tool calls and sub-agent blocks (inside `MessageItem`), plus the unpersisted streaming tool uses.

## Verification

- New unit tests for the boundary: renders children when healthy; shows the error box on throw; toggles raw payload; reports to Sentry with the right tags/extra.
- An **end-to-end** test renders a real `MessageItem` containing the exact crash from #202 (an `AskUserQuestion` tool call with a stringified `questions` arg — a bug this branch deliberately does **not** fix) and asserts it degrades to the tool-call error box while the message's own text still renders.
- `tsc --noEmit` + eslint clean; existing message-item/message-list suites (81 tests) still pass.

Complements (does not depend on) #202: that PR fixes the specific `AskUserQuestion` parse bug; this PR contains the whole class of render crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)