### PR TITLE
fix: bypass localhost restriction for /api/x-agent (WSL2 cross-agent 403)

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -36,7 +36,7 @@ import { db } from '@shared/lib/db'
 import { user as userTable } from '@shared/lib/db/schema'
 import { authEnforcementMiddleware, getAuthSettings } from './middleware/auth-enforcement'
 import { getPublicAuthProviders } from '@shared/lib/auth/provider-config'
-import { LocalModeAuth } from './middleware/local-mode-auth'
+import { LocalModeAuth, isContainerFacingPath } from './middleware/local-mode-auth'
 
 const app = new Hono()
 
@@ -57,11 +57,9 @@ if (!isAuthMode()) {
   const localModeAuth = LocalModeAuth()
 
   app.use('/api/*', async (c, next) => {
-    const path = c.req.path
-    // Container endpoints: protected by IsAgent() bearer tokens
-    if (path.startsWith('/api/proxy/') ||
-        path.startsWith('/api/mcp-proxy/') ||
-        path.startsWith('/api/browser/')) {
+    // Container endpoints: protected by per-agent bearer tokens, and reached
+    // from a non-loopback container IP — they must skip the localhost check.
+    if (isContainerFacingPath(c.req.path)) {
       return next()
     }
     return localModeAuth(c, next)

--- a/src/api/middleware/local-mode-auth.test.ts
+++ b/src/api/middleware/local-mode-auth.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Hono } from 'hono'
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+const mockIsAuthMode = vi.fn<() => boolean>()
+vi.mock('@shared/lib/auth/mode', () => ({
+  isAuthMode: () => mockIsAuthMode(),
+}))
+
+const mockGetConnInfo = vi.fn<() => { remote: { address?: string } }>()
+vi.mock('@hono/node-server/conninfo', () => ({
+  getConnInfo: () => mockGetConnInfo(),
+}))
+
+// Import after mocks
+import { LocalModeAuth, isContainerFacingPath } from './local-mode-auth'
+
+// ---------------------------------------------------------------------------
+// isContainerFacingPath — the bypass list. This is the actual regression
+// surface: x-agent calls 403'd on WSL2 because /api/x-agent/ was omitted here.
+// ---------------------------------------------------------------------------
+
+describe('isContainerFacingPath', () => {
+  it('bypasses every container→host endpoint', () => {
+    expect(isContainerFacingPath('/api/proxy/agent-1/foo')).toBe(true)
+    expect(isContainerFacingPath('/api/mcp-proxy/agent-1/call')).toBe(true)
+    expect(isContainerFacingPath('/api/browser/agent-1/screenshot')).toBe(true)
+  })
+
+  // Regression: cross-agent calls (list/invoke/get-sessions and x-agent/chat)
+  // are container-facing and authenticate via the proxy bearer token. Omitting
+  // them here made LocalModeAuth 403 every call from a non-loopback container
+  // (WSL2's 172.x NAT gateway), even with all cross-agent permissions Allowed.
+  it('bypasses x-agent routes (main router and chat)', () => {
+    expect(isContainerFacingPath('/api/x-agent/list')).toBe(true)
+    expect(isContainerFacingPath('/api/x-agent/invoke')).toBe(true)
+    expect(isContainerFacingPath('/api/x-agent/get-sessions')).toBe(true)
+    expect(isContainerFacingPath('/api/x-agent/chat/send')).toBe(true)
+  })
+
+  it('does NOT bypass browser-facing API routes', () => {
+    expect(isContainerFacingPath('/api/agents')).toBe(false)
+    expect(isContainerFacingPath('/api/agents/foo/x-agent-policies')).toBe(false)
+    expect(isContainerFacingPath('/api/settings')).toBe(false)
+    expect(isContainerFacingPath('/api/connected-accounts')).toBe(false)
+  })
+
+  it('respects the prefix boundary (no lookalike-path leakage)', () => {
+    // A route that merely starts with the prefix string but isn't under it.
+    expect(isContainerFacingPath('/api/x-agentstuff')).toBe(false)
+    expect(isContainerFacingPath('/api/proxydashboard')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// LocalModeAuth — the localhost IP restriction itself.
+// ---------------------------------------------------------------------------
+
+describe('LocalModeAuth', () => {
+  const originalProcessType = (process as { type?: string }).type
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Simulate the packaged Electron main process, where the restriction is
+    // actually active. In the Vite dev server process.type is undefined.
+    ;(process as { type?: string }).type = 'browser'
+    mockIsAuthMode.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    if (originalProcessType === undefined) {
+      delete (process as { type?: string }).type
+    } else {
+      ;(process as { type?: string }).type = originalProcessType
+    }
+  })
+
+  function buildApp() {
+    const app = new Hono()
+    app.use('*', LocalModeAuth())
+    app.get('/', (c) => c.json({ ok: true }))
+    return app
+  }
+
+  it('allows loopback callers in Electron local mode', async () => {
+    for (const addr of ['127.0.0.1', '::1', '::ffff:127.0.0.1']) {
+      mockGetConnInfo.mockReturnValue({ remote: { address: addr } })
+      const res = await buildApp().request('/')
+      expect(res.status, `addr ${addr}`).toBe(200)
+    }
+  })
+
+  // The WSL2 case: container reaches the host across the NAT bridge, so the
+  // host sees the distro's 172.x gateway IP — not loopback.
+  it('blocks a non-loopback (container/WSL2) caller with 403 Forbidden', async () => {
+    mockGetConnInfo.mockReturnValue({ remote: { address: '172.22.192.5' } })
+    const res = await buildApp().request('/')
+    expect(res.status).toBe(403)
+    expect(await res.json()).toEqual({ error: 'Forbidden' })
+  })
+
+  it('blocks when the remote address is missing', async () => {
+    mockGetConnInfo.mockReturnValue({ remote: {} })
+    const res = await buildApp().request('/')
+    expect(res.status).toBe(403)
+  })
+
+  it('skips the restriction entirely in auth mode', async () => {
+    mockIsAuthMode.mockReturnValue(true)
+    mockGetConnInfo.mockReturnValue({ remote: { address: '172.22.192.5' } })
+    const res = await buildApp().request('/')
+    expect(res.status).toBe(200)
+  })
+
+  // The Vite dev server / web deployment: not the Electron main process, so the
+  // IP restriction is off (infra handles network security). This is why the bug
+  // was invisible in `npm run dev`.
+  it('skips the restriction when not in the Electron main process', async () => {
+    delete (process as { type?: string }).type
+    mockGetConnInfo.mockReturnValue({ remote: { address: '172.22.192.5' } })
+    const res = await buildApp().request('/')
+    expect(res.status).toBe(200)
+  })
+})

--- a/src/api/middleware/local-mode-auth.ts
+++ b/src/api/middleware/local-mode-auth.ts
@@ -4,6 +4,35 @@ import { isAuthMode } from '@shared/lib/auth/mode'
 
 const LOCALHOST_ADDRS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1'])
 
+/**
+ * API path prefixes hit by the agent container, NOT a browser. These
+ * authenticate via per-agent bearer tokens (IsAgent() / proxy token), so they
+ * must bypass the localhost IP restriction below.
+ *
+ * Why the bypass is required (not just an optimization): the container reaches
+ * the host across its runtime's network bridge, so the host server (bound to
+ * 0.0.0.0) sees a NON-loopback source — e.g. WSL2's `172.x` NAT gateway or
+ * Docker's bridge IP. Runtimes that SNAT host traffic to loopback (macOS Lima)
+ * happen to pass the check, which is exactly why an omission here is invisible
+ * on a dev's Mac yet 403s every cross-agent call on Windows/WSL2.
+ *
+ * Keep this in sync with the container-facing routers mounted in api/index.ts.
+ */
+const CONTAINER_FACING_PREFIXES = [
+  '/api/proxy/',
+  '/api/mcp-proxy/',
+  '/api/x-agent/', // covers /api/x-agent and /api/x-agent/chat
+  '/api/browser/',
+]
+
+/**
+ * True when `path` is a container→host endpoint that authenticates via a
+ * bearer token rather than the localhost IP restriction.
+ */
+export function isContainerFacingPath(path: string): boolean {
+  return CONTAINER_FACING_PREFIXES.some((prefix) => path.startsWith(prefix))
+}
+
 export function LocalModeAuth(): MiddlewareHandler {
   return async (c, next) => {
     if (isAuthMode()) return next()


### PR DESCRIPTION
## Problem

A user reported cross-agent tools (`list_agents`, `invoke_agent`, …) failing with **`Forbidden`** even though the Cross-agent permissions UI showed everything set to **Allow**. The denial was immediate (~30ms) and a *bare* `"Forbidden"` — which no path in the x-agent policy engine produces (every policy denial carries a reason like `"Blocked by policy"`). That pointed one layer up, to middleware.

## Root cause

In packaged Electron local mode, `LocalModeAuth` restricts `/api/*` to loopback callers. `src/api/index.ts` exempts container→host endpoints (`/api/proxy/`, `/api/mcp-proxy/`, `/api/browser/`) — but **`/api/x-agent/` was never added**. It shipped a month after the restriction (`3c910781` vs `8862dbfe`) and was missed.

The container reaches the host via `host.docker.internal`, so the host's `0.0.0.0`-bound server sees a **non-loopback** source. Whether that 403s is runtime-dependent:

- **macOS + Lima** — VZ/gvisor NAT SNATs host traffic to loopback → `127.0.0.1` → passes ✅
- **Windows + WSL2** — NAT surfaces the distro's `172.x` gateway IP → not loopback → bare `403 Forbidden` ❌

So every cross-agent call (`/api/x-agent/*`, incl. `/api/x-agent/chat`) died above the policy engine — hence "permissions all say Allowed, but nothing works." We use WSL2 **NAT** mode (never configure mirrored), and our own host-IP detection depends on the `172.x` gateway, so it's structural.

## Fix

- Extract the bypass list into a tested `isContainerFacingPath()` predicate in `local-mode-auth.ts` and add `/api/x-agent/` (covers the main router **and** `/api/x-agent/chat`).
- Safe: the x-agent router has its own proxy-token auth (`x-agent.ts:57-68`), identical protection to the other exempt endpoints.

## Completeness audit

Traced the full container→host surface from both sides. The only HTTP `/api/*` prefixes the container hits are `proxy`, `mcp-proxy`, `x-agent`, `browser` — now all exempt. `user-input` / `dashboards` / `computer-use` make **no** container→host HTTP calls; they reach the host over the host-initiated WebSocket (`server.ts` `WebSocketServer({ noServer: true })`), so they're unaffected.

## Tests

`src/api/middleware/local-mode-auth.test.ts` (9 tests). The key regression assertion is `isContainerFacingPath('/api/x-agent/list') === true` — it would have failed before this change. Middleware tests also encode the two reasons the bug stayed hidden:

- can't repro in `npm run dev` — middleware is off when `process.type !== 'browser'`
- can't repro on macOS Lima — loopback source

so the test stubs `process.type='browser'` + a non-loopback `getConnInfo` to lock in the WSL2 path.

## Verification

`npx vitest run` (9/9 pass), `tsc --noEmit` clean, eslint clean on changed files. Live verification needs a packaged Windows/WSL2 build (the middleware is a no-op in dev and on Lima), which the unit test stands in for.

## Follow-up (out of scope)

The bypass list is hand-maintained and drifted once. A durable guard: unify `proxy`/`mcp-proxy`/`x-agent` under the shared `IsAgent()` middleware (only `browser.ts` uses it today) and assert in a test that every `IsAgent()`-mounted route is in the bypass list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)