### PR TITLE
fix(proxy): allow files.slack.com for Slack file downloads (SUP-303)

### DIFF
--- a/src/shared/lib/proxy/allowed-hosts.test.ts
+++ b/src/shared/lib/proxy/allowed-hosts.test.ts
@@ -26,6 +26,8 @@ describe('isHostAllowed', () => {
 
   it('handles slack toolkit', () => {
     expect(isHostAllowed('slack', 'slack.com')).toBe(true)
+    // files.slack.com serves private file downloads (SUP-303)
+    expect(isHostAllowed('slack', 'files.slack.com')).toBe(true)
     expect(isHostAllowed('slack', 'api.slack.com')).toBe(false)
   })
 

--- a/src/shared/lib/proxy/allowed-hosts.ts
+++ b/src/shared/lib/proxy/allowed-hosts.ts
@@ -18,7 +18,9 @@ export const TOOLKIT_ALLOWED_HOSTS: Record<string, string[]> = {
   microsoft_teams: ['graph.microsoft.com'],
 
   // Communication
-  slack: ['slack.com'],
+  // slack.com hosts the Web API (slack.com/api/...); files.slack.com serves
+  // private file downloads (url_private / url_private_download).
+  slack: ['slack.com', 'files.slack.com'],
   discord: ['discord.com'],
 
   // Developer Tools


### PR DESCRIPTION
## Problem

The per-toolkit API request proxy validates the target host against an allowlist (`src/shared/lib/proxy/allowed-hosts.ts`). The `slack` toolkit only permitted `slack.com` — the Web API host (`slack.com/api/...`). Slack file downloads (`url_private` / `url_private_download`) are served from **`files.slack.com`**, so any agent trying to download a Slack file hit a hard 403:

```
{"error":"Host 'files.slack.com' is not allowed for toolkit 'slack'"}
```

## Fix

Add `files.slack.com` to the `slack` allowlist. Once the host passes the allowlist check, the request flows through the normal scope-matching → policy-resolution path like every other toolkit (a download path matches no scope, so it falls through to the account/global default `defaultApiPolicy`, which defaults to `review`). No policy behavior is changed — this only removes the hard host-block.

## Tests

- Added a `files.slack.com → true` assertion to `allowed-hosts.test.ts` (kept the existing `api.slack.com → false` assertion).
- `allowed-hosts.test.ts`: 15/15 pass
- `tsc --noEmit`: clean · `eslint` on changed files: clean
- `proxy.test.ts` unaffected (it mocks `isHostAllowed`)

Closes SUP-303

🤖 Generated with [Claude Code](https://claude.com/claude-code)