### PR TITLE
Improve unit test coverage for high-risk flows

### DIFF
--- a/agent-container/vitest.config.ts
+++ b/agent-container/vitest.config.ts
@@ -5,5 +5,11 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/**/*.d.ts'],
+    },
   },
 })

--- a/src/api/routes/connected-accounts.test.ts
+++ b/src/api/routes/connected-accounts.test.ts
@@ -114,12 +114,18 @@ vi.mock('@shared/lib/analytics/server-analytics', () => ({
   trackServerEvent: vi.fn(),
 }))
 
+const mockLogAuditEvent = vi.fn()
+
 vi.mock('@shared/lib/services/audit-log-service', () => ({
-  logAuditEvent: vi.fn(),
+  logAuditEvent: (...args: unknown[]) => mockLogAuditEvent(...args),
 }))
 
+const mockCountActiveTriggersPerAccount = vi.fn()
+const mockCancelTriggersForConnectedAccount = vi.fn()
+
 vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
-  countActiveTriggersPerAccount: vi.fn().mockResolvedValue({}),
+  countActiveTriggersPerAccount: (...args: unknown[]) => mockCountActiveTriggersPerAccount(...args),
+  cancelTriggersForConnectedAccount: (...args: unknown[]) => mockCancelTriggersForConnectedAccount(...args),
 }))
 
 import connectedAccountsRouter from './connected-accounts'
