### PR TITLE
fix: loopback bridge redirect for MCP OAuth (custom scheme rejected by some AS)

### DIFF
--- a/src/api/routes/remote-mcps.ts
+++ b/src/api/routes/remote-mcps.ts
@@ -5,7 +5,7 @@ import { remoteMcpServers, agentRemoteMcps } from '@shared/lib/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { initiateOAuthFlow, initiateNewServerOAuth, completeOAuthFlow, discoverOAuthMetadata } from '@shared/lib/mcp/oauth'
 import type { McpToolInfo } from '@shared/lib/mcp/types'
-import { getAppBaseUrlFromRequest, getCurrentUserId } from '@shared/lib/auth/config'
+import { getAppBaseUrl, getAppBaseUrlFromRequest, getCurrentUserId } from '@shared/lib/auth/config'
 import { isAuthMode } from '@shared/lib/auth/mode'
 import { Authenticated, UsersMcpServer, IsAdmin, Or } from '../middleware/auth'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
@@ -313,9 +313,10 @@ remoteMcps.post('/initiate-oauth', async (c) => {
       ? body.clientSecret.trim()
       : undefined
 
-  const protocol = process.env.SUPERAGENT_PROTOCOL || 'superagent'
+  // Desktop uses an http loopback (RFC 8252); some auth servers reject the
+  // custom scheme at /authorize. /oauth-bridge bounces back to superagent://.
   const redirectUri = body.electron
-    ? `${protocol}://mcp-oauth-callback`
+    ? `${getAppBaseUrl()}/api/remote-mcps/oauth-bridge`
     : `${getAppBaseUrlFromRequest(c)}/api/remote-mcps/oauth-callback`
 
   if (body.mcpId) {
@@ -367,6 +368,13 @@ remoteMcps.post('/initiate-oauth', async (c) => {
   } else {
     return c.json({ error: 'Either mcpId or name+url is required' }, 400)
   }
+})
+
+// Bounce the http loopback callback to superagent:// (before /:id, no shadow).
+remoteMcps.get('/oauth-bridge', (c) => {
+  const protocol = process.env.SUPERAGENT_PROTOCOL || 'superagent'
+  const query = new URL(c.req.url).search
+  return c.redirect(`${protocol}://mcp-oauth-callback${query}`)
 })
 
 // OAuth callback handler (must be before /:id to avoid route shadowing)


### PR DESCRIPTION
## What bug it fixes

MCP OAuth from the **desktop (Electron) app** never reached the consent screen for auth servers that reject custom-scheme redirect URIs.

We sent `redirect_uri=superagent://mcp-oauth-callback` to the AS's `/authorize`. Fireflies (and similar) only accept http(s) redirects, so it bounced the request.

## Repro (verified with curl against Fireflies)

| redirect_uri | `/authorize` result |
|---|---|
| `superagent://mcp-oauth-callback` | **HTTP 400 `Invalid redirect_uri`** |
| `http://localhost:<port>/...` | HTTP 302 → proceeds to OIDC consent |

Note: Fireflies' DCR `/register` *accepts* the custom scheme (so a `client_id` is issued and it looks like it worked), but `/authorize` rejects it — the failure surfaces only at the redirect step.

## What changed

Single file, `src/api/routes/remote-mcps.ts` (+15/−3):

- Desktop now registers an **http loopback** redirect pointing at the API server's own port (`getAppBaseUrl()` → `process.env.PORT`, not the request origin which is the renderer dev server in dev): `…/api/remote-mcps/oauth-bridge`.
- New `GET /oauth-bridge` route 302-redirects the result back to `superagent://mcp-oauth-callback?<query>`.
- The existing `superagent://` open-url handler in `main/index.ts` then completes the token exchange and notifies the renderer **unchanged** — no main-process or renderer changes.

The AS only ever sees an http redirect; the custom scheme is reduced to a post-consent app-wakeup the AS never touches.

## Test plan

- [x] `typecheck` clean (no new `src/` errors)
- [x] `remote-mcps.test.ts` (48) + `oauth.test.ts` (34) green
- [x] End-to-end: connected Fireflies MCP from the desktop app — consent → bridge 302 → app foreground → server connected
- [ ] Confirm the `http → superagent://` 302 doesn't trigger a browser block prompt on Windows/Linux (verified on macOS)

Made with [Cursor](https://cursor.com)