### PR TITLE
fix(lima): self-heal dirty instance dir + reachability-based runtime health check (SUP-291)

### DIFF
--- a/src/shared/lib/container/base-container-client.test.ts
+++ b/src/shared/lib/container/base-container-client.test.ts
@@ -677,6 +677,67 @@ describe('BaseContainerClient.isPortConflictError', () => {
 })
 
 // ============================================================================
+// ensureImageExistsWithRecovery — SUP-291: the image BUILD step runs before
+// start()'s run-retry loop, so a dirty/unreachable runtime must get the same
+// one-shot self-heal the run step gets (else a scheduled task firing against a
+// not-yet-healed Lima VM hard-fails on a missing ha.sock).
+// ============================================================================
+
+describe('BaseContainerClient.ensureImageExistsWithRecovery', () => {
+  function makeClient() {
+    return new TestContainerClient({ agentId: 'test-agent' }) as any
+  }
+
+  it('builds once and never calls recovery when the build succeeds', async () => {
+    const client = makeClient()
+    const build = vi.spyOn(client, 'ensureImageExists').mockResolvedValue(undefined)
+    const recover = vi.spyOn(client, 'handleRunError').mockResolvedValue(true)
+
+    await client.ensureImageExistsWithRecovery()
+
+    expect(build).toHaveBeenCalledTimes(1)
+    expect(recover).not.toHaveBeenCalled()
+  })
+
+  it('self-heals and retries the build once when recovery succeeds', async () => {
+    const client = makeClient()
+    const buildErr = new Error('Container build failed with code 255: stat …/ha.sock: no such file or directory')
+    const build = vi.spyOn(client, 'ensureImageExists')
+      .mockRejectedValueOnce(buildErr)
+      .mockResolvedValueOnce(undefined)
+    const recover = vi.spyOn(client, 'handleRunError').mockResolvedValue(true)
+
+    await expect(client.ensureImageExistsWithRecovery()).resolves.toBeUndefined()
+
+    expect(recover).toHaveBeenCalledWith(buildErr)
+    expect(build).toHaveBeenCalledTimes(2)
+  })
+
+  it('rethrows the original build error when recovery is a no-op (e.g. non-Lima runner)', async () => {
+    const client = makeClient()
+    const buildErr = new Error('Dockerfile syntax error')
+    const build = vi.spyOn(client, 'ensureImageExists').mockRejectedValueOnce(buildErr)
+    const recover = vi.spyOn(client, 'handleRunError').mockResolvedValue(false) // base default
+
+    await expect(client.ensureImageExistsWithRecovery()).rejects.toThrow('Dockerfile syntax error')
+
+    expect(recover).toHaveBeenCalledTimes(1)
+    expect(build).toHaveBeenCalledTimes(1) // not retried
+  })
+
+  it('propagates a second build failure after recovery (one retry, no loop)', async () => {
+    const client = makeClient()
+    const build = vi.spyOn(client, 'ensureImageExists')
+      .mockRejectedValueOnce(new Error('first: ha.sock missing'))
+      .mockRejectedValueOnce(new Error('second: still broken'))
+    vi.spyOn(client, 'handleRunError').mockResolvedValue(true)
+
+    await expect(client.ensureImageExistsWithRecovery()).rejects.toThrow('second: still broken')
+    expect(build).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ============================================================================
 // isHealthy — the /health probe must be bounded (it gates the request hot path
 // via ensureRunning's stale-cache liveness check; an unresponsive port-forward
 // would otherwise hang the caller indefinitely).

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -104,10 +104,16 @@ export function shellEscape(value: string): string {
  * original `.stderr`/`.stdout`/`.code` properties are preserved for callers
  * that inspect them directly.
  */
-export async function execWithPath(command: string): Promise<{ stdout: string; stderr: string }> {
+export async function execWithPath(
+  command: string,
+  opts?: { timeoutMs?: number }
+): Promise<{ stdout: string; stderr: string }> {
   try {
     return await execAsync(command, {
       env: { ...process.env, PATH: getEnhancedPath() },
+      // When set, exec kills the child with SIGKILL after timeoutMs so a hung
+      // command (e.g. a guest liveness probe against a wedged VM) can't dangle.
+      ...(opts?.timeoutMs ? { timeout: opts.timeoutMs, killSignal: 'SIGKILL' as const } : {}),
     })
   } catch (err) {
     // WSL emits UTF-16LE with embedded nulls; strip them so the message is readable.
@@ -560,8 +566,9 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       const image = settings.container.agentImage
       const { cpu, memory } = settings.container.resourceLimits
 
-      // Ensure image exists (build if not)
-      await this.ensureImageExists()
+      // Ensure image exists (build if not), self-healing the runtime if the
+      // build fails because the VM is dirty/unreachable (SUP-291).
+      await this.ensureImageExistsWithRecovery()
 
       // Ensure workspace directory exists for persistent storage
       const workspaceDir = getAgentWorkspaceDir(this.config.agentId)
@@ -1338,6 +1345,28 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       }
     } catch (error) {
       console.warn('[ContainerManager] Failed to remove old images:', error)
+    }
+  }
+
+  /**
+   * Ensure the agent image exists, giving the BUILD step the same one-shot
+   * runtime recovery the container-run step gets.
+   *
+   * The build runs before start()'s run-retry loop, so a dirty/unreachable
+   * runtime here (e.g. a Lima VM with a missing ha.sock after a force-kill)
+   * fails the build with no recovery — which is how a scheduled task firing
+   * against a not-yet-healed VM hard-fails instead of self-healing (SUP-291).
+   * handleRunError() self-heals when it can and is a no-op for runners that
+   * can't (returns false → original build error rethrown), so this is safe for
+   * docker/podman/etc. too.
+   */
+  protected async ensureImageExistsWithRecovery(): Promise<void> {
+    try {
+      await this.ensureImageExists()
+    } catch (buildError) {
+      if (!(await this.handleRunError(buildError))) throw buildError
+      // Recovered (e.g. Lima VM cleaned + restarted) — retry the build once.
+      await this.ensureImageExists()
     }
   }
 

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -848,11 +848,28 @@ class ContainerManager {
     // This is the only path that catches a stale-but-running VM, since startRunner()
     // (which normally handles version checks) is skipped when the VM is already up.
     if (runnerStatus?.running) {
-      const rebuilt = await reconcileRunnerState(configuredRunner)
-      if (rebuilt) {
-        clearRunnerAvailabilityCache()
-        allAvailability = await checkAllRunnersAvailability()
-        runnerStatus = allAvailability.find((r) => r.runner === configuredRunner)
+      try {
+        const rebuilt = await reconcileRunnerState(configuredRunner)
+        if (rebuilt) {
+          clearRunnerAvailabilityCache()
+          allAvailability = await checkAllRunnersAvailability()
+          runnerStatus = allAvailability.find((r) => r.runner === configuredRunner)
+        }
+      } catch (error: any) {
+        // reconcile → ensureLimaReady can throw — e.g. a wedged Lima VM surfaces a
+        // recoverable error instead of a destructive rebuild (SUP-291). Don't let
+        // it escape ensureImageReady (whose callers only .catch+log), which would
+        // leave the readiness spinner stuck forever. Surface it as unavailable.
+        captureException(error, {
+          tags: { component: 'runtime', operation: 'reconcile' },
+          extra: { runner: configuredRunner },
+        })
+        this.setReadiness({
+          status: 'RUNTIME_UNAVAILABLE',
+          message: error?.message || `Failed to reconcile ${getRunnerDisplayName(configuredRunner)} runtime.`,
+          pullProgress: null,
+        })
+        return
       }
     }
 

--- a/src/shared/lib/container/lima-container-client.test.ts
+++ b/src/shared/lib/container/lima-container-client.test.ts
@@ -15,12 +15,14 @@ vi.mock('fs', () => ({
     writeFileSync: vi.fn(),
     unlinkSync: vi.fn(),
     readFileSync: vi.fn(),
+    readdirSync: vi.fn(() => []),
   },
   existsSync: vi.fn(),
   mkdirSync: vi.fn(),
   writeFileSync: vi.fn(),
   unlinkSync: vi.fn(),
   readFileSync: vi.fn(),
+  readdirSync: vi.fn(() => []),
 }))
 
 vi.mock('./base-container-client', () => ({
@@ -72,6 +74,82 @@ import {
 const mockedFs = vi.mocked(fs)
 const mockedExecWithPath = vi.mocked(execWithPath)
 const mockedGetSettings = vi.mocked(getSettings)
+
+// ============================================================================
+// Shared mock helpers
+//
+// isRunning() and ensureLimaReady() now probe REAL VM health (SUP-291), so a
+// single call can fan out to `limactl list`, an `ha.sock` fs check, an `ha.pid`
+// liveness check, and a `limactl shell -- true` guest probe. Drive execWithPath
+// by inspecting the limactl subcommand (not a fixed sequence) so adding a probe
+// doesn't desync the mocks, and make fs reads path-aware.
+// ============================================================================
+
+/**
+ * @param opts.list           VMs returned by `limactl list --json`
+ * @param opts.guestReachable does `limactl shell -- true` resolve? (default true)
+ * @param opts.startError     make `limactl start` reject with this error
+ */
+function mockExec(opts: { list?: any[]; guestReachable?: boolean; startError?: Error } = {}) {
+  const listJson = (opts.list ?? []).map((v) => JSON.stringify(v)).join('\n')
+  mockedExecWithPath.mockImplementation(((cmd: string) => {
+    if (cmd.includes('list --json')) return Promise.resolve({ stdout: listJson, stderr: '' })
+    if (cmd.includes('-- true')) {
+      return (opts.guestReachable ?? true)
+        ? Promise.resolve({ stdout: '', stderr: '' })
+        : Promise.reject(new Error('guest unreachable'))
+    }
+    if (cmd.includes(' start ')) {
+      return opts.startError ? Promise.reject(opts.startError) : Promise.resolve({ stdout: '', stderr: '' })
+    }
+    // create / delete / stop — succeed
+    return Promise.resolve({ stdout: '', stderr: '' })
+  }) as any)
+}
+
+/**
+ * Path-aware fs mock for the version/ha.pid/ha.sock reads the health check makes.
+ * @param opts.version      contents of `lima-version` (undefined → file missing)
+ * @param opts.haSockExists is `ha.sock` present?
+ * @param opts.haPid        contents of `ha.pid` (undefined → file missing)
+ */
+function mockFsState(opts: { version?: string; haSockExists?: boolean; haPid?: string } = {}) {
+  mockedFs.readFileSync.mockImplementation(((p: any) => {
+    const s = String(p)
+    if (s.endsWith('ha.pid')) {
+      if (opts.haPid === undefined) { const e: any = new Error('ENOENT'); e.code = 'ENOENT'; throw e }
+      return opts.haPid
+    }
+    if (s.endsWith('lima-version')) {
+      if (opts.version === undefined) { const e: any = new Error('ENOENT'); e.code = 'ENOENT'; throw e }
+      return opts.version
+    }
+    return ''
+  }) as any)
+  mockedFs.existsSync.mockImplementation(((p: any) => {
+    const s = String(p)
+    if (s.endsWith('ha.sock')) return !!opts.haSockExists
+    if (s.endsWith('ha.pid')) return opts.haPid !== undefined
+    return false
+  }) as any)
+}
+
+/** Make `process.kill(pid, 0)` report the pid as dead (ESRCH) — host agent gone. */
+function deadPid(): any {
+  return vi.spyOn(process, 'kill').mockImplementation((() => {
+    const e: any = new Error('ESRCH'); e.code = 'ESRCH'; throw e
+  }) as any)
+}
+
+/** Make `process.kill(pid, 0)` succeed — host agent process is alive. */
+function alivePid(): any {
+  return vi.spyOn(process, 'kill').mockImplementation((() => true) as any)
+}
+
+/** The full limactl command strings execWithPath was called with. */
+function execCmds(): string[] {
+  return mockedExecWithPath.mock.calls.map((c) => c[0] as string)
+}
 
 // ============================================================================
 // parseLimaList — test indirectly via LimaContainerClient.isRunning()
@@ -157,6 +235,8 @@ describe('getLimaHome', () => {
 // ============================================================================
 
 describe('ensureLimaReady', () => {
+  let killSpy: any
+
   beforeEach(() => {
     vi.clearAllMocks()
     mockedGetSettings.mockReturnValue({
@@ -170,161 +250,207 @@ describe('ensureLimaReady', () => {
     })
     // Default: getNerdctlWrapperPath needs HOME
     process.env.HOME = '/Users/testuser'
+    mockedFs.readdirSync.mockReturnValue([] as any)
+    // Default: any referenced host-agent pid is dead unless a test says otherwise.
+    killSpy = deadPid()
   })
 
-  function mockLimaList(vms: any[]) {
-    const ndjson = vms.map((v) => JSON.stringify(v)).join('\n')
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: ndjson, stderr: '' })
-  }
-
-  /** Mock the lima-version file so the version check doesn't trigger a recreate */
-  function mockLimaVersion(version = 'v99.0.0') {
-    mockedFs.readFileSync.mockReturnValue(version)
-  }
+  afterEach(() => {
+    killSpy.mockRestore()
+  })
 
   it('creates VM and starts it when no VM exists', async () => {
-    // First list: no VMs (VM exists check)
-    mockLimaList([])
-    // createLimaVm: execLimactl('create ...')
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: '', stderr: '' })
-    // Second list: VM exists but stopped (running check)
-    mockLimaList([{ name: LIMA_VM_NAME, status: 'Stopped' }])
-    // start VM
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    mockExec({ list: [] })
+    mockFsState({})
 
     await ensureLimaReady()
 
-    // Verify create and start were called
-    const calls = mockedExecWithPath.mock.calls.map((c) => c[0] as string)
-    expect(calls.some((c) => c.includes('create'))).toBe(true)
-    expect(calls.some((c) => c.includes('start'))).toBe(true)
+    expect(execCmds().some((c) => c.includes('create'))).toBe(true)
+    expect(execCmds().some((c) => c.includes(' start '))).toBe(true)
   })
 
-  it('skips creation when VM already exists and running', async () => {
-    mockLimaVersion()
-    // First list: VM exists and running
-    mockLimaList([{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 * 1024 * 1024 }])
-    // Second list: still running
-    mockLimaList([{ name: LIMA_VM_NAME, status: 'Running' }])
+  it('skips creation and start when VM exists and is healthy', async () => {
+    // Running + ha.sock present + guest reachable = genuinely healthy.
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 * 1024 * 1024 }], guestReachable: true })
+    mockFsState({ version: 'v99.0.0', haSockExists: true })
 
     await ensureLimaReady()
 
-    const calls = mockedExecWithPath.mock.calls.map((c) => c[0] as string)
-    expect(calls.some((c) => c.includes('create'))).toBe(false)
-    expect(calls.some((c) => c.includes('start '))).toBe(false)
+    expect(execCmds().some((c) => c.includes('create'))).toBe(false)
+    expect(execCmds().some((c) => c.includes(' start '))).toBe(false)
   })
 
   it('mutex serializes concurrent calls', async () => {
-    mockLimaVersion()
+    mockFsState({ version: 'v99.0.0', haSockExists: true })
+    const runningJson = JSON.stringify({ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 * 1024 * 1024 }) + '\n'
     let resolveList: ((v: any) => void) | null = null
     let callCount = 0
 
-    mockedExecWithPath.mockImplementation(() => {
+    mockedExecWithPath.mockImplementation((() => {
       callCount++
       if (callCount === 1) {
         // First list call — slow
-        return new Promise((resolve) => {
-          resolveList = resolve
-        })
+        return new Promise((resolve) => { resolveList = resolve })
       }
-      // Subsequent calls resolve immediately
-      return Promise.resolve({ stdout: JSON.stringify({ name: LIMA_VM_NAME, status: 'Running' }) + '\n', stderr: '' })
-    })
+      // Subsequent calls (list / guest probe) resolve immediately
+      return Promise.resolve({ stdout: runningJson, stderr: '' })
+    }) as any)
 
-    // Launch two concurrent calls
     const p1 = ensureLimaReady()
     const p2 = ensureLimaReady()
 
-    // Only one should be in-flight (callCount should be 1 from the first list call)
+    // Only one should be in-flight (the first list call)
     expect(callCount).toBe(1)
 
-    // Resolve the first list call
-    resolveList!({ stdout: JSON.stringify({ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 * 1024 * 1024 }) + '\n', stderr: '' })
+    resolveList!({ stdout: runningJson, stderr: '' })
 
     await Promise.all([p1, p2])
   })
 
   it('cleans up zombie VM when start fails after creation', async () => {
-    // First list: no VMs
-    mockLimaList([])
-    // createLimaVm succeeds
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: '', stderr: '' })
-    // Second list: VM exists but stopped
-    mockLimaList([{ name: LIMA_VM_NAME, status: 'Stopped' }])
-    // start VM fails
-    mockedExecWithPath.mockRejectedValueOnce(new Error('disk full'))
-    // delete VM (cleanup)
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    mockExec({ list: [], startError: new Error('disk full') })
+    mockFsState({})
 
     await expect(ensureLimaReady()).rejects.toThrow('disk full')
 
-    const calls = mockedExecWithPath.mock.calls.map((c) => c[0] as string)
-    expect(calls.some((c) => c.includes('delete') && c.includes('--force'))).toBe(true)
+    expect(execCmds().some((c) => c.includes('delete') && c.includes('--force'))).toBe(true)
   })
 
   it('does NOT delete VM when start fails on pre-existing VM', async () => {
-    mockLimaVersion()
-    // First list: VM exists
-    mockLimaList([{ name: LIMA_VM_NAME, status: 'Stopped', memory: 4 * 1024 * 1024 * 1024 }])
-    // Second list: still stopped
-    mockLimaList([{ name: LIMA_VM_NAME, status: 'Stopped' }])
-    // start VM fails
-    mockedExecWithPath.mockRejectedValueOnce(new Error('network error'))
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Stopped', memory: 4 * 1024 * 1024 * 1024 }], startError: new Error('network error') })
+    mockFsState({ version: 'v99.0.0' })
 
     await expect(ensureLimaReady()).rejects.toThrow('network error')
 
-    // Should NOT have called delete — VM existed before this call
-    const calls = mockedExecWithPath.mock.calls.map((c) => c[0] as string)
-    expect(calls.some((c) => c.includes('delete'))).toBe(false)
+    // VM existed before this call → must not be destroyed.
+    expect(execCmds().some((c) => c.includes('delete'))).toBe(false)
   })
 
   it('recreates VM when memory setting differs', async () => {
-    mockLimaVersion()
     mockedGetSettings.mockReturnValue({
       container: { runtimeSettings: { lima: { vmMemory: '8GiB' } } },
     } as any)
-
-    // First list: VM exists with 4GiB
-    mockLimaList([{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 * 1024 * 1024 }])
-    // stop --force
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: '', stderr: '' })
-    // delete --force
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: '', stderr: '' })
-    // createLimaVm
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: '', stderr: '' })
-    // list (running check)
-    mockLimaList([{ name: LIMA_VM_NAME, status: 'Stopped' }])
-    // start
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 * 1024 * 1024 }] })
+    mockFsState({ version: 'v99.0.0' })
 
     await ensureLimaReady()
 
