### PR TITLE
fix(settings): clear all agent-owned tables on factory reset (SUP-206)

### DIFF
--- a/src/api/routes/factory-reset.sup206.test.ts
+++ b/src/api/routes/factory-reset.sup206.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import { is, Table, getTableName } from 'drizzle-orm'
+import * as schema from '@shared/lib/db/schema'
+
+// ---------------------------------------------------------------------------
+// SUP-206 — POST /api/settings/factory-reset must clear EVERY agent/app-owned
+// relational table, not just the historical subset of 8. We mock @shared/lib/db
+// so db.delete is a spy that records the table object it received, but we import
+// the REAL schema so the recorded objects can be matched by identity against the
+// full set of tables. The expected set is derived dynamically from the schema
+// (all Drizzle tables minus the Better Auth set), so it can never drift: adding
+// a new agent/app-owned table without wiring it into factory-reset fails here.
+// ---------------------------------------------------------------------------
+
+// Names prefixed with `mock` so vitest's vi.mock hoisting allows referencing it.
+const mockDeletedTables: unknown[] = []
+
+vi.mock('@shared/lib/db', () => ({
+  db: {
+    delete: (t: unknown) => {
+      mockDeletedTables.push(t)
+      return { run: () => undefined, where: () => ({ run: () => undefined }) }
+    },
+  },
+}))
+
+// IMPORTANT: do NOT mock '@shared/lib/db/schema' — we use the real table objects.
+
+// --- Heavy deps the route pulls in at import time / during factory-reset ----
+
+const mockClearSettingsCache = vi.fn()
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  clearSettingsCache: (...args: unknown[]) => mockClearSettingsCache(...args),
+  getBrowserbaseApiKeyStatus: vi.fn(),
+  getComposioApiKeyStatus: vi.fn(),
+  getNangoApiKeyStatus: vi.fn(),
+  getComposioUserId: vi.fn(),
+  getAccountProviderUserId: vi.fn(),
+  getVoiceSettings: vi.fn(),
+  getEffectiveModels: vi.fn(),
+  getEffectiveAgentLimits: vi.fn(),
+  getCustomEnvVars: vi.fn(),
+}))
+
+const mockStopAll = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: {
+    hasRunningAgents: vi.fn().mockReturnValue(false),
+    getRunningAgentIds: vi.fn().mockResolvedValue([]),
+    clearClients: vi.fn(),
+    ensureImageReady: vi.fn().mockResolvedValue(undefined),
+    getReadiness: vi.fn().mockReturnValue({ ready: true }),
+    stopAll: (...args: unknown[]) => mockStopAll(...args),
+  },
+}))
+
+vi.mock('@shared/lib/container/client-factory', () => ({
+  checkAllRunnersAvailability: vi.fn().mockResolvedValue([]),
+  refreshRunnerAvailability: vi.fn().mockResolvedValue([]),
+  startRunner: vi.fn(),
+  restartRunner: vi.fn(),
+  SUPPORTED_RUNNERS: ['docker', 'podman'],
+}))
+
+vi.mock('@shared/lib/config/data-dir', () => ({
+  getDataDir: () => '/mock/data',
+  getAgentsDataDir: () => '/mock/data/agents',
+}))
+
+vi.mock('../../main/host-browser', () => ({
+  detectAllProviders: () => [],
+}))
+
+vi.mock('@shared/lib/stt', () => ({
+  getSttProvider: () => ({
+    getApiKeyStatus: () => ({ isConfigured: false, source: 'none' }),
+    validateKey: vi.fn(),
+  }),
+}))
+
+// Auth middleware: no-op in tests (non-auth mode)
+vi.mock('../middleware/auth', () => ({
+  Authenticated: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  IsAdmin: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}))
+
+vi.mock('@shared/lib/auth/mode', () => ({
+  isAuthMode: () => false,
+}))
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: vi.fn(),
+}))
+
+const mockRevokePlatformToken = vi.fn().mockResolvedValue(true)
+
+vi.mock('@shared/lib/services/platform-auth-service', () => ({
+  revokePlatformToken: (...args: unknown[]) => mockRevokePlatformToken(...args),
+}))
+
+vi.mock('fs', () => ({
+  default: { promises: { rm: vi.fn().mockResolvedValue(undefined) } },
+}))
+
+vi.mock('@shared/lib/analytics/tenant-id', () => ({
+  getTenantId: () => 'mock-tenant-id',
+}))
+
+vi.mock('path', () => ({
+  default: { join: (...args: string[]) => args.join('/') },
+}))
+
+import settings from './settings'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createApp() {
+  const app = new Hono()
+  app.route('/api/settings', settings)
+  return app
+}
+
+// Better Auth tables are intentionally NOT wiped by factory reset.
+const BETTER_AUTH_TABLES = new Set<unknown>([
+  schema.user,
+  schema.authSession,
+  schema.authAccount,
+  schema.verification,
+])
+
+/** Every Drizzle table defined in the schema (by object identity). */
+function allSchemaTables(): unknown[] {
+  return Object.values(schema).filter((v) => is(v, Table))
+}
+
+/** Agent/app-owned relational tables that factory reset MUST clear. */
+function agentOwnedTables(): unknown[] {
+  return allSchemaTables().filter((t) => !BETTER_AUTH_TABLES.has(t))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/settings/factory-reset — agent/app-owned table cleanup', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDeletedTables.length = 0
+    app = createApp()
+  })
+
+  async function factoryReset(): Promise<Response> {
+    return app.request('http://localhost/api/settings/factory-reset', {
+      method: 'POST',
+    })
+  }
+
+  it('returns 200 and stops containers + clears settings cache', async () => {
+    const res = await factoryReset()
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true })
+    expect(mockStopAll).toHaveBeenCalledOnce()
+    expect(mockClearSettingsCache).toHaveBeenCalledOnce()
+  })
+
+  it('clears all agent-owned relational data (every non-Better-Auth table)', async () => {
+    const res = await factoryReset()
+    expect(res.status).toBe(200)
+
+    // Sanity: the schema actually has the agent/app-owned tables we expect.
+    const expectedTables = agentOwnedTables()
+    expect(expectedTables.length).toBeGreaterThanOrEqual(19)
+
+    // Every agent/app-owned table must have been passed to db.delete().
+    for (const table of expectedTables) {
+      expect(
+        mockDeletedTables,
+        `factory-reset must delete agent/app-owned table "${getTableName(table as Table)}"`,
+      ).toContain(table)
+    }
+  })
+
+  it('does NOT delete Better Auth tables (user accounts survive a factory reset)', async () => {
+    const res = await factoryReset()
+    expect(res.status).toBe(200)
+
+    for (const table of BETTER_AUTH_TABLES) {
+      expect(
+        mockDeletedTables,
+        `factory-reset must NOT delete Better Auth table "${getTableName(table as Table)}"`,
+      ).not.toContain(table)
+    }
+  })
+})

