### PR TITLE
feat(home): redesigned agent home — widget-grid of live halftone cards

### DIFF
--- a/src/renderer/components/home/dashboard-card.tsx
+++ b/src/renderer/components/home/dashboard-card.tsx
@@ -3,12 +3,12 @@ import { getApiBaseUrl } from '@renderer/lib/env'
 import { SquareMousePointer, ArrowUpRight } from 'lucide-react'
 import type { ApiAgentDashboard } from '@shared/lib/types/api'
 
-function CardContent({ screenshotUrl }: { screenshotUrl: string | null }) {
+function CardContent({ screenshotUrl, objectClass = 'object-top' }: { screenshotUrl: string | null; objectClass?: string }) {
   return screenshotUrl ? (
     <img
       src={screenshotUrl}
       alt=""
-      className="absolute inset-0 h-full w-full object-cover object-top"
+      className={`absolute inset-0 h-full w-full object-cover ${objectClass}`}
       loading="lazy"
       draggable={false}
     />
@@ -23,10 +23,13 @@ export function DashboardCard({
   dashboard,
   agentSlug,
   variant = 'push',
+  align = 'top',
 }: {
   dashboard: ApiAgentDashboard
   agentSlug: string
-  variant?: 'overlay' | 'push'
+  variant?: 'fill' | 'push'
+  /** Screenshot crop anchor for the fill variant (Small tiles read better top-left). */
+  align?: 'top' | 'top-left'
 }) {
   const linkProps = {
     to: '/agents/$slug/dashboards/$dashSlug',
@@ -37,22 +40,21 @@ export function DashboardCard({
     ? `${getApiBaseUrl()}/api/agents/${encodeURIComponent(agentSlug)}/artifacts/${encodeURIComponent(dashboard.slug)}/screenshot.png`
     : null
 
-  if (variant === 'overlay') {
+  if (variant === 'fill') {
+    // Fills its container (a widget-grid tile) — the screenshot is just the card.
     return (
-      <div className="relative h-24 group z-0 hover:z-20 [transition:z-index_0s_420ms] hover:[transition:z-index_0s]">
-        <AppLink
-          {...linkProps}
-          className="absolute inset-x-0 top-0 h-24 group-hover:h-40 group-hover:scale-x-[1.04] group-hover:shadow-lg rounded-lg border bg-card hover:border-accent-foreground/20 text-left overflow-hidden origin-top [transition:transform_150ms_ease-out,height_300ms_cubic-bezier(0.2,0.8,0.2,1)_120ms,box-shadow_250ms_ease-out,border-color_200ms_ease-out]"
-        >
-          <CardContent screenshotUrl={screenshotUrl} />
-          <div className="relative z-10 flex h-full flex-col items-end justify-end p-3 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-            <span className="inline-flex items-center gap-1 rounded-md border border-input bg-background px-3 h-8 text-xs font-medium shadow-sm [&_svg]:size-4">
-              Open app
-              <ArrowUpRight />
-            </span>
-          </div>
-        </AppLink>
-      </div>
+      <AppLink
+        {...linkProps}
+        className="group relative block h-full w-full overflow-hidden rounded-lg border bg-card text-left shadow-sm transition-[box-shadow,border-color] duration-150 hover:border-accent-foreground/20 group-hover/widget:shadow-md"
+      >
+        <CardContent screenshotUrl={screenshotUrl} objectClass={align === 'top-left' ? 'object-left-top' : 'object-top'} />
+        <div className="relative z-10 flex h-full flex-col items-end justify-end p-2.5 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+          <span className="inline-flex items-center gap-1 rounded-md border border-input bg-background px-2 h-6 text-xs font-medium shadow-sm [&_svg]:size-3.5">
+            Open app
+            <ArrowUpRight />
+          </span>
+        </div>
+      </AppLink>
     )
   }
 

--- a/src/renderer/components/home/home-page.test.tsx
+++ b/src/renderer/components/home/home-page.test.tsx
@@ -46,17 +46,39 @@ vi.mock('@renderer/hooks/use-sessions', () => ({
   useSessions: () => ({ data: [] }),
 }))
 
+vi.mock('@renderer/hooks/use-activity-stats', () => ({
+  useAgentActivityStats: () => ({ data: undefined, isPending: true }),
+}))
+
+// The home page fetches the /api/home-graph topology snapshot for the cards'
+// health carousels; return an empty topology so no carousel renders.
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: vi.fn(async () => ({
+    ok: true,
+    json: async () => ({
+      accountLinks: [],
+      mcpLinks: [],
+      chats: [],
+      webhooks: [],
+      crons: [],
+      permissions: [],
+      invocations: [],
+      accountUsage: {},
+      mcpUsage: {},
+    }),
+  })),
+}))
+
 const mockAgentsData = vi.fn()
 vi.mock('@renderer/hooks/use-agents', () => ({
   useAgents: () => mockAgentsData(),
+  useStartAgent: () => ({ mutate: vi.fn(), isPending: false }),
+  useStopAgent: () => ({ mutate: vi.fn(), isPending: false }),
 }))
 
 vi.mock('@renderer/hooks/use-user-settings', () => ({
   useUserSettings: () => ({ data: null }),
-}))
-
-vi.mock('@renderer/hooks/use-usage', () => ({
-  useUsageData: () => ({ data: undefined, refetch: vi.fn() }),
+  useUpdateUserSettings: () => ({ mutate: vi.fn(), isPending: false }),
 }))
 
 vi.mock('@renderer/lib/agent-ordering', () => ({
@@ -67,10 +89,6 @@ vi.mock('@renderer/components/agents/agent-context-menu', () => ({
   AgentContextMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 
-vi.mock('@renderer/components/agents/agent-status', () => ({
-  AgentStatus: ({ status }: { status: string }) => <span data-testid="agent-status">{status}</span>,
-  getAgentActivityStatus: () => 'sleeping',
-}))
 
 vi.mock('@renderer/hooks/use-create-untitled-agent', () => ({
   useCreateUntitledAgent: () => ({
@@ -136,14 +154,14 @@ describe('HomePage AgentCard', () => {
     vi.useRealTimers()
   })
 
-  it('renders agent name and description', () => {
+  it('renders agent name without the description (compact card)', () => {
     mockAgentsData.mockReturnValue({
       data: [makeAgent()],
       isLoading: false,
     })
     renderWithProviders(<HomePage />)
     expect(screen.getByText('Test Agent')).toBeInTheDocument()
-    expect(screen.getByText('A test description')).toBeInTheDocument()
+    expect(screen.queryByText('A test description')).not.toBeInTheDocument()
   })
 
   it('renders last worked time when lastActivityAt is set', () => {
@@ -152,7 +170,7 @@ describe('HomePage AgentCard', () => {
       isLoading: false,
     })
     renderWithProviders(<HomePage />)
-    expect(screen.getByText('about 3 hours ago')).toBeInTheDocument()
+    expect(screen.getByText('Last run about 3 hours ago')).toBeInTheDocument()
   })
 
   it('does not render last worked when lastActivityAt is null', () => {
@@ -164,32 +182,13 @@ describe('HomePage AgentCard', () => {
     expect(screen.queryByText(/ago/)).not.toBeInTheDocument()
   })
 
-  it('renders scheduled task count with singular form', () => {
-    mockAgentsData.mockReturnValue({
-      data: [makeAgent({ scheduledTaskCount: 1, nextScheduledTaskAt: new Date('2026-03-26T14:00:00Z') })],
-      isLoading: false,
-    })
-    renderWithProviders(<HomePage />)
-    expect(screen.getByText('1 task')).toBeInTheDocument()
-    expect(screen.getByText(/in about 2 hours/)).toBeInTheDocument()
-  })
-
-  it('renders scheduled task count with plural form', () => {
+  it('does not render scheduled task details (removed from the compact card)', () => {
     mockAgentsData.mockReturnValue({
       data: [makeAgent({ scheduledTaskCount: 3, nextScheduledTaskAt: new Date('2026-03-27T12:00:00Z') })],
       isLoading: false,
     })
     renderWithProviders(<HomePage />)
-    expect(screen.getByText('3 tasks')).toBeInTheDocument()
-  })
-
-  it('does not render scheduled tasks when count is 0', () => {
-    mockAgentsData.mockReturnValue({
-      data: [makeAgent({ scheduledTaskCount: 0 })],
-      isLoading: false,
-    })
-    renderWithProviders(<HomePage />)
-    expect(screen.queryByText(/task/)).not.toBeInTheDocument()
+    expect(screen.queryByText('3 tasks')).not.toBeInTheDocument()
   })
 
   it('renders a dashboard card per dashboard alongside the agent card', () => {
@@ -205,8 +204,8 @@ describe('HomePage AgentCard', () => {
       isLoading: false,
     })
     renderWithProviders(<HomePage />)
-    const cards = document.querySelectorAll('[class*="h-24"]')
-    expect(cards.length).toBeGreaterThanOrEqual(2)
+    // Each dashboard tile is an "Open app" screenshot card; agent cards aren't.
+    expect(screen.getAllByText('Open app').length).toBeGreaterThanOrEqual(2)
   })
 
   it('renders a screenshot img when hasScreenshot is true', () => {
@@ -267,19 +266,18 @@ describe('HomePage AgentCard', () => {
       isLoading: false,
     })
     renderWithProviders(<HomePage />)
-    expect(screen.getByText('about 1 hour ago')).toBeInTheDocument()
-    expect(screen.getByText('2 tasks')).toBeInTheDocument()
-    expect(screen.getByText(/in about 1 hour/)).toBeInTheDocument()
+    expect(screen.getByText('Last run about 1 hour ago')).toBeInTheDocument()
   })
 
-  it('passes pre-aggregated status to AgentStatus', () => {
+  it('surfaces the aggregated activity status on the card indicator', () => {
     mockAgentsData.mockReturnValue({
       data: [makeAgent({ hasActiveSessions: true, hasSessionsAwaitingInput: true })],
       isLoading: false,
     })
     renderWithProviders(<HomePage />)
-    // The mocked AgentStatus just renders the status prop
-    expect(screen.getByTestId('agent-status')).toBeInTheDocument()
+    // status='running' + hasSessionsAwaitingInput → getAgentActivityStatus aggregates
+    // to 'awaiting_input', surfaced as the dot-matrix indicator's aria-label.
+    expect(screen.getByRole('img', { name: 'awaiting_input' })).toBeInTheDocument()
   })
 })
 

--- a/src/renderer/components/home/home-page.tsx
+++ b/src/renderer/components/home/home-page.tsx
@@ -1,15 +1,31 @@
 
-import { lazy, Suspense, useMemo } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useState, type ReactNode } from 'react'
 import { useNavigate, useSearch as useRouteSearch } from '@tanstack/react-router'
-import { useAgents } from '@renderer/hooks/use-agents'
-import { useUserSettings } from '@renderer/hooks/use-user-settings'
+import { WidgetBoard, WidgetSizePopover, WidgetToggleRow, type GridRect, type WidgetItem, type WidgetSizeKey } from './widget-grid'
+import { useAgents, useStartAgent, useStopAgent } from '@renderer/hooks/use-agents'
+import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user-settings'
+import { useMarkSessionNotificationsRead } from '@renderer/hooks/use-notifications'
+import { useAgentActivityStats } from '@renderer/hooks/use-activity-stats'
 import { applyAgentOrder } from '@renderer/lib/agent-ordering'
-import { useUsageData } from '@renderer/hooks/use-usage'
 import { useSessions } from '@renderer/hooks/use-sessions'
-import { AppLink } from '@renderer/components/ui/app-link'
-import { AgentStatus } from '@renderer/components/agents/agent-status'
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@renderer/lib/api'
+import { Halftone } from '@renderer/components/agents/halftone'
+import {
+  ActivitySparkChart,
+  ActivitySparkChartSkeleton,
+  CronSparkChart,
+  summarizeDailyActivity,
+} from '@renderer/components/activity/activity-spark-chart'
+import { DEFAULT_ACTIVITY_DAYS } from '@shared/lib/types/activity'
+import {
+  homeGraphSchema,
+  type HomeGraphCron,
+  type HomeGraphData,
+  type HomeGraphWebhook,
+} from '@shared/lib/types/home-graph-schema'
 import { getAgentActivityStatus } from '@shared/lib/types/agent-activity-status'
-import { WorkingDots, AwaitingDot } from '@renderer/components/agents/status-indicators'
+import { WorkingDots, AwaitingDot, UnreadDot } from '@renderer/components/agents/status-indicators'
 import { AgentContextMenu } from '@renderer/components/agents/agent-context-menu'
 import { useCreateUntitledAgent } from '@renderer/hooks/use-create-untitled-agent'
 import { SidebarTrigger } from '@renderer/components/ui/sidebar'
@@ -19,11 +35,10 @@ import { useFullScreen } from '@renderer/hooks/use-fullscreen'
 import { DashboardCard } from './dashboard-card'
 import { PwaInstallBanner } from './pwa-install-banner'
 import { isElectron, getPlatform } from '@renderer/lib/env'
-import { Plus, Bot, Loader2, Clock, CalendarClock, SquareMousePointer, Search, LayoutGrid, Waypoints } from 'lucide-react'
+import { Plus, Bot, Loader2, Search, Power, Square, Check, ArrowRight, LayoutGrid, Waypoints } from 'lucide-react'
 import { useSearch } from '@renderer/context/search-context'
-import { AreaChart, Area, ResponsiveContainer, Tooltip } from 'recharts'
+import { cn } from '@shared/lib/utils/cn'
 import type { ApiAgent } from '@shared/lib/types/api'
-import type { DailyUsageEntry } from '@shared/lib/types/usage'
 import { formatDistanceToNow } from 'date-fns'
 import { useRenderTracker } from '@renderer/lib/perf'
 
@@ -33,265 +48,704 @@ const AgentGraph = lazy(() =>
   import('./graph/agent-graph').then((m) => ({ default: m.AgentGraph })),
 )
 
-/** Extract per-agent daily cost from the global usage data */
-function useAgentUsageSpark(agentSlug: string, dailyUsage: DailyUsageEntry[] | undefined) {
-  return useMemo(() => {
-    if (!dailyUsage?.length) return null
-    const points = dailyUsage.map((day) => {
-      const agentEntry = day.byAgent.find((a) => a.agentSlug === agentSlug)
-      return { date: day.date, tokens: agentEntry?.totalTokens ?? 0 }
-    })
-    if (points.every((p) => p.tokens === 0)) return null
-    return points
-  }, [agentSlug, dailyUsage])
+// Per-status ink color for the card's halftone banner. Motion/form (the motif)
+// distinguishes agents; color just reflects activity state.
+const HALFTONE_INK: Record<ReturnType<typeof getAgentActivityStatus>, string> = {
+  sleeping: 'text-muted-foreground/50',
+  idle: 'text-muted-foreground',
+  working: 'text-foreground',
+  awaiting_input: 'text-orange-500',
 }
 
-function formatTokenCount(tokens: number): string {
-  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`
-  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(0)}k`
-  return String(tokens)
+function hashSlug(s: string): number {
+  let h = 2166136261
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = (h * 16777619) >>> 0
+  }
+  return h
 }
 
-function UsageSparkBackground({ data, agentSlug }: { data: { date: string; tokens: number }[]; agentSlug: string }) {
-  // Unique gradient IDs per agent to avoid SVG ID collisions
-  const fillId = `sparkFill-${agentSlug}`
+// State label for the top-right status/control chip.
+const AGENT_STATE_TAG: Record<'sleeping' | 'idle' | 'working' | 'awaiting', string> = {
+  sleeping: 'Sleeping',
+  idle: 'Idle',
+  working: 'Working…',
+  awaiting: 'Needs input',
+}
+
+function AgentCardPowerButton({ agent }: { agent: ApiAgent }) {
+  const startAgent = useStartAgent()
+  const stopAgent = useStopAgent()
+  const isRunning = agent.status === 'running'
+  const isPending = isRunning ? stopAgent.isPending : startAgent.isPending
+  const tagState: 'sleeping' | 'idle' | 'working' | 'awaiting' = !isRunning
+    ? 'sleeping'
+    : agent.hasSessionsAwaitingInput
+      ? 'awaiting'
+      : agent.hasActiveSessions
+        ? 'working'
+        : 'idle'
+  const label = AGENT_STATE_TAG[tagState]
+
+  const activate = (e: React.SyntheticEvent) => {
+    e.stopPropagation()
+    if (isPending) return
+    if (isRunning) {
+      stopAgent.mutate(agent.slug)
+    } else {
+      startAgent.mutate(agent.slug)
+    }
+  }
+
   return (
-    <div
-      className="absolute bottom-0 left-1/3 -right-px -bottom-px h-[60%]"
-      style={{ maskImage: 'linear-gradient(to right, transparent 0%, black 30%)', WebkitMaskImage: 'linear-gradient(to right, transparent 0%, black 30%)' }}
-    >
-      <ResponsiveContainer width="100%" height="100%">
-      <AreaChart
-        data={data}
-        margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+    // Frosted status chip with a white-bordered stop/power button inside. It's a
+    // flex item in the card's control row (see AgentCard), so the kebab aligns
+    // with it natively.
+    <div className="flex items-center gap-1.5 rounded-md border border-border/50 bg-white/10 py-0.5 pl-1.5 pr-1 text-xs backdrop-blur-sm">
+      <span className="leading-none text-muted-foreground">{label}</span>
+      <span
+        role="button"
+        tabIndex={0}
+        aria-label={isRunning ? 'Stop agent' : 'Wake up agent'}
+        title={isRunning ? 'Stop agent' : 'Wake up agent'}
+        onClick={activate}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            activate(e)
+          }
+        }}
+        className={cn(
+          'flex h-5 w-5 shrink-0 items-center justify-center rounded border bg-background text-foreground shadow-sm',
+          'cursor-pointer transition-colors hover:bg-muted',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
+          isPending && 'pointer-events-none opacity-60'
+        )}
       >
-        <defs>
-          <linearGradient id={fillId} x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stopColor="hsl(var(--primary))" stopOpacity={0.15} />
-            <stop offset="100%" stopColor="hsl(var(--primary))" stopOpacity={0.02} />
-          </linearGradient>
-        </defs>
-        <Tooltip
-          cursor={false}
-          content={({ active, payload }) => {
-            if (!active || !payload?.[0]) return null
-            const d = payload[0].payload as { date: string; tokens: number }
-            return (
-              <div className="rounded border bg-popover px-2 py-1 text-xs shadow-sm">
-                <span className="text-muted-foreground">{d.date}</span>{' '}
-                <span className="font-medium">{formatTokenCount(d.tokens)} tokens</span>
-              </div>
-            )
-          }}
-        />
-        <Area
-          type="monotone"
-          dataKey="tokens"
-          stroke="hsl(var(--primary))"
-          strokeWidth={1}
-          strokeOpacity={0.3}
-          fill={`url(#${fillId})`}
-          isAnimationActive={false}
-        />
-      </AreaChart>
-      </ResponsiveContainer>
+        {isPending ? (
+          <Loader2 className="h-3 w-3 animate-spin" />
+        ) : isRunning ? (
+          <Square className="h-2.5 w-2.5 fill-current" />
+        ) : (
+          <Power className="h-2.5 w-2.5" />
+        )}
+      </span>
     </div>
   )
 }
 
-const statusTabBg = {
-  sleeping: 'bg-muted',
-  idle: 'bg-muted',
-  working: 'bg-green-100 dark:bg-green-900/40',
-  awaiting_input: 'bg-orange-100 dark:bg-orange-900/40',
-} as const
+// Baked halftone render settings + per-state motion (chosen during exploration;
+// the dev tweak panel that produced them lives on the animation-experiments-draft
+// branch). flow_3d is the working/idle/sleeping identity; pulse (in orange ink,
+// via HALFTONE_INK) is the needs-input state.
+const HALFTONE_STATE: Record<'sleeping' | 'idle' | 'working', { speed: number; dim: number; contrast: number }> = {
+  // Clear separation: sleeping/idle are slow + faint + soft; working is notably
+  // faster, fuller, and higher-contrast (bolder, denser dots).
+  sleeping: { speed: 0.25, dim: 0.4, contrast: 1.35 },
+  idle: { speed: 0.4, dim: 0.5, contrast: 1.4 },
+  working: { speed: 0.9, dim: 1, contrast: 1.95 },
+}
 
-function StatusTab({ status, hasActiveSessions, hasSessionsAwaitingInput }: {
+function AgentCardMatrix({
+  slug,
+  status,
+  hasActiveSessions,
+  hasSessionsAwaitingInput,
+  className,
+}: {
+  slug: string
   status: 'running' | 'stopped'
   hasActiveSessions: boolean
   hasSessionsAwaitingInput: boolean
+  /** Banner geometry (aspect ratio or fixed height); defaults to the wide strip. */
+  className?: string
 }) {
   const activityStatus = getAgentActivityStatus(status, hasActiveSessions, hasSessionsAwaitingInput)
+  const stateTweak = activityStatus === 'awaiting_input' ? undefined : HALFTONE_STATE[activityStatus]
   return (
-    <div className={`absolute top-0 right-4 z-20 rounded-b-md px-2.5 py-1 ${statusTabBg[activityStatus]}`}>
-      <AgentStatus status={status} hasActiveSessions={hasActiveSessions} hasSessionsAwaitingInput={hasSessionsAwaitingInput} size="sm" workingDotClassName="bg-foreground" />
+    <div
+      role="img"
+      aria-label={activityStatus}
+      className={cn('w-full overflow-hidden', className ?? 'aspect-[32/9]', HALFTONE_INK[activityStatus])}
+    >
+      <Halftone
+        motif={activityStatus === 'awaiting_input' ? 'pulse' : 'flow_3d'}
+        state={activityStatus === 'working' ? 'working' : activityStatus === 'awaiting_input' ? 'alert' : 'idle'}
+        speed={stateTweak?.speed}
+        dim={stateTweak?.dim}
+        spacing={5}
+        maxRadius={1.3}
+        vignette={0.4}
+        contrast={stateTweak?.contrast ?? 1.6}
+        speedScale={1}
+        seed={hashSlug(slug)}
+      />
     </div>
   )
 }
 
-function AgentCard({ agent, dailyUsage }: { agent: ApiAgent; dailyUsage?: DailyUsageEntry[] }) {
-  useRenderTracker('AgentCard')
-  const lastWorked = agent.lastActivityAt ? formatDistanceToNow(new Date(agent.lastActivityAt), { addSuffix: true }) : null
-  const nextRun = agent.nextScheduledTaskAt ? formatDistanceToNow(new Date(agent.nextScheduledTaskAt), { addSuffix: true }) : null
-  const dashboardCount = agent.dashboardCount ?? 0
-  const scheduledTaskCount = agent.scheduledTaskCount ?? 0
-  const sparkData = useAgentUsageSpark(agent.slug, dailyUsage)
-  const totalTokens = sparkData?.reduce((sum, d) => sum + d.tokens, 0) ?? 0
+interface NotableSession {
+  id: string
+  name: string
+  isActive?: boolean
+  isAwaitingInput?: boolean
+  hasUnreadNotifications?: boolean
+  lastActivityAt?: Date | string
+}
 
-  // Only fetch sessions when there are notable ones to show
-  const hasNotable = agent.hasActiveSessions || agent.hasSessionsAwaitingInput || agent.hasUnreadNotifications
-  const { data: sessions } = useSessions(hasNotable ? agent.slug : null, { staleTime: 30_000 })
+/**
+ * Strip a leading agent-name prefix from a session name — inside the agent's
+ * own card it's redundant ("Test Agent One Story Session" → "Story Session").
+ * Matches the longest run of the agent's leading words (so partial prefixes
+ * like "Test Agent Linear…" under "Test Agent One" still strip), but requires
+ * at least two words (or the full single-word name) to avoid false positives.
+ */
+function stripAgentPrefix(sessionName: string, agentName: string): string {
+  const sessionWords = sessionName.trim().split(/\s+/)
+  const agentWords = agentName.trim().split(/\s+/).filter(Boolean)
+  if (agentWords.length === 0) return sessionName
+  let matched = 0
+  while (
+    matched < agentWords.length &&
+    matched < sessionWords.length &&
+    sessionWords[matched].toLowerCase() === agentWords[matched].toLowerCase()
+  ) {
+    matched++
+  }
+  if (matched < Math.min(2, agentWords.length)) return sessionName
+  const rest = sessionWords.slice(matched).join(' ').replace(/^[\s:–—\-·]+/, '')
+  return rest.length >= 3 ? rest : sessionName
+}
 
-  const notableSessions = useMemo(() => {
-    if (!sessions) return []
-    return sessions.filter(
-      (s) => s.isActive || s.isAwaitingInput || (!s.isActive && !s.isAwaitingInput && s.hasUnreadNotifications)
-    )
-  }, [sessions])
+/** Compact relative age: 4m, 1h, 2d. */
+function compactAgo(date: Date | string | undefined): string | null {
+  if (!date) return null
+  const mins = Math.max(0, Math.round((Date.now() - new Date(date).getTime()) / 60_000))
+  if (mins < 1) return 'now'
+  if (mins < 60) return `${mins}m`
+  const hours = Math.round(mins / 60)
+  if (hours < 24) return `${hours}h`
+  return `${Math.round(hours / 24)}d`
+}
 
-  // Always show active/awaiting sessions; cap unread-only notifications at 3
-  const MAX_UNREAD_ROWS = 3
-  const { visibleSessions, collapsedUnreadCount } = useMemo(() => {
-    const active: typeof notableSessions = []
-    const unread: typeof notableSessions = []
-    for (const s of notableSessions) {
-      if (s.isActive || s.isAwaitingInput) {
-        active.push(s)
-      } else {
-        unread.push(s)
+type SessionState = 'awaiting' | 'working' | 'unread'
+
+// Notification-row prefix describing what happened in the session.
+const SESSION_STATE_PREFIX: Record<SessionState, string> = {
+  awaiting: 'Input needed',
+  working: 'Working',
+  unread: 'New message',
+}
+
+function sessionState(s: NotableSession): SessionState {
+  if (s.isAwaitingInput) return 'awaiting'
+  if (s.isActive) return 'working'
+  return 'unread'
+}
+
+function SessionStateDot({ state }: { state: SessionState }) {
+  // The three dots have different intrinsic footprints (awaiting reserves 12px
+  // for its ping halo, unread is a bare 6px). Center each in one fixed 12px box
+  // so the dot centers — and the text start — align across rows.
+  const dot =
+    state === 'awaiting' ? <AwaitingDot /> : state === 'working' ? <WorkingDots dotClassName="bg-foreground" /> : <UnreadDot />
+  return <span className="flex h-3 w-3 shrink-0 items-center justify-center">{dot}</span>
+}
+
+/** Keyboard-activatable span — cards are <button>s, so inner controls can't be native buttons. */
+function rowButtonProps(onActivate: (e: React.SyntheticEvent) => void) {
+  return {
+    role: 'button' as const,
+    tabIndex: 0,
+    onClick: (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onActivate(e)
+    },
+    onKeyDown: (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        e.stopPropagation()
+        onActivate(e)
       }
-    }
-    const shownUnread = unread.slice(0, MAX_UNREAD_ROWS)
-    const collapsed = unread.length - shownUnread.length
-    return { visibleSessions: [...active, ...shownUnread], collapsedUnreadCount: collapsed }
-  }, [notableSessions])
+    },
+  }
+}
+
+/**
+ * Notifications section: a frosted panel (matching the title pill / health
+ * chips) of hairline-divided rows — state dot, name, and a right-aligned
+ * compact timestamp. Sizes to its content and scrolls when the list outgrows
+ * the space available in the card.
+ */
+function AgentCardSessions({
+  agentSlug,
+  agentDisplaySlug,
+  agentName,
+  sessions,
+}: {
+  agentSlug: string
+  agentDisplaySlug: string
+  agentName: string
+  sessions: NotableSession[] | undefined
+}) {
+  const navigate = useNavigate()
+  const markRead = useMarkSessionNotificationsRead()
+  const notable = useMemo(
+    () => (sessions ?? []).filter((s) => s.isActive || s.isAwaitingInput || s.hasUnreadNotifications),
+    [sessions]
+  )
+  if (notable.length === 0) return null
+  const open = (id: string) => {
+    void navigate({ to: '/agents/$slug/sessions/$sessionId', params: { slug: agentSlug, sessionId: id } })
+  }
+  // Show up to three rows as-is; with four or more, show two and collapse the
+  // rest into a trailing "{X} more →" row.
+  const visible = notable.length > 3 ? notable.slice(0, 2) : notable
+  const moreCount = notable.length - visible.length
 
   return (
-    <div className="flex flex-col">
-      <AgentContextMenu agent={agent}>
-        <AppLink
-          to="/agents/$slug"
-          params={{ slug: agent.displaySlug }}
-          className="relative text-left p-4 rounded-lg border bg-card hover:border-accent-foreground/20 transition-colors flex flex-col gap-3 z-10 h-24 overflow-hidden"
-        >
-          {/* Spark chart background */}
-          {sparkData && <UsageSparkBackground data={sparkData} agentSlug={agent.slug} />}
-
-          {/* Status tab dropping from top-right */}
-          <StatusTab
-            status={agent.status}
-            hasActiveSessions={agent.hasActiveSessions ?? false}
-            hasSessionsAwaitingInput={agent.hasSessionsAwaitingInput ?? false}
-          />
-
-          {/* Content sits above the chart */}
-          <div className="relative z-10 flex flex-col gap-3 flex-1 justify-between">
-            {/* Header: name */}
-            <div className="flex items-center gap-2 min-w-0 pr-20">
-              <span className="font-medium truncate">{agent.name}</span>
-            </div>
-
-            {/* Description */}
-            {agent.description && (
-              <p className="text-xs text-muted-foreground line-clamp-2">{agent.description}</p>
-            )}
-
-            {/* Details row */}
-            <div className="flex items-center gap-3 flex-wrap text-xs text-muted-foreground">
-              {/* Last worked */}
-              {lastWorked && (
-                <span className="flex items-center gap-1">
-                  <Clock className="h-3 w-3" />
-                  {lastWorked}
-                </span>
-              )}
-
-              {/* Scheduled tasks */}
-              {scheduledTaskCount > 0 && (
-                <span className="flex items-center gap-1" title={nextRun ? `Next run: ${nextRun}` : undefined}>
-                  <CalendarClock className="h-3 w-3" />
-                  {scheduledTaskCount} task{scheduledTaskCount !== 1 ? 's' : ''}
-                  {nextRun && <span className="text-muted-foreground/70">&middot; {nextRun}</span>}
-                </span>
-              )}
-
-              {/* Dashboard count (each dashboard also gets its own card below) */}
-              {dashboardCount > 0 && (
-                <span className="flex items-center gap-1">
-                  <SquareMousePointer className="h-3 w-3" />
-                  {dashboardCount} dashboard{dashboardCount !== 1 ? 's' : ''}
-                </span>
-              )}
-
-              {/* Usage tokens */}
-              {sparkData && (
-                <span className="flex items-center gap-1">
-                  {formatTokenCount(totalTokens)} tokens/7d
-                </span>
-              )}
-            </div>
-          </div>
-        </AppLink>
-      </AgentContextMenu>
-
-      {/* Session appendages — each tucks up behind the rounded corners of the one above */}
-      {visibleSessions.map((session, i) => {
-        const isAwaiting = session.isAwaitingInput
-        const isWorking = session.isActive && !session.isAwaitingInput
-        const hasUnread = !session.isActive && !session.isAwaitingInput && session.hasUnreadNotifications
-
-        const colors = isAwaiting
-          ? 'bg-orange-50 border-orange-200 dark:bg-orange-900 dark:border-orange-800'
-          : isWorking
-          ? 'bg-green-50 border-green-200 dark:bg-green-900 dark:border-green-800'
-          : 'bg-blue-50 border-blue-200 dark:bg-blue-950 dark:border-blue-800'
-
-        return (
-          <div
-            key={session.id}
-            className="relative px-1"
-            style={{ marginTop: -6, zIndex: visibleSessions.length + 1 - i }}
-          >
-            <AppLink
-              to="/agents/$slug/sessions/$sessionId"
-              params={{ slug: agent.slug, sessionId: session.id }}
-              className={`w-full flex items-center gap-2 px-3 py-1.5 pt-3 text-left text-xs border rounded-b-lg transition-colors hover:brightness-95 ${colors}`}
+    <div className="flex max-h-full min-h-0 flex-col overflow-hidden rounded-md border border-border/50 bg-white/10 backdrop-blur-sm">
+      <div className="min-h-0 overflow-y-auto px-2 py-1">
+        {visible.map((s) => {
+          const st = sessionState(s)
+          const right = compactAgo(s.lastActivityAt) ?? ''
+          return (
+            <div
+              key={s.id}
+              className="group/row flex h-6 w-full items-center gap-2.5 text-xs"
             >
-              {isAwaiting ? (
-                <AwaitingDot />
-              ) : isWorking ? (
-                <WorkingDots dotClassName="bg-foreground" />
-              ) : hasUnread ? (
-                <span className="h-2 w-2 shrink-0 rounded-full bg-blue-500" />
-              ) : null}
-              <span className="truncate font-medium">{session.name}</span>
-              <span className="ml-auto shrink-0 text-muted-foreground">
-                {isAwaiting ? 'needs input' : isWorking ? 'working' : 'new message'}
+              <span {...rowButtonProps(() => open(s.id))} className="flex min-w-0 flex-1 cursor-pointer items-center gap-2.5 text-left">
+                <SessionStateDot state={st} />
+                <span className="truncate text-foreground">
+                  <span className="text-muted-foreground">{SESSION_STATE_PREFIX[st]}: </span>
+                  {stripAgentPrefix(s.name, agentName)}
+                </span>
               </span>
-            </AppLink>
-          </div>
-        )
-      })}
-
-      {/* Collapsed unread notification summary */}
-      {collapsedUnreadCount > 0 && (
-        <div
-          className="relative px-1"
-          style={{ marginTop: -6, zIndex: 0 }}
-        >
-          <AppLink
-            to="/agents/$slug"
-            params={{ slug: agent.displaySlug }}
-            className="w-full flex items-center gap-2 px-3 py-1.5 pt-3 text-left text-xs border rounded-b-lg transition-colors hover:brightness-95 bg-blue-50 border-blue-200 dark:bg-blue-950 dark:border-blue-800"
+              {st === 'unread' || st === 'awaiting' ? (
+                <>
+                  {/* The timestamp swaps for actions on hover: unread gets
+                      clear + open; needs-input has nothing to clear, just open. */}
+                  <span className="shrink-0 text-muted-foreground tabular-nums group-hover/row:hidden">{right}</span>
+                  <span className="hidden shrink-0 items-center gap-0.5 group-hover/row:flex">
+                    {st === 'unread' && (
+                      <span
+                        {...rowButtonProps(() => markRead.mutate(s.id))}
+                        aria-label="Mark as read"
+                        title="Mark as read"
+                        className="inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      >
+                        <Check className="h-3.5 w-3.5" />
+                      </span>
+                    )}
+                    <span
+                      {...rowButtonProps(() => open(s.id))}
+                      aria-label="Open session"
+                      title="Open session"
+                      className="inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                    >
+                      <ArrowRight className="h-3.5 w-3.5" />
+                    </span>
+                  </span>
+                </>
+              ) : (
+                <span className="shrink-0 text-muted-foreground tabular-nums">{right}</span>
+              )}
+            </div>
+          )
+        })}
+        {moreCount > 0 && (
+          <span
+            {...rowButtonProps(() => {
+              void navigate({ to: '/agents/$slug', params: { slug: agentDisplaySlug } })
+            })}
+            className="group/row flex h-6 w-full cursor-pointer items-center justify-end gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
           >
-            <span className="h-2 w-2 shrink-0 rounded-full bg-blue-500" />
-            <span className="font-medium">{collapsedUnreadCount} more notification{collapsedUnreadCount !== 1 ? 's' : ''}</span>
-          </AppLink>
+            <span>{moreCount} more</span>
+            <span className="hidden h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground group-hover/row:inline-flex">
+              <ArrowRight className="h-3.5 w-3.5" />
+            </span>
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+type HealthSlide = { kind: 'cron' | 'webhook'; id: string; name: string }
+
+/**
+ * Rotating health carousel for the card's bottom row. One full-width slide at
+ * a time — each cron's run history (CronSparkChart) and each webhook's daily
+ * volume (ActivitySparkChart), fed by the real /api/activity rollups — so
+ * labels get the whole row instead of clipping. Auto-advances every few
+ * seconds, pauses on hover; the dots jump straight to a slide; a slide click
+ * opens that trigger's page.
+ */
+function AgentHealthCarousel({
+  agent,
+  crons,
+  webhooks,
+}: {
+  agent: ApiAgent
+  crons: HomeGraphCron[]
+  webhooks: HomeGraphWebhook[]
+}) {
+  const navigate = useNavigate()
+  // live:false — many cards mount at once; same reasoning as the graph's
+  // hover cards (no poll, refetch only when stale).
+  const { data: stats, isPending: statsPending } = useAgentActivityStats(agent.slug, DEFAULT_ACTIVITY_DAYS, {
+    live: false,
+  })
+
+  const slides = useMemo<HealthSlide[]>(
+    () => [
+      ...crons.map((c) => ({ kind: 'cron' as const, id: c.id, name: c.name ?? c.scheduleExpression })),
+      ...webhooks.map((w) => ({ kind: 'webhook' as const, id: w.id, name: w.name ?? w.triggerType })),
+    ],
+    [crons, webhooks]
+  )
+  const count = slides.length
+  const [index, setIndex] = useState(0)
+  const [paused, setPaused] = useState(false)
+
+  useEffect(() => {
+    if (paused || count < 2) return
+    const t = setInterval(() => setIndex((i) => (i + 1) % count), 4000)
+    return () => clearInterval(t)
+  }, [paused, count])
+
+  if (count === 0) return null
+  const active = slides[index % count]
+
+  const openSlide = (s: HealthSlide) => {
+    if (s.kind === 'cron') {
+      void navigate({ to: '/agents/$slug/tasks/$taskId', params: { slug: agent.slug, taskId: s.id } })
+    } else {
+      void navigate({ to: '/agents/$slug/webhooks/$webhookId', params: { slug: agent.slug, webhookId: s.id } })
+    }
+  }
+
+  const renderSlide = (s: HealthSlide) => {
+    let chart: ReactNode
+    let metric = ''
+    if (statsPending) {
+      chart = <ActivitySparkChartSkeleton className="h-5 w-24" />
+    } else if (s.kind === 'cron') {
+      const activity = stats?.cronByTaskId[s.id] ?? []
+      const succeeded = activity.filter((p) => p.status === 'succeeded').length
+      chart = <CronSparkChart label={s.name} data={activity} className="h-5 w-24" />
+      metric = `${succeeded}/${activity.length}`
+    } else {
+      const activity = stats?.webhookByTriggerId[s.id] ?? []
+      const { total } = summarizeDailyActivity(activity)
+      chart = <ActivitySparkChart label={s.name} data={activity} className="h-5 w-24" />
+      metric = `${total}/${DEFAULT_ACTIVITY_DAYS}d`
+    }
+    return (
+      <span
+        {...rowButtonProps(() => openSlide(s))}
+        className="flex w-full cursor-pointer items-center gap-2 text-xs"
+      >
+        <span className="min-w-0 flex-1 truncate">
+          <span className="text-foreground">{s.name}</span>{' '}
+          <span className="text-muted-foreground">{s.kind === 'cron' ? 'Cron' : 'Webhook'}</span>
+        </span>
+        <span className="shrink-0">{chart}</span>
+        <span className="shrink-0 tabular-nums text-muted-foreground">{metric}</span>
+      </span>
+    )
+  }
+
+  return (
+    <div
+      className="mt-auto flex shrink-0 items-center gap-1.5"
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+    >
+      {/* The frosted panel (title's bg-white/10 + backdrop-blur) lives on the
+          container so the halftone reads softly through it and never flashes.
+          A single content layer slides up inside it on each change — nothing
+          underneath to bleed through. */}
+      <div className="relative min-w-0 flex-1 overflow-hidden rounded-md border border-border/50 bg-white/10 backdrop-blur-sm">
+        <div
+          key={active.id}
+          className="px-2 py-1.5 animate-in slide-in-from-bottom-full duration-300"
+        >
+          {renderSlide(active)}
         </div>
+      </div>
+      {/* Vertical position dots, outside the chip to the right */}
+      {count > 1 && (
+        <span className="flex shrink-0 flex-col items-center gap-1">
+          {slides.map((s, i) => (
+            <span
+              key={s.id}
+              {...rowButtonProps(() => setIndex(i))}
+              aria-label={`Show health row ${i + 1} of ${count}`}
+              className={cn(
+                'h-[3px] w-[3px] cursor-pointer rounded-full transition-colors',
+                i === index % count ? 'bg-foreground/70' : 'bg-muted-foreground/30 hover:bg-muted-foreground/60'
+              )}
+            />
+          ))}
+        </span>
       )}
     </div>
   )
 }
 
+/**
+ * Small-card title meta as a ticker: a single line that continuously scrolls
+ * "Last run X · {N} new notifications" (orange needs-input dot wins over blue
+ * unread), looping seamlessly via a duplicated run.
+ */
+function TickerTitleMeta({
+  lastWorked,
+  notifCount,
+  notifState,
+}: {
+  lastWorked: string | null
+  notifCount: number
+  notifState: SessionState
+}) {
+  const run = (
+    <span className="flex items-center gap-1.5 pr-8 text-muted-foreground">
+      <span>Last run {lastWorked ?? 'never'}</span>
+      <SessionStateDot state={notifState} />
+      <span>
+        {notifCount} new notification{notifCount !== 1 ? 's' : ''}
+      </span>
+    </span>
+  )
+  return (
+    <div className="relative h-4 overflow-hidden text-xs">
+      <style>{'@keyframes title-ticker{from{transform:translateX(0)}to{transform:translateX(-50%)}}'}</style>
+      <div
+        className="flex w-max items-center whitespace-nowrap"
+        style={{ animation: 'title-ticker 14s linear infinite' }}
+      >
+        {run}
+        {run}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Agent card, size-aware for the widget grid:
+ *   S (1×1) — full-bleed halftone glance tile: title + last run + state pill.
+ *   W (2×1) — banner strip, notifications in the middle, cron + webhook charts
+ *             sharing one row pinned to the bottom.
+ */
+function AgentCard({
+  agent,
+  size = 'W',
+  sizeControl,
+  crons = [],
+  webhooks = [],
+}: {
+  agent: ApiAgent
+  size?: WidgetSizeKey
+  sizeControl?: ReactNode
+  crons?: HomeGraphCron[]
+  webhooks?: HomeGraphWebhook[]
+}) {
+  useRenderTracker('AgentCard')
+  const navigate = useNavigate()
+  const lastWorked = agent.lastActivityAt ? formatDistanceToNow(new Date(agent.lastActivityAt), { addSuffix: true }) : null
+
+  const isSmall = size === 'S'
+
+  // Fetch sessions whenever there are notable ones — the Wide card lists them,
+  // the Small card rotates a count into the title.
+  const hasNotable = agent.hasActiveSessions || agent.hasSessionsAwaitingInput || agent.hasUnreadNotifications
+  const { data: sessions } = useSessions(hasNotable ? agent.slug : null, { staleTime: 30_000 })
+
+  // Notification summary for the Small card's rotating title meta. Orange
+  // (needs input) always wins over blue (unread).
+  const notifSessions = useMemo(
+    () => (sessions ?? []).filter((s) => s.isAwaitingInput || s.hasUnreadNotifications),
+    [sessions]
+  )
+  const notifState: SessionState | null = notifSessions.some((s) => s.isAwaitingInput)
+    ? 'awaiting'
+    : notifSessions.length > 0
+      ? 'unread'
+      : null
+
+  const titleOverlay = (
+    <div className="absolute bottom-2 left-4 max-w-[calc(100%-2rem)] rounded-md bg-white/10 px-2.5 py-1 backdrop-blur-sm">
+      <div className="truncate text-sm font-normal text-foreground">{agent.name}</div>
+      {isSmall && notifState ? (
+        <TickerTitleMeta lastWorked={lastWorked} notifCount={notifSessions.length} notifState={notifState} />
+      ) : (
+        <div className="truncate text-xs text-muted-foreground">Last run {lastWorked ?? 'never'}</div>
+      )}
+    </div>
+  )
+
+  return (
+    <AgentContextMenu agent={agent}>
+      <button
+        onClick={() => {
+          void navigate({ to: '/agents/$slug', params: { slug: agent.displaySlug } })
+        }}
+        className="relative flex h-full w-full flex-col gap-3 overflow-hidden rounded-lg border bg-card p-4 text-left shadow-sm transition-[box-shadow,transform,border-color] duration-150 hover:border-accent-foreground/20 group-hover/widget:-translate-y-0.5 group-hover/widget:shadow-md"
+      >
+        {/* Control row: status chip + size kebab share one flex row, so
+            items-center vertically centers the kebab against the chip, and the
+            kebab simply appears to its right on hover (right-anchored row). */}
+        <div className="absolute top-2 right-4 z-30 flex items-center gap-1.5">
+          <AgentCardPowerButton agent={agent} />
+          {sizeControl}
+        </div>
+
+        {isSmall ? (
+          /* Glance tile: the halftone fills the card, content overlays it. */
+          <>
+            <div className="absolute inset-0">
+              <AgentCardMatrix
+                slug={agent.slug}
+                status={agent.status}
+                hasActiveSessions={agent.hasActiveSessions ?? false}
+                hasSessionsAwaitingInput={agent.hasSessionsAwaitingInput ?? false}
+                className="h-full"
+              />
+            </div>
+            {titleOverlay}
+          </>
+        ) : (
+          /* Wide: same glance-tile footing as Small — halftone fills the card,
+             title in the bottom-left corner — with the notifications + health
+             carousel overlaid on top. The content reserves bottom space (pb-11)
+             so it clears the title pill. */
+          <>
+            <div className="absolute inset-0">
+              <AgentCardMatrix
+                slug={agent.slug}
+                status={agent.status}
+                hasActiveSessions={agent.hasActiveSessions ?? false}
+                hasSessionsAwaitingInput={agent.hasSessionsAwaitingInput ?? false}
+                className="h-full"
+              />
+            </div>
+            <div className="relative z-10 flex min-h-0 flex-1 flex-col gap-1.5 pb-11">
+              {/* Notifications sit directly above the cron/webhook carousel
+                  (bottom-aligned); any slack opens up above them. Scrolls when
+                  the list overflows. */}
+              <div className="flex min-h-0 flex-1 flex-col justify-end">
+                <AgentCardSessions
+                  agentSlug={agent.slug}
+                  agentDisplaySlug={agent.displaySlug}
+                  agentName={agent.name}
+                  sessions={sessions}
+                />
+              </div>
+              {/* Rotating cron/webhook health carousel (renders nothing when
+                  the agent has no triggers). */}
+              <AgentHealthCarousel agent={agent} crons={crons} webhooks={webhooks} />
+            </div>
+            {titleOverlay}
+          </>
+        )}
+      </button>
+    </AgentContextMenu>
+  )
+}
+
+/** Widget-grid key for a dashboard tile. Agents use their bare slug. */
+const dashKey = (agentSlug: string, dashSlug: string) => `dash::${agentSlug}::${dashSlug}`
+
 export function HomePage() {
   useRenderTracker('HomePage')
   const { data: agents, isLoading: agentsLoading } = useAgents()
   const { data: userSettings } = useUserSettings()
-  const { data: usageData } = useUsageData(7)
+  const updateSettings = useUpdateUserSettings()
+
+  // agentOrder (sidebar drag order) drives the initial flow-pack order of
+  // uncustomized boards; once the user drags/resizes here, homeGridLayout wins.
   const orderedAgents = useMemo(
     () => applyAgentOrder(agents ?? [], userSettings?.agentOrder),
     [agents, userSettings?.agentOrder]
   )
+
+  // Optimistic local layout while the homeGridLayout mutation is in flight.
+  const [localLayout, setLocalLayout] = useState<Record<string, GridRect> | null>(null)
+  const savedLayout = localLayout ?? userSettings?.homeGridLayout
+
+  // Agents whose associated app/dashboard card is toggled off. localHidden is a
+  // session override that wins over the server value, so the toggle takes effect
+  // immediately and isn't clobbered by the post-save refetch.
+  const [localHidden, setLocalHidden] = useState<Set<string> | null>(null)
+  const hiddenApps = useMemo(
+    () => localHidden ?? new Set(userSettings?.hiddenAppCards ?? []),
+    [localHidden, userSettings?.hiddenAppCards]
+  )
+
+  const { widgetItems, dashboardsById, agentsWithApp } = useMemo(() => {
+    const items: WidgetItem[] = []
+    const dashes = new Map<string, { agentSlug: string; dashboard: { slug: string; name: string } }>()
+    const withApp = new Set<string>()
+    for (const agent of orderedAgents) {
+      items.push({ id: agent.slug, rect: savedLayout?.[agent.slug], defaultSize: 'W' })
+      const dashboards = Array.isArray(agent.dashboards) ? agent.dashboards : []
+      if (dashboards.length > 0) withApp.add(agent.slug)
+      if (hiddenApps.has(agent.slug)) continue // app card toggled off — skip its dashboard tiles
+      for (const d of dashboards) {
+        const id = dashKey(agent.slug, d.slug)
+        items.push({ id, rect: savedLayout?.[id], defaultSize: 'S' })
+        dashes.set(id, { agentSlug: agent.slug, dashboard: d })
+      }
+    }
+    return { widgetItems: items, dashboardsById: dashes, agentsWithApp: withApp }
+  }, [orderedAgents, savedLayout, hiddenApps])
+
+  const agentBySlug = useMemo(() => new Map(orderedAgents.map((a) => [a.slug, a])), [orderedAgents])
+
+  // Shared topology snapshot for the cards' health carousels (cron/webhook
+  // names per agent in one request). Same query key as the graph view, so
+  // cards⇄graph flips reuse the cache; parsed at the boundary like the graph.
+  const { data: topology } = useQuery<HomeGraphData>({
+    queryKey: ['home-graph'],
+    queryFn: async () => {
+      const res = await apiFetch('/api/home-graph')
+      if (!res.ok) throw new Error('Failed to fetch home graph')
+      return homeGraphSchema.parse(await res.json())
+    },
+    staleTime: 60_000,
+  })
+  const { cronsByAgent, webhooksByAgent } = useMemo(() => {
+    const cronsMap = new Map<string, HomeGraphCron[]>()
+    const webhooksMap = new Map<string, HomeGraphWebhook[]>()
+    for (const cron of topology?.crons ?? []) {
+      if (cron.status === 'cancelled') continue
+      const list = cronsMap.get(cron.agentSlug) ?? []
+      list.push(cron)
+      cronsMap.set(cron.agentSlug, list)
+    }
+    for (const webhook of topology?.webhooks ?? []) {
+      if (webhook.status === 'cancelled') continue
+      const list = webhooksMap.get(webhook.agentSlug) ?? []
+      list.push(webhook)
+      webhooksMap.set(webhook.agentSlug, list)
+    }
+    return { cronsByAgent: cronsMap, webhooksByAgent: webhooksMap }
+  }, [topology])
+
+  const commitLayout = (layout: Record<string, GridRect>) => {
+    setLocalLayout(layout)
+    updateSettings.mutate({ homeGridLayout: layout }, { onSettled: () => setLocalLayout(null) })
+  }
+
+  const toggleAppCard = (agentSlug: string) => {
+    const next = new Set(hiddenApps)
+    if (next.has(agentSlug)) next.delete(agentSlug)
+    else next.add(agentSlug)
+    setLocalHidden(next)
+    updateSettings.mutate({ hiddenAppCards: [...next] })
+  }
+
   const { createUntitledAgent, isPending: isCreatingAgent } = useCreateUntitledAgent()
   const { state: sidebarState } = useSidebar()
   const isFullScreen = useFullScreen()
@@ -394,7 +848,7 @@ export function HomePage() {
         </div>
       ) : (
       <div className="flex-1 overflow-y-auto px-4 py-6 md:p-6">
-        <div className="max-w-4xl mx-auto space-y-8">
+        <div className="max-w-7xl mx-auto space-y-8">
           {/* Mobile web/PWA only — "Install Gamut" prompt; renders nothing on desktop/Electron. */}
           <PwaInstallBanner />
 
@@ -418,25 +872,52 @@ export function HomePage() {
                 <Loader2 className="h-5 w-5 animate-spin" />
               </div>
             ) : hasAgents ? (
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-                {orderedAgents.flatMap((agent) => {
-                  const dashboards = Array.isArray(agent.dashboards) ? agent.dashboards : []
-                  const cells = [
-                    <AgentCard key={agent.slug} agent={agent} dailyUsage={usageData?.daily} />,
-                  ]
-                  for (const d of dashboards) {
-                    cells.push(
-                      <DashboardCard
-                        key={`${agent.slug}::dashboard::${d.slug}`}
-                        dashboard={d}
-                        agentSlug={agent.slug}
-                        variant="overlay"
-                      />
+              <WidgetBoard
+                items={widgetItems}
+                onCommit={commitLayout}
+                renderItem={(id, size, onResize) => {
+                  const dash = dashboardsById.get(id)
+                  if (dash) {
+                    return (
+                      <div className="relative h-full transition-transform duration-150 group-hover/widget:-translate-y-0.5">
+                        <DashboardCard dashboard={dash.dashboard} agentSlug={dash.agentSlug} variant="fill" align={size === 'S' ? 'top-left' : 'top'} />
+                        <div className="absolute right-4 top-2 z-30 flex h-[26px] items-center">
+                          <WidgetSizePopover size={size} onPick={onResize} />
+                        </div>
+                      </div>
                     )
                   }
-                  return cells
-                })}
-              </div>
+                  const agent = agentBySlug.get(id)
+                  if (!agent) return null
+                  const sizeControl = (
+                    <WidgetSizePopover
+                      size={size}
+                      onPick={onResize}
+                      extra={(close) =>
+                        agentsWithApp.has(agent.slug) ? (
+                          <WidgetToggleRow
+                            label="Show app"
+                            checked={!hiddenApps.has(agent.slug)}
+                            onToggle={() => {
+                              close()
+                              toggleAppCard(agent.slug)
+                            }}
+                          />
+                        ) : null
+                      }
+                    />
+                  )
+                  return (
+                    <AgentCard
+                      agent={agent}
+                      size={size}
+                      sizeControl={sizeControl}
+                      crons={cronsByAgent.get(agent.slug)}
+                      webhooks={webhooksByAgent.get(agent.slug)}
+                    />
+                  )
+                }}
+              />
             ) : (
               <div className="text-center py-12 border rounded-lg bg-muted/30">
                 <Bot className="h-10 w-10 mx-auto text-muted-foreground mb-3" />
@@ -448,7 +929,6 @@ export function HomePage() {
               </div>
             )}
           </section>
-
         </div>
       </div>
       )}

--- a/src/shared/lib/services/user-settings-service.ts
+++ b/src/shared/lib/services/user-settings-service.ts
@@ -52,6 +52,21 @@ export const userSettingsSchema = z.object({
   // Home graph view: the "Details" toggle (pin every resource's detail card
   // + count chips open). Absent = off.
   graphShowDetails: z.boolean().optional(),
+  // Home page widget grid: per-card position + footprint in grid cells,
+  // keyed by card id (agent slug or dashboard key). Absent = never customized
+  // (the board auto-packs responsively until the user drags/resizes).
+  homeGridLayout: z.record(
+    z.string(),
+    z.object({
+      x: z.number().int().min(0),
+      y: z.number().int().min(0),
+      w: z.number().int().min(1).max(2),
+      h: z.number().int().min(1).max(2),
+    })
+  ).optional(),
+  // Agent slugs whose associated app/dashboard card is hidden from the home grid
+  // (toggled from the agent card). Absent/empty = all app cards shown.
+  hiddenAppCards: z.array(z.string()).optional(),
   defaultApiPolicy: z.enum(['allow', 'review', 'block']).default('review'),
   defaultMcpPolicy: z.enum(['allow', 'review', 'block']).default('review'),
   keepAwakeEnabled: z.boolean().default(false),


### PR DESCRIPTION
`4/4` of the home-page redesign stack (base: #533 — merge #531 → #532 → #533 first; this PR's diff narrows to the home page itself).

## Summary

Rebuilds the home page's **cards view** as a widget grid of animated agent cards, keeping main's shell (cards ⇄ graph toggle, router navigation, PWA banner).

### Agent cards
- Full-bleed **halftone** glance tile (flow_3d; orange **pulse** when a session needs input), title + last-run overlay.
- **Status chip** (Needs input / Working… / Idle / Sleeping) with stop/power button; kebab **Card options** menu: **Expanded** toggle (Small 1×1 ⇄ Medium 2×1) and per-agent **Show app** toggle.
- **Notifications panel** (max 3 rows + "N more"), session rows open the session; small cards show a scrolling ticker summary.
- **Health carousel**: real cron run history (`CronSparkChart`) + webhook daily volume (`ActivitySparkChart`) from `/api/home-graph` topology (shared query key with the graph view) + per-agent `useAgentActivityStats` (`live:false`); slide click opens the trigger page.

### Dashboard/app tiles
- `DashboardCard` gains a `fill` variant: screenshot fills the tile (top-left crop on Small), "Open app" pill sized to the status chip; navigates via `AppLink`.

### Persistence
- `homeGridLayout` (per-card rect) and `hiddenAppCards` (per-agent Show-app) in user settings, Zod-validated.

## Notes
- Layout/drag engine and halftone are reviewed in #533 / #532; the settings-cache flicker fix in #531.
- The full animation exploration (dither blob, gallery, tweak panels) is preserved on `animation-experiments-draft`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)