### PR TITLE
refactor(connections): add reusable row primitives for the Connections redesign

### DIFF
--- a/src/renderer/components/connections/connection-agent-count.tsx
+++ b/src/renderer/components/connections/connection-agent-count.tsx
@@ -1,0 +1,27 @@
+import { useAccountAgents } from '@renderer/hooks/use-connected-accounts'
+import { useMcpAgents } from '@renderer/hooks/use-remote-mcps'
+
+interface ConnectionAgentCountProps {
+  type: 'oauth' | 'mcp'
+  id: string
+}
+
+/**
+ * Plain-text "N agent(s)" snippet for the connection row subtitle. Replaces
+ * the dropdown pill on the connection list — the row click opens the detail
+ * page where agent access can be edited.
+ */
+export function ConnectionAgentCount({ type, id }: ConnectionAgentCountProps) {
+  const accountAgents = useAccountAgents(type === 'oauth' ? id : '')
+  const mcpAgents = useMcpAgents(type === 'mcp' ? id : '')
+  const data = type === 'oauth' ? accountAgents.data : mcpAgents.data
+  const count = data?.agentSlugs.length ?? 0
+  if (count === 0) {
+    return <span className="whitespace-nowrap shrink-0">Not in use</span>
+  }
+  return (
+    <span className="whitespace-nowrap shrink-0 tabular-nums">
+      Used by {count} {count === 1 ? 'agent' : 'agents'}
+    </span>
+  )
+}

