### PR TITLE
feat(connections): redesign global Connections settings + add detail page

### DIFF
--- a/e2e/specs/global-connections.spec.ts
+++ b/e2e/specs/global-connections.spec.ts
@@ -69,8 +69,8 @@ test.describe('Global Settings → Connections — Add MCP flow', () => {
     const newRow = page.getByText(mcpName, { exact: true }).first()
     await expect(newRow).toBeVisible({ timeout: 10000 })
 
-    // 6. The agents pill is rendered for the row and reads "0 agents" — the
-    //    server has the MCP but it's not mapped to anyone yet.
+    // 6. The row subtitle shows the agent-count snippet and reads "Not in use"
+    //    — the server has the MCP but it's not mapped to anyone yet.
     const allMcps = await (await request.get(`${API}/api/remote-mcps`)).json()
     const created = (allMcps.servers as Array<{ id: string; name: string; url: string }>).find(
       (m) => m.url === mockMcp.url,
@@ -78,9 +78,9 @@ test.describe('Global Settings → Connections — Add MCP flow', () => {
     expect(created, 'newly added MCP missing from /api/remote-mcps').toBeDefined()
     expect(created!.name).toBe(mcpName)
 
-    const agentsPill = page.locator(`[data-testid="connection-agents-pill-mcp-${created!.id}"]`)
-    await expect(agentsPill).toBeVisible()
-    await expect(agentsPill).toContainText('0 agents')
+    const agentCount = page.locator(`[data-testid="connection-agent-count-mcp-${created!.id}"]`)
+    await expect(agentCount).toBeVisible()
+    await expect(agentCount).toContainText('Not in use')
 
     // 7. Backend cross-check: the new /:id/agents endpoint returns an empty list.
     const agentsRes = await request.get(`${API}/api/remote-mcps/${created!.id}/agents`)

--- a/e2e/specs/policy-settings.spec.ts
+++ b/e2e/specs/policy-settings.spec.ts
@@ -1,11 +1,28 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page, type APIRequestContext } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 
 test.describe.configure({ mode: 'serial' })
 
+/**
+ * Opens Global Settings → Connections and clicks through to the detail page
+ * for the named connection. The scope/tool policy editor renders inline there
+ * (the per-row policy pill + dialog were removed in the connections redesign).
+ */
+async function openConnectionDetail(page: Page, name: string) {
+  await page.locator('[data-testid="settings-button"]').click()
+  await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
+  await page.locator('[data-testid="settings-nav-connections"]').click()
+
+  const row = page.getByRole('button', { name: `Open ${name} connection details` })
+  await expect(row).toBeVisible({ timeout: 5000 })
+  await row.click()
+  await expect(page.locator('[data-testid="connection-detail-back"]')).toBeVisible()
+}
+
 test.describe('Policy Settings', () => {
   let appPage: AppPage
   let accountId: string
+  const accountName = 'E2E Slack Account'
 
   test.beforeAll(async ({ request }) => {
     // Unique per run so a retry (which re-runs beforeAll in a new worker) does
@@ -15,50 +32,41 @@ test.describe('Policy Settings', () => {
       data: {
         providerConnectionId,
         toolkitSlug: 'slack',
-        displayName: 'E2E Slack Account',
+        displayName: accountName,
       },
     })
     const body = await res.json()
     accountId = body.account.id
   })
 
-  test('settings: connections tab shows policy pill for connected account', async ({ page }) => {
+  // The inline editor has no dialog-close to await after Save, so persistence
+  // is asserted against the API instead of pill text (the pill is gone).
+  const scopePolicies = async (request: APIRequestContext) => {
+    const res = await request.get(`/api/policies/scope/${accountId}`)
+    const body = await res.json()
+    return body.policies as Array<{ scope: string; decision: string }>
+  }
+
+  test('settings: connection row opens the detail page with the inline scope editor', async ({ page }) => {
     appPage = new AppPage(page)
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
 
-    // Open global settings
-    await page.locator('[data-testid="settings-button"]').click()
-    await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
+    await openConnectionDetail(page, accountName)
 
-    // Navigate to Connections tab
-    await page.locator('[data-testid="settings-nav-connections"]').click()
-
-    // Should see the policy pill for our account (no policies yet)
-    const pill = page.locator(`[data-testid="policy-pill-${accountId}"]`)
-    await expect(pill).toBeVisible({ timeout: 5000 })
-    await expect(pill).toContainText('Protected')
+    // The scope policy editor renders inline in the Permissions column.
+    await expect(page.getByText('Permissions')).toBeVisible()
+    await expect(page.locator('[data-testid="scope-group-write"]')).toBeVisible({ timeout: 5000 })
   })
 
-  test('settings: can open scope policy editor and set a policy', async ({ page }) => {
+  test('settings: can set a scope policy from the detail page', async ({ page, request }) => {
     appPage = new AppPage(page)
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
 
-    // Open settings → Accounts
-    await page.locator('[data-testid="settings-button"]').click()
-    await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
-    await page.locator('[data-testid="settings-nav-connections"]').click()
+    await openConnectionDetail(page, accountName)
 
-    // Click the policy pill to open scope editor
-    const pill = page.locator(`[data-testid="policy-pill-${accountId}"]`)
-    await expect(pill).toBeVisible({ timeout: 5000 })
-    await pill.click()
-
-    // Scope policy editor dialog should open
-    await expect(page.getByText('Scope Policies')).toBeVisible({ timeout: 5000 })
-
-    // Find the chat:write scope row and set it to "allow"
+    // Find the chat:write scope row and set it to "allow".
     // The Write group is an accordion collapsed by default — expand it first.
     await page.locator('[data-testid="scope-group-toggle-write"]').click()
     const chatWriteRow = page.locator('[data-testid="scope-row-chat:write"]')
@@ -72,32 +80,22 @@ test.describe('Policy Settings', () => {
     await allowToggle.click()
     await expect(allowToggle).toHaveAttribute('data-active', 'true')
 
-    // Save
+    // Save — the inline editor stays on screen; verify persistence via API.
     await page.locator('[data-testid="scope-policy-save"]').click()
-
-    // Dialog should close
-    await expect(page.getByText('Scope Policies')).not.toBeVisible({ timeout: 5000 })
-
-    // The pill flips from "Protected" to "Protected • Custom" once a policy is set.
-    await expect(pill).toContainText('Custom', { timeout: 5000 })
+    await expect
+      .poll(
+        async () => (await scopePolicies(request)).find((p) => p.scope === 'chat:write')?.decision,
+        { timeout: 5000 },
+      )
+      .toBe('allow')
   })
 
-  test('settings: saved policy persists after reopening editor', async ({ page }) => {
+  test('settings: saved policy persists after reopening the editor', async ({ page }) => {
     appPage = new AppPage(page)
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
 
-    // Open settings → Accounts
-    await page.locator('[data-testid="settings-button"]').click()
-    await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
-    await page.locator('[data-testid="settings-nav-connections"]').click()
-
-    // Open the policy editor again
-    const pill = page.locator(`[data-testid="policy-pill-${accountId}"]`)
-    await expect(pill).toBeVisible({ timeout: 5000 })
-    await pill.click()
-
-    await expect(page.getByText('Scope Policies')).toBeVisible({ timeout: 5000 })
+    await openConnectionDetail(page, accountName)
 
     // The chat:write scope should still have allow active (from previous test)
     // The Write group is an accordion collapsed by default — expand it first.
@@ -108,20 +106,12 @@ test.describe('Policy Settings', () => {
     await expect(allowToggle).toHaveAttribute('data-active', 'true')
   })
 
-  test('settings: can change policy from allow to block', async ({ page }) => {
+  test('settings: can change policy from allow to block', async ({ page, request }) => {
     appPage = new AppPage(page)
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
 
-    // Open settings → Accounts → scope editor
-    await page.locator('[data-testid="settings-button"]').click()
-    await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
-    await page.locator('[data-testid="settings-nav-connections"]').click()
-
-    const pill = page.locator(`[data-testid="policy-pill-${accountId}"]`)
-    await expect(pill).toBeVisible({ timeout: 5000 })
-    await pill.click()
-    await expect(page.getByText('Scope Policies')).toBeVisible({ timeout: 5000 })
+    await openConnectionDetail(page, accountName)
 
     // The Write group is an accordion collapsed by default — expand it first.
     await page.locator('[data-testid="scope-group-toggle-write"]').click()
@@ -140,25 +130,22 @@ test.describe('Policy Settings', () => {
     await expect(allowToggle).toHaveAttribute('data-active', 'false')
     await expect(blockToggle).toHaveAttribute('data-active', 'true')
 
-    // Save
+    // Save and verify the flip persisted.
     await page.locator('[data-testid="scope-policy-save"]').click()
-    await expect(page.getByText('Scope Policies')).not.toBeVisible({ timeout: 5000 })
+    await expect
+      .poll(
+        async () => (await scopePolicies(request)).find((p) => p.scope === 'chat:write')?.decision,
+        { timeout: 5000 },
+      )
+      .toBe('block')
   })
 
-  test('settings: can deselect to reset to default', async ({ page }) => {
+  test('settings: can deselect to reset to default', async ({ page, request }) => {
     appPage = new AppPage(page)
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
 
-    // Open settings → Accounts → scope editor
-    await page.locator('[data-testid="settings-button"]').click()
-    await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
-    await page.locator('[data-testid="settings-nav-connections"]').click()
-
-    const pill = page.locator(`[data-testid="policy-pill-${accountId}"]`)
-    await expect(pill).toBeVisible({ timeout: 5000 })
-    await pill.click()
-    await expect(page.getByText('Scope Policies')).toBeVisible({ timeout: 5000 })
+    await openConnectionDetail(page, accountName)
 
     // The Write group is an accordion collapsed by default — expand it first.
     await page.locator('[data-testid="scope-group-toggle-write"]').click()
@@ -178,11 +165,15 @@ test.describe('Policy Settings', () => {
     await expect(chatWriteRow.locator('[data-testid="policy-toggle-review"]')).toHaveAttribute('data-active', 'false')
     await expect(chatWriteRow.locator('[data-testid="policy-toggle-block"]')).toHaveAttribute('data-active', 'false')
 
-    // Save and verify pill drops the "Custom" suffix (= no policies set).
+    // Save and verify the per-scope row is gone from the persisted policies
+    // (label-default rows may remain — only chat:write must be absent).
     await page.locator('[data-testid="scope-policy-save"]').click()
-    await expect(page.getByText('Scope Policies')).not.toBeVisible({ timeout: 5000 })
-    await expect(pill).not.toContainText('Custom', { timeout: 5000 })
-    await expect(pill).toContainText('Protected', { timeout: 5000 })
+    await expect
+      .poll(
+        async () => (await scopePolicies(request)).some((p) => p.scope === 'chat:write'),
+        { timeout: 5000 },
+      )
+      .toBe(false)
   })
 
   test('settings: global default policy toggle works', async ({ page }) => {
@@ -195,8 +186,8 @@ test.describe('Policy Settings', () => {
     await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
     await page.locator('[data-testid="settings-nav-connections"]').click()
 
-    // Find the global default policy section — the border div containing the label
-    const globalSection = page.locator('div.border').filter({ hasText: 'Default API Request Policy' })
+    // The API default-policy row inside the "Default Policies" card.
+    const globalSection = page.locator('[data-testid="default-policy-api"]')
     const reviewToggle = globalSection.locator('[data-testid="policy-toggle-review"]')
     const allowToggle = globalSection.locator('[data-testid="policy-toggle-allow"]')
 

--- a/e2e/specs/scope-policy-grouping.spec.ts
+++ b/e2e/specs/scope-policy-grouping.spec.ts
@@ -1,9 +1,25 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 
 // web-chromium's request fixture has no baseURL configured, so use an absolute
 // API base (matches connections-page-policy-modal.spec.ts).
 const API = 'http://localhost:3000'
+
+/**
+ * Opens Global Settings → Connections and clicks through to the detail page
+ * for the named connection. The scope policy editor renders inline there
+ * (the per-row policy pill + dialog were removed in the connections redesign).
+ */
+async function openConnectionDetail(page: Page, name: string) {
+  await page.locator('[data-testid="settings-button"]').click()
+  await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
+  await page.locator('[data-testid="settings-nav-connections"]').click()
+
+  const row = page.getByRole('button', { name: `Open ${name} connection details` })
+  await expect(row).toBeVisible({ timeout: 5000 })
+  await row.click()
+  await expect(page.locator('[data-testid="connection-detail-back"]')).toBeVisible()
+}
 
 test.describe('Scope Policy Editor — risk-label grouping', () => {
   test('groups scopes by risk label and pre-fills the recommended defaults', async ({ page, request }) => {
@@ -29,18 +45,8 @@ test.describe('Scope Policy Editor — risk-label grouping', () => {
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
 
-    // Settings → Connections → open the policy editor via the pill
-    await page.locator('[data-testid="settings-button"]').click()
-    await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
-    await page.locator('[data-testid="settings-nav-connections"]').click()
-
-    const pill = page.locator(`[data-testid="policy-pill-${account.id}"]`)
-    await expect(pill).toBeVisible({ timeout: 5000 })
-    // No persisted policies → pill stays "Protected", not "Custom".
-    await expect(pill).not.toContainText('Custom')
-    await pill.click()
-
-    await expect(page.getByText('Scope Policies')).toBeVisible({ timeout: 5000 })
+    // Settings → Connections → open the inline editor via the connection row.
+    await openConnectionDetail(page, 'E2E Grouping Slack')
 
     // The three risk-label groups render (Slack has read/write/destructive scopes).
     await expect(page.locator('[data-testid="scope-group-read"]')).toBeVisible()
@@ -57,6 +63,10 @@ test.describe('Scope Policy Editor — risk-label grouping', () => {
     await expect(
       page.locator('[data-testid="group-default-destructive"] [data-testid="policy-toggle-block"]'),
     ).toHaveAttribute('data-active', 'true')
+
+    // Still display-only — nothing persisted until Save.
+    const after = await (await request.get(`${API}/api/policies/scope/${account.id}`)).json()
+    expect(after.policies).toHaveLength(0)
   })
 
   test('changing a group default persists and is reflected on reopen', async ({ page, request }) => {
@@ -74,14 +84,8 @@ test.describe('Scope Policy Editor — risk-label grouping', () => {
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
 
-    // Open settings → Connections and the policy editor via the pill.
-    await page.locator('[data-testid="settings-button"]').click()
-    await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
-    await page.locator('[data-testid="settings-nav-connections"]').click()
-    const pill = page.locator(`[data-testid="policy-pill-${account.id}"]`)
-    await expect(pill).toBeVisible({ timeout: 5000 })
-    await pill.click()
-    await expect(page.getByText('Scope Policies')).toBeVisible({ timeout: 5000 })
+    // Settings → Connections → open the inline editor via the connection row.
+    await openConnectionDetail(page, 'E2E Grouping Persist Slack')
 
     const destAllow = () =>
       page.locator('[data-testid="group-default-destructive"] [data-testid="policy-toggle-allow"]')
@@ -91,16 +95,25 @@ test.describe('Scope Policy Editor — risk-label grouping', () => {
     await destAllow().click()
     await expect(destAllow()).toHaveAttribute('data-active', 'true')
 
+    // Save — the inline editor stays on screen; verify persistence via API.
     await page.locator('[data-testid="scope-policy-save"]').click()
-    await expect(page.getByText('Scope Policies')).not.toBeVisible({ timeout: 5000 })
+    await expect
+      .poll(async () => {
+        const body = await (await request.get(`${API}/api/policies/scope/${account.id}`)).json()
+        return (body.policies as Array<{ scope: string; decision: string }>).find(
+          (p) => p.scope === '*destructive',
+        )?.decision
+      }, { timeout: 5000 })
+      .toBe('allow')
 
-    // Deviating from the baseline now marks the account "Custom".
-    await expect(pill).toContainText('Custom', { timeout: 5000 })
-
-    // Reopen via the pill (we're still on the connections tab — the app shell,
-    // and its settings button, is unmounted while settings is open).
-    await pill.click()
-    await expect(page.getByText('Scope Policies')).toBeVisible({ timeout: 5000 })
-    await expect(destAllow()).toHaveAttribute('data-active', 'true')
+    // Reopen the editor by going back to the list and into the row again —
+    // remounting the inline editor refetches the persisted policies.
+    await page.locator('[data-testid="connection-detail-back"]').click()
+    const row = page.getByRole('button', {
+      name: 'Open E2E Grouping Persist Slack connection details',
+    })
+    await expect(row).toBeVisible({ timeout: 5000 })
+    await row.click()
+    await expect(destAllow()).toHaveAttribute('data-active', 'true', { timeout: 5000 })
   })
 })

--- a/src/renderer/components/connections/connection-agent-count.tsx
+++ b/src/renderer/components/connections/connection-agent-count.tsx
@@ -18,12 +18,24 @@ export function ConnectionAgentCount({ type, id }: ConnectionAgentCountProps) {
   // Render nothing until the query resolves so rows don't flash "Not in use".
   if (!data) return null
   const count = data.agentSlugs.length
+  // The leading `·` lives inside the component so the subtitle row shows no
+  // dangling separator while the query is still loading (null above).
   if (count === 0) {
-    return <span className="whitespace-nowrap shrink-0">Not in use</span>
+    return (
+      <>
+        <span className="shrink-0">·</span>
+        <span data-testid={`connection-agent-count-${type}-${id}`} className="whitespace-nowrap shrink-0">
+          Not in use
+        </span>
+      </>
+    )
   }
   return (
-    <span className="whitespace-nowrap shrink-0 tabular-nums">
-      Used by {count} {count === 1 ? 'agent' : 'agents'}
-    </span>
+    <>
+      <span className="shrink-0">·</span>
+      <span data-testid={`connection-agent-count-${type}-${id}`} className="whitespace-nowrap shrink-0 tabular-nums">
+        Used by {count} {count === 1 ? 'agent' : 'agents'}
+      </span>
+    </>
   )
 }

--- a/src/renderer/components/connections/connection-agents-dialog.tsx
+++ b/src/renderer/components/connections/connection-agents-dialog.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, type CSSProperties } from 'react'
+import { flushSync } from 'react-dom'
 import { Loader2 } from 'lucide-react'
 import type { ApiAgent } from '@renderer/hooks/use-agents'
+import { startViewTransition } from '@renderer/lib/view-transition'
 import {
   Dialog,
   DialogContent,
@@ -94,7 +96,16 @@ export function ConnectionAgentsList({ type, id, name, sectioned = false }: Conn
   }
 
   const handleToggle = async (slug: string, next: boolean) => {
-    setOverrides((prev) => ({ ...prev, [slug]: next }))
+    // Optimistically flip the agent into its new section. In the sectioned
+    // layout, wrap it in a View Transition (flushSync so the optimistic state
+    // hits the DOM before the "before" snapshot) so the row animates between
+    // With/Without Access — matching the per-agent connections list.
+    const applyOverride = () => setOverrides((prev) => ({ ...prev, [slug]: next }))
+    if (sectioned) {
+      startViewTransition(() => flushSync(applyOverride))
+    } else {
+      applyOverride()
+    }
     try {
       if (type === 'oauth') {
         if (next) {
@@ -139,7 +150,12 @@ export function ConnectionAgentsList({ type, id, name, sectioned = false }: Conn
     const granted = overrides[agent.slug] ?? grantedSet.has(agent.slug)
     const pending = isPending(agent.slug)
     return (
-      <li key={agent.slug} className="flex items-center gap-3 px-3 py-2.5">
+      <li
+        key={agent.slug}
+        className="flex items-center gap-3 px-3 py-2.5"
+        // Stable name so the View Transition can pair the row across sections.
+        style={sectioned ? ({ viewTransitionName: `connection-agent-${agent.slug}` } as CSSProperties) : undefined}
+      >
         <div className="min-w-0 flex-1">
           <div className="text-xs font-medium truncate">{agent.name}</div>
           <div className="text-[11px] text-muted-foreground truncate">{agent.slug}</div>
@@ -159,11 +175,12 @@ export function ConnectionAgentsList({ type, id, name, sectioned = false }: Conn
   }
 
   if (sectioned) {
-    // Partition on confirmed server state, not the optimistic override, so a
-    // row doesn't jump sections out from under the user's cursor mid-toggle —
-    // it moves once the mutation persists and the agents query refetches.
-    const grantedAgents = visibleAgents.filter((a) => grantedSet.has(a.slug))
-    const notGrantedAgents = visibleAgents.filter((a) => !grantedSet.has(a.slug))
+    // Partition on the optimistic grant state so a toggled agent moves to its
+    // new section immediately; the View Transition in handleToggle animates the
+    // move, and the override clears once the mutation persists.
+    const isGranted = (slug: string) => overrides[slug] ?? grantedSet.has(slug)
+    const grantedAgents = visibleAgents.filter((a) => isGranted(a.slug))
+    const notGrantedAgents = visibleAgents.filter((a) => !isGranted(a.slug))
 
     return (
       <div className="space-y-6">

--- a/src/renderer/components/connections/connection-detail-page.tsx
+++ b/src/renderer/components/connections/connection-detail-page.tsx
@@ -1,0 +1,100 @@
+import { ChevronLeft } from 'lucide-react'
+import { Button } from '@renderer/components/ui/button'
+import { ServiceIcon } from '@renderer/components/ui/service-icon'
+import { ConnectionAgentsList } from '@renderer/components/connections/connection-agents-dialog'
+import { IntegrationRowActions } from '@renderer/components/connections/integration-row-actions'
+import { ScopePolicyEditorBody } from '@renderer/components/settings/scope-policy-editor'
+import { ToolPolicyEditorBody } from '@renderer/components/settings/tool-policy-editor'
+import { useHideSettingsHeader } from '@renderer/components/settings/settings-page'
+import { formatCompactDistance, safeDate } from '@renderer/components/connections/utils'
+import type { UnifiedRow } from '@renderer/components/connections/unified-rows'
+
+interface ConnectionDetailPageProps {
+  row: UnifiedRow
+  onBack: () => void
+}
+
+/**
+ * Detail view for a single connection: two columns showing which agents have
+ * access and the per-scope / per-tool permissions for the connection.
+ */
+export function ConnectionDetailPage({ row, onBack }: ConnectionDetailPageProps) {
+  // Hide the default SettingsPage header — the detail page owns its own.
+  useHideSettingsHeader(true)
+  return (
+    <div className="space-y-4 lg:-mx-[152px]">
+      {/* Back / breadcrumb */}
+      <div className="flex items-center gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onBack}
+          className="-ml-2 h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
+          data-testid="connection-detail-back"
+        >
+          <ChevronLeft className="h-3.5 w-3.5 mr-1" />
+          Connections
+        </Button>
+      </div>
+
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <div className="h-10 w-10 rounded-md bg-muted dark:bg-zinc-200 flex items-center justify-center shrink-0">
+          <ServiceIcon
+            slug={row.iconSlug}
+            fallback={row.iconFallback}
+            className="h-5 w-5 text-muted-foreground/60"
+          />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h2 className="text-base font-medium truncate">{row.name}</h2>
+          <p className="text-xs text-muted-foreground truncate">
+            {row.type === 'oauth' ? 'API' : 'MCP'}
+            {row.subtitle ? ` · ${row.subtitle}` : ''}
+            {' · '}
+            <span className="tabular-nums">{formatCompactDistance(safeDate(row.date))}</span>
+          </p>
+        </div>
+        <div className="shrink-0">
+          <IntegrationRowActions
+            type={row.type}
+            id={row.id}
+            name={row.name}
+            toolkit={row.toolkit}
+            mcpTools={row.mcpTools}
+            accountStatus={row.accountStatus}
+            layout="buttons"
+          />
+        </div>
+      </div>
+
+      {/* Two columns */}
+      <div className="grid grid-cols-1 lg:grid-cols-[5fr_6fr] gap-4 pt-4">
+        {/* Agents column */}
+        <section className="min-w-0">
+          <ConnectionAgentsList type={row.type} id={row.id} name={row.name} sectioned />
+        </section>
+
+        {/* Permissions column */}
+        <section className="space-y-2 min-w-0">
+          <h3 className="text-xs font-normal text-muted-foreground">Permissions</h3>
+          <div className="rounded-xl border bg-background p-3">
+            {row.type === 'oauth' && row.toolkit ? (
+              <ScopePolicyEditorBody accountId={row.id} toolkit={row.toolkit} />
+            ) : row.type === 'mcp' ? (
+              <ToolPolicyEditorBody
+                mcpId={row.id}
+                mcpName={row.name}
+                tools={row.mcpTools ?? []}
+              />
+            ) : (
+              <p className="text-sm text-muted-foreground py-4 text-center">
+                No permissions configurable for this connection.
+              </p>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/connections/connection-detail-page.tsx
+++ b/src/renderer/components/connections/connection-detail-page.tsx
@@ -5,7 +5,10 @@ import { ConnectionAgentsList } from '@renderer/components/connections/connectio
 import { IntegrationRowActions } from '@renderer/components/connections/integration-row-actions'
 import { ScopePolicyEditorBody } from '@renderer/components/settings/scope-policy-editor'
 import { ToolPolicyEditorBody } from '@renderer/components/settings/tool-policy-editor'
-import { useHideSettingsHeader } from '@renderer/components/settings/settings-page'
+import {
+  useHideSettingsHeader,
+  useFullWidthSettingsContent,
+} from '@renderer/components/settings/settings-page'
 import { formatCompactDistance, safeDate } from '@renderer/components/connections/utils'
 import type { UnifiedRow } from '@renderer/components/connections/unified-rows'
 
@@ -19,10 +22,12 @@ interface ConnectionDetailPageProps {
  * access and the per-scope / per-tool permissions for the connection.
  */
 export function ConnectionDetailPage({ row, onBack }: ConnectionDetailPageProps) {
-  // Hide the default SettingsPage header — the detail page owns its own.
+  // Hide the default SettingsPage header — the detail page owns its own — and
+  // use the full inset width so the two columns can lay out like the agent home.
   useHideSettingsHeader(true)
+  useFullWidthSettingsContent(true)
   return (
-    <div className="space-y-4 lg:-mx-[152px]">
+    <div className="space-y-4 w-full max-w-6xl mx-auto">
       {/* Back / breadcrumb */}
       <div className="flex items-center gap-2">
         <Button
@@ -68,8 +73,9 @@ export function ConnectionDetailPage({ row, onBack }: ConnectionDetailPageProps)
         </div>
       </div>
 
-      {/* Two columns */}
-      <div className="grid grid-cols-1 lg:grid-cols-[5fr_6fr] gap-4 pt-4">
+      {/* Two columns (like the agent home): the agents column is flexible and
+          grows/shrinks with the window; the permissions column is a fixed width. */}
+      <div className="grid gap-4 items-start grid-cols-1 xl:grid-cols-[1fr_32rem] pt-4">
         {/* Agents column */}
         <section className="min-w-0">
           <ConnectionAgentsList type={row.type} id={row.id} name={row.name} sectioned />

--- a/src/renderer/components/connections/connection-detail-page.tsx
+++ b/src/renderer/components/connections/connection-detail-page.tsx
@@ -84,7 +84,6 @@ export function ConnectionDetailPage({ row, onBack }: ConnectionDetailPageProps)
             ) : row.type === 'mcp' ? (
               <ToolPolicyEditorBody
                 mcpId={row.id}
-                mcpName={row.name}
                 tools={row.mcpTools ?? []}
               />
             ) : (

--- a/src/renderer/components/connections/connection-row.tsx
+++ b/src/renderer/components/connections/connection-row.tsx
@@ -9,7 +9,11 @@ interface ConnectionRowProps {
   row: UnifiedRow
   /** Right-side slot — pills, actions, switch, etc. */
   right: ReactNode
-  /** Optional trailing item appended after the timestamp (e.g. trigger count). */
+  /**
+   * Optional trailing items appended after the timestamp (e.g. agent count,
+   * trigger count). Items render their own leading `·` separators so that
+   * async items can mount late without leaving a dangling dot.
+   */
   subtitleExtra?: ReactNode
   /**
    * Optional content right-justified at the end of the subtitle row (no `·`
@@ -66,12 +70,7 @@ export function ConnectionRow({
           <span className="whitespace-nowrap shrink-0 tabular-nums">
             {formatCompactDistance(safeDate(row.date))}
           </span>
-          {subtitleExtra && (
-            <>
-              <span className="shrink-0">·</span>
-              {subtitleExtra}
-            </>
-          )}
+          {subtitleExtra}
           {subtitleTrailing && (
             <span className="ml-auto shrink-0 pl-2">{subtitleTrailing}</span>
           )}

--- a/src/renderer/components/layout/settings-page.tsx
+++ b/src/renderer/components/layout/settings-page.tsx
@@ -8,6 +8,8 @@ interface SettingsPageContainerProps {
   className?: string
   /** Use a wider, less padded frame for content like tables. */
   fullScreen?: boolean
+  /** Drop the 720px cap and fill the full inset width (sub-views lay out their own width). */
+  fullWidth?: boolean
 }
 
 /**
@@ -15,12 +17,13 @@ interface SettingsPageContainerProps {
  * sibling pages). Centers content at 720px, adds vertical rhythm, and scrolls
  * independently of the app shell.
  */
-export function SettingsPageContainer({ children, className, fullScreen }: SettingsPageContainerProps) {
+export function SettingsPageContainer({ children, className, fullScreen, fullWidth }: SettingsPageContainerProps) {
   return (
     <div className="flex-1 overflow-auto">
       <div
         className={cn(
-          'mx-auto w-full max-w-[720px] px-6 pt-10 pb-6 space-y-10',
+          'mx-auto w-full px-6 pt-10 pb-6 space-y-10',
+          fullWidth ? 'max-w-none' : 'max-w-[720px]',
           fullScreen && 'max-w-5xl pt-4 space-y-6',
           className,
         )}

--- a/src/renderer/components/settings/connections-tab.tsx
+++ b/src/renderer/components/settings/connections-tab.tsx
@@ -1,9 +1,6 @@
 import { useMemo, useState } from 'react'
-import { Loader2, Zap } from 'lucide-react'
-import { Label } from '@renderer/components/ui/label'
+import { ChevronRight, Loader2, Zap } from 'lucide-react'
 import { PolicyDecisionToggle } from '@renderer/components/ui/policy-decision-toggle'
-import { PolicySummaryPill } from '@renderer/components/ui/policy-summary-pill'
-import { ToolPolicySummaryPill } from '@renderer/components/ui/tool-policy-summary-pill'
 import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user-settings'
 import {
   useConnectedAccounts,
@@ -13,12 +10,9 @@ import { useRemoteMcps } from '@renderer/hooks/use-remote-mcps'
 import { IntegrationList } from '@renderer/components/connections/integration-row'
 import { NewIntegrationButton } from '@renderer/components/connections/connections-list'
 import { FeaturedServicesStack } from '@renderer/components/connections/featured-services-stack'
-import { IntegrationRowActions } from '@renderer/components/connections/integration-row-actions'
 import { ConnectionRow } from '@renderer/components/connections/connection-row'
-import { ConnectionAgentsPill } from '@renderer/components/connections/connection-agents-pill'
-import { ConnectionAgentsDialog } from '@renderer/components/connections/connection-agents-dialog'
-import { ScopePolicyEditor } from '@renderer/components/settings/scope-policy-editor'
-import { ToolPolicyEditor } from '@renderer/components/settings/tool-policy-editor'
+import { ConnectionAgentCount } from '@renderer/components/connections/connection-agent-count'
+import { ConnectionDetailPage } from '@renderer/components/connections/connection-detail-page'
 import { buildUnifiedRows, type UnifiedRow } from '@renderer/components/connections/unified-rows'
 import { useOAuthReconnect } from '@renderer/hooks/use-oauth-reconnect'
 
@@ -30,9 +24,7 @@ export function ConnectionsTab() {
   const { data: triggerCounts } = useTriggerCountsPerAccount()
   const { reconnect: oauthReconnect, pendingAccountId } = useOAuthReconnect()
 
-  const [policyEditorAccount, setPolicyEditorAccount] = useState<{ id: string; toolkit: string } | null>(null)
-  const [policyEditorMcp, setPolicyEditorMcp] = useState<{ id: string; name: string; tools: Array<{ name: string; description?: string }> } | null>(null)
-  const [agentsDialogRow, setAgentsDialogRow] = useState<UnifiedRow | null>(null)
+  const [selectedRowKey, setSelectedRowKey] = useState<string | null>(null)
 
   const apiPolicy = settings?.defaultApiPolicy ?? 'review'
   const mcpPolicy = settings?.defaultMcpPolicy ?? 'review'
@@ -40,57 +32,64 @@ export function ConnectionsTab() {
   const rows = useMemo(() => {
     const allAccounts = Array.isArray(accountsData?.accounts) ? accountsData.accounts : []
     const allMcps = Array.isArray(mcpsData?.servers) ? mcpsData.servers : []
-    return buildUnifiedRows({ allAccounts, allMcps })
+    return buildUnifiedRows({ allAccounts, allMcps }).sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+    )
   }, [accountsData, mcpsData])
 
   const isLoading = isLoadingAccounts || isLoadingMcps
 
+  // Resolve the selected row from the latest rows list (so it stays in sync if
+  // data refetches). If the row disappeared, clear the selection.
+  const selectedRow = selectedRowKey ? rows.find((r) => r.key === selectedRowKey) ?? null : null
+  if (selectedRowKey && !selectedRow && !isLoading) {
+    // Defer clearing to next tick to avoid setState during render
+    queueMicrotask(() => setSelectedRowKey(null))
+  }
+
+  if (selectedRow) {
+    return (
+      <ConnectionDetailPage
+        row={selectedRow}
+        onBack={() => setSelectedRowKey(null)}
+      />
+    )
+  }
+
   const renderRow = (row: UnifiedRow) => {
     const triggerCount = row.type === 'oauth' ? triggerCounts?.[row.id] ?? 0 : 0
+    const openDetail = () => setSelectedRowKey(row.key)
     return (
       <ConnectionRow
         key={row.key}
         row={row}
-        onReconnect={row.type === 'oauth' && row.accountStatus && row.accountStatus !== 'active' && row.toolkit
-          ? () => oauthReconnect(row.id, row.toolkit!)
-          : undefined}
+        onActivate={openDetail}
+        ariaLabel={`Open ${row.name} connection details`}
+        onReconnect={
+          row.type === 'oauth' && row.accountStatus && row.accountStatus !== 'active' && row.toolkit
+            ? () => oauthReconnect(row.id, row.toolkit!)
+            : undefined
+        }
         reconnecting={pendingAccountId === row.id}
         subtitleExtra={
-          triggerCount > 0 ? (
-            <span className="inline-flex items-center gap-0.5 shrink-0">
-              <Zap className="h-3 w-3" />
-              {triggerCount} trigger{triggerCount > 1 ? 's' : ''}
-            </span>
-          ) : undefined
+          <>
+            <ConnectionAgentCount type={row.type} id={row.id} />
+            {triggerCount > 0 && (
+              <>
+                <span className="shrink-0">·</span>
+                <span className="inline-flex items-center gap-0.5 shrink-0">
+                  <Zap className="h-3 w-3" />
+                  {triggerCount} trigger{triggerCount > 1 ? 's' : ''}
+                </span>
+              </>
+            )}
+          </>
         }
         right={
-          <>
-            {row.type === 'oauth' && row.toolkit && (
-              <PolicySummaryPill
-                accountId={row.id}
-                onClick={() => setPolicyEditorAccount({ id: row.id, toolkit: row.toolkit! })}
-              />
-            )}
-            {row.type === 'mcp' && (
-              <ToolPolicySummaryPill
-                mcpId={row.id}
-                onClick={() => setPolicyEditorMcp({ id: row.id, name: row.name, tools: row.mcpTools ?? [] })}
-              />
-            )}
-            <ConnectionAgentsPill
-              type={row.type}
-              id={row.id}
-              onClick={() => setAgentsDialogRow(row)}
-            />
-            <IntegrationRowActions
-              type={row.type}
-              id={row.id}
-              name={row.name}
-              toolkit={row.toolkit}
-              mcpTools={row.mcpTools}
-              accountStatus={row.accountStatus}
-            />
-          </>
+          <ChevronRight
+            className="h-4 w-4 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
+            aria-hidden="true"
+          />
         }
       />
     )
@@ -98,91 +97,62 @@ export function ConnectionsTab() {
 
   return (
     <div className="space-y-6">
-      <p className="text-xs text-muted-foreground">
-        Manage API accounts and MCP servers that agents can use.
-      </p>
-
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <div className="flex items-start justify-between rounded-md border p-3 gap-3">
-          <div className="min-w-0">
-            <Label className="text-sm font-medium">Default API Request Policy</Label>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              Controls what happens when agents make API calls without a specific scope policy.
-            </p>
+      <div className="space-y-2">
+        <h3 className="text-xs font-normal text-muted-foreground">Default Policies</h3>
+        <div className="rounded-xl border bg-background divide-y divide-border/50 overflow-hidden">
+        <div className="py-3 px-4 flex items-center gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="text-xs font-medium">Default API Request Policy</div>
+            <div className="text-[11px] text-muted-foreground mt-0.5">
+              Used for connections that don&apos;t have an explicit API request policy set.
+            </div>
           </div>
-          <PolicyDecisionToggle
-            value={apiPolicy}
-            onChange={(value) => {
-              if (value === 'default') return
-              updateSettings.mutate({ defaultApiPolicy: value })
-            }}
-            size="md"
-          />
+          <div className="shrink-0">
+            <PolicyDecisionToggle
+              value={apiPolicy}
+              onChange={(value) => {
+                if (value === 'default') return
+                updateSettings.mutate({ defaultApiPolicy: value })
+              }}
+              size="sm"
+            />
+          </div>
         </div>
 
-        <div className="flex items-start justify-between rounded-md border p-3 gap-3">
-          <div className="min-w-0">
-            <Label className="text-sm font-medium">Default MCP Tool Policy</Label>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              Controls what happens when agents use MCP tools without a specific tool policy.
-            </p>
+        <div className="py-3 px-4 flex items-center gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="text-xs font-medium">Default MCP Tool Policy</div>
+            <div className="text-[11px] text-muted-foreground mt-0.5">
+              Used for connections that don&apos;t have an explicit MCP tool policy set.
+            </div>
           </div>
-          <PolicyDecisionToggle
-            value={mcpPolicy}
-            onChange={(value) => {
-              if (value === 'default') return
-              updateSettings.mutate({ defaultMcpPolicy: value })
-            }}
-            size="md"
-          />
+          <div className="shrink-0">
+            <PolicyDecisionToggle
+              value={mcpPolicy}
+              onChange={(value) => {
+                if (value === 'default') return
+                updateSettings.mutate({ defaultMcpPolicy: value })
+              }}
+              size="sm"
+            />
+          </div>
+        </div>
         </div>
       </div>
 
-      {isLoading ? (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          Loading connections...
-        </div>
-      ) : rows.length === 0 ? (
-        <ConnectionsEmptyState />
-      ) : (
-        <IntegrationList>{rows.map(renderRow)}</IntegrationList>
-      )}
-
-      {policyEditorAccount && (
-        <ScopePolicyEditor
-          accountId={policyEditorAccount.id}
-          toolkit={policyEditorAccount.toolkit}
-          open={!!policyEditorAccount}
-          onOpenChange={(open) => {
-            if (!open) setPolicyEditorAccount(null)
-          }}
-        />
-      )}
-
-      {policyEditorMcp && (
-        <ToolPolicyEditor
-          mcpId={policyEditorMcp.id}
-          mcpName={policyEditorMcp.name}
-          tools={policyEditorMcp.tools}
-          open={!!policyEditorMcp}
-          onOpenChange={(open) => {
-            if (!open) setPolicyEditorMcp(null)
-          }}
-        />
-      )}
-
-      {agentsDialogRow && (
-        <ConnectionAgentsDialog
-          type={agentsDialogRow.type}
-          id={agentsDialogRow.id}
-          name={agentsDialogRow.name}
-          open={!!agentsDialogRow}
-          onOpenChange={(open) => {
-            if (!open) setAgentsDialogRow(null)
-          }}
-        />
-      )}
+      <div className="space-y-2">
+        <h3 className="text-xs font-normal text-muted-foreground">Connections</h3>
+        {isLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading connections...
+          </div>
+        ) : rows.length === 0 ? (
+          <ConnectionsEmptyState />
+        ) : (
+          <IntegrationList>{rows.map(renderRow)}</IntegrationList>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/renderer/components/settings/connections-tab.tsx
+++ b/src/renderer/components/settings/connections-tab.tsx
@@ -100,43 +100,43 @@ export function ConnectionsTab() {
       <div className="space-y-2">
         <h3 className="text-xs font-normal text-muted-foreground">Default Policies</h3>
         <div className="rounded-xl border bg-background divide-y divide-border/50 overflow-hidden">
-        <div className="py-3 px-4 flex items-center gap-3">
-          <div className="min-w-0 flex-1">
-            <div className="text-xs font-medium">Default API Request Policy</div>
-            <div className="text-[11px] text-muted-foreground mt-0.5">
-              Used for connections that don&apos;t have an explicit API request policy set.
+          <div data-testid="default-policy-api" className="py-3 px-4 flex items-center gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="text-xs font-medium">Default API Request Policy</div>
+              <div className="text-[11px] text-muted-foreground mt-0.5">
+                Used for connections that don&apos;t have an explicit API request policy set.
+              </div>
+            </div>
+            <div className="shrink-0">
+              <PolicyDecisionToggle
+                value={apiPolicy}
+                onChange={(value) => {
+                  if (value === 'default') return
+                  updateSettings.mutate({ defaultApiPolicy: value })
+                }}
+                size="sm"
+              />
             </div>
           </div>
-          <div className="shrink-0">
-            <PolicyDecisionToggle
-              value={apiPolicy}
-              onChange={(value) => {
-                if (value === 'default') return
-                updateSettings.mutate({ defaultApiPolicy: value })
-              }}
-              size="sm"
-            />
-          </div>
-        </div>
 
-        <div className="py-3 px-4 flex items-center gap-3">
-          <div className="min-w-0 flex-1">
-            <div className="text-xs font-medium">Default MCP Tool Policy</div>
-            <div className="text-[11px] text-muted-foreground mt-0.5">
-              Used for connections that don&apos;t have an explicit MCP tool policy set.
+          <div data-testid="default-policy-mcp" className="py-3 px-4 flex items-center gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="text-xs font-medium">Default MCP Tool Policy</div>
+              <div className="text-[11px] text-muted-foreground mt-0.5">
+                Used for connections that don&apos;t have an explicit MCP tool policy set.
+              </div>
+            </div>
+            <div className="shrink-0">
+              <PolicyDecisionToggle
+                value={mcpPolicy}
+                onChange={(value) => {
+                  if (value === 'default') return
+                  updateSettings.mutate({ defaultMcpPolicy: value })
+                }}
+                size="sm"
+              />
             </div>
           </div>
-          <div className="shrink-0">
-            <PolicyDecisionToggle
-              value={mcpPolicy}
-              onChange={(value) => {
-                if (value === 'default') return
-                updateSettings.mutate({ defaultMcpPolicy: value })
-              }}
-              size="sm"
-            />
-          </div>
-        </div>
         </div>
       </div>
 

--- a/src/renderer/components/settings/scope-policy-editor.test.tsx
+++ b/src/renderer/components/settings/scope-policy-editor.test.tsx
@@ -70,4 +70,47 @@ describe('ScopePolicyEditor', () => {
     // Only the three baseline label rows — no account '*' default, no per-scope rows.
     expect(byScope).toEqual({ '*read': 'allow', '*write': 'review', '*destructive': 'block' })
   })
+
+  it('disables Save for a configured account until a change is made', async () => {
+    // Already configured → the form matches what's persisted, so nothing to save.
+    policiesFixture = [{ scope: 'gmail.send', decision: 'block' }]
+    renderWithProviders(
+      <ScopePolicyEditor accountId="acc-4" toolkit="gmail" open onOpenChange={() => {}} />,
+    )
+    await waitFor(() => expect(screen.getByTestId('group-default-read')).toBeInTheDocument())
+
+    expect(screen.getByTestId('scope-policy-save')).toBeDisabled()
+
+    // Flip a risk-level default — now the editor differs from what's persisted.
+    groupToggle('read', 'allow').click()
+    await waitFor(() => expect(screen.getByTestId('scope-policy-save')).toBeEnabled())
+  })
+
+  it('keeps Save enabled for an untouched account (unsaved baseline)', async () => {
+    // No saved rows, but the recommended baseline is pre-filled and not yet
+    // persisted — so there genuinely is something to save.
+    policiesFixture = []
+    renderWithProviders(
+      <ScopePolicyEditor accountId="acc-5" toolkit="gmail" open onOpenChange={() => {}} />,
+    )
+    await waitFor(() => expect(screen.getByTestId('group-default-read')).toBeInTheDocument())
+
+    expect(screen.getByTestId('scope-policy-save')).toBeEnabled()
+  })
+
+  it('re-disables Save after a successful save', async () => {
+    policiesFixture = [{ scope: 'gmail.send', decision: 'block' }]
+    renderWithProviders(
+      <ScopePolicyEditor accountId="acc-6" toolkit="gmail" open onOpenChange={() => {}} />,
+    )
+    await waitFor(() => expect(screen.getByTestId('group-default-read')).toBeInTheDocument())
+
+    groupToggle('read', 'allow').click()
+    await waitFor(() => expect(screen.getByTestId('scope-policy-save')).toBeEnabled())
+
+    screen.getByTestId('scope-policy-save').click()
+    await waitFor(() => expect(lastPutBody).not.toBeNull())
+    // The just-saved state is now the persisted baseline → nothing left to save.
+    await waitFor(() => expect(screen.getByTestId('scope-policy-save')).toBeDisabled())
+  })
 })

--- a/src/renderer/components/settings/scope-policy-editor.tsx
+++ b/src/renderer/components/settings/scope-policy-editor.tsx
@@ -63,6 +63,17 @@ const emptyLabelDefaults: Record<ScopeLabel, PolicyDecision> = {
   destructive: 'default',
 }
 
+/**
+ * Stable string form of the non-default policy entries, used to detect whether
+ * the editor has unsaved changes. Defaults are dropped (they're never written)
+ * and entries are sorted so order doesn't affect the comparison.
+ */
+function serializePolicies(entries: Iterable<readonly [string, string]>): string {
+  return JSON.stringify(
+    [...entries].filter(([, decision]) => decision !== 'default').sort(([a], [b]) => a.localeCompare(b)),
+  )
+}
+
 interface ScopePolicyEditorBodyProps {
   accountId: string
   toolkit: string
@@ -93,6 +104,8 @@ export function ScopePolicyEditorBody({
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [fetchError, setFetchError] = useState<string | null>(null)
+  // Snapshot of the persisted (non-default) policies, for dirty detection.
+  const [savedSnapshot, setSavedSnapshot] = useState('')
   const [textFilter, setTextFilter] = useState('')
   const [decisionFilter, setDecisionFilter] = useState<'all' | PolicyDecision>('all')
   // Risk-label groups are accordions, collapsed by default.
@@ -169,12 +182,17 @@ export function ScopePolicyEditorBody({
           }
         }
         setPolicies(scopePolicies)
+        // Persisted baseline for dirty detection. Note: an untouched account
+        // has no saved rows, so the pre-filled baseline above reads as "dirty"
+        // — Save stays enabled so the recommended defaults can be persisted.
+        setSavedSnapshot(serializePolicies(existing))
         setLoading(false)
       })
       .catch((err) => {
         console.error('Failed to fetch scope policies:', err)
         setFetchError('Failed to load policies. Showing defaults.')
         setPolicies(allScopes.map((scope) => ({ scope, decision: 'default' })))
+        setSavedSnapshot('[]')
         setLoading(false)
       })
   }, [accountId, allScopes])
@@ -226,24 +244,34 @@ export function ScopePolicyEditorBody({
       destructive: LABEL_DEFAULT_BASELINE.destructive,
     })
 
+  // The non-default policies that a Save would write, keyed by scope.
+  const currentBatch = useMemo(() => {
+    const batch = new Map<string, 'allow' | 'review' | 'block'>()
+    if (accountDefault !== 'default') {
+      batch.set('*', accountDefault as 'allow' | 'review' | 'block')
+    }
+    for (const g of LABEL_GROUPS) {
+      const d = labelDefaults[g.key]
+      if (d !== 'default') {
+        batch.set(labelDefaultKey(g.key), d as 'allow' | 'review' | 'block')
+      }
+    }
+    for (const p of policies) {
+      if (p.decision !== 'default') {
+        batch.set(p.scope, p.decision as 'allow' | 'review' | 'block')
+      }
+    }
+    return batch
+  }, [accountDefault, labelDefaults, policies])
+
+  const currentSnapshot = useMemo(() => serializePolicies(currentBatch), [currentBatch])
+  // Save is only meaningful when the editor differs from what's persisted.
+  const isDirty = currentSnapshot !== savedSnapshot
+
   const handleSave = async () => {
     setSaving(true)
     try {
-      const batch: Array<{ scope: string; decision: 'allow' | 'review' | 'block' }> = []
-      if (accountDefault !== 'default') {
-        batch.push({ scope: '*', decision: accountDefault as 'allow' | 'review' | 'block' })
-      }
-      for (const g of LABEL_GROUPS) {
-        const d = labelDefaults[g.key]
-        if (d !== 'default') {
-          batch.push({ scope: labelDefaultKey(g.key), decision: d as 'allow' | 'review' | 'block' })
-        }
-      }
-      for (const p of policies) {
-        if (p.decision !== 'default') {
-          batch.push({ scope: p.scope, decision: p.decision as 'allow' | 'review' | 'block' })
-        }
-      }
+      const batch = [...currentBatch.entries()].map(([scope, decision]) => ({ scope, decision }))
 
       await apiFetch(`/api/policies/scope/${accountId}`, {
         method: 'PUT',
@@ -251,6 +279,7 @@ export function ScopePolicyEditorBody({
         body: JSON.stringify({ policies: batch }),
       })
       queryClient.invalidateQueries({ queryKey: ['scope-policies', accountId] })
+      setSavedSnapshot(currentSnapshot)
       onSaved?.()
     } catch (error) {
       console.error('Failed to save policies:', error)
@@ -452,13 +481,13 @@ export function ScopePolicyEditorBody({
         )}
       </div>
       {!hideActions && (
-        <div className="flex justify-end gap-2 pt-2 border-t">
+        <div className="flex justify-end gap-2 pt-2">
           {onCancel && (
             <Button variant="outline" size="sm" onClick={onCancel}>
               Cancel
             </Button>
           )}
-          <Button data-testid="scope-policy-save" size="sm" onClick={handleSave} disabled={saving}>
+          <Button data-testid="scope-policy-save" size="sm" onClick={handleSave} disabled={saving || !isDirty}>
             {saving && <Loader2 className="h-4 w-4 animate-spin mr-1" />}
             Save Policies
           </Button>

--- a/src/renderer/components/settings/settings-page.tsx
+++ b/src/renderer/components/settings/settings-page.tsx
@@ -56,6 +56,28 @@ export function useHideSettingsHeader(hidden: boolean): void {
   }, [setHidden, hidden])
 }
 
+/**
+ * Lets the active section drop the default 720px content cap and use the full
+ * inset width — for sub-views (like the connection detail page) that lay out
+ * their own wide, centered content.
+ */
+const SettingsPageContentWidthContext = React.createContext<
+  ((fullWidth: boolean) => void) | null
+>(null)
+
+/**
+ * Call from inside a section to make the SettingsPage content area full-width
+ * for as long as the component is mounted with `fullWidth === true`.
+ */
+export function useFullWidthSettingsContent(fullWidth: boolean): void {
+  const setFullWidth = React.useContext(SettingsPageContentWidthContext)
+  React.useEffect(() => {
+    if (!setFullWidth) return
+    setFullWidth(fullWidth)
+    return () => setFullWidth(false)
+  }, [setFullWidth, fullWidth])
+}
+
 interface SettingsPageProps {
   groups: SettingsPageSectionGroup[]
   initialSection?: string
@@ -120,10 +142,12 @@ function SettingsPageContent({
   const needsTrafficLightPadding = isElectron() && getPlatform() === 'darwin' && !isFullScreen
 
   const [headerHidden, setHeaderHidden] = React.useState(false)
-  // Reset header visibility whenever the active section changes so a hide
-  // from one section doesn't leak into the next.
+  const [contentFullWidth, setContentFullWidth] = React.useState(false)
+  // Reset header visibility / width override whenever the active section changes
+  // so a setting from one section doesn't leak into the next.
   React.useEffect(() => {
     setHeaderHidden(false)
+    setContentFullWidth(false)
   }, [active])
 
   if (isMobile) {
@@ -228,7 +252,7 @@ function SettingsPageContent({
       </Sidebar>
       <SidebarInset className="min-w-0">
         <div className="h-12 shrink-0 app-drag-region" />
-        <SettingsPageContainer>
+        <SettingsPageContainer fullWidth={contentFullWidth}>
           {!headerHidden && (
             <PageTitle
               title={activeSection?.label ?? 'Settings'}
@@ -236,7 +260,9 @@ function SettingsPageContent({
             />
           )}
           <SettingsPageHeaderContext.Provider value={setHeaderHidden}>
-            {activeSection?.render()}
+            <SettingsPageContentWidthContext.Provider value={setContentFullWidth}>
+              {activeSection?.render()}
+            </SettingsPageContentWidthContext.Provider>
           </SettingsPageHeaderContext.Provider>
         </SettingsPageContainer>
       </SidebarInset>

--- a/src/renderer/components/settings/settings-page.tsx
+++ b/src/renderer/components/settings/settings-page.tsx
@@ -34,6 +34,28 @@ export interface SettingsPageSectionGroup {
   sections: SettingsPageSection[]
 }
 
+/**
+ * Lets the active section suppress the default SettingsPage header (title +
+ * actions) — useful when the section is showing a sub-view that wants to own
+ * its own header (e.g. a detail page with a back button).
+ */
+const SettingsPageHeaderContext = React.createContext<
+  ((hidden: boolean) => void) | null
+>(null)
+
+/**
+ * Call from inside a section to hide the SettingsPage's PageTitle + actions
+ * for as long as the component is mounted with `hidden === true`.
+ */
+export function useHideSettingsHeader(hidden: boolean): void {
+  const setHidden = React.useContext(SettingsPageHeaderContext)
+  React.useEffect(() => {
+    if (!setHidden) return
+    setHidden(hidden)
+    return () => setHidden(false)
+  }, [setHidden, hidden])
+}
+
 interface SettingsPageProps {
   groups: SettingsPageSectionGroup[]
   initialSection?: string
@@ -96,6 +118,13 @@ function SettingsPageContent({
   const activeSection = allSections.find((s) => s.id === active)
   const isFullScreen = useFullScreen()
   const needsTrafficLightPadding = isElectron() && getPlatform() === 'darwin' && !isFullScreen
+
+  const [headerHidden, setHeaderHidden] = React.useState(false)
+  // Reset header visibility whenever the active section changes so a hide
+  // from one section doesn't leak into the next.
+  React.useEffect(() => {
+    setHeaderHidden(false)
+  }, [active])
 
   if (isMobile) {
     if (mobileView === 'menu') {
@@ -200,11 +229,15 @@ function SettingsPageContent({
       <SidebarInset className="min-w-0">
         <div className="h-12 shrink-0 app-drag-region" />
         <SettingsPageContainer>
-          <PageTitle
-            title={activeSection?.label ?? 'Settings'}
-            actions={activeSection?.headerActions}
-          />
-          {activeSection?.render()}
+          {!headerHidden && (
+            <PageTitle
+              title={activeSection?.label ?? 'Settings'}
+              actions={activeSection?.headerActions}
+            />
+          )}
+          <SettingsPageHeaderContext.Provider value={setHeaderHidden}>
+            {activeSection?.render()}
+          </SettingsPageHeaderContext.Provider>
         </SettingsPageContainer>
       </SidebarInset>
     </>

--- a/src/renderer/components/settings/tool-policy-editor.test.tsx
+++ b/src/renderer/components/settings/tool-policy-editor.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ToolPolicyEditor } from './tool-policy-editor'
+import { renderWithProviders, screen, waitFor, within } from '@renderer/test/test-utils'
+
+// Route apiFetch: GET returns the configured policies fixture; PUT captures its body.
+let policiesFixture: Array<{ toolName: string; decision: string }> = []
+let lastPutBody: { policies: Array<{ toolName: string; decision: string }> } | null = null
+
+const mockApiFetch = vi.fn((url: string, opts?: { method?: string; body?: string }) => {
+  if (opts?.method === 'PUT') {
+    lastPutBody = JSON.parse(opts.body as string)
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) })
+  }
+  return Promise.resolve({ ok: true, json: () => Promise.resolve({ policies: policiesFixture }) })
+})
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...(args as [string, never])),
+}))
+
+const TOOLS = [
+  { name: 'search', description: 'Search the index' },
+  { name: 'send', description: 'Send a message' },
+]
+
+const toolToggle = (tool: string, decision: 'allow' | 'review' | 'block') =>
+  within(screen.getByTestId(`tool-row-${tool}`)).getByTestId(`policy-toggle-${decision}`)
+
+const renderEditor = (mcpId: string) =>
+  renderWithProviders(
+    <ToolPolicyEditor mcpId={mcpId} mcpName="Test MCP" tools={TOOLS} open onOpenChange={() => {}} />,
+  )
+
+describe('ToolPolicyEditor — Save enable/disable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    policiesFixture = []
+    lastPutBody = null
+  })
+
+  it('disables Save for a configured MCP until a change is made', async () => {
+    // Already configured → the form matches what's persisted, so nothing to save.
+    policiesFixture = [{ toolName: 'send', decision: 'block' }]
+    renderEditor('mcp-1')
+    await waitFor(() => expect(screen.getByTestId('tool-row-send')).toBeInTheDocument())
+
+    expect(screen.getByTestId('tool-policy-save')).toBeDisabled()
+
+    // Flip a per-tool policy — now the editor differs from what's persisted.
+    toolToggle('search', 'allow').click()
+    await waitFor(() => expect(screen.getByTestId('tool-policy-save')).toBeEnabled())
+  })
+
+  it('disables Save on load for a fresh MCP (no baseline, nothing to save)', async () => {
+    // Unlike the scope editor, the tool editor pre-fills nothing, so a brand-new
+    // MCP starts all-default → there is genuinely nothing to save yet.
+    policiesFixture = []
+    renderEditor('mcp-2')
+    await waitFor(() => expect(screen.getByTestId('tool-row-send')).toBeInTheDocument())
+
+    expect(screen.getByTestId('tool-policy-save')).toBeDisabled()
+
+    toolToggle('send', 'block').click()
+    await waitFor(() => expect(screen.getByTestId('tool-policy-save')).toBeEnabled())
+  })
+
+  it('re-disables Save after a successful save', async () => {
+    policiesFixture = [{ toolName: 'send', decision: 'block' }]
+    renderEditor('mcp-3')
+    await waitFor(() => expect(screen.getByTestId('tool-row-send')).toBeInTheDocument())
+
+    toolToggle('search', 'allow').click()
+    await waitFor(() => expect(screen.getByTestId('tool-policy-save')).toBeEnabled())
+
+    screen.getByTestId('tool-policy-save').click()
+    await waitFor(() => expect(lastPutBody).not.toBeNull())
+    // The just-saved state is now the persisted baseline → nothing left to save.
+    await waitFor(() => expect(screen.getByTestId('tool-policy-save')).toBeDisabled())
+  })
+
+  it('disables Save again when a change is reverted by hand', async () => {
+    policiesFixture = []
+    renderEditor('mcp-4')
+    await waitFor(() => expect(screen.getByTestId('tool-row-send')).toBeInTheDocument())
+
+    // Set then unset the same toggle → back to the persisted (empty) state.
+    toolToggle('search', 'allow').click()
+    await waitFor(() => expect(screen.getByTestId('tool-policy-save')).toBeEnabled())
+    toolToggle('search', 'allow').click() // clicking the active option resets to default
+    await waitFor(() => expect(screen.getByTestId('tool-policy-save')).toBeDisabled())
+  })
+})

--- a/src/renderer/components/settings/tool-policy-editor.tsx
+++ b/src/renderer/components/settings/tool-policy-editor.tsx
@@ -28,6 +28,17 @@ interface ToolPolicy {
   decision: PolicyDecision
 }
 
+/**
+ * Stable string form of the non-default policy entries, used to detect whether
+ * the editor has unsaved changes. Defaults are dropped (they're never written)
+ * and entries are sorted so order doesn't affect the comparison.
+ */
+function serializePolicies(entries: Iterable<readonly [string, string]>): string {
+  return JSON.stringify(
+    [...entries].filter(([, decision]) => decision !== 'default').sort(([a], [b]) => a.localeCompare(b)),
+  )
+}
+
 interface ToolPolicyEditorBodyProps {
   mcpId: string
   tools: Array<{ name: string; description?: string }>
@@ -53,6 +64,8 @@ export function ToolPolicyEditorBody({
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [fetchError, setFetchError] = useState<string | null>(null)
+  // Snapshot of the persisted (non-default) policies, for dirty detection.
+  const [savedSnapshot, setSavedSnapshot] = useState('')
   const [textFilter, setTextFilter] = useState('')
   const [decisionFilter, setDecisionFilter] = useState<'all' | PolicyDecision>('all')
 
@@ -75,12 +88,14 @@ export function ToolPolicyEditorBody({
           decision: existing.get(tool.name) ?? 'default',
         }))
         setPolicies(toolPolicies)
+        setSavedSnapshot(serializePolicies(existing))
         setLoading(false)
       })
       .catch((err) => {
         console.error('Failed to fetch tool policies:', err)
         setFetchError('Failed to load policies. Showing defaults.')
         setPolicies(tools.map((tool) => ({ toolName: tool.name, decision: 'default' })))
+        setSavedSnapshot('[]')
         setLoading(false)
       })
   }, [mcpId, tools])
@@ -100,18 +115,28 @@ export function ToolPolicyEditorBody({
     })
   }, [policies, textFilter, decisionFilter, tools])
 
+  // The non-default policies that a Save would write, keyed by tool name.
+  const currentBatch = useMemo(() => {
+    const batch = new Map<string, 'allow' | 'review' | 'block'>()
+    if (mcpDefault !== 'default') {
+      batch.set('*', mcpDefault as 'allow' | 'review' | 'block')
+    }
+    for (const p of policies) {
+      if (p.decision !== 'default') {
+        batch.set(p.toolName, p.decision as 'allow' | 'review' | 'block')
+      }
+    }
+    return batch
+  }, [mcpDefault, policies])
+
+  const currentSnapshot = useMemo(() => serializePolicies(currentBatch), [currentBatch])
+  // Save is only meaningful when the editor differs from what's persisted.
+  const isDirty = currentSnapshot !== savedSnapshot
+
   const handleSave = async () => {
     setSaving(true)
     try {
-      const batch: Array<{ toolName: string; decision: 'allow' | 'review' | 'block' }> = []
-      if (mcpDefault !== 'default') {
-        batch.push({ toolName: '*', decision: mcpDefault as 'allow' | 'review' | 'block' })
-      }
-      for (const p of policies) {
-        if (p.decision !== 'default') {
-          batch.push({ toolName: p.toolName, decision: p.decision as 'allow' | 'review' | 'block' })
-        }
-      }
+      const batch = [...currentBatch.entries()].map(([toolName, decision]) => ({ toolName, decision }))
 
       await apiFetch(`/api/policies/tool/${mcpId}`, {
         method: 'PUT',
@@ -119,6 +144,7 @@ export function ToolPolicyEditorBody({
         body: JSON.stringify({ policies: batch }),
       })
       queryClient.invalidateQueries({ queryKey: ['tool-policies', mcpId] })
+      setSavedSnapshot(currentSnapshot)
       onSaved?.()
     } catch (error) {
       console.error('Failed to save policies:', error)
@@ -212,6 +238,7 @@ export function ToolPolicyEditorBody({
               return (
                 <div
                   key={p.toolName}
+                  data-testid={`tool-row-${p.toolName}`}
                   className="flex items-center justify-between rounded border px-2 py-1.5"
                 >
                   <div className="flex-1 min-w-0 mr-2">
@@ -236,13 +263,13 @@ export function ToolPolicyEditorBody({
       </div>
 
       {!hideActions && (
-        <div className="flex justify-end gap-2 pt-2 border-t">
+        <div className="flex justify-end gap-2 pt-2">
           {onCancel && (
             <Button variant="outline" size="sm" onClick={onCancel}>
               Cancel
             </Button>
           )}
-          <Button size="sm" onClick={handleSave} disabled={saving}>
+          <Button data-testid="tool-policy-save" size="sm" onClick={handleSave} disabled={saving || !isDirty}>
             {saving && <Loader2 className="h-4 w-4 animate-spin mr-1" />}
             Save Policies
           </Button>


### PR DESCRIPTION
## Summary
Third of 3 PRs splitting #171 — the actual user-facing redesign. Stacked on
#1 (primitives) and #2 (editor panels); the diff here is just the list restyle
and the new detail page.

**List view**
- Group the two default policies into one bordered "Default Policies" card with
  compact toggles and clearer fallback copy.
- Sort connections A→Z; surface "Used by N agents" / "Not in use" and a compact
  timestamp inline in the subtitle; reveal a right chevron on hover.
- Drop the per-row Protected / Agents dropdown pills — the row now opens the
  detail page instead.

**Detail page (`ConnectionDetailPage`)**
- Clicking a row opens a dedicated view that hides the SettingsPage header (via
  `useHideSettingsHeader`) and breaks out to a two-column layout: agents with /
  without access, and the scope/tool policy editor inline.
- Header shows the connection icon, name and timestamp, with Rename / Delete
  (and Reconnect for expired OAuth) as buttons.

## Test plan
- [ ] Settings → Connections: two default-policy rows render in one bordered
      card; toggles persist. Rows sorted A→Z; subtitle shows agent count +
      compact timestamp; right chevron fades in on hover.
- [ ] Click a row → detail page appears; the "Connections" page header +
      "+ New connection" button are hidden; two columns at desktop width.
- [ ] Toggle an agent's access in the Agents column; the row jumps between
      With Access / Without Access.
- [ ] Change a scope/tool policy and Save; verify persistence.
- [ ] Rename and Delete from the header work; reconnect appears for an expired
      OAuth account.
- [ ] Back chevron / "Connections" breadcrumb restores the list + global header.
- [ ] The per-agent Connections tab (Agent → Connections) still uses the dialog
      editors and renders normally.
- [x] `npm run typecheck && npm run lint` pass (verified locally).

> Note: the detail page is desktop-focused (`lg:` layout). On mobile
> `useHideSettingsHeader` is a deliberate no-op (the mobile top bar stays).

> Stacked PR 3 of 3 · `connections/detail-page` → `connections/editor-panels`.
> Review/merge after #1 and #2; the base retargets up the stack as they land.

🤖 Split out from #171 with Claude Code.
