### PR TITLE
feat(updates): generic R2 auto-update feed + dual-publish CI (SUP-284, SUP-286)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,25 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  # Extract version from tag
+  # Extract version + update channel from tag
   prepare:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      channel: ${{ steps.version.outputs.channel }}
     steps:
-      - name: Extract version from tag
+      - name: Extract version + channel from tag
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        run: |
+          echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+          # Channel = the prerelease identifier (rc/beta/alpha) so electron-builder
+          # writes rc-*.yml for prereleases and latest-*.yml for stable. Matches the
+          # app's runtime autoUpdater.channel derivation in auto-updater.ts.
+          if [[ "$GITHUB_REF_NAME" =~ -([a-zA-Z]+) ]]; then
+            echo "channel=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+          else
+            echo "channel=latest" >> $GITHUB_OUTPUT
+          fi
 
   # Build and push agent container with version tag
   build-agent-container:
@@ -154,7 +164,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
           PLATFORM_PROXY_URL: ${{ secrets.PLATFORM_PROXY_URL }}
-        run: npm run dist:mac
+        run: npm run dist:mac -- -c.publish.channel=${{ needs.prepare.outputs.channel }}
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
@@ -197,7 +207,7 @@ jobs:
           AZURE_CODE_SIGNING_ACCOUNT: ${{ secrets.AZURE_CODE_SIGNING_ACCOUNT }}
           AZURE_CODE_SIGNING_PROFILE: ${{ secrets.AZURE_CODE_SIGNING_PROFILE }}
           AZURE_CODE_SIGNING_PUBLISHER: ${{ secrets.AZURE_CODE_SIGNING_PUBLISHER }}
