### PR TITLE
refactor(auth): AUTH_MODE ownership helpers (infra for SUP auth-mode batch)

### DIFF
--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -58,6 +58,7 @@ import { connectedAccounts, agentConnectedAccounts, proxyAuditLog, remoteMcpServ
 import { eq, and, inArray, desc, count, like, or } from 'drizzle-orm'
 import { isAuthMode } from '@shared/lib/auth/mode'
 import { getCurrentUserId } from '@shared/lib/auth/config'
+import { ownerScope } from '@shared/lib/auth/ownership'
 import { getProvider } from '@shared/lib/account-providers'
 // getAgentSkills is superseded by getAgentSkillsWithStatus from skillset-service
 // import { getAgentSkills } from '@shared/lib/skills'
@@ -1933,13 +1934,12 @@ agents.post('/:id/sessions/:sessionId/provide-connected-account', AgentUser(), a
     }
 
     // Get the selected accounts (scoped to user in auth mode)
-    const userId = getCurrentUserId(c)
     const accounts = await db
       .select()
       .from(connectedAccounts)
       .where(and(
         inArray(connectedAccounts.id, accountIds),
-        isAuthMode() ? eq(connectedAccounts.userId, userId) : undefined
+        ownerScope(c, connectedAccounts.userId)
       ))
 
     if (accounts.length === 0) {
@@ -2764,13 +2764,12 @@ agents.post('/:id/connected-accounts', AgentUser(), async (c) => {
     }
 
     // Verify ownership of accounts in auth mode
-    const userId = getCurrentUserId(c)
     const ownedAccounts = await db
       .select()
       .from(connectedAccounts)
       .where(and(
         inArray(connectedAccounts.id, accountIds),
-        isAuthMode() ? eq(connectedAccounts.userId, userId) : undefined
+        ownerScope(c, connectedAccounts.userId)
       ))
     const ownedAccountIds = new Set(ownedAccounts.map(a => a.id))
     const validAccountIds = accountIds.filter(id => ownedAccountIds.has(id))

--- a/src/api/routes/connected-accounts.ts
+++ b/src/api/routes/connected-accounts.ts
@@ -11,6 +11,7 @@ import {
 } from '@shared/lib/account-providers'
 import { getAppBaseUrlFromRequest, getCurrentUserId } from '@shared/lib/auth/config'
 import { isAuthMode } from '@shared/lib/auth/mode'
+import { isOwnedByCaller } from '@shared/lib/auth/ownership'
 import { getAccountProviderUserId } from '@shared/lib/config/settings'
 import { Authenticated, OwnsAccount, IsAdmin, Or } from '../middleware/auth'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
@@ -132,7 +133,7 @@ connectedAccountsRouter.post('/initiate', async (c) => {
         .from(connectedAccounts)
         .where(eq(connectedAccounts.id, reconnectAccountId))
         .limit(1)
-      if (!existing || (isAuthMode() && existing.userId !== getCurrentUserId(c))) {
+      if (!existing || !isOwnedByCaller(c, existing)) {
         return c.json({ error: 'Account not found' }, 404)
       }
     }
@@ -251,7 +252,7 @@ connectedAccountsRouter.post('/complete', async (c) => {
 
       // The account must exist and, in auth mode, be owned by the acting user.
       // Otherwise a user could overwrite another user's connection (SUP-198).
-      if (!oldRecord || (isAuthMode() && oldRecord.userId !== getCurrentUserId(c))) {
+      if (!oldRecord || !isOwnedByCaller(c, oldRecord)) {
         return c.json({ error: 'Account not found' }, 404)
       }
 
@@ -376,7 +377,7 @@ connectedAccountsRouter.get('/callback', async (c) => {
 
       // The account must exist and, in auth mode, be owned by the acting user.
       // Otherwise a user could overwrite another user's connection (SUP-198).
-      if (!oldRecord || (isAuthMode() && oldRecord.userId !== getCurrentUserId(c))) {
+      if (!oldRecord || !isOwnedByCaller(c, oldRecord)) {
         return c.html(
           generateCallbackHtml({ success: false, error: 'Account not found' })
         )

--- a/src/shared/lib/auth/ownership.test.ts
+++ b/src/shared/lib/auth/ownership.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Context } from 'hono'
+
+// Mock the two primitives the helpers gate on.
+const { mockIsAuthMode, mockGetCurrentUserId } = vi.hoisted(() => ({
+  mockIsAuthMode: vi.fn<() => boolean>(),
+  mockGetCurrentUserId: vi.fn<(c: Context) => string>(),
+}))
+vi.mock('@shared/lib/auth/mode', () => ({ isAuthMode: mockIsAuthMode }))
+vi.mock('@shared/lib/auth/config', () => ({ getCurrentUserId: mockGetCurrentUserId }))
+
+import { ownerScope, isOwnedByCaller } from './ownership'
+import { connectedAccounts } from '@shared/lib/db/schema'
+
+const c = {} as Context
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ownerScope', () => {
+  it('returns undefined in non-auth mode (no scoping, getCurrentUserId not called)', () => {
+    mockIsAuthMode.mockReturnValue(false)
+    expect(ownerScope(c, connectedAccounts.userId)).toBeUndefined()
+    expect(mockGetCurrentUserId).not.toHaveBeenCalled()
+  })
+
+  it('returns a WHERE fragment scoped to the acting user in auth mode', () => {
+    mockIsAuthMode.mockReturnValue(true)
+    mockGetCurrentUserId.mockReturnValue('user-123')
+    const scope = ownerScope(c, connectedAccounts.userId)
+    expect(scope).toBeDefined()
+    expect(mockGetCurrentUserId).toHaveBeenCalledWith(c)
+  })
+})
+
+describe('isOwnedByCaller', () => {
+  it('is true in non-auth mode regardless of record owner', () => {
+    mockIsAuthMode.mockReturnValue(false)
+    expect(isOwnedByCaller(c, { userId: 'someone-else' })).toBe(true)
+    expect(mockGetCurrentUserId).not.toHaveBeenCalled()
+  })
+
+  it('is true in auth mode when the record belongs to the acting user', () => {
+    mockIsAuthMode.mockReturnValue(true)
+    mockGetCurrentUserId.mockReturnValue('user-123')
+    expect(isOwnedByCaller(c, { userId: 'user-123' })).toBe(true)
+  })
+
+  it('is false in auth mode when the record belongs to another user', () => {
+    mockIsAuthMode.mockReturnValue(true)
+    mockGetCurrentUserId.mockReturnValue('user-123')
+    expect(isOwnedByCaller(c, { userId: 'attacker' })).toBe(false)
+  })
+
+  it('is false in auth mode for a null/undefined record or missing userId', () => {
+    mockIsAuthMode.mockReturnValue(true)
+    mockGetCurrentUserId.mockReturnValue('user-123')
+    expect(isOwnedByCaller(c, null)).toBe(false)
+    expect(isOwnedByCaller(c, undefined)).toBe(false)
+    expect(isOwnedByCaller(c, { userId: null })).toBe(false)
+  })
+})

--- a/src/shared/lib/auth/ownership.ts
+++ b/src/shared/lib/auth/ownership.ts
@@ -1,0 +1,46 @@
+/**
+ * AUTH_MODE ownership helpers.
+ *
+ * Across the API, resource access in multi-user (AUTH_MODE) deployments must be
+ * scoped to the acting user: a list query filters by `userId`, and a handler
+ * that loads a record by a caller-supplied id must reject it if it belongs to
+ * someone else (SUP-198/199). In single-user / Electron mode there is no user
+ * to scope to, so these checks must be no-ops.
+ *
+ * These helpers encapsulate the `isAuthMode() && ... getCurrentUserId(c)`
+ * boilerplate so call sites stay readable:
+ *   - ownerScope(c, col)        → a WHERE fragment, or undefined in non-auth mode
+ *   - isOwnedByCaller(c, record) → boolean (always true in non-auth mode)
+ *
+ * Both are no-ops outside AUTH_MODE.
+ */
+
+import type { Context } from 'hono'
+import { eq, type Column, type SQL } from 'drizzle-orm'
+import { isAuthMode } from './mode'
+import { getCurrentUserId } from './config'
+
+/**
+ * A drizzle WHERE fragment scoping `column` to the acting user — or `undefined`
+ * in non-auth mode. `and()` ignores undefined, so spread it directly:
+ *
+ *   .where(and(inArray(table.id, ids), ownerScope(c, table.userId)))
+ */
+export function ownerScope(c: Context, column: Column): SQL | undefined {
+  if (!isAuthMode()) return undefined
+  return eq(column, getCurrentUserId(c))
+}
+
+/**
+ * True when `record` is owned by the acting user. Always true in non-auth mode.
+ *
+ * The caller owns the existence check, so the canonical guard is:
+ *   if (!record || !isOwnedByCaller(c, record)) return c.json({ error: 'Not found' }, 404)
+ */
+export function isOwnedByCaller(
+  c: Context,
+  record: { userId?: string | null } | null | undefined,
+): boolean {
+  if (!isAuthMode()) return true
+  return !!record && record.userId === getCurrentUserId(c)
+}


### PR DESCRIPTION
## Infra PR B — AUTH_MODE ownership helpers

**Infra-first** foundation for the AUTH_MODE-scoping issues in the SUP-202..235 batch (notably SUP-227 notifications, and the parent/child scoping pattern). Consolidates the repeated `isAuthMode() && … getCurrentUserId(c)` boilerplate behind two helpers, both **no-ops outside auth mode** so call sites stay readable.

### What this adds — `src/shared/lib/auth/ownership.ts`
- **`ownerScope(c, column)`** → a drizzle WHERE fragment scoping `column` to the acting user, or `undefined` in non-auth mode (`and()` drops it). Spread it directly: `.where(and(inArray(t.id, ids), ownerScope(c, t.userId)))`.
- **`isOwnedByCaller(c, record)`** → boolean, always `true` in non-auth mode. Canonical guard: `if (!record || !isOwnedByCaller(c, record)) return c.json({ error: 'Not found' }, 404)`.

### Refactors (proving the helpers against merged, test-covered code)
- **`connected-accounts.ts` (SUP-198)** — the three reconnect ownership guards (`/initiate`, `/complete`, `/callback`) now read `!isOwnedByCaller(c, record)` instead of the inline `isAuthMode() && record.userId !== getCurrentUserId(c)`.
- **`agents.ts` (SUP-199-adjacent)** — the two connected-account ownership-filter ternaries (the pre-existing pattern SUP-199 mirrored) now use `ownerScope(c, connectedAccounts.userId)`, dropping the now-unused local `userId` vars.

SUP-199's remote-MCP guards are intentionally left as explicit `if (isAuthMode())` blocks — that structure *was* the SUP-199 refactor; `ownerScope` targets the `and()`-ternary shape.

### Tests / checks
- `ownership.test.ts`: no-op in non-auth mode (and `getCurrentUserId` not called), scoped in auth mode, foreign/null/missing-userId record rejected.
- `security-repro` (SUP-198/199/200/201) stays green.
- `tsc --noEmit` clean; `eslint` clean on touched files.

Pairs with #213 (path-containment infra). Status: **waiting for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)