### PR TITLE
fix(messages): reconcile transcript after session_idle so turn finalizes promptly

### DIFF
--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -767,6 +767,102 @@ describe('useMessageStream', () => {
     expect(spy).toHaveBeenCalledWith({ queryKey: ['sessions'] })
   })
 
+  // The session_idle SSE can arrive before the final assistant line is durably
+  // readable in the JSONL transcript, so the handler's immediate invalidate may
+  // refetch stale data. A bounded reconcile loop refetches a few more times until
+  // the persisted tail matches the streamed text, so finalization (the "Worked
+  // for Xs" line) doesn't wait for the slow safety-net poll.
+  const countMessageInvalidations = (spy: ReturnType<typeof vi.spyOn>): number =>
+    spy.mock.calls.filter((call: unknown[]) => {
+      const key = (call[0] as { queryKey?: unknown[] } | undefined)?.queryKey
+      return Array.isArray(key) && key[0] === 'messages' && key[1] === 'session-1'
+    }).length
+
+  it('reconciles messages after session_idle when the transcript lags, then stops', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream } = await getHookModule()
+      const wrapper = createWrapper()
+      const qc = wrapper.queryClient
+      const spy = vi.spyOn(qc, 'invalidateQueries')
+      renderHook(() => useMessageStream('session-1', 'agent-1'), { wrapper })
+
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'stream_start' })
+      })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'stream_delta', text: 'Final answer' })
+      })
+
+      // Persisted transcript does NOT yet contain the final assistant line.
+      qc.setQueryData(['messages', 'session-1', 'agent-1'], [
+        { id: 'u1', type: 'user', content: { text: 'hi' }, createdAt: '2026-01-01T00:00:00Z' },
+      ])
+
+      spy.mockClear()
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'session_idle' })
+      })
+      // Immediate invalidate from the handler.
+      expect(countMessageInvalidations(spy)).toBe(1)
+
+      // First backoff tick: still no match → an extra refetch fires.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300)
+      })
+      expect(countMessageInvalidations(spy)).toBeGreaterThan(1)
+
+      // Drain well past the reconcile window — it must self-terminate (bounded:
+      // 1 immediate + at most 3 reconcile attempts).
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000)
+      })
+      expect(countMessageInvalidations(spy)).toBeLessThanOrEqual(4)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not reconcile after session_idle when the persisted message already matches', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream } = await getHookModule()
+      const wrapper = createWrapper()
+      const qc = wrapper.queryClient
+      const spy = vi.spyOn(qc, 'invalidateQueries')
+      renderHook(() => useMessageStream('session-1', 'agent-1'), { wrapper })
+
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'stream_delta', text: 'Final answer' })
+      })
+
+      // Transcript already has the final assistant line (no write/read race).
+      qc.setQueryData(['messages', 'session-1', 'agent-1'], [
+        { id: 'u1', type: 'user', content: { text: 'hi' }, createdAt: '2026-01-01T00:00:00Z' },
+        { id: 'a1', type: 'assistant', content: { text: 'Final answer' }, toolCalls: [], createdAt: '2026-01-01T00:00:01Z' },
+      ])
+
+      spy.mockClear()
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'session_idle' })
+      })
+
+      // Only the handler's immediate invalidate — the reconcile sees a match and bails.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000)
+      })
+      expect(countMessageInvalidations(spy)).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('invalidates messages and sessions queries on session_error', async () => {
     const { useMessageStream } = await getHookModule()
     const wrapper = createWrapper()

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -4,6 +4,7 @@ import { useQueryClient, QueryClient } from '@tanstack/react-query'
 import { getApiBaseUrl } from '@renderer/lib/env'
 import type { SessionUsage } from '@shared/lib/types/agent'
 import type { SlashCommandInfo } from '@shared/lib/container/types'
+import type { ApiMessage, ApiMessageOrBoundary } from '@shared/lib/types/api'
 
 interface SecretRequest {
   toolUseId: string
@@ -184,6 +185,69 @@ const sessionAutoApprovedScriptRunIds = new Map<string, Set<string>>()
 const eventSources = new Map<string, EventSource>()
 const refCounts = new Map<string, number>()
 
+// Sessions with an in-flight post-idle reconcile loop, so overlapping
+// session_idle events don't spawn duplicate loops for the same session.
+const reconcilingIdleSessions = new Set<string>()
+
+// Does the last persisted assistant message in the messages cache match the
+// just-streamed text? Mirrors MessageList's `isStreamingMessagePersisted` so we
+// stop reconciling at exactly the point the UI considers the turn finalized.
+function lastPersistedAssistantMatches(
+  queryClient: QueryClient,
+  sessionId: string,
+  expectedText: string
+): boolean {
+  const entries = queryClient.getQueriesData<ApiMessageOrBoundary[]>({
+    queryKey: ['messages', sessionId],
+  })
+  for (const [, data] of entries) {
+    if (!Array.isArray(data)) continue
+    for (let i = data.length - 1; i >= 0; i--) {
+      if (data[i].type === 'assistant') {
+        const content = (data[i] as ApiMessage).content as { text?: string } | undefined
+        const persisted = content?.text?.trim() || ''
+        if (!persisted) return false
+        return persisted.startsWith(expectedText) || expectedText.startsWith(persisted)
+      }
+    }
+  }
+  return false
+}
+
+// The session_idle SSE event can arrive before the final assistant line is
+// durably readable in the JSONL transcript (it's written across the container
+// boundary), so the immediate invalidate's refetch may come back without it.
+// No further SSE event follows, so without this the UI would only reconcile on
+// the slow safety-net poll (useMessages, 15s) — the regression where a turn's
+// "Worked for Xs" line takes seconds to appear. Refetch a few times with short
+// backoff until the persisted tail matches the streamed text, then stop.
+// Bounded and self-terminating; the background poll remains the ultimate backstop.
+async function reconcileMessagesAfterIdle(
+  sessionId: string,
+  queryClient: QueryClient,
+  streamingText: string | null
+): Promise<void> {
+  const expected = streamingText?.trim()
+  // Nothing streamed (e.g. a tool-only or interrupted turn) — no text to match
+  // against, so the handler's immediate invalidate is all we can do.
+  if (!expected) return
+  if (reconcilingIdleSessions.has(sessionId)) return
+  reconcilingIdleSessions.add(sessionId)
+  try {
+    // ~1.5s total across 3 tries — long enough to beat the write/read race,
+    // short enough that a genuine mismatch falls through to the poll quickly.
+    for (const delay of [250, 500, 750]) {
+      if (lastPersistedAssistantMatches(queryClient, sessionId, expected)) return
+      await new Promise((resolve) => setTimeout(resolve, delay))
+      // refetchType defaults to 'active': refetches the mounted messages query
+      // (the session being viewed) and resolves once the cache is updated.
+      await queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+    }
+  } finally {
+    reconcilingIdleSessions.delete(sessionId)
+  }
+}
+
 function getOrCreateEventSource(
   sessionId: string,
   agentSlug: string,
@@ -348,6 +412,11 @@ function getOrCreateEventSource(
         })
         queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
         queryClient.invalidateQueries({ queryKey: ['sessions'] })
+        // The immediate invalidate above can refetch before the final assistant
+        // line is durably readable in the JSONL transcript. Beat that race with a
+        // short bounded reconcile so the turn's "Worked for Xs" line appears
+        // promptly instead of waiting for the next safety-net poll.
+        void reconcileMessagesAfterIdle(sessionId, queryClient, current?.streamingMessage ?? null)
       }
       // Agent turn ended but background tasks are still running — allow sending messages
       else if (data.type === 'session_waiting_background') {


### PR DESCRIPTION
## Problem

In the session view, after the agent replies there was a multi-second delay before the turn "finalized" — the **"Worked for Xs"** line that appears under the message. This regressed after `ea31c53f` (perf) raised the `useMessages` poll from 5s → 15s.

## Root cause

The "Worked for Xs" line only renders once **both**:
1. `isActive === false`, and
2. the **persisted** final assistant message is present in the `useMessages` cache (so `isStreamingMessagePersisted` flips true and the turn isn't deferred — `message-list.tsx`).

The turn-done event (`session_idle`, broadcast by `message-persister.ts` on the SDK `result`) **already** flips `isActive=false` instantly *and* calls `invalidateQueries(['messages'])`. The residual lag is a **write/read race**: the messages API reads the JSONL transcript fresh (`session-service.ts`), and the transcript is written across the container boundary — so `session_idle`'s immediate refetch can return *before* the final assistant line is durably readable. No further SSE event follows, so the UI only reconciled on the safety-net poll — now 15s instead of 5s.

## Fix

On `session_idle`, after the existing immediate invalidate, run a bounded `reconcileMessagesAfterIdle` loop: re-invalidate with short backoff (~250/500/750ms, ~1.5s total) until the last persisted assistant text matches the just-streamed text (`lastPersistedAssistantMatches`, which mirrors the renderer's `isStreamingMessagePersisted`), then stop.

- **Self-terminating & bounded** (≤3 retries), guarded against overlapping loops per session.
- **Robust to both sub-causes** — the JSONL write/read race *and* any React-Query invalidation coalescing.
- **Keeps the perf win**: the 15s background poll is left unchanged as the ultimate backstop; this only adds work for ~1.5s right at turn-end.

## Testing

- `tsc --noEmit`: clean
- `eslint` on changed files: clean
- `use-message-stream.test.ts`: **84 passed** (82 existing + 2 new)
  - reconcile fires follow-up refetches when the transcript lags, and self-terminates (bounded)
  - reconcile does **zero** extra refetches when the persisted message already matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)