--- a/src/renderer/components/connections/connection-agent-count.tsx
+++ b/src/renderer/components/connections/connection-agent-count.tsx
@@ -15,7 +15,9 @@ export function ConnectionAgentCount({ type, id }: ConnectionAgentCountProps) {
   const accountAgents = useAccountAgents(type === 'oauth' ? id : '')
   const mcpAgents = useMcpAgents(type === 'mcp' ? id : '')
   const data = type === 'oauth' ? accountAgents.data : mcpAgents.data
-  const count = data?.agentSlugs.length ?? 0
+  // Render nothing until the query resolves so rows don't flash "Not in use".
+  if (!data) return null
+  const count = data.agentSlugs.length
   if (count === 0) {
     return <span className="whitespace-nowrap shrink-0">Not in use</span>
   }

--- a/src/renderer/components/connections/connection-row.tsx
+++ b/src/renderer/components/connections/connection-row.tsx
@@ -1,9 +1,8 @@
 import type { ReactNode } from 'react'
-import { formatDistanceToNow } from 'date-fns'
 import { IntegrationRow } from './integration-row'
 import { McpStatusPill } from './mcp-status-pill'
 import { AccountStatusBadge } from './account-status-badge'
-import { safeDate } from './utils'
+import { formatCompactDistance, safeDate } from './utils'
 import type { UnifiedRow } from './unified-rows'
 
 interface ConnectionRowProps {
@@ -12,21 +11,42 @@ interface ConnectionRowProps {
   right: ReactNode
   /** Optional trailing item appended after the timestamp (e.g. trigger count). */
   subtitleExtra?: ReactNode
+  /**
+   * Optional content right-justified at the end of the subtitle row (no `·`
+   * separator). Used for inline metadata like "N agents connected".
+   */
+  subtitleTrailing?: ReactNode
   /** When set, animates row position via the View Transitions API. */
   viewTransitionName?: string
+  /** When provided, the row becomes clickable (and Enter/Space-activatable). */
+  onActivate?: () => void
+  /** Accessible label for the row when interactive. */
+  ariaLabel?: string
   /** Called when the user clicks the status badge to reconnect. */
   onReconnect?: () => void
   /** Show spinner on the status badge while reconnecting. */
   reconnecting?: boolean
 }
 
-export function ConnectionRow({ row, right, subtitleExtra, viewTransitionName, onReconnect, reconnecting }: ConnectionRowProps) {
+export function ConnectionRow({
+  row,
+  right,
+  subtitleExtra,
+  subtitleTrailing,
+  viewTransitionName,
+  onActivate,
+  ariaLabel,
+  onReconnect,
+  reconnecting,
+}: ConnectionRowProps) {
   return (
     <IntegrationRow
       viewTransitionName={viewTransitionName}
       iconSlug={row.iconSlug}
       iconFallback={row.iconFallback}
       name={row.name}
+      onActivate={onActivate}
+      ariaLabel={ariaLabel}
       nameBadge={
         <>
           <McpStatusPill status={row.mcpStatus} errorMessage={row.mcpErrorMessage} />
@@ -43,14 +63,17 @@ export function ConnectionRow({ row, right, subtitleExtra, viewTransitionName, o
             </>
           )}
           <span className="shrink-0">·</span>
-          <span className="whitespace-nowrap shrink-0">
-            {formatDistanceToNow(safeDate(row.date), { addSuffix: true })}
+          <span className="whitespace-nowrap shrink-0 tabular-nums">
+            {formatCompactDistance(safeDate(row.date))}
           </span>
           {subtitleExtra && (
             <>
               <span className="shrink-0">·</span>
               {subtitleExtra}
             </>
+          )}
+          {subtitleTrailing && (
+            <span className="ml-auto shrink-0 pl-2">{subtitleTrailing}</span>
           )}
         </>
       }

--- a/src/renderer/components/connections/integration-row-actions.tsx
+++ b/src/renderer/components/connections/integration-row-actions.tsx
@@ -63,9 +63,16 @@ export interface IntegrationRowActionsProps {
   hideRemoveFromAgent?: boolean
   /** Account status for OAuth rows. Shows reconnect action when not active. */
   accountStatus?: 'active' | 'expired' | 'revoked'
+  /**
+   * Rendering layout:
+   *  - 'menu' (default): a single Settings icon button that opens a popover with all actions.
+   *  - 'buttons': two inline outline buttons (Rename + Delete). Used on the
+   *    connection detail page where actions are surfaced directly in the header.
+   */
+  layout?: 'menu' | 'buttons'
 }
 
-export function IntegrationRowActions({ type, id, name, toolkit, mcpTools, agentSlug, hideRemoveFromAgent, accountStatus }: IntegrationRowActionsProps) {
+export function IntegrationRowActions({ type, id, name, toolkit, mcpTools, agentSlug, hideRemoveFromAgent, accountStatus, layout = 'menu' }: IntegrationRowActionsProps) {
   const [menuOpen, setMenuOpen] = useState(false)
   const [renameOpen, setRenameOpen] = useState(false)
   const [renameValue, setRenameValue] = useState(name)
@@ -291,6 +298,51 @@ export function IntegrationRowActions({ type, id, name, toolkit, mcpTools, agent
 
   return (
     <>
+      {layout === 'buttons' ? (
+        <div className="flex items-center gap-2">
+          {type === 'oauth' && accountStatus && accountStatus !== 'active' && (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-8 text-amber-700 dark:text-amber-400"
+              onClick={runOAuthReconnect}
+              disabled={oauthReconnectPending}
+              data-testid={`integration-row-actions-reconnect-${type}-${id}`}
+            >
+              {oauthReconnectPending ? (
+                <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
+              )}
+              Reconnect
+            </Button>
+          )}
+          <Button
+            ref={triggerRef}
+            type="button"
+            size="icon"
+            variant="outline"
+            className="h-8 w-8"
+            aria-label={`Rename ${name}`}
+            onClick={openRename}
+            data-testid={`integration-row-actions-rename-${type}-${id}`}
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-8"
+            onClick={openDelete}
+            data-testid={`integration-row-actions-delete-${type}-${id}`}
+          >
+            <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+            Delete
+          </Button>
+        </div>
+      ) : (
       <Popover
         open={menuOpen}
         onOpenChange={(open) => {
@@ -421,6 +473,7 @@ export function IntegrationRowActions({ type, id, name, toolkit, mcpTools, agent
           )}
         </PopoverContent>
       </Popover>
+      )}
 
       {/* Rename dialog */}
       <Dialog open={renameOpen} onOpenChange={(open) => { if (!renamePending) setRenameOpen(open) }}>

--- a/src/renderer/components/connections/integration-row-actions.tsx
+++ b/src/renderer/components/connections/integration-row-actions.tsx
@@ -306,7 +306,7 @@ export function IntegrationRowActions({ type, id, name, toolkit, mcpTools, agent
               size="sm"
               variant="outline"
               className="h-8 text-amber-700 dark:text-amber-400"
-              onClick={runOAuthReconnect}
+              onClick={(e) => { e.stopPropagation(); void runOAuthReconnect() }}
               disabled={oauthReconnectPending}
               data-testid={`integration-row-actions-reconnect-${type}-${id}`}
             >
@@ -321,21 +321,21 @@ export function IntegrationRowActions({ type, id, name, toolkit, mcpTools, agent
           <Button
             ref={triggerRef}
             type="button"
-            size="icon"
+            size="sm"
             variant="outline"
-            className="h-8 w-8"
-            aria-label={`Rename ${name}`}
-            onClick={openRename}
+            className="h-8"
+            onClick={(e) => { e.stopPropagation(); openRename() }}
             data-testid={`integration-row-actions-rename-${type}-${id}`}
           >
-            <Pencil className="h-3.5 w-3.5" />
+            <Pencil className="h-3.5 w-3.5 mr-1.5" />
+            Rename
           </Button>
           <Button
             type="button"
             size="sm"
             variant="outline"
-            className="h-8"
-            onClick={openDelete}
+            className="h-8 text-destructive hover:text-destructive hover:bg-destructive/10"
+            onClick={(e) => { e.stopPropagation(); openDelete() }}
             data-testid={`integration-row-actions-delete-${type}-${id}`}
           >
             <Trash2 className="h-3.5 w-3.5 mr-1.5" />
@@ -343,136 +343,136 @@ export function IntegrationRowActions({ type, id, name, toolkit, mcpTools, agent
           </Button>
         </div>
       ) : (
-      <Popover
-        open={menuOpen}
-        onOpenChange={(open) => {
-          setMenuOpen(open)
-          if (!open) setMcpStatus(null)
-        }}
-      >
-        <PopoverTrigger asChild>
-          <Button
-            ref={triggerRef}
-            type="button"
-            size="icon"
-            variant="ghost"
-            className="h-7 overflow-hidden w-0 -ml-2 opacity-0 group-hover:w-7 group-hover:ml-0 group-hover:opacity-100 focus-visible:w-7 focus-visible:ml-0 focus-visible:opacity-100 data-[state=open]:w-7 data-[state=open]:ml-0 data-[state=open]:opacity-100 transition-[width,margin,opacity] duration-200"
-            aria-label={`Actions for ${name}`}
-            onClick={(e) => e.stopPropagation()}
-            data-testid={`integration-row-actions-${type}-${id}`}
-          >
-            <Settings className="h-4 w-4 text-muted-foreground" />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent
-          align="end"
-          className="w-48 p-1"
-          onClick={(e) => e.stopPropagation()}
+        <Popover
+          open={menuOpen}
+          onOpenChange={(open) => {
+            setMenuOpen(open)
+            if (!open) setMcpStatus(null)
+          }}
         >
-          <button
-            type="button"
-            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
-            onClick={openRename}
+          <PopoverTrigger asChild>
+            <Button
+              ref={triggerRef}
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="h-7 overflow-hidden w-0 -ml-2 opacity-0 group-hover:w-7 group-hover:ml-0 group-hover:opacity-100 focus-visible:w-7 focus-visible:ml-0 focus-visible:opacity-100 data-[state=open]:w-7 data-[state=open]:ml-0 data-[state=open]:opacity-100 transition-[width,margin,opacity] duration-200"
+              aria-label={`Actions for ${name}`}
+              onClick={(e) => e.stopPropagation()}
+              data-testid={`integration-row-actions-${type}-${id}`}
+            >
+              <Settings className="h-4 w-4 text-muted-foreground" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="end"
+            className="w-48 p-1"
+            onClick={(e) => e.stopPropagation()}
           >
-            <Pencil className="h-3.5 w-3.5" />
-            Rename
-          </button>
-          {type === 'oauth' && accountStatus && accountStatus !== 'active' && (
-            <button
-              type="button"
-              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400 hover:bg-amber-500/10 transition-colors"
-              onClick={runOAuthReconnect}
-              disabled={oauthReconnectPending}
-            >
-              {oauthReconnectPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
-              Reconnect
-            </button>
-          )}
-          {canEditScopes && (
             <button
               type="button"
               className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
-              onClick={openScopes}
+              onClick={openRename}
             >
-              <Shield className="h-3.5 w-3.5" />
-              Edit permissions
+              <Pencil className="h-3.5 w-3.5" />
+              Rename
             </button>
-          )}
-          {type === 'mcp' && (
-            <button
-              type="button"
-              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
-              onClick={openTools}
-            >
-              <Wrench className="h-3.5 w-3.5" />
-              Discover tools
-            </button>
-          )}
-          {agentSlug && !hideRemoveFromAgent && (
-            <button
-              type="button"
-              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
-              onClick={openRemoveFromAgent}
-            >
-              <LogOut className="h-3.5 w-3.5" />
-              Remove from agent
-            </button>
-          )}
-          <button
-            type="button"
-            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-destructive hover:bg-destructive/10 transition-colors"
-            onClick={openDelete}
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-            {agentSlug ? 'Delete for all agents' : 'Delete'}
-          </button>
-          {type === 'mcp' && (
-            <>
-              <div className="my-1 h-px bg-border" role="separator" />
+            {type === 'oauth' && accountStatus && accountStatus !== 'active' && (
               <button
                 type="button"
-                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors disabled:opacity-50"
-                onClick={() => {
-                  if (mcpStatus?.kind === 'error') void runReconnect()
-                  else void runTestConnection()
-                }}
-                disabled={
-                  testMcpConnection.isPending ||
-                  discoverMcpTools.isPending ||
-                  initiateMcpOAuth.isPending ||
-                  oauthPending
-                }
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400 hover:bg-amber-500/10 transition-colors"
+                onClick={runOAuthReconnect}
+                disabled={oauthReconnectPending}
               >
-                {testMcpConnection.isPending || initiateMcpOAuth.isPending || oauthPending ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : mcpStatus?.kind === 'success' ? (
-                  <span className="flex h-3.5 w-3.5 items-center justify-center rounded-sm bg-emerald-500/15">
-                    <Check className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
-                  </span>
-                ) : mcpStatus?.kind === 'error' ? (
-                  <span className="flex h-3.5 w-3.5 items-center justify-center rounded-sm bg-destructive/15">
-                    <X className="h-3 w-3 text-destructive" />
-                  </span>
-                ) : (
-                  <RefreshCw className="h-3.5 w-3.5" />
-                )}
-                {oauthPending ? (
-                  'Waiting for OAuth...'
-                ) : mcpStatus?.kind === 'success' ? (
-                  'Connected'
-                ) : mcpStatus?.kind === 'error' ? (
-                  <>
-                    Reconnect
-                    <ArrowUpRight className="h-3 w-3" aria-hidden="true" />
-                  </>
-                ) : (
-                  'Test connection'
-                )}
+                {oauthReconnectPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+                Reconnect
               </button>
-            </>
-          )}
-        </PopoverContent>
-      </Popover>
+            )}
+            {canEditScopes && (
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
+                onClick={openScopes}
+              >
+                <Shield className="h-3.5 w-3.5" />
+                Edit permissions
+              </button>
+            )}
+            {type === 'mcp' && (
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
+                onClick={openTools}
+              >
+                <Wrench className="h-3.5 w-3.5" />
+                Discover tools
+              </button>
+            )}
+            {agentSlug && !hideRemoveFromAgent && (
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
+                onClick={openRemoveFromAgent}
+              >
+                <LogOut className="h-3.5 w-3.5" />
+                Remove from agent
+              </button>
+            )}
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-destructive hover:bg-destructive/10 transition-colors"
+              onClick={openDelete}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              {agentSlug ? 'Delete for all agents' : 'Delete'}
+            </button>
+            {type === 'mcp' && (
+              <>
+                <div className="my-1 h-px bg-border" role="separator" />
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors disabled:opacity-50"
+                  onClick={() => {
+                    if (mcpStatus?.kind === 'error') void runReconnect()
+                    else void runTestConnection()
+                  }}
+                  disabled={
+                    testMcpConnection.isPending ||
+                    discoverMcpTools.isPending ||
+                    initiateMcpOAuth.isPending ||
+                    oauthPending
+                  }
+                >
+                  {testMcpConnection.isPending || initiateMcpOAuth.isPending || oauthPending ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : mcpStatus?.kind === 'success' ? (
+                    <span className="flex h-3.5 w-3.5 items-center justify-center rounded-sm bg-emerald-500/15">
+                      <Check className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
+                    </span>
+                  ) : mcpStatus?.kind === 'error' ? (
+                    <span className="flex h-3.5 w-3.5 items-center justify-center rounded-sm bg-destructive/15">
+                      <X className="h-3 w-3 text-destructive" />
+                    </span>
+                  ) : (
+                    <RefreshCw className="h-3.5 w-3.5" />
+                  )}
+                  {oauthPending ? (
+                    'Waiting for OAuth...'
+                  ) : mcpStatus?.kind === 'success' ? (
+                    'Connected'
+                  ) : mcpStatus?.kind === 'error' ? (
+                    <>
+                      Reconnect
+                      <ArrowUpRight className="h-3 w-3" aria-hidden="true" />
+                    </>
+                  ) : (
+                    'Test connection'
+                  )}
+                </button>
+              </>
+            )}
+          </PopoverContent>
+        </Popover>
       )}
 
       {/* Rename dialog */}

--- a/src/renderer/components/connections/utils.test.ts
+++ b/src/renderer/components/connections/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { safeDate } from './utils'
+import { safeDate, formatCompactDistance } from './utils'
 
 describe('safeDate', () => {
   it('handles a numeric epoch (milliseconds)', () => {
@@ -21,5 +21,44 @@ describe('safeDate', () => {
     const d = safeDate('not a date')
     expect(d).toBeInstanceOf(Date)
     expect(Number.isNaN(d.getTime())).toBe(true)
+  })
+})
+
+describe('formatCompactDistance', () => {
+  const NOW = new Date('2026-06-09T12:00:00.000Z')
+  const secondsAgo = (s: number) => new Date(NOW.getTime() - s * 1000)
+  const daysAgo = (d: number) => secondsAgo(d * 86400)
+
+  it('renders sub-minute ages as "just now"', () => {
+    expect(formatCompactDistance(secondsAgo(0), NOW)).toBe('just now')
+    expect(formatCompactDistance(secondsAgo(59), NOW)).toBe('just now')
+  })
+
+  it('renders minutes, hours, and days compactly', () => {
+    expect(formatCompactDistance(secondsAgo(60), NOW)).toBe('1m ago')
+    expect(formatCompactDistance(secondsAgo(5 * 60), NOW)).toBe('5m ago')
+    expect(formatCompactDistance(secondsAgo(3 * 3600), NOW)).toBe('3h ago')
+    expect(formatCompactDistance(daysAgo(2), NOW)).toBe('2d ago')
+  })
+
+  it('has no weeks tier — mid-range ages stay in days', () => {
+    expect(formatCompactDistance(daysAgo(10), NOW)).toBe('10d ago')
+  })
+
+  it('renders months and years', () => {
+    expect(formatCompactDistance(daysAgo(61), NOW)).toBe('2mo ago')
+    expect(formatCompactDistance(daysAgo(800), NOW)).toBe('2y ago')
+  })
+
+  it('renders ~360-day ages as "1y ago", never "0y ago"', () => {
+    expect(formatCompactDistance(daysAgo(362), NOW)).toBe('1y ago')
+  })
+
+  it('clamps future dates (clock skew) to "just now"', () => {
+    expect(formatCompactDistance(secondsAgo(-300), NOW)).toBe('just now')
+  })
+
+  it('returns an empty string for invalid dates', () => {
+    expect(formatCompactDistance(safeDate('not a date'), NOW)).toBe('')
   })
 })

--- a/src/renderer/components/connections/utils.ts
+++ b/src/renderer/components/connections/utils.ts
@@ -5,3 +5,25 @@ export function safeDate(value: string | number): Date {
   const num = Number(value)
   return Number.isFinite(num) ? new Date(num) : new Date(value)
 }
+
+/**
+ * Compact relative timestamp — e.g. "5m", "3h", "2d", "4w", "6mo", "2y".
+ * Designed for dense row metadata where "5 minutes ago" is too long.
+ */
+export function formatCompactDistance(date: Date, now: Date = new Date()): string {
+  const diffMs = Math.max(0, now.getTime() - date.getTime())
+  const sec = Math.floor(diffMs / 1000)
+  if (sec < 60) return 'just now'
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m ago`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  const day = Math.floor(hr / 24)
+  if (day < 7) return `${day}d ago`
+  const week = Math.floor(day / 7)
+  if (week < 5) return `${week}w ago`
+  const month = Math.floor(day / 30)
+  if (month < 12) return `${month}mo ago`
+  const year = Math.floor(day / 365)
+  return `${year}y ago`
+}

--- a/src/renderer/components/connections/utils.ts
+++ b/src/renderer/components/connections/utils.ts
@@ -1,3 +1,7 @@
+import { formatDistanceStrict } from 'date-fns'
+import { enUS } from 'date-fns/locale'
+import type { Locale } from 'date-fns'
+
 // MCP `mappedAt` can be a numeric-string epoch in ms; OAuth `createdAt` is
 // an ISO string. The numeric branch only protects the MCP case.
 export function safeDate(value: string | number): Date {
@@ -6,24 +10,36 @@ export function safeDate(value: string | number): Date {
   return Number.isFinite(num) ? new Date(num) : new Date(value)
 }
 
+// `formatDistanceStrict` only ever emits the exact-unit tokens (xSeconds,
+// xMinutes, ...) — never the "about"/"almost" variants.
+const COMPACT_UNITS: Record<string, string> = {
+  xMinutes: 'm',
+  xHours: 'h',
+  xDays: 'd',
+  xMonths: 'mo',
+  xYears: 'y',
+}
+
+const compactDistanceLocale: Locale = {
+  ...enUS,
+  formatDistance: (token, count, options) => {
+    if (token === 'xSeconds') return 'just now'
+    const unit = COMPACT_UNITS[token]
+    if (!unit) return enUS.formatDistance(token, count, options)
+    return options?.addSuffix ? `${count}${unit} ago` : `${count}${unit}`
+  },
+}
+
 /**
- * Compact relative timestamp — e.g. "5m", "3h", "2d", "4w", "6mo", "2y".
- * Designed for dense row metadata where "5 minutes ago" is too long.
+ * Compact relative timestamp — "just now", "5m ago", "3h ago", "2d ago",
+ * "2mo ago", "1y ago". Designed for dense row metadata where
+ * "5 minutes ago" is too long. Unit boundaries come from date-fns
+ * `formatDistanceStrict`, which has no weeks tier (10 days → "10d ago").
+ * Returns '' for invalid dates (`safeDate` can produce one).
  */
 export function formatCompactDistance(date: Date, now: Date = new Date()): string {
-  const diffMs = Math.max(0, now.getTime() - date.getTime())
-  const sec = Math.floor(diffMs / 1000)
-  if (sec < 60) return 'just now'
-  const min = Math.floor(sec / 60)
-  if (min < 60) return `${min}m ago`
-  const hr = Math.floor(min / 60)
-  if (hr < 24) return `${hr}h ago`
-  const day = Math.floor(hr / 24)
-  if (day < 7) return `${day}d ago`
-  const week = Math.floor(day / 7)
-  if (week < 5) return `${week}w ago`
-  const month = Math.floor(day / 30)
-  if (month < 12) return `${month}mo ago`
-  const year = Math.floor(day / 365)
-  return `${year}y ago`
+  if (Number.isNaN(date.getTime())) return ''
+  // Clamp future dates (clock skew) to "just now" rather than "in 5m".
+  const past = date.getTime() > now.getTime() ? now : date
+  return formatDistanceStrict(past, now, { addSuffix: true, locale: compactDistanceLocale })
 }


### PR DESCRIPTION
## Summary
First of 3 PRs that split #171 (closed as unreviewable) into reviewable pieces.

Additive, low-risk building blocks for the Connections settings redesign,
landed on their own so the feature PR (#3) stays focused. **No existing
behavior changes other than the connection-row timestamp format.**

- `formatCompactDistance()` — short relative timestamps ("5m", "3h", "2d")
- `ConnectionRow` — new `subtitleTrailing` and `onActivate` / `ariaLabel`
  slots; renders the compact timestamp in the subtitle
- `IntegrationRowActions` — new `layout="buttons"` mode (inline Rename /
  Delete, plus Reconnect for expired OAuth) alongside the existing popover menu
- `ConnectionAgentCount` — plain-text "Used by N agents" / "Not in use" snippet

These are consumed by PRs #2/#3 in the stack; nothing wires them up yet.

## Test plan
- [ ] Settings → Connections list still renders; rows now show a compact
      timestamp ("3h" instead of "3 hours ago").
- [ ] Existing row actions (the Settings popover menu) still work — Rename,
      Delete, edit scopes/tools, reconnect.
- [x] `npm run typecheck && npm run lint` pass (verified locally).

> Stacked PR 1 of 3 · `connections/primitives` → `main`. Rebased onto current
> `main` and verified locally (typecheck + lint clean).

🤖 Split out from #171 with Claude Code.
