### PR TITLE
Add route-specific document titles

### DIFF
--- a/src/renderer/components/layout/route-layouts.tsx
+++ b/src/renderer/components/layout/route-layouts.tsx
@@ -19,6 +19,7 @@ import { useFullScreen } from '@renderer/hooks/use-fullscreen'
 import { useUser } from '@renderer/context/user-context'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { useSettings } from '@renderer/hooks/use-settings'
+import { useDocumentTitle } from '@renderer/hooks/use-document-title'
 import { isElectron, getPlatform } from '@renderer/lib/env'
 import { setRendererErrorReportingEnabled, setRendererErrorReportingUser } from '@renderer/lib/error-reporting'
 
@@ -30,6 +31,7 @@ import { setRendererErrorReportingEnabled, setRendererErrorReportingUser } from 
 export function RootLayout() {
   useTheme()
   useInsetRadius()
+  useDocumentTitle()
 
   const [wizardOpen, setWizardOpen] = useState(false)
   const [wizardAgentOnly, setWizardAgentOnly] = useState(false)

--- a/src/renderer/hooks/use-document-title.test.tsx
+++ b/src/renderer/hooks/use-document-title.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppLocation } from '@renderer/router/route-state'
+
+const DOT = ' \u00b7 '
+const DASH = ' \u2014 '
+
+const mocks = vi.hoisted(() => ({
+  routeLocation: { selectedAgentSlug: null, view: { kind: 'home' } } as AppLocation,
+  routerMatches: [] as Array<{ params: Record<string, string | undefined>; fullPath?: string }>,
+  agent: undefined as { name?: string; dashboards?: Array<{ slug: string; name: string }> } | undefined,
+  session: undefined as { name?: string } | undefined,
+}))
+
+vi.mock('@renderer/router/use-route-location', () => ({
+  useRouteLocation: () => mocks.routeLocation,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouterState: <T,>(opts: {
+    select: (state: { matches: Array<{ params: Record<string, string | undefined>; fullPath?: string }> }) => T
+  }): T => opts.select({ matches: mocks.routerMatches }),
+}))
+
+vi.mock('@renderer/hooks/use-agents', () => ({
+  useAgent: () => ({ data: mocks.agent }),
+}))
+
+vi.mock('@renderer/hooks/use-sessions', () => ({
+  useSession: () => ({ data: mocks.session }),
+}))
+
+import { getDocumentTitle, useDocumentTitle } from './use-document-title'
+
+function DocumentTitleHarness() {
+  useDocumentTitle()
+  return null
+}
+
+function location(view: AppLocation['view'], selectedAgentSlug: string | null = null): AppLocation {
+  return { selectedAgentSlug, view }
+}
+
+describe('getDocumentTitle', () => {
+  it('formats global and agent home titles', () => {
+    expect(getDocumentTitle({ location: location({ kind: 'home' }) })).toBe('SuperAgent')
+    expect(getDocumentTitle({ location: location({ kind: 'home' }, 'agent-one'), agentName: 'Agent One' })).toBe(
+      `Agent One${DOT}SuperAgent`,
+    )
+    expect(getDocumentTitle({ location: location({ kind: 'home' }, 'agent-one') })).toBe(`agent-one${DOT}SuperAgent`)
+  })
+
+  it('formats sessions and agent-scoped tool views', () => {
+    const base = location({ kind: 'session', id: 'session-1' }, 'agent-one')
+
+    expect(getDocumentTitle({ location: base, agentName: 'Agent One', sessionName: 'Launch Plan' })).toBe(
+      `Launch Plan${DASH}Agent One`,
+    )
+    expect(getDocumentTitle({ location: base })).toBe(`Session${DASH}agent-one`)
+    expect(getDocumentTitle({ location: location({ kind: 'connections' }, 'agent-one'), agentName: 'Agent One' })).toBe(
+      `Agent One${DASH}Connections`,
+    )
+    expect(getDocumentTitle({ location: location({ kind: 'apiLogs' }, 'agent-one'), agentName: 'Agent One' })).toBe(
+      `Agent One${DASH}API Logs`,
+    )
+    expect(
+      getDocumentTitle({
+        location: location({ kind: 'dashboard', slug: 'sales-dashboard' }, 'agent-one'),
+        agentName: 'Agent One',
+        dashboardName: 'Sales Dashboard',
+      }),
+    ).toBe(`Agent One${DASH}Sales Dashboard`)
+  })
+
+  it('formats notifications and settings routes', () => {
+    expect(getDocumentTitle({ location: location({ kind: 'notifications' }) })).toBe(`Notifications${DOT}SuperAgent`)
+    expect(getDocumentTitle({ location: location({ kind: 'home' }), isSettingsRoute: true })).toBe(`Settings${DOT}SuperAgent`)
+    expect(getDocumentTitle({ location: location({ kind: 'home' }), isSettingsRoute: true, settingsTab: 'llm' })).toBe(
+      `Settings${DASH}LLM Provider`,
+    )
+  })
+})
+
+describe('useDocumentTitle', () => {
+  beforeEach(() => {
+    document.title = 'Old Title'
+    mocks.routeLocation = location({ kind: 'home' })
+    mocks.routerMatches = [{ params: {}, fullPath: '/' }]
+    mocks.agent = undefined
+    mocks.session = undefined
+  })
+
+  it('applies the current route title and updates on navigation', async () => {
+    const { rerender } = render(<DocumentTitleHarness />)
+
+    await waitFor(() => expect(document.title).toBe('SuperAgent'))
+
+    mocks.routeLocation = location({ kind: 'home' }, 'agent-one')
+    mocks.routerMatches = [{ params: { slug: 'agent-one' }, fullPath: '/agents/$slug' }]
+    mocks.agent = { name: 'Agent One' }
+    rerender(<DocumentTitleHarness />)
+
+    await waitFor(() => expect(document.title).toBe(`Agent One${DOT}SuperAgent`))
+
+    mocks.routeLocation = location({ kind: 'session', id: 'session-1' }, 'agent-one')
+    mocks.routerMatches = [
+      { params: { slug: 'agent-one' }, fullPath: '/agents/$slug' },
+      { params: { sessionId: 'session-1' }, fullPath: '/agents/$slug/sessions/$sessionId' },
+    ]
+    mocks.session = { name: 'Launch Plan' }
+    rerender(<DocumentTitleHarness />)
+
+    await waitFor(() => expect(document.title).toBe(`Launch Plan${DASH}Agent One`))
+  })
+
+  it('derives settings titles from the router matches even though AppLocation degrades to home', async () => {
+    mocks.routeLocation = location({ kind: 'home' })
+    mocks.routerMatches = [
+      { params: {}, fullPath: '/settings' },
+      { params: { tab: 'connections' }, fullPath: '/settings/$tab' },
+    ]
+
+    render(<DocumentTitleHarness />)
+
+    await waitFor(() => expect(document.title).toBe(`Settings${DASH}Connections`))
+  })
+})