-    const calls = mockedExecWithPath.mock.calls.map((c) => c[0] as string)
-    expect(calls.some((c) => c.includes('delete') && c.includes('--force'))).toBe(true)
-    expect(calls.some((c) => c.includes('create'))).toBe(true)
+    expect(execCmds().some((c) => c.includes('delete') && c.includes('--force'))).toBe(true)
+    expect(execCmds().some((c) => c.includes('create'))).toBe(true)
   })
 
   it('recreates VM when lima-version is older than minimum', async () => {
-    mockLimaVersion('v2.0.3')
-
-    // First list: VM exists
-    mockLimaList([{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 * 1024 * 1024 }])
-    // stop --force
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: '', stderr: '' })
-    // delete --force
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: '', stderr: '' })
-    // createLimaVm
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: '', stderr: '' })
-    // list (running check)
-    mockLimaList([{ name: LIMA_VM_NAME, status: 'Stopped' }])
-    // start
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 * 1024 * 1024 }] })
+    mockFsState({ version: 'v2.0.3' })
 
     await ensureLimaReady()
 
-    const calls = mockedExecWithPath.mock.calls.map((c) => c[0] as string)
-    expect(calls.some((c) => c.includes('delete') && c.includes('--force'))).toBe(true)
-    expect(calls.some((c) => c.includes('create'))).toBe(true)
+    expect(execCmds().some((c) => c.includes('delete') && c.includes('--force'))).toBe(true)
+    expect(execCmds().some((c) => c.includes('create'))).toBe(true)
+  })
+
+  // ==========================================================================
+  // SUP-291: self-heal a dirty instance dir + reachability-based health check
+  // ==========================================================================
+
+  it('self-heals a dirty instance dir (dead ha.pid) by cleaning stale sockets then restarting', async () => {
+    // limactl says Running, but a force-killed vz left ha.sock gone and a stale
+    // ha.pid pointing at a dead process.
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 * 1024 * 1024 }] })
+    mockFsState({ version: 'v99.0.0', haSockExists: false, haPid: '4242' })
+    killSpy.mockRestore()
+    killSpy = deadPid() // pid 4242 is dead
+
+    await ensureLimaReady()
+
+    const unlinked = mockedFs.unlinkSync.mock.calls.map((c) => String(c[0]))
+    expect(unlinked.some((p) => p.endsWith('ha.pid'))).toBe(true)
+    // Restarted to recover — and NOT a destructive delete/recreate.
+    expect(execCmds().some((c) => c.includes(' start '))).toBe(true)
+    expect(execCmds().some((c) => c.includes('delete'))).toBe(false)
+  })
+
+  it('recovers a VM whose ha.sock was deleted (ELECTRON-4S) by restarting on next launch', async () => {
+    // ha.sock missing, no ha.pid (host agent gone) — the canonical ELECTRON-4S dir.
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 * 1024 * 1024 }] })
+    mockFsState({ version: 'v99.0.0', haSockExists: false })
+
+    await ensureLimaReady()
+
+    expect(execCmds().some((c) => c.includes(' start '))).toBe(true)
+    expect(execCmds().some((c) => c.includes('delete'))).toBe(false)
+  })
+
+  it('does NOT rebuild, restart, or clean a wedged-but-live VM (guest probe times out)', async () => {
+    // Running + ha.sock present + guest unreachable + host agent ALIVE = memory wedge.
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 * 1024 * 1024 }], guestReachable: false })
+    mockFsState({ version: 'v99.0.0', haSockExists: true, haPid: '777' })
+    killSpy.mockRestore()
+    killSpy = alivePid()
+
+    await expect(ensureLimaReady()).rejects.toThrow(/memory|unreachable/i)
+
+    // Recoverable surface, NOT a destructive rebuild — and never touch a live VM's sockets.
+    expect(execCmds().some((c) => c.includes('delete'))).toBe(false)
+    expect(execCmds().some((c) => c.includes(' start '))).toBe(false)
+    expect(mockedFs.unlinkSync).not.toHaveBeenCalled()
+  })
+
+  it('treats sock-missing + LIVE host agent as wedged — never cleans a live VM', async () => {
+    // ha.sock gone but the host-agent process is still alive: must NOT be cleaned
+    // (would orphan the live VM) and must NOT be restarted/rebuilt.
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 * 1024 * 1024 }] })
+    mockFsState({ version: 'v99.0.0', haSockExists: false, haPid: '777' })
+    killSpy.mockRestore()
+    killSpy = alivePid()
+
+    await expect(ensureLimaReady()).rejects.toThrow(/memory|unreachable|load/i)
+
+    expect(mockedFs.unlinkSync).not.toHaveBeenCalled()
+    expect(execCmds().some((c) => c.includes(' start '))).toBe(false)
+    expect(execCmds().some((c) => c.includes('delete'))).toBe(false)
+  })
+
+  it('heals an orphaned-socket dirty dir (ha.sock present, guest unreachable, host agent DEAD) — dirty, not wedged', async () => {
+    // Distinct from a wedge: the socket file lingers but the host-agent process
+    // is gone, so this is a dead-agent dirty dir → clean + restart, NOT a throw.
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 * 1024 * 1024 }], guestReachable: false })
+    mockFsState({ version: 'v99.0.0', haSockExists: true }) // no ha.pid → agent dead
+
+    await ensureLimaReady()
+
+    const unlinked = mockedFs.unlinkSync.mock.calls.map((c) => String(c[0]))
+    expect(unlinked.some((p) => p.endsWith('ha.sock'))).toBe(true)
+    expect(execCmds().some((c) => c.includes(' start '))).toBe(true)
+    expect(execCmds().some((c) => c.includes('delete'))).toBe(false)
+  })
+
+  it('sweeps orphaned *.sock files (e.g. ssh.sock) when cleaning a dirty dir, leaving non-sockets', async () => {
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 * 1024 * 1024 }] })
+    // dirty: ha.sock + ha.pid gone (dead agent), but orphaned runtime sockets remain
+    mockedFs.readFileSync.mockImplementation(((p: any) => {
+      const s = String(p)
+      if (s.endsWith('ha.pid')) { const e: any = new Error('ENOENT'); e.code = 'ENOENT'; throw e }
+      if (s.endsWith('lima-version')) return 'v99.0.0'
+      return ''
+    }) as any)
+    mockedFs.existsSync.mockImplementation(((p: any) => {
+      const s = String(p)
+      if (s.endsWith('ha.sock')) return false // missing → dirty
+      if (s.endsWith('ssh.sock') || s.endsWith('default_ep.sock')) return true
+      return false
+    }) as any)
+    mockedFs.readdirSync.mockReturnValue(['ssh.sock', 'default_ep.sock', 'cidata.iso', 'lima.yaml'] as any)
+
+    await ensureLimaReady()
+
+    const unlinked = mockedFs.unlinkSync.mock.calls.map((c) => String(c[0]))
+    expect(unlinked.some((p) => p.endsWith('ssh.sock'))).toBe(true)
+    expect(unlinked.some((p) => p.endsWith('default_ep.sock'))).toBe(true)
+    // non-socket files are never touched
+    expect(unlinked.some((p) => p.endsWith('cidata.iso'))).toBe(false)
+    expect(unlinked.some((p) => p.endsWith('lima.yaml'))).toBe(false)
+    expect(execCmds().some((c) => c.includes(' start '))).toBe(true)
   })
 })
 
