### PR TITLE
fix(container): prevent custom env vars from overriding reserved runtime vars (SUP-210)

### DIFF
--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -593,6 +593,28 @@ describe('settings route', () => {
       expect(saved.customEnvVars).toEqual({ NEW_VAR: 'value' })
     })
 
+    // SUP-210: reject customEnvVars that try to override reserved runtime vars.
+    it('rejects customEnvVars containing a reserved runtime key (400)', async () => {
+      const res = await putSettings({
+        customEnvVars: { PROXY_TOKEN: 'attacker', MY_OK: 'fine' },
+      })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toContain('PROXY_TOKEN')
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it('accepts customEnvVars with only non-reserved keys (200)', async () => {
+      const res = await putSettings({
+        customEnvVars: { MY_OK: 'fine', ANOTHER: 'x' },
+      })
+
+      expect(res.status).toBe(200)
+      const saved = mockUpdateSettings.mock.calls[0][0]
+      expect(saved.customEnvVars).toEqual({ MY_OK: 'fine', ANOTHER: 'x' })
+    })
+
     it('merges auth settings with existing', async () => {
       const res = await putSettings({
         auth: { signupMode: 'closed' as const },

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -30,6 +30,7 @@ import { getSttProvider } from '@shared/lib/stt'
 import { containerManager } from '@shared/lib/container/container-manager'
 import { checkAllRunnersAvailability, refreshRunnerAvailability, startRunner, restartRunner, SUPPORTED_RUNNERS, type ContainerRunner } from '@shared/lib/container/client-factory'
 import { VALID_LIMA_VM_MEMORY_OPTIONS, EFFORT_LEVELS } from '@shared/lib/container/types'
+import { customEnvVarsSchema } from '@shared/lib/container/reserved-env-vars'
 import { detectAllProviders } from '../../main/host-browser'
 import { revokePlatformToken } from '@shared/lib/services/platform-auth-service'
 import { db } from '@shared/lib/db'
@@ -160,6 +161,16 @@ settings.put('/', async (c) => {
       const limaSettings = body.container.runtimeSettings.lima
       if (limaSettings?.vmMemory && !VALID_LIMA_VM_MEMORY_OPTIONS.includes(limaSettings.vmMemory)) {
         return c.json({ error: `Invalid VM memory setting. Must be one of: ${VALID_LIMA_VM_MEMORY_OPTIONS.join(', ')}` }, 400)
+      }
+    }
+
+    // Validate customEnvVars at the write boundary (defense-in-depth for
+    // SUP-210): reject payloads that try to set reserved runtime env vars so
+    // they never reach persisted settings.
+    if (body.customEnvVars !== undefined) {
+      const parsed = customEnvVarsSchema.safeParse(body.customEnvVars)
+      if (!parsed.success) {
+        return c.json({ error: parsed.error.issues[0]?.message ?? 'Invalid customEnvVars' }, 400)
       }
     }
 

--- a/src/shared/lib/container/container-manager.reserved-env.sup210.test.ts
+++ b/src/shared/lib/container/container-manager.reserved-env.sup210.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ============================================================================
+// SUP-210 — Custom env vars must not override reserved agent runtime env vars
+//
+// Standalone harness (separate from container-manager.test.ts) so it can mock
+// getSettings to return `customEnvVars` containing reserved keys. The shared
+// test file's getSettings mock returns app:{} with no customEnvVars hook.
+// ============================================================================
+
+const mockStart = vi.fn()
+const mockStop = vi.fn()
+const mockStopSync = vi.fn()
+const mockGetInfoFromRuntime = vi.fn()
+const mockGetStats = vi.fn()
+const mockIsHealthy = vi.fn()
+const mockBuildVolumeFlag = vi.fn(
+  (hostPath: string, containerPath: string) => `"${hostPath}:${containerPath}"`
+)
+
+vi.mock('./client-factory', () => ({
+  createContainerClient: () => ({
+    start: mockStart,
+    stop: mockStop,
+    stopSync: mockStopSync,
+    getInfoFromRuntime: mockGetInfoFromRuntime,
+    getStats: mockGetStats,
+    isHealthy: (...args: unknown[]) => mockIsHealthy(...args),
+    fetch: vi.fn(),
+    buildVolumeFlag: (...args: unknown[]) => mockBuildVolumeFlag(...(args as [string, string])),
+  }),
+  checkAllRunnersAvailability: vi.fn().mockResolvedValue([]),
+  checkImageExists: vi.fn().mockResolvedValue(true),
+  pullImage: vi.fn(),
+  canBuildImage: vi.fn().mockReturnValue(false),
+  buildImage: vi.fn(),
+  startRunner: vi.fn(),
+  refreshRunnerAvailability: vi.fn(),
+  clearRunnerAvailabilityCache: vi.fn(),
+  getRunnerDisplayName: (runner: string) => runner,
+  reconcileRunnerState: vi.fn().mockResolvedValue(false),
+}))
+
+const mockGetOrCreateProxyToken = vi.fn()
+vi.mock('@shared/lib/proxy/token-store', () => ({
+  getOrCreateProxyToken: (...args: unknown[]) => mockGetOrCreateProxyToken(...args),
+}))
+
+const mockGetContainerHostUrl = vi.fn()
+const mockGetAppPort = vi.fn()
+vi.mock('@shared/lib/proxy/host-url', () => ({
+  getContainerHostUrl: () => mockGetContainerHostUrl(),
+  getAppPort: () => mockGetAppPort(),
+}))
+
+const mockDbWhere = vi.fn()
+const mockDbInnerJoin = vi.fn()
+const mockMcpWhere = vi.fn()
+const mockMcpInnerJoin = vi.fn()
+
+vi.mock('@shared/lib/db', () => ({
+  db: {
+    select: () => ({
+      from: vi.fn().mockImplementation((table: unknown) => {
+        if (table === 'agent_connected_accounts_table') {
+          return { innerJoin: mockDbInnerJoin }
+        }
+        if (table === 'agent_remote_mcps_table') {
+          return { innerJoin: mockMcpInnerJoin }
+        }
+        return { innerJoin: mockDbInnerJoin }
+      }),
+    }),
+  },
+}))
+
+vi.mock('@shared/lib/db/schema', () => ({
+  connectedAccounts: {
+    id: 'id',
+    toolkitSlug: 'toolkit_slug',
+    providerConnectionId: 'provider_connection_id',
+    providerName: 'provider_name',
+    status: 'status',
+    displayName: 'display_name',
+  },
+  agentConnectedAccounts: 'agent_connected_accounts_table',
+  agentRemoteMcps: 'agent_remote_mcps_table',
+  remoteMcpServers: 'remote_mcp_servers_table',
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq: (col: string, val: string) => ({ col, val }),
+}))
+
+// The reserved-env repro: settings provide customEnvVars that try to clobber
+// reserved runtime keys plus one benign key that should pass through.
+const mockGetSettings = vi.fn()
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => mockGetSettings(),
+  updateSettings: vi.fn(),
+}))
+
+vi.mock('@shared/lib/config/data-dir', () => ({
+  getAgentWorkspaceDir: (id: string) => `/workspace/${id}`,
+}))
+
+vi.mock('./message-persister', () => ({
+  messagePersister: {
+    broadcastGlobal: vi.fn(),
+    setStopContainerCallback: vi.fn(),
+    markAllSessionsInactiveForAgent: vi.fn(),
+  },
+}))
+
+vi.mock('./health-monitor', () => ({
+  healthMonitor: { checkAll: vi.fn().mockReturnValue([]) },
+}))
+
+vi.mock('@shared/lib/browser/chrome-profile', () => ({
+  copyChromeProfileData: vi.fn().mockReturnValue(false),
+}))
+
+vi.mock('@shared/lib/services/agent-service', () => ({}))
+
+vi.mock('node:fs/promises', () => ({
+  statfs: vi.fn(),
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addErrorBreadcrumb: vi.fn(),
+}))
+
+vi.mock('@shared/lib/composio/client', () => ({
+  isPlatformComposioActive: () => false,
+}))
+
+vi.mock('@shared/lib/services/timezone-resolver', () => ({
+  resolveTimezoneForAgent: () => 'America/New_York',
+}))
+
+const mockGetMountsWithHealth = vi.fn()
+vi.mock('@shared/lib/services/mount-service', () => ({
+  getMountsWithHealth: (...args: unknown[]) => mockGetMountsWithHealth(...args),
+}))
+
+import { containerManager } from './container-manager'
+
+describe('SUP-210 — customEnvVars cannot override reserved runtime env vars', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    containerManager.removeClient('test-agent')
+
+    mockGetOrCreateProxyToken.mockResolvedValue('real-proxy-token')
+    mockGetContainerHostUrl.mockReturnValue('192.168.1.100')
+    mockGetAppPort.mockReturnValue(3000)
+    mockGetMountsWithHealth.mockReturnValue([])
+
+    containerManager.updateCachedStatus('test-agent', 'stopped', null)
+    mockStart.mockResolvedValue(undefined)
+    mockGetInfoFromRuntime.mockResolvedValue({ status: 'running', port: 8080 })
+
+    // No connected accounts / MCPs by default
+    mockDbInnerJoin.mockReturnValue({ where: mockDbWhere })
+    mockDbWhere.mockResolvedValue([])
+    mockMcpInnerJoin.mockReturnValue({ where: mockMcpWhere })
+    mockMcpWhere.mockResolvedValue([])
+
+    // Settings include customEnvVars that try to clobber reserved keys, plus a
+    // benign custom var that should pass through untouched.
+    mockGetSettings.mockReturnValue({
+      container: { agentImage: 'test-image', containerRunner: 'docker' },
+      app: {},
+      customEnvVars: {
+        PROXY_TOKEN: 'attacker-token',
+        PROXY_BASE_URL: 'http://evil.example/api/proxy/spoofed',
+        SUPERAGENT_AGENT_SLUG: 'not-the-real-agent',
+        SUPERAGENT_HOST_API_URL: 'http://evil.example/api',
+        CONNECTED_ACCOUNTS: '{"gmail":[{"name":"spoof","id":"x"}]}',
+        TZ: 'Antarctica/Troll',
+        HOST_PLATFORM: 'spoofed-os',
+        CLAUDE_CODE_ATTRIBUTION_HEADER: '1',
+        MY_CUSTOM: 'foo',
+      },
+    })
+  })
+
+  it('keeps PROXY_TOKEN from getOrCreateProxyToken, not the custom override', async () => {
+    await containerManager.ensureRunning('test-agent')
+
+    expect(mockStart).toHaveBeenCalledOnce()
+    const envVars = mockStart.mock.calls[0][0].envVars
+    expect(envVars.PROXY_TOKEN).toBe('real-proxy-token')
+  })
+
+  it('keeps computed PROXY_BASE_URL / SUPERAGENT_* / CONNECTED_ACCOUNTS', async () => {
+    await containerManager.ensureRunning('test-agent')
+
+    const envVars = mockStart.mock.calls[0][0].envVars
+    expect(envVars.PROXY_BASE_URL).toBe('http://192.168.1.100:3000/api/proxy/test-agent')
+    expect(envVars.SUPERAGENT_AGENT_SLUG).toBe('test-agent')
+    expect(envVars.SUPERAGENT_HOST_API_URL).toBe('http://192.168.1.100:3000/api')
+    // No active accounts -> empty object, not the spoofed metadata.
+    expect(envVars.CONNECTED_ACCOUNTS).toBe('{}')
+  })
+
+  it('keeps computed TZ / HOST_PLATFORM / CLAUDE_CODE_ATTRIBUTION_HEADER', async () => {
+    await containerManager.ensureRunning('test-agent')
+
+    const envVars = mockStart.mock.calls[0][0].envVars
+    expect(envVars.TZ).toBe('America/New_York')
+    expect(envVars.HOST_PLATFORM).toBe(process.platform)
+    expect(envVars.CLAUDE_CODE_ATTRIBUTION_HEADER).toBe('0')
+  })
+
+  it('still passes non-reserved custom env vars through unchanged', async () => {
+    await containerManager.ensureRunning('test-agent')
+
+    const envVars = mockStart.mock.calls[0][0].envVars
+    expect(envVars.MY_CUSTOM).toBe('foo')
+  })
+})

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -20,6 +20,7 @@ import { captureException, captureMessage, addErrorBreadcrumb } from '@shared/li
 import { resolveTimezoneForAgent } from '@shared/lib/services/timezone-resolver'
 import { getMountsWithHealth } from '@shared/lib/services/mount-service'
 import { isPlatformComposioActive } from '@shared/lib/composio/client'
+import { mergeCustomEnvVars } from './reserved-env-vars'
 
 /** Interval for syncing container status with reality (in ms). Default: 300 seconds */
 const STATUS_SYNC_INTERVAL_MS = parseInt(
@@ -608,10 +609,11 @@ class ContainerManager {
         envVars['COMPOSIO_PLATFORM_MODE'] = 'true'
       }
 
-      // Inject user-defined custom env vars (set in global settings)
-      if (settings.customEnvVars) {
-        Object.assign(envVars, settings.customEnvVars)
-      }
+      // Inject user-defined custom env vars (set in global settings). Reserved
+      // runtime keys are skipped so custom config can never clobber required
+      // wiring (proxy auth, agent identity, connected accounts, etc.). See
+      // SUP-210 / reserved-env-vars.ts.
+      mergeCustomEnvVars(envVars, settings.customEnvVars)
 
       envVars['CLAUDE_CODE_ATTRIBUTION_HEADER'] = '0'
 

--- a/src/shared/lib/container/reserved-env-vars.test.ts
+++ b/src/shared/lib/container/reserved-env-vars.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  RESERVED_ENV_VAR_KEYS,
+  isReservedEnvVar,
+  mergeCustomEnvVars,
+  findReservedEnvVarKeys,
+  customEnvVarsSchema,
+} from './reserved-env-vars'
+
+describe('reserved-env-vars', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reserves the full set of runtime keys', () => {
+    for (const key of [
+      'PROXY_BASE_URL',
+      'PROXY_TOKEN',
+      'SUPERAGENT_HOST_API_URL',
+      'SUPERAGENT_AGENT_SLUG',
+      'CONNECTED_ACCOUNTS',
+      'REMOTE_MCPS',
+      'AGENT_BROWSER_USE_HOST',
+      'HOST_APP_URL',
+      'AGENT_ID',
+      'TZ',
+      'HOST_PLATFORM',
+      'COMPOSIO_PLATFORM_MODE',
+      'CLAUDE_CODE_ATTRIBUTION_HEADER',
+    ]) {
+      expect(RESERVED_ENV_VAR_KEYS.has(key)).toBe(true)
+      expect(isReservedEnvVar(key)).toBe(true)
+    }
+    expect(isReservedEnvVar('MY_CUSTOM')).toBe(false)
+  })
+
+  describe('mergeCustomEnvVars', () => {
+    it('skips reserved keys and warns, but passes non-reserved through', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const target: Record<string, string> = { PROXY_TOKEN: 'real', TZ: 'America/New_York' }
+
+      const result = mergeCustomEnvVars(target, {
+        PROXY_TOKEN: 'attacker',
+        TZ: 'Antarctica/Troll',
+        MY_CUSTOM: 'foo',
+      })
+
+      expect(result).toBe(target) // mutates + returns the same object
+      expect(target.PROXY_TOKEN).toBe('real')
+      expect(target.TZ).toBe('America/New_York')
+      expect(target.MY_CUSTOM).toBe('foo')
+      expect(warn).toHaveBeenCalled()
+    })
+
+    it('is a no-op when customEnvVars is undefined', () => {
+      const target = { A: '1' }
+      expect(mergeCustomEnvVars(target, undefined)).toEqual({ A: '1' })
+    })
+  })
+
+  describe('findReservedEnvVarKeys', () => {
+    it('returns only the reserved keys present', () => {
+      expect(
+        findReservedEnvVarKeys({ PROXY_TOKEN: 'x', AGENT_ID: 'y', SAFE: 'z' }).sort()
+      ).toEqual(['AGENT_ID', 'PROXY_TOKEN'])
+      expect(findReservedEnvVarKeys({ SAFE: 'z' })).toEqual([])
+      expect(findReservedEnvVarKeys(undefined)).toEqual([])
+    })
+  })
+
+  describe('customEnvVarsSchema', () => {
+    it('accepts a map of only non-reserved string vars', () => {
+      expect(customEnvVarsSchema.safeParse({ A: '1', B: '2' }).success).toBe(true)
+    })
+
+    it('rejects a map containing any reserved key', () => {
+      const parsed = customEnvVarsSchema.safeParse({ A: '1', PROXY_BASE_URL: 'http://evil' })
+      expect(parsed.success).toBe(false)
+      if (!parsed.success) {
+        expect(parsed.error.issues[0].message).toContain('PROXY_BASE_URL')
+      }
+    })
+
+    it('rejects non-string values', () => {
+      expect(customEnvVarsSchema.safeParse({ A: 1 }).success).toBe(false)
+    })
+  })
+})

