### PR TITLE
fix(security): scope connected-account reconnects to the current user (SUP-198)

### DIFF
--- a/src/api/routes/connected-accounts.ts
+++ b/src/api/routes/connected-accounts.ts
@@ -123,14 +123,16 @@ connectedAccountsRouter.post('/initiate', async (c) => {
       return c.json({ error: 'Missing required field: providerSlug' }, 400)
     }
 
-    // If reconnecting, verify the account exists and belongs to this user
+    // If reconnecting, verify the account exists and belongs to this user.
+    // In auth mode, scope ownership to the acting user so a user cannot take
+    // over another user's connected account by guessing its id (SUP-198).
     if (reconnectAccountId) {
       const [existing] = await db
         .select()
         .from(connectedAccounts)
         .where(eq(connectedAccounts.id, reconnectAccountId))
         .limit(1)
-      if (!existing) {
+      if (!existing || (isAuthMode() && existing.userId !== getCurrentUserId(c))) {
         return c.json({ error: 'Account not found' }, 404)
       }
     }
@@ -236,12 +238,22 @@ connectedAccountsRouter.post('/complete', async (c) => {
     let id: string
 
     if (reconnectAccountId) {
-      // Look up old connection ID before updating so we can clean it up remotely
+      // Look up old connection ID (and owner) before updating so we can clean it
+      // up remotely and verify ownership.
       const [oldRecord] = await db
-        .select({ providerConnectionId: connectedAccounts.providerConnectionId })
+        .select({
+          providerConnectionId: connectedAccounts.providerConnectionId,
+          userId: connectedAccounts.userId,
+        })
         .from(connectedAccounts)
         .where(eq(connectedAccounts.id, reconnectAccountId))
         .limit(1)
+
+      // The account must exist and, in auth mode, be owned by the acting user.
+      // Otherwise a user could overwrite another user's connection (SUP-198).
+      if (!oldRecord || (isAuthMode() && oldRecord.userId !== getCurrentUserId(c))) {
+        return c.json({ error: 'Account not found' }, 404)
+      }
 
       // Reconnecting: update existing record to preserve agent mappings and scope policies
       await db.update(connectedAccounts)
@@ -354,10 +366,21 @@ connectedAccountsRouter.get('/callback', async (c) => {
 
     if (reconnectAccountId) {
       const [oldRecord] = await db
-        .select({ providerConnectionId: connectedAccounts.providerConnectionId })
+        .select({
+          providerConnectionId: connectedAccounts.providerConnectionId,
+          userId: connectedAccounts.userId,
+        })
         .from(connectedAccounts)
         .where(eq(connectedAccounts.id, reconnectAccountId))
         .limit(1)
+
+      // The account must exist and, in auth mode, be owned by the acting user.
+      // Otherwise a user could overwrite another user's connection (SUP-198).
+      if (!oldRecord || (isAuthMode() && oldRecord.userId !== getCurrentUserId(c))) {
+        return c.html(
+          generateCallbackHtml({ success: false, error: 'Account not found' })
+        )
+      }
 
       await db.update(connectedAccounts)
         .set({

--- a/src/api/routes/security-repro.test.ts
+++ b/src/api/routes/security-repro.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+// ---------------------------------------------------------------------------
+// Security guardrail repro tests.
+//
+// These exercise the connected-account reconnect flow in AUTH_MODE and assert
+// that a user cannot reconnect (take over) an account owned by another user by
+// supplying a `reconnectAccountId` they happen to know. See SUP-198.
+//
+// The db mock is driven by `selectQueue`: each terminal `.limit()` of a select
+// chain shifts the next pre-seeded result. `updateWhereCalls` records every
+// `db.update(...).set(...).where(...)` so we can assert no write happened.
+// ---------------------------------------------------------------------------
+
+let selectQueue: unknown[][] = []
+const updateWhereCalls: unknown[][] = []
+
+const mockDbSelectLimit = vi.fn(() => Promise.resolve(selectQueue.shift() ?? []))
+const mockDbUpdateWhere = vi.fn((...args: unknown[]) => {
+  updateWhereCalls.push(args)
+  return Promise.resolve(undefined)
+})
+const mockDbInsertValues = vi.fn().mockResolvedValue(undefined)
+const mockDbDeleteWhere = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@shared/lib/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => mockDbSelectLimit(),
+          orderBy: () => ({ $dynamic: () => ({ where: () => mockDbSelectLimit() }) }),
+        }),
+        orderBy: () => ({ $dynamic: () => ({ where: () => mockDbSelectLimit() }) }),
+      }),
+    }),
+    insert: () => ({ values: (...vArgs: unknown[]) => mockDbInsertValues(...vArgs) }),
+    update: () => ({
+      set: () => ({ where: (...wArgs: unknown[]) => mockDbUpdateWhere(...wArgs) }),
+    }),
+    delete: () => ({ where: (...wArgs: unknown[]) => mockDbDeleteWhere(...wArgs) }),
+  },
+}))
+
+vi.mock('@shared/lib/db/schema', () => ({
+  connectedAccounts: {
+    id: 'id',
+    providerConnectionId: 'provider_connection_id',
+    providerName: 'provider_name',
+    userId: 'user_id',
+  },
+  agentConnectedAccounts: {},
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq: (col: string, val: string) => ({ col, val }),
+  desc: (col: string) => ({ desc: col }),
+  and: (...args: unknown[]) => args,
+}))
+
+const mockProvider = {
+  name: 'composio',
+  initiateConnection: vi.fn(),
+  getConnection: vi.fn(),
+  deleteConnection: vi.fn(),
+  getAccountDisplayName: vi.fn(),
+}
+
+vi.mock('@shared/lib/account-providers', () => ({
+  getDefaultAccountProvider: () => mockProvider,
+  getAccountProviderByName: () => mockProvider,
+  isValidProviderName: (name: string) => ['composio', 'nango'].includes(name),
+  isProviderSupported: () => true,
+  getProvider: (slug: string) => ({ slug, displayName: slug.charAt(0).toUpperCase() + slug.slice(1) }),
+}))
+
+// Acting (attacker) user. The victim rows seeded into `selectQueue` are owned by
+// a different user, so ownership checks must reject the reconnect.
+const ACTING_USER_ID = 'attacker-user'
+
+vi.mock('@shared/lib/auth/config', () => ({
+  getAppBaseUrlFromRequest: () => 'http://localhost:3000',
+  getCurrentUserId: () => ACTING_USER_ID,
+}))
+
+vi.mock('@shared/lib/auth/mode', () => ({
+  isAuthMode: () => true,
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getAccountProviderUserId: () => 'test-user',
+}))
+
+vi.mock('../middleware/auth', () => ({
+  Authenticated: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  OwnsAccount: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  IsAdmin: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  Or: (..._mw: unknown[]) => async (_c: unknown, next: () => Promise<void>) => next(),
+}))
+
+vi.mock('@shared/lib/analytics/server-analytics', () => ({
+  trackServerEvent: vi.fn(),
+}))
+
+vi.mock('@shared/lib/services/audit-log-service', () => ({
+  logAuditEvent: vi.fn(),
+}))
+
+vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
+  countActiveTriggersPerAccount: vi.fn().mockResolvedValue({}),
+}))
+
+import connectedAccountsRouter from './connected-accounts'
+
+function appWithConnectedAccounts() {
+  const app = new Hono()
+  app.route('/api/connected-accounts', connectedAccountsRouter)
+  return app
+}
+
+function expectClientError(status: number) {
+  expect(status).toBeGreaterThanOrEqual(400)
+  expect(status).toBeLessThan(500)
+}
+
+describe('SUP-198: connected account reconnect ownership (AUTH_MODE)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    selectQueue = []
+    updateWhereCalls.length = 0
+    // Defaults so /complete reaches the reconnect branch (active connection).
+    mockProvider.getConnection.mockResolvedValue({ id: 'attacker-new-connection', status: 'ACTIVE' })
+    mockProvider.getAccountDisplayName.mockResolvedValue('Attacker GitHub')
+    mockProvider.deleteConnection.mockResolvedValue(undefined)
+  })
+
+  it('rejects initiating reconnect for another user connected account by id', async () => {
+    selectQueue = [[{ id: 'victim-account-id', providerConnectionId: 'victim-old-connection', userId: 'victim-user' }]]
+
+    const res = await appWithConnectedAccounts().request('http://localhost/api/connected-accounts/initiate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        providerSlug: 'github',
+        reconnectAccountId: 'victim-account-id',
+      }),
+    })
+
+    expectClientError(res.status)
+    expect(mockProvider.initiateConnection).not.toHaveBeenCalled()
+  })
+
+  it('rejects reconnecting another user connected account by id', async () => {
+    selectQueue = [[{ providerConnectionId: 'victim-old-connection', userId: 'victim-user' }]]
+
+    const res = await appWithConnectedAccounts().request('http://localhost/api/connected-accounts/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        connectionId: 'attacker-new-connection',
+        toolkit: 'github',
+        providerName: 'composio',
+        reconnectAccountId: 'victim-account-id',
+      }),
+    })
+
+    expectClientError(res.status)
+    expect(updateWhereCalls).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Fixes **SUP-198** — a cross-user account-takeover vulnerability in the connected-account reconnect flow under `AUTH_MODE=true`.

