### PR TITLE
fix(chat-integrations): scope session clear/archive to URL integration (SUP-202, SUP-229)

### DIFF
--- a/src/api/routes/chat-integrations.sup229.test.ts
+++ b/src/api/routes/chat-integrations.sup229.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+// ---------------------------------------------------------------------------
+// SUP-229 — Chat integration session clear can archive sessions from another
+// integration (cross-tenant IDOR).
+//
+// `DELETE /api/chat-integrations/:integrationId/sessions/:sessionId` authorizes
+// the caller against :integrationId but loads the session row by sessionId and
+// archives/clears it without verifying `session.integrationId === integrationId`.
+// A user with 'user' role on integration A's agent can archive any session row
+// belonging to a different integration B / agent.
+//
+// Seeded scenario:
+//   integration A (agentSlug 'agent-a')  -> attacker has 'user'
+//   integration B (agentSlug 'agent-b')  -> attacker has NO role
+//   sessionOfB.integrationId === B
+// Request: DELETE /chat-integrations/<A>/sessions/<sessionOfB> must be rejected
+// (404) and must NOT call clearChatSessionById / archiveChatIntegrationSession.
+// ---------------------------------------------------------------------------
+
+const INTEGRATION_A = 'integration-a'
+const INTEGRATION_B = 'integration-b'
+const SESSION_OF_B = 'session-of-b'
+const SESSION_OF_A = 'session-of-a'
+
+const mockAuthUser = { id: 'attacker-user', name: 'Attacker', email: 'attacker@example.com' }
+
+// Auth middleware — faithful passthrough. EntityAgentRole authorizes the URL
+// integration only (attacker has 'user' on agent-a), exactly mirroring how the
+// real middleware scopes auth to :integrationId and never sees the session.
+vi.mock('../middleware/auth', () => ({
+  Authenticated: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
+  AgentUser: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
+  EntityAgentRole: (opts: any) => (_minRole: string) => async (c: any, next: () => Promise<void>) => {
+    const id = c.req.param(opts.paramName)
+    const entity = await opts.lookupFn(id)
+    if (!entity) return c.json({ error: `${opts.entityName} not found` }, 404)
+    c.set(opts.contextKey, entity)
+    c.set('user', mockAuthUser)
+    return next()
+  },
+}))
+
+// Two integrations: A (agent-a) and B (agent-b).
+const integrations: Record<string, { id: string; agentSlug: string }> = {
+  [INTEGRATION_A]: { id: INTEGRATION_A, agentSlug: 'agent-a' },
+  [INTEGRATION_B]: { id: INTEGRATION_B, agentSlug: 'agent-b' },
+}
+const mockGetChatIntegration = vi.fn(async (id: string) => integrations[id] ?? null)
+
+vi.mock('@shared/lib/services/chat-integration-service', () => ({
+  getChatIntegration: (id: string) => mockGetChatIntegration(id),
+  createChatIntegration: vi.fn(),
+  updateChatIntegration: vi.fn(),
+  updateChatIntegrationStatus: vi.fn(),
+  deleteChatIntegration: vi.fn(),
+  DuplicateBotTokenError: class DuplicateBotTokenError extends Error {},
+}))
+
+const mockGetChatIntegrationSessionById = vi.fn()
+const mockArchiveChatIntegrationSession = vi.fn()
+
+vi.mock('@shared/lib/services/chat-integration-session-service', () => ({
+  getChatIntegrationSessionById: (id: string) => mockGetChatIntegrationSessionById(id),
+  archiveChatIntegrationSession: (id: string) => mockArchiveChatIntegrationSession(id),
+  listChatIntegrationSessions: vi.fn(() => []),
+  deleteChatIntegrationSessionsByIntegration: vi.fn(),
+}))
+
+const mockClearChatSessionById = vi.fn()
+vi.mock('@shared/lib/chat-integrations/chat-integration-manager', () => ({
+  chatIntegrationManager: {
+    clearChatSessionById: (id: string) => mockClearChatSessionById(id),
+    isIntegrationConnected: vi.fn(() => false),
+    addIntegration: vi.fn(),
+    removeIntegration: vi.fn(),
+    pauseIntegration: vi.fn(),
+    resumeIntegration: vi.fn(),
+  },
+}))
+
+vi.mock('@shared/lib/chat-integrations/config-schema', () => ({
+  validateChatIntegrationConfig: vi.fn(),
+  CHAT_PROVIDERS: ['telegram', 'slack', 'imessage'],
+  IMESSAGE_GATEWAY_URL: 'https://imessage.example.com',
+  imessageSetupSchema: { safeParse: () => ({ success: true, data: {} }) },
+}))
+
+vi.mock('@shared/lib/auth/config', () => ({
+  getCurrentUserId: () => mockAuthUser.id,
+}))
+
+vi.mock('@shared/lib/services/audit-log-service', () => ({
+  logAuditEvent: vi.fn(),
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+}))
+
+import chatIntegrationsRouter from './chat-integrations'
+
+function app() {
+  const a = new Hono()
+  a.route('/api/chat-integrations', chatIntegrationsRouter)
+  return a
+}
+
+describe('SUP-229: chat session clear must not archive sessions from another integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetChatIntegration.mockImplementation(async (id: string) => integrations[id] ?? null)
+  })
+
+  it('rejects clearing a chat session that belongs to a different integration', async () => {
+    // Session row belongs to integration B; the request authorizes A.
+    mockGetChatIntegrationSessionById.mockReturnValue({
+      id: SESSION_OF_B,
+      integrationId: INTEGRATION_B,
+      sessionId: 'b-agent-session',
+      archivedAt: null,
+    })
+
+    const res = await app().request(
+      `http://localhost/api/chat-integrations/${INTEGRATION_A}/sessions/${SESSION_OF_B}`,
+      { method: 'DELETE' },
+    )
+
+    expect(res.status).toBe(404)
+    expect(mockClearChatSessionById).not.toHaveBeenCalled()
+    expect(mockArchiveChatIntegrationSession).not.toHaveBeenCalled()
+  })
+
+  it('clears a chat session that belongs to the authorized integration', async () => {
+    mockGetChatIntegrationSessionById.mockReturnValue({
+      id: SESSION_OF_A,
+      integrationId: INTEGRATION_A,
+      sessionId: 'a-agent-session',
+      archivedAt: null,
+    })
+
+    const res = await app().request(
+      `http://localhost/api/chat-integrations/${INTEGRATION_A}/sessions/${SESSION_OF_A}`,
+      { method: 'DELETE' },
+    )
+
+    expect(res.status).toBe(200)
+    expect(mockClearChatSessionById).toHaveBeenCalledWith(SESSION_OF_A)
+    expect(mockArchiveChatIntegrationSession).toHaveBeenCalledWith(SESSION_OF_A)
+  })
+})

