### PR TITLE
fix(notifications): scope auth-mode notifications by user_id (SUP-227)

### DIFF
--- a/src/api/middleware/auth.test.ts
+++ b/src/api/middleware/auth.test.ts
@@ -777,11 +777,9 @@ describe('Auth Middleware', () => {
       expect(mockSelect).not.toHaveBeenCalled()
     })
 
-    it('allows when user has access to notification agent', async () => {
-      // First query returns notification with agentSlug
-      mockLimit.mockResolvedValueOnce([{ agentSlug: 'test-agent' }])
-      // Second query returns user's role on that agent
-      mockLimit.mockResolvedValueOnce([{ role: 'user' }])
+    it('allows when user owns the notification (SUP-227)', async () => {
+      // Notifications are per-user rows; the caller must own this one.
+      mockLimit.mockResolvedValueOnce([{ userId: 'user-1' }])
 
       const app = new Hono()
       setUser(app, { id: 'user-1', role: 'user' })
@@ -791,18 +789,16 @@ describe('Auth Middleware', () => {
       expect(res.status).toBe(200)
     })
 
-    it('returns 403 when user has no access to notification agent', async () => {
-      // First query returns notification with agentSlug
-      mockLimit.mockResolvedValueOnce([{ agentSlug: 'test-agent' }])
-      // Second query returns no role (no access)
-      mockLimit.mockResolvedValueOnce([])
+    it('returns 404 when the notification is owned by another user (SUP-227)', async () => {
+      // Row exists but belongs to a teammate — agent ACL access is not enough.
+      mockLimit.mockResolvedValueOnce([{ userId: 'user-2' }])
 
       const app = new Hono()
       setUser(app, { id: 'user-1', role: 'user' })
       app.get('/:id', HasNotificationAccess(), (c) => c.json({ ok: true }))
 
       const res = await request(app, '/notif-1')
-      expect(res.status).toBe(403)
+      expect(res.status).toBe(404)
     })
 
     it('returns 404 when notification does not exist', async () => {

--- a/src/api/middleware/auth.ts
+++ b/src/api/middleware/auth.ts
@@ -5,6 +5,7 @@ import { runWithRequestUser } from '@shared/lib/platform-attribution'
 import { db } from '@shared/lib/db'
 import { agentAcl, connectedAccounts, remoteMcpServers, notifications } from '@shared/lib/db/schema'
 import { validateProxyToken } from '@shared/lib/proxy/token-store'
+import { isOwnedByCaller } from '@shared/lib/auth/ownership'
 
 // Lazy import to avoid pulling in better-auth ESM at import time
 let _getAuth: (() => ReturnType<typeof import('@shared/lib/auth/index').getAuth>) | null = null
@@ -286,9 +287,13 @@ export function OwnsMcpByParam(param: string): MiddlewareHandler {
 }
 
 /**
- * HasNotificationAccess — user has access to the notification's agent.
- * Admins can access any notification. Regular users need an agentAcl entry
- * for the notification's agentSlug. Expects `:id` route param.
+ * HasNotificationAccess — caller owns the notification referenced by `:id`.
+ *
+ * Notifications are per-user rows (auth mode fans each event out to one row per
+ * ACL member). Gating only by agent role let a teammate flip/delete another
+ * user's row and read its body (SUP-227); a non-admin must therefore own the
+ * row (`notifications.user_id === user.id`). Admins retain bypass access. A
+ * non-owned (or missing) row is reported as 404 so existence does not leak.
  */
 export function HasNotificationAccess(): MiddlewareHandler {
   return async (c: Context, next: Next) => {
@@ -299,15 +304,16 @@ export function HasNotificationAccess(): MiddlewareHandler {
 
     const notificationId = c.req.param('id')!
     const row = await db
-      .select({ agentSlug: notifications.agentSlug })
+      .select({ userId: notifications.userId })
       .from(notifications)
       .where(eq(notifications.id, notificationId))
       .limit(1)
 
     if (!row[0]) return c.json({ error: 'Not found' }, 404)
 
-    const role = await getUserAgentRole(user.id, row[0].agentSlug)
-    if (!role) return c.json({ error: 'Forbidden' }, 403)
+    // Non-admins must own the row. isOwnedByCaller compares against the acting
+    // user id and is a no-op outside auth mode (already short-circuited above).
+    if (!isOwnedByCaller(c, row[0])) return c.json({ error: 'Not found' }, 404)
 
     return next()
   }

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -147,12 +147,14 @@ function toSkillsetRef(config: Pick<SkillsetConfig, 'id' | 'url' | 'name' | 'pro
  * active/awaiting sessions, last activity, scheduled tasks, dashboards.
  * Batch DB queries upfront, then parallelize per-agent FS operations.
  */
-async function enrichAgentsWithSummary(agents: ApiAgent[]): Promise<ApiAgent[]> {
+async function enrichAgentsWithSummary(agents: ApiAgent[], userId?: string): Promise<ApiAgent[]> {
   const slugs = agents.map(a => a.slug)
 
-  // Batch DB queries: 2 queries instead of 2*N individual queries
+  // Batch DB queries: 2 queries instead of 2*N individual queries.
+  // `userId` scopes unread indicators to the caller in auth mode (SUP-227);
+  // undefined in non-auth mode preserves the aggregate-across-owners behavior.
   const [unreadByAgent, tasksByAgent, chatIntegrationsByAgent] = await Promise.all([
-    getUnreadNotificationsByAgents(slugs),
+    getUnreadNotificationsByAgents(slugs, userId),
     listPendingScheduledTasksByAgents(slugs),
     Promise.resolve(listChatIntegrationsByAgents(slugs)),
   ])
@@ -648,7 +650,7 @@ agents.get('/', async (c) => {
       agentList = await listAgentsWithStatus()
     }
 
-    return c.json(await enrichAgentsWithSummary(agentList))
+    return c.json(await enrichAgentsWithSummary(agentList, isAuthMode() ? getCurrentUserId(c) : undefined))
   } catch (error) {
     console.error('Failed to fetch agents:', error)
     return c.json({ error: 'Failed to fetch agents' }, 500)
@@ -690,7 +692,7 @@ agents.get('/:id', AgentRead(), async (c) => {
       return c.json({ error: 'Agent not found' }, 404)
     }
 
-    const [enriched] = await enrichAgentsWithSummary([agent])
+    const [enriched] = await enrichAgentsWithSummary([agent], isAuthMode() ? getCurrentUserId(c) : undefined)
     return c.json(enriched)
   } catch (error) {
     console.error('Failed to fetch agent:', error)
@@ -1167,7 +1169,7 @@ agents.get('/:id/sessions', AgentRead(), async (c) => {
 
 
     const sessionList = await listSessions(slug, { excludeAutomated: true })
-    const unreadSessionIds = await getSessionIdsWithUnreadNotifications(slug)
+    const unreadSessionIds = await getSessionIdsWithUnreadNotifications(slug, isAuthMode() ? getCurrentUserId(c) : undefined)
     const hasAgentLevelReviews = reviewManager.getPendingReviewsForAgent(slug).length > 0
     const sessionsWithStatus = sessionList.map((session) => {
       const isActive = messagePersister.isSessionActive(session.id)

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -246,15 +246,26 @@ export function GlobalNotificationHandler() {
                 notificationId: data.notificationId ?? baseContext.notificationId,
               }
               showOSNotification(title, body, undefined, { actions, context })
-            } else if (suppressedByActiveView && typeof data.notificationId === 'string') {
+            } else if (suppressedByActiveView) {
               // Popup suppressed because the user is actively viewing this
               // focused session — but the backend still created the DB record.
               // Mark it read here, otherwise the unread badge inflates for a
               // session the user is watching live. main-content's auto-mark-read
               // only fires on session open / tab refocus, not for notifications
               // that arrive mid-view. (PR #175 follow-up.)
-              apiFetch(`/api/notifications/${data.notificationId}/read`, { method: 'POST' })
-                .then((res) => {
+              //
+              // In auth mode the backend fans a notification out to one per-user
+              // row, so the global broadcast carries no single notificationId
+              // (SUP-227). Fall back to the user-scoped read-by-session endpoint,
+              // which marks only the caller's own rows for this session.
+              const markReadRequest =
+                typeof data.notificationId === 'string'
+                  ? apiFetch(`/api/notifications/${data.notificationId}/read`, { method: 'POST' })
+                  : typeof notificationSessionId === 'string'
+                    ? apiFetch(`/api/notifications/read-by-session/${notificationSessionId}`, { method: 'POST' })
+                    : null
+              markReadRequest
+                ?.then((res) => {
                   if (res.ok) {
                     queryClient.invalidateQueries({ queryKey: ['notifications'] })
                   }

--- a/src/shared/lib/notifications/notification-manager.ts
+++ b/src/shared/lib/notifications/notification-manager.ts
@@ -11,6 +11,7 @@
 import { messagePersister } from '@shared/lib/container/message-persister'
 import {
   createNotification,
+  getAgentAclUserIds,
   type NotificationType,
 } from '@shared/lib/services/notification-service'
 import { getUserSettings } from '@shared/lib/services/user-settings-service'
@@ -86,28 +87,43 @@ class NotificationManager {
       return
     }
 
-    // Always create DB notification (for badge/dropdown history)
-    const notificationId = await createNotification({
-      type,
-      sessionId,
-      agentSlug,
-      title,
-      body,
-    })
+    // Create the DB notification record(s) used for badge/dropdown history.
+    //
+    // Session lifecycle events have no single requesting user, so in auth mode
+    // we fan out to one per-user row per ACL member of the agent. Each recipient
+    // then owns their own read state (SUP-227) — the service queries filter by
+    // notifications.user_id. A single shared row would be invisible to every
+    // user (the auth-mode queries require user_id) and would also reintroduce
+    // the shared isRead bit. In non-auth (single-user) mode we keep one row with
+    // a null owner, and stamp its id into the broadcast so the renderer can mark
+    // it read on interaction.
+    let broadcastNotificationId: string | undefined
+    if (isAuthMode()) {
+      const recipientIds = await getAgentAclUserIds(agentSlug)
+      for (const recipientId of recipientIds) {
+        await createNotification({ type, sessionId, agentSlug, title, body }, recipientId)
+      }
+      // No single owning row to reference — each recipient has a distinct id.
+      // The renderer refreshes its (user-scoped) list on the broadcast and falls
+      // back to marking the session read when no notificationId is present.
+      broadcastNotificationId = undefined
+    } else {
+      broadcastNotificationId = await createNotification({ type, sessionId, agentSlug, title, body })
+    }
 
-    // Stamp the actionContext with notificationId so the renderer dispatcher
-    // can mark the DB record as read when the user clicks the OS notification
-    // or one of its action buttons (otherwise the badge stays incremented
-    // even after the user has clearly seen and acted on the notification).
+    // Stamp the actionContext with notificationId (non-auth only) so the renderer
+    // dispatcher can mark the DB record as read when the user clicks the OS
+    // notification or one of its action buttons (otherwise the badge stays
+    // incremented even after the user has clearly seen and acted on it).
     const stampedActionContext = actionContext
-      ? { ...actionContext, notificationId }
+      ? { ...actionContext, ...(broadcastNotificationId ? { notificationId: broadcastNotificationId } : {}) }
       : undefined
 
     // Broadcast OS notification event to all connected clients
     // Frontend will decide whether to show based on tab visibility and selected session
     messagePersister.broadcastGlobal({
       type: 'os_notification',
-      notificationId,
+      ...(broadcastNotificationId ? { notificationId: broadcastNotificationId } : {}),
       notificationType: type,
       sessionId,
       agentSlug,

--- a/src/shared/lib/services/notification-service-user-scoping.sup227.test.ts
+++ b/src/shared/lib/services/notification-service-user-scoping.sup227.test.ts
@@ -1,0 +1,269 @@
+/**
+ * SUP-227 — Auth-mode notifications must scope by `notifications.user_id`, not
+ * just by accessible-agent ACL.
+ *
+ * In AUTH_MODE the notification service scoped list/count/mark-read queries by
+ * the caller's accessible agent slugs only and never by the per-user owner
+ * column (`notifications.user_id`). Two users who share an agent therefore saw
+ * each other's notification bodies/history and cleared each other's unread/read
+ * state through a single shared `isRead` bit. The `:id/read` + `DELETE :id`
+ * endpoints were likewise agent-scoped, so a teammate could flip/delete a
+ * notification they do not own.
+ *
+ * These tests seed per-user notification rows directly (notif-a → userA,
+ * notif-b → userB) on the same shared agent + session and assert that auth-mode
+ * scoping is by user. They FAIL on the pre-fix code (agent-ACL-only scoping) and
+ * PASS once each auth-mode query / the middleware also matches user_id. Non-auth
+ * behavior (userId undefined) must stay unchanged.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as path from 'path'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import { eq } from 'drizzle-orm'
+import { Hono } from 'hono'
+import * as schema from '../db/schema'
+
+let testDb: ReturnType<typeof drizzle>
+let testSqlite: InstanceType<typeof Database>
+let authModeEnabled = true
+
+vi.mock('../db', () => ({
+  get db() {
+    return testDb
+  },
+  get sqlite() {
+    return testSqlite
+  },
+}))
+
+// isAuthMode is consulted by the route middleware (HasNotificationAccess) and by
+// the ownership helpers. The service functions branch on the userId argument, so
+// they are independent of this toggle.
+vi.mock('@shared/lib/auth/mode', () => ({
+  isAuthMode: () => authModeEnabled,
+}))
+
+import {
+  listNotifications,
+  getUnreadCount,
+  markSessionNotificationsRead,
+  markAsRead,
+  getUnreadNotificationsByAgents,
+  getSessionIdsWithUnreadNotifications,
+} from './notification-service'
+import { notifications, agentAcl } from '../db/schema'
+import { HasNotificationAccess } from '../../../api/middleware/auth'
+
+const USER_A = 'user-a'
+const USER_B = 'user-b'
+const AGENT = 'shared-agent'
+const SESSION = 'shared-session'
+
+async function seedAcl() {
+  await testDb.insert(agentAcl).values([
+    { id: 'acl-a', userId: USER_A, agentSlug: AGENT, role: 'owner', createdAt: new Date() },
+    { id: 'acl-b', userId: USER_B, agentSlug: AGENT, role: 'user', createdAt: new Date() },
+  ])
+}
+
+describe('SUP-227: auth-mode notifications scope by user_id', () => {
+  beforeEach(() => {
+    authModeEnabled = true
+    testSqlite = new Database(':memory:')
+    testDb = drizzle(testSqlite, { schema })
+    const migrationsFolder = path.join(process.cwd(), 'src/shared/lib/db/migrations')
+    migrate(testDb, { migrationsFolder })
+  })
+
+  afterEach(() => {
+    testSqlite?.close()
+  })
+
+  describe('same session, two owners', () => {
+    beforeEach(async () => {
+      await seedAcl()
+      // Two per-user notifications on the SAME agent + session (the row-per-user
+      // shape the fix relies on; createNotification can populate user_id post-fix,
+      // but here we seed directly so the test is independent of the writer).
+      await testDb.insert(notifications).values([
+        {
+          id: 'notif-a',
+          type: 'session_waiting',
+          sessionId: SESSION,
+          agentSlug: AGENT,
+          title: 'For A',
+          body: 'secret addressed to A',
+          isRead: false,
+          userId: USER_A,
+          createdAt: new Date(1_000),
+        },
+        {
+          id: 'notif-b',
+          type: 'session_waiting',
+          sessionId: SESSION,
+          agentSlug: AGENT,
+          title: 'For B',
+          body: 'secret addressed to B',
+          isRead: false,
+          userId: USER_B,
+          createdAt: new Date(2_000),
+        },
+      ])
+    })
+
+    it('listNotifications returns only the calling user rows', async () => {
+      expect((await listNotifications(50, USER_B)).map((n) => n.id)).toEqual(['notif-b'])
+      expect((await listNotifications(50, USER_A)).map((n) => n.id)).toEqual(['notif-a'])
+    })
+
+    it('getUnreadCount counts only the calling user rows', async () => {
+      expect(await getUnreadCount(USER_B)).toBe(1)
+      expect(await getUnreadCount(USER_A)).toBe(1)
+    })
+
+    it('markSessionNotificationsRead marks only the calling user rows (no shared isRead bit)', async () => {
+      const marked = await markSessionNotificationsRead(SESSION, USER_B)
+      expect(marked).toBe(1)
+      // userB cleared their own; userA's row is untouched.
+      expect(await getUnreadCount(USER_B)).toBe(0)
+      expect(await getUnreadCount(USER_A)).toBe(1)
+
+      const aRow = await testDb.select().from(notifications).where(eq(notifications.id, 'notif-a'))
+      expect(aRow[0]?.isRead).toBe(false)
+      const bRow = await testDb.select().from(notifications).where(eq(notifications.id, 'notif-b'))
+      expect(bRow[0]?.isRead).toBe(true)
+    })
+
+    it('non-auth mode (userId undefined) is unchanged — sees every row', async () => {
+      expect((await listNotifications(50)).map((n) => n.id).sort()).toEqual(['notif-a', 'notif-b'])
+      expect(await getUnreadCount()).toBe(2)
+    })
+  })
+
+  describe('per-user unread session indicators (different sessions)', () => {
+    beforeEach(async () => {
+      await seedAcl()
+      await testDb.insert(notifications).values([
+        {
+          id: 'notif-a',
+          type: 'session_waiting',
+          sessionId: 'session-a',
+          agentSlug: AGENT,
+          title: 'For A',
+          body: 'b',
+          isRead: false,
+          userId: USER_A,
+          createdAt: new Date(1_000),
+        },
+        {
+          id: 'notif-b',
+          type: 'session_waiting',
+          sessionId: 'session-b',
+          agentSlug: AGENT,
+          title: 'For B',
+          body: 'b',
+          isRead: false,
+          userId: USER_B,
+          createdAt: new Date(2_000),
+        },
+      ])
+    })
+
+    it('getUnreadNotificationsByAgents groups only the calling user sessions', async () => {
+      const mapB = await getUnreadNotificationsByAgents([AGENT], USER_B)
+      expect([...(mapB.get(AGENT) ?? new Set())]).toEqual(['session-b'])
+
+      const mapA = await getUnreadNotificationsByAgents([AGENT], USER_A)
+      expect([...(mapA.get(AGENT) ?? new Set())]).toEqual(['session-a'])
+    })
+
+    it('getSessionIdsWithUnreadNotifications returns only the calling user sessions', async () => {
+      const setB = await getSessionIdsWithUnreadNotifications(AGENT, USER_B)
+      expect([...setB]).toEqual(['session-b'])
+
+      const setA = await getSessionIdsWithUnreadNotifications(AGENT, USER_A)
+      expect([...setA]).toEqual(['session-a'])
+    })
+
+    it('non-auth mode (userId undefined) still aggregates across all owners', async () => {
+      const map = await getUnreadNotificationsByAgents([AGENT])
+      expect([...(map.get(AGENT) ?? new Set())].sort()).toEqual(['session-a', 'session-b'])
+    })
+  })
+
+  describe('HasNotificationAccess ownership gate (route middleware)', () => {
+    beforeEach(async () => {
+      await seedAcl()
+      await testDb.insert(notifications).values([
+        {
+          id: 'notif-a',
+          type: 'session_waiting',
+          sessionId: SESSION,
+          agentSlug: AGENT,
+          title: 'For A',
+          body: 'secret addressed to A',
+          isRead: false,
+          userId: USER_A,
+          createdAt: new Date(1_000),
+        },
+        {
+          id: 'notif-b',
+          type: 'session_waiting',
+          sessionId: SESSION,
+          agentSlug: AGENT,
+          title: 'For B',
+          body: 'secret addressed to B',
+          isRead: false,
+          userId: USER_B,
+          createdAt: new Date(2_000),
+        },
+      ])
+    })
+
+    function appAs(userId: string) {
+      const app = new Hono()
+      app.use('*', async (c, next) => {
+        c.set('user' as never, { id: userId } as never)
+        return next()
+      })
+      app.post('/api/notifications/:id/read', HasNotificationAccess(), async (c) => {
+        const ok = await markAsRead(c.req.param('id'))
+        return c.json({ success: ok })
+      })
+      return app
+    }
+
+    it("rejects userB marking userA's notification and does not flip it", async () => {
+      const res = await appAs(USER_B).request('http://localhost/api/notifications/notif-a/read', {
+        method: 'POST',
+      })
+      expect([403, 404]).toContain(res.status)
+
+      const aRow = await testDb.select().from(notifications).where(eq(notifications.id, 'notif-a'))
+      expect(aRow[0]?.isRead).toBe(false)
+    })
+
+    it('allows userB to mark their own notification', async () => {
+      const res = await appAs(USER_B).request('http://localhost/api/notifications/notif-b/read', {
+        method: 'POST',
+      })
+      expect(res.status).toBe(200)
+
+      const bRow = await testDb.select().from(notifications).where(eq(notifications.id, 'notif-b'))
+      expect(bRow[0]?.isRead).toBe(true)
+    })
+
+    it('non-auth mode passes through (no ownership concept)', async () => {
+      authModeEnabled = false
+      const res = await appAs('ignored').request('http://localhost/api/notifications/notif-a/read', {
+        method: 'POST',
+      })
+      expect(res.status).toBe(200)
+      const aRow = await testDb.select().from(notifications).where(eq(notifications.id, 'notif-a'))
+      expect(aRow[0]?.isRead).toBe(true)
+    })
+  })
+})

--- a/src/shared/lib/services/notification-service.ts
+++ b/src/shared/lib/services/notification-service.ts
@@ -45,15 +45,35 @@ export async function getAccessibleAgentSlugs(userId: string): Promise<string[]>
   return rows.map((r) => r.agentSlug)
 }
 
+/**
+ * Get all user IDs that hold an ACL entry for an agent (inverse of
+ * getAccessibleAgentSlugs). Used to fan a notification out to one per-user row
+ * per ACL member in auth mode so each recipient owns their own read state.
+ */
+export async function getAgentAclUserIds(agentSlug: string): Promise<string[]> {
+  const rows = await db
+    .select({ userId: agentAcl.userId })
+    .from(agentAcl)
+    .where(eq(agentAcl.agentSlug, agentSlug))
+  return rows.map((r) => r.userId)
+}
+
 // ============================================================================
 // Create Operations
 // ============================================================================
 
 /**
- * Create a new notification
+ * Create a new notification.
+ *
+ * `userId` is the per-user owner of the row. In auth mode the caller fans a
+ * single event out to one row per ACL member (see notification-manager); in
+ * non-auth (single-user) mode it is left undefined/null and queries fall back to
+ * agent scoping. Auth-mode queries below filter by this column, so an
+ * auth-mode notification created without a userId is invisible to every user.
  */
 export async function createNotification(
-  params: CreateNotificationParams
+  params: CreateNotificationParams,
+  userId?: string
 ): Promise<string> {
   const id = crypto.randomUUID()
 
@@ -65,6 +85,7 @@ export async function createNotification(
     title: params.title,
     body: params.body,
     isRead: false,
+    userId: userId ?? null,
     createdAt: new Date(),
   }
 
@@ -88,7 +109,7 @@ export async function listNotifications(limit: number = 50, userId?: string, off
     return db
       .select()
       .from(notifications)
-      .where(inArray(notifications.agentSlug, slugs))
+      .where(and(eq(notifications.userId, userId), inArray(notifications.agentSlug, slugs)))
       .orderBy(desc(notifications.createdAt))
       .limit(limit)
       .offset(offset)
@@ -108,7 +129,7 @@ export async function countNotifications(userId?: string): Promise<number> {
     const result = await db
       .select({ count: count() })
       .from(notifications)
-      .where(inArray(notifications.agentSlug, slugs))
+      .where(and(eq(notifications.userId, userId), inArray(notifications.agentSlug, slugs)))
     return result[0]?.count ?? 0
   }
   const result = await db
@@ -139,6 +160,8 @@ export async function getSessionIdsWithUnreadNotifications(agentSlug: string, us
   if (userId) {
     const slugs = await getAccessibleAgentSlugs(userId)
     if (!slugs.includes(agentSlug)) return new Set()
+    // Scope to the caller's own rows — the unread dot is per-user (SUP-227).
+    conditions.push(eq(notifications.userId, userId))
   }
 
   const rows = await db
@@ -153,17 +176,21 @@ export async function getSessionIdsWithUnreadNotifications(agentSlug: string, us
  * Batch version: get unread notification session IDs for multiple agents in a single query.
  * Returns a Map from agentSlug to Set of sessionIds with unread notifications.
  */
-export async function getUnreadNotificationsByAgents(agentSlugs: string[]): Promise<Map<string, Set<string>>> {
+export async function getUnreadNotificationsByAgents(agentSlugs: string[], userId?: string): Promise<Map<string, Set<string>>> {
   if (agentSlugs.length === 0) return new Map()
+
+  const conditions = [
+    inArray(notifications.agentSlug, agentSlugs),
+    eq(notifications.isRead, false),
+    inArray(notifications.type, [...USER_ACTIONABLE_NOTIFICATION_TYPES]),
+  ]
+  // Per-user unread indicators in auth mode (SUP-227). Undefined in non-auth.
+  if (userId) conditions.push(eq(notifications.userId, userId))
 
   const rows = await db
     .select({ agentSlug: notifications.agentSlug, sessionId: notifications.sessionId })
     .from(notifications)
-    .where(and(
-      inArray(notifications.agentSlug, agentSlugs),
-      eq(notifications.isRead, false),
-      inArray(notifications.type, [...USER_ACTIONABLE_NOTIFICATION_TYPES]),
-    ))
+    .where(and(...conditions))
 
   const result = new Map<string, Set<string>>()
   for (const row of rows) {
@@ -185,7 +212,7 @@ export async function listUnreadNotifications(limit: number = 50, userId?: strin
     return db
       .select()
       .from(notifications)
-      .where(and(eq(notifications.isRead, false), inArray(notifications.agentSlug, slugs)))
+      .where(and(eq(notifications.userId, userId), eq(notifications.isRead, false), inArray(notifications.agentSlug, slugs)))
       .orderBy(desc(notifications.createdAt))
       .limit(limit)
   }
@@ -209,7 +236,7 @@ export async function getUnreadCount(userId?: string): Promise<number> {
     const result = await db
       .select({ count: count() })
       .from(notifications)
-      .where(and(eq(notifications.isRead, false), inArray(notifications.agentSlug, slugs), actionable))
+      .where(and(eq(notifications.userId, userId), eq(notifications.isRead, false), inArray(notifications.agentSlug, slugs), actionable))
     return result[0]?.count ?? 0
   }
   const result = await db
@@ -265,6 +292,8 @@ export async function markSessionNotificationsRead(sessionId: string, userId?: s
     const slugs = await getAccessibleAgentSlugs(userId)
     if (slugs.length === 0) return 0
     conditions.push(inArray(notifications.agentSlug, slugs))
+    // Only clear the caller's own rows — no shared isRead bit (SUP-227).
+    conditions.push(eq(notifications.userId, userId))
   }
 
   const result = await db
@@ -292,7 +321,7 @@ export async function markAllAsRead(userId?: string): Promise<number> {
         isRead: true,
         readAt: new Date(),
       })
-      .where(and(eq(notifications.isRead, false), inArray(notifications.agentSlug, slugs)))
+      .where(and(eq(notifications.userId, userId), eq(notifications.isRead, false), inArray(notifications.agentSlug, slugs)))
     return result.changes ?? 0
   }
 


### PR DESCRIPTION
## SUP-227 — Auth-mode notifications scope by agent ACL, not user_id

### Bug
In `AUTH_MODE`, the notification service scoped list/count/mark-read queries by the caller's accessible-agent ACL only and **never** by the per-user owner column `notifications.user_id`, while `createNotification` left `user_id` null. Consequences for users who share an agent:
- They could read each other's notification **bodies and history** (`listNotifications`, `countNotifications`, unread queries all filtered by `agentSlug` only).
- They cleared each other's unread/read state through a single shared `isRead` bit (`markSessionNotificationsRead` / `markAllAsRead` — opening a shared session marked *everyone's* rows read).
- `POST /:id/read` and `DELETE /:id` were gated by `HasNotificationAccess`, which only checked agent role — a teammate could flip or delete a notification they did not own.

### Fix (per-recipient fan-out — the smaller change matching the existing `user_id` column intent)
- **`notification-service.ts`**: `createNotification` gains a `userId` owner param; new `getAgentAclUserIds` (inverse of `getAccessibleAgentSlugs`). Every auth-mode query now *also* filters by `eq(notifications.userId, userId)` — `listNotifications`, `countNotifications`, `listUnreadNotifications`, `getUnreadCount`, `getSessionIdsWithUnreadNotifications`, `getUnreadNotificationsByAgents`, `markSessionNotificationsRead`, `markAllAsRead`. Non-auth behavior (`userId` undefined) is unchanged.
- **`notification-manager.ts`**: session lifecycle events have no single owning user, so in auth mode the event is fanned out to one row per agent ACL member; non-auth mode keeps a single null-owner row. The global SSE broadcast omits a per-user `notificationId` in auth mode (each recipient owns a distinct row).
- **`auth.ts` (`HasNotificationAccess`)**: non-admins must now **own** the row via `isOwnedByCaller` from `@shared/lib/auth/ownership`; non-owned/missing rows return `404` so existence does not leak. Admins retain bypass.
- **`agents.ts`**: thread the scoped `userId` into `enrichAgentsWithSummary` → `getUnreadNotificationsByAgents` and into `getSessionIdsWithUnreadNotifications`, so sidebar/list unread indicators are per-user.
- **`global-notification-handler.tsx`**: when the broadcast carries no `notificationId` (auth-mode fan-out), the mid-view auto-mark falls back to the user-scoped `read-by-session` endpoint so the badge still clears.

### Tests (failing-then-green regression)
New `src/shared/lib/services/notification-service-user-scoping.sup227.test.ts` (in-memory sqlite + drizzle harness). Seeds `agentAcl` so userA and userB both access `shared-agent`, inserts `notif-a` (owner userA) and `notif-b` (owner userB) on the same agent+session, and asserts behavior that **failed on the pre-fix code and now passes**:
- `listNotifications(50, userB)` → `['notif-b']` (was `[notif-a, notif-b]`)
- `getUnreadCount(userB) === 1` (was `2`)
- `markSessionNotificationsRead(session, userB)` marks only `notif-b`; `getUnreadCount(userA)` stays `1` (no shared isRead bit)
- per-user `getUnreadNotificationsByAgents` / `getSessionIdsWithUnreadNotifications` scoping
- route/middleware: `POST /api/notifications/:notifA/read` as userB → `403/404` and `notif-a.isRead` stays false; userB marking their own row → `200`
- non-auth-mode regression guards (userId undefined) preserved

Also updated the stale agent-role `HasNotificationAccess` unit tests in `auth.test.ts` to the new ownership semantics.

Note: notifications are stored as typed columns (no JSON (de)serialization at the DB boundary), so no new Zod schema was required; the SSE `actions` payload remains validated by the existing `NotificationActionsArraySchema`.

### Validation
- New + closely-related existing suites green (`auth.test.ts`, `security-repro.test.ts`, `agents.test.ts`, `notification-manager.test.ts`, `notification-service.test.ts`): 317 passing.
- `npx tsc --noEmit` clean; `eslint` on changed files clean.

### Changed files
- `src/shared/lib/services/notification-service.ts`
- `src/shared/lib/notifications/notification-manager.ts`
- `src/api/middleware/auth.ts`
- `src/api/routes/agents.ts`
- `src/renderer/components/notifications/global-notification-handler.tsx`
- `src/api/middleware/auth.test.ts`
- `src/shared/lib/services/notification-service-user-scoping.sup227.test.ts` (new)

Status: waiting for review.
🤖 Generated with [Claude Code](https://claude.com/claude-code)