### PR TITLE
Fix MCP policy setup default save

### DIFF
--- a/src/renderer/components/connections/connections-list.tsx
+++ b/src/renderer/components/connections/connections-list.tsx
@@ -95,6 +95,7 @@ export function NewIntegrationButton() {
           tools={newMcp.tools}
           open
           onOpenChange={(isOpen) => { if (!isOpen) setNewMcp(null) }}
+          allowSaveWithoutChanges
         />
       )}
     </>

--- a/src/renderer/components/connections/new-integration-button.test.tsx
+++ b/src/renderer/components/connections/new-integration-button.test.tsx
@@ -4,8 +4,10 @@ import { screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@renderer/test/test-utils'
 import { NewIntegrationButton } from './connections-list'
+import { useMcpOAuthListener } from '@renderer/hooks/use-mcp-oauth-listener'
 
 const MOCK_ACCOUNT_ID = 'new-account-123'
+const MOCK_MCP_ID = 'new-mcp-123'
 
 const mockApiFetch = vi.fn()
 vi.mock('@renderer/lib/api', () => ({
@@ -28,10 +30,12 @@ vi.mock('@renderer/hooks/use-mcp-oauth-listener', () => ({
 }))
 
 let capturedOAuthCallback: ((params: any) => void) | null = null
+let capturedMcpOAuthCallback: ((result: { success: boolean; error?: string }) => void) | null = null
 let originalElectronAPI: typeof window.electronAPI
+let lastToolPoliciesPutBody: { policies: Array<{ toolName: string; decision: string }> } | null = null
 
 function mockFetchResponses() {
-  mockApiFetch.mockImplementation(async (url: string) => {
+  mockApiFetch.mockImplementation(async (url: string, opts?: { method?: string; body?: string }) => {
     if (url === '/api/providers') {
       return {
         ok: true,
@@ -51,7 +55,44 @@ function mockFetchResponses() {
         }),
       }
     }
+    if (url === '/api/remote-mcps/initiate-oauth') {
+      return {
+        ok: true,
+        json: async () => ({ redirectUrl: 'https://oauth.example/authorize', state: 'oauth-state' }),
+      }
+    }
+    if (url === '/api/remote-mcps') {
+      return {
+        ok: true,
+        json: async () => ({
+          servers: [
+            {
+              id: MOCK_MCP_ID,
+              name: 'Linear',
+              url: 'https://mcp.linear.app/mcp',
+              authType: 'oauth',
+              status: 'active',
+              errorMessage: null,
+              tools: [
+                { name: 'list_issues', description: 'List issues' },
+                { name: 'create_issue', description: 'Create issue' },
+              ],
+              toolsDiscoveredAt: '2026-06-16T00:00:00.000Z',
+              createdAt: '2026-06-16T00:00:00.000Z',
+              updatedAt: '2026-06-16T00:00:00.000Z',
+            },
+          ],
+        }),
+      }
+    }
     if (url.startsWith('/api/policies/scope/')) {
+      return { ok: true, json: async () => ({ policies: [] }) }
+    }
+    if (url.startsWith('/api/policies/tool/')) {
+      if (opts?.method === 'PUT') {
+        lastToolPoliciesPutBody = JSON.parse(opts.body as string)
+        return { ok: true, json: async () => ({ ok: true }) }
+      }
       return { ok: true, json: async () => ({ policies: [] }) }
     }
     return { ok: true, json: async () => ({}) }
@@ -61,12 +102,18 @@ function mockFetchResponses() {
 beforeEach(() => {
   originalElectronAPI = window.electronAPI
   vi.clearAllMocks()
+  capturedMcpOAuthCallback = null
+  lastToolPoliciesPutBody = null
   mockFetchResponses()
+  vi.mocked(useMcpOAuthListener).mockImplementation((active, onComplete) => {
+    if (active) capturedMcpOAuthCallback = onComplete
+  })
 })
 
 afterEach(() => {
   window.electronAPI = originalElectronAPI
   capturedOAuthCallback = null
+  capturedMcpOAuthCallback = null
 })
 
 describe('NewIntegrationButton — post-OAuth policy editor', () => {
@@ -151,5 +198,27 @@ describe('NewIntegrationButton — post-OAuth policy editor', () => {
       expect(screen.queryByText('Add New Connection')).not.toBeInTheDocument()
     })
     expect(screen.queryByText(/Successfully Connected/i)).not.toBeInTheDocument()
+  })
+
+  it('lets a newly connected MCP save default tool policies', async () => {
+    window.electronAPI = undefined
+
+    renderWithProviders(<NewIntegrationButton />)
+
+    await userEvent.click(screen.getByTestId('connections-add-button'))
+    await userEvent.click(screen.getByTestId('directory-tab-mcps'))
+    await userEvent.click(screen.getByTestId('directory-connect-mcp-linear'))
+    await userEvent.click(screen.getByTestId('mcp-form-submit'))
+
+    await waitFor(() => expect(capturedMcpOAuthCallback).not.toBeNull())
+
+    await act(async () => {
+      capturedMcpOAuthCallback!({ success: true })
+    })
+
+    await waitFor(() => expect(screen.getByTestId('tool-policy-save')).toBeEnabled())
+
+    await userEvent.click(screen.getByTestId('tool-policy-save'))
+    await waitFor(() => expect(lastToolPoliciesPutBody).toEqual({ policies: [] }))
   })
 })

--- a/src/renderer/components/settings/tool-policy-editor.test.tsx
+++ b/src/renderer/components/settings/tool-policy-editor.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ToolPolicyEditor } from './tool-policy-editor'
 import { renderWithProviders, screen, waitFor, within } from '@renderer/test/test-utils'
+import type { ComponentProps } from 'react'
 
 // Route apiFetch: GET returns the configured policies fixture; PUT captures its body.
 let policiesFixture: Array<{ toolName: string; decision: string }> = []
@@ -26,9 +27,19 @@ const TOOLS = [
 const toolToggle = (tool: string, decision: 'allow' | 'review' | 'block') =>
   within(screen.getByTestId(`tool-row-${tool}`)).getByTestId(`policy-toggle-${decision}`)
 
-const renderEditor = (mcpId: string) =>
+const renderEditor = (
+  mcpId: string,
+  props: Partial<ComponentProps<typeof ToolPolicyEditor>> = {},
+) =>
   renderWithProviders(
-    <ToolPolicyEditor mcpId={mcpId} mcpName="Test MCP" tools={TOOLS} open onOpenChange={() => {}} />,
+    <ToolPolicyEditor
+      mcpId={mcpId}
+      mcpName="Test MCP"
+      tools={TOOLS}
+      open
+      onOpenChange={() => {}}
+      {...props}
+    />,
   )
 
 describe('ToolPolicyEditor — Save enable/disable', () => {
@@ -62,6 +73,17 @@ describe('ToolPolicyEditor — Save enable/disable', () => {
 
     toolToggle('send', 'block').click()
     await waitFor(() => expect(screen.getByTestId('tool-policy-save')).toBeEnabled())
+  })
+
+  it('allows setup flow to save defaults for a fresh MCP', async () => {
+    policiesFixture = []
+    renderEditor('mcp-new', { allowSaveWithoutChanges: true })
+    await waitFor(() => expect(screen.getByTestId('tool-row-send')).toBeInTheDocument())
+
+    expect(screen.getByTestId('tool-policy-save')).toBeEnabled()
+
+    screen.getByTestId('tool-policy-save').click()
+    await waitFor(() => expect(lastPutBody).toEqual({ policies: [] }))
   })
 
   it('re-disables Save after a successful save', async () => {

--- a/src/renderer/components/settings/tool-policy-editor.tsx
+++ b/src/renderer/components/settings/tool-policy-editor.tsx
@@ -45,6 +45,7 @@ interface ToolPolicyEditorBodyProps {
   onSaved?: () => void
   onCancel?: () => void
   hideActions?: boolean
+  allowSaveWithoutChanges?: boolean
 }
 
 /**
@@ -57,6 +58,7 @@ export function ToolPolicyEditorBody({
   onSaved,
   onCancel,
   hideActions,
+  allowSaveWithoutChanges = false,
 }: ToolPolicyEditorBodyProps) {
   const queryClient = useQueryClient()
   const [policies, setPolicies] = useState<ToolPolicy[]>([])
@@ -132,6 +134,7 @@ export function ToolPolicyEditorBody({
   const currentSnapshot = useMemo(() => serializePolicies(currentBatch), [currentBatch])
   // Save is only meaningful when the editor differs from what's persisted.
   const isDirty = currentSnapshot !== savedSnapshot
+  const canSave = isDirty || allowSaveWithoutChanges
 
   const handleSave = async () => {
     setSaving(true)
@@ -269,7 +272,7 @@ export function ToolPolicyEditorBody({
               Cancel
             </Button>
           )}
-          <Button data-testid="tool-policy-save" size="sm" onClick={handleSave} disabled={saving || !isDirty}>
+          <Button data-testid="tool-policy-save" size="sm" onClick={handleSave} disabled={saving || !canSave}>
             {saving && <Loader2 className="h-4 w-4 animate-spin mr-1" />}
             Save Policies
           </Button>
@@ -285,6 +288,7 @@ interface ToolPolicyEditorProps {
   tools: Array<{ name: string; description?: string }>
   open: boolean
   onOpenChange: (open: boolean) => void
+  allowSaveWithoutChanges?: boolean
 }
 
 export function ToolPolicyEditor({
@@ -293,6 +297,7 @@ export function ToolPolicyEditor({
   tools,
   open,
   onOpenChange,
+  allowSaveWithoutChanges,
 }: ToolPolicyEditorProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -306,6 +311,7 @@ export function ToolPolicyEditor({
           tools={tools}
           onSaved={() => onOpenChange(false)}
           onCancel={() => onOpenChange(false)}
+          allowSaveWithoutChanges={allowSaveWithoutChanges}
         />
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary

Fixes SUP-266 by letting the post-OAuth MCP setup flow save the default tool policy state without requiring the user to customize a granular permission first.

## Root Cause

ToolPolicyEditor only enabled Save when the current policy snapshot differed from the persisted snapshot. A newly connected MCP with no custom policies has an empty/default snapshot, so the setup modal treated the default configuration as nothing to save and disabled Save.

## Changes

- Added an opt-in allowSaveWithoutChanges mode to ToolPolicyEditor.
- Enabled that mode only for newly connected MCPs opened from the connection flow.
- Kept ordinary policy editing behavior unchanged: Save remains disabled when there are no changes.
- Added regression coverage for the editor and the MCP post-OAuth connection flow.

## Validation

- npm run test:run -- src/renderer/components/settings/tool-policy-editor.test.tsx src/renderer/components/connections/new-integration-button.test.tsx
- npm run typecheck