--- a/src/api/routes/chat-integrations.ts
+++ b/src/api/routes/chat-integrations.ts
@@ -370,9 +370,16 @@ chatIntegrationsRouter.get('/:integrationId/sessions', IntegrationAgentRole('vie
 // DELETE /api/chat-integrations/:integrationId/sessions/:sessionId - Clear a chat session
 chatIntegrationsRouter.delete('/:integrationId/sessions/:sessionId', IntegrationAgentRole('user'), async (c) => {
   try {
+    const integrationId = c.req.param('integrationId')
     const sessionId = c.req.param('sessionId')
     const session = getChatIntegrationSessionById(sessionId)
-    if (!session) {
+    // Scope the session to the authorized integration. `IntegrationAgentRole`
+    // only authorizes :integrationId; the session is loaded by primary key, so
+    // we must verify it belongs to that integration before mutating it.
+    // Otherwise a user with access to one integration could clear/archive a
+    // session belonging to another integration/agent (BOLA — SUP-202/SUP-229).
+    // Return 404 (not 403) so foreign session IDs are not enumerable.
+    if (!session || session.integrationId !== integrationId) {
       return c.json({ error: 'Session not found' }, 404)
     }
     // Notify the manager to clean up SSE subscriptions

--- a/src/api/routes/chat-session-scope.sup202.test.ts
+++ b/src/api/routes/chat-session-scope.sup202.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+// ---------------------------------------------------------------------------
+// SUP-202 — Chat session clear/archive must be scoped to the URL integrationId.
+//
+// `DELETE /api/chat-integrations/:integrationId/sessions/:sessionId` authorizes
+// the caller against :integrationId (via IntegrationAgentRole), but the handler
+// loads the session purely by primary-key sessionId and clears/archives it
+// without verifying `session.integrationId === integrationId`. A user with
+// 'user' access to one integration can therefore clear/archive a session that
+// belongs to a DIFFERENT integration (and another agent) by knowing its row id
+// (BOLA / cross-tenant IDOR).
+//
+// We mount the REAL chatIntegrationsRouter with the auth middleware reduced to a
+// faithful passthrough (the URL integration IS one the attacker can access, so
+// authorization legitimately succeeds), and spy on the session-service /
+// manager mutators to assert they never fire for a foreign session.
+// ---------------------------------------------------------------------------
+
+const ATTACKER_INTEGRATION_ID = 'attacker-integration-id'
+const VICTIM_INTEGRATION_ID = 'victim-integration-id'
+const VICTIM_SESSION_ROW_ID = 'victim-session'
+
+const mockAuthUser = { id: 'attacker-user', name: 'Attacker', email: 'attacker@example.com' }
+
+// Auth middleware — faithful passthrough. EntityAgentRole loads the integration
+// named by the URL param (so authorization is scoped to :integrationId, exactly
+// like production) and proceeds; in this repro the attacker holds 'user' on that
+// integration's agent, so the real role check would pass anyway.
+vi.mock('../middleware/auth', () => ({
+  Authenticated: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
+  AgentUser: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
+  EntityAgentRole: (opts: any) => (_minRole: string) => async (c: any, next: () => Promise<void>) => {
+    const id = c.req.param(opts.paramName)
+    const entity = await opts.lookupFn(id)
+    if (!entity) return c.json({ error: `${opts.entityName} not found` }, 404)
+    c.set(opts.contextKey, entity)
+    c.set('user', mockAuthUser)
+    return next()
+  },
+}))
+
+// getChatIntegration resolves only the attacker's own integration — the auth
+// layer never sees the victim integration or session.
+const mockGetChatIntegration = vi.fn(async (id: string) =>
+  id === ATTACKER_INTEGRATION_ID ? { id: ATTACKER_INTEGRATION_ID, agentSlug: 'attacker-agent' } : null,
+)
+
+vi.mock('@shared/lib/services/chat-integration-service', () => ({
+  getChatIntegration: (id: string) => mockGetChatIntegration(id),
+  createChatIntegration: vi.fn(),
+  updateChatIntegration: vi.fn(),
+  updateChatIntegrationStatus: vi.fn(),
+  deleteChatIntegration: vi.fn(),
+  DuplicateBotTokenError: class DuplicateBotTokenError extends Error {},
+}))
+
+// Session service — getChatIntegrationSessionById is an UNSCOPED `WHERE id = ?`
+// lookup, so it returns the victim session row (which carries integrationId).
+const mockGetChatIntegrationSessionById = vi.fn()
+const mockArchiveChatIntegrationSession = vi.fn()
+
+vi.mock('@shared/lib/services/chat-integration-session-service', () => ({
+  getChatIntegrationSessionById: (id: string) => mockGetChatIntegrationSessionById(id),
+  archiveChatIntegrationSession: (id: string) => mockArchiveChatIntegrationSession(id),
+  listChatIntegrationSessions: vi.fn(() => []),
+  deleteChatIntegrationSessionsByIntegration: vi.fn(),
+}))
+
+const mockClearChatSessionById = vi.fn()
+vi.mock('@shared/lib/chat-integrations/chat-integration-manager', () => ({
+  chatIntegrationManager: {
+    clearChatSessionById: (id: string) => mockClearChatSessionById(id),
+    isIntegrationConnected: vi.fn(() => false),
+    addIntegration: vi.fn(),
+    removeIntegration: vi.fn(),
+    pauseIntegration: vi.fn(),
+    resumeIntegration: vi.fn(),
+  },
+}))
+
+vi.mock('@shared/lib/chat-integrations/config-schema', () => ({
+  validateChatIntegrationConfig: vi.fn(),
+  CHAT_PROVIDERS: ['telegram', 'slack', 'imessage'],
+  IMESSAGE_GATEWAY_URL: 'https://imessage.example.com',
+  imessageSetupSchema: { safeParse: () => ({ success: true, data: {} }) },
+}))
+
+vi.mock('@shared/lib/auth/config', () => ({
+  getCurrentUserId: () => mockAuthUser.id,
+}))
+
+vi.mock('@shared/lib/services/audit-log-service', () => ({
+  logAuditEvent: vi.fn(),
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+}))
+
+// Import the router after all mocks are registered.
+import chatIntegrationsRouter from './chat-integrations'
+
+function app() {
+  const a = new Hono()
+  a.route('/api/chat-integrations', chatIntegrationsRouter)
+  return a
+}
+
+describe('SUP-202: chat session clear/archive must be scoped to the URL integration (BOLA)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetChatIntegration.mockImplementation(async (id: string) =>
+      id === ATTACKER_INTEGRATION_ID ? { id: ATTACKER_INTEGRATION_ID, agentSlug: 'attacker-agent' } : null,
+    )
+  })
+
+  it('rejects clearing a chat session that belongs to a different integration', async () => {
+    // Victim session row belongs to a different integration entirely.
+    mockGetChatIntegrationSessionById.mockReturnValue({
+      id: VICTIM_SESSION_ROW_ID,
+      integrationId: VICTIM_INTEGRATION_ID,
+      sessionId: 'victim-agent-session',
+      archivedAt: null,
+    })
+
+    const res = await app().request(
+      `http://localhost/api/chat-integrations/${ATTACKER_INTEGRATION_ID}/sessions/${VICTIM_SESSION_ROW_ID}`,
+      { method: 'DELETE' },
+    )
+
+    expect(res.status).toBe(404)
+    expect(mockClearChatSessionById).not.toHaveBeenCalled()
+    expect(mockArchiveChatIntegrationSession).not.toHaveBeenCalled()
+  })
+
+  it('still clears a chat session that belongs to the authorized integration', async () => {
+    // Legit session — its integrationId matches the URL param.
+    mockGetChatIntegrationSessionById.mockReturnValue({
+      id: 'own-session',
+      integrationId: ATTACKER_INTEGRATION_ID,
+      sessionId: 'own-agent-session',
+      archivedAt: null,
+    })
+
+    const res = await app().request(
+      `http://localhost/api/chat-integrations/${ATTACKER_INTEGRATION_ID}/sessions/own-session`,
+      { method: 'DELETE' },
+    )
+
+    expect(res.status).toBe(200)
+    expect(mockClearChatSessionById).toHaveBeenCalledWith('own-session')
+    expect(mockArchiveChatIntegrationSession).toHaveBeenCalledWith('own-session')
+  })
+
+  it('returns 404 without mutating when the session does not exist', async () => {
+    mockGetChatIntegrationSessionById.mockReturnValue(null)
+
+    const res = await app().request(
+      `http://localhost/api/chat-integrations/${ATTACKER_INTEGRATION_ID}/sessions/missing-session`,
+      { method: 'DELETE' },
+    )
+
+    expect(res.status).toBe(404)
+    expect(mockClearChatSessionById).not.toHaveBeenCalled()
+    expect(mockArchiveChatIntegrationSession).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes **SUP-202** and **SUP-229** — both describe the same cross-tenant IDOR/BOLA in the chat-integration session-clear route.

`DELETE /api/chat-integrations/:integrationId/sessions/:sessionId` authorizes the caller against the URL `:integrationId` (via the `IntegrationAgentRole('user')` middleware, which only loads `getChatIntegration(integrationId)` and checks the role on *that* integration's agent). The handler then loads the session purely by its primary-key `sessionId` (`getChatIntegrationSessionById` is an unscoped `WHERE id = ?` lookup) and runs `chatIntegrationManager.clearChatSessionById(sessionId)` + `archiveChatIntegrationSession(sessionId)` **without** verifying `session.integrationId === integrationId`.

### Impact
In `AUTH_MODE`, a user with `user` access to one integration could clear/archive any session row belonging to a different integration (and another agent) by knowing/guessing its row id. The discriminator (`integrationId`) was present on the loaded row but unused.

## Fix
- **SUP-202 / SUP-229** (`src/api/routes/chat-integrations.ts`): after loading the session and before any mutation, verify ownership: `if (!session || session.integrationId !== integrationId) return c.json({ error: 'Session not found' }, 404)`. Returns **404** (not 403) so foreign session IDs are not enumerable. The guard sits before both `clearChatSessionById` and `archiveChatIntegrationSession`. The sibling list route was already naturally scoped via `listChatIntegrationSessions(integrationId)`.

## Tests (failing-before, green-after regression)
- `src/api/routes/chat-session-scope.sup202.test.ts` — mounts the real router with passthrough auth; the negative test (foreign session) asserted 200 + both mutators firing **before** the fix and now asserts 404 with neither mutator called; positive control (same-integration session) returns 200 and calls both mutators; plus a missing-session 404 case.
- `src/api/routes/chat-integrations.sup229.test.ts` — seeds integration A (agent-a) + B (agent-b); DELETE of a B-owned session via A's URL is rejected 404 with no mutation; positive control of an A-owned session returns 200 and archives.

All new tests pass; the existing `src/api/routes/security-repro.test.ts` (SUP-198/199/200/201) suite still passes. `tsc --noEmit` and `eslint` on the changed files are clean.

## Changed files
- `src/api/routes/chat-integrations.ts`
- `src/api/routes/chat-session-scope.sup202.test.ts` (new)
- `src/api/routes/chat-integrations.sup229.test.ts` (new)

Status: waiting for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)