--- a/src/shared/lib/container/reserved-env-vars.ts
+++ b/src/shared/lib/container/reserved-env-vars.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod'
+
+/**
+ * Reserved environment variable keys that ContainerManager.doStartContainer()
+ * computes and injects into the agent container to wire up required runtime
+ * behaviour (proxy auth, agent identity, connected accounts, remote MCPs, host
+ * browser, timezone, platform flags, attribution header).
+ *
+ * User-defined `customEnvVars` from global settings must never clobber these,
+ * or they could break proxy authentication, point the agent at the wrong proxy
+ * URL, misidentify the agent slug, or spoof connected-account metadata.
+ *
+ * Keys are reserved UNCONDITIONALLY — even ones only set on some code paths
+ * (e.g. REMOTE_MCPS or the host-browser vars) — so a custom config can never
+ * spoof them by exploiting a branch where the runtime did not set them.
+ */
+export const RESERVED_ENV_VAR_KEYS: ReadonlySet<string> = new Set([
+  // Proxy authentication
+  'PROXY_BASE_URL',
+  'PROXY_TOKEN',
+  // Cross-agent / host API wiring
+  'SUPERAGENT_HOST_API_URL',
+  'SUPERAGENT_AGENT_SLUG',
+  // Account + MCP metadata
+  'CONNECTED_ACCOUNTS',
+  'REMOTE_MCPS',
+  // Host browser
+  'AGENT_BROWSER_USE_HOST',
+  'HOST_APP_URL',
+  'AGENT_ID',
+  // Runtime environment
+  'TZ',
+  'HOST_PLATFORM',
+  'COMPOSIO_PLATFORM_MODE',
+  'CLAUDE_CODE_ATTRIBUTION_HEADER',
+])
+
+/** True when `key` is a reserved runtime env var that custom config must not override. */
+export function isReservedEnvVar(key: string): boolean {
+  return RESERVED_ENV_VAR_KEYS.has(key)
+}
+
+/**
+ * Merge user-defined custom env vars into the computed runtime env map without
+ * letting them override reserved keys. Reserved keys are skipped (with a
+ * console.warn) so the required runtime wiring always wins; non-reserved keys
+ * pass through unchanged. Mutates and returns `target`.
+ */
+export function mergeCustomEnvVars(
+  target: Record<string, string>,
+  customEnvVars: Record<string, string> | undefined,
+): Record<string, string> {
+  if (!customEnvVars) return target
+  for (const [key, value] of Object.entries(customEnvVars)) {
+    if (isReservedEnvVar(key)) {
+      console.warn(
+        `[ContainerManager] Ignoring custom env var "${key}": it is a reserved runtime variable and cannot be overridden.`
+      )
+      continue
+    }
+    target[key] = value
+  }
+  return target
+}
+
+/**
+ * Return the subset of `customEnvVars` keys that collide with reserved runtime
+ * variables. Used at the settings write boundary to reject/strip reserved keys.
+ */
+export function findReservedEnvVarKeys(
+  customEnvVars: Record<string, string> | undefined,
+): string[] {
+  if (!customEnvVars) return []
+  return Object.keys(customEnvVars).filter(isReservedEnvVar)
+}
+
+/**
+ * Zod schema for the `customEnvVars` map at the settings write boundary.
+ * Defense-in-depth (per CLAUDE.md's validate-at-boundary rule): rejects any
+ * payload that tries to set a reserved runtime key so it never even reaches
+ * persisted settings. The container merge (mergeCustomEnvVars) is the primary
+ * guard; this stops the bad config at the door.
+ */
+export const customEnvVarsSchema = z
+  .record(z.string(), z.string())
+  .superRefine((vars, ctx) => {
+    const reserved = findReservedEnvVarKeys(vars)
+    if (reserved.length > 0) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `customEnvVars may not override reserved runtime variables: ${reserved.join(', ')}`,
+      })
+    }
+  })


