### PR TITLE
Disable session message sending while runtime is pending (SUP-269)

### DIFF
--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -42,6 +42,19 @@ vi.mock('@renderer/context/connectivity-context', () => ({
   ConnectivityProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
+// Mock useRuntimeStatus — default ready, override per test
+const mockRuntimeStatus = {
+  data: {
+    runtimeReadiness: { status: 'READY' as string, message: 'Ready' },
+    hasRunningAgents: true,
+    apiKeyConfigured: true,
+  },
+  isPending: false,
+}
+vi.mock('@renderer/hooks/use-runtime-status', () => ({
+  useRuntimeStatus: () => mockRuntimeStatus,
+}))
+
 const mockSettings = {
   data: {
     llmProvider: 'anthropic',
@@ -72,6 +85,8 @@ describe('MessageInput', () => {
     mockStreamState.slashCommands = []
     mockSendMessage.isPending = false
     mockIsOnline = true
+    mockRuntimeStatus.data.runtimeReadiness.status = 'READY'
+    mockRuntimeStatus.isPending = false
   })
 
   it('renders textarea with placeholder', () => {
@@ -433,6 +448,60 @@ describe('MessageInput', () => {
         <MessageInput sessionId="s-1" agentSlug="agent-1" />
       )
       expect(screen.getByTitle('Add files')).toBeDisabled()
+    })
+  })
+
+  // ---- Runtime not ready (pending) ----
+  describe('runtime pending state', () => {
+    it('disables the textarea while the runtime image is pulling', () => {
+      mockRuntimeStatus.data.runtimeReadiness.status = 'PULLING_IMAGE'
+      renderWithProviders(
+        <MessageInput sessionId="s-1" agentSlug="agent-1" />
+      )
+      expect(screen.getByTestId('message-input')).toBeDisabled()
+    })
+
+    it('disables the textarea while the runtime is being checked', () => {
+      mockRuntimeStatus.data.runtimeReadiness.status = 'CHECKING'
+      renderWithProviders(
+        <MessageInput sessionId="s-1" agentSlug="agent-1" />
+      )
+      expect(screen.getByTestId('message-input')).toBeDisabled()
+    })
+
+    it('keeps the send button disabled even after typing when runtime is pending', async () => {
+      mockRuntimeStatus.data.runtimeReadiness.status = 'PULLING_IMAGE'
+      const user = userEvent.setup()
+      renderWithProviders(
+        <MessageInput sessionId="s-1" agentSlug="agent-1" />
+      )
+      const input = screen.getByTestId('message-input')
+      await user.type(input, 'Hello')
+      expect(screen.getByTestId('send-button')).toBeDisabled()
+    })
+
+    it('does not send on Enter when runtime is pending', async () => {
+      mockRuntimeStatus.data.runtimeReadiness.status = 'PULLING_IMAGE'
+      const user = userEvent.setup()
+      const onMessageSent = vi.fn()
+      renderWithProviders(
+        <MessageInput sessionId="s-1" agentSlug="agent-1" onMessageSent={onMessageSent} />
+      )
+      const input = screen.getByTestId('message-input')
+      await user.type(input, 'Hello{Enter}')
+      expect(mockSendMessage.mutateAsync).not.toHaveBeenCalled()
+      expect(onMessageSent).not.toHaveBeenCalled()
+    })
+
+    it('enables the send button once the runtime is ready', async () => {
+      mockRuntimeStatus.data.runtimeReadiness.status = 'READY'
+      const user = userEvent.setup()
+      renderWithProviders(
+        <MessageInput sessionId="s-1" agentSlug="agent-1" />
+      )
+      const input = screen.getByTestId('message-input')
+      await user.type(input, 'Hello')
+      expect(screen.getByTestId('send-button')).toBeEnabled()
     })
   })
 

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -13,6 +13,7 @@ import { SlashCommandMenu } from './slash-command-menu'
 import { AttachmentPicker } from '@renderer/components/ui/attachment-picker'
 import { MountChoiceDialog } from '@renderer/components/ui/mount-choice-dialog'
 import { useMessageComposer } from '@renderer/hooks/use-message-composer'
+import { useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
 import { ChatComposerBox } from './chat-composer-box'
 import { ComposerOptions, useComposerOptions } from './composer-options'
 import { useRenderTracker } from '@renderer/lib/perf'
@@ -50,6 +51,12 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
   const isOnline = useIsOnline()
   const isOffline = !isOnline
   const { track } = useAnalyticsTracking()
+  // Block sends while the container runtime is still coming up (checking,
+  // pulling image, unavailable). A message sent then has nothing to run it,
+  // so the agent would silently drop it. `isPending` is the initial query
+  // load — treat it as ready to avoid a disabled-input flash on mount.
+  const { data: runtimeStatus, isPending: isRuntimePending } = useRuntimeStatus()
+  const isRuntimeReady = isRuntimePending || runtimeStatus?.runtimeReadiness?.status === 'READY'
 
   const composer = useMessageComposer({
     agentSlug,
@@ -91,7 +98,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
       }
       track('message_sent')
     }, [onMessageSent, onMessageUuidAssigned, onMessageFailed, sendMessage, sessionId, agentSlug, track, composerOptions, isActive, isWaitingBackground]),
-    submitDisabled: sendMessage.isPending || isOffline,
+    submitDisabled: sendMessage.isPending || isOffline || !isRuntimeReady,
     draftKey: `session:${sessionId}`,
   })
 
@@ -188,7 +195,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
     }
   }
 
-  const isDisabled = sendMessage.isPending || composer.isUploading || isOffline
+  const isDisabled = sendMessage.isPending || composer.isUploading || isOffline || !isRuntimeReady
 
 
   if (isViewOnly) {


### PR DESCRIPTION
## Summary

Inside an open session, the message composer let you send (and queue) messages even while the container runtime was still coming up — `CHECKING`, `PULLING_IMAGE`, or `RUNTIME_UNAVAILABLE`. A message sent in that window has nothing to execute it and is silently dropped, with no feedback to the user.

The new-session composer on the agent home page already guards against this via `useRuntimeStatus()` / `isRuntimeReady`. This change brings the in-session `MessageInput` to parity.

## Changes

- `MessageInput` now reads `useRuntimeStatus()` and derives `isRuntimeReady` (the initial react-query `isPending` load is treated as ready to avoid a disabled-input flash on mount).
- `!isRuntimeReady` is added to both `submitDisabled` (disables the send button and blocks Enter-to-send) and `isDisabled` (disables the textarea, attachment picker, and voice button).

## Tests

- Added a `runtime pending state` suite to `message-input.test.tsx`: textarea disabled while `PULLING_IMAGE` / `CHECKING`, send button stays disabled after typing, Enter does not send, and sending re-enables once `READY`.
- Verified red before the fix / green after (TDD). Full suite: 5194 passed. Typecheck and lint clean.

Closes SUP-269

Linear: https://linear.app/datawizz/issue/SUP-269/bug-sending-messages-inside-sessions-should-be-disabled-when-runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)
