### PR TITLE
feat(file-preview): render CSV/TSV as a table with per-cell comments

### DIFF
--- a/e2e/specs/file-preview.spec.ts
+++ b/e2e/specs/file-preview.spec.ts
@@ -116,6 +116,75 @@ test.describe('File Preview', () => {
     await expect(markdown(page).getByRole('heading', { name: 'Version 2' })).toBeVisible({ timeout: 10000 })
   })
 
+  test('renders CSV as a table and supports the raw toggle', async ({ page }) => {
+    await agentPage.createAgent(`CsvPreview ${Date.now()}`)
+    const agentSlug = await getLatestAgentSlug(page)
+    seedWorkspaceFile(
+      agentSlug,
+      'output/data.csv',
+      'Name,Email,Age\nAlice,alice@example.com,30\nBob,bob@example.com,25',
+    )
+
+    await sessionPage.sendMessage('deliver csv')
+    await sessionPage.waitForResponse(15000)
+
+    const filePill = getFilePill(page, 'data.csv').first()
+    await expect(filePill).toBeVisible({ timeout: 10000 })
+    await filePill.click()
+
+    await expect(page.getByTestId('file-preview-header')).toBeVisible({ timeout: 5000 })
+    const csv = page.getByTestId('csv-renderer')
+    await expect(csv).toBeVisible({ timeout: 10000 })
+
+    // Header cells and data cells are rendered as a table.
+    await expect(csv.getByRole('columnheader', { name: 'Email' })).toBeVisible()
+    await expect(csv.getByRole('cell', { name: 'alice@example.com' })).toBeVisible()
+
+    // Toggle to raw text and back.
+    await csv.getByRole('button', { name: 'Raw' }).click()
+    await expect(csv.getByRole('columnheader', { name: 'Email' })).not.toBeVisible()
+    await csv.getByRole('button', { name: 'Table' }).click()
+    await expect(csv.getByRole('columnheader', { name: 'Email' })).toBeVisible()
+  })
+
+  test('pins a comment to a CSV cell and sends it to the agent', async ({ page }) => {
+    await agentPage.createAgent(`CsvComment ${Date.now()}`)
+    const agentSlug = await getLatestAgentSlug(page)
+    seedWorkspaceFile(
+      agentSlug,
+      'output/data.csv',
+      'Name,Email,Age\nAlice,alice@example.com,30\nBob,bob@example.com,25',
+    )
+
+    await sessionPage.sendMessage('deliver csv')
+    await sessionPage.waitForResponse(15000)
+
+    const filePill = getFilePill(page, 'data.csv').first()
+    await expect(filePill).toBeVisible({ timeout: 10000 })
+    await filePill.click()
+
+    const csv = page.getByTestId('csv-renderer')
+    await expect(csv).toBeVisible({ timeout: 10000 })
+
+    // Click a data cell → comment affordance appears.
+    await csv.getByRole('cell', { name: 'alice@example.com' }).click()
+    const overlay = page.locator('[data-comment-overlay]')
+    await overlay.getByRole('button', { name: 'Comment' }).click()
+
+    // Add a comment for that cell.
+    await page.getByPlaceholder('Add your comment...').fill('This email looks wrong')
+    await overlay.getByRole('button', { name: 'Add' }).click()
+
+    // The comment bar shows the cell identifier and the comment text.
+    const tray = page.getByTestId('file-preview-tray')
+    await expect(tray.getByText('Cell 1:Email', { exact: false })).toBeVisible({ timeout: 5000 })
+    await expect(tray.getByText('This email looks wrong')).toBeVisible()
+
+    // Submitting posts the formatted feedback back into the conversation.
+    await tray.getByRole('button', { name: 'Submit' }).click()
+    await expect(page.getByText('At cell 1:Email', { exact: false })).toBeVisible({ timeout: 10000 })
+  })
+
   test('multiple file tabs, switching, and image rendering', async ({ page }) => {
     await agentPage.createAgent(`MultiFile ${Date.now()}`)
     const agentSlug = await getLatestAgentSlug(page)

--- a/src/renderer/components/file-preview/comments/comment-bar.test.ts
+++ b/src/renderer/components/file-preview/comments/comment-bar.test.ts
@@ -56,6 +56,86 @@ describe('formatComments', () => {
     expect(result).toContain('At position (50%, 10%)')
   })
 
+  it('formats cell comments with a Row:Col_Name identifier, column position and value', () => {
+    const comments: FileComment[] = [
+      {
+        id: '1',
+        filePath: '/workspace/contacts.csv',
+        text: 'This email looks malformed',
+        cell: { row: 3, col: 2, column: 'Email', value: 'john@@example' },
+      },
+    ]
+    const result = formatComments('/workspace/contacts.csv', comments)
+    expect(result).toContain('File feedback on `contacts.csv`')
+    expect(result).toContain('At cell 3:Email (col 3, value: "john@@example"):')
+    expect(result).toContain('This email looks malformed')
+  })
+
+  it('formats cell comments without a value', () => {
+    const comments: FileComment[] = [
+      {
+        id: '1',
+        filePath: '/workspace/data.csv',
+        text: 'Missing value here',
+        cell: { row: 5, col: 0, column: 'Name' },
+      },
+    ]
+    const result = formatComments('/workspace/data.csv', comments)
+    expect(result).toContain('At cell 5:Name (col 1):')
+    expect(result).not.toContain('value:')
+  })
+
+  it('marks a comment on an empty cell as empty rather than dropping it', () => {
+    const comments: FileComment[] = [
+      {
+        id: '1',
+        filePath: '/workspace/data.csv',
+        text: 'should not be blank',
+        cell: { row: 2, col: 1, column: 'Email', value: '' },
+      },
+    ]
+    const result = formatComments('/workspace/data.csv', comments)
+    expect(result).toContain('At cell 2:Email (col 2, empty cell):')
+  })
+
+  it('escapes double quotes inside a cell value', () => {
+    const comments: FileComment[] = [
+      {
+        id: '1',
+        filePath: '/workspace/specs.csv',
+        text: 'check this',
+        cell: { row: 4, col: 0, column: 'Size', value: '27" monitor' },
+      },
+    ]
+    const result = formatComments('/workspace/specs.csv', comments)
+    expect(result).toContain('value: "27\\" monitor"')
+  })
+
+  it('disambiguates duplicate column names via the column position', () => {
+    const comments: FileComment[] = [
+      { id: '1', filePath: '/d.csv', text: 'a', cell: { row: 1, col: 1, column: 'Email', value: 'x' } },
+      { id: '2', filePath: '/d.csv', text: 'b', cell: { row: 1, col: 2, column: 'Email', value: 'y' } },
+    ]
+    const result = formatComments('/d.csv', comments)
+    expect(result).toContain('At cell 1:Email (col 2, value: "x"):')
+    expect(result).toContain('At cell 1:Email (col 3, value: "y"):')
+  })
+
+  it('truncates very long cell values', () => {
+    const long = 'x'.repeat(500)
+    const comments: FileComment[] = [
+      {
+        id: '1',
+        filePath: '/workspace/data.csv',
+        text: 'too long',
+        cell: { row: 1, col: 0, column: 'Blob', value: long },
+      },
+    ]
+    const result = formatComments('/workspace/data.csv', comments)
+    expect(result).toContain('…')
+    expect(result).not.toContain(long)
+  })
+
   it('extracts filename from full path', () => {
     const result = formatComments('/workspace/deep/nested/file.pdf', [
       { id: '1', filePath: '/workspace/deep/nested/file.pdf', text: 'test' },

--- a/src/renderer/components/file-preview/comments/comment-bar.tsx
+++ b/src/renderer/components/file-preview/comments/comment-bar.tsx
@@ -15,12 +15,35 @@ function getFilename(filePath: string): string {
   return filePath.split('/').pop() || filePath
 }
 
+/** Cap long cell values so a single comment can't bloat the prompt. */
+function truncateValue(value: string, max = 200): string {
+  return value.length > max ? value.slice(0, max) + '…' : value
+}
+
+/** Escape double quotes so a value containing `"` can't unbalance the wrapper. */
+function escapeQuotes(value: string): string {
+  return value.replace(/"/g, '\\"')
+}
+
 export function formatComments(filePath: string, comments: FileComment[]): string {
   const filename = getFilename(filePath)
   const lines: string[] = [`File feedback on \`${filename}\`:\n`]
 
   comments.forEach((comment, i) => {
-    if (comment.selectedText) {
+    if (comment.cell) {
+      const { row, col, column, value } = comment.cell
+      // Include the 1-based column position so duplicate header names stay
+      // unambiguous, and escape the value so embedded quotes don't break out.
+      const ref = `${row}:${column} (col ${col + 1}`
+      if (value === undefined) {
+        lines.push(`At cell ${ref}):`)
+      } else if (value === '') {
+        lines.push(`At cell ${ref}, empty cell):`)
+      } else {
+        lines.push(`At cell ${ref}, value: "${escapeQuotes(truncateValue(value))}"):`)
+      }
+      lines.push(comment.text)
+    } else if (comment.selectedText) {
       lines.push(`> "${comment.selectedText}"`)
       lines.push(comment.text)
     } else if (comment.x != null && comment.y != null) {
@@ -60,6 +83,14 @@ export function CommentBar({ comments, filePath, agentSlug, sessionId }: Comment
           <div key={comment.id} className="flex items-start gap-2 text-xs group">
             <span className="text-muted-foreground shrink-0 tabular-nums">{i + 1}.</span>
             <div className="flex-1 min-w-0">
+              {comment.cell && (
+                <div className="text-muted-foreground/70 truncate">
+                  <span className="font-medium">Cell {comment.cell.row}:{comment.cell.column}</span>
+                  {comment.cell.value
+                    ? <span className="italic"> &mdash; &ldquo;{comment.cell.value}&rdquo;</span>
+                    : comment.cell.value === '' ? <span className="italic"> &mdash; empty</span> : null}
+                </div>
+              )}
               {comment.selectedText && (
                 <div className="text-muted-foreground/70 italic truncate">&ldquo;{comment.selectedText}&rdquo;</div>
               )}

--- a/src/renderer/components/file-preview/comments/comment-overlay.tsx
+++ b/src/renderer/components/file-preview/comments/comment-overlay.tsx
@@ -30,6 +30,7 @@ export function CommentOverlay({ selection, filePath, onClose }: CommentOverlayP
       selectedText: selection.text || undefined,
       x: selection.x,
       y: selection.y,
+      cell: selection.cell,
     })
     setCommentText('')
     setIsEditing(false)
@@ -80,6 +81,14 @@ export function CommentOverlay({ selection, filePath, onClose }: CommentOverlayP
         {selection.x != null && selection.y != null && (
           <div className="text-xs text-muted-foreground bg-muted/50 rounded p-1.5">
             Point at ({Math.round(selection.x)}%, {Math.round(selection.y)}%)
+          </div>
+        )}
+        {selection.cell && (
+          <div className="text-xs text-muted-foreground bg-muted/50 rounded p-1.5">
+            <span className="font-medium">Cell {selection.cell.row}:{selection.cell.column}</span>
+            {selection.cell.value
+              ? <span className="italic"> &mdash; &ldquo;{selection.cell.value}&rdquo;</span>
+              : selection.cell.value === '' ? <span className="italic"> &mdash; empty cell</span> : null}
           </div>
         )}
         <textarea

--- a/src/renderer/components/file-preview/comments/use-dismiss-on-outside-click.ts
+++ b/src/renderer/components/file-preview/comments/use-dismiss-on-outside-click.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Dismiss a transient popover (comment overlay, click point, text selection)
+ * when the user mousedowns anywhere outside it. Clicks landing inside an
+ * element matching one of `ignoreSelectors` are left alone.
+ *
+ * Shared by the text/image/CSV comment affordances, which all need the same
+ * "click away to cancel" behaviour. The listener is only attached while
+ * `active` is true and reads `onDismiss` through a ref, so it doesn't churn the
+ * document listener on every render.
+ */
+export function useDismissOnOutsideClick(
+  active: boolean,
+  onDismiss: () => void,
+  ignoreSelectors: string[] = [],
+) {
+  const onDismissRef = useRef(onDismiss)
+  onDismissRef.current = onDismiss
+
+  const selector = ignoreSelectors.join(',')
+
+  useEffect(() => {
+    if (!active) return
+    const handleMouseDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement
+      if (selector && target.closest?.(selector)) return
+      onDismissRef.current()
+    }
+    document.addEventListener('mousedown', handleMouseDown)
+    return () => document.removeEventListener('mousedown', handleMouseDown)
+  }, [active, selector])
+}

--- a/src/renderer/components/file-preview/comments/use-text-selection.ts
+++ b/src/renderer/components/file-preview/comments/use-text-selection.ts
@@ -1,10 +1,13 @@
 import { useState, useEffect, useCallback, type RefObject } from 'react'
+import type { CellRef } from '@renderer/context/file-preview-context'
+import { useDismissOnOutsideClick } from './use-dismiss-on-outside-click'
 
 export interface TextSelectionInfo {
   text: string
   rect: DOMRect
   x?: number
   y?: number
+  cell?: CellRef
 }
 
 export function useTextSelection(containerRef: RefObject<HTMLElement | null>) {
@@ -48,20 +51,17 @@ export function useTextSelection(containerRef: RefObject<HTMLElement | null>) {
       })
     }
 
-    // Dismiss the overlay on any mousedown, unless the click is inside
-    // the comment overlay itself (marked with data-comment-overlay).
-    const handleDocumentMouseDown = (e: MouseEvent) => {
-      if ((e.target as HTMLElement).closest?.('[data-comment-overlay]')) return
-      setSelection(null)
-    }
-
     container.addEventListener('mouseup', handleMouseUp)
-    document.addEventListener('mousedown', handleDocumentMouseDown)
     return () => {
       container.removeEventListener('mouseup', handleMouseUp)
-      document.removeEventListener('mousedown', handleDocumentMouseDown)
     }
   }, [containerRef])
 
+  // Dismiss the pending comment affordance on any mousedown, unless the click
+  // is inside the comment overlay itself (marked with data-comment-overlay).
+  useDismissOnOutsideClick(selection != null, () => setSelection(null), DISMISS_IGNORE)
+
   return { selection, clearSelection }
 }
+
+const DISMISS_IGNORE = ['[data-comment-overlay]']

--- a/src/renderer/components/file-preview/renderers/csv-parse.test.ts
+++ b/src/renderer/components/file-preview/renderers/csv-parse.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { parseCsv } from './csv-parse'
+
+describe('parseCsv', () => {
+  it('parses a simple comma-separated file', () => {
+    const { headers, rows, delimiter, columnCount } = parseCsv('name,age\nAlice,30\nBob,25')
+    expect(delimiter).toBe(',')
+    expect(columnCount).toBe(2)
+    expect(headers).toEqual(['name', 'age'])
+    expect(rows).toEqual([
+      ['Alice', '30'],
+      ['Bob', '25'],
+    ])
+  })
+
+  it('handles quoted fields containing the delimiter', () => {
+    const { rows } = parseCsv('name,note\nAlice,"hello, world"')
+    expect(rows[0]).toEqual(['Alice', 'hello, world'])
+  })
+
+  it('handles escaped quotes inside quoted fields', () => {
+    const { rows } = parseCsv('value\n"she said ""hi"""')
+    expect(rows[0]).toEqual(['she said "hi"'])
+  })
+
+  it('handles embedded newlines inside quoted fields', () => {
+    const { headers, rows } = parseCsv('name,bio\nAlice,"line one\nline two"')
+    expect(headers).toEqual(['name', 'bio'])
+    expect(rows).toEqual([['Alice', 'line one\nline two']])
+  })
+
+  it('detects a tab delimiter', () => {
+    const { delimiter, headers, rows } = parseCsv('name\tage\nAlice\t30')
+    expect(delimiter).toBe('\t')
+    expect(headers).toEqual(['name', 'age'])
+    expect(rows).toEqual([['Alice', '30']])
+  })
+
+  it('detects a semicolon delimiter', () => {
+    const { delimiter, headers } = parseCsv('a;b;c\n1;2;3')
+    expect(delimiter).toBe(';')
+    expect(headers).toEqual(['a', 'b', 'c'])
+  })
+
+  it('pads ragged rows to a rectangular shape', () => {
+    const { columnCount, headers, rows } = parseCsv('a,b,c\n1,2\n4,5,6,7')
+    expect(columnCount).toBe(4)
+    expect(headers).toEqual(['a', 'b', 'c', ''])
+    expect(rows[0]).toEqual(['1', '2', '', ''])
+    expect(rows[1]).toEqual(['4', '5', '6', '7'])
+  })
+
+  it('preserves blank lines so row numbers stay aligned (no trailing empty row)', () => {
+    const { rows } = parseCsv('a,b\n1,2\n\n3,4\n')
+    expect(rows).toEqual([
+      ['1', '2'],
+      ['', ''],
+      ['3', '4'],
+    ])
+  })
+
+  it('keeps a blank cell in a single-column file (does not shift later rows)', () => {
+    const { rows } = parseCsv('name\nAlice\n\nBob')
+    expect(rows).toEqual([['Alice'], [''], ['Bob']])
+  })
+
+  it('detects a tab delimiter despite commas inside quoted fields', () => {
+    const text = '"Last, First"\tScore\n"Doe, John"\t90\n"Roe, Jane"\t85'
+    const { delimiter, headers, rows } = parseCsv(text)
+    expect(delimiter).toBe('\t')
+    expect(headers).toEqual(['Last, First', 'Score'])
+    expect(rows).toEqual([
+      ['Doe, John', '90'],
+      ['Roe, Jane', '85'],
+    ])
+  })
+
+  it('does not overflow the stack on a file with millions of rows', () => {
+    const huge = 'x\n'.repeat(1_000_000)
+    expect(() => parseCsv(huge)).not.toThrow()
+    const { columnCount, rows } = parseCsv(huge)
+    expect(columnCount).toBe(1)
+    expect(rows.length).toBe(999_999) // header consumes the first row
+  })
+
+  it('handles CRLF line endings', () => {
+    const { headers, rows } = parseCsv('a,b\r\n1,2\r\n3,4')
+    expect(headers).toEqual(['a', 'b'])
+    expect(rows).toEqual([
+      ['1', '2'],
+      ['3', '4'],
+    ])
+  })
+
+  it('returns empty headers for an empty file', () => {
+    const { headers, rows, columnCount } = parseCsv('')
+    expect(headers).toEqual([])
+    expect(rows).toEqual([])
+    expect(columnCount).toBe(0)
+  })
+
+  it('treats a single-column file as a one-column table', () => {
+    const { columnCount, headers, rows } = parseCsv('url\nhttps://a.com\nhttps://b.com')
+    expect(columnCount).toBe(1)
+    expect(headers).toEqual(['url'])
+    expect(rows).toEqual([['https://a.com'], ['https://b.com']])
+  })
+})

--- a/src/renderer/components/file-preview/renderers/csv-parse.ts
+++ b/src/renderer/components/file-preview/renderers/csv-parse.ts
@@ -175,6 +175,10 @@ function maxLength(rows: string[][], floor: number): number {
   return max
 }
 
+// TODO: candidate to replace with PapaParse — battle-tested on real-world CSV
+// edge cases (BOM, loose quoting, encodings) and supports streaming, which
+// would let us lift the 5MB/1000-row caps for huge files. Swap here behind the
+// ParsedCsv boundary; keep skipEmptyLines off to preserve row-number alignment.
 export function parseCsv(text: string): ParsedCsv {
   const delimiter = detectDelimiter(text)
   // Blank lines are intentionally kept so the table's row numbers line up with

--- a/src/renderer/components/file-preview/renderers/csv-parse.ts
+++ b/src/renderer/components/file-preview/renderers/csv-parse.ts
@@ -1,0 +1,199 @@
+// Minimal, dependency-free CSV/TSV parser (RFC 4180-ish): handles quoted
+// fields, escaped quotes (""), embedded newlines, and a small set of common
+// delimiters. Used by the CSV renderer to display delimited files as a table.
+
+const DELIMITERS = [',', '\t', ';', '|'] as const
+
+export interface ParsedCsv {
+  /** First (header) row, padded to columnCount. */
+  headers: string[]
+  /** Data rows (header excluded), each padded to columnCount. Blank source
+   * lines are preserved as empty rows so displayed row numbers stay aligned. */
+  rows: string[][]
+  /** The delimiter that was detected and used for parsing. */
+  delimiter: string
+  /** Number of columns (max across header + rows). */
+  columnCount: number
+}
+
+const MAX_SAMPLE_LINES = 10
+
+function isDelimiter(ch: string): ch is (typeof DELIMITERS)[number] {
+  return ch === ',' || ch === '\t' || ch === ';' || ch === '|'
+}
+
+/**
+ * Guess the delimiter by counting candidate separators across the first few
+ * logical lines. Counting is quote-aware — separators inside quoted fields are
+ * ignored — so a comma inside a quoted cell can't outvote a real tab delimiter.
+ * Delimiters that appear consistently on every line are favoured.
+ */
+function detectDelimiter(text: string): string {
+  const sample = text.slice(0, 65_536)
+  const perLine: Record<string, number[]> = {}
+  for (const d of DELIMITERS) perLine[d] = []
+
+  let lineCounts: Record<string, number> = {}
+  const resetLine = () => {
+    lineCounts = {}
+    for (const d of DELIMITERS) lineCounts[d] = 0
+  }
+  resetLine()
+
+  let inQuotes = false
+  let lineHasContent = false
+  let sampled = 0
+
+  const flushLine = () => {
+    if (lineHasContent) {
+      for (const d of DELIMITERS) perLine[d].push(lineCounts[d])
+      sampled++
+    }
+    resetLine()
+    lineHasContent = false
+  }
+
+  for (let i = 0; i < sample.length && sampled < MAX_SAMPLE_LINES; i++) {
+    const ch = sample[i]
+    if (inQuotes) {
+      if (ch === '"') {
+        if (sample[i + 1] === '"') {
+          i++ // escaped quote
+          continue
+        }
+        inQuotes = false
+      }
+      lineHasContent = true
+      continue
+    }
+    if (ch === '"') {
+      inQuotes = true
+      lineHasContent = true
+      continue
+    }
+    if (ch === '\n' || ch === '\r') {
+      if (ch === '\r' && sample[i + 1] === '\n') i++ // CRLF
+      flushLine()
+      continue
+    }
+    if (isDelimiter(ch)) {
+      lineCounts[ch]++
+      lineHasContent = true
+      continue
+    }
+    // A line counts as content once it has any non-whitespace character; bare
+    // spaces don't make a blank line "real".
+    if (ch !== ' ') lineHasContent = true
+  }
+  if (sampled < MAX_SAMPLE_LINES) flushLine()
+
+  if (sampled === 0) return ','
+
+  let best = ','
+  let bestScore = 0
+  for (const d of DELIMITERS) {
+    const counts = perLine[d]
+    const total = counts.reduce((a, b) => a + b, 0)
+    if (total === 0) continue
+    const min = Math.min(...counts)
+    // Reward both raw frequency and consistency across lines.
+    const score = total + min * 10
+    if (score > bestScore) {
+      bestScore = score
+      best = d
+    }
+  }
+  return best
+}
+
+/** Tokenize the full text into rows of raw field strings. */
+function parseRows(text: string, delimiter: string): string[][] {
+  const rows: string[][] = []
+  let field = ''
+  let row: string[] = []
+  let inQuotes = false
+  let started = false // current row has at least begun (guards trailing newline)
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"'
+          i++ // skip the escaped quote
+        } else {
+          inQuotes = false
+        }
+      } else {
+        field += ch
+      }
+      continue
+    }
+
+    if (ch === '"') {
+      inQuotes = true
+      started = true
+      continue
+    }
+    if (ch === delimiter) {
+      row.push(field)
+      field = ''
+      started = true
+      continue
+    }
+    if (ch === '\n' || ch === '\r') {
+      if (ch === '\r' && text[i + 1] === '\n') i++ // CRLF
+      row.push(field)
+      rows.push(row)
+      row = []
+      field = ''
+      started = false
+      continue
+    }
+
+    field += ch
+    started = true
+  }
+
+  // Flush the trailing row unless the file ended on a clean newline.
+  if (started || field.length > 0 || row.length > 0) {
+    row.push(field)
+    rows.push(row)
+  }
+
+  return rows
+}
+
+/** Largest value in a numeric array, without spreading (which overflows the
+ * call stack for files with millions of rows). */
+function maxLength(rows: string[][], floor: number): number {
+  let max = floor
+  for (const r of rows) {
+    if (r.length > max) max = r.length
+  }
+  return max
+}
+
+export function parseCsv(text: string): ParsedCsv {
+  const delimiter = detectDelimiter(text)
+  // Blank lines are intentionally kept so the table's row numbers line up with
+  // the source file (a comment pinned to a row references its true position).
+  const all = parseRows(text, delimiter)
+
+  const headers = all.length > 0 ? [...all[0]] : []
+  const rows = all.slice(1)
+
+  const columnCount = maxLength(rows, headers.length)
+
+  // Pad to a rectangular shape so the table renders cleanly.
+  while (headers.length < columnCount) headers.push('')
+  const paddedRows = rows.map(r => {
+    if (r.length >= columnCount) return r
+    const copy = r.slice()
+    while (copy.length < columnCount) copy.push('')
+    return copy
+  })
+
+  return { headers, rows: paddedRows, delimiter, columnCount }
+}

--- a/src/renderer/components/file-preview/renderers/csv-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/csv-renderer.tsx
@@ -1,0 +1,263 @@
+import { Loader2, AlertCircle, Table2, FileText } from 'lucide-react'
+import { memo, useMemo, useRef, useState, useCallback } from 'react'
+import { cn } from '@shared/lib/utils/cn'
+import { parseCsv } from './csv-parse'
+import { TextRenderer } from './text-renderer'
+import { useFileContent } from './use-file-content'
+import { CommentOverlay } from '../comments/comment-overlay'
+import { useDismissOnOutsideClick } from '../comments/use-dismiss-on-outside-click'
+import { useFilePreview } from '@renderer/context/file-preview-context'
+
+interface CsvRendererProps {
+  url: string
+  filePath: string
+}
+
+const MAX_ROWS = 1000
+const CSV_DISMISS_IGNORE = ['[data-comment-overlay]', '[data-csv-cell]']
+
+interface CellTarget {
+  row: number // 1-based data row
+  col: number // 0-based column index
+  column: string // column label
+  value: string
+  rect: DOMRect // relative to the container
+}
+
+type CellClickHandler = (e: React.MouseEvent, row: number, col: number, column: string, value: string) => void
+
+interface CsvTableProps {
+  rows: string[][]
+  columnLabels: string[]
+  /** "row:col" -> 1-based comment numbers pinned to that cell. */
+  commentsByCell: Map<string, number[]>
+  onCellClick: CellClickHandler
+}
+
+/**
+ * The grid itself, memoized so opening/closing the comment overlay (parent
+ * `cellTarget` state) doesn't re-render up to MAX_ROWS × columns of cells.
+ * Only re-renders when the data or pinned comments actually change.
+ */
+const CsvTable = memo(function CsvTable({ rows, columnLabels, commentsByCell, onCellClick }: CsvTableProps) {
+  return (
+    <table className="border-collapse text-xs font-mono">
+      <thead>
+        <tr>
+          <th className="sticky top-0 left-0 z-20 bg-muted px-2 py-1 text-right text-muted-foreground/60 font-normal select-none border-b border-r border-border/40 w-[1%]">
+            #
+          </th>
+          {columnLabels.map((label, c) => (
+            <th
+              key={c}
+              className="sticky top-0 z-10 bg-muted px-3 py-1.5 text-left font-semibold whitespace-nowrap border-b border-r border-border/40"
+            >
+              {label}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, r) => {
+          const rowNum = r + 1
+          return (
+            <tr key={r} className="hover:bg-muted/20">
+              <td className="sticky left-0 z-10 bg-background px-2 py-1 text-right text-muted-foreground/50 select-none align-top tabular-nums border-b border-r border-border/30 w-[1%]">
+                {rowNum}
+              </td>
+              {row.map((value, c) => {
+                const cellComments = commentsByCell.get(`${rowNum}:${c}`)
+                return (
+                  <td
+                    key={c}
+                    data-csv-cell
+                    onClick={(e) => onCellClick(e, rowNum, c, columnLabels[c], value)}
+                    className={cn(
+                      'relative px-3 py-1 align-top whitespace-pre-wrap break-words max-w-[28rem] cursor-pointer border-b border-r border-border/30 hover:bg-primary/5',
+                      cellComments && 'bg-primary/10',
+                    )}
+                  >
+                    {value}
+                    {cellComments && (
+                      <span
+                        className="absolute top-0.5 right-0.5 min-w-3.5 h-3.5 px-1 rounded-full bg-primary text-primary-foreground text-[9px] font-bold leading-[0.875rem] text-center shadow-sm pointer-events-none"
+                        title={`${cellComments.length} comment${cellComments.length === 1 ? '' : 's'}`}
+                      >
+                        {cellComments.length}
+                      </span>
+                    )}
+                  </td>
+                )
+              })}
+            </tr>
+          )
+        })}
+      </tbody>
+    </table>
+  )
+})
+
+export function CsvRenderer({ url, filePath }: CsvRendererProps) {
+  const [view, setView] = useState<'table' | 'raw'>('table')
+  const [cellTarget, setCellTarget] = useState<CellTarget | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const { comments } = useFilePreview()
+
+  // The context Map preserves untouched per-file arrays across unrelated
+  // mutations, so keying the memo on this file's array (not the whole Map)
+  // keeps the table from re-rendering when another file's comments change.
+  const fileComments = comments.get(filePath)
+  const commentsByCell = useMemo(() => {
+    const map = new Map<string, number[]>()
+    fileComments?.forEach((c, i) => {
+      if (c.cell) {
+        const key = `${c.cell.row}:${c.cell.col}`
+        const list = map.get(key)
+        if (list) list.push(i + 1)
+        else map.set(key, [i + 1])
+      }
+    })
+    return map
+  }, [fileComments])
+
+  const { data, isLoading, error } = useFileContent(url)
+  const sizeTruncated = data?.truncated ?? false
+
+  const parsed = useMemo(() => {
+    if (!data) return null
+    const result = parseCsv(data.text)
+    // A size-truncated file is sliced mid-stream, so the final parsed row is
+    // very likely a partial/garbled record (or a runaway unclosed quote). Drop
+    // it rather than render a malformed row; the banner explains the omission.
+    if (sizeTruncated && result.rows.length > 0) {
+      return { ...result, rows: result.rows.slice(0, -1) }
+    }
+    return result
+  }, [data, sizeTruncated])
+
+  const columnLabels = useMemo(
+    () => (parsed ? parsed.headers.map((h, i) => h.trim() || `Column ${i + 1}`) : []),
+    [parsed],
+  )
+
+  const rowCount = parsed?.rows.length ?? 0
+  const rowsTruncated = rowCount > MAX_ROWS
+  const visibleRows = useMemo(
+    () => (parsed ? (rowsTruncated ? parsed.rows.slice(0, MAX_ROWS) : parsed.rows) : []),
+    [parsed, rowsTruncated],
+  )
+
+  useDismissOnOutsideClick(cellTarget != null, () => setCellTarget(null), CSV_DISMISS_IGNORE)
+
+  const handleCellClick = useCallback<CellClickHandler>((e, row, col, column, value) => {
+    const containerRect = containerRef.current?.getBoundingClientRect()
+    if (!containerRect) return
+    setCellTarget({
+      row,
+      col,
+      column,
+      value,
+      rect: new DOMRect(e.clientX - containerRect.left, e.clientY - containerRect.top, 0, 0),
+    })
+  }, [])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 p-4 text-sm text-destructive">
+        <AlertCircle className="h-4 w-4 shrink-0" />
+        <span>Failed to load file</span>
+      </div>
+    )
+  }
+
+  if (!parsed || parsed.headers.length === 0) {
+    return <div className="p-4 text-sm text-muted-foreground">This file is empty.</div>
+  }
+
+  return (
+    <div ref={containerRef} className="relative" data-testid="csv-renderer">
+      {/* Toolbar: dimensions + table/raw toggle */}
+      <div className="flex items-center justify-between gap-2 px-3 py-1.5 text-xs text-muted-foreground border-b border-border/40">
+        <span className="tabular-nums">
+          {parsed.columnCount} {parsed.columnCount === 1 ? 'column' : 'columns'} ·{' '}
+          {rowCount.toLocaleString()} {rowCount === 1 ? 'row' : 'rows'}
+        </span>
+        <div className="flex items-center gap-0.5 rounded-md border border-border/60 p-0.5">
+          <button
+            onClick={() => setView('table')}
+            className={cn(
+              'flex items-center gap-1 rounded px-1.5 py-0.5 transition-colors',
+              view === 'table' ? 'bg-muted text-foreground' : 'hover:bg-muted/50',
+            )}
+            title="Table view"
+          >
+            <Table2 className="h-3 w-3" />
+            Table
+          </button>
+          <button
+            onClick={() => setView('raw')}
+            className={cn(
+              'flex items-center gap-1 rounded px-1.5 py-0.5 transition-colors',
+              view === 'raw' ? 'bg-muted text-foreground' : 'hover:bg-muted/50',
+            )}
+            title="Raw text view"
+          >
+            <FileText className="h-3 w-3" />
+            Raw
+          </button>
+        </div>
+      </div>
+
+      {view === 'raw' ? (
+        <TextRenderer url={url} filePath={filePath} />
+      ) : (
+        <>
+          <CsvTable
+            rows={visibleRows}
+            columnLabels={columnLabels}
+            commentsByCell={commentsByCell}
+            onCellClick={handleCellClick}
+          />
+          {sizeTruncated && (
+            <div className="px-4 py-3 border-t text-xs text-muted-foreground text-center">
+              File is larger than 5&nbsp;MB and was truncated before parsing &mdash; later rows are missing. Download the
+              file for the full content.
+            </div>
+          )}
+          {rowsTruncated && (
+            <div className="px-4 py-3 border-t text-xs text-muted-foreground text-center">
+              Showing first {MAX_ROWS.toLocaleString()} of {rowCount.toLocaleString()} rows. Switch to Raw or download the
+              file for the full content.
+            </div>
+          )}
+        </>
+      )}
+
+      {cellTarget && (
+        <CommentOverlay
+          selection={{
+            text: '',
+            rect: cellTarget.rect,
+            cell: {
+              row: cellTarget.row,
+              col: cellTarget.col,
+              column: cellTarget.column,
+              value: cellTarget.value,
+            },
+          }}
+          filePath={filePath}
+          onClose={() => setCellTarget(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/file-preview/renderers/file-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/file-renderer.tsx
@@ -3,6 +3,7 @@ import { Loader2 } from 'lucide-react'
 import { getFileExtension } from '@shared/lib/utils/mime'
 import { MarkdownRenderer } from './markdown-renderer'
 import { TextRenderer } from './text-renderer'
+import { CsvRenderer } from './csv-renderer'
 import { ImageRenderer } from './image-renderer'
 import { HtmlRenderer } from './html-renderer'
 import { UnsupportedRenderer } from './unsupported-renderer'
@@ -10,8 +11,9 @@ import { UnsupportedRenderer } from './unsupported-renderer'
 const PdfRenderer = lazy(() => import('./pdf-renderer').then(m => ({ default: m.PdfRenderer })))
 
 const MARKDOWN_EXTS = new Set(['md', 'markdown'])
+const CSV_EXTS = new Set(['csv', 'tsv'])
 const TEXT_EXTS = new Set([
-  'txt', 'log', 'csv', 'json', 'xml', 'yml', 'yaml', 'toml', 'ini', 'cfg',
+  'txt', 'log', 'json', 'xml', 'yml', 'yaml', 'toml', 'ini', 'cfg',
   'env', 'sh', 'bash', 'zsh', 'py', 'js', 'ts', 'tsx', 'jsx', 'css',
   'scss', 'less', 'sql', 'graphql', 'proto', 'dockerfile', 'makefile',
   'gitignore', 'editorconfig', 'rs', 'go', 'java', 'kt', 'swift', 'rb', 'php',
@@ -34,6 +36,10 @@ export function FileRenderer({ filePath, fileUrl, agentSlug }: FileRendererProps
 
   if (ext === 'html' || ext === 'htm') {
     return <HtmlRenderer url={fileUrl} />
+  }
+
+  if (CSV_EXTS.has(ext)) {
+    return <CsvRenderer url={fileUrl} filePath={filePath} />
   }
 
   if (TEXT_EXTS.has(ext)) {

--- a/src/renderer/components/file-preview/renderers/image-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/image-renderer.tsx
@@ -1,8 +1,9 @@
-import { useState, useRef, useCallback, useEffect } from 'react'
+import { useState, useRef, useCallback } from 'react'
 import { Loader2 } from 'lucide-react'
 import { useFilePreview, type FileComment } from '@renderer/context/file-preview-context'
 import { CommentPin } from '../comments/comment-pin'
 import { CommentOverlay } from '../comments/comment-overlay'
+import { useDismissOnOutsideClick } from '../comments/use-dismiss-on-outside-click'
 
 interface ImageRendererProps {
   url: string
@@ -15,6 +16,8 @@ interface ClickPoint {
   rect: DOMRect
 }
 
+const IMAGE_DISMISS_IGNORE = ['[data-comment-overlay]']
+
 export function ImageRenderer({ url, filePath }: ImageRendererProps) {
   const [loaded, setLoaded] = useState(false)
   const [clickPoint, setClickPoint] = useState<ClickPoint | null>(null)
@@ -23,15 +26,7 @@ export function ImageRenderer({ url, filePath }: ImageRendererProps) {
   const fileComments = comments.get(filePath) || []
   const imageComments = fileComments.filter((c): c is FileComment & { x: number; y: number } => c.x != null && c.y != null)
 
-  useEffect(() => {
-    if (!clickPoint) return
-    const handleMouseDown = (e: MouseEvent) => {
-      if ((e.target as HTMLElement).closest?.('[data-comment-overlay]')) return
-      setClickPoint(null)
-    }
-    document.addEventListener('mousedown', handleMouseDown)
-    return () => document.removeEventListener('mousedown', handleMouseDown)
-  }, [clickPoint])
+  useDismissOnOutsideClick(clickPoint != null, () => setClickPoint(null), IMAGE_DISMISS_IGNORE)
 
   const handleImageClick = useCallback((e: React.MouseEvent<HTMLImageElement>) => {
     const img = e.currentTarget

--- a/src/renderer/components/file-preview/renderers/markdown-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/markdown-renderer.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query'
 import { Loader2, AlertCircle } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -6,6 +5,7 @@ import { markdownUrlTransform } from '@renderer/lib/markdown-url-transform'
 import { useRef } from 'react'
 import { useTextSelection } from '../comments/use-text-selection'
 import { CommentOverlay } from '../comments/comment-overlay'
+import { useFileContent } from './use-file-content'
 
 interface MarkdownRendererProps {
   url: string
@@ -16,15 +16,10 @@ export function MarkdownRenderer({ url, filePath }: MarkdownRendererProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const { selection, clearSelection } = useTextSelection(containerRef)
 
-  const { data: content, isLoading, error } = useQuery({
-    queryKey: ['file-content', url],
-    queryFn: async () => {
-      const res = await fetch(url)
-      if (!res.ok) throw new Error(`Failed to load file: ${res.status}`)
-      return res.text()
-    },
-    staleTime: 30_000,
-  })
+  // Shares the ['file-content', url] cache with the text/CSV renderers, so all
+  // consumers of that key must agree on the cached shape (see use-file-content).
+  const { data, isLoading, error } = useFileContent(url)
+  const content = data?.text
 
   return (
     <div ref={containerRef} className="relative p-4">
@@ -78,6 +73,11 @@ export function MarkdownRenderer({ url, filePath }: MarkdownRendererProps) {
           >
             {content || ''}
           </ReactMarkdown>
+          {data?.truncated && (
+            <div className="mt-3 pt-3 border-t text-xs text-muted-foreground text-center not-prose">
+              File is larger than 5&nbsp;MB and was truncated. Download the file for the full content.
+            </div>
+          )}
         </div>
       )}
       {selection && (

--- a/src/renderer/components/file-preview/renderers/text-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/text-renderer.tsx
@@ -1,8 +1,8 @@
-import { useQuery } from '@tanstack/react-query'
 import { Loader2, AlertCircle } from 'lucide-react'
 import { useRef } from 'react'
 import { useTextSelection } from '../comments/use-text-selection'
 import { CommentOverlay } from '../comments/comment-overlay'
+import { useFileContent } from './use-file-content'
 
 interface TextRendererProps {
   url: string
@@ -13,22 +13,11 @@ export function TextRenderer({ url, filePath }: TextRendererProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const { selection, clearSelection } = useTextSelection(containerRef)
 
-  const { data: content, isLoading, error } = useQuery({
-    queryKey: ['file-content', url],
-    queryFn: async () => {
-      const res = await fetch(url)
-      if (!res.ok) throw new Error(`Failed to load file: ${res.status}`)
-      const text = await res.text()
-      if (text.length > 5_000_000) {
-        return text.slice(0, 5_000_000) + '\n\n... (file truncated at 5MB)'
-      }
-      return text
-    },
-    staleTime: 30_000,
-  })
+  const { data, isLoading, error } = useFileContent(url)
+  const sizeTruncated = data?.truncated ?? false
 
   const MAX_LINES = 5000
-  const allLines = (content || '').split('\n')
+  const allLines = (data?.text || '').split('\n')
   const truncated = allLines.length > MAX_LINES
   const lines = truncated ? allLines.slice(0, MAX_LINES) : allLines
 
@@ -61,6 +50,11 @@ export function TextRenderer({ url, filePath }: TextRendererProps) {
             </tbody>
           </table>
         </pre>
+        {sizeTruncated && (
+          <div className="px-4 py-3 border-t text-xs text-muted-foreground text-center">
+            File is larger than 5&nbsp;MB and was truncated. Download the file for the full content.
+          </div>
+        )}
         {truncated && (
           <div className="px-4 py-3 border-t text-xs text-muted-foreground text-center">
             Showing first {MAX_LINES.toLocaleString()} of {allLines.length.toLocaleString()} lines. Download the file for the full content.

--- a/src/renderer/components/file-preview/renderers/use-file-content.ts
+++ b/src/renderer/components/file-preview/renderers/use-file-content.ts
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query'
+
+/**
+ * Hard cap on how much text we pull into the renderer. Measured in UTF-16 code
+ * units (string length), which is what the previous inline fetches used.
+ */
+export const MAX_CONTENT_CHARS = 5_000_000
+
+export interface FileContent {
+  text: string
+  /** True when the file exceeded MAX_CONTENT_CHARS and `text` is a prefix. */
+  truncated: boolean
+}
+
+/**
+ * Shared loader for text-like file previews. Text and CSV renderers both key on
+ * ['file-content', url] (the CSV raw toggle reuses TextRenderer for the same
+ * URL), so they must agree on the cached shape — hence a single hook rather than
+ * inline useQuery calls. The truncation marker is returned as a flag instead of
+ * being appended to the text, so callers can render a banner without polluting
+ * parsed content.
+ */
+export function useFileContent(url: string) {
+  return useQuery<FileContent>({
+    queryKey: ['file-content', url],
+    queryFn: async () => {
+      const res = await fetch(url)
+      if (!res.ok) throw new Error(`Failed to load file: ${res.status}`)
+      const text = await res.text()
+      if (text.length > MAX_CONTENT_CHARS) {
+        return { text: text.slice(0, MAX_CONTENT_CHARS), truncated: true }
+      }
+      return { text, truncated: false }
+    },
+    staleTime: 30_000,
+  })
+}

--- a/src/renderer/context/file-preview-context.tsx
+++ b/src/renderer/context/file-preview-context.tsx
@@ -9,6 +9,18 @@ export interface FileTab {
   version: number
 }
 
+export interface CellRef {
+  /** 1-based data row index (header row excluded). */
+  row: number
+  /** 0-based column index, used to place the comment pin in the grid. */
+  col: number
+  /** Column header name (or "Column N" when the header is blank). */
+  column: string
+  /** Current cell value, included as context for the agent. */
+  value?: string
+}
+
+// TODO should create specific types for CSV / Image (x,y) and text, and FileComment can be a union of those with a `type` field. Deeper validation - if we have x we need y etc...
 export interface FileComment {
   id: string
   filePath: string
@@ -16,6 +28,7 @@ export interface FileComment {
   selectedText?: string
   x?: number
   y?: number
+  cell?: CellRef
 }
 
 interface FilePreviewContextType {

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1218,6 +1218,12 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
       'File delivered successfully (size: 2048 bytes)',
       'Here is the sales chart.'
     )],
+    ['deliver csv', new ToolUseScenario(
+      'mcp__user-input__deliver_file',
+      { filePath: '/workspace/output/data.csv', description: 'Contacts export' },
+      'File delivered successfully (size: 256 bytes)',
+      'Here is the contacts export.'
+    )],
     // API error scenarios
     ['auth error', new ApiErrorScenario('authentication_failed', 'Invalid API key')],
     ['rate limit error', new ApiErrorScenario('rate_limit', 'Rate limit exceeded, please try again later')],


### PR DESCRIPTION
## Summary

Closes [SUP-259](https://linear.app/datawizz/issue/SUP-259/file-preview-render-csvs-more-nicely). CSVs previously rendered as plain text in the file preview. This renders `.csv`/`.tsv` files as an interactive table and lets users pin comments to individual cells, which are sent to the agent with a `Row:Col_Name` identifier.

### Rendering
- **Dependency-free CSV/TSV parser** (`csv-parse.ts`): handles quoted fields, escaped `""`, embedded newlines, CRLF; **quote-aware delimiter detection** (`,`/`\t`/`;`/`|`) so a comma inside a quoted cell can't outvote a real tab; stack-safe column-count pass; blank lines are preserved so displayed row numbers stay aligned with the file.
- **`CsvRenderer`**: sticky header + sticky row-number column, dimensions readout, **Table / Raw toggle** (Raw reuses `TextRenderer` via the shared cache — no refetch), truncation banners for the 5 MB fetch cap and the 1,000-row display cap, and a `memo`'d grid so opening the comment overlay doesn't re-render large tables.

### Per-cell comments
- New `CellRef` on `FileComment` (`row`, `col`, `column`, `value`). Clicking a cell opens the existing comment overlay; commented cells show a count badge.
- `formatComments` emits `At cell <row>:<col_name> (col N, value: "...")` — quotes escaped, empty cells labelled, and the 1-based column position disambiguates duplicate headers.

### Refactors (from review)
- Shared **`useFileContent`** hook gives text/CSV/markdown a consistent `['file-content', url]` cache shape and surfaces truncation as a flag instead of an in-band marker.
- Shared **`useDismissOnOutsideClick`** hook dedupes the click-away logic across the text/image/CSV comment affordances.

## Testing
- `tsc --noEmit` clean, `eslint` clean
- **Unit (31):** `csv-parse` edge cases incl. a 1M-row stack-overflow guard and quoted-comma TSV detection; `formatComments` cell cases (value/empty/escaping/duplicate-header)
- **E2E (6/6):** table render + Raw toggle, and pinning a cell comment + confirming the formatted feedback reaches the conversation

## Notes
- A full multi-angle code review was run on this branch; all P1/P2 findings are fixed. One deferred item is captured as a `TODO` in `file-preview-context.tsx`: collapse the `FileComment` text/point/cell shapes into a discriminated union.
- No new runtime dependencies. CSV preview tops out at 5 MB / 1,000 displayed rows (banner + download/Raw fallback); no virtualization yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)