### PR TITLE
Add dashboards to Cmd-K search

### DIFF
--- a/src/renderer/components/search/filter.test.ts
+++ b/src/renderer/components/search/filter.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { filterAgentsAndSessions, flattenGroups, getRecentAgents } from './filter'
-import type { ApiAgent, ApiSession } from '@shared/lib/types/api'
+import type { ApiAgent, ApiAgentDashboard, ApiSession } from '@shared/lib/types/api'
 
-function agent(slug: string, name: string, lastActivityAt?: Date): ApiAgent {
+function agent(
+  slug: string,
+  name: string,
+  lastActivityAt?: Date,
+  dashboards?: ApiAgentDashboard[]
+): ApiAgent {
   return {
     slug,
     name,
@@ -10,6 +15,7 @@ function agent(slug: string, name: string, lastActivityAt?: Date): ApiAgent {
     status: 'stopped',
     containerPort: null,
     lastActivityAt: lastActivityAt ?? undefined,
+    dashboards,
   }
 }
 
@@ -45,6 +51,7 @@ describe('filterAgentsAndSessions', () => {
     expect(groups).toHaveLength(1)
     expect(groups[0].agent.slug).toBe('alpha')
     expect(groups[0].matchedAgent).toBe(true)
+    expect(groups[0].dashboards).toEqual([])
     expect(groups[0].sessions).toEqual([])
   })
 
@@ -65,7 +72,55 @@ describe('filterAgentsAndSessions', () => {
     expect(groups).toHaveLength(1)
     expect(groups[0].agent.slug).toBe('alpha')
     expect(groups[0].matchedAgent).toBe(true)
+    expect(groups[0].dashboards).toEqual([])
     expect(groups[0].sessions).toEqual([])
+  })
+
+  it('surfaces a non-matching agent because one of its dashboards matches', () => {
+    const groups = filterAgentsAndSessions(
+      [
+        agent('alpha', 'Alpha Bot', new Date('2025-01-01'), [
+          { slug: 'sales-overview', name: 'Sales Overview' },
+          { slug: 'ops', name: 'Operations' },
+        ]),
+        beta,
+      ],
+      sessions,
+      'sales'
+    )
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].agent.slug).toBe('alpha')
+    expect(groups[0].matchedAgent).toBe(false)
+    expect(groups[0].dashboards.map((d) => d.slug)).toEqual(['sales-overview'])
+    expect(groups[0].sessions).toEqual([])
+  })
+
+  it('matches dashboard slugs when the display name does not match', () => {
+    const groups = filterAgentsAndSessions(
+      [agent('alpha', 'Alpha Bot', new Date('2025-01-01'), [{ slug: 'revops', name: 'Metrics' }])],
+      {},
+      'rev'
+    )
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].dashboards.map((d) => d.slug)).toEqual(['revops'])
+  })
+
+  it('falls back to dashboard summary names and slugs', () => {
+    const legacyAgent: ApiAgent = {
+      ...agent('legacy', 'Legacy Bot', new Date('2025-01-01')),
+      dashboards: undefined,
+      dashboardNames: ['Legacy Dashboard'],
+      dashboardSlugs: ['legacy-dashboard'],
+    }
+
+    const groups = filterAgentsAndSessions([legacyAgent], {}, 'legacy dashboard')
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].dashboards).toEqual([
+      { slug: 'legacy-dashboard', name: 'Legacy Dashboard' },
+    ])
   })
 
   it('hides agents with no name match and no session match', () => {
@@ -111,25 +166,37 @@ describe('getRecentAgents', () => {
     expect(result[0].sessions[0].id).toBe('s11')
     expect(result[0].sessions[9].id).toBe('s2')
   })
+
+  it('includes dashboards for recent agents', () => {
+    const a = agent('a', 'Agent A', new Date('2025-01-01'), [
+      { slug: 'overview', name: 'Overview' },
+    ])
+
+    const result = getRecentAgents([a], {})
+
+    expect(result[0].dashboards).toEqual([{ slug: 'overview', name: 'Overview' }])
+  })
 })
 
 describe('flattenGroups', () => {
   const alpha = agent('alpha', 'Alpha', new Date('2025-01-01'))
+  const d1: ApiAgentDashboard = { slug: 'dash-one', name: 'Dash one' }
   const s1 = session('s1', 'alpha', 'one')
   const s2 = session('s2', 'alpha', 'two')
 
-  it('without expandedSlugs, emits agent and all sessions', () => {
-    const flat = flattenGroups([{ agent: alpha, matchedAgent: true, sessions: [s1, s2] }])
+  it('without expandedSlugs, emits agent and all dashboards/sessions', () => {
+    const flat = flattenGroups([{ agent: alpha, matchedAgent: true, dashboards: [d1], sessions: [s1, s2] }])
     expect(flat).toEqual([
       { kind: 'agent', agent: alpha },
+      { kind: 'dashboard', agent: alpha, dashboard: d1 },
       { kind: 'session', agent: alpha, session: s1 },
       { kind: 'session', agent: alpha, session: s2 },
     ])
   })
 
-  it('with expandedSlugs, only emits sessions for expanded agents', () => {
+  it('with expandedSlugs, only emits dashboards/sessions for expanded agents', () => {
     const flat = flattenGroups(
-      [{ agent: alpha, matchedAgent: true, sessions: [s1, s2] }],
+      [{ agent: alpha, matchedAgent: true, dashboards: [d1], sessions: [s1, s2] }],
       new Set()
     )
     expect(flat).toEqual([{ kind: 'agent', agent: alpha }])
@@ -137,18 +204,19 @@ describe('flattenGroups', () => {
 
   it('with expandedSlugs containing the agent, emits sessions', () => {
     const flat = flattenGroups(
-      [{ agent: alpha, matchedAgent: true, sessions: [s1, s2] }],
+      [{ agent: alpha, matchedAgent: true, dashboards: [d1], sessions: [s1, s2] }],
       new Set(['alpha'])
     )
     expect(flat).toEqual([
       { kind: 'agent', agent: alpha },
+      { kind: 'dashboard', agent: alpha, dashboard: d1 },
       { kind: 'session', agent: alpha, session: s1 },
       { kind: 'session', agent: alpha, session: s2 },
     ])
   })
 
   it('emits an agent header even when it has no sessions', () => {
-    const flat = flattenGroups([{ agent: alpha, matchedAgent: true, sessions: [] }])
+    const flat = flattenGroups([{ agent: alpha, matchedAgent: true, dashboards: [], sessions: [] }])
     expect(flat).toEqual([{ kind: 'agent', agent: alpha }])
   })
 })

--- a/src/renderer/components/search/filter.ts
+++ b/src/renderer/components/search/filter.ts
@@ -1,15 +1,28 @@
-import type { ApiSession } from '@shared/lib/types/api'
+import type { ApiAgentDashboard, ApiSession } from '@shared/lib/types/api'
 import type { ApiAgent } from '@renderer/hooks/use-agents'
 
 export interface AgentGroup {
   agent: ApiAgent
   matchedAgent: boolean
+  dashboards: ApiAgentDashboard[]
   sessions: ApiSession[]
 }
 
 export type FlatItem =
   | { kind: 'agent'; agent: ApiAgent }
+  | { kind: 'dashboard'; agent: ApiAgent; dashboard: ApiAgentDashboard }
   | { kind: 'session'; agent: ApiAgent; session: ApiSession }
+
+function getAgentDashboards(agent: ApiAgent): ApiAgentDashboard[] {
+  if (Array.isArray(agent.dashboards)) return agent.dashboards
+
+  const slugs = agent.dashboardSlugs ?? []
+  const names = agent.dashboardNames ?? []
+  return slugs.map((slug, index) => ({
+    slug,
+    name: names[index] || slug,
+  }))
+}
 
 /**
  * Return the top N most recently used agents with their sessions sorted by recency.
@@ -32,15 +45,15 @@ export function getRecentAgents(
         .slice()
         .sort((a, b) => new Date(b.lastActivityAt).getTime() - new Date(a.lastActivityAt).getTime())
         .slice(0, 10)
-      return { agent, matchedAgent: true, sessions }
+      return { agent, matchedAgent: true, dashboards: getAgentDashboards(agent), sessions }
     })
 }
 
 /**
- * Filter agents and sessions by a substring query. Case-insensitive.
+ * Filter agents, dashboards, and sessions by a substring query. Case-insensitive.
  *
- * - An agent is included if its name matches OR if any of its sessions match.
- * - Only matching sessions are returned within an agent group.
+ * - An agent is included if its name matches OR if any of its dashboards/sessions match.
+ * - Only matching dashboards/sessions are returned within an agent group.
  */
 export function filterAgentsAndSessions(
   agents: ApiAgent[],
@@ -51,13 +64,17 @@ export function filterAgentsAndSessions(
   if (!trimmed) return []
   const groups = agents.map<AgentGroup>((agent) => {
     const sessions = sessionsByAgent[agent.slug] ?? []
+    const dashboards = getAgentDashboards(agent)
     const matchedAgent = agent.name.toLowerCase().includes(trimmed)
+    const matchedDashboards = dashboards.filter((d) =>
+      d.name.toLowerCase().includes(trimmed) || d.slug.toLowerCase().includes(trimmed)
+    )
     const matchedSessions = sessions.filter((s) =>
       s.name.toLowerCase().includes(trimmed)
     )
-    return { agent, matchedAgent, sessions: matchedSessions }
+    return { agent, matchedAgent, dashboards: matchedDashboards, sessions: matchedSessions }
   })
-  return groups.filter((g) => g.matchedAgent || g.sessions.length > 0)
+  return groups.filter((g) => g.matchedAgent || g.dashboards.length > 0 || g.sessions.length > 0)
 }
 
 /** Flatten visible groups into the linear list used for keyboard navigation. */
@@ -69,6 +86,9 @@ export function flattenGroups(
   for (const g of groups) {
     items.push({ kind: 'agent', agent: g.agent })
     if (!expandedSlugs || expandedSlugs.has(g.agent.slug)) {
+      for (const d of g.dashboards) {
+        items.push({ kind: 'dashboard', agent: g.agent, dashboard: d })
+      }
       for (const s of g.sessions) {
         items.push({ kind: 'session', agent: g.agent, session: s })
       }

--- a/src/renderer/components/search/search-dialog.tsx
+++ b/src/renderer/components/search/search-dialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQueries } from '@tanstack/react-query'
-import { Bot, ChevronRight, MessageSquare, Search } from 'lucide-react'
+import { Bot, ChevronRight, MessageSquare, Search, SquareMousePointer } from 'lucide-react'
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@renderer/components/ui/dialog'
 import { HighlightMatch } from '@renderer/components/ui/highlight-match'
 import { useAgents } from '@renderer/hooks/use-agents'
@@ -114,6 +114,11 @@ export function SearchDialog() {
     closeSearch()
     if (item.kind === 'agent') {
       void navigate({ to: '/agents/$slug', params: { slug: item.agent.slug } })
+    } else if (item.kind === 'dashboard') {
+      void navigate({
+        to: '/agents/$slug/dashboards/$dashSlug',
+        params: { slug: item.agent.slug, dashSlug: item.dashboard.slug },
+      })
     } else {
       void navigate({
         to: '/agents/$slug/sessions/$sessionId',
@@ -142,7 +147,7 @@ export function SearchDialog() {
       const item = flatItems[activeIndex]
       if (item?.kind === 'agent' && expandedSlugs.has(item.agent.slug)) {
         toggleExpand(item.agent.slug)
-      } else if (item?.kind === 'session') {
+      } else if (item?.kind === 'dashboard' || item?.kind === 'session') {
         // Collapse the parent agent and move focus to it
         toggleExpand(item.agent.slug)
         const agentIdx = flatItems.findIndex(
@@ -162,10 +167,10 @@ export function SearchDialog() {
       <DialogContent
         className="max-w-xl p-0 gap-0 overflow-hidden [&>button]:top-3 [&>button]:right-3"
         onKeyDown={handleKeyDown}
-        aria-label="Search agents and sessions"
+        aria-label="Search agents, dashboards, and sessions"
       >
-        <DialogTitle className="sr-only">Search agents and sessions</DialogTitle>
-        <DialogDescription className="sr-only">Find agents and sessions by name</DialogDescription>
+        <DialogTitle className="sr-only">Search agents, dashboards, and sessions</DialogTitle>
+        <DialogDescription className="sr-only">Find agents, dashboards, and sessions by name</DialogDescription>
         <div className="flex items-center gap-2 border-b px-3 py-2.5">
           <Search className="h-4 w-4 text-muted-foreground shrink-0" />
           <input
@@ -176,7 +181,7 @@ export function SearchDialog() {
               setQuery(e.target.value)
               setActiveIndex(0)
             }}
-            placeholder="Search agents and sessions..."
+            placeholder="Search agents, dashboards, and sessions..."
             className="flex-1 bg-transparent outline-none text-sm placeholder:text-muted-foreground"
             data-testid="search-input"
           />
@@ -196,7 +201,7 @@ export function SearchDialog() {
               return visibleGroups.map((g) => {
                 const agentIdx = idx++
                 const isExpanded = isSearchMode || expandedSlugs.has(g.agent.slug)
-                const hasSessions = g.sessions.length > 0
+                const hasChildren = g.dashboards.length > 0 || g.sessions.length > 0
                 return (
                   <div key={g.agent.slug} className="py-1">
                     <button
@@ -212,7 +217,7 @@ export function SearchDialog() {
                         activeIndex === agentIdx ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50'
                       )}
                     >
-                      {!isSearchMode && hasSessions && (
+                      {!isSearchMode && hasChildren && (
                         <ChevronRight
                           data-testid="search-agent-expand"
                           data-agent-slug={g.agent.slug}
@@ -226,7 +231,7 @@ export function SearchDialog() {
                           }}
                         />
                       )}
-                      {!isSearchMode && !hasSessions && (
+                      {!isSearchMode && !hasChildren && (
                         <span className="w-3.5 shrink-0" />
                       )}
                       <Bot className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -239,6 +244,32 @@ export function SearchDialog() {
                         </span>
                       )}
                     </button>
+                    {isExpanded && g.dashboards.map((d) => {
+                      const dashboardIdx = idx++
+                      return (
+                        <button
+                          key={d.slug}
+                          type="button"
+                          data-index={dashboardIdx}
+                          data-testid="search-dashboard-row"
+                          data-agent-name={g.agent.name}
+                          data-agent-slug={g.agent.slug}
+                          data-dashboard-name={d.name}
+                          data-dashboard-slug={d.slug}
+                          onClick={() => handleSelect({ kind: 'dashboard', agent: g.agent, dashboard: d })}
+                          onMouseEnter={() => setActiveIndex(dashboardIdx)}
+                          className={cn(
+                            'w-full flex items-center gap-2 pl-9 pr-3 py-1.5 text-left text-sm rounded-sm',
+                            activeIndex === dashboardIdx ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50'
+                          )}
+                        >
+                          <SquareMousePointer className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                          <span className="truncate text-muted-foreground">
+                            <HighlightMatch text={d.name} query={query} />
+                          </span>
+                        </button>
+                      )
+                    })}
                     {isExpanded && g.sessions.map((s) => {
                       const sessionIdx = idx++
                       return (


### PR DESCRIPTION
## Summary
- Adds dashboard/artifact entries to the Cmd-K search palette alongside agents and sessions.
- Supports dashboard name and slug matching, including fallback metadata from existing agent summary fields.
- Wires dashboard result selection to /agents/$slug/dashboards/$dashSlug and updates keyboard flattening behavior.

## Validation
- npm run test:run -- src/renderer/components/search/filter.test.ts
- npm run typecheck
- ./node_modules/.bin/eslint src/renderer/components/search/filter.ts src/renderer/components/search/search-dialog.tsx src/renderer/components/search/filter.test.ts
- git diff --check

Linear: SUP-288