-        run: npm run dist:win
+        run: npm run dist:win -- -c.publish.channel=${{ needs.prepare.outputs.channel }}
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
@@ -215,6 +225,10 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     needs: [prepare, build-agent-container, build-app-container, build-mac, build-win]
+    # Mapped from the secret so the R2 upload step can self-gate on its presence
+    # (the `secrets` context isn't available in a step `if:` condition).
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -248,3 +262,28 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "$GITHUB_REF_NAME" --draft=false --repo "$GITHUB_REPOSITORY"
+
+      # Dual-publish bridge (SUP-286): populate the owned R2 feed
+      # (updates.gamutagents.com) AFTER the GitHub release is published, so a
+      # transient R2 hiccup can never block the primary (GitHub) feed during the
+      # bridge. continue-on-error keeps a failed upload from failing the release —
+      # generic-feed builds update from R2; pre-generic clients keep updating from
+      # GitHub until the cutover subtask (SUP-287) retires the GitHub feed. Skipped
+      # if the Cloudflare credentials aren't configured. Uses the same
+      # CLOUDFLARE_API_TOKEN as the gamut-releases Worker deploy — no separate R2
+      # S3 keys to manage.
+      - name: Upload release feed to Cloudflare R2
+        if: ${{ env.CLOUDFLARE_ACCOUNT_ID != '' }}
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          shopt -s nullglob
+          for f in ./release-artifacts/*; do
+            name="$(basename "$f")"
+            # builder-debug.yml is electron-builder's debug dump, not a feed file.
+            [ "$name" = "builder-debug.yml" ] && continue
+            echo "→ R2: $name"
+            npx --yes wrangler@4 r2 object put "gamut-releases/$name" --file "$f" --remote
+          done

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
         "dmg",
         "zip"
       ],
-      "artifactName": "Gamut-${arch}.${ext}",
+      "artifactName": "Gamut-${version}-${arch}.${ext}",
       "category": "public.app-category.developer-tools",
       "icon": "build/icon.icon",
       "hardenedRuntime": true,
@@ -257,12 +257,12 @@
       "createStartMenuShortcut": true,
       "shortcutName": "Gamut",
       "uninstallDisplayName": "Gamut",
-      "artifactName": "Gamut-Setup.${ext}"
+      "artifactName": "Gamut-${version}-Setup.${ext}"
     },
     "publish": {
-      "provider": "github",
-      "owner": "SkillfulAgents",
-      "repo": "SuperAgent"
+      "provider": "generic",
+      "url": "https://updates.gamutagents.com/",
+      "channel": "latest"
     }
   }
 }

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -332,17 +332,21 @@ export async function initAutoUpdater(mainWindow: BrowserWindow) {
       return
     }
 
-    // Dev-only escape hatch: pretend we're an older version so the GitHub feed
+    // Dev-only escape hatch: pretend we're an older version so the update feed
     // returns "update available". Activated by SUPERAGENT_TEST_UPDATES=1.
     // SUPERAGENT_FAKE_VERSION overrides the reported version (default 0.0.1).
+    // SUPERAGENT_TEST_FEED_URL overrides the generic feed origin (default the
+    // prod feed) — point it at a local `wrangler dev` of the gamut-releases
+    // Worker (e.g. http://localhost:8787/) to hand-test updates before deploy.
     // Gated on !app.isPackaged so a stray env var on a shipped build can't
     // redirect the auto-updater feed.
     if (process.env.SUPERAGENT_TEST_UPDATES === '1' && !app.isPackaged) {
       const fakeVersion = process.env.SUPERAGENT_FAKE_VERSION || '0.0.1'
+      const feedUrl = process.env.SUPERAGENT_TEST_FEED_URL || 'https://updates.gamutagents.com/'
       const cfgPath = path.join(os.tmpdir(), 'superagent-dev-app-update.yml')
       fs.writeFileSync(
         cfgPath,
-        'provider: github\nowner: SkillfulAgents\nrepo: SuperAgent\n',
+        `provider: generic\nurl: ${feedUrl}\nchannel: latest\n`,
       )
       autoUpdater.updateConfigPath = cfgPath
       autoUpdater.forceDevUpdateConfig = true


### PR DESCRIPTION
## What & why

Moves the desktop auto-update feed off the GitHub provider (baked per-binary as `github SkillfulAgents/SuperAgent`) onto an owned, R2-backed origin **`updates.gamutagents.com`** — so the update backend is repointable forever without shipping another build, and the `Superagent → Gamut` repo rename becomes invisible to updates. Part of **SUP-283**.

This PR is the **app + release-pipeline** half (SUP-284 + SUP-286). The infra half (**SUP-285**) — the Cloudflare Worker + R2 bucket — lives in the new **`SkillfulAgents/gamut-releases`** repo and is already deployed.

## Changes

**SUP-284 — app → generic feed** (`package.json`, `src/main/auto-updater.ts`)
- `build.publish` → `{ provider: generic, url: https://updates.gamutagents.com/, channel: latest }`
- Version-stamped `artifactName`: mac `Gamut-${version}-${arch}.${ext}`, nsis `Gamut-${version}-Setup.${ext}` (the multi-arch nsis is a single combined installer). Required so the flat R2 namespace is unambiguous across the stable/rc channels.
- Dev test-feed → generic; new `SUPERAGENT_TEST_FEED_URL` to point at a local `wrangler dev`.

**SUP-286 — release CI → dual-publish** (`.github/workflows/release.yml`)
- `prepare` derives the update channel (`rc`/`beta`/… vs `latest`) from the tag; build jobs pass `-c.publish.channel` so electron-builder writes `rc-*.yml` vs `latest-*.yml`.
- Uploads every artifact + channel yml to the `gamut-releases` R2 bucket **after** the GitHub release is published, with **`continue-on-error`** — strictly additive, can't block the primary GitHub feed. Uses the same `CLOUDFLARE_API_TOKEN` as the Worker deploy (no separate R2 S3 keys).

## Reader-first bridge (no stranded installs)

The GitHub release publish is **unchanged** — already-installed (github-feed) clients keep polling GitHub and updating normally. Only NEW (generic-feed) builds use R2. Version-stamped filenames don't break old clients (they resolve assets by the yml's filename). The GitHub feed is retired later under **SUP-287** once the pre-generic fleet drains.

## Testing

- Worker: 21 unit tests; deployed to prod; `/healthz` green; GHA auto-deploy on `main`.
- Feed validated **e2e against prod** with real signed 0.3.45 + 0.4.0-rc.2 artifacts backfilled to R2: served zip/exe **sha512 matches the yml** (electron-updater's integrity gate), HTTP Range byte-identical, `/download/{mac,win}` 302 → installer. Both platforms, both channels.
- Drove the **real `electron-updater` library** headless against the live feed: faking 0.3.44 → detects 0.3.45 (stable); faking 0.4.0-rc.1 → detects 0.4.0-rc.2 (rc).
- `tsc` + eslint clean; 34 auto-updater unit tests pass.

## Required secrets (already configured)

`CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` on this repo, used by the new R2 upload step.

## Follow-ups (not in this PR)

- Recommend the **first real release be an RC** to exercise the whole pipeline before a stable.
- Repoint the website's GitHub `.dmg`/`.exe` links → `updates.gamutagents.com/download/*`.
- `CLAUDE.md` still documents the auto-updater dev test as hitting the GitHub feed (now generic).

Closes SUP-284, SUP-286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)