### PR TITLE
fix: show running state for in-flight subagent tool calls

### DIFF
--- a/src/renderer/components/messages/subagent-block.test.tsx
+++ b/src/renderer/components/messages/subagent-block.test.tsx
@@ -14,8 +14,10 @@ vi.mock('@renderer/hooks/use-messages', () => ({
 
 // Mock ToolCallItem
 vi.mock('./tool-call-item', () => ({
-  ToolCallItem: ({ toolCall }: { toolCall: ApiToolCall }) => (
-    <div data-testid={`sub-tool-${toolCall.name}`}>{toolCall.name}</div>
+  ToolCallItem: ({ toolCall, isSessionActive }: { toolCall: ApiToolCall; isSessionActive?: boolean }) => (
+    <div data-testid={`sub-tool-${toolCall.name}`} data-session-active={String(!!isSessionActive)}>
+      {toolCall.name}
+    </div>
   ),
   StreamingToolCallItem: ({ name }: { name: string }) => (
     <div data-testid="sub-streaming-tool">{name}</div>
@@ -145,6 +147,47 @@ describe('SubAgentBlock', () => {
 
     expect(screen.getByText('I found the config file.')).toBeInTheDocument()
     expect(screen.getByTestId('sub-tool-Read')).toBeInTheDocument()
+  })
+
+  it('passes isSessionActive to in-flight subagent tools so they show running, not cancelled', () => {
+    const tc = createToolCall({
+      name: 'Task',
+      input: { subagent_type: 'Explore', description: 'Working' },
+      result: undefined,
+    })
+
+    // In-flight tool inside the subagent (no result yet)
+    mockSubMessages = [
+      createAssistantMessage({
+        id: 'sub-msg-1',
+        content: { text: 'snapshotting' },
+        toolCalls: [createToolCall({ name: 'Bash', result: undefined })],
+      }),
+    ]
+
+    render(
+      <SubAgentBlock
+        toolCall={tc}
+        sessionId="s-1"
+        agentSlug="agent-1"
+        isSessionActive
+        activeSubagent={{
+          parentToolId: tc.id,
+          agentId: 'sub-1',
+          streamingMessage: null,
+          streamingToolUse: null,
+          progressSummary: null,
+          subagentType: null,
+          description: null,
+          usage: null,
+          lastToolName: null,
+        }}
+      />
+    )
+
+    // Running subagent auto-expands; the in-flight tool must be told the session
+    // is active, otherwise getStatus() resolves it to 'cancelled' (the Ban icon).
+    expect(screen.getByTestId('sub-tool-Bash')).toHaveAttribute('data-session-active', 'true')
   })
 
   it('shows "Sub-agent is working..." when running with no messages', async () => {

--- a/src/renderer/components/messages/subagent-block.tsx
+++ b/src/renderer/components/messages/subagent-block.tsx
@@ -247,6 +247,7 @@ export function SubAgentBlock({
                   toolCall={item.toolCall}
                   messageCreatedAt={item.messageCreatedAt}
                   agentSlug={agentSlug}
+                  isSessionActive={isSessionActive}
                 />
               )
             )}


### PR DESCRIPTION
## Problem
Inside subagents, tool calls never showed the loading/running state — they appeared as "blocked" (the ⊘ `Ban` icon) and then flipped straight to success.

## Root cause
`getStatus()` in `tool-call-item.tsx` resolves a tool whose `result` is still null to `running` **only** when `isSessionActive` is true, otherwise `cancelled`. The top-level message list threads `isSessionActive` down (`message-item.tsx`), but `subagent-block.tsx` rendered its `<ToolCallItem>` without it — so every in-flight subagent tool resolved to `cancelled` until its result landed.

This is **pre-existing** (present even pre-merge on `main`); PR #112's restyle swapped the `cancelled` icon from a neutral `StopCircle` to `Ban` (⊘), which made the long-standing bug conspicuous.

## Fix
Thread `isSessionActive` into the subagent's `ToolCallItem`, matching the top-level path. Adds a regression test (asserts an active subagent's in-flight tool receives `isSessionActive=true`).

Typecheck + lint clean; 10/10 subagent-block tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)