### PR TITLE
feat: chunked uploads for upload-file + user-visible upload errors

### DIFF
--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -378,9 +378,8 @@ function parseChunkFields(formData: FormData): ParsedChunkFields {
 
 type StoreChunkResult = { status: 'received' } | { status: 'assembled'; buffer: Buffer }
 
-// Persist one chunk; once all chunks are present, assemble them into a single
-// buffer (a `.assembling` lock prevents duplicate assembly from concurrent
-// requests). Shared by import-template and upload-file.
+// Persist one chunk; assemble once all arrive (`.assembling` lock prevents double assembly).
+// TODO(upload-memory): cap total size before reading; stream to disk instead of Buffer.concat.
 async function storeUploadChunk(uploadId: string, chunkIndex: number, totalChunks: number, chunk: Buffer): Promise<StoreChunkResult> {
   const uploadDir = path.join(getTempUploadsDir(), uploadId)
   await ensureDirectory(uploadDir)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -343,67 +343,85 @@ agents.post('/import-template', async (c) => {
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to import template'
     console.error('Failed to import template:', error)
+    captureException(error, { tags: { component: 'agents', operation: 'import-template' } })
     return c.json({ error: message }, 500)
   }
 })
 
-async function handleChunkedImport(c: Context, formData: FormData, chunk: File) {
+type ParsedChunkFields =
+  | { ok: true; uploadId: string; chunkIndex: number; totalChunks: number }
+  | { ok: false; error: string }
+
+// Validate the chunked-upload metadata fields shared by import-template and
+// upload-file. Keeps the three routes thin and the validation in one place.
+function parseChunkFields(formData: FormData): ParsedChunkFields {
   const uploadId = formData.get('uploadId') as string | null
   const chunkIndexStr = formData.get('chunkIndex') as string | null
   const totalChunksStr = formData.get('totalChunks') as string | null
 
   if (!uploadId || chunkIndexStr === null || totalChunksStr === null) {
-    return c.json({ error: 'Missing chunked upload fields: uploadId, chunkIndex, totalChunks' }, 400)
+    return { ok: false, error: 'Missing chunked upload fields: uploadId, chunkIndex, totalChunks' }
   }
-
-  // Validate uploadId format (UUID only — prevent path traversal)
+  // uploadId becomes a directory name — UUID only, prevents path traversal
   if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(uploadId)) {
-    return c.json({ error: 'Invalid uploadId format' }, 400)
+    return { ok: false, error: 'Invalid uploadId format' }
   }
 
   const chunkIndex = parseInt(chunkIndexStr, 10)
   const totalChunks = parseInt(totalChunksStr, 10)
-
   if (isNaN(chunkIndex) || isNaN(totalChunks) || chunkIndex < 0 || totalChunks < 1 || chunkIndex >= totalChunks || totalChunks > 200) {
-    return c.json({ error: 'Invalid chunkIndex or totalChunks' }, 400)
+    return { ok: false, error: 'Invalid chunkIndex or totalChunks' }
   }
 
+  return { ok: true, uploadId, chunkIndex, totalChunks }
+}
+
+type StoreChunkResult = { status: 'received' } | { status: 'assembled'; buffer: Buffer }
+
+// Persist one chunk; once all chunks are present, assemble them into a single
+// buffer (a `.assembling` lock prevents duplicate assembly from concurrent
+// requests). Shared by import-template and upload-file.
+async function storeUploadChunk(uploadId: string, chunkIndex: number, totalChunks: number, chunk: Buffer): Promise<StoreChunkResult> {
   const uploadDir = path.join(getTempUploadsDir(), uploadId)
   await ensureDirectory(uploadDir)
 
-  // Write this chunk to disk
-  const chunkBuffer = Buffer.from(await chunk.arrayBuffer())
-  await fs.promises.writeFile(path.join(uploadDir, `chunk-${chunkIndex}`), chunkBuffer)
+  await fs.promises.writeFile(path.join(uploadDir, `chunk-${chunkIndex}`), chunk)
 
-  // Check if all chunks are present
   const files = await fs.promises.readdir(uploadDir)
   const chunkFiles = files.filter((f) => f.startsWith('chunk-'))
-
   if (chunkFiles.length < totalChunks) {
-    return c.json({ status: 'chunk_received', chunkIndex })
+    return { status: 'received' }
   }
 
-  // Prevent duplicate assembly from concurrent requests
   const lockPath = path.join(uploadDir, '.assembling')
   try {
     await fs.promises.writeFile(lockPath, '', { flag: 'wx' }) // fails if already exists
   } catch {
-    return c.json({ status: 'chunk_received', chunkIndex })
+    return { status: 'received' }
   }
 
-  // All chunks received — assemble and process
   try {
     const buffers: Buffer[] = []
     for (let i = 0; i < totalChunks; i++) {
       buffers.push(await fs.promises.readFile(path.join(uploadDir, `chunk-${i}`)))
     }
-    const zipBuffer = Buffer.concat(buffers)
-
-    return await processImport(c, zipBuffer, formData)
+    return { status: 'assembled', buffer: Buffer.concat(buffers) }
   } finally {
-    // Clean up temp chunks
     try { await removeDirectory(uploadDir) } catch { /* ignore cleanup errors */ }
   }
+}
+
+async function handleChunkedImport(c: Context, formData: FormData, chunk: File) {
+  const parsed = parseChunkFields(formData)
+  if (!parsed.ok) return c.json({ error: parsed.error }, 400)
+
+  const result = await storeUploadChunk(parsed.uploadId, parsed.chunkIndex, parsed.totalChunks, Buffer.from(await chunk.arrayBuffer()))
+
+  if (result.status === 'received') {
+    return c.json({ status: 'chunk_received', chunkIndex: parsed.chunkIndex })
+  }
+
+  return await processImport(c, result.buffer, formData)
 }
 
 async function processImport(c: Context, zipBuffer: Buffer, formData: FormData) {
@@ -3814,10 +3832,8 @@ agents.get('/:id/audit-log', AgentAdmin(), async (c) => {
   }
 })
 
-// Shared upload logic - writes file to agent workspace
-async function handleFileUpload(agentSlug: string, file: File, relativePath?: string) {
-  const filename = file.name
-
+// Shared upload logic - writes a buffer to the agent workspace
+async function writeUploadedFile(agentSlug: string, filename: string, buffer: Buffer, relativePath?: string) {
   // If relativePath is provided (folder upload), preserve directory structure
   let uploadPath: string
   if (relativePath) {
@@ -3835,9 +3851,6 @@ async function handleFileUpload(agentSlug: string, file: File, relativePath?: st
     throw new Error('Invalid file path')
   }
 
-  const arrayBuffer = await file.arrayBuffer()
-  const buffer = Buffer.from(arrayBuffer)
-
   // Write directly to host filesystem (volume-mounted into container)
   await fs.promises.mkdir(path.dirname(fullPath), { recursive: true })
   await fs.promises.writeFile(fullPath, buffer)
@@ -3850,16 +3863,58 @@ async function handleFileUpload(agentSlug: string, file: File, relativePath?: st
   }
 }
 
-// POST /api/agents/:id/upload-file - Upload a file to the agent workspace (no session required)
-agents.post('/:id/upload-file', AgentUser(), async (c) => {
+async function handleFileUpload(agentSlug: string, file: File, relativePath?: string) {
+  const buffer = Buffer.from(await file.arrayBuffer())
+  return writeUploadedFile(agentSlug, file.name, buffer, relativePath)
+}
+
+// Shared by both upload-file routes. When a `chunk` field is present, persist it
+// and only write the final file once every chunk has arrived. Returns
+// `{ pending }` (a Response to return immediately — either a 400 or the interim
+// `chunk_received` ack) or `{ uploadResult }` once the file is fully assembled.
+type ChunkedFileUploadOutcome = {
+  pending: Response | null
+  uploadResult?: Awaited<ReturnType<typeof writeUploadedFile>>
+}
+
+async function handleChunkedFileUpload(c: Context, agentSlug: string, formData: FormData, chunk: File): Promise<ChunkedFileUploadOutcome> {
+  const parsed = parseChunkFields(formData)
+  if (!parsed.ok) return { pending: c.json({ error: parsed.error }, 400) }
+
+  const filename = (formData.get('filename') as string | null) || 'upload'
+  const relativePath = formData.get('relativePath') as string | null
+
+  const result = await storeUploadChunk(parsed.uploadId, parsed.chunkIndex, parsed.totalChunks, Buffer.from(await chunk.arrayBuffer()))
+
+  if (result.status === 'received') {
+    return { pending: c.json({ status: 'chunk_received', chunkIndex: parsed.chunkIndex }) }
+  }
+
+  const uploadResult = await writeUploadedFile(agentSlug, filename, result.buffer, relativePath || undefined)
+  return { pending: null, uploadResult }
+}
+
+// Shared handler for both agent-level and session-level upload-file routes.
+// Supports single-request uploads (`file` field) and chunked uploads (`chunk`
+// field) so files above Cloudflare's 100MB request-body limit go through in
+// <100MB slices.
+async function respondUploadFile(c: Context) {
   try {
     const agentSlug = c.req.param('id')
-
-
+    if (!agentSlug) return c.json({ error: 'Missing agent id' }, 400)
     const formData = await c.req.formData()
+
+    const chunk = formData.get('chunk') as File | null
+    if (chunk) {
+      const outcome = await handleChunkedFileUpload(c, agentSlug, formData, chunk)
+      if (outcome.pending) return outcome.pending
+      const result = outcome.uploadResult!
+      logAuditEvent({ userId: getCurrentUserId(c), object: 'file', objectId: `${agentSlug}/${result.filename}`, action: 'uploaded' })
+      return c.json(result)
+    }
+
     const file = formData.get('file') as File | null
     const relativePath = formData.get('relativePath') as string | null
-
     if (!file) {
       return c.json({ error: 'No file provided' }, 400)
     }
@@ -3869,32 +3924,16 @@ agents.post('/:id/upload-file', AgentUser(), async (c) => {
     return c.json(result)
   } catch (error) {
     console.error('Failed to upload file:', error)
+    captureException(error, { tags: { component: 'agents', operation: 'upload-file' }, extra: { agentSlug: c.req.param('id') } })
     return c.json({ error: 'Failed to upload file' }, 500)
   }
-})
+}
+
+// POST /api/agents/:id/upload-file - Upload a file to the agent workspace (no session required)
+agents.post('/:id/upload-file', AgentUser(), respondUploadFile)
 
 // POST /api/agents/:id/sessions/:sessionId/upload-file - Upload a file to the agent workspace
-agents.post('/:id/sessions/:sessionId/upload-file', AgentUser(), async (c) => {
-  try {
-    const agentSlug = c.req.param('id')
-
-
-    const formData = await c.req.formData()
-    const file = formData.get('file') as File | null
-    const relativePath = formData.get('relativePath') as string | null
-
-    if (!file) {
-      return c.json({ error: 'No file provided' }, 400)
-    }
-
-    const result = await handleFileUpload(agentSlug, file, relativePath || undefined)
-    logAuditEvent({ userId: getCurrentUserId(c), object: 'file', objectId: `${agentSlug}/${result.filename}`, action: 'uploaded' })
-    return c.json(result)
-  } catch (error) {
-    console.error('Failed to upload file:', error)
-    return c.json({ error: 'Failed to upload file' }, 500)
-  }
-})
+agents.post('/:id/sessions/:sessionId/upload-file', AgentUser(), respondUploadFile)
 
 async function handleFolderUpload(agentSlug: string, sourcePath: string) {
   const stat = await fs.promises.stat(sourcePath)
@@ -3932,6 +3971,7 @@ agents.post('/:id/upload-folder', AgentUser(), async (c) => {
     return c.json(result)
   } catch (error) {
     console.error('Failed to upload folder:', error)
+    captureException(error, { tags: { component: 'agents', operation: 'upload-folder' }, extra: { agentSlug: c.req.param('id') } })
     return c.json({ error: 'Failed to upload folder' }, 500)
   }
 })
@@ -3947,6 +3987,7 @@ agents.post('/:id/sessions/:sessionId/upload-folder', AgentUser(), async (c) => 
     return c.json(result)
   } catch (error) {
     console.error('Failed to upload folder:', error)
+    captureException(error, { tags: { component: 'agents', operation: 'upload-folder' }, extra: { agentSlug: c.req.param('id') } })
     return c.json({ error: 'Failed to upload folder' }, 500)
   }
 })

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -7,6 +7,7 @@ import { ArrowUp, Loader2, Eye, Settings2, Maximize2, Minimize2, Search, Check }
 import { useCreateSession, useSessions } from '@renderer/hooks/use-sessions'
 import { useScheduledTasks } from '@renderer/hooks/use-scheduled-tasks'
 import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
+import { UploadError } from '@renderer/components/ui/upload-error'
 import { RelatedSessions, type SortOrder } from '@renderer/components/sessions/related-sessions'
 import { SortPopover } from '@renderer/components/sessions/sort-popover'
 import { useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
@@ -14,6 +15,7 @@ import { useSelection } from '@renderer/context/selection-context'
 import { useUser } from '@renderer/context/user-context'
 import { toast } from 'sonner'
 import { apiFetch } from '@renderer/lib/api'
+import { uploadFileChunked } from '@renderer/lib/upload'
 import { AttachmentPicker } from '@renderer/components/ui/attachment-picker'
 import { MountChoiceDialog } from '@renderer/components/ui/mount-choice-dialog'
 import { useMessageComposer } from '@renderer/hooks/use-message-composer'
@@ -148,15 +150,11 @@ export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHome
 
   const composer = useMessageComposer({
     agentSlug: agent.slug,
-    uploadFile: useCallback(async ({ file }: { file: File }) => {
-      const formData = new FormData()
-      formData.append('file', file)
-      const res = await apiFetch(
-        `/api/agents/${agent.slug}/upload-file`,
-        { method: 'POST', body: formData }
-      )
-      if (!res.ok) throw new Error('Failed to upload file')
-      return res.json() as Promise<{ path: string }>
+    uploadFile: useCallback(({ file }: { file: File }) => {
+      return uploadFileChunked<{ path: string }>({
+        url: `/api/agents/${agent.slug}/upload-file`,
+        file,
+      })
     }, [agent.slug]),
     uploadFolder: useCallback(async ({ sourcePath }: { sourcePath: string }) => {
       const res = await apiFetch(
@@ -450,7 +448,10 @@ export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHome
                     </>
                   )}
                   footer={(
-                    <VoiceInputError error={composer.voiceInput.error} onDismiss={composer.voiceInput.clearError} className="mt-2 justify-center" />
+                    <>
+                      <VoiceInputError error={composer.voiceInput.error} onDismiss={composer.voiceInput.clearError} className="mt-2 justify-center" />
+                      <UploadError error={composer.uploadError} onDismiss={composer.clearUploadError} className="mt-2 justify-center" />
+                    </>
                   )}
                 />
               </form>

--- a/src/renderer/components/messages/file-request-item.test.tsx
+++ b/src/renderer/components/messages/file-request-item.test.tsx
@@ -106,7 +106,7 @@ describe('FileRequestItem', () => {
     expect(defaultProps.onComplete).toHaveBeenCalled()
   })
 
-  it('shows error on upload failure', async () => {
+  it('shows the backend error message on upload failure', async () => {
     const user = userEvent.setup()
     mockApiFetch.mockResolvedValueOnce({
       ok: false,
@@ -125,7 +125,7 @@ describe('FileRequestItem', () => {
     await user.click(screen.getByText('Upload file'))
 
     await waitFor(() => {
-      expect(screen.getByText(/Error:.*Failed to upload file/)).toBeInTheDocument()
+      expect(screen.getByText(/Error:.*Upload failed/)).toBeInTheDocument()
     })
   })
 })

--- a/src/renderer/components/messages/file-request-item.tsx
+++ b/src/renderer/components/messages/file-request-item.tsx
@@ -1,4 +1,5 @@
 import { apiFetch } from '@renderer/lib/api'
+import { uploadFileChunked } from '@renderer/lib/upload'
 import { useState, useRef, useCallback } from 'react'
 import { CloudUpload, FileIcon, X } from 'lucide-react'
 import { useRequestHandler } from '@renderer/hooks/use-request-handler'
@@ -43,15 +44,10 @@ export function FileRequestItem({
   const handleUpload = () => {
     if (!selectedFile) return
     submit(async () => {
-      const formData = new FormData()
-      formData.append('file', selectedFile)
-      const uploadResponse = await apiFetch(
-        `/api/agents/${agentSlug}/sessions/${sessionId}/upload-file`,
-        { method: 'POST', body: formData }
-      )
-      if (!uploadResponse.ok) throw new Error('Failed to upload file')
-
-      const { path } = await uploadResponse.json()
+      const { path } = await uploadFileChunked<{ path: string }>({
+        url: `/api/agents/${agentSlug}/sessions/${sessionId}/upload-file`,
+        file: selectedFile,
+      })
 
       const provideResponse = await apiFetch(
         `/api/agents/${agentSlug}/sessions/${sessionId}/provide-file`,

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -7,6 +7,7 @@ import { useIsOnline } from '@renderer/context/connectivity-context'
 import { useUser } from '@renderer/context/user-context'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
+import { UploadError } from '@renderer/components/ui/upload-error'
 import { ComposerActionButton } from './composer-action-button'
 import { SlashCommandMenu } from './slash-command-menu'
 import { AttachmentPicker } from '@renderer/components/ui/attachment-picker'
@@ -239,6 +240,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, initialEffor
               </div>
             )}
             <VoiceInputError error={composer.voiceInput.error} onDismiss={composer.voiceInput.clearError} className="mt-2" />
+            <UploadError error={composer.uploadError} onDismiss={composer.clearUploadError} className="mt-2" />
           </>
         )}
       />

--- a/src/renderer/components/ui/upload-error.tsx
+++ b/src/renderer/components/ui/upload-error.tsx
@@ -1,0 +1,16 @@
+import { AlertCircle, X } from 'lucide-react'
+
+export function UploadError({ error, onDismiss, className }: { error: string | null; onDismiss?: () => void; className?: string }) {
+  if (!error) return null
+  return (
+    <div className={`flex items-center gap-1.5 text-xs text-destructive ${className ?? ''}`}>
+      <AlertCircle className="h-3 w-3 shrink-0" />
+      <span>{error}</span>
+      {onDismiss && (
+        <button type="button" onClick={onDismiss} className="ml-auto shrink-0 hover:opacity-70" aria-label="Dismiss">
+          <X className="h-3 w-3" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/hooks/use-agent-templates.ts
+++ b/src/renderer/hooks/use-agent-templates.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { apiFetch } from '@renderer/lib/api'
+import { uploadFileChunked, type UploadProgress } from '@renderer/lib/upload'
 import { downloadBlob } from '@renderer/lib/download'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
@@ -92,9 +93,7 @@ export function useExportAgentFull() {
   })
 }
 
-export type ImportProgress = { phase: 'uploading' | 'processing'; percent: number }
-
-const CHUNK_SIZE = 50 * 1024 * 1024 // 50MB — under Cloudflare's 100MB limit
+export type ImportProgress = UploadProgress
 
 export function useImportAgentTemplate() {
   const queryClient = useQueryClient()
@@ -107,61 +106,12 @@ export function useImportAgentTemplate() {
   >({
     meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ file, mode, onProgress }) => {
-      if (file.size <= CHUNK_SIZE) {
-        // Small file — single request (existing behavior)
-        const formData = new FormData()
-        formData.append('file', file)
-        if (mode) formData.append('mode', mode)
-
-        onProgress?.({ phase: 'uploading', percent: 100 })
-        const res = await apiFetch('/api/agents/import-template', {
-          method: 'POST',
-          body: formData,
-        })
-        if (!res.ok) {
-          const data = await res.json()
-          throw new Error(data.error || 'Failed to import template')
-        }
-        onProgress?.({ phase: 'processing', percent: 100 })
-        return res.json()
-      }
-
-      // Large file — chunked upload
-      const uploadId = crypto.randomUUID()
-      const totalChunks = Math.ceil(file.size / CHUNK_SIZE)
-
-      for (let i = 0; i < totalChunks; i++) {
-        const start = i * CHUNK_SIZE
-        const end = Math.min(start + CHUNK_SIZE, file.size)
-        const chunkBlob = file.slice(start, end)
-
-        const formData = new FormData()
-        formData.append('chunk', chunkBlob)
-        formData.append('uploadId', uploadId)
-        formData.append('chunkIndex', String(i))
-        formData.append('totalChunks', String(totalChunks))
-        formData.append('mode', mode || 'template')
-
-        onProgress?.({ phase: 'uploading', percent: (i / totalChunks) * 100 })
-
-        const res = await apiFetch('/api/agents/import-template', {
-          method: 'POST',
-          body: formData,
-        })
-        if (!res.ok) {
-          const data = await res.json()
-          throw new Error(data.error || 'Failed to upload chunk')
-        }
-
-        // Last chunk returns the final agent result
-        if (i === totalChunks - 1) {
-          onProgress?.({ phase: 'processing', percent: 100 })
-          return res.json()
-        }
-      }
-
-      // Should not reach here, but satisfy TypeScript
-      throw new Error('Unexpected end of chunked upload')
+      return uploadFileChunked<ApiAgent & { hasOnboarding?: boolean }>({
+        url: '/api/agents/import-template',
+        file,
+        fields: { mode: mode || 'template' },
+        onProgress,
+      })
     },
     onSuccess: () => {
       track('agent_created', { source: 'file_import' })

--- a/src/renderer/hooks/use-message-composer.ts
+++ b/src/renderer/hooks/use-message-composer.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
+import { captureRendererException } from '@renderer/lib/error-reporting'
 import { useAttachments } from './use-attachments'
 import { useVoiceInput } from './use-voice-input'
 import { useAddMount } from './use-mounts'
@@ -28,6 +29,7 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
   const [draft, setDraft] = useDraft<string>(draftKey)
   const [message, setMessage] = useState(draft ?? '')
   const [isUploading, setIsUploading] = useState(false)
+  const [uploadError, setUploadError] = useState<string | null>(null)
   const addMountMutation = useAddMount()
 
   // Persist local message to the draft store so it survives unmount. Skip the
@@ -129,6 +131,7 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     // Upload attachments first
     if (attachments.length > 0) {
       setIsUploading(true)
+      setUploadError(null)
       try {
         const uploadResults: { path: string }[] = []
         const mountResults: { containerPath: string; hostPath: string }[] = []
@@ -159,6 +162,8 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
         content = appendAttachedFiles(content, uploadResults.map((r) => r.path))
       } catch (error) {
         console.error('Failed to upload attachments:', error)
+        captureRendererException(error, { tags: { source: 'attachment-upload' }, extra: { agentSlug } })
+        setUploadError(error instanceof Error ? error.message : 'Upload failed. Please try again.')
         setIsUploading(false)
         return
       }
@@ -221,5 +226,9 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     handleSubmit,
     handlePaste,
     canSubmit,
+
+    // Upload error (surfaced to the user; cleared on next submit attempt)
+    uploadError,
+    clearUploadError: useCallback(() => setUploadError(null), []),
   }
 }

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from '@renderer/lib/api'
+import { uploadFileChunked } from '@renderer/lib/upload'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiMessage, ApiMessageOrBoundary } from '@shared/lib/types/api'
 import type { EffortLevel } from '@shared/lib/container/types'
@@ -63,17 +64,11 @@ export function useSendMessage() {
 export function useUploadFile() {
   return useMutation({
     mutationFn: async (data: { sessionId: string; agentSlug: string; file: File; relativePath?: string }) => {
-      const formData = new FormData()
-      formData.append('file', data.file)
-      if (data.relativePath) {
-        formData.append('relativePath', data.relativePath)
-      }
-      const res = await apiFetch(
-        `/api/agents/${data.agentSlug}/sessions/${data.sessionId}/upload-file`,
-        { method: 'POST', body: formData }
-      )
-      if (!res.ok) throw new Error('Failed to upload file')
-      return res.json() as Promise<{ path: string; filename: string; size: number }>
+      return uploadFileChunked<{ path: string; filename: string; size: number }>({
+        url: `/api/agents/${data.agentSlug}/sessions/${data.sessionId}/upload-file`,
+        file: data.file,
+        fields: data.relativePath ? { relativePath: data.relativePath } : undefined,
+      })
     },
   })
 }

--- a/src/renderer/hooks/use-request-handler.ts
+++ b/src/renderer/hooks/use-request-handler.ts
@@ -7,6 +7,7 @@
  */
 
 import { useState, useCallback } from 'react'
+import { captureRendererException } from '@renderer/lib/error-reporting'
 
 export function useRequestHandler(onComplete: () => void) {
   const [status, setStatus] = useState<string>('pending')
@@ -28,6 +29,7 @@ export function useRequestHandler(onComplete: () => void) {
       setStatus(successStatus)
       onComplete()
     } catch (err: unknown) {
+      captureRendererException(err, { tags: { source: 'request-item' } })
       setError(err instanceof Error ? err.message : 'Request failed')
       setStatus('pending')
     }

--- a/src/renderer/lib/upload.ts
+++ b/src/renderer/lib/upload.ts
@@ -1,0 +1,76 @@
+import { apiFetch } from '@renderer/lib/api'
+
+// 50MB — keeps each request under Cloudflare's 100MB request-body limit so
+// large files don't 413 at the edge before reaching the API.
+export const UPLOAD_CHUNK_SIZE = 50 * 1024 * 1024
+
+export type UploadProgress = { phase: 'uploading' | 'processing'; percent: number }
+
+async function readError(res: Response, fallback: string): Promise<string> {
+  try {
+    const data = await res.json()
+    return (data && typeof data.error === 'string' && data.error) || fallback
+  } catch {
+    return fallback
+  }
+}
+
+interface UploadOptions {
+  /** Endpoint that accepts both single-request (`file`) and chunked (`chunk`) uploads. */
+  url: string
+  file: File
+  /** Extra multipart fields sent with every request (e.g. `mode`, `relativePath`). */
+  fields?: Record<string, string>
+  onProgress?: (p: UploadProgress) => void
+}
+
+/**
+ * Upload a file to an endpoint that supports chunked uploads. Files at or below
+ * UPLOAD_CHUNK_SIZE go in a single request; larger files are sliced so each
+ * request stays under Cloudflare's 100MB limit. The endpoint's JSON response
+ * (from the single/final request) is returned. On failure the backend's error
+ * message is surfaced so callers can show it to the user.
+ */
+export async function uploadFileChunked<T>({ url, file, fields = {}, onProgress }: UploadOptions): Promise<T> {
+  if (file.size <= UPLOAD_CHUNK_SIZE) {
+    const formData = new FormData()
+    formData.append('file', file)
+    for (const [k, v] of Object.entries(fields)) formData.append(k, v)
+
+    onProgress?.({ phase: 'uploading', percent: 100 })
+    const res = await apiFetch(url, { method: 'POST', body: formData })
+    if (!res.ok) throw new Error(await readError(res, 'Upload failed. Please try again.'))
+    onProgress?.({ phase: 'processing', percent: 100 })
+    return res.json() as Promise<T>
+  }
+
+  const uploadId = crypto.randomUUID()
+  const totalChunks = Math.ceil(file.size / UPLOAD_CHUNK_SIZE)
+
+  for (let i = 0; i < totalChunks; i++) {
+    const start = i * UPLOAD_CHUNK_SIZE
+    const end = Math.min(start + UPLOAD_CHUNK_SIZE, file.size)
+    const chunkBlob = file.slice(start, end)
+
+    const formData = new FormData()
+    formData.append('chunk', chunkBlob)
+    formData.append('uploadId', uploadId)
+    formData.append('chunkIndex', String(i))
+    formData.append('totalChunks', String(totalChunks))
+    formData.append('filename', file.name)
+    for (const [k, v] of Object.entries(fields)) formData.append(k, v)
+
+    onProgress?.({ phase: 'uploading', percent: (i / totalChunks) * 100 })
+
+    const res = await apiFetch(url, { method: 'POST', body: formData })
+    if (!res.ok) throw new Error(await readError(res, 'Upload failed. Please try again.'))
+
+    // The final chunk returns the assembled result.
+    if (i === totalChunks - 1) {
+      onProgress?.({ phase: 'processing', percent: 100 })
+      return res.json() as Promise<T>
+    }
+  }
+
+  throw new Error('Unexpected end of chunked upload')
+}


### PR DESCRIPTION
## Bug

Uploading a file >100MB via the composer fails with a Cloudflare edge `413 Content Too Large` — the request never reaches the API (observed on `datawizz.ondispatch.ai/api/agents/.../upload-file`). On top of that, upload failures were silently swallowed in the composer (`console.error` only), so the UI just looked stuck with no feedback.

## Repro

1. On a cloud deployment behind Cloudflare, attach a file >100MB in the composer and send.
2. Network tab shows `413` from Cloudflare (HTML error page, `server: cloudflare`).
3. UI shows no error; the message is never sent.

## What changed

**Chunked uploads for `upload-file`** (reuses the existing `import-template` pattern):
- Server: extracted the chunk store/assemble logic from `handleChunkedImport` into shared local helpers (`parseChunkFields`, `storeUploadChunk`) in `agents.ts`; both `upload-file` routes now accept a `chunk` field and assemble on the final chunk. The two identical routes were collapsed into one shared handler.
- Client: extracted the chunk loop from `useImportAgentTemplate` into `renderer/lib/upload.ts` (`uploadFileChunked`, 50MB slices). All upload call sites (composer session uploads, agent-home, file-request-item, import-template) now use it.

**User-visible upload errors:**
- Composer now shows a dismissible error bar (new `UploadError` component) instead of silently returning; the backend's real error message is propagated (e.g. `File too large (...)`), with fallback "Upload failed. Please try again."

**Sentry:**
- Upload errors are reported at the catch sites that swallow them: composer attachment-upload, `useRequestHandler` (request items), and the `upload-file` / `upload-folder` / `import-template` routes. Mutation-path uploads were already covered by the global MutationCache handler.

## Test plan

- [x] `vitest`: 203 tests green across `agents.test.ts`, `use-message-composer.test.tsx`, `use-request-handler.test.ts`, `file-request-item.test.tsx` (existing chunked-import tests unchanged)
- [x] typecheck clean (pre-existing `tools/` errors unrelated)
- [ ] E2E: upload a >100MB file through a Cloudflare-fronted deployment and confirm it succeeds in 50MB chunks
- [ ] Verify the composer error bar shows the backend message on a failed upload

Made with [Cursor](https://cursor.com)