### PR TITLE
style: tree connector lines linking sidebar sessions to their agent

### DIFF
--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -92,6 +92,22 @@ const THIN_SCROLLBAR =
   '[&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-track]:bg-transparent ' +
   '[&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-muted-foreground/20'
 
+// Tree connectors on the agent submenu: a vertical rail hanging from
+// the agent row's chevron plus an elbow into each sub-item row. Geometry is
+// coupled to the surrounding layout: the rail sits 15px from the submenu's
+// left edge (chevron = left-1.5 + p-0.5 + half a 14px icon) and rows are
+// indented pl-5 (20px), so connectors anchor at -5px from each <li>. Elbows
+// sit at 14px = half the h-7 row. Each row draws its own rail segment
+// (stretched -top-1 to bridge the gap-1 between rows) so the rail tracks
+// variable row heights; the last row's segment stops at its elbow.
+const TREE_CONNECTORS =
+  '[&>li]:relative ' +
+  '[&>li]:before:absolute [&>li]:before:-left-[5px] [&>li]:before:top-[14px] [&>li]:before:w-[5px] ' +
+  '[&>li]:before:border-t [&>li]:before:border-muted-foreground/25 ' +
+  '[&>li]:after:absolute [&>li]:after:-left-[5px] [&>li]:after:-top-1 [&>li]:after:bottom-0 ' +
+  '[&>li]:after:border-l [&>li]:after:border-muted-foreground/25 ' +
+  '[&>li:last-child]:after:bottom-auto [&>li:last-child]:after:h-[18px]'
+
 // Session sub-item that tracks its streaming state
 function SessionSubItem({
   session,
@@ -604,7 +620,7 @@ export const AgentMenuItem = React.forwardRef<
         {hasExpandableContent ? (
           <>
             <CollapsibleContent>
-              <SidebarMenuSub className="pb-2">
+              <SidebarMenuSub className={cn('pb-2', TREE_CONNECTORS)}>
                 {isOpen && sessionsLoading && showSkeleton ? (
                   <SessionsSkeleton />
                 ) : (

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -99,14 +99,19 @@ const THIN_SCROLLBAR =
 // indented pl-5 (20px), so connectors anchor at -5px from each <li>. Elbows
 // sit at 14px = half the h-7 row. Each row draws its own rail segment
 // (stretched -top-1 to bridge the gap-1 between rows) so the rail tracks
-// variable row heights; the last row's segment stops at its elbow.
+// variable row heights; the last row's segment stops at its elbow. The
+// first row instead starts at -top-0.5 so the rail tops out flush with the
+// agent row's bottom edge (the ul's py-0.5) rather than poking 2px up into
+// the agent row's highlight.
 const TREE_CONNECTORS =
   '[&>li]:relative ' +
   '[&>li]:before:absolute [&>li]:before:-left-[5px] [&>li]:before:top-[14px] [&>li]:before:w-[5px] ' +
   '[&>li]:before:border-t [&>li]:before:border-muted-foreground/25 ' +
   '[&>li]:after:absolute [&>li]:after:-left-[5px] [&>li]:after:-top-1 [&>li]:after:bottom-0 ' +
   '[&>li]:after:border-l [&>li]:after:border-muted-foreground/25 ' +
-  '[&>li:last-child]:after:bottom-auto [&>li:last-child]:after:h-[18px]'
+  '[&>li:first-child]:after:-top-0.5 ' +
+  '[&>li:last-child]:after:bottom-auto [&>li:last-child]:after:h-[18px] ' +
+  '[&>li:first-child:last-child]:after:h-[16px]'
 
 // Session sub-item that tracks its streaming state
 function SessionSubItem({


### PR DESCRIPTION
## What

Adds file-tree-style connector lines to the agent sidebar: a vertical rail hangs from the agent row's expand chevron, with an elbow branching into each sub-item row (sessions, dashboards, chat integrations, "Show all"). This makes the parent-child relationship between an agent and its sessions visually explicit.

## How

Pure CSS via a `TREE_CONNECTORS` Tailwind class constant applied to the agent-level `SidebarMenuSub`. Each `<li>` draws its own rail segment (`::after`, stretched across the `gap-1`) plus an elbow (`::before`); the last row's segment stops at its elbow. Solid 1px lines in `muted-foreground/25`, so they theme correctly in light and dark mode.

Geometry is documented on the constant: the rail sits at the chevron's x-center (15px), rows are indented `pl-5`, elbows at half the `h-7` row height.

## Verification

Verified in the running app (mock-mode web server + Playwright screenshots): light/dark themes, collapse/re-expand, multiple expanded agents, selected-row highlight — connectors align and don't clash with row hover backgrounds. Typecheck and lint clean (9 pre-existing warnings in unrelated test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)