@@ -140,6 +146,8 @@ describe('connected-accounts reconnect flow', () => {
     mockDbInsertValues.mockResolvedValue(undefined)
     mockDbDeleteWhere.mockResolvedValue(undefined)
     mockDeleteConnection.mockResolvedValue(undefined)
+    mockCancelTriggersForConnectedAccount.mockResolvedValue(undefined)
+    mockCountActiveTriggersPerAccount.mockResolvedValue({})
   })
 
   describe('POST /initiate with reconnectAccountId', () => {
@@ -270,6 +278,95 @@ describe('connected-accounts reconnect flow', () => {
       expect(res.status).toBe(200)
       expect(mockDbInsertValues).toHaveBeenCalled()
       expect(mockDbUpdateSet).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('DELETE /:id', () => {
+    it('cancels webhook triggers before deleting the provider connection and account row', async () => {
+      mockDbSelectLimit.mockResolvedValue([{
+        id: 'existing-acc',
+        providerConnectionId: 'remote-conn',
+        providerName: 'composio',
+        toolkitSlug: 'github',
+      }])
+
+      const res = await app.request('http://localhost/api/connected-accounts/existing-acc', {
+        method: 'DELETE',
+      })
+
+      expect(res.status).toBe(204)
+      expect(mockCancelTriggersForConnectedAccount).toHaveBeenCalledWith('existing-acc')
+      expect(mockDeleteConnection).toHaveBeenCalledWith('remote-conn', 'github')
+      expect(mockDbDeleteWhere).toHaveBeenCalledWith({ col: 'id', val: 'existing-acc' })
+      expect(mockLogAuditEvent).toHaveBeenCalledWith({
+        userId: 'local',
+        object: 'account',
+        objectId: 'existing-acc',
+        action: 'disconnected',
+        details: { toolkitSlug: 'github' },
+      })
+
+      expect(mockCancelTriggersForConnectedAccount.mock.invocationCallOrder[0])
+        .toBeLessThan(mockDeleteConnection.mock.invocationCallOrder[0])
+      expect(mockDeleteConnection.mock.invocationCallOrder[0])
+        .toBeLessThan(mockDbDeleteWhere.mock.invocationCallOrder[0])
+    })
+
+    it('still deletes the local row when remote provider cleanup fails', async () => {
+      mockDbSelectLimit.mockResolvedValue([{
+        id: 'existing-acc',
+        providerConnectionId: 'remote-conn',
+        providerName: 'composio',
+        toolkitSlug: 'github',
+      }])
+      mockDeleteConnection.mockRejectedValue(new Error('remote unavailable'))
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const res = await app.request('http://localhost/api/connected-accounts/existing-acc', {
+        method: 'DELETE',
+      })
+
+      expect(res.status).toBe(204)
+      expect(mockCancelTriggersForConnectedAccount).toHaveBeenCalledWith('existing-acc')
+      expect(mockDbDeleteWhere).toHaveBeenCalledWith({ col: 'id', val: 'existing-acc' })
+      expect(warnSpy).toHaveBeenCalledWith('Failed to delete connection from provider:', expect.any(Error))
+    })
+
+    it('does not run cleanup when the account does not exist', async () => {
+      mockDbSelectLimit.mockResolvedValue([])
+
+      const res = await app.request('http://localhost/api/connected-accounts/missing-account', {
+        method: 'DELETE',
+      })
+
+      expect(res.status).toBe(404)
+      expect(await res.json()).toEqual({ error: 'Connected account not found' })
+      expect(mockCancelTriggersForConnectedAccount).not.toHaveBeenCalled()
+      expect(mockDeleteConnection).not.toHaveBeenCalled()
+      expect(mockDbDeleteWhere).not.toHaveBeenCalled()
+    })
+
+    it('stops deletion if trigger cancellation fails', async () => {
+      mockDbSelectLimit.mockResolvedValue([{
+        id: 'existing-acc',
+        providerConnectionId: 'remote-conn',
+        providerName: 'composio',
+        toolkitSlug: 'github',
+      }])
+      mockCancelTriggersForConnectedAccount.mockRejectedValue(new Error('trigger cleanup failed'))
+
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const res = await app.request('http://localhost/api/connected-accounts/existing-acc', {
+        method: 'DELETE',
+      })
+
+      expect(res.status).toBe(500)
+      expect(await res.json()).toEqual({ error: 'Failed to delete connected account' })
+      expect(mockDeleteConnection).not.toHaveBeenCalled()
+      expect(mockDbDeleteWhere).not.toHaveBeenCalled()
+      expect(errorSpy).toHaveBeenCalledWith('Failed to delete connected account:', expect.any(Error))
     })
   })
 })

--- a/src/api/routes/scheduled-tasks.test.ts
+++ b/src/api/routes/scheduled-tasks.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+const mockGetScheduledTask = vi.fn()
+const mockCancelScheduledTask = vi.fn()
+const mockResetScheduledTask = vi.fn()
+const mockUpdateTaskTimezone = vi.fn()
+const mockMarkTaskExecuted = vi.fn()
+const mockRecordManualExecution = vi.fn()
+const mockUpdateScheduleExpression = vi.fn()
+const mockUpdateTaskPrompt = vi.fn()
+const mockUpdateTaskRuntimeOptions = vi.fn()
+const mockPauseScheduledTask = vi.fn()
+const mockResumeScheduledTask = vi.fn()
+
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  getScheduledTask: (...args: unknown[]) => mockGetScheduledTask(...args),
+  cancelScheduledTask: (...args: unknown[]) => mockCancelScheduledTask(...args),
+  resetScheduledTask: (...args: unknown[]) => mockResetScheduledTask(...args),
+  updateTaskTimezone: (...args: unknown[]) => mockUpdateTaskTimezone(...args),
+  markTaskExecuted: (...args: unknown[]) => mockMarkTaskExecuted(...args),
+  recordManualExecution: (...args: unknown[]) => mockRecordManualExecution(...args),
+  updateScheduleExpression: (...args: unknown[]) => mockUpdateScheduleExpression(...args),
+  updateTaskPrompt: (...args: unknown[]) => mockUpdateTaskPrompt(...args),
+  updateTaskRuntimeOptions: (...args: unknown[]) => mockUpdateTaskRuntimeOptions(...args),
+  pauseScheduledTask: (...args: unknown[]) => mockPauseScheduledTask(...args),
+  resumeScheduledTask: (...args: unknown[]) => mockResumeScheduledTask(...args),
+}))
+
+const mockGetSessionsByScheduledTask = vi.fn()
+const mockRegisterSession = vi.fn()
+const mockUpdateSessionMetadata = vi.fn()
+
+vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionsByScheduledTask: (...args: unknown[]) => mockGetSessionsByScheduledTask(...args),
+  registerSession: (...args: unknown[]) => mockRegisterSession(...args),
+  updateSessionMetadata: (...args: unknown[]) => mockUpdateSessionMetadata(...args),
+}))
+
+const mockGetSecretEnvVars = vi.fn()
+
+vi.mock('@shared/lib/services/secrets-service', () => ({
+  getSecretEnvVars: (...args: unknown[]) => mockGetSecretEnvVars(...args),
+}))
+
+const mockCreateSession = vi.fn()
+const mockEnsureRunning = vi.fn()
+
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: {
+    ensureRunning: (...args: unknown[]) => mockEnsureRunning(...args),
+  },
+}))
+
+const mockMessagePersister = vi.hoisted(() => ({
+  isSessionActive: vi.fn(),
+  subscribeToSession: vi.fn(),
+  markSessionActive: vi.fn(),
+}))
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: mockMessagePersister,
+}))
+
+const mockGetEffectiveModels = vi.fn()
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getEffectiveModels: (...args: unknown[]) => mockGetEffectiveModels(...args),
+}))
+
+const mockValidateCronExpression = vi.fn()
+
+vi.mock('@shared/lib/services/schedule-parser', () => ({
+  validateCronExpression: (...args: unknown[]) => mockValidateCronExpression(...args),
+}))
+
+const mockMessagesCreate = vi.fn()
+const mockExtractTextFromLlmResponse = vi.fn()
+
+vi.mock('@shared/lib/llm-provider/helpers', () => ({
+  getConfiguredLlmClient: () => ({
+    messages: {
+      create: (...args: unknown[]) => mockMessagesCreate(...args),
+    },
+  }),
+  extractTextFromLlmResponse: (...args: unknown[]) => mockExtractTextFromLlmResponse(...args),
+}))
+
+const mockWithRetry = vi.fn(async (fn: () => Promise<unknown>) => fn())
+
+vi.mock('@shared/lib/utils/retry', () => ({
+  withRetry: (...args: Parameters<typeof mockWithRetry>) => mockWithRetry(...args),
+}))
+
+vi.mock('@shared/lib/auth/config', () => ({
+  getCurrentUserId: () => 'test-user',
+}))
+
+const mockLogAuditEvent = vi.fn()
+
+vi.mock('@shared/lib/services/audit-log-service', () => ({
+  logAuditEvent: (...args: unknown[]) => mockLogAuditEvent(...args),
+}))
+
+vi.mock('../middleware/auth', () => ({
+  Authenticated: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  EntityAgentRole: (opts: {
+    paramName: string
+    lookupFn: (id: string) => Promise<unknown>
+    contextKey: string
+    entityName: string
+  }) => () => async (c: {
+    req: { param: (name: string) => string }
+    set: (key: string, value: unknown) => void
+    json: (body: unknown, status?: number) => Response
+  }, next: () => Promise<void>) => {
+    const entity = await opts.lookupFn(c.req.param(opts.paramName))
+    if (!entity) {
+      return c.json({ error: `${opts.entityName} not found` }, 404)
+    }
+    c.set(opts.contextKey, entity)
+    return next()
+  },
+}))
+
+import scheduledTasksRouter from './scheduled-tasks'
+
+function createApp() {
+  const app = new Hono()
+  app.route('/api/scheduled-tasks', scheduledTasksRouter)
+  return app
+}
+
+function createTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'task-1',
+    agentSlug: 'agent-one',
+    name: 'Daily report',
+    prompt: 'Summarize yesterday',
+    scheduleType: 'cron',
+    scheduleExpression: '0 9 * * 1-5',
+    status: 'pending',
+    isRecurring: true,
+    model: null,
+    effort: null,
+    ...overrides,
+  }
+}
+
+describe('scheduled-tasks route', () => {
+  let app: ReturnType<typeof createApp>
+  let task: ReturnType<typeof createTask>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    task = createTask()
+
+    mockGetScheduledTask.mockImplementation(async () => task)
+    mockGetSessionsByScheduledTask.mockResolvedValue([
+      { id: 'session-active', name: 'Active session' },
+      { id: 'session-idle', name: 'Idle session' },
+    ])
+    mockMessagePersister.isSessionActive.mockImplementation((sessionId: string) => sessionId === 'session-active')
+    mockCreateSession.mockResolvedValue({ id: 'container-session-1' })
+    mockEnsureRunning.mockResolvedValue({ createSession: mockCreateSession })
+    mockGetSecretEnvVars.mockResolvedValue(['GITHUB_TOKEN'])
+    mockGetEffectiveModels.mockReturnValue({
+      agentModel: 'claude-agent',
+      browserModel: 'claude-browser',
+      summarizerModel: 'claude-summary',
+    })
+    mockValidateCronExpression.mockReturnValue({ valid: true })
+    mockMessagesCreate.mockResolvedValue({ content: [{ type: 'text', text: 'Every weekday at 9:00 AM' }] })
+    mockExtractTextFromLlmResponse.mockReturnValue('Every weekday at 9:00 AM')
+    mockPauseScheduledTask.mockResolvedValue(true)
+    mockResumeScheduledTask.mockResolvedValue(true)
+    mockUpdateScheduleExpression.mockResolvedValue(true)
+  })
+
+  it('returns task sessions with live activity from the message persister', async () => {
+    const res = await app.request('http://localhost/api/scheduled-tasks/task-1/sessions')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([
+      { id: 'session-active', name: 'Active session', isActive: true },
+      { id: 'session-idle', name: 'Idle session', isActive: false },
+    ])
+    expect(mockGetSessionsByScheduledTask).toHaveBeenCalledWith('agent-one', 'task-1')
+  })
+
+  it('runs a recurring task immediately and records a manual execution', async () => {
+    const res = await app.request('http://localhost/api/scheduled-tasks/task-1/run-now', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(201)
+    expect(await res.json()).toMatchObject({
+      sessionId: 'container-session-1',
+      agentSlug: 'agent-one',
+      task,
+    })
+    expect(mockEnsureRunning).toHaveBeenCalledWith('agent-one')
+    expect(mockCreateSession).toHaveBeenCalledWith({
+      availableEnvVars: ['GITHUB_TOKEN'],
+      initialMessage: 'Summarize yesterday',
+      model: 'claude-agent',
+      browserModel: 'claude-browser',
+    })
+    expect(mockRegisterSession).toHaveBeenCalledWith('agent-one', 'container-session-1', 'Daily report')
+    expect(mockUpdateSessionMetadata).toHaveBeenCalledWith('agent-one', 'container-session-1', {
+      isScheduledExecution: true,
+      scheduledTaskId: 'task-1',
+      scheduledTaskName: 'Daily report',
+    })
+    expect(mockMessagePersister.subscribeToSession).toHaveBeenCalledWith(
+      'container-session-1',
+      { createSession: mockCreateSession },
+      'container-session-1',
+      'agent-one',
+    )
+    expect(mockMessagePersister.markSessionActive).toHaveBeenCalledWith('container-session-1', 'agent-one')
+    expect(mockRecordManualExecution).toHaveBeenCalledWith('task-1', 'container-session-1')
+    expect(mockMarkTaskExecuted).not.toHaveBeenCalled()
+  })
+
+  it('marks a one-time task executed when run-now succeeds', async () => {
+    task = createTask({ isRecurring: false, scheduleType: 'once', name: null, model: 'custom-model', effort: 'high' })
+
+    const res = await app.request('http://localhost/api/scheduled-tasks/task-1/run-now', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(201)
+    expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'custom-model',
+      effort: 'high',
+    }))
+    expect(mockRegisterSession).toHaveBeenCalledWith('agent-one', 'container-session-1', 'Scheduled Task (Run Now)')
+    expect(mockMarkTaskExecuted).toHaveBeenCalledWith('task-1', 'container-session-1')
+    expect(mockRecordManualExecution).not.toHaveBeenCalled()
+  })
+
+  it('does not start a container for non-runnable task statuses', async () => {
+    task = createTask({ status: 'cancelled' })
+
+    const res = await app.request('http://localhost/api/scheduled-tasks/task-1/run-now', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Task is not pending' })
+    expect(mockEnsureRunning).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid cron updates before mutating the schedule', async () => {
+    mockValidateCronExpression.mockReturnValue({ valid: false })
+
+    const res = await app.request('http://localhost/api/scheduled-tasks/task-1/schedule', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scheduleExpression: 'not cron' }),
+    })
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Invalid cron expression' })
+    expect(mockUpdateScheduleExpression).not.toHaveBeenCalled()
+  })
+
+  it('returns 422 when the LLM generates an invalid cron expression', async () => {
+    mockExtractTextFromLlmResponse.mockReturnValue('every weekday morning')
+    mockValidateCronExpression.mockReturnValue({ valid: false })
+
+    const res = await app.request('http://localhost/api/scheduled-tasks/task-1/parse-schedule', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description: 'Every weekday morning' }),
+    })
+
+    expect(res.status).toBe(422)
+    expect(await res.json()).toEqual({
+      error: 'Generated expression is not valid cron syntax',
+      expression: 'every weekday morning',
+    })
+    expect(mockMessagesCreate).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'claude-summary',
+      max_tokens: 50,
+    }))
+  })
+
+  it('only allows recurring cron tasks to be paused', async () => {
+    task = createTask({ scheduleType: 'once', isRecurring: false })
+
+    const res = await app.request('http://localhost/api/scheduled-tasks/task-1/pause', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Only recurring cron tasks can be paused' })
+    expect(mockPauseScheduledTask).not.toHaveBeenCalled()
+  })
+})

