### PR TITLE
fix(e2e): wizard test asserts old 'Superagent' name after Gamut rebrand

### DIFF
--- a/e2e/specs/getting-started-wizard.spec.ts
+++ b/e2e/specs/getting-started-wizard.spec.ts
@@ -146,7 +146,7 @@ test.describe('Getting Started Wizard', () => {
     // Step 5: Privacy
     await wizardPage.clickNext()
     await wizardPage.expectStep(5)
-    await expect(page.getByText('Help improve Superagent')).toBeVisible()
+    await expect(page.getByText('Help improve Gamut')).toBeVisible()
 
     // Step 6: Create Agent (skippable)
     await wizardPage.clickNext()


### PR DESCRIPTION
## Problem

The Gamut rebrand (`4f164554`, #287) renamed the setup wizard's privacy step to **"Help improve Gamut"** but left the e2e asserting **"Help improve Superagent"** (`getting-started-wizard.spec.ts:149`). The assertion looks for text that no longer exists.

Because the `wizard` project is the e2e dependency root, its failure **skips every downstream e2e project** (`global-state`, `web-chromium`) — so `e2e-tests` is red on **main and on every open PR**.

## Fix

One line: assert "Help improve Gamut" to match the rebranded UI.

## Verification

`E2E_MOCK=true npx playwright test --project=wizard` → **7/7 green** locally (the secondary "auto-opens" flake was a cascade off this failure and clears with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)