### PR TITLE
fix(renderer): preserve tel:/sms: link hrefs in agent markdown (SUP-238)

### DIFF
--- a/src/renderer/components/file-preview/renderers/markdown-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/markdown-renderer.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Loader2, AlertCircle } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { markdownUrlTransform } from '@renderer/lib/markdown-url-transform'
 import { useRef } from 'react'
 import { useTextSelection } from '../comments/use-text-selection'
 import { CommentOverlay } from '../comments/comment-overlay'
@@ -40,6 +41,7 @@ export function MarkdownRenderer({ url, filePath }: MarkdownRendererProps) {
         <div className="prose prose-sm max-w-none min-w-0 break-words dark:prose-invert">
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
+            urlTransform={markdownUrlTransform}
             components={{
               pre: ({ children }) => (
                 <pre className="rounded-lg p-3 text-sm overflow-x-auto bg-black/[0.03] dark:bg-white/[0.06]">

--- a/src/renderer/components/messages/message-item-markdown-links.sup238.test.tsx
+++ b/src/renderer/components/messages/message-item-markdown-links.sup238.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { MarkdownBlock } from './message-item'
+
+// ---------------------------------------------------------------------------
+// SUP-238 — agent-rendered markdown blanked tel:/sms: link hrefs.
+//
+// react-markdown applies `defaultUrlTransform` to every URL property; its
+// safe-protocol allowlist is /^(https?|ircs?|mailto|xmpp)$/i, so any other
+// scheme is rewritten to ''. tel: and sms: fell outside it, so links agents
+// emitted rendered as <a href=""> — dead. https:/mailto: survived, which is
+// exactly the asymmetry the tester reported.
+//
+// The fix is a shared `urlTransform` (markdown-url-transform.ts) that composes
+// defaultUrlTransform and additionally permits the tel:/sms: composer schemes
+// the Electron shell opener already allows (SUP-214 POPUP_PROTOCOLS). Genuinely
+// dangerous schemes (javascript:, file:, data:, vbscript:) must STILL be blanked.
+//
+// This renders the real MarkdownBlock used by MessageItem, so it also guards the
+// per-callsite wiring (drop the urlTransform prop and these assertions fail).
+// ---------------------------------------------------------------------------
+
+const MARKDOWN = [
+  '[Website](https://www.anthropic.com)',
+  '[Email](mailto:hello@example.com)',
+  '[SMS](sms:+15551234567)',
+  '[Phone](tel:+15551234567)',
+  '[Script](javascript:steal)',
+  '[Local](file:///etc/passwd)',
+].join('\n\n')
+
+const hrefOf = (linkText: string): string | null =>
+  screen.getByText(linkText).getAttribute('href')
+
+describe('SUP-238: agent markdown link scheme handling', () => {
+  afterEach(cleanup)
+
+  it('preserves https:, mailto:, tel:, and sms: hrefs', () => {
+    render(<MarkdownBlock text={MARKDOWN} />)
+    expect(hrefOf('Website')).toBe('https://www.anthropic.com')
+    expect(hrefOf('Email')).toBe('mailto:hello@example.com')
+    expect(hrefOf('SMS')).toBe('sms:+15551234567')
+    expect(hrefOf('Phone')).toBe('tel:+15551234567')
+  })
+
+  it('still blanks dangerous schemes (javascript:, file:)', () => {
+    render(<MarkdownBlock text={MARKDOWN} />)
+    // defaultUrlTransform rewrites these to '' — the fix must not loosen that.
+    expect(hrefOf('Script')).toBe('')
+    expect(hrefOf('Local')).toBe('')
+  })
+})

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -15,6 +15,7 @@ import { PROVIDER_ERROR_CODES } from '@shared/lib/types/api'
 import type { ApiMessage, ApiToolCall } from '@shared/lib/types/api'
 import type { SubagentInfo } from '@renderer/hooks/use-message-stream'
 import { useRenderTracker } from '@renderer/lib/perf'
+import { markdownUrlTransform } from '@renderer/lib/markdown-url-transform'
 
 // Re-export for use by other components
 export type { ApiToolCall }
@@ -123,9 +124,11 @@ const MARKDOWN_COMPONENTS: Components = {
 // A single markdown block. Memoized so that, while a response streams, each
 // already-settled block parses exactly once even though later deltas keep
 // re-rendering the parent MessageItem. See split-streaming-markdown.ts.
-const MarkdownBlock = memo(function MarkdownBlock({ text }: { text: string }) {
+// Exported so the agent-markdown link/scheme handling can be tested directly
+// (SUP-238) without standing up a full MessageItem.
+export const MarkdownBlock = memo(function MarkdownBlock({ text }: { text: string }) {
   return (
-    <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={MARKDOWN_COMPONENTS}>
+    <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={MARKDOWN_COMPONENTS} urlTransform={markdownUrlTransform}>
       {text}
     </ReactMarkdown>
   )

--- a/src/renderer/components/messages/proxy-review-request-item.tsx
+++ b/src/renderer/components/messages/proxy-review-request-item.tsx
@@ -12,6 +12,7 @@ import { cn } from '@shared/lib/utils/cn'
 import { getScopeLabel, type ScopeLabel } from '@shared/lib/proxy/scope-metadata'
 import { labelDefaultKey } from '@shared/lib/proxy/policy-sentinels'
 import ReactMarkdown from 'react-markdown'
+import { markdownUrlTransform } from '@renderer/lib/markdown-url-transform'
 import { RequestItemShell } from './request-item-shell'
 import { RequestItemActions } from './request-item-actions'
 
@@ -262,6 +263,7 @@ export function ProxyReviewRequestItem({
                             {scopeDescriptions[scope] && (
                               <span className="block w-full truncate text-xs font-normal text-muted-foreground/80 [&_a]:font-normal [&_a]:text-inherit [&_a]:underline">
                                 <ReactMarkdown
+                                  urlTransform={markdownUrlTransform}
                                   components={{
                                     p: ({ children }) => <>{children}</>,
                                     a: ({ href, children }) => (
@@ -449,6 +451,7 @@ export function ProxyReviewRequestItem({
                               {scopeDescriptions[scope] && (
                                 <span className="block w-full truncate text-xs font-normal text-muted-foreground/80 [&_a]:font-normal [&_a]:text-inherit [&_a]:underline">
                                   <ReactMarkdown
+                                    urlTransform={markdownUrlTransform}
                                     components={{
                                       p: ({ children }) => <>{children}</>,
                                       a: ({ href, children }) => (

--- a/src/renderer/components/messages/subagent-block.tsx
+++ b/src/renderer/components/messages/subagent-block.tsx
@@ -10,6 +10,7 @@ import type { SubagentInfo } from '@renderer/hooks/use-message-stream'
 import { formatElapsed } from '@renderer/hooks/use-elapsed-timer'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { markdownUrlTransform } from '@renderer/lib/markdown-url-transform'
 
 interface SubAgentBlockProps {
   toolCall: ApiToolCall
@@ -245,7 +246,7 @@ export function SubAgentBlock({
             {visibleItems.map((item) =>
               item.kind === 'text' ? (
                 <div key={item.key} className="prose prose-sm max-w-none break-words dark:prose-invert text-xs">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  <ReactMarkdown remarkPlugins={[remarkGfm]} urlTransform={markdownUrlTransform}>
                     {item.text}
                   </ReactMarkdown>
                 </div>
@@ -262,7 +263,7 @@ export function SubAgentBlock({
             {/* Streaming text from subagent (not yet persisted) */}
             {subagentStreamingMessage && !isStreamingMessagePersisted && (
               <div className="prose prose-sm max-w-none break-words dark:prose-invert text-xs">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                <ReactMarkdown remarkPlugins={[remarkGfm]} urlTransform={markdownUrlTransform}>
                   {subagentStreamingMessage}
                 </ReactMarkdown>
               </div>
@@ -279,7 +280,7 @@ export function SubAgentBlock({
             {/* Result summary from tool_result (available immediately, no JSONL refetch needed) */}
             {resultText && !isResultInFlatItems && !isRunning && (
               <div className="prose prose-sm max-w-none break-words dark:prose-invert text-xs">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                <ReactMarkdown remarkPlugins={[remarkGfm]} urlTransform={markdownUrlTransform}>
                   {resultText}
                 </ReactMarkdown>
               </div>

--- a/src/renderer/components/messages/tool-renderers/web-search.tsx
+++ b/src/renderer/components/messages/tool-renderers/web-search.tsx
@@ -2,6 +2,7 @@
 import { Globe } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { markdownUrlTransform } from '@renderer/lib/markdown-url-transform'
 import { webSearchDef } from '@shared/lib/tool-definitions/web-search'
 import type { ToolRenderer, ToolRendererProps } from './types'
 
@@ -93,7 +94,7 @@ function ExpandedView({ input, result, isError }: ToolRendererProps) {
       {/* Markdown content */}
       {markdown && (
         <div className="prose prose-sm max-w-none dark:prose-invert">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]} urlTransform={markdownUrlTransform}>
             {markdown}
           </ReactMarkdown>
         </div>

--- a/src/renderer/lib/markdown-url-transform.test.ts
+++ b/src/renderer/lib/markdown-url-transform.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { markdownUrlTransform } from './markdown-url-transform'
+
+// react-markdown's UrlTransform is (url, key, node); node is unused here.
+const node = {} as never
+const onHref = (url: string) => markdownUrlTransform(url, 'href', node)
+const onSrc = (url: string) => markdownUrlTransform(url, 'src', node)
+
+describe('markdownUrlTransform (SUP-238)', () => {
+  it('preserves the react-markdown default-safe link schemes', () => {
+    expect(onHref('https://example.com/x?y=1#z')).toBe('https://example.com/x?y=1#z')
+    expect(onHref('http://localhost:3000')).toBe('http://localhost:3000')
+    expect(onHref('mailto:hello@example.com')).toBe('mailto:hello@example.com')
+  })
+
+  it('additionally preserves tel: and sms: (SUP-214 composer schemes)', () => {
+    expect(onHref('tel:+15551234567')).toBe('tel:+15551234567')
+    expect(onHref('sms:+15551234567')).toBe('sms:+15551234567')
+    expect(onHref('sms:+15551234567?&body=hi')).toBe('sms:+15551234567?&body=hi')
+  })
+
+  it('matches the extra schemes case-insensitively', () => {
+    expect(onHref('TEL:+15551234567')).toBe('TEL:+15551234567')
+    expect(onHref('SmS:+15551234567')).toBe('SmS:+15551234567')
+  })
+
+  it('preserves relative / fragment / query links', () => {
+    expect(onHref('/agents/foo')).toBe('/agents/foo')
+    expect(onHref('./sibling')).toBe('./sibling')
+    expect(onHref('../up')).toBe('../up')
+    expect(onHref('#section')).toBe('#section')
+    expect(onHref('?q=1')).toBe('?q=1')
+  })
+
+  it('still blanks dangerous / unknown schemes exactly as the default does', () => {
+    expect(onHref('javascript:alert(1)')).toBe('')
+    expect(onHref('file:///etc/passwd')).toBe('')
+    expect(onHref('data:text/html,<script>alert(1)</script>')).toBe('')
+    expect(onHref('vbscript:msgbox(1)')).toBe('')
+    expect(onHref('myapp://do-something')).toBe('')
+  })
+
+  it('only widens link hrefs, not other URL properties (e.g. img src)', () => {
+    // The tel:/sms: allowance is scoped to key === 'href'; for an image src the
+    // default behavior (blank) still applies.
+    expect(onSrc('tel:+15551234567')).toBe('')
+    expect(onSrc('sms:+15551234567')).toBe('')
+    // …while genuinely safe src schemes still pass through the default.
+    expect(onSrc('https://example.com/a.png')).toBe('https://example.com/a.png')
+  })
+})

--- a/src/renderer/lib/markdown-url-transform.ts
+++ b/src/renderer/lib/markdown-url-transform.ts
@@ -1,0 +1,30 @@
+import { defaultUrlTransform, type UrlTransform } from 'react-markdown'
+
+// react-markdown's defaultUrlTransform passes only URLs whose scheme matches
+// ^(https?|ircs?|mailto|xmpp)$ and rewrites everything else to '' (an empty
+// href). That silently kills the tel:/sms: links agents emit (SUP-238), even
+// though the Electron shell opener explicitly allows them — see
+// src/main/safe-open-external.ts POPUP_PROTOCOLS, added in SUP-214.
+//
+// These are the extra link schemes the renderer should keep so the renderer and
+// the opener stay in lockstep. They are communication composers (dialer / SMS
+// composer): inert until the user confirms the call/text, and never executed in
+// the page like javascript:/data:.
+const EXTRA_ALLOWED_HREF_SCHEME = /^(?:tel|sms):/i
+
+/**
+ * Shared `urlTransform` for every <ReactMarkdown> renderer.
+ *
+ * Composes react-markdown's defaultUrlTransform — so dangerous schemes
+ * (javascript:, file:, data:, vbscript:, custom protocols, …) are still blanked
+ * exactly as before — and additionally permits tel:/sms: on link hrefs.
+ *
+ * Scoped to `key === 'href'` on purpose: it widens what links may point at, not
+ * what images/other resources may load.
+ */
+export const markdownUrlTransform: UrlTransform = (url, key) => {
+  if (key === 'href' && typeof url === 'string' && EXTRA_ALLOWED_HREF_SCHEME.test(url)) {
+    return url
+  }
+  return defaultUrlTransform(url)
+}


### PR DESCRIPTION
## Summary

`tel:` and `sms:` links in agent-rendered markdown rendered with an **empty** `href` (`<a href="">`), so they were dead — while `https:`/`mailto:` in the same message worked. Found while verifying SUP-214 (which made the Electron opener *allow* `sms:`/`tel:`), so the two ends were inconsistent.

**Root cause:** every `<ReactMarkdown>` inherits `defaultUrlTransform`, whose safe-protocol allowlist is `^(https?|ircs?|mailto|xmpp)$`. Anything else is rewritten to `''`. `tel:`/`sms:` fall outside it; none of our call sites passed a custom `urlTransform`.

## Fix

New shared `src/renderer/lib/markdown-url-transform.ts`:
- **composes** `defaultUrlTransform`, so `javascript:`/`file:`/`data:`/`vbscript:`/unknown schemes are **still blanked** exactly as before;
- additionally permits `tel:`/`sms:` **on link hrefs**, mirroring the Electron opener's `POPUP_PROTOCOLS` (SUP-214) so renderer and opener stay in lockstep;
- scoped to `key === 'href'` — it widens what links may point at, not what images/resources may load.

Wired into all five `<ReactMarkdown>` call sites: `message-item`, `subagent-block`, `proxy-review-request-item`, `web-search`, file-preview `markdown-renderer`.

End-to-end: once the href renders, clicking a `target="_blank"` `tel:`/`sms:` link routes through `setWindowOpenHandler → safeOpenExternal`, which already allows these schemes (SUP-214).

## Tests

- `markdown-url-transform.test.ts` (node): default-safe schemes, `tel:`/`sms:`, case-insensitivity, relative/fragment/query links, `href`-only scoping (img `src` stays blanked), and dangerous schemes still blanked.
- `message-item-markdown-links.sup238.test.tsx` (jsdom): renders the real exported `MarkdownBlock` with all four link types — asserts `https:`/`mailto:`/`tel:`/`sms:` keep their href and `javascript:`/`file:` stay blanked. Verified red before the fix (`sms:` came back `''`), green after.

`npx tsc --noEmit` and `eslint` clean; the 26 existing `message-item` + 9 `subagent-block` tests still pass.

Out of scope (intentionally untouched): `chart.tsx` `dangerouslySetInnerHTML` (recharts CSS, not links) and `telegram-connector.ts` `marked` (outbound Telegram formatting, different target).

Closes SUP-238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)