### PR TITLE
fix(mcp): guard OAuth discovery metadata URLs against SSRF (SUP-235)

### DIFF
--- a/src/api/routes/remote-mcps.ts
+++ b/src/api/routes/remote-mcps.ts
@@ -10,7 +10,7 @@ import { isAuthMode } from '@shared/lib/auth/mode'
 import { Authenticated, UsersMcpServer, IsAdmin, Or } from '../middleware/auth'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
-import { validateHttpUrl, isPrivateHost, isLocalhostHost } from '@shared/lib/utils/url-safety'
+import { validateMcpDiscoveryUrl } from '@shared/lib/utils/url-safety'
 import { captureMessage } from '@shared/lib/error-reporting'
 
 function safeParseTools(json: string | null): McpToolInfo[] {
@@ -45,17 +45,11 @@ function escapeHtml(str: string): string {
     .replace(/'/g, '&#039;')
 }
 
+// Entry-path SSRF guard for the user-supplied MCP server URL. Delegates to the
+// shared policy so it cannot drift from the OAuth-discovery checks, which must
+// reject the same private/loopback hosts on every server-supplied metadata URL.
 function validateMcpServerUrl(url: string): URL {
-  const parsed = validateHttpUrl(url)
-  if (isPrivateHost(parsed.hostname)) {
-    // in electron - allow localhost MCP servers since users may be running them locally, but still block other private addresses
-    const isElectron = process.type === 'browser'
-    if ((isElectron || process.env.E2E_MOCK) && isLocalhostHost(parsed.hostname)) {
-      return parsed
-    }
-    throw new Error(`MCP server URL must not point to a private or loopback address: ${parsed.hostname}`)
-  }
-  return parsed
+  return validateMcpDiscoveryUrl(url)
 }
 
 const remoteMcps = new Hono()

--- a/src/shared/lib/mcp/oauth-ssrf.sup235.test.ts
+++ b/src/shared/lib/mcp/oauth-ssrf.sup235.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// SUP-235 — MCP OAuth discovery follows unvalidated metadata URLs (SSRF).
+//
+// The remote-MCP SSRF guard (validateMcpServerUrl in remote-mcps.ts) is only
+// applied to the *initial* server URL. discoverOAuthMetadata then fetches
+// server-controlled URLs with no private/loopback host check:
+//   - resource_metadata from the WWW-Authenticate header
+//   - authorization_servers[0] from the protected-resource metadata
+//   - the generated .well-known/* URLs derived from the auth server
+//
+// A public MCP endpoint can therefore make Superagent fetch arbitrary
+// internal/loopback URLs server-side. These tests assert discovery rejects
+// private/loopback metadata URLs (never fetching them) while still discovering
+// fully-public metadata.
+// ---------------------------------------------------------------------------
+
+// Mock DB so importing oauth.ts does not pull in a real connection. The
+// discovery path under test issues no DB queries, so the chain stubs below are
+// intentionally minimal.
+const mockSet = vi.fn()
+const mockDbFrom = vi.fn()
+const mockInsertValues = vi.fn()
+
+vi.mock('@shared/lib/db', () => ({
+  db: {
+    select: () => ({ from: mockDbFrom }),
+    insert: () => ({ values: mockInsertValues }),
+    update: () => ({ set: mockSet }),
+  },
+}))
+
+vi.mock('@shared/lib/db/schema', () => ({
+  remoteMcpServers: { id: 'id', oauthClientId: 'oauth_client_id' },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq: (col: string, val: string) => ({ col, val }),
+}))
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+// Must import after mocks
+import { discoverOAuthMetadata } from './oauth'
+
+/** Did any fetch call target a URL whose string contains `needle`? */
+function fetchedAny(needle: string): boolean {
+  return mockFetch.mock.calls.some((call) => String(call[0]).includes(needle))
+}
+
+const PUBLIC_MCP_URL = 'https://mcp.example.com/mcp'
+
+describe('SUP-235: discoverOAuthMetadata SSRF guard', () => {
+  let originalE2EMock: string | undefined
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Any fetch we did not explicitly script returns a benign 404 so a leaked
+    // call cannot crash on `undefined.ok` (and stays visible in mock.calls).
+    mockFetch.mockResolvedValue(new Response(null, { status: 404 }))
+    // Ensure the localhost exception is OFF for the negative cases. 127.0.0.1
+    // is classed as localhost, so under E2E_MOCK it would be (intentionally)
+    // allowed — we want the default, non-mock policy here.
+    originalE2EMock = process.env.E2E_MOCK
+    delete process.env.E2E_MOCK
+  })
+
+  afterEach(() => {
+    if (originalE2EMock === undefined) delete process.env.E2E_MOCK
+    else process.env.E2E_MOCK = originalE2EMock
+  })
+
+  // Case 1: loopback resource_metadata from the WWW-Authenticate header.
+  it('rejects a loopback resource_metadata URL and never fetches it', async () => {
+    // Probe (to the public MCP URL) returns 401 pointing resource_metadata at
+    // a loopback address.
+    mockFetch.mockResolvedValueOnce(
+      new Response(null, {
+        status: 401,
+        headers: {
+          'WWW-Authenticate':
+            'Bearer resource_metadata="http://127.0.0.1:8765/.well-known/oauth-protected-resource"',
+        },
+      })
+    )
+
+    const result = await discoverOAuthMetadata(PUBLIC_MCP_URL)
+
+    expect(result).toBeNull()
+    // The loopback metadata URL must never have been fetched.
+    expect(fetchedAny('127.0.0.1')).toBe(false)
+    // Only the initial probe (to the public host) should have been issued.
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch.mock.calls[0][0]).toBe(PUBLIC_MCP_URL)
+  })
+
+  // Case 2: public resource_metadata that points authorization_servers at a
+  // link-local metadata endpoint (cloud instance metadata service).
+  it('rejects a link-local authorization_servers URL and never fetches its well-known URLs', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(null, {
+        status: 401,
+        headers: {
+          'WWW-Authenticate':
+            'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"',
+        },
+      })
+    )
+    // Public resource metadata, but it advertises a link-local auth server.
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          resource: 'https://mcp.example.com',
+          authorization_servers: ['http://169.254.169.254/'],
+        }),
+        { status: 200 }
+      )
+    )
+
+    const result = await discoverOAuthMetadata(PUBLIC_MCP_URL)
+
+    expect(result).toBeNull()
+    expect(fetchedAny('169.254.169.254')).toBe(false)
+  })
+
+  // Case 3 (regression/positive): a fully-public discovery chain still works.
+  it('discovers metadata for a fully-public resource + auth server', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(null, {
+        status: 401,
+        headers: {
+          'WWW-Authenticate':
+            'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"',
+        },
+      })
+    )
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          resource: 'https://mcp.example.com',
+          authorization_servers: ['https://auth.example.com'],
+        }),
+        { status: 200 }
+      )
+    )
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          authorization_endpoint: 'https://auth.example.com/authorize',
+          token_endpoint: 'https://auth.example.com/token',
+        }),
+        { status: 200 }
+      )
+    )
+
+    const result = await discoverOAuthMetadata(PUBLIC_MCP_URL)
+
+    expect(result).not.toBeNull()
+    expect(result!.metadata.authorization_endpoint).toBe(
+      'https://auth.example.com/authorize'
+    )
+    expect(result!.metadata.token_endpoint).toBe('https://auth.example.com/token')
+    expect(result!.resource).toBe('https://mcp.example.com')
+  })
+
+  // Case 4: the Electron/E2E_MOCK localhost exception must still allow a
+  // localhost auth server — mirroring validateMcpServerUrl's intended behavior
+  // for users running MCP servers locally.
+  it('allows a localhost auth server only under the E2E_MOCK / Electron exception', async () => {
+    function scriptLocalhostDiscovery() {
+      mockFetch.mockResolvedValueOnce(
+        new Response(null, {
+          status: 401,
+          headers: {
+            'WWW-Authenticate':
+              'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"',
+          },
+        })
+      )
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            resource: 'https://mcp.example.com',
+            authorization_servers: ['http://localhost:8899'],
+          }),
+          { status: 200 }
+        )
+      )
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            authorization_endpoint: 'http://localhost:8899/authorize',
+            token_endpoint: 'http://localhost:8899/token',
+          }),
+          { status: 200 }
+        )
+      )
+    }
+
+    // Without the exception flag: localhost is blocked, discovery fails closed.
+    scriptLocalhostDiscovery()
+    const blocked = await discoverOAuthMetadata(PUBLIC_MCP_URL)
+    expect(blocked).toBeNull()
+    expect(fetchedAny('localhost:8899')).toBe(false)
+
+    // With E2E_MOCK set: the localhost auth server is allowed.
+    // mockReset (not clearAllMocks) flushes the leftover mockResolvedValueOnce
+    // the blocked phase never consumed, so the second sequence starts clean.
+    mockFetch.mockReset()
+    mockFetch.mockResolvedValue(new Response(null, { status: 404 }))
+    process.env.E2E_MOCK = 'true'
+    scriptLocalhostDiscovery()
+    const allowed = await discoverOAuthMetadata(PUBLIC_MCP_URL)
+    expect(allowed).not.toBeNull()
+    expect(allowed!.metadata.token_endpoint).toBe('http://localhost:8899/token')
+  })
+})

