### PR TITLE
feat(platform-auth): show account details in cloud (org-JWT) mode

### DIFF
--- a/src/api/routes/platform-auth.ts
+++ b/src/api/routes/platform-auth.ts
@@ -9,6 +9,7 @@ import {
 } from '@shared/lib/services/platform-device-service'
 import {
   getPlatformAuthStatus,
+  getEnrichedPlatformAuthStatus,
   savePlatformAuth,
   revokePlatformToken,
 } from '@shared/lib/services/platform-auth-service'
@@ -21,10 +22,10 @@ const platformAuth = new Hono()
 
 platformAuth.use('*', Authenticated())
 
-platformAuth.get('/', (c) => {
+platformAuth.get('/', async (c) => {
   const userId = getCurrentUserId(c)
   return c.json({
-    ...getPlatformAuthStatus(userId),
+    ...(await getEnrichedPlatformAuthStatus(userId)),
     platformBaseUrl: getPlatformBaseUrl(),
   })
 })

--- a/src/renderer/hooks/use-platform-auth.ts
+++ b/src/renderer/hooks/use-platform-auth.ts
@@ -39,6 +39,10 @@ export function usePlatformAuthStatus() {
   const queryClient = useQueryClient()
   const query = useQuery<PlatformAuthStatus>({
     queryKey: ['platform-auth'],
+    // Matches the server-side introspection TTL: the status only changes via
+    // connect/revoke (which invalidate this key explicitly), so remounts within
+    // the window shouldn't re-hit the endpoint.
+    staleTime: 5 * 60 * 1000,
     queryFn: async () => {
       const res = await apiFetch('/api/platform-auth')
       if (!res.ok) {

--- a/src/shared/lib/services/platform-auth-service.test.ts
+++ b/src/shared/lib/services/platform-auth-service.test.ts
@@ -37,6 +37,7 @@ import {
   _resetEnvManagedPlatformStatusForTest,
   getPlatformAccessToken,
   getPlatformAuthStatus,
+  getEnrichedPlatformAuthStatus,
   initEnvManagedPlatformStatus,
   savePlatformAuth,
   refreshStoredPlatformAccount,
@@ -505,6 +506,80 @@ describe('platform-auth-service', () => {
     const status = getPlatformAuthStatus()
     expect(status.userId).toBeNull()
     expect(mockDbGet).not.toHaveBeenCalled()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Env-managed (org-JWT) account enrichment via /v1/account introspection
+  // ---------------------------------------------------------------------------
+
+  it('enriches env-managed status with email/orgName/role from /v1/account', async () => {
+    process.env.AUTH_MODE = 'true'
+    process.env.PLATFORM_TOKEN = await signTestOrgToken('org_env')
+    process.env.PLATFORM_PROXY_URL = 'http://proxy.test'
+    await initEnvManagedPlatformStatus()
+
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          memberId: 'sub_member_1',
+          orgId: 'org_env',
+          orgName: 'Acme Inc',
+          role: 'owner',
+          userId: 'user_1',
+          email: 'owner@example.com',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+
+    const status = await getEnrichedPlatformAuthStatus('ba-user')
+
+    expect(fetchSpy).toHaveBeenCalledWith('http://proxy.test/v1/account', expect.anything())
+    expect(status).toMatchObject({
+      source: 'env',
+      email: 'owner@example.com',
+      orgName: 'Acme Inc',
+      role: 'owner',
+    })
+    // env-managed connections have no "last changed" anchor; updatedAt stays null.
+    expect(status.updatedAt).toBeNull()
+  })
+
+  it('falls back to the base env-managed status when introspection fails', async () => {
+    process.env.AUTH_MODE = 'true'
+    process.env.PLATFORM_TOKEN = await signTestOrgToken('org_env')
+    process.env.PLATFORM_PROXY_URL = 'http://proxy.test'
+    await initEnvManagedPlatformStatus()
+
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: 'nope' } }), { status: 401 }),
+    )
+
+    const status = await getEnrichedPlatformAuthStatus('ba-user')
+
+    expect(status).toMatchObject({
+      source: 'env',
+      email: null,
+      orgName: null,
+      role: null,
+    })
+  })
+
+  it('does not introspect for settings-stored (opaque key) connections', async () => {
+    await savePlatformAuth('local', {
+      token: 'plat_superagent_token_1234567890abcdef',
+      email: 'stored@example.com',
+      orgId: 'org_stored',
+      orgName: 'Stored Org',
+      role: 'member',
+    })
+
+    const fetchSpy = vi.spyOn(global, 'fetch')
+
+    const status = await getEnrichedPlatformAuthStatus('local')
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(status).toMatchObject({ source: 'settings', orgName: 'Stored Org', email: 'stored@example.com' })
   })
 
   // Helpers for the org-switch / lifecycle tests below.

--- a/src/shared/lib/services/platform-auth-service.test.ts
+++ b/src/shared/lib/services/platform-auth-service.test.ts
@@ -565,6 +565,50 @@ describe('platform-auth-service', () => {
     })
   })
 
+  it('memoizes introspection per user within the TTL (second read does not re-fetch)', async () => {
+    process.env.AUTH_MODE = 'true'
+    process.env.PLATFORM_TOKEN = await signTestOrgToken('org_env')
+    process.env.PLATFORM_PROXY_URL = 'http://proxy.test'
+    await initEnvManagedPlatformStatus()
+
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          memberId: 'sub_member_1',
+          orgId: 'org_env',
+          orgName: 'Acme Inc',
+          role: 'owner',
+          userId: 'user_1',
+          email: 'owner@example.com',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+
+    await getEnrichedPlatformAuthStatus('ba-user')
+    const second = await getEnrichedPlatformAuthStatus('ba-user')
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(second).toMatchObject({ email: 'owner@example.com', orgName: 'Acme Inc', role: 'owner' })
+  })
+
+  it('caches a failed introspection so it is not retried within the TTL', async () => {
+    process.env.AUTH_MODE = 'true'
+    process.env.PLATFORM_TOKEN = await signTestOrgToken('org_env')
+    process.env.PLATFORM_PROXY_URL = 'http://proxy.test'
+    await initEnvManagedPlatformStatus()
+
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: 'nope' } }), { status: 401 }),
+    )
+
+    await getEnrichedPlatformAuthStatus('ba-user')
+    const second = await getEnrichedPlatformAuthStatus('ba-user')
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(second).toMatchObject({ source: 'env', email: null, orgName: null, role: null })
+  })
+
   it('does not introspect for settings-stored (opaque key) connections', async () => {
     await savePlatformAuth('local', {
       token: 'plat_superagent_token_1234567890abcdef',

--- a/src/shared/lib/services/platform-auth-service.ts
+++ b/src/shared/lib/services/platform-auth-service.ts
@@ -327,6 +327,58 @@ export function getPlatformAuthStatus(userId?: string): PlatformAuthStatus {
   }
 }
 
+// The org JWT carries only `orgId`, so email/orgName/role come from a
+// `/v1/account` introspect. `updatedAt` stays null: env connections have no
+// "last changed" anchor, so the introspect time would be meaningless.
+interface EnrichedEnvAccount {
+  email: string | null
+  orgName: string | null
+  role: string | null
+}
+
+async function introspectEnvManagedAccount(userId: string): Promise<EnrichedEnvAccount | null> {
+  const token = getPlatformAccessToken()
+  if (!token) return null
+  try {
+    // Dynamic import breaks the module cycle (platform-attribution imports this
+    // service for the token + stored member id).
+    const { runWithRequestUser } = await import('@shared/lib/platform-attribution')
+    const account = await runWithRequestUser(userId, () =>
+      fetchPlatformJson({
+        path: '/v1/account',
+        token,
+        schema: PlatformAccountInfoSchema,
+        area: 'platform-auth',
+        mapStatusError: (status) => ({ message: 'Account introspection failed', status }),
+      }),
+    )
+    return { email: account.email, orgName: account.orgName, role: account.role }
+  } catch (error) {
+    captureException(error, { tags: { area: 'platform-auth', op: 'introspect-env-account' } })
+    return null
+  }
+}
+
+/**
+ * Like {@link getPlatformAuthStatus}, but for env-managed (org-JWT) connections
+ * fills email/orgName/role by introspecting the acting member's account.
+ * Opaque-key (settings) and disconnected statuses are returned as-is.
+ */
+export async function getEnrichedPlatformAuthStatus(userId?: string): Promise<PlatformAuthStatus> {
+  const base = getPlatformAuthStatus(userId)
+  if (base.source !== 'env' || !base.connected || !userId) return base
+
+  const account = await introspectEnvManagedAccount(userId)
+  if (!account) return base
+
+  return {
+    ...base,
+    email: account.email,
+    orgName: account.orgName,
+    role: account.role,
+  }
+}
+
 export async function savePlatformAuth(_userId: string, input: SavePlatformAuthInput): Promise<PlatformAuthStatus> {
   const trimmedToken = input.token.trim()
   if (!trimmedToken) {

--- a/src/shared/lib/services/platform-auth-service.ts
+++ b/src/shared/lib/services/platform-auth-service.ts
@@ -152,6 +152,9 @@ function buildEnvManagedStatus(envToken: string, orgId: string | null): Platform
 
 // Verifies PLATFORM_TOKEN against the issuer JWKS at startup; warns on failure.
 export async function initEnvManagedPlatformStatus(): Promise<void> {
+  // The env token (and so the org the introspect resolves against) may have
+  // changed since the cache was filled.
+  enrichedAccountCache.clear()
   if (!isAuthMode()) {
     cachedEnvManagedStatus = null
     return
@@ -186,6 +189,7 @@ export async function initEnvManagedPlatformStatus(): Promise<void> {
 
 export function _resetEnvManagedPlatformStatusForTest(): void {
   cachedEnvManagedStatus = undefined
+  enrichedAccountCache.clear()
 }
 
 function readRecord(): PlatformAuthRecord | null {
@@ -336,6 +340,16 @@ interface EnrichedEnvAccount {
   role: string | null
 }
 
+// Introspection is memoized per user: the Account screen re-fetches the status
+// on every mount/focus, and the membership it reflects changes rarely.
+// Failures are cached too, so a proxy without `/v1/account` org-JWT support
+// doesn't cost a failing round-trip (and a Sentry event) per page view.
+const ENRICHED_ACCOUNT_TTL_MS = 5 * 60 * 1000
+const enrichedAccountCache = new Map<
+  string,
+  { account: EnrichedEnvAccount | null; expiresAt: number }
+>()
+
 async function introspectEnvManagedAccount(userId: string): Promise<EnrichedEnvAccount | null> {
   const token = getPlatformAccessToken()
   if (!token) return null
@@ -368,7 +382,16 @@ export async function getEnrichedPlatformAuthStatus(userId?: string): Promise<Pl
   const base = getPlatformAuthStatus(userId)
   if (base.source !== 'env' || !base.connected || !userId) return base
 
-  const account = await introspectEnvManagedAccount(userId)
+  let entry = enrichedAccountCache.get(userId)
+  if (!entry || entry.expiresAt <= Date.now()) {
+    entry = {
+      account: await introspectEnvManagedAccount(userId),
+      expiresAt: Date.now() + ENRICHED_ACCOUNT_TTL_MS,
+    }
+    enrichedAccountCache.set(userId, entry)
+  }
+
+  const { account } = entry
   if (!account) return base
 
   return {


### PR DESCRIPTION
## What bug this fixes

In `AUTH_MODE=true` (cloud), `PLATFORM_TOKEN` is an org-runtime JWT that carries only `orgId`. `buildEnvManagedStatus` hard-coded `email` / `orgName` / `role` / `updatedAt` to `null`, so the **Account** settings screen showed `—` for Email, Organization, Role, and Last updated. Local (opaque-key) mode resolves these via `/v1/account` and was unaffected.

## Repro

1. Run SuperAgent with `AUTH_MODE=true` and an env-managed org JWT `PLATFORM_TOKEN`.
2. Open Settings → Account.
3. Email / Organization / Role / Last updated all render `—`.

## What changed (SuperAgent side kept minimal)

- New `getEnrichedPlatformAuthStatus(userId)`: for **env-managed** connections it introspects `/v1/account` inside the acting member's request scope (the platform fetch interceptor stamps `::memberId`) and fills `email` / `orgName` / `role`. `updatedAt` stays `null` — env connections have no "last changed" anchor, so the introspection time would be meaningless and the screen keeps showing `—` for Last updated.
- Introspection is **memoized per user (5 min TTL)** at module scope; failures are cached too, so a proxy without `/v1/account` org-JWT support doesn't cost a failing round-trip (and a Sentry event) per page view. The cache is cleared when `initEnvManagedPlatformStatus` re-verifies the env token.
- The renderer's `['platform-auth']` query mirrors the TTL with `staleTime: 5 min`, so remounts within the window skip the HTTP request entirely (connect/revoke still invalidate the key explicitly).
- Opaque-key (`source: 'settings'`) and disconnected statuses are returned unchanged — no network call.
- Introspection failure → falls back to the base env-managed status (fields stay `null`); the screen never blanks or crashes, error is sent to Sentry.
- `GET /api/platform-auth` now `await`s the enriched status. All other call sites of `getPlatformAuthStatus` are untouched.

## Dependency

Requires platform proxy PR (`/v1/account` org-JWT + member support). Without it, introspection returns 400 and this gracefully falls back to the old blank behavior.

## Test plan

- [x] `vitest run src/shared/lib/services/platform-auth-service.test.ts` — 31 passed
- [x] env-managed status enriched with email/orgName/role from `/v1/account`
- [x] introspection failure → falls back to base (null fields)
- [x] memoized within TTL (second read does not re-fetch); failed introspection not retried within TTL
- [x] settings/opaque-key connection → no introspection
- [x] `tsc --noEmit` clean for `src/`, eslint clean on changed files

Made with [Cursor](https://cursor.com)
