### PR TITLE
fix(webhooks): poll paused triggers and fall back to account owner (SUP-225, SUP-226)

### DIFF
--- a/src/shared/lib/scheduler/trigger-manager.test.ts
+++ b/src/shared/lib/scheduler/trigger-manager.test.ts
@@ -46,11 +46,17 @@ const mockGetWebhookTriggersByComposioId = vi.fn()
 const mockMarkTriggerFired = vi.fn().mockResolvedValue(undefined)
 const mockMarkTriggerFailed = vi.fn().mockResolvedValue(undefined)
 const mockGetDistinctMemberIds = vi.fn(() => ['sub_test_member'])
+const mockResolvePlatformMemberForCandidates =
+  vi.fn<(candidates: Array<string | null | undefined>) => { userId: string; memberId: string } | null>(
+    () => null,
+  )
 vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
   getDistinctPlatformMemberIdsForActiveTriggers: () => mockGetDistinctMemberIds(),
   getWebhookTriggersByComposioId: (...args: unknown[]) => mockGetWebhookTriggersByComposioId(...args),
   markTriggerFired: (...args: unknown[]) => mockMarkTriggerFired(...args),
   markTriggerFailed: (...args: unknown[]) => mockMarkTriggerFailed(...args),
+  resolvePlatformMemberForCandidates: (...args: [Array<string | null | undefined>]) =>
+    mockResolvePlatformMemberForCandidates(...args),
 }))
 
 vi.mock('@shared/lib/services/session-service', () => ({
@@ -80,8 +86,12 @@ vi.mock('@shared/lib/services/platform-auth-service', () => ({
 }))
 
 const mockDecodeOrgIdFromToken = vi.fn<(token: string) => string | null>(() => null)
+const mockRunWithOptionalUser = vi.fn(
+  (_userId: string | null | undefined, fn: () => unknown) => fn(),
+)
 vi.mock('@shared/lib/platform-attribution', () => ({
-  runWithOptionalUser: (_userId: string | null, fn: () => unknown) => fn(),
+  runWithOptionalUser: (userId: string | null | undefined, fn: () => unknown) =>
+    mockRunWithOptionalUser(userId, fn),
   attribution: {
     // Mirror the real impl, driven by the same mocks the tests already control.
     requiresActingMember: () => {
@@ -126,6 +136,7 @@ describe('TriggerManager', () => {
     mockGetDistinctMemberIds.mockReturnValue(['sub_test_member'])
     mockGetPlatformAccessToken.mockReturnValue('opaque_test_token')
     mockDecodeOrgIdFromToken.mockReturnValue(null)
+    mockResolvePlatformMemberForCandidates.mockReturnValue(null)
   })
 
   describe('start', () => {
@@ -269,6 +280,48 @@ describe('TriggerManager', () => {
 
       triggerManager.stop()
       mockAgentExists.mockResolvedValue(true) // restore for other tests
+    })
+
+    // SUP-226: runtime attribution must select the same user the poller claimed
+    // under — the connected-account owner when the creator has no platform
+    // member — so the session's proxy calls carry the correct acting member.
+    it('attributes the session to the connected-account owner when the creator lacks a platform member', async () => {
+      const trigger = {
+        id: 'trigger_1',
+        agentSlug: 'test-agent',
+        composioTriggerId: 'ti_abc',
+        connectedAccountId: 'ca_owned',
+        triggerType: 'GMAIL_NEW_EMAIL',
+        prompt: 'Handle this email',
+        status: 'active',
+        fireCount: 0,
+        createdByUserId: 'creator_user',
+      }
+
+      mockPollAndClaimEvents.mockResolvedValue({
+        events: [
+          { id: 'whe_1', composio_trigger_id: 'ti_abc', trigger_type: 'GMAIL', payload: {}, created_at: '' },
+        ],
+        realtime: null,
+      })
+      mockGetWebhookTriggersByComposioId.mockResolvedValue([trigger])
+      // Creator has no platform member; resolution falls back to the owner.
+      mockResolvePlatformMemberForCandidates.mockReturnValue({
+        userId: 'owner_user',
+        memberId: 'sub_owner_member',
+      })
+
+      await triggerManager.start()
+
+      expect(mockResolvePlatformMemberForCandidates).toHaveBeenCalledWith([
+        'creator_user',
+        // resolveConnectedAccountOwner is read through the db mock (returns null here).
+        null,
+      ])
+      expect(mockRunWithOptionalUser).toHaveBeenCalledWith('owner_user', expect.any(Function))
+      expect(mockCreateSession).toHaveBeenCalledTimes(1)
+
+      triggerManager.stop()
     })
   })
 

--- a/src/shared/lib/scheduler/trigger-manager.ts
+++ b/src/shared/lib/scheduler/trigger-manager.ts
@@ -22,6 +22,7 @@ import {
   getWebhookTriggersByComposioId,
   markTriggerFired,
   markTriggerFailed,
+  resolvePlatformMemberForCandidates,
 } from '@shared/lib/services/webhook-trigger-service'
 import type { WebhookTrigger } from '@shared/lib/services/webhook-trigger-service'
 import type { EffortLevel } from '@shared/lib/container/types'
@@ -263,8 +264,17 @@ class TriggerManager {
     trigger: WebhookTrigger,
     events: WebhookEvent[]
   ): Promise<void> {
-    // Attribute to trigger creator; fall back to the connected_account owner.
-    const ownerUserId = trigger.createdByUserId ?? resolveConnectedAccountOwner(trigger.connectedAccountId)
+    // Attribute to the same user the poller claimed events under: prefer the
+    // trigger creator, but fall back to the connected_account owner when the
+    // creator has no platform member (SUP-226). If neither resolves to a
+    // platform member (e.g. opaque-key / single-user mode), keep the prior
+    // best-effort attribution (creator, else owner).
+    const candidates = [
+      trigger.createdByUserId,
+      resolveConnectedAccountOwner(trigger.connectedAccountId),
+    ]
+    const resolved = resolvePlatformMemberForCandidates(candidates)
+    const ownerUserId = resolved?.userId ?? candidates.find((c) => c) ?? null
     return runWithOptionalUser(ownerUserId, () => this.spawnSessionInner(trigger, events))
   }
 

--- a/src/shared/lib/services/webhook-events-client.test.ts
+++ b/src/shared/lib/services/webhook-events-client.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetPlatformAccessToken = vi.fn()
 const mockDecodeOrgIdFromToken = vi.fn()
-const mockGetActiveComposioTriggerIds = vi.fn()
+const mockGetSubscribedComposioTriggerIds = vi.fn()
 const mockFetch = vi.fn()
 let originalFetch: typeof globalThis.fetch
 
@@ -15,7 +15,10 @@ vi.mock('@shared/lib/platform-attribution', () => ({
 }))
 
 vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
-  getActiveComposioTriggerIds: () => mockGetActiveComposioTriggerIds(),
+  // The poll scope includes paused triggers (still subscribed upstream) so
+  // paused-period events are claimed and acked/discarded rather than firing on
+  // resume (SUP-225).
+  getSubscribedComposioTriggerIds: () => mockGetSubscribedComposioTriggerIds(),
 }))
 
 vi.mock('@shared/lib/platform-auth/config', () => ({
@@ -39,9 +42,9 @@ describe('webhook-events-client', () => {
     globalThis.fetch = originalFetch
   })
 
-  it('sends local active trigger_ids in org JWT mode with ::memberId bearer', async () => {
+  it('sends local subscribed trigger_ids in org JWT mode with ::memberId bearer', async () => {
     mockDecodeOrgIdFromToken.mockReturnValue('org_1')
-    mockGetActiveComposioTriggerIds.mockReturnValue(['ti_host_a', 'ti_host_b'])
+    mockGetSubscribedComposioTriggerIds.mockReturnValue(['ti_host_a', 'ti_host_b'])
 
     await pollAndClaimEvents('sub_member_1')
 
@@ -52,9 +55,9 @@ describe('webhook-events-client', () => {
     expect(headers.get('Authorization')).toBe('Bearer token-value::sub_member_1')
   })
 
-  it('sends local active trigger_ids in opaque key mode (no ::memberId suffix)', async () => {
+  it('sends local subscribed trigger_ids in opaque key mode (no ::memberId suffix)', async () => {
     mockDecodeOrgIdFromToken.mockReturnValue(null)
-    mockGetActiveComposioTriggerIds.mockReturnValue(['ti_local_a'])
+    mockGetSubscribedComposioTriggerIds.mockReturnValue(['ti_local_a'])
 
     await pollAndClaimEvents('sub_member_1')
 
@@ -65,8 +68,8 @@ describe('webhook-events-client', () => {
     expect(headers.get('Authorization')).toBe('Bearer token-value')
   })
 
-  it('sends empty trigger_ids when no local active triggers (proxy short-circuits)', async () => {
-    mockGetActiveComposioTriggerIds.mockReturnValue([])
+  it('sends empty trigger_ids when no local subscribed triggers (proxy short-circuits)', async () => {
+    mockGetSubscribedComposioTriggerIds.mockReturnValue([])
 
     await pollAndClaimEvents('sub_member_1')
 

--- a/src/shared/lib/services/webhook-events-client.ts
+++ b/src/shared/lib/services/webhook-events-client.ts
@@ -8,7 +8,7 @@
 import { decodeOrgIdFromToken } from '@shared/lib/platform-attribution'
 import { getPlatformProxyBaseUrl } from '@shared/lib/platform-auth/config'
 import { getPlatformAccessToken } from '@shared/lib/services/platform-auth-service'
-import { getActiveComposioTriggerIds } from '@shared/lib/services/webhook-trigger-service'
+import { getSubscribedComposioTriggerIds } from '@shared/lib/services/webhook-trigger-service'
 
 // ============================================================================
 // Types
@@ -70,11 +70,13 @@ async function webhookEventsFetch<T>(
   return response.json()
 }
 
-// Always scope by local trigger_ids
+// Always scope by local trigger_ids. Includes paused triggers (still subscribed
+// upstream) so paused-period events are claimed and acked/discarded rather than
+// piling up pending and firing a session on resume (SUP-225).
 export async function pollAndClaimEvents(memberId: string): Promise<PollResult> {
   return webhookEventsFetch<PollResult>('/poll', memberId, {
     method: 'POST',
-    body: JSON.stringify({ trigger_ids: getActiveComposioTriggerIds() }),
+    body: JSON.stringify({ trigger_ids: getSubscribedComposioTriggerIds() }),
   })
 }
 

--- a/src/shared/lib/services/webhook-trigger-poll-scoping.sup225.test.ts
+++ b/src/shared/lib/services/webhook-trigger-poll-scoping.sup225.test.ts
@@ -1,0 +1,165 @@
+/**
+ * SUP-225 — Paused webhook trigger events are not polled or acked while paused.
+ *
+ * `pauseWebhookTrigger()` keeps the upstream Composio subscription alive (see
+ * `countActiveTriggersForComposioId`, which counts active+paused), and the
+ * docstring promises paused-period events will be acked/discarded. But the
+ * platform poll filter is built from `getActiveComposioTriggerIds()`
+ * (status='active' only), so events for a Composio ID whose only local trigger
+ * is paused are never claimed/acked — they accumulate and fire a session on
+ * resume.
+ *
+ * Fix: a dedicated `getSubscribedComposioTriggerIds()` helper returns the
+ * distinct composio IDs for rows still subscribed (status IN active/paused),
+ * and `pollAndClaimEvents` uses it to scope the poll. `processEventGroup` then
+ * acks/discards events for paused-only IDs (no active local trigger).
+ *
+ * These tests reproduce the bug:
+ *   - the helper must include paused IDs (currently absent → throws / wrong)
+ *   - the real poll body must include the paused Composio ID
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import * as schema from '../db/schema'
+
+let testDir: string
+let testDb: ReturnType<typeof drizzle>
+let testSqlite: InstanceType<typeof Database>
+
+vi.mock('@shared/lib/db', () => ({
+  get db() {
+    return testDb
+  },
+  get sqlite() {
+    return testSqlite
+  },
+}))
+
+vi.mock('../analytics/server-analytics', () => ({
+  trackServerEvent: vi.fn(),
+}))
+
+// Platform deps required by webhook-events-client's real poll path.
+vi.mock('@shared/lib/platform-auth/config', () => ({
+  getPlatformProxyBaseUrl: () => 'https://proxy.test',
+}))
+vi.mock('@shared/lib/services/platform-auth-service', () => ({
+  getPlatformAccessToken: () => 'test-token',
+}))
+vi.mock('@shared/lib/platform-attribution', () => ({
+  // Opaque (non-org) token → buildBearer returns the bare token.
+  decodeOrgIdFromToken: () => null,
+}))
+
+import {
+  createWebhookTrigger,
+  pauseWebhookTrigger,
+  cancelWebhookTrigger,
+  getActiveComposioTriggerIds,
+  // New helper introduced by the SUP-225 fix.
+  getSubscribedComposioTriggerIds,
+} from './webhook-trigger-service'
+import { pollAndClaimEvents } from './webhook-events-client'
+
+describe('SUP-225: paused webhook triggers stay pollable', () => {
+  beforeEach(async () => {
+    testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'sup225-'))
+    testSqlite = new Database(':memory:')
+    testDb = drizzle(testSqlite, { schema })
+
+    const migrationsFolder = path.join(process.cwd(), 'src/shared/lib/db/migrations')
+    migrate(testDb, { migrationsFolder })
+  })
+
+  afterEach(async () => {
+    vi.unstubAllGlobals()
+    testSqlite?.close()
+    await fs.promises.rm(testDir, { recursive: true, force: true })
+  })
+
+  async function seedActiveAndPaused() {
+    await createWebhookTrigger({
+      agentSlug: 'agent-1',
+      composioTriggerId: 'ti_active',
+      connectedAccountId: 'ca_1',
+      triggerType: 'GMAIL_NEW_EMAIL',
+      prompt: 'Active',
+    })
+    const pausedId = await createWebhookTrigger({
+      agentSlug: 'agent-1',
+      composioTriggerId: 'ti_paused',
+      connectedAccountId: 'ca_2',
+      triggerType: 'GMAIL_NEW_EMAIL',
+      prompt: 'Paused',
+    })
+    const paused = await pauseWebhookTrigger(pausedId)
+    expect(paused).toBe(true)
+  }
+
+  describe('getSubscribedComposioTriggerIds', () => {
+    it('includes paused trigger composio IDs (reproduces the lost-poll-scope bug)', async () => {
+      await seedActiveAndPaused()
+
+      // The whole point of the fix: the subscribed-ids set must contain BOTH the
+      // active and the paused composio IDs so the platform keeps handing us
+      // paused-period events to ack/discard. Before the fix this helper does not
+      // exist; the active-only helper returns just ['ti_active'].
+      expect(getSubscribedComposioTriggerIds().sort()).toEqual(['ti_active', 'ti_paused'])
+
+      // Guard the existing helper's narrower contract is unchanged.
+      expect(getActiveComposioTriggerIds().sort()).toEqual(['ti_active'])
+    })
+
+    it('skips cancelled and null-composioId rows', async () => {
+      await seedActiveAndPaused()
+
+      // A cancelled trigger drops its subscription entirely.
+      const cancelledId = await createWebhookTrigger({
+        agentSlug: 'agent-1',
+        composioTriggerId: 'ti_cancelled',
+        connectedAccountId: 'ca_3',
+        triggerType: 'GMAIL_NEW_EMAIL',
+        prompt: 'Cancelled',
+      })
+      await cancelWebhookTrigger(cancelledId)
+
+      // A trigger that has not yet received its composio ID contributes nothing.
+      await createWebhookTrigger({
+        agentSlug: 'agent-2',
+        connectedAccountId: 'ca_4',
+        triggerType: 'GMAIL_NEW_EMAIL',
+        prompt: 'No composio id yet',
+      })
+
+      expect(getSubscribedComposioTriggerIds().sort()).toEqual(['ti_active', 'ti_paused'])
+    })
+  })
+
+  describe('pollAndClaimEvents poll scope', () => {
+    it('posts trigger_ids including the paused Composio ID so paused-period events get claimed', async () => {
+      await seedActiveAndPaused()
+
+      const fetchMock = vi.fn(async (_url: string, _init: RequestInit) => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ events: [], realtime: null }),
+        text: async () => '',
+      }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await pollAndClaimEvents('member_1')
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const [, init] = fetchMock.mock.calls[0]
+      const body = JSON.parse(init.body as string) as { trigger_ids: string[] }
+      // Before the fix the poll scope is active-only and excludes 'ti_paused',
+      // so those events are never claimed/acked while paused.
+      expect(body.trigger_ids.sort()).toEqual(['ti_active', 'ti_paused'])
+    })
+  })
+})

--- a/src/shared/lib/services/webhook-trigger-service.sup226.test.ts
+++ b/src/shared/lib/services/webhook-trigger-service.sup226.test.ts
@@ -1,0 +1,171 @@
+/**
+ * SUP-226 — Webhook polling skips the connected-account owner when the trigger
+ * creator lacks a platform auth row.
+ *
+ * `getDistinctPlatformMemberIdsForActiveTriggers()` collapses the creator/owner
+ * candidates with `??` and only resolves a member ID for whichever user `??`
+ * picked. When `createdByUserId` is set but that user has no platform
+ * `authAccount` row, the function never tries the connected-account owner, so an
+ * otherwise-resolvable trigger is dropped from the per-member poll set.
+ *
+ * Fix: iterate [createdByUserId, ownerUserId] in priority order and add the
+ * first candidate that resolves to a platform member ID, so the creator is
+ * preferred but the owner is a fallback.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import * as schema from '../db/schema'
+
+let testDir: string
+let testDb: ReturnType<typeof drizzle>
+let testSqlite: InstanceType<typeof Database>
+
+vi.mock('@shared/lib/db', () => ({
+  get db() {
+    return testDb
+  },
+  get sqlite() {
+    return testSqlite
+  },
+}))
+
+vi.mock('../analytics/server-analytics', () => ({
+  trackServerEvent: vi.fn(),
+}))
+
+import {
+  createWebhookTrigger,
+  getDistinctPlatformMemberIdsForActiveTriggers,
+} from './webhook-trigger-service'
+
+const NOW = new Date('2026-04-01T12:00:00.000Z')
+
+async function insertUser(id: string) {
+  await testDb.insert(schema.user).values({
+    id,
+    name: id,
+    email: `${id}@example.com`,
+    createdAt: NOW,
+    updatedAt: NOW,
+  })
+}
+
+async function insertConnectedAccount(id: string, ownerUserId: string | null) {
+  await testDb.insert(schema.connectedAccounts).values({
+    id,
+    providerConnectionId: `pc_${id}`,
+    providerName: 'composio',
+    toolkitSlug: 'gmail',
+    displayName: 'Gmail',
+    status: 'active',
+    userId: ownerUserId,
+    createdAt: NOW,
+    updatedAt: NOW,
+  })
+}
+
+async function insertPlatformAccount(userId: string, memberId: string) {
+  await testDb.insert(schema.authAccount).values({
+    id: `acct_${memberId}`,
+    accountId: memberId,
+    providerId: 'platform',
+    userId,
+    createdAt: NOW,
+    updatedAt: NOW,
+  })
+}
+
+describe('SUP-226: getDistinctPlatformMemberIdsForActiveTriggers owner fallback', () => {
+  beforeEach(async () => {
+    testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'sup226-'))
+    testSqlite = new Database(':memory:')
+    testDb = drizzle(testSqlite, { schema })
+
+    const migrationsFolder = path.join(process.cwd(), 'src/shared/lib/db/migrations')
+    migrate(testDb, { migrationsFolder })
+  })
+
+  afterEach(async () => {
+    testSqlite?.close()
+    await fs.promises.rm(testDir, { recursive: true, force: true })
+  })
+
+  it('falls back to the connected-account owner when the creator has no platform member', async () => {
+    // Connected account owned by owner_user, who HAS a platform member id.
+    await insertUser('owner_user')
+    await insertConnectedAccount('ca_owned', 'owner_user')
+    await insertPlatformAccount('owner_user', 'sub_owner_member')
+
+    // Trigger created by creator_user, who has NO platform account row.
+    await createWebhookTrigger({
+      agentSlug: 'agent-1',
+      composioTriggerId: 'ti_1',
+      connectedAccountId: 'ca_owned',
+      triggerType: 'GMAIL_NEW_EMAIL',
+      prompt: 'Handle email',
+      createdByUserId: 'creator_user',
+    })
+
+    // Before the fix the `??` resolves to creator_user, whose lookup returns
+    // null, and the owner is never tried → returns []. The trigger is dropped.
+    expect(getDistinctPlatformMemberIdsForActiveTriggers()).toEqual(['sub_owner_member'])
+  })
+
+  it('prefers the creator when the creator does have a platform member (creator priority)', async () => {
+    await insertUser('owner_user')
+    await insertUser('creator_user')
+    await insertConnectedAccount('ca_owned', 'owner_user')
+    await insertPlatformAccount('owner_user', 'sub_owner_member')
+    await insertPlatformAccount('creator_user', 'sub_creator_member')
+
+    await createWebhookTrigger({
+      agentSlug: 'agent-1',
+      composioTriggerId: 'ti_1',
+      connectedAccountId: 'ca_owned',
+      triggerType: 'GMAIL_NEW_EMAIL',
+      prompt: 'Handle email',
+      createdByUserId: 'creator_user',
+    })
+
+    expect(getDistinctPlatformMemberIdsForActiveTriggers()).toEqual(['sub_creator_member'])
+  })
+
+  it('resolves the owner when the trigger has no creator at all', async () => {
+    await insertUser('owner_user')
+    await insertConnectedAccount('ca_owned', 'owner_user')
+    await insertPlatformAccount('owner_user', 'sub_owner_member')
+
+    await createWebhookTrigger({
+      agentSlug: 'agent-1',
+      composioTriggerId: 'ti_1',
+      connectedAccountId: 'ca_owned',
+      triggerType: 'GMAIL_NEW_EMAIL',
+      prompt: 'Handle email',
+      // no createdByUserId
+    })
+
+    expect(getDistinctPlatformMemberIdsForActiveTriggers()).toEqual(['sub_owner_member'])
+  })
+
+  it('drops triggers when neither creator nor owner resolves to a platform member', async () => {
+    // Owner exists but has no platform account row.
+    await insertUser('owner_user')
+    await insertConnectedAccount('ca_owned', 'owner_user')
+
+    await createWebhookTrigger({
+      agentSlug: 'agent-1',
+      composioTriggerId: 'ti_1',
+      connectedAccountId: 'ca_owned',
+      triggerType: 'GMAIL_NEW_EMAIL',
+      prompt: 'Handle email',
+      createdByUserId: 'creator_user',
+    })
+
+    expect(getDistinctPlatformMemberIdsForActiveTriggers()).toEqual([])
+  })
+})

--- a/src/shared/lib/services/webhook-trigger-service.ts
+++ b/src/shared/lib/services/webhook-trigger-service.ts
@@ -31,6 +31,30 @@ function lookupPlatformMemberId(userId: string): string | null {
   return rows[0]?.accountId ?? null
 }
 
+/**
+ * Resolve the platform member ID for an ordered list of candidate user IDs,
+ * preferring earlier candidates. Returns the first candidate that resolves to a
+ * platform `authAccount` row (and the user ID it resolved from), or null if none
+ * do. Null/duplicate candidates are skipped.
+ *
+ * Used by both the poller (which member to claim events under) and runtime
+ * attribution (which user to run the session as) so the two never diverge: the
+ * trigger creator is preferred, but the connected-account owner is a fallback
+ * when the creator has no platform member (SUP-226).
+ */
+export function resolvePlatformMemberForCandidates(
+  candidates: Array<string | null | undefined>,
+): { userId: string; memberId: string } | null {
+  const seen = new Set<string>()
+  for (const userId of candidates) {
+    if (!userId || seen.has(userId)) continue
+    seen.add(userId)
+    const memberId = lookupPlatformMemberId(userId)
+    if (memberId) return { userId, memberId }
+  }
+  return null
+}
+
 /** Distinct member IDs of active/paused trigger owners; used by TriggerManager to poll per-member. */
 export function getDistinctPlatformMemberIdsForActiveTriggers(): string[] {
   const rows = db
@@ -45,10 +69,11 @@ export function getDistinctPlatformMemberIdsForActiveTriggers(): string[] {
 
   const ids = new Set<string>()
   for (const row of rows) {
-    const userId = row.createdByUserId ?? row.ownerUserId
-    if (!userId) continue
-    const memberId = lookupPlatformMemberId(userId)
-    if (memberId) ids.add(memberId)
+    // Prefer the creator, but fall back to the connected-account owner when the
+    // creator has no platform member — otherwise the trigger is silently dropped
+    // from the poll set even though the owner could claim its events (SUP-226).
+    const resolved = resolvePlatformMemberForCandidates([row.createdByUserId, row.ownerUserId])
+    if (resolved) ids.add(resolved.memberId)
   }
   return [...ids]
 }
@@ -66,6 +91,29 @@ export function getActiveComposioTriggerIds(): string[] {
     )
     .all()
     .map((r) => r.composioTriggerId!)
+}
+
+/**
+ * Distinct composio trigger IDs that still hold an upstream subscription
+ * (status IN 'active'/'paused'), mirroring countActiveTriggersForComposioId /
+ * listActiveWebhookTriggers. Used to scope the platform poll so paused-period
+ * events are still claimed: TriggerManager finds no *active* local trigger and
+ * acks/discards them, instead of letting them accumulate pending and fire a
+ * session on resume (SUP-225).
+ */
+export function getSubscribedComposioTriggerIds(): string[] {
+  const ids = db
+    .selectDistinct({ composioTriggerId: webhookTriggers.composioTriggerId })
+    .from(webhookTriggers)
+    .where(
+      and(
+        inArray(webhookTriggers.status, ['active', 'paused']),
+        isNotNull(webhookTriggers.composioTriggerId),
+      ),
+    )
+    .all()
+    .map((r) => r.composioTriggerId!)
+  return ids
 }
 
 export type { WebhookTrigger, NewWebhookTrigger }


### PR DESCRIPTION
## Summary

Two related webhook-polling fixes in `webhook-trigger-service.ts` and its callers.

### SUP-225 — Paused webhook trigger events are not polled or acked while paused
A trigger paused via `pauseWebhookTrigger()` keeps its upstream Composio subscription alive (`countActiveTriggersForComposioId` counts `active`+`paused`), but the platform poll filter was built from `getActiveComposioTriggerIds()` (status `'active'` only). Events for a Composio ID whose only local trigger is paused were therefore never claimed or acked — they accumulated pending and fired an agent session unexpectedly when the trigger was resumed.

**Fix:** added a dedicated `getSubscribedComposioTriggerIds()` (distinct composio IDs for rows with status IN `active`/`paused` and non-null composio ID, mirroring the "still subscribed" semantics of `countActiveTriggersForComposioId` / `listActiveWebhookTriggers`) and used it to scope `pollAndClaimEvents`. The platform now hands paused-period events to `processEventGroup`, whose existing no-active-local-trigger branch acks/discards them. `getActiveComposioTriggerIds` (and its test) is left unchanged.

### SUP-226 — Webhook polling skips connected-account owner when trigger creator lacks platform auth
`getDistinctPlatformMemberIdsForActiveTriggers()` collapsed the creator/owner candidates with `??` and only resolved a member ID for whichever the `??` picked. When `createdByUserId` was set but that user had no platform `authAccount` row, the connected-account owner was never tried, so an otherwise-resolvable trigger contributed nothing to the per-member poll set (observed: `expected [] to deeply equal [ 'sub_owner_member' ]`).

**Fix:** introduced a shared `resolvePlatformMemberForCandidates()` that walks `[creator, owner]` in priority order and returns the first candidate that resolves to a platform member. Used it in the poller and mirrored it in `TriggerManager.spawnSessionForTrigger()` so runtime attribution (`runWithOptionalUser`) runs the session under the same user the poller claimed events for — preferring the creator, falling back to the owner, and keeping prior best-effort attribution when neither resolves (opaque-key / single-user mode).

## Failing-test-first regressions (now green)
- `src/shared/lib/services/webhook-trigger-poll-scoping.sup225.test.ts` — helper includes paused IDs; real `pollAndClaimEvents` body includes the paused Composio ID.
- `src/shared/lib/services/webhook-trigger-service.sup226.test.ts` — owner fallback, creator priority, no-creator, and neither-resolves cases.

Each reproduced the exact issue failure before the fix and passes after it.

## Changed files
- `src/shared/lib/services/webhook-trigger-service.ts` — new `getSubscribedComposioTriggerIds()` and `resolvePlatformMemberForCandidates()`; owner-fallback in `getDistinctPlatformMemberIdsForActiveTriggers()`.
- `src/shared/lib/services/webhook-events-client.ts` — poll scope uses `getSubscribedComposioTriggerIds()`.
- `src/shared/lib/scheduler/trigger-manager.ts` — runtime attribution mirrors the shared resolver.
- `src/shared/lib/services/webhook-events-client.test.ts`, `src/shared/lib/scheduler/trigger-manager.test.ts` — updated for the renamed dep / new export (plus a trigger-manager owner-attribution case).
- New test files listed above.

## Validation
- New + related existing tests pass (34 tests across the 5 webhook files).
- `npx tsc --noEmit` clean; `npx eslint <changed files>` 0 errors.

Status: waiting for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)