### PR TITLE
fix(slack): reply in-thread when tagged inside a thread with "Reply in thread" off (SUP-282)

### DIFF
--- a/src/shared/lib/chat-integrations/slack-channel-behavior.test.ts
+++ b/src/shared/lib/chat-integrations/slack-channel-behavior.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { routeSlackMessage, resolveSlackChannel, type SlackMessageRoutingParams } from './slack-connector'
+import { routeSlackMessage, resolveSlackChannel, touchAndCapSet, touchAndCapMap, type SlackMessageRoutingParams } from './slack-connector'
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -202,6 +202,150 @@ describe('routeSlackMessage', () => {
     })
   })
 
+  // ── thread reply when answerInThread is off (SUP-282) ──────────────
+
+  describe('answerInThread off but message is inside a thread (SUP-282)', () => {
+    it('replies in the thread when the inbound message has a thread_ts', () => {
+      const result = routeSlackMessage(makeParams({
+        ts: '2000.002',
+        threadTs: '1000.001',
+        config: { answerInThread: false },
+      }))
+      expect(result.threadContext).toEqual({ channel: 'C123', threadTs: '1000.001' })
+      expect(result.threadKey).toBe('C123|1000.001')
+    })
+
+    it('does NOT thread a top-level channel message when answerInThread is off', () => {
+      const result = routeSlackMessage(makeParams({
+        ts: '1000.001',
+        config: { answerInThread: false },
+      }))
+      expect(result.threadContext).toBeUndefined()
+      expect(result.threadKey).toBeUndefined()
+      expect(result.effectiveChatId).toBe('C123')
+    })
+
+    it('replies in the thread for a mention inside a thread with onlyMentioned on', () => {
+      const result = routeSlackMessage(makeParams({
+        rawText: '<@U_BOT> help me here',
+        ts: '2000.002',
+        threadTs: '1000.001',
+        config: { onlyMentioned: true, answerInThread: false },
+      }))
+      expect(result.shouldProcess).toBe(true)
+      expect(result.threadContext).toEqual({ channel: 'C123', threadTs: '1000.001' })
+    })
+
+    it('does not thread DMs even when inside a thread', () => {
+      const result = routeSlackMessage(makeParams({
+        channelType: 'im',
+        chatId: 'D456',
+        ts: '2000.002',
+        threadTs: '1000.001',
+        config: { answerInThread: false },
+      }))
+      expect(result.threadContext).toBeUndefined()
+    })
+
+    it('uses a per-thread session (composite chatId) for an in-thread message when answerInThread is off', () => {
+      // Race-free routing: the channel otherwise shares one session across threads,
+      // so the reply destination would live only in the mutable threadContextMap.
+      // Encoding the anchor in effectiveChatId makes it travel with the session.
+      const result = routeSlackMessage(makeParams({
+        ts: '2000.002',
+        threadTs: '1000.001',
+        config: { answerInThread: false, newSessionPerThread: false },
+      }))
+      expect(result.effectiveChatId).toBe('C123|1000.001')
+    })
+
+    it('reply destination is recoverable from the composite chatId alone — no shared map needed (race-free)', () => {
+      const result = routeSlackMessage(makeParams({
+        ts: '2000.002',
+        threadTs: '1000.001',
+        config: { answerInThread: false },
+      }))
+      // Pass an EMPTY map: a concurrent message could have cleared/overwritten it.
+      // The destination must still resolve to the correct thread.
+      expect(resolveSlackChannel(result.effectiveChatId, new Map())).toEqual({
+        channel: 'C123',
+        threadTs: '1000.001',
+      })
+    })
+
+    it('distinct threads in the same channel get distinct sessions (no collision)', () => {
+      const t1 = routeSlackMessage(makeParams({ ts: '2000.002', threadTs: '1000.001', config: { answerInThread: false } }))
+      const t2 = routeSlackMessage(makeParams({ ts: '3000.003', threadTs: '1500.001', config: { answerInThread: false } }))
+      expect(t1.effectiveChatId).toBe('C123|1000.001')
+      expect(t2.effectiveChatId).toBe('C123|1500.001')
+      expect(t1.effectiveChatId).not.toBe(t2.effectiveChatId)
+    })
+  })
+
+  // ── isNewThreadEntry (thread-history backfill trigger) ─────────────
+
+  describe('isNewThreadEntry', () => {
+    it('is true on first tag inside an existing thread even when answerInThread is off (SUP-282)', () => {
+      const result = routeSlackMessage(makeParams({
+        ts: '2000.002',
+        threadTs: '1000.001',
+        config: { answerInThread: false },
+        activeThreads: new Set(),
+      }))
+      expect(result.isNewThreadEntry).toBe(true)
+    })
+
+    it('is true on first entry into an existing thread when answerInThread is on', () => {
+      const result = routeSlackMessage(makeParams({
+        ts: '2000.002',
+        threadTs: '1000.001',
+        config: { answerInThread: true },
+        activeThreads: new Set(),
+      }))
+      expect(result.isNewThreadEntry).toBe(true)
+    })
+
+    it('is false once the thread is already active (no re-fetch of history)', () => {
+      const result = routeSlackMessage(makeParams({
+        ts: '2000.003',
+        threadTs: '1000.001',
+        config: { answerInThread: false },
+        activeThreads: new Set(['C123|1000.001']),
+      }))
+      expect(result.isNewThreadEntry).toBe(false)
+    })
+
+    it('is false for a brand-new top-level message (nothing to backfill)', () => {
+      const result = routeSlackMessage(makeParams({
+        ts: '1000.001',
+        config: { answerInThread: true },
+      }))
+      expect(result.isNewThreadEntry).toBe(false)
+    })
+
+    it('is false for DMs even inside a thread', () => {
+      const result = routeSlackMessage(makeParams({
+        channelType: 'im',
+        chatId: 'D456',
+        ts: '2000.002',
+        threadTs: '1000.001',
+        config: {},
+      }))
+      expect(result.isNewThreadEntry).toBe(false)
+    })
+
+    it('is false for a filtered-out message (onlyMentioned, no mention, unknown thread)', () => {
+      const result = routeSlackMessage(makeParams({
+        rawText: 'just chatting',
+        threadTs: '9999.999',
+        config: { onlyMentioned: true },
+        activeThreads: new Set(),
+      }))
+      expect(result.shouldProcess).toBe(false)
+      expect(result.isNewThreadEntry).toBe(false)
+    })
+  })
+
   // ── newSessionPerThread ───────────────────────────────────────────
 
   describe('newSessionPerThread', () => {
@@ -272,5 +416,63 @@ describe('resolveSlackChannel', () => {
   it('returns DM channel as-is', () => {
     const result = resolveSlackChannel('D456', new Map())
     expect(result).toEqual({ channel: 'D456' })
+  })
+})
+
+// ── bounded MRU eviction (touchAndCapSet / touchAndCapMap) ─────────────
+
+describe('touchAndCapSet', () => {
+  it('adds keys and keeps them under the cap', () => {
+    const set = new Set<string>()
+    touchAndCapSet(set, 'a', 3)
+    touchAndCapSet(set, 'b', 3)
+    expect([...set]).toEqual(['a', 'b'])
+  })
+
+  it('evicts the oldest entry once the cap is exceeded', () => {
+    const set = new Set<string>()
+    touchAndCapSet(set, 'a', 2)
+    touchAndCapSet(set, 'b', 2)
+    touchAndCapSet(set, 'c', 2) // evicts 'a'
+    expect([...set]).toEqual(['b', 'c'])
+    expect(set.has('a')).toBe(false)
+  })
+
+  it('re-touching an existing key refreshes its recency so it survives eviction', () => {
+    const set = new Set<string>()
+    touchAndCapSet(set, 'a', 2)
+    touchAndCapSet(set, 'b', 2)
+    touchAndCapSet(set, 'a', 2) // 'a' becomes most-recent
+    touchAndCapSet(set, 'c', 2) // evicts 'b' (now oldest), not 'a'
+    expect([...set]).toEqual(['a', 'c'])
+  })
+
+  it('never grows beyond the cap across many inserts', () => {
+    const set = new Set<string>()
+    for (let i = 0; i < 5000; i++) touchAndCapSet(set, `k${i}`, 1000)
+    expect(set.size).toBe(1000)
+    expect(set.has('k4999')).toBe(true)
+    expect(set.has('k0')).toBe(false)
+  })
+})
+
+describe('touchAndCapMap', () => {
+  it('evicts the oldest entry once the cap is exceeded', () => {
+    const map = new Map<string, number>()
+    touchAndCapMap(map, 'a', 1, 2)
+    touchAndCapMap(map, 'b', 2, 2)
+    touchAndCapMap(map, 'c', 3, 2) // evicts 'a'
+    expect([...map.keys()]).toEqual(['b', 'c'])
+    expect(map.has('a')).toBe(false)
+  })
+
+  it('updating an existing key refreshes recency and value without growing', () => {
+    const map = new Map<string, number>()
+    touchAndCapMap(map, 'a', 1, 2)
+    touchAndCapMap(map, 'b', 2, 2)
+    touchAndCapMap(map, 'a', 99, 2) // refresh 'a' (value + recency)
+    touchAndCapMap(map, 'c', 3, 2) // evicts 'b', not 'a'
+    expect(map.get('a')).toBe(99)
+    expect([...map.keys()]).toEqual(['a', 'c'])
   })
 })

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -133,6 +133,13 @@ export interface SlackMessageRoutingResult {
   effectiveChatId: string
   threadContext?: { channel: string; threadTs: string }
   threadKey?: string
+  /**
+   * True when this message is the bot's first appearance in an already-existing
+   * thread (the thread isn't in `activeThreads` yet). The caller should backfill
+   * earlier thread messages as context. Computed against `activeThreads` as
+   * passed in — i.e. before the caller marks this thread active.
+   */
+  isNewThreadEntry: boolean
 }
 
 export function routeSlackMessage(params: SlackMessageRoutingParams): SlackMessageRoutingResult {
@@ -143,7 +150,7 @@ export function routeSlackMessage(params: SlackMessageRoutingParams): SlackMessa
     const isMentioned = botUserId ? rawText.includes(`<@${botUserId}>`) : false
     if (!isMentioned) {
       if (!threadTs || !activeThreads.has(`${chatId}|${threadTs}`)) {
-        return { shouldProcess: false, effectiveChatId: chatId }
+        return { shouldProcess: false, effectiveChatId: chatId, isNewThreadEntry: false }
       }
     }
   }
@@ -152,16 +159,36 @@ export function routeSlackMessage(params: SlackMessageRoutingParams): SlackMessa
   let threadContext: { channel: string; threadTs: string } | undefined
   let threadKey: string | undefined
 
-  if (isChannel && config.answerInThread) {
+  // Reply inside a thread when either:
+  // - answerInThread is on (thread every channel message), or
+  // - the inbound message is itself already inside a thread — continue that
+  //   thread instead of dropping the reply into the main channel, even when
+  //   answerInThread is off (SUP-282).
+  const inExistingThread = !!threadTs
+  if (isChannel && (config.answerInThread || inExistingThread)) {
     const threadAnchor = threadTs || ts
-    if (config.newSessionPerThread) {
+    // Give the thread its own session (composite chatId) when newSessionPerThread
+    // is on, OR when answerInThread is off but the message is inside a thread.
+    // In the latter case the channel otherwise shares a single session across all
+    // threads, so the reply destination would live only in the mutable
+    // threadContextMap — which a concurrent message can overwrite before the reply
+    // streams back (replies arrive async on a separate SSE queue). Encoding the
+    // anchor in effectiveChatId makes the destination travel immutably with the
+    // session: resolveSlackChannel recovers it by parsing the composite id, so
+    // routing never depends on shared state a later message could clobber (SUP-282).
+    if (config.newSessionPerThread || (!config.answerInThread && inExistingThread)) {
       effectiveChatId = `${chatId}|${threadAnchor}`
     }
     threadContext = { channel: chatId, threadTs: threadAnchor }
     threadKey = `${chatId}|${threadAnchor}`
   }
 
-  return { shouldProcess: true, effectiveChatId, threadContext, threadKey }
+  // Joining an existing thread for the first time: backfill its history. Only
+  // when the message is itself in a thread (threadTs) and we haven't tracked
+  // that thread yet — a brand-new top-level message has no history to fetch.
+  const isNewThreadEntry = !!(threadKey && threadTs && !activeThreads.has(threadKey))
+
+  return { shouldProcess: true, effectiveChatId, threadContext, threadKey, isNewThreadEntry }
 }
 
 export function resolveSlackChannel(
@@ -180,6 +207,34 @@ export function resolveSlackChannel(
   }
 
   return { channel: effectiveChatId }
+}
+
+/**
+ * Insert `key` at the most-recently-used position of an insertion-ordered Set,
+ * evicting the oldest entries once size exceeds `max`. Keeps long-lived tracking
+ * sets bounded so a connector that touches more and more threads over a
+ * long-running process can't leak memory. Re-inserting an existing key refreshes
+ * its recency (delete + re-add).
+ */
+export function touchAndCapSet(set: Set<string>, key: string, max: number): void {
+  set.delete(key)
+  set.add(key)
+  while (set.size > max) {
+    const oldest = set.values().next().value
+    if (oldest === undefined) break
+    set.delete(oldest)
+  }
+}
+
+/** Map counterpart of {@link touchAndCapSet}: (re)inserts `key` as MRU and evicts the oldest beyond `max`. */
+export function touchAndCapMap<V>(map: Map<string, V>, key: string, value: V, max: number): void {
+  map.delete(key)
+  map.set(key, value)
+  while (map.size > max) {
+    const oldest = map.keys().next().value
+    if (oldest === undefined) break
+    map.delete(oldest)
+  }
 }
 
 // ── Connector ───────────────────────────────────────────────────────────
@@ -212,6 +267,11 @@ export class SlackConnector extends ChatClientConnector {
   private threadContextMap: Map<string, { channel: string; threadTs: string }> = new Map()
   // Tracks threads the bot has participated in (for allowing thread replies without re-mention)
   private activeThreads: Set<string> = new Set() // channelId|threadTs
+  // Upper bound on tracked threads (per-collection) so a long-running connector in
+  // a busy workspace can't grow threadContextMap/activeThreads without limit. Evicts
+  // least-recently-touched threads; an evicted thread just re-fetches history /
+  // requires a re-mention if it ever resurfaces.
+  private static readonly MAX_TRACKED_THREADS = 1000
 
   constructor(private config: SlackConfig) {
     super()
@@ -258,15 +318,26 @@ export class SlackConnector extends ChatClientConnector {
 
       if (!routing.shouldProcess) return
 
-      // Detect new thread entry before marking it active
-      const isNewThreadEntry = !!(routing.threadKey && !this.activeThreads.has(routing.threadKey) && threadTs)
+      // routeSlackMessage decides this against activeThreads before we mark the
+      // thread active below, so read it now rather than recomputing post-add.
+      const isNewThreadEntry = routing.isNewThreadEntry
 
       const effectiveChatId = routing.effectiveChatId
-      if (routing.threadContext) this.threadContextMap.set(effectiveChatId, routing.threadContext)
-      if (routing.threadKey) this.activeThreads.add(routing.threadKey)
+      // Record the reply destination and mark the thread active (both bounded — see
+      // MAX_TRACKED_THREADS). For in-thread replies the destination is also encoded
+      // in effectiveChatId (composite id), so resolveSlackChannel can recover it by
+      // parsing even if this map entry is later evicted or overwritten — no stale
+      // entry can misroute a concurrent reply, so there's nothing to clear here.
+      if (routing.threadContext) {
+        touchAndCapMap(this.threadContextMap, effectiveChatId, routing.threadContext, SlackConnector.MAX_TRACKED_THREADS)
+      }
+      if (routing.threadKey) {
+        touchAndCapSet(this.activeThreads, routing.threadKey, SlackConnector.MAX_TRACKED_THREADS)
+      }
 
-      // Track message ts for reaction-based typing
-      this.lastUserMessageTs.set(effectiveChatId, ts)
+      // Track message ts for reaction-based typing (bounded: in-thread sessions
+      // make effectiveChatId per-thread, so this would otherwise grow with threads).
+      touchAndCapMap(this.lastUserMessageTs, effectiveChatId, ts, SlackConnector.MAX_TRACKED_THREADS)
 
       // Resolve real user and channel names
       const userName = await this.resolveUserName(userId)
@@ -275,8 +346,9 @@ export class SlackConnector extends ChatClientConnector {
       // Resolve <@U123>, <#C123|name>, links, and special mentions in the text
       let text = await this.resolveMentionsInText(rawText)
 
-      // When joining a thread mid-conversation, fetch earlier messages as context
-      if (isNewThreadEntry) {
+      // When joining a thread mid-conversation, fetch earlier messages as context.
+      // isNewThreadEntry already implies threadTs is set; the check narrows the type.
+      if (isNewThreadEntry && threadTs) {
         const history = await this.fetchThreadHistory(chatId, threadTs, ts)
         if (history) text = history + '\n\n' + text
       }


### PR DESCRIPTION
## SUP-282 — Slack: reply in the thread when tagged inside a thread (even with "Reply in thread" off)

Fixes [SUP-282](https://linear.app/datawizz/issue/SUP-282).

### Bug
With the Slack integration's **"Reply in thread"** toggle **off**, tagging the agent inside an existing thread made it:
1. Reply in the **main channel** instead of in the thread, and
2. See **only the message it was tagged on** — it never loaded the thread's prior messages.

### Root cause
`routeSlackMessage` only recorded thread context (reply destination + thread-history trigger) when `answerInThread` was on. The reply destination also lived in a mutable, channel-keyed `threadContextMap` written at ingestion but read later when the reply streams back on a **separate async SSE queue** — so it was both unset (the bug) and, once set, racy.

### Changes
- **Reply in-thread whenever the inbound message is itself threaded.** `answerInThread` now only governs whether *new top-level* messages start a thread. `isNewThreadEntry` is surfaced from `routeSlackMessage` so the thread-history backfill fires on the first in-thread tag regardless of the toggle.
- **Race-free routing.** In-thread replies use a per-thread session via a composite `effectiveChatId` (`channel|threadTs`). `resolveSlackChannel` recovers the destination by *parsing* that id, so routing no longer depends on shared mutable state a concurrent message could overwrite before the reply is sent. This let me drop a stale-context `delete` workaround entirely.
- **Bounded memory.** `activeThreads`, `threadContextMap`, and `lastUserMessageTs` now use MRU eviction (`MAX_TRACKED_THREADS = 1000`) so a long-running connector can't grow unbounded as it touches more threads.

### Behavior note
A thread you tag the bot into (with "Reply in thread" off) is now its **own isolated agent session** rather than sharing the main channel's conversation. Combined with the thread-history backfill, the agent gets that thread's context. This is intentional — an out-of-band thread mention reads as a distinct sub-conversation.

`answerInThread:on + newSessionPerThread:off` (an explicit "single shared channel session" choice) is intentionally left unchanged.

### Testing
- New/updated unit tests: in-thread routing, race-free composite resolution (resolves correctly from an *empty* map), distinct-session-per-thread, `isNewThreadEntry`, and MRU eviction helpers — in `slack-channel-behavior.test.ts`.
- Full chat-integrations suite green (**434/434**); `tsc` + eslint clean.
- Manually validated in Slack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
