### PR TITLE
fix(secrets): close reserved-env-var enforcement gaps in secrets/runtime UI (SUP-239)

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -220,6 +220,7 @@ vi.mock('@shared/lib/services/session-service', () => ({
 
 vi.mock('@shared/lib/services/secrets-service', () => ({
   listSecrets: vi.fn(),
+  listUserSecrets: vi.fn(),
   getSecret: vi.fn(),
   setSecret: vi.fn(),
   deleteSecret: vi.fn(),
@@ -371,6 +372,7 @@ import { listPendingScheduledTasks, listPendingScheduledTasksByAgents } from '@s
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds } from '@shared/lib/services/notification-service'
 import { messagePersister } from '@shared/lib/container/message-persister'
+import { listUserSecrets, setSecret, getSecret, keyToEnvVar } from '@shared/lib/services/secrets-service'
 
 // ============================================================================
 // Test Helpers
@@ -2989,5 +2991,100 @@ describe('POST /api/agents/:id/skills/import-zip', () => {
 
     const body = await res.json()
     expect(body.error).toBe('SKILL.md not found in package')
+  })
+})
+
+// ============================================================================
+// Secrets routes — reserved-env-var enforcement (SUP-239 bugs 2 & 3)
+// ============================================================================
+
+describe('Secrets routes — reserved-env-var enforcement (SUP-239)', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+  })
+
+  describe('GET /:id/secrets (bug 3 — reserved runtime vars are not user secrets)', () => {
+    it('surfaces exactly what listUserSecrets returns (filtered upstream)', async () => {
+      // The container writes CONNECTED_ACCOUNTS into the same .env; listUserSecrets
+      // strips it, and the route must use that filtered list — never listSecrets.
+      vi.mocked(listUserSecrets).mockResolvedValue([
+        { envVar: 'GITHUB_TOKEN', value: 'x', key: 'GitHub Token' },
+      ])
+
+      const res = await getReq(app, '/api/agents/my-agent/secrets')
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual([
+        { id: 'GITHUB_TOKEN', key: 'GitHub Token', envVar: 'GITHUB_TOKEN', hasValue: true },
+      ])
+      expect(listUserSecrets).toHaveBeenCalledWith('my-agent')
+    })
+  })
+
+  describe('POST /:id/secrets (bug 2 — reject reserved names)', () => {
+    it('rejects a reserved env var (CONNECTED_ACCOUNTS) with 400 and never writes', async () => {
+      vi.mocked(keyToEnvVar).mockReturnValue('CONNECTED_ACCOUNTS')
+
+      const res = await postJson(app, '/api/agents/my-agent/secrets', {
+        key: 'Connected Accounts',
+        value: 'spoofed',
+      })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toContain('CONNECTED_ACCOUNTS')
+      expect(body.error).toContain('reserved')
+      expect(setSecret).not.toHaveBeenCalled()
+    })
+
+    it('rejects another reserved name (PROXY_TOKEN)', async () => {
+      vi.mocked(keyToEnvVar).mockReturnValue('PROXY_TOKEN')
+
+      const res = await postJson(app, '/api/agents/my-agent/secrets', {
+        key: 'proxy token',
+        value: 'x',
+      })
+
+      expect(res.status).toBe(400)
+      expect(setSecret).not.toHaveBeenCalled()
+    })
+
+    it('allows a non-reserved secret through to setSecret', async () => {
+      vi.mocked(keyToEnvVar).mockReturnValue('MY_API_KEY')
+      vi.mocked(getSecret).mockResolvedValue(null)
+      vi.mocked(setSecret).mockResolvedValue(undefined)
+
+      const res = await postJson(app, '/api/agents/my-agent/secrets', {
+        key: 'My API Key',
+        value: 'k',
+      })
+
+      expect(res.status).toBe(201)
+      expect(setSecret).toHaveBeenCalledWith('my-agent', {
+        key: 'My API Key',
+        envVar: 'MY_API_KEY',
+        value: 'k',
+      })
+    })
+  })
+
+  describe('PUT /:id/secrets/:secretId (bug 2 — reject renaming onto reserved)', () => {
+    it('rejects renaming a secret onto a reserved env var with 400 and never writes', async () => {
+      vi.mocked(getSecret).mockResolvedValue({ envVar: 'MY_API_KEY', value: 'k', key: 'My API Key' })
+      vi.mocked(keyToEnvVar).mockReturnValue('REMOTE_MCPS')
+
+      const res = await app.request('http://localhost/api/agents/my-agent/secrets/MY_API_KEY', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: 'Remote MCPs', value: 'k' }),
+      })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toContain('REMOTE_MCPS')
+      expect(setSecret).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -40,13 +40,14 @@ import {
 import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, getTempUploadsDir, ensureDirectory, removeDirectory } from '@shared/lib/utils/file-storage'
 import { getMountsWithHealth, addMount, removeMount } from '@shared/lib/services/mount-service'
 import {
-  listSecrets,
+  listUserSecrets,
   getSecret,
   setSecret,
   deleteSecret,
   keyToEnvVar,
   getSecretEnvVars,
 } from '@shared/lib/services/secrets-service'
+import { isReservedEnvVar } from '@shared/lib/container/reserved-env-vars'
 import {
   listScheduledTasks,
   listPendingScheduledTasks,
@@ -2656,8 +2657,10 @@ agents.get('/:id/secrets', AgentRead(), async (c) => {
   try {
     const slug = c.req.param('id')
 
-
-    const secrets = await listSecrets(slug)
+    // Only user-managed secrets — reserved runtime vars (e.g. CONNECTED_ACCOUNTS)
+    // that the container writes into the same .env are system-managed and must
+    // not surface as user-editable secrets (SUP-239 bug 3).
+    const secrets = await listUserSecrets(slug)
     const response = secrets.map((secret) => ({
       id: secret.envVar,
       key: secret.key,
@@ -2689,6 +2692,17 @@ agents.post('/:id/secrets', AgentUser(), async (c) => {
 
 
     const envVar = keyToEnvVar(key.trim())
+
+    // A secret is just an env var injected into the container, so it must obey
+    // the same reserved-runtime-var rule as global custom env vars (SUP-210 /
+    // SUP-239 bug 2): reject names that would clobber required runtime wiring.
+    if (isReservedEnvVar(envVar)) {
+      return c.json(
+        { error: `"${envVar}" is a reserved runtime variable and cannot be used as a secret` },
+        400
+      )
+    }
+
     const existing = await getSecret(slug, envVar)
 
     await setSecret(slug, {
@@ -2722,6 +2736,14 @@ agents.put('/:id/secrets/:secretId', AgentUser(), async (c) => {
     const newKey = key?.trim() || existing.key
     const newEnvVar = keyToEnvVar(newKey)
     const newValue = value !== undefined ? value : existing.value
+
+    // Renaming a secret onto a reserved runtime var is blocked too (SUP-239 bug 2).
+    if (isReservedEnvVar(newEnvVar)) {
+      return c.json(
+        { error: `"${newEnvVar}" is a reserved runtime variable and cannot be used as a secret` },
+        400
+      )
+    }
 
     if (newEnvVar !== envVar) {
       await deleteSecret(slug, envVar)

--- a/src/renderer/components/agents/settings/secrets-tab.tsx
+++ b/src/renderer/components/agents/settings/secrets-tab.tsx
@@ -11,6 +11,7 @@ import {
   useDeleteSecret,
   type ApiSecretDisplay,
 } from '@renderer/hooks/use-secrets'
+import { isReservedEnvVar } from '@shared/lib/container/reserved-env-vars'
 
 // Convert a display key to an environment variable name (preview)
 function keyToEnvVar(key: string): string {
@@ -133,6 +134,9 @@ function AddSecretForm({ agentSlug, existingEnvVars, onAdd }: AddSecretFormProps
 
   const envVarPreview = key ? keyToEnvVar(key) : ''
   const isDuplicate = envVarPreview && existingEnvVars.includes(envVarPreview)
+  // A secret is injected as an env var, so reserved runtime vars are blocked
+  // here too — the server rejects them, this gives instant feedback (SUP-239).
+  const isReserved = !!envVarPreview && isReservedEnvVar(envVarPreview)
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -145,6 +149,11 @@ function AddSecretForm({ agentSlug, existingEnvVars, onAdd }: AddSecretFormProps
 
     if (isDuplicate) {
       setError(`A secret with env var name "${envVarPreview}" already exists`)
+      return
+    }
+
+    if (isReserved) {
+      setError(`"${envVarPreview}" is a reserved runtime variable and cannot be used as a secret`)
       return
     }
 
@@ -173,9 +182,10 @@ function AddSecretForm({ agentSlug, existingEnvVars, onAdd }: AddSecretFormProps
             placeholder="e.g., My API Key"
           />
           {envVarPreview && (
-            <div className={`text-xs font-mono ${isDuplicate ? 'text-destructive' : 'text-muted-foreground'}`}>
+            <div className={`text-xs font-mono ${isDuplicate || isReserved ? 'text-destructive' : 'text-muted-foreground'}`}>
               Env var: {envVarPreview}
               {isDuplicate && ' (duplicate)'}
+              {isReserved && ' (reserved)'}
             </div>
           )}
         </div>
@@ -210,7 +220,7 @@ function AddSecretForm({ agentSlug, existingEnvVars, onAdd }: AddSecretFormProps
       <Button
         type="submit"
         size="sm"
-        disabled={!key.trim() || !value || isDuplicate || createSecret.isPending}
+        disabled={!key.trim() || !value || isDuplicate || isReserved || createSecret.isPending}
       >
         <Plus className="h-4 w-4 mr-1" />
         {createSecret.isPending ? 'Adding...' : 'Add Secret'}

--- a/src/renderer/components/settings/runtime-tab.test.tsx
+++ b/src/renderer/components/settings/runtime-tab.test.tsx
@@ -147,6 +147,24 @@ describe('RuntimeTab', () => {
     })
   })
 
+  it('rejects a reserved env var: shows the error, does not save, and does not keep the row (SUP-239 bug 1)', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<RuntimeTab />)
+
+    await user.click(screen.getByRole('button', { name: 'Add Variable' }))
+    await user.type(screen.getByLabelText('Variable Name'), 'PROXY_BASE_URL')
+    await user.type(screen.getByLabelText('Value'), 'evil')
+    const dialog = screen.getByRole('dialog')
+    await user.click(within(dialog).getByRole('button', { name: 'Add Variable' }))
+
+    // The reserved-runtime-var error is surfaced…
+    expect(await screen.findByText(/reserved runtime variable/i)).toBeInTheDocument()
+    // …the value is never sent to the server (client-side guard)…
+    expect(mockUpdateSettings.mutateAsync).not.toHaveBeenCalled()
+    // …and the rejected row does not linger as if it had been saved.
+    expect(screen.queryByDisplayValue('PROXY_BASE_URL')).not.toBeInTheDocument()
+  })
+
   it('saves edited custom env vars with the full current draft', async () => {
     const user = userEvent.setup()
     mockSettings.data.customEnvVars = {

--- a/src/renderer/components/settings/runtime-tab.tsx
+++ b/src/renderer/components/settings/runtime-tab.tsx
@@ -22,6 +22,7 @@ import { useSettings, useUpdateSettings, useStartRunner, useRestartRunner, useRe
 import { AlertCircle, AlertTriangle, Play, Loader2, RefreshCw, Plus, X } from 'lucide-react'
 import { RunnerSetupErrorPanel, getRunnerSetupPayload } from '@renderer/components/settings/runner-setup-error-panel'
 import { DEFAULT_LIMA_VM_MEMORY, VALID_LIMA_VM_MEMORY_OPTIONS } from '@shared/lib/container/types'
+import { findReservedEnvVarKeys } from '@shared/lib/container/reserved-env-vars'
 import { getDefaultAgentImage } from '@shared/lib/config/version'
 
 const CPU_LIMIT_OPTIONS = [1, 2, 4, 6, 8]
@@ -246,11 +247,29 @@ export function RuntimeTab() {
   }
 
   const persistCustomEnvVars = async (updated: Record<string, string>) => {
+    // Remember the last-good draft so a rejected save can be rolled back instead
+    // of leaving the bad value on screen as if it had saved (SUP-239 bug 1).
+    const previous = customEnvVarsDraft
     setCustomEnvVarsDraft(updated)
+
+    // Mirror the server-side reserved-runtime-var guard (SUP-210) client-side so
+    // the rejection is instant and the offending row never lingers.
+    const reserved = findReservedEnvVarKeys(updated)
+    if (reserved.length > 0) {
+      setCustomEnvVarsDraft(previous)
+      setCustomEnvError(
+        `customEnvVars may not override reserved runtime variables: ${reserved.join(', ')}`
+      )
+      return
+    }
+
     setCustomEnvError(null)
     try {
       await updateSettings.mutateAsync({ customEnvVars: updated })
     } catch (error) {
+      // The server did not persist (e.g. 400) — revert so the draft reflects
+      // what is actually saved rather than the rejected value.
+      setCustomEnvVarsDraft(previous)
       const message =
         error && typeof error === 'object' && 'error' in error && typeof error.error === 'string'
           ? error.error

--- a/src/shared/lib/services/secrets-service.test.ts
+++ b/src/shared/lib/services/secrets-service.test.ts
@@ -7,6 +7,7 @@ import {
   serializeEnvFile,
   keyToEnvVar,
   listSecrets,
+  listUserSecrets,
   getSecret,
   setSecret,
   deleteSecret,
@@ -274,6 +275,50 @@ describe('secrets service integration', () => {
         value: 'ghp_xxxxxxxxxxxxxxxxxxxx',
         key: 'GitHub Token',
       })
+    })
+  })
+
+  describe('listUserSecrets (SUP-239 bug 3)', () => {
+    const envPathFor = () =>
+      path.join(testDir, 'agents', 'test-agent', 'workspace', '.env')
+
+    it('omits reserved runtime env vars but keeps user secrets', async () => {
+      // CONNECTED_ACCOUNTS / PROXY_TOKEN are written into the same .env by the
+      // container runtime; they are reserved (SUP-210) and must not show as
+      // user-editable secrets.
+      await fs.promises.writeFile(
+        envPathFor(),
+        [
+          'GITHUB_TOKEN=ghp_x  # GitHub Token',
+          'CONNECTED_ACCOUNTS=systemvalue',
+          'PROXY_TOKEN=systemtoken',
+          'MY_API_KEY=k',
+        ].join('\n')
+      )
+
+      // listSecrets stays unfiltered — runtime consumers (getSecretEnvVars) need
+      // every var passed to the session.
+      const all = await listSecrets('test-agent')
+      expect(all.map((s) => s.envVar).sort()).toEqual(
+        ['CONNECTED_ACCOUNTS', 'GITHUB_TOKEN', 'MY_API_KEY', 'PROXY_TOKEN'].sort()
+      )
+
+      // listUserSecrets drops the reserved runtime vars.
+      const userSecrets = await listUserSecrets('test-agent')
+      expect(userSecrets.map((s) => s.envVar).sort()).toEqual(['GITHUB_TOKEN', 'MY_API_KEY'].sort())
+      expect(userSecrets.some((s) => s.envVar === 'CONNECTED_ACCOUNTS')).toBe(false)
+      expect(userSecrets.some((s) => s.envVar === 'PROXY_TOKEN')).toBe(false)
+    })
+
+    it('returns all secrets when none are reserved', async () => {
+      await fs.promises.writeFile(envPathFor(), 'FOO=1\nBAR=2')
+      const userSecrets = await listUserSecrets('test-agent')
+      expect(userSecrets.map((s) => s.envVar).sort()).toEqual(['BAR', 'FOO'])
+    })
+
+    it('returns empty array when no .env file exists', async () => {
+      const userSecrets = await listUserSecrets('test-agent')
+      expect(userSecrets).toEqual([])
     })
   })
 

--- a/src/shared/lib/services/secrets-service.ts
+++ b/src/shared/lib/services/secrets-service.ts
@@ -14,6 +14,7 @@ import {
   fileExists,
 } from '@shared/lib/utils/file-storage'
 import { AgentSecret } from '@shared/lib/types/agent'
+import { isReservedEnvVar } from '@shared/lib/container/reserved-env-vars'
 
 // ============================================================================
 // .env File Parsing
@@ -153,6 +154,24 @@ export async function listSecrets(agentSlug: string): Promise<AgentSecret[]> {
   }
 
   return secrets
+}
+
+/**
+ * List the user-managed secrets for an agent — the subset of the agent .env
+ * that users actually own and edit via the Secrets UI.
+ *
+ * The agent's /workspace/.env doubles as the container runtime env file: the
+ * container's POST /env handler (server.ts updateEnvFile) writes reserved
+ * runtime vars such as CONNECTED_ACCOUNTS into it so uv/python scripts can read
+ * them. Those are system-managed (see RESERVED_ENV_VAR_KEYS / SUP-210) and must
+ * not surface as user-editable secrets (SUP-239 bug 3).
+ *
+ * listSecrets() stays unfiltered for runtime consumers (getSecretEnvVars), which
+ * legitimately need every var passed to the session.
+ */
+export async function listUserSecrets(agentSlug: string): Promise<AgentSecret[]> {
+  const secrets = await listSecrets(agentSlug)
+  return secrets.filter((s) => !isReservedEnvVar(s.envVar))
 }
 
 /**


### PR DESCRIPTION
Three coupled gaps around the SUP-210 reserved-runtime-env-var protection, found in testing. `RESERVED_ENV_VAR_KEYS` (13 keys: `PROXY_BASE_URL`, `PROXY_TOKEN`, `SUPERAGENT_HOST_API_URL`, `SUPERAGENT_AGENT_SLUG`, `CONNECTED_ACCOUNTS`, `REMOTE_MCPS`, `AGENT_BROWSER_USE_HOST`, `HOST_APP_URL`, `AGENT_ID`, `TZ`, `HOST_PLATFORM`, `COMPOSIO_PLATFORM_MODE`, `CLAUDE_CODE_ATTRIBUTION_HEADER`).

## Bug 1 — Runtime Settings: reserved var shows an error but lingers as if saved
`runtime-tab.tsx` `persistCustomEnvVars` set the draft optimistically and, on the server's 400, showed the error but **never reverted the draft** — so the rejected row stayed under the error, looking saved. (It wasn't actually persisted: `PUT /api/settings` 400s before writing and there's no optimistic cache write.)

**Fix:** capture the previous draft, add a client-side `findReservedEnvVarKeys` guard (instant feedback, mirrors the server), and revert the draft on rejection/error.

## Bug 2 — Agent secrets didn't apply the reserved-var validation
`POST/PUT /api/agents/:id/secrets` called `setSecret` without checking the computed env-var name, so a user could create a secret named `CONNECTED_ACCOUNTS` / `PROXY_BASE_URL` that global settings already reject.

**Fix:** both routes reject reserved names with **400** before writing; the Add Secret form guards client-side (shows `(reserved)`, disables submit).

## Bug 3 — Agent secrets listed `CONNECTED_ACCOUNTS` by default
The container `/env` handler writes runtime vars (incl. `CONNECTED_ACCOUNTS`) into the agent's `/workspace/.env` (`server.ts` `updateEnvFile`), and `listSecrets` returns every key in that file — so a system-managed var surfaced as a user secret.

**Fix:** new `listUserSecrets` (= `listSecrets` minus `RESERVED_ENV_VAR_KEYS`) backs the `GET /secrets` display. `listSecrets`/`getSecretEnvVars` stay unfiltered so the runtime still receives every var passed to the session.

## Not in scope
`ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` are intentionally **not** in `RESERVED_ENV_VAR_KEYS` (SUP-210 targets runtime wiring, not credentials), so they remain settable. Whether to protect those is a separate decision.

## Tests
- `secrets-service.test.ts`: `listUserSecrets` filters reserved / keeps user secrets / empty when no `.env`; `listSecrets` stays unfiltered.
- `agents.test.ts`: POST & PUT reject reserved names (400, `setSecret` not called); non-reserved still creates; GET surfaces `listUserSecrets`.
- `runtime-tab.test.tsx`: adding a reserved var shows the error, never calls the server, and does not keep the row.

`tsc --noEmit` clean; `eslint` clean (the 2 remaining warnings are pre-existing and unrelated). Full `agents.test.ts` (157) + `runtime-tab.test.tsx` (9) + `secrets-service.test.ts` suites pass.

Closes SUP-239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)