### PR TITLE
test: add connection factories for e2e

### DIFF
--- a/e2e/helpers/agents.ts
+++ b/e2e/helpers/agents.ts
@@ -5,6 +5,11 @@ export interface TestAgent {
   name: string
 }
 
+export interface TestSession {
+  id: string
+  name: string
+}
+
 async function expectAgentInApi(
   request: APIRequestContext,
   agent: Pick<TestAgent, 'slug' | 'name'>,
@@ -41,6 +46,46 @@ export async function createAgent(request: APIRequestContext, name: string): Pro
   return agent
 }
 
+export async function createSession(
+  request: APIRequestContext,
+  agent: Pick<TestAgent, 'slug'>,
+  message: string,
+): Promise<TestSession> {
+  const response = await request.post(`/api/agents/${agent.slug}/sessions`, {
+    data: { message },
+  })
+
+  expect(response.ok()).toBeTruthy()
+  const session = await response.json() as TestSession
+  expect(session.id).toBeTruthy()
+  expect(session.name).toBeTruthy()
+
+  await expect.poll(async () => {
+    const sessionsResponse = await request.get(`/api/agents/${agent.slug}/sessions`)
+    if (!sessionsResponse.ok()) return false
+
+    const sessions = await sessionsResponse.json() as TestSession[]
+    return sessions.some((candidate) => candidate.id === session.id)
+  }, { timeout: 15000 }).toBe(true)
+
+  return session
+}
+
+export async function waitForSessionIdle(
+  request: APIRequestContext,
+  agent: Pick<TestAgent, 'slug'>,
+  session: Pick<TestSession, 'id'>,
+) {
+  await expect.poll(async () => {
+    const response = await request.get(`/api/agents/${agent.slug}/sessions`)
+    if (!response.ok()) return false
+
+    const sessions = await response.json() as Array<TestSession & { isActive?: boolean }>
+    const current = sessions.find((candidate) => candidate.id === session.id)
+    return current ? current.isActive === false : false
+  }, { timeout: 15000 }).toBe(true)
+}
+
 export async function openAgentHome(page: Page, agent: Pick<TestAgent, 'slug' | 'name'>) {
   let lastError: unknown
 
@@ -67,4 +112,47 @@ export async function openAgentHome(page: Page, agent: Pick<TestAgent, 'slug' | 
   throw lastError instanceof Error
     ? lastError
     : new Error(`Could not open agent "${agent.name}" (${agent.slug})`)
+}
+
+export async function openAgentSession(
+  page: Page,
+  agent: Pick<TestAgent, 'slug' | 'name'>,
+  session: Pick<TestSession, 'id'>,
+) {
+  let lastError: unknown
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const agentItem = getAgentItem(page, agent)
+
+    try {
+      await expect(agentItem).toBeVisible({ timeout: 10000 })
+      await agentItem.scrollIntoViewIfNeeded({ timeout: 10000 })
+
+      const agentLi = agentItem.locator('xpath=ancestor::li[1]')
+      const expandChevron = agentLi.locator('button[aria-label="Expand"]').first()
+      if (await expandChevron.isVisible({ timeout: 500 }).catch(() => false)) {
+        await expandChevron.click()
+      }
+
+      const sessionItem = page.locator(`[data-testid="session-item-${session.id}"]`)
+      await expect(sessionItem).toBeVisible({ timeout: 15000 })
+      await sessionItem.scrollIntoViewIfNeeded({ timeout: 10000 })
+      await sessionItem.click()
+
+      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name, { timeout: 15000 })
+      await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
+      await expect(page.locator('[data-testid="message-input"]')).toBeVisible({ timeout: 15000 })
+      return
+    } catch (error) {
+      lastError = error
+      if (attempt === 1) break
+
+      await page.reload()
+      await expect(page.locator('[data-testid="new-agent-button"]')).toBeVisible({ timeout: 15000 })
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`Could not open session "${session.id}" for agent "${agent.name}" (${agent.slug})`)
 }

--- a/e2e/helpers/connections.ts
+++ b/e2e/helpers/connections.ts
@@ -1,0 +1,109 @@
+import { expect, type APIRequestContext } from '@playwright/test'
+
+export interface TestRemoteMcp {
+  id: string
+  name: string
+  url: string
+  authType: 'none' | 'oauth' | 'bearer'
+  status: 'active' | 'error' | 'auth_required'
+  tools: Array<{ name: string; description?: string; inputSchema?: Record<string, unknown> }>
+}
+
+export async function listRemoteMcps(request: APIRequestContext): Promise<TestRemoteMcp[]> {
+  const response = await request.get('/api/remote-mcps')
+  expect(response.ok()).toBeTruthy()
+
+  const body = await response.json() as { servers: TestRemoteMcp[] }
+  return body.servers
+}
+
+export async function findRemoteMcpByUrl(
+  request: APIRequestContext,
+  url: string,
+  name?: string,
+): Promise<TestRemoteMcp | undefined> {
+  const servers = await listRemoteMcps(request)
+  return servers.find((server) => (
+    server.url === url && (name === undefined || server.name === name)
+  ))
+}
+
+export async function expectRemoteMcpByUrl(
+  request: APIRequestContext,
+  url: string,
+  name: string,
+): Promise<TestRemoteMcp> {
+  await expect.poll(async () => {
+    const server = await findRemoteMcpByUrl(request, url, name)
+    return server?.id
+  }, { timeout: 15000 }).toBeTruthy()
+
+  const server = await findRemoteMcpByUrl(request, url, name)
+  expect(server, `remote MCP "${name}" (${url}) not found`).toBeDefined()
+  return server!
+}
+
+export async function createRemoteMcp(
+  request: APIRequestContext,
+  data: { name: string; url: string; authType?: 'none' | 'bearer'; accessToken?: string },
+): Promise<TestRemoteMcp> {
+  const response = await request.post('/api/remote-mcps', {
+    data,
+  })
+
+  expect(response.ok()).toBeTruthy()
+  const body = await response.json() as { server: TestRemoteMcp }
+  expect(body.server.id).toBeTruthy()
+  expect(body.server.name).toBe(data.name)
+  expect(body.server.url).toBe(data.url)
+  expect(body.server.status).toBe('active')
+  await expectRemoteMcpByUrl(request, data.url, data.name)
+
+  return body.server
+}
+
+export async function getAgentRemoteMcpIds(
+  request: APIRequestContext,
+  agentSlug: string,
+): Promise<string[]> {
+  const response = await request.get(`/api/agents/${agentSlug}/remote-mcps`)
+  expect(response.ok()).toBeTruthy()
+
+  const body = await response.json() as { mcps: Array<{ id: string }> }
+  return body.mcps.map((mcp) => mcp.id)
+}
+
+export async function expectAgentHasRemoteMcp(
+  request: APIRequestContext,
+  agentSlug: string,
+  mcpId: string,
+) {
+  await expect.poll(
+    async () => getAgentRemoteMcpIds(request, agentSlug),
+    { timeout: 10000, message: `agent ${agentSlug} never received MCP ${mcpId}` },
+  ).toContain(mcpId)
+}
+
+export async function expectAgentMissingRemoteMcp(
+  request: APIRequestContext,
+  agentSlug: string,
+  mcpId: string,
+) {
+  await expect.poll(
+    async () => getAgentRemoteMcpIds(request, agentSlug),
+    { timeout: 10000, message: `agent ${agentSlug} still has MCP ${mcpId}` },
+  ).not.toContain(mcpId)
+}
+
+export async function assignRemoteMcpToAgent(
+  request: APIRequestContext,
+  agentSlug: string,
+  mcpId: string,
+) {
+  const response = await request.post(`/api/agents/${agentSlug}/remote-mcps`, {
+    data: { mcpIds: [mcpId] },
+  })
+
+  expect(response.ok()).toBeTruthy()
+  await expectAgentHasRemoteMcp(request, agentSlug, mcpId)
+}

--- a/e2e/helpers/mock-mcp-server.ts
+++ b/e2e/helpers/mock-mcp-server.ts
@@ -87,9 +87,11 @@ export async function startMockMcpServer(port = 9876): Promise<MockMcpServer> {
     })
 
     server.listen(port, () => {
+      const address = server.address()
+      const actualPort = typeof address === 'object' && address ? address.port : port
       resolve({
-        url: `http://127.0.0.1:${port}/mcp`,
-        port,
+        url: `http://127.0.0.1:${actualPort}/mcp`,
+        port: actualPort,
         close: () => new Promise<void>((res) => server.close(() => res())),
       })
     })

--- a/e2e/pages/agent.page.ts
+++ b/e2e/pages/agent.page.ts
@@ -2,6 +2,10 @@ import { Page, expect } from '@playwright/test'
 
 export type AgentActivityStatus = 'sleeping' | 'idle' | 'working' | 'awaiting_input'
 
+type CreateAgentOptions = {
+  waitForSidebarName?: boolean
+}
+
 /**
  * Page object for agent-related operations
  */
