### PR TITLE
fix(agent-container): treat empty browser_run command/args as omitted

### DIFF
--- a/agent-container/src/tools/browser.test.ts
+++ b/agent-container/src/tools/browser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { stripAnsi, extractScreenshotPath } from './browser'
+import { stripAnsi, extractScreenshotPath, resolveBrowserRunInput } from './browser'
 
 describe('stripAnsi', () => {
   it('removes color codes', () => {
@@ -59,5 +59,43 @@ describe('extractScreenshotPath', () => {
   it('handles path with spaces in surrounding text but not in path', () => {
     const output = '\x1b[32m✓\x1b[0m Saved to \x1b[32m/var/data/img.png\x1b[0m done'
     expect(extractScreenshotPath(output)).toBe('/var/data/img.png')
+  })
+})
+
+describe('resolveBrowserRunInput', () => {
+  it('accepts command only', () => {
+    expect(resolveBrowserRunInput({ command: 'get url' })).toEqual({ command: 'get url' })
+  })
+
+  it('accepts args only', () => {
+    expect(resolveBrowserRunInput({ args: ['click', '@e1'] })).toEqual({ args: ['click', '@e1'] })
+  })
+
+  it('treats an empty args array as not provided (the GPT case)', () => {
+    expect(resolveBrowserRunInput({ command: 'click @e37', args: [] })).toEqual({
+      command: 'click @e37',
+    })
+  })
+
+  it('treats an empty/whitespace command string as not provided', () => {
+    expect(resolveBrowserRunInput({ command: '', args: ['click', '@e1'] })).toEqual({
+      args: ['click', '@e1'],
+    })
+    expect(resolveBrowserRunInput({ command: '   ', args: ['get', 'url'] })).toEqual({
+      args: ['get', 'url'],
+    })
+  })
+
+  it('errors when neither has an effective value', () => {
+    expect(resolveBrowserRunInput({})).toEqual({
+      error: 'Provide exactly one of "command" (string) or "args" (array of strings).',
+    })
+    expect(resolveBrowserRunInput({ command: '', args: [] })).toHaveProperty('error')
+  })
+
+  it('errors when both have effective values', () => {
+    expect(
+      resolveBrowserRunInput({ command: 'get url', args: ['click', '@e1'] }),
+    ).toHaveProperty('error')
   })
 })

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -39,6 +39,18 @@ export function extractScreenshotPath(output: string): string {
   return match ? match[1] : clean
 }
 
+
+export function resolveBrowserRunInput(
+  input: { command?: string; args?: string[] },
+): { command: string } | { args: string[] } | { error: string } {
+  const hasCommand = typeof input.command === 'string' && input.command.trim() !== ''
+  const hasArgs = Array.isArray(input.args) && input.args.length > 0
+  if (hasCommand === hasArgs) {
+    return { error: 'Provide exactly one of "command" (string) or "args" (array of strings).' }
+  }
+  return hasCommand ? { command: input.command! } : { args: input.args! }
+}
+
 async function readScreenshotAsBase64(filePath: string): Promise<{ data: string; mimeType: string } | null> {
   try {
     const buffer = await readFile(filePath.trim())
@@ -555,10 +567,11 @@ Available commands:
     args: z.array(z.string()).optional().describe('Pre-tokenized argv — preferred when any argument contains spaces or quotes, e.g. ["fill", "@e1", "hello world"]. Provide either this or command, not both.'),
   },
   async (args) => {
-    if ((args.command === undefined) === (args.args === undefined)) {
-      return errorResult('Provide exactly one of "command" (string) or "args" (array of strings).')
+    const resolved = resolveBrowserRunInput(args)
+    if ('error' in resolved) {
+      return errorResult(resolved.error)
     }
-    const result = await browserFetch('run', { command: args.command, args: args.args })
+    const result = await browserFetch('run', resolved)
     if (!result.success) return errorResult(result.error!)
     const data = result.data as Record<string, unknown>
     let text = data.output ? String(data.output) : 'Command executed.'


### PR DESCRIPTION
## What bug it fixes

`browser_run` rejects valid calls with:

> Provide exactly one of "command" (string) or "args" (array of strings).

even when the model only meant to send one field.

## Root cause

The handler enforced the command/args XOR with a **presence** check
(`(args.command === undefined) === (args.args === undefined)`). GPT (and other
models) frequently serialize the *unused* optional field as an empty value
instead of omitting it, e.g.:

```json
{ "command": "click @e37 && wait --load", "args": [] }
```

`args: []` is still "defined", so the presence check counted it as "both
provided" and 400'd. The schema itself can't express the XOR, and the model's
serialization can't be relied on to omit the key — so the gate has to be
value-based.

## What changed

- Extract the resolution into a pure, exported `resolveBrowserRunInput` that
  treats an empty string / empty array as **not provided** (whitespace-only
  command too), returns the single effective field, or an error when zero/two
  effective values are given.
- Handler uses it and forwards **only** the effective field to the browser CLI
  (previously it passed both `command` and `args` through).
- Unit tests for: command-only, args-only, empty-args + command (the GPT case),
  empty/whitespace command + args, neither, both.

## Repro

Call `browser_run` with `{ "command": "get url", "args": [] }` on a GPT-backed
session → before: 400 "Provide exactly one…"; after: runs `get url`.

## Test plan

- [x] `vitest run src/tools/browser.test.ts` (18 passed)
- [x] `tsc --noEmit` clean
- [ ] Live GPT session: trigger a `browser_run` that previously emitted empty `args`

Made with [Cursor](https://cursor.com)