### PR TITLE
fix: browser_eval runs statement bodies in a fresh async scope (audit NEW-A)

### DIFF
--- a/agent-container/src/eval-script.test.ts
+++ b/agent-container/src/eval-script.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { prepareEvalScript, finalizeEvalOutput, evalErrorHint } from './eval-script'
+import { prepareEvalScript, scanTopLevel, finalizeEvalOutput, evalErrorHint } from './eval-script'
 
 describe('prepareEvalScript', () => {
   it('auto-invokes a bare arrow function (the {} trap)', () => {
@@ -42,6 +42,68 @@ describe('prepareEvalScript', () => {
     ]) {
       expect(prepareEvalScript(expr)).toEqual({ script: expr, wrapped: false })
     }
+  })
+
+  it('wraps a top-level return in a fresh async scope (fixes "Illegal return")', () => {
+    expect(prepareEvalScript('const t = document.title; return t;')).toEqual({
+      script: '(async () => {\nconst t = document.title; return t\n})()',
+      wrapped: true,
+    })
+  })
+
+  it('wraps top-level const/let so it cannot collide across calls ("already declared")', () => {
+    expect(prepareEvalScript('const x = 1; foo(x)').wrapped).toBe(true)
+    expect(prepareEvalScript('let y = 2; y').wrapped).toBe(true)
+    expect(prepareEvalScript('const x = 1; foo(x)').script).toContain('(async () => {')
+  })
+
+  it('does NOT wrap an expression whose return/decl live inside a nested function (depth>0)', () => {
+    // the inner return must not be mistaken for a top-level statement, or the
+    // array value would be lost to an undefined function body
+    const expr = '[...document.querySelectorAll("a")].map(a => { return a.href })'
+    expect(prepareEvalScript(expr)).toEqual({ script: expr, wrapped: false })
+    const filt = 'rows.filter(r => { const v = r.value; return v > 0 })'
+    expect(prepareEvalScript(filt)).toEqual({ script: filt, wrapped: false })
+  })
+
+  it('wraps a plain top-level await expression while preserving its value', () => {
+    expect(prepareEvalScript('await fetch("/x").then(r => r.json())')).toEqual({
+      script: '(async () => (await fetch("/x").then(r => r.json())))()',
+      wrapped: true,
+    })
+  })
+
+  it('wraps multiple top-level statements', () => {
+    expect(prepareEvalScript('document.querySelector("#a").remove(); document.querySelector("#b").click()').wrapped).toBe(true)
+  })
+
+  it('does not treat keywords inside strings as statements', () => {
+    expect(prepareEvalScript('document.querySelector("[data-x=\'return\']")')).toEqual({
+      script: 'document.querySelector("[data-x=\'return\']")',
+      wrapped: false,
+    })
+  })
+
+  it('handles empty / whitespace input', () => {
+    expect(prepareEvalScript('   ')).toEqual({ script: '   ', wrapped: false })
+  })
+})
+
+describe('scanTopLevel', () => {
+  it('detects top-level statement keywords', () => {
+    expect(scanTopLevel('return 5').isStatementBody).toBe(true)
+    expect(scanTopLevel('const x = 1').isStatementBody).toBe(true)
+    expect(scanTopLevel('if (a) b()').isStatementBody).toBe(true)
+  })
+  it('ignores keywords nested in functions, strings, and member access', () => {
+    expect(scanTopLevel('xs.map(x => { return x })').isStatementBody).toBe(false)
+    expect(scanTopLevel('el.return').isStatementBody).toBe(false)
+    expect(scanTopLevel('f("const y")').isStatementBody).toBe(false)
+    expect(scanTopLevel('returnValue + 1').isStatementBody).toBe(false) // not the keyword
+  })
+  it('reports top-level await', () => {
+    expect(scanTopLevel('await x()').hasAwait).toBe(true)
+    expect(scanTopLevel('xs.map(async x => await f(x))').hasAwait).toBe(false)
   })
 })
 

--- a/agent-container/src/eval-script.ts
+++ b/agent-container/src/eval-script.ts
@@ -11,26 +11,105 @@
 
 const MAX_EVAL_OUTPUT_CHARS = 8000
 