@@ -21,7 +25,9 @@ export class AgentPage {
    * click the agent breadcrumb so the caller lands on agent-home (where
    * agent-settings-button lives) rather than the first session view.
    */
-  async createAgent(prompt: string) {
+  async createAgent(prompt: string, options: CreateAgentOptions = {}) {
+    const { waitForSidebarName = true } = options
+
     await this.clickCreateAgent()
 
     // Wait until we've actually landed on the fresh Untitled agent's AgentHome
@@ -40,11 +46,13 @@ export class AgentPage {
     await expect(this.page.locator('[data-testid="agent-settings-button"]')).toBeVisible()
 
     // The agent is created as "Untitled" then renamed async after session
-    // creation. Wait for the rename to land so downstream selectAgent(name)
-    // lookups by visible text match. We accept any non-"Untitled" value — in
-    // E2E the LLM is unconfigured so the server fallback yields the prompt's
-    // first ~5 words, matching what the test passed in.
-    await expect(this.page.locator('[data-testid="agent-breadcrumb"]')).not.toHaveText('Untitled', { timeout: 15000 })
+    // creation. Downstream tests that re-select agents by name need the
+    // sidebar row to be indexed, but session-only tests can avoid coupling to
+    // the sidebar refresh.
+    await expect(this.page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(prompt, { timeout: 15000 })
+    if (waitForSidebarName) {
+      await expect(this.getAgentItem(prompt)).toBeVisible({ timeout: 15000 })
+    }
   }
 
   /**

--- a/e2e/pages/session.page.ts
+++ b/e2e/pages/session.page.ts
@@ -26,6 +26,63 @@ export class SessionPage {
     return regular.or(home)
   }
 
+  private async findMatchingLocator(locators: Locator[], options: { enabled?: boolean } = {}) {
+    for (const locator of locators) {
+      const count = await locator.count().catch(() => 0)
+      for (let index = 0; index < count; index++) {
+        const candidate = locator.nth(index)
+        const isVisible = await candidate.isVisible().catch(() => false)
+        if (!isVisible) continue
+        const isEnabled = await candidate.isEnabled().catch(() => false)
+        if (options.enabled && !isEnabled) continue
+        return candidate
+      }
+    }
+    return undefined
+  }
+
+  private getMessageInputLocators() {
+    const regular = this.page.locator('[data-testid="message-input"]')
+    const home = this.page.locator('[data-testid="home-message-input"]')
+    return [regular, home]
+  }
+
+  private getSendButtonLocators() {
+    const regular = this.page.locator('[data-testid="send-button"]')
+    const home = this.page.locator('[data-testid="home-send-button"]')
+    return [regular, home]
+  }
+
+  private async getVisibleMessageInput(timeout = 10000) {
+    let visibleInput: Locator | undefined
+    await expect.poll(async () => {
+      visibleInput = await this.findMatchingLocator(this.getMessageInputLocators())
+      return visibleInput ? 'found' : 'none'
+    }, { timeout }).not.toBe('none')
+
+    return visibleInput ?? this.page.locator('[data-testid="message-input"]').first()
+  }
+
+  private async getEnabledMessageInput(timeout = 10000) {
+    let enabledInput: Locator | undefined
+    await expect.poll(async () => {
+      enabledInput = await this.findMatchingLocator(this.getMessageInputLocators(), { enabled: true })
+      return enabledInput ? 'found' : 'none'
+    }, { timeout }).not.toBe('none')
+
+    return enabledInput ?? this.page.locator('[data-testid="message-input"]').first()
+  }
+
+  private async getVisibleSendButton(timeout = 10000) {
+    let visibleButton: Locator | undefined
+    await expect.poll(async () => {
+      visibleButton = await this.findMatchingLocator(this.getSendButtonLocators())
+      return visibleButton ? 'found' : 'none'
+    }, { timeout }).not.toBe('none')
+
+    return visibleButton ?? this.page.locator('[data-testid="send-button"]').first()
+  }
+
   /**
    * Get the stop button (visible when agent is working)
    */
@@ -65,7 +122,9 @@ export class SessionPage {
    * Type a message into the input
    */
   async typeMessage(content: string) {
-    await this.getMessageInput().fill(content)
+    const input = await this.getEnabledMessageInput()
+    await input.fill(content)
+    await expect(input).toHaveValue(content)
   }
 
   /**
@@ -73,7 +132,9 @@ export class SessionPage {
    */
   async sendMessage(content: string) {
     await this.typeMessage(content)
-    await this.getSendButton().click()
+    const sendButton = await this.getVisibleSendButton()
+    await expect(sendButton).toBeEnabled({ timeout: 10000 })
+    await sendButton.click()
   }
 
   /**
@@ -167,7 +228,7 @@ export class SessionPage {
    * Wait for the input to be enabled (agent finished responding)
    */
   async waitForInputEnabled(timeout = 10000) {
-    await expect(this.getMessageInput()).toBeEnabled({ timeout })
+    await this.getEnabledMessageInput(timeout)
   }
 
   /**

--- a/e2e/specs/account-status.spec.ts
+++ b/e2e/specs/account-status.spec.ts
@@ -3,7 +3,7 @@ import { AppPage } from '../pages/app.page'
 
 test.describe.configure({ mode: 'serial' })
 
-const API = 'http://localhost:3000'
+const API = ''
 
 test.describe('Account Status & Reconnect', () => {
   let appPage: AppPage

--- a/e2e/specs/connections-management.spec.ts
+++ b/e2e/specs/connections-management.spec.ts
@@ -1,169 +1,126 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page, type TestInfo } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
-import { AgentPage } from '../pages/agent.page'
+import { createAgent, openAgentHome, type TestAgent } from '../helpers/agents'
+import {
+  assignRemoteMcpToAgent,
+  createRemoteMcp,
+  expectAgentHasRemoteMcp,
+  expectAgentMissingRemoteMcp,
+  expectRemoteMcpByUrl,
+  listRemoteMcps,
+} from '../helpers/connections'
 import { startMockMcpServer, type MockMcpServer } from '../helpers/mock-mcp-server'
 
-// Serial: tests cross-check DB state via the API, sensitive to concurrent writes.
-test.describe.configure({ mode: 'serial' })
+async function withMockMcp<T>(run: (mockMcp: MockMcpServer) => Promise<T>): Promise<T> {
+  const mockMcp = await startMockMcpServer(0)
+  try {
+    return await run(mockMcp)
+  } finally {
+    await mockMcp.close()
+  }
+}
 
-const API = 'http://localhost:3000'
+async function openAgentConnectionsPage(
+  page: Page,
+  agent: Pick<TestAgent, 'slug' | 'name'>,
+) {
+  const appPage = new AppPage(page)
+  await appPage.goto()
+  await appPage.waitForAgentsLoaded()
+  await openAgentHome(page, agent)
+  await page.locator('[data-testid="home-connections-open-page"]').click()
+  await expect(page.locator('[data-testid="connections-add-button"]')).toBeVisible()
+}
+
+function uniqueName(testInfo: TestInfo, label: string) {
+  const suffix = [
+    testInfo.workerIndex,
+    testInfo.repeatEachIndex,
+    Date.now(),
+    Math.random().toString(36).slice(2, 8),
+  ].join('-')
+
+  return `${label} ${suffix}`
+}
 
 test.describe('Connections Management - Manual Add Flow', () => {
-  let appPage: AppPage
-  let agentPage: AgentPage
-  let mockMcp: MockMcpServer
-  // 9877 avoids colliding with connected-accounts.spec.ts which uses 9876.
-  const MCP_PORT = 9877
+  test('user adds an MCP from the directory and toggles it on for the agent', async ({ page, request }, testInfo) => {
+    await withMockMcp(async (mockMcp) => {
+      const agentName = uniqueName(testInfo, 'Connections Manual')
+      const mcpName = uniqueName(testInfo, 'Manual MCP')
+      const agent = await createAgent(request, agentName)
 
-  test.beforeAll(async () => {
-    mockMcp = await startMockMcpServer(MCP_PORT)
+      // 1. From agent home, open the connections page.
+      await openAgentConnectionsPage(page, agent)
+
+      // 2. Open the "New connection" directory dialog and switch to MCPs.
+      await page.locator('[data-testid="connections-add-button"]').click()
+      await page.locator('[data-testid="directory-tab-mcps"]').click()
+
+      // 3. Expand the Custom MCP tile and fill the form (no-auth path).
+      await page.locator('[data-testid="directory-connect-mcp-custom"]').click()
+      await page.locator('[data-testid="mcp-form-name"]').fill(mcpName)
+      await page.locator('[data-testid="mcp-form-url"]').fill(mockMcp.url)
+      // authType defaults to "No Authentication" — no need to change.
+
+      // 4. Submit. The dialog closes and the Tool Policy editor opens.
+      await page.locator('[data-testid="mcp-form-submit"]').click()
+
+      // Dismiss the Tool Policy editor that opens for the new MCP.
+      const policyDialog = page.getByText('Tool Policies')
+      await expect(policyDialog).toBeVisible({ timeout: 10000 })
+      await page.getByRole('button', { name: 'Cancel' }).click()
+      await expect(policyDialog).not.toBeVisible({ timeout: 5000 })
+
+      // 5. Cross-check that the global MCP record landed in the DB.
+      const created = await expectRemoteMcpByUrl(request, mockMcp.url, mcpName)
+      expect(created.name).toBe(mcpName)
+
+      const switchLocator = page.locator(`[data-testid="connection-switch-mcp-${created.id}"]`)
+      await expect(switchLocator).toBeVisible({ timeout: 10000 })
+
+      // 6. Initially the agent does not have access — verify before toggling.
+      await expectAgentMissingRemoteMcp(request, agent.slug, created.id)
+
+      // 7. Toggle the row on.
+      await switchLocator.click()
+
+      // The toggle is async (optimistic + server roundtrip). Wait for the API to
+      // reflect the assignment rather than relying solely on UI state, since the
+      // local override clears once the server catches up — by then the DB is the
+      // source of truth.
+      await expectAgentHasRemoteMcp(request, agent.slug, created.id)
+
+      // UI also reflects the granted state.
+      await expect(switchLocator).toHaveAttribute('data-state', 'checked')
+    })
   })
 
-  test.afterAll(async () => {
-    await mockMcp.close()
-  })
+  test('toggling off removes the agent mapping but keeps the global MCP', async ({ page, request }, testInfo) => {
+    await withMockMcp(async (mockMcp) => {
+      const agentName = uniqueName(testInfo, 'Connections Toggle Off')
+      const mcpName = uniqueName(testInfo, 'Toggle MCP')
+      const agent = await createAgent(request, agentName)
+      const mcp = await createRemoteMcp(request, { name: mcpName, url: mockMcp.url })
+      await assignRemoteMcpToAgent(request, agent.slug, mcp.id)
 
-  test.beforeEach(async ({ page }) => {
-    appPage = new AppPage(page)
-    agentPage = new AgentPage(page)
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
-  })
+      await openAgentConnectionsPage(page, agent)
 
-  test('user adds an MCP from the directory and toggles it on for the agent', async ({ page, request }) => {
-    const agentName = `Connections Manual ${Date.now()}`
-    const mcpName = `Manual MCP ${Date.now()}`
+      const switchLocator = page.locator(`[data-testid="connection-switch-mcp-${mcp.id}"]`)
+      await expect(switchLocator).toBeVisible({ timeout: 10000 })
+      await expect(switchLocator).toHaveAttribute('data-state', 'checked', { timeout: 10000 })
 
-    await agentPage.createAgent(agentName)
+      // Toggle off through the UI.
+      await switchLocator.click()
 
-    // Resolve agent slug from the API rather than guessing — server-side slug
-    // generation may diverge from a naive lowercase-hyphenate.
-    const agentsRes = await request.get(`${API}/api/agents`)
-    expect(agentsRes.ok()).toBeTruthy()
-    const agents = await agentsRes.json()
-    const agent = agents.find((a: { name: string }) => a.name === agentName)
-    expect(agent, `agent "${agentName}" not found via /api/agents`).toBeDefined()
-    const agentSlug: string = agent.slug
+      // Mapping disappears from the agent list...
+      await expectAgentMissingRemoteMcp(request, agent.slug, mcp.id)
+      await expect(switchLocator).toHaveAttribute('data-state', 'unchecked')
 
-    // 1. From agent home, open the connections page.
-    await page.locator('[data-testid="home-connections-open-page"]').click()
-    await expect(page.locator('[data-testid="connections-add-button"]')).toBeVisible()
-
-    // 2. Open the "New connection" directory dialog and switch to MCPs.
-    await page.locator('[data-testid="connections-add-button"]').click()
-    await page.locator('[data-testid="directory-tab-mcps"]').click()
-
-    // 3. Expand the Custom MCP tile and fill the form (no-auth path).
-    await page.locator('[data-testid="directory-connect-mcp-custom"]').click()
-    await page.locator('[data-testid="mcp-form-name"]').fill(mcpName)
-    await page.locator('[data-testid="mcp-form-url"]').fill(mockMcp.url)
-    // authType defaults to "No Authentication" — no need to change.
-
-    // 4. Submit. The dialog closes and the Tool Policy editor opens.
-    await page.locator('[data-testid="mcp-form-submit"]').click()
-
-    // Dismiss the Tool Policy editor that opens for the new MCP.
-    const policyDialog = page.getByText('Tool Policies')
-    await expect(policyDialog).toBeVisible({ timeout: 10000 })
-    await page.getByRole('button', { name: 'Cancel' }).click()
-    await expect(policyDialog).not.toBeVisible({ timeout: 5000 })
-
-    // The mcp row's testid uses the server-assigned id, so match by prefix.
-    const switchLocator = page.locator('[data-testid^="connection-switch-mcp-"]')
-    await expect(switchLocator).toBeVisible({ timeout: 10000 })
-
-    // 5. Cross-check that the global MCP record landed in the DB.
-    const allMcpsRes = await request.get(`${API}/api/remote-mcps`)
-    expect(allMcpsRes.ok()).toBeTruthy()
-    const allMcps = await allMcpsRes.json()
-    const created = (allMcps.servers as Array<{ id: string; name: string; url: string }>).find(
-      (m) => m.url === mockMcp.url,
-    )
-    expect(created, 'newly added MCP missing from /api/remote-mcps').toBeDefined()
-    expect(created!.name).toBe(mcpName)
-
-    // 6. Initially the agent does not have access — verify before toggling.
-    const beforeRes = await request.get(`${API}/api/agents/${agentSlug}/remote-mcps`)
-    expect(beforeRes.ok()).toBeTruthy()
-    const before = await beforeRes.json()
-    const beforeIds = (before.mcps as Array<{ id: string }>).map((m) => m.id)
-    expect(beforeIds).not.toContain(created!.id)
-
-    // 7. Toggle the row on.
-    await switchLocator.click()
-
-    // The toggle is async (optimistic + server roundtrip). Wait for the API to
-    // reflect the assignment rather than relying solely on UI state, since the
-    // local override clears once the server catches up — by then the DB is the
-    // source of truth.
-    await expect.poll(
-      async () => {
-        const r = await request.get(`${API}/api/agents/${agentSlug}/remote-mcps`)
-        if (!r.ok()) return []
-        const j = (await r.json()) as { mcps: Array<{ id: string }> }
-        return j.mcps.map((m) => m.id)
-      },
-      { timeout: 10000, message: 'agent never received the MCP mapping' },
-    ).toContain(created!.id)
-
-    // UI also reflects the granted state.
-    await expect(switchLocator).toHaveAttribute('data-state', 'checked')
-  })
-
-  test('toggling off removes the agent mapping but keeps the global MCP', async ({ page, request }) => {
-    const agentName = `Connections Toggle Off ${Date.now()}`
-    const mcpName = `Toggle MCP ${Date.now()}`
-
-    await agentPage.createAgent(agentName)
-
-    const agentsRes = await request.get(`${API}/api/agents`)
-    const agents = await agentsRes.json()
-    const agent = agents.find((a: { name: string }) => a.name === agentName)
-    expect(agent).toBeDefined()
-    const agentSlug: string = agent.slug
-
-    // Add the MCP and turn the toggle on (compressed version of the first test).
-    await page.locator('[data-testid="home-connections-open-page"]').click()
-    await page.locator('[data-testid="connections-add-button"]').click()
-    await page.locator('[data-testid="directory-tab-mcps"]').click()
-    await page.locator('[data-testid="directory-connect-mcp-custom"]').click()
-    await page.locator('[data-testid="mcp-form-name"]').fill(mcpName)
-    await page.locator('[data-testid="mcp-form-url"]').fill(mockMcp.url)
-    await page.locator('[data-testid="mcp-form-submit"]').click()
-
-    // Dismiss the Tool Policy editor that opens for the new MCP.
-    const policyDialog = page.getByText('Tool Policies')
-    await expect(policyDialog).toBeVisible({ timeout: 10000 })
-    await page.getByRole('button', { name: 'Cancel' }).click()
-    await expect(policyDialog).not.toBeVisible({ timeout: 5000 })
-
-    const switchLocator = page.locator('[data-testid^="connection-switch-mcp-"]').first()
-    await expect(switchLocator).toBeVisible({ timeout: 10000 })
-    await switchLocator.click()
-    await expect(switchLocator).toHaveAttribute('data-state', 'checked', { timeout: 10000 })
-
-    // Look up the MCP id once for the assertions below.
-    const allMcps = await (await request.get(`${API}/api/remote-mcps`)).json()
-    const target = (allMcps.servers as Array<{ id: string; url: string }>).find(
-      (m) => m.url === mockMcp.url,
-    )!
-
-    // Toggle off.
-    await switchLocator.click()
-
-    // Mapping disappears from the agent list...
-    await expect.poll(
-      async () => {
-        const r = await request.get(`${API}/api/agents/${agentSlug}/remote-mcps`)
-        const j = (await r.json()) as { mcps: Array<{ id: string }> }
-        return j.mcps.map((m) => m.id)
-      },
-      { timeout: 10000, message: 'mapping not removed from agent' },
-    ).not.toContain(target.id)
-
-    // ...but the global server is still registered.
-    const allAfter = await (await request.get(`${API}/api/remote-mcps`)).json()
-    const stillThere = (allAfter.servers as Array<{ id: string }>).some((m) => m.id === target.id)
-    expect(stillThere, 'toggling off must not delete the global MCP').toBe(true)
+      // ...but the global server is still registered.
+      const allAfter = await listRemoteMcps(request)
+      const stillThere = allAfter.some((server) => server.id === mcp.id)
+      expect(stillThere, 'toggling off must not delete the global MCP').toBe(true)
+    })
   })
 })

--- a/e2e/specs/connections-page-policy-modal.spec.ts
+++ b/e2e/specs/connections-page-policy-modal.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 
-const API = 'http://localhost:3000'
+const API = ''
 
 test.describe('Connections Page — Policy Modal After OAuth', () => {
   let appPage: AppPage

--- a/e2e/specs/file-preview.spec.ts
+++ b/e2e/specs/file-preview.spec.ts
@@ -5,7 +5,7 @@ import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
 
-const e2eDataDir = path.join(__dirname, '..', '..', '.e2e-data')
+const e2eDataDir = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
 
 function getFilePill(page: import('@playwright/test').Page, fileName: string) {
   return page.getByTestId('file-pill').filter({ hasText: fileName })
@@ -23,7 +23,7 @@ async function getLatestAgentSlug(page: import('@playwright/test').Page): Promis
   const breadcrumb = page.locator('[data-testid="agent-breadcrumb"]')
   const agentName = await breadcrumb.textContent() || ''
 
-  const response = await page.request.get('http://localhost:3000/api/agents')
+  const response = await page.request.get('/api/agents')
   const agents = await response.json() as Array<{ slug: string; name: string; createdAt: string }>
   const match = agents.find(a => a.name === agentName.trim())
   if (match) return match.slug

--- a/e2e/specs/getting-started-wizard.spec.ts
+++ b/e2e/specs/getting-started-wizard.spec.ts
@@ -7,6 +7,8 @@ import { WizardPage } from '../pages/wizard.page'
 
 test.describe.configure({ mode: 'serial' })
 
+const e2eDataDir = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
+
 /**
  * Manual wizard steps (0-indexed):
  *   0: LLM  |  1: Browser  |  2: Composio  |  3: Runtime  |  4: Privacy  |  5: Agent
@@ -28,25 +30,25 @@ test.describe('Getting Started Wizard', () => {
     agentPage = new AgentPage(page)
 
     // Set a mock API key so the LLM step's Next button is enabled
-    await request.put('http://localhost:3000/api/settings', {
+    await request.put('/api/settings', {
       data: { apiKeys: { anthropicApiKey: 'sk-ant-test-key-for-e2e' } },
     })
   })
 
   test.afterEach(async ({ request }) => {
     // Restore setupCompleted to true so subsequent test files don't see the wizard
-    await request.put('http://localhost:3000/api/user-settings', {
+    await request.put('/api/user-settings', {
       data: { setupCompleted: true },
     })
     // Restore global setupCompleted and clean up mock API key
-    await request.put('http://localhost:3000/api/settings', {
+    await request.put('/api/settings', {
       data: { app: { setupCompleted: true }, apiKeys: { anthropicApiKey: '' } },
     })
   })
 
   test('auto-opens when setupCompleted is false', async ({ page, request }) => {
     // Reset setupCompleted via API so the wizard will auto-open on next load
-    await request.put('http://localhost:3000/api/user-settings', {
+    await request.put('/api/user-settings', {
       data: { setupCompleted: false },
     })
 
@@ -76,7 +78,7 @@ test.describe('Getting Started Wizard', () => {
 
   test('does not auto-open when setupCompleted is true', async ({ page, request }) => {
     // Ensure setupCompleted is true
-    await request.put('http://localhost:3000/api/user-settings', {
+    await request.put('/api/user-settings', {
       data: { setupCompleted: true },
     })
 
@@ -89,7 +91,7 @@ test.describe('Getting Started Wizard', () => {
 
   test('navigates through all steps with Next and Back', async ({ page, request }) => {
     // Reset to trigger wizard
-    await request.put('http://localhost:3000/api/user-settings', {
+    await request.put('/api/user-settings', {
       data: { setupCompleted: false },
     })
 
@@ -150,7 +152,7 @@ test.describe('Getting Started Wizard', () => {
   })
 
   test('skip buttons work on optional steps', async ({ page, request }) => {
-    await request.put('http://localhost:3000/api/user-settings', {
+    await request.put('/api/user-settings', {
       data: { setupCompleted: false },
     })
 
@@ -183,7 +185,7 @@ test.describe('Getting Started Wizard', () => {
   })
 
   test('sets setupCompleted after finishing', async ({ page, request }) => {
-    await request.put('http://localhost:3000/api/user-settings', {
+    await request.put('/api/user-settings', {
       data: { setupCompleted: false },
     })
 
@@ -207,7 +209,7 @@ test.describe('Getting Started Wizard', () => {
     await wizardPage.expectNotVisible()
 
     // Verify setupCompleted is now true via API
-    const response = await request.get('http://localhost:3000/api/user-settings')
+    const response = await request.get('/api/user-settings')
     const settings = await response.json()
     expect(settings.setupCompleted).toBe(true)
 
@@ -223,12 +225,12 @@ test.describe('Getting Started Wizard', () => {
 
     // Clear any prior hostBrowserProvider value so we're starting from the
     // "never explicitly chose" state this bug targets.
-    await request.put('http://localhost:3000/api/settings', {
+    await request.put('/api/settings', {
       data: { app: { hostBrowserProvider: null } },
     })
 
     // Only meaningful when Chrome is actually detected (smart default picks Chrome).
-    const preRes = await request.get('http://localhost:3000/api/settings')
+    const preRes = await request.get('/api/settings')
     const preSettings = await preRes.json()
     const chromeProvider = preSettings.hostBrowserStatus?.providers?.find(
       (p: { id: string; available: boolean }) => p.id === 'chrome',
@@ -237,7 +239,7 @@ test.describe('Getting Started Wizard', () => {
     expect(preSettings.app?.hostBrowserProvider).toBeUndefined()
 
     // Reset setupCompleted so the wizard auto-opens
-    await request.put('http://localhost:3000/api/user-settings', {
+    await request.put('/api/user-settings', {
       data: { setupCompleted: false, onboardingProgress: null },
     })
 
@@ -264,19 +266,19 @@ test.describe('Getting Started Wizard', () => {
     await wizardPage.expectNotVisible()
 
     // Assert via API that hostBrowserProvider was persisted as 'chrome'
-    const postRes = await request.get('http://localhost:3000/api/settings')
+    const postRes = await request.get('/api/settings')
     const postSettings = await postRes.json()
     expect(postSettings.app?.hostBrowserProvider).toBe('chrome')
 
     // Also validate on-disk settings.json to rule out an API-only illusion
-    const settingsJsonPath = path.join(process.cwd(), '.e2e-data', 'settings.json')
+    const settingsJsonPath = path.join(e2eDataDir, 'settings.json')
     const onDisk = JSON.parse(fs.readFileSync(settingsJsonPath, 'utf-8'))
     expect(onDisk.app?.hostBrowserProvider).toBe('chrome')
   })
 
   test('re-run wizard button opens wizard from settings', async ({ page, request }) => {
     // Ensure setup is completed so wizard doesn't auto-open
-    await request.put('http://localhost:3000/api/user-settings', {
+    await request.put('/api/user-settings', {
       data: { setupCompleted: true },
     })
 

--- a/e2e/specs/global-connections.spec.ts
+++ b/e2e/specs/global-connections.spec.ts
@@ -5,7 +5,7 @@ import { startMockMcpServer, type MockMcpServer } from '../helpers/mock-mcp-serv
 // Serial: cross-checks DB state via the API; sensitive to concurrent writes.
 test.describe.configure({ mode: 'serial' })
 
-const API = 'http://localhost:3000'
+const API = ''
 
 test.describe('Global Settings → Connections — Add MCP flow', () => {
   let appPage: AppPage

--- a/e2e/specs/model-selection.spec.ts
+++ b/e2e/specs/model-selection.spec.ts
@@ -5,7 +5,7 @@ import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
 
-const E2E_DATA_DIR = path.join(__dirname, '..', '..', '.e2e-data')
+const E2E_DATA_DIR = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
 const RECORDER_FILE = path.join(E2E_DATA_DIR, '.e2e-mock-recorder.jsonl')
 
 interface MockRecord {

--- a/e2e/specs/persistence.spec.ts
+++ b/e2e/specs/persistence.spec.ts
@@ -51,7 +51,7 @@ test.describe('Persistence', () => {
     await expect(sessionPage.getAssistantMessages().first()).toBeVisible()
 
     // Get the agent slug from the agents list API
-    const agentsResponse = await request.get('http://localhost:3000/api/agents')
+    const agentsResponse = await request.get('/api/agents')
     expect(agentsResponse.ok()).toBeTruthy()
     const agents = await agentsResponse.json()
     const agent = agents.find((a: { name: string }) => a.name === agentName)
@@ -59,7 +59,7 @@ test.describe('Persistence', () => {
     const agentSlug = agent.slug
 
     // Get sessions for this agent via API
-    const sessionsResponse = await request.get(`http://localhost:3000/api/agents/${agentSlug}/sessions`)
+    const sessionsResponse = await request.get(`/api/agents/${agentSlug}/sessions`)
     expect(sessionsResponse.ok()).toBeTruthy()
     const sessions = await sessionsResponse.json()
     expect(sessions.length).toBeGreaterThan(0)
@@ -68,7 +68,7 @@ test.describe('Persistence', () => {
 
     // Get messages for the session via API
     const messagesResponse = await request.get(
-      `http://localhost:3000/api/agents/${agentSlug}/sessions/${sessionId}/messages`
+      `/api/agents/${agentSlug}/sessions/${sessionId}/messages`
     )
     expect(messagesResponse.ok()).toBeTruthy()
     const messages = await messagesResponse.json()
@@ -85,7 +85,7 @@ test.describe('Persistence', () => {
 
     // Verify via API that messages still exist after reload
     const messagesAfterReload = await request.get(
-      `http://localhost:3000/api/agents/${agentSlug}/sessions/${sessionId}/messages`
+      `/api/agents/${agentSlug}/sessions/${sessionId}/messages`
     )
     expect(messagesAfterReload.ok()).toBeTruthy()
     const messagesAfter = await messagesAfterReload.json()

--- a/e2e/specs/proxy-review.spec.ts
+++ b/e2e/specs/proxy-review.spec.ts
@@ -119,7 +119,7 @@ test.describe('X-Agent Review Requests', () => {
     await appPage.waitForAgentsLoaded()
 
     testAgentName = `XAgent Review Agent ${testInfo.workerIndex}-${Date.now()}`
-    await agentPage.createAgent(testAgentName)
+    await agentPage.createAgent(testAgentName, { waitForSidebarName: false })
   })
 
   test('x-agent review: interrupt dismisses the review card', async ({ page }) => {

--- a/e2e/specs/scope-policy-grouping.spec.ts
+++ b/e2e/specs/scope-policy-grouping.spec.ts
@@ -1,9 +1,7 @@
 import { test, expect, type Page } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 
-// web-chromium's request fixture has no baseURL configured, so use an absolute
-// API base (matches connections-page-policy-modal.spec.ts).
-const API = 'http://localhost:3000'
+const API = ''
 
 /**
  * Opens Global Settings → Connections and clicks through to the detail page

--- a/e2e/specs/search.spec.ts
+++ b/e2e/specs/search.spec.ts
@@ -30,7 +30,7 @@ test.describe('Search palette', () => {
     // Agents are created as "Untitled" with a random slug, then renamed
     // asynchronously. The display name maps to the prompt; the slug does not.
     // Look up the actual slug from the API by name.
-    const agentsRes = await request.get('http://localhost:3000/api/agents')
+    const agentsRes = await request.get('/api/agents')
     expect(agentsRes.ok()).toBe(true)
     const agents = (await agentsRes.json()) as Array<{ slug: string; name: string }>
     const slug = agents.find((a) => a.name === agentName)?.slug
@@ -38,16 +38,18 @@ test.describe('Search palette', () => {
 
     // The auto-created session keeps its default name in mock mode (no real
     // LLM). Rename it via the API so we can match it by a distinctive substring.
-    const sessionsRes = await request.get(`http://localhost:3000/api/agents/${slug}/sessions`)
+    const sessionsRes = await request.get(`/api/agents/${slug}/sessions`)
     expect(sessionsRes.ok()).toBe(true)
     const sessions = (await sessionsRes.json()) as Array<{ id: string }>
     expect(sessions.length).toBeGreaterThan(0)
     const sessionId = sessions[0].id
-    const patchRes = await request.patch(
-      `http://localhost:3000/api/agents/${slug}/sessions/${sessionId}`,
-      { data: { name: sessionName } }
-    )
-    expect(patchRes.ok()).toBe(true)
+    await expect(async () => {
+      const patchRes = await request.patch(
+        `/api/agents/${slug}/sessions/${sessionId}`,
+        { data: { name: sessionName } }
+      )
+      expect(patchRes.ok()).toBe(true)
+    }).toPass({ timeout: 5000 })
 
     // Sessions are cached by React Query — the renderer hasn't seen the rename
     // yet. Reload so the search palette pulls fresh data on first open.
@@ -101,14 +103,14 @@ test.describe('Search palette', () => {
     await agentPage.createAgent(agentName)
 
     // Look up the slug
-    const agentsRes = await request.get('http://localhost:3000/api/agents')
+    const agentsRes = await request.get('/api/agents')
     expect(agentsRes.ok()).toBe(true)
     const agents = (await agentsRes.json()) as Array<{ slug: string; name: string }>
     const slug = agents.find((a) => a.name === agentName)?.slug
     expect(slug, `agent ${agentName} not found in API`).toBeDefined()
 
     // Wait for the session to finish processing before renaming
-    const sessionsRes = await request.get(`http://localhost:3000/api/agents/${slug}/sessions`)
+    const sessionsRes = await request.get(`/api/agents/${slug}/sessions`)
     expect(sessionsRes.ok()).toBe(true)
     const sessions = (await sessionsRes.json()) as Array<{ id: string }>
     expect(sessions.length).toBeGreaterThan(0)
@@ -117,7 +119,7 @@ test.describe('Search palette', () => {
     // Retry the PATCH in case the session is still being processed
     await expect(async () => {
       const res = await request.patch(
-        `http://localhost:3000/api/agents/${slug}/sessions/${sessionId}`,
+        `/api/agents/${slug}/sessions/${sessionId}`,
         { data: { name: sessionName } }
       )
       expect(res.ok()).toBe(true)

--- a/e2e/specs/settings.spec.ts
+++ b/e2e/specs/settings.spec.ts
@@ -522,11 +522,11 @@ test.describe('Settings validation errors', () => {
 test.describe('Settings deep-link reset', () => {
   test('voice-button deep link does not stick after close', async ({ page, request }) => {
     // Skip the first-launch wizard so the app renders straight to the agent view.
-    await request.put('http://localhost:3000/api/user-settings', {
+    await request.put('/api/user-settings', {
       data: { setupCompleted: true },
     })
     // Seed an agent via API so the home message-input (which hosts the voice button) renders.
-    const createRes = await request.post('http://localhost:3000/api/agents', {
+    const createRes = await request.post('/api/agents', {
       data: { name: 'Voice Deep Link Test' },
     })
     const agent = await createRes.json() as { slug: string }
@@ -552,6 +552,6 @@ test.describe('Settings deep-link reset', () => {
     await expect(page.locator('[data-testid="settings-nav-voice"]')).toHaveAttribute('data-active', 'false')
 
     // Clean up: delete the seeded agent via API so other tests aren't affected.
-    await request.delete(`http://localhost:3000/api/agents/${agent.slug}`)
+    await request.delete(`/api/agents/${agent.slug}`)
   })
 })

--- a/e2e/specs/tool-rendering.spec.ts
+++ b/e2e/specs/tool-rendering.spec.ts
@@ -137,16 +137,22 @@ test.describe('Tool Call Rendering', () => {
     const toolCall = renderedToolCall(sessionPage, 'Bash')
     await expect(toolCall).toBeVisible({ timeout: 20000 })
 
-    // Collapse first so the expand/collapse assertions start from a known state.
-    await setToolCallExpanded(toolCall, 'Bash', false)
-    await expect(toolCall.getByTestId('bash-terminal')).not.toBeVisible()
+    // The row's expanded state is local; a post-turn message refetch can remount
+    // it and reset the toggle. Re-drive each transition until the rendered
+    // terminal matches, so the assertions don't race that remount.
+    await expect(async () => {
+      await setToolCallExpanded(toolCall, 'Bash', false)
+      await expect(toolCall.getByTestId('bash-terminal')).not.toBeVisible({ timeout: 1000 })
+    }).toPass({ timeout: 20000 })
 
-    // Click to expand
-    await setToolCallExpanded(toolCall, 'Bash', true)
-    await expect(toolCall.getByTestId('bash-terminal')).toBeVisible()
+    await expect(async () => {
+      await setToolCallExpanded(toolCall, 'Bash', true)
+      await expect(toolCall.getByTestId('bash-terminal')).toBeVisible({ timeout: 1000 })
+    }).toPass({ timeout: 20000 })
 
-    // Click to collapse
-    await setToolCallExpanded(toolCall, 'Bash', false)
-    await expect(toolCall.getByTestId('bash-terminal')).not.toBeVisible()
+    await expect(async () => {
+      await setToolCallExpanded(toolCall, 'Bash', false)
+      await expect(toolCall.getByTestId('bash-terminal')).not.toBeVisible({ timeout: 1000 })
+    }).toPass({ timeout: 20000 })
   })
 })

--- a/e2e/specs/tool-rendering.spec.ts
+++ b/e2e/specs/tool-rendering.spec.ts
@@ -1,7 +1,7 @@
-import { test, expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
+import { test, expect, type APIRequestContext, type Locator, type Page, type TestInfo } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 import { SessionPage } from '../pages/session.page'
-import { createAgent, openAgentHome } from '../helpers/agents'
+import { createAgent, createSession, openAgentSession, waitForSessionIdle } from '../helpers/agents'
 
 async function setupToolTest(
   page: Page,
@@ -13,12 +13,32 @@ async function setupToolTest(
   const sessionPage = new SessionPage(page)
   const agentName = `Tool Agent ${label} ${testInfo.workerIndex}-${testInfo.repeatEachIndex}-${Date.now()}`
   const agent = await createAgent(request, agentName)
+  const setupSession = await createSession(
+    request,
+    agent,
+    `setup tool rendering ${label} ${testInfo.workerIndex}-${testInfo.repeatEachIndex}`,
+  )
+  await waitForSessionIdle(request, agent, setupSession)
 
   await appPage.goto()
   await appPage.waitForAgentsLoaded()
-  await openAgentHome(page, agent)
+  await openAgentSession(page, agent, setupSession)
+  await sessionPage.waitForInputEnabled(15000)
 
   return { sessionPage }
+}
+
+function renderedToolCall(sessionPage: SessionPage, toolName: string) {
+  return sessionPage.getToolCall(toolName).last()
+}
+
+async function setToolCallExpanded(toolCall: Locator, toolName: string, expanded: boolean) {
+  const toggle = toolCall.getByTestId(`tool-call-toggle-${toolName}`)
+  await expect(toggle).toBeVisible()
+  if (await toggle.getAttribute('aria-expanded') !== String(expanded)) {
+    await toggle.click()
+  }
+  await expect(toggle).toHaveAttribute('aria-expanded', String(expanded))
 }
 
 test.describe('Tool Call Rendering', () => {
@@ -27,15 +47,15 @@ test.describe('Tool Call Rendering', () => {
 
     // Trigger the existing "list files" scenario which uses Bash tool
     await sessionPage.sendMessage('list files in the current directory')
-    await sessionPage.waitForResponse(15000)
+    await sessionPage.waitForInputEnabled(20000)
 
     // Verify Bash tool call is rendered
-    await sessionPage.expectToolCall('Bash', 15000)
-    const toolCall = sessionPage.getToolCall('Bash')
+    await sessionPage.expectToolCall('Bash', 20000)
+    const toolCall = renderedToolCall(sessionPage, 'Bash')
     await expect(toolCall).toBeVisible()
 
     // Click to expand
-    await toolCall.locator('button').first().click()
+    await setToolCallExpanded(toolCall, 'Bash', true)
 
     // Verify terminal-style display (black background)
     await expect(toolCall.getByTestId('bash-terminal')).toBeVisible()
@@ -45,11 +65,11 @@ test.describe('Tool Call Rendering', () => {
     const { sessionPage } = await setupToolTest(page, request, testInfo, 'Read')
 
     await sessionPage.sendMessage('read file please')
-    await sessionPage.waitForResponse(15000)
+    await sessionPage.waitForInputEnabled(20000)
 
     // Verify Read tool call is rendered
-    await sessionPage.expectToolCall('Read', 15000)
-    const toolCall = sessionPage.getToolCall('Read')
+    await sessionPage.expectToolCall('Read', 20000)
+    const toolCall = renderedToolCall(sessionPage, 'Read')
     await expect(toolCall).toBeVisible()
 
     // Should show file path in summary
@@ -60,11 +80,11 @@ test.describe('Tool Call Rendering', () => {
     const { sessionPage } = await setupToolTest(page, request, testInfo, 'Write')
 
     await sessionPage.sendMessage('write file for me')
-    await sessionPage.waitForResponse(15000)
+    await sessionPage.waitForInputEnabled(20000)
 
     // Verify Write tool call is rendered
-    await sessionPage.expectToolCall('Write', 15000)
-    const toolCall = sessionPage.getToolCall('Write')
+    await sessionPage.expectToolCall('Write', 20000)
+    const toolCall = renderedToolCall(sessionPage, 'Write')
     await expect(toolCall).toBeVisible()
 
     // Should show file path in summary
@@ -75,11 +95,11 @@ test.describe('Tool Call Rendering', () => {
     const { sessionPage } = await setupToolTest(page, request, testInfo, 'Grep')
 
     await sessionPage.sendMessage('search code for TODOs')
-    await sessionPage.waitForResponse(15000)
+    await sessionPage.waitForInputEnabled(20000)
 
     // Verify Grep tool call is rendered
-    await sessionPage.expectToolCall('Grep', 15000)
-    const toolCall = sessionPage.getToolCall('Grep')
+    await sessionPage.expectToolCall('Grep', 20000)
+    const toolCall = renderedToolCall(sessionPage, 'Grep')
     await expect(toolCall).toBeVisible()
   })
 
@@ -87,21 +107,21 @@ test.describe('Tool Call Rendering', () => {
     const { sessionPage } = await setupToolTest(page, request, testInfo, 'Glob')
 
     await sessionPage.sendMessage('find files matching pattern')
-    await sessionPage.waitForResponse(15000)
+    await sessionPage.waitForInputEnabled(20000)
 
     // Verify Glob tool call is rendered
-    await sessionPage.expectToolCall('Glob', 15000)
+    await sessionPage.expectToolCall('Glob', 20000)
   })
 
   test('renders WebSearch tool call', async ({ page, request }, testInfo) => {
     const { sessionPage } = await setupToolTest(page, request, testInfo, 'WebSearch')
 
     await sessionPage.sendMessage('search web for TypeScript tips')
-    await sessionPage.waitForResponse(15000)
+    await sessionPage.waitForInputEnabled(20000)
 
     // Verify WebSearch tool call is rendered
-    await sessionPage.expectToolCall('WebSearch', 15000)
-    const toolCall = sessionPage.getToolCall('WebSearch')
+    await sessionPage.expectToolCall('WebSearch', 20000)
+    const toolCall = renderedToolCall(sessionPage, 'WebSearch')
     await expect(toolCall).toBeVisible()
 
     // Should show search query in summary
@@ -112,20 +132,21 @@ test.describe('Tool Call Rendering', () => {
     const { sessionPage } = await setupToolTest(page, request, testInfo, 'Expand')
 
     await sessionPage.sendMessage('list files in the current directory')
-    await sessionPage.waitForResponse(15000)
+    await sessionPage.waitForInputEnabled(20000)
 
-    const toolCall = sessionPage.getToolCall('Bash')
-    await expect(toolCall).toBeVisible()
+    const toolCall = renderedToolCall(sessionPage, 'Bash')
+    await expect(toolCall).toBeVisible({ timeout: 20000 })
 
-    // Initially collapsed - no expanded content
+    // Collapse first so the expand/collapse assertions start from a known state.
+    await setToolCallExpanded(toolCall, 'Bash', false)
     await expect(toolCall.getByTestId('bash-terminal')).not.toBeVisible()
 
     // Click to expand
-    await toolCall.locator('button').first().click()
+    await setToolCallExpanded(toolCall, 'Bash', true)
     await expect(toolCall.getByTestId('bash-terminal')).toBeVisible()
 
     // Click to collapse
-    await toolCall.locator('button').first().click()
+    await setToolCallExpanded(toolCall, 'Bash', false)
     await expect(toolCall.getByTestId('bash-terminal')).not.toBeVisible()
   })
 })

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -145,9 +145,23 @@ interface MessageItemProps {
   completedSubagents?: Set<string> | null
   onRemoveMessage?: (messageId: string) => void
   onRemoveToolCall?: (toolCallId: string) => void
+  expandedToolCallIds?: Set<string>
+  onToolCallExpandedChange?: (toolCallId: string, expanded: boolean) => void
 }
 
-function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSessionActive, activeSubagents, completedSubagents, onRemoveMessage, onRemoveToolCall }: MessageItemProps) {
+function MessageItemComponent({
+  message,
+  isStreaming,
+  agentSlug,
+  sessionId,
+  isSessionActive,
+  activeSubagents,
+  completedSubagents,
+  onRemoveMessage,
+  onRemoveToolCall,
+  expandedToolCallIds,
+  onToolCallExpandedChange,
+}: MessageItemProps) {
   useRenderTracker('MessageItem')
   const isUser = message.type === 'user'
   const isAssistant = message.type === 'assistant'
@@ -313,7 +327,18 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
                         isCompleted={completedSubagents?.has(toolCall.id) ?? false}
                       />
                     ) : (
-                      <ToolCallItem toolCall={toolCall} messageCreatedAt={message.createdAt} agentSlug={agentSlug} isSessionActive={isSessionActive} />
+                      <ToolCallItem
+                        toolCall={toolCall}
+                        messageCreatedAt={message.createdAt}
+                        agentSlug={agentSlug}
+                        isSessionActive={isSessionActive}
+                        expanded={expandedToolCallIds?.has(toolCall.id)}
+                        onExpandedChange={
+                          onToolCallExpandedChange
+                            ? (expanded) => onToolCallExpandedChange(toolCall.id, expanded)
+                            : undefined
+                        }
+                      />
                     )}
                   </MessageErrorBoundary>
                 </div>

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -145,23 +145,9 @@ interface MessageItemProps {
   completedSubagents?: Set<string> | null
   onRemoveMessage?: (messageId: string) => void
   onRemoveToolCall?: (toolCallId: string) => void
-  expandedToolCallIds?: Set<string>
-  onToolCallExpandedChange?: (toolCallId: string, expanded: boolean) => void
 }
 
-function MessageItemComponent({
-  message,
-  isStreaming,
-  agentSlug,
-  sessionId,
-  isSessionActive,
-  activeSubagents,
-  completedSubagents,
-  onRemoveMessage,
-  onRemoveToolCall,
-  expandedToolCallIds,
-  onToolCallExpandedChange,
-}: MessageItemProps) {
+function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSessionActive, activeSubagents, completedSubagents, onRemoveMessage, onRemoveToolCall }: MessageItemProps) {
   useRenderTracker('MessageItem')
   const isUser = message.type === 'user'
   const isAssistant = message.type === 'assistant'
@@ -327,18 +313,7 @@ function MessageItemComponent({
                         isCompleted={completedSubagents?.has(toolCall.id) ?? false}
                       />
                     ) : (
-                      <ToolCallItem
-                        toolCall={toolCall}
-                        messageCreatedAt={message.createdAt}
-                        agentSlug={agentSlug}
-                        isSessionActive={isSessionActive}
-                        expanded={expandedToolCallIds?.has(toolCall.id)}
-                        onExpandedChange={
-                          onToolCallExpandedChange
-                            ? (expanded) => onToolCallExpandedChange(toolCall.id, expanded)
-                            : undefined
-                        }
-                      />
+                      <ToolCallItem toolCall={toolCall} messageCreatedAt={message.createdAt} agentSlug={agentSlug} isSessionActive={isSessionActive} />
                     )}
                   </MessageErrorBoundary>
                 </div>

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -71,7 +71,6 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   // the message up, so cancelling is no longer possible; the ghost will
   // materialize on the next refetch.
   const [pickedUpIds, setPickedUpIds] = useState<Set<string>>(new Set())
-  const [expandedToolCallIds, setExpandedToolCallIds] = useState<Set<string>>(new Set())
   const { user } = useUser()
   const [, setSessionDraft] = useDraft<string>(`session:${sessionId}`)
   // Imperative draft access for restoring undelivered messages at idle (must not
@@ -91,18 +90,6 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     },
     [sessionId, agentSlug, deleteToolCall]
   )
-
-  const handleToolCallExpandedChange = useCallback((toolCallId: string, expanded: boolean) => {
-    setExpandedToolCallIds((current) => {
-      const next = new Set(current)
-      if (expanded) {
-        next.add(toolCallId)
-      } else {
-        next.delete(toolCallId)
-      }
-      return next
-    })
-  }, [])
 
   // Voice Agent feedback dialog state
   const { data: agentData } = useAgent(agentSlug)
@@ -690,18 +677,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
             ) : (
               <>
                 <MessageErrorBoundary kind="message" raw={item} itemId={item.id}>
-                  <MessageItem
-                    message={item as ApiMessage}
-                    agentSlug={agentSlug}
-                    sessionId={sessionId}
-                    isSessionActive={canHaveRunningToolCalls.has(item.id)}
-                    activeSubagents={activeSubagents}
-                    completedSubagents={completedSubagents}
-                    onRemoveMessage={handleRemoveMessage}
-                    onRemoveToolCall={handleRemoveToolCall}
-                    expandedToolCallIds={expandedToolCallIds}
-                    onToolCallExpandedChange={handleToolCallExpandedChange}
-                  />
+                  <MessageItem message={item as ApiMessage} agentSlug={agentSlug} sessionId={sessionId} isSessionActive={canHaveRunningToolCalls.has(item.id)} activeSubagents={activeSubagents} completedSubagents={completedSubagents} onRemoveMessage={handleRemoveMessage} onRemoveToolCall={handleRemoveToolCall} />
                 </MessageErrorBoundary>
                 {turnDeliveredFiles.has(item.id) && item.id !== deferredElapsedMessageId && (
                   <DeliveredFiles files={turnDeliveredFiles.get(item.id)!} agentSlug={agentSlug} />
@@ -787,13 +763,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
             } else {
               inner = (
                 <div className="max-w-[80%]">
-                  <ToolCallItem
-                    toolCall={syntheticToolCall}
-                    agentSlug={agentSlug}
-                    isSessionActive={isActive}
-                    expanded={expandedToolCallIds.has(syntheticToolCall.id)}
-                    onExpandedChange={(expanded) => handleToolCallExpandedChange(syntheticToolCall.id, expanded)}
-                  />
+                  <ToolCallItem toolCall={syntheticToolCall} agentSlug={agentSlug} isSessionActive={isActive} />
                 </div>
               )
             }

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -71,6 +71,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   // the message up, so cancelling is no longer possible; the ghost will
   // materialize on the next refetch.
   const [pickedUpIds, setPickedUpIds] = useState<Set<string>>(new Set())
+  const [expandedToolCallIds, setExpandedToolCallIds] = useState<Set<string>>(new Set())
   const { user } = useUser()
   const [, setSessionDraft] = useDraft<string>(`session:${sessionId}`)
   // Imperative draft access for restoring undelivered messages at idle (must not
@@ -90,6 +91,18 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     },
     [sessionId, agentSlug, deleteToolCall]
   )
+
+  const handleToolCallExpandedChange = useCallback((toolCallId: string, expanded: boolean) => {
+    setExpandedToolCallIds((current) => {
+      const next = new Set(current)
+      if (expanded) {
+        next.add(toolCallId)
+      } else {
+        next.delete(toolCallId)
+      }
+      return next
+    })
+  }, [])
 
   // Voice Agent feedback dialog state
   const { data: agentData } = useAgent(agentSlug)
@@ -677,7 +690,18 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
             ) : (
               <>
                 <MessageErrorBoundary kind="message" raw={item} itemId={item.id}>
-                  <MessageItem message={item as ApiMessage} agentSlug={agentSlug} sessionId={sessionId} isSessionActive={canHaveRunningToolCalls.has(item.id)} activeSubagents={activeSubagents} completedSubagents={completedSubagents} onRemoveMessage={handleRemoveMessage} onRemoveToolCall={handleRemoveToolCall} />
+                  <MessageItem
+                    message={item as ApiMessage}
+                    agentSlug={agentSlug}
+                    sessionId={sessionId}
+                    isSessionActive={canHaveRunningToolCalls.has(item.id)}
+                    activeSubagents={activeSubagents}
+                    completedSubagents={completedSubagents}
+                    onRemoveMessage={handleRemoveMessage}
+                    onRemoveToolCall={handleRemoveToolCall}
+                    expandedToolCallIds={expandedToolCallIds}
+                    onToolCallExpandedChange={handleToolCallExpandedChange}
+                  />
                 </MessageErrorBoundary>
                 {turnDeliveredFiles.has(item.id) && item.id !== deferredElapsedMessageId && (
                   <DeliveredFiles files={turnDeliveredFiles.get(item.id)!} agentSlug={agentSlug} />
@@ -763,7 +787,13 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
             } else {
               inner = (
                 <div className="max-w-[80%]">
-                  <ToolCallItem toolCall={syntheticToolCall} agentSlug={agentSlug} isSessionActive={isActive} />
+                  <ToolCallItem
+                    toolCall={syntheticToolCall}
+                    agentSlug={agentSlug}
+                    isSessionActive={isActive}
+                    expanded={expandedToolCallIds.has(syntheticToolCall.id)}
+                    onExpandedChange={(expanded) => handleToolCallExpandedChange(syntheticToolCall.id, expanded)}
+                  />
                 </div>
               )
             }

--- a/src/renderer/components/messages/tool-call-item.test.tsx
+++ b/src/renderer/components/messages/tool-call-item.test.tsx
@@ -118,7 +118,7 @@ describe('ToolCallItem', () => {
       render(<ToolCallItem toolCall={tc} />)
 
       // Click to expand
-      await user.click(screen.getByText('Bash'))
+      await user.click(screen.getByTestId('tool-call-toggle-Bash'))
       expect(screen.getByText('Input')).toBeInTheDocument()
       expect(screen.getByText('Output')).toBeInTheDocument()
     })
@@ -128,7 +128,7 @@ describe('ToolCallItem', () => {
       const tc = createToolCall({ result: 'command not found', isError: true })
       render(<ToolCallItem toolCall={tc} />)
 
-      await user.click(screen.getByText('Bash'))
+      await user.click(screen.getByTestId('tool-call-toggle-Bash'))
       expect(screen.getByText('Error')).toBeInTheDocument()
       expect(screen.queryByText('Output')).not.toBeInTheDocument()
     })
@@ -138,11 +138,30 @@ describe('ToolCallItem', () => {
       const tc = createToolCall({ result: 'output' })
       render(<ToolCallItem toolCall={tc} />)
 
-      await user.click(screen.getByText('Bash'))
+      await user.click(screen.getByTestId('tool-call-toggle-Bash'))
       expect(screen.getByText('Input')).toBeInTheDocument()
 
-      await user.click(screen.getByText('Bash'))
+      await user.click(screen.getByTestId('tool-call-toggle-Bash'))
       expect(screen.queryByText('Input')).not.toBeInTheDocument()
+    })
+
+    it('supports controlled expansion state', async () => {
+      const user = userEvent.setup()
+      const onExpandedChange = vi.fn()
+      const tc = createToolCall({ input: { command: 'ls -la' }, result: 'file list' })
+      const { rerender } = render(
+        <ToolCallItem toolCall={tc} expanded={false} onExpandedChange={onExpandedChange} />
+      )
+
+      const toggle = screen.getByTestId('tool-call-toggle-Bash')
+      expect(toggle).toHaveAttribute('aria-expanded', 'false')
+      await user.click(toggle)
+      expect(onExpandedChange).toHaveBeenCalledWith(true)
+      expect(screen.queryByText('Input')).not.toBeInTheDocument()
+
+      rerender(<ToolCallItem toolCall={tc} expanded onExpandedChange={onExpandedChange} />)
+      expect(toggle).toHaveAttribute('aria-expanded', 'true')
+      expect(screen.getByText('Input')).toBeInTheDocument()
     })
   })
 
@@ -152,7 +171,7 @@ describe('ToolCallItem', () => {
       const tc = createToolCall({ input: { command: 'echo hello' }, result: 'hello' })
       render(<ToolCallItem toolCall={tc} />)
 
-      await user.click(screen.getByText('Bash'))
+      await user.click(screen.getByTestId('tool-call-toggle-Bash'))
       // JSON.stringify with indentation
       expect(screen.getByText(/echo hello/)).toBeInTheDocument()
     })

--- a/src/renderer/components/messages/tool-call-item.test.tsx
+++ b/src/renderer/components/messages/tool-call-item.test.tsx
@@ -144,25 +144,6 @@ describe('ToolCallItem', () => {
       await user.click(screen.getByTestId('tool-call-toggle-Bash'))
       expect(screen.queryByText('Input')).not.toBeInTheDocument()
     })
-
-    it('supports controlled expansion state', async () => {
-      const user = userEvent.setup()
-      const onExpandedChange = vi.fn()
-      const tc = createToolCall({ input: { command: 'ls -la' }, result: 'file list' })
-      const { rerender } = render(
-        <ToolCallItem toolCall={tc} expanded={false} onExpandedChange={onExpandedChange} />
-      )
-
-      const toggle = screen.getByTestId('tool-call-toggle-Bash')
-      expect(toggle).toHaveAttribute('aria-expanded', 'false')
-      await user.click(toggle)
-      expect(onExpandedChange).toHaveBeenCalledWith(true)
-      expect(screen.queryByText('Input')).not.toBeInTheDocument()
-
-      rerender(<ToolCallItem toolCall={tc} expanded onExpandedChange={onExpandedChange} />)
-      expect(toggle).toHaveAttribute('aria-expanded', 'true')
-      expect(screen.getByText('Input')).toBeInTheDocument()
-    })
   })
 
   describe('input display', () => {

--- a/src/renderer/components/messages/tool-call-item.tsx
+++ b/src/renderer/components/messages/tool-call-item.tsx
@@ -1,7 +1,7 @@
 
 import { cn } from '@shared/lib/utils/cn'
 import { Check, X, Ban, ChevronDown, ChevronRight, Loader2, Search } from 'lucide-react'
-import { useState, useRef, useMemo, memo } from 'react'
+import { useState, useRef, useMemo, memo, useCallback } from 'react'
 import { getToolRenderer } from './tool-renderers'
 import { parseToolResult } from '@renderer/lib/parse-tool-result'
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
@@ -15,6 +15,8 @@ interface ToolCallItemProps {
   messageCreatedAt?: Date | string
   agentSlug?: string
   isSessionActive?: boolean
+  expanded?: boolean
+  onExpandedChange?: (expanded: boolean) => void
 }
 
 interface StreamingToolCallItemProps {
@@ -88,8 +90,27 @@ export function StatusIndicator({ status }: { status: string }) {
   )
 }
 
-function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessionActive }: ToolCallItemProps) {
-  const [expanded, setExpanded] = useState(false)
+function ToolCallItemComponent({
+  toolCall,
+  messageCreatedAt,
+  agentSlug,
+  isSessionActive,
+  expanded: controlledExpanded,
+  onExpandedChange,
+}: ToolCallItemProps) {
+  const [uncontrolledExpanded, setUncontrolledExpanded] = useState(false)
+  const expanded = controlledExpanded ?? uncontrolledExpanded
+  const setExpanded = useCallback(
+    (next: boolean | ((current: boolean) => boolean)) => {
+      const nextValue = typeof next === 'function' ? next(expanded) : next
+      if (onExpandedChange) {
+        onExpandedChange(nextValue)
+      } else {
+        setUncontrolledExpanded(nextValue)
+      }
+    },
+    [expanded, onExpandedChange]
+  )
   const status = getStatus(toolCall, isSessionActive)
   const renderer = getToolRenderer(toolCall.name)
   const isPendingUserInput = status === 'running' && isUserInputTool(toolCall.name)
@@ -116,7 +137,11 @@ function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessio
   return (
     <div className="text-sm border border-border/70 rounded-md overflow-hidden" data-testid={`tool-call-${toolCall.name}`}>
       <button
-        onClick={() => setExpanded(!expanded)}
+        type="button"
+        aria-expanded={expanded}
+        aria-label={`${expanded ? 'Collapse' : 'Expand'} ${toolCall.name} tool call`}
+        data-testid={`tool-call-toggle-${toolCall.name}`}
+        onClick={() => setExpanded((current) => !current)}
         className={cn('flex w-full items-center gap-2 pl-2 pr-2 py-1.5 group hover:bg-muted/50 transition-colors', expanded && 'bg-muted/50')}
       >
         <ToolIcon className="h-3.5 w-3.5 shrink-0 text-foreground/45 group-hover:text-foreground transition-colors" />

--- a/src/renderer/components/messages/tool-call-item.tsx
+++ b/src/renderer/components/messages/tool-call-item.tsx
@@ -1,7 +1,7 @@
 
 import { cn } from '@shared/lib/utils/cn'
 import { Check, X, Ban, ChevronDown, ChevronRight, Loader2, Search } from 'lucide-react'
-import { useState, useRef, useMemo, memo, useCallback } from 'react'
+import { useState, useRef, useMemo, memo } from 'react'
 import { getToolRenderer } from './tool-renderers'
 import { parseToolResult } from '@renderer/lib/parse-tool-result'
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
@@ -15,8 +15,6 @@ interface ToolCallItemProps {
   messageCreatedAt?: Date | string
   agentSlug?: string
   isSessionActive?: boolean
-  expanded?: boolean
-  onExpandedChange?: (expanded: boolean) => void
 }
 
 interface StreamingToolCallItemProps {
@@ -90,27 +88,8 @@ export function StatusIndicator({ status }: { status: string }) {
   )
 }
 
-function ToolCallItemComponent({
-  toolCall,
-  messageCreatedAt,
-  agentSlug,
-  isSessionActive,
-  expanded: controlledExpanded,
-  onExpandedChange,
-}: ToolCallItemProps) {
-  const [uncontrolledExpanded, setUncontrolledExpanded] = useState(false)
-  const expanded = controlledExpanded ?? uncontrolledExpanded
-  const setExpanded = useCallback(
-    (next: boolean | ((current: boolean) => boolean)) => {
-      const nextValue = typeof next === 'function' ? next(expanded) : next
-      if (onExpandedChange) {
-        onExpandedChange(nextValue)
-      } else {
-        setUncontrolledExpanded(nextValue)
-      }
-    },
-    [expanded, onExpandedChange]
-  )
+function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessionActive }: ToolCallItemProps) {
+  const [expanded, setExpanded] = useState(false)
   const status = getStatus(toolCall, isSessionActive)
   const renderer = getToolRenderer(toolCall.name)
   const isPendingUserInput = status === 'running' && isUserInputTool(toolCall.name)

--- a/src/renderer/components/settings/runtime-tab.test.tsx
+++ b/src/renderer/components/settings/runtime-tab.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, within } from '@testing-library/react'
+import { fireEvent, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { RuntimeTab } from './runtime-tab'
 import { renderWithProviders } from '@renderer/test/test-utils'
@@ -87,12 +87,10 @@ describe('RuntimeTab', () => {
   })
 
   it('disables save when agent image is blank', async () => {
-    const user = userEvent.setup()
     renderWithProviders(<RuntimeTab />)
 
     const agentImageInput = screen.getByLabelText('Agent Image')
-    await user.clear(agentImageInput)
-    await user.type(agentImageInput, '   ')
+    fireEvent.change(agentImageInput, { target: { value: '   ' } })
 
     expect(screen.getByText('Agent image is required.')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -2725,11 +2725,19 @@ describe('MessagePersister', () => {
       })
     }
 
-    // Wait for async handler to complete (they are fire-and-forget via ;(async () => {...})())
-    // Multiple awaits needed because the handlers chain several async operations
-    async function flushHandlers() {
-      await new Promise((resolve) => setTimeout(resolve, 50))
-      await new Promise((resolve) => setTimeout(resolve, 50))
+    // Wait for the fire-and-forget handler to resolve or reject the exact
+    // blocking tool input this test emitted. Fixed sleeps were flaky under
+    // coverage instrumentation because the async handler chains DB and service
+    // promises before calling the container.
+    async function flushHandlers(expectedPath: string) {
+      const deadline = Date.now() + 3000
+      while (Date.now() < deadline) {
+        const call = mockContainerClientFetch.mock.calls.find((c) => c[0] === expectedPath)
+        if (call) return call
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+      const paths = mockContainerClientFetch.mock.calls.map((c) => String(c[0])).join(', ')
+      throw new Error(`Timed out waiting for ${expectedPath}; observed container fetches: ${paths || '<none>'}`)
     }
 
     beforeEach(() => {
@@ -2765,7 +2773,7 @@ describe('MessagePersister', () => {
           name: 'Email Handler',
         })
 
-        await flushHandlers()
+        await flushHandlers('/inputs/tool-setup-1/resolve')
 
         const sseCreated = sseEvents.filter(e => e.type === 'webhook_trigger_created')
         expect(sseCreated).toHaveLength(1)
@@ -2796,7 +2804,7 @@ describe('MessagePersister', () => {
           prompt: 'Test',
         })
 
-        await flushHandlers()
+        await flushHandlers('/inputs/tool-setup-bad/reject')
 
         // Should reject with helpful error
         expect(mockContainerClientFetch).toHaveBeenCalledWith(
@@ -2822,7 +2830,7 @@ describe('MessagePersister', () => {
           prompt: 'Test',
         })
 
-        await flushHandlers()
+        await flushHandlers('/inputs/tool-setup-noplatform/reject')
 
         expect(mockContainerClientFetch).toHaveBeenCalledWith(
           '/inputs/tool-setup-noplatform/reject',
@@ -2843,7 +2851,7 @@ describe('MessagePersister', () => {
           prompt: 'Test',
         })
 
-        await flushHandlers()
+        await flushHandlers('/inputs/tool-setup-noaccount/reject')
 
         expect(mockContainerClientFetch).toHaveBeenCalledWith(
           '/inputs/tool-setup-noaccount/reject',
@@ -2864,7 +2872,7 @@ describe('MessagePersister', () => {
           prompt: 'Test',
         })
 
-        await flushHandlers()
+        await flushHandlers('/inputs/tool-setup-dbfail/reject')
 
         expect(mockEnableComposioTrigger).toHaveBeenCalled()
         expect(mockDeleteComposioTrigger).toHaveBeenCalledWith('composio_trigger_id')
@@ -2888,7 +2896,7 @@ describe('MessagePersister', () => {
           trigger_id: 'trigger_existing',
         })
 
-        await flushHandlers()
+        await flushHandlers('/inputs/tool-cancel-1/resolve')
 
         const sseCancelled = sseEvents.filter(e => e.type === 'webhook_trigger_cancelled')
         expect(sseCancelled).toHaveLength(1)
@@ -2914,7 +2922,7 @@ describe('MessagePersister', () => {
           trigger_id: 'trigger_gone',
         })
 
-        await flushHandlers()
+        await flushHandlers('/inputs/tool-cancel-notfound/reject')
 
         expect(mockContainerClientFetch).toHaveBeenCalledWith(
           '/inputs/tool-cancel-notfound/reject',
@@ -2933,7 +2941,7 @@ describe('MessagePersister', () => {
 
         simulateToolUse('mcp__user-input__cancel_trigger', 'tool-cancel-noid', {})
 
-        await flushHandlers()
+        await flushHandlers('/inputs/tool-cancel-noid/reject')
 
         expect(mockContainerClientFetch).toHaveBeenCalledWith(
           '/inputs/tool-cancel-noid/reject',
@@ -2960,7 +2968,7 @@ describe('MessagePersister', () => {
 
         simulateToolUse('mcp__user-input__list_triggers', 'tool-list-1', {})
 
-        await flushHandlers()
+        await flushHandlers('/inputs/tool-list-1/resolve')
 
         expect(mockContainerClientFetch).toHaveBeenCalledWith(
           '/inputs/tool-list-1/resolve',
@@ -2984,7 +2992,7 @@ describe('MessagePersister', () => {
 
         simulateToolUse('mcp__user-input__list_triggers', 'tool-list-empty', {})
 
-        await flushHandlers()
+        await flushHandlers('/inputs/tool-list-empty/resolve')
 
         const resolveCall = mockContainerClientFetch.mock.calls.find(
           (c) => c[0] === '/inputs/tool-list-empty/resolve'
@@ -3001,7 +3009,7 @@ describe('MessagePersister', () => {
           connected_account_id: 'ca_1',
         })
 
-        await flushHandlers()
+        await flushHandlers('/inputs/tool-avail-1/resolve')
 
         const resolveCall = mockContainerClientFetch.mock.calls.find(
           (c) => c[0] === '/inputs/tool-avail-1/resolve'
@@ -3020,7 +3028,7 @@ describe('MessagePersister', () => {
           connected_account_id: 'ca_missing',
         })
 
-        await flushHandlers()
+        await flushHandlers('/inputs/tool-avail-noaccount/reject')
 
         expect(mockContainerClientFetch).toHaveBeenCalledWith(
           '/inputs/tool-avail-noaccount/reject',
@@ -3038,7 +3046,7 @@ describe('MessagePersister', () => {
           connected_account_id: 'ca_1',
         })
 
-        await flushHandlers()
+        await flushHandlers('/inputs/tool-avail-noplatform/reject')
 
         expect(mockContainerClientFetch).toHaveBeenCalledWith(
           '/inputs/tool-avail-noplatform/reject',
@@ -3056,7 +3064,7 @@ describe('MessagePersister', () => {
           connected_account_id: 'ca_1',
         })
 
-        await flushHandlers()
+        await flushHandlers('/inputs/tool-avail-empty/resolve')
 
         const resolveCall = mockContainerClientFetch.mock.calls.find(
           (c) => c[0] === '/inputs/tool-avail-empty/resolve'

--- a/src/shared/lib/services/agent-template-service.test.ts
+++ b/src/shared/lib/services/agent-template-service.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
-import { createZipBuffer, openZipFromBuffer } from '@shared/lib/utils/zip'
+import { createZipBuffer, openZipFromBuffer, type ZipEntryMeta } from '@shared/lib/utils/zip'
 import type { SkillsetConfig, InstalledAgentMetadata } from '@shared/lib/types/skillset'
 
 // ============================================================================
@@ -54,6 +54,7 @@ vi.mock('@shared/lib/platform-auth/config', () => ({
 
 import {
   validateAgentTemplate,
+  validateTemplateEntries,
   exportAgentTemplate,
   exportAgentFull,
   importAgentFromTemplate,
@@ -86,6 +87,22 @@ description: An agent without a name field
 const CLAUDE_MD_NO_FRONTMATTER = `# Just Markdown
 No frontmatter at all.
 `
+
+function zipEntry(fileName: string, uncompressedSize: number): ZipEntryMeta {
+  return {
+    fileName,
+    uncompressedSize,
+    compressedSize: Math.min(uncompressedSize, 1024),
+    isDirectory: fileName.endsWith('/'),
+  }
+}
+
+function templateEntriesWithSizes(sizes: number[]): ZipEntryMeta[] {
+  return [
+    zipEntry('CLAUDE.md', Buffer.byteLength(MINIMAL_CLAUDE_MD, 'utf-8')),
+    ...sizes.map((size, index) => zipEntry(`data-${index}.bin`, size)),
+  ]
+}
 
 /** Helper: create a zip buffer from a map of { path: content } */
 async function makeZip(files: Record<string, string>): Promise<Buffer> {
@@ -382,69 +399,46 @@ describe('validateAgentTemplate', () => {
   // Size limits
   // --------------------------------------------------------------------------
 
-  // Each case below builds and zlib-compresses ~500MB in memory, which can run
-  // right up against the 5s default test timeout under `vitest --coverage` on
-  // CI runners (a pre-existing flake). Give these the headroom they need.
   describe('total size limits', () => {
-    it('rejects template exceeding 500MB uncompressed', async () => {
-      const largeContent = 'x'.repeat(10 * 1024 * 1024)
-      const files: Record<string, string> = {
-        'CLAUDE.md': MINIMAL_CLAUDE_MD,
-      }
-      for (let i = 0; i < 51; i++) {
-        files[`large-${i}.bin`] = largeContent
-      }
-      const result = await validateAgentTemplate(await makeZip(files))
+    it('rejects template exceeding 500MB uncompressed', () => {
+      const tenMB = 10 * 1024 * 1024
+      const result = validateTemplateEntries(templateEntriesWithSizes(Array(51).fill(tenMB)), 'template')
       expect(result.valid).toBe(false)
       expect(result.error).toContain('too large')
       expect(result.error).toContain('500MB')
-    }, 30_000)
+    })
 
-    it('accepts template at exactly the uncompressed size limit', async () => {
-      const chunkContent = 'a'.repeat(10 * 1024 * 1024)
-      const files: Record<string, string> = {
-        'CLAUDE.md': MINIMAL_CLAUDE_MD,
-      }
-      for (let i = 0; i < 49; i++) {
-        files[`data-${i}.bin`] = chunkContent
-      }
+    it('accepts template at exactly the uncompressed size limit', () => {
+      const tenMB = 10 * 1024 * 1024
       // Fill the remaining budget: 500MB - 49*10MB - CLAUDE.md size
       const claudeMdSize = Buffer.byteLength(MINIMAL_CLAUDE_MD, 'utf-8')
-      const remaining = 500 * 1024 * 1024 - 49 * 10 * 1024 * 1024 - claudeMdSize
-      files['data-last.bin'] = 'b'.repeat(remaining)
-      const result = await validateAgentTemplate(await makeZip(files))
+      const remaining = 500 * 1024 * 1024 - 49 * tenMB - claudeMdSize
+      const result = validateTemplateEntries(templateEntriesWithSizes([
+        ...Array(49).fill(tenMB),
+        remaining,
+      ]), 'template')
       expect(result.valid).toBe(true)
-    }, 30_000)
+    })
 
-    it('rejects template at exactly one byte over the limit', async () => {
-      const chunkContent = 'a'.repeat(10 * 1024 * 1024)
-      const files: Record<string, string> = {
-        'CLAUDE.md': MINIMAL_CLAUDE_MD,
-      }
-      for (let i = 0; i < 49; i++) {
-        files[`data-${i}.bin`] = chunkContent
-      }
+    it('rejects template at exactly one byte over the limit', () => {
+      const tenMB = 10 * 1024 * 1024
       const claudeMdSize = Buffer.byteLength(MINIMAL_CLAUDE_MD, 'utf-8')
-      const remaining = 500 * 1024 * 1024 - 49 * 10 * 1024 * 1024 - claudeMdSize
-      files['data-last.bin'] = 'b'.repeat(remaining + 1)
-      const result = await validateAgentTemplate(await makeZip(files))
+      const remaining = 500 * 1024 * 1024 - 49 * tenMB - claudeMdSize
+      const result = validateTemplateEntries(templateEntriesWithSizes([
+        ...Array(49).fill(tenMB),
+        remaining + 1,
+      ]), 'template')
       expect(result.valid).toBe(false)
       expect(result.error).toContain('too large')
-    }, 30_000)
+    })
 
-    it('rejects when multiple small files sum to over the limit', async () => {
-      const files: Record<string, string> = {
-        'CLAUDE.md': MINIMAL_CLAUDE_MD,
-      }
+    it('rejects when multiple small files sum to over the limit', () => {
       // 51 files × 10MB each = 510MB > 500MB
-      const tenMB = 'x'.repeat(10 * 1024 * 1024)
-      for (let i = 0; i < 51; i++) {
-        files[`chunk-${i}.bin`] = tenMB
-      }
-      const result = await validateAgentTemplate(await makeZip(files))
+      const tenMB = 10 * 1024 * 1024
+      const result = validateTemplateEntries(templateEntriesWithSizes(Array(51).fill(tenMB)), 'template')
       expect(result.valid).toBe(false)
       expect(result.error).toContain('too large')
-    }, 30_000)
+    })
   })
 
   // --------------------------------------------------------------------------

--- a/src/shared/lib/services/agent-template-service.ts
+++ b/src/shared/lib/services/agent-template-service.ts
@@ -345,7 +345,7 @@ export interface TemplateValidationResult {
  * Validate ZIP entry metadata without extracting file contents.
  * Checks file count, declared uncompressed size, and path traversal.
  */
-function validateEntries(
+export function validateTemplateEntries(
   entries: ZipEntryMeta[],
   mode: 'template' | 'full',
 ): Omit<TemplateValidationResult, 'agentName'> {
@@ -402,7 +402,7 @@ export async function validateAgentTemplate(zipBuffer: Buffer, mode: 'template' 
   try {
     reader = await openZipFromBuffer(zipBuffer)
 
-    const result = validateEntries(reader.entries, mode)
+    const result = validateTemplateEntries(reader.entries, mode)
     if (!result.valid) return { ...result, agentName: undefined }
 
     const claudeMdFileName = reader.entries.find((e) => {
@@ -442,7 +442,7 @@ export async function importAgentFromTemplate(
 ): Promise<ApiAgent> {
   const reader = await openZipFromBuffer(zipBuffer)
   try {
-    const validation = validateEntries(reader.entries, mode)
+    const validation = validateTemplateEntries(reader.entries, mode)
     if (!validation.valid) {
       throw new Error(validation.error || 'Invalid template')
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     setupFiles: ['src/renderer/test/setup.ts'],
+    testTimeout: 15_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary', 'json'],


### PR DESCRIPTION
## Summary
- Add remote MCP API helpers for creating, listing, assigning, and polling agent mappings.
- Let the mock MCP server bind to an OS-assigned port, so connection tests can run safely in parallel.
- Refactor connections-management to use factories for setup while preserving UI coverage: the first test still creates a custom MCP through the UI and toggles it on through the UI; the second test uses API setup for the revoke path and toggles off through the UI.

## Validation
- git diff --check
- npm run typecheck
- npm run lint:e2e (passes with existing warnings)
- Focused repeat: connections-management x5 with 4 workers: 10 passed
- Focused repeat: connections-management x10 with 6 workers: 20 passed
- Full web suite on default port: 135 passed, 18 skipped, 8 failed in unrelated chat-flow, file-preview, and model-selection specs; connections-management did not fail. Local caveat: model-selection reads the repo-root .e2e-data recorder while the app writes SUPERAGENT_DATA_DIR, so local full-suite runs can pick up stale records from previous runs. I kept that out of this scoped PR.