### PR TITLE
fix: harden browser_input requirements against non-array model output + per-request-card error boundary

### DIFF
--- a/src/renderer/components/layout/session-chat-column.tsx
+++ b/src/renderer/components/layout/session-chat-column.tsx
@@ -2,6 +2,7 @@ import { MessageInput } from '@renderer/components/messages/message-input'
 import { SessionThread } from '@renderer/components/messages/session-thread'
 import { PendingRequestStack } from '@renderer/components/messages/pending-request-stack'
 import { renderPendingRequest, type RenderContext } from '@renderer/components/messages/pending-request-renderer'
+import { PendingRequestErrorBoundary } from '@renderer/components/messages/pending-request-error-boundary'
 import { usePendingRequests } from '@renderer/components/messages/use-pending-requests'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useFileDeliveryWatcher } from '@renderer/hooks/use-file-delivery-watcher'
@@ -60,7 +61,18 @@ export function SessionChatColumn({
         pendingRequestCount > 0 ? (
           <div className="px-4 pb-4" data-testid="pending-request-slot">
             <PendingRequestStack>
-              {pendingRequestItems.map((d) => renderPendingRequest(d, renderCtx))}
+              {pendingRequestItems.map((d) => (
+                <PendingRequestErrorBoundary
+                  key={d.key}
+                  sessionId={sessionId}
+                  agentSlug={agentSlug}
+                  onDismiss={d.onComplete}
+                  itemId={d.key}
+                  kind={d.kind}
+                >
+                  {renderPendingRequest(d, renderCtx)}
+                </PendingRequestErrorBoundary>
+              ))}
             </PendingRequestStack>
           </div>
         ) : (

--- a/src/renderer/components/messages/browser-input-request-item.test.tsx
+++ b/src/renderer/components/messages/browser-input-request-item.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders as render } from '@renderer/test/test-utils'
+import { BrowserInputRequestItem } from './browser-input-request-item'
+
+vi.mock('@renderer/lib/api', () => ({ apiFetch: vi.fn() }))
+
+const baseProps = {
+  toolUseId: 'tu-1',
+  message: 'Log in to the dashboard',
+  sessionId: 's-1',
+  agentSlug: 'agent-1',
+  onComplete: vi.fn(),
+}
+
+describe('BrowserInputRequestItem', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the requirements list when requirements is an array', () => {
+    render(<BrowserInputRequestItem {...baseProps} requirements={['Enter email', 'Solve 2FA']} />)
+    expect(screen.getByText('Enter email')).toBeInTheDocument()
+    expect(screen.getByText('Solve 2FA')).toBeInTheDocument()
+  })
+
+  // Regression for the "requirements.map is not a function" full-view crash.
+  // The model can emit `requirements` as a bare string instead of a string[].
+  // A non-empty string passes `.length > 0` and then throws on `.map` — and
+  // because request cards render outside the per-message error boundary, that
+  // throw blanked the entire chat view. The component must coerce non-arrays.
+  it('does not crash when requirements is a non-array string', () => {
+    expect(() =>
+      render(
+        <BrowserInputRequestItem
+          {...baseProps}
+          requirements={'Enter your email and password' as unknown as string[]}
+        />
+      )
+    ).not.toThrow()
+
+    // The request message still renders; the malformed requirements are dropped
+    // (not rendered as a stray string).
+    expect(screen.getByText('Log in to the dashboard')).toBeInTheDocument()
+    expect(screen.queryByText('Enter your email and password')).not.toBeInTheDocument()
+  })
+
+  it('does not render a requirements block when requirements is missing', () => {
+    render(
+      <BrowserInputRequestItem
+        {...baseProps}
+        requirements={undefined as unknown as string[]}
+      />
+    )
+    expect(screen.getByText('Log in to the dashboard')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/messages/browser-input-request-item.tsx
+++ b/src/renderer/components/messages/browser-input-request-item.tsx
@@ -32,6 +32,11 @@ export function BrowserInputRequestItem({
   const [submittingAction, setSubmittingAction] = useState<SubmittingAction | null>(null)
   const [error, setError] = useState<string | null>(null)
 
+  // `requirements` is typed string[] but originates from model tool input, so a
+  // malformed value (e.g. a bare string) can reach here. Normalize to an array
+  // before any `.length`/`.map` so a bad payload can't throw.
+  const safeRequirements = Array.isArray(requirements) ? requirements : []
+
   const submitBrowserInput = async (body: object, successStatus: RequestStatus, action: SubmittingAction) => {
     setStatus('submitting')
     setSubmittingAction(action)
@@ -102,11 +107,11 @@ export function BrowserInputRequestItem({
       data-testid={isCompleted ? 'browser-input-request-completed' : 'browser-input-request'}
       data-status={isCompleted ? status : undefined}
     >
-      {requirements.length > 0 && (
+      {safeRequirements.length > 0 && (
         <div className="pt-4">
           <div className="rounded-md border border-border bg-white p-3 dark:bg-background">
             <ul className="space-y-1.5">
-              {requirements.map((req, i) => (
+              {safeRequirements.map((req, i) => (
                 <li key={i} className="flex items-start gap-2 text-foreground">
                   <span className="mt-0.5 shrink-0 text-xs text-muted-foreground">{i + 1}.</span>
                   <span>{req}</span>

--- a/src/renderer/components/messages/pending-request-error-boundary.test.tsx
+++ b/src/renderer/components/messages/pending-request-error-boundary.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders as render } from '@renderer/test/test-utils'
+
+const mockApiFetch = vi.fn()
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}))
+
+const captureRendererException = vi.fn()
+vi.mock('@renderer/lib/error-reporting', () => ({
+  captureRendererException: (...args: unknown[]) => captureRendererException(...args),
+}))
+
+import { PendingRequestErrorBoundary } from './pending-request-error-boundary'
+
+function Boom(): never {
+  throw new Error('requirements.map is not a function')
+}
+
+const defaultProps = {
+  sessionId: 's-1',
+  agentSlug: 'agent-1',
+}
+
+describe('PendingRequestErrorBoundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Both useInterruptSession and useSendMessage go through apiFetch.
+    mockApiFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ success: true }) })
+  })
+
+  it('renders children when they do not throw', () => {
+    render(
+      <PendingRequestErrorBoundary {...defaultProps} onDismiss={vi.fn()}>
+        <div>healthy card</div>
+      </PendingRequestErrorBoundary>
+    )
+    expect(screen.getByText('healthy card')).toBeInTheDocument()
+    expect(screen.queryByTestId('pending-request-error-boundary')).not.toBeInTheDocument()
+  })
+
+  it('shows the fallback (not a crash) when a child throws', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(
+      <PendingRequestErrorBoundary {...defaultProps} onDismiss={vi.fn()}>
+        <Boom />
+      </PendingRequestErrorBoundary>
+    )
+    expect(screen.getByTestId('pending-request-error-boundary')).toBeInTheDocument()
+    expect(screen.getByText("This request couldn't be displayed")).toBeInTheDocument()
+    spy.mockRestore()
+  })
+
+  it('reports the error to Sentry with the request kind', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(
+      <PendingRequestErrorBoundary {...defaultProps} onDismiss={vi.fn()} itemId="tu-9" kind="browser_input">
+        <Boom />
+      </PendingRequestErrorBoundary>
+    )
+    expect(captureRendererException).toHaveBeenCalledTimes(1)
+    const [error, context] = captureRendererException.mock.calls[0] as [
+      Error,
+      { tags: Record<string, string>; extra: Record<string, unknown> },
+    ]
+    expect(error).toBeInstanceOf(Error)
+    expect(context.tags).toMatchObject({ feature: 'pending-request-render', request_kind: 'browser_input' })
+    expect(context.extra).toMatchObject({ itemId: 'tu-9' })
+    spy.mockRestore()
+  })
+
+  it('dismiss interrupts the session and sends corrective feedback, then clears the card', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const user = userEvent.setup()
+    const onDismiss = vi.fn()
+
+    render(
+      <PendingRequestErrorBoundary {...defaultProps} onDismiss={onDismiss}>
+        <Boom />
+      </PendingRequestErrorBoundary>
+    )
+
+    await user.click(screen.getByTestId('pending-request-error-dismiss'))
+
+    // The broken card is always cleared (onDismiss = the descriptor's onComplete).
+    await waitFor(() => expect(onDismiss).toHaveBeenCalledTimes(1))
+
+    const urls = mockApiFetch.mock.calls.map((c) => c[0] as string)
+    expect(urls.some((u) => u.includes('/agents/agent-1/sessions/s-1/interrupt'))).toBe(true)
+    expect(urls.some((u) => u.includes('/agents/agent-1/sessions/s-1/messages'))).toBe(true)
+
+    // The message body carries actionable feedback to the agent.
+    const messagesCall = mockApiFetch.mock.calls.find((c) => (c[0] as string).includes('/messages'))!
+    const body = JSON.parse((messagesCall[1] as { body: string }).body) as { content: string }
+    expect(body.content).toMatch(/malformed/i)
+
+    spy.mockRestore()
+  })
+
+  it('still clears the card when the network calls fail', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const user = userEvent.setup()
+    const onDismiss = vi.fn()
+    mockApiFetch.mockRejectedValue(new Error('network down'))
+
+    render(
+      <PendingRequestErrorBoundary {...defaultProps} onDismiss={onDismiss}>
+        <Boom />
+      </PendingRequestErrorBoundary>
+    )
+
+    await user.click(screen.getByTestId('pending-request-error-dismiss'))
+    await waitFor(() => expect(onDismiss).toHaveBeenCalledTimes(1))
+
+    spy.mockRestore()
+  })
+})

--- a/src/renderer/components/messages/pending-request-error-boundary.tsx
+++ b/src/renderer/components/messages/pending-request-error-boundary.tsx
@@ -1,0 +1,128 @@
+import { Component, useState, type ErrorInfo, type ReactNode } from 'react'
+import { AlertTriangle } from 'lucide-react'
+import { Button } from '@renderer/components/ui/button'
+import { useInterruptSession, useSendMessage } from '@renderer/hooks/use-messages'
+import { captureRendererException } from '@renderer/lib/error-reporting'
+
+// Sent back to the agent when the user dismisses a request card that failed to
+// render. The agent's input request is interrupted first, so this starts a
+// fresh turn carrying the feedback.
+const DISMISS_FEEDBACK =
+  "I couldn't display your last request — the tool call arguments appear to be malformed, so it was dismissed. Please double-check the arguments against the tool's schema and try again."
+
+interface PendingRequestErrorBoundaryProps {
+  children: ReactNode
+  sessionId: string
+  agentSlug: string
+  /** Removes the broken card from the pending list (the descriptor's onComplete). */
+  onDismiss: () => void
+  /** Stable id (descriptor key / tool-call id) for Sentry correlation. */
+  itemId?: string
+  /** The request kind, for Sentry tags. */
+  kind?: string
+}
+
+interface PendingRequestErrorBoundaryState {
+  error: Error | null
+}
+
+/**
+ * Isolates a single pending-request card so a render error in one card can't
+ * crash the whole chat view (the cards render in the composer slot, OUTSIDE the
+ * per-message MessageErrorBoundary). On error it swaps the card for a notice
+ * with a Dismiss action that interrupts the session and tells the agent its
+ * tool call was malformed, then reports the error to Sentry.
+ */
+export class PendingRequestErrorBoundary extends Component<
+  PendingRequestErrorBoundaryProps,
+  PendingRequestErrorBoundaryState
+> {
+  state: PendingRequestErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): PendingRequestErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    captureRendererException(error, {
+      tags: { feature: 'pending-request-render', request_kind: this.props.kind ?? 'unknown' },
+      extra: {
+        itemId: this.props.itemId,
+        componentStack: info.componentStack,
+      },
+    })
+  }
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return (
+        <PendingRequestErrorFallback
+          sessionId={this.props.sessionId}
+          agentSlug={this.props.agentSlug}
+          onDismiss={this.props.onDismiss}
+        />
+      )
+    }
+    return this.props.children
+  }
+}
+
+function PendingRequestErrorFallback({
+  sessionId,
+  agentSlug,
+  onDismiss,
+}: {
+  sessionId: string
+  agentSlug: string
+  onDismiss: () => void
+}) {
+  const interruptSession = useInterruptSession()
+  const sendMessage = useSendMessage()
+  const [dismissing, setDismissing] = useState(false)
+
+  const handleDismiss = async () => {
+    if (dismissing) return
+    setDismissing(true)
+    try {
+      // Interrupt the in-flight request (the agent is blocked awaiting input),
+      // then send feedback so it can correct course on the next turn.
+      await interruptSession.mutateAsync({ sessionId, agentSlug })
+      await sendMessage.mutateAsync({ sessionId, agentSlug, content: DISMISS_FEEDBACK })
+    } catch (err) {
+      console.error('Failed to dismiss broken request card:', err)
+    } finally {
+      // Always clear the broken card locally, even if the network calls failed.
+      onDismiss()
+      setDismissing(false)
+    }
+  }
+
+  return (
+    <div
+      className="border border-amber-300/70 dark:border-amber-700/60 rounded-[12px] bg-amber-50 dark:bg-amber-950/30 shadow-md text-sm"
+      data-testid="pending-request-error-boundary"
+    >
+      <div className="flex items-start gap-2 p-4 text-amber-800 dark:text-amber-200">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+        <div className="flex-1 min-w-0">
+          <p className="font-medium">{"This request couldn't be displayed"}</p>
+          <p className="mt-1 text-xs text-amber-700/90 dark:text-amber-300/80">
+            The agent sent a malformed request. Dismiss it to interrupt the agent and let it try again.
+          </p>
+        </div>
+      </div>
+      <div className="flex justify-end px-4 pb-4">
+        <Button
+          onClick={handleDismiss}
+          loading={dismissing}
+          size="xs"
+          variant="outline"
+          className="h-8 min-w-24"
+          data-testid="pending-request-error-dismiss"
+        >
+          Dismiss
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/messages/tool-renderers/request-browser-input.tsx
+++ b/src/renderer/components/messages/tool-renderers/request-browser-input.tsx
@@ -23,7 +23,7 @@ function ExpandedView({ input, result, isError }: ToolRendererProps) {
   return (
     <div className="space-y-2">
       {message && <Field label="Message">{message}</Field>}
-      {requirements && requirements.length > 0 && <RequirementsBlock requirements={requirements} />}
+      {Array.isArray(requirements) && requirements.length > 0 && <RequirementsBlock requirements={requirements} />}
       {result && <ResultField result={result} isError={isError} />}
     </div>
   )
@@ -43,7 +43,7 @@ function StreamingView({ partialInput }: StreamingToolRendererProps) {
         {parsed.message || <span className="text-muted-foreground italic">...</span>}
         <span className="animate-pulse">|</span>
       </Field>
-      {parsed.requirements && parsed.requirements.length > 0 && (
+      {Array.isArray(parsed.requirements) && parsed.requirements.length > 0 && (
         <RequirementsBlock requirements={parsed.requirements} />
       )}
     </div>

--- a/src/renderer/components/messages/use-pending-requests.test.tsx
+++ b/src/renderer/components/messages/use-pending-requests.test.tsx
@@ -352,6 +352,33 @@ describe('usePendingRequests', () => {
     expect(matches[0].url).toBe('https://mcp.example.com')
   })
 
+  it('coerces a non-array requirements to [] (model emitted a bare string)', () => {
+    // Regression: the model can emit `requirements` as a string instead of a
+    // string[]. The old `input.requirements || []` guard let a non-empty string
+    // through, which then crashed `.map()` in the request card. The intake must
+    // coerce any non-array to [].
+    mockStreamState.isActive = true
+    mockMessagesData.data = [
+      createAssistantMessage({
+        content: { text: '' },
+        toolCalls: [
+          createToolCall({
+            id: 'tc-bi',
+            name: 'mcp__user-input__request_browser_input',
+            input: { message: 'Log in', requirements: 'Enter your email and password' },
+            result: undefined,
+          }),
+        ],
+      }),
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    const matches = ofKind(result.current.items, 'browser_input')
+    expect(matches).toHaveLength(1)
+    expect(matches[0].requirements).toEqual([])
+  })
+
   it('skips message-based requests when subsequent user message exists', () => {
     mockStreamState.isActive = true
     mockMessagesData.data = [

--- a/src/renderer/components/messages/use-pending-requests.tsx
+++ b/src/renderer/components/messages/use-pending-requests.tsx
@@ -143,12 +143,15 @@ export function usePendingRequests({
             })
           }
         } else if (toolCall.name === 'mcp__user-input__request_browser_input') {
-          const input = toolCall.input as { message?: string; requirements?: string[] }
+          const input = toolCall.input as { message?: string; requirements?: unknown }
           if (input.message) {
             browserInputRequests.push({
               toolUseId: toolCall.id,
               message: input.message,
-              requirements: input.requirements || [],
+              // Model-controlled: coerce a non-array (e.g. a bare string) to []
+              // so downstream `.map()` can't crash the request card. `|| []`
+              // would let a non-empty string through.
+              requirements: Array.isArray(input.requirements) ? input.requirements : [],
             })
           }
         } else if (toolCall.name === 'mcp__user-input__request_script_run') {

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -826,7 +826,10 @@ function getOrCreateEventSource(
           const newRequest: BrowserInputRequest = {
             toolUseId: data.toolUseId,
             message: data.message,
-            requirements: data.requirements || [],
+            // Guard against the model emitting a non-array (e.g. a bare string):
+            // `|| []` only catches falsy values, so a string would survive and
+            // crash `.map()` in the renderer. See SUP browser-input crash.
+            requirements: Array.isArray(data.requirements) ? data.requirements : [],
           }
           streamStates.set(sessionId, {
             ...current,

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -2590,7 +2590,9 @@ class MessagePersister {
         type: 'browser_input_request',
         toolUseId,
         message: input.message,
-        requirements: input.requirements || [],
+        // The model controls this field — coerce a non-array (e.g. a bare
+        // string) to [] so the renderer never calls `.map()` on a non-array.
+        requirements: Array.isArray(input.requirements) ? input.requirements : [],
         agentSlug,
       })
 


### PR DESCRIPTION
## Problem

A session blanked the entire chat view with **"Something went wrong — `requirements.map is not a function`"** (content-area `ErrorBoundary` fallback, with Retry / Reload Page).

`requirements` on `request_browser_input` is **model-controlled tool input** typed `string[]`, but every intake point guarded only with `input.requirements || []` — which replaces *falsy* values, not a *wrong type*. When the model emits `requirements` as a non-empty **string**, it passes the guard unchanged, then `"...".length > 0` is `true` and `"...".map(...)` throws.

Crucially, pending-request cards render in the composer footer slot (`session-chat-column.tsx`), **outside** the per-message `MessageErrorBoundary` — so the throw bubbled to the content-area `ErrorBoundary` and blanked the whole view instead of degrading to an inline notice.

## Fix

1. **Coerce with `Array.isArray` at all intake + render sites** (replacing the `|| []` guards):
   - `message-persister.ts` — SSE `browser_input_request` broadcast
   - `use-message-stream.ts` — SSE event → stream state
   - `use-pending-requests.tsx` — message-history recovery path
   - Render defense-in-depth: `browser-input-request-item.tsx` and the `request-browser-input` tool renderer (both views)

2. **`PendingRequestErrorBoundary`** wrapping every pending-request card (modeled on `MessageErrorBoundary`). A render throw in one card now shows a *"This request couldn't be displayed"* notice instead of blanking the view. Its **Dismiss** button interrupts the session and sends the agent corrective feedback (*the tool call was malformed — retry against the schema*), then clears the card via the descriptor's `onComplete` (and clears it even if the network calls fail). Reports to Sentry with `feature: 'pending-request-render'` + request kind.

This contains the whole class of "a malformed request card crashes the view" bugs going forward.

## Tests

- **Bug repro (proven red before the fix):** string `requirements` via the component (`browser-input-request-item.test.tsx`) and via the recovery path (`use-pending-requests.test.tsx`) — both threw the exact `TypeError: requirements.map is not a function` against unfixed code, pass after.
- **Boundary (`pending-request-error-boundary.test.tsx`):** renders children normally, shows fallback on throw, Sentry tagging, Dismiss calls interrupt + messages endpoints with malformed-feedback body, and clears the card on network failure.

## Verification

- New/related renderer tests: **49 passed** · `tsc --noEmit`: clean · `eslint` (all touched files): clean
- `message-persister` suite: the 10 failures are **pre-existing on `main`** (webhook/Composio/scheduled-task, environment-dependent) — confirmed by stashing the one-line change; the `request_browser_input` test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