@@ -379,6 +505,8 @@ describe('stopLimaVm', () => {
 // ============================================================================
 
 describe('LimaContainerClient.isRunning', () => {
+  let killSpy: any
+
   beforeEach(() => {
     vi.clearAllMocks()
     Object.defineProperty(process, 'resourcesPath', {
@@ -386,40 +514,74 @@ describe('LimaContainerClient.isRunning', () => {
       writable: true,
       configurable: true,
     })
+    process.env.HOME = '/Users/testuser'
+    mockedFs.readdirSync.mockReturnValue([] as any)
+    killSpy = deadPid()
   })
 
-  it('returns true when VM is running (tests parseLimaList indirectly)', async () => {
-    const ndjson = JSON.stringify({ name: LIMA_VM_NAME, status: 'Running' })
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: ndjson, stderr: '' })
+  afterEach(() => {
+    killSpy.mockRestore()
+  })
+
+  it('returns true when the VM is healthy (Running + ha.sock present + guest reachable)', async () => {
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running' }], guestReachable: true })
+    mockFsState({ haSockExists: true })
 
     expect(await LimaContainerClient.isRunning()).toBe(true)
   })
 
   it('returns false when VM is stopped', async () => {
-    const ndjson = JSON.stringify({ name: LIMA_VM_NAME, status: 'Stopped' })
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: ndjson, stderr: '' })
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Stopped' }] })
+    mockFsState({})
 
     expect(await LimaContainerClient.isRunning()).toBe(false)
   })
 
   it('returns false when no VMs exist (empty output)', async () => {
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    mockExec({ list: [] })
+    mockFsState({})
 
     expect(await LimaContainerClient.isRunning()).toBe(false)
   })
 
   it('returns false on exec error', async () => {
-    mockedExecWithPath.mockRejectedValueOnce(new Error('limactl not found'))
+    mockedExecWithPath.mockRejectedValue(new Error('limactl not found'))
+
+    expect(await LimaContainerClient.isRunning()).toBe(false)
+  })
+
+  it('returns false when limactl reports Running but ha.sock is missing (dirty dir → ELECTRON-4S)', async () => {
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running' }] })
+    mockFsState({ haSockExists: false }) // no ha.pid → host agent dead → dirty
+
+    expect(await LimaContainerClient.isRunning()).toBe(false)
+  })
+
+  it('returns false when Running with ha.sock but the guest probe times out (wedge)', async () => {
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running' }], guestReachable: false })
+    mockFsState({ haSockExists: true, haPid: '777' })
+    killSpy.mockRestore()
+    killSpy = alivePid()
+
+    expect(await LimaContainerClient.isRunning()).toBe(false)
+  })
+
+  it('returns false for an orphaned socket (Running, ha.sock present, guest unreachable, host agent DEAD → dirty)', async () => {
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running' }], guestReachable: false })
+    mockFsState({ haSockExists: true }) // no ha.pid → dead agent → dirty (not wedged)
 
     expect(await LimaContainerClient.isRunning()).toBe(false)
   })
 
   it('handles multi-line NDJSON with multiple VMs', async () => {
-    const lines = [
-      JSON.stringify({ name: 'other-vm', status: 'Running' }),
-      JSON.stringify({ name: LIMA_VM_NAME, status: 'Running' }),
-    ].join('\n')
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: lines, stderr: '' })
+    mockExec({
+      list: [
+        { name: 'other-vm', status: 'Running' },
+        { name: LIMA_VM_NAME, status: 'Running' },
+      ],
+      guestReachable: true,
+    })
+    mockFsState({ haSockExists: true })
 
     expect(await LimaContainerClient.isRunning()).toBe(true)
   })
@@ -430,7 +592,11 @@ describe('LimaContainerClient.isRunning', () => {
       JSON.stringify({ name: LIMA_VM_NAME, status: 'Running' }),
       '{broken',
     ].join('\n')
-    mockedExecWithPath.mockResolvedValueOnce({ stdout: lines, stderr: '' })
+    mockedExecWithPath.mockImplementation(((cmd: string) => {
+      if (cmd.includes('list --json')) return Promise.resolve({ stdout: lines, stderr: '' })
+      return Promise.resolve({ stdout: '', stderr: '' }) // guest probe ok
+    }) as any)
+    mockFsState({ haSockExists: true })
 
     expect(await LimaContainerClient.isRunning()).toBe(true)
   })
@@ -485,5 +651,67 @@ describe('LimaContainerClient.extractInaccessibleMountPath', () => {
 
   it('returns null for permission errors without a parseable path', () => {
     expect(client.extractInaccessibleMountPath(new Error('operation not permitted'))).toBe(null)
+  })
+})
+
+// ============================================================================
+// handleRunError — SUP-291: recovery is driven by the REAL health probe, not
+// `limactl list` trust, so a Running-but-dirty VM (e.g. a build that failed on
+// a missing ha.sock) is recognized and self-healed, while a wedged VM is
+// surfaced but never destructively rebuilt.
+// ============================================================================
+
+describe('LimaContainerClient.handleRunError', () => {
+  let killSpy: any
+  const makeClient = () => new LimaContainerClient({ agentId: 'test-agent' } as any) as any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedGetSettings.mockReturnValue({ container: { runtimeSettings: {} } } as any)
+    Object.defineProperty(process, 'resourcesPath', { value: undefined, writable: true, configurable: true })
+    process.env.HOME = '/Users/testuser'
+    mockedFs.readdirSync.mockReturnValue([] as any)
+    killSpy = deadPid()
+  })
+
+  afterEach(() => {
+    killSpy.mockRestore()
+  })
+
+  it('self-heals a dirty VM on a build failure whose message is not a known-issue string', async () => {
+    // A "Container build failed" message contains lowercase "no such file" which
+    // does NOT match the known-issue list — so recovery hinges on the health probe.
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 ** 3 }] })
+    mockFsState({ version: 'v99.0.0', haSockExists: false, haPid: '4242' }) // sock gone + pid dead → dirty
+
+    const recovered = await makeClient().handleRunError(
+      new Error('Container build failed with code 255: stat …/ha.sock: no such file or directory')
+    )
+
+    expect(recovered).toBe(true)
+    expect(execCmds().some((c) => c.includes(' start '))).toBe(true)
+  })
+
+  it('does NOT recover when the VM is healthy (the VM is not the fault)', async () => {
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 ** 3 }], guestReachable: true })
+    mockFsState({ version: 'v99.0.0', haSockExists: true })
+
+    const recovered = await makeClient().handleRunError(new Error('some unexpected build error'))
+
+    expect(recovered).toBe(false)
+    expect(execCmds().some((c) => c.includes(' start '))).toBe(false)
+  })
+
+  it('does NOT rebuild a wedged VM — recovery surfaces it and reports unrecovered', async () => {
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 ** 3 }], guestReachable: false })
+    mockFsState({ version: 'v99.0.0', haSockExists: true, haPid: '777' })
+    killSpy.mockRestore()
+    killSpy = alivePid()
+
+    const recovered = await makeClient().handleRunError(new Error('some unexpected build error'))
+
+    expect(recovered).toBe(false)
+    expect(execCmds().some((c) => c.includes('delete'))).toBe(false)
+    expect(execCmds().some((c) => c.includes(' start '))).toBe(false)
   })
 })