The reconnect path accepted a `reconnectAccountId` and looked up / updated that account **by id only**, never scoping to `getCurrentUserId(c)`. Any authenticated user who learned another user's connected-account id could repoint that row to their own provider connection — preserving the victim's existing agent mappings and scope policies, and deleting the victim's old remote connection fire-and-forget. The result: the victim's agents would call the **attacker's** provider connection.

## Fix

Scope the reconnect ownership check to the acting user (in auth mode) across all three entry points, rejecting **before** the provider flow starts or the row is updated:

- `POST /api/connected-accounts/initiate` — reject with `404` if the account isn't owned by the current user.
- `POST /api/connected-accounts/complete` — fetch `userId` alongside the old connection and reject with `404` before the `db.update`.
- `GET /api/connected-accounts/callback` (web OAuth redirect) — same check, returning the failure callback HTML.

Non-auth mode (`isAuthMode() === false`, single-user/local) behavior is unchanged — the ownership comparison is gated on `isAuthMode()`.

## Test

Adds `src/api/routes/security-repro.test.ts`, the guardrail referenced in the ticket:

```sh
npx vitest run src/api/routes/security-repro.test.ts -t "connected account"
```

- `rejects initiating reconnect for another user connected account by id` — asserts a 4xx and that the provider flow never starts.
- `rejects reconnecting another user connected account by id` — asserts a 4xx and that no `db.update().where()` runs.

Both **fail on `main`** (initiate reaches the provider; complete returns `200` and updates the victim row) and **pass with this fix**.

## Validation

- ✅ New guardrail tests pass (2/2)
- ✅ Existing `connected-accounts.test.ts` regression suite passes (6/6, non-auth flows unchanged)
- ✅ `tsc --noEmit` clean
- ✅ `eslint` clean on changed files

Closes SUP-198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)