### PR TITLE
feat(models): Platform GPT models with accurate context window + non-Claude prompt hints

### DIFF
--- a/agent-container/src/claude-code-effort.test.ts
+++ b/agent-container/src/claude-code-effort.test.ts
@@ -253,3 +253,23 @@ describe('ClaudeCodeProcess model handling', () => {
     expect(calls[1].options.model).toBe('claude-opus-4-7')
   })
 })
+
+describe('ClaudeCodeProcess model prompt hints', () => {
+  beforeEach(() => {
+    calls.length = 0
+  })
+
+  it('injects model-specific prompt hints into the system prompt', async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-prompt-hints',
+      workingDirectory: '/tmp',
+      modelPromptHints: ['Use exact ToolSearch names.', 'Do not send pages as an empty string.'],
+    })
+
+    await process.start()
+    expect(calls).toHaveLength(1)
+    expect(calls[0].options.systemPrompt).toContain('## Model-Specific Instructions')
+    expect(calls[0].options.systemPrompt).toContain('- Use exact ToolSearch names.')
+    expect(calls[0].options.systemPrompt).toContain('- Do not send pages as an empty string.')
+  })
+})

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -117,11 +117,18 @@ function parseConnectedAccounts(): Map<string, Array<{ name: string; id: string 
  */
 function generateSystemPrompt(
   availableEnvVars?: string[],
-  userSystemPrompt?: string
+  userSystemPrompt?: string,
+  modelPromptHints?: string[],
 ): string {
   const sections: string[] = [];
 
   sections.push(SYSTEM_PROMPT);
+
+  if (modelPromptHints?.length) {
+    sections.push(`## Model-Specific Instructions
+
+${modelPromptHints.map(hint => `- ${hint}`).join('\n')}`);
+  }
 
   // Parse connected accounts metadata
   const connectedAccounts = parseConnectedAccounts();
@@ -291,6 +298,7 @@ export interface ClaudeCodeProcessOptions {
   workingDirectory: string;
   claudeSessionId?: string;
   userSystemPrompt?: string;
+  modelPromptHints?: string[];
   availableEnvVars?: string[];
   model?: string;
   browserModel?: string;
@@ -346,7 +354,8 @@ export class ClaudeCodeProcess extends EventEmitter {
     this.effort = options.effort;
     this.systemPrompt = generateSystemPrompt(
       options.availableEnvVars,
-      options.userSystemPrompt
+      options.userSystemPrompt,
+      options.modelPromptHints
     );
     // Set module-level reference for tools that need access to the process
     currentProcess = this;

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -105,6 +105,7 @@ export class SessionManager extends EventEmitter {
       sessionId: tempSessionId,
       workingDirectory,
       userSystemPrompt: request.systemPrompt,
+      modelPromptHints: request.modelPromptHints,
       availableEnvVars: request.availableEnvVars,
       model: request.model,
       browserModel: request.browserModel,
@@ -162,6 +163,7 @@ export class SessionManager extends EventEmitter {
       workingDirectory,
       envVars: request.envVars,
       systemPrompt: request.systemPrompt,
+      modelPromptHints: request.modelPromptHints,
       availableEnvVars: request.availableEnvVars,
       slashCommands: process.slashCommands,
     };
@@ -194,6 +196,7 @@ export class SessionManager extends EventEmitter {
       createdAt: session.createdAt.toISOString(),
       lastActivity: session.lastActivity.toISOString(),
       systemPrompt: request.systemPrompt,
+      modelPromptHints: request.modelPromptHints,
       availableEnvVars: request.availableEnvVars,
       model: request.model,
       browserModel: request.browserModel,
@@ -228,6 +231,7 @@ export class SessionManager extends EventEmitter {
         workingDirectory: persisted.workingDirectory,
         claudeSessionId: persisted.claudeSessionId,
         userSystemPrompt: persisted.systemPrompt,
+        modelPromptHints: persisted.modelPromptHints,
         availableEnvVars: persisted.availableEnvVars,
         model: persisted.model,
         browserModel: persisted.browserModel,
@@ -246,6 +250,7 @@ export class SessionManager extends EventEmitter {
         lastActivity: new Date(),
         workingDirectory: persisted.workingDirectory,
         systemPrompt: persisted.systemPrompt,
+        modelPromptHints: persisted.modelPromptHints,
         availableEnvVars: persisted.availableEnvVars,
       };
 

--- a/agent-container/src/session-persistence.ts
+++ b/agent-container/src/session-persistence.ts
@@ -8,6 +8,7 @@ interface SessionMetadata {
   createdAt: string;
   lastActivity: string;
   systemPrompt?: string;
+  modelPromptHints?: string[];
   availableEnvVars?: string[];
   model?: string;
   browserModel?: string;

--- a/agent-container/src/types.ts
+++ b/agent-container/src/types.ts
@@ -31,6 +31,7 @@ export interface Session {
   workingDirectory: string;
   envVars?: Record<string, string>;
   systemPrompt?: string;
+  modelPromptHints?: string[];
   availableEnvVars?: string[];
   slashCommands?: SlashCommandInfo[];
 }
@@ -55,6 +56,7 @@ export interface CreateSessionRequest {
   workingDirectory?: string;
   envVars?: Record<string, string>;
   systemPrompt?: string; // Custom system prompt to append to default
+  modelPromptHints?: string[];
   availableEnvVars?: string[]; // List of env var names available to the agent
   initialMessage: string; // Required: first message to send (triggers session ID generation)
   initialMessageUuid?: UUID; // Optional UUID for message author attribution

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -23,7 +23,7 @@ import { getAgentWorkspaceDir } from '@shared/lib/config/data-dir'
 import { getContainerHostUrl, getAppPort } from '@shared/lib/proxy/host-url'
 import { getSettings } from '@shared/lib/config/settings'
 import { getActiveLlmProvider } from '@shared/lib/llm-provider'
-import { resolveContainerModel } from './resolve-model'
+import { resolveContainerModel, getContainerModelPromptHints } from './resolve-model'
 import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 
 const execAsync = promisify(exec)
@@ -980,6 +980,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     const resolvedModel = resolveContainerModel(options.model, 'agent')
     const resolvedBrowserModel = resolveContainerModel(options.browserModel, 'browser')
     const resolvedDashboardBuilderModel = resolveContainerModel(options.dashboardBuilderModel, 'dashboard')
+    const modelPromptHints = getContainerModelPromptHints(resolvedModel)
 
     try {
       const controller = new AbortController()
@@ -991,6 +992,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
         body: JSON.stringify({
           metadata: options.metadata,
           systemPrompt: options.systemPrompt,
+          modelPromptHints: modelPromptHints.length > 0 ? modelPromptHints : undefined,
           availableEnvVars: options.availableEnvVars,
           initialMessage: options.initialMessage,
           initialMessageUuid: options.initialMessageUuid,

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -1696,6 +1696,85 @@ describe('MessagePersister', () => {
     })
   })
 
+  describe('context window fallback from catalog (non-Claude result events)', () => {
+    function seedAssistantUsage() {
+      mockClient._sendMessage({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'hi' }],
+          usage: {
+            input_tokens: 100,
+            output_tokens: 10,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+        },
+      })
+    }
+
+    it('uses the catalog contextWindow when the SDK omits it (gpt via platform)', () => {
+      mockGetSettings.mockReturnValue({ llmProvider: 'platform' })
+      seedAssistantUsage()
+      sseEvents.length = 0
+
+      mockClient._sendMessage({
+        type: 'result',
+        subtype: 'success',
+        modelUsage: { 'gpt-5.5': { inputTokens: 100, outputTokens: 10 } },
+      })
+
+      const usageEvents = sseEvents.filter((e) => e.type === 'context_usage')
+      expect(usageEvents.at(-1)).toMatchObject({ contextWindow: 1_050_000 })
+    })
+
+    it('prefers the catalog window over the SDK default for a listed non-Claude model', () => {
+      mockGetSettings.mockReturnValue({ llmProvider: 'platform' })
+      seedAssistantUsage()
+      sseEvents.length = 0
+
+      // The SDK reports a generic 200K default for gpt; the catalog (1.05M) wins.
+      mockClient._sendMessage({
+        type: 'result',
+        subtype: 'success',
+        modelUsage: { 'gpt-5.5': { contextWindow: 200_000 } },
+      })
+
+      const usageEvents = sseEvents.filter((e) => e.type === 'context_usage')
+      expect(usageEvents.at(-1)).toMatchObject({ contextWindow: 1_050_000 })
+    })
+
+    it('uses the SDK window for Claude (no catalog window) — e.g. 1M opus', () => {
+      mockGetSettings.mockReturnValue({ llmProvider: 'platform' })
+      seedAssistantUsage()
+      sseEvents.length = 0
+
+      mockClient._sendMessage({
+        type: 'result',
+        subtype: 'success',
+        modelUsage: { 'claude-opus-4-8': { contextWindow: 1_000_000 } },
+      })
+
+      const usageEvents = sseEvents.filter((e) => e.type === 'context_usage')
+      expect(usageEvents.at(-1)).toMatchObject({ contextWindow: 1_000_000 })
+    })
+
+    it('keeps the 200K default when neither SDK nor catalog has a window', () => {
+      mockGetSettings.mockReturnValue({ llmProvider: 'platform' })
+      seedAssistantUsage()
+      sseEvents.length = 0
+
+      mockClient._sendMessage({
+        type: 'result',
+        subtype: 'success',
+        modelUsage: { 'totally-unknown-model': { inputTokens: 1 } },
+      })
+
+      const usageEvents = sseEvents.filter((e) => e.type === 'context_usage')
+      expect(usageEvents.at(-1)).toMatchObject({ contextWindow: 200_000 })
+    })
+  })
+
   describe('context usage from message_delta stream events', () => {
     it('broadcasts context_usage from message_delta with real token counts', () => {
       // Simulate OpenRouter: assistant message has zeros, message_delta has real values

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -34,6 +34,7 @@ import { getSessionMetadata, updateSessionMetadata } from '@shared/lib/services/
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
 import { VALID_SCRIPT_TYPES } from '@shared/lib/config/settings'
+import { getActiveLlmProvider, getModelContextWindow } from '@shared/lib/llm-provider'
 import { computerUsePermissionManager } from '@shared/lib/computer-use/permission-manager'
 import { resolveAppFromWindowRef } from '@shared/lib/computer-use/executor'
 import { getRequiredPermissionLevel, resolveTargetApp, type ComputerUsePermissionLevel } from '@shared/lib/computer-use/types'
@@ -2924,11 +2925,20 @@ class MessagePersister {
     content: any
   ): void {
     try {
-      // Extract contextWindow from modelUsage (per-model breakdown in SDK result)
+      // contextWindow precedence: catalog (non-Claude) > SDK-reported > 200K default.
+      // The SDK always reports a number, but for non-Claude models it's a generic
+      // 200K default — so catalog (which only carries non-Claude windows) must win
+      // when present. Claude entries have no catalog window, so they use the SDK value.
       const modelUsage = content.modelUsage
       if (modelUsage && typeof modelUsage === 'object') {
-        const firstModel = Object.values(modelUsage)[0] as { contextWindow?: number } | undefined
-        if (firstModel?.contextWindow) {
+        const [modelId] = Object.keys(modelUsage)
+        const firstModel = modelUsage[modelId] as { contextWindow?: number } | undefined
+        const catalogWindow = modelId
+          ? getModelContextWindow(modelId, getActiveLlmProvider().id)
+          : undefined
+        if (catalogWindow) {
+          state.lastContextWindow = catalogWindow
+        } else if (firstModel?.contextWindow) {
           state.lastContextWindow = firstModel.contextWindow
         }
       }

--- a/src/shared/lib/container/resolve-model.test.ts
+++ b/src/shared/lib/container/resolve-model.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// getActiveLlmProvider reads settings for the active provider id; stub it so
+// the host-side hint lookup is deterministic.
+const settingsMock = vi.fn()
+vi.mock('../config/settings', () => ({
+  getSettings: () => settingsMock(),
+}))
+
+import { getContainerModelPromptHints } from './resolve-model'
+
+beforeEach(() => {
+  settingsMock.mockReturnValue({ llmProvider: 'platform' })
+})
+
+describe('getContainerModelPromptHints', () => {
+  it('returns GPT tool-use hints for a resolved Platform GPT id', () => {
+    const hints = getContainerModelPromptHints('gpt-5.5')
+    expect(hints.some((h) => h.includes('ToolSearch'))).toBe(true)
+    expect(hints.some((h) => h.includes('pages as an empty string'))).toBe(true)
+  })
+
+  it('returns no hints for a Claude model on the active provider', () => {
+    expect(getContainerModelPromptHints('claude-opus-4-8')).toEqual([])
+  })
+
+  it('returns no hints for an undefined or unknown model', () => {
+    expect(getContainerModelPromptHints(undefined)).toEqual([])
+    expect(getContainerModelPromptHints('nope')).toEqual([])
+  })
+})

--- a/src/shared/lib/container/resolve-model.ts
+++ b/src/shared/lib/container/resolve-model.ts
@@ -1,4 +1,9 @@
-import { resolveActiveProviderModel, type ModelPurpose } from '@shared/lib/llm-provider'
+import {
+  getActiveLlmProvider,
+  getModelPromptHints,
+  resolveActiveProviderModel,
+  type ModelPurpose,
+} from '@shared/lib/llm-provider'
 
 /**
  * Resolve a stored model selection (bare family alias or concrete id) to the
@@ -20,5 +25,21 @@ export function resolveContainerModel(
     // contexts that partially mock the settings module those may be absent;
     // fall back to the raw selection (the SDK still accepts bare aliases).
     return selection
+  }
+}
+
+/**
+ * Catalog prompt hints for an already-resolved wire model id (the value
+ * resolveContainerModel produced), looked up in the active provider's catalog.
+ * Empty for Claude/unknown models.
+ */
+export function getContainerModelPromptHints(resolvedModel: string | undefined): string[] {
+  if (!resolvedModel) return []
+  try {
+    return getModelPromptHints(resolvedModel, getActiveLlmProvider().id)
+  } catch {
+    // Same test-context fallback as resolveContainerModel: settings/provider
+    // registry may be unmocked, in which case there are no hints to apply.
+    return []
   }
 }

--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -1,5 +1,6 @@
 import type { EffortLevel } from '../container/types'
 import type { ModelDefinition } from './model-catalog-schema'
+import { GPT_TOOL_USE_PROMPT_HINTS } from './model-prompt-hints'
 import { pricingFor } from './model-pricing-lookup'
 
 /**
@@ -156,6 +157,7 @@ const OPENROUTER_EXTRA_MODELS: ModelDefinition[] = [
     pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.4).
     contextWindow: 1_050_000,
+    promptHints: GPT_TOOL_USE_PROMPT_HINTS,
   },
   {
     id: 'openai/gpt-5.5',
@@ -173,6 +175,7 @@ const OPENROUTER_EXTRA_MODELS: ModelDefinition[] = [
     pricing: { inputPerMtok: 5, outputPerMtok: 30 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.5).
     contextWindow: 1_050_000,
+    promptHints: GPT_TOOL_USE_PROMPT_HINTS,
   },
   {
     id: 'z-ai/glm-5.2',
@@ -213,6 +216,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.4).
     contextWindow: 1_050_000,
+    promptHints: GPT_TOOL_USE_PROMPT_HINTS,
   },
   {
     id: 'gpt-5.5',
@@ -226,6 +230,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     pricing: { inputPerMtok: 5, outputPerMtok: 30 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.5).
     contextWindow: 1_050_000,
+    promptHints: GPT_TOOL_USE_PROMPT_HINTS,
   },
 ]
 

--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -5,9 +5,9 @@ import { pricingFor } from './model-pricing-lookup'
 /**
  * Built-in model catalogs shipped in code, one shape per provider.
  *
- * Each provider's getBuiltinCatalog() returns one of these. Anthropic,
- * OpenRouter, and Platform all speak the bare Claude ids, so they share
- * CLAUDE_BARE_CATALOG; Bedrock uses region-prefixed ids but the same families.
+ * Each provider's getBuiltinCatalog() returns one of these. Anthropic uses
+ * CLAUDE_BARE_CATALOG; OpenRouter and Platform extend it with non-Claude models
+ * (different ids/pricing per upstream); Bedrock uses region-prefixed Claude ids.
  *
  * `isLatest` marks the id a bare family alias resolves to. Effort support is
  * per model: Opus/Fable accept all five levels, Sonnet/Haiku the lower three.
@@ -154,6 +154,8 @@ const OPENROUTER_EXTRA_MODELS: ModelDefinition[] = [
     supportsWebSearch: false,
     // Baked from OpenRouter's live model list (per-Mtok USD), fetched 2026-06-18.
     pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
+    // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.4).
+    contextWindow: 1_050_000,
   },
   {
     id: 'openai/gpt-5.5',
@@ -169,6 +171,8 @@ const OPENROUTER_EXTRA_MODELS: ModelDefinition[] = [
     // Non-Claude ids aren't in model-pricing.json; baked from OpenRouter's live
     // model list (per-Mtok USD), fetched 2026-06-18. Refresh if OpenRouter repricing.
     pricing: { inputPerMtok: 5, outputPerMtok: 30 },
+    // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.5).
+    contextWindow: 1_050_000,
   },
   {
     id: 'z-ai/glm-5.2',
@@ -188,4 +192,45 @@ const OPENROUTER_EXTRA_MODELS: ModelDefinition[] = [
 export const OPENROUTER_CATALOG: ModelDefinition[] = [
   ...CLAUDE_BARE_CATALOG,
   ...OPENROUTER_EXTRA_MODELS,
+]
+
+/**
+ * Non-Claude models the Platform proxy can serve. Unlike OpenRouter these use
+ * BARE ids (`gpt-5.5`): the proxy's routing/pricing all key off bare ids, so a
+ * vendor-prefixed slug would miss every match.
+ */
+const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
+  {
+    id: 'gpt-5.4',
+    label: 'GPT-5.4',
+    blurb: 'OpenAI, served via Platform',
+    family: 'gpt',
+    icon: 'openai',
+    supportedEfforts: NON_CLAUDE_EFFORTS,
+    // Platform serves gpt over the OpenAI Responses wire, which maps the agent's
+    // web_search server tool to the native web_search tool — so search works.
+    supportsWebSearch: true,
+    pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
+    // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.4).
+    contextWindow: 1_050_000,
+  },
+  {
+    id: 'gpt-5.5',
+    label: 'GPT-5.5',
+    blurb: 'OpenAI flagship, served via Platform',
+    family: 'gpt',
+    isLatest: true,
+    icon: 'openai',
+    supportedEfforts: NON_CLAUDE_EFFORTS,
+    supportsWebSearch: true,
+    pricing: { inputPerMtok: 5, outputPerMtok: 30 },
+    // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.5).
+    contextWindow: 1_050_000,
+  },
+]
+
+/** Platform — bare Claude models plus the GPT models the proxy serves. */
+export const PLATFORM_CATALOG: ModelDefinition[] = [
+  ...CLAUDE_BARE_CATALOG,
+  ...PLATFORM_EXTRA_MODELS,
 ]

--- a/src/shared/lib/llm-provider/index.ts
+++ b/src/shared/lib/llm-provider/index.ts
@@ -9,6 +9,7 @@ export type { ModelDefinition } from './model-catalog-schema'
 export {
   getProviderCatalog,
   getModelDefinition,
+  getModelContextWindow,
   hasVersionSegment,
   resolveModelForProvider,
 } from './model-catalog'

--- a/src/shared/lib/llm-provider/index.ts
+++ b/src/shared/lib/llm-provider/index.ts
@@ -10,6 +10,7 @@ export {
   getProviderCatalog,
   getModelDefinition,
   getModelContextWindow,
+  getModelPromptHints,
   hasVersionSegment,
   resolveModelForProvider,
 } from './model-catalog'

--- a/src/shared/lib/llm-provider/model-catalog-schema.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.test.ts
@@ -40,6 +40,19 @@ describe('modelDefinitionSchema', () => {
     ).toThrow()
   })
 
+  it('accepts an optional positive-int contextWindow and omits cleanly', () => {
+    expect(modelDefinitionSchema.parse({ ...base, contextWindow: 1_050_000 })).toMatchObject({
+      contextWindow: 1_050_000,
+    })
+    expect(modelDefinitionSchema.parse(base).contextWindow).toBeUndefined()
+  })
+
+  it('rejects a non-positive or non-integer contextWindow', () => {
+    expect(() => modelDefinitionSchema.parse({ ...base, contextWindow: 0 })).toThrow()
+    expect(() => modelDefinitionSchema.parse({ ...base, contextWindow: -1 })).toThrow()
+    expect(() => modelDefinitionSchema.parse({ ...base, contextWindow: 1.5 })).toThrow()
+  })
+
   it('validates a catalog array', () => {
     expect(modelCatalogSchema.parse([base])).toHaveLength(1)
   })

--- a/src/shared/lib/llm-provider/model-catalog-schema.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.test.ts
@@ -53,6 +53,13 @@ describe('modelDefinitionSchema', () => {
     expect(() => modelDefinitionSchema.parse({ ...base, contextWindow: 1.5 })).toThrow()
   })
 
+  it('accepts non-empty prompt hints and rejects empty hints', () => {
+    expect(modelDefinitionSchema.parse({ ...base, promptHints: ['Use exact tool names.'] })).toMatchObject({
+      promptHints: ['Use exact tool names.'],
+    })
+    expect(() => modelDefinitionSchema.parse({ ...base, promptHints: [''] })).toThrow()
+  })
+
   it('validates a catalog array', () => {
     expect(modelCatalogSchema.parse([base])).toHaveLength(1)
   })

--- a/src/shared/lib/llm-provider/model-catalog-schema.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.ts
@@ -36,6 +36,8 @@ export const modelDefinitionSchema = z.object({
    * non-Claude models routed via OpenRouter so the picker can warn.
    */
   supportsWebSearch: z.boolean().optional(),
+  /** Extra system-prompt guidance needed by model families with weaker tool priors. */
+  promptHints: z.array(z.string().min(1)).optional(),
   /**
    * Optional display pricing (per-million-token). Built-ins seed this from
    * model-pricing.json; actual cost accounting still keys off that file.

--- a/src/shared/lib/llm-provider/model-catalog-schema.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.ts
@@ -46,6 +46,10 @@ export const modelDefinitionSchema = z.object({
       outputPerMtok: z.number().nonnegative(),
     })
     .optional(),
+  // Static context window (tokens) for non-Claude models. The SDK reports a
+  // generic 200K default for these, so the host prefers this over the SDK value
+  // (see handleResultUsage). Claude entries omit it and use the SDK's real window.
+  contextWindow: z.number().int().positive().optional(),
 })
 
 export type ModelDefinition = z.infer<typeof modelDefinitionSchema>

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -10,6 +10,7 @@ vi.mock('../config/settings', () => ({
 import {
   getProviderCatalog,
   getModelDefinition,
+  getModelContextWindow,
   hasVersionSegment,
   resolveModelForProvider,
 } from './model-catalog'
@@ -81,6 +82,43 @@ describe('getProviderCatalog', () => {
     const gptLatest = catalog.filter((m) => m.family === 'gpt' && m.isLatest)
     expect(gptLatest.map((m) => m.id)).toEqual(['openai/gpt-5.5'])
   })
+
+  it('exposes the Platform GPT built-ins under BARE ids the proxy routes', () => {
+    const catalog = getProviderCatalog('platform')
+    const gpt = catalog.find((m) => m.id === 'gpt-5.5')!
+    // gpt rides the OpenAI Responses wire, which maps native web_search.
+    expect(gpt).toMatchObject({
+      family: 'gpt',
+      isLatest: true,
+      icon: 'openai',
+      supportsWebSearch: true,
+      pricing: { inputPerMtok: 5, outputPerMtok: 30 },
+    })
+    // Platform keys off bare ids, never the OpenRouter vendor-prefixed slugs.
+    expect(catalog.some((m) => m.id === 'openai/gpt-5.5')).toBe(false)
+    expect(catalog.some((m) => m.id === 'z-ai/glm-5.2')).toBe(false)
+    expect(catalog.some((m) => m.id === 'glm-5.2')).toBe(false)
+  })
+})
+
+describe('getModelContextWindow', () => {
+  it('returns the catalog window for Platform GPT models', () => {
+    expect(getModelContextWindow('gpt-5.5', 'platform')).toBe(1_050_000)
+    expect(getModelContextWindow('gpt-5.4', 'platform')).toBe(1_050_000)
+  })
+
+  it('returns the catalog window for OpenRouter GPT models', () => {
+    expect(getModelContextWindow('openai/gpt-5.5', 'openrouter')).toBe(1_050_000)
+    expect(getModelContextWindow('z-ai/glm-5.2', 'openrouter')).toBeUndefined()
+  })
+
+  it('returns undefined for Claude models (SDK supplies their window)', () => {
+    expect(getModelContextWindow('claude-opus-4-8', 'anthropic')).toBeUndefined()
+  })
+
+  it('returns undefined for an unknown id', () => {
+    expect(getModelContextWindow('nope', 'platform')).toBeUndefined()
+  })
 })
 
 describe('hasVersionSegment', () => {
@@ -128,6 +166,12 @@ describe('resolveModelForProvider', () => {
   it('resolves OpenRouter non-Claude models (gpt alias → latest id, glm slug passthrough)', () => {
     expect(resolveModelForProvider('gpt', 'openrouter', 'agent')).toBe('openai/gpt-5.5')
     expect(resolveModelForProvider('z-ai/glm-5.2', 'openrouter', 'agent')).toBe('z-ai/glm-5.2')
+  })
+
+  it('resolves Platform GPT models to bare ids and falls back for unsupported glm', () => {
+    expect(resolveModelForProvider('gpt', 'platform', 'agent')).toBe('gpt-5.5')
+    expect(resolveModelForProvider('gpt-5.4', 'platform', 'agent')).toBe('gpt-5.4')
+    expect(resolveModelForProvider('glm', 'platform', 'agent')).toBe('claude-opus-4-8')
   })
 
   it('resolves the SAME bare alias to each provider concrete id (cross-provider portability)', () => {

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -11,6 +11,7 @@ import {
   getProviderCatalog,
   getModelDefinition,
   getModelContextWindow,
+  getModelPromptHints,
   hasVersionSegment,
   resolveModelForProvider,
 } from './model-catalog'
@@ -118,6 +119,24 @@ describe('getModelContextWindow', () => {
 
   it('returns undefined for an unknown id', () => {
     expect(getModelContextWindow('nope', 'platform')).toBeUndefined()
+  })
+})
+
+describe('getModelPromptHints', () => {
+  it('returns GPT-specific tool guidance for Platform and OpenRouter GPT models', () => {
+    for (const [providerId, modelId] of [
+      ['platform', 'gpt-5.5'],
+      ['openrouter', 'openai/gpt-5.5'],
+    ] as const) {
+      const hints = getModelPromptHints(modelId, providerId)
+      expect(hints.some((hint) => hint.includes('ToolSearch'))).toBe(true)
+      expect(hints.some((hint) => hint.includes('pages as an empty string'))).toBe(true)
+    }
+  })
+
+  it('returns an empty list for Claude models and unknown ids', () => {
+    expect(getModelPromptHints('claude-opus-4-8', 'anthropic')).toEqual([])
+    expect(getModelPromptHints('nope', 'platform')).toEqual([])
   })
 })
 

--- a/src/shared/lib/llm-provider/model-catalog.ts
+++ b/src/shared/lib/llm-provider/model-catalog.ts
@@ -57,6 +57,14 @@ export function getModelContextWindow(
   return getModelDefinition(id, providerId)?.contextWindow
 }
 
+/** Static catalog prompt hints for a model, or an empty list if unset. */
+export function getModelPromptHints(
+  id: string,
+  providerId: LlmProviderId,
+): string[] {
+  return getModelDefinition(id, providerId)?.promptHints ?? []
+}
+
 /**
  * Resolve a stored selection to the concrete wire id for `providerId`.
  * Never throws.

--- a/src/shared/lib/llm-provider/model-catalog.ts
+++ b/src/shared/lib/llm-provider/model-catalog.ts
@@ -49,6 +49,14 @@ export function getModelDefinition(
   return getProviderCatalog(providerId).find(model => model.id === id)
 }
 
+/** Static catalog context-window for a model, or undefined if unset. */
+export function getModelContextWindow(
+  id: string,
+  providerId: LlmProviderId,
+): number | undefined {
+  return getModelDefinition(id, providerId)?.contextWindow
+}
+
 /**
  * Resolve a stored selection to the concrete wire id for `providerId`.
  * Never throws.

--- a/src/shared/lib/llm-provider/model-prompt-hints.ts
+++ b/src/shared/lib/llm-provider/model-prompt-hints.ts
@@ -1,4 +1,4 @@
 export const GPT_TOOL_USE_PROMPT_HINTS = [
   'When tools are deferred, use ToolSearch before declaring a capability unavailable. For select: queries, use exact full tool names from the deferred-tools reminder, such as mcp__browser__browser_open, not shortened names like browser_open; keyword queries are also valid.',
-  'For the Read tool, omit optional parameters you do not need. In particular, do not send pages as an empty string; either omit pages or use a valid range like "1" or "1-5".',
+  'Omit optional tool parameters you are not using — never send an empty value (empty string, empty array, empty object) in their place, as that counts as supplying the field and is often rejected. For example, with Read, omit pages or give a valid range like "1-5" and never send pages as an empty string; and when a tool accepts exactly one of two parameters (e.g. browser_run\'s command vs args), send only the one you use and omit the other rather than passing it as [].',
 ]

--- a/src/shared/lib/llm-provider/model-prompt-hints.ts
+++ b/src/shared/lib/llm-provider/model-prompt-hints.ts
@@ -1,0 +1,4 @@
+export const GPT_TOOL_USE_PROMPT_HINTS = [
+  'When tools are deferred, use ToolSearch before declaring a capability unavailable. For select: queries, use exact full tool names from the deferred-tools reminder, such as mcp__browser__browser_open, not shortened names like browser_open; keyword queries are also valid.',
+  'For the Read tool, omit optional parameters you do not need. In particular, do not send pages as an empty string; either omit pages or use a valid range like "1" or "1-5".',
+]

--- a/src/shared/lib/llm-provider/platform-provider.ts
+++ b/src/shared/lib/llm-provider/platform-provider.ts
@@ -1,7 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { BaseLlmProvider, type ModelPurpose } from './base-llm-provider'
 import type { ModelDefinition } from './model-catalog-schema'
-import { CLAUDE_BARE_CATALOG } from './builtin-catalogs'
+import { PLATFORM_CATALOG } from './builtin-catalogs'
 import { attribution } from '@shared/lib/platform-attribution'
 import { getPlatformAccessToken } from '@shared/lib/services/platform-auth-service'
 import { getPlatformProxyBaseUrl } from '@shared/lib/platform-auth/config'
@@ -41,7 +41,7 @@ export class PlatformLlmProvider extends BaseLlmProvider {
   }
 
   getBuiltinCatalog(): ModelDefinition[] {
-    return CLAUDE_BARE_CATALOG
+    return PLATFORM_CATALOG
   }
 
   getDefaultModel(purpose: ModelPurpose): string {


### PR DESCRIPTION
## What & why

Builds on the SUP-275 dynamic per-provider catalog (already on `main`, #286). Two related additions for serving **non-Claude models** well:

### 1. Platform GPT models + accurate context window
- Adds `gpt-5.4` / `gpt-5.5` to the **Platform** catalog under **bare ids** (`gpt-5.5`), since the Platform proxy routes/prices off bare ids — a vendor-prefixed slug would miss every match. (OpenRouter keeps its `openai/gpt-*` vendor-prefixed slugs.)
- Platform serves GPT over the OpenAI Responses wire, which maps the agent's `web_search` server tool to the native one, so `supportsWebSearch: true` for Platform GPT (OpenRouter GPT stays `false`).
- New optional `contextWindow` on the catalog. The SDK reports a generic 200K for non-Claude models, so the host prefers the catalog value (`getModelContextWindow`, consumed in `message-persister`) — GPT is 1.05M, not 200K. Claude entries omit it and keep the SDK's real window.

### 2. Per-model prompt hints for non-Claude tool use (was #292)
GPT isn't post-trained on two things Claude is, and both showed up as user-visible failures:
- **ToolSearch** — when tools are deferred, GPT called `ToolSearch` with shortened names (`select:browser_open`) instead of the real deferred names (`mcp__browser__browser_open`), got an empty result, and wrongly told the user the capability was unavailable (same class as #289).
- **Read tool** — GPT passed `pages: ""` to `Read`, which the validator rejects, so reading an image/file failed repeatedly.

Rather than hard-code these into the global `system-prompt.md` (where they'd hit Claude too), they're attached to the **GPT catalog entries** via a new optional `promptHints` field. The host resolves the selection to the active provider's concrete model, looks up its hints, and sends them on `createSession`; the container's `generateSystemPrompt` appends them as a `## Model-Specific Instructions` section **right after the base `system-prompt.md`** (base prompt + catalog-driven hint). Persisted so the hint survives container resume.

## Known limitation

Mid-session model switches via the SDK's dynamic `setModel` do not rebuild the system prompt, so prompt hints + context window are applied based on the model at session creation. Switching to GPT mid-session won't inject hints until the next session/restart. Out of scope here.

## Test plan

- `model-catalog.test.ts` / `model-catalog-schema.test.ts` — Platform GPT bare-id catalog, `contextWindow` + `promptHints` schema validation, `getModelContextWindow` / `getModelPromptHints`.
- `resolve-model.test.ts` — host seam: Platform GPT id → hints, Claude/unknown → none.
- `message-persister.test.ts` — host prefers catalog context window over the SDK's generic 200K for non-Claude models.
- `claude-code-effort.test.ts` — container injects hints under `## Model-Specific Instructions`.
- `agent-container` `tsc` build clean.