--- a/src/api/routes/x-agent-chat.test.ts
+++ b/src/api/routes/x-agent-chat.test.ts
@@ -1,67 +1,262 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import * as fs from 'fs'
-import * as path from 'path'
-import * as os from 'os'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Hono } from 'hono'
 
-describe('appendAssistantMessage JSONL format', () => {
-  let testDir: string
+const mockEnsureRunning = vi.fn()
 
-  beforeEach(async () => {
-    testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'chat-jsonl-test-'))
-  })
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: {
+    ensureRunning: (...args: unknown[]) => mockEnsureRunning(...args),
+  },
+}))
 
-  afterEach(async () => {
-    await fs.promises.rm(testDir, { recursive: true, force: true })
-  })
+const mockValidateProxyToken = vi.fn()
 
-  it('writes a valid JSONL entry with correct fields', () => {
-    const jsonlPath = path.join(testDir, 'test-session.jsonl')
-    const sessionId = 'test-session-id'
-    const text = 'Hello from the agent'
+vi.mock('@shared/lib/proxy/token-store', () => ({
+  validateProxyToken: (...args: unknown[]) => mockValidateProxyToken(...args),
+}))
 
-    // Replicate the appendAssistantMessage logic
-    const entry = {
-      type: 'assistant',
-      message: { content: [{ type: 'text', text }] },
-      uuid: 'test-uuid',
-      parentUuid: null,
-      sessionId,
-      timestamp: '2026-05-23T12:00:00.000Z',
+const mockGetChatIntegration = vi.fn()
+const mockCreateChatIntegration = vi.fn()
+const mockListChatIntegrations = vi.fn()
+const mockUpdateChatIntegrationStatus = vi.fn()
+
+const MockDuplicateBotTokenError = vi.hoisted(() => class DuplicateBotTokenError extends Error {})
+
+vi.mock('@shared/lib/services/chat-integration-service', () => ({
+  getChatIntegration: (...args: unknown[]) => mockGetChatIntegration(...args),
+  createChatIntegration: (...args: unknown[]) => mockCreateChatIntegration(...args),
+  listChatIntegrations: (...args: unknown[]) => mockListChatIntegrations(...args),
+  updateChatIntegrationStatus: (...args: unknown[]) => mockUpdateChatIntegrationStatus(...args),
+  DuplicateBotTokenError: MockDuplicateBotTokenError,
+}))
+
+const mockListChatIntegrationSessions = vi.fn()
+
+vi.mock('@shared/lib/services/chat-integration-session-service', () => ({
+  listChatIntegrationSessions: (...args: unknown[]) => mockListChatIntegrationSessions(...args),
+}))
+
+const mockAddIntegration = vi.fn()
+const mockGetConnector = vi.fn()
+const mockGetActiveIntegrationIds = vi.fn()
+const mockEnsureSession = vi.fn()
+
+vi.mock('@shared/lib/chat-integrations/chat-integration-manager', () => ({
+  chatIntegrationManager: {
+    addIntegration: (...args: unknown[]) => mockAddIntegration(...args),
+    getConnector: (...args: unknown[]) => mockGetConnector(...args),
+    getActiveIntegrationIds: (...args: unknown[]) => mockGetActiveIntegrationIds(...args),
+    ensureSession: (...args: unknown[]) => mockEnsureSession(...args),
+  },
+}))
+
+const mockValidateChatIntegrationConfig = vi.fn()
+
+vi.mock('@shared/lib/chat-integrations/config-schema', () => ({
+  validateChatIntegrationConfig: (...args: unknown[]) => mockValidateChatIntegrationConfig(...args),
+  CHAT_PROVIDERS: ['slack', 'telegram', 'imessage'],
+  IMESSAGE_GATEWAY_URL: 'https://imessage-gateway.example.com',
+  imessageSetupSchema: {
+    safeParse: () => ({ success: true, data: { phoneNumber: '+15555550100', code: '123456' } }),
+  },
+}))
+
+const mockGetSessionJsonlPath = vi.fn()
+
+vi.mock('@shared/lib/utils/file-storage', () => ({
+  getSessionJsonlPath: (...args: unknown[]) => mockGetSessionJsonlPath(...args),
+}))
+
+const mockCaptureException = vi.fn()
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}))
+
+const mockExistsSync = vi.fn()
+const mockMkdirSync = vi.fn()
+const mockAppendFileSync = vi.fn()
+
+vi.mock('fs', () => ({
+  existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  mkdirSync: (...args: unknown[]) => mockMkdirSync(...args),
+  appendFileSync: (...args: unknown[]) => mockAppendFileSync(...args),
+}))
+
+import xAgentChat from './x-agent-chat'
+
+function createApp() {
+  const app = new Hono()
+  app.route('/api/x-agent/chat', xAgentChat)
+  return app
+}
+
+function createIntegration(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'integration-1',
+    agentSlug: 'agent-one',
+    provider: 'slack',
+    name: 'Team Slack',
+    status: 'connected',
+    ...overrides,
+  }
+}
+
+function immediateTimeout() {
+  vi.spyOn(globalThis, 'setTimeout').mockImplementation(((handler: Parameters<typeof setTimeout>[0]) => {
+    if (typeof handler === 'function') handler()
+    return 0 as unknown as ReturnType<typeof setTimeout>
+  }) as typeof setTimeout)
+}
+
+describe('x-agent chat route', () => {
+  let app: ReturnType<typeof createApp>
+  let connector: {
+    showTypingIndicator: ReturnType<typeof vi.fn>
+    sendMessage: ReturnType<typeof vi.fn>
+  }
+  let containerSendMessage: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    connector = {
+      showTypingIndicator: vi.fn().mockResolvedValue(undefined),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
     }
-    fs.appendFileSync(jsonlPath, JSON.stringify(entry) + '\n')
+    containerSendMessage = vi.fn().mockResolvedValue(undefined)
 
-    const content = fs.readFileSync(jsonlPath, 'utf-8').trim()
-    const parsed = JSON.parse(content)
-
-    expect(parsed.type).toBe('assistant')
-    expect(parsed.message.content).toEqual([{ type: 'text', text: 'Hello from the agent' }])
-    expect(parsed.sessionId).toBe(sessionId)
-    expect(parsed.parentUuid).toBeNull()
-    expect(parsed.uuid).toBe('test-uuid')
-    expect(parsed.timestamp).toBeTruthy()
+    mockValidateProxyToken.mockResolvedValue('agent-one')
+    mockGetChatIntegration.mockReturnValue(createIntegration())
+    mockListChatIntegrations.mockReturnValue([createIntegration()])
+    mockListChatIntegrationSessions.mockReturnValue([
+      { externalChatId: 'chat-1', displayName: 'General', archivedAt: null },
+    ])
+    mockGetConnector.mockReturnValue(connector)
+    mockGetActiveIntegrationIds.mockReturnValue(['integration-1'])
+    mockEnsureSession.mockResolvedValue('session-1')
+    mockEnsureRunning.mockResolvedValue({ sendMessage: containerSendMessage })
+    mockGetSessionJsonlPath.mockReturnValue('/tmp/superagent/agent-one/session-1.jsonl')
+    mockExistsSync.mockReturnValue(false)
+    vi.spyOn(Math, 'random').mockReturnValue(0)
   })
 
