### PR TITLE
fix(security): path-containment helper + lint rule (infra for SUP path-traversal batch)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,7 @@
     "no-template-curly-in-string": "error",
     "react/jsx-no-target-blank": "error",
     "local-rules/no-unhandled-throwing-builtins": "warn",
+    "local-rules/no-path-containment-startswith": "warn",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
     "no-extra-semi": "off",
@@ -40,7 +41,8 @@
     {
       "files": ["**/*.test.ts", "**/*.test.tsx"],
       "rules": {
-        "local-rules/no-unhandled-throwing-builtins": "off"
+        "local-rules/no-unhandled-throwing-builtins": "off",
+        "local-rules/no-path-containment-startswith": "off"
       }
     }
   ],

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -1,3 +1,4 @@
 module.exports = {
   'no-unhandled-throwing-builtins': require('./eslint-rules/no-unhandled-throwing-builtins'),
+  'no-path-containment-startswith': require('./eslint-rules/no-path-containment-startswith'),
 }

--- a/eslint-rules/no-path-containment-startswith.js
+++ b/eslint-rules/no-path-containment-startswith.js
@@ -1,0 +1,94 @@
+/**
+ * Flag path-containment checks written as `resolvedPath.startsWith(baseDir)`.
+ *
+ * A bare prefix check is unsafe: a sibling directory sharing the base's string
+ * prefix passes it (base `/data/agent` vs `/data/agent-victim`). See SUP-200.
+ * Use `isPathWithinDir()` / `assertPathWithinDir()` from
+ * `@shared/lib/utils/path-safety`, which compare via `path.relative`.
+ *
+ * Heuristic: report `<receiver>.startsWith(...)` when `<receiver>` is
+ *   (a) an inline `path.resolve(...)` / `path.join(...)` call, or
+ *   (b) an identifier initialized from `path.resolve(...)` / `path.join(...)`
+ *       somewhere in the visible scope chain.
+ * This catches both the inline and the stored-variable forms. It will not catch
+ * a resolved path passed through several intermediate variables — those are rare
+ * and the runtime helper remains the real safety net.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow path-containment checks via startsWith(); use isPathWithinDir/assertPathWithinDir from @shared/lib/utils/path-safety',
+    },
+    schema: [],
+    messages: {
+      pathStartsWith:
+        "Unsafe path-containment check: '.startsWith()' on a path.resolve/join result lets a sibling dir sharing the prefix escape. Use isPathWithinDir()/assertPathWithinDir() from '@shared/lib/utils/path-safety'.",
+    },
+  },
+
+  create(context) {
+    const PATH_METHODS = new Set(['resolve', 'join'])
+
+    function isPathResolveCall(node) {
+      return (
+        node &&
+        node.type === 'CallExpression' &&
+        node.callee.type === 'MemberExpression' &&
+        node.callee.object.type === 'Identifier' &&
+        node.callee.object.name === 'path' &&
+        node.callee.property.type === 'Identifier' &&
+        PATH_METHODS.has(node.callee.property.name)
+      )
+    }
+
+    function getScopeForNode(node) {
+      // ESLint 9 prefers sourceCode.getScope(node); ESLint 8 uses getScope().
+      const sourceCode = context.sourceCode || context.getSourceCode()
+      if (sourceCode && typeof sourceCode.getScope === 'function') {
+        return sourceCode.getScope(node)
+      }
+      return context.getScope()
+    }
+
+    // True if `node` is an identifier whose nearest binding was initialized from
+    // a path.resolve/join call.
+    function identifierFromPathResolve(node) {
+      if (!node || node.type !== 'Identifier') return false
+      let scope = getScopeForNode(node)
+      let variable = null
+      while (scope && !variable) {
+        variable = scope.variables.find((v) => v.name === node.name) || null
+        scope = scope.upper
+      }
+      if (!variable) return false
+      return variable.defs.some(
+        (def) =>
+          def.node &&
+          def.node.type === 'VariableDeclarator' &&
+          def.node.init &&
+          isPathResolveCall(def.node.init),
+      )
+    }
+
+    return {
+      CallExpression(node) {
+        const callee = node.callee
+        if (
+          callee.type !== 'MemberExpression' ||
+          callee.property.type !== 'Identifier' ||
+          callee.property.name !== 'startsWith'
+        ) {
+          return
+        }
+        const receiver = callee.object
+        if (isPathResolveCall(receiver) || identifierFromPathResolve(receiver)) {
+          context.report({ node, messageId: 'pathStartsWith' })
+        }
+      },
+    }
+  },
+}

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -116,6 +116,7 @@ import { resolveTargetApp } from '@shared/lib/computer-use/types'
 import { getConfiguredLlmClient, extractTextFromLlmResponse } from '@shared/lib/llm-provider/helpers'
 import { revokeProxyToken } from '@shared/lib/proxy/token-store'
 import { getAgentWorkspaceDir } from '@shared/lib/utils/file-storage'
+import { isPathWithinDir } from '@shared/lib/utils/path-safety'
 import { readAgentPreferences, updateAgentPreferences } from '@shared/lib/services/agent-preferences-service'
 import { cleanupAgentData } from '@shared/lib/services/agent-cleanup-service'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
@@ -3599,7 +3600,7 @@ agents.get('/:id/skills/:dir/files/content', AgentAdmin(), async (c) => {
     const skillDir = path.join(getAgentWorkspaceDir(agentSlug), '.claude', 'skills', dir)
     const resolved = path.resolve(skillDir, filePath)
 
-    if (!resolved.startsWith(skillDir + path.sep) && resolved !== skillDir) {
+    if (!isPathWithinDir(skillDir, resolved)) {
       return c.json({ error: 'Invalid file path' }, 400)
     }
 
@@ -3631,7 +3632,7 @@ agents.put('/:id/skills/:dir/files/content', AgentAdmin(), async (c) => {
     const skillDir = path.join(getAgentWorkspaceDir(agentSlug), '.claude', 'skills', dir)
     const resolved = path.resolve(skillDir, filePath)
 
-    if (!resolved.startsWith(skillDir + path.sep) && resolved !== skillDir) {
+    if (!isPathWithinDir(skillDir, resolved)) {
       return c.json({ error: 'Invalid file path' }, 400)
     }
 
@@ -3738,7 +3739,7 @@ async function handleFileUpload(agentSlug: string, file: File, relativePath?: st
   const fullPath = path.resolve(workspaceDir, uploadPath)
 
   // Security: ensure path doesn't escape the uploads directory
-  if (!fullPath.startsWith(path.resolve(workspaceDir, 'uploads'))) {
+  if (!isPathWithinDir(path.resolve(workspaceDir, 'uploads'), fullPath)) {
     throw new Error('Invalid file path')
   }
 
@@ -3814,7 +3815,7 @@ async function handleFolderUpload(agentSlug: string, sourcePath: string) {
   const destPath = path.resolve(workspaceDir, 'uploads', folderName)
 
   // Security: ensure dest doesn't escape uploads directory
-  if (!destPath.startsWith(path.resolve(workspaceDir, 'uploads'))) {
+  if (!isPathWithinDir(path.resolve(workspaceDir, 'uploads'), destPath)) {
     throw new Error('Invalid path')
   }
 
@@ -3946,10 +3947,9 @@ agents.get('/:id/files/*', AgentRead(), async (c) => {
 
     // Security: ensure path doesn't escape workspace. A bare startsWith() check
     // is unsafe because a sibling directory can share the workspace path prefix
-    // (e.g. workspace "agent" vs sibling "agent-victim"), so use path.relative
-    // to confirm the resolved path is genuinely contained within the workspace.
-    const relativePath = path.relative(workspaceDir, fullPath)
-    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    // (e.g. workspace "agent" vs sibling "agent-victim"), so confirm genuine
+    // containment via isPathWithinDir (path.relative based).
+    if (!isPathWithinDir(workspaceDir, fullPath)) {
       return c.json({ error: 'Invalid path' }, 400)
     }
 
@@ -4160,7 +4160,7 @@ agents.get('/:id/artifacts/:artifactSlug/screenshot.png', AgentRead(), async (c)
   const screenshotPath = path.join(artifactsDir, artifactSlug, 'screenshot.png')
   // Belt-and-suspenders path traversal guard: slug cannot escape artifactsDir.
   const resolved = path.resolve(screenshotPath)
-  if (!resolved.startsWith(path.resolve(artifactsDir) + path.sep)) {
+  if (!isPathWithinDir(artifactsDir, resolved)) {
     return c.json({ error: 'Invalid artifact slug' }, 400)
   }
 

--- a/src/shared/lib/services/agent-template-service.ts
+++ b/src/shared/lib/services/agent-template-service.ts
@@ -27,6 +27,7 @@ import {
 import { getEffectiveModels } from '@shared/lib/config/settings'
 import { getConfiguredLlmClient, extractTextFromLlmResponse } from '@shared/lib/llm-provider/helpers'
 import { withRetry } from '@shared/lib/utils/retry'
+import { isPathWithinDir } from '@shared/lib/utils/path-safety'
 import {
   readIndexJson,
   ensureSkillsetCached,
@@ -483,7 +484,9 @@ export async function importAgentFromTemplate(
       }
 
       const destPath = path.resolve(workspaceDir, entryName)
-      if (!destPath.startsWith(workspaceDir)) continue
+      // Defense-in-depth: validateEntries already rejects `..`/absolute entries
+      // upfront, but confirm genuine containment here too (prefix-safe).
+      if (!isPathWithinDir(workspaceDir, destPath)) continue
 
       await ensureDirectory(path.dirname(destPath))
       const bytesWritten = await reader.extractEntry(

--- a/src/shared/lib/services/artifact-service.ts
+++ b/src/shared/lib/services/artifact-service.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import { getAgentWorkspaceDir } from '@shared/lib/utils/file-storage'
+import { isPathWithinDir } from '@shared/lib/utils/path-safety'
 
 const ARTIFACT_SCREENSHOT_FILENAME = 'screenshot.png'
 
@@ -87,7 +88,7 @@ export async function renameArtifactOnFilesystem(
   // Ensure the path is within the expected artifacts directory
   const artifactsDir = path.join(workspaceDir, 'artifacts')
   const resolved = path.resolve(artifactDir)
-  if (!resolved.startsWith(path.resolve(artifactsDir) + path.sep)) {
+  if (!isPathWithinDir(artifactsDir, resolved)) {
     throw new Error('Invalid artifact slug')
   }
 
@@ -116,7 +117,7 @@ export async function deleteArtifactFromFilesystem(
   // Ensure the path is within the expected artifacts directory
   const artifactsDir = path.join(workspaceDir, 'artifacts')
   const resolved = path.resolve(artifactDir)
-  if (!resolved.startsWith(path.resolve(artifactsDir) + path.sep)) {
+  if (!isPathWithinDir(artifactsDir, resolved)) {
     throw new Error('Invalid artifact slug')
   }
 

--- a/src/shared/lib/services/mount-service.ts
+++ b/src/shared/lib/services/mount-service.ts
@@ -3,6 +3,7 @@ import os from 'os'
 import fs from 'fs'
 import crypto from 'crypto'
 import { getAgentDir } from '@shared/lib/utils/file-storage'
+import { isPathWithinDir } from '@shared/lib/utils/path-safety'
 import type { AgentMount, AgentMountWithHealth } from '@shared/lib/types/mount'
 import { agentMountsSchema } from './mount-schema'
 
@@ -46,9 +47,7 @@ function getCloudStoragePrefixes(): string[] {
 export function isCloudStoragePath(hostPath: string): boolean {
   if (process.platform !== 'darwin') return false
   const normalized = path.resolve(hostPath)
-  return getCloudStoragePrefixes().some(
-    (prefix) => normalized === prefix || normalized.startsWith(prefix + path.sep)
-  )
+  return getCloudStoragePrefixes().some((prefix) => isPathWithinDir(prefix, normalized))
 }
 
 /** User-facing message shown when a cloud-synced folder is rejected as a mount. */

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -16,6 +16,7 @@ import { getDataDir } from '@shared/lib/config/data-dir'
 import { getEffectiveModels } from '@shared/lib/config/settings'
 import { getConfiguredLlmClient, extractTextFromLlmResponse } from '@shared/lib/llm-provider/helpers'
 import { withRetry } from '@shared/lib/utils/retry'
