### PR TITLE
Add configurable web favicon

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -22,6 +22,7 @@ import policies from './routes/policies'
 import runtimeStatusRouter from './routes/runtime-status'
 import sttRouter from './routes/stt'
 import llmRouter from './routes/llm'
+import faviconRouter from './routes/favicon'
 import { getPolyfillJs } from './speech-recognition-polyfill'
 import { getLlmPolyfillJs } from './llm-polyfill'
 import { ANTHROPIC_SDK_BUNDLE } from './llm-sdk-bundle'
@@ -188,6 +189,7 @@ app.route('/api/audit-log', auditLogRouter)
 app.route('/api/platform-auth', platformAuth)
 app.route('/api/stt', sttRouter)
 app.route('/api/llm', llmRouter)
+app.route('/api/favicon', faviconRouter)
 app.route('/api/debug', debugRouter)
 
 // Global error handler

--- a/src/api/routes/favicon.test.ts
+++ b/src/api/routes/favicon.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+const mockGetSettings = vi.fn()
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: (...args: unknown[]) => mockGetSettings(...args),
+}))
+
+import favicon from './favicon'
+
+function createApp() {
+  const app = new Hono()
+  app.route('/api/favicon', favicon)
+  return app
+}
+
+describe('favicon route', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSettings.mockReturnValue({ app: {} })
+    app = createApp()
+  })
+
+  it('serves the default SVG favicon', async () => {
+    const res = await app.request('http://localhost/api/favicon')
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/svg+xml')
+    expect(res.headers.get('cache-control')).toContain('no-cache')
+    expect(await res.text()).toContain('<svg')
+  })
+
+  it('serves a configured image favicon', async () => {
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    mockGetSettings.mockReturnValue({
+      app: {
+        faviconDataUrl: `data:image/png;base64,${bytes.toString('base64')}`,
+      },
+    })
+
+    const res = await app.request('http://localhost/api/favicon')
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/png')
+    expect(Buffer.from(await res.arrayBuffer())).toEqual(bytes)
+  })
+
+  it('falls back to the default favicon when the saved value is invalid', async () => {
+    mockGetSettings.mockReturnValue({
+      app: {
+        faviconDataUrl: 'data:text/html;base64,PGgxPk5vcGU8L2gxPg==',
+      },
+    })
+
+    const res = await app.request('http://localhost/api/favicon')
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/svg+xml')
+  })
+})

--- a/src/api/routes/favicon.ts
+++ b/src/api/routes/favicon.ts
@@ -1,0 +1,37 @@
+import { Hono } from 'hono'
+import { getSettings } from '@shared/lib/config/settings'
+import {
+  DEFAULT_WEB_FAVICON_MIME_TYPE,
+  DEFAULT_WEB_FAVICON_SVG,
+  parseFaviconDataUrl,
+} from '@shared/lib/config/favicon'
+
+const favicon = new Hono()
+
+function faviconHeaders(contentType: string): Record<string, string> {
+  return {
+    'Content-Type': contentType,
+    'Cache-Control': 'no-cache, max-age=0',
+    'X-Content-Type-Options': 'nosniff',
+    'Content-Security-Policy': "default-src 'none'; script-src 'none'; sandbox",
+  }
+}
+
+function responseBytes(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
+  const body = new Uint8Array(bytes.byteLength)
+  body.set(bytes)
+  return body
+}
+
+favicon.get('/', (c) => {
+  const configured = getSettings().app?.faviconDataUrl
+  const parsed = configured ? parseFaviconDataUrl(configured) : null
+
+  if (parsed) {
+    return c.body(responseBytes(parsed.bytes), 200, faviconHeaders(parsed.mimeType))
+  }
+
+  return c.body(DEFAULT_WEB_FAVICON_SVG, 200, faviconHeaders(DEFAULT_WEB_FAVICON_MIME_TYPE))
+})
+
+export default favicon

--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -1062,6 +1062,58 @@ describe('settings route', () => {
   })
 
   // =========================================================================
