### PR TITLE
refactor(connections): extract inline editor panels from the policy/agent dialogs

### DIFF
--- a/src/renderer/components/connections/connection-agents-dialog.tsx
+++ b/src/renderer/components/connections/connection-agents-dialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Loader2 } from 'lucide-react'
+import type { ApiAgent } from '@renderer/hooks/use-agents'
 import {
   Dialog,
   DialogContent,
@@ -21,15 +22,23 @@ import {
   useRemoveMcpFromAgent,
 } from '@renderer/hooks/use-remote-mcps'
 
-interface ConnectionAgentsDialogProps {
+interface ConnectionAgentsListProps {
   type: 'oauth' | 'mcp'
   id: string
   name: string
-  open: boolean
-  onOpenChange: (open: boolean) => void
+  /**
+   * Split agents into two sectioned lists ("Access granted" / "Access not
+   * granted") instead of one flat list — matches the per-agent connections
+   * page pattern. Defaults to false for the dialog.
+   */
+  sectioned?: boolean
 }
 
-export function ConnectionAgentsDialog({ type, id, name, open, onOpenChange }: ConnectionAgentsDialogProps) {
+/**
+ * Inline list of agents that can use a given connection — same content as the
+ * Dialog version. Toggles auto-save on change. Reused on the detail page.
+ */
+export function ConnectionAgentsList({ type, id, name, sectioned = false }: ConnectionAgentsListProps) {
   const { isAuthMode, rolesReady, canAdminAgent } = useUser()
   const { data: agents, isLoading: agentsLoading } = useAgents()
 
@@ -44,10 +53,6 @@ export function ConnectionAgentsDialog({ type, id, name, open, onOpenChange }: C
   const removeMcp = useRemoveMcpFromAgent()
 
   const [overrides, setOverrides] = useState<Record<string, boolean>>({})
-
-  useEffect(() => {
-    if (!open) setOverrides({})
-  }, [open])
 
   const grantedSet = useMemo(
     () => new Set(data?.agentSlugs ?? []),
@@ -113,6 +118,103 @@ export function ConnectionAgentsDialog({ type, id, name, open, onOpenChange }: C
     }
   }
 
+  if (agentsLoading || isLoading) {
+    return (
+      <div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading agents...
+      </div>
+    )
+  }
+
+  if (visibleAgents.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-muted-foreground">
+        No agents available.
+      </p>
+    )
+  }
+
+  const renderAgentRow = (agent: ApiAgent) => {
+    const granted = overrides[agent.slug] ?? grantedSet.has(agent.slug)
+    const pending = isPending(agent.slug)
+    return (
+      <li key={agent.slug} className="flex items-center gap-3 px-3 py-2.5">
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-medium truncate">{agent.name}</div>
+          <div className="text-[11px] text-muted-foreground truncate">{agent.slug}</div>
+        </div>
+        {pending ? (
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        ) : (
+          <Switch
+            checked={granted}
+            onCheckedChange={(next) => { void handleToggle(agent.slug, next) }}
+            aria-label={`${granted ? 'Revoke' : 'Grant'} ${name} access for ${agent.name}`}
+            data-testid={`connection-agent-toggle-${type}-${id}-${agent.slug}`}
+          />
+        )}
+      </li>
+    )
+  }
+
+  if (sectioned) {
+    const grantedAgents = visibleAgents.filter(
+      (a) => overrides[a.slug] ?? grantedSet.has(a.slug),
+    )
+    const notGrantedAgents = visibleAgents.filter(
+      (a) => !(overrides[a.slug] ?? grantedSet.has(a.slug)),
+    )
+
+    return (
+      <div className="space-y-6">
+        <div className="space-y-1.5">
+          <p className="text-xs font-normal text-muted-foreground px-1">
+            Agents With Access
+          </p>
+          {grantedAgents.length > 0 ? (
+            <ul className="rounded-xl border bg-background divide-y divide-border/50 overflow-hidden">
+              {grantedAgents.map((agent) => renderAgentRow(agent))}
+            </ul>
+          ) : (
+            <div className="rounded-xl border border-dashed bg-background px-4 py-6 text-center">
+              <p className="text-xs text-muted-foreground">
+                No agents have access yet. Grant one below.
+              </p>
+            </div>
+          )}
+        </div>
+        {notGrantedAgents.length > 0 && (
+          <div className="space-y-1.5">
+            <p className="text-xs font-normal text-muted-foreground px-1">
+              Agents Without Access
+            </p>
+            <ul className="rounded-xl border bg-background divide-y divide-border/50 overflow-hidden">
+              {notGrantedAgents.map((agent) => renderAgentRow(agent))}
+            </ul>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <ul className="divide-y divide-border/50">
+      {visibleAgents.map((agent) => renderAgentRow(agent))}
+    </ul>
+  )
+}
+
+interface ConnectionAgentsDialogProps {
+  type: 'oauth' | 'mcp'
+  id: string
+  name: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ConnectionAgentsDialog({ type, id, name, open, onOpenChange }: ConnectionAgentsDialogProps) {
+  const { isAuthMode } = useUser()
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
@@ -127,44 +229,9 @@ export function ConnectionAgentsDialog({ type, id, name, open, onOpenChange }: C
             {isAuthMode ? ' Only agents you own are shown.' : ''}
           </DialogDescription>
         </DialogHeader>
-
-        {agentsLoading || isLoading ? (
-          <div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            Loading agents...
-          </div>
-        ) : visibleAgents.length === 0 ? (
-          <p className="py-6 text-center text-sm text-muted-foreground">
-            No agents available.
-          </p>
-        ) : (
-          <div className="max-h-[50vh] overflow-y-auto -mx-2">
-            <ul className="divide-y divide-border/50">
-              {visibleAgents.map((agent) => {
-                const granted = overrides[agent.slug] ?? grantedSet.has(agent.slug)
-                const pending = isPending(agent.slug)
-                return (
-                  <li key={agent.slug} className="flex items-center gap-3 px-3 py-2.5">
-                    <div className="min-w-0 flex-1">
-                      <div className="text-xs font-medium truncate">{agent.name}</div>
-                      <div className="text-[11px] text-muted-foreground truncate">{agent.slug}</div>
-                    </div>
-                    {pending ? (
-                      <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-                    ) : (
-                      <Switch
-                        checked={granted}
-                        onCheckedChange={(next) => { void handleToggle(agent.slug, next) }}
-                        aria-label={`${granted ? 'Revoke' : 'Grant'} ${name} access for ${agent.name}`}
-                        data-testid={`connection-agent-toggle-${type}-${id}-${agent.slug}`}
-                      />
-                    )}
-                  </li>
-                )
-              })}
-            </ul>
-          </div>
-        )}
+        <div className="max-h-[50vh] overflow-y-auto -mx-2">
+          {open && <ConnectionAgentsList type={type} id={id} name={name} />}
+        </div>
       </DialogContent>
     </Dialog>
   )

--- a/src/renderer/components/connections/connection-agents-dialog.tsx
+++ b/src/renderer/components/connections/connection-agents-dialog.tsx
@@ -27,9 +27,9 @@ interface ConnectionAgentsListProps {
   id: string
   name: string
   /**
-   * Split agents into two sectioned lists ("Access granted" / "Access not
-   * granted") instead of one flat list — matches the per-agent connections
-   * page pattern. Defaults to false for the dialog.
+   * Split agents into two sectioned lists ("Agents With Access" / "Agents
+   * Without Access") instead of one flat list — matches the per-agent
+   * connections page pattern. Defaults to false for the dialog.
    */
   sectioned?: boolean
 }
@@ -159,12 +159,11 @@ export function ConnectionAgentsList({ type, id, name, sectioned = false }: Conn
   }
 
   if (sectioned) {
-    const grantedAgents = visibleAgents.filter(
-      (a) => overrides[a.slug] ?? grantedSet.has(a.slug),
-    )
-    const notGrantedAgents = visibleAgents.filter(
-      (a) => !(overrides[a.slug] ?? grantedSet.has(a.slug)),
-    )
+    // Partition on confirmed server state, not the optimistic override, so a
+    // row doesn't jump sections out from under the user's cursor mid-toggle —
+    // it moves once the mutation persists and the agents query refetches.
+    const grantedAgents = visibleAgents.filter((a) => grantedSet.has(a.slug))
+    const notGrantedAgents = visibleAgents.filter((a) => !grantedSet.has(a.slug))
 
     return (
       <div className="space-y-6">
@@ -230,7 +229,7 @@ export function ConnectionAgentsDialog({ type, id, name, open, onOpenChange }: C
           </DialogDescription>
         </DialogHeader>
         <div className="max-h-[50vh] overflow-y-auto -mx-2">
-          {open && <ConnectionAgentsList type={type} id={id} name={name} />}
+          <ConnectionAgentsList type={type} id={id} name={name} />
         </div>
       </DialogContent>
     </Dialog>

--- a/src/renderer/components/settings/scope-policy-editor.tsx
+++ b/src/renderer/components/settings/scope-policy-editor.tsx
@@ -63,22 +63,28 @@ const emptyLabelDefaults: Record<ScopeLabel, PolicyDecision> = {
   destructive: 'default',
 }
 
-interface ScopePolicyEditorProps {
+interface ScopePolicyEditorBodyProps {
   accountId: string
   toolkit: string
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  /** Optional custom header to replace the default title. */
-  header?: React.ReactNode
+  /** Called after a successful save. */
+  onSaved?: () => void
+  /** Called when the user clicks Cancel. */
+  onCancel?: () => void
+  /** Hide the bottom action bar (Save/Cancel). When true, the parent is responsible for triggering save. */
+  hideActions?: boolean
 }
 
-export function ScopePolicyEditor({
+/**
+ * Inline body of the scope policy editor — the same content as the Dialog
+ * version, just without the Dialog frame. Reused on the connection detail page.
+ */
+export function ScopePolicyEditorBody({
   accountId,
   toolkit,
-  open,
-  onOpenChange,
-  header,
-}: ScopePolicyEditorProps) {
+  onSaved,
+  onCancel,
+  hideActions,
+}: ScopePolicyEditorBodyProps) {
   const queryClient = useQueryClient()
   const [policies, setPolicies] = useState<ScopePolicy[]>([])
   const [accountDefault, setAccountDefault] = useState<PolicyDecision>('default')
@@ -121,7 +127,6 @@ export function ScopePolicyEditor({
 
   // Fetch existing policies
   useEffect(() => {
-    if (!open) return
     setLoading(true)
     setFetchError(null)
     setTextFilter('')
@@ -172,7 +177,7 @@ export function ScopePolicyEditor({
         setPolicies(allScopes.map((scope) => ({ scope, decision: 'default' })))
         setLoading(false)
       })
-  }, [open, accountId, allScopes])
+  }, [accountId, allScopes])
 
   // Filtered policies
   const filteredPolicies = useMemo(() => {
@@ -246,7 +251,7 @@ export function ScopePolicyEditor({
         body: JSON.stringify({ policies: batch }),
       })
       queryClient.invalidateQueries({ queryKey: ['scope-policies', accountId] })
-      onOpenChange(false)
+      onSaved?.()
     } catch (error) {
       console.error('Failed to save policies:', error)
     } finally {
@@ -280,6 +285,205 @@ export function ScopePolicyEditor({
     </div>
   )
 
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3 min-h-0 flex-1">
+      {fetchError && (
+        <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/50 rounded-md px-2 py-1.5">
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+          {fetchError}
+        </div>
+      )}
+
+      {/* Account default */}
+      <div className="flex items-center justify-between rounded-md border p-2">
+        <div>
+          <span className="text-sm font-medium">Account Default</span>
+          <p className="text-xs text-muted-foreground">
+            Fallback for scopes without a per-scope or risk-level policy
+          </p>
+        </div>
+        <PolicyDecisionToggle
+          value={accountDefault}
+          onChange={(v) => setAccountDefault(v)}
+          size="md"
+        />
+      </div>
+
+      {/* Filters */}
+      {allScopes.length > 0 && (
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+            <Input
+              placeholder="Filter scopes..."
+              value={textFilter}
+              onChange={(e) => setTextFilter(e.target.value)}
+              className="h-8 text-xs pl-7"
+            />
+          </div>
+          <Select
+            value={decisionFilter}
+            onValueChange={(v) => setDecisionFilter(v as 'all' | PolicyDecision)}
+          >
+            <SelectTrigger className="w-[100px] h-8 text-xs shrink-0">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              <SelectItem value="allow">Allow</SelectItem>
+              <SelectItem value="review">Review</SelectItem>
+              <SelectItem value="block">Block</SelectItem>
+              <SelectItem value="default">Default</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {allScopes.length > 0 && (
+        <button
+          type="button"
+          onClick={resetToRecommended}
+          data-testid="reset-recommended-defaults"
+          className="self-start text-xs text-muted-foreground hover:text-foreground hover:underline underline-offset-2"
+        >
+          Reset risk-level defaults to recommended
+        </button>
+      )}
+
+      {/* Per-scope policies, grouped by risk label */}
+      <div className="flex-1 overflow-y-auto space-y-3">
+        {allScopes.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-4 text-center">
+            No scopes defined for this API.
+          </p>
+        ) : filteredPolicies.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-4 text-center">
+            No scopes match your filters.
+          </p>
+        ) : (
+          <>
+            {LABEL_GROUPS.map((g) => {
+              const rows = groupedPolicies[g.key]
+              if (rows.length === 0) return null
+              const Icon = g.Icon
+              // Collapsed by default; a filter reveals matches, but an explicit
+              // collapse/expand by the user (sets openGroups[key]) always wins —
+              // so the trigger never feels "dead" while filtering.
+              const isOpen = openGroups[g.key] ?? filtering
+              return (
+                <Collapsible
+                  key={g.key}
+                  open={isOpen}
+                  onOpenChange={(o) => setOpenGroup(g.key, o)}
+                  data-testid={`scope-group-${g.key}`}
+                  className="space-y-1"
+                >
+                  <div
+                    data-testid={`group-default-${g.key}`}
+                    className="flex items-center justify-between rounded-md bg-muted/40 px-2 py-1.5"
+                  >
+                    <CollapsibleTrigger
+                      data-testid={`scope-group-toggle-${g.key}`}
+                      className="flex flex-1 items-center gap-1.5 min-w-0 text-left"
+                    >
+                      <ChevronRight
+                        className={cn(
+                          'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform',
+                          isOpen && 'rotate-90',
+                        )}
+                      />
+                      <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      <span className="text-xs font-semibold">{g.title}</span>
+                      <span className="text-xs text-muted-foreground tabular-nums">
+                        ({rows.length})
+                      </span>
+                      <span className="text-xs text-muted-foreground truncate">· {g.hint}</span>
+                    </CollapsibleTrigger>
+                    <PolicyDecisionToggle
+                      value={labelDefaults[g.key]}
+                      onChange={(v) => setLabelDefault(g.key, v)}
+                    />
+                  </div>
+                  <CollapsibleContent className="space-y-1 pl-1">
+                    {rows.map(renderRow)}
+                  </CollapsibleContent>
+                </Collapsible>
+              )
+            })}
+            {groupedPolicies.other.length > 0 && (
+              <Collapsible
+                open={openGroups.other ?? filtering}
+                onOpenChange={(o) => setOpenGroup('other', o)}
+                data-testid="scope-group-other"
+                className="space-y-1"
+              >
+                <CollapsibleTrigger
+                  data-testid="scope-group-toggle-other"
+                  className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left"
+                >
+                  <ChevronRight
+                    className={cn(
+                      'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform',
+                      (openGroups.other ?? filtering) && 'rotate-90',
+                    )}
+                  />
+                  <span className="text-xs font-semibold">Other</span>
+                  <span className="text-xs text-muted-foreground tabular-nums">
+                    ({groupedPolicies.other.length})
+                  </span>
+                  <span className="text-xs text-muted-foreground truncate">
+                    · uses the account default
+                  </span>
+                </CollapsibleTrigger>
+                <CollapsibleContent className="space-y-1 pl-1">
+                  {groupedPolicies.other.map(renderRow)}
+                </CollapsibleContent>
+              </Collapsible>
+            )}
+          </>
+        )}
+      </div>
+      {!hideActions && (
+        <div className="flex justify-end gap-2 pt-2 border-t">
+          {onCancel && (
+            <Button variant="outline" size="sm" onClick={onCancel}>
+              Cancel
+            </Button>
+          )}
+          <Button data-testid="scope-policy-save" size="sm" onClick={handleSave} disabled={saving}>
+            {saving && <Loader2 className="h-4 w-4 animate-spin mr-1" />}
+            Save Policies
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface ScopePolicyEditorProps {
+  accountId: string
+  toolkit: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Optional custom header to replace the default title. */
+  header?: React.ReactNode
+}
+
+export function ScopePolicyEditor({
+  accountId,
+  toolkit,
+  open,
+  onOpenChange,
+  header,
+}: ScopePolicyEditorProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg max-h-[80vh] overflow-hidden flex flex-col">
@@ -287,181 +491,14 @@ export function ScopePolicyEditor({
           {header ?? <DialogTitle className="capitalize">{toolkit} Scope Policies</DialogTitle>}
           <DialogDescription className="sr-only">Configure per-scope access policies for {toolkit}</DialogDescription>
         </DialogHeader>
-
-        {loading ? (
-          <div className="flex items-center justify-center py-8">
-            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-          </div>
-        ) : (
-          <>
-            {fetchError && (
-              <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/50 rounded-md px-2 py-1.5">
-                <AlertCircle className="h-3.5 w-3.5 shrink-0" />
-                {fetchError}
-              </div>
-            )}
-
-            {/* Account default */}
-            <div className="flex items-center justify-between rounded-md border p-2">
-              <div>
-                <span className="text-sm font-medium">Account Default</span>
-                <p className="text-xs text-muted-foreground">
-                  Fallback for scopes without a per-scope or risk-level policy
-                </p>
-              </div>
-              <PolicyDecisionToggle
-                value={accountDefault}
-                onChange={(v) => setAccountDefault(v)}
-                size="md"
-              />
-            </div>
-
-            {/* Filters */}
-            {allScopes.length > 0 && (
-              <div className="flex gap-2">
-                <div className="relative flex-1">
-                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-                  <Input
-                    placeholder="Filter scopes..."
-                    value={textFilter}
-                    onChange={(e) => setTextFilter(e.target.value)}
-                    className="h-8 text-xs pl-7"
-                  />
-                </div>
-                <Select
-                  value={decisionFilter}
-                  onValueChange={(v) => setDecisionFilter(v as 'all' | PolicyDecision)}
-                >
-                  <SelectTrigger className="w-[100px] h-8 text-xs shrink-0">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All</SelectItem>
-                    <SelectItem value="allow">Allow</SelectItem>
-                    <SelectItem value="review">Review</SelectItem>
-                    <SelectItem value="block">Block</SelectItem>
-                    <SelectItem value="default">Default</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-
-            {allScopes.length > 0 && (
-              <button
-                type="button"
-                onClick={resetToRecommended}
-                data-testid="reset-recommended-defaults"
-                className="self-start text-xs text-muted-foreground hover:text-foreground hover:underline underline-offset-2"
-              >
-                Reset risk-level defaults to recommended
-              </button>
-            )}
-
-            {/* Per-scope policies, grouped by risk label */}
-            <div className="flex-1 overflow-y-auto space-y-3">
-              {allScopes.length === 0 ? (
-                <p className="text-sm text-muted-foreground py-4 text-center">
-                  No scopes defined for this API.
-                </p>
-              ) : filteredPolicies.length === 0 ? (
-                <p className="text-sm text-muted-foreground py-4 text-center">
-                  No scopes match your filters.
-                </p>
-              ) : (
-                <>
-                  {LABEL_GROUPS.map((g) => {
-                    const rows = groupedPolicies[g.key]
-                    if (rows.length === 0) return null
-                    const Icon = g.Icon
-                    // Collapsed by default; a filter reveals matches, but an explicit
-                    // collapse/expand by the user (sets openGroups[key]) always wins —
-                    // so the trigger never feels "dead" while filtering.
-                    const isOpen = openGroups[g.key] ?? filtering
-                    return (
-                      <Collapsible
-                        key={g.key}
-                        open={isOpen}
-                        onOpenChange={(o) => setOpenGroup(g.key, o)}
-                        data-testid={`scope-group-${g.key}`}
-                        className="space-y-1"
-                      >
-                        <div
-                          data-testid={`group-default-${g.key}`}
-                          className="flex items-center justify-between rounded-md bg-muted/40 px-2 py-1.5"
-                        >
-                          <CollapsibleTrigger
-                            data-testid={`scope-group-toggle-${g.key}`}
-                            className="flex flex-1 items-center gap-1.5 min-w-0 text-left"
-                          >
-                            <ChevronRight
-                              className={cn(
-                                'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform',
-                                isOpen && 'rotate-90',
-                              )}
-                            />
-                            <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                            <span className="text-xs font-semibold">{g.title}</span>
-                            <span className="text-xs text-muted-foreground tabular-nums">
-                              ({rows.length})
-                            </span>
-                            <span className="text-xs text-muted-foreground truncate">· {g.hint}</span>
-                          </CollapsibleTrigger>
-                          <PolicyDecisionToggle
-                            value={labelDefaults[g.key]}
-                            onChange={(v) => setLabelDefault(g.key, v)}
-                          />
-                        </div>
-                        <CollapsibleContent className="space-y-1 pl-1">
-                          {rows.map(renderRow)}
-                        </CollapsibleContent>
-                      </Collapsible>
-                    )
-                  })}
-                  {groupedPolicies.other.length > 0 && (
-                    <Collapsible
-                      open={openGroups.other ?? filtering}
-                      onOpenChange={(o) => setOpenGroup('other', o)}
-                      data-testid="scope-group-other"
-                      className="space-y-1"
-                    >
-                      <CollapsibleTrigger
-                        data-testid="scope-group-toggle-other"
-                        className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left"
-                      >
-                        <ChevronRight
-                          className={cn(
-                            'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform',
-                            (openGroups.other ?? filtering) && 'rotate-90',
-                          )}
-                        />
-                        <span className="text-xs font-semibold">Other</span>
-                        <span className="text-xs text-muted-foreground tabular-nums">
-                          ({groupedPolicies.other.length})
-                        </span>
-                        <span className="text-xs text-muted-foreground truncate">
-                          · uses the account default
-                        </span>
-                      </CollapsibleTrigger>
-                      <CollapsibleContent className="space-y-1 pl-1">
-                        {groupedPolicies.other.map(renderRow)}
-                      </CollapsibleContent>
-                    </Collapsible>
-                  )}
-                </>
-              )}
-            </div>
-          </>
+        {open && (
+          <ScopePolicyEditorBody
+            accountId={accountId}
+            toolkit={toolkit}
+            onSaved={() => onOpenChange(false)}
+            onCancel={() => onOpenChange(false)}
+          />
         )}
-
-        <div className="flex justify-end gap-2 pt-2 border-t">
-          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button data-testid="scope-policy-save" size="sm" onClick={handleSave} disabled={saving || loading}>
-            {saving && <Loader2 className="h-4 w-4 animate-spin mr-1" />}
-            Save Policies
-          </Button>
-        </div>
       </DialogContent>
     </Dialog>
   )

--- a/src/renderer/components/settings/scope-policy-editor.tsx
+++ b/src/renderer/components/settings/scope-policy-editor.tsx
@@ -359,7 +359,7 @@ export function ScopePolicyEditorBody({
       )}
 
       {/* Per-scope policies, grouped by risk label */}
-      <div className="flex-1 overflow-y-auto space-y-3">
+      <div className="flex-1 overflow-y-auto min-h-0 space-y-3">
         {allScopes.length === 0 ? (
           <p className="text-sm text-muted-foreground py-4 text-center">
             No scopes defined for this API.
@@ -491,14 +491,12 @@ export function ScopePolicyEditor({
           {header ?? <DialogTitle className="capitalize">{toolkit} Scope Policies</DialogTitle>}
           <DialogDescription className="sr-only">Configure per-scope access policies for {toolkit}</DialogDescription>
         </DialogHeader>
-        {open && (
-          <ScopePolicyEditorBody
-            accountId={accountId}
-            toolkit={toolkit}
-            onSaved={() => onOpenChange(false)}
-            onCancel={() => onOpenChange(false)}
-          />
-        )}
+        <ScopePolicyEditorBody
+          accountId={accountId}
+          toolkit={toolkit}
+          onSaved={() => onOpenChange(false)}
+          onCancel={() => onOpenChange(false)}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/src/renderer/components/settings/tool-policy-editor.tsx
+++ b/src/renderer/components/settings/tool-policy-editor.tsx
@@ -28,21 +28,27 @@ interface ToolPolicy {
   decision: PolicyDecision
 }
 
-interface ToolPolicyEditorProps {
+interface ToolPolicyEditorBodyProps {
   mcpId: string
   mcpName: string
   tools: Array<{ name: string; description?: string }>
-  open: boolean
-  onOpenChange: (open: boolean) => void
+  onSaved?: () => void
+  onCancel?: () => void
+  hideActions?: boolean
 }
 
-export function ToolPolicyEditor({
+/**
+ * Inline body of the tool policy editor — same content as the Dialog version,
+ * just without the Dialog frame. Reused on the connection detail page.
+ */
+export function ToolPolicyEditorBody({
   mcpId,
-  mcpName,
+  mcpName: _mcpName,
   tools,
-  open,
-  onOpenChange,
-}: ToolPolicyEditorProps) {
+  onSaved,
+  onCancel,
+  hideActions,
+}: ToolPolicyEditorBodyProps) {
   const queryClient = useQueryClient()
   const [policies, setPolicies] = useState<ToolPolicy[]>([])
   const [mcpDefault, setMcpDefault] = useState<PolicyDecision>('default')
@@ -54,7 +60,6 @@ export function ToolPolicyEditor({
 
   // Fetch existing policies
   useEffect(() => {
-    if (!open) return
     setLoading(true)
     setFetchError(null)
     setTextFilter('')
@@ -80,7 +85,7 @@ export function ToolPolicyEditor({
         setPolicies(tools.map((tool) => ({ toolName: tool.name, decision: 'default' })))
         setLoading(false)
       })
-  }, [open, mcpId, tools])
+  }, [mcpId, tools])
 
   // Filtered policies
   const filteredPolicies = useMemo(() => {
@@ -116,7 +121,7 @@ export function ToolPolicyEditor({
         body: JSON.stringify({ policies: batch }),
       })
       queryClient.invalidateQueries({ queryKey: ['tool-policies', mcpId] })
-      onOpenChange(false)
+      onSaved?.()
     } catch (error) {
       console.error('Failed to save policies:', error)
     } finally {
@@ -130,6 +135,140 @@ export function ToolPolicyEditor({
     )
   }
 
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3 min-h-0 flex-1">
+      {fetchError && (
+        <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/50 rounded-md px-2 py-1.5">
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+          {fetchError}
+        </div>
+      )}
+
+      {/* MCP default */}
+      <div className="flex items-center justify-between rounded-md border p-2">
+        <div>
+          <span className="text-sm font-medium">MCP Default</span>
+          <p className="text-xs text-muted-foreground">
+            Applies to tools without an explicit policy
+          </p>
+        </div>
+        <PolicyDecisionToggle
+          value={mcpDefault}
+          onChange={(v) => setMcpDefault(v)}
+          size="md"
+        />
+      </div>
+
+      {/* Filters */}
+      {tools.length > 0 && (
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+            <Input
+              placeholder="Filter tools..."
+              value={textFilter}
+              onChange={(e) => setTextFilter(e.target.value)}
+              className="h-8 text-xs pl-7"
+            />
+          </div>
+          <Select
+            value={decisionFilter}
+            onValueChange={(v) => setDecisionFilter(v as 'all' | PolicyDecision)}
+          >
+            <SelectTrigger className="w-[100px] h-8 text-xs shrink-0">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              <SelectItem value="allow">Allow</SelectItem>
+              <SelectItem value="review">Review</SelectItem>
+              <SelectItem value="block">Block</SelectItem>
+              <SelectItem value="default">Default</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {/* Per-tool policies */}
+      <div className="flex-1 overflow-y-auto min-h-0">
+        {tools.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-4 text-center">
+            No tools discovered for this MCP server.
+          </p>
+        ) : filteredPolicies.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-4 text-center">
+            No tools match your filters.
+          </p>
+        ) : (
+          <div className="space-y-1">
+            {filteredPolicies.map((p) => {
+              const tool = tools.find((t) => t.name === p.toolName)
+              return (
+                <div
+                  key={p.toolName}
+                  className="flex items-center justify-between rounded border px-2 py-1.5"
+                >
+                  <div className="flex-1 min-w-0 mr-2">
+                    <span className="text-xs font-mono font-medium">
+                      <HighlightMatch text={p.toolName} query={textFilter} />
+                    </span>
+                    {tool?.description && (
+                      <p className="text-xs text-muted-foreground truncate">
+                        <HighlightMatch text={tool.description} query={textFilter} />
+                      </p>
+                    )}
+                  </div>
+                  <PolicyDecisionToggle
+                    value={p.decision}
+                    onChange={(v) => updateToolPolicy(p.toolName, v)}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {!hideActions && (
+        <div className="flex justify-end gap-2 pt-2 border-t">
+          {onCancel && (
+            <Button variant="outline" size="sm" onClick={onCancel}>
+              Cancel
+            </Button>
+          )}
+          <Button size="sm" onClick={handleSave} disabled={saving}>
+            {saving && <Loader2 className="h-4 w-4 animate-spin mr-1" />}
+            Save Policies
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface ToolPolicyEditorProps {
+  mcpId: string
+  mcpName: string
+  tools: Array<{ name: string; description?: string }>
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ToolPolicyEditor({
+  mcpId,
+  mcpName,
+  tools,
+  open,
+  onOpenChange,
+}: ToolPolicyEditorProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg max-h-[80vh] overflow-hidden flex flex-col">
@@ -137,116 +276,15 @@ export function ToolPolicyEditor({
           <DialogTitle>{mcpName} Tool Policies</DialogTitle>
           <DialogDescription className="sr-only">Configure per-tool access policies for {mcpName}</DialogDescription>
         </DialogHeader>
-
-        {loading ? (
-          <div className="flex items-center justify-center py-8">
-            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-          </div>
-        ) : (
-          <>
-            {fetchError && (
-              <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/50 rounded-md px-2 py-1.5">
-                <AlertCircle className="h-3.5 w-3.5 shrink-0" />
-                {fetchError}
-              </div>
-            )}
-
-            {/* MCP default */}
-            <div className="flex items-center justify-between rounded-md border p-2">
-              <div>
-                <span className="text-sm font-medium">MCP Default</span>
-                <p className="text-xs text-muted-foreground">
-                  Applies to tools without an explicit policy
-                </p>
-              </div>
-              <PolicyDecisionToggle
-                value={mcpDefault}
-                onChange={(v) => setMcpDefault(v)}
-                size="md"
-              />
-            </div>
-
-            {/* Filters */}
-            {tools.length > 0 && (
-              <div className="flex gap-2">
-                <div className="relative flex-1">
-                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-                  <Input
-                    placeholder="Filter tools..."
-                    value={textFilter}
-                    onChange={(e) => setTextFilter(e.target.value)}
-                    className="h-8 text-xs pl-7"
-                  />
-                </div>
-                <Select
-                  value={decisionFilter}
-                  onValueChange={(v) => setDecisionFilter(v as 'all' | PolicyDecision)}
-                >
-                  <SelectTrigger className="w-[100px] h-8 text-xs shrink-0">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All</SelectItem>
-                    <SelectItem value="allow">Allow</SelectItem>
-                    <SelectItem value="review">Review</SelectItem>
-                    <SelectItem value="block">Block</SelectItem>
-                    <SelectItem value="default">Default</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-
-            {/* Per-tool policies */}
-            <div className="flex-1 overflow-y-auto">
-              {tools.length === 0 ? (
-                <p className="text-sm text-muted-foreground py-4 text-center">
-                  No tools discovered for this MCP server.
-                </p>
-              ) : filteredPolicies.length === 0 ? (
-                <p className="text-sm text-muted-foreground py-4 text-center">
-                  No tools match your filters.
-                </p>
-              ) : (
-                <div className="space-y-1">
-                  {filteredPolicies.map((p) => {
-                    const tool = tools.find((t) => t.name === p.toolName)
-                    return (
-                      <div
-                        key={p.toolName}
-                        className="flex items-center justify-between rounded border px-2 py-1.5"
-                      >
-                        <div className="flex-1 min-w-0 mr-2">
-                          <span className="text-xs font-mono font-medium">
-                            <HighlightMatch text={p.toolName} query={textFilter} />
-                          </span>
-                          {tool?.description && (
-                            <p className="text-xs text-muted-foreground truncate">
-                              <HighlightMatch text={tool.description} query={textFilter} />
-                            </p>
-                          )}
-                        </div>
-                        <PolicyDecisionToggle
-                          value={p.decision}
-                          onChange={(v) => updateToolPolicy(p.toolName, v)}
-                        />
-                      </div>
-                    )
-                  })}
-                </div>
-              )}
-            </div>
-          </>
+        {open && (
+          <ToolPolicyEditorBody
+            mcpId={mcpId}
+            mcpName={mcpName}
+            tools={tools}
+            onSaved={() => onOpenChange(false)}
+            onCancel={() => onOpenChange(false)}
+          />
         )}
-
-        <div className="flex justify-end gap-2 pt-2 border-t">
-          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button size="sm" onClick={handleSave} disabled={saving || loading}>
-            {saving && <Loader2 className="h-4 w-4 animate-spin mr-1" />}
-            Save Policies
-          </Button>
-        </div>
       </DialogContent>
     </Dialog>
   )

--- a/src/renderer/components/settings/tool-policy-editor.tsx
+++ b/src/renderer/components/settings/tool-policy-editor.tsx
@@ -30,7 +30,6 @@ interface ToolPolicy {
 
 interface ToolPolicyEditorBodyProps {
   mcpId: string
-  mcpName: string
   tools: Array<{ name: string; description?: string }>
   onSaved?: () => void
   onCancel?: () => void
@@ -43,7 +42,6 @@ interface ToolPolicyEditorBodyProps {
  */
 export function ToolPolicyEditorBody({
   mcpId,
-  mcpName: _mcpName,
   tools,
   onSaved,
   onCancel,
@@ -276,15 +274,12 @@ export function ToolPolicyEditor({
           <DialogTitle>{mcpName} Tool Policies</DialogTitle>
           <DialogDescription className="sr-only">Configure per-tool access policies for {mcpName}</DialogDescription>
         </DialogHeader>
-        {open && (
-          <ToolPolicyEditorBody
-            mcpId={mcpId}
-            mcpName={mcpName}
-            tools={tools}
-            onSaved={() => onOpenChange(false)}
-            onCancel={() => onOpenChange(false)}
-          />
-        )}
+        <ToolPolicyEditorBody
+          mcpId={mcpId}
+          tools={tools}
+          onSaved={() => onOpenChange(false)}
+          onCancel={() => onOpenChange(false)}
+        />
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
## Summary
Second of 3 PRs splitting #171. **Pure refactor — no behavior change for
existing callers.** Stacked on #1 (connections/primitives).

The message-item review prompts, the post-OAuth scope editor, and the
per-agent Connections tab keep using the Dialog wrappers exactly as before.
The editor bodies are split out so the detail page in PR #3 can render them
inline, without the Dialog frame.

- `ScopePolicyEditorBody` — the scope (OAuth) policy editor as a standalone
  panel; `ScopePolicyEditor` now wraps it in the Dialog.
- `ToolPolicyEditorBody` — the same split for the MCP tool policy editor.
- `ConnectionAgentsList` — extracted from `ConnectionAgentsDialog`, with a new
  `sectioned` mode that splits agents into "with access" / "without access".

> Review note: each of the three editors is split the same way — the existing
> editor body is extracted into a `*Body` component and the old `*Editor`
> becomes a thin Dialog wrapper around it. Logic moves verbatim; the only
> semantic changes are `handleSave` calling `onSaved?.()` instead of closing
> the dialog, and the loading spinner now early-returns from the body (so the
> Save/Cancel bar is hidden while loading rather than shown disabled).

## Test plan
- [ ] Agent → Connections tab: open a connection's scope/tool policy editor;
      it still opens as a dialog, loads, edits, and saves.
- [ ] Connect a new OAuth account; the post-OAuth scope editor dialog still
      pops and saves.
- [ ] Open the "manage agents" dialog for a connection; toggles still persist.
- [x] `npm run typecheck && npm run lint` pass (verified locally).

> Stacked PR 2 of 3 · `connections/editor-panels` → `connections/primitives`.
> After #1 merges, this base will retarget to `main` automatically.

🤖 Split out from #171 with Claude Code.
