### PR TITLE
Make E2E base URL configurable

### DIFF
--- a/e2e/auth/fixtures/multi-user.fixture.ts
+++ b/e2e/auth/fixtures/multi-user.fixture.ts
@@ -1,6 +1,9 @@
 import { test as base, type BrowserContext, type Page } from '@playwright/test'
 
-const BASE_URL = 'http://localhost:3001'
+export function getAuthBaseUrl() {
+  const port = process.env.E2E_PORT ?? process.env.PORT ?? '3001'
+  return process.env.E2E_BASE_URL ?? `http://localhost:${port}`
+}
 
 /**
  * Multi-user fixture for auth E2E tests.
@@ -28,7 +31,7 @@ export const test = base.extend<
 
   user1Page: [async ({ user1Context }, use) => {
     const page = await user1Context.newPage()
-    await page.goto(BASE_URL)
+    await page.goto(getAuthBaseUrl())
     await use(page)
   }, { scope: 'worker' }],
 
@@ -40,7 +43,7 @@ export const test = base.extend<
 
   user2Page: [async ({ user2Context }, use) => {
     const page = await user2Context.newPage()
-    await page.goto(BASE_URL)
+    await page.goto(getAuthBaseUrl())
     await use(page)
   }, { scope: 'worker' }],
 
@@ -52,7 +55,7 @@ export const test = base.extend<
 
   user3Page: [async ({ user3Context }, use) => {
     const page = await user3Context.newPage()
-    await page.goto(BASE_URL)
+    await page.goto(getAuthBaseUrl())
     await use(page)
   }, { scope: 'worker' }],
 })

--- a/e2e/auth/specs/auth-settings.spec.ts
+++ b/e2e/auth/specs/auth-settings.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../fixtures/multi-user.fixture'
+import { getAuthBaseUrl, test, expect } from '../fixtures/multi-user.fixture'
 import { AuthPage } from '../pages/auth.page'
 import { SettingsPage } from '../pages/settings.page'
 import { AppPage } from '../../pages/app.page'
@@ -12,6 +12,7 @@ const admin = { email: 'alice@test.com', password: 'password123' }
 const newUser = { name: 'Dave Domain', email: 'dave@allowed.com', password: 'password123' }
 const blockedUser = { name: 'Eve External', email: 'eve@blocked.com', password: 'password123' }
 const approvalUser = { name: 'Frank Pending', email: 'frank@test.com', password: 'password123' }
+const authBaseUrl = getAuthBaseUrl()
 
 test.describe('Auth Settings Enforcement', () => {
   // ── Setup: admin signs in ───────────────────────────────────────────
@@ -28,9 +29,9 @@ test.describe('Auth Settings Enforcement', () => {
       user3Page.context().clearCookies(),
     ])
     await Promise.all([
-      user1Page.goto('http://localhost:3001'),
-      user2Page.goto('http://localhost:3001'),
-      user3Page.goto('http://localhost:3001'),
+      user1Page.goto(authBaseUrl),
+      user2Page.goto(authBaseUrl),
+      user3Page.goto(authBaseUrl),
     ])
 
     await authPage.expectVisible()

--- a/e2e/specs/search.spec.ts
+++ b/e2e/specs/search.spec.ts
@@ -96,7 +96,7 @@ test.describe('Search palette', () => {
 
     // Agents are created as "Untitled" with a random slug, then renamed
     // asynchronously. Look up the actual slug from the API by name.
-    const agentsRes = await request.get('http://localhost:3000/api/agents')
+    const agentsRes = await request.get('/api/agents')
     expect(agentsRes.ok()).toBe(true)
     const agents = (await agentsRes.json()) as Array<{ slug: string; name: string }>
     const slug = agents.find((a) => a.name === agentName)?.slug
@@ -110,12 +110,12 @@ test.describe('Search palette', () => {
     await expect
       .poll(
         async () => {
-          const sessionsRes = await request.get(`http://localhost:3000/api/agents/${slug}/sessions`)
+          const sessionsRes = await request.get(`/api/agents/${slug}/sessions`)
           if (!sessionsRes.ok()) return false
           const sessions = (await sessionsRes.json()) as Array<{ id: string }>
           if (sessions.length === 0) return false
           const patchRes = await request.patch(
-            `http://localhost:3000/api/agents/${slug}/sessions/${sessions[0].id}`,
+            `/api/agents/${slug}/sessions/${sessions[0].id}`,
             { data: { name: sessionName } },
           )
           return patchRes.ok()

--- a/e2e/specs/settings.spec.ts
+++ b/e2e/specs/settings.spec.ts
@@ -581,8 +581,8 @@ test.describe('Settings deep-link reset', () => {
 
 test.describe('Settings ?from= close-target', () => {
   test('close pushes to the captured ?from origin', async ({ page, request }) => {
-    await request.put('http://localhost:3000/api/user-settings', { data: { setupCompleted: true } })
-    const createRes = await request.post('http://localhost:3000/api/agents', { data: { name: 'Settings From Origin' } })
+    await request.put('/api/user-settings', { data: { setupCompleted: true } })
+    const createRes = await request.post('/api/agents', { data: { name: 'Settings From Origin' } })
     const agent = await createRes.json() as { slug: string }
 
     const appPage = new AppPage(page)
@@ -597,11 +597,11 @@ test.describe('Settings ?from= close-target', () => {
     await page.locator('[data-testid="settings-back"]').click()
     await expect(page).toHaveURL(origin)
 
-    await request.delete(`http://localhost:3000/api/agents/${agent.slug}`)
+    await request.delete(`/api/agents/${agent.slug}`)
   })
 
   test('cold deep-link to /settings/general closes to home (no ?from)', async ({ page, request }) => {
-    await request.put('http://localhost:3000/api/user-settings', { data: { setupCompleted: true } })
+    await request.put('/api/user-settings', { data: { setupCompleted: true } })
     await page.goto('/settings/general')
     await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
     await expect(page.locator('[data-testid="settings-nav-general"]')).toHaveAttribute('data-active', 'true')
@@ -610,8 +610,8 @@ test.describe('Settings ?from= close-target', () => {
   })
 
   test('settings survives a refresh and still closes to origin (?from= is durable)', async ({ page, request }) => {
-    await request.put('http://localhost:3000/api/user-settings', { data: { setupCompleted: true } })
-    const createRes = await request.post('http://localhost:3000/api/agents', { data: { name: 'Settings Refresh From' } })
+    await request.put('/api/user-settings', { data: { setupCompleted: true } })
+    const createRes = await request.post('/api/agents', { data: { name: 'Settings Refresh From' } })
     const agent = await createRes.json() as { slug: string }
 
     const appPage = new AppPage(page)
@@ -628,6 +628,6 @@ test.describe('Settings ?from= close-target', () => {
     await page.locator('[data-testid="settings-back"]').click()
     await expect(page).toHaveURL(origin)
 
-    await request.delete(`http://localhost:3000/api/agents/${agent.slug}`)
+    await request.delete(`/api/agents/${agent.slug}`)
   })
 })

--- a/playwright.auth.config.ts
+++ b/playwright.auth.config.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 // Use a separate data directory for auth E2E tests.
 const e2eDataDir = path.resolve(process.env.SUPERAGENT_DATA_DIR ?? path.join(__dirname, '.e2e-data-auth'))
-const e2ePort = process.env.PORT ?? process.env.E2E_PORT ?? '3001'
+const e2ePort = process.env.E2E_PORT ?? process.env.PORT ?? '3001'
 const e2eBaseUrl = process.env.E2E_BASE_URL ?? `http://localhost:${e2ePort}`
 const playwrightOutputDir = process.env.PLAYWRIGHT_OUTPUT_DIR ?? 'test-results'
 const playwrightHtmlReportDir = process.env.PLAYWRIGHT_HTML_REPORT ?? 'playwright-report'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@ import path from 'path'
 // Use a separate data directory for E2E tests to avoid polluting production data.
 // CI can override these so suites can keep isolated state and artifacts.
 const e2eDataDir = path.resolve(process.env.SUPERAGENT_DATA_DIR ?? path.join(__dirname, '.e2e-data'))
-const e2ePort = process.env.PORT ?? process.env.E2E_PORT ?? '3000'
+const e2ePort = process.env.E2E_PORT ?? process.env.PORT ?? '3000'
 const e2eBaseUrl = process.env.E2E_BASE_URL ?? `http://localhost:${e2ePort}`
 const playwrightOutputDir = process.env.PLAYWRIGHT_OUTPUT_DIR ?? 'test-results'
 const playwrightHtmlReportDir = process.env.PLAYWRIGHT_HTML_REPORT ?? 'playwright-report'


### PR DESCRIPTION
## Summary

Fixes SUP-273 by making the E2E Playwright suites run cleanly on non-default ports.

- Prefer `E2E_PORT` over generic `PORT` in both Playwright configs.
- Replace hardcoded `localhost:3000` API calls in regular E2E specs with baseURL-relative request paths.
- Replace hardcoded `localhost:3001` auth navigation with a shared auth base URL helper that honors `E2E_BASE_URL`, `E2E_PORT`, and `PORT`.

## Root Cause

The main Playwright config was already mostly configurable, but some specs still bypassed Playwright's `baseURL` with absolute localhost URLs. The auth suite also kept its own hardcoded `localhost:3001` navigation in the multi-user fixture/settings spec.

## Impact

The full E2E suite can now be run on alternate ports, including when multiple local/test runs need isolated dev servers.

## Validation

- Hardcoded `localhost:3000` / `localhost:3001` scan returned no matches.
- Absolute `page.goto("http...")` and Playwright `request.*("http...")` scan under `e2e` returned no matches.
- `npm run lint:e2e -- --quiet`
- `git diff --check`
- `E2E_PORT=3100 ... node_modules/.bin/playwright test` passed: 202 passed, 18 skipped.
- `E2E_PORT=3101 ... node_modules/.bin/playwright test --config=playwright.auth.config.ts` passed: 43 passed.
