### PR TITLE
refactor(k8s-runtime): name agent pods gamut-agent-container

### DIFF
--- a/src/shared/lib/container/platform-k8s-runtime.ts
+++ b/src/shared/lib/container/platform-k8s-runtime.ts
@@ -249,7 +249,7 @@ export class PlatformK8sRuntimeClient extends BaseContainerClient {
   }
 
   private podName(): string {
-    return kubeResourceName('superagent', this.config.agentId)
+    return kubeResourceName('gamut-agent-container', this.config.agentId)
   }
 
   private serviceName(): string {


### PR DESCRIPTION
## Summary
- Rename the k8s agent pod/Service prefix from `superagent` to `gamut-agent-container` so pods read `gamut-agent-container-<id>-<hash>` instead of `superagent-<id>-<hash>`.
- Single-line change at the only source of the prefix (`podName()` → `kubeResourceName('gamut-agent-container', agentId)`); `serviceName`, selectors, and all addressing derive from it.
- `kubeResourceName` already caps the result at 63 chars, so the longer prefix is length-safe.

## Why
Cloud (gamut) deployment is rebranding workload names away from `superagent` (host-app is being renamed to `gamut-host-app` in gamut-infra). This aligns the agent pods.

## Test plan
- [x] `vitest run platform-k8s-runtime.test.ts` — 30/30 pass (no test asserted the old prefix; names are passed explicitly).
- [ ] After host-app image rebuild + chart `hostAppImage` bump: provision an org, confirm a new agent pod is named `gamut-agent-container-*` and is reachable via its Service.

## Notes / deploy
- Takes effect only after the host-app image (`superagent:*-auth`) is rebuilt with this change and the gamut-infra chart `hostAppImage` is repointed.
- Existing `superagent-*` agents are not re-adopted by the new host-app; they drain and orphans are GC'd via ownerReferences.

Made with [Cursor](https://cursor.com)