-  it('appends to existing JSONL without overwriting', () => {
-    const jsonlPath = path.join(testDir, 'test-session.jsonl')
-
-    // Write two entries
-    const entry1 = { type: 'user', message: { content: 'Hi' }, uuid: 'u1', sessionId: 's1', timestamp: 't1' }
-    const entry2 = { type: 'assistant', message: { content: [{ type: 'text', text: 'Hello' }] }, uuid: 'u2', parentUuid: null, sessionId: 's1', timestamp: 't2' }
-
-    fs.appendFileSync(jsonlPath, JSON.stringify(entry1) + '\n')
-    fs.appendFileSync(jsonlPath, JSON.stringify(entry2) + '\n')
-
-    const lines = fs.readFileSync(jsonlPath, 'utf-8').trim().split('\n')
-    expect(lines).toHaveLength(2)
-    expect(JSON.parse(lines[0]).type).toBe('user')
-    expect(JSON.parse(lines[1]).type).toBe('assistant')
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
-  it('inlines context with message text', () => {
-    const message = 'Your daily summary is ready'
-    const context = 'Triggered by cron at 12:00 PM'
-    const messageText = `[Internal context: ${context}]\n\n${message}`
+  it('rejects requests without a valid proxy token', async () => {
+    mockValidateProxyToken.mockResolvedValue(null)
 
-    expect(messageText).toBe('[Internal context: Triggered by cron at 12:00 PM]\n\nYour daily summary is ready')
+    const res = await app.request('http://localhost/api/x-agent/chat/list', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer bad-token' },
+    })
+
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'Unauthorized' })
+  })
+
+  it('lists integrations with only active chat sessions', async () => {
+    mockListChatIntegrationSessions.mockReturnValue([
+      { externalChatId: 'chat-1', displayName: 'General', archivedAt: null },
+      { externalChatId: 'chat-archived', displayName: 'Old thread', archivedAt: '2026-01-01T00:00:00.000Z' },
+    ])
+
+    const res = await app.request('http://localhost/api/x-agent/chat/list', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer good-token' },
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      integrations: [{
+        id: 'integration-1',
+        provider: 'slack',
+        name: 'Team Slack',
+        status: 'connected',
+        chats: [{ chatId: 'chat-1', displayName: 'General' }],
+      }],
+    })
+    expect(mockListChatIntegrations).toHaveBeenCalledWith('agent-one')
+  })
+
+  it('does not send through integrations owned by another agent', async () => {
+    mockGetChatIntegration.mockReturnValue(createIntegration({ agentSlug: 'agent-two' }))
+
+    const res = await app.request('http://localhost/api/x-agent/chat/send', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer good-token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        integration_id: 'integration-1',
+        message: 'Ship the update',
+        chat_id: 'chat-1',
+      }),
+    })
+
+    expect(res.status).toBe(403)
+    expect(await res.json()).toEqual({ error: 'Chat integration does not belong to this agent' })
+    expect(connector.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('reconnects a missing connector, sends the message, and notifies the agent session', async () => {
+    immediateTimeout()
+    mockGetConnector.mockReturnValueOnce(undefined).mockReturnValue(connector)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const res = await app.request('http://localhost/api/x-agent/chat/send', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer good-token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        integration_id: 'integration-1',
+        message: 'Ship the update',
+        context: 'Asked from a scheduled task',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ chatId: 'chat-1', provider: 'slack' })
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('getConnector returned undefined'))
+    expect(mockAddIntegration).toHaveBeenCalledWith('integration-1')
+    expect(connector.showTypingIndicator).toHaveBeenCalledWith('chat-1')
+    expect(connector.sendMessage).toHaveBeenCalledWith('chat-1', { text: 'Ship the update' })
+    expect(mockEnsureSession).toHaveBeenCalledWith('integration-1', 'chat-1')
+    expect(mockEnsureRunning).toHaveBeenCalledWith('agent-one')
+    expect(containerSendMessage).toHaveBeenCalledWith(
+      'session-1',
+      '[SYSTEM] A message was sent to the user on your behalf via chat integration:\n[Internal context: Asked from a scheduled task]\n\nShip the update',
+      undefined,
+      { shouldQuery: false },
+    )
+  })
+
+  it('falls back to appending JSONL when the live container cannot be notified', async () => {
+    immediateTimeout()
+    mockEnsureRunning.mockRejectedValue(new Error('container down'))
+
+    const res = await app.request('http://localhost/api/x-agent/chat/send', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer good-token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        integration_id: 'integration-1',
+        message: 'Daily summary is ready',
+        chat_id: 'chat-1',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockMkdirSync).toHaveBeenCalledWith('/tmp/superagent/agent-one', { recursive: true })
+    expect(mockAppendFileSync).toHaveBeenCalledWith(
+      '/tmp/superagent/agent-one/session-1.jsonl',
+      expect.stringContaining('"type":"assistant"'),
+    )
+
+    const entry = JSON.parse((mockAppendFileSync.mock.calls[0][1] as string).trim())
+    expect(entry.sessionId).toBe('session-1')
+    expect(entry.parentUuid).toBeNull()
+    expect(entry.message.content).toEqual([{
+      type: 'text',
+      text: '[SYSTEM] A message was sent to the user on your behalf via chat integration:\nDaily summary is ready',
+    }])
   })
 })

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const electronMocks = vi.hoisted(() => ({
+  exposeInMainWorld: vi.fn(),
+  invoke: vi.fn(),
+  send: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn(),
+  removeAllListeners: vi.fn(),
+  removeListener: vi.fn(),
+  getPathForFile: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  contextBridge: {
+    exposeInMainWorld: electronMocks.exposeInMainWorld,
+  },
+  ipcRenderer: {
+    invoke: electronMocks.invoke,
+    send: electronMocks.send,
+    on: electronMocks.on,
+    off: electronMocks.off,
+    removeAllListeners: electronMocks.removeAllListeners,
+    removeListener: electronMocks.removeListener,
+  },
+  webUtils: {
+    getPathForFile: electronMocks.getPathForFile,
+  },
+}))
+
+type ExposedApi = {
+  [key: string]: unknown
+  getApiUrl: () => Promise<string>
+  platform: string
+  osVersion: string
+  openExternal: (url: string) => Promise<void>
+  createDockShortcut: (agentSlug: string, dashboardSlug: string, dashboardName: string, iconPng: Uint8Array) => Promise<void>
+  getPathForFile: (file: File) => string
+  showNotification: (
+    title: string,
+    body: string,
+    actions?: Array<{ text: string }>,
+    context?: unknown,
+  ) => Promise<void>
+  minimizeWindow: () => void
+  setSidebarCollapsed: (collapsed: boolean) => void
+  onNavigateToAgent: (callback: (agentSlug: string, sessionId?: string | null) => void) => void
+  removeNavigateToAgent: () => void
+  onNotificationEvent: (
+    callback: (event: { type: 'click' | 'action'; actionIndex?: number; context?: unknown }) => void,
+  ) => () => void
+  onUpdateStatus: (callback: (status: unknown) => void) => () => void
+  removeUpdateStatus: () => void
+}
+
+const processWithSystemVersion = process as typeof process & {
+  getSystemVersion?: () => string
+}
+
+const originalGetSystemVersion = processWithSystemVersion.getSystemVersion
+
+async function loadApi(): Promise<ExposedApi> {
+  vi.resetModules()
+  electronMocks.exposeInMainWorld.mockClear()
+
+  await import('./index')
+
+  expect(electronMocks.exposeInMainWorld).toHaveBeenCalledWith('electronAPI', expect.any(Object))
+  return electronMocks.exposeInMainWorld.mock.calls[0][1] as ExposedApi
+}
+
+describe('preload electronAPI bridge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    processWithSystemVersion.getSystemVersion = () => '14.4.1'
+  })
+
+  afterEach(() => {
+    if (originalGetSystemVersion) {
+      processWithSystemVersion.getSystemVersion = originalGetSystemVersion
+    } else {
+      Reflect.deleteProperty(processWithSystemVersion, 'getSystemVersion')
+    }
+  })
+
+  it('exposes stable metadata and invoke wrappers without exposing ipcRenderer', async () => {
+    const api = await loadApi()
+
+    electronMocks.invoke.mockResolvedValueOnce('http://localhost:3173')
+    await expect(api.getApiUrl()).resolves.toBe('http://localhost:3173')
+    expect(electronMocks.invoke).toHaveBeenCalledWith('get-api-url')
+
+    await api.openExternal('https://example.com')
+    expect(electronMocks.invoke).toHaveBeenLastCalledWith('open-external', 'https://example.com')
+
+    await api.showNotification('Ready', 'The job finished', [{ text: 'Open' }], { sessionId: 's1' })
+    expect(electronMocks.invoke).toHaveBeenLastCalledWith('show-notification', {
+      title: 'Ready',
+      body: 'The job finished',
+      actions: [{ text: 'Open' }],
+      context: { sessionId: 's1' },
+    })
+
+    await api.createDockShortcut('agent-one', 'dashboard-one', 'Dashboard', new Uint8Array([1, 2, 3]))
+    expect(electronMocks.invoke).toHaveBeenLastCalledWith('create-dock-shortcut', {
+      agentSlug: 'agent-one',
+      dashboardSlug: 'dashboard-one',
+      dashboardName: 'Dashboard',
+      iconPng: [1, 2, 3],
+    })
+
+    expect(api.platform).toBe(process.platform)
+    expect(api.osVersion).toBe('14.4.1')
+    expect(api).not.toHaveProperty('ipcRenderer')
+  })
+
+  it('maps one-way window commands to ipcRenderer.send channels', async () => {
+    const api = await loadApi()
+
+    api.minimizeWindow()
+    api.setSidebarCollapsed(true)
+
+    expect(electronMocks.send).toHaveBeenCalledWith('window-minimize')
+    expect(electronMocks.send).toHaveBeenCalledWith('set-sidebar-collapsed', true)
+  })
+
+  it('forwards navigation events and removes channel listeners', async () => {
+    const api = await loadApi()
+    const callback = vi.fn()
+
+    api.onNavigateToAgent(callback)
+
+    const handler = electronMocks.on.mock.calls.find(([channel]) => channel === 'navigate-to-agent')?.[1] as
+      | ((event: unknown, agentSlug: string, sessionId?: string | null) => void)
+      | undefined
+    expect(handler).toBeDefined()
+
+    handler?.({}, 'agent-one', 'session-one')
+    expect(callback).toHaveBeenCalledWith('agent-one', 'session-one')
+
+    api.removeNavigateToAgent()
+    expect(electronMocks.removeAllListeners).toHaveBeenCalledWith('navigate-to-agent')
+  })
+
+  it('returns a precise unsubscribe for notification events', async () => {
+    const api = await loadApi()
+    const callback = vi.fn()
+
+    const unsubscribe = api.onNotificationEvent(callback)
+    const handler = electronMocks.on.mock.calls.find(([channel]) => channel === 'notification-event')?.[1] as
+      | ((event: unknown, payload: { type: 'click' | 'action'; actionIndex?: number; context?: unknown }) => void)
+      | undefined
+    expect(handler).toBeDefined()
+
+    handler?.({}, { type: 'action', actionIndex: 0, context: { agentSlug: 'agent-one' } })
+    expect(callback).toHaveBeenCalledWith({ type: 'action', actionIndex: 0, context: { agentSlug: 'agent-one' } })
+
+    unsubscribe()
+    expect(electronMocks.off).toHaveBeenCalledWith('notification-event', handler)
+  })
+
+  it('uses removeListener for update-status unsubscribe and supports bulk cleanup', async () => {
+    const api = await loadApi()
+    const callback = vi.fn()
+
+    const unsubscribe = api.onUpdateStatus(callback)
+    const handler = electronMocks.on.mock.calls.find(([channel]) => channel === 'update-status')?.[1] as
+      | ((event: unknown, status: unknown) => void)
+      | undefined
+    expect(handler).toBeDefined()
+
+    handler?.({}, { state: 'downloaded' })
+    expect(callback).toHaveBeenCalledWith({ state: 'downloaded' })
+
+    unsubscribe()
+    expect(electronMocks.removeListener).toHaveBeenCalledWith('update-status', handler)
+
+    api.removeUpdateStatus()
+    expect(electronMocks.removeAllListeners).toHaveBeenCalledWith('update-status')
+  })
+
+  it('delegates dropped-file path resolution to Electron webUtils', async () => {
+    const api = await loadApi()
+    const file = {} as File
+    electronMocks.getPathForFile.mockReturnValue('/Users/test/file.txt')
+
+    expect(api.getPathForFile(file)).toBe('/Users/test/file.txt')
+    expect(electronMocks.getPathForFile).toHaveBeenCalledWith(file)
+  })
+})