### PR DESCRIPTION
## SUP-210 — Custom env vars can override reserved agent runtime env vars

### Bug
`ContainerManager.doStartContainer()` (src/shared/lib/container/container-manager.ts) merged user-defined `customEnvVars` over the computed runtime env map via `Object.assign(envVars, settings.customEnvVars)` **after** every reserved var was written. `Object.assign(target, source)` gives source keys precedence, so a custom var named `PROXY_TOKEN`, `PROXY_BASE_URL`, `SUPERAGENT_HOST_API_URL`, `SUPERAGENT_AGENT_SLUG`, `CONNECTED_ACCOUNTS`, `REMOTE_MCPS`, `TZ`, `HOST_PLATFORM`, the host-browser vars, etc. silently clobbered the required wiring — breaking proxy authentication, redirecting the proxy URL, misidentifying the agent slug, or spoofing connected-account metadata. The settings write boundary accepted `body.customEnvVars` raw with no validation.

### Fix
- New `src/shared/lib/container/reserved-env-vars.ts`: `RESERVED_ENV_VAR_KEYS` set + `mergeCustomEnvVars()` which iterates `customEnvVars` and **skips reserved keys** (with a `console.warn`) instead of a blanket `Object.assign`, so non-reserved custom vars still pass through unchanged. Keys are reserved unconditionally — even ones only set on some branches (`REMOTE_MCPS`, host-browser vars) — so custom config can never spoof them.
- `container-manager.ts`: replace the `Object.assign` merge with `mergeCustomEnvVars(envVars, settings.customEnvVars)`.
- Defense-in-depth (per CLAUDE.md validate-at-boundary rule): `customEnvVarsSchema` (Zod) rejects reserved keys at the `PUT /api/settings` write boundary, returning 400 before the bad config is persisted.

