### PR TITLE
Add inline cron rename

### DIFF
--- a/src/api/routes/scheduled-tasks.test.ts
+++ b/src/api/routes/scheduled-tasks.test.ts
@@ -9,6 +9,7 @@ const mockMarkTaskExecuted = vi.fn()
 const mockRecordManualExecution = vi.fn()
 const mockUpdateScheduleExpression = vi.fn()
 const mockUpdateTaskPrompt = vi.fn()
+const mockUpdateTaskName = vi.fn()
 const mockUpdateTaskRuntimeOptions = vi.fn()
 const mockPauseScheduledTask = vi.fn()
 const mockResumeScheduledTask = vi.fn()
@@ -22,6 +23,7 @@ vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   recordManualExecution: (...args: unknown[]) => mockRecordManualExecution(...args),
   updateScheduleExpression: (...args: unknown[]) => mockUpdateScheduleExpression(...args),
   updateTaskPrompt: (...args: unknown[]) => mockUpdateTaskPrompt(...args),
+  updateTaskName: (...args: unknown[]) => mockUpdateTaskName(...args),
   updateTaskRuntimeOptions: (...args: unknown[]) => mockUpdateTaskRuntimeOptions(...args),
   pauseScheduledTask: (...args: unknown[]) => mockPauseScheduledTask(...args),
   resumeScheduledTask: (...args: unknown[]) => mockResumeScheduledTask(...args),
@@ -176,6 +178,7 @@ describe('scheduled-tasks route', () => {
     mockPauseScheduledTask.mockResolvedValue(true)
     mockResumeScheduledTask.mockResolvedValue(true)
     mockUpdateScheduleExpression.mockResolvedValue(true)
+    mockUpdateTaskName.mockResolvedValue(true)
   })
 
   it('returns task sessions with live activity from the message persister', async () => {
@@ -265,6 +268,54 @@ describe('scheduled-tasks route', () => {
     expect(res.status).toBe(400)
     expect(await res.json()).toEqual({ error: 'Invalid cron expression' })
     expect(mockUpdateScheduleExpression).not.toHaveBeenCalled()
+  })
+
+  it('renames a scheduled task title', async () => {
+    mockUpdateTaskName.mockImplementation(async (_taskId: string, name: string) => {
+      task = createTask({ name })
+      return true
+    })
+
+    const res = await app.request('http://localhost/api/scheduled-tasks/task-1/name', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: '  Weekly digest  ' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ id: 'task-1', name: 'Weekly digest' })
+    expect(mockUpdateTaskName).toHaveBeenCalledWith('task-1', 'Weekly digest')
+    expect(mockLogAuditEvent).toHaveBeenCalledWith(expect.objectContaining({
+      object: 'task',
+      objectId: 'task-1',
+      action: 'updated',
+      details: { field: 'name' },
+    }))
+  })
+
+  it('rejects blank scheduled task names', async () => {
+    const res = await app.request('http://localhost/api/scheduled-tasks/task-1/name', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: '   ' }),
+    })
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'name is required and must be a non-empty string' })
+    expect(mockUpdateTaskName).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when a scheduled task name cannot be updated', async () => {
+    mockUpdateTaskName.mockResolvedValue(false)
+
+    const res = await app.request('http://localhost/api/scheduled-tasks/task-1/name', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Weekly digest' }),
+    })
+
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: 'Task not found or not editable' })
   })
 
   it('returns 422 when the LLM generates an invalid cron expression', async () => {

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -16,6 +16,7 @@ import {
   recordManualExecution,
   updateScheduleExpression,
   updateTaskPrompt,
+  updateTaskName,
   updateTaskRuntimeOptions,
   pauseScheduledTask,
   resumeScheduledTask,
@@ -174,6 +175,31 @@ scheduledTasksRouter.patch('/:taskId/prompt', TaskAgentRole('user'), async (c) =
   } catch (error) {
     console.error('Failed to update scheduled task prompt:', error)
     return c.json({ error: 'Failed to update prompt' }, 500)
+  }
+})
+
+// PATCH /api/scheduled-tasks/:taskId/name - Rename a scheduled task
+scheduledTasksRouter.patch('/:taskId/name', TaskAgentRole('user'), async (c) => {
+  try {
+    const task = c.get('scheduledTask' as never) as Awaited<ReturnType<typeof getScheduledTask>>
+    const body = await c.req.json().catch(() => ({}))
+    const { name } = body as { name?: unknown }
+
+    if (typeof name !== 'string' || !name.trim()) {
+      return c.json({ error: 'name is required and must be a non-empty string' }, 400)
+    }
+
+    const updated = await updateTaskName(task!.id, name.trim())
+    if (!updated) {
+      return c.json({ error: 'Task not found or not editable' }, 404)
+    }
+
+    const refreshed = await getScheduledTask(task!.id)
+    logAuditEvent({ userId: getCurrentUserId(c), object: 'task', objectId: task!.id, action: 'updated', details: { field: 'name' } })
+    return c.json(refreshed)
+  } catch (error) {
+    console.error('Failed to update scheduled task name:', error)
+    return c.json({ error: 'Failed to update name' }, 500)
   }
 })
 

--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, act } from '@testing-library/react'
+import { screen, act, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AgentHome } from './agent-home'
 import { renderWithProviders } from '@renderer/test/test-utils'