+// Keywords that can only begin a STATEMENT (never a plain expression) — their
+// presence at top level means the script is a statement body that must be
+// wrapped. `await` is deliberately NOT here: it is an operator valid inside an
+// expression, so it only flips hasAwait (handled with a value-preserving wrap).
+const STATEMENT_KEYWORDS = new Set(['return', 'const', 'let', 'var', 'class', 'function', 'throw', 'if', 'for', 'while', 'switch', 'try'])
+
 /**
- * If the script is a bare (un-invoked) function expression, wrap it in an
- * IIFE so it actually runs. Already-invoked and non-function expressions pass
- * through untouched.
+ * Scan for statement-body markers that appear at bracket/quote depth 0:
+ * a `return`/`const`/`let`/`var`/`class`/`function`/`await`/... keyword used
+ * as a statement, or a `;` separating statements. Depth tracking is what keeps
+ * an inner `return` (e.g. inside `.map(a => { return a.href })`) from being
+ * mistaken for a top-level one — that script is a plain expression and must
+ * pass through unwrapped to preserve its value.
+ */
+export function scanTopLevel(s: string): { isStatementBody: boolean; hasAwait: boolean } {
+  let depth = 0
+  let quote: string | null = null
+  let hasStatementKeyword = false
+  let hasTopLevelSemicolon = false
+  let hasAwait = false
+  let prevSignificant = '' // last non-space char seen, for member-access (.) checks
+
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]
+    if (quote) {
+      if (ch === '\\') { i++; continue }
+      if (ch === quote) quote = null
+      continue
+    }
+    // comments
+    if (ch === '/' && s[i + 1] === '/') { while (i < s.length && s[i] !== '\n') i++; continue }
+    if (ch === '/' && s[i + 1] === '*') { i += 2; while (i < s.length && !(s[i] === '*' && s[i + 1] === '/')) i++; i++; continue }
+    if (ch === '"' || ch === "'" || ch === '`') { quote = ch; prevSignificant = ch; continue }
+    if (ch === '(' || ch === '[' || ch === '{') { depth++; prevSignificant = ch; continue }
+    if (ch === ')' || ch === ']' || ch === '}') { depth--; prevSignificant = ch; continue }
+
+    if (depth === 0) {
+      if (ch === ';') {
+        if (s.slice(i + 1).trim() !== '') hasTopLevelSemicolon = true // more statements follow
+        prevSignificant = ch
+        continue
+      }
+      // identifier word starting here, not a member access (foo.return)
+      if (/[A-Za-z_$]/.test(ch) && prevSignificant !== '.' && !/[\w$]/.test(s[i - 1] || '')) {
+        let j = i
+        while (j < s.length && /[\w$]/.test(s[j])) j++
+        const word = s.slice(i, j)
+        if (word === 'await') hasAwait = true
+        else if (STATEMENT_KEYWORDS.has(word)) hasStatementKeyword = true
+        i = j - 1
+        prevSignificant = word[word.length - 1]
+        continue
+      }
+    }
+    if (!/\s/.test(ch)) prevSignificant = ch
+  }
+
+  return { isStatementBody: hasStatementKeyword || hasTopLevelSemicolon, hasAwait }
+}
+
+/**
+ * Prepare a script for agent-browser's `eval`, which runs every script as a
+ * statement list in ONE long-lived shared V8 realm. That means a top-level
+ * `return` is illegal and a `const`/`let` collides with the same name from a
+ * prior call ("already declared") — the most pervasive failure in the
+ * browser-tools audit (13/47 transcripts). Wrapping a statement body in a
+ * fresh async IIFE makes `return`/`await` legal and scopes declarations so
+ * they can't collide. Plain expressions are left raw so their value is still
+ * returned (wrapping `document.title` in a function body would yield
+ * undefined); bare function literals are invoked as before.
  */
 export function prepareEvalScript(raw: string): { script: string; wrapped: boolean } {
   const s = raw.trim().replace(/;+\s*$/, '')
+  if (s === '') return { script: raw, wrapped: false }
 
   // A function literal, optionally parenthesized: (async) arrow with parened
   // or bare single param, or a function keyword expression.
   const isFunctionLiteral = /^\(?\s*(async\s+)?(\([^)]*\)\s*=>|[A-Za-z_$][\w$]*\s*=>|function\b)/.test(s)
-  if (!isFunctionLiteral) return { script: raw, wrapped: false }
+  if (isFunctionLiteral) {
+    // Already invoked: ends with `)(...)` (one nesting level of parens allowed
+    // in the argument list). Mis-detection here fails loudly ("x is not a
+    // function") rather than silently, and the wrapped flag is reported.
+    const isInvoked = /\)\s*\((?:[^()]|\([^()]*\))*\)$/.test(s)
+    if (isInvoked) return { script: raw, wrapped: false }
+    return { script: `(${s})()`, wrapped: true }
+  }
 
