### PR TITLE
test(messages): fix main unit-tests — render real MessageItem under providers in error-boundary test

### DIFF
--- a/src/renderer/components/messages/message-error-boundary.test.tsx
+++ b/src/renderer/components/messages/message-error-boundary.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@renderer/test/test-utils'
 
 const captureRendererException = vi.fn()
 vi.mock('@renderer/lib/error-reporting', () => ({
@@ -99,7 +100,10 @@ describe('MessageErrorBoundary', () => {
       createdAt: new Date(),
     } as unknown as ApiMessage
 
-    render(<MessageItem message={message} sessionId="s1" agentSlug="agent" isSessionActive={false} />)
+    // A real MessageItem now depends on a QueryClient (the insufficient-balance
+    // billing hook calls usePlatformAuthStatus); render under the app providers
+    // so the crash under test is the tool call itself, not a missing provider.
+    renderWithProviders(<MessageItem message={message} sessionId="s1" agentSlug="agent" isSessionActive={false} />)
 
     expect(screen.getByText('Failed to display this tool call')).toBeInTheDocument()
     expect(screen.getByText('Running a command:')).toBeInTheDocument()


### PR DESCRIPTION
## Summary
Unblocks the `unit-tests` job on `main` (currently red — first failed on the PR #200 merge run; every open PR inherits it, e.g. #247).

**Two greens that collide on `main`:** PR #200 ("actionable billing card") added an **unconditional** hook to `MessageItem` (`message-item.tsx:171`):
```ts
const billingUrl = usePlatformBillingUrl(rawText ?? '')   // → usePlatformAuthStatus → useQuery → useQueryClient()
```
The error-boundary test `message-error-boundary.test.tsx` renders a **bare `<MessageItem/>` with no `QueryClientProvider`**, so `useQueryClient()` now throws *"No QueryClient set"* at the MessageItem top level — *above* the per-tool-call boundary — crashing the whole render instead of degrading to the "Failed to display this tool call" box the test asserts. #200 branched before that test existed, so neither PR's own CI caught it.

## Fix
Render the real-MessageItem case via `renderWithProviders` (the existing test-utils `AllProviders`, which wraps `QueryClientProvider` + the app contexts). The other tests render `<Boom/>` directly and are unchanged.

**Intent preserved:** with a QueryClient present, `usePlatformAuthStatus` returns no data → `billingUrl` is null → the billing card isn't rendered → the `Bash` tool call with a non-string `command` still throws in `getSummary().split()` and is caught by the tool-call error boundary.

## Validation
- All 5 tests in `message-error-boundary.test.tsx` pass; `eslint` clean.
- Reproduced the failure on a clean `main` branch beforehand and confirmed this change turns it green.

Once merged, the other open PRs (#247 et al.) just need `main` merged in to clear the same red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)