+  // Settings merge — web favicon
+  // =========================================================================
+  describe('web favicon handling', () => {
+    const pngDataUrl = `data:image/png;base64,${Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64')}`
+
+    it('stores a valid favicon data URL and stamps the update time', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-06-20T01:02:03.000Z'))
+
+      const res = await putSettings({ app: { faviconDataUrl: pngDataUrl } })
+
+      expect(res.status).toBe(200)
+      const saved = mockUpdateSettings.mock.calls[0][0]
+      expect(saved.app.faviconDataUrl).toBe(pngDataUrl)
+      expect(saved.app.faviconUpdatedAt).toBe('2026-06-20T01:02:03.000Z')
+
+      vi.useRealTimers()
+    })
+
+    it('rejects an invalid favicon payload', async () => {
+      const res = await putSettings({ app: { faviconDataUrl: 'data:text/html;base64,PGgxPk5vcGU8L2gxPg==' } })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toContain('Favicon must be')
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it('removes the custom favicon when set to null', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-06-20T02:03:04.000Z'))
+      mockGetSettings.mockReturnValue({
+        ...defaultSettings(),
+        app: {
+          showMenuBarIcon: true,
+          faviconDataUrl: pngDataUrl,
+          faviconUpdatedAt: '2026-06-20T01:02:03.000Z',
+        },
+      })
+
+      const res = await putSettings({ app: { faviconDataUrl: null } })
+
+      expect(res.status).toBe(200)
+      const saved = mockUpdateSettings.mock.calls[0][0]
+      expect(saved.app.faviconDataUrl).toBeUndefined()
+      expect(saved.app.faviconUpdatedAt).toBe('2026-06-20T02:03:04.000Z')
+
+      vi.useRealTimers()
+    })
+  })
+
+  // =========================================================================
   // Settings merge — llmProvider
   // =========================================================================
   describe('llmProvider handling', () => {

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -21,10 +21,12 @@ import {
   getEffectiveAgentLimits,
   getCustomEnvVars,
   type AppSettings,
+  type AppPreferences,
   type ApiKeySettings,
   type ContainerSettings,
   type GlobalSettingsResponse,
 } from '@shared/lib/config/settings'
+import { validateFaviconDataUrl } from '@shared/lib/config/favicon'
 import { getTenantId } from '@shared/lib/analytics/tenant-id'
 import { getSttProvider } from '@shared/lib/stt'
 import { containerManager } from '@shared/lib/container/container-manager'
@@ -120,6 +122,11 @@ const API_KEY_FIELDS: (keyof ApiKeySettings)[] = [
   'nangoSecretKey',
   'accountProviderUserId',
 ]
+
+type AppPreferencesPatch = Partial<AppPreferences> & {
+  faviconDataUrl?: unknown
+  hostBrowserProvider?: unknown
+}
 
 /** Build the GlobalSettingsResponse shared by GET and PUT handlers. */
 function buildSettingsResponse(
@@ -236,6 +243,20 @@ settings.put('/', async (c) => {
       }
     }
 
+    let appPatch = body.app as AppPreferencesPatch | undefined
+    if (appPatch && Object.prototype.hasOwnProperty.call(appPatch, 'faviconDataUrl')) {
+      const validation = validateFaviconDataUrl(appPatch.faviconDataUrl)
+      if (!validation.ok) {
+        return c.json({ error: validation.error }, 400)
+      }
+
+      appPatch = { ...appPatch }
+      appPatch.faviconUpdatedAt = new Date().toISOString()
+      if (appPatch.faviconDataUrl === null || appPatch.faviconDataUrl === '') {
+        appPatch.faviconDataUrl = undefined
+      }
+    }
+
     // When the active LLM provider changes, reset model selections to the new
     // provider's defaults (bare aliases) — unless the same request sets `models`
     // explicitly. Prevents a pin from the old provider's catalog (which may not
@@ -270,10 +291,10 @@ settings.put('/', async (c) => {
       },
       app: {
         ...currentSettings.app,
-        ...body.app,
+        ...appPatch,
         // If hostBrowserProvider was explicitly set to null (meaning "use container"),
         // remove it from settings so consumers treat it as "no host provider"
-        ...(body.app && 'hostBrowserProvider' in body.app && body.app.hostBrowserProvider == null
+        ...(appPatch && 'hostBrowserProvider' in appPatch && appPatch.hostBrowserProvider == null
           ? { hostBrowserProvider: undefined }
           : {}),
       },

--- a/src/renderer/components/settings/general-tab.tsx
+++ b/src/renderer/components/settings/general-tab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type ReactNode } from 'react'
+import { useCallback, useRef, useState, type ChangeEvent, type ReactNode } from 'react'
 import { Button } from '@renderer/components/ui/button'
 import { Switch } from '@renderer/components/ui/switch'
 import {
@@ -14,6 +14,7 @@ import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
 import { useUser } from '@renderer/context/user-context'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { useUpdateStatus } from '@renderer/context/update-status-context'
+import { applyWebFavicon, getWebFaviconHref } from '@renderer/lib/favicon'
 import {
   Wand2,
   TriangleAlert,
@@ -24,6 +25,8 @@ import {
   Monitor,
   Sun,
   Moon,
+  Upload,
+  Trash2,
 } from 'lucide-react'
 
 interface SettingRowProps {
@@ -91,6 +94,36 @@ function KeepAwakeRow({ enabled, onToggle, disabled }: KeepAwakeRowProps) {
 
 const CARD_CLASS = 'rounded-xl border bg-background divide-y divide-border/50 overflow-hidden'
 const SECTION_HEADING = 'text-xs font-medium text-muted-foreground px-1'
+const FAVICON_ACCEPT = 'image/png,image/jpeg,image/webp,image/x-icon,image/vnd.microsoft.icon,image/svg+xml,.ico'
+const FAVICON_MAX_BYTES = 256 * 1024
+const FAVICON_ALLOWED_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/x-icon',
+  'image/vnd.microsoft.icon',
+  'image/svg+xml',
+])
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      if (typeof reader.result === 'string') resolve(reader.result)
+      else reject(new Error('Failed to read image'))
+    }
+    reader.onerror = () => reject(new Error('Failed to read image'))
+    reader.readAsDataURL(file)
+  })
+}
+
+function errorMessage(error: unknown): string {
+  if (error && typeof error === 'object' && 'error' in error && typeof error.error === 'string') {
+    return error.error
+  }
+  if (error instanceof Error) return error.message
+  return 'Failed to update web icon'
+}
 
 interface GeneralTabProps {
   onOpenWizard: () => void
@@ -104,9 +137,15 @@ export function GeneralTab({ onOpenWizard }: GeneralTabProps) {
   const { isAuthMode, isAdmin } = useUser()
   const showAdminFeatures = !isAuthMode || isAdmin
   const [keepAwakeLoading, setKeepAwakeLoading] = useState(false)
+  const [faviconSaving, setFaviconSaving] = useState(false)
+  const [faviconError, setFaviconError] = useState<string | null>(null)
+  const faviconInputRef = useRef<HTMLInputElement>(null)
 
   const isElectronApp = !!window.electronAPI
   const isMacElectron = window.electronAPI?.platform === 'darwin'
+  const showWebFaviconSettings = !isElectronApp && showAdminFeatures
+  const customFavicon = globalSettings?.app?.faviconDataUrl
+  const faviconPreviewSrc = customFavicon || getWebFaviconHref(globalSettings?.app?.faviconUpdatedAt)
 
   const handleKeepAwakeToggle = async (checked: boolean) => {
     setKeepAwakeLoading(true)
@@ -117,6 +156,51 @@ export function GeneralTab({ onOpenWizard }: GeneralTabProps) {
       // User cancelled the sudo dialog or pmset failed — don't persist
     } finally {
       setKeepAwakeLoading(false)
+    }
+  }
+
+  const handleFaviconFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.currentTarget.files?.[0]
+    event.currentTarget.value = ''
+    if (!file) return
+
+    const isIcoWithMissingType = !file.type && file.name.toLowerCase().endsWith('.ico')
+    if (!FAVICON_ALLOWED_TYPES.has(file.type) && !isIcoWithMissingType) {
+      setFaviconError('Choose a PNG, JPEG, WebP, ICO, or SVG image.')
+      return
+    }
+
+    if (file.size > FAVICON_MAX_BYTES) {
+      setFaviconError('Choose an image smaller than 256KB.')
+      return
+    }
+
+    setFaviconSaving(true)
+    setFaviconError(null)
+    try {
+      let dataUrl = await readFileAsDataUrl(file)
+      if (isIcoWithMissingType) {
+        dataUrl = dataUrl.replace(/^data:[^;]*;base64,/, 'data:image/x-icon;base64,')
+      }
+      const updated = await updateGlobalSettings.mutateAsync({ app: { faviconDataUrl: dataUrl } })
+      applyWebFavicon(updated.app.faviconUpdatedAt)
+    } catch (error) {
+      setFaviconError(errorMessage(error))
+    } finally {
+      setFaviconSaving(false)
+    }
+  }
+
+  const handleResetFavicon = async () => {
+    setFaviconSaving(true)
+    setFaviconError(null)
+    try {
+      const updated = await updateGlobalSettings.mutateAsync({ app: { faviconDataUrl: null } })
+      applyWebFavicon(updated.app.faviconUpdatedAt)
+    } catch (error) {
+      setFaviconError(errorMessage(error))
+    } finally {
+      setFaviconSaving(false)
     }
   }
 
@@ -220,6 +304,67 @@ export function GeneralTab({ onOpenWizard }: GeneralTabProps) {
           )}
         </div>
       </div>
+
+      {showWebFaviconSettings && (
+        <div className="space-y-2">
+          <h3 className={SECTION_HEADING}>Branding</h3>
+          <div className={CARD_CLASS}>
+            <div className="py-3 px-4">
+              <div className="flex items-center gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="text-xs font-medium truncate block cursor-default">Web Icon</div>
+                  <div className="text-[11px] text-muted-foreground mt-0.5">Shown in browser tabs for web deployments</div>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <div className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-md border bg-muted">
+                    <img src={faviconPreviewSrc} alt="" className="h-6 w-6 object-contain" />
+                  </div>
+                  <input
+                    ref={faviconInputRef}
+                    type="file"
+                    accept={FAVICON_ACCEPT}
+                    className="hidden"
+                    onChange={handleFaviconFileChange}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => faviconInputRef.current?.click()}
+                    disabled={!globalSettings || faviconSaving}
+                  >
+                    {faviconSaving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Upload className="h-4 w-4 mr-2" />}
+                    Upload
+                  </Button>
+                  {customFavicon && (
+                    <TooltipProvider delayDuration={0}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            onClick={handleResetFavicon}
+                            disabled={!globalSettings || faviconSaving}
+                            aria-label="Reset web icon"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Reset web icon</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  )}
+                </div>
+              </div>
+              {faviconError && (
+                <p className="mt-2 text-[11px] text-destructive">{faviconError}</p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {!isAuthMode && (
         <div className="space-y-2">

--- a/src/renderer/hooks/use-settings.ts
+++ b/src/renderer/hooks/use-settings.ts
@@ -32,7 +32,7 @@ export function useSettings(options?: { enabled?: boolean }) {
 
 export interface UpdateSettingsParams {
   container?: Partial<ContainerSettings>
-  app?: Partial<AppPreferences>
+  app?: Omit<Partial<AppPreferences>, 'faviconDataUrl'> & { faviconDataUrl?: string | null }
   llmProvider?: LlmProviderId
   apiKeys?: {
     anthropicApiKey?: string

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Gamut</title>
   <meta name="description" content="Run sophisticated AI code agents powered by Claude Code" />
+  <script>
+    if (!window.electronAPI) {
+      var favicon = document.createElement('link')
+      favicon.rel = 'icon'
+      favicon.href = '/api/favicon'
+      favicon.setAttribute('data-managed-favicon', 'true')
+      document.head.appendChild(favicon)
+    }
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/src/renderer/lib/favicon.ts
+++ b/src/renderer/lib/favicon.ts
@@ -1,0 +1,19 @@
+import { isElectron } from './env'
+
+export function getWebFaviconHref(version?: string): string {
+  return version ? `/api/favicon?v=${encodeURIComponent(version)}` : '/api/favicon'
+}
+
+export function applyWebFavicon(version?: string): void {
+  if (typeof document === 'undefined' || isElectron()) return
+
+  let link = document.querySelector<HTMLLinkElement>('link[data-managed-favicon="true"]')
+  if (!link) {
+    link = document.createElement('link')
+    link.rel = 'icon'
+    link.setAttribute('data-managed-favicon', 'true')
+    document.head.appendChild(link)
+  }
+
+  link.href = getWebFaviconHref(version)
+}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -4,6 +4,7 @@ import App from './App'
 import './globals.css'
 import { initApiBaseUrl, isElectron, getPlatform } from './lib/env'
 import { initRendererErrorReporting } from './lib/error-reporting'
+import { applyWebFavicon } from './lib/favicon'
 
 // Initialize Sentry error reporting as early as possible
 initRendererErrorReporting()
@@ -17,6 +18,10 @@ if (isElectron() && (getPlatform() === 'darwin' || getPlatform() === 'win32')) {
 }
 
 async function init() {
+  if (__WEB__) {
+    applyWebFavicon()
+  }
+
   // Load render tracking instrumentation before any components (must patch React first)
   if (__RENDER_TRACKING__) {
     await import('./lib/render-tracking')

--- a/src/shared/lib/config/favicon.ts
+++ b/src/shared/lib/config/favicon.ts
@@ -1,0 +1,77 @@
+export const FAVICON_MAX_BYTES = 256 * 1024
+
+export const ALLOWED_FAVICON_MIME_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/x-icon',
+  'image/vnd.microsoft.icon',
+  'image/svg+xml',
+] as const
+
+export type FaviconMimeType = (typeof ALLOWED_FAVICON_MIME_TYPES)[number]
+
+const ALLOWED_FAVICON_MIME_TYPE_SET = new Set<string>(ALLOWED_FAVICON_MIME_TYPES)
+
+export const DEFAULT_WEB_FAVICON_MIME_TYPE = 'image/svg+xml'
+
+export const DEFAULT_WEB_FAVICON_SVG = `<svg width="600" height="600" viewBox="0 0 600 600" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="600" height="600" rx="132" fill="#111827"/>
+<g transform="translate(35 35) scale(0.88)">
+<path d="M78.0056 314.341C100.937 354.026 131.37 393.855 168.486 430.971C208.357 470.841 251.358 503 293.949 526.432C266.624 554.832 228.44 572.471 186.187 572.471C103.108 572.471 35.7585 504.282 35.7585 420.167C35.7586 379.052 51.851 341.742 78.0056 314.341ZM62.0544 61.4181C134.713 -11.2404 300.168 36.4105 431.607 167.85C563.046 299.289 610.697 464.744 538.039 537.402C487.42 588.021 391.765 580.247 293.949 526.432C320.351 498.991 336.616 461.502 336.616 420.167C336.616 336.052 269.266 267.864 186.187 267.863C143.717 267.863 105.359 285.684 78.0056 314.341C19.7299 213.488 9.91302 113.56 62.0544 61.4181Z" fill="white"/>
+</g>
+</svg>`
+
+export interface ParsedFaviconDataUrl {
+  mimeType: FaviconMimeType
+  bytes: Buffer
+}
+
+export type FaviconValidationResult =
+  | { ok: true }
+  | { ok: false; error: string }
+
+function isUnsafeSvg(svg: string): boolean {
+  return (
+    /<\s*(script|foreignObject)\b/i.test(svg) ||
+    /\son[a-z]+\s*=/i.test(svg) ||
+    /javascript\s*:/i.test(svg)
+  )
+}
+
+export function parseFaviconDataUrl(value: string): ParsedFaviconDataUrl | null {
+  const match = /^data:([^;,]+);base64,([A-Za-z0-9+/]+={0,2})$/.exec(value)
+  if (!match) return null
+
+  const mimeType = match[1].toLowerCase()
+  if (!ALLOWED_FAVICON_MIME_TYPE_SET.has(mimeType)) return null
+
+  const bytes = Buffer.from(match[2], 'base64')
+  if (bytes.byteLength === 0 || bytes.byteLength > FAVICON_MAX_BYTES) return null
+
+  if (mimeType === 'image/svg+xml') {
+    const svg = bytes.toString('utf8')
+    if (!/<svg[\s>]/i.test(svg) || isUnsafeSvg(svg)) return null
+  }
+
+  return { mimeType: mimeType as FaviconMimeType, bytes }
+}
+
+export function validateFaviconDataUrl(value: unknown): FaviconValidationResult {
+  if (value === undefined || value === null || value === '') {
+    return { ok: true }
+  }
+
+  if (typeof value !== 'string') {
+    return { ok: false, error: 'faviconDataUrl must be a data URL string' }
+  }
+
+  if (!parseFaviconDataUrl(value)) {
+    return {
+      ok: false,
+      error: `Favicon must be a ${ALLOWED_FAVICON_MIME_TYPES.join(', ')} image up to ${FAVICON_MAX_BYTES / 1024}KB`,
+    }
+  }
+
+  return { ok: true }
+}

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -89,6 +89,8 @@ export interface AppPreferences {
   allowPrereleaseUpdates?: boolean
   theme?: 'system' | 'light' | 'dark'
   maxBrowserTabs?: number
+  faviconDataUrl?: string
+  faviconUpdatedAt?: string
 
   // Browserbase session settings
   browserbaseAdvancedStealth?: boolean


### PR DESCRIPTION
## Summary
- Add a public `/api/favicon` endpoint with the Gamut SVG fallback for web deployments.
- Allow admins in web/auth mode to upload or reset a custom favicon from General settings.
- Validate uploaded favicon data URLs, including size/type checks and basic unsafe SVG rejection.

## Validation
- `npm run test:run -- src/api/routes/favicon.test.ts src/api/routes/settings.test.ts`
- `npm run typecheck`
- `npx eslint src/api/routes/favicon.ts src/api/routes/favicon.test.ts src/shared/lib/config/favicon.ts src/renderer/lib/favicon.ts src/renderer/components/settings/general-tab.tsx src/api/routes/settings.ts src/api/routes/settings.test.ts src/renderer/hooks/use-settings.ts src/renderer/main.tsx`
- Browser smoke at `http://127.0.0.1:47891/` verified the managed favicon link and `/api/favicon` response.

Linear: SUP-289