-  // Already invoked: ends with `)(...)` (one nesting level of parens allowed
-  // in the argument list). Mis-detection here fails loudly ("x is not a
-  // function") rather than silently, and the wrapped flag is reported.
-  const isInvoked = /\)\s*\((?:[^()]|\([^()]*\))*\)$/.test(s)
-  if (isInvoked) return { script: raw, wrapped: false }
-
-  return { script: `(${s})()`, wrapped: true }
+  const { isStatementBody, hasAwait } = scanTopLevel(s)
+  if (isStatementBody) {
+    // Statement body: fresh async scope makes return/await legal and isolates
+    // declarations. Use `return` inside to produce a value.
+    return { script: `(async () => {\n${s}\n})()`, wrapped: true }
+  }
+  if (hasAwait) {
+    // Plain expression using top-level await — wrap so await is legal while
+    // preserving the expression's value.
+    return { script: `(async () => (${s}))()`, wrapped: true }
+  }
+  return { script: raw, wrapped: false }
 }
 
 /** Cap eval output, appending an actionable truncation notice. */

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -497,12 +497,12 @@ const browserEvalTool = tool(
   'browser_eval',
   `Run JavaScript in the page and return the result. Prefer this over browser_run("eval ...").
 
-- Evaluated as an expression; await is supported. Bare function expressions are automatically invoked for you.
+- A single expression returns its value (e.g. document.title). A multi-line/statement body runs in a fresh scope — use \`return\` to produce a value (top-level return and await are supported; const/let won't collide across calls). Bare function expressions are auto-invoked.
 - Return JSON-serializable data — for structured results, end with JSON.stringify(...).
 - TOP FRAME ONLY: elements inside cross-origin iframes (e.g. Stripe payment frames) are unreachable from JavaScript. For those, click the field by coordinates and type with browser_type.
 - Output is capped at ~8000 chars — query only the fields you need instead of dumping HTML.`,
   {
-    script: z.string().describe('JavaScript to evaluate in the page, e.g. document.title or (() => JSON.stringify({n: document.querySelectorAll("a").length}))()'),
+    script: z.string().describe('JavaScript to evaluate. An expression (document.title) returns its value; a statement body should use return, e.g. "const n = document.querySelectorAll(\'a\').length; return n;"'),
   },
   async (args) => {
     const result = await browserFetch('eval', { script: args.script })
@@ -510,7 +510,7 @@ const browserEvalTool = tool(
     const data = result.data as Record<string, unknown>
     let text = data.output ? String(data.output) : '(no output)'
     if (data.wrapped) {
-      text += '\n(note: your script was a bare function expression — it was auto-invoked as (fn)())'
+      text += '\n(note: ran in a fresh function scope — add `return` if you expected a value back)'
     }
     text += getTabWarning()
     return {

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -22,7 +22,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 - `browser_open(url)` — Navigate to a URL
 
 **JavaScript:**
-- `browser_eval(script)` — Run JavaScript in the page and get the result. Bare functions are auto-invoked; return `JSON.stringify(...)` for structured data. TOP FRAME ONLY — cross-origin iframes (payment frames) are unreachable from JS.
+- `browser_eval(script)` — Run JavaScript in the page and get the result. A single expression returns its value; a statement body runs in a fresh scope — use `return` to get a value (top-level `return`/`await` work, `const`/`let` won't collide across calls). Return `JSON.stringify(...)` for structured data. TOP FRAME ONLY — cross-origin iframes (payment frames) are unreachable from JS.
 
 **Catch-all for advanced commands:**
 - `browser_run(command)` / `browser_run(args)` — Run any agent-browser CLI command. Use the `command` string for simple commands; whenever ANY argument contains spaces or quotes, pass the pre-tokenized `args` array instead — each element reaches the CLI verbatim, no escaping needed: `browser_run(args: ["type", "@e1", "chat isn't enough"])`, `browser_run(args: ["frame", "iframe[title=\"Payment frame\"]"])`. Examples:


### PR DESCRIPTION
## What

`browser_eval` runs every script as a statement list in agent-browser's **one long-lived shared V8 realm**, so:
- a top-level `return` is illegal → `SyntaxError: Illegal return statement`
- a `const`/`let` collides with the same name from a *prior* call → `Identifier 'x' has already been declared`

This was the **most pervasive failure in the second browser-tools audit — 13 of 47 transcripts** — and agents only self-recovered by manually wrapping in an IIFE.

## Fix

`prepareEvalScript` now classifies the script and transforms accordingly:
- **bare function literal** → invoked `(fn)()` (unchanged)
- **statement body** (top-level `return`/`const`/`let`/`var`/`class`/`function`/`throw`/`if`/… or `;`-separated statements) → wrapped in `(async () => { … })()` — makes `return` legal, scopes declarations so they can't collide across calls, and allows `await`
- **plain expression** → left raw so its value is still returned (wrapping `document.title` in a function body would yield `undefined`)

A new depth/quote/comment-aware scanner (`scanTopLevel`) ensures an inner `return` inside `.map(a => { return … })` is **not** mistaken for a top-level one — that script stays raw and keeps returning its value. A bare top-level `await` expression gets a value-preserving `(async () => (expr))()` wrap.

Tool description + web-browser prompt updated to teach "expression returns its value; statement body should use `return`"; the post-run note now reflects the fresh-scope wrap.

## Validation

347/347 agent-container tests pass (7 new), tsc + eslint clean. Transformed strings executed end-to-end against the live agent-browser **0.27.2** CLI:

| input | before | after |
|---|---|---|
| `document.title` | "Example Domain" | unchanged (raw) |
| `const t=…; return t;` | ✗ Illegal return | ✅ value |
| `const x=1; return x;` then `const x=2; return x;` | ✗ already declared | ✅ `1` then `2` |
| `[...].map(a => a.href)` | array | ✅ array (raw — depth case) |
| `await Promise.resolve(42)` | ✗ await only valid in async | ✅ `42` |

Background: see `browser-tools-audit.md` "Second audit (2026-06-15)" — this is item **NEW-A**, the highest hit-rate-per-effort fix in the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)