@@ -23,6 +23,24 @@ const mockCreateSession = {
   mutateAsync: vi.fn().mockResolvedValue({ id: 'session-123', initialMessageUuid: 'srv-msg-uuid' }),
   isPending: false,
 }
+
+const mockUpdateAgentMutate = vi.fn()
+const mockUpdateAgentMutateAsync = vi.fn()
+const mockDeleteAgentMutate = vi.fn()
+
+vi.mock('@renderer/hooks/use-agents', () => ({
+  useAgent: () => ({ data: { ...testAgent, mounts: [] } }),
+  useAgents: () => ({ data: [testAgent] }),
+  useUpdateAgent: () => ({
+    mutate: mockUpdateAgentMutate,
+    mutateAsync: mockUpdateAgentMutateAsync,
+    isPending: false,
+  }),
+  useDeleteAgent: () => ({
+    mutate: mockDeleteAgentMutate,
+    isPending: false,
+  }),
+}))
 
 // Default to "loaded, empty" — most tests don't care, and the new
 // first-session Opus tests want this state. Specific tests that need a
@@ -133,6 +151,9 @@ vi.mock('@renderer/hooks/use-agent-skills', () => ({
   useAgentSkills: () => ({ data: [] }),
   useDiscoverableSkills: () => ({ data: [] }),
   useRefreshAgentSkills: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateSkill: () => ({ mutate: vi.fn(), isPending: false }),
+  useExportSkill: () => ({ mutate: vi.fn(), isPending: false }),
+  useImportSkillZip: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }))
 
 const mockRuntimeStatus = {
@@ -167,6 +188,7 @@ describe('AgentHome', () => {
     vi.clearAllMocks()
     mockCreateSession.isPending = false
     mockCreateSession.mutateAsync.mockResolvedValue({ id: 'session-123', initialMessageUuid: 'srv-msg-uuid' })
+    mockUpdateAgentMutateAsync.mockResolvedValue({ ...testAgent })
     mockComposer.message = ''
     mockComposer.attachments = []
     mockComposer.isUploading = false
@@ -188,6 +210,27 @@ describe('AgentHome', () => {
       <AgentHome agent={testAgent} onSessionCreated={onSessionCreated} />
     )
     expect(screen.getByText('Test Agent')).toBeInTheDocument()
+  })
+
+  it('renames the agent inline for owners', async () => {
+    const user = userEvent.setup()
+    mockCanAdminAgent = true
+
+    renderWithProviders(
+      <AgentHome agent={testAgent} onSessionCreated={onSessionCreated} />
+    )
+
+    await user.click(screen.getByTestId('agent-name'))
+    await user.clear(screen.getByTestId('agent-name-input'))
+    await user.type(screen.getByTestId('agent-name-input'), 'Renamed Agent')
+    await user.click(screen.getByTestId('agent-name-save'))
+
+    await waitFor(() => {
+      expect(mockUpdateAgentMutateAsync).toHaveBeenCalledWith({
+        slug: 'test-agent',
+        name: 'Renamed Agent',
+      })
+    })
   })
 
   it('renders textarea with placeholder', () => {

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -3,7 +3,7 @@ import { useState, useRef, useMemo, useCallback, useEffect } from 'react'
 import { cn } from '@shared/lib/utils/cn'
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
-import { ArrowUp, Loader2, Eye, Settings2, Maximize2, Minimize2, Search, Check } from 'lucide-react'
+import { ArrowUp, Loader2, Eye, Settings2, Maximize2, Minimize2, Search } from 'lucide-react'
 import { useCreateSession, useSessions } from '@renderer/hooks/use-sessions'
 import { useScheduledTasks } from '@renderer/hooks/use-scheduled-tasks'
 import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
@@ -21,6 +21,7 @@ import { MountChoiceDialog } from '@renderer/components/ui/mount-choice-dialog'
 import { useMessageComposer } from '@renderer/hooks/use-message-composer'
 import { ChatComposerBox } from '@renderer/components/messages/chat-composer-box'
 import { ComposerOptions, useComposerOptions } from '@renderer/components/messages/composer-options'
+import { InlineEditableTitle } from '@renderer/components/ui/inline-editable-title'
 import { HomeTriggers } from './home-triggers'
 import { HomeSkills } from './home-skills'
 import { HomeExtras } from './home-extras'
@@ -97,35 +98,6 @@ export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHome
   // Tracks whether a name has already been assigned (e.g. by the voice agent)
   // so the post-submit deriveAgentName fallback doesn't clobber it.
   const nameAssignedRef = useRef(false)
-  const [isEditingName, setIsEditingName] = useState(false)
-  const [editedName, setEditedName] = useState(agent.name)
-
-  const handleStartRename = () => {
-    setEditedName(agent.name)
-    setIsEditingName(true)
-  }
-
-  const handleCancelRename = () => {
-    setIsEditingName(false)
-    setEditedName(agent.name)
-  }
-
-  const handleSaveRename = async () => {
-    const trimmed = editedName.trim()
-    if (!trimmed || trimmed === agent.name) {
-      handleCancelRename()
-      return
-    }
-    try {
-      await updateAgent.mutateAsync({ slug: agent.slug, name: trimmed })
-      setIsEditingName(false)
-    } catch (error) {
-      console.error('Failed to rename agent:', error)
-      toast.error('Failed to rename agent', {
-        description: error instanceof Error ? error.message : 'Please try again.',
-      })
-    }
-  }
 
   const sessions = useMemo(() => {
     if (!Array.isArray(sessionsData)) return []
@@ -284,56 +256,28 @@ export function AgentHome({ agent, onSessionCreated, onOpenSettings }: AgentHome
         {/* Left Column — Chat composer + Sessions */}
         <div className="space-y-6 w-full min-w-0 xl:min-w-[480px] xl:max-w-[720px]">
           <div className="flex items-center justify-between gap-2 intro-step intro-step-1">
-            {isEditingName && isOwner ? (
-              <div className="flex items-center gap-2 flex-1 min-w-0">
-                <Input
-                  value={editedName}
-                  onChange={(e) => setEditedName(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      e.preventDefault()
-                      handleSaveRename()
-                    } else if (e.key === 'Escape') {
-                      e.preventDefault()
-                      handleCancelRename()
-                    }
-                  }}
-                  autoFocus
-                  disabled={updateAgent.isPending}
-                  className="h-9 text-xl font-semibold"
-                  data-testid="agent-name-input"
-                />
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="ghost"
-                  className="h-8 w-8 shrink-0"
-                  onClick={handleSaveRename}
-                  disabled={updateAgent.isPending}
-                  aria-label="Save name"
-                  data-testid="agent-name-save"
-                >
-                  {updateAgent.isPending ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Check className="h-4 w-4" />
-                  )}
-                </Button>
-              </div>
-            ) : isOwner ? (
-              <button
-                type="button"
-                className="text-xl font-semibold truncate text-left cursor-pointer hover:opacity-80"
-                onClick={handleStartRename}
-                data-testid="agent-name"
-              >
-                {agent.name}
-              </button>
-            ) : (
-              <h1 className="text-xl font-semibold truncate" data-testid="agent-name">
-                {agent.name}
-              </h1>
-            )}
+            <InlineEditableTitle
+              value={agent.name}
+              canEdit={isOwner}
+              isSaving={updateAgent.isPending}
+              onSave={async (name) => {
+                await updateAgent.mutateAsync({ slug: agent.slug, name })
+              }}
+              onError={(error) => {
+                console.error('Failed to rename agent:', error)
+                toast.error('Failed to rename agent', {
+                  description: error instanceof Error ? error.message : 'Please try again.',
+                })
+              }}
+              displayClassName="text-xl font-semibold"
+              inputClassName="h-9 text-xl font-semibold"
+              saveButtonClassName="h-8 w-8"
+              ariaLabel="Rename agent"
+              saveAriaLabel="Save name"
+              displayTestId="agent-name"
+              inputTestId="agent-name-input"
+              saveButtonTestId="agent-name-save"
+            />
             <Button type="button" size="icon" variant="ghost" className="h-8 w-8 shrink-0" onClick={() => onOpenSettings?.()} aria-label="Agent settings" data-testid="agent-settings-button">
               <Settings2 className="h-4 w-4" />
             </Button>

--- a/src/renderer/components/layout/settings-page.tsx
+++ b/src/renderer/components/layout/settings-page.tsx
@@ -35,7 +35,7 @@ export function SettingsPageContainer({ children, className, fullScreen, fullWid
 }
 
 interface PageTitleProps {
-  title: string
+  title: ReactNode
   back?: { onClick: () => void; label?: string; testId?: string }
   actions?: ReactNode
 }
@@ -60,7 +60,11 @@ export function PageTitle({ title, back, actions }: PageTitleProps) {
         </Button>
       )}
       <div className="flex items-end justify-between gap-4">
-        <h2 className="text-xl font-medium">{title}</h2>
+        {typeof title === 'string' ? (
+          <h2 className="text-xl font-medium">{title}</h2>
+        ) : (
+          <div className="min-w-0 flex-1">{title}</div>
+        )}
         {actions && <div className="shrink-0">{actions}</div>}
       </div>
     </div>

--- a/src/renderer/components/scheduled-tasks/scheduled-task-view.test.tsx
+++ b/src/renderer/components/scheduled-tasks/scheduled-task-view.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderWithProviders, screen, userEvent, waitFor } from '@renderer/test/test-utils'
+import type { ApiScheduledTask } from '@shared/lib/types/api'
+
+const mockSetView = vi.fn()
+const mockHandleScheduledTaskDeleted = vi.fn()
+const mockUpdateScheduledTaskName = vi.fn()
+const mockCancelScheduledTask = vi.fn()
+let mockCanUseAgent = true
+let mockTask: ApiScheduledTask
+
+vi.mock('@renderer/context/selection-context', () => ({
+  useSelection: () => ({
+    selectedAgentSlug: 'agent-one',
+    view: { kind: 'task', id: 'task-1' },
+    setView: mockSetView,
+    handleScheduledTaskDeleted: mockHandleScheduledTaskDeleted,
+  }),
+  SelectionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@renderer/context/user-context', () => ({
+  useUser: () => ({
+    canUseAgent: () => mockCanUseAgent,
+  }),
+  UserProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@renderer/hooks/use-humanized-cron', () => ({
+  useHumanizedCron: () => 'Every day at 9:00 AM',
+}))
+
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useSettings: () => ({
+    data: {
+      llmProvider: 'anthropic',
+      models: { agentModel: 'claude-sonnet' },
+      llmProviderStatus: [
+        {
+          id: 'anthropic',
+          composerModels: [
+            { family: 'sonnet', modelId: 'claude-sonnet', label: 'Sonnet' },
+          ],
+        },
+      ],
+    },
+  }),
+}))
+
+vi.mock('@renderer/hooks/use-scheduled-tasks', () => ({
+  useScheduledTask: () => ({ data: mockTask, isLoading: false, error: null }),
+  useScheduledTaskSessions: () => ({ data: [] }),
+  useCancelScheduledTask: () => ({ mutateAsync: mockCancelScheduledTask, isPending: false }),
+  useUpdateScheduledTaskTimezone: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRunScheduledTaskNow: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  usePauseScheduledTask: () => ({ mutate: vi.fn(), isPending: false }),
+  useResumeScheduledTask: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateScheduledTaskPrompt: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateScheduledTaskName: () => ({
+    mutateAsync: mockUpdateScheduledTaskName,
+    isPending: false,
+  }),
+  useUpdateScheduledTaskRuntimeOptions: () => ({ mutate: vi.fn(), isPending: false }),
+  useDescribeSchedule: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useParseSchedule: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateSchedule: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}))
+
+import { ScheduledTaskView } from './scheduled-task-view'
+
+function createTask(overrides: Partial<ApiScheduledTask> = {}): ApiScheduledTask {
+  return {
+    id: 'task-1',
+    agentSlug: 'agent-one',
+    scheduleType: 'cron',
+    scheduleExpression: '0 9 * * *',
+    prompt: 'Summarize yesterday',
+    name: 'Daily report',
+    status: 'pending',
+    nextExecutionAt: new Date('2026-06-16T16:00:00.000Z'),
+    lastExecutedAt: null,
+    isRecurring: true,
+    executionCount: 0,
+    lastSessionId: null,
+    createdBySessionId: null,
+    timezone: 'UTC',
+    model: null,
+    effort: null,
+    createdAt: new Date('2026-06-15T16:00:00.000Z'),
+    cancelledAt: null,
+    pausedAt: null,
+    ...overrides,
+  }
+}
+
+describe('ScheduledTaskView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockTask = createTask()
+    mockCanUseAgent = true
+    mockUpdateScheduledTaskName.mockResolvedValue(createTask({ name: 'Weekly report' }))
+  })
+
+  it('renames the cron inline from the title', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<ScheduledTaskView taskId="task-1" agentSlug="agent-one" />)
+
+    await user.click(screen.getByTestId('scheduled-task-title'))
+    await user.clear(screen.getByTestId('scheduled-task-title-input'))
+    await user.type(screen.getByTestId('scheduled-task-title-input'), 'Weekly report')
+    await user.click(screen.getByTestId('scheduled-task-title-save'))
+
+    await waitFor(() => {
+      expect(mockUpdateScheduledTaskName).toHaveBeenCalledWith({
+        taskId: 'task-1',
+        agentSlug: 'agent-one',
+        name: 'Weekly report',
+      })
+    })
+  })
+
+  it('does not show rename in the gear menu', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<ScheduledTaskView taskId="task-1" agentSlug="agent-one" />)
+
+    await user.click(screen.getByRole('button', { name: 'Cron settings' }))
+
+    expect(screen.queryByText('Rename Cron')).not.toBeInTheDocument()
+    expect(screen.getByText('Edit Schedule')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
+++ b/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
@@ -10,6 +10,7 @@ import { Trash2, Play, Pencil, Loader2, Settings as SettingsIcon } from 'lucide-
 import { useHumanizedCron } from '@renderer/hooks/use-humanized-cron'
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
+import { InlineEditableTitle } from '@renderer/components/ui/inline-editable-title'
 import { Label } from '@renderer/components/ui/label'
 import { TimezonePicker } from '@renderer/components/ui/timezone-picker'
 import { DetailCard } from '@renderer/components/triggers/detail-card'
@@ -28,6 +29,7 @@ import {
   useParseSchedule,
   useUpdateSchedule,
   useUpdateScheduledTaskPrompt,
+  useUpdateScheduledTaskName,
   useUpdateScheduledTaskRuntimeOptions,
   usePauseScheduledTask,
   useResumeScheduledTask,
@@ -55,6 +57,7 @@ import {
 } from '@renderer/components/ui/dialog'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { SettingsPageContainer, PageTitle } from '@renderer/components/layout/settings-page'
+import { toast } from 'sonner'
 
 interface ScheduledTaskViewProps {
   taskId: string
@@ -71,6 +74,7 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
   const pauseTask = usePauseScheduledTask()
   const resumeTask = useResumeScheduledTask()
   const updatePrompt = useUpdateScheduledTaskPrompt()
+  const updateName = useUpdateScheduledTaskName()
   const updateRuntimeOptions = useUpdateScheduledTaskRuntimeOptions()
   const { handleScheduledTaskDeleted, setView } = useSelection()
   const { canUseAgent } = useUser()
@@ -114,6 +118,8 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
   }
 
   const taskTzLabel = task?.timezone?.replace(/_/g, ' ') || 'UTC'
+  const taskTitle = task?.name || 'Scheduled Task'
+  const canEditTaskName = Boolean(isActive && canCancel)
 
   const handleCancel = async () => {
     try {
@@ -131,6 +137,10 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
     } catch (err) {
       console.error('Failed to run scheduled task:', err)
     }
+  }
+
+  const handleSaveName = async (name: string) => {
+    await updateName.mutateAsync({ taskId, agentSlug, name })
   }
 
   const handleOpenEditSchedule = async () => {
@@ -287,7 +297,29 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
   return (
     <SettingsPageContainer fullScreen>
       <PageTitle
-        title={task.name || 'Scheduled Task'}
+        title={
+          <InlineEditableTitle
+            value={taskTitle}
+            canEdit={canEditTaskName}
+            isSaving={updateName.isPending}
+            onSave={handleSaveName}
+            onError={(err) => {
+              console.error('Failed to rename scheduled task:', err)
+              toast.error('Failed to rename cron', {
+                description: err instanceof Error ? err.message : 'Please try again.',
+              })
+            }}
+            displayClassName="text-xl font-medium"
+            inputClassName="h-9 text-xl font-medium"
+            saveButtonClassName="h-8 w-8"
+            readOnlyAs="h2"
+            ariaLabel="Rename cron"
+            saveAriaLabel="Save cron name"
+            displayTestId="scheduled-task-title"
+            inputTestId="scheduled-task-title-input"
+            saveButtonTestId="scheduled-task-title-save"
+          />
+        }
         back={{
           onClick: () => setView({ kind: 'home' }),
           testId: 'scheduled-task-back-button',

--- a/src/renderer/components/ui/inline-editable-title.test.tsx
+++ b/src/renderer/components/ui/inline-editable-title.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { InlineEditableTitle } from './inline-editable-title'
+
+describe('InlineEditableTitle', () => {
+  it('enters edit mode when the title is clicked', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <InlineEditableTitle
+        value="Daily report"
+        canEdit
+        isSaving={false}
+        onSave={vi.fn()}
+        displayTestId="title"
+        inputTestId="title-input"
+      />,
+    )
+
+    await user.click(screen.getByTestId('title'))
+
+    expect(screen.getByTestId('title-input')).toHaveValue('Daily report')
+  })
+
+  it('saves a trimmed title from the save button', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <InlineEditableTitle
+        value="Daily report"
+        canEdit
+        isSaving={false}
+        onSave={onSave}
+        displayTestId="title"
+        inputTestId="title-input"
+        saveButtonTestId="title-save"
+      />,
+    )
+
+    await user.click(screen.getByTestId('title'))
+    await user.clear(screen.getByTestId('title-input'))
+    await user.type(screen.getByTestId('title-input'), '  Weekly report  ')
+    await user.click(screen.getByTestId('title-save'))
+
+    expect(onSave).toHaveBeenCalledWith('Weekly report')
+    expect(screen.queryByTestId('title-input')).not.toBeInTheDocument()
+  })
+
+  it('saves from Enter', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <InlineEditableTitle
+        value="Daily report"
+        canEdit
+        isSaving={false}
+        onSave={onSave}
+        displayTestId="title"
+        inputTestId="title-input"
+      />,
+    )
+
+    await user.click(screen.getByTestId('title'))
+    await user.clear(screen.getByTestId('title-input'))
+    await user.type(screen.getByTestId('title-input'), 'Weekly report{Enter}')
+
+    expect(onSave).toHaveBeenCalledWith('Weekly report')
+  })
+
+  it('cancels from Escape without saving', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+
+    render(
+      <InlineEditableTitle
+        value="Daily report"
+        canEdit
+        isSaving={false}
+        onSave={onSave}
+        displayTestId="title"
+        inputTestId="title-input"
+      />,
+    )
+
+    await user.click(screen.getByTestId('title'))
+    await user.type(screen.getByTestId('title-input'), ' changed')
+    await user.keyboard('{Escape}')
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('title-input')).not.toBeInTheDocument()
+    expect(screen.getByTestId('title')).toHaveTextContent('Daily report')
+  })
+
+  it('closes without saving blank or unchanged titles', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+
+    const { rerender } = render(
+      <InlineEditableTitle
+        value="Daily report"
+        canEdit
+        isSaving={false}
+        onSave={onSave}
+        displayTestId="title"
+        inputTestId="title-input"
+        saveButtonTestId="title-save"
+      />,
+    )
+
+    await user.click(screen.getByTestId('title'))
+    await user.click(screen.getByTestId('title-save'))
+    expect(onSave).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('title-input')).not.toBeInTheDocument()
+
+    rerender(
+      <InlineEditableTitle
+        value="Daily report"
+        canEdit
+        isSaving={false}
+        onSave={onSave}
+        displayTestId="title"
+        inputTestId="title-input"
+        saveButtonTestId="title-save"
+      />,
+    )
+
+    await user.click(screen.getByTestId('title'))
+    await user.clear(screen.getByTestId('title-input'))
+    await user.type(screen.getByTestId('title-input'), '   ')
+    await user.click(screen.getByTestId('title-save'))
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('title-input')).not.toBeInTheDocument()
+  })
+
+  it('keeps editing and reports errors when save fails', async () => {
+    const user = userEvent.setup()
+    const error = new Error('Nope')
+    const onSave = vi.fn().mockRejectedValue(error)
+    const onError = vi.fn()
+
+    render(
+      <InlineEditableTitle
+        value="Daily report"
+        canEdit
+        isSaving={false}
+        onSave={onSave}
+        onError={onError}
+        displayTestId="title"
+        inputTestId="title-input"
+        saveButtonTestId="title-save"
+      />,
+    )
+
+    await user.click(screen.getByTestId('title'))
+    await user.clear(screen.getByTestId('title-input'))
+    await user.type(screen.getByTestId('title-input'), 'Weekly report')
+    await user.click(screen.getByTestId('title-save'))
+
+    expect(onError).toHaveBeenCalledWith(error)
+    expect(screen.getByTestId('title-input')).toBeInTheDocument()
+  })
+
+  it('renders read-only headings when editing is disabled', () => {
+    render(
+      <InlineEditableTitle
+        value="Daily report"
+        canEdit={false}
+        isSaving={false}
+        onSave={vi.fn()}
+        readOnlyAs="h2"
+        displayTestId="title"
+      />,
+    )
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Daily report' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Daily report' })).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/ui/inline-editable-title.tsx
+++ b/src/renderer/components/ui/inline-editable-title.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react'
+import { Check, Loader2 } from 'lucide-react'
+import { Button } from '@renderer/components/ui/button'
+import { Input } from '@renderer/components/ui/input'
+import { cn } from '@shared/lib/utils/cn'
+
+type HeadingLevel = 'h1' | 'h2'
+
+interface InlineEditableTitleProps {
+  value: string
+  canEdit: boolean
+  isSaving: boolean
+  onSave: (value: string) => void | Promise<void>
+  onError?: (error: unknown) => void
+  displayClassName?: string
+  inputClassName?: string
+  editContainerClassName?: string
+  saveButtonClassName?: string
+  readOnlyAs?: HeadingLevel
+  ariaLabel?: string
+  saveAriaLabel?: string
+  displayTestId?: string
+  inputTestId?: string
+  saveButtonTestId?: string
+}
+
+export function InlineEditableTitle({
+  value,
+  canEdit,
+  isSaving,
+  onSave,
+  onError,
+  displayClassName,
+  inputClassName,
+  editContainerClassName,
+  saveButtonClassName,
+  readOnlyAs = 'h1',
+  ariaLabel = 'Edit title',
+  saveAriaLabel = 'Save title',
+  displayTestId,
+  inputTestId,
+  saveButtonTestId,
+}: InlineEditableTitleProps) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+
+  useEffect(() => {
+    if (!isEditing) setDraft(value)
+  }, [isEditing, value])
+
+  const cancel = () => {
+    setDraft(value)
+    setIsEditing(false)
+  }
+
+  const save = async () => {
+    const trimmed = draft.trim()
+    if (!trimmed || trimmed === value) {
+      cancel()
+      return
+    }
+
+    try {
+      await onSave(trimmed)
+      setIsEditing(false)
+    } catch (error) {
+      onError?.(error)
+    }
+  }
+
+  if (canEdit && isEditing) {
+    return (
+      <div className={cn('flex items-center gap-2 flex-1 min-w-0', editContainerClassName)}>
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              void save()
+            } else if (e.key === 'Escape') {
+              e.preventDefault()
+              cancel()
+            }
+          }}
+          autoFocus
+          disabled={isSaving}
+          className={inputClassName}
+          data-testid={inputTestId}
+        />
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className={cn('shrink-0', saveButtonClassName)}
+          onClick={() => { void save() }}
+          disabled={isSaving}
+          aria-label={saveAriaLabel}
+          data-testid={saveButtonTestId}
+        >
+          {isSaving ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Check className="h-4 w-4" />
+          )}
+        </Button>
+      </div>
+    )
+  }
+
+  if (canEdit) {
+    return (
+      <button
+        type="button"
+        className={cn('truncate text-left cursor-pointer hover:opacity-80', displayClassName)}
+        onClick={() => setIsEditing(true)}
+        aria-label={ariaLabel}
+        data-testid={displayTestId}
+      >
+        {value}
+      </button>
+    )
+  }
+
+  if (readOnlyAs === 'h2') {
+    return (
+      <h2 className={cn('truncate', displayClassName)} data-testid={displayTestId}>
+        {value}
+      </h2>
+    )
+  }
+
+  return (
+    <h1 className={cn('truncate', displayClassName)} data-testid={displayTestId}>
+      {value}
+    </h1>
+  )
+}

