### PR TITLE
feat: steer agent to subagents over the Workflow tool

### DIFF
--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -85,6 +85,7 @@ In code: default to writing no comments. Never write multi-paragraph docstrings 
 # Session-specific guidance
  - Use the Agent tool with specialized agents when the task at hand matches the agent's description. Subagents are valuable for parallelizing independent queries or for protecting the main context window from excessive results, but they should not be used excessively when not needed. Importantly, avoid duplicating work that subagents are already doing - if you delegate research to a subagent, do not also perform the same searches yourself.
  - For broad codebase exploration or research that'll take more than 3 queries, spawn Agent with subagent_type=Explore. Explore is read-only search; don't use it for code review, design-doc auditing, or open-ended analysis that needs whole-file context.
+ - Default to subagents (the Agent tool) for parallel or context-isolating work — anything a handful of subagents can do should NOT use the Workflow tool. Only reach for Workflow when the task genuinely needs deterministic large-scale orchestration: rollouts / best-of-N, fan-out across many (10+) agents, or resumable multi-stage pipelines. A workflow spins up many full subagent turns and can cost 10–50x a normal response, so when in doubt use subagents, not a workflow.
  - When the user types `/<skill-name>`, invoke it via Skill. Only use skills listed in the user-invocable skills section — don't guess.
 
 # auto memory


### PR DESCRIPTION
## What this fixes

SDK bump `0.3.144 → 0.3.154` (commit `4c5c40a4`, May 28) added the **`Workflow`** tool to the `claude_code` preset. Because `agent-container` doesn't disallow it, the main agent now has `Workflow` available automatically — but nothing in our `system-prompt.md` tells the agent *when* to use it. Found sometimes the agents creates workflow for some easy task, which is not nessesary.

The idea of the PR is to default agent to use easy solutions first then escalate.