--- a/src/shared/lib/container/lima-container-client.ts
+++ b/src/shared/lib/container/lima-container-client.ts
@@ -182,10 +182,10 @@ export function getLimactlPath(): string {
  * Run a limactl command with LIMA_HOME set.
  * Uses shell env var prefix so it works with execWithPath.
  */
-function execLimactl(args: string): Promise<{ stdout: string; stderr: string }> {
+function execLimactl(args: string, opts?: { timeoutMs?: number }): Promise<{ stdout: string; stderr: string }> {
   const limaHome = getLimaHome()
   const limactl = getLimactlPath()
-  return execWithPath(`LIMA_HOME="${limaHome}" "${limactl}" ${args}`)
+  return execWithPath(`LIMA_HOME="${limaHome}" "${limactl}" ${args}`, opts)
 }
 
 /**
@@ -196,6 +196,148 @@ function parseLimaList(stdout: string): any[] {
     .filter(Boolean)
     .map(line => { try { return JSON.parse(line) } catch { return null } })
     .filter(Boolean)
+}
+
+/** Path to the Lima host-agent Unix socket (`ha.sock`) for our VM. */
+function getHostAgentSocketPath(): string {
+  return path.join(getLimaHome(), LIMA_VM_NAME, 'ha.sock')
+}
+
+/** Path to the Lima host-agent pid file (`ha.pid`) for our VM. */
+function getHostAgentPidPath(): string {
+  return path.join(getLimaHome(), LIMA_VM_NAME, 'ha.pid')
+}
+
+/**
+ * Is the Lima host-agent process recorded in `ha.pid` still alive?
+ *
+ * This is the load-bearing guardrail for self-heal (SUP-291): a DEAD host agent
+ * means leftover `ha.sock`/`ha.pid` are stale and safe to remove before a fresh
+ * `limactl start`; a LIVE host agent means the VM process is up (possibly just
+ * thrashing under memory pressure) and its sockets must NOT be touched — removing
+ * them would orphan a live VM.
+ *
+ * Returns false when `ha.pid` is missing or unparseable (nothing known to be
+ * alive). A surviving process (kill(pid, 0) succeeds, or fails EPERM) is alive.
+ */
+function isHostAgentAlive(): boolean {
+  let pid: number
+  try {
+    pid = parseInt(fs.readFileSync(getHostAgentPidPath(), 'utf-8').trim(), 10)
+  } catch {
+    return false
+  }
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (e: any) {
+    // ESRCH → no such process (dead). EPERM → exists but not signalable (alive).
+    return e?.code === 'EPERM'
+  }
+}
+
+/**
+ * Remove stale host-agent artifacts (`ha.pid`, `ha.sock`, and any orphaned
+ * `*.sock`) from a dirty Lima instance dir so the next `limactl start` succeeds
+ * instead of failing forever with "failed to connect to …/ha.sock: no such file
+ * or directory" (ELECTRON-4S) after a force-/OOM-killed vz left the dir dirty.
+ *
+ * GUARDRAIL: refuses to touch anything while the host agent is still alive —
+ * removing a live VM's sockets would orphan it. Returns true if it was safe to
+ * clean (agent dead), false if it bailed because the agent is alive.
+ */
+function cleanStaleHostAgentArtifacts(): boolean {
+  if (isHostAgentAlive()) return false
+
+  const vmDir = path.join(getLimaHome(), LIMA_VM_NAME)
+  const removed: string[] = []
+  const tryUnlink = (p: string) => {
+    try {
+      if (fs.existsSync(p)) {
+        fs.unlinkSync(p)
+        removed.push(path.basename(p))
+      }
+    } catch { /* best-effort */ }
+  }
+
+  tryUnlink(getHostAgentPidPath())
+  tryUnlink(getHostAgentSocketPath())
+  // Sweep any other orphaned Unix sockets the dead VM left behind (e.g. ssh.sock).
+  try {
+    for (const entry of fs.readdirSync(vmDir)) {
+      if (entry.endsWith('.sock')) tryUnlink(path.join(vmDir, entry))
+    }
+  } catch { /* dir may not exist yet */ }
+
+  if (removed.length) {
+    addErrorBreadcrumb({ category: 'lima', message: 'Cleaned stale host-agent artifacts', data: { removed } })
+  }
+  return true
+}
+
+/** How long to wait for the guest liveness probe before treating it as a timeout. */
+const GUEST_PROBE_TIMEOUT_MS = 8000
+
+export type LimaHealthState = 'healthy' | 'not-running' | 'dirty' | 'wedged'
+
+/**
+ * Real reachability check for the Lima VM — replaces blind trust in
+ * `limactl list` status == "Running" (SUP-291). The two states that actually
+ * cause the stuck "Checking runtime availability…" spinner — Running-but-dirty
+ * and Running-but-wedged — are invisible to `limactl list`, so we probe.
+ *
+ * - `not-running`: VM absent or not Running per limactl. Normal start path.
+ * - `dirty`:       Running per limactl, but the host agent is DEAD (`ha.sock`
+ *                  missing or guest unreachable with a dead `ha.pid`). A force-/
+ *                  OOM-killed vz left a dirty dir → safe to clean + restart.
+ * - `wedged`:      Running, host agent ALIVE, but the guest doesn't answer a
+ *                  liveness probe (timed out). Memory-wedge signature → surface
+ *                  it, do NOT rebuild (would orphan a live VM and fix nothing).
+ * - `healthy`:     Running, `ha.sock` present, guest answers the liveness probe.
+ */
+async function probeLimaHealth(): Promise<{ state: LimaHealthState; vmStatus?: string }> {
+  let vmStatus: string | undefined
+  try {
+    const { stdout } = await execLimactl('list --json')
+    vmStatus = parseLimaList(stdout).find((v: any) => v.name === LIMA_VM_NAME)?.status
+  } catch {
+    return { state: 'not-running' }
+  }
+  if (vmStatus !== 'Running') return { state: 'not-running', vmStatus }
+
+  // VM claims Running. A dirty dir (force-/OOM-killed vz) loses `ha.sock`.
+  if (!fs.existsSync(getHostAgentSocketPath())) {
+    return { state: isHostAgentAlive() ? 'wedged' : 'dirty', vmStatus }
+  }
+
+  // Socket present — probe the guest for REAL reachability.
+  if (await probeGuestReachable()) return { state: 'healthy', vmStatus }
+
+  // Unreachable: distinguish a dead agent (orphaned socket → dirty, clean+restart)
+  // from a live-but-thrashing agent (memory wedge → leave the live VM intact).
+  return { state: isHostAgentAlive() ? 'wedged' : 'dirty', vmStatus }
+}
+
+/**
+ * Short guest liveness probe via `limactl shell -- true`.
+ *
+ * Two bounded attempts: a single slow SSH round-trip on a healthy-but-busy VM
+ * (heavy build / host I/O stall) shouldn't flip it to "wedged" — a false negative
+ * that then sticks for the availability-cache TTL. Each attempt is hard-bounded
+ * by exec's own timeout (SIGKILL), so a wedged guest can't leave the probe (or
+ * its `limactl shell` child) dangling. Only genuine unreachability fails twice.
+ */
+async function probeGuestReachable(timeoutMs = GUEST_PROBE_TIMEOUT_MS): Promise<boolean> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      await execLimactl(`shell ${LIMA_VM_NAME} -- true`, { timeoutMs })
+      return true
+    } catch {
+      // timed out or errored — retry once, then conclude unreachable
+    }
+  }
+  return false
 }
 
 /**
@@ -341,15 +483,17 @@ export class LimaContainerClient extends BaseContainerClient {
       msg.includes('No such file') ||
       msg.includes('EACCES')
 
-    // Check if the VM is in a broken/non-running state — if so, recovery is
-    // worth attempting even for unexpected error messages (e.g. "Bad port '0'").
+    // Check if the VM is actually unusable — if so, recovery is worth attempting
+    // even for unexpected error messages (e.g. "Bad port '0'"). Use the real
+    // reachability probe, NOT `limactl list` trust (SUP-291): a Running-but-dirty
+    // (missing ha.sock) or wedged VM also warrants recovery. ensureLimaReady()
+    // then picks the safe action — clean+restart for dirty, surface-not-rebuild
+    // for wedged — so routing both here is safe.
     let vmUnhealthy = false
     if (!isKnownVmIssue) {
       try {
-        const { stdout } = await execLimactl('list --json')
-        const vms = parseLimaList(stdout)
-        const vm = vms.find((v: any) => v.name === LIMA_VM_NAME)
-        vmUnhealthy = !vm || vm.status !== 'Running'
+        const { state } = await probeLimaHealth()
+        vmUnhealthy = state !== 'healthy'
       } catch {
         vmUnhealthy = true
       }
@@ -455,19 +599,25 @@ export class LimaContainerClient extends BaseContainerClient {
   }
 
   /**
-   * Check if the Lima VM named 'superagent' is running.
+   * Check if the Lima VM named 'superagent' is actually usable.
+   *
+   * Does NOT trust `limactl list` status alone (SUP-291): a force-/OOM-killed vz
+   * can report "Running" while the host agent is gone (dirty dir → ELECTRON-4S)
+   * or the guest is wedged (memory pressure). Only a VM that passes the real
+   * reachability probe counts as running; a `dirty` or `wedged` VM reports false
+   * so the start path can self-heal it (dirty) or surface it (wedged) instead of
+   * the app blindly proceeding into hung container ops.
    */
   static async isRunning(): Promise<boolean> {
     try {
-      const { stdout } = await execLimactl(`list --json`)
-      const vms = parseLimaList(stdout)
-      const running = vms.some((vm: any) => vm.name === LIMA_VM_NAME && vm.status === 'Running')
-      if (running) {
+      const { state } = await probeLimaHealth()
+      if (state === 'healthy') {
         // Ensure the nerdctl wrapper points to the current limactl binary.
         // The wrapper hardcodes the limactl path, which goes stale on app updates.
         createNerdctlWrapper()
+        return true
       }
-      return running
+      return false
     } catch {
       return false
     }
@@ -610,25 +760,43 @@ async function ensureLimaReadyImpl(): Promise<void> {
     }
   }
 
-  // Check if VM is running
-  let vmRunning = false
-  try {
-    const { stdout } = await execLimactl('list --json')
-    const vms = parseLimaList(stdout)
-    vmRunning = vms.some((vm: any) => vm.name === LIMA_VM_NAME && vm.status === 'Running')
-  } catch {
-    // assume not running
+  // Verify the VM's REAL health — don't trust `limactl list` status alone.
+  // A freshly created or recreated VM hasn't been started yet, so skip the probe
+  // and go straight to start.
+  const health = vmExists && !needsRecreate ? await probeLimaHealth() : { state: 'not-running' as const }
+
+  if (health.state === 'wedged') {
+    // Running + live host agent + unreachable guest. Restarting/rebuilding a live
+    // VM here would orphan it and fix nothing — surface the signal and bail with a
+    // recoverable error instead of a destructive rebuild. (SUP-291 guardrail.)
+    // The likely cause is host memory pressure, but a healthy VM under heavy load
+    // can also land here, so don't over-assert the cause.
+    captureMessage('Lima VM is Running with a live host-agent but the guest is unreachable (possible memory pressure or heavy load); not rebuilding', {
+      level: 'warning',
+      tags: { component: 'lima', operation: 'wedge-detected' },
+      extra: { vmStatus: (health as { vmStatus?: string }).vmStatus, ...collectLimaDiagnostics() },
+    })
+    throw new Error(
+      'Built-in runtime is unreachable — the host may be low on memory or under heavy load. ' +
+      'Try again in a moment. (The VM was left running to avoid data loss.)'
+    )
   }
 
-  if (!vmRunning) {
+  if (health.state !== 'healthy') {
+    // not-running or dirty → (re)start. Self-heal a dirty instance dir first:
+    // clean stale ha.pid/ha.sock/orphaned sockets a force-killed vz left behind
+    // so `limactl start` succeeds instead of erroring on a missing ha.sock
+    // forever (ELECTRON-4S). No-ops on a clean dir or a live VM (guardrail).
+    cleanStaleHostAgentArtifacts()
+
     console.log('Starting Lima VM...')
-    addErrorBreadcrumb({ category: 'lima', message: 'Starting Lima VM' })
+    addErrorBreadcrumb({ category: 'lima', message: 'Starting Lima VM', data: { health: health.state } })
     try {
       await execLimactl(`start ${LIMA_VM_NAME}`)
     } catch (error) {
       captureException(error, {
         tags: { component: 'lima', operation: 'start-vm' },
-        extra: { limaHome, vmExists, explicitMemory, ...collectLimaDiagnostics() },
+        extra: { limaHome, vmExists, explicitMemory, health: health.state, ...collectLimaDiagnostics() },
       })
       // If start fails on a freshly created VM, delete it to avoid a zombie
       if (!vmExists) {
@@ -638,6 +806,18 @@ async function ensureLimaReadyImpl(): Promise<void> {
         } catch { /* best-effort cleanup */ }
       }
       throw error
+    }
+
+    // The VM reported "Running" but its host agent was dead (missing/orphaned
+    // ha.sock) and we just cleaned + restarted it. Record it as a real event
+    // (not just a breadcrumb) so we can measure ELECTRON-4S self-heal rate in
+    // prod and confirm the fix is working. (SUP-291)
+    if (health.state === 'dirty') {
+      captureMessage('Self-healed a dirty Lima instance dir (dead host-agent / missing ha.sock) and restarted the VM', {
+        level: 'warning',
+        tags: { component: 'lima', operation: 'dirty-dir-self-heal' },
+        extra: { vmStatus: (health as { vmStatus?: string }).vmStatus },
+      })
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the recurring **"Checking runtime availability…" stuck spinner** on the bundled Lima (macOS) runtime (Sentry **ELECTRON-4S / ELECTRON-55 / ELECTRON-3Z**).

Root cause was a recovery gap: `isRunning()` trusted `limactl list == "Running"` and never verified the host-agent socket or guest reachability. The two states that actually wedge users — **Running-but-dirty** (force-/OOM-killed `vz` left a missing/orphaned `ha.sock`) and **Running-but-wedged** (host memory pressure) — were invisible to `limactl list`, so the auto-rebuild never fired and the next `limactl start` failed forever on `failed to connect to …/ha.sock: no such file`.

## What changed

- **Real reachability health check.** New `probeLimaHealth()` (shared by `isRunning()` and `ensureLimaReady`) classifies the VM as `healthy | not-running | dirty | wedged` using `ha.sock` presence + a bounded `limactl shell -- true` guest liveness probe.
- **Self-heal a dirty instance dir before start.** When the host agent is **dead** (`isHostAgentAlive()` via `process.kill(pid,0)` on `ha.pid`), clean stale `ha.pid`/`ha.sock`/orphaned `*.sock` and `limactl start` — instead of erroring forever.
- **Guardrail.** A **live-but-wedged** VM is surfaced as a recoverable error (`RUNTIME_UNAVAILABLE`), **never destructively rebuilt**; sockets are never removed while `ha.pid` points to a live process (would orphan a live VM).
- **Build-step recovery.** `ensureImageExistsWithRecovery()` gives the image **build** the same one-shot self-heal the container **run** step already had, so a scheduled task firing against a not-yet-healed VM recovers instead of hard-failing (observed live in testing). No-op for docker/podman/etc. (`handleRunError` returns false → original error rethrown).
- `handleRunError()` now keys recovery on the real health probe, not `limactl list` status.

### Review hardening (from an adversarial pass)
- Wrapped the previously **un-guarded** `reconcileRunnerState()` call so a wedge-throw can't escape `ensureImageReady()` and hang the spinner.
- **Two bounded guest-probe attempts** so a slow probe on a busy-but-healthy VM no longer false-flags `wedged` (which would stick for the 60s availability cache); probe is **hard-killed on timeout** (`exec` `timeout`+`SIGKILL`) so it can't leave an orphaned `limactl shell`.
- `captureMessage(operation: 'dirty-dir-self-heal')` telemetry so we can measure ELECTRON-4S recovery rate in prod.

## Testing
- `npx vitest run src/shared/lib/container/` → **551 passing** (incl. dead-pid cleanup, live-pid no-touch, sock-missing heal, orphaned-socket→dirty, `*.sock` sweep, shell-timeout no-rebuild, build-step recover/retry/rethrow).
- `tsc --noEmit` clean, `eslint` clean.
- Manually verified against a signed local dist: `rm ~/.superagent/lima/superagent/ha.sock` then launch → self-heals (`Starting Lima VM...`) instead of hanging.

## Notes / follow-ups
- **SUP-302** (filed): gate agent-spawning services (scheduler/triggers/chat) on runtime-readiness at startup — removes the startup *race* this PR makes *recover*.
- Sibling **SUP-298**: serialize VM lifecycle ops + sleep/wake recovery.
- Known limitation (documented, not a regression): if a dead host-agent's PID is recycled by an unrelated live process, the dirty VM reads as `wedged` and won't auto-heal — still surfaced via the wedge `captureMessage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)