### Tests (failing-before, green-after)
- `src/shared/lib/container/container-manager.reserved-env.sup210.test.ts` — standalone repro driving `ensureRunning('test-agent')` with `customEnvVars` containing reserved keys; asserts `PROXY_TOKEN` keeps the real `getOrCreateProxyToken` value, `PROXY_BASE_URL`/`SUPERAGENT_*`/`CONNECTED_ACCOUNTS`/`TZ`/`HOST_PLATFORM`/`CLAUDE_CODE_ATTRIBUTION_HEADER` keep computed values, and a benign `MY_CUSTOM` still passes through. Failed on the unfixed code (custom values won), passes now.
- `src/shared/lib/container/reserved-env-vars.test.ts` — unit coverage for the helper + schema.
- `src/api/routes/settings.test.ts` — boundary regression: PUT with a reserved key in `customEnvVars` returns 400 and does not persist; non-reserved keys still succeed.

Existing `container-manager.test.ts` and `settings.test.ts` suites still pass (156 tests green). `tsc --noEmit` clean; eslint 0 errors on changed files.

### Changed files
- `src/shared/lib/container/reserved-env-vars.ts` (new)
- `src/shared/lib/container/reserved-env-vars.test.ts` (new)
- `src/shared/lib/container/container-manager.reserved-env.sup210.test.ts` (new)
- `src/shared/lib/container/container-manager.ts`
- `src/api/routes/settings.ts`
- `src/api/routes/settings.test.ts`

Status: waiting for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)