### PR TITLE
fix(notifications): delete stale notifications for removed sessions (SUP-228)

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -265,6 +265,7 @@ vi.mock('@shared/lib/services/chat-integration-service', () => ({
 vi.mock('@shared/lib/services/notification-service', () => ({
   getSessionIdsWithUnreadNotifications: vi.fn(() => Promise.resolve(new Set())),
   getUnreadNotificationsByAgents: vi.fn(() => Promise.resolve(new Map())),
+  deleteNotificationsBySessionIds: vi.fn(() => Promise.resolve(0)),
 }))
 
 vi.mock('@shared/lib/proxy/host-url', () => ({
@@ -368,6 +369,7 @@ import { getAgent, listAgentsWithStatus } from '@shared/lib/services/agent-servi
 import { listSessions, getSessionMessagesWithCompact, getSessionSummary, sessionExists, deleteSession, getSession } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks, listPendingScheduledTasksByAgents } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
+import { deleteNotificationsBySessionIds } from '@shared/lib/services/notification-service'
 import { messagePersister } from '@shared/lib/container/message-persister'
 
 // ============================================================================
@@ -2189,6 +2191,18 @@ describe('DELETE /:id/sessions/:sessionId', () => {
 
     expect(res.status).toBe(204)
     expect(deleteSession).toHaveBeenCalledWith('test-agent', 'sess-1')
+  })
+
+  it('cleans up notification rows for the deleted session (both modes)', async () => {
+    // SUP-228: deleting a session must not leave stale notification history
+    // pointing at it. Notifications exist in non-auth mode too, so this runs
+    // even with auth mode off.
+    vi.mocked(deleteSession).mockResolvedValue(true)
+
+    const res = await deleteReq(app, URL)
+
+    expect(res.status).toBe(204)
+    expect(deleteNotificationsBySessionIds).toHaveBeenCalledWith(['sess-1'])
   })
 
   it('deletes a dangling session whose transcript JSONL is gone (no getSession gate)', async () => {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -77,7 +77,7 @@ import {
   SKILL_MAX_COMPRESSED_SIZE,
 } from '@shared/lib/services/skillset-service'
 import { type ArtifactInfo, listArtifactsFromFilesystem, deleteArtifactFromFilesystem, renameArtifactOnFilesystem } from '@shared/lib/services/artifact-service'
-import { getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
+import { getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents, deleteNotificationsBySessionIds } from '@shared/lib/services/notification-service'
 import { reviewManager } from '@shared/lib/proxy/review-manager'
 import { isValidApiScope } from '@shared/lib/proxy/scope-matcher'
 import { isLabelDefaultKey } from '@shared/lib/proxy/policy-sentinels'
@@ -1614,10 +1614,15 @@ agents.delete('/:id/sessions/:sessionId', AgentAdmin(), async (c) => {
       return c.json({ error: 'Session not found' }, 404)
     }
 
-    // Clean up message author records for this session
+    // Clean up message author records for this session (auth mode only).
     if (isAuthMode()) {
       await db.delete(messageAuthor).where(eq(messageAuthor.sessionId, sessionId))
     }
+
+    // Clean up notification rows for this session in BOTH modes (notifications
+    // are stored regardless of auth mode; userId is nullable), so deleting a
+    // session never leaves stale notification history pointing at it.
+    await deleteNotificationsBySessionIds([sessionId])
 
     return c.body(null, 204)
   } catch (error) {

--- a/src/shared/lib/scheduler/session-auto-delete-monitor.test.ts
+++ b/src/shared/lib/scheduler/session-auto-delete-monitor.test.ts
@@ -16,7 +16,7 @@ const mockIsAuthMode = vi.fn(() => false)
 const mockIsSessionActive = vi.fn((_id: string) => false)
 const mockUnsubscribeFromSession = vi.fn()
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockDbDelete = vi.fn((..._args: any[]) => ({ where: vi.fn() }))
+const mockDbDelete = vi.fn((..._args: any[]) => ({ where: vi.fn(() => ({ changes: 0 })) }))
 
 vi.mock('@shared/lib/services/agent-service', () => ({
   listAgents: () => mockListAgents(),
@@ -53,7 +53,9 @@ vi.mock('@shared/lib/db', () => ({
 }))
 
 vi.mock('@shared/lib/db/schema', () => ({
-  messageAuthor: { sessionId: 'session_id' },
+  messageAuthor: { sessionId: 'message_author_session_id' },
+  notifications: { sessionId: 'notifications_session_id' },
+  agentAcl: { agentSlug: 'agent_acl_slug', userId: 'agent_acl_user_id' },
 }))
 
 vi.mock('drizzle-orm', () => ({
@@ -307,7 +309,7 @@ describe('SessionAutoDeleteMonitor', () => {
     expect(mockUnsubscribeFromSession).not.toHaveBeenCalledWith('failed')
   })
 
-  it('does not clean DB records when not in auth mode', async () => {
+  it('cleans notifications but not messageAuthor when not in auth mode', async () => {
     const now = Date.now()
     const old = makeSession('old', new Date(now - 60 * 86_400_000))
 
@@ -320,7 +322,11 @@ describe('SessionAutoDeleteMonitor', () => {
 
     await startAndTrigger()
 
-    expect(mockDbDelete).not.toHaveBeenCalled()
+    // Notification cleanup is unconditional (notifications exist in both modes);
+    // messageAuthor cleanup stays gated on auth mode.
+    const deletedTables = mockDbDelete.mock.calls.map((call) => call[0])
+    expect(deletedTables).toContainEqual({ sessionId: 'notifications_session_id' })
+    expect(deletedTables).not.toContainEqual({ sessionId: 'message_author_session_id' })
   })
 
   // --------------------------------------------------------------------------

--- a/src/shared/lib/scheduler/session-auto-delete-monitor.ts
+++ b/src/shared/lib/scheduler/session-auto-delete-monitor.ts
@@ -5,6 +5,7 @@ import {
   deleteSessionsBatch,
 } from '@shared/lib/services/session-service'
 import { readAgentPreferences } from '@shared/lib/services/agent-preferences-service'
+import { deleteNotificationsBySessionIds } from '@shared/lib/services/notification-service'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { getSettings } from '@shared/lib/config/settings'
 import { isAuthMode } from '@shared/lib/auth/mode'
@@ -125,6 +126,19 @@ class SessionAutoDeleteMonitor {
           error
         )
       }
+    }
+
+    // Remove notification rows for the deleted sessions. Notifications exist in
+    // both auth and non-auth modes (userId is nullable), so this runs
+    // unconditionally. Use `deletedIds` (not `toDelete`) so failed filesystem
+    // deletions never wipe DB state for a session that still exists on disk.
+    try {
+      await deleteNotificationsBySessionIds(deletedIds)
+    } catch (error) {
+      console.error(
+        `[SessionAutoDeleteMonitor] Failed to clean notification records for ${agentSlug}:`,
+        error
+      )
     }
 
     console.log(

--- a/src/shared/lib/scheduler/session-auto-delete.sup228.test.ts
+++ b/src/shared/lib/scheduler/session-auto-delete.sup228.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { SessionInfo } from '@shared/lib/types/agent'
+import type { AgentConfig } from '@shared/lib/types/agent'
+
+// ============================================================================
+// SUP-228 — Session auto-delete leaves stale notifications for deleted sessions
+//
+// cleanupAgent() removed session JSONL files, unsubscribed the persister and
+// (auth mode only) deleted message_author rows, but it never deleted the
+// `notifications` rows for the removed session IDs. Notifications are stored in
+// BOTH auth and non-auth modes (userId is nullable), so the leak affects both.
+//
+// These tests mirror session-auto-delete-monitor.test.ts's mocking style. The
+// real `notification-service` is intentionally NOT mocked so that the monitor
+// drives the real `deleteNotificationsBySessionIds()` helper against the mocked
+// `db`/`schema`/`drizzle-orm`, letting us assert the exact delete predicate.
+// ============================================================================
+
+// Schema table identities. These are read EAGERLY inside the schema vi.mock
+// factory, so they must be available before the (hoisted) module imports run —
+// hence vi.hoisted, which is lifted above everything.
+const tables = vi.hoisted(() => ({
+  notifications: { sessionId: 'notifications.session_id' },
+  messageAuthor: { sessionId: 'message_author.session_id' },
+  agentAcl: { agentSlug: 'agent_acl.agent_slug', userId: 'agent_acl.user_id' },
+}))
+
+interface DeleteCall {
+  table: unknown
+  predicate: unknown
+}
+const mockDeleteCalls: DeleteCall[] = []
+
+const mockDbDelete = vi.fn((table: unknown) => ({
+  where: (predicate: unknown) => {
+    mockDeleteCalls.push({ table, predicate })
+    return { changes: 0 }
+  },
+}))
+
+const mockInArray = vi.fn((col: unknown, vals: unknown) => ({ __pred: 'inArray', col, vals }))
+
+const mockListAgents = vi.fn()
+const mockListSessions = vi.fn()
+const mockReadSessionMetadata = vi.fn()
+const mockDeleteSessionsBatch = vi.fn()
+const mockReadAgentPreferences = vi.fn()
+const mockGetSettings = vi.fn()
+const mockIsAuthMode = vi.fn(() => false)
+const mockIsSessionActive = vi.fn((_id: string) => false)
+const mockUnsubscribeFromSession = vi.fn()
+
+vi.mock('@shared/lib/services/agent-service', () => ({
+  listAgents: () => mockListAgents(),
+}))
+
+vi.mock('@shared/lib/services/session-service', () => ({
+  listSessions: (slug: string) => mockListSessions(slug),
+  readSessionMetadata: (slug: string) => mockReadSessionMetadata(slug),
+  deleteSessionsBatch: (slug: string, ids: string[]) => mockDeleteSessionsBatch(slug, ids),
+}))
+
+vi.mock('@shared/lib/services/agent-preferences-service', () => ({
+  readAgentPreferences: (slug: string) => mockReadAgentPreferences(slug),
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => mockGetSettings(),
+}))
+
+vi.mock('@shared/lib/auth/mode', () => ({
+  isAuthMode: () => mockIsAuthMode(),
+}))
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    isSessionActive: (id: string) => mockIsSessionActive(id),
+    unsubscribeFromSession: (id: string) => mockUnsubscribeFromSession(id),
+  },
+}))
+
+vi.mock('@shared/lib/db', () => ({
+  db: { delete: (table: unknown) => mockDbDelete(table) },
+}))
+
+// notification-service imports `notifications` and `agentAcl`; the monitor
+// imports `messageAuthor`. Provide stable identities so we can match calls.
+vi.mock('@shared/lib/db/schema', () => ({
+  notifications: tables.notifications,
+  messageAuthor: tables.messageAuthor,
+  agentAcl: tables.agentAcl,
+}))
+
+// notification-service imports eq/desc/and/lt/inArray/count; the monitor uses
+// inArray. Only `inArray` is exercised here — the rest are inert stubs.
+vi.mock('drizzle-orm', () => ({
+  inArray: (col: unknown, vals: unknown) => mockInArray(col, vals),
+  eq: vi.fn((col: unknown, val: unknown) => ({ __pred: 'eq', col, val })),
+  and: vi.fn((...a: unknown[]) => ({ __pred: 'and', a })),
+  desc: vi.fn(),
+  lt: vi.fn(),
+  count: vi.fn(),
+}))
+
+// NOTE: notification-service is deliberately NOT mocked.
+
+// Import after mocks are set up.
+import { sessionAutoDeleteMonitor } from './session-auto-delete-monitor'
+import { deleteNotificationsBySessionIds } from '@shared/lib/services/notification-service'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeSession(
+  id: string,
+  lastActivityAt: Date,
+  agentSlug = 'test-agent'
+): SessionInfo {
+  return {
+    id,
+    agentSlug,
+    name: `Session ${id}`,
+    createdAt: new Date('2026-01-01'),
+    lastActivityAt,
+    messageCount: 5,
+  }
+}
+
+function makeAgent(slug: string): AgentConfig {
+  return {
+    slug,
+    frontmatter: { name: slug, createdAt: '2026-01-01T00:00:00Z' },
+    instructions: '',
+  }
+}
+
+function notificationDeleteCalls(): DeleteCall[] {
+  return mockDeleteCalls.filter((c) => c.table === tables.notifications)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('SUP-228: session auto-delete removes stale notifications', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    mockDeleteCalls.length = 0
+
+    mockGetSettings.mockReturnValue({ app: { autoDeleteInactiveDays: 30 } })
+    mockListAgents.mockResolvedValue([])
+    mockReadAgentPreferences.mockResolvedValue({})
+    mockDeleteSessionsBatch.mockImplementation((_slug: string, ids: string[]) =>
+      Promise.resolve(ids)
+    )
+    mockReadSessionMetadata.mockResolvedValue({})
+    mockIsSessionActive.mockReturnValue(false)
+    mockIsAuthMode.mockReturnValue(false)
+  })
+
+  afterEach(async () => {
+    sessionAutoDeleteMonitor.stop()
+    vi.useRealTimers()
+  })
+
+  async function startAndTrigger() {
+    await sessionAutoDeleteMonitor.start()
+    await vi.advanceTimersByTimeAsync(30_000)
+  }
+
+  it('deletes notifications for only the actually-deleted session IDs (non-auth mode)', async () => {
+    const now = Date.now()
+    const s1 = makeSession('s1', new Date(now - 60 * 86_400_000))
+    const s2 = makeSession('s2', new Date(now - 60 * 86_400_000))
+    const s3 = makeSession('s3', new Date(now - 60 * 86_400_000))
+
+    mockListAgents.mockResolvedValue([makeAgent('test-agent')])
+    mockListSessions.mockResolvedValue([s1, s2, s3])
+    mockReadSessionMetadata.mockResolvedValue({})
+    // s3 simulates a filesystem-delete failure: deletedIds excludes it.
+    mockDeleteSessionsBatch.mockResolvedValue(['s1', 's2'])
+    // Cleanup must run unconditionally, NOT gated on auth mode.
+    mockIsAuthMode.mockReturnValue(false)
+
+    await startAndTrigger()
+
+    const notifCalls = notificationDeleteCalls()
+    expect(notifCalls).toHaveLength(1)
+    // The predicate is built over exactly the deletedIds [s1, s2] — not s3,
+    // and not the full toDelete list [s1, s2, s3].
+    expect(notifCalls[0].predicate).toEqual({
+      __pred: 'inArray',
+      col: tables.notifications.sessionId,
+      vals: ['s1', 's2'],
+    })
+    expect(mockInArray).toHaveBeenCalledWith(tables.notifications.sessionId, ['s1', 's2'])
+  })
+
+  it('does not delete notifications when nothing was actually deleted', async () => {
+    const now = Date.now()
+    const s1 = makeSession('s1', new Date(now - 60 * 86_400_000))
+
+    mockListAgents.mockResolvedValue([makeAgent('test-agent')])
+    mockListSessions.mockResolvedValue([s1])
+    mockReadSessionMetadata.mockResolvedValue({})
+    // Every filesystem delete failed → deletedIds is empty.
+    mockDeleteSessionsBatch.mockResolvedValue([])
+
+    await startAndTrigger()
+
+    expect(notificationDeleteCalls()).toHaveLength(0)
+  })
+})
+
+// ============================================================================
+// Direct unit coverage for the reusable helper.
+// ============================================================================
+
+describe('SUP-228: deleteNotificationsBySessionIds helper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDeleteCalls.length = 0
+  })
+
+  it('deletes notification rows by session id with an inArray predicate', async () => {
+    await deleteNotificationsBySessionIds(['a', 'b'])
+
+    const notifCalls = notificationDeleteCalls()
+    expect(notifCalls).toHaveLength(1)
+    expect(notifCalls[0].predicate).toEqual({
+      __pred: 'inArray',
+      col: tables.notifications.sessionId,
+      vals: ['a', 'b'],
+    })
+  })
+
+  it('is a no-op on an empty session id list', async () => {
+    const deleted = await deleteNotificationsBySessionIds([])
+
+    expect(deleted).toBe(0)
+    expect(mockDbDelete).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/lib/services/notification-service.test.ts
+++ b/src/shared/lib/services/notification-service.test.ts
@@ -22,6 +22,8 @@ import {
   getUnreadCount,
   getSessionIdsWithUnreadNotifications,
   getUnreadNotificationsByAgents,
+  deleteNotificationsBySessionIds,
+  listNotifications,
   USER_ACTIONABLE_NOTIFICATION_TYPES,
   type NotificationType,
 } from './notification-service'
@@ -142,6 +144,46 @@ describe('notification-service', () => {
       const map = await getUnreadNotificationsByAgents(['agent-a', 'agent-b'])
       expect(map.has('agent-a')).toBe(true)
       expect(map.has('agent-b')).toBe(false)
+    })
+  })
+
+  // SUP-228: retention cleanup must remove notification rows for deleted sessions.
+  describe('deleteNotificationsBySessionIds', () => {
+    it('removes rows for the given session ids and leaves others intact', async () => {
+      await createNotification({ type: 'session_complete', sessionId: 's1', agentSlug: 'a', title: 't', body: 'b' })
+      await createNotification({ type: 'session_waiting', sessionId: 's2', agentSlug: 'a', title: 't', body: 'b' })
+      await createNotification({ type: 'session_complete', sessionId: 's3', agentSlug: 'a', title: 't', body: 'b' })
+
+      // s3 simulates a session whose filesystem delete failed — it must survive.
+      const deleted = await deleteNotificationsBySessionIds(['s1', 's2'])
+      expect(deleted).toBe(2)
+
+      const remaining = await listNotifications(50)
+      const sessionIds = remaining.map((n) => n.sessionId)
+      expect(sessionIds).toEqual(['s3'])
+    })
+
+    it('removes every notification type for a session (not just actionable ones)', async () => {
+      await seedOneOfEachType('a', 'sess')
+      // sessionIds are `sess-<type>`; delete two of them.
+      const deleted = await deleteNotificationsBySessionIds([
+        'sess-session_complete',
+        'sess-session_webhook',
+      ])
+      expect(deleted).toBe(2)
+      const remaining = await listNotifications(50)
+      expect(remaining.map((n) => n.sessionId).sort()).toEqual([
+        'sess-session_chat_integration',
+        'sess-session_scheduled',
+        'sess-session_waiting',
+      ])
+    })
+
+    it('is a no-op on an empty list (returns 0, deletes nothing)', async () => {
+      await createNotification({ type: 'session_complete', sessionId: 's1', agentSlug: 'a', title: 't', body: 'b' })
+      const deleted = await deleteNotificationsBySessionIds([])
+      expect(deleted).toBe(0)
+      expect((await listNotifications(50)).length).toBe(1)
     })
   })
 })

--- a/src/shared/lib/services/notification-service.ts
+++ b/src/shared/lib/services/notification-service.ts
@@ -323,6 +323,27 @@ export async function deleteNotification(notificationId: string): Promise<boolea
 }
 
 /**
+ * Delete all notifications for the given session IDs.
+ *
+ * Used by session retention cleanup (SessionAutoDeleteMonitor) and manual
+ * session deletion so that notification history does not retain rows pointing
+ * at sessions that no longer exist. Notifications are stored in BOTH auth and
+ * non-auth modes (userId is nullable), so callers should invoke this
+ * unconditionally — not gated on auth mode.
+ *
+ * No-op (returns 0) when the input list is empty.
+ */
+export async function deleteNotificationsBySessionIds(sessionIds: string[]): Promise<number> {
+  if (sessionIds.length === 0) return 0
+
+  const result = await db
+    .delete(notifications)
+    .where(inArray(notifications.sessionId, sessionIds))
+
+  return result.changes ?? 0
+}
+
+/**
  * Delete old notifications (older than specified days)
  */
 export async function deleteOldNotifications(olderThanDays: number = 30): Promise<number> {


### PR DESCRIPTION
## SUP-228 — Session auto-delete leaves stale notifications for deleted sessions

### Bug
`SessionAutoDeleteMonitor.cleanupAgent()` removed session JSONL files, unsubscribed the persister, and (auth mode only) deleted `message_author` rows, but it never deleted `notifications` rows for the removed session IDs. The manual `DELETE /:id/sessions/:sessionId` route had the identical gap (it only deleted `message_author`, gated on auth mode). Because notifications are stored in **both** auth and non-auth modes (`userId` is nullable), retention cleanup and manual deletion left notification history pointing at sessions that no longer exist — users could see stale unread/history entries and click into missing sessions.

### Fix
- Added a reusable `deleteNotificationsBySessionIds(sessionIds)` helper in `notification-service.ts` that runs `db.delete(notifications).where(inArray(notifications.sessionId, ids))` and no-ops (returns 0) on an empty array.
- `session-auto-delete-monitor.ts`: call the helper **unconditionally** (not gated on `isAuthMode()`) after `deleteSessionsBatch()`, using the returned `deletedIds` (not the full `toDelete` list) so a failed filesystem delete never wipes DB state for a session still on disk. Wrapped in try/catch + log, mirroring the existing `messageAuthor` block.
- `agents.ts` manual delete route: call the same helper after the auth-gated `messageAuthor` cleanup.

### Tests (failing-test-now-green regression)
- **New** `src/shared/lib/scheduler/session-auto-delete.sup228.test.ts`: reproduces the leak — 3 stale sessions, `deleteSessionsBatch` returns only `[s1,s2]` (s3 simulates a filesystem-delete failure); asserts `db.delete` is called with the `notifications` table and an `inArray` predicate over exactly `[s1,s2]` (not s3, not the full `toDelete`), with `isAuthMode()=false` (proves it is unconditional); plus a no-op-when-empty case and direct helper coverage.
- Updated `session-auto-delete-monitor.test.ts`: the `not-in-auth-mode` case now asserts notifications are cleaned while `messageAuthor` is not (it previously passed only incidentally once the new path existed).
- Updated `agents.test.ts`: the DELETE-session suite now asserts `deleteNotificationsBySessionIds(['sess-1'])` is invoked.
- Added real in-memory-DB integration coverage in `notification-service.test.ts`: seeds rows for s1/s2/s3, deletes s1/s2, asserts s3 survives and all notification types (not just actionable) are removed.

All new tests fail before the fix and pass after. `tsc --noEmit` clean; eslint 0 errors on changed files.

### Changed files
- `src/shared/lib/services/notification-service.ts`
- `src/shared/lib/scheduler/session-auto-delete-monitor.ts`
- `src/api/routes/agents.ts`
- `src/shared/lib/scheduler/session-auto-delete.sup228.test.ts` (new)
- `src/shared/lib/scheduler/session-auto-delete-monitor.test.ts`
- `src/api/routes/agents.test.ts`
- `src/shared/lib/services/notification-service.test.ts`

Status: waiting for review.
🤖 Generated with [Claude Code](https://claude.com/claude-code)