### PR TITLE
fix(security): validate remote MCP ownership before assigning to agents (SUP-199)

### DIFF
--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2898,16 +2898,34 @@ agents.post('/:id/remote-mcps', AgentUser(), async (c) => {
       return c.json({ error: 'mcpIds array is required' }, 400)
     }
 
+    // Verify the acting user owns the requested MCPs in auth mode. Without this,
+    // a user with access to any agent could attach another user's remote MCP
+    // (and its stored bearer/OAuth credentials) by ID. See SUP-199.
+    const userId = getCurrentUserId(c)
+    const ownedMcps = await db
+      .select({ id: remoteMcpServers.id })
+      .from(remoteMcpServers)
+      .where(and(
+        inArray(remoteMcpServers.id, body.mcpIds),
+        isAuthMode() ? eq(remoteMcpServers.userId, userId) : undefined
+      ))
+    const ownedMcpIds = new Set(ownedMcps.map((m) => m.id))
+    const validMcpIds = body.mcpIds.filter((id) => ownedMcpIds.has(id))
+
+    if (validMcpIds.length === 0) {
+      return c.json({ error: 'No valid remote MCPs found' }, 400)
+    }
+
     // Check which MCPs are already assigned to avoid phantom audit events
     const existingMappings = await db
       .select({ remoteMcpId: agentRemoteMcps.remoteMcpId })
       .from(agentRemoteMcps)
       .where(eq(agentRemoteMcps.agentSlug, slug))
     const alreadyAssigned = new Set(existingMappings.map(m => m.remoteMcpId))
-    const newMcpIds = body.mcpIds.filter(id => !alreadyAssigned.has(id))
+    const newMcpIds = validMcpIds.filter(id => !alreadyAssigned.has(id))
 
     const now = new Date()
-    const values = body.mcpIds.map((mcpId) => ({
+    const values = validMcpIds.map((mcpId) => ({
       id: crypto.randomUUID(),
       agentSlug: slug,
       remoteMcpId: mcpId,
@@ -2974,6 +2992,24 @@ agents.post('/:id/sessions/:sessionId/provide-remote-mcp', AgentUser(), async (c
     }
     if (!body.decline && requestedMcpIds.length === 0) {
       return c.json({ error: 'remoteMcpId or remoteMcpIds is required when not declining' }, 400)
+    }
+
+    // Verify the acting user owns every requested MCP in auth mode before mapping
+    // it to the agent. Otherwise a user could approve another user's remote MCP
+    // (and its stored credentials) for the agent's proxy to use. See SUP-199.
+    if (!body.decline) {
+      const userId = getCurrentUserId(c)
+      const ownedMcps = await db
+        .select({ id: remoteMcpServers.id })
+        .from(remoteMcpServers)
+        .where(and(
+          inArray(remoteMcpServers.id, requestedMcpIds),
+          isAuthMode() ? eq(remoteMcpServers.userId, userId) : undefined
+        ))
+      const ownedMcpIds = new Set(ownedMcps.map((m) => m.id))
+      if (requestedMcpIds.some((mcpId) => !ownedMcpIds.has(mcpId))) {
+        return c.json({ error: 'One or more remote MCPs are not owned by the current user' }, 403)
+      }
     }
 
     const client = containerManager.getClient(slug)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2898,22 +2898,25 @@ agents.post('/:id/remote-mcps', AgentUser(), async (c) => {
       return c.json({ error: 'mcpIds array is required' }, 400)
     }
 
-    // Verify the acting user owns the requested MCPs in auth mode. Without this,
+    // In auth mode, the caller may only attach remote MCPs they own. Without this,
     // a user with access to any agent could attach another user's remote MCP
     // (and its stored bearer/OAuth credentials) by ID. See SUP-199.
-    const userId = getCurrentUserId(c)
-    const ownedMcps = await db
-      .select({ id: remoteMcpServers.id })
-      .from(remoteMcpServers)
-      .where(and(
-        inArray(remoteMcpServers.id, body.mcpIds),
-        isAuthMode() ? eq(remoteMcpServers.userId, userId) : undefined
-      ))
-    const ownedMcpIds = new Set(ownedMcps.map((m) => m.id))
-    const validMcpIds = body.mcpIds.filter((id) => ownedMcpIds.has(id))
+    let validMcpIds = body.mcpIds
+    if (isAuthMode()) {
+      const userId = getCurrentUserId(c)
+      const ownedMcps = await db
+        .select({ id: remoteMcpServers.id })
+        .from(remoteMcpServers)
+        .where(and(
+          inArray(remoteMcpServers.id, body.mcpIds),
+          eq(remoteMcpServers.userId, userId)
+        ))
+      const ownedMcpIds = new Set(ownedMcps.map((m) => m.id))
+      validMcpIds = body.mcpIds.filter((id) => ownedMcpIds.has(id))
 
-    if (validMcpIds.length === 0) {
-      return c.json({ error: 'No valid remote MCPs found' }, 400)
+      if (validMcpIds.length === 0) {
+        return c.json({ error: 'No valid remote MCPs found' }, 400)
+      }
     }
 
     // Check which MCPs are already assigned to avoid phantom audit events
@@ -2994,17 +2997,17 @@ agents.post('/:id/sessions/:sessionId/provide-remote-mcp', AgentUser(), async (c
       return c.json({ error: 'remoteMcpId or remoteMcpIds is required when not declining' }, 400)
     }
 
-    // Verify the acting user owns every requested MCP in auth mode before mapping
-    // it to the agent. Otherwise a user could approve another user's remote MCP
-    // (and its stored credentials) for the agent's proxy to use. See SUP-199.
-    if (!body.decline) {
+    // In auth mode, only allow providing remote MCPs the caller owns before
+    // mapping them to the agent. Otherwise a user could approve another user's
+    // remote MCP (and its stored credentials) for the agent's proxy. See SUP-199.
+    if (!body.decline && isAuthMode()) {
       const userId = getCurrentUserId(c)
       const ownedMcps = await db
         .select({ id: remoteMcpServers.id })
         .from(remoteMcpServers)
         .where(and(
           inArray(remoteMcpServers.id, requestedMcpIds),
-          isAuthMode() ? eq(remoteMcpServers.userId, userId) : undefined
+          eq(remoteMcpServers.userId, userId)
         ))
       const ownedMcpIds = new Set(ownedMcps.map((m) => m.id))
       if (requestedMcpIds.some((mcpId) => !ownedMcpIds.has(mcpId))) {

--- a/src/api/routes/security-repro.test.ts
+++ b/src/api/routes/security-repro.test.ts
@@ -592,8 +592,9 @@ describe('SUP-199: remote MCP assignment ownership (AUTH_MODE)', () => {
 
   it('does not gate on ownership when auth mode is disabled', async () => {
     mockIsAuthMode.mockReturnValue(false)
-    // 1) ownership lookup (no userId filter) → exists; 2) existing-mappings → none.
-    selectQueue = [[{ id: 'shared-mcp-id' }], []]
+    // Ownership lookup is skipped entirely in non-auth mode, so the only select
+    // is the existing-mappings lookup → none assigned yet.
+    selectQueue = [[]]
 
     const res = await appWithAgents().request('http://localhost/api/agents/my-agent/remote-mcps', {
       method: 'POST',

--- a/src/api/routes/security-repro.test.ts
+++ b/src/api/routes/security-repro.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+// ============================================================================
+// Security repro guardrails for the agents router.
+//
+// These tests prove that the remote-MCP assignment routes verify the acting
+// user owns the requested MCP IDs (SUP-199). Without the ownership check, a
+// user with access to any agent could attach another user's remote MCP — and
+// its stored bearer/OAuth credentials — to that agent.
+//
+// Harness: db.select() drains `selectQueue` in call order; db.insert().values()
+// records into `insertValuesCalls`. Auth is mocked so AgentUser() passes and the
+// acting user / auth-mode are controllable per test.
+// ============================================================================
+
+// --- Mutable harness state (referenced only by mock *implementations*, set in
+// --- beforeEach / individual tests — never inside a vi.mock factory) ---------
+let selectQueue: unknown[] = []
+let insertValuesCalls: unknown[] = []
+
+// Auth middleware — passthrough (caller already proved AgentUser access)
+vi.mock('../middleware/auth', () => ({
+  Authenticated: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  AgentRead: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  AgentUser: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  AgentAdmin: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}))
+
+// Container manager (provide-remote-mcp grabs a client; ownership rejection
+// returns before it is ever used)
+const mockContainerFetch = vi.fn()
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: {
+    getClient: () => ({
+      fetch: (...args: unknown[]) => mockContainerFetch(...args),
+      start: vi.fn(),
+      stop: vi.fn(),
+    }),
+    ensureRunning: vi.fn(),
+    getCachedInfo: () => ({ status: 'running', port: 8080 }),
+  },
+}))
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    broadcastGlobal: vi.fn(),
+    persistMessage: vi.fn(),
+    markAllSessionsInactiveForAgent: vi.fn(),
+  },
+}))
+
+// DB mock — select drains selectQueue; insert.values() records the rows.
+const mockDbSelect = vi.fn()
+const mockDbInsert = vi.fn()
+vi.mock('@shared/lib/db', () => ({
+  db: {
+    select: (...args: unknown[]) => mockDbSelect(...args),
+    insert: (...args: unknown[]) => mockDbInsert(...args),
+    update: () => ({ set: () => ({ where: () => Promise.resolve(undefined) }) }),
+    delete: () => ({ where: () => Promise.resolve(undefined) }),
+  },
+}))
+
+vi.mock('@shared/lib/db/schema', () => ({
+  remoteMcpServers: { id: 'id', userId: 'user_id', name: 'name', url: 'url', status: 'status', toolsJson: 'tools_json' },
+  agentRemoteMcps: { id: 'id', agentSlug: 'agent_slug', remoteMcpId: 'remote_mcp_id', createdAt: 'created_at' },
+  connectedAccounts: {},
+  agentConnectedAccounts: {},
+  proxyAuditLog: {},
+  mcpAuditLog: {},
+  agentAcl: {},
+  user: {},
+  messageAuthor: {},
+  apiScopePolicies: {},
+  mcpToolPolicies: {},
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq: (col: string, val: string) => ({ col, val }),
+  and: (...args: unknown[]) => args,
+  inArray: (col: string, vals: string[]) => ({ col, vals }),
+  desc: (col: string) => ({ col }),
+  count: () => 'count',
+  like: (col: string, val: string) => ({ col, val }),
+  or: (...args: unknown[]) => args,
+}))
+
+// Auth mode + current user — controllable per test
+const mockIsAuthMode = vi.fn(() => true)
+const mockGetCurrentUserId = vi.fn(() => 'user-b')
+vi.mock('@shared/lib/auth/mode', () => ({ isAuthMode: () => mockIsAuthMode() }))
+vi.mock('@shared/lib/auth/config', () => ({ getCurrentUserId: () => mockGetCurrentUserId() }))
+
+// Remaining agents.ts dependencies (not exercised here, but needed to import it)
+vi.mock('@shared/lib/services/agent-service', () => ({
+  listAgentsWithStatus: vi.fn(), createAgent: vi.fn(), getAgentWithStatus: vi.fn(),
+  getAgent: vi.fn(), updateAgent: vi.fn(), deleteAgent: vi.fn(),
+  agentExists: vi.fn().mockResolvedValue(true),
+}))
+vi.mock('@shared/lib/services/session-service', () => ({
+  listSessions: vi.fn(), updateSessionName: vi.fn(), registerSession: vi.fn(),
+  getSessionMessagesWithCompact: vi.fn(), getSession: vi.fn(), getSessionMetadata: vi.fn(),
+  updateSessionMetadata: vi.fn(), deleteSession: vi.fn(), removeMessage: vi.fn(), removeToolCall: vi.fn(),
+}))
+vi.mock('@shared/lib/services/secrets-service', () => ({
+  listSecrets: vi.fn(), getSecret: vi.fn(), setSecret: vi.fn(), deleteSecret: vi.fn(),
+  keyToEnvVar: vi.fn(), getSecretEnvVars: vi.fn(),
+}))
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  listScheduledTasks: vi.fn(), listPendingScheduledTasks: vi.fn(),
+}))
+vi.mock('@shared/lib/account-providers', () => ({ getProvider: vi.fn() }))
+vi.mock('@shared/lib/services/skillset-service', () => ({
+  getAgentSkillsWithStatus: vi.fn(), getDiscoverableSkills: vi.fn(), installSkillFromSkillset: vi.fn(),
+  updateSkillFromSkillset: vi.fn(), createSkillPR: vi.fn(), getSkillPRInfo: vi.fn(),
+  getSkillPublishInfo: vi.fn(), publishSkillToSkillset: vi.fn(), refreshAgentSkills: vi.fn(),
+}))
+vi.mock('@shared/lib/services/artifact-service', () => ({ listArtifactsFromFilesystem: vi.fn() }))
+vi.mock('@shared/lib/proxy/host-url', () => ({
+  getContainerHostUrl: () => 'localhost', getAppPort: () => 3000,
+}))
+vi.mock('@shared/lib/services/agent-template-service', () => ({
+  exportAgentTemplate: vi.fn(), importAgentFromTemplate: vi.fn(), installAgentFromSkillset: vi.fn(),
+  updateAgentFromSkillset: vi.fn(), getAgentTemplateStatus: vi.fn(), getDiscoverableAgents: vi.fn(),
+  refreshSkillsetCaches: vi.fn(), getAgentPRInfo: vi.fn(), createAgentPR: vi.fn(),
+  getAgentPublishInfo: vi.fn(), publishAgentToSkillset: vi.fn(), refreshAgentTemplates: vi.fn(),
+  hasOnboardingSkill: vi.fn(),
+}))
+vi.mock('@shared/lib/utils/retry', () => ({ withRetry: vi.fn() }))
+vi.mock('@shared/lib/utils/message-transform', () => ({ transformMessages: vi.fn() }))
+vi.mock('@shared/lib/config/settings', () => ({
+  getEffectiveAnthropicApiKey: () => 'test-key', getEffectiveModels: () => ({}),
+  getEffectiveAgentLimits: () => ({}), getCustomEnvVars: () => ({}), getSettings: () => ({ container: {} }),
+}))
+vi.mock('@shared/lib/proxy/token-store', () => ({ revokeProxyToken: vi.fn(), validateProxyToken: vi.fn() }))
+vi.mock('@shared/lib/services/audit-log-service', () => ({ logAuditEvent: vi.fn() }))
+vi.mock('@shared/lib/utils/file-storage', () => ({
+  getSessionJsonlPath: vi.fn(), readFileOrNull: vi.fn(), getAgentSessionsDir: vi.fn(),
+  readJsonlFile: vi.fn(), getAgentWorkspaceDir: vi.fn(), getTempUploadsDir: vi.fn(),
+  ensureDirectory: vi.fn(), removeDirectory: vi.fn(),
+}))
+
+// Import the agents router after all mocks are set up
+import agents from './agents'
+
+// --- Harness helpers ---------------------------------------------------------
+
+// A thenable that ignores all query-builder chaining and resolves to the next
+// queued select result (defaulting to [] when the queue is drained).
+function makeSelectChain() {
+  const result = selectQueue.length > 0 ? selectQueue.shift() : []
+  const chain: Record<string, unknown> = {}
+  for (const method of ['from', 'innerJoin', 'leftJoin', 'rightJoin', 'where', 'orderBy', 'limit', 'offset', 'groupBy', 'having']) {
+    chain[method] = () => chain
+  }
+  chain.then = (onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) => Promise.resolve(result).then(onF, onR)
+  chain.catch = (onR: (e: unknown) => unknown) => Promise.resolve(result).catch(onR)
+  chain.finally = (onF: () => void) => Promise.resolve(result).finally(onF)
+  return chain
+}
+
+// insert(table).values(rows) records rows and is awaitable both directly and
+// via .onConflictDoNothing().
+function makeInsertChain() {
+  return {
+    values: (rows: unknown) => {
+      insertValuesCalls.push(rows)
+      const settled = Promise.resolve(undefined)
+      return {
+        onConflictDoNothing: () => settled,
+        then: (onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) => settled.then(onF, onR),
+        catch: (onR: (e: unknown) => unknown) => settled.catch(onR),
+        finally: (onF: () => void) => settled.finally(onF),
+      }
+    },
+  }
+}
+
+function appWithAgents() {
+  const app = new Hono()
+  app.route('/api/agents', agents)
+  return app
+}
+
+function expectClientError(status: number) {
+  expect(status).toBeGreaterThanOrEqual(400)
+  expect(status).toBeLessThan(500)
+}
+
+describe('security repro: remote MCP ownership (SUP-199)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    selectQueue = []
+    insertValuesCalls = []
+    mockIsAuthMode.mockReturnValue(true)
+    mockGetCurrentUserId.mockReturnValue('user-b')
+    mockDbSelect.mockImplementation(() => makeSelectChain())
+    mockDbInsert.mockImplementation(() => makeInsertChain())
+  })
+
+  it('rejects attaching another user remote MCP id to an agent', async () => {
+    selectQueue = [[]]
+
+    const res = await appWithAgents().request('http://localhost/api/agents/attacker-agent/remote-mcps', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mcpIds: ['victim-mcp-id'] }),
+    })
+
+    expectClientError(res.status)
+    expect(insertValuesCalls).toEqual([])
+  })
+
+  it('rejects providing another user remote MCP id at runtime approval', async () => {
+    selectQueue = [[]]
+
+    const res = await appWithAgents().request('http://localhost/api/agents/attacker-agent/sessions/sess-1/provide-remote-mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ toolUseId: 'tu-1', remoteMcpId: 'victim-mcp-id' }),
+    })
+
+    expectClientError(res.status)
+    expect(insertValuesCalls).toEqual([])
+    expect(mockContainerFetch).not.toHaveBeenCalled()
+  })
+
+  it('allows attaching a remote MCP the acting user owns', async () => {
+    mockGetCurrentUserId.mockReturnValue('user-a')
+    // 1) ownership lookup -> owned; 2) existing-mappings lookup -> none
+    selectQueue = [[{ id: 'my-mcp-id' }], []]
+
+    const res = await appWithAgents().request('http://localhost/api/agents/my-agent/remote-mcps', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mcpIds: ['my-mcp-id'] }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(insertValuesCalls).toHaveLength(1)
+    expect(insertValuesCalls[0]).toEqual([
+      expect.objectContaining({ agentSlug: 'my-agent', remoteMcpId: 'my-mcp-id' }),
+    ])
+  })
+
+  it('does not gate on ownership when auth mode is disabled', async () => {
+    mockIsAuthMode.mockReturnValue(false)
+    // 1) ownership lookup (no userId filter) -> exists; 2) existing-mappings -> none
+    selectQueue = [[{ id: 'shared-mcp-id' }], []]
+
+    const res = await appWithAgents().request('http://localhost/api/agents/my-agent/remote-mcps', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mcpIds: ['shared-mcp-id'] }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(insertValuesCalls).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Problem

`POST /api/agents/:id/remote-mcps` and `POST /api/agents/:id/sessions/:sessionId/provide-remote-mcp` only proved the caller had `AgentUser()` access to the target agent. They did **not** verify that the requested `mcpIds` belong to the acting user in `AUTH_MODE`.

### Impact
A user with access to any agent could attach **another user's** remote MCP server by ID. Once the `agent_remote_mcps` mapping existed, the agent could call `/api/mcp-proxy/:agent/:mcpId` with its proxy token, causing the proxy to use the victim MCP's stored bearer/OAuth credentials.

## Fix

Both routes now resolve the requested MCP IDs scoped to the acting user before inserting any mapping — mirroring the existing connected-accounts ownership check (`agents.ts` map-connected-accounts, `remote-mcps.ts:334`):

- **`POST /:id/remote-mcps`** — filters `mcpIds` to those owned by the user and returns `400 No valid remote MCPs found` when none are valid; inserts only owned IDs.
- **`POST /:id/sessions/:sessionId/provide-remote-mcp`** — returns `403` if any requested ID is not owned by the user, before touching the container.

The ownership filter is gated on `isAuthMode()`, so single-user (non-auth) installs are unaffected (`getCurrentUserId` returns the `local` sentinel there).

## Tests

New `src/api/routes/security-repro.test.ts` guardrails (the failing guardrail from the ticket, plus coverage for the second route and the non-regression cases):

1. ✅ `rejects attaching another user remote MCP id to an agent` — the exact repro from the ticket (4xx + no insert).
2. ✅ `rejects providing another user remote MCP id at runtime approval` — same protection on the runtime-approval route.
3. ✅ `allows attaching a remote MCP the acting user owns` — guards against over-blocking.
4. ✅ `does not gate on ownership when auth mode is disabled` — non-auth installs still work.

Verified these 2 security tests **fail on the pre-fix code** and all 4 pass after the fix.

```sh
npx vitest run src/api/routes/security-repro.test.ts -t "remote MCP"
```

Typecheck, lint, and the related route suites (`remote-mcps`, `provide-connected-account`, `mcp-proxy`, 162 tests) all pass.

Closes SUP-199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)