### PR TITLE
fix(chat-integrations): self-heal when the container lost the agent session

### DIFF
--- a/src/shared/lib/chat-integrations/chat-integration-e2e.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-e2e.test.ts
@@ -92,6 +92,7 @@ vi.mock('./telegram-connector', () => ({
 
 import { chatIntegrationManager } from './chat-integration-manager'
 import { createChatIntegration, getChatIntegration } from '@shared/lib/services/chat-integration-service'
+import { listChatIntegrationSessions } from '@shared/lib/services/chat-integration-session-service'
 import { containerManager } from '@shared/lib/container/container-manager'
 import { MockContainerClient } from '@shared/lib/container/mock-container-client'
 
@@ -268,6 +269,78 @@ describe('Chat integration E2E', () => {
       await waitForCondition(() => MockContainerClient.createSessionCalls.length === 2)
 
       expect(MockContainerClient.createSessionCalls[1].initialMessage).toBe('After clear')
+    })
+  })
+
+  describe('session self-heal (container lost the session)', () => {
+    it('archives the dead session and starts a fresh one instead of failing forever', async () => {
+      const integrationId = createTestIntegration()
+      await chatIntegrationManager.addIntegration(integrationId)
+
+      // First message establishes a real session: DB row + live container session.
+      mockConnector.simulateIncomingMessage('Hello', 'chat-1', 'user-1')
+      await waitForCondition(() => MockContainerClient.createSessionCalls.length === 1)
+      await waitForCondition(
+        () => mockConnector.sentMessages.length > 0 || mockConnector.finalizedMessages.length > 0,
+        3000,
+      )
+
+      // Simulate the container EVICTING the session (e.g. dev container recreated):
+      // the DB row stays non-archived but the container no longer has the session,
+      // so the next sendMessage 404s with "Session not found".
+      const deadSessionId = [...(mockContainerClient as any).sessions.keys()][0] as string
+      await mockContainerClient.deleteSession(deadSessionId)
+
+      // Next message to the same chat — the manager should self-heal: archive the
+      // dead row and transparently start a fresh session with the same message,
+      // instead of dead-ending on every future message.
+      mockConnector.simulateIncomingMessage('Still there?', 'chat-1', 'user-1')
+      await waitForCondition(() => MockContainerClient.createSessionCalls.length === 2)
+
+      // The user's message was carried into the fresh session as its first message.
+      expect(MockContainerClient.createSessionCalls[1].initialMessage).toBe('Still there?')
+
+      // The dead row is archived; a fresh non-archived row now serves this chat.
+      const rows = listChatIntegrationSessions(integrationId).filter((r) => r.externalChatId === 'chat-1')
+      const dead = rows.find((r) => r.sessionId === deadSessionId)
+      const fresh = rows.find((r) => r.sessionId !== deadSessionId && !r.archivedAt)
+      expect(dead?.archivedAt).toBeTruthy()
+      expect(fresh).toBeDefined()
+    })
+
+    it('does NOT rotate the session on a transient (non-session-gone) error', async () => {
+      const integrationId = createTestIntegration()
+      await chatIntegrationManager.addIntegration(integrationId)
+
+      mockConnector.simulateIncomingMessage('Hello', 'chat-1', 'user-1')
+      await waitForCondition(() => MockContainerClient.createSessionCalls.length === 1)
+      await waitForCondition(
+        () => mockConnector.sentMessages.length > 0 || mockConnector.finalizedMessages.length > 0,
+        3000,
+      )
+
+      const liveSessionId = [...(mockContainerClient as any).sessions.keys()][0] as string
+
+      // Next send fails with a TRANSIENT error (not "session not found").
+      const sendSpy = vi
+        .spyOn(mockContainerClient, 'sendMessage')
+        .mockRejectedValueOnce(new Error('Container is not running'))
+
+      const createBefore = MockContainerClient.createSessionCalls.length
+      const sentBefore = mockConnector.sentMessages.length
+      mockConnector.simulateIncomingMessage('Transient please', 'chat-1', 'user-1')
+
+      // Manager surfaces a retry prompt and does NOT rotate the session.
+      await waitForCondition(
+        () => mockConnector.sentMessages.slice(sentBefore).some((m) => /try again/i.test(m.message.text ?? '')),
+        3000,
+      )
+      expect(MockContainerClient.createSessionCalls.length).toBe(createBefore)
+
+      const rows = listChatIntegrationSessions(integrationId).filter((r) => r.externalChatId === 'chat-1')
+      expect(rows.find((r) => r.sessionId === liveSessionId)?.archivedAt).toBeFalsy()
+
+      sendSpy.mockRestore()
     })
   })
 

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -32,7 +32,7 @@ import {
   resolveActiveSession,
   getLastDisplayName,
 } from '@shared/lib/services/chat-integration-session-service'
-import type { EffortLevel } from '@shared/lib/container/types'
+import type { EffortLevel, ContainerClient } from '@shared/lib/container/types'
 import type { ChatIntegration } from '@shared/lib/db/schema'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { runWithOptionalUser } from '@shared/lib/platform-attribution'
@@ -641,12 +641,6 @@ class ChatIntegrationManager {
     if (!chatSession) {
       // New chat — create a new agent session
       try {
-        const { getEffectiveModels } = await import('@shared/lib/config/settings')
-        const { getSecretEnvVars } = await import('@shared/lib/services/secrets-service')
-        const { registerSession, updateSessionMetadata } = await import('@shared/lib/services/session-service')
-
-        const availableEnvVars = await getSecretEnvVars(integration.agentSlug)
-
         const { text: messageText, failedFiles } = await this.buildMessageContent(integration, message)
 
         if (failedFiles.length > 0 && !messageText.trim()) {
@@ -663,47 +657,7 @@ class ChatIntegrationManager {
           })
         }
 
-        const models = getEffectiveModels()
-        const containerSession = await client.createSession({
-          availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
-          initialMessage: messageText,
-          model: integration.model || models.agentModel,
-          browserModel: models.browserModel,
-          ...(integration.effort ? { effort: integration.effort as EffortLevel } : {}),
-          ...(integration.provider === 'imessage' ? { systemPrompt: IMESSAGE_SYSTEM_PROMPT } : {}),
-        })
-
-        const sessionId = containerSession.id
-        breadcrumb('New chat session created', { integrationId, sessionId, provider: integration.provider })
-
-        const displayName = this.deriveDisplayName(integration.provider, message)
-
-        const sessionName = buildSessionName(
-          integration.name,
-          integration.provider,
-          displayName,
-          integration.sessionTimeout,
-        )
-
-        await registerSession(integration.agentSlug, sessionId, sessionName)
-
-        await updateSessionMetadata(integration.agentSlug, sessionId, {
-          isChatIntegrationSession: true,
-          chatIntegrationId: integrationId,
-          ...(integration.createdByUserId ? { createdByUserId: integration.createdByUserId } : {}),
-        })
-
-        createChatIntegrationSession({
-          integrationId,
-          externalChatId: chatId,
-          sessionId,
-          displayName,
-        })
-
-        await messagePersister.subscribeToSession(sessionId, client, sessionId, integration.agentSlug)
-        messagePersister.markSessionActive(sessionId, integration.agentSlug)
-        this.subscribeChatSession(integrationId, chatId, sessionId)
-
+        await this.startNewChatSession(integration, client, chatId, message, messageText)
         return // initialMessage already sent via createSession
       } catch (err) {
         console.error(`[ChatIntegrationManager] Failed to create new session for ${integrationId}:`, err)
@@ -725,6 +679,8 @@ class ChatIntegrationManager {
 
     const sessionId = chatSession.sessionId
 
+    // Hoisted so the catch can reuse it for self-heal without re-downloading.
+    let messageText = ''
     try {
       if (!messagePersister.isSubscribed(sessionId)) {
         await messagePersister.subscribeToSession(sessionId, client, sessionId, integration.agentSlug)
@@ -733,7 +689,9 @@ class ChatIntegrationManager {
       // Ensure SSE → chat forwarding is active (may have been torn down by reconnect)
       this.subscribeChatSession(integrationId, chatId, sessionId)
 
-      const { text: messageText, failedFiles } = await this.buildMessageContent(integration, message)
+      const built = await this.buildMessageContent(integration, message)
+      messageText = built.text
+      const failedFiles = built.failedFiles
 
       if (failedFiles.length > 0 && !messageText.trim()) {
         const names = failedFiles.join(', ')
@@ -758,6 +716,32 @@ class ChatIntegrationManager {
         this.lastSessionTouch.set(chatSession.id, now)
       }
     } catch (err) {
+      // Self-heal: the container no longer has this agent session (e.g. it was
+      // evicted and could not be resumed). Without recovery, resolveActiveSession
+      // keeps returning this dead row, so EVERY future message to this chat would
+      // fail. Archive the stale mapping and transparently start a fresh session
+      // with the same message. Transient failures (dead container, network) are
+      // NOT session-gone, so they keep the retry prompt below.
+      if (this.isSessionGoneError(err)) {
+        console.warn(`[ChatIntegrationManager] Agent session ${sessionId} gone in container; rotating chat ${chatId} to a fresh session`)
+        breadcrumb('Chat agent session gone, self-healing', { integrationId, chatId, sessionId })
+        this.teardownManagedSession(integrationId, chatId, { archive: chatSession.id })
+        try {
+          // messageText is already built unless we failed before it (e.g. the
+          // subscribe threw); rebuild in that rare case so the message isn't lost.
+          if (!messageText) {
+            messageText = (await this.buildMessageContent(integration, message)).text
+          }
+          await this.startNewChatSession(integration, client, chatId, message, messageText)
+          return
+        } catch (healErr) {
+          console.error(`[ChatIntegrationManager] Self-heal failed for ${integrationId}/${chatId}:`, healErr)
+          reportError(healErr, 'send-message-selfheal', { integrationId, chatId, provider: integration.provider }, isContainerNotRunning(healErr) ? 'warning' : 'error')
+          await conn.connector.sendMessage(chatId, { text: 'Error: Failed to send your message to the agent. Please try again.' }).catch(() => {})
+          return
+        }
+      }
+
       console.error(`[ChatIntegrationManager] Failed to send message for ${integrationId}/${sessionId}:`, err)
       // Recovered path (user is told to retry); a dead container is expected and
       // self-healing, so downgrade it to a warning to cut Sentry noise.
@@ -769,6 +753,80 @@ class ChatIntegrationManager {
     // Show typing indicator
     this.chatSessions.get(this.getChatSessionKey(integrationId, chatId))
       ?.connector.showTypingIndicator(chatId).catch(() => {})
+  }
+
+  /**
+   * Create a fresh agent session for a chat, persist the (integration, chat) →
+   * session mapping, and wire up SSE forwarding. `messageText` is sent as the
+   * session's initial message via createSession. Callers build messageText (and
+   * surface any failed-download warnings) and archive any prior session for this
+   * chat first. Shared by the new-chat path and the send-time self-heal.
+   */
+  private async startNewChatSession(
+    integration: ChatIntegration,
+    client: ContainerClient,
+    chatId: string,
+    message: IncomingMessage,
+    messageText: string,
+  ): Promise<void> {
+    const { getEffectiveModels } = await import('@shared/lib/config/settings')
+    const { getSecretEnvVars } = await import('@shared/lib/services/secrets-service')
+    const { registerSession, updateSessionMetadata } = await import('@shared/lib/services/session-service')
+
+    const availableEnvVars = await getSecretEnvVars(integration.agentSlug)
+    const models = getEffectiveModels()
+
+    const containerSession = await client.createSession({
+      availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
+      initialMessage: messageText,
+      model: integration.model || models.agentModel,
+      browserModel: models.browserModel,
+      ...(integration.effort ? { effort: integration.effort as EffortLevel } : {}),
+      ...(integration.provider === 'imessage' ? { systemPrompt: IMESSAGE_SYSTEM_PROMPT } : {}),
+    })
+
+    const sessionId = containerSession.id
+    breadcrumb('New chat session created', { integrationId: integration.id, sessionId, provider: integration.provider })
+
+    const displayName = this.deriveDisplayName(integration.provider, message)
+    const sessionName = buildSessionName(
+      integration.name,
+      integration.provider,
+      displayName,
+      integration.sessionTimeout,
+    )
+
+    await registerSession(integration.agentSlug, sessionId, sessionName)
+    await updateSessionMetadata(integration.agentSlug, sessionId, {
+      isChatIntegrationSession: true,
+      chatIntegrationId: integration.id,
+      ...(integration.createdByUserId ? { createdByUserId: integration.createdByUserId } : {}),
+    })
+
+    createChatIntegrationSession({
+      integrationId: integration.id,
+      externalChatId: chatId,
+      sessionId,
+      displayName,
+    })
+
+    await messagePersister.subscribeToSession(sessionId, client, sessionId, integration.agentSlug)
+    messagePersister.markSessionActive(sessionId, integration.agentSlug)
+    this.subscribeChatSession(integration.id, chatId, sessionId)
+  }
+
+  /**
+   * True when a container call failed because the agent session no longer exists
+   * there (evicted / not resumable) — as opposed to a transient container or
+   * network error. Gates the send-time self-heal so only genuinely-gone sessions
+   * are rotated, while transient errors still surface a retry prompt.
+   */
+  private isSessionGoneError(err: unknown): boolean {
+    if (!(err instanceof Error)) return false
+    // Matches both shapes the container surfaces: the 404 guard's generic
+    // "Session not found" (host client: "Failed to send message: Session not
+    // found") and the resume-failure form "Session <id> not found".
+    return /session(\s+\S+)?\s+not\s+found/i.test(err.message)
   }
 
   private teardownManagedSession(integrationId: string, chatId: string, opts?: { archive?: string }): void {


### PR DESCRIPTION
## Problem
When a chat's mapped agent session no longer exists in the container — e.g. the dev container was recreated, or the session couldn't be resumed — sending a message **failed on every future message**. `resolveActiveSession` kept returning the stale, non-archived DB row and `client.sendMessage` 404'd with `Session not found`, so the chat was permanently stuck (the only workaround was `/clear`).

This was found while testing Slack against a `dev:electron` install: a month-old chat session's container session was gone, and each new Slack message dead-ended with `Failed to send message: Session not found`.

## Fix
The existing-session send path now detects a *session-gone* error and **self-heals**:
1. `isSessionGoneError(err)` distinguishes a genuinely-gone session from a transient failure. It matches both shapes the container surfaces — the 404 guard's generic `Session not found` (host client: `Failed to send message: Session not found`) and the resume-failure form `Session <id> not found`.
2. On session-gone: archive the stale mapping (`teardownManagedSession(..., { archive })`) and transparently start a fresh session **with the same message**, so the chat recovers automatically and the user's message isn't lost.
3. Transient errors (`Container is not running`, network) are **not** treated as session-gone — they keep the existing "please try again" retry prompt.

## Refactor
Extracted the session-creation block into a private `startNewChatSession()`, now shared by the new-chat path and the self-heal. `messageText` is hoisted so the heal reuses already-built content without re-downloading attachments (with a rebuild fallback for the rare pre-build failure).

## Tests
Added to `chat-integration-e2e.test.ts` (real connector → manager → mock container harness):
- Evicting a live session from the container → asserts the dead row is archived, a fresh session is created, and the user's message is carried into it.
- A transient (`Container is not running`) failure → asserts the session is **not** rotated and a retry prompt is sent.

Full chat-integrations suite: 367 passing. `tsc --noEmit` clean; eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)