### PR TITLE
fix(agents): run peripheral cleanup before irreversible workspace removal (SUP-208)

### DIFF
--- a/src/api/routes/agents.delete-ordering.sup208.test.ts
+++ b/src/api/routes/agents.delete-ordering.sup208.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+// ---------------------------------------------------------------------------
+// SUP-208: agent delete must run peripheral cleanup BEFORE the irreversible
+// workspace removal.
+//
+// `DELETE /api/agents/:id` used to call `deleteAgent(slug)` (which removes the
+// agent workspace directory) first, then run `deletePoliciesForAgent` and
+// `cleanupAgentData`. If peripheral cleanup threw, the route returned 500 with
+// the workspace already gone, orphaning scheduled tasks / integrations / ACLs /
+// policies / messages / audit rows that point at a non-existent agent.
+//
+// These tests mount the REAL agents router (its db + peripheral services
+// mocked) and assert ordering:
+//   1. when `cleanupAgentData` rejects, `deleteAgent` (workspace removal) must
+//      NOT have been called — peripheral cleanup gates the irreversible step.
+//   2. in the happy path, `cleanupAgentData` + `deletePoliciesForAgent` run
+//      BEFORE `deleteAgent` (asserted via mock.invocationCallOrder).
+//
+// Recorded mock fns are prefixed `mock*` so they can be referenced from the
+// hoisted `vi.mock` factories; the router is imported at the bottom of the file
+// after every mock is registered.
+// ---------------------------------------------------------------------------
+
+// --- agent-service ----------------------------------------------------------
+// `getAgent` provides the existence check + audit name; `deleteAgent` is the
+// irreversible workspace removal we are gating.
+const mockGetAgent = vi.fn()
+const mockDeleteAgent = vi.fn()
+vi.mock('@shared/lib/services/agent-service', () => ({
+  listAgentsWithStatus: vi.fn(),
+  createAgent: vi.fn(),
+  getAgentWithStatus: vi.fn(),
+  getAgent: (...args: unknown[]) => mockGetAgent(...args),
+  updateAgent: vi.fn(),
+  deleteAgent: (...args: unknown[]) => mockDeleteAgent(...args),
+  agentExists: vi.fn().mockResolvedValue(true),
+}))
+
+// --- peripheral cleanup services --------------------------------------------
+const mockCleanupAgentData = vi.fn()
+vi.mock('@shared/lib/services/agent-cleanup-service', () => ({
+  cleanupAgentData: (...args: unknown[]) => mockCleanupAgentData(...args),
+}))
+
+const mockDeletePoliciesForAgent = vi.fn()
+vi.mock('@shared/lib/services/x-agent-policy-service', () => ({
+  deletePoliciesForAgent: (...args: unknown[]) => mockDeletePoliciesForAgent(...args),
+  listPoliciesForCaller: vi.fn(() => []),
+  replacePoliciesForCaller: vi.fn(),
+  replacePoliciesForCallerInputSchema: { safeParse: vi.fn(() => ({ success: false, error: {} })) },
+}))
+
+const mockRevokeProxyToken = vi.fn()
+vi.mock('@shared/lib/proxy/token-store', () => ({
+  revokeProxyToken: (...args: unknown[]) => mockRevokeProxyToken(...args),
+  validateProxyToken: vi.fn(),
+}))
+
+const mockRemoveClient = vi.fn()
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: {
+    getClient: () => ({ fetch: vi.fn(), sendMessage: vi.fn(), start: vi.fn(), stop: vi.fn() }),
+    ensureRunning: vi.fn(),
+    getCachedInfo: () => ({ status: 'running', port: 8080 }),
+    removeClient: (...args: unknown[]) => mockRemoveClient(...args),
+    keepAlive: vi.fn(),
+  },
+}))
+
+const mockLogAuditEvent = vi.fn()
+vi.mock('@shared/lib/services/audit-log-service', () => ({
+  logAuditEvent: (...args: unknown[]) => mockLogAuditEvent(...args),
+}))
+
+// --- generic db / orm harness (unused by the DELETE path; satisfies imports) -
+vi.mock('@shared/lib/db', () => ({
+  db: {
+    select: () => ({ from: () => ({ where: () => ({ limit: () => Promise.resolve([]), all: () => [] }) }) }),
+    insert: () => ({ values: () => ({ onConflictDoNothing: () => Promise.resolve(undefined) }) }),
+    update: () => ({ set: () => ({ where: () => Promise.resolve(undefined) }) }),
+    delete: () => ({ where: () => Promise.resolve(undefined) }),
+    transaction: (cb: (tx: unknown) => unknown) => cb({}),
+  },
+}))
+
+vi.mock('@shared/lib/db/schema', () => ({
+  connectedAccounts: {}, agentConnectedAccounts: {}, proxyAuditLog: {}, remoteMcpServers: {},
+  agentRemoteMcps: {}, mcpAuditLog: {}, agentAcl: {}, user: {}, messageAuthor: {},
+  apiScopePolicies: {}, mcpToolPolicies: {},
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq: (col: string, val: string) => ({ col, val }),
+  desc: (col: string) => ({ desc: col }),
+  and: (...args: unknown[]) => args,
+  inArray: (col: string, vals: string[]) => ({ col, vals }),
+  count: () => 'count_fn',
+  like: (col: string, val: string) => ({ col, val }),
+  or: (...args: unknown[]) => args,
+}))
+
+// --- auth + config ----------------------------------------------------------
+const mockAuthUser = { id: 'test-user-id', name: 'Test User', email: 'test@example.com' }
+vi.mock('../middleware/auth', () => ({
+  Authenticated: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
+  AgentRead: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
+  AgentUser: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
+  AgentAdmin: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
+}))
+
+vi.mock('@shared/lib/auth/config', () => ({
+  getAppBaseUrlFromRequest: () => 'http://localhost:3000',
+  getCurrentUserId: () => 'test-user-id',
+}))
+
+vi.mock('@shared/lib/auth/mode', () => ({ isAuthMode: () => false }))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getAccountProviderUserId: () => 'test-user',
+  getEffectiveAnthropicApiKey: () => 'test-key',
+  getEffectiveModels: () => ({ summarizerModel: 'claude-3-haiku' }),
+  getEffectiveAgentLimits: () => ({}),
+  getCustomEnvVars: () => ({}),
+  getSettings: () => ({ container: {}, skillsets: [] }),
+  VALID_SCRIPT_TYPES: [],
+}))
+
+// --- remaining imports pulled in by the agents router -----------------------
+vi.mock('@shared/lib/analytics/server-analytics', () => ({ trackServerEvent: vi.fn() }))
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    broadcastGlobal: vi.fn(), broadcastSessionUpdate: vi.fn(), persistMessage: vi.fn(),
+    markAllSessionsInactiveForAgent: vi.fn(), isSessionActive: vi.fn(() => false),
+    isSessionAwaitingInput: vi.fn(() => false), hasActiveSessionsForAgent: vi.fn(() => false),
+    hasSessionsAwaitingInputForAgent: vi.fn(() => false), isSubscribed: vi.fn(() => true),
+    subscribeToSession: vi.fn(), unsubscribeFromSession: vi.fn(), markSessionActive: vi.fn(),
+    broadcastSessionEvent: vi.fn(),
+  },
+}))
+
+vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
+  countActiveTriggersPerAccount: vi.fn().mockResolvedValue({}),
+  listWebhookTriggers: vi.fn(), listActiveWebhookTriggers: vi.fn(), listCancelledWebhookTriggers: vi.fn(),
+}))
+
+vi.mock('@shared/lib/services/session-service', () => ({
+  listSessions: vi.fn(), updateSessionName: vi.fn(), registerSession: vi.fn(),
+  getSessionMessagesWithCompact: vi.fn(), getSession: vi.fn(), getSessionMetadata: vi.fn(),
+  sessionExists: vi.fn().mockResolvedValue(true), updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
+  deleteSession: vi.fn(), removeMessage: vi.fn(), removeToolCall: vi.fn(),
+  getSessionSummary: vi.fn().mockResolvedValue({ sessionIds: [], sessionCount: 0, lastActivityAt: null }),
+}))
+
+vi.mock('@shared/lib/services/secrets-service', () => ({
+  listSecrets: vi.fn(), getSecret: vi.fn(), setSecret: vi.fn(), deleteSecret: vi.fn(),
+  keyToEnvVar: vi.fn(), getSecretEnvVars: vi.fn(),
+}))
+
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  listScheduledTasks: vi.fn(), listPendingScheduledTasks: vi.fn(),
+  listPendingScheduledTasksByAgents: vi.fn(() => Promise.resolve(new Map())),
+  listCancelledScheduledTasks: vi.fn(),
+}))
+
+vi.mock('@shared/lib/services/skillset-service', () => ({
+  getAgentSkillsWithStatus: vi.fn(), getDiscoverableSkills: vi.fn(), installSkillFromSkillset: vi.fn(),
+  updateSkillFromSkillset: vi.fn(), createSkillPR: vi.fn(), getSkillPRInfo: vi.fn(),
+  getSkillPublishInfo: vi.fn(), publishSkillToSkillset: vi.fn(), refreshAgentSkills: vi.fn(),
+  exportSkill: vi.fn(), importSkillFromZip: vi.fn(), SKILL_MAX_COMPRESSED_SIZE: 100 * 1024 * 1024,
+}))
+
+vi.mock('@shared/lib/services/artifact-service', () => ({
+  listArtifactsFromFilesystem: vi.fn(), deleteArtifactFromFilesystem: vi.fn(), renameArtifactOnFilesystem: vi.fn(),
+}))
+
+vi.mock('@shared/lib/services/chat-integration-service', () => ({
+  listChatIntegrations: vi.fn(() => []), listChatIntegrationsByAgents: vi.fn(() => new Map()),
+}))
+
+vi.mock('@shared/lib/services/notification-service', () => ({
+  getSessionIdsWithUnreadNotifications: vi.fn(() => Promise.resolve(new Set())),
+  getUnreadNotificationsByAgents: vi.fn(() => Promise.resolve(new Map())),
+}))
+
+vi.mock('@shared/lib/proxy/host-url', () => ({
+  getContainerHostUrl: () => 'localhost', getAppPort: () => 3000,
+}))
+
+vi.mock('@shared/lib/proxy/review-manager', () => ({
+  reviewManager: {
+    getPendingReviewsForAgent: () => [], submitDecision: vi.fn(), resolveMatchingPending: vi.fn(),
+    resolveMatchingPendingByLabel: vi.fn(), resolveMatchingXAgentByOperation: vi.fn(),
+  },
+}))
+
+vi.mock('@shared/lib/services/agent-template-service', () => ({
+  exportAgentTemplate: vi.fn(), exportAgentFull: vi.fn(), importAgentFromTemplate: vi.fn(),
+  MAX_COMPRESSED_SIZE: 500 * 1024 * 1024, installAgentFromSkillset: vi.fn(), updateAgentFromSkillset: vi.fn(),
+  getAgentTemplateStatus: vi.fn(), getDiscoverableAgents: vi.fn(), refreshSkillsetCaches: vi.fn(),
+  getAgentPRInfo: vi.fn(), createAgentPR: vi.fn(), getAgentPublishInfo: vi.fn(),
+  publishAgentToSkillset: vi.fn(), refreshAgentTemplates: vi.fn(), hasOnboardingSkill: vi.fn(),
+}))
+
+vi.mock('@shared/lib/utils/retry', () => ({ withRetry: vi.fn((fn: () => unknown) => fn()) }))
+
+vi.mock('@shared/lib/llm-provider/helpers', () => ({
+  getConfiguredLlmClient: () => ({ messages: { create: vi.fn() } }),
+  extractTextFromLlmResponse: () => null,
+}))
+
+vi.mock('@shared/lib/utils/message-transform', () => ({
+  transformMessages: vi.fn(), resolveInterruptedSubagents: vi.fn(),
+}))
+
+vi.mock('@shared/lib/utils/file-storage', () => ({
+  getSessionJsonlPath: vi.fn(), readFileOrNull: vi.fn(), writeFile: vi.fn(),
+  getAgentSessionsDir: vi.fn(() => '/mock/sessions'), readJsonlFile: vi.fn(),
+  getAgentWorkspaceDir: vi.fn((slug: string) => `/mock/workspace/${slug}`),
+  getAgentPreferencesPath: vi.fn((slug: string) => `/mock/workspace/${slug}/agent-preferences.json`),
+  getTempUploadsDir: vi.fn(() => '/mock/tmp/uploads'),
+  ensureDirectory: vi.fn(), removeDirectory: vi.fn(),
+}))
+
+vi.mock('@anthropic-ai/sdk', () => ({ default: vi.fn() }))
+vi.mock('hono/streaming', () => ({ streamSSE: vi.fn() }))
+
+// Import the router after all mocks are registered.
+import agents from './agents'
+
+function appWithAgents() {
+  const app = new Hono()
+  app.route('/api/agents', agents)
+  return app
+}
+
+function deleteAgentReq() {
+  return appWithAgents().request('http://localhost/api/agents/test-agent', { method: 'DELETE' })
+}
+
+describe('SUP-208: DELETE /api/agents/:id — peripheral cleanup precedes workspace removal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default happy-path wiring: agent exists, all cleanup steps succeed.
+    mockGetAgent.mockResolvedValue({ slug: 'test-agent', frontmatter: { name: 'Test Agent' } })
+    mockDeleteAgent.mockResolvedValue(true)
+    mockDeletePoliciesForAgent.mockResolvedValue(undefined)
+    mockCleanupAgentData.mockResolvedValue(undefined)
+    mockRevokeProxyToken.mockResolvedValue(undefined)
+  })
+
+  it('does not remove the workspace before peripheral cleanup succeeds', async () => {
+    // cleanupAgentData fails — the irreversible workspace removal must not have
+    // run, so the operation is safely retryable instead of half-destroyed.
+    mockCleanupAgentData.mockRejectedValue(new Error('db cleanup failed'))
+
+    const res = await deleteAgentReq()
+
+    expect(res.status).toBe(500)
+    expect(mockDeleteAgent).not.toHaveBeenCalled()
+  })
+
+  it('does not remove the workspace if policy cleanup fails', async () => {
+    mockDeletePoliciesForAgent.mockRejectedValue(new Error('policy cleanup failed'))
+
+    const res = await deleteAgentReq()
+
+    expect(res.status).toBe(500)
+    expect(mockDeleteAgent).not.toHaveBeenCalled()
+  })
+
+  it('runs peripheral cleanup BEFORE the irreversible workspace removal (happy path)', async () => {
+    const res = await deleteAgentReq()
+
+    expect(res.status).toBe(204)
+    expect(mockDeleteAgent).toHaveBeenCalledTimes(1)
+    expect(mockCleanupAgentData).toHaveBeenCalledTimes(1)
+    expect(mockDeletePoliciesForAgent).toHaveBeenCalledTimes(1)
+
+    const deleteOrder = mockDeleteAgent.mock.invocationCallOrder[0]
+    const cleanupOrder = mockCleanupAgentData.mock.invocationCallOrder[0]
+    const policyOrder = mockDeletePoliciesForAgent.mock.invocationCallOrder[0]
+
+    expect(cleanupOrder).toBeLessThan(deleteOrder)
+    expect(policyOrder).toBeLessThan(deleteOrder)
+  })
+
+  it('returns 404 and never touches the workspace when the agent does not exist', async () => {
+    mockGetAgent.mockResolvedValue(null)
+
+    const res = await deleteAgentReq()
+
+    expect(res.status).toBe(404)
+    expect(mockDeleteAgent).not.toHaveBeenCalled()
+    expect(mockCleanupAgentData).not.toHaveBeenCalled()
+  })
+})

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -728,29 +728,43 @@ agents.put('/:id', AgentAdmin(), async (c) => {
 agents.delete('/:id', AgentAdmin(), async (c) => {
   try {
     const slug = c.req.param('id')
-    const agentBeforeDelete = await getAgent(slug)
-    const deleted = await deleteAgent(slug)
 
-    if (!deleted) {
+    // Existence check up front so we never start the destructive flow for a
+    // missing agent. We rely on getAgent (not deleteAgent's return value)
+    // because the irreversible workspace removal is deferred to the last step.
+    const agentBeforeDelete = await getAgent(slug)
+    if (!agentBeforeDelete) {
       return c.json({ error: 'Agent not found' }, 404)
     }
 
+    // Stop/forget the running container before tearing anything down.
     containerManager.removeClient(slug)
 
-    // Clean up proxy token
+    // Clean up proxy token (best-effort — a revoked token is harmless on its own).
     try {
       await revokeProxyToken(slug)
     } catch (error) {
       console.error('Failed to revoke proxy token:', error)
     }
 
-    // Clean up x-agent invoke policies referencing this agent (caller or target)
+    // Clean up x-agent invoke policies referencing this agent (caller or target).
     await deletePoliciesForAgent(slug)
 
-    // Clean up all peripheral data (triggers, integrations, tasks, ACLs, etc.)
+    // Clean up all peripheral data (triggers, integrations, tasks, ACLs, etc.).
+    // This runs BEFORE the irreversible workspace removal: if any peripheral
+    // cleanup throws, the route returns 500 with the workspace still intact, so
+    // the delete is safely retryable instead of leaving orphaned rows pointing
+    // at a workspace that no longer exists (SUP-208).
     await cleanupAgentData(slug)
 
-    logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: slug, action: 'deleted', details: { name: agentBeforeDelete?.frontmatter.name } })
+    // Irreversible: remove the agent workspace directory. Done LAST so it only
+    // happens once every peripheral cleanup above has succeeded.
+    const deleted = await deleteAgent(slug)
+    if (!deleted) {
+      return c.json({ error: 'Agent not found' }, 404)
+    }
+
+    logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: slug, action: 'deleted', details: { name: agentBeforeDelete.frontmatter.name } })
     return c.body(null, 204)
   } catch (error) {
     console.error('Failed to delete agent:', error)

--- a/src/shared/lib/services/agent-cleanup-service.ts
+++ b/src/shared/lib/services/agent-cleanup-service.ts
@@ -18,15 +18,20 @@ import { isPlatformComposioActive } from '@shared/lib/composio/client'
 export async function cleanupAgentData(agentSlug: string): Promise<void> {
   await cleanupWebhookTriggers(agentSlug)
 
-  db.delete(chatIntegrations).where(eq(chatIntegrations.agentSlug, agentSlug)).run()
-  db.delete(scheduledTasks).where(eq(scheduledTasks.agentSlug, agentSlug)).run()
-  db.delete(notifications).where(eq(notifications.agentSlug, agentSlug)).run()
-  db.delete(agentConnectedAccounts).where(eq(agentConnectedAccounts.agentSlug, agentSlug)).run()
-  db.delete(agentRemoteMcps).where(eq(agentRemoteMcps.agentSlug, agentSlug)).run()
-  db.delete(proxyAuditLog).where(eq(proxyAuditLog.agentSlug, agentSlug)).run()
-  db.delete(mcpAuditLog).where(eq(mcpAuditLog.agentSlug, agentSlug)).run()
-  db.delete(agentAcl).where(eq(agentAcl.agentSlug, agentSlug)).run()
-  db.delete(messageAuthor).where(eq(messageAuthor.agentSlug, agentSlug)).run()
+  // Delete all peripheral rows in a single transaction so the cleanup is atomic:
+  // either every row referencing this agent is removed or none is, never a
+  // half-cleaned state (SUP-208).
+  db.transaction(() => {
+    db.delete(chatIntegrations).where(eq(chatIntegrations.agentSlug, agentSlug)).run()
+    db.delete(scheduledTasks).where(eq(scheduledTasks.agentSlug, agentSlug)).run()
+    db.delete(notifications).where(eq(notifications.agentSlug, agentSlug)).run()
+    db.delete(agentConnectedAccounts).where(eq(agentConnectedAccounts.agentSlug, agentSlug)).run()
+    db.delete(agentRemoteMcps).where(eq(agentRemoteMcps.agentSlug, agentSlug)).run()
+    db.delete(proxyAuditLog).where(eq(proxyAuditLog.agentSlug, agentSlug)).run()
+    db.delete(mcpAuditLog).where(eq(mcpAuditLog.agentSlug, agentSlug)).run()
+    db.delete(agentAcl).where(eq(agentAcl.agentSlug, agentSlug)).run()
+    db.delete(messageAuthor).where(eq(messageAuthor.agentSlug, agentSlug)).run()
+  })
 }
 
 async function cleanupWebhookTriggers(agentSlug: string): Promise<void> {


### PR DESCRIPTION
## SUP-208 — Agent delete removes workspace before peripheral cleanup succeeds

### The bug
`DELETE /api/agents/:id` (`src/api/routes/agents.ts`) was destructive-first: it called `deleteAgent(slug)` — which irreversibly `removeDirectory(agentDir)`s the agent workspace (`agent-service.ts:306`) — **before** running `deletePoliciesForAgent(slug)` and `cleanupAgentData(slug)`. `cleanupAgentData` issues 9 separate `db.delete().run()` calls plus an async Composio webhook call, none transactional. If any peripheral cleanup threw, the route returned `500` with the workspace already gone, orphaning stale `scheduledTasks`, `chatIntegrations`, `agentAcl`, `agentConnectedAccounts`, `agentRemoteMcps`, `proxyAuditLog`, `mcpAuditLog`, `notifications`, `messageAuthor` and x-agent policy rows pointing at a workspace that no longer exists.

### The fix
Reorder the DELETE handler so the irreversible filesystem removal is the **last** step:
1. `getAgent(slug)` existence check → `404` if missing (no longer relies on `deleteAgent`'s return value).
2. `containerManager.removeClient(slug)`.
3. `revokeProxyToken(slug)` (best-effort, as before).
4. `deletePoliciesForAgent(slug)`.
5. `cleanupAgentData(slug)`.
6. **only then** `deleteAgent(slug)` to remove the workspace directory.

A cleanup failure now leaves the workspace intact and the delete is safely retryable instead of half-destroyed.

**Secondary hardening:** the synchronous `db.delete().run()` calls in `cleanupAgentData` are now wrapped in a single better-sqlite3 `db.transaction(...)` so peripheral row deletion is atomic. The async Composio webhook call stays best-effort/try-catch as before.

### Tests (failing-test-first, now green)
New `src/api/routes/agents.delete-ordering.sup208.test.ts` mounts the real agents router (db + peripheral services mocked) and asserts:
- when `cleanupAgentData` rejects → `500` **and `deleteAgent` (workspace removal) was never called**;
- same when `deletePoliciesForAgent` rejects;
- happy path → `cleanupAgentData` + `deletePoliciesForAgent` run **before** `deleteAgent` (via `mock.invocationCallOrder`) and the route returns `204`;
- `404` (and no destructive calls) when the agent does not exist.

All four failed against the old destructive-first code and pass now. Existing `agents.test.ts` (151), `security-repro.test.ts`, and `agent-cleanup-service.test.ts` (17, real in-memory sqlite — validates the transaction wrapping) remain green. `tsc --noEmit` and `eslint` on changed files are clean.

### Changed files
- `src/api/routes/agents.ts`
- `src/shared/lib/services/agent-cleanup-service.ts`
- `src/api/routes/agents.delete-ordering.sup208.test.ts` (new)

Status: waiting for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)