### PR TITLE
add agent factory for tool rendering e2e

### DIFF
--- a/e2e/helpers/agents.ts
+++ b/e2e/helpers/agents.ts
@@ -1,0 +1,70 @@
+import { expect, type APIRequestContext, type Page } from '@playwright/test'
+
+export interface TestAgent {
+  slug: string
+  name: string
+}
+
+async function expectAgentInApi(
+  request: APIRequestContext,
+  agent: Pick<TestAgent, 'slug' | 'name'>,
+) {
+  await expect.poll(async () => {
+    const response = await request.get('/api/agents')
+    if (!response.ok()) return false
+
+    const agents = await response.json() as TestAgent[]
+    return agents.some((candidate) => (
+      candidate.slug === agent.slug && candidate.name === agent.name
+    ))
+  }, { timeout: 15000 }).toBe(true)
+}
+
+function getAgentItem(page: Page, agent: Pick<TestAgent, 'slug' | 'name'>) {
+  return page
+    .locator(`[data-testid="agent-item-${agent.slug}"]`)
+    .or(page.locator('[data-testid^="agent-item-"]', { hasText: agent.name }))
+    .first()
+}
+
+export async function createAgent(request: APIRequestContext, name: string): Promise<TestAgent> {
+  const response = await request.post('/api/agents', {
+    data: { name },
+  })
+
+  expect(response.ok()).toBeTruthy()
+  const agent = await response.json() as TestAgent
+  expect(agent.slug).toBeTruthy()
+  expect(agent.name).toBe(name)
+  await expectAgentInApi(request, agent)
+
+  return agent
+}
+
+export async function openAgentHome(page: Page, agent: Pick<TestAgent, 'slug' | 'name'>) {
+  let lastError: unknown
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const agentItem = getAgentItem(page, agent)
+
+    try {
+      await expect(agentItem).toBeVisible({ timeout: 10000 })
+      await agentItem.scrollIntoViewIfNeeded({ timeout: 10000 })
+      await agentItem.click()
+
+      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name, { timeout: 15000 })
+      await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
+      return
+    } catch (error) {
+      lastError = error
+      if (attempt === 1) break
+
+      await page.reload()
+      await expect(page.locator('[data-testid="new-agent-button"]')).toBeVisible({ timeout: 15000 })
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`Could not open agent "${agent.name}" (${agent.slug})`)
+}

