### PR TITLE
feat(models): per-model prompt hints for non-Claude tool use

### DIFF
--- a/agent-container/src/claude-code-effort.test.ts
+++ b/agent-container/src/claude-code-effort.test.ts
@@ -253,3 +253,23 @@ describe('ClaudeCodeProcess model handling', () => {
     expect(calls[1].options.model).toBe('claude-opus-4-7')
   })
 })
+
+describe('ClaudeCodeProcess model prompt hints', () => {
+  beforeEach(() => {
+    calls.length = 0
+  })
+
+  it('injects model-specific prompt hints into the system prompt', async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-prompt-hints',
+      workingDirectory: '/tmp',
+      modelPromptHints: ['Use exact ToolSearch names.', 'Do not send pages as an empty string.'],
+    })
+
+    await process.start()
+    expect(calls).toHaveLength(1)
+    expect(calls[0].options.systemPrompt).toContain('## Model-Specific Instructions')
+    expect(calls[0].options.systemPrompt).toContain('- Use exact ToolSearch names.')
+    expect(calls[0].options.systemPrompt).toContain('- Do not send pages as an empty string.')
+  })
+})

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -117,11 +117,18 @@ function parseConnectedAccounts(): Map<string, Array<{ name: string; id: string 
  */
 function generateSystemPrompt(
   availableEnvVars?: string[],
-  userSystemPrompt?: string
+  userSystemPrompt?: string,
+  modelPromptHints?: string[],
 ): string {
   const sections: string[] = [];
 
   sections.push(SYSTEM_PROMPT);
+
+  if (modelPromptHints?.length) {
+    sections.push(`## Model-Specific Instructions
+
+${modelPromptHints.map(hint => `- ${hint}`).join('\n')}`);
+  }
 
   // Parse connected accounts metadata
   const connectedAccounts = parseConnectedAccounts();
@@ -291,6 +298,7 @@ export interface ClaudeCodeProcessOptions {
   workingDirectory: string;
   claudeSessionId?: string;
   userSystemPrompt?: string;
+  modelPromptHints?: string[];
   availableEnvVars?: string[];
   model?: string;
   browserModel?: string;
@@ -346,7 +354,8 @@ export class ClaudeCodeProcess extends EventEmitter {
     this.effort = options.effort;
     this.systemPrompt = generateSystemPrompt(
       options.availableEnvVars,
-      options.userSystemPrompt
+      options.userSystemPrompt,
+      options.modelPromptHints
     );
     // Set module-level reference for tools that need access to the process
     currentProcess = this;

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -105,6 +105,7 @@ export class SessionManager extends EventEmitter {
       sessionId: tempSessionId,
       workingDirectory,
       userSystemPrompt: request.systemPrompt,
+      modelPromptHints: request.modelPromptHints,
       availableEnvVars: request.availableEnvVars,
       model: request.model,
       browserModel: request.browserModel,
@@ -162,6 +163,7 @@ export class SessionManager extends EventEmitter {
       workingDirectory,
       envVars: request.envVars,
       systemPrompt: request.systemPrompt,
+      modelPromptHints: request.modelPromptHints,
       availableEnvVars: request.availableEnvVars,
       slashCommands: process.slashCommands,
     };
@@ -194,6 +196,7 @@ export class SessionManager extends EventEmitter {
       createdAt: session.createdAt.toISOString(),
       lastActivity: session.lastActivity.toISOString(),
       systemPrompt: request.systemPrompt,
+      modelPromptHints: request.modelPromptHints,
       availableEnvVars: request.availableEnvVars,
       model: request.model,
       browserModel: request.browserModel,
@@ -228,6 +231,7 @@ export class SessionManager extends EventEmitter {
         workingDirectory: persisted.workingDirectory,
         claudeSessionId: persisted.claudeSessionId,
         userSystemPrompt: persisted.systemPrompt,
+        modelPromptHints: persisted.modelPromptHints,
         availableEnvVars: persisted.availableEnvVars,
         model: persisted.model,
         browserModel: persisted.browserModel,
@@ -246,6 +250,7 @@ export class SessionManager extends EventEmitter {
         lastActivity: new Date(),
         workingDirectory: persisted.workingDirectory,
         systemPrompt: persisted.systemPrompt,
+        modelPromptHints: persisted.modelPromptHints,
         availableEnvVars: persisted.availableEnvVars,
       };
 

--- a/agent-container/src/session-persistence.ts
+++ b/agent-container/src/session-persistence.ts
@@ -8,6 +8,7 @@ interface SessionMetadata {
   createdAt: string;
   lastActivity: string;
   systemPrompt?: string;
+  modelPromptHints?: string[];
   availableEnvVars?: string[];
   model?: string;
   browserModel?: string;

--- a/agent-container/src/types.ts
+++ b/agent-container/src/types.ts
@@ -31,6 +31,7 @@ export interface Session {
   workingDirectory: string;
   envVars?: Record<string, string>;
   systemPrompt?: string;
+  modelPromptHints?: string[];
   availableEnvVars?: string[];
   slashCommands?: SlashCommandInfo[];
 }
@@ -55,6 +56,7 @@ export interface CreateSessionRequest {
   workingDirectory?: string;
   envVars?: Record<string, string>;
   systemPrompt?: string; // Custom system prompt to append to default
+  modelPromptHints?: string[];
   availableEnvVars?: string[]; // List of env var names available to the agent
   initialMessage: string; // Required: first message to send (triggers session ID generation)
   initialMessageUuid?: UUID; // Optional UUID for message author attribution

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -23,7 +23,7 @@ import { getAgentWorkspaceDir } from '@shared/lib/config/data-dir'
 import { getContainerHostUrl, getAppPort } from '@shared/lib/proxy/host-url'
 import { getSettings } from '@shared/lib/config/settings'
 import { getActiveLlmProvider } from '@shared/lib/llm-provider'
-import { resolveContainerModel } from './resolve-model'
+import { resolveContainerModel, getContainerModelPromptHints } from './resolve-model'
 import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 
 const execAsync = promisify(exec)
@@ -980,6 +980,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     const resolvedModel = resolveContainerModel(options.model, 'agent')
     const resolvedBrowserModel = resolveContainerModel(options.browserModel, 'browser')
     const resolvedDashboardBuilderModel = resolveContainerModel(options.dashboardBuilderModel, 'dashboard')
+    const modelPromptHints = getContainerModelPromptHints(resolvedModel)
 
     try {
       const controller = new AbortController()
@@ -991,6 +992,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
         body: JSON.stringify({
           metadata: options.metadata,
           systemPrompt: options.systemPrompt,
+          modelPromptHints: modelPromptHints.length > 0 ? modelPromptHints : undefined,
           availableEnvVars: options.availableEnvVars,
           initialMessage: options.initialMessage,
           initialMessageUuid: options.initialMessageUuid,

--- a/src/shared/lib/container/resolve-model.test.ts
+++ b/src/shared/lib/container/resolve-model.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// getActiveLlmProvider reads settings for the active provider id; stub it so
+// the host-side hint lookup is deterministic.
+const settingsMock = vi.fn()
+vi.mock('../config/settings', () => ({
+  getSettings: () => settingsMock(),
+}))
+
+import { getContainerModelPromptHints } from './resolve-model'
+
+beforeEach(() => {
+  settingsMock.mockReturnValue({ llmProvider: 'platform' })
+})
+
+describe('getContainerModelPromptHints', () => {
+  it('returns GPT tool-use hints for a resolved Platform GPT id', () => {
+    const hints = getContainerModelPromptHints('gpt-5.5')
+    expect(hints.some((h) => h.includes('ToolSearch'))).toBe(true)
+    expect(hints.some((h) => h.includes('pages as an empty string'))).toBe(true)
+  })
+
+  it('returns no hints for a Claude model on the active provider', () => {
+    expect(getContainerModelPromptHints('claude-opus-4-8')).toEqual([])
+  })
+
+  it('returns no hints for an undefined or unknown model', () => {
+    expect(getContainerModelPromptHints(undefined)).toEqual([])
+    expect(getContainerModelPromptHints('nope')).toEqual([])
+  })
+})

--- a/src/shared/lib/container/resolve-model.ts
+++ b/src/shared/lib/container/resolve-model.ts
@@ -1,4 +1,9 @@
-import { resolveActiveProviderModel, type ModelPurpose } from '@shared/lib/llm-provider'
+import {
+  getActiveLlmProvider,
+  getModelPromptHints,
+  resolveActiveProviderModel,
+  type ModelPurpose,
+} from '@shared/lib/llm-provider'
 
 /**
  * Resolve a stored model selection (bare family alias or concrete id) to the
@@ -20,5 +25,21 @@ export function resolveContainerModel(
     // contexts that partially mock the settings module those may be absent;
     // fall back to the raw selection (the SDK still accepts bare aliases).
     return selection
+  }
+}
+
+/**
+ * Catalog prompt hints for an already-resolved wire model id (the value
+ * resolveContainerModel produced), looked up in the active provider's catalog.
+ * Empty for Claude/unknown models.
+ */
+export function getContainerModelPromptHints(resolvedModel: string | undefined): string[] {
+  if (!resolvedModel) return []
+  try {
+    return getModelPromptHints(resolvedModel, getActiveLlmProvider().id)
+  } catch {
+    // Same test-context fallback as resolveContainerModel: settings/provider
+    // registry may be unmocked, in which case there are no hints to apply.
+    return []
   }
 }

--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -1,5 +1,6 @@
 import type { EffortLevel } from '../container/types'
 import type { ModelDefinition } from './model-catalog-schema'
+import { GPT_TOOL_USE_PROMPT_HINTS } from './model-prompt-hints'
 import { pricingFor } from './model-pricing-lookup'
 
 /**
@@ -156,6 +157,7 @@ const OPENROUTER_EXTRA_MODELS: ModelDefinition[] = [
     pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.4).
     contextWindow: 1_050_000,
+    promptHints: GPT_TOOL_USE_PROMPT_HINTS,
   },
   {
     id: 'openai/gpt-5.5',
@@ -173,6 +175,7 @@ const OPENROUTER_EXTRA_MODELS: ModelDefinition[] = [
     pricing: { inputPerMtok: 5, outputPerMtok: 30 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.5).
     contextWindow: 1_050_000,
+    promptHints: GPT_TOOL_USE_PROMPT_HINTS,
   },
   {
     id: 'z-ai/glm-5.2',
@@ -213,6 +216,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.4).
     contextWindow: 1_050_000,
+    promptHints: GPT_TOOL_USE_PROMPT_HINTS,
   },
   {
     id: 'gpt-5.5',
@@ -226,6 +230,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     pricing: { inputPerMtok: 5, outputPerMtok: 30 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.5).
     contextWindow: 1_050_000,
+    promptHints: GPT_TOOL_USE_PROMPT_HINTS,
   },
 ]
 

--- a/src/shared/lib/llm-provider/index.ts
+++ b/src/shared/lib/llm-provider/index.ts
@@ -10,6 +10,7 @@ export {
   getProviderCatalog,
   getModelDefinition,
   getModelContextWindow,
+  getModelPromptHints,
   hasVersionSegment,
   resolveModelForProvider,
 } from './model-catalog'

--- a/src/shared/lib/llm-provider/model-catalog-schema.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.test.ts
@@ -53,6 +53,13 @@ describe('modelDefinitionSchema', () => {
     expect(() => modelDefinitionSchema.parse({ ...base, contextWindow: 1.5 })).toThrow()
   })
 
+  it('accepts non-empty prompt hints and rejects empty hints', () => {
+    expect(modelDefinitionSchema.parse({ ...base, promptHints: ['Use exact tool names.'] })).toMatchObject({
+      promptHints: ['Use exact tool names.'],
+    })
+    expect(() => modelDefinitionSchema.parse({ ...base, promptHints: [''] })).toThrow()
+  })
+
   it('validates a catalog array', () => {
     expect(modelCatalogSchema.parse([base])).toHaveLength(1)
   })

--- a/src/shared/lib/llm-provider/model-catalog-schema.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.ts
@@ -36,6 +36,8 @@ export const modelDefinitionSchema = z.object({
    * non-Claude models routed via OpenRouter so the picker can warn.
    */
   supportsWebSearch: z.boolean().optional(),
+  /** Extra system-prompt guidance needed by model families with weaker tool priors. */
+  promptHints: z.array(z.string().min(1)).optional(),
   /**
    * Optional display pricing (per-million-token). Built-ins seed this from
    * model-pricing.json; actual cost accounting still keys off that file.

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -11,6 +11,7 @@ import {
   getProviderCatalog,
   getModelDefinition,
   getModelContextWindow,
+  getModelPromptHints,
   hasVersionSegment,
   resolveModelForProvider,
 } from './model-catalog'
@@ -118,6 +119,24 @@ describe('getModelContextWindow', () => {
 
   it('returns undefined for an unknown id', () => {
     expect(getModelContextWindow('nope', 'platform')).toBeUndefined()
+  })
+})
+
+describe('getModelPromptHints', () => {
+  it('returns GPT-specific tool guidance for Platform and OpenRouter GPT models', () => {
+    for (const [providerId, modelId] of [
+      ['platform', 'gpt-5.5'],
+      ['openrouter', 'openai/gpt-5.5'],
+    ] as const) {
+      const hints = getModelPromptHints(modelId, providerId)
+      expect(hints.some((hint) => hint.includes('ToolSearch'))).toBe(true)
+      expect(hints.some((hint) => hint.includes('pages as an empty string'))).toBe(true)
+    }
+  })
+
+  it('returns an empty list for Claude models and unknown ids', () => {
+    expect(getModelPromptHints('claude-opus-4-8', 'anthropic')).toEqual([])
+    expect(getModelPromptHints('nope', 'platform')).toEqual([])
   })
 })
 

--- a/src/shared/lib/llm-provider/model-catalog.ts
+++ b/src/shared/lib/llm-provider/model-catalog.ts
@@ -57,6 +57,14 @@ export function getModelContextWindow(
   return getModelDefinition(id, providerId)?.contextWindow
 }
 
+/** Static catalog prompt hints for a model, or an empty list if unset. */
+export function getModelPromptHints(
+  id: string,
+  providerId: LlmProviderId,
+): string[] {
+  return getModelDefinition(id, providerId)?.promptHints ?? []
+}
+
 /**
  * Resolve a stored selection to the concrete wire id for `providerId`.
  * Never throws.

--- a/src/shared/lib/llm-provider/model-prompt-hints.ts
+++ b/src/shared/lib/llm-provider/model-prompt-hints.ts
@@ -1,0 +1,4 @@
+export const GPT_TOOL_USE_PROMPT_HINTS = [
+  'When tools are deferred, use ToolSearch before declaring a capability unavailable. For select: queries, use exact full tool names from the deferred-tools reminder, such as mcp__browser__browser_open, not shortened names like browser_open; keyword queries are also valid.',
+  'For the Read tool, omit optional parameters you do not need. In particular, do not send pages as an empty string; either omit pages or use a valid range like "1" or "1-5".',
+]


### PR DESCRIPTION
## What & why

Stacked on #291 (`feat/platform-gpt-catalog`).

GPT models (Platform + OpenRouter) aren't post-trained on two things Claude is, and it shows up as user-visible failures:

1. **ToolSearch** — when tools are deferred, GPT called `ToolSearch` with shortened names (`select:browser_open`) instead of the real deferred names (`mcp__browser__browser_open`), got an empty result, and wrongly told the user the capability was unavailable. (Same class of bug as #289, fixed there in the base prompt.)
2. **Read tool** — GPT passed `pages: ""` (empty string) to `Read`, which the validator rejects, so reading an image/file failed repeatedly.

Rather than hard-code these into the global `system-prompt.md` (where they'd apply to Claude too), they're attached to the **GPT catalog entries** so only non-Claude models that need them get them.

## What changed

- New optional `promptHints: string[]` on the model catalog schema.
- GPT entries (Platform `gpt-5.4`/`gpt-5.5`, OpenRouter `openai/gpt-5.4`/`gpt-5.5`) carry a shared `GPT_TOOL_USE_PROMPT_HINTS` (kept in `model-prompt-hints.ts`, not inline in the catalog data).
- Host resolves the selection to the active provider's concrete model and looks up its hints (`getContainerModelPromptHints`), then sends them on `createSession`.
- Container's `generateSystemPrompt` appends them as a `## Model-Specific Instructions` section **right after the base `system-prompt.md`** — i.e. base prompt + catalog-driven hint. Persisted so the hint survives container resume.
- Claude/Bedrock catalogs are unchanged (no hints → no section).

## Known limitation

Switching model mid-session via the SDK's dynamic `setModel` does not rebuild the system prompt, so hints are applied based on the model at session creation. A mid-session switch to GPT won't inject hints until the next session/restart. Out of scope here.

## Test plan

- `resolve-model.test.ts` (new) — host seam: Platform GPT id → hints, Claude/unknown → none.
- `model-catalog.test.ts` / `model-catalog-schema.test.ts` — `getModelPromptHints` + `promptHints` schema validation.
- `claude-code-effort.test.ts` — container injects hints into the system prompt under `## Model-Specific Instructions`.
- `agent-container` `tsc` build clean.

Made with [Cursor](https://cursor.com)