### PR TITLE
fix(container): escape mount volume specs and clean up unhealthy start (SUP-211, SUP-212)

### DIFF
--- a/src/shared/lib/container/base-container-client-start-cleanup.sup212.test.ts
+++ b/src/shared/lib/container/base-container-client-start-cleanup.sup212.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ============================================================================
+// SUP-212 — An unhealthy container start must not leave the failed container
+// running. In start(), when waitForHealthy() returns false the code grabs
+// logs, reports to Sentry and throws — but (pre-fix) never stops/removes the
+// container it just created. A leftover process-alive-but-unhealthy container
+// then short-circuits the next start() via the running-status early return,
+// caching it as 'running' even though /health never passed.
+//
+// This test records every command the runtime runner is asked to execute and
+// asserts that, after the failed health check, a `stop`/`rm superagent-<id>`
+// is issued AFTER the `run -d ... --name superagent-<id>` command.
+// ============================================================================
+
+// Record every command string handed to child_process.exec (which
+// base-container-client promisifies into execAsync at module load).
+const execCommands: string[] = []
+
+vi.mock('child_process', () => {
+  // promisify(exec) calls exec(command, options, callback) and resolves with
+  // whatever the callback's second arg is. We resolve every command with an
+  // { stdout, stderr } object so `const { stdout } = await execAsync(...)`
+  // works, pattern-matching the few commands start() actually cares about.
+  const exec = (
+    command: string,
+    optionsOrCb: unknown,
+    maybeCb?: (err: Error | null, result?: { stdout: string; stderr: string }) => void
+  ) => {
+    const cb = (typeof optionsOrCb === 'function' ? optionsOrCb : maybeCb) as (
+      err: Error | null,
+      result?: { stdout: string; stderr: string }
+    ) => void
+    execCommands.push(command)
+
+    let stdout = ''
+    if (/run\s+-d/.test(command)) stdout = 'fake-container-id'
+    // image inspect → image found (skip build); ps → no used ports; logs → empty.
+    // stop/rm/everything else → resolve empty. Nothing rejects: the runner
+    // succeeds, only the health check fails.
+    cb(null, { stdout, stderr: '' })
+    return {}
+  }
+  return {
+    exec,
+    execSync: vi.fn(),
+    spawn: vi.fn(),
+  }
+})
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+  addErrorBreadcrumb: vi.fn(),
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: vi.fn(() => ({
+    enableToolSearch: false,
+    container: {
+      agentImage: 'superagent/agent:test',
+      containerRunner: 'docker',
+      resourceLimits: { cpu: 2, memory: '2g' },
+    },
+  })),
+}))
+
+vi.mock('@shared/lib/llm-provider', () => ({
+  getActiveLlmProvider: vi.fn(() => ({
+    getContainerEnvVars: () => ({}),
+  })),
+}))
+
+vi.mock('@shared/lib/config/data-dir', () => ({
+  getAgentWorkspaceDir: vi.fn(() => '/tmp/sup212-workspace'),
+}))
+
+vi.mock('fs', () => {
+  const noop = vi.fn()
+  return {
+    default: { mkdirSync: noop, writeFileSync: noop, unlinkSync: noop },
+    mkdirSync: noop,
+    writeFileSync: noop,
+    unlinkSync: noop,
+  }
+})
+
+import { BaseContainerClient } from './base-container-client'
+import type { ContainerConfig, ContainerInfo } from './types'
+
+/**
+ * Concrete subclass whose health check always fails immediately (no 60s real
+ * wait), and which reports the container as stopped at the start() early-return
+ * guard so we proceed into the run+health path instead of short-circuiting.
+ */
+class TestContainerClient extends BaseContainerClient {
+  protected getRunnerCommand(): string {
+    return 'docker'
+  }
+  // Report stopped at the line 504 early-return so start() runs the full path.
+  async getInfoFromRuntime(): Promise<ContainerInfo> {
+    return { status: 'stopped', port: null }
+  }
+  // Fail fast so we don't sit in waitForHealthy's 60s loop.
+  async waitForHealthy(): Promise<boolean> {
+    return false
+  }
+}
+
+describe('SUP-212 start() cleans up an unhealthy container', () => {
+  beforeEach(() => {
+    execCommands.length = 0
+  })
+
+  it('removes the just-created container after the health check fails', async () => {
+    const client = new TestContainerClient({ agentId: 'abc123' } as ContainerConfig)
+    // No 'error' listener — start() emits 'error'; safeEmitError no-ops without one.
+
+    await expect(client.start()).rejects.toThrow(/failed to become healthy/i)
+
+    const containerName = 'superagent-abc123'
+    const runIndex = execCommands.findIndex(
+      (c) => /run\s+-d/.test(c) && c.includes(`--name ${containerName}`)
+    )
+    expect(runIndex).toBeGreaterThanOrEqual(0)
+
+    // The fix issues a best-effort stop + rm AFTER the run command. Pre-fix,
+    // the only stop/rm are the pre-run cleanup (before runIndex), so these fail.
+    const stopAfterRun = execCommands
+      .slice(runIndex + 1)
+      .some((c) => c.includes(`stop ${containerName}`))
+    const rmAfterRun = execCommands
+      .slice(runIndex + 1)
+      .some((c) => c.includes(`rm ${containerName}`))
+
+    expect(rmAfterRun).toBe(true)
+    expect(stopAfterRun).toBe(true)
+  })
+
+  it('still surfaces the health-check error to the caller', async () => {
+    const client = new TestContainerClient({ agentId: 'abc123' } as ContainerConfig)
+    await expect(client.start()).rejects.toThrow(/failed to become healthy/i)
+  })
+})

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -64,9 +64,34 @@ const isWindows = process.platform === 'win32'
 /**
  * Wrap a value in the platform-appropriate shell quotes.
  * On Unix, single quotes; on Windows cmd.exe, double quotes.
+ *
+ * NOTE: this is a naive wrapper — it does NOT escape quote characters embedded
+ * in `value`. It is safe only for known-literal arguments (e.g. Go template
+ * format strings like `{{json .}}`). For user-controlled values that are
+ * interpolated into a command string and run through a real shell, use
+ * shellEscape() instead.
  */
 export function shellQuote(value: string): string {
   return isWindows ? `"${value}"` : `'${value}'`
+}
+
+/**
+ * Shell-escape a user-controlled value so it survives interpolation into a
+ * command string executed by a real shell (child_process.exec → /bin/sh -c on
+ * Unix). Unlike shellQuote(), this escapes embedded quote characters so the
+ * value can never break out of its quoted region and re-enable expansion.
+ *
+ * On Unix: wrap in single quotes and rewrite each embedded `'` as `'\''`
+ * (close-quote, escaped-quote, reopen-quote). Inside single quotes nothing —
+ * not `$(...)`, backticks, nor `$VAR` — is special, so the value is inert.
+ * On Windows cmd.exe: wrap in double quotes and escape embedded `"` (a path
+ * cannot legally contain `"`, so this is belt-and-suspenders).
+ */
+export function shellEscape(value: string): string {
+  if (isWindows) {
+    return `"${value.replace(/"/g, '\\"')}"`
+  }
+  return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
 /**
@@ -323,7 +348,10 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
    * Encapsulates hostPathForRuntime() + getVolumeMountSuffix().
    */
   public buildVolumeFlag(hostPath: string, containerPath: string): string {
-    return `"${this.hostPathForRuntime(hostPath)}:${containerPath}${this.getVolumeMountSuffix()}"`
+    // hostPath is user-controlled (a selected mount). shellEscape() (not raw
+    // double quotes) so a path like `/tmp/a$(...)` can't trigger command
+    // substitution when start() runs the joined command through a real shell.
+    return shellEscape(`${this.hostPathForRuntime(hostPath)}:${containerPath}${this.getVolumeMountSuffix()}`)
   }
 
   /**
@@ -543,7 +571,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
           runner, 'run', '-d',
           '--name', containerName,
           '-p', `${port}:${CONTAINER_INTERNAL_PORT}`,
-          '-v', `"${this.hostPathForRuntime(workspaceDir)}:/workspace${this.getVolumeMountSuffix()}"`,
+          '-v', shellEscape(`${this.hostPathForRuntime(workspaceDir)}:/workspace${this.getVolumeMountSuffix()}`),
           ...volumes.flatMap(v => ['-v', v]),
           resourceFlags,
           additionalFlags,
@@ -631,6 +659,15 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
             containerLogs: logs,
           },
         })
+        // Stop + remove the just-created-but-unhealthy container. Otherwise it
+        // stays process-alive, and the next start() short-circuits on the
+        // running-status early return (getInfoFromRuntime derives 'running'
+        // from inspect's State.Running, not /health), caching a container that
+        // never became healthy. Best-effort/silent so an already-gone container
+        // is harmless and cleanup failure never masks the health error. Logs
+        // were already captured above, before this removes the container.
+        await execWithPathSilent(`${runner} stop ${containerName}`)
+        await execWithPathSilent(`${runner} rm ${containerName}`)
         throw healthError
       }
 

--- a/src/shared/lib/container/build-volume-flag-shell-quote.sup211.test.ts
+++ b/src/shared/lib/container/build-volume-flag-shell-quote.sup211.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { execSync } from 'child_process'
+import * as fs from 'fs'
+import { BaseContainerClient } from './base-container-client'
+import type { ContainerConfig } from './types'
+
+// ============================================================================
+// SUP-211 — Container mount volume specs must be shell-escaped so that a
+// user-controlled host path can never trigger command substitution / variable
+// expansion when start() interpolates the flag into a single command string
+// run through child_process.exec (a real /bin/sh -c on Unix).
+//
+// Before the fix, buildVolumeFlag() wrapped the spec in RAW double quotes
+// (`"host:container"`). Inside Unix double quotes, $(...), backticks and $VAR
+// still expand — so `/tmp/a$(touch /tmp/pwn)b` would execute `touch` on the
+// host. The fix wraps the spec in single quotes (Unix) with embedded single
+// quotes escaped as '\'' so the whole spec is an inert literal.
+// ============================================================================
+
+/** Minimal concrete subclass so we can call the public buildVolumeFlag(). */
+class TestContainerClient extends BaseContainerClient {
+  protected getRunnerCommand(): string {
+    return 'docker'
+  }
+}
+
+function makeClient(): TestContainerClient {
+  return new TestContainerClient({ agentId: 'sup211' } as ContainerConfig)
+}
+
+// Marker files the malicious command-substitution payloads would create if the
+// shell ever evaluated the spec. We assert they never appear.
+const PWN_CMD_SUB = '/tmp/superagent-volume-pwn'
+const PWN_QUOTE = '/tmp/superagent-volume-pwn2'
+
+describe('SUP-211 buildVolumeFlag shell escaping', () => {
+  afterEach(() => {
+    // Clean up any marker file in case a regression let the payload run.
+    for (const f of [PWN_CMD_SUB, PWN_QUOTE]) {
+      try { fs.unlinkSync(f) } catch { /* never created — expected */ }
+    }
+  })
+
+  it('produces a flag that does NOT execute command substitution via a real shell', () => {
+    if (process.platform === 'win32') return // shell-execution assertion is Unix-only
+
+    // Pre-condition: the marker must not already exist.
+    expect(fs.existsSync(PWN_CMD_SUB)).toBe(false)
+
+    const malicious = `/tmp/a$(touch ${PWN_CMD_SUB})b`
+    const flag = makeClient().buildVolumeFlag(malicious, '/work')
+
+    // Behavioral / end-to-end: feed the flag to a real /bin/sh exactly the way
+    // start() does (interpolated, unquoted, into a command string). `printf %s`
+    // echoes its argument back so we can compare against the literal spec.
+    const stdout = execSync(`printf %s ${flag}`, { shell: '/bin/sh' }).toString()
+
+    expect(stdout).toBe(`/tmp/a$(touch ${PWN_CMD_SUB})b:/work`)
+    // The command substitution must NOT have run.
+    expect(fs.existsSync(PWN_CMD_SUB)).toBe(false)
+  })
+
+  it('survives a single-quote in the host path (naive-quoting regression)', () => {
+    if (process.platform === 'win32') return
+
+    expect(fs.existsSync(PWN_QUOTE)).toBe(false)
+
+    // A single quote would break out of a naive single-quoted region and
+    // re-enable expansion unless embedded quotes are escaped as '\''.
+    const malicious = `/tmp/a'$(touch ${PWN_QUOTE})'b`
+    const flag = makeClient().buildVolumeFlag(malicious, '/work')
+
+    const stdout = execSync(`printf %s ${flag}`, { shell: '/bin/sh' }).toString()
+
+    expect(stdout).toBe(`/tmp/a'$(touch ${PWN_QUOTE})'b:/work`)
+    expect(fs.existsSync(PWN_QUOTE)).toBe(false)
+  })
+
+  it('structurally wraps the whole spec in single quotes on Unix', () => {
+    if (process.platform === 'win32') return
+
+    const flag = makeClient().buildVolumeFlag(`/tmp/a$(touch ${PWN_CMD_SUB})b`, '/work')
+
+    // Fully single-quoted: any $(...)/backtick/$VAR is inside the quoted literal.
+    expect(flag.startsWith("'")).toBe(true)
+    expect(flag.endsWith("'")).toBe(true)
+    // Exact expected escaping: no embedded single quote in this path, so the
+    // spec passes through verbatim inside one pair of single quotes.
+    expect(flag).toBe(`'/tmp/a$(touch ${PWN_CMD_SUB})b:/work'`)
+  })
+
+  it('escapes embedded single quotes as the POSIX \'\\\'\' sequence', () => {
+    if (process.platform === 'win32') return
+
+    const flag = makeClient().buildVolumeFlag(`/tmp/it's`, '/work')
+    expect(flag).toBe(`'/tmp/it'\\''s:/work'`)
+  })
+
+  it('preserves an ordinary path as a single shell token', () => {
+    if (process.platform === 'win32') return
+
+    const flag = makeClient().buildVolumeFlag('/home/user/project', '/workspace')
+    const stdout = execSync(`printf %s ${flag}`, { shell: '/bin/sh' }).toString()
+    expect(stdout).toBe('/home/user/project:/workspace')
+  })
+})


### PR DESCRIPTION
Both fixes are in `src/shared/lib/container/base-container-client.ts`.

## SUP-211 — Quote container mount volume specs to prevent shell expansion
`BaseContainerClient.buildVolumeFlag()` and the inline workspace mount wrapped the `host:container` spec in **raw double quotes**. `start()` joins the `docker/podman/nerdctl run` command into a single string and runs it through `child_process.exec` (`/bin/sh -c` on Unix), where `$(...)`, backticks and `$VAR` **still expand inside double quotes**. The host path is user-controlled (a selected mount, validated only for absolute/exists), so a path like `/tmp/a$(touch /tmp/pwn)b` could trigger command substitution on the host.

**Fix:** add a hardened `shellEscape()` helper — on Unix wrap in single quotes and rewrite each embedded `'` as `'\''` (so a single quote can't break out and re-enable expansion); on Windows wrap in double quotes and escape `"`. Use it for both `buildVolumeFlag()` and the workspace `-v` mount. The naive `shellQuote()` is intentionally left as-is for its known-literal callsites (Go template format strings).

## SUP-212 — Unhealthy container start leaves the failed container running
When `waitForHealthy()` returns false, `start()` grabbed logs, reported to Sentry and threw — but never stopped/removed the container it just created. A process-alive-but-unhealthy leftover then short-circuited the next `start()` via the running-status early return (`getInfoFromRuntime()` derives status from inspect's `State.Running`, not `/health`), so the manager cached it as `running` even though `/health` never passed.

**Fix:** in the health-failure branch, best-effort `stop` + `rm` the container before throwing (after logs are captured). Silent so an already-gone container is harmless and cleanup failure never masks the original health error.

## Tests (failing-before, green-after regression)
- `src/shared/lib/container/build-volume-flag-shell-quote.sup211.test.ts` — structural assertions plus a **behavioral** test that feeds the escaped flag to a real `/bin/sh` and asserts the command-substitution payload (and a single-quote-injection variant) never executes; Unix-gated shell assertions.
- `src/shared/lib/container/base-container-client-start-cleanup.sup212.test.ts` — records every runner command and asserts a `stop`/`rm superagent-<id>` is issued **after** the `run -d` command, and that the health-check error still surfaces.

Both new files fail on `main` and pass with this change. The existing `base-container-client.test.ts` (77 tests, incl. the `shellQuote` block) plus container-manager/lima/wsl2/client-factory suites remain green (189 related tests).

## Changed files
- `src/shared/lib/container/base-container-client.ts`
- `src/shared/lib/container/build-volume-flag-shell-quote.sup211.test.ts` (new)
- `src/shared/lib/container/base-container-client-start-cleanup.sup212.test.ts` (new)

Status: waiting for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)