### PR TITLE
fix(lima): bump bundled Lima 2.1.1 → 2.1.3 (SUP-290)

### DIFF
--- a/scripts/download-lima.sh
+++ b/scripts/download-lima.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-LIMA_VERSION="2.1.1"
+LIMA_VERSION="2.1.3"
 ALPINE_VERSION="3.23.3"
 ARCH="${1:-$(uname -m)}"
 


### PR DESCRIPTION
## What

Bumps the bundled Lima from **2.1.1 → 2.1.3** (`scripts/download-lima.sh`). One line; no SHA to re-pin (the script greps `SHA256SUMS` at build time).

## Why (P0)

2.1.2 carries **lima-vm/lima#4911** — a fix for the host↔guest gRPC connection permanently breaking after any guest-agent reconnect / VM reboot (the `ga.sock` guest-agent socket was double-deleted and left missing, recoverable only by `limactl stop && start`). That reconnect trigger is exactly what our memory-pressure hiccups cause, so this plausibly fixes the "VM `Running` but containers unreachable" slice of our wedges (parts of **ELECTRON-55 / ELECTRON-3Z**). 2.1.2/2.1.3 also carry nerdctl / CVE / stability fixes.

**Does NOT fix:** the `ha.sock`-missing dirty-dir errors (ELECTRON-4S) or the memory root cause — those are separate tickets.

## Safety: existing VMs are not force-recreated

`MIN_LIMA_VM_VERSION` is a hardcoded `'v2.1.1'` (`lima-container-client.ts:117`), **decoupled** from the bundled version. The check is `vmVersion < MIN_LIMA_VM_VERSION`, so `'v2.1.1' < 'v2.1.1'` = false → existing 2.1.1 VMs stay. The #4911 fix lives in the **guest agent**, which limactl re-embeds into `cidata.iso` on every `limactl start` — so the fix activates on the next VM start with no recreate and no version skew. (Verified on a real VM: `cidata.iso` is regenerated each start while the creation-time identity files stay fixed.)

## Validation performed

- **Ran `download-lima.sh arm64`**: checksum verified, `limactl version 2.1.3`, guest agent extracted (the `tar` extract is the AC tripwire — it did not fail).
- **AC — guest agent still in the main tarball** (2.1.3 split out `lima-additional-guestagents-*`): confirmed both arches' main tarballs still contain the native agent — `lima-2.1.3-Darwin-arm64.tar.gz` → `Linux-aarch64.gz`, `…-x86_64.tar.gz` → `Linux-x86_64.gz`. The split-out tarballs only hold cross-arch agents we never extract.
- **Fresh-VM (no boot)**: isolated `limactl create` with the app's exact VM config + bundled Alpine image → 2.1.3 accepts the config, writes `lima-version=v2.1.3` (so fresh VMs also aren't force-recreated). Torn down, no prod impact.
- **Existing-VM upgrade**: a real `v2.1.1` VM → no force-recreate (logic + live state).
- **Shipped artifact**: built `dist:mac`; bundled `limactl` inside `Gamut.app` reports **2.1.3**, native guest agent + `alpine.qcow2` present at the resources path the app reads. Signed, signature valid.

## Acceptance criteria

- [x] arm64 main tarball still contains native guest agent at the extract path (x86_64 verified too, though mac ships arm64-only on `macos-26`)
- [x] Fresh VM creates with 2.1.3 (no-boot `create` smoke test)
- [x] Existing-VM upgrade → no forced recreate
- [ ] **Canary before fleet rollout** — runtime ~60% of users depend on; failure mode = "nobody's agents start". An arm64 `dist:mac` build is attached locally for canary testing.

Closes SUP-290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)