--- a/src/shared/lib/container/base-container-client-start-cleanup.sup212.test.ts
+++ b/src/shared/lib/container/base-container-client-start-cleanup.sup212.test.ts
@@ -48,6 +48,26 @@ vi.mock('child_process', () => {
   }
 })
 
+vi.mock('net', () => {
+  const createServer = vi.fn(() => {
+    const listeners = new Map<string, () => void>()
+    return {
+      once: vi.fn((event: string, callback: () => void) => {
+        listeners.set(event, callback)
+      }),
+      close: vi.fn(),
+      listen: vi.fn(() => {
+        queueMicrotask(() => listeners.get('listening')?.())
+      }),
+    }
+  })
+
+  return {
+    default: { createServer },
+    createServer,
+  }
+})
+
 vi.mock('@shared/lib/error-reporting', () => ({
   captureException: vi.fn(),
   addErrorBreadcrumb: vi.fn(),


### PR DESCRIPTION
## Summary

This PR expands unit coverage around several high-risk flows identified in the coverage audit:

- Adds scheduled task route coverage for session listing, run-now execution, recurring vs one-time task state, cron validation, LLM parse failures, and pause eligibility.
- Replaces the shallow x-agent chat JSONL test with production route coverage for proxy auth, integration listing, ownership checks, connector reconnect/send behavior, live session notification, and JSONL fallback.
- Adds connected account delete coverage for webhook trigger cleanup ordering, provider cleanup failure behavior, missing accounts, and cancellation failure handling.
- Adds preload IPC bridge contract tests for exposed API shape, invoke/send channels, listener cleanup, notification/update subscriptions, and file path resolution.
- Makes agent-container coverage include all source files explicitly.
- Makes the SUP-212 unhealthy-container cleanup test deterministic by mocking port availability instead of depending on host socket binding.

## Validation

Run under `nvm use 22.22.3`:

- `npm run test:run` passed: 5095 tests
- `npm run typecheck` passed
- `npm test` in `agent-container` passed: 336 tests
- `npx vitest run --coverage --coverage.reporter=text-summary` in `agent-container` passed
- `git diff --check` passed