+import { isPathWithinDir } from '@shared/lib/utils/path-safety'
 import {
   getAgentWorkspaceDir,
   readFileOrNull,
@@ -1868,7 +1869,9 @@ export async function importSkillFromZip(
       if (baseName === '.skillset-metadata.json' || baseName === '.skillset-original.md') continue
 
       const destPath = path.resolve(destDir, entryName)
-      if (!destPath.startsWith(destDir)) continue
+      // Defense-in-depth: validateSkillZip already rejects `..`/absolute entries
+      // upfront, but confirm genuine containment here too (prefix-safe).
+      if (!isPathWithinDir(destDir, destPath)) continue
 
       await ensureDirectory(path.dirname(destPath))
       const bytesWritten = await reader.extractEntry(

--- a/src/shared/lib/skillset-provider/public-provider.ts
+++ b/src/shared/lib/skillset-provider/public-provider.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import { ensureDirectory } from '@shared/lib/utils/file-storage'
 import { openZipFromBuffer, detectZipPrefix } from '@shared/lib/utils/zip'
 import { validateSafeCloneUrl } from '@shared/lib/utils/url-safety'
+import { isPathWithinDir } from '@shared/lib/utils/path-safety'
 import { withRetry, NonRetryableError } from '@shared/lib/utils/retry'
 import { atomicSwapCacheDir } from './atomic-cache-swap'
 import {
@@ -138,7 +139,7 @@ async function downloadAndExtract(
       if (entryName.startsWith('__MACOSX/')) continue
 
       const destPath = path.resolve(destDir, entryName)
-      if (!destPath.startsWith(path.resolve(destDir) + path.sep)) continue
+      if (!isPathWithinDir(destDir, destPath)) continue
 
       await ensureDirectory(path.dirname(destPath))
       const bytesWritten = await reader.extractEntry(

--- a/src/shared/lib/utils/no-path-containment-startswith.lint.test.ts
+++ b/src/shared/lib/utils/no-path-containment-startswith.lint.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'vitest'
+// eslint ships no bundled types and @types/eslint isn't a dependency; the
+// RuleTester runtime API is all we need here.
+// @ts-ignore -- no type declarations for 'eslint'
+import { RuleTester } from 'eslint'
+import rule from '../../../../eslint-rules/no-path-containment-startswith.js'
+
+// Drive ESLint's RuleTester through vitest's test hooks.
+RuleTester.describe = describe as unknown as typeof RuleTester.describe
+RuleTester.it = it as unknown as typeof RuleTester.it
+
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2021, sourceType: 'module' },
+})
+
+ruleTester.run('no-path-containment-startswith', rule as unknown as Parameters<RuleTester['run']>[1], {
+  valid: [
+    // Ordinary string prefix checks — receiver is not a resolved path.
+    { code: "url.startsWith('https://')" },
+    { code: "name.startsWith('foo')" },
+    { code: "req.url.startsWith('/api/')" },
+    // Receiver comes from a non-path call.
+    { code: "const x = getThing(); x.startsWith(dir)" },
+    // The sanctioned replacement uses the helper, no startsWith at all.
+    { code: "import { isPathWithinDir } from '@shared/lib/utils/path-safety'; const ok = isPathWithinDir(base, full)" },
+    // path.resolve result used for something other than a containment check.
+    { code: "const full = path.resolve(base, x); const n = full.length" },
+  ],
+  invalid: [
+    // Inline path.resolve(...).startsWith(...)
+    {
+      code: "if (path.resolve(base, input).startsWith(base)) {}",
+      errors: [{ messageId: 'pathStartsWith' }],
+    },
+    // Inline path.join(...).startsWith(...)
+    {
+      code: "const ok = path.join(base, input).startsWith(base)",
+      errors: [{ messageId: 'pathStartsWith' }],
+    },
+    // Stored-variable form (the SUP-200 / skillset / agent-template shape).
+    {
+      code: "const full = path.resolve(workspaceDir, filePath); if (!full.startsWith(workspaceDir)) { throw new Error('no') }",
+      errors: [{ messageId: 'pathStartsWith' }],
+    },
+    // Stored var inside a function scope.
+    {
+      code: "function f(a, b) { const p = path.resolve(a, b); return p.startsWith(a) }",
+      errors: [{ messageId: 'pathStartsWith' }],
+    },
+    // Even the trailing-separator 'safe' form is discouraged — steer to the helper.
+    {
+      code: "const dest = path.resolve(dir, name); if (dest.startsWith(dir + path.sep)) {}",
+      errors: [{ messageId: 'pathStartsWith' }],
+    },
+  ],
+})

--- a/src/shared/lib/utils/path-safety.test.ts
+++ b/src/shared/lib/utils/path-safety.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import path from 'path'
+import { isPathWithinDir, assertPathWithinDir } from './path-safety'
+
+// ---------------------------------------------------------------------------
+// Path containment guard (SUP-200 generalization). The motivating bug: a bare
+// `resolved.startsWith(baseDir)` check lets a SIBLING directory that shares the
+// base's string prefix slip through. These tests pin the correct behavior.
+// ---------------------------------------------------------------------------
+
+describe('isPathWithinDir', () => {
+  const base = '/data/agents/agent'
+
+  it('accepts the base directory itself', () => {
+    expect(isPathWithinDir(base, base)).toBe(true)
+    expect(isPathWithinDir(base, base + '/')).toBe(true)
+  })
+
+  it('accepts files and nested dirs inside the base', () => {
+    expect(isPathWithinDir(base, path.resolve(base, 'file.txt'))).toBe(true)
+    expect(isPathWithinDir(base, path.resolve(base, 'a/b/c.txt'))).toBe(true)
+    expect(isPathWithinDir(base, path.resolve(base, './nested/x'))).toBe(true)
+  })
+
+  it('rejects the SIBLING-PREFIX escape (the SUP-200 vector)', () => {
+    // `/data/agents/agent-victim` shares the `/data/agents/agent` prefix, so a
+    // naive startsWith() check would wrongly accept it.
+    expect('/data/agents/agent-victim/secret'.startsWith(base)).toBe(true) // demonstrates the trap
+    expect(isPathWithinDir(base, '/data/agents/agent-victim/secret')).toBe(false)
+    expect(isPathWithinDir(base, path.resolve(base, '../agent-victim/secret'))).toBe(false)
+  })
+
+  it('rejects parent-directory traversal', () => {
+    expect(isPathWithinDir(base, path.resolve(base, '..'))).toBe(false)
+    expect(isPathWithinDir(base, path.resolve(base, '../..'))).toBe(false)
+    expect(isPathWithinDir(base, path.resolve(base, '../../etc/passwd'))).toBe(false)
+    expect(isPathWithinDir(base, '/data/agents')).toBe(false) // the parent
+  })
+
+  it('rejects already-decoded ../ traversal coming from path.resolve', () => {
+    // Mirrors the agent file-download route: decodeURIComponent('%2e%2e%2f') === '../'
+    const decoded = '../'.repeat(3) + 'etc/passwd'
+    expect(isPathWithinDir(base, path.resolve(base, decoded))).toBe(false)
+  })
+
+  it('rejects absolute paths outside the base', () => {
+    expect(isPathWithinDir(base, '/etc/passwd')).toBe(false)
+    expect(isPathWithinDir(base, '/tmp/file.txt')).toBe(false)
+    expect(isPathWithinDir('/workspace', '/root/.ssh/id_rsa')).toBe(false)
+  })
+
+  it('treats relative candidates against the base via resolve', () => {
+    // path.resolve(base, 'uploads/x') stays inside; '../x' escapes.
+    expect(isPathWithinDir(base, path.resolve(base, 'uploads/x'))).toBe(true)
+    expect(isPathWithinDir(base, path.resolve(base, '../x'))).toBe(false)
+  })
+
+  it('normalizes . and redundant separators inside the base', () => {
+    expect(isPathWithinDir(base, base + '/./a/./b')).toBe(true)
+    expect(isPathWithinDir(base, base + '/a/../b')).toBe(true) // stays inside
+    expect(isPathWithinDir(base, base + '/a/../../agent-victim')).toBe(false)
+  })
+})
+
+describe('assertPathWithinDir', () => {
+  const base = '/workspace'
+
+  it('returns the resolved path for contained candidates', () => {
+    expect(assertPathWithinDir(base, path.resolve(base, 'uploads/file.txt'))).toBe(
+      path.resolve(base, 'uploads/file.txt'),
+    )
+    expect(assertPathWithinDir(base, base)).toBe(path.resolve(base))
+  })
+
+  it('throws on escape with the default message', () => {
+    expect(() => assertPathWithinDir(base, '/etc/passwd')).toThrow('Invalid path')
+    expect(() => assertPathWithinDir(base, path.resolve(base, '../etc/passwd'))).toThrow('Invalid path')
+  })
+
+  it('throws on the sibling-prefix escape', () => {
+    expect(() => assertPathWithinDir(base, '/workspace-evil/x')).toThrow()
+  })
+
+  it('supports a custom error message', () => {
+    expect(() => assertPathWithinDir(base, '/etc/passwd', 'nope')).toThrow('nope')
+  })
+})

--- a/src/shared/lib/utils/path-safety.ts
+++ b/src/shared/lib/utils/path-safety.ts
@@ -1,0 +1,60 @@
+/**
+ * Path containment helpers — defense against directory traversal when we
+ * join a trusted base directory with untrusted input (a URL path segment, a
+ * ZIP entry name, a user-supplied filename) via `path.resolve`/`path.join`.
+ *
+ * Why not `resolved.startsWith(baseDir)`?
+ *   A bare prefix check is unsafe: a SIBLING directory that shares the base's
+ *   string prefix passes it. With base `/data/agent`, the path
+ *   `/data/agent-victim/secret` satisfies `.startsWith('/data/agent')` yet is
+ *   clearly outside the base. (See SUP-200.) Always decode the input first —
+ *   encoded `..` (`%2e%2e%2f`) slips past URL normalization until
+ *   `decodeURIComponent`.
+ *
+ * The correct check uses `path.relative(base, candidate)`: the candidate is
+ * contained iff the relative path does not start with `..` and is not absolute.
+ *
+ * Exposed helpers:
+ *   - isPathWithinDir(baseDir, candidate): boolean — for loops that `continue`
+ *     on a bad entry, or callers that want to branch.
+ *   - assertPathWithinDir(baseDir, candidate, message?): the resolved absolute
+ *     path on success; throws on escape — for callers that fail the request.
+ */
+
+import path from 'path'
+
+/**
+ * True iff `candidate` resolves to a location inside (or equal to) `baseDir`.
+ *
+ * Both arguments are resolved to absolute paths first, so relative inputs are
+ * interpreted against the process cwd — pass already-absolute paths (the usual
+ * `path.resolve(baseDir, untrusted)` result) for predictable behavior.
+ */
+export function isPathWithinDir(baseDir: string, candidate: string): boolean {
+  const base = path.resolve(baseDir)
+  const resolved = path.resolve(candidate)
+  const rel = path.relative(base, resolved)
+  if (rel === '') return true // candidate === base
+  // Escapes the base (`..`, `../x`) or is on a different root (absolute).
+  if (rel === '..' || rel.startsWith('..' + path.sep)) return false
+  if (path.isAbsolute(rel)) return false
+  return true
+}
+
+/**
+ * Assert that `candidate` is contained within `baseDir`, returning the resolved
+ * absolute path. Throws an Error (default message `Invalid path`) on escape.
+ *
+ * Use in request handlers that should reject with a 4xx — wrap the throw, or let
+ * it propagate to the route's error boundary, as the call site requires.
+ */
+export function assertPathWithinDir(
+  baseDir: string,
+  candidate: string,
+  message = 'Invalid path',
+): string {
+  if (!isPathWithinDir(baseDir, candidate)) {
+    throw new Error(message)
+  }
+  return path.resolve(candidate)
+}


### PR DESCRIPTION
## Infra PR A — path containment

**Infra-first** foundation for the SUP-202..235 tester batch. Establishes one sanctioned way to check that a `path.resolve(base, untrusted)` result stays inside `base`, then migrates every in-`src` call site to it. Callsite PRs (SUP-203 browser upload, SUP-231 chat deliver_file, etc.) will build on this.

### What this adds
- **`src/shared/lib/utils/path-safety.ts`** — `isPathWithinDir(baseDir, candidate)` (boolean, for loops that `continue`) and `assertPathWithinDir(...)` (throws), both `path.relative`-based. Generalizes the merged **SUP-200** fix.
- **`local-rules/no-path-containment-startswith`** (warn) — custom ESLint rule flagging `.startsWith()` on a `path.resolve`/`path.join` result, both inline and stored-variable forms. Test files are exempt (matching `no-unhandled-throwing-builtins`).

### Why `startsWith` is unsafe
A bare prefix check lets a **sibling** directory sharing the base's string prefix slip through: `'/data/agent-victim/secret'.startsWith('/data/agent')` is `true`. The helper uses `path.relative` instead.

### Sites migrated (the rule surfaced these — most were not in the tester batch)
| File | Notes |
|---|---|
| `agents.ts` ×5 | file download (SUP-200), skill file read/write, **upload + folder-upload guards were the unsafe no-separator form**, artifact screenshot |
| `artifact-service.ts` ×2 | rename/delete containment |
| `mount-service.ts` | `isCloudStoragePath` (non-security "is under dir" classification — helper fits exactly) |
| `public-provider.ts` | skill zip extraction |
| `skillset-service.ts`, `agent-template-service.ts` | zip extraction — **defense-in-depth only**: `validateSkillZip`/`validateEntries` already reject `..`/absolute entries upfront, so these were not independently exploitable (the original triage note missed the upfront validation) |

`chat-integration-manager.ts` deliver_file (**SUP-231**) is intentionally left for its own security PR (needs a reachability repro test); it remains a single `warn` until then.

### Tests / checks
- Exhaustive `path-safety` unit tests incl. the sibling-prefix vector, encoded `../`, absolute escape, base-equality.
- `RuleTester` coverage for the lint rule (inline + stored-var + safe-form all flagged; ordinary `startsWith` not).
- Existing suites stay green: `security-repro` (SUP-200), skillset/agent-template importers, artifact, mount, public-provider.
- `tsc --noEmit` clean; `eslint src` 0 errors.

Status: **waiting for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)