### PR TITLE
fix(electron): encode dashboard popout slugs (SUP-218) and restrict popout window.open (SUP-219)

### DIFF
--- a/src/main/dashboard-window.ts
+++ b/src/main/dashboard-window.ts
@@ -1,0 +1,64 @@
+import { BrowserWindow, shell, type WebContents } from 'electron'
+import { buildDashboardViewUrl } from '@shared/lib/dashboard-url'
+
+// Open dashboard popouts keyed by `${agentSlug}/${dashboardSlug}`. The raw join
+// is fine as a dedup key — only the loaded URL needs per-segment encoding.
+const dashboardWindows: Map<string, BrowserWindow> = new Map()
+
+/**
+ * Deny-and-route popup policy for a window's webContents.
+ *
+ * Applied to both the main window and the agent-generated dashboard popouts so
+ * untrusted dashboard content cannot spawn arbitrary child windows via
+ * window.open(). File-download URLs are streamed via downloadURL; everything
+ * else is handed to the system browser. The popup itself is always denied
+ * (SUP-219).
+ */
+export function installPopupHandler(webContents: WebContents) {
+  webContents.setWindowOpenHandler(({ url }) => {
+    // Handle file download URLs - download directly without opening a popup
+    if (url.includes('/api/agents/') && url.includes('/files/')) {
+      webContents.downloadURL(url)
+      return { action: 'deny' }
+    }
+    // For other URLs (OAuth, external links), open in the system browser
+    shell.openExternal(url)
+    return { action: 'deny' }
+  })
+}
+
+export function openDashboardWindow(agentSlug: string, dashboardSlug: string, apiPort: number) {
+  const key = `${agentSlug}/${dashboardSlug}`
+
+  // Focus existing window if already open
+  const existing = dashboardWindows.get(key)
+  if (existing && !existing.isDestroyed()) {
+    existing.show()
+    existing.focus()
+    return
+  }
+
+  const url = buildDashboardViewUrl(apiPort, agentSlug, dashboardSlug)
+  const win = new BrowserWindow({
+    width: 1000,
+    height: 700,
+    title: 'SuperAgent Dashboard',
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  })
+  // Dashboard content is agent-generated/untrusted — apply the same deny-and-route
+  // popup policy as the main window so window.open() can't spawn child windows.
+  installPopupHandler(win.webContents)
+  win.loadURL(url)
+  dashboardWindows.set(key, win)
+  win.on('closed', () => dashboardWindows.delete(key))
+}
+
+export function closeAllDashboardWindows() {
+  for (const win of dashboardWindows.values()) {
+    if (!win.isDestroyed()) win.close()
+  }
+  dashboardWindows.clear()
+}