--- a/src/shared/lib/mcp/oauth.ts
+++ b/src/shared/lib/mcp/oauth.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto'
 import { db } from '@shared/lib/db'
 import { remoteMcpServers } from '@shared/lib/db/schema'
 import { eq } from 'drizzle-orm'
+import { validateMcpDiscoveryUrl } from '@shared/lib/utils/url-safety'
 import type { OAuthMetadata, OAuthTokenResponse } from './types'
 
 /**
@@ -82,8 +83,13 @@ export async function discoverOAuthMetadata(mcpUrl: string): Promise<{
     let resource: string
 
     if (resourceMetadataMatch) {
-      // RFC 9728: Fetch Protected Resource Metadata
+      // RFC 9728: Fetch Protected Resource Metadata.
+      // SSRF guard (SUP-235): this URL comes straight from the server-controlled
+      // WWW-Authenticate header, so apply the same private/loopback host policy
+      // as the entry path before fetching. Rejection throws -> discovery fails
+      // closed (returns null) instead of fetching an internal address.
       const resourceMetadataUrl = resourceMetadataMatch[1]
+      validateMcpDiscoveryUrl(resourceMetadataUrl)
       const resourceRes = await fetch(resourceMetadataUrl)
       if (!resourceRes.ok) {
         throw new Error(`Failed to fetch resource metadata: ${resourceRes.status}`)
@@ -111,10 +117,20 @@ export async function discoverOAuthMetadata(mcpUrl: string): Promise<{
     // https://host/.well-known/oauth-authorization-server/path), not appended.
     // Some servers (e.g. Meta's MCP) only expose the path-aware form.
     // OpenID Connect Discovery 1.0 instead appends to the issuer.
+    // SSRF guard (SUP-235): authServerUrl is server-supplied (either from the
+    // protected-resource metadata's authorization_servers[0] or the MCP
+    // origin). Reject private/loopback auth servers before deriving and
+    // fetching any well-known URLs from them; throwing fails discovery closed.
+    validateMcpDiscoveryUrl(authServerUrl)
+
     const wellKnownUrls = buildAuthServerMetadataUrls(authServerUrl)
 
     for (const url of wellKnownUrls) {
       try {
+        // Defense in depth: re-validate each generated URL so a future change
+        // to buildAuthServerMetadataUrls can never reintroduce an unchecked
+        // fetch. A rejected URL is skipped, not fetched.
+        validateMcpDiscoveryUrl(url)
         const res = await fetch(url)
         if (res.ok) {
           const metadata = (await res.json()) as OAuthMetadata

--- a/src/shared/lib/utils/url-safety.ts
+++ b/src/shared/lib/utils/url-safety.ts
@@ -81,6 +81,38 @@ export function validateHttpUrl(url: string): URL {
   return parsed
 }
 
+/**
+ * SSRF host policy for remote-MCP server and OAuth-discovery URLs.
+ *
+ * Runs validateHttpUrl + isPrivateHost, with a localhost exception that is
+ * allowed only inside Electron (`process.type === 'browser'`) or under the
+ * E2E mock — users may legitimately run an MCP server on localhost there, but
+ * other private/loopback addresses are always rejected.
+ *
+ * This is the single source of truth shared by the remote-MCP entry guard
+ * (validateMcpServerUrl) AND the OAuth metadata discovery path
+ * (discoverOAuthMetadata), so the two cannot drift: every server-supplied
+ * metadata URL the discovery flow follows is held to the same policy.
+ *
+ * Returns the parsed URL on success; throws on rejection so callers can fail
+ * closed without ever issuing the fetch.
+ */
+export function validateMcpDiscoveryUrl(url: string): URL {
+  const parsed = validateHttpUrl(url)
+  if (isPrivateHost(parsed.hostname)) {
+    // In Electron (or under the E2E mock) allow localhost MCP servers since
+    // users may be running them locally, but still block other private hosts.
+    const isElectron = process.type === 'browser'
+    if ((isElectron || process.env.E2E_MOCK) && isLocalhostHost(parsed.hostname)) {
+      return parsed
+    }
+    throw new Error(
+      `URL must not point to a private or loopback address: ${parsed.hostname}`,
+    )
+  }
+  return parsed
+}
+
 export interface SafeCloneUrlOptions {
   /**
    * If provided, the URL's origin (scheme://host[:port]) must start with one


### PR DESCRIPTION
## SUP-235 — MCP OAuth discovery follows unvalidated metadata URLs, enabling SSRF

### Bug
The remote-MCP SSRF guard (`validateMcpServerUrl` in `remote-mcps.ts`) was applied only to the **initial** server URL. `discoverOAuthMetadata` then followed server-controlled URLs with **no** private/loopback host check:

- the `resource_metadata` URL taken straight from the `WWW-Authenticate` header (`oauth.ts:86-87`),
- the chosen `authorization_servers[0]` from the protected-resource metadata (`oauth.ts:100`),
- each generated `.well-known/*` URL (`oauth.ts:116-118`).

A public MCP endpoint could therefore return e.g. `WWW-Authenticate: Bearer resource_metadata="http://127.0.0.1:.../..."` or advertise `authorization_servers: ["http://169.254.169.254/"]` and make Superagent fetch arbitrary internal/loopback URLs server-side.

### Fix
- Hoist the Electron/`E2E_MOCK` localhost-exception policy into a shared, exported `validateMcpDiscoveryUrl(url)` in `url-safety.ts` (runs `validateHttpUrl` + `isPrivateHost`, with the `isLocalhostHost` exception gated on `process.type === 'browser' || process.env.E2E_MOCK`).
- `remote-mcps.ts` `validateMcpServerUrl` now delegates to that helper so the entry guard and the discovery guard share one source of truth and cannot drift.
- `discoverOAuthMetadata` validates the `resource_metadata` URL, the chosen `authServerUrl`, and each generated well-known URL **before** fetching. Rejection throws, so discovery **fails closed** (returns `null`) instead of issuing the request. Localhost stays allowed only under the existing Electron/`E2E_MOCK` exception.

### Tests (failing-test-first, now green)
New `src/shared/lib/mcp/oauth-ssrf.sup235.test.ts` (reproduced the bug, then verified the fix):
1. loopback `resource_metadata` from `WWW-Authenticate` → returns `null`, `127.0.0.1` never fetched (only the public probe is issued).
2. public `resource_metadata` advertising link-local `authorization_servers: ["http://169.254.169.254/"]` → returns `null`, no well-known URL fetched.
3. regression/positive: a fully-public resource + auth server still discovers metadata.
4. localhost auth server allowed only under `E2E_MOCK`, blocked otherwise (mirrors `validateMcpServerUrl`).

All 133 tests across the new file + `oauth.test.ts`, `url-safety.test.ts`, `remote-mcps.test.ts` pass. `tsc --noEmit` clean; eslint 0 errors on changed files.

### Changed files
- `src/shared/lib/utils/url-safety.ts` (new `validateMcpDiscoveryUrl` helper)
- `src/api/routes/remote-mcps.ts` (reuse shared helper)
- `src/shared/lib/mcp/oauth.ts` (validate every discovered URL before fetch)
- `src/shared/lib/mcp/oauth-ssrf.sup235.test.ts` (new)

Status: waiting for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)