### PR TITLE
Add Electron history navigation controls

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -372,6 +372,19 @@ function createWindow() {
     mainWindow?.webContents.send('window-maximized-change', false)
   })
 
+  // Browser-style hardware buttons (e.g. mouse Back/Forward) arrive as app
+  // commands on Windows/Linux. Forward them to the renderer so TanStack Router's
+  // history, not Electron's document history, owns app navigation.
+  mainWindow.on('app-command', (event, command) => {
+    if (command === 'browser-backward') {
+      event.preventDefault()
+      mainWindow?.webContents.send('history-navigation-command', 'back')
+    } else if (command === 'browser-forward') {
+      event.preventDefault()
+      mainWindow?.webContents.send('history-navigation-command', 'forward')
+    }
+  })
+
   processPendingProtocolUrls()
 }
 

--- a/src/preload/index.sup215.test.ts
+++ b/src/preload/index.sup215.test.ts
@@ -117,6 +117,7 @@ const channels: Array<{ name: string; on: string; channel: string; payload: unkn
   { name: 'onNavigateToAgent', on: 'onNavigateToAgent', channel: 'navigate-to-agent', payload: ['agent-slug', 'session-id'] },
   { name: 'onOpenSettings', on: 'onOpenSettings', channel: 'open-settings', payload: [] },
   { name: 'onOpenCreateAgent', on: 'onOpenCreateAgent', channel: 'open-create-agent', payload: [] },
+  { name: 'onHistoryNavigationCommand', on: 'onHistoryNavigationCommand', channel: 'history-navigation-command', payload: ['back'] },
   // Window-state channels: these had the most concurrent subscribers (useFullScreen
   // is mounted in ~5 places; window-maximized-change is shared by WindowControls +
   // useInsetRadius), so they must honor per-listener unsubscribe too.

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -46,6 +46,8 @@ type ExposedApi = {
   setSidebarCollapsed: (collapsed: boolean) => void
   onNavigateToAgent: (callback: (agentSlug: string, sessionId?: string | null) => void) => void
   removeNavigateToAgent: () => void
+  onHistoryNavigationCommand: (callback: (command: 'back' | 'forward') => void) => void
+  removeHistoryNavigationCommand: () => void
   onNotificationEvent: (
     callback: (event: { type: 'click' | 'action'; actionIndex?: number; context?: unknown }) => void,
   ) => () => void
@@ -140,6 +142,28 @@ describe('preload electronAPI bridge', () => {
 
     api.removeNavigateToAgent()
     expect(electronMocks.removeAllListeners).toHaveBeenCalledWith('navigate-to-agent')
+  })
+
+  it('forwards history navigation commands and filters invalid payloads', async () => {
+    const api = await loadApi()
+    const callback = vi.fn()
+
+    api.onHistoryNavigationCommand(callback)
+
+    const handler = electronMocks.on.mock.calls.find(([channel]) => channel === 'history-navigation-command')?.[1] as
+      | ((event: unknown, command: string) => void)
+      | undefined
+    expect(handler).toBeDefined()
+
+    handler?.({}, 'back')
+    handler?.({}, 'forward')
+    handler?.({}, 'sideways')
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback).toHaveBeenNthCalledWith(1, 'back')
+    expect(callback).toHaveBeenNthCalledWith(2, 'forward')
+
+    api.removeHistoryNavigationCommand()
+    expect(electronMocks.removeAllListeners).toHaveBeenCalledWith('history-navigation-command')
   })
 
   it('returns a precise unsubscribe for notification events', async () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -164,6 +164,21 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.removeAllListeners('open-create-agent')
   },
 
+  onHistoryNavigationCommand: (callback: (command: 'back' | 'forward') => void): (() => void) => {
+    const handler = (_event: unknown, command: unknown) => {
+      if (command === 'back' || command === 'forward') callback(command)
+    }
+    ipcRenderer.on('history-navigation-command', handler)
+    return () => {
+      ipcRenderer.removeListener('history-navigation-command', handler)
+    }
+  },
+
+  // Channel-wide reset — prefer the unsubscribe returned by onHistoryNavigationCommand.
+  removeHistoryNavigationCommand: () => {
+    ipcRenderer.removeAllListeners('history-navigation-command')
+  },
+
   // Reclaim window focus (e.g. after Chrome steals it by opening a new tab)
   focusWindow: () => {
     ipcRenderer.send('focus-window')
@@ -359,6 +374,8 @@ declare global {
       removeOpenSettings: () => void
       onOpenCreateAgent: (callback: () => void) => () => void
       removeOpenCreateAgent: () => void
+      onHistoryNavigationCommand: (callback: (command: 'back' | 'forward') => void) => () => void
+      removeHistoryNavigationCommand: () => void
       setSidebarCollapsed: (collapsed: boolean) => void
       setTrayVisible: (visible: boolean) => Promise<void>
       showNotification: (

--- a/src/renderer/components/history-navigation-handler.test.tsx
+++ b/src/renderer/components/history-navigation-handler.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { HistoryNavigationHandler } from './history-navigation-handler'
+
+const mockIsElectron = vi.hoisted(() => vi.fn(() => false))
+const mockGetPlatform = vi.hoisted(() => vi.fn(() => 'darwin'))
+const mockBack = vi.hoisted(() => vi.fn())
+const mockForward = vi.hoisted(() => vi.fn())
+
+vi.mock('@renderer/lib/env', () => ({
+  isElectron: mockIsElectron,
+  getPlatform: mockGetPlatform,
+}))
+
+vi.mock('@renderer/router/use-history-navigation', () => ({
+  useHistoryNavigation: () => ({
+    back: mockBack,
+    forward: mockForward,
+    canGoBack: true,
+    canGoForward: true,
+  }),
+}))
+
+function dispatchKeyboardEvent(init: KeyboardEventInit) {
+  const event = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  })
+  window.dispatchEvent(event)
+  return event
+}
+
+function dispatchMouseEvent(type: 'mousedown' | 'auxclick', button: number) {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    button,
+  })
+  window.dispatchEvent(event)
+  return event
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal('__WEB__', true)
+  mockIsElectron.mockReturnValue(false)
+  mockGetPlatform.mockReturnValue('darwin')
+  delete window.electronAPI
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('HistoryNavigationHandler', () => {
+  it('does not handle browser web shortcuts', () => {
+    render(<HistoryNavigationHandler />)
+
+    dispatchKeyboardEvent({ key: '[', code: 'BracketLeft', metaKey: true })
+    dispatchMouseEvent('mousedown', 3)
+
+    expect(mockBack).not.toHaveBeenCalled()
+    expect(mockForward).not.toHaveBeenCalled()
+  })
+
+  it('handles Electron keyboard shortcuts', () => {
+    vi.stubGlobal('__WEB__', false)
+    mockIsElectron.mockReturnValue(true)
+    render(<HistoryNavigationHandler />)
+
+    const backEvent = dispatchKeyboardEvent({ key: '[', code: 'BracketLeft', metaKey: true })
+    const forwardEvent = dispatchKeyboardEvent({ key: ']', code: 'BracketRight', metaKey: true })
+
+    expect(backEvent.defaultPrevented).toBe(true)
+    expect(forwardEvent.defaultPrevented).toBe(true)
+    expect(mockBack).toHaveBeenCalledTimes(1)
+    expect(mockForward).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles Electron Alt+Arrow shortcuts', () => {
+    vi.stubGlobal('__WEB__', false)
+    mockIsElectron.mockReturnValue(true)
+    mockGetPlatform.mockReturnValue('win32')
+    render(<HistoryNavigationHandler />)
+
+    dispatchKeyboardEvent({ key: 'ArrowLeft', altKey: true })
+    dispatchKeyboardEvent({ key: 'ArrowRight', altKey: true })
+
+    expect(mockBack).toHaveBeenCalledTimes(1)
+    expect(mockForward).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles Electron auxiliary mouse buttons', () => {
+    vi.stubGlobal('__WEB__', false)
+    mockIsElectron.mockReturnValue(true)
+    render(<HistoryNavigationHandler />)
+
+    const backEvent = dispatchMouseEvent('mousedown', 3)
+    const forwardEvent = dispatchMouseEvent('auxclick', 4)
+
+    expect(backEvent.defaultPrevented).toBe(true)
+    expect(forwardEvent.defaultPrevented).toBe(true)
+    expect(mockBack).toHaveBeenCalledTimes(1)
+    expect(mockForward).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles native app-command events forwarded by preload', () => {
+    vi.stubGlobal('__WEB__', false)
+    mockIsElectron.mockReturnValue(true)
+    let nativeCallback: ((command: 'back' | 'forward') => void) | null = null
+    const unsubscribe = vi.fn()
+    window.electronAPI = {
+      onHistoryNavigationCommand: vi.fn((callback) => {
+        nativeCallback = callback
+        return unsubscribe
+      }),
+    } as unknown as typeof window.electronAPI
+
+    const { unmount } = render(<HistoryNavigationHandler />)
+
+    act(() => {
+      nativeCallback?.('back')
+      nativeCallback?.('forward')
+    })
+
+    expect(mockBack).toHaveBeenCalledTimes(1)
+    expect(mockForward).toHaveBeenCalledTimes(1)
+
+    unmount()
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/components/history-navigation-handler.tsx
+++ b/src/renderer/components/history-navigation-handler.tsx
@@ -1,0 +1,85 @@
+import { useEffect } from 'react'
+import { isElectron, getPlatform } from '@renderer/lib/env'
+import { useHistoryNavigation } from '@renderer/router/use-history-navigation'
+
+type HistoryNavigationCommand = 'back' | 'forward'
+
+function isBracketKey(event: KeyboardEvent, bracket: '[' | ']'): boolean {
+  const code = bracket === '[' ? 'BracketLeft' : 'BracketRight'
+  return event.key === bracket || event.code === code
+}
+
+function getKeyboardNavigationCommand(event: KeyboardEvent): HistoryNavigationCommand | null {
+  if (event.defaultPrevented || event.repeat) return null
+
+  const bracketModifier =
+    getPlatform() === 'darwin'
+      ? event.metaKey && !event.ctrlKey
+      : event.ctrlKey && !event.metaKey
+
+  if (bracketModifier && !event.altKey && !event.shiftKey) {
+    if (isBracketKey(event, '[')) return 'back'
+    if (isBracketKey(event, ']')) return 'forward'
+  }
+
+  if (event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
+    if (event.key === 'ArrowLeft') return 'back'
+    if (event.key === 'ArrowRight') return 'forward'
+  }
+
+  return null
+}
+
+function getMouseNavigationCommand(event: MouseEvent): HistoryNavigationCommand | null {
+  if (event.defaultPrevented) return null
+  if (event.button === 3) return 'back'
+  if (event.button === 4) return 'forward'
+  return null
+}
+
+/**
+ * App-local browser-style history shortcuts for Electron. Mounted at the root
+ * so it survives the shell/settings route switch and drives TanStack history
+ * rather than Electron's document navigation stack.
+ */
+export function HistoryNavigationHandler() {
+  const { back, forward } = useHistoryNavigation()
+
+  useEffect(() => {
+    if (__WEB__ || !isElectron()) return
+
+    const dispatch = (command: HistoryNavigationCommand) => {
+      if (command === 'back') back()
+      else forward()
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const command = getKeyboardNavigationCommand(event)
+      if (!command) return
+      event.preventDefault()
+      dispatch(command)
+    }
+
+    const handleMouseNavigation = (event: MouseEvent) => {
+      const command = getMouseNavigationCommand(event)
+      if (!command) return
+      event.preventDefault()
+      dispatch(command)
+    }
+
+    const unsubscribeNativeCommand = window.electronAPI?.onHistoryNavigationCommand?.(dispatch)
+
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('mousedown', handleMouseNavigation, true)
+    window.addEventListener('auxclick', handleMouseNavigation, true)
+
+    return () => {
+      unsubscribeNativeCommand?.()
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('mousedown', handleMouseNavigation, true)
+      window.removeEventListener('auxclick', handleMouseNavigation, true)
+    }
+  }, [back, forward])
+
+  return null
+}

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { cloneElement, isValidElement, type ReactElement } from 'react'
-import { screen } from '@testing-library/react'
+import { act, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AppSidebar } from './app-sidebar'
 import { renderWithProviders } from '@renderer/test/test-utils'
@@ -12,10 +12,14 @@ import { renderWithProviders } from '@renderer/test/test-utils'
 vi.stubGlobal('__APP_VERSION__', '0.1.0-test')
 vi.stubGlobal('__RENDER_TRACKING__', false)
 
+const mockIsElectron = vi.hoisted(() => vi.fn(() => false))
+const mockGetPlatform = vi.hoisted(() => vi.fn(() => 'web'))
+const mockOpenDashboardExternal = vi.hoisted(() => vi.fn())
+
 vi.mock('@renderer/lib/env', () => ({
-  isElectron: () => false,
-  getPlatform: () => 'web',
-  openDashboardExternal: vi.fn(),
+  isElectron: mockIsElectron,
+  getPlatform: mockGetPlatform,
+  openDashboardExternal: mockOpenDashboardExternal,
   getApiBaseUrl: () => 'http://localhost:3000',
 }))
 
@@ -91,10 +95,24 @@ vi.mock('@renderer/hooks/use-fullscreen', () => ({
 // (matches the global setup mock, which this file-level mock replaces).
 let mockRouteParams: Record<string, string | undefined> = {}
 let mockRoutePathname = '/'
+let mockHistorySubscribers: Array<(opts: { action: { type: string } }) => void> = []
+const mockHistory = {
+  location: { state: { __TSR_index: 0 } },
+  canGoBack: vi.fn(() => false),
+  back: vi.fn(),
+  forward: vi.fn(),
+  subscribe: vi.fn((cb: (opts: { action: { type: string } }) => void) => {
+    mockHistorySubscribers.push(cb)
+    return () => {
+      mockHistorySubscribers = mockHistorySubscribers.filter((subscriber) => subscriber !== cb)
+    }
+  }),
+}
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
   return {
     ...actual,
+    useRouter: () => ({ history: mockHistory }),
     useNavigate: () => () => {},
     useParams: () => mockRouteParams,
     useRouterState: (opts?: { select?: (s: { location: { pathname: string } }) => unknown }) =>
@@ -289,10 +307,24 @@ function makeSession(overrides: Record<string, any> = {}) {
   }
 }
 
+function setMockHistoryIndex(index: number) {
+  mockHistory.location = { state: { __TSR_index: index } }
+  mockHistory.canGoBack.mockImplementation(() => index > 0)
+}
+
+function notifyHistory(actionType: string) {
+  mockHistorySubscribers.forEach((subscriber) => subscriber({ action: { type: actionType } }))
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
+  vi.stubGlobal('__WEB__', true)
+  mockIsElectron.mockReturnValue(false)
+  mockGetPlatform.mockReturnValue('web')
   mockRouteParams = {}
   mockRoutePathname = '/'
+  mockHistorySubscribers = []
+  setMockHistoryIndex(0)
   mockUseAgents.mockReturnValue({
     data: [makeAgent(), makeAgent({ slug: 'other-agent', name: 'Other Agent', status: 'stopped', sessionCount: 0 })],
     isLoading: false,
@@ -365,6 +397,42 @@ describe('AppSidebar — layout & top nav', () => {
     const header = screen.getByTestId('sidebar-header')
     expect(header.className).toMatch(/h-0/)
     expect(header.className).not.toMatch(/h-12\b/)
+  })
+
+  it('does not render history navigation controls in web mode', () => {
+    renderWithProviders(<AppSidebar />)
+    expect(screen.queryByTestId('history-back-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('history-forward-button')).not.toBeInTheDocument()
+  })
+
+  it('renders Electron history controls and syncs their enabled state', async () => {
+    const user = userEvent.setup()
+    vi.stubGlobal('__WEB__', false)
+    mockIsElectron.mockReturnValue(true)
+    mockGetPlatform.mockReturnValue('darwin')
+
+    renderWithProviders(<AppSidebar />)
+
+    const backButton = screen.getByTestId('history-back-button')
+    const forwardButton = screen.getByTestId('history-forward-button')
+    expect(backButton).toBeDisabled()
+    expect(forwardButton).toBeDisabled()
+
+    setMockHistoryIndex(1)
+    act(() => notifyHistory('PUSH'))
+    expect(backButton).toBeEnabled()
+    expect(forwardButton).toBeDisabled()
+
+    await user.click(backButton)
+    expect(mockHistory.back).toHaveBeenCalledTimes(1)
+
+    setMockHistoryIndex(0)
+    act(() => notifyHistory('BACK'))
+    expect(backButton).toBeDisabled()
+    expect(forwardButton).toBeEnabled()
+
+    await user.click(forwardButton)
+    expect(mockHistory.forward).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -1,5 +1,5 @@
 
-import { Bell, ChevronDown, ChevronRight, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, User, Users, Compass } from 'lucide-react'
+import { Bell, ChevronDown, ChevronLeft, ChevronRight, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, User, Users, Compass } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
 import { Skeleton } from '@renderer/components/ui/skeleton'
 import { ErrorBoundary } from '@renderer/components/ui/error-boundary'
@@ -54,6 +54,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useParams, useRouterState, useSearch as useRouteSearch } from '@tanstack/react-router'
 import { apiFetch } from '@renderer/lib/api'
 import { useRouteLocation } from '@renderer/router/use-route-location'
+import { useHistoryNavigation } from '@renderer/router/use-history-navigation'
 import { useSearch } from '@renderer/context/search-context'
 import { useArtifacts, type ArtifactInfo } from '@renderer/hooks/use-artifacts'
 import { useChatIntegrations, useChatIntegrationSessions, type ChatIntegration } from '@renderer/hooks/use-chat-integrations'
@@ -773,6 +774,48 @@ function ApiKeyWarning({ onOpenSettings }: { onOpenSettings: () => void }) {
   )
 }
 
+function HistoryNavigationButtons() {
+  const { canGoBack, canGoForward, back, forward } = useHistoryNavigation()
+  const buttonClassName =
+    'h-7 w-7 inline-flex items-center justify-center rounded-md text-muted-foreground transition-colors ' +
+    'hover:bg-foreground/10 hover:text-foreground disabled:cursor-default disabled:text-muted-foreground/30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground/30'
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={back}
+            disabled={!canGoBack}
+            aria-label="Back"
+            className={buttonClassName}
+            data-testid="history-back-button"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Back</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={forward}
+            disabled={!canGoForward}
+            aria-label="Forward"
+            className={buttonClassName}
+            data-testid="history-forward-button"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Forward</TooltipContent>
+      </Tooltip>
+    </>
+  )
+}
+
 export function AppSidebar() {
   useRenderTracker('AppSidebar')
   const { openSettings } = useDialogs()
@@ -849,6 +892,7 @@ export function AppSidebar() {
   const needsTrafficLightPadding = isElectron() && getPlatform() === 'darwin' && !animatedFullScreen
   const isWindowsElectron = isElectron() && getPlatform() === 'win32'
   const showHeaderBar = needsTrafficLightPadding
+  const showHistoryNavigation = !__WEB__ && isElectron()
 
   return (
     <>
@@ -899,25 +943,28 @@ export function AppSidebar() {
                   <ChevronDown className="h-4 w-4 text-foreground/60" />
                 </button>
               )}
-              <TooltipProvider delayDuration={200}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={openSearch}
-                      aria-label="Search"
-                      className="app-no-drag ml-auto -mr-2 h-7 w-7 inline-flex items-center justify-center rounded-md text-muted-foreground hover:bg-foreground/10 transition-colors"
-                      data-testid="search-button"
-                    >
-                      <Search className="h-4 w-4 -translate-y-[1px]" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" className="flex items-center gap-2">
-                    <span>Search</span>
-                    <span className="opacity-70">{getPlatform() === 'darwin' ? '⌘K' : 'Ctrl+K'}</span>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <div className="app-no-drag ml-auto -mr-2 flex items-center gap-0.5">
+                <TooltipProvider delayDuration={200}>
+                  {showHistoryNavigation && <HistoryNavigationButtons />}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={openSearch}
+                        aria-label="Search"
+                        className="h-7 w-7 inline-flex items-center justify-center rounded-md text-muted-foreground hover:bg-foreground/10 transition-colors"
+                        data-testid="search-button"
+                      >
+                        <Search className="h-4 w-4 -translate-y-[1px]" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" className="flex items-center gap-2">
+                      <span>Search</span>
+                      <span className="opacity-70">{getPlatform() === 'darwin' ? '⌘K' : 'Ctrl+K'}</span>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
             </div>
 
             {/* Status banners — render under the wordmark so they sit inside the

--- a/src/renderer/components/layout/route-layouts.tsx
+++ b/src/renderer/components/layout/route-layouts.tsx
@@ -8,6 +8,7 @@ import { WindowControls } from '@renderer/components/layout/window-controls'
 import { ContainerSetupHandler } from '@renderer/components/settings/container-setup-handler'
 import { SidebarProvider, SidebarInset, useSidebar } from '@renderer/components/ui/sidebar'
 import { MenuCommandHandler } from '@renderer/components/menu-command-handler'
+import { HistoryNavigationHandler } from '@renderer/components/history-navigation-handler'
 import { GlobalNotificationHandler } from '@renderer/components/notifications/global-notification-handler'
 import { OnboardingProvider } from '@renderer/context/onboarding-context'
 import { GettingStartedWizard } from '@renderer/components/wizard/getting-started-wizard'
@@ -93,6 +94,7 @@ export function RootLayout() {
               useNavigate / useDialogs / useUser / useUserSettings — available at
               the root route. */}
           <MenuCommandHandler />
+          <HistoryNavigationHandler />
           <GlobalNotificationHandler />
           <ContainerSetupHandler />
           <WindowControls />

--- a/src/renderer/router/use-history-navigation.ts
+++ b/src/renderer/router/use-history-navigation.ts
@@ -1,0 +1,74 @@
+import { useRouter } from '@tanstack/react-router'
+import type { RouterHistory } from '@tanstack/react-router'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+type HistoryStackState = {
+  currentIndex: number
+  furthestIndex: number
+}
+
+function getHistoryIndex(history: RouterHistory): number {
+  const index = history.location.state?.__TSR_index
+  return typeof index === 'number' && Number.isFinite(index) && index >= 0 ? index : 0
+}
+
+function getInitialStackState(history: RouterHistory): HistoryStackState {
+  const currentIndex = getHistoryIndex(history)
+  return { currentIndex, furthestIndex: currentIndex }
+}
+
+export function useHistoryNavigation() {
+  const router = useRouter()
+  const history = router.history
+  const [stackState, setStackState] = useState(() => getInitialStackState(history))
+
+  useEffect(() => {
+    const syncStackState = (action?: { type: string }) => {
+      const currentIndex = getHistoryIndex(history)
+
+      setStackState((previous) => {
+        const furthestIndex =
+          action?.type === 'PUSH'
+            ? currentIndex
+            : Math.max(previous.furthestIndex, currentIndex)
+
+        if (
+          previous.currentIndex === currentIndex &&
+          previous.furthestIndex === furthestIndex
+        ) {
+          return previous
+        }
+
+        return { currentIndex, furthestIndex }
+      })
+    }
+
+    syncStackState()
+    return history.subscribe(({ action }) => syncStackState(action))
+  }, [history])
+
+  const canGoBack = useMemo(
+    () => stackState.currentIndex > 0 && history.canGoBack(),
+    [history, stackState.currentIndex]
+  )
+  const canGoForward = stackState.currentIndex < stackState.furthestIndex
+
+  const back = useCallback(() => {
+    if (getHistoryIndex(history) > 0 && history.canGoBack()) {
+      history.back()
+    }
+  }, [history])
+
+  const forward = useCallback(() => {
+    if (getHistoryIndex(history) < stackState.furthestIndex) {
+      history.forward()
+    }
+  }, [history, stackState.furthestIndex])
+
+  return {
+    canGoBack,
+    canGoForward,
+    back,
+    forward,
+  }
+}


### PR DESCRIPTION
## Summary
- Add Electron-only sidebar back/forward buttons beside search, powered by TanStack Router history state.
- Add a root history navigation handler for Cmd/Ctrl bracket shortcuts, Alt+Arrow shortcuts, DOM auxiliary mouse buttons, and native Electron app-command forwarding.
- Expose a preload IPC bridge for main-process browser-backward/browser-forward commands and cover the flow with focused renderer/preload tests.

## Review
- Final code review found no blocking issues.
- macOS Logitech side buttons remain limited by Electron/Chromium input delivery; users can map the buttons to Cmd+[ and Cmd+] in Logi Options+ as the practical workaround.

## Validation
- `npm run test:run -- src/renderer/components/history-navigation-handler.test.tsx src/preload/index.test.ts src/preload/index.sup215.test.ts src/renderer/components/layout/app-sidebar.test.tsx`
- `npm run typecheck`
- `npx eslint src/renderer/components/history-navigation-handler.tsx src/renderer/components/history-navigation-handler.test.tsx src/renderer/components/layout/route-layouts.tsx src/renderer/components/layout/app-sidebar.tsx src/renderer/components/layout/app-sidebar.test.tsx src/renderer/router/use-history-navigation.ts src/preload/index.ts src/preload/index.test.ts src/preload/index.sup215.test.ts src/main/index.ts`
- `npm run build:electron`