--- a/src/main/index.popout-window-handler.sup219.test.ts
+++ b/src/main/index.popout-window-handler.sup219.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// SUP-219: dashboard popout BrowserWindows render untrusted, agent-generated
+// dashboard content but never installed a `setWindowOpenHandler`, so
+// window.open() fell back to Electron's default ALLOW behavior — bypassing the
+// deny-and-route popup policy the main window enforces. The popout must install
+// a handler that denies child windows and safely routes external URLs / file
+// downloads.
+
+type FakeWebContents = {
+  setWindowOpenHandler: ReturnType<typeof vi.fn>
+  downloadURL: ReturnType<typeof vi.fn>
+}
+type FakeWindow = {
+  webContents: FakeWebContents
+  loadURL: ReturnType<typeof vi.fn>
+  on: ReturnType<typeof vi.fn>
+  show: ReturnType<typeof vi.fn>
+  focus: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+  isDestroyed: ReturnType<typeof vi.fn>
+}
+
+// --- electron mock ----------------------------------------------------------
+// BrowserWindow is mocked as a constructor that records the created window and
+// exposes a webContents stub with spies for setWindowOpenHandler / downloadURL.
+// `vi.hoisted` keeps the shared state in scope for the hoisted `vi.mock` factory.
+const { openExternal, createdWindows } = vi.hoisted(() => ({
+  openExternal: vi.fn(),
+  createdWindows: [] as FakeWindow[],
+}))
+
+vi.mock('electron', () => {
+  // Regular function (not an arrow) so `new BrowserWindow(...)` works.
+  const BrowserWindow = vi.fn(function () {
+    const win: FakeWindow = {
+      webContents: {
+        setWindowOpenHandler: vi.fn(),
+        downloadURL: vi.fn(),
+      },
+      loadURL: vi.fn(),
+      on: vi.fn(),
+      show: vi.fn(),
+      focus: vi.fn(),
+      close: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+    }
+    createdWindows.push(win)
+    return win
+  })
+  return {
+    BrowserWindow,
+    shell: { openExternal },
+  }
+})
+
+import { openDashboardWindow, closeAllDashboardWindows } from './dashboard-window'
+
+beforeEach(() => {
+  // The module keeps a dedup Map of open windows; clear it so each test starts
+  // from a clean slate and actually creates a fresh window.
+  closeAllDashboardWindows()
+  createdWindows.length = 0
+  openExternal.mockClear()
+})
+
+describe('openDashboardWindow popup policy (SUP-219)', () => {
+  it('installs a popup handler on the dashboard window webContents', () => {
+    openDashboardWindow('agent-one', 'sales', 3838)
+
+    expect(createdWindows).toHaveLength(1)
+    const win = createdWindows[0]
+    // The load-bearing assertion: the popout must register a window-open handler.
+    expect(win.webContents.setWindowOpenHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it('denies external popups and routes them through the system browser', () => {
+    openDashboardWindow('agent-one', 'sales', 3838)
+    const win = createdWindows[0]
+    const handler = win.webContents.setWindowOpenHandler.mock.calls[0][0] as (arg: {
+      url: string
+    }) => { action: string }
+
+    const result = handler({ url: 'https://example.com/evil' })
+
+    expect(result).toEqual({ action: 'deny' })
+    expect(openExternal).toHaveBeenCalledWith('https://example.com/evil')
+    expect(win.webContents.downloadURL).not.toHaveBeenCalled()
+  })
+
+  it('routes /api/agents/.../files/ URLs through downloadURL and denies the popup', () => {
+    openDashboardWindow('agent-one', 'sales', 3838)
+    const win = createdWindows[0]
+    const handler = win.webContents.setWindowOpenHandler.mock.calls[0][0] as (arg: {
+      url: string
+    }) => { action: string }
+
+    const fileUrl = 'http://localhost:3838/api/agents/agent-one/files/report.csv'
+    const result = handler({ url: fileUrl })
+
+    expect(result).toEqual({ action: 'deny' })
+    expect(win.webContents.downloadURL).toHaveBeenCalledWith(fileUrl)
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -37,6 +37,7 @@ import { getSettings } from '@shared/lib/config/settings'
 import { detectAllProviders } from './host-browser'
 import { registerUpdateHandlers, initAutoUpdater, updateAutoUpdaterWindow } from './auto-updater'
 import { enableKeepAwake, disableKeepAwake, cleanupKeepAwake, restoreKeepAwakeOnStartup } from './keep-awake'
+import { openDashboardWindow, installPopupHandler, closeAllDashboardWindows } from './dashboard-window'
 
 // In dev mode, use a separate data directory to avoid mixing with production data.
 // Setting app.name before getPath('userData') changes the resolved directory.
@@ -88,7 +89,6 @@ if (process.platform === 'darwin') {
 const DEFAULT_API_PORT = 47891
 let actualApiPort: number = DEFAULT_API_PORT
 let mainWindow: BrowserWindow | null = null
-const dashboardWindows: Map<string, BrowserWindow> = new Map()
 let apiServer: ReturnType<typeof serve> | null = null
 let notificationEventSource: EventSource | null = null
 let apiReady = false
@@ -193,32 +193,6 @@ function isNotificationTypeAllowedLocally(notificationType: string | undefined):
     // install, which is worse than the spam from failing open.
     return true
   }
-}
-
-function openDashboardWindow(agentSlug: string, dashboardSlug: string) {
-  const key = `${agentSlug}/${dashboardSlug}`
-
-  // Focus existing window if already open
-  const existing = dashboardWindows.get(key)
-  if (existing && !existing.isDestroyed()) {
-    existing.show()
-    existing.focus()
-    return
-  }
-
-  const url = `http://localhost:${actualApiPort}/api/agents/${agentSlug}/artifacts/${dashboardSlug}/view`
-  const win = new BrowserWindow({
-    width: 1000,
-    height: 700,
-    title: 'SuperAgent Dashboard',
-    webPreferences: {
-      contextIsolation: true,
-      nodeIntegration: false,
-    },
-  })
-  win.loadURL(url)
-  dashboardWindows.set(key, win)
-  win.on('closed', () => dashboardWindows.delete(key))
 }
 
 // Register custom protocol for OAuth callbacks
@@ -352,17 +326,8 @@ function createWindow() {
     menu.popup()
   })
 
-  // Handle window.open() calls - prevent popup windows
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    // Handle file download URLs - download directly without opening a popup
-    if (url.includes('/api/agents/') && url.includes('/files/')) {
-      mainWindow?.webContents.downloadURL(url)
-      return { action: 'deny' }
-    }
-    // For other URLs (OAuth, external links), open in system browser
-    shell.openExternal(url)
-    return { action: 'deny' }
-  })
+  // Handle window.open() calls - deny popups and route external links / downloads.
+  installPopupHandler(mainWindow.webContents)
 
   // Load the app
   if (process.env.ELECTRON_RENDERER_URL) {
@@ -749,7 +714,7 @@ ipcMain.handle('show-emoji-panel', () => {
 
 // IPC handler for opening a dashboard in a separate window
 ipcMain.handle('open-dashboard-window', (_event, { agentSlug, dashboardSlug }: { agentSlug: string; dashboardSlug: string }) => {
-  openDashboardWindow(agentSlug, dashboardSlug)
+  openDashboardWindow(agentSlug, dashboardSlug, actualApiPort)
 })
 
 // IPC handler for creating a macOS dock shortcut for a dashboard
@@ -949,7 +914,7 @@ function handleDeepLinkUrl(url: string, fromQueue = false) {
       const agentSlug = decodeURIComponent(parts[0])
       const dashboardSlug = decodeURIComponent(parts[1])
       if (apiReady) {
-        openDashboardWindow(agentSlug, dashboardSlug)
+        openDashboardWindow(agentSlug, dashboardSlug, actualApiPort)
       } else {
         pendingDashboardLinks.push({ agentSlug, dashboardSlug })
       }
@@ -1278,7 +1243,7 @@ async function startApp() {
   // Mark API as ready and process any queued dashboard deep links
   apiReady = true
   for (const link of pendingDashboardLinks) {
-    openDashboardWindow(link.agentSlug, link.dashboardSlug)
+    openDashboardWindow(link.agentSlug, link.dashboardSlug, actualApiPort)
   }
   pendingDashboardLinks.length = 0
   processPendingProtocolUrls()
@@ -1389,10 +1354,7 @@ async function gracefulShutdown() {
   stopNotificationListener()
 
   // Close all dashboard windows
-  for (const win of dashboardWindows.values()) {
-    if (!win.isDestroyed()) win.close()
-  }
-  dashboardWindows.clear()
+  closeAllDashboardWindows()
 
   // Destroy tray and app menu
   destroyTray()

--- a/src/renderer/components/dashboards/dashboard-view.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.tsx
@@ -6,6 +6,7 @@ import { useKeepAlive } from '@renderer/hooks/use-keep-alive'
 import { useArtifacts } from '@renderer/hooks/use-artifacts'
 import { useUser } from '@renderer/context/user-context'
 import { getApiBaseUrl, isElectron, getPlatform, openDashboardExternal } from '@renderer/lib/env'
+import { buildDashboardArtifactPath } from '@shared/lib/dashboard-url'
 import { AddToDockDialog } from './add-to-dock-dialog'
 import { PendingAgentReviews } from './pending-agent-reviews'
 import { useRenderTracker } from '@renderer/lib/perf'
@@ -32,7 +33,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   const isDashboardRunning = dashboard?.status === 'running'
 
   const baseUrl = getApiBaseUrl()
-  const iframeSrc = `${baseUrl}/api/agents/${agentSlug}/artifacts/${dashboardSlug}/`
+  const iframeSrc = `${baseUrl}${buildDashboardArtifactPath(agentSlug, dashboardSlug)}`
 
   const handleRefresh = useCallback(() => {
     if (iframeRef.current) {

--- a/src/renderer/lib/env.ts
+++ b/src/renderer/lib/env.ts
@@ -1,3 +1,5 @@
+import { buildDashboardViewPath } from '@shared/lib/dashboard-url'
+
 // Cache for the API base URL (fetched once from Electron main process)
 let cachedApiBaseUrl: string | null = null
 let apiUrlPromise: Promise<string> | null = null
@@ -83,7 +85,7 @@ export function openDashboardExternal(agentSlug: string, dashboardSlug: string, 
     window.electronAPI.openDashboardWindow(agentSlug, dashboardSlug, dashboardName)
   } else {
     const baseUrl = getApiBaseUrl()
-    const url = `${baseUrl}/api/agents/${agentSlug}/artifacts/${dashboardSlug}/view`
+    const url = `${baseUrl}${buildDashboardViewPath(agentSlug, dashboardSlug)}`
     window.open(url, '_blank')
   }
 }

--- a/src/shared/lib/dashboard-url.sup218.test.ts
+++ b/src/shared/lib/dashboard-url.sup218.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildDashboardArtifactPath,
+  buildDashboardViewPath,
+  buildDashboardViewUrl,
+} from './dashboard-url'
+
+// SUP-218: the Electron dashboard popout / iframe URL builders concatenated
+// agentSlug and dashboardSlug into the local API path WITHOUT encoding each
+// segment, so a slug containing a slash, space, or other path-significant
+// character produced a wrong or broken path (and an embedded slash created an
+// extra path segment). Each segment must be URL-encoded independently, matching
+// the deep-link launcher and the screenshot URL.
+
+describe('buildDashboardViewPath (SUP-218)', () => {
+  it('URL-encodes agent and dashboard path segments', () => {
+    // space -> %20, slash -> %2F (so "sales/report" stays a single segment).
+    expect(buildDashboardViewPath('agent one', 'sales/report')).toBe(
+      '/api/agents/agent%20one/artifacts/sales%2Freport/view',
+    )
+  })
+
+  it('encodes a traversal-ish slug so it cannot escape its segment', () => {
+    expect(buildDashboardViewPath('a', '../../etc')).toBe(
+      '/api/agents/a/artifacts/..%2F..%2Fetc/view',
+    )
+  })
+
+  it('leaves a plain slug unchanged', () => {
+    expect(buildDashboardViewPath('sales-agent', 'weekly')).toBe(
+      '/api/agents/sales-agent/artifacts/weekly/view',
+    )
+  })
+})
+
+describe('buildDashboardArtifactPath (SUP-218)', () => {
+  it('encodes both segments and ends with a trailing slash for the iframe src', () => {
+    expect(buildDashboardArtifactPath('agent one', 'sales/report')).toBe(
+      '/api/agents/agent%20one/artifacts/sales%2Freport/',
+    )
+  })
+
+  it('leaves a plain slug unchanged', () => {
+    expect(buildDashboardArtifactPath('sales-agent', 'weekly')).toBe(
+      '/api/agents/sales-agent/artifacts/weekly/',
+    )
+  })
+})
+
+describe('buildDashboardViewUrl (SUP-218)', () => {
+  it('prefixes the encoded view path with the localhost API origin', () => {
+    expect(buildDashboardViewUrl(3838, 'agent one', 'sales/report')).toBe(
+      'http://localhost:3838/api/agents/agent%20one/artifacts/sales%2Freport/view',
+    )
+  })
+
+  it('leaves a plain slug unchanged', () => {
+    expect(buildDashboardViewUrl(3838, 'sales-agent', 'weekly')).toBe(
+      'http://localhost:3838/api/agents/sales-agent/artifacts/weekly/view',
+    )
+  })
+})

--- a/src/shared/lib/dashboard-url.ts
+++ b/src/shared/lib/dashboard-url.ts
@@ -1,0 +1,24 @@
+/**
+ * Builders for the local dashboard-view / dashboard-iframe API paths.
+ *
+ * Each path segment (agentSlug, dashboardSlug) is URL-encoded independently via
+ * encodeURIComponent so a slug containing a slash, space, or other
+ * path-significant character can't break out of its segment (SUP-218).
+ *
+ * Mirrors the encoding already used by the deep-link launcher
+ * (src/main/index.ts), the dashboard screenshot URL
+ * (src/renderer/components/home/dashboard-card.tsx), and the server-side view
+ * wrapper (src/api/routes/agents.ts).
+ */
+
+export function buildDashboardArtifactPath(agentSlug: string, dashboardSlug: string): string {
+  return `/api/agents/${encodeURIComponent(agentSlug)}/artifacts/${encodeURIComponent(dashboardSlug)}/`
+}
+
+export function buildDashboardViewPath(agentSlug: string, dashboardSlug: string): string {
+  return `${buildDashboardArtifactPath(agentSlug, dashboardSlug)}view`
+}
+
+export function buildDashboardViewUrl(port: number, agentSlug: string, dashboardSlug: string): string {
+  return `http://localhost:${port}${buildDashboardViewPath(agentSlug, dashboardSlug)}`
+}


### PR DESCRIPTION
## Summary

Two related hardening fixes in the Electron dashboard-popout area of `src/main/index.ts`. Both are batched because they touch the same `openDashboardWindow` path.

### SUP-218 — popout URLs built from unencoded slugs
The dashboard popout / iframe URL builders concatenated `agentSlug` and `dashboardSlug` directly into the local API path without URL-encoding each segment. A slug containing a slash, space, or other path-significant character produced a wrong or broken path — an embedded slash (e.g. `sales/report`) created an extra path segment, e.g. `/api/agents/agent one/artifacts/sales/report/view` instead of `/api/agents/agent%20one/artifacts/sales%2Freport/view`. This was inconsistent with the sibling deep-link launcher, screenshot URL, and server-side view wrapper, which all use `encodeURIComponent`.

**Fix:** extract a pure, unit-testable helper `src/shared/lib/dashboard-url.ts` (`buildDashboardViewPath` / `buildDashboardArtifactPath` / `buildDashboardViewUrl`) that `encodeURIComponent`s each segment, and call it from all three builders:
- the main-process popout (`openDashboardWindow`, now in `dashboard-window.ts`)
- the renderer web fallback (`src/renderer/lib/env.ts`)
- the iframe `src` (`src/renderer/components/dashboards/dashboard-view.tsx`)

The dedup `Map` key still uses the raw `${agentSlug}/${dashboardSlug}` join — only the loaded URL string changed.

### SUP-219 — popout windows did not restrict `window.open`
Dashboard popout `BrowserWindow`s render untrusted, agent-generated content but never installed a `setWindowOpenHandler`, so `window.open()` fell back to Electron's default *allow* behavior — bypassing the deny-and-route popup policy the main window enforces.

**Fix:** extract `installPopupHandler(webContents)` and apply it to **both** the main window and the popout. It denies child windows (`{ action: 'deny' }`), streams `/api/agents/.../files/` URLs via `downloadURL`, and routes other external URLs through `shell.openExternal`.

To make `openDashboardWindow` testable without importing the heavyweight main entrypoint (which boots the API server on import), it now lives in `src/main/dashboard-window.ts` and takes the API port explicitly.

## Failing-test-now-green regression
- `src/shared/lib/dashboard-url.sup218.test.ts` — asserts both segments are encoded (`agent one` → `agent%20one`, `sales/report` → `sales%2Freport`, `../../etc` → `..%2F..%2Fetc`), plus plain-slug no-op cases. Failed on the raw-concat baseline; passes now.
- `src/main/index.popout-window-handler.sup219.test.ts` — mocks `electron`, drives `openDashboardWindow`, and asserts `setWindowOpenHandler` is installed, that an external URL returns `{ action: 'deny' }` + routes via `shell.openExternal`, and that a `/files/` URL triggers `downloadURL` + deny. Failed (`setWindowOpenHandler` called 0 times) on baseline; passes now.

Validation: both new tests pass; related `auto-updater.test.ts` and `app-sidebar.test.tsx` still pass; `npx tsc --noEmit` clean; `npx eslint` on changed files clean.

## Changed files
- `src/shared/lib/dashboard-url.ts` (new)
- `src/shared/lib/dashboard-url.sup218.test.ts` (new)
- `src/main/dashboard-window.ts` (new — extracted `openDashboardWindow` + `installPopupHandler` + `closeAllDashboardWindows`)
- `src/main/index.popout-window-handler.sup219.test.ts` (new)
- `src/main/index.ts`
- `src/renderer/lib/env.ts`
- `src/renderer/components/dashboards/dashboard-view.tsx`

Status: waiting for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)