--- a/e2e/specs/tool-rendering.spec.ts
+++ b/e2e/specs/tool-rendering.spec.ts
@@ -1,25 +1,29 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
-import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
+import { createAgent, openAgentHome } from '../helpers/agents'
+
+async function setupToolTest(
+  page: Page,
+  request: APIRequestContext,
+  testInfo: TestInfo,
+  label: string,
+) {
+  const appPage = new AppPage(page)
+  const sessionPage = new SessionPage(page)
+  const agentName = `Tool Agent ${label} ${testInfo.workerIndex}-${testInfo.repeatEachIndex}-${Date.now()}`
+  const agent = await createAgent(request, agentName)
+
+  await appPage.goto()
+  await appPage.waitForAgentsLoaded()
+  await openAgentHome(page, agent)
+
+  return { sessionPage }
+}
 
 test.describe('Tool Call Rendering', () => {
-  let appPage: AppPage
-  let agentPage: AgentPage
-  let sessionPage: SessionPage
-
-  test.beforeEach(async ({ page }) => {
-    appPage = new AppPage(page)
-    agentPage = new AgentPage(page)
-    sessionPage = new SessionPage(page)
-
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
-  })
-
-  test('renders Bash tool call with terminal display', async ({ page }) => {
-    const agentName = `Tool Agent Bash ${Date.now()}`
-    await agentPage.createAgent(agentName)
+  test('renders Bash tool call with terminal display', async ({ page, request }, testInfo) => {
+    const { sessionPage } = await setupToolTest(page, request, testInfo, 'Bash')
 
     // Trigger the existing "list files" scenario which uses Bash tool
     await sessionPage.sendMessage('list files in the current directory')
@@ -37,9 +41,8 @@ test.describe('Tool Call Rendering', () => {
     await expect(toolCall.getByTestId('bash-terminal')).toBeVisible()
   })
 
-  test('renders Read tool call with file path summary', async ({ page }) => {
-    const agentName = `Tool Agent Read ${Date.now()}`
-    await agentPage.createAgent(agentName)
+  test('renders Read tool call with file path summary', async ({ page, request }, testInfo) => {
+    const { sessionPage } = await setupToolTest(page, request, testInfo, 'Read')
 
     await sessionPage.sendMessage('read file please')
     await sessionPage.waitForResponse(15000)
@@ -53,9 +56,8 @@ test.describe('Tool Call Rendering', () => {
     await expect(toolCall).toContainText('src/index.ts')
   })
 
-  test('renders Write tool call', async ({ page }) => {
-    const agentName = `Tool Agent Write ${Date.now()}`
-    await agentPage.createAgent(agentName)
+  test('renders Write tool call', async ({ page, request }, testInfo) => {
+    const { sessionPage } = await setupToolTest(page, request, testInfo, 'Write')
 
     await sessionPage.sendMessage('write file for me')
     await sessionPage.waitForResponse(15000)
@@ -69,9 +71,8 @@ test.describe('Tool Call Rendering', () => {
     await expect(toolCall).toContainText('hello.ts')
   })
 
-  test('renders Grep tool call with search pattern', async ({ page }) => {
-    const agentName = `Tool Agent Grep ${Date.now()}`
-    await agentPage.createAgent(agentName)
+  test('renders Grep tool call with search pattern', async ({ page, request }, testInfo) => {
+    const { sessionPage } = await setupToolTest(page, request, testInfo, 'Grep')
 
     await sessionPage.sendMessage('search code for TODOs')
     await sessionPage.waitForResponse(15000)
@@ -82,9 +83,8 @@ test.describe('Tool Call Rendering', () => {
     await expect(toolCall).toBeVisible()
   })
 
-  test('renders Glob tool call', async ({ page }) => {
-    const agentName = `Tool Agent Glob ${Date.now()}`
-    await agentPage.createAgent(agentName)
+  test('renders Glob tool call', async ({ page, request }, testInfo) => {
+    const { sessionPage } = await setupToolTest(page, request, testInfo, 'Glob')
 
     await sessionPage.sendMessage('find files matching pattern')
     await sessionPage.waitForResponse(15000)
@@ -93,9 +93,8 @@ test.describe('Tool Call Rendering', () => {
     await sessionPage.expectToolCall('Glob', 15000)
   })
 
-  test('renders WebSearch tool call', async ({ page }) => {
-    const agentName = `Tool Agent WebSearch ${Date.now()}`
-    await agentPage.createAgent(agentName)
+  test('renders WebSearch tool call', async ({ page, request }, testInfo) => {
+    const { sessionPage } = await setupToolTest(page, request, testInfo, 'WebSearch')
 
     await sessionPage.sendMessage('search web for TypeScript tips')
     await sessionPage.waitForResponse(15000)
@@ -109,9 +108,8 @@ test.describe('Tool Call Rendering', () => {
     await expect(toolCall).toContainText('TypeScript best practices')
   })
 
-  test('tool call expand/collapse works', async ({ page }) => {
-    const agentName = `Tool Agent Expand ${Date.now()}`
-    await agentPage.createAgent(agentName)
+  test('tool call expand/collapse works', async ({ page, request }, testInfo) => {
+    const { sessionPage } = await setupToolTest(page, request, testInfo, 'Expand')
 
     await sessionPage.sendMessage('list files in the current directory')
     await sessionPage.waitForResponse(15000)


### PR DESCRIPTION
## Summary
- add a Playwright API factory for creating agents and waiting until the new agent is readable from /api/agents
- add a shared openAgentHome helper with stable slug/name selectors and a bounded reload for stale renderer state
- migrate tool-rendering away from shared AgentPage setup so each test creates its own agent via API

## Validation
- git diff --check
- npm run typecheck
- npm run lint:e2e (passes with the existing 49 warnings)
- PORT=3082 SUPERAGENT_DATA_DIR=.e2e-data/tool-rendering-factory PLAYWRIGHT_WORKERS=10 PLAYWRIGHT_OUTPUT_DIR=test-results/tool-rendering-factory PLAYWRIGHT_HTML_REPORT=playwright-report/tool-rendering-factory npm run test:e2e:web -- --fail-on-flaky-tests e2e/specs/tool-rendering.spec.ts --repeat-each=10 (70 passed, 1.0m)