--- a/src/renderer/hooks/use-document-title.ts
+++ b/src/renderer/hooks/use-document-title.ts
@@ -1,0 +1,177 @@
+import { useEffect, useMemo } from 'react'
+import { useRouterState } from '@tanstack/react-router'
+import { useAgent } from '@renderer/hooks/use-agents'
+import { useSession } from '@renderer/hooks/use-sessions'
+import { useRouteLocation } from '@renderer/router/use-route-location'
+import { settingsTabSchema, type SettingsTab } from '@renderer/router/search-schemas'
+import type { AppLocation, AgentView } from '@renderer/router/route-state'
+
+const APP_TITLE = 'SuperAgent'
+const BRAND_SEPARATOR = ' \u00b7 '
+const VIEW_SEPARATOR = ' \u2014 '
+
+const SETTINGS_TAB_TITLES = {
+  profile: 'Profile & Login',
+  general: 'General',
+  notifications: 'Notifications',
+  platform: 'Account',
+  connections: 'Connections',
+  usage: 'Usage',
+  llm: 'LLM Provider',
+  runtime: 'Runtime',
+  browser: 'Browser Use',
+  'computer-use': 'Computer Use',
+  'account-provider': 'Account Provider',
+  voice: 'Voice',
+  skillsets: 'Skillsets',
+  analytics: 'Analytics',
+  'audit-log': 'Audit Log',
+  admin: 'Admin',
+  users: 'Users',
+  auth: 'Auth',
+} satisfies Record<SettingsTab, string>
+
+interface SettingsTitleState {
+  isSettingsRoute: boolean
+  tab: string | null
+}
+
+export interface DocumentTitleInput {
+  location: AppLocation
+  isSettingsRoute?: boolean
+  settingsTab?: string | null
+  agentName?: string | null
+  agentSlug?: string | null
+  sessionName?: string | null
+  dashboardName?: string | null
+}
+
+function cleanTitlePart(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+function humanizeIdentifier(value: string | null | undefined): string | null {
+  const cleaned = cleanTitlePart(value)
+  if (!cleaned) return null
+  return cleaned
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+function formatSettingsTabTitle(tab: string | null | undefined): string | null {
+  const parsed = settingsTabSchema.safeParse(tab)
+  if (!parsed.success) return null
+  return SETTINGS_TAB_TITLES[parsed.data]
+}
+
+function formatAgentTitlePart(agentName: string | null | undefined, agentSlug: string | null | undefined): string {
+  return cleanTitlePart(agentName) ?? cleanTitlePart(agentSlug) ?? APP_TITLE
+}
+
+function joinWithBrand(title: string): string {
+  return `${title}${BRAND_SEPARATOR}${APP_TITLE}`
+}
+
+function joinView(agentTitle: string, viewTitle: string): string {
+  return `${agentTitle}${VIEW_SEPARATOR}${viewTitle}`
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled AgentView kind: ${JSON.stringify(value)}`)
+}
+
+function titleForAgentView(view: AgentView, input: DocumentTitleInput): string {
+  const agentTitle = formatAgentTitlePart(input.agentName, input.agentSlug ?? input.location.selectedAgentSlug)
+
+  switch (view.kind) {
+    case 'home':
+      return input.location.selectedAgentSlug ? joinWithBrand(agentTitle) : APP_TITLE
+    case 'session':
+      return `${cleanTitlePart(input.sessionName) ?? 'Session'}${VIEW_SEPARATOR}${agentTitle}`
+    case 'task':
+      return joinView(agentTitle, 'Scheduled Task')
+    case 'webhook':
+      return joinView(agentTitle, 'Webhook Trigger')
+    case 'chat':
+      return joinView(agentTitle, 'Remote Chat')
+    case 'dashboard':
+      return joinView(agentTitle, cleanTitlePart(input.dashboardName) ?? humanizeIdentifier(view.slug) ?? 'Dashboard')
+    case 'apiLogs':
+      return joinView(agentTitle, 'API Logs')
+    case 'connections':
+      return joinView(agentTitle, 'Connections')
+    case 'notifications':
+      return joinWithBrand('Notifications')
+    default:
+      return assertNever(view)
+  }
+}
+
+export function getDocumentTitle(input: DocumentTitleInput): string {
+  if (input.isSettingsRoute) {
+    const tabTitle = formatSettingsTabTitle(input.settingsTab)
+    return tabTitle ? `Settings${VIEW_SEPARATOR}${tabTitle}` : joinWithBrand('Settings')
+  }
+
+  return titleForAgentView(input.location.view, input)
+}
+
+function useSettingsTitleState(): SettingsTitleState {
+  return useRouterState({
+    structuralSharing: true,
+    select: (state): SettingsTitleState => {
+      const params: Record<string, string | undefined> = {}
+      for (const match of state.matches) {
+        Object.assign(params, match.params)
+      }
+
+      const deepest = state.matches[state.matches.length - 1]
+      const fullPath = deepest?.fullPath ?? ''
+      const normalizedPath = fullPath.length > 1 && fullPath.endsWith('/') ? fullPath.slice(0, -1) : fullPath
+      const isSettingsRoute = normalizedPath === '/settings' || normalizedPath === '/settings/$tab'
+
+      return {
+        isSettingsRoute,
+        tab: typeof params.tab === 'string' ? params.tab : null,
+      }
+    },
+  })
+}
+
+export function useDocumentTitle() {
+  const location = useRouteLocation()
+  const settings = useSettingsTitleState()
+  const agentSlug = location.selectedAgentSlug
+  const sessionId = location.view.kind === 'session' ? location.view.id : null
+
+  const { data: agent } = useAgent(agentSlug)
+  const { data: session } = useSession(sessionId, agentSlug)
+
+  const dashboardName = useMemo(() => {
+    if (location.view.kind !== 'dashboard') return null
+    const dashboardSlug = location.view.slug
+    return agent?.dashboards?.find((dashboard) => dashboard.slug === dashboardSlug)?.name ?? null
+  }, [agent, location.view])
+
+  const title = useMemo(
+    () =>
+      getDocumentTitle({
+        location,
+        isSettingsRoute: settings.isSettingsRoute,
+        settingsTab: settings.tab,
+        agentName: agent?.name,
+        agentSlug,
+        sessionName: session?.name,
+        dashboardName,
+      }),
+    [agent?.name, agentSlug, dashboardName, location, session?.name, settings.isSettingsRoute, settings.tab],
+  )
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    document.title = title
+  }, [title])
+}


### PR DESCRIPTION
## Summary

Adds a central useDocumentTitle() hook mounted in RootLayout so browser tab titles are derived from the active TanStack route plus cached agent/session data.

The title resolver covers global home, agent home, sessions, agent subviews, dashboards, notifications, and settings tabs with resilient fallbacks for cold deep links and missing cache data.

## Validation

- npm run typecheck
- npm run test:run -- src/renderer/hooks/use-document-title.test.tsx
- npx eslint src/renderer/hooks/use-document-title.ts src/renderer/hooks/use-document-title.test.tsx src/renderer/components/layout/route-layouts.tsx