### PR TITLE
feat(renderer): global mutation/query error handling — Sentry report + default error toast

### DIFF
--- a/src/renderer/components/agents/settings/access-tab.tsx
+++ b/src/renderer/components/agents/settings/access-tab.tsx
@@ -74,6 +74,7 @@ export function AccessTab({ agentSlug }: AccessTabProps) {
 
   // Invite user
   const inviteUser = useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ userId, role }: { userId: string; role: AgentRole }) => {
       const res = await apiFetch(`/api/agents/${agentSlug}/access`, {
         method: 'POST',
@@ -99,6 +100,7 @@ export function AccessTab({ agentSlug }: AccessTabProps) {
 
   // Change role
   const changeRole = useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ userId, role }: { userId: string; role: AgentRole }) => {
       const res = await apiFetch(`/api/agents/${agentSlug}/access/${userId}`, {
         method: 'PATCH',
@@ -120,6 +122,7 @@ export function AccessTab({ agentSlug }: AccessTabProps) {
 
   // Remove access
   const removeAccess = useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (userId: string) => {
       const res = await apiFetch(`/api/agents/${agentSlug}/access/${userId}`, {
         method: 'DELETE',

--- a/src/renderer/components/agents/settings/x-agent-policies-tab.tsx
+++ b/src/renderer/components/agents/settings/x-agent-policies-tab.tsx
@@ -83,6 +83,7 @@ export function XAgentPoliciesTab({ agentSlug }: XAgentPoliciesTabProps) {
 
   // Single mutation: build the full policy set with the change applied, PUT it.
   const savePolicies = useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (params: {
       operation: Operation
       targetSlug: string | null

--- a/src/renderer/hooks/use-agent-preferences.ts
+++ b/src/renderer/hooks/use-agent-preferences.ts
@@ -21,6 +21,7 @@ type AgentPreferencesUpdate = {
 export function useUpdateAgentPreferences(agentSlug: string) {
   const queryClient = useQueryClient()
   return useMutation<AgentPreferences, Error, AgentPreferencesUpdate>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (data) => {
       const res = await apiFetch(`/api/agents/${agentSlug}/preferences`, {
         method: 'PUT',

--- a/src/renderer/hooks/use-agent-skills.ts
+++ b/src/renderer/hooks/use-agent-skills.ts
@@ -157,6 +157,7 @@ export function useCreateSkillPR() {
     Error,
     { agentSlug: string; skillDir: string; title: string; body: string; newVersion?: string }
   >({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ agentSlug, skillDir, title, body, newVersion }) => {
       const res = await apiFetch(`/api/agents/${encodeURIComponent(agentSlug)}/skills/${encodeURIComponent(skillDir)}/create-pr`, {
         method: 'POST',
@@ -221,6 +222,7 @@ export function usePublishSkill() {
       newVersion?: string
     }
   >({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ agentSlug, skillDir, skillsetId, title, body, newVersion }) => {
       const res = await apiFetch(`/api/agents/${encodeURIComponent(agentSlug)}/skills/${encodeURIComponent(skillDir)}/publish`, {
         method: 'POST',
@@ -242,6 +244,7 @@ export function usePublishSkill() {
 
 export function useExportSkill() {
   return useMutation<void, Error, { agentSlug: string; skillDir: string; skillName: string }>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ agentSlug, skillDir, skillName }) => {
       const res = await apiFetch(
         `/api/agents/${encodeURIComponent(agentSlug)}/skills/${encodeURIComponent(skillDir)}/export`,
@@ -264,6 +267,7 @@ export function useImportSkillZip() {
     Error,
     { agentSlug: string; file: File }
   >({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ agentSlug, file }) => {
       const formData = new FormData()
       formData.append('file', file)

--- a/src/renderer/hooks/use-agent-templates.ts
+++ b/src/renderer/hooks/use-agent-templates.ts
@@ -105,6 +105,7 @@ export function useImportAgentTemplate() {
     Error,
     { file: File; mode?: 'template' | 'full'; onProgress?: (p: ImportProgress) => void }
   >({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ file, mode, onProgress }) => {
       if (file.size <= CHUNK_SIZE) {
         // Small file — single request (existing behavior)
@@ -184,6 +185,7 @@ export function useInstallAgentFromSkillset() {
       agentVersion: string
     }
   >({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ skillsetId, agentPath, agentName, agentVersion }) => {
       const res = await apiFetch('/api/agents/install-from-skillset', {
         method: 'POST',
@@ -275,6 +277,7 @@ export function useRefreshAgentTemplateStatus() {
     Error,
     { agentSlug: string }
   >({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ agentSlug }) => {
       const res = await apiFetch(`/api/agents/${encodeURIComponent(agentSlug)}/template-refresh`, {
         method: 'POST',
@@ -356,6 +359,7 @@ export function useCreateAgentTemplatePR() {
     Error,
     { agentSlug: string; title: string; body: string; newVersion?: string }
   >({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ agentSlug, title, body, newVersion }) => {
       const res = await apiFetch(`/api/agents/${encodeURIComponent(agentSlug)}/template-create-pr`, {
         method: 'POST',
@@ -417,6 +421,7 @@ export function usePublishAgentTemplate() {
       newVersion?: string
     }
   >({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ agentSlug, skillsetId, title, body, newVersion }) => {
       const res = await apiFetch(`/api/agents/${encodeURIComponent(agentSlug)}/template-publish`, {
         method: 'POST',

--- a/src/renderer/hooks/use-agents.ts
+++ b/src/renderer/hooks/use-agents.ts
@@ -37,6 +37,7 @@ export function useCreateAgent() {
   const queryClient = useQueryClient()
 
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (data: { name: string; description?: string }) => {
       const res = await apiFetch('/api/agents', {
         method: 'POST',
@@ -62,6 +63,7 @@ export function useDeleteAgent() {
   const queryClient = useQueryClient()
 
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (slug: string) => {
       const res = await apiFetch(`/api/agents/${slug}`, { method: 'DELETE' })
       if (!res.ok) {
@@ -125,6 +127,7 @@ export function useStartAgent() {
   const { track } = useAnalyticsTracking()
 
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (slug: string) => {
       const res = await apiFetch(`/api/agents/${slug}/start`, { method: 'POST' })
       if (!res.ok) {

--- a/src/renderer/hooks/use-chat-integrations.ts
+++ b/src/renderer/hooks/use-chat-integrations.ts
@@ -110,6 +110,7 @@ export function useCreateChatIntegration() {
   const queryClient = useQueryClient()
 
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (params: {
       agentSlug: string
       provider: ChatProvider
@@ -155,6 +156,7 @@ export function useUpdateChatIntegration() {
   const queryClient = useQueryClient()
 
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({
       id,
       ...params
@@ -209,6 +211,7 @@ export function useClearChatSession() {
   const queryClient = useQueryClient()
 
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ integrationId, sessionId }: { integrationId: string; sessionId: string }) => {
       const res = await apiFetch(`/api/chat-integrations/${integrationId}/sessions/${sessionId}`, {
         method: 'DELETE',
@@ -227,6 +230,7 @@ export function useClearChatSession() {
 
 export function useTestChatIntegrationCredentials() {
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (params: {
       provider: ChatProvider
       config: Record<string, unknown>

--- a/src/renderer/hooks/use-connected-accounts.ts
+++ b/src/renderer/hooks/use-connected-accounts.ts
@@ -81,6 +81,7 @@ export function useInitiateConnection() {
   const { track } = useAnalyticsTracking()
 
   return useMutation<InitiateConnectionResponse, Error, { providerSlug: string; electron?: boolean; location?: string }>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ providerSlug, electron }) => {
       const res = await apiFetch('/api/connected-accounts/initiate', {
         method: 'POST',
@@ -108,6 +109,7 @@ export function useDeleteConnectedAccount() {
   const queryClient = useQueryClient()
 
   return useMutation<void, Error, string>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (accountId) => {
       const res = await apiFetch(`/api/connected-accounts/${accountId}`, {
         method: 'DELETE',
@@ -134,6 +136,7 @@ export function useRenameConnectedAccount() {
   const queryClient = useQueryClient()
 
   return useMutation<ConnectedAccount, Error, { accountId: string; displayName: string }>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ accountId, displayName }) => {
       const res = await apiFetch(`/api/connected-accounts/${accountId}`, {
         method: 'PATCH',
@@ -163,6 +166,7 @@ export function useAssignAccountsToAgent() {
   const queryClient = useQueryClient()
 
   return useMutation<void, Error, { agentSlug: string; accountIds: string[] }>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ agentSlug, accountIds }) => {
       const res = await apiFetch(`/api/agents/${agentSlug}/connected-accounts`, {
         method: 'POST',
@@ -191,6 +195,7 @@ export function useRemoveAgentConnectedAccount() {
   const queryClient = useQueryClient()
 
   return useMutation<void, Error, { agentSlug: string; accountId: string }>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ agentSlug, accountId }) => {
       const res = await apiFetch(`/api/agents/${agentSlug}/connected-accounts/${accountId}`, {
         method: 'DELETE',

--- a/src/renderer/hooks/use-notifications.ts
+++ b/src/renderer/hooks/use-notifications.ts
@@ -47,6 +47,7 @@ export function useMarkNotificationRead() {
   const queryClient = useQueryClient()
 
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (notificationId: string) => {
       const res = await apiFetch(`/api/notifications/${notificationId}/read`, {
         method: 'POST',
@@ -67,6 +68,7 @@ export function useMarkAllNotificationsRead() {
   const queryClient = useQueryClient()
 
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async () => {
       const res = await apiFetch('/api/notifications/read-all', {
         method: 'POST',
@@ -87,6 +89,7 @@ export function useMarkSessionNotificationsRead() {
   const queryClient = useQueryClient()
 
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (sessionId: string) => {
       const res = await apiFetch(`/api/notifications/read-by-session/${sessionId}`, {
         method: 'POST',

--- a/src/renderer/hooks/use-platform-auth.ts
+++ b/src/renderer/hooks/use-platform-auth.ts
@@ -63,6 +63,7 @@ export function usePlatformAuthStatus() {
 
 function useInitiatePlatformLogin() {
   return useMutation<{ loginUrl: string; platformBaseUrl: string }, Error>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async () => {
       const res = await apiFetch('/api/platform-auth/initiate', {
         method: 'POST',
@@ -78,6 +79,7 @@ function useInitiatePlatformLogin() {
 
 function useRevokePlatformToken() {
   return useMutation<{ success: boolean }, Error, { clearLocal?: boolean } | undefined>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (options) => {
       const res = await apiFetch('/api/platform-auth/revoke', {
         method: 'POST',
@@ -140,6 +142,7 @@ export function useSavePlatformAccessKey() {
   const applyPlatformDefaults = useApplyPlatformDefaults()
 
   return useMutation<unknown, Error, string>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (token: string) => {
       const res = await apiFetch('/api/platform-auth/complete', {
         method: 'POST',

--- a/src/renderer/hooks/use-remote-mcps.ts
+++ b/src/renderer/hooks/use-remote-mcps.ts
@@ -61,6 +61,7 @@ export function useAddRemoteMcp() {
     Error,
     { name: string; url: string; authType?: string; accessToken?: string }
   >({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (data) => {
       const res = await apiFetch('/api/remote-mcps', {
         method: 'POST',
@@ -86,6 +87,7 @@ export function useRenameRemoteMcp() {
   const queryClient = useQueryClient()
 
   return useMutation<void, Error, { mcpId: string; name: string }>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ mcpId, name }) => {
       const res = await apiFetch(`/api/remote-mcps/${mcpId}`, {
         method: 'PATCH',
@@ -112,6 +114,7 @@ export function useDeleteRemoteMcp() {
   const queryClient = useQueryClient()
 
   return useMutation<void, Error, string>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (id) => {
       const res = await apiFetch(`/api/remote-mcps/${id}`, {
         method: 'DELETE',
@@ -137,6 +140,7 @@ export function useAssignMcpToAgent() {
   const queryClient = useQueryClient()
 
   return useMutation<void, Error, { agentSlug: string; mcpIds: string[] }>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ agentSlug, mcpIds }) => {
       const res = await apiFetch(`/api/agents/${agentSlug}/remote-mcps`, {
         method: 'POST',
@@ -164,6 +168,7 @@ export function useRemoveMcpFromAgent() {
   const queryClient = useQueryClient()
 
   return useMutation<void, Error, { agentSlug: string; mcpId: string }>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ agentSlug, mcpId }) => {
       const res = await apiFetch(`/api/agents/${agentSlug}/remote-mcps/${mcpId}`, {
         method: 'DELETE',
@@ -206,6 +211,7 @@ export function useDiscoverMcpTools() {
     Error,
     string
   >({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (mcpId) => {
       const res = await apiFetch(`/api/remote-mcps/${mcpId}/discover-tools`, {
         method: 'POST',
@@ -230,6 +236,7 @@ export function useTestMcpConnection() {
   const queryClient = useQueryClient()
 
   return useMutation<{ success: boolean; error?: string; needsAuth?: boolean }, Error, string>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (mcpId) => {
       const res = await apiFetch(`/api/remote-mcps/${mcpId}/test-connection`, {
         method: 'POST',
@@ -263,6 +270,7 @@ export function useInvalidateRemoteMcps() {
  */
 export function useInitiateMcpOAuth() {
   return useMutation<{ redirectUrl: string; state: string }, Error, { mcpId?: string; name?: string; url?: string; electron?: boolean; clientName?: string; clientId?: string; clientSecret?: string }>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (data) => {
       const res = await apiFetch('/api/remote-mcps/initiate-oauth', {
         method: 'POST',

--- a/src/renderer/hooks/use-rename-untitled-agent.ts
+++ b/src/renderer/hooks/use-rename-untitled-agent.ts
@@ -15,6 +15,7 @@ import type { ApiAgent } from '@shared/lib/types/api'
 export function useRenameUntitledAgent() {
   const queryClient = useQueryClient()
   return useMutation<ApiAgent | null, Error, { slug: string; prompt: string }>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ slug, prompt }) => {
       const name = await deriveAgentName(prompt)
       if (!name) return null

--- a/src/renderer/hooks/use-scheduled-tasks.ts
+++ b/src/renderer/hooks/use-scheduled-tasks.ts
@@ -150,6 +150,7 @@ export function useRunScheduledTaskNow() {
  */
 export function useDescribeSchedule() {
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ taskId }: { taskId: string }) => {
       const res = await apiFetch(`/api/scheduled-tasks/${taskId}/describe-schedule`, {
         method: 'POST',
@@ -165,6 +166,7 @@ export function useDescribeSchedule() {
  */
 export function useParseSchedule() {
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ taskId, description }: { taskId: string; description: string }) => {
       const res = await apiFetch(`/api/scheduled-tasks/${taskId}/parse-schedule`, {
         method: 'POST',
@@ -187,6 +189,7 @@ export function useUpdateScheduledTaskPrompt() {
   const queryClient = useQueryClient()
 
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ taskId, prompt }: { taskId: string; agentSlug: string; prompt: string }) => {
       const res = await apiFetch(`/api/scheduled-tasks/${taskId}/prompt`, {
         method: 'PATCH',

--- a/src/renderer/hooks/use-secrets.ts
+++ b/src/renderer/hooks/use-secrets.ts
@@ -23,6 +23,7 @@ export function useCreateSecret() {
   const { track } = useAnalyticsTracking()
 
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({
       agentSlug,
       key,

--- a/src/renderer/hooks/use-settings.ts
+++ b/src/renderer/hooks/use-settings.ts
@@ -133,6 +133,7 @@ export function useRefreshAvailability() {
   const queryClient = useQueryClient()
 
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async () => {
       const res = await apiFetch('/api/settings/refresh-availability', {
         method: 'POST',
@@ -150,6 +151,7 @@ export function useStartRunner() {
   const queryClient = useQueryClient()
 
   return useMutation<StartRunnerResponse, Error, string>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (runner) => {
       const res = await apiFetch('/api/settings/start-runner', {
         method: 'POST',
@@ -178,6 +180,7 @@ export function useRestartRunner() {
   const queryClient = useQueryClient()
 
   return useMutation<StartRunnerResponse, Error, string>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (runner) => {
       // Immediately invalidate so the next poll sees the runner as stopped
       queryClient.invalidateQueries({ queryKey: ['settings'] })

--- a/src/renderer/hooks/use-skill-files.ts
+++ b/src/renderer/hooks/use-skill-files.ts
@@ -44,6 +44,7 @@ export function useSaveSkillFile() {
     Error,
     { agentSlug: string; skillDir: string; filePath: string; content: string }
   >({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ agentSlug, skillDir, filePath, content }) => {
       const res = await apiFetch(
         `/api/agents/${encodeURIComponent(agentSlug)}/skills/${encodeURIComponent(skillDir)}/files/content`,

--- a/src/renderer/hooks/use-skillsets.ts
+++ b/src/renderer/hooks/use-skillsets.ts
@@ -21,6 +21,7 @@ export function useValidateSkillset() {
     Error,
     string
   >({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (url: string) => {
       const res = await apiFetch('/api/skillsets/validate', {
         method: 'POST',
@@ -36,6 +37,7 @@ export function useAddSkillset() {
   const queryClient = useQueryClient()
 
   return useMutation<ApiSkillsetConfig, Error, string>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (url: string) => {
       const res = await apiFetch('/api/skillsets', {
         method: 'POST',

--- a/src/renderer/hooks/use-user-settings.ts
+++ b/src/renderer/hooks/use-user-settings.ts
@@ -19,6 +19,7 @@ export function useUpdateUserSettings() {
   const queryClient = useQueryClient()
 
   return useMutation<UserSettingsData, Error, Partial<UserSettingsData>>({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async (data) => {
       const res = await apiFetch('/api/user-settings', {
         method: 'PUT',

--- a/src/renderer/hooks/use-webhook-triggers.ts
+++ b/src/renderer/hooks/use-webhook-triggers.ts
@@ -59,6 +59,7 @@ export function useUpdateWebhookTriggerPrompt() {
   const queryClient = useQueryClient()
 
   return useMutation({
+    meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ triggerId, prompt }: { triggerId: string; agentSlug: string; prompt: string }) => {
       const res = await apiFetch(`/api/webhook-triggers/${triggerId}/prompt`, {
         method: 'PATCH',

--- a/src/renderer/lib/query-client.test.ts
+++ b/src/renderer/lib/query-client.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CancelledError } from '@tanstack/react-query'
+
+// Mock the toast + Sentry sinks so we can assert on them.
+const { mockToastError } = vi.hoisted(() => ({ mockToastError: vi.fn() }))
+vi.mock('sonner', () => ({ toast: { error: mockToastError } }))
+
+const { mockCapture } = vi.hoisted(() => ({ mockCapture: vi.fn() }))
+vi.mock('./error-reporting', () => ({ captureRendererException: mockCapture }))
+
+import { handleMutationError, handleQueryError, createAppQueryClient } from './query-client'
+
+beforeEach(() => {
+  mockToastError.mockClear()
+  mockCapture.mockClear()
+})
+
+describe('handleMutationError', () => {
+  it('reports to Sentry and toasts the error message by default', () => {
+    handleMutationError(new Error('boom'))
+    expect(mockCapture).toHaveBeenCalledTimes(1)
+    expect(mockCapture.mock.calls[0][1]).toMatchObject({ tags: { source: 'mutation' } })
+    expect(mockToastError).toHaveBeenCalledWith('boom')
+  })
+
+  it('skips the toast (but still reports) when skipGlobalErrorToast is set', () => {
+    handleMutationError(new Error('boom'), { skipGlobalErrorToast: true })
+    expect(mockCapture).toHaveBeenCalledTimes(1)
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
+  it('uses meta.errorMessage as the toast text when provided', () => {
+    handleMutationError(new Error('raw server detail'), { errorMessage: 'Friendly message' })
+    expect(mockToastError).toHaveBeenCalledWith('Friendly message')
+  })
+
+  it('falls back to a generic message for a non-Error / empty value', () => {
+    handleMutationError(undefined)
+    expect(mockToastError).toHaveBeenCalledWith('Something went wrong. Please try again.')
+  })
+
+  it('passes through a thrown string', () => {
+    handleMutationError('plain string error')
+    expect(mockToastError).toHaveBeenCalledWith('plain string error')
+  })
+})
+
+describe('handleQueryError', () => {
+  it('reports to Sentry but does NOT toast by default (queries are silent)', () => {
+    handleQueryError(new Error('fetch failed'))
+    expect(mockCapture).toHaveBeenCalledTimes(1)
+    expect(mockCapture.mock.calls[0][1]).toMatchObject({ tags: { source: 'query' } })
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
+  it('toasts when the query opts in via meta.showErrorToast', () => {
+    handleQueryError(new Error('fetch failed'), { showErrorToast: true })
+    expect(mockToastError).toHaveBeenCalledWith('fetch failed')
+  })
+
+  it('ignores a CancelledError entirely (no report, no toast)', () => {
+    handleQueryError(new CancelledError())
+    expect(mockCapture).not.toHaveBeenCalled()
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+})
+
+describe('createAppQueryClient wiring', () => {
+  it('routes mutation cache errors through the mutation handler (report + default toast)', () => {
+    const client = createAppQueryClient()
+    const onError = client.getMutationCache().config.onError
+    expect(onError).toBeTypeOf('function')
+
+    // Simulate a mutation that did NOT opt out. v5 onError args:
+    // (error, variables, onMutateResult, mutation, context).
+    onError?.(new Error('mutate failed'), undefined, undefined, { options: { meta: undefined } } as never, undefined as never)
+    expect(mockCapture).toHaveBeenCalledTimes(1)
+    expect(mockToastError).toHaveBeenCalledWith('mutate failed')
+  })
+
+  it('respects a mutation that opts out of the toast via meta', () => {
+    const client = createAppQueryClient()
+    const onError = client.getMutationCache().config.onError
+
+    onError?.(new Error('silent'), undefined, undefined, { options: { meta: { skipGlobalErrorToast: true } } } as never, undefined as never)
+    expect(mockCapture).toHaveBeenCalledTimes(1)
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
+  it('routes query cache errors through the query handler (report, no default toast)', () => {
+    const client = createAppQueryClient()
+    const onError = client.getQueryCache().config.onError
+    expect(onError).toBeTypeOf('function')
+
+    onError?.(new Error('query failed'), { meta: undefined } as never)
+    expect(mockCapture).toHaveBeenCalledTimes(1)
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/lib/query-client.ts
+++ b/src/renderer/lib/query-client.ts
@@ -1,0 +1,91 @@
+/**
+ * The app's TanStack Query client + global error handling.
+ *
+ * Two cross-cutting concerns are handled once here instead of at every call site:
+ *
+ *  1. Reporting — EVERY mutation and (post-retry) query failure is reported to
+ *     Sentry via the cache-level `onError`. This is the safety net that makes
+ *     silent failures observable, regardless of whether the call site handles
+ *     the error.
+ *
+ *  2. A default error toast for MUTATIONS — discrete, user-initiated actions
+ *     (delete / save / create) should never fail silently. The global handler
+ *     shows `toast.error` by default. Mutations that surface errors themselves
+ *     (inline form errors, a custom toast) or are background/optimistic opt out
+ *     with `meta: { skipGlobalErrorToast: true }` — they are still reported to
+ *     Sentry. A mutation may override the toast text with `meta.errorMessage`.
+ *
+ * Queries are SILENT by default (they retry and usually render inline/empty
+ * states); a query opts INTO a toast with `meta: { showErrorToast: true }`.
+ */
+import { QueryClient, QueryCache, MutationCache, CancelledError } from '@tanstack/react-query'
+import type { MutationMeta, QueryMeta } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { captureRendererException } from './error-reporting'
+
+// Type the meta fields the global handlers read. Augmenting `Register` makes
+// `mutation.options.meta` / `query.meta` strongly typed everywhere.
+declare module '@tanstack/react-query' {
+  interface Register {
+    mutationMeta: {
+      /**
+       * Skip the global default error toast. Use when the mutation surfaces the
+       * error itself (inline form error / its own toast) or is background /
+       * passive / fire-and-forget / optimistic. The error is still reported to
+       * Sentry.
+       */
+      skipGlobalErrorToast?: boolean
+      /** Override the global error toast text for this mutation. */
+      errorMessage?: string
+    }
+    queryMeta: {
+      /** Opt a query INTO a global error toast (queries are silent by default). */
+      showErrorToast?: boolean
+      /** Override the global error toast text for this query. */
+      errorMessage?: string
+    }
+  }
+}
+
+const GENERIC_MESSAGE = 'Something went wrong. Please try again.'
+
+/** Prefer a meaningful Error message (incl. server messages thrown by hooks); fall back to generic. */
+function messageFromError(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message
+  if (typeof error === 'string' && error.trim()) return error
+  return GENERIC_MESSAGE
+}
+
+/** Exported for unit tests. Report to Sentry, then toast unless opted out. */
+export function handleMutationError(error: unknown, meta?: MutationMeta): void {
+  captureRendererException(error, { tags: { source: 'mutation' } })
+  if (meta?.skipGlobalErrorToast) return
+  toast.error(meta?.errorMessage ?? messageFromError(error))
+}
+
+/** Exported for unit tests. Report to Sentry; toast only if the query opted in. */
+export function handleQueryError(error: unknown, meta?: QueryMeta): void {
+  // A cancelled fetch (navigation / unmount / refetch supersede) is not a failure.
+  if (error instanceof CancelledError) return
+  captureRendererException(error, { tags: { source: 'query' } })
+  if (meta?.showErrorToast) toast.error(meta.errorMessage ?? messageFromError(error))
+}
+
+export function createAppQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 5 * 1000,
+        refetchOnWindowFocus: false,
+      },
+    },
+    mutationCache: new MutationCache({
+      // v5 signature: (error, variables, onMutateResult, mutation, context)
+      onError: (error, _variables, _onMutateResult, mutation) =>
+        handleMutationError(error, mutation.options.meta),
+    }),
+    queryCache: new QueryCache({
+      onError: (error, query) => handleQueryError(error, query.meta),
+    }),
+  })
+}

--- a/src/renderer/providers/query-provider.tsx
+++ b/src/renderer/providers/query-provider.tsx
@@ -1,19 +1,12 @@
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { useState } from 'react'
+import { createAppQueryClient } from '@renderer/lib/query-client'
 
 export function QueryProvider({ children }: { children: React.ReactNode }) {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            staleTime: 5 * 1000,
-            refetchOnWindowFocus: false,
-          },
-        },
-      })
-  )
+  // Query defaults + global error handling (Sentry reporting + default mutation
+  // error toast) live in createAppQueryClient — see src/renderer/lib/query-client.ts.
+  const [queryClient] = useState(createAppQueryClient)
 
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>


### PR DESCRIPTION
## Summary

Adds a single global safety net in the TanStack Query client so renderer failures can't be silently swallowed — the class of bug behind the agent-delete no-op (a mutation rejects, the call site only `console.error`s, the user sees nothing). Two cross-cutting concerns, handled once instead of at ~80 call sites:

1. **Sentry reporting** for **every** mutation failure and every (post-retry) query failure.
2. A **default error toast for mutations** (discrete user actions shouldn't fail silently), with a `meta` convention to opt out where a site already surfaces the error or is background/optimistic.

## How it works — `src/renderer/lib/query-client.ts`
`createAppQueryClient()`:
- **`MutationCache.onError`** → `captureRendererException(...)` always, then `toast.error(meta.errorMessage ?? error.message)` **unless** `meta.skipGlobalErrorToast`.
- **`QueryCache.onError`** → `captureRendererException(...)` only. Queries are **silent by default** (they retry + render inline/empty states); opt a query *into* a toast with `meta.showErrorToast`. `CancelledError` (navigation/unmount/superseded refetch) is ignored entirely.
- **`Register` type augmentation** so the `meta` fields are strongly typed everywhere:
  - mutations: `skipGlobalErrorToast?: boolean`, `errorMessage?: string`
  - queries: `showErrorToast?: boolean`, `errorMessage?: string`
- **Reporting is never skipped** — opt-out only suppresses the user-facing toast, not Sentry.

`query-provider.tsx` now uses the factory.

## Opt-out audit (53 mutations, 19 files)
A full classification of every `useMutation` (incl. call-site usage and shared-hook conflicts) marked these `skipGlobalErrorToast` because they **already surface the error** or are **background/passive**:
- **Inline-error dialogs/forms** — skill/template/secret/skillset/platform-key/MCP/chat create·publish·import dialogs, `access-tab`, `x-agent-policies-tab`, runner start/restart (rich remediation panels).
- **Optimistic toggles** whose UI reverts on failure — assign/remove connected-account & MCP grants.
- **Background / high-frequency / fire-and-forget** — notification mark-read (×3), autosave (preferences, user-settings, skill-file-on-keystroke), refresh availability / template-status, auto-rename untitled agent, connectivity tests.
- **`useDeleteAgent`** — its real-delete call sites already `toast.error` the server message (incl. the SUP-209 **409**), so a global toast would double up; the fire-and-forget Untitled-draft cleanup then stays silent.

The ~45 **discrete actions that currently fail silently** keep the default toast — exactly the gap this closes: stop agent, delete/rename session, delete message/tool-call, install/update skill, save/delete secret, export template, cancel/pause/resume task & trigger, update bookmarks, factory reset, etc.

## Relationship to PR #227 (merged)
`#227` added per-site `toast.error` to the two real delete buttons + made `useDeleteAgent` throw the server's message. By opting `useDeleteAgent` **out** here, those keep owning the delete toast (with the nice 409 text) and there's **no double-toast** — no changes to `#227`'s files needed.

## Known minor edge (follow-up, not blocking)
`useUpdateAgent` stays **default-on** so its silent save dialogs (`system-prompt-dialog`, `agent-settings-dialog`) get covered — but the `agent-home` inline rename, which already self-toasts, will double-toast on that one path. Options to resolve later: drop the per-site rename toast, or split the hook. Left as-is to prioritize closing the silent-save gap.

## Validation
- `npx tsc --noEmit` clean (validates all 53 `meta` insertions + the typing across every file); `eslint` clean.
- **45 tests green**: new `query-client.test.ts` (11 — report+toast, opt-out, `errorMessage` override, generic fallback, query silence, opt-in, `CancelledError` skip, cache wiring) + touched suites (`use-agent-automations`, `use-settings`, `app-sidebar`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)