### PR TITLE
Faster mic input: start listening sooner without losing dictation

### DIFF
--- a/src/api/speech-recognition-polyfill.test.ts
+++ b/src/api/speech-recognition-polyfill.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { getPolyfillJs } from './speech-recognition-polyfill'
+import { MockWebSocket } from '@shared/test/mock-websocket'
 
 // ---------------------------------------------------------------------------
 // Helpers to set up the polyfill in jsdom
@@ -15,42 +16,6 @@ function installPolyfill() {
 
 function getSpeechRecognition(): any {
   return (window as any).SpeechRecognition
-}
-
-// Minimal mock WebSocket that records sent messages and can simulate server events
-class MockWebSocket {
-  static instances: MockWebSocket[] = []
-  url: string
-  protocols: string | string[]
-  readyState = 0 // CONNECTING
-  onopen: ((ev: any) => void) | null = null
-  onclose: ((ev: any) => void) | null = null
-  onmessage: ((ev: any) => void) | null = null
-  onerror: ((ev: any) => void) | null = null
-  sent: any[] = []
-
-  constructor(url: string, protocols?: string | string[]) {
-    this.url = url
-    this.protocols = protocols || []
-    MockWebSocket.instances.push(this)
-    // Auto-open via microtask so it resolves within the same promise chain tick
-    Promise.resolve().then(() => {
-      this.readyState = 1 // OPEN
-      this.onopen?.({})
-    })
-  }
-
-  send(data: any) { this.sent.push(data) }
-  close() { this.readyState = 3 }
-
-  simulateMessage(data: any) {
-    this.onmessage?.({ data: JSON.stringify(data) })
-  }
-
-  simulateClose(code = 1000, reason = '') {
-    this.readyState = 3
-    this.onclose?.({ code, reason })
-  }
 }
 
 // Mock AudioContext and getUserMedia
@@ -92,7 +57,8 @@ function mockAudioCapture() {
 
 describe('SpeechRecognition polyfill', () => {
   beforeEach(() => {
-    MockWebSocket.instances = [];
+    MockWebSocket.instances = []
+    MockWebSocket.autoOpen = true; // the polyfill assumes the socket opens on its own
     (window as any).WebSocket = MockWebSocket as any
     delete (window as any).SpeechRecognition
     delete (window as any).webkitSpeechRecognition
@@ -285,7 +251,7 @@ describe('SpeechRecognition polyfill', () => {
       })
 
       const ws = MockWebSocket.instances[0]
-      const config = JSON.parse(ws.sent[0])
+      const config = JSON.parse(ws.sent[0] as string)
       expect(config.type).toBe('session.update')
       expect(config.session.type).toBe('transcription')
     })

--- a/src/renderer/components/settings/voice-tab.tsx
+++ b/src/renderer/components/settings/voice-tab.tsx
@@ -256,9 +256,11 @@ function VoiceTest() {
         <span className="text-sm text-muted-foreground">
           {voiceInput.isConnecting
             ? 'Connecting...'
-            : voiceInput.isRecording
-              ? 'Listening — speak now'
-              : 'Click to test voice input'}
+            : voiceInput.isFinalizing
+              ? 'Finishing…'
+              : voiceInput.isRecording
+                ? 'Listening — speak now'
+                : 'Click to test voice input'}
         </span>
       </div>
 

--- a/src/renderer/components/ui/voice-input-button.tsx
+++ b/src/renderer/components/ui/voice-input-button.tsx
@@ -42,7 +42,11 @@ export function VoiceInputButton({ voiceInput, message, disabled, size = 'defaul
   // In auth mode, only admins can configure voice settings
   const canConfigureVoice = !isAuthMode || isAdmin
 
-  const { isRecording, isConnecting, stopRecording, startRecording } = voiceInput
+  const { isRecording, isConnecting, isFinalizing, stopRecording, startRecording } = voiceInput
+  // Mic engaged: recording, connecting, or flushing the tail after stop.
+  const active = isRecording || isConnecting || isFinalizing
+  // Spinner while connecting or finalizing (no live waveform to show).
+  const busy = isConnecting || isFinalizing
 
   const handleToggle = useCallback(() => {
     if (!hasVoiceConfigured) {
@@ -51,10 +55,12 @@ export function VoiceInputButton({ voiceInput, message, disabled, size = 'defaul
     }
     if (isRecording || isConnecting) {
       stopRecording()
-    } else {
+    }
+    // While finalizing we ignore clicks (stop already in progress); otherwise start.
+    else if (!isFinalizing) {
       startRecording(message)
     }
-  }, [hasVoiceConfigured, canConfigureVoice, openSettings, isRecording, isConnecting, stopRecording, startRecording, message])
+  }, [hasVoiceConfigured, canConfigureVoice, openSettings, isRecording, isConnecting, isFinalizing, stopRecording, startRecording, message])
 
   if (!voiceInput.isSupported) return null
 
@@ -88,17 +94,17 @@ export function VoiceInputButton({ voiceInput, message, disabled, size = 'defaul
     <button
       type="button"
       onClick={handleToggle}
-      disabled={disabled && !isRecording && !isConnecting}
+      disabled={disabled && !active}
       data-testid="voice-input-button"
       className={cn(
         buttonVariants({ variant: 'outline', size: 'icon' }),
         'overflow-hidden px-0 transition-[width,padding,background-color,border-color,color,border-radius] duration-200 ease-out',
-        isRecording || isConnecting
+        active
           ? `${config.pill} gap-2 justify-between rounded-md border-input bg-background px-2 text-foreground hover:bg-zinc-100`
           : `gap-0 rounded-md ${config.button}`
       )}
       title={
-        isRecording || isConnecting
+        active
           ? 'Stop recording'
           : !hasVoiceConfigured
             ? 'Set up voice input'
@@ -108,12 +114,12 @@ export function VoiceInputButton({ voiceInput, message, disabled, size = 'defaul
       <span
         className={cn(
           'overflow-hidden transition-[max-width,opacity] duration-200 ease-out',
-          isRecording || isConnecting ? 'max-w-[64px] opacity-100' : 'max-w-0 opacity-0'
+          active ? 'max-w-[64px] opacity-100' : 'max-w-0 opacity-0'
         )}
       >
         <MiniWaveform analyserRef={voiceInput.analyserRef} color="black" {...config.waveform} />
       </span>
-      {isConnecting ? (
+      {busy ? (
         <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
       ) : isRecording ? (
         <Square className="h-3 w-3 shrink-0 fill-current" />

--- a/src/renderer/hooks/use-message-composer.test.tsx
+++ b/src/renderer/hooks/use-message-composer.test.tsx
@@ -239,6 +239,25 @@ describe('useMessageComposer', () => {
     expect(opts.onSubmit).toHaveBeenCalledWith('partial text')
   })
 
+  it('awaits the async stop so a late-flushed transcript is the submitted text', async () => {
+    mockVoiceInput.isRecording = true
+    // stopRecording resolves only once its trailing-transcript flush completes
+    let resolveStop!: (text: string) => void
+    mockVoiceInput.stopRecording.mockReturnValue(new Promise<string>((res) => { resolveStop = res }))
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+
+    await act(async () => {
+      const submit = result.current.handleSubmit({ preventDefault: vi.fn() } as any)
+      // Still flushing — must not submit before the tail arrives
+      expect(opts.onSubmit).not.toHaveBeenCalled()
+      resolveStop('flushed tail text')
+      await submit
+    })
+
+    expect(opts.onSubmit).toHaveBeenCalledWith('flushed tail text')
+  })
+
   // --- File upload orchestration ---
 
   it('uploads file attachments and appends paths to message', async () => {

--- a/src/renderer/hooks/use-message-composer.ts
+++ b/src/renderer/hooks/use-message-composer.ts
@@ -116,10 +116,12 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-    // Stop voice recording first — use returned text since React state won't update synchronously
+    // Stop voice recording first and await the final text: stopRecording flushes
+    // buffered audio and waits for the server's trailing transcripts, so a quick
+    // speak-then-Enter doesn't submit before the dictated words are in.
     let voiceText: string | undefined
     if (voiceInput.isRecording || voiceInput.isConnecting) {
-      voiceText = voiceInput.stopRecording()
+      voiceText = await voiceInput.stopRecording()
     }
 
     const effectiveMessage = voiceText ?? message

--- a/src/renderer/hooks/use-voice-agent.ts
+++ b/src/renderer/hooks/use-voice-agent.ts
@@ -7,7 +7,7 @@ import {
   type VoiceAgentEvent,
   type SttProvider,
 } from '@renderer/lib/voice-agent'
-import { float32ToInt16 } from '@renderer/lib/stt'
+import { acquireMicStream, float32ToInt16 } from '@renderer/lib/stt'
 
 export type VoiceAgentState = 'idle' | 'connecting' | 'active' | 'error'
 export type SpeakingState = 'none' | 'user' | 'agent'
@@ -239,16 +239,10 @@ export function useVoiceAgent({ config, onFunctionCall, onError }: UseVoiceAgent
       // 3. Connect
       await adapter.connect(token, config)
 
-      // 4. Set up audio capture
+      // 4. Set up audio capture (AudioContext resamples to the provider rate;
+      // the getUserMedia sampleRate constraint is a no-op — see acquireMicStream)
       const sampleRate = adapter.inputSampleRate
-      const stream = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          channelCount: 1,
-          sampleRate,
-          echoCancellation: true,
-          noiseSuppression: true,
-        },
-      })
+      const stream = await acquireMicStream()
       streamRef.current = stream
 
       const audioContext = new AudioContext({ sampleRate })

--- a/src/renderer/hooks/use-voice-input.ts
+++ b/src/renderer/hooks/use-voice-input.ts
@@ -2,9 +2,11 @@ import { useState, useRef, useCallback, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { apiFetch } from '@renderer/lib/api'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
-import { createSttAdapter, startAudioCapture, type SttAdapter, type SttProvider, type AudioCaptureHandle } from '@renderer/lib/stt'
+import { acquireMicStream, createSttAdapter, startAudioCapture, type SttAdapter, type SttProvider, type AudioCaptureHandle } from '@renderer/lib/stt'
 
-export type VoiceInputState = 'idle' | 'connecting' | 'recording' | 'stopping'
+// 'finalizing': mic released, but we're flushing buffered audio and awaiting the
+// server's trailing transcripts before the final text is ready.
+export type VoiceInputState = 'idle' | 'connecting' | 'recording' | 'finalizing'
 
 interface UseVoiceInputOptions {
   onTranscriptUpdate: (text: string) => void
@@ -55,6 +57,14 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
   const captureRef = useRef<AudioCaptureHandle | null>(null)
   const analyserRef = useRef<AnalyserNode | null>(null)
   const stateRef = useRef<VoiceInputState>('idle')
+  // True for the duration of a stopRecording() call so a second trigger
+  // (submit + button, or an error callback) can't start a second finish.
+  const stoppingRef = useRef(false)
+  // Per-attempt token. Bumped by each startRecording and on unmount, so an
+  // in-flight startRecording whose awaits resolve after a stop/restart or after
+  // the component unmounts can detect it's stale and release what it acquired
+  // instead of resurrecting a session nobody owns.
+  const generationRef = useRef(0)
 
   // Keep stateRef in sync so callbacks always see the latest value
   stateRef.current = state
@@ -67,6 +77,9 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
   const isSupported = typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getUserMedia
 
   const cleanup = useCallback(() => {
+    // Tearing down invalidates the current attempt, so an in-flight startRecording
+    // whose awaits resolve afterward sees a stale generation and bails.
+    generationRef.current++
     captureRef.current?.cleanup()
     captureRef.current = null
     analyserRef.current = null
@@ -75,12 +88,29 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
     adapterRef.current = null
   }, [])
 
-  /** Stop recording and return the final text (including any pending interim transcript). */
-  const stopRecording = useCallback((): string | undefined => {
-    if (stateRef.current !== 'recording' && stateRef.current !== 'connecting') return undefined
-    setState('stopping')
+  /**
+   * Stop recording and resolve with the final text. Releases the mic immediately,
+   * then keeps the adapter alive long enough to flush any audio buffered during
+   * the handshake and collect the server's trailing transcripts (bounded by the
+   * adapter's own finish() timeout) so the tail of the utterance isn't lost.
+   */
+  const stopRecording = useCallback(async (): Promise<string | undefined> => {
+    const st = stateRef.current
+    if (stoppingRef.current || (st !== 'recording' && st !== 'connecting')) return undefined
+    stoppingRef.current = true
+    setState('finalizing')
 
-    cleanup()
+    // Release the mic right away; keep the adapter to flush + await finals.
+    captureRef.current?.cleanup()
+    captureRef.current = null
+    analyserRef.current = null
+
+    // Detach the adapter before awaiting so late error/connect callbacks (which
+    // guard on adapter identity) treat this session as already gone.
+    const adapter = adapterRef.current
+    adapterRef.current = null
+    await adapter?.finish().catch(() => {}) // finish() never rejects; guard anyway
+
     // Include both finalized and any pending interim text
     const prefix = prefixRef.current
     const finalized = finalizedRef.current
@@ -98,12 +128,18 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
       track('dictation_used', { length: transcribed.length })
     }
     setState('idle')
+    stoppingRef.current = false
     return finalText
-  }, [cleanup, onTranscriptUpdate, track])
+  }, [onTranscriptUpdate, track])
 
   const startRecording = useCallback(async (existingText: string) => {
     if (stateRef.current !== 'idle') return
     setError(null)
+
+    // Claim this attempt. If the generation moves on (restart or unmount) while
+    // we're awaiting below, isStale() is true and we bail without resurrecting.
+    const generation = ++generationRef.current
+    const isStale = () => generation !== generationRef.current
 
     // Save prefix (text already in textarea before recording)
     prefixRef.current = existingText ? existingText + ' ' : ''
@@ -111,6 +147,20 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
     interimRef.current = ''
 
     setState('connecting')
+
+    // Request the mic right away so permission/hardware spin-up runs in
+    // parallel with the token round-trip instead of after it.
+    const streamPromise = acquireMicStream()
+    // Observe the rejection synchronously: a fast getUserMedia failure (denied
+    // permission, no device) during the token round-trip would otherwise fire an
+    // unhandledrejection before a handler is attached below. The error is still
+    // surfaced via the awaits/releaseStream that consume the promise.
+    streamPromise.catch(() => {})
+    const releaseStream = () => {
+      streamPromise.then((stream) => {
+        if (captureRef.current?.stream !== stream) stream.getTracks().forEach((t) => t.stop())
+      }).catch(() => {})
+    }
 
     try {
       // 1. Get API key from backend
@@ -120,6 +170,13 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
         throw new Error(('error' in credData ? credData.error : null) || 'Failed to get STT credentials')
       }
       const { provider, token } = credData as SttCredentials
+
+      // Bail if a stop/restart or unmount happened while fetching the token.
+      // Cast needed because TS narrows the ref, but callbacks can mutate it during awaits.
+      if (isStale() || (stateRef.current as VoiceInputState) !== 'connecting') {
+        releaseStream()
+        return
+      }
 
       // 2. Create adapter and wire transcript events
       const adapter = createSttAdapter(provider)
@@ -142,27 +199,42 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
       })
 
       adapter.onError((err) => {
+        if (adapterRef.current !== adapter) return // stale/orphaned adapter — don't touch the live session
         console.error('STT adapter error:', err)
         setError(err.message)
         stopRecording()
       })
 
-      await adapter.connect(token)
+      // 3. Connect in the background — the adapter buffers audio sent before
+      // the socket opens, so recording can start while the handshake is in flight.
+      adapter.connect(token).catch((err: unknown) => {
+        if (adapterRef.current !== adapter) return // recording already stopped
+        const message = err instanceof Error ? err.message : 'Failed to connect'
+        console.error('STT connect error:', err)
+        setError(message)
+        stopRecording()
+      })
 
-      // 3. Start mic capture and pipe audio to the adapter
-      captureRef.current = await startAudioCapture(adapter, { withAnalyser: true })
-      analyserRef.current = captureRef.current.analyser
-
-      // Guard against race: if an error callback already triggered stopRecording
-      // while we were awaiting above, don't overwrite the idle state.
-      // Cast needed because TS narrows the ref, but callbacks can mutate it during awaits.
-      if ((stateRef.current as VoiceInputState) !== 'connecting') return
+      // 4. Start mic capture and pipe audio to the adapter
+      const capture = await startAudioCapture(adapter, await streamPromise, { withAnalyser: true })
+      // Stale (restart/unmount) or superseded: tear down everything we acquired —
+      // nobody else holds these, so we own the cleanup.
+      if (isStale() || adapterRef.current !== adapter || (stateRef.current as VoiceInputState) !== 'connecting') {
+        capture.cleanup()
+        adapter.close()
+        if (adapterRef.current === adapter) adapterRef.current = null
+        releaseStream()
+        return
+      }
+      captureRef.current = capture
+      analyserRef.current = capture.analyser
 
       setState('recording')
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to start recording'
       console.error('Voice input error:', err)
       setError(message)
+      releaseStream()
       cleanup()
       // Restore original text that was in the textarea before recording started
       onTranscriptUpdate(existingText)
@@ -173,7 +245,7 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
     }
   }, [cleanup, onTranscriptUpdate, stopRecording])
 
-  // Cleanup on unmount
+  // Cleanup on unmount (also bumps the generation, invalidating any in-flight start)
   useEffect(() => {
     return () => {
       cleanup()
@@ -186,6 +258,7 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
     state,
     isRecording: state === 'recording',
     isConnecting: state === 'connecting',
+    isFinalizing: state === 'finalizing',
     error,
     clearError,
     isSupported,

--- a/src/renderer/lib/stt.test.ts
+++ b/src/renderer/lib/stt.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest'
-import { createSttAdapter } from './stt'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createSttAdapter, type TranscriptEvent } from './stt'
+import { MockWebSocket } from '@shared/test/mock-websocket'
 
 // float32ToInt16 and arrayBufferToBase64 are not exported, so we test them
 // indirectly or replicate the logic. Since they're private, we test via the
@@ -161,5 +162,372 @@ describe('createSttAdapter', () => {
 
   it('throws for unknown provider', () => {
     expect(() => createSttAdapter('unknown' as any)).toThrow('Unknown STT provider: unknown')
+  })
+})
+
+// ============================================================================
+// Pre-connection audio buffering
+// ============================================================================
+
+// Local alias so the existing test bodies (FakeWebSocket.OPEN, .instances, etc.)
+// keep reading naturally against the shared mock.
+const FakeWebSocket = MockWebSocket
+
+function chunkOf(byteLength: number, fillByte: number): ArrayBuffer {
+  return new Uint8Array(byteLength).fill(fillByte).buffer
+}
+
+describe('pre-connection audio buffering', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = []
+    FakeWebSocket.autoOpen = false // these tests drive open via simulateOpen()
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    // Keep the adapters' connect timeout from outliving the suite
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('deepgram: buffers audio sent before open and flushes it on open, in order', async () => {
+    const adapter = createSttAdapter('deepgram')
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+
+    const a = chunkOf(4, 1)
+    const b = chunkOf(4, 2)
+    adapter.sendAudio(a)
+    adapter.sendAudio(b)
+    expect(ws.sent).toHaveLength(0)
+
+    ws.simulateOpen()
+    await connectPromise
+
+    expect(ws.sent).toHaveLength(2)
+    expect(ws.sent[0]).toBe(a)
+    expect(ws.sent[1]).toBe(b)
+
+    // Live audio after open goes straight through
+    const c = chunkOf(4, 3)
+    adapter.sendAudio(c)
+    expect(ws.sent).toHaveLength(3)
+    expect(ws.sent[2]).toBe(c)
+  })
+
+  it('deepgram: drops oldest chunks when the pre-open buffer overflows', async () => {
+    const adapter = createSttAdapter('deepgram')
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+
+    // 3 chunks of 400KB against a 1MB cap — the first should be dropped
+    const big1 = chunkOf(400_000, 1)
+    const big2 = chunkOf(400_000, 2)
+    const big3 = chunkOf(400_000, 3)
+    adapter.sendAudio(big1)
+    adapter.sendAudio(big2)
+    adapter.sendAudio(big3)
+
+    ws.simulateOpen()
+    await connectPromise
+
+    expect(ws.sent).toHaveLength(2)
+    expect(ws.sent[0]).toBe(big2)
+    expect(ws.sent[1]).toBe(big3)
+  })
+
+  it('deepgram: discards buffered audio and stops buffering after close', () => {
+    const adapter = createSttAdapter('deepgram')
+    adapter.connect('token').catch(() => {})
+    adapter.sendAudio(chunkOf(4, 1))
+    adapter.close()
+    adapter.sendAudio(chunkOf(4, 2))
+
+    const ws = FakeWebSocket.instances[0]
+    expect(ws.sent).toHaveLength(0)
+  })
+
+  it('deepgram: deliberate close during connect does not surface an error', () => {
+    const adapter = createSttAdapter('deepgram')
+    const errors: Error[] = []
+    adapter.onError((err) => errors.push(err))
+    adapter.connect('token').catch(() => {})
+    const ws = FakeWebSocket.instances[0]
+
+    adapter.close()
+    // Closing a CONNECTING socket fires a non-clean close event
+    ws.simulateClose(1006)
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it('openai: flushes buffered audio as append messages after the session config', async () => {
+    const adapter = createSttAdapter('openai')
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+
+    adapter.sendAudio(new Uint8Array([1, 2, 3]).buffer)
+    adapter.sendAudio(new Uint8Array([4, 5, 6]).buffer)
+    expect(ws.sent).toHaveLength(0)
+
+    ws.simulateOpen()
+    await connectPromise
+
+    const messages = ws.sent.map((m) => JSON.parse(m as string))
+    expect(messages).toHaveLength(3)
+    expect(messages[0].type).toBe('session.update')
+    expect(messages[1]).toEqual({ type: 'input_audio_buffer.append', audio: btoa('\x01\x02\x03') })
+    expect(messages[2]).toEqual({ type: 'input_audio_buffer.append', audio: btoa('\x04\x05\x06') })
+  })
+
+  it('openai: deliberate close during connect does not surface an error', () => {
+    const adapter = createSttAdapter('openai')
+    const errors: Error[] = []
+    adapter.onError((err) => errors.push(err))
+    adapter.connect('token').catch(() => {})
+    const ws = FakeWebSocket.instances[0]
+
+    adapter.close()
+    ws.simulateClose(1006)
+
+    expect(errors).toHaveLength(0)
+  })
+})
+
+// ============================================================================
+// Graceful finish (flush buffered audio + await trailing transcripts)
+// ============================================================================
+
+const FLUSH_TIMEOUT_MS = 1_500
+
+function jsonSent(ws: { sent: (string | ArrayBuffer)[] }): any[] {
+  return ws.sent.filter((m): m is string => typeof m === 'string').map((m) => JSON.parse(m))
+}
+
+describe('graceful finish', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = []
+    FakeWebSocket.autoOpen = false // these tests drive open via simulateOpen()
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('deepgram: finish during the handshake flushes buffered audio, THEN sends CloseStream', async () => {
+    const adapter = createSttAdapter('deepgram')
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+
+    const a = chunkOf(4, 1)
+    const b = chunkOf(4, 2)
+    adapter.sendAudio(a)
+    adapter.sendAudio(b)
+
+    const finishPromise = adapter.finish()
+    expect(ws.sent).toHaveLength(0) // nothing sent until the socket opens
+
+    ws.simulateOpen()
+    await connectPromise
+
+    // Buffered audio flushed first, then the finalize message
+    expect(ws.sent.slice(0, 2)).toEqual([a, b])
+    expect(JSON.parse(ws.sent[2] as string)).toEqual({ type: 'CloseStream' })
+
+    // Server flushes trailing finals then closes — that resolves finish()
+    ws.simulateClose(1000)
+    await finishPromise
+    expect(ws.readyState).toBe(FakeWebSocket.CLOSED)
+  })
+
+  it('deepgram: trailing finals after CloseStream reach the transcript callback before finish resolves', async () => {
+    const adapter = createSttAdapter('deepgram')
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+    ws.simulateOpen()
+    await connectPromise
+
+    const events: TranscriptEvent[] = []
+    adapter.onTranscript((e) => events.push(e))
+
+    adapter.sendAudio(chunkOf(4, 1)) // live, goes straight through
+    const finishPromise = adapter.finish()
+    expect(JSON.parse(ws.sent.at(-1) as string)).toEqual({ type: 'CloseStream' })
+
+    ws.simulateMessage({ type: 'Results', speech_final: true, channel: { alternatives: [{ transcript: 'ship it' }] } })
+    ws.simulateClose(1000)
+    await finishPromise
+
+    expect(events).toEqual([{ type: 'final', text: 'ship it' }])
+  })
+
+  it('deepgram: finish resolves via the backstop timeout if the server never closes', async () => {
+    const adapter = createSttAdapter('deepgram')
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+    ws.simulateOpen()
+    await connectPromise
+
+    const finishPromise = adapter.finish()
+    let resolved = false
+    finishPromise.then(() => { resolved = true })
+
+    expect(resolved).toBe(false)
+    await vi.advanceTimersByTimeAsync(FLUSH_TIMEOUT_MS)
+    await finishPromise
+    expect(resolved).toBe(true)
+    expect(ws.readyState).toBe(FakeWebSocket.CLOSED)
+  })
+
+  it('deepgram: finish with no live socket resolves immediately', async () => {
+    const adapter = createSttAdapter('deepgram')
+    await adapter.finish() // never connected — must not hang
+  })
+
+  it('deepgram: a deliberate close() while finish() is pending resolves the finish promise', async () => {
+    const adapter = createSttAdapter('deepgram')
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+    ws.simulateOpen()
+    await connectPromise
+
+    const finishPromise = adapter.finish() // pending, awaiting trailing finals
+    adapter.close()
+    await finishPromise // would hang if close() didn't unblock it
+    expect(ws.readyState).toBe(FakeWebSocket.CLOSED)
+  })
+
+  it('deepgram: finish does not surface a spurious error if the socket errors mid-flush', async () => {
+    const adapter = createSttAdapter('deepgram')
+    const errors: Error[] = []
+    adapter.onError((e) => errors.push(e))
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+    ws.simulateOpen()
+    await connectPromise
+
+    const finishPromise = adapter.finish()
+    ws.onerror?.() // connection drops while we await finals
+    ws.simulateClose(1006)
+    await finishPromise
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it('openai: finish during the handshake flushes appends, THEN commits, and resolves on completed', async () => {
+    const adapter = createSttAdapter('openai')
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+
+    adapter.sendAudio(new Uint8Array([1, 2, 3]).buffer)
+    const finishPromise = adapter.finish()
+    expect(ws.sent).toHaveLength(0)
+
+    ws.simulateOpen()
+    await connectPromise
+
+    const messages = jsonSent(ws)
+    expect(messages[0].type).toBe('session.update')
+    expect(messages[1]).toEqual({ type: 'input_audio_buffer.append', audio: btoa('\x01\x02\x03') })
+    expect(messages[2]).toEqual({ type: 'input_audio_buffer.commit' })
+
+    const events: TranscriptEvent[] = []
+    adapter.onTranscript((e) => events.push(e))
+    ws.simulateMessage({ type: 'conversation.item.input_audio_transcription.completed', transcript: 'ship it' })
+    await finishPromise
+
+    expect(events).toEqual([{ type: 'final', text: 'ship it' }])
+    expect(ws.readyState).toBe(FakeWebSocket.CLOSED)
+  })
+
+  it('openai: finish resolves via the backstop timeout if no completion arrives', async () => {
+    const adapter = createSttAdapter('openai')
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+    ws.simulateOpen()
+    await connectPromise
+
+    adapter.sendAudio(new Uint8Array([1, 2, 3]).buffer) // uncommitted audio → commit + wait
+    const finishPromise = adapter.finish()
+    let resolved = false
+    finishPromise.then(() => { resolved = true })
+
+    expect(resolved).toBe(false)
+    await vi.advanceTimersByTimeAsync(FLUSH_TIMEOUT_MS)
+    await finishPromise
+    expect(resolved).toBe(true)
+  })
+
+  it('openai: finish with no uncommitted audio does NOT commit and completes immediately', async () => {
+    const adapter = createSttAdapter('openai')
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+    ws.simulateOpen()
+    await connectPromise
+    const sentBefore = ws.sent.length
+
+    // Nothing spoken since the last commit — finish must not send a commit
+    // (committing an empty buffer triggers OpenAI's "buffer too small" error).
+    await adapter.finish()
+
+    expect(jsonSent(ws).some((m) => m.type === 'input_audio_buffer.commit')).toBe(false)
+    expect(ws.sent.length).toBe(sentBefore)
+    expect(ws.readyState).toBe(FakeWebSocket.CLOSED)
+  })
+
+  it('openai: a server auto-commit clears pending audio so a later finish skips the commit', async () => {
+    const adapter = createSttAdapter('openai')
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+    ws.simulateOpen()
+    await connectPromise
+
+    // Speak, then the server auto-commits + transcribes the utterance (server_vad)
+    adapter.sendAudio(new Uint8Array([1, 2, 3]).buffer)
+    ws.simulateMessage({ type: 'input_audio_buffer.committed' })
+    const sentBefore = ws.sent.length
+
+    // Stop after the transcribe — nothing left uncommitted
+    await adapter.finish()
+
+    expect(ws.sent.length).toBe(sentBefore) // no commit sent
+  })
+
+  it('openai: a benign error while finishing is suppressed, not surfaced', async () => {
+    const adapter = createSttAdapter('openai')
+    const errors: Error[] = []
+    adapter.onError((e) => errors.push(e))
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+    ws.simulateOpen()
+    await connectPromise
+
+    adapter.sendAudio(new Uint8Array([1, 2, 3]).buffer)
+    const finishPromise = adapter.finish() // sends commit, awaits completion
+    // Server rejects the commit (e.g. raced its own auto-commit)
+    ws.simulateMessage({ type: 'error', error: { message: 'buffer too small' } })
+    await finishPromise
+
+    expect(errors).toHaveLength(0)
+    expect(ws.readyState).toBe(FakeWebSocket.CLOSED)
+  })
+
+  it('openai: a real error during normal streaming is still surfaced', async () => {
+    const adapter = createSttAdapter('openai')
+    const errors: Error[] = []
+    adapter.onError((e) => errors.push(e))
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+    ws.simulateOpen()
+    await connectPromise
+
+    ws.simulateMessage({ type: 'error', error: { message: 'something broke' } })
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toBe('something broke')
   })
 })

--- a/src/renderer/lib/stt.ts
+++ b/src/renderer/lib/stt.ts
@@ -5,6 +5,21 @@ export type { SttProvider }
 
 const CONNECT_TIMEOUT_MS = 10_000
 
+/**
+ * Cap on audio buffered while the WebSocket is still connecting
+ * (~30s of int16 PCM at 16kHz, ~20s at 24kHz — well past CONNECT_TIMEOUT_MS).
+ * On overflow the oldest chunks are dropped.
+ */
+const MAX_BUFFERED_AUDIO_BYTES = 1_000_000
+
+/**
+ * Upper bound on how long finish() waits for the server's trailing transcripts
+ * after the audio has been flushed. The providers normally signal completion
+ * sooner (Deepgram closes the socket, OpenAI sends a `completed` event); this is
+ * only the backstop so a stuck connection can't hang the caller's stop/submit.
+ */
+const FLUSH_TIMEOUT_MS = 1_500
+
 export interface TranscriptEvent {
   type: 'interim' | 'final' | 'speech_ended'
   text: string
@@ -20,7 +35,195 @@ export interface SttAdapter {
   sendAudio(chunk: ArrayBuffer): void
   onTranscript(cb: TranscriptCallback): void
   onError(cb: ErrorCallback): void
+  /**
+   * Gracefully stop: flush any audio buffered during the handshake, ask the
+   * server to finalize, and resolve once the trailing transcripts have been
+   * delivered (or after FLUSH_TIMEOUT_MS). Unlike close(), this preserves the
+   * tail of the utterance — callers that need the final text should await it.
+   */
+  finish(): Promise<void>
   close(): void
+}
+
+// --- Base WebSocket adapter ---
+
+/**
+ * Shared WebSocket lifecycle for the STT adapters: pre-open audio buffering,
+ * deliberate-close error suppression, and graceful finish() (flush buffered
+ * audio + await the server's trailing transcripts). Subclasses supply only the
+ * provider-specific bits — how to open the socket, configure the session, write
+ * a chunk, finalize, and parse incoming messages.
+ */
+abstract class WebSocketSttAdapter implements SttAdapter {
+  protected ws: WebSocket | null = null
+  private transcriptCb: TranscriptCallback | null = null
+  private errorCb: ErrorCallback | null = null
+  private connected = false
+  private closed = false
+  private finishing = false
+  private finishResolve: (() => void) | null = null
+  private finishTimer: ReturnType<typeof setTimeout> | null = null
+  private pendingAudio: ArrayBuffer[] = []
+  private pendingBytes = 0
+
+  /** Open the provider's WebSocket, authenticated with `token`. */
+  protected abstract createSocket(token: string): WebSocket
+  /** Label for the "<label> WebSocket connection failed/timed out" errors. */
+  protected abstract readonly connectErrorLabel: string
+  /** Label for the "<label> connection closed: ..." error. */
+  protected abstract readonly closeErrorLabel: string
+  /** Write one audio chunk to the already-open socket. */
+  protected abstract writeAudio(chunk: ArrayBuffer): void
+  /**
+   * Ask the server to finalize so it emits the utterance's trailing transcripts.
+   * Returns true if a finalize was sent and the caller should await completion;
+   * false if there was nothing to finalize (e.g. the server already auto-committed
+   * the audio), in which case finish() completes immediately instead of waiting.
+   */
+  protected abstract requestFinalize(): boolean
+  /** Handle one decoded server message (transcripts, errors, completion). */
+  protected abstract handleMessage(data: any): void
+  /** Hook run once the socket opens, before buffered audio is flushed (e.g. session config). */
+  protected onConnected(): void {}
+
+  /** Whether a finish() is in progress (for subclasses to suppress teardown-time noise). */
+  protected get isFinishing(): boolean {
+    return this.finishing
+  }
+
+  async connect(token: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.ws = this.createSocket(token)
+
+      const timeout = setTimeout(() => {
+        this.ws?.close()
+        reject(new Error(`${this.connectErrorLabel} WebSocket connection timed out`))
+      }, CONNECT_TIMEOUT_MS)
+
+      this.ws.onopen = () => {
+        clearTimeout(timeout)
+        this.connected = true
+        this.onConnected()
+        for (const chunk of this.pendingAudio) this.writeAudio(chunk)
+        this.pendingAudio = []
+        this.pendingBytes = 0
+        // If finish() was requested during the handshake, finalize now that the
+        // buffered audio is on its way (or complete now if there's nothing to send).
+        if (this.finishing && !this.requestFinalize()) this.completeFinish()
+        resolve()
+      }
+
+      this.ws.onerror = () => {
+        clearTimeout(timeout)
+        const err = new Error(`${this.connectErrorLabel} WebSocket connection failed`)
+        if (!this.connected) {
+          reject(err)
+        } else if (!this.closed && !this.finishing) {
+          this.errorCb?.(err)
+        }
+      }
+
+      this.ws.onmessage = (event) => {
+        try {
+          this.handleMessage(JSON.parse(event.data as string))
+        } catch {
+          // Ignore non-JSON messages
+        }
+      }
+
+      this.ws.onclose = (event) => {
+        // A close during finish() (server flushed finals / closed after commit)
+        // is finish()'s completion signal.
+        if (this.finishResolve) { this.completeFinish(); return }
+        if (this.closed) return
+        if (event.code !== 1000 && event.code !== 1005) {
+          this.errorCb?.(new Error(`${this.closeErrorLabel} connection closed: ${event.code} ${event.reason}`))
+        }
+      }
+    })
+  }
+
+  sendAudio(chunk: ArrayBuffer): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.writeAudio(chunk)
+    } else if (!this.connected && !this.closed) {
+      // Capture can start before the socket opens — buffer and flush on open
+      this.pendingAudio.push(chunk)
+      this.pendingBytes += chunk.byteLength
+      while (this.pendingBytes > MAX_BUFFERED_AUDIO_BYTES && this.pendingAudio.length > 0) {
+        this.pendingBytes -= this.pendingAudio.shift()!.byteLength
+      }
+    }
+  }
+
+  onTranscript(cb: TranscriptCallback): void {
+    this.transcriptCb = cb
+  }
+
+  onError(cb: ErrorCallback): void {
+    this.errorCb = cb
+  }
+
+  finish(): Promise<void> {
+    if (this.closed || this.finishing) return Promise.resolve()
+    this.finishing = true
+    return new Promise<void>((resolve) => {
+      this.finishResolve = resolve
+      this.finishTimer = setTimeout(() => this.completeFinish(), FLUSH_TIMEOUT_MS)
+
+      const ws = this.ws
+      if (ws?.readyState === WebSocket.OPEN) {
+        // Mid-stream stop: flush is already done. Ask for trailing finals, or
+        // complete now if the server has nothing left to finalize.
+        if (!this.requestFinalize()) this.completeFinish()
+      } else if (ws?.readyState !== WebSocket.CONNECTING) {
+        // No live socket to flush through — nothing to wait for.
+        this.completeFinish()
+      }
+      // CONNECTING: onopen flushes the buffer then finalizes.
+    })
+  }
+
+  close(): void {
+    // finish() already sent the finalize message; don't send it twice.
+    if (!this.closed && !this.finishing && this.ws?.readyState === WebSocket.OPEN) {
+      this.requestFinalize()
+    }
+    // Unblock a finish() still awaiting trailing transcripts, if any.
+    if (this.finishResolve) this.completeFinish()
+    else this.hardClose()
+  }
+
+  /** Resolve a pending finish() exactly once, then tear down the socket. */
+  protected completeFinish(): void {
+    if (this.finishResolve === null) return
+    const resolve = this.finishResolve
+    this.finishResolve = null
+    if (this.finishTimer !== null) {
+      clearTimeout(this.finishTimer)
+      this.finishTimer = null
+    }
+    this.hardClose()
+    resolve()
+  }
+
+  private hardClose(): void {
+    this.closed = true
+    this.pendingAudio = []
+    this.pendingBytes = 0
+    if (this.ws) {
+      this.ws.close()
+      this.ws = null
+    }
+  }
+
+  protected emitTranscript(event: TranscriptEvent): void {
+    this.transcriptCb?.(event)
+  }
+
+  protected emitError(error: Error): void {
+    this.errorCb?.(error)
+  }
 }
 
 // --- Deepgram Adapter ---
@@ -37,91 +240,33 @@ const DEEPGRAM_WS_PARAMS = new URLSearchParams({
   channels: '1',
 })
 
-class DeepgramAdapter implements SttAdapter {
-  private ws: WebSocket | null = null
-  private transcriptCb: TranscriptCallback | null = null
-  private errorCb: ErrorCallback | null = null
-  private connected = false
+class DeepgramAdapter extends WebSocketSttAdapter {
+  protected readonly connectErrorLabel = 'Deepgram'
+  protected readonly closeErrorLabel = 'Deepgram'
 
-  async connect(token: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const url = `wss://api.deepgram.com/v1/listen?${DEEPGRAM_WS_PARAMS.toString()}`
-      this.ws = new WebSocket(url, ['bearer', token])
-
-      const timeout = setTimeout(() => {
-        this.ws?.close()
-        reject(new Error('Deepgram WebSocket connection timed out'))
-      }, CONNECT_TIMEOUT_MS)
-
-      this.ws.onopen = () => {
-        clearTimeout(timeout)
-        this.connected = true
-        resolve()
-      }
-
-      this.ws.onerror = () => {
-        clearTimeout(timeout)
-        const err = new Error('Deepgram WebSocket connection failed')
-        if (!this.connected) {
-          reject(err)
-        } else {
-          this.errorCb?.(err)
-        }
-      }
-
-      this.ws.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data as string)
-          if (data.type === 'Results') {
-            const alt = data.channel?.alternatives?.[0]
-            if (!alt) return
-            const text = alt.transcript || ''
-            if (!text) return
-
-            if (data.speech_final) {
-              this.transcriptCb?.({ type: 'final', text })
-            } else if (data.is_final) {
-              this.transcriptCb?.({ type: 'final', text })
-            } else {
-              this.transcriptCb?.({ type: 'interim', text })
-            }
-          } else if (data.type === 'UtteranceEnd') {
-            this.transcriptCb?.({ type: 'speech_ended', text: '' })
-          }
-        } catch {
-          // Ignore non-JSON messages
-        }
-      }
-
-      this.ws.onclose = (event) => {
-        if (event.code !== 1000 && event.code !== 1005) {
-          this.errorCb?.(new Error(`Deepgram connection closed: ${event.code} ${event.reason}`))
-        }
-      }
-    })
+  protected createSocket(token: string): WebSocket {
+    const url = `wss://api.deepgram.com/v1/listen?${DEEPGRAM_WS_PARAMS.toString()}`
+    return new WebSocket(url, ['bearer', token])
   }
 
-  sendAudio(chunk: ArrayBuffer): void {
-    if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(chunk)
-    }
+  protected writeAudio(chunk: ArrayBuffer): void {
+    this.ws?.send(chunk)
   }
 
-  onTranscript(cb: TranscriptCallback): void {
-    this.transcriptCb = cb
+  protected requestFinalize(): boolean {
+    // CloseStream is safe even with no buffered audio — Deepgram just closes.
+    this.ws?.send(JSON.stringify({ type: 'CloseStream' }))
+    return true
   }
 
-  onError(cb: ErrorCallback): void {
-    this.errorCb = cb
-  }
-
-  close(): void {
-    if (this.ws) {
-      if (this.ws.readyState === WebSocket.OPEN) {
-        this.ws.send(JSON.stringify({ type: 'CloseStream' }))
-      }
-      this.ws.close()
-      this.ws = null
+  protected handleMessage(data: any): void {
+    if (data.type === 'Results') {
+      const alt = data.channel?.alternatives?.[0]
+      const text = alt?.transcript || ''
+      if (!text) return
+      this.emitTranscript({ type: data.speech_final || data.is_final ? 'final' : 'interim', text })
+    } else if (data.type === 'UtteranceEnd') {
+      this.emitTranscript({ type: 'speech_ended', text: '' })
     }
   }
 }
@@ -148,131 +293,99 @@ export function arrayBufferToBase64(buffer: ArrayBuffer): string {
   return btoa(binary)
 }
 
-class OpenaiAdapter implements SttAdapter {
-  private ws: WebSocket | null = null
-  private transcriptCb: TranscriptCallback | null = null
-  private errorCb: ErrorCallback | null = null
-  private pendingDelta = ''
-  private connected = false
+class OpenaiAdapter extends WebSocketSttAdapter {
   readonly sampleRate = 24000
+  protected readonly connectErrorLabel = 'OpenAI Realtime'
+  protected readonly closeErrorLabel = 'OpenAI'
+  private pendingDelta = ''
+  // Tracks audio appended but not yet committed. With server_vad the server
+  // auto-commits each utterance, so a manual commit with nothing pending fails
+  // with "buffer too small" — only commit when there's actually audio to flush.
+  private hasUncommittedAudio = false
 
-  async connect(token: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const url = 'wss://api.openai.com/v1/realtime?intent=transcription'
-      this.ws = new WebSocket(url, [
-        'realtime',
-        `openai-insecure-api-key.${token}`,
-      ])
+  protected createSocket(token: string): WebSocket {
+    const url = 'wss://api.openai.com/v1/realtime?intent=transcription'
+    return new WebSocket(url, ['realtime', `openai-insecure-api-key.${token}`])
+  }
 
-      const timeout = setTimeout(() => {
-        this.ws?.close()
-        reject(new Error('OpenAI Realtime WebSocket connection timed out'))
-      }, CONNECT_TIMEOUT_MS)
-
-      this.ws.onopen = () => {
-        clearTimeout(timeout)
-        this.connected = true
-        this.ws?.send(JSON.stringify({
-          type: 'session.update',
-          session: {
-            type: 'transcription',
-            audio: {
-              input: {
-                format: { type: 'audio/pcm', rate: 24000 },
-                noise_reduction: { type: 'near_field' },
-                transcription: {
-                  model: 'gpt-4o-mini-transcribe',
-                },
-                turn_detection: {
-                  type: 'server_vad',
-                  threshold: 0.5,
-                  silence_duration_ms: 500,
-                  prefix_padding_ms: 300,
-                },
-              },
+  protected onConnected(): void {
+    this.ws?.send(JSON.stringify({
+      type: 'session.update',
+      session: {
+        type: 'transcription',
+        audio: {
+          input: {
+            format: { type: 'audio/pcm', rate: 24000 },
+            noise_reduction: { type: 'near_field' },
+            transcription: {
+              model: 'gpt-4o-mini-transcribe',
+            },
+            turn_detection: {
+              type: 'server_vad',
+              threshold: 0.5,
+              silence_duration_ms: 500,
+              prefix_padding_ms: 300,
             },
           },
-        }))
-        resolve()
-      }
+        },
+      },
+    }))
+  }
 
-      this.ws.onerror = () => {
-        clearTimeout(timeout)
-        const err = new Error('OpenAI Realtime WebSocket connection failed')
-        if (!this.connected) {
-          reject(err)
-        } else {
-          this.errorCb?.(err)
+  protected writeAudio(chunk: ArrayBuffer): void {
+    this.ws?.send(JSON.stringify({
+      type: 'input_audio_buffer.append',
+      audio: arrayBufferToBase64(chunk),
+    }))
+    this.hasUncommittedAudio = true
+  }
+
+  protected requestFinalize(): boolean {
+    // Nothing to commit (server_vad already committed it) — committing now would
+    // fail with "buffer too small". Skip and let finish() complete immediately.
+    if (!this.hasUncommittedAudio) return false
+    this.ws?.send(JSON.stringify({ type: 'input_audio_buffer.commit' }))
+    this.hasUncommittedAudio = false
+    return true
+  }
+
+  protected handleMessage(data: any): void {
+    switch (data.type) {
+      case 'conversation.item.input_audio_transcription.delta':
+        if (data.delta) {
+          // Accumulate deltas so interim events carry the full text so far
+          this.pendingDelta += data.delta
+          this.emitTranscript({ type: 'interim', text: this.pendingDelta })
         }
-      }
-
-      this.ws.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data as string)
-
-          switch (data.type) {
-            case 'conversation.item.input_audio_transcription.delta':
-              if (data.delta) {
-                // Accumulate deltas so interim events carry the full text so far
-                this.pendingDelta += data.delta
-                this.transcriptCb?.({ type: 'interim', text: this.pendingDelta })
-              }
-              break
-            case 'conversation.item.input_audio_transcription.completed':
-              this.pendingDelta = ''
-              if (data.transcript) {
-                this.transcriptCb?.({ type: 'final', text: data.transcript })
-              }
-              break
-            case 'input_audio_buffer.speech_stopped':
-              this.transcriptCb?.({ type: 'speech_ended', text: '' })
-              break
-            case 'error':
-              this.errorCb?.(friendlyRealtimeError(data.error))
-              break
-            case 'response.done':
-              if (data.response?.status === 'failed') {
-                this.errorCb?.(friendlyRealtimeError(data.response?.status_details?.error))
-              }
-              break
-          }
-        } catch {
-          // Ignore non-JSON messages
+        break
+      case 'conversation.item.input_audio_transcription.completed':
+        this.pendingDelta = ''
+        if (data.transcript) {
+          this.emitTranscript({ type: 'final', text: data.transcript })
         }
-      }
-
-      this.ws.onclose = (event) => {
-        if (event.code !== 1000 && event.code !== 1005) {
-          this.errorCb?.(new Error(`OpenAI connection closed: ${event.code} ${event.reason}`))
+        // The committed utterance's transcript is in — complete a pending finish()
+        // (no-op during normal streaming, when nothing is awaiting).
+        this.completeFinish()
+        break
+      case 'input_audio_buffer.committed':
+        // Server committed the buffer (server_vad) — nothing left to flush.
+        this.hasUncommittedAudio = false
+        break
+      case 'input_audio_buffer.speech_stopped':
+        this.emitTranscript({ type: 'speech_ended', text: '' })
+        break
+      case 'error':
+        // A late error while wrapping up (e.g. an empty-buffer commit that raced
+        // the server's auto-commit) is benign — finish quietly instead of alarming
+        // the user, who already has their transcript.
+        if (this.isFinishing) this.completeFinish()
+        else this.emitError(friendlyRealtimeError(data.error))
+        break
+      case 'response.done':
+        if (data.response?.status === 'failed') {
+          this.emitError(friendlyRealtimeError(data.response?.status_details?.error))
         }
-      }
-    })
-  }
-
-  sendAudio(chunk: ArrayBuffer): void {
-    if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({
-        type: 'input_audio_buffer.append',
-        audio: arrayBufferToBase64(chunk),
-      }))
-    }
-  }
-
-  onTranscript(cb: TranscriptCallback): void {
-    this.transcriptCb = cb
-  }
-
-  onError(cb: ErrorCallback): void {
-    this.errorCb = cb
-  }
-
-  close(): void {
-    if (this.ws) {
-      if (this.ws.readyState === WebSocket.OPEN) {
-        this.ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }))
-      }
-      this.ws.close()
-      this.ws = null
+        break
     }
   }
 }
@@ -312,25 +425,37 @@ export interface AudioCaptureHandle {
 }
 
 /**
+ * Request microphone access. Split out from startAudioCapture so callers can
+ * start acquiring the mic in parallel with credential/connection setup.
+ *
+ * No sampleRate constraint: browsers treat it as a hint and capture at the
+ * hardware's native rate regardless; the AudioContext in startAudioCapture
+ * (created at the provider's required rate) does the actual resampling.
+ */
+export async function acquireMicStream(): Promise<MediaStream> {
+  return navigator.mediaDevices.getUserMedia({
+    audio: {
+      channelCount: 1,
+      echoCancellation: true,
+      noiseSuppression: true,
+    },
+  })
+}
+
+/**
  * Set up microphone capture and pipe PCM audio chunks to an SttAdapter.
- * Returns handles for the resources and a cleanup function.
+ * Returns handles for the resources and a cleanup function. The caller owns
+ * the passed-in stream (acquire via acquireMicStream) and is responsible for
+ * releasing it if this rejects; on success the returned cleanup() stops it.
  *
  * TODO: Migrate from deprecated createScriptProcessor to AudioWorkletNode.
  */
 export async function startAudioCapture(
   adapter: SttAdapter,
+  stream: MediaStream,
   options?: { withAnalyser?: boolean },
 ): Promise<AudioCaptureHandle> {
   const sampleRate = adapter.sampleRate ?? 16000
-
-  const stream = await navigator.mediaDevices.getUserMedia({
-    audio: {
-      channelCount: 1,
-      sampleRate,
-      echoCancellation: true,
-      noiseSuppression: true,
-    },
-  })
 
   const audioContext = new AudioContext({ sampleRate })
   // The context may start suspended if created outside a synchronous user-gesture

--- a/src/renderer/lib/voice-agent-deepgram.ts
+++ b/src/renderer/lib/voice-agent-deepgram.ts
@@ -8,6 +8,7 @@ export class DeepgramVoiceAgentAdapter implements VoiceAgentAdapter {
   private eventCb: VoiceAgentEventCallback | null = null
   private keepAliveTimer: ReturnType<typeof setInterval> | null = null
   private connected = false
+  private closed = false
   readonly inputSampleRate = 16000
   readonly outputSampleRate = 24000
 
@@ -39,7 +40,7 @@ export class DeepgramVoiceAgentAdapter implements VoiceAgentAdapter {
         const err = new Error('Deepgram Voice Agent WebSocket connection failed')
         if (!this.connected) {
           reject(err)
-        } else {
+        } else if (!this.closed) {
           this.eventCb?.({ type: 'error', message: err.message })
         }
       }
@@ -61,7 +62,9 @@ export class DeepgramVoiceAgentAdapter implements VoiceAgentAdapter {
 
       this.ws.onclose = (event) => {
         this.stopKeepAlive()
-        if (event.code !== 1000 && event.code !== 1005) {
+        // Suppress the error for a deliberate close (e.g. stopping a still-connecting
+        // session yields a non-1000 close that isn't a real failure).
+        if (!this.closed && event.code !== 1000 && event.code !== 1005) {
           this.eventCb?.({ type: 'error', message: `Deepgram connection closed: ${event.code} ${event.reason}` })
         }
         this.eventCb?.({ type: 'disconnected' })
@@ -207,6 +210,7 @@ export class DeepgramVoiceAgentAdapter implements VoiceAgentAdapter {
   }
 
   close(): void {
+    this.closed = true
     this.stopKeepAlive()
     if (this.ws) {
       this.ws.close()

--- a/src/renderer/lib/voice-agent-openai.ts
+++ b/src/renderer/lib/voice-agent-openai.ts
@@ -7,6 +7,7 @@ export class OpenAIVoiceAgentAdapter implements VoiceAgentAdapter {
   private ws: WebSocket | null = null
   private eventCb: VoiceAgentEventCallback | null = null
   private connected = false
+  private closed = false
   readonly inputSampleRate = 24000
   readonly outputSampleRate = 24000
 
@@ -36,7 +37,7 @@ export class OpenAIVoiceAgentAdapter implements VoiceAgentAdapter {
         const err = new Error('OpenAI Realtime WebSocket connection failed')
         if (!this.connected) {
           reject(err)
-        } else {
+        } else if (!this.closed) {
           this.eventCb?.({ type: 'error', message: err.message })
         }
       }
@@ -51,7 +52,9 @@ export class OpenAIVoiceAgentAdapter implements VoiceAgentAdapter {
       }
 
       this.ws.onclose = (event) => {
-        if (event.code !== 1000 && event.code !== 1005) {
+        // Suppress the error for a deliberate close (e.g. stopping a still-connecting
+        // session yields a non-1000 close that isn't a real failure).
+        if (!this.closed && event.code !== 1000 && event.code !== 1005) {
           this.eventCb?.({ type: 'error', message: `OpenAI connection closed: ${event.code} ${event.reason}` })
         }
         this.eventCb?.({ type: 'disconnected' })
@@ -228,6 +231,7 @@ export class OpenAIVoiceAgentAdapter implements VoiceAgentAdapter {
   }
 
   close(): void {
+    this.closed = true
     if (this.ws) {
       this.ws.close()
       this.ws = null

--- a/src/shared/test/mock-websocket.ts
+++ b/src/shared/test/mock-websocket.ts
@@ -1,0 +1,56 @@
+/**
+ * Test double for the browser WebSocket. Records sent frames and lets tests
+ * drive server events (open / message / close). Shared by the STT adapter tests
+ * and the speech-recognition polyfill tests.
+ *
+ * By default the socket stays CONNECTING until `simulateOpen()` is called. For
+ * code paths that assume the socket opens on its own, set the static
+ * `MockWebSocket.autoOpen = true` in a `beforeEach` — it then opens on a
+ * microtask after construction. Each test file should reset `instances` (and
+ * `autoOpen`, if it sets it) in `beforeEach`.
+ */
+export class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+  static instances: MockWebSocket[] = []
+  static autoOpen = false
+
+  readyState: number = MockWebSocket.CONNECTING
+  sent: (string | ArrayBuffer)[] = []
+  onopen: ((ev?: unknown) => void) | null = null
+  onclose: ((ev: { code: number; reason: string }) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onerror: ((ev?: unknown) => void) | null = null
+
+  constructor(public url: string, public protocols?: string | string[]) {
+    MockWebSocket.instances.push(this)
+    if (MockWebSocket.autoOpen) {
+      // Open on a microtask so it resolves within the same promise-chain tick.
+      Promise.resolve().then(() => this.simulateOpen())
+    }
+  }
+
+  send(data: string | ArrayBuffer): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED
+  }
+
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.({})
+  }
+
+  simulateMessage(data: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(data) })
+  }
+
+  simulateClose(code = 1000, reason = ''): void {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.({ code, reason })
+  }
+}


### PR DESCRIPTION
## Problem

Pressing the mic button had a multi-second delay before speech was picked up: the flow was fully serial — mint an ephemeral STT token, `await` the WebSocket handshake, *then* `getUserMedia` + start the audio pipeline. On top of that, both adapters silently dropped any audio captured before the socket opened.

The first cut at speeding this up (parallel mic-acquire + background connect + pre-open buffering) introduced a worse regression: the UI flipped to "recording" before the socket was open, but stop/submit during the handshake — and OpenAI's `server_vad` auto-commit — meant **dictated words were silently lost**.

## What this does

**Time-to-listening** drops from `token mint + WSS handshake + mic spin-up` (serial) to roughly `max(token fetch, mic spin-up)`: the mic is acquired in parallel with the token fetch, the WebSocket connects in the background, and the adapter buffers audio sent before the socket opens, flushing it on open.

**No lost dictation.** A new graceful `finish()` on the adapter contract flushes buffered audio, asks the server to finalize, and awaits the trailing transcripts (bounded by a 1.5s backstop) before returning. `stopRecording` is now async and `await`s it; submit awaits the final text — so a quick speak-then-Enter no longer sends an empty message. This also fixes a pre-existing tail-loss (stop used to drop the last untranscribed sliver even with an open socket).

**OpenAI "buffer too small" fix.** With `server_vad`, the server auto-commits each utterance, so committing again on stop failed with "buffer too small." The OpenAI adapter now tracks uncommitted audio and only commits when there's something pending; a benign error during finalize is suppressed (you already have the transcript).

## Notable changes

- **`WebSocketSttAdapter` base class** — the two STT adapters duplicated buffering, the finish lifecycle, and deliberate-close error suppression. Extracted into a shared base; each adapter is now ~25 lines of provider specifics (`createSocket` / `writeAudio` / `requestFinalize` / `handleMessage`).
- **`finalizing` state** — the brief flush window after stop shows a spinner ("Finishing…") instead of claiming "recording" during a window where audio could be lost.
- **Generation-token cancellation** — a per-attempt counter (bumped on teardown/unmount) lets an in-flight `startRecording` whose awaits resolve after a stop/restart or unmount detect it's stale and release what it acquired, instead of resurrecting a mic + socket nobody owns. Closes the unmount-leak and double-start-orphan races.
- **Unhandled-rejection + stale-adapter guards** — the parallel mic-acquire promise is observed synchronously; `adapter.onError` bails on a stale adapter.
- **Voice-agent adapters** — applied the same deliberate-close suppression so stopping a still-connecting session no longer surfaces "connection closed: 1006."
- **Cleanups** — `startAudioCapture` takes the stream as a required param (explicit ownership); `use-voice-agent` reuses `acquireMicStream`; the duplicated test WebSocket mock is extracted to `src/shared/test/mock-websocket.ts`.

## Testing

- 37 STT adapter tests (pre-open buffering, finish ordering/backstop, no-commit-on-empty-buffer, benign-error suppression) + a composer test proving submit awaits the async stop.
- Full renderer + polyfill suites green: **1259 tests across 86 files**. tsc and eslint clean.
- Manually verified: speak → wait for transcript → stop closes cleanly with the text kept; mid-utterance stop still pulls in the trailing words.

## Known follow-up

The voice-agent adapters' new close-suppression has no direct test coverage (those adapters have no existing harness); the extracted `MockWebSocket` now makes adding it straightforward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