--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -111,6 +111,19 @@ vi.mock('@shared/lib/db/schema', () => ({
   scheduledTasks: {},
   notifications: {},
   connectedAccounts: {},
+  userSettings: {},
+  auditLog: {},
+  webhookTriggers: {},
+  chatIntegrations: {},
+  chatIntegrationSessions: {},
+  remoteMcpServers: {},
+  agentRemoteMcps: {},
+  mcpAuditLog: {},
+  mcpToolPolicies: {},
+  agentAcl: {},
+  messageAuthor: {},
+  xAgentPolicies: {},
+  apiScopePolicies: {},
 }))
 
 vi.mock('fs', () => ({

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -33,10 +33,72 @@ import { VALID_LIMA_VM_MEMORY_OPTIONS, EFFORT_LEVELS } from '@shared/lib/contain
 import { detectAllProviders } from '../../main/host-browser'
 import { revokePlatformToken } from '@shared/lib/services/platform-auth-service'
 import { db } from '@shared/lib/db'
-import { proxyAuditLog, proxyTokens, agentConnectedAccounts, scheduledTasks, notifications, connectedAccounts, userSettings, auditLog } from '@shared/lib/db/schema'
+import type { SQLiteTable } from 'drizzle-orm/sqlite-core'
+import {
+  proxyAuditLog,
+  proxyTokens,
+  agentConnectedAccounts,
+  scheduledTasks,
+  notifications,
+  connectedAccounts,
+  userSettings,
+  auditLog,
+  webhookTriggers,
+  chatIntegrations,
+  chatIntegrationSessions,
+  remoteMcpServers,
+  agentRemoteMcps,
+  mcpAuditLog,
+  mcpToolPolicies,
+  agentAcl,
+  messageAuthor,
+  xAgentPolicies,
+  apiScopePolicies,
+} from '@shared/lib/db/schema'
 import fs from 'fs'
 
 const settings = new Hono()
+
+/**
+ * Canonical set of agent/app-owned relational tables wiped by factory reset.
+ *
+ * Ordered children-before-parents so deletes succeed regardless of FK-cascade
+ * state. Better Auth tables (user, session, account, verification) are
+ * intentionally excluded — a factory reset clears app/agent data but does NOT
+ * delete user accounts.
+ *
+ * Keep this reconciled with the per-agent set in agent-cleanup-service.ts. The
+ * test in factory-reset.sup206.test.ts enumerates the schema dynamically and
+ * fails if a new agent/app-owned table is added without being listed here, so
+ * the set cannot silently drift again.
+ */
+const FACTORY_RESET_TABLES: SQLiteTable[] = [
+  // Leaf / no-FK-to-reset-table audit + attribution rows
+  proxyAuditLog,
+  proxyTokens,
+  mcpAuditLog,
+  messageAuthor,
+  agentAcl,
+  xAgentPolicies,
+  webhookTriggers,
+  notifications,
+  scheduledTasks,
+  // chat integrations (sessions cascade-cascade from integrations)
+  chatIntegrationSessions,
+  chatIntegrations,
+  // connected accounts + dependents (api scope policies + agent mappings cascade)
+  agentConnectedAccounts,
+  apiScopePolicies,
+  connectedAccounts,
+  // remote MCP servers + dependents (tool policies + agent mappings cascade)
+  agentRemoteMcps,
+  mcpToolPolicies,
+  remoteMcpServers,
+  // per-user settings (user row itself is preserved)
+  userSettings,
+  // global app audit log
+  auditLog,
+]
 
 settings.use('*', Authenticated(), IsAdmin())
 
@@ -554,15 +616,11 @@ settings.post('/factory-reset', async (c) => {
     const agentsDir = getAgentsDataDir()
     await fs.promises.rm(agentsDir, { recursive: true, force: true })
 
-    // Clear all DB tables (order matters for FK constraints)
-    db.delete(proxyAuditLog).run()
-    db.delete(proxyTokens).run()
-    db.delete(agentConnectedAccounts).run()
-    db.delete(scheduledTasks).run()
-    db.delete(notifications).run()
-    db.delete(connectedAccounts).run()
-    db.delete(userSettings).run()
-    db.delete(auditLog).run()
+    // Clear every agent/app-owned relational table (children before parents).
+    // Better Auth tables (user/session/account/verification) are preserved.
+    for (const table of FACTORY_RESET_TABLES) {
+      db.delete(table).run()
+    }
 
     // Delete settings file (includes platform auth token)
     const settingsPath = path.join(getDataDir(), 'settings.json')


### PR DESCRIPTION
## SUP-206 — Factory reset leaves stale agent-owned database rows behind

### Bug
`POST /api/settings/factory-reset` deleted the agents directory but cleared only 8 DB tables (`proxyAuditLog`, `proxyTokens`, `agentConnectedAccounts`, `scheduledTasks`, `notifications`, `connectedAccounts`, `userSettings`, `auditLog`). It omitted ~11 other agent/app-owned relational tables that have no FK-cascade path to a deleted parent, so they leaked across a "factory reset":

`webhookTriggers`, `chatIntegrations`, `chatIntegrationSessions`, `remoteMcpServers`, `agentRemoteMcps`, `mcpAuditLog`, `mcpToolPolicies`, `agentAcl`, `messageAuthor`, `xAgentPolicies` (and `apiScopePolicies`, which was covered indirectly via the `connectedAccounts` ON DELETE CASCADE but is now wiped explicitly for clarity).

Result: stale automation/integration/ACL/policy rows survived a reset, causing ghost integrations/triggers, stale access-policy behavior, and pre/post-reset state leakage.

### Fix
- Replaced the hand-maintained delete block in `src/api/routes/settings.ts` with a single canonical `FACTORY_RESET_TABLES` list covering every agent/app-owned table, ordered children-before-parents.
- Better Auth tables (`user`, `session`, `account`, `verification`) are intentionally preserved — a factory reset clears app/agent data, not user accounts.
- Reconciled against the per-agent set in `agent-cleanup-service.ts` so the two cleanup paths cannot drift apart.

### Regression test (failing → green)
- New file `src/api/routes/factory-reset.sup206.test.ts` drives the handler with a `db.delete` spy and the **real** schema, then asserts every non-Better-Auth Drizzle table was passed to `db.delete`. The expected set is enumerated dynamically from the schema, so adding a new agent/app-owned table without wiring it into factory reset will fail this test. It also asserts the Better Auth tables are NOT deleted.
- This test fails on `main` (e.g. `remote_mcp_servers` never deleted) and passes after the fix.
- Updated the pre-existing `src/api/routes/settings.test.ts` schema mock to include the newly-imported tables (now referenced at module load by `FACTORY_RESET_TABLES`). All 81 tests across both files pass; `tsc --noEmit` and `eslint` are clean.

### Changed files
- `src/api/routes/settings.ts`
- `src/api/routes/factory-reset.sup206.test.ts` (new)
- `src/api/routes/settings.test.ts`

Status: waiting for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)