### PR TITLE
fix(platform-auth): reject deployment-global auth mutations in auth mode (SUP-201)

### DIFF
--- a/src/api/routes/platform-auth.ts
+++ b/src/api/routes/platform-auth.ts
@@ -1,6 +1,8 @@
 import { Hono } from 'hono'
+import type { MiddlewareHandler } from 'hono'
 
 import { Authenticated } from '../middleware/auth'
+import { isAuthMode } from '@shared/lib/auth/mode'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { buildPlatformLoginUrl, getPlatformBaseUrl } from '@shared/lib/platform-auth/config'
 import {
@@ -20,6 +22,27 @@ import { setErrorReportingUser } from '@shared/lib/error-reporting'
 const platformAuth = new Hono()
 
 platformAuth.use('*', Authenticated())
+
+// SUP-201: In AUTH_MODE platform credentials are deployment-managed (the
+// `PLATFORM_TOKEN` env var) and the settings-backed connection is a single
+// deployment-global record. `savePlatformAuth`/`revokePlatformToken` write and
+// clear that shared record while ignoring the caller, so guarding these routes
+// with only `Authenticated()` let any logged-in user overwrite or wipe the
+// workspace-wide platform identity (breaking everyone's platform-backed flows).
+// The UI already renders platform auth read-only in auth mode ("managed by this
+// deployment"); mirror that on the API by rejecting the mutating endpoints
+// outright. Connection changes are made via the deployment environment bundle.
+// Auth mode is web-only (Electron's OAuth `/complete` caller is never in auth
+// mode), so this does not affect the local/desktop connect flow.
+const rejectMutationInAuthMode: MiddlewareHandler = async (c, next) => {
+  if (isAuthMode()) {
+    return c.json(
+      { error: 'Platform access is managed by this deployment and cannot be changed here.' },
+      403,
+    )
+  }
+  return next()
+}
 
 platformAuth.get('/', (c) => {
   const userId = getCurrentUserId(c)
@@ -73,7 +96,7 @@ platformAuth.post('/initiate', (c) => {
   })
 })
 
-platformAuth.post('/complete', async (c) => {
+platformAuth.post('/complete', rejectMutationInAuthMode, async (c) => {
   const userId = getCurrentUserId(c)
   const body = await c.req.json<{
     token?: string
@@ -118,7 +141,7 @@ platformAuth.post('/complete', async (c) => {
   return c.json(status)
 })
 
-platformAuth.post('/revoke', async (c) => {
+platformAuth.post('/revoke', rejectMutationInAuthMode, async (c) => {
   const body = await c.req.json<{ clearLocal?: boolean }>().catch(() => ({} as { clearLocal?: boolean }))
   const success = await revokePlatformToken({ clearLocal: body.clearLocal })
 

--- a/src/api/routes/security-repro.test.ts
+++ b/src/api/routes/security-repro.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import type { Context, Next } from 'hono'
+
+// ---------------------------------------------------------------------------
+// SUP-201 — focused security guardrail for the platform-auth API.
+//
+// The platform-auth `/complete` and `/revoke` endpoints write/clear a single
+// deployment-global `settings.platformAuth` record and ignore the calling user.
+// In AUTH_MODE the UI renders these controls read-only ("managed by this
+// deployment"), but the API was guarded only by `Authenticated()`, so any
+// logged-in user could overwrite or wipe the shared platform identity.
+//
+// These tests mount the REAL route (with the service layer mocked) and assert
+// that, in auth mode, an ordinary user is rejected with a 4xx and the mutating
+// service functions are never reached.
+// ---------------------------------------------------------------------------
+
+const {
+  mockSavePlatformAuth,
+  mockRevokePlatformToken,
+  mockGetPlatformAuthStatus,
+  mockIsAuthMode,
+} = vi.hoisted(() => ({
+  mockSavePlatformAuth: vi.fn(),
+  mockRevokePlatformToken: vi.fn(),
+  mockGetPlatformAuthStatus: vi.fn(),
+  mockIsAuthMode: vi.fn<() => boolean>(),
+}))
+
+vi.mock('@shared/lib/auth/mode', () => ({
+  isAuthMode: () => mockIsAuthMode(),
+}))
+
+// `Authenticated()` — simulate a successfully logged-in ordinary (non-admin)
+// user, matching the repro ("authenticate as any normal user"). Mocked so the
+// test doesn't pull in better-auth / db.
+vi.mock('../middleware/auth', () => ({
+  Authenticated: () => async (c: Context, next: Next) => {
+    c.set('user' as never, { id: 'ordinary-user', role: 'user' } as never)
+    return next()
+  },
+}))
+
+vi.mock('@shared/lib/auth/config', () => ({
+  getCurrentUserId: () => 'ordinary-user',
+}))
+
+vi.mock('@shared/lib/services/platform-auth-service', () => ({
+  savePlatformAuth: (...args: unknown[]) => mockSavePlatformAuth(...args),
+  revokePlatformToken: (...args: unknown[]) => mockRevokePlatformToken(...args),
+  getPlatformAuthStatus: (...args: unknown[]) => mockGetPlatformAuthStatus(...args),
+}))
+
+vi.mock('@shared/lib/services/platform-service', () => ({
+  platformService: {
+    refreshBilling: vi.fn(),
+    getCachedBilling: vi.fn(),
+    getLastRefreshedAt: vi.fn(),
+  },
+}))
+
+vi.mock('@shared/lib/services/platform-device-service', () => ({
+  getOrCreatePlatformClientInstanceId: () => 'client-instance',
+  getPlatformDeviceName: () => 'device',
+}))
+
+vi.mock('@shared/lib/platform-auth/config', () => ({
+  buildPlatformLoginUrl: () => 'https://example.test/login',
+  getPlatformBaseUrl: () => 'https://example.test',
+}))
+
+vi.mock('@shared/lib/platform-auth/platform-fetch', () => ({
+  PlatformRequestError: class PlatformRequestError extends Error {
+    status: number
+    constructor(message: string, status = 400) {
+      super(message)
+      this.status = status
+    }
+  },
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  setErrorReportingUser: vi.fn(),
+  captureException: vi.fn(),
+}))
+
+// Import the real route AFTER the mocks are registered.
+import platformAuthRoute from './platform-auth'
+
+function appWithPlatformAuth() {
+  const app = new Hono()
+  app.route('/api/platform-auth', platformAuthRoute)
+  return app
+}
+
+function expectClientError(status: number) {
+  expect(status, `expected a 4xx client error, got ${status}`).toBeGreaterThanOrEqual(400)
+  expect(status, `expected a 4xx client error, got ${status}`).toBeLessThan(500)
+}
+
+describe('platform auth: deployment-global mutation guard (SUP-201)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Auth mode on, no env-managed PLATFORM_TOKEN — the deployment-global
+    // settings record is what would be written.
+    mockIsAuthMode.mockReturnValue(true)
+    delete process.env.PLATFORM_TOKEN
+    mockSavePlatformAuth.mockResolvedValue({ connected: true, tokenPreview: 'plat_…', email: null })
+    mockRevokePlatformToken.mockResolvedValue(true)
+    mockGetPlatformAuthStatus.mockReturnValue({ connected: false })
+  })
+
+  it('rejects changing deployment-global platform auth in auth mode without an env token', async () => {
+    const res = await appWithPlatformAuth().request('http://localhost/api/platform-auth/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        token: 'plat_attacker_token_1234567890abcdef',
+        orgId: 'attacker-org',
+        userId: 'attacker-platform-user',
+        memberId: 'attacker-member',
+      }),
+    })
+
+    expectClientError(res.status)
+    expect(mockSavePlatformAuth).not.toHaveBeenCalled()
+  })
+
+  it('rejects revoking deployment-global platform auth in auth mode without an env token', async () => {
+    const res = await appWithPlatformAuth().request('http://localhost/api/platform-auth/revoke', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clearLocal: true }),
+    })
+
+    expectClientError(res.status)
+    expect(mockRevokePlatformToken).not.toHaveBeenCalled()
+  })
+
+  // Guard must not regress local/Electron (non-auth) mode, where platform auth
+  // is genuinely user-owned and the connect/disconnect flow is expected to work.
+  it('still allows platform auth changes when auth mode is disabled', async () => {
+    mockIsAuthMode.mockReturnValue(false)
+
+    const complete = await appWithPlatformAuth().request('http://localhost/api/platform-auth/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: 'plat_local_token_1234567890', orgId: 'my-org' }),
+    })
+    expect(complete.status).toBe(200)
+    expect(mockSavePlatformAuth).toHaveBeenCalledOnce()
+
+    const revoke = await appWithPlatformAuth().request('http://localhost/api/platform-auth/revoke', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clearLocal: true }),
+    })
+    expect(revoke.status).toBe(200)
+    expect(mockRevokePlatformToken).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes **SUP-201** — _Security: prevent ordinary AUTH_MODE users from mutating deployment-global platform auth._

The platform-auth API was guarded only by `Authenticated()`. In `AUTH_MODE=true` the UI renders platform auth read-only, but the API still let **any logged-in user** call `POST /api/platform-auth/complete` or `POST /api/platform-auth/revoke`.

When no env-managed `PLATFORM_TOKEN` is set, `savePlatformAuth()` writes a deployment-global `settings.platformAuth` record and `revokePlatformToken()` clears it — the service ignores the passed user ID. So any authenticated user could overwrite the shared platform token/org identity or wipe it, breaking everyone's platform-backed LLM/STT/skillset/billing flows, or pointing the workspace at an attacker's platform identity.

## Fix

Add a `rejectMutationInAuthMode` guard to the two mutating routes (`/complete`, `/revoke`) that returns **403** when `isAuthMode()` is true — *before* the service is reached.

- Platform credentials in auth mode are deployment-managed via the `PLATFORM_TOKEN` env var; connection changes are made through the deployment environment bundle. This mirrors the read-only UI (`<PlatformTab readOnly={isAuthMode} />`, _"managed by this deployment"_).
- Auth mode is **web-only** — Electron's OAuth `/complete` caller (`src/main/index.ts`) is never in auth mode (`isAuthMode()` returns `false` in the Electron main process), so the local/desktop connect flow is unaffected.
- Authorization stays at the route layer (the standard pattern in this codebase); the service's internal `refreshStoredPlatformAccount` → `savePlatformAuth('local', …)` path is untouched.

## Test

Adds the failing guardrail from the ticket: `src/api/routes/security-repro.test.ts`. It mounts the **real** route with the service layer mocked and asserts that, in auth mode, an ordinary user gets a 4xx and `savePlatformAuth`/`revokePlatformToken` are never called. A third test confirms non-auth (local/Electron) mode still works.

```sh
npx vitest run src/api/routes/security-repro.test.ts -t "platform auth"
```

- Before the fix: both repro tests return `200` ❌
- After the fix: all 3 pass ✅

### Validation
- ✅ `npx vitest run src/api/routes/security-repro.test.ts` — 3/3 pass
- ✅ Related suites green: `platform-auth-service.test.ts`, `auth.test.ts` (149 tests)
- ✅ `tsc --noEmit` clean
- ✅ `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)