### PR TITLE
fix(scheduled-tasks): allow paused recurring tasks to save edited cron schedules (SUP-205)

### DIFF
--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -411,7 +411,7 @@ scheduledTasksRouter.patch('/:taskId/schedule', TaskAgentRole('user'), async (c)
 
     const updated = await updateScheduleExpression(task.id, body.scheduleExpression.trim())
     if (!updated) {
-      return c.json({ error: 'Task not found or not pending' }, 404)
+      return c.json({ error: 'Task not found or not editable' }, 404)
     }
 
     const refreshed = await getScheduledTask(task.id)

--- a/src/shared/lib/services/scheduled-task-service.sup205.test.ts
+++ b/src/shared/lib/services/scheduled-task-service.sup205.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression test for SUP-205 — Paused recurring tasks cannot save edited
+ * cron schedules.
+ *
+ * `updateScheduleExpression()` historically gated on `task.status === 'pending'`,
+ * which rejected paused recurring tasks even though the UI exposes "Edit
+ * Schedule" for paused tasks (and every sibling mutator allows paused). This
+ * test reproduces the bug: a paused cron task must accept a new schedule
+ * expression and remain paused.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import * as schema from '../db/schema'
+
+// We need to set up a test database before importing the service
+let testDir: string
+let testDb: ReturnType<typeof drizzle>
+let testSqlite: InstanceType<typeof Database>
+
+// Mock the db module
+vi.mock('../db', async () => {
+  return {
+    get db() {
+      return testDb
+    },
+    get sqlite() {
+      return testSqlite
+    },
+  }
+})
+
+// Import after mocking
+import {
+  createScheduledTask,
+  getScheduledTask,
+  pauseScheduledTask,
+  cancelScheduledTask,
+  updateScheduleExpression,
+} from './scheduled-task-service'
+
+describe('scheduled-task-service — SUP-205 paused cron schedule edit', () => {
+  beforeEach(() => {
+    // Create a temp directory for the test database
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduled-task-sup205-'))
+
+    // Create an in-memory SQLite database
+    testSqlite = new Database(':memory:')
+    testDb = drizzle(testSqlite, { schema })
+
+    // Run migrations
+    const migrationsFolder = path.join(process.cwd(), 'src/shared/lib/db/migrations')
+    migrate(testDb, { migrationsFolder })
+
+    // Mock timers for predictable dates
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-06-15T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    testSqlite?.close()
+    fs.rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it('updates a paused recurring task without resuming it', async () => {
+    // (1) Create a recurring cron task.
+    const taskId = await createScheduledTask({
+      agentSlug: 'test-agent',
+      scheduleType: 'cron',
+      scheduleExpression: '0 9 * * *',
+      prompt: 'Morning report',
+    })
+
+    // (2) Pause it.
+    const paused = await pauseScheduledTask(taskId)
+    expect(paused).toBe(true)
+    const afterPause = await getScheduledTask(taskId)
+    expect(afterPause!.status).toBe('paused')
+
+    // (3) Edit the cron expression while paused — this is the repro.
+    const updated = await updateScheduleExpression(taskId, '0 18 * * *')
+    expect(updated).toBe(true)
+
+    // (4) Schedule expression updated, task still paused, nextExecutionAt
+    // recomputed to a future date.
+    const afterEdit = await getScheduledTask(taskId)
+    expect(afterEdit!.scheduleExpression).toBe('0 18 * * *')
+    expect(afterEdit!.status).toBe('paused')
+    expect(afterEdit!.nextExecutionAt.getTime()).toBeGreaterThan(Date.now())
+  })
+
+  it('still updates a pending recurring task (regression guard)', async () => {
+    const taskId = await createScheduledTask({
+      agentSlug: 'test-agent',
+      scheduleType: 'cron',
+      scheduleExpression: '0 9 * * *',
+      prompt: 'Morning report',
+    })
+
+    const updated = await updateScheduleExpression(taskId, '0 18 * * *')
+    expect(updated).toBe(true)
+
+    const afterEdit = await getScheduledTask(taskId)
+    expect(afterEdit!.scheduleExpression).toBe('0 18 * * *')
+    expect(afterEdit!.status).toBe('pending')
+  })
+
+  it('rejects schedule edits for cancelled tasks (negative control)', async () => {
+    const taskId = await createScheduledTask({
+      agentSlug: 'test-agent',
+      scheduleType: 'cron',
+      scheduleExpression: '0 9 * * *',
+      prompt: 'Morning report',
+    })
+
+    const cancelled = await cancelScheduledTask(taskId)
+    expect(cancelled).toBe(true)
+
+    const updated = await updateScheduleExpression(taskId, '0 18 * * *')
+    expect(updated).toBe(false)
+
+    const afterEdit = await getScheduledTask(taskId)
+    expect(afterEdit!.scheduleExpression).toBe('0 9 * * *')
+    expect(afterEdit!.status).toBe('cancelled')
+  })
+
+  it('rejects schedule edits for non-cron (one-time) tasks (negative control)', async () => {
+    const taskId = await createScheduledTask({
+      agentSlug: 'test-agent',
+      scheduleType: 'at',
+      scheduleExpression: 'at now + 1 hour',
+      prompt: 'One-time task',
+    })
+
+    const updated = await updateScheduleExpression(taskId, '0 18 * * *')
+    expect(updated).toBe(false)
+  })
+})

--- a/src/shared/lib/services/scheduled-task-service.ts
+++ b/src/shared/lib/services/scheduled-task-service.ts
@@ -390,7 +390,12 @@ export async function updateScheduleExpression(
   scheduleExpression: string
 ): Promise<boolean> {
   const task = await getScheduledTask(taskId)
-  if (!task || task.status !== 'pending' || task.scheduleType !== 'cron') return false
+  if (
+    !task ||
+    (task.status !== 'pending' && task.status !== 'paused') ||
+    task.scheduleType !== 'cron'
+  )
+    return false
 
   const tz = task.timezone || undefined
   const nextExecutionAt = getNextCronTime(scheduleExpression, tz)


### PR DESCRIPTION
## SUP-205 — Paused recurring tasks cannot save edited cron schedules

### Bug
`updateScheduleExpression()` in `src/shared/lib/services/scheduled-task-service.ts` gated on `task.status === 'pending'`, so saving a new cron expression for a **paused** recurring task failed with HTTP 404 `"Task not found or not pending"`. The scheduled-task UI (`scheduled-task-view.tsx`) exposes "Edit Schedule" for paused tasks (`isActive = pending || paused`), and every sibling mutator — `updateTaskPrompt`, `updateTaskRuntimeOptions`, `updateTaskTimezone` — already allows `paused`. `updateScheduleExpression` was the only status-gated mutator omitting it.

### Fix
Broaden the status guard to allow `paused`, mirroring the siblings:

```
if (!task || (task.status !== 'pending' && task.status !== 'paused') || task.scheduleType !== 'cron') return false
```

This is safe: `getDueTasks` dispatches only `status === 'pending'` tasks, and `updateScheduleExpression` writes only `{ scheduleExpression, nextExecutionAt }` (never `status`), so a paused task stays paused; `resumeScheduledTask` recomputes `nextExecutionAt` from the updated expression on resume. Also updated the now-stale route error string at `scheduled-tasks.ts` to `"Task not found or not editable"` for accuracy.

### Tests (failing-now-green regression)
New file `src/shared/lib/services/scheduled-task-service.sup205.test.ts` using the existing in-memory better-sqlite3 + drizzle migrate harness:
- **updates a paused recurring task without resuming it** — the precise repro: pause a cron task, edit the expression, assert it returns `true`, the expression is updated, status is still `paused`, and `nextExecutionAt` is a future date. (Failed before the fix at step 3; passes now.)
- **still updates a pending recurring task** — regression guard.
- **rejects schedule edits for cancelled tasks** — negative control.
- **rejects schedule edits for non-cron (one-time) tasks** — negative control.

### Validation
- New suite: 4/4 pass (the repro failed pre-fix for the right reason: returned `false`).
- Existing `scheduled-task-service.test.ts`: 26/26 pass.
- `npx tsc --noEmit`: clean.
- `npx eslint` on changed files: 0 errors.

### Changed files
- `src/shared/lib/services/scheduled-task-service.ts`
- `src/api/routes/scheduled-tasks.ts`
- `src/shared/lib/services/scheduled-task-service.sup205.test.ts` (new)

Status: waiting for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)