### PR TITLE
fix(release): unbreak Windows release — set update channel via package.json (SUP-283)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,19 @@ jobs:
           echo "$APPLE_API_KEY_BASE64" | base64 --decode > /tmp/AuthKey.p8
           echo "APPLE_API_KEY=/tmp/AuthKey.p8" >> $GITHUB_ENV
 
+      # Write the update channel into package.json's build.publish.channel via
+      # Node (value comes from an env var, never a CLI arg) so it can't be mangled
+      # by Windows arg-passing — the `-c.publish.channel=` electron-builder flag
+      # got split into `-c .publish.channel=rc` through npm -> cmd.exe -> the
+      # electron-builder.cmd shim and was read as a config-file path (SUP-283).
+      - name: Set update channel
+        shell: bash
+        env:
+          UPDATE_CHANNEL: ${{ needs.prepare.outputs.channel }}
+        run: |
+          node -e "const fs=require('fs'),p=require('./package.json');p.build.publish.channel=process.env.UPDATE_CHANNEL;fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+          echo "build.publish.channel set to $UPDATE_CHANNEL"
+
       - name: Build and sign macOS app
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
@@ -164,7 +177,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PLATFORM_BASE_URL: ${{ secrets.PLATFORM_BASE_URL }}
           PLATFORM_PROXY_URL: ${{ secrets.PLATFORM_PROXY_URL }}
-        run: npm run dist:mac -- -c.publish.channel=${{ needs.prepare.outputs.channel }}
+        run: npm run dist:mac
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
@@ -195,6 +208,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # See build-mac: set the channel via Node from an env var so Windows
+      # arg-passing can't mangle a `-c.publish.channel=` CLI flag (SUP-283).
+      - name: Set update channel
+        shell: bash
+        env:
+          UPDATE_CHANNEL: ${{ needs.prepare.outputs.channel }}
+        run: |
+          node -e "const fs=require('fs'),p=require('./package.json');p.build.publish.channel=process.env.UPDATE_CHANNEL;fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+          echo "build.publish.channel set to $UPDATE_CHANNEL"
+
       - name: Build and sign Windows app
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -207,7 +230,7 @@ jobs:
           AZURE_CODE_SIGNING_ACCOUNT: ${{ secrets.AZURE_CODE_SIGNING_ACCOUNT }}
           AZURE_CODE_SIGNING_PROFILE: ${{ secrets.AZURE_CODE_SIGNING_PROFILE }}
           AZURE_CODE_SIGNING_PUBLISHER: ${{ secrets.AZURE_CODE_SIGNING_PUBLISHER }}
-        run: npm run dist:win -- -c.publish.channel=${{ needs.prepare.outputs.channel }}
+        run: npm run dist:win
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem

The `v0.4.0-rc.3` Release run failed on **build-win** ([run](https://github.com/SkillfulAgents/SuperAgent/actions/runs/27988599773)):

```
⨯ ENOENT: no such file or directory, open '...\.publish.channel=rc'  failedTask=build
    at readConfig (app-builder-lib/.../config/load.ts)
```

Regression from #301. We pass the update channel to electron-builder as `npm run dist:win -- -c.publish.channel=${channel}`. On **Windows** that arg gets mangled through npm → `cmd.exe` → the `electron-builder.cmd` shim: electron-builder receives `-c` with value `.publish.channel=rc` and tries to open it as a **config file** → ENOENT. macOS parsed the same arg correctly (build-mac passed), so only Windows releases broke — i.e. cutting any release was broken.

## Fix

Stop passing the channel as a fragile `-c.publish.channel=` CLI arg. Instead, before the build, a small **Node step writes `build.publish.channel` into `package.json`**, taking the value from an **env var** (`UPDATE_CHANNEL`) — so it's never a shell-mangled CLI argument. The `dist:mac`/`dist:win` commands go back to plain `npm run dist:*`.

```yaml
- name: Set update channel
  shell: bash
  env: { UPDATE_CHANNEL: ${{ needs.prepare.outputs.channel }} }
  run: |
    node -e "const fs=require('fs'),p=require('./package.json');p.build.publish.channel=process.env.UPDATE_CHANNEL;fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
```

Cross-platform and robust (no CLI-arg quoting/`.cmd`-shim hazards). `prepare` still derives the channel (`rc`/`beta`/… vs `latest`) from the tag.

## Verified locally
- `UPDATE_CHANNEL=rc` → `build.publish.channel: "rc"`; `latest` → `"latest"`; all other `build` fields (artifactNames, publish url/provider) unchanged.
- YAML valid; the "Set update channel" step runs before "Build and sign" in both jobs.

## After merge
Re-cut the release (e.g. retag `v0.4.0-rc.3` or a fresh `-rc.4`). build-win should produce `rc.yml`/`rc-mac.yml` + version-stamped artifacts, then the GitHub release + R2 dual-publish steps run.

Refs SUP-283 / #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)