### PR TITLE
test(e2e): pending-request reconnect recovery specs + SUP-213 TODO

### DIFF
--- a/e2e/specs/pending-request-reconnect.spec.ts
+++ b/e2e/specs/pending-request-reconnect.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+
+/**
+ * Regression coverage for the SSE late-join / reconnect recovery of pending input
+ * requests. The agent's `*_request` events are one-shot SSE broadcasts; the server
+ * (MessagePersister) stores them and the /stream route replays them on (re)connect,
+ * and the renderer dedupes by toolUseId. See the "pending request missing on
+ * reconnect" fix and SUP-213.
+ *
+ * These exercise the reconnect path directly (toggle the network so the EventSource
+ * drops and re-establishes while the agent is still awaiting input), which the
+ * happy-path user-input-requests specs don't.
+ */
+test.describe('Pending request reconnect recovery', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+    await agentPage.createAgent(`Reconnect Agent ${testInfo.workerIndex}-${Date.now()}`)
+  })
+
+  // Drop and re-establish the SSE connection while staying on the session view.
+  async function cycleConnection(page: import('@playwright/test').Page) {
+    await page.context().setOffline(true)
+    await page.waitForTimeout(1000)
+    await page.context().setOffline(false)
+    // EventSource native reconnect (~3s) + the /stream connect-time replay.
+    await page.waitForTimeout(5000)
+  }
+
+  test('secret request survives an SSE reconnect without duplicating', async ({ page }) => {
+    await sessionPage.sendMessage('ask secret')
+    await sessionPage.waitForSecretRequest('OPENAI_API_KEY')
+    await expect(sessionPage.getSecretRequests()).toHaveCount(1)
+
+    await cycleConnection(page)
+
+    // Still present, still exactly one (replay must not double the card).
+    await expect(sessionPage.getSecretRequests()).toHaveCount(1, { timeout: 10000 })
+
+    // And it's still functional: providing it completes the session.
+    await sessionPage.provideSecret('sk-test-123', 'OPENAI_API_KEY')
+    await expect(sessionPage.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
+    await sessionPage.waitForInputEnabled(15000)
+  })
+
+  test('parallel requests survive reconnect — one of each, no duplicates', async ({ page }) => {
+    await sessionPage.sendMessage('ask parallel')
+    await sessionPage.waitForSecretRequest('DATABASE_URL')
+    await sessionPage.waitForQuestionRequest()
+    await expect(sessionPage.getSecretRequests()).toHaveCount(1)
+    await expect(sessionPage.getQuestionRequests()).toHaveCount(1)
+
+    await cycleConnection(page)
+
+    await expect(sessionPage.getSecretRequests()).toHaveCount(1, { timeout: 10000 })
+    await expect(sessionPage.getQuestionRequests()).toHaveCount(1, { timeout: 10000 })
+  })
+
+  test('interrupting while awaiting input clears the request and it stays gone after reconnect', async ({ page }) => {
+    await sessionPage.sendMessage('ask secret')
+    await sessionPage.waitForSecretRequest('OPENAI_API_KEY')
+
+    // Interrupt the session from the request card (the X / stop button).
+    await sessionPage.stopSessionFromRequest()
+    await expect(sessionPage.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
+
+    // After an interrupt the server must have dropped the request from its replay
+    // store (cleared on session_idle). If it hadn't, the reconnect below would
+    // resurface the now-stale card — the renderer state was cleared by the interrupt,
+    // so any card that reappears can only have come from the server replay.
+    await cycleConnection(page)
+    await expect(sessionPage.getSecretRequests()).toHaveCount(0)
+  })
+})

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -69,6 +69,10 @@ interface StreamingState {
   activeSubagents: Map<string, SubagentStreamingState>
   slashCommands: SlashCommandInfo[] // Available slash commands from SDK
   isAwaitingInput: boolean // True when session is waiting for user input (e.g., secret, file, question)
+  // TODO: computer-use and the other input requests are tracked in two separate maps with
+  // divergent clearing rules (this one is cleared only via explicit route calls; pendingInputRequests
+  // below is cleared on tool_result + turn boundaries — so e.g. interrupt clears one but not the
+  // other). Unify into a single store + single SSE replay loop. Tracked: SUP-213 (sibling of SUP-163).
   pendingComputerUseRequests: Map<string, { toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string; agentSlug?: string }> // Pending computer use requests awaiting user approval (keyed by toolUseId)
   // Pending user-input request broadcasts (secret/connected_account/question/file/remote_mcp/
   // script_run/browser_input), keyed by toolUseId. These are one-shot SSE events, so a client


### PR DESCRIPTION
Follow-up to the merged **pending request missing on reconnect** fix (`c7218db0`). Adds the e2e regression coverage that the happy-path user-input specs don't have, plus a code TODO for the server-side unification ticket.

## What

Exercises the SSE late-join / reconnect path directly — drop and re-establish the EventSource (network offline→online) while the agent is **awaiting input**, then assert the pending cards recover (server-side replay) and stay deduped to one each.

New specs (`e2e/specs/pending-request-reconnect.spec.ts`):
- secret request survives an SSE reconnect without duplicating (then still functional → provide → completes)
- parallel requests survive reconnect — one of each, no duplicates
- interrupt while awaiting input clears the request and it stays gone after reconnect — validates the **server** clearing its replay store on `session_idle` (the renderer state is wiped by the interrupt, so any reappearing card could only come from the server replay)

Also drops a `TODO` in `MessagePersister` flagging the divergent per-type pending stores (computer-use vs input requests have different clearing rules — e.g. interrupt clears one but not the other) for unification.

## Why

The reconnect/late-join path is exactly where the original flake lived, but the existing specs only cover first-render. These guard the replay + dedupe + clear-on-idle behavior against regression.

## Tickets
- **SUP-213** (created) — unify the server pending stores + SSE replay. Sibling of **SUP-163** (renderer half). Both updated with full context.

## Notes
- The one observed flake in local runs was the shared `createAgent` `beforeEach` helper (`home-send-button` not "stable") — the pre-existing agent-creation flake that affects all agent-creating specs; CI retries cover it. The reconnect assertions themselves passed every run.
- Deferred (noted on SUP-213): partial-resolve-then-reconnect (mock doesn't emit `tool_result` on resolve, so it can't isolate the server clear), container-restart-while-awaiting-input (better as a persister unit test), and the computer-use interrupt-clear gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)