### PR TITLE
feat(onboarding): add default-model selection step

### DIFF
--- a/e2e/pages/wizard.page.ts
+++ b/e2e/pages/wizard.page.ts
@@ -4,10 +4,10 @@ import { Page, expect } from '@playwright/test'
  * Page object for the Getting Started Wizard
  *
  * Manual flow steps (0-indexed):
- *   0: LLM  |  1: Browser  |  2: Composio  |  3: Runtime  |  4: Privacy  |  5: Agent
+ *   0: LLM  |  1: Model  |  2: Browser  |  3: Composio  |  4: Runtime  |  5: Privacy  |  6: Agent
  *
- * Skippable steps: Composio (2), Agent (5)
- * Non-skippable steps with gating: LLM (needs key), Browser (default ok), Runtime (needs available runner)
+ * Skippable steps: Composio (3), Agent (6)
+ * Non-skippable steps with gating: LLM (needs key), Model (default ok), Browser (default ok), Runtime (needs available runner)
  */
 export class WizardPage {
   constructor(private page: Page) {}
@@ -77,21 +77,23 @@ export class WizardPage {
    * Requires a mock API key to be configured (LLM step gating)
    * and a runtime to be available (Runtime step gating).
    *
-   * Steps: LLM(Next) -> Browser(Next) -> Composio(Skip) -> Runtime(Next) -> Privacy(Next) -> Agent(Skip=Finish)
+   * Steps: LLM(Next) -> Model(Next) -> Browser(Next) -> Composio(Skip) -> Runtime(Next) -> Privacy(Next) -> Agent(Skip=Finish)
    */
   async dismissManualFlow() {
     await this.chooseManualSetup()
     await this.expectStep(0)
-    await this.clickNext()    // LLM -> Browser
+    await this.clickNext()    // LLM -> Model
     await this.expectStep(1)
-    await this.clickNext()    // Browser -> Composio
+    await this.clickNext()    // Model -> Browser
     await this.expectStep(2)
-    await this.clickSkip()    // Composio -> Runtime
+    await this.clickNext()    // Browser -> Composio
     await this.expectStep(3)
-    await this.clickNext()    // Runtime -> Privacy
+    await this.clickSkip()    // Composio -> Runtime
     await this.expectStep(4)
-    await this.clickNext()    // Privacy -> Agent
+    await this.clickNext()    // Runtime -> Privacy
     await this.expectStep(5)
+    await this.clickNext()    // Privacy -> Agent
+    await this.expectStep(6)
     await this.clickSkip()    // Agent (skip = finish)
   }
 

--- a/e2e/specs/getting-started-wizard.spec.ts
+++ b/e2e/specs/getting-started-wizard.spec.ts
@@ -9,13 +9,13 @@ test.describe.configure({ mode: 'serial' })
 
 /**
  * Manual wizard steps (0-indexed):
- *   0: LLM  |  1: Browser  |  2: Composio  |  3: Runtime  |  4: Privacy  |  5: Agent
+ *   0: LLM  |  1: Model  |  2: Browser  |  3: Composio  |  4: Runtime  |  5: Privacy  |  6: Agent
  *
- * Skippable: Composio (2), Agent (5)
+ * Skippable: Composio (3), Agent (6)
  * Gated (Next disabled until configured): LLM (needs key), Runtime (needs available runner)
  *
  * In E2E mock mode the mock API key is pre-configured and the runtime reports READY,
- * so Next is enabled on LLM, Browser, Runtime, and Privacy steps.
+ * so Next is enabled on LLM, Model, Browser, Runtime, and Privacy steps.
  */
 test.describe('Getting Started Wizard', () => {
   let appPage: AppPage
@@ -60,16 +60,18 @@ test.describe('Getting Started Wizard', () => {
     await wizardPage.expectStep(0)
 
     // Dismiss it for cleanup (wait for each step to render before clicking)
-    await wizardPage.clickNext()  // LLM -> Browser
+    await wizardPage.clickNext()  // LLM -> Model
     await wizardPage.expectStep(1)
-    await wizardPage.clickNext()  // Browser -> Composio
+    await wizardPage.clickNext()  // Model -> Browser
     await wizardPage.expectStep(2)
-    await wizardPage.clickSkip()  // Composio -> Runtime
+    await wizardPage.clickNext()  // Browser -> Composio
     await wizardPage.expectStep(3)
-    await wizardPage.clickNext()  // Runtime -> Privacy
+    await wizardPage.clickSkip()  // Composio -> Runtime
     await wizardPage.expectStep(4)
-    await wizardPage.clickNext()  // Privacy -> Agent
+    await wizardPage.clickNext()  // Runtime -> Privacy
     await wizardPage.expectStep(5)
+    await wizardPage.clickNext()  // Privacy -> Agent
+    await wizardPage.expectStep(6)
     await wizardPage.clickSkip()  // Agent (skip = finish)
     await wizardPage.expectNotVisible()
   })
@@ -109,39 +111,44 @@ test.describe('Getting Started Wizard', () => {
     await expect(page.getByText('Connect an LLM provider')).toBeVisible()
     await wizardPage.expectBackEnabled()
 
-    // Step 1: Browser
+    // Step 1: Model
     await wizardPage.clickNext()
     await wizardPage.expectStep(1)
-    await expect(page.getByText('Give your agents browser access')).toBeVisible()
+    await expect(page.getByText('Pick a default model for your agents')).toBeVisible()
 
     // Go back to Step 0: LLM
     await wizardPage.clickBack()
     await wizardPage.expectStep(0)
     await expect(page.getByText('Connect an LLM provider')).toBeVisible()
 
-    // Forward again to Step 1: Browser
+    // Forward again to Step 1: Model
     await wizardPage.clickNext()
     await wizardPage.expectStep(1)
-    await expect(page.getByText('Give your agents browser access')).toBeVisible()
+    await expect(page.getByText('Pick a default model for your agents')).toBeVisible()
 
-    // Step 2: Composio (skippable)
+    // Step 2: Browser
     await wizardPage.clickNext()
     await wizardPage.expectStep(2)
+    await expect(page.getByText('Give your agents browser access')).toBeVisible()
+
+    // Step 3: Composio (skippable)
+    await wizardPage.clickNext()
+    await wizardPage.expectStep(3)
     await expect(page.getByText('Let your agents connect to your apps')).toBeVisible()
 
-    // Step 3: Runtime
+    // Step 4: Runtime
     await wizardPage.clickSkip()
-    await wizardPage.expectStep(3)
+    await wizardPage.expectStep(4)
     await expect(page.getByText('Choose a container runtime')).toBeVisible()
 
-    // Step 4: Privacy
-    await wizardPage.clickNext()
-    await wizardPage.expectStep(4)
-    await expect(page.getByText('Help improve Superagent')).toBeVisible()
-
-    // Step 5: Create Agent (skippable)
+    // Step 5: Privacy
     await wizardPage.clickNext()
     await wizardPage.expectStep(5)
+    await expect(page.getByText('Help improve Superagent')).toBeVisible()
+
+    // Step 6: Create Agent (skippable)
+    await wizardPage.clickNext()
+    await wizardPage.expectStep(6)
     await expect(page.getByRole('heading', { name: /create your first agent/i })).toBeVisible()
 
     // Skip on last step finishes
@@ -158,24 +165,26 @@ test.describe('Getting Started Wizard', () => {
     await appPage.waitForAppLoaded()
     await wizardPage.expectVisible()
 
-    // Choose manual setup, navigate to Composio (step 2) — first skippable step
+    // Choose manual setup, navigate to Composio (step 3) — first skippable step
     await wizardPage.chooseManualSetup()
-    await wizardPage.clickNext() // LLM -> Browser
+    await wizardPage.clickNext() // LLM -> Model
     await wizardPage.expectStep(1)
-    await wizardPage.clickNext() // Browser -> Composio
+    await wizardPage.clickNext() // Model -> Browser
     await wizardPage.expectStep(2)
+    await wizardPage.clickNext() // Browser -> Composio
+    await wizardPage.expectStep(3)
 
     // Skip should advance to Runtime
     await wizardPage.clickSkip()
-    await wizardPage.expectStep(3)
+    await wizardPage.expectStep(4)
 
     // Runtime is not skippable — use Next to advance to Privacy
     await wizardPage.clickNext()
-    await wizardPage.expectStep(4)
+    await wizardPage.expectStep(5)
 
     // Privacy is not skippable — use Next to advance to Agent
     await wizardPage.clickNext()
-    await wizardPage.expectStep(5)
+    await wizardPage.expectStep(6)
 
     // Skip on last step should finish
     await wizardPage.clickSkip()
@@ -193,16 +202,18 @@ test.describe('Getting Started Wizard', () => {
     await wizardPage.chooseManualSetup()
 
     // Navigate through and finish (wait for each step to render)
-    await wizardPage.clickNext()  // LLM -> Browser
+    await wizardPage.clickNext()  // LLM -> Model
     await wizardPage.expectStep(1)
-    await wizardPage.clickNext()  // Browser -> Composio
+    await wizardPage.clickNext()  // Model -> Browser
     await wizardPage.expectStep(2)
-    await wizardPage.clickSkip()  // Composio -> Runtime
+    await wizardPage.clickNext()  // Browser -> Composio
     await wizardPage.expectStep(3)
-    await wizardPage.clickNext()  // Runtime -> Privacy
+    await wizardPage.clickSkip()  // Composio -> Runtime
     await wizardPage.expectStep(4)
-    await wizardPage.clickNext()  // Privacy -> Agent
+    await wizardPage.clickNext()  // Runtime -> Privacy
     await wizardPage.expectStep(5)
+    await wizardPage.clickNext()  // Privacy -> Agent
+    await wizardPage.expectStep(6)
     await wizardPage.clickSkip()  // Agent (skip = finish)
     await wizardPage.expectNotVisible()
 
@@ -246,20 +257,23 @@ test.describe('Getting Started Wizard', () => {
     await wizardPage.expectVisible()
     await wizardPage.chooseManualSetup()
 
-    // LLM -> Browser
+    // LLM -> Model
     await wizardPage.clickNext()
     await wizardPage.expectStep(1)
+    // Model -> Browser
+    await wizardPage.clickNext()
+    await wizardPage.expectStep(2)
 
     // Don't click Chrome — the bug is that users rely on the auto-selection.
     // Just advance through the rest of the wizard.
     await wizardPage.clickNext()  // Browser -> Composio
-    await wizardPage.expectStep(2)
-    await wizardPage.clickSkip()  // Composio -> Runtime
     await wizardPage.expectStep(3)
-    await wizardPage.clickNext()  // Runtime -> Privacy
+    await wizardPage.clickSkip()  // Composio -> Runtime
     await wizardPage.expectStep(4)
-    await wizardPage.clickNext()  // Privacy -> Agent
+    await wizardPage.clickNext()  // Runtime -> Privacy
     await wizardPage.expectStep(5)
+    await wizardPage.clickNext()  // Privacy -> Agent
+    await wizardPage.expectStep(6)
     await wizardPage.clickSkip()  // Agent -> finish
     await wizardPage.expectNotVisible()
 
@@ -290,16 +304,18 @@ test.describe('Getting Started Wizard', () => {
     await wizardPage.expectStep(0)
 
     // Dismiss it (wait for each step to render)
-    await wizardPage.clickNext()  // LLM -> Browser
+    await wizardPage.clickNext()  // LLM -> Model
     await wizardPage.expectStep(1)
-    await wizardPage.clickNext()  // Browser -> Composio
+    await wizardPage.clickNext()  // Model -> Browser
     await wizardPage.expectStep(2)
-    await wizardPage.clickSkip()  // Composio -> Runtime
+    await wizardPage.clickNext()  // Browser -> Composio
     await wizardPage.expectStep(3)
-    await wizardPage.clickNext()  // Runtime -> Privacy
+    await wizardPage.clickSkip()  // Composio -> Runtime
     await wizardPage.expectStep(4)
-    await wizardPage.clickNext()  // Privacy -> Agent
+    await wizardPage.clickNext()  // Runtime -> Privacy
     await wizardPage.expectStep(5)
+    await wizardPage.clickNext()  // Privacy -> Agent
+    await wizardPage.expectStep(6)
     await wizardPage.clickSkip()  // Agent (skip = finish)
     await wizardPage.expectNotVisible()
   })

--- a/src/renderer/components/wizard/configure-model-step.tsx
+++ b/src/renderer/components/wizard/configure-model-step.tsx
@@ -1,4 +1,5 @@
-import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
+import { useSettings, useUpdateSettings, type GlobalSettingsResponse } from '@renderer/hooks/use-settings'
+import { useQueryClient } from '@tanstack/react-query'
 import { inferFamily } from '@renderer/components/messages/composer-options-popover'
 import type { ComposerModelFamily } from '@shared/lib/llm-provider'
 
@@ -14,28 +15,48 @@ const MODEL_OPTIONS: Array<{
     label: 'Opus',
     tag: 'Most capable',
     description: 'Best for complex, multi-step tasks.',
-    subdescription: 'Slower, and uses 5x more tokens than Sonnet.',
+    subdescription: 'Slower, and uses 5x more credits than Sonnet.',
   },
   {
     family: 'sonnet',
     label: 'Sonnet',
     tag: 'Fast & efficient',
     description: 'Best for everyday tasks and most agent work.',
-    subdescription: 'Far lower token cost than Opus.',
+    subdescription: 'Far lower credit cost than Opus.',
   },
 ]
 
 export function ConfigureModelStep() {
   const { data: settings } = useSettings()
   const updateSettings = useUpdateSettings()
+  const queryClient = useQueryClient()
 
   // The global "Default model" setting (LLM tab) persists `models.agentModel`
   // as a bare family alias (emit="family"). Mirror that here so onboarding and
   // settings stay in sync. Fall back to the persisted default ('opus').
   const selectedFamily = inferFamily(settings?.models?.agentModel) ?? 'opus'
 
-  const handleSelect = (family: ComposerModelFamily) => {
-    updateSettings.mutate({ models: { agentModel: family } })
+  const handleSelect = async (family: ComposerModelFamily) => {
+    if (family === selectedFamily) return
+    // Optimistically reflect the choice in the settings cache so the card
+    // updates instantly. The mutation's onSuccess invalidation refetches to
+    // reconcile with the server; onError rolls back to the previous value.
+    await queryClient.cancelQueries({ queryKey: ['settings'] })
+    const previous = queryClient.getQueryData<GlobalSettingsResponse>(['settings'])
+    if (previous) {
+      queryClient.setQueryData<GlobalSettingsResponse>(['settings'], {
+        ...previous,
+        models: { ...previous.models, agentModel: family },
+      })
+    }
+    updateSettings.mutate(
+      { models: { agentModel: family } },
+      {
+        onError: () => {
+          if (previous) queryClient.setQueryData(['settings'], previous)
+        },
+      },
+    )
   }
 
   return (
@@ -47,7 +68,7 @@ export function ConfigureModelStep() {
         </p>
       </div>
 
-      <div className="space-y-3">
+      <div className="space-y-3" role="radiogroup" aria-label="Default model">
         {MODEL_OPTIONS.map((option) => {
           const isSelected = selectedFamily === option.family
           return (
@@ -59,6 +80,8 @@ export function ConfigureModelStep() {
             >
               <button
                 type="button"
+                role="radio"
+                aria-checked={isSelected}
                 className="w-full flex items-start gap-3 p-3 text-left"
                 onClick={() => handleSelect(option.family)}
                 data-testid={`wizard-model-${option.family}`}

--- a/src/renderer/components/wizard/configure-model-step.tsx
+++ b/src/renderer/components/wizard/configure-model-step.tsx
@@ -1,0 +1,91 @@
+import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
+import { inferFamily } from '@renderer/components/messages/composer-options-popover'
+import type { ComposerModelFamily } from '@shared/lib/llm-provider'
+
+const MODEL_OPTIONS: Array<{
+  family: ComposerModelFamily
+  label: string
+  tag: string
+  description: string
+  subdescription: string
+}> = [
+  {
+    family: 'opus',
+    label: 'Opus',
+    tag: 'Most capable',
+    description: 'Best for complex, multi-step tasks.',
+    subdescription: 'Slower, and uses 5x more tokens than Sonnet.',
+  },
+  {
+    family: 'sonnet',
+    label: 'Sonnet',
+    tag: 'Fast & efficient',
+    description: 'Best for everyday tasks and most agent work.',
+    subdescription: 'Far lower token cost than Opus.',
+  },
+]
+
+export function ConfigureModelStep() {
+  const { data: settings } = useSettings()
+  const updateSettings = useUpdateSettings()
+
+  // The global "Default model" setting (LLM tab) persists `models.agentModel`
+  // as a bare family alias (emit="family"). Mirror that here so onboarding and
+  // settings stay in sync. Fall back to the persisted default ('opus').
+  const selectedFamily = inferFamily(settings?.models?.agentModel) ?? 'opus'
+
+  const handleSelect = (family: ComposerModelFamily) => {
+    updateSettings.mutate({ models: { agentModel: family } })
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-normal max-w-sm">Pick a default model for your agents</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          New conversations will start with this model by default, but you can always choose a different one from the model selector if needed.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {MODEL_OPTIONS.map((option) => {
+          const isSelected = selectedFamily === option.family
+          return (
+            <div
+              key={option.family}
+              className={`rounded-lg border text-left transition-colors ${
+                isSelected ? 'border-primary bg-muted/50' : 'hover:border-muted-foreground/50'
+              }`}
+            >
+              <button
+                type="button"
+                className="w-full flex items-start gap-3 p-3 text-left"
+                onClick={() => handleSelect(option.family)}
+                data-testid={`wizard-model-${option.family}`}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-sm">{option.label}</span>
+                    <span className="text-xs text-muted-foreground">{option.tag}</span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    {option.description}<br />{option.subdescription}
+                  </p>
+                </div>
+                <div className={`mt-1 h-4 w-4 rounded-full border-2 shrink-0 flex items-center justify-center ${
+                  isSelected ? 'border-primary' : 'border-muted-foreground/40'
+                }`}>
+                  {isSelected && <div className="h-2 w-2 rounded-full bg-primary" />}
+                </div>
+              </button>
+            </div>
+          )
+        })}
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        Change this default at any time in the settings.
+      </p>
+    </div>
+  )
+}

--- a/src/renderer/components/wizard/getting-started-wizard.tsx
+++ b/src/renderer/components/wizard/getting-started-wizard.tsx
@@ -9,6 +9,7 @@ import {
 import { isElectron, getPlatform } from '@renderer/lib/env'
 import { WelcomeStep } from './welcome-step'
 import { ConfigureLLMStep } from './configure-llm-step'
+import { ConfigureModelStep } from './configure-model-step'
 import { DockerSetupStep } from './docker-setup-step'
 import { BrowserSetupStep } from './browser-setup-step'
 import { ComposioStep } from './composio-step'
@@ -16,10 +17,11 @@ import { CreateAgentStep } from './create-agent-step'
 import { PrivacyStep } from './privacy-step'
 import { RibbonWave } from './ribbon-wave'
 
-type WizardStepId = 'llm' | 'browser' | 'composio' | 'runtime' | 'privacy' | 'agent'
+type WizardStepId = 'llm' | 'model' | 'browser' | 'composio' | 'runtime' | 'privacy' | 'agent'
 
 const MANUAL_STEPS: { id: WizardStepId; label: string; skippable: boolean }[] = [
   { id: 'llm', label: 'LLM', skippable: false },
+  { id: 'model', label: 'Model', skippable: false },
   { id: 'browser', label: 'Browser', skippable: false },
   { id: 'composio', label: 'Composio', skippable: true },
   { id: 'runtime', label: 'Runtime', skippable: false },
@@ -28,6 +30,7 @@ const MANUAL_STEPS: { id: WizardStepId; label: string; skippable: boolean }[] = 
 ]
 
 const PLATFORM_STEPS: { id: WizardStepId; label: string; skippable: boolean }[] = [
+  { id: 'model', label: 'Model', skippable: false },
   { id: 'browser', label: 'Browser', skippable: false },
   { id: 'runtime', label: 'Runtime', skippable: false },
   { id: 'privacy', label: 'Privacy', skippable: false },
@@ -195,6 +198,7 @@ export function GettingStartedWizard({ agentOnly, onClose }: GettingStartedWizar
                 onCanProceedChange={setLlmCanProceed}
               />
             )}
+            {activeStep?.id === 'model' && <ConfigureModelStep />}
             {activeStep?.id === 'browser' && <BrowserSetupStep onCanProceedChange={setBrowserCanProceed} />}
             {activeStep?.id === 'composio' && <ComposioStep onCanProceedChange={setComposioCanProceed} saveRef={composioSaveRef} />}
             {activeStep?.id === 'runtime' && <DockerSetupStep onCanProceedChange={setRuntimeCanProceed} />}


### PR DESCRIPTION
## What

Adds a standalone **Model** step to the getting-started wizard so users pick their default agent model during onboarding, in **both** flows:

- **Manual / BYOK:** `LLM → `**`Model`**` → Browser → Composio → Runtime → Privacy → Agent`
- **Platform:** **`Model`**` → Browser → Runtime → Privacy → Agent`

The step presents two selection cards — **Opus** (Most capable) and **Sonnet** (Fast & efficient) — styled to match the existing Browser step, with copy explaining that the default sets the starting model and can be overridden per-conversation via the model selector or changed later in settings.

## How

- New component `configure-model-step.tsx`.
- Reuses the existing global-settings model plumbing rather than introducing new endpoints: persists `models.agentModel` as a **family alias** via `useUpdateSettings` (mirroring the LLM tab's `emit="family"`), and reads the current selection back through `settings.models.agentModel` + `inferFamily`. Onboarding and the LLM settings tab stay in sync.
- Wired into `getting-started-wizard.tsx`: added `'model'` to `WizardStepId`, both step lists, the import, and the render branch. Not gated — `agentModel` always has a default, so the card is pre-selected and Next stays enabled.

## Notes / open question

- **Opus is the pre-selected card** (it matches the persisted default `agentModel`), while the copy frames Sonnet as the everyday choice. If we want to actively steer new users to Sonnet, we'd add a "Recommended" tag and make Sonnet the default selection — that's a behavior/billing change, so left out of this PR pending a product call.
- Step placement (Model first in platform, after LLM in manual) is easy to move if preferred.

## Testing

- `eslint` clean on changed files.
- `tsc` shows only two **pre-existing**, unrelated errors in `pdf-renderer.tsx` (missing `react-pdf` module) — nothing from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)