--- a/src/renderer/hooks/use-scheduled-tasks.ts
+++ b/src/renderer/hooks/use-scheduled-tasks.ts
@@ -210,6 +210,33 @@ export function useUpdateScheduledTaskPrompt() {
 }
 
 /**
+ * Update a scheduled task's display name
+ */
+export function useUpdateScheduledTaskName() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    meta: { skipGlobalErrorToast: true },
+    mutationFn: async ({ taskId, name }: { taskId: string; agentSlug: string; name: string }) => {
+      const res = await apiFetch(`/api/scheduled-tasks/${taskId}/name`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(err.error || 'Failed to update name')
+      }
+      return res.json() as Promise<ApiScheduledTask>
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['scheduled-task', data.id] })
+      queryClient.invalidateQueries({ queryKey: ['scheduled-tasks', data.agentSlug] })
+    },
+  })
+}
+
+/**
  * Update a scheduled task's runtime options (model and/or effort)
  */
 export function useUpdateScheduledTaskRuntimeOptions() {

--- a/src/shared/lib/services/scheduled-task-service.test.ts
+++ b/src/shared/lib/services/scheduled-task-service.test.ts
@@ -37,6 +37,7 @@ import {
   updateNextExecution,
   markTaskFailed,
   resetScheduledTask,
+  updateTaskName,
   deleteScheduledTask,
 } from './scheduled-task-service'
 
@@ -462,6 +463,45 @@ describe('scheduled-task-service', () => {
       const task = await getScheduledTask(taskId)
       expect(task!.status).toBe('failed')
       expect(task!.lastExecutedAt).not.toBeNull()
+    })
+  })
+
+  // ============================================================================
+  // updateTaskName Tests
+  // ============================================================================
+
+  describe('updateTaskName', () => {
+    it('updates the display name for a pending task', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'cron',
+        scheduleExpression: '0 9 * * *',
+        prompt: 'Test',
+        name: 'Old name',
+      })
+
+      const result = await updateTaskName(taskId, 'New name')
+
+      expect(result).toBe(true)
+      const task = await getScheduledTask(taskId)
+      expect(task!.name).toBe('New name')
+    })
+
+    it('does not update completed tasks', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Test',
+        name: 'Old name',
+      })
+      await markTaskExecuted(taskId, 'session-abc')
+
+      const result = await updateTaskName(taskId, 'New name')
+
+      expect(result).toBe(false)
+      const task = await getScheduledTask(taskId)
+      expect(task!.name).toBe('Old name')
     })
   })
 

--- a/src/shared/lib/services/scheduled-task-service.ts
+++ b/src/shared/lib/services/scheduled-task-service.ts
@@ -383,6 +383,25 @@ export async function updateTaskPrompt(
 }
 
 /**
+ * Update a scheduled task's display name.
+ * Allowed for pending or paused tasks.
+ */
+export async function updateTaskName(
+  taskId: string,
+  name: string,
+): Promise<boolean> {
+  const task = await getScheduledTask(taskId)
+  if (!task || (task.status !== 'pending' && task.status !== 'paused')) return false
+
+  const result = await db
+    .update(scheduledTasks)
+    .set({ name })
+    .where(eq(scheduledTasks.id, taskId))
+
+  return (result.changes ?? 0) > 0
+}
+
+/**
  * Update a recurring task's schedule expression and recalculate next execution time.
  */
 export async function updateScheduleExpression(


### PR DESCRIPTION
## Summary

Implements SUP-253 by allowing scheduled cron jobs to be renamed from the title itself instead of from the settings gear menu.

## Changes

- Added a scheduled-task name update service and `PATCH /api/scheduled-tasks/:taskId/name` route.
- Added a React Query hook for scheduled task title updates.
- Extracted reusable `InlineEditableTitle` for click-to-edit title behavior.
- Reused the shared inline title editor for agent names and cron titles.
- Removed cron rename from the gear menu; the gear menu now keeps schedule/delete actions.
- Added backend, reusable component, AgentHome regression, and ScheduledTaskView coverage.

## Validation

- `npm run test:run -- src/renderer/components/ui/inline-editable-title.test.tsx src/renderer/components/scheduled-tasks/scheduled-task-view.test.tsx src/renderer/components/agents/agent-home/agent-home.test.tsx src/api/routes/scheduled-tasks.test.ts src/shared/lib/services/scheduled-task-service.test.ts`
- `npm run typecheck`
- Focused ESLint over touched files
- `git diff --check`

Note: `npm rebuild better-sqlite3` was needed locally before running the service tests because the native module had a Node ABI mismatch.