### PR TITLE
fix(SUP-216): bind IsAgent token to host-browser agentId (cross-agent IDOR)

### DIFF
--- a/src/api/middleware/auth.ts
+++ b/src/api/middleware/auth.ts
@@ -320,13 +320,20 @@ export function HasNotificationAccess(): MiddlewareHandler {
 /**
  * IsAgent — validates synthetic bearer token from a container.
  * Works in both auth and non-auth modes (containers always use proxy tokens).
+ *
+ * Stashes the resolved agent slug on the context as `agentSlug` so route
+ * handlers can bind their action to the token's agent instead of trusting an
+ * attacker-controlled body/param (see SUP-216). Each agent has exactly one
+ * proxy token, so the token uniquely identifies the agent.
  */
 export function IsAgent(): MiddlewareHandler {
   return async (c: Context, next: Next) => {
     const token = c.req.header('Authorization')?.replace('Bearer ', '')
-    if (!token || !(await validateProxyToken(token))) {
+    const agentSlug = token ? await validateProxyToken(token) : null
+    if (!token || !agentSlug) {
       return c.json({ error: 'Unauthorized' }, 401)
     }
+    c.set('agentSlug' as never, agentSlug as never)
     return next()
   }
 }

--- a/src/api/routes/browser-schema.ts
+++ b/src/api/routes/browser-schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+/**
+ * Request body schema for the Electron host-browser control routes
+ * (`/api/browser/launch-host-browser`, `/stop-host-browser`, `/debug-info`).
+ *
+ * `agentId` is optional and, when present, must match the agent slug resolved
+ * from the caller's proxy token (enforced in the route handlers — see SUP-216).
+ * The effective agent acted upon is ALWAYS the token's slug, never the raw body
+ * value, so a container holding one agent's token cannot drive another agent's
+ * host browser.
+ */
+export const hostBrowserRequestSchema = z.object({
+  agentId: z.string().min(1).optional(),
+})
+
+export type HostBrowserRequest = z.infer<typeof hostBrowserRequestSchema>

--- a/src/api/routes/browser.sup216.test.ts
+++ b/src/api/routes/browser.sup216.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+// ---------------------------------------------------------------------------
+// SUP-216 — Electron host-browser routes must bind the IsAgent token to the
+// agent it acts on. The /api/browser/* routes authenticate with IsAgent() (any
+// valid container proxy token) but then trust the attacker-controlled
+// body.agentId. A container holding agent-a's token must NOT be able to
+// launch/stop/inspect agent-b's host browser by sending { agentId: 'agent-b' }.
+//
+// These tests mount the REAL browser routes and the REAL IsAgent() middleware,
+// with validateProxyToken mocked to resolve the bearer token to 'agent-a' and
+// getActiveProvider() returning a spy provider. The secure contract is: for a
+// cross-agent request the route either returns 403, OR it operates strictly on
+// the token's own agent ('agent-a') and NEVER passes the attacker's 'agent-b'
+// to provider.launch/stop/getDebugInfo.
+// ---------------------------------------------------------------------------
+
+// validateProxyToken resolves the bearer token to an agent slug (real shape:
+// string | null). IsAgent() must stash that slug on the Hono context.
+const mockValidateProxyToken = vi.fn<(token: string) => Promise<string | null>>()
+vi.mock('@shared/lib/proxy/token-store', () => ({
+  validateProxyToken: (token: string) => mockValidateProxyToken(token),
+}))
+
+// Spy host-browser provider — records exactly which instanceId/agentId reaches it.
+const mockProvider = {
+  launch: vi.fn(),
+  stop: vi.fn(),
+  getDebugInfo: vi.fn(),
+}
+const mockGetActiveProvider = vi.fn<() => typeof mockProvider | null>(() => mockProvider)
+vi.mock('../../main/host-browser', () => ({
+  getActiveProvider: () => mockGetActiveProvider(),
+  setOnExternalClose: vi.fn(),
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({ app: {} }),
+}))
+
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: { getClient: () => ({ fetch: vi.fn() }) },
+}))
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: { broadcastGlobal: vi.fn() },
+}))
+
+// auth.ts dependencies — we deliberately use the REAL IsAgent() so the token →
+// slug binding is exercised end to end. IsAgent() never touches the db / auth
+// mode, so these are minimal stubs to keep the import graph light.
+vi.mock('@shared/lib/auth/mode', () => ({ isAuthMode: () => false }))
+vi.mock('@shared/lib/platform-attribution', () => ({
+  runWithRequestUser: (_id: string, fn: () => unknown) => fn(),
+}))
+vi.mock('@shared/lib/db', () => ({ db: {} }))
+vi.mock('@shared/lib/db/schema', () => ({
+  agentAcl: {}, connectedAccounts: {}, remoteMcpServers: {}, notifications: {},
+}))
+
+// Import after mocks.
+import browser from './browser'
+import { IsAgent } from '../middleware/auth'
+
+const TOKEN = 'agent-a-token'
+const TOKEN_SLUG = 'agent-a'
+const ATTACKER_AGENT = 'agent-b'
+
+function appWithBrowser() {
+  const app = new Hono()
+  app.route('/api/browser', browser)
+  return app
+}
+
+function post(path: string, body: unknown, token = TOKEN) {
+  return appWithBrowser().request(`http://localhost/api/browser/${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  })
+}
+
+/** The attacker-supplied agent id must never reach the provider in any call. */
+function expectNeverActedOnAgent(spy: typeof mockProvider.launch, badAgentId: string) {
+  for (const call of spy.mock.calls) {
+    expect(call).not.toContain(badAgentId)
+  }
+}
+
+/** When the route does act, it must act strictly on the token's own agent. */
+function expectActedOnlyOnTokenAgent(spy: typeof mockProvider.launch) {
+  expect(spy).toHaveBeenCalled()
+  for (const call of spy.mock.calls) {
+    expect(call[0]).toBe(TOKEN_SLUG)
+  }
+}
+
+describe('SUP-216: host-browser routes bind IsAgent token to the acted-on agent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActiveProvider.mockReturnValue(mockProvider)
+    mockProvider.launch.mockResolvedValue({ port: 9222 })
+    mockProvider.stop.mockResolvedValue(undefined)
+    mockProvider.getDebugInfo.mockResolvedValue({ pages: [] })
+    // Token resolves to agent-a regardless of the requested agentId.
+    mockValidateProxyToken.mockResolvedValue(TOKEN_SLUG)
+  })
+
+  // -------------------------------------------------------------------------
+  // Cross-agent IDOR: attacker token (agent-a) + body { agentId: 'agent-b' }
+  // -------------------------------------------------------------------------
+
+  it('launch-host-browser: must not launch another agent\'s browser via body.agentId', async () => {
+    const res = await post('launch-host-browser', { agentId: ATTACKER_AGENT })
+
+    expectNeverActedOnAgent(mockProvider.launch, ATTACKER_AGENT)
+    if (res.status !== 403) {
+      expectActedOnlyOnTokenAgent(mockProvider.launch)
+    }
+  })
+
+  it('stop-host-browser: must not stop another agent\'s browser via body.agentId', async () => {
+    const res = await post('stop-host-browser', { agentId: ATTACKER_AGENT })
+
+    expectNeverActedOnAgent(mockProvider.stop, ATTACKER_AGENT)
+    if (res.status !== 403) {
+      expectActedOnlyOnTokenAgent(mockProvider.stop)
+    }
+  })
+
+  it('debug-info: must not leak another agent\'s CDP/screencast info via body.agentId', async () => {
+    const res = await post('debug-info', { agentId: ATTACKER_AGENT })
+
+    expectNeverActedOnAgent(mockProvider.getDebugInfo, ATTACKER_AGENT)
+    if (res.status !== 403) {
+      expectActedOnlyOnTokenAgent(mockProvider.getDebugInfo)
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  // Positive / regression: legitimate container drives ITS OWN agent.
+  // -------------------------------------------------------------------------
+
+  it('launch-host-browser: acts on the token agent when body.agentId matches', async () => {
+    const res = await post('launch-host-browser', { agentId: TOKEN_SLUG })
+    expect(res.status).toBe(200)
+    expectActedOnlyOnTokenAgent(mockProvider.launch)
+  })
+
+  it('launch-host-browser: acts on the token agent when body.agentId is omitted', async () => {
+    const res = await post('launch-host-browser', {})
+    expect(res.status).toBe(200)
+    expectActedOnlyOnTokenAgent(mockProvider.launch)
+    expectNeverActedOnAgent(mockProvider.launch, 'default')
+  })
+
+  it('debug-info: returns the token agent\'s debug info when body.agentId matches', async () => {
+    const res = await post('debug-info', { agentId: TOKEN_SLUG })
+    expect(res.status).toBe(200)
+    expectActedOnlyOnTokenAgent(mockProvider.getDebugInfo)
+  })
+
+  it('rejects requests without a valid proxy token (IsAgent gate intact)', async () => {
+    mockValidateProxyToken.mockResolvedValue(null)
+    const res = await post('launch-host-browser', { agentId: TOKEN_SLUG })
+    expect(res.status).toBe(401)
+    expect(mockProvider.launch).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // Middleware companion: IsAgent() stashes the resolved slug on context.
+  // -------------------------------------------------------------------------
+
+  it('IsAgent() stashes the resolved agent slug on the Hono context', async () => {
+    mockValidateProxyToken.mockResolvedValue(TOKEN_SLUG)
+    let captured: unknown = null
+    const app = new Hono()
+    app.get('/probe', IsAgent(), (c) => {
+      captured = c.get('agentSlug' as never)
+      return c.json({ ok: true })
+    })
+
+    const res = await app.request('http://localhost/probe', {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    })
+
+    expect(res.status).toBe(200)
+    expect(captured).toBe(TOKEN_SLUG)
+  })
+})

--- a/src/api/routes/browser.ts
+++ b/src/api/routes/browser.ts
@@ -1,18 +1,49 @@
 import { Hono } from 'hono'
+import type { Context } from 'hono'
 import { getActiveProvider, setOnExternalClose } from '../../main/host-browser'
 import { getSettings } from '@shared/lib/config/settings'
 import { containerManager } from '@shared/lib/container/container-manager'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { IsAgent } from '../middleware/auth'
+import { hostBrowserRequestSchema } from './browser-schema'
 
 const browser = new Hono()
+
+/**
+ * Resolve the agent a host-browser request may act on, bound to the IsAgent
+ * proxy token (SUP-216). The token uniquely identifies the agent, so the
+ * effective instanceId/agentId is ALWAYS the token's slug — never the raw
+ * body.agentId. If the body carries a different agentId, the request is a
+ * cross-agent attempt and is rejected with 403.
+ */
+async function resolveTokenBoundAgentId(
+  c: Context,
+): Promise<{ agentId: string } | { error: Response }> {
+  const tokenAgentId = c.get('agentSlug' as never) as string | undefined
+  if (!tokenAgentId) {
+    // IsAgent() should always stash this; fail closed if it did not.
+    return { error: c.json({ error: 'Unauthorized' }, 401) }
+  }
+
+  const raw = await c.req.json().catch(() => ({}))
+  const parsed = hostBrowserRequestSchema.safeParse(raw)
+  if (!parsed.success) {
+    return { error: c.json({ error: 'Invalid request body' }, 400) }
+  }
+
+  if (parsed.data.agentId && parsed.data.agentId !== tokenAgentId) {
+    return { error: c.json({ error: 'Forbidden: agentId does not match token agent' }, 403) }
+  }
+
+  return { agentId: tokenAgentId }
+}
 
 // POST /api/browser/launch-host-browser - Launch browser on host for CDP connection
 browser.post('/launch-host-browser', IsAgent(), async (c) => {
   try {
-    const body = await c.req.json<{ agentId?: string }>().catch(() => ({} as { agentId?: string }))
-    // Fall back to 'default' for backward compat with containers that don't send agentId yet
-    const agentId = body.agentId || 'default'
+    const resolved = await resolveTokenBoundAgentId(c)
+    if ('error' in resolved) return resolved.error
+    const agentId = resolved.agentId
 
     const provider = getActiveProvider()
     if (!provider) {
@@ -40,9 +71,9 @@ browser.post('/launch-host-browser', IsAgent(), async (c) => {
 // POST /api/browser/stop-host-browser - Stop the host browser process for a specific agent
 browser.post('/stop-host-browser', IsAgent(), async (c) => {
   try {
-    const body = await c.req.json<{ agentId?: string }>().catch(() => ({} as { agentId?: string }))
-    // Fall back to 'default' for backward compat with containers that don't send agentId yet
-    const agentId = body.agentId || 'default'
+    const resolved = await resolveTokenBoundAgentId(c)
+    if ('error' in resolved) return resolved.error
+    const agentId = resolved.agentId
 
     const provider = getActiveProvider()
     if (provider) {
@@ -59,8 +90,9 @@ browser.post('/stop-host-browser', IsAgent(), async (c) => {
 // POST /api/browser/debug-info - Get fresh debug/screencast connection info for an active browser session
 browser.post('/debug-info', IsAgent(), async (c) => {
   try {
-    const body = await c.req.json<{ agentId?: string }>().catch(() => ({} as { agentId?: string }))
-    const agentId = body.agentId || 'default'
+    const resolved = await resolveTokenBoundAgentId(c)
+    if ('error' in resolved) return resolved.error
+    const agentId = resolved.agentId
 
     const provider = getActiveProvider()
     if (!provider?.getDebugInfo) {


### PR DESCRIPTION
## SUP-216 — Electron host-browser routes trust body.agentId without binding it to the IsAgent token's agent (cross-agent IDOR)

### Bug
The Electron-only `/api/browser/*` routes authenticate with `IsAgent()` (any valid container proxy token) but then operate on the attacker-controlled `body.agentId` without checking it matches the agent slug that `validateProxyToken()` resolved from the bearer token. `IsAgent()` resolved the slug but discarded it (only checked truthiness). A container holding `agent-a`'s token could:
- `POST /api/browser/launch-host-browser` `{ "agentId": "agent-b" }` → `provider.launch('agent-b', ..., 'agent-b')`
- `POST /api/browser/stop-host-browser` → `provider.stop('agent-b')`
- `POST /api/browser/debug-info` → `provider.getDebugInfo('agent-b')`, leaking another agent's CDP/screencast endpoint.

`instanceId == body.agentId` keys the per-agent state (instances map, profile dir, downloads dir) in `chrome-provider.ts`, so this crosses agent boundaries. These routes are exempt from the localhost `LocalModeAuth` gate.

### Fix
- `src/api/middleware/auth.ts` — `IsAgent()` now captures `validateProxyToken()`'s resolved agent slug and stashes it on the Hono context as `agentSlug`. Each agent has exactly one proxy token, so the token uniquely identifies the agent.
- `src/api/routes/browser.ts` — all three routes (`launch`/`stop`/`debug-info`) derive the effective `agentId` from the token slug via a shared `resolveTokenBoundAgentId()` helper, never the raw body. The body is validated with a Zod schema; if `body.agentId` is present and `!==` the token slug the request is rejected with `403`. The `|| 'default'` fallback is dropped.
- `src/api/routes/browser-schema.ts` — new Zod schema for the host-browser request body (per repo convention: schemas in a dedicated file, validate at the boundary).

### Tests
`src/api/routes/browser.sup216.test.ts` (new) mounts the real browser routes + real `IsAgent()` with `validateProxyToken` mocked to resolve `agent-a` and a spy provider:
- Cross-agent requests (`{ agentId: 'agent-b' }` + `Bearer agent-a-token`) — provider is NEVER invoked for `agent-b`; route returns `403` or acts strictly on `agent-a`. **Reproduced the IDOR on the pre-fix code (`provider.launch('agent-b', …)`), now green.**
- Positive/regression: legit container (`agentId` matching the token, or omitted) acts on the token slug; no `'default'` leakage.
- IsAgent gate intact (invalid token → 401).
- Middleware assertion: `IsAgent()` stashes the resolved slug (`c.get('agentSlug') === 'agent-a'`).

Validation: new test passes; existing `auth.test.ts` (120), `settings.test.ts`, `security-repro.test.ts` still pass; `tsc --noEmit` clean; eslint clean on changed files.

### Changed files
- `src/api/middleware/auth.ts`
- `src/api/routes/browser.ts`
- `src/api/routes/browser-schema.ts` (new)
- `src/api/routes/browser.sup216.test.ts` (new)

Status: waiting for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)