### PR TITLE
fix(mcp): request OAuth scopes per spec scope-selection strategy

### DIFF
--- a/src/shared/lib/mcp/oauth.test.ts
+++ b/src/shared/lib/mcp/oauth.test.ts
@@ -469,8 +469,121 @@ describe('oauth', () => {
       // RFC 8707: resource indicator must be sent on the authorization request
       // so the AS binds the token audience to this MCP server.
       expect(url.searchParams.get('resource')).toBe('https://mcp.example.com')
-      // No scope when using existing client (scope only from fresh registration)
-      expect(url.searchParams.has('scope')).toBe(false)
+      // MCP auth spec scope-selection strategy: with no `scope` in the 401
+      // WWW-Authenticate, request all advertised scopes_supported — regardless
+      // of whether the client was freshly registered or pre-existing.
+      expect(url.searchParams.get('scope')).toBe('read write')
+    })
+
+    it('sends scopes_supported from the resource metadata when DCR returns no scope (Robinhood case)', async () => {
+      // Probe: 401 with resource_metadata
+      mockFetch.mockResolvedValueOnce(
+        new Response(null, {
+          status: 401,
+          headers: {
+            'WWW-Authenticate':
+              'Bearer resource_metadata="https://mcp.example.com/.well-known/res"',
+          },
+        })
+      )
+      // Resource metadata advertises the scope (like Robinhood's ["internal"])
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            resource: 'https://mcp.example.com',
+            authorization_servers: ['https://auth.example.com'],
+            scopes_supported: ['internal'],
+          }),
+          { status: 200 }
+        )
+      )
+      // Auth server metadata: registration endpoint present, no scopes_supported
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            registration_endpoint: 'https://auth.example.com/register',
+          }),
+          { status: 200 }
+        )
+      )
+      // DCR response echoes no `scope` (exactly what Robinhood returns)
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ client_id: 'dyn-client-id' }),
+          { status: 200 }
+        )
+      )
+
+      // DB: new server has no stored client credentials yet
+      mockDbFrom.mockReturnValue({ where: mockWhere })
+      mockWhere.mockReturnValue({ limit: mockLimit })
+      mockLimit.mockResolvedValue([{ oauthClientId: null, oauthClientSecret: null }])
+      mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) })
+
+      const result = await initiateOAuthFlow(
+        'mcp-1',
+        'https://mcp.example.com/mcp',
+        'http://localhost:3000/callback'
+      )
+
+      expect(result).not.toBeNull()
+      const url = new URL(result!.authorizationUrl)
+      // Without this the AS bounces the user back with no consent screen.
+      expect(url.searchParams.get('scope')).toBe('internal')
+    })
+
+    it('prefers the scope challenged in WWW-Authenticate over scopes_supported', async () => {
+      // Probe: 401 whose WWW-Authenticate names a required scope (RFC 6750 §3).
+      // Per the MCP auth spec this is priority #1, ahead of scopes_supported.
+      mockFetch.mockResolvedValueOnce(
+        new Response(null, {
+          status: 401,
+          headers: {
+            'WWW-Authenticate':
+              'Bearer resource_metadata="https://mcp.example.com/.well-known/res", scope="files:read files:write"',
+          },
+        })
+      )
+      // Resource metadata advertises a *different* scopes_supported set
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            resource: 'https://mcp.example.com',
+            authorization_servers: ['https://auth.example.com'],
+            scopes_supported: ['read', 'write'],
+          }),
+          { status: 200 }
+        )
+      )
+      // Auth server metadata
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+          }),
+          { status: 200 }
+        )
+      )
+
+      // DB: existing server with a stored client id (no fresh registration)
+      mockDbFrom.mockReturnValue({ where: mockWhere })
+      mockWhere.mockReturnValue({ limit: mockLimit })
+      mockLimit.mockResolvedValue([{ oauthClientId: 'existing-client-id', oauthClientSecret: null }])
+      mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) })
+
+      const result = await initiateOAuthFlow(
+        'mcp-1',
+        'https://mcp.example.com/mcp',
+        'http://localhost:3000/callback'
+      )
+
+      expect(result).not.toBeNull()
+      const url = new URL(result!.authorizationUrl)
+      // The challenged scope wins over scopes_supported ('read write').
+      expect(url.searchParams.get('scope')).toBe('files:read files:write')
     })
 
     it('returns null when discovery fails', async () => {

--- a/src/shared/lib/mcp/oauth.ts
+++ b/src/shared/lib/mcp/oauth.ts
@@ -61,6 +61,8 @@ function generatePKCE(): { codeVerifier: string; codeChallenge: string } {
 export async function discoverOAuthMetadata(mcpUrl: string): Promise<{
   metadata: OAuthMetadata
   resource: string
+  scopesSupported?: string[]
+  challengeScope?: string
 } | null> {
   try {
     // Step 1: Make unauthenticated request to get 401
@@ -75,12 +77,22 @@ export async function discoverOAuthMetadata(mcpUrl: string): Promise<{
       return null
     }
 
-    // Step 2: Extract resource_metadata from WWW-Authenticate
+    // Step 2: Extract resource_metadata (and any scope challenge) from
+    // WWW-Authenticate. RFC 6750 §3 lets the resource server name the scopes
+    // required for access; the MCP auth spec makes this the top-priority source
+    // for the scope the client requests, ahead of scopes_supported.
     const wwwAuth = probeResponse.headers.get('WWW-Authenticate') || ''
     const resourceMetadataMatch = wwwAuth.match(/resource_metadata="([^"]+)"/)
+    const challengeScopeMatch = wwwAuth.match(/scope="([^"]+)"/)
+    const challengeScope = challengeScopeMatch ? challengeScopeMatch[1] : undefined
 
     let authServerUrl: string
     let resource: string
+    // Scopes advertised by the Protected Resource Metadata (RFC 9728). Per the
+    // MCP auth spec's scope-selection strategy, when the 401 WWW-Authenticate
+    // carries no `scope`, the client requests all of the resource's
+    // scopes_supported. Captured here so the caller can put it on the auth URL.
+    let resourceScopes: string[] | undefined
 
     if (resourceMetadataMatch) {
       // RFC 9728: Fetch Protected Resource Metadata.
@@ -97,8 +109,10 @@ export async function discoverOAuthMetadata(mcpUrl: string): Promise<{
       const resourceMetadata = (await resourceRes.json()) as {
         resource?: string
         authorization_servers?: string[]
+        scopes_supported?: string[]
       }
       resource = resourceMetadata.resource || new URL(mcpUrl).origin
+      resourceScopes = resourceMetadata.scopes_supported
       const authServers = resourceMetadata.authorization_servers || []
       if (authServers.length === 0) {
         throw new Error('No authorization servers found in resource metadata')
@@ -135,7 +149,14 @@ export async function discoverOAuthMetadata(mcpUrl: string): Promise<{
         if (res.ok) {
           const metadata = (await res.json()) as OAuthMetadata
           if (metadata.authorization_endpoint && metadata.token_endpoint) {
-            return { metadata, resource }
+            // Prefer the resource's advertised scopes; fall back to the
+            // authorization server's scopes_supported.
+            return {
+              metadata,
+              resource,
+              scopesSupported: resourceScopes ?? metadata.scopes_supported,
+              challengeScope,
+            }
           }
         }
       } catch {
@@ -219,7 +240,7 @@ export async function initiateOAuthFlow(
   const discovery = await discoverOAuthMetadata(mcpUrl)
   if (!discovery) return null
 
-  const { metadata, resource } = discovery
+  const { metadata, resource, scopesSupported, challengeScope } = discovery
 
   // Verify S256 is supported
   const supportedMethods = metadata.code_challenge_methods_supported || []
@@ -309,9 +330,16 @@ export async function initiateOAuthFlow(
   // here lets the AS issue a token with the wrong audience, which the resource
   // server then rejects on initialize (401).
   authUrl.searchParams.set('resource', resource)
-  // Use scope from client registration response if available
-  if (registeredScope) {
-    authUrl.searchParams.set('scope', registeredScope)
+  // Scope selection follows the MCP auth spec's priority order:
+  //   1. the scope challenged in the 401 WWW-Authenticate header (RFC 6750 §3)
+  //   2. the scope granted at dynamic client registration
+  //   3. all scopes the resource/AS advertise in scopes_supported
+  // Servers like Robinhood challenge no scope and their DCR echoes none, so we
+  // fall to (3) and send scopes_supported (["internal"]); without any scope the
+  // AS ignores the request and bounces the user back with no consent screen.
+  const scope = challengeScope || registeredScope || scopesSupported?.join(' ')
+  if (scope) {
+    authUrl.searchParams.set('scope', scope)
   }
 
   return {
@@ -339,7 +367,7 @@ export async function initiateNewServerOAuth(
   const discovery = await discoverOAuthMetadata(mcpUrl)
   if (!discovery) return null
 
-  const { metadata, resource } = discovery
+  const { metadata, resource, scopesSupported, challengeScope } = discovery
 
   const supportedMethods = metadata.code_challenge_methods_supported || []
   if (supportedMethods.length > 0 && !supportedMethods.includes('S256')) {
@@ -403,9 +431,16 @@ export async function initiateNewServerOAuth(
   // here lets the AS issue a token with the wrong audience, which the resource
   // server then rejects on initialize (401).
   authUrl.searchParams.set('resource', resource)
-  // Use scope from client registration response if available
-  if (registeredScope) {
-    authUrl.searchParams.set('scope', registeredScope)
+  // Scope selection follows the MCP auth spec's priority order:
+  //   1. the scope challenged in the 401 WWW-Authenticate header (RFC 6750 §3)
+  //   2. the scope granted at dynamic client registration
+  //   3. all scopes the resource/AS advertise in scopes_supported
+  // Servers like Robinhood challenge no scope and their DCR echoes none, so we
+  // fall to (3) and send scopes_supported (["internal"]); without any scope the
+  // AS ignores the request and bounces the user back with no consent screen.
+  const scope = challengeScope || registeredScope || scopesSupported?.join(' ')
+  if (scope) {
+    authUrl.searchParams.set('scope', scope)
   }
 
   return { authorizationUrl: authUrl.toString(), state }


### PR DESCRIPTION
## Problem

Connecting a remote MCP server that uses OAuth could fail with the user **redirected to the provider and then bounced straight back with no consent screen** — the connection never completes. Hit in practice with Robinhood's trading MCP (`https://agent.robinhood.com/mcp/trading`).

Root cause: our client only put a `scope` on the authorization request when **Dynamic Client Registration echoed a scope back**. Robinhood (and other spec-compliant servers) advertise `scopes_supported: ["internal"]` but their DCR response carries no scope, so we sent an authorization request with **no `scope` at all**. The provider's authorize endpoint then ignores the request and redirects back without prompting for consent.

## Fix

Implement the [MCP authorization spec's Scope Selection Strategy](https://modelcontextprotocol.io/specification/draft/basic/authorization) priority order:

1. the scope challenged in the 401 `WWW-Authenticate` header (RFC 6750 §3)
2. the scope granted at dynamic client registration
3. all scopes advertised in `scopes_supported` — **Protected Resource Metadata preferred**, falling back to Authorization Server metadata
4. omit the `scope` parameter entirely when none is available (per spec)

`discoverOAuthMetadata` now surfaces `challengeScope` + `scopesSupported`; both `initiateOAuthFlow` and `initiateNewServerOAuth` resolve and set the scope on the authorization URL.

## Spec alignment

| Scope Selection Strategy clause | Before | After |
| --- | --- | --- |
| #1 — `scope` from the 401 `WWW-Authenticate` challenge | ❌ | ✅ |
| #2 — else `scopes_supported` from Protected Resource Metadata | ❌ (discarded) | ✅ (PRM preferred over AS metadata) |
| omit `scope` when `scopes_supported` is undefined | ⚠️ always omitted | ✅ guarded |

The pre-existing RFC 8707 `resource` indicator and SUP-235 SSRF guards in `discoverOAuthMetadata` are untouched.

## Validation

- New unit tests: scope falls back to `scopes_supported` when DCR returns none (the Robinhood case), and a challenged `WWW-Authenticate` scope wins over `scopes_supported`. Existing test that asserted "no scope for existing client" updated to the corrected behavior.
- `oauth.test.ts`: **34/34 pass**; typecheck + lint clean.
- Verified end-to-end against the live Robinhood endpoints: a generated authorization URL **with** `scope=internal` reaches the real consent screen; **without** it reproduces the bounce.

## Not included (follow-up)

RFC 9207 `iss` validation (record issuer at authorize time, validate `iss` on the callback) is still unimplemented — independent of this change, harmless for Robinhood (it doesn't advertise `iss` support), flagged for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
