### PR TITLE
feat(models): handle GPT 272K long-context pricing — picker warning + usage cost

### DIFF
--- a/src/renderer/components/messages/model-family-list.test.tsx
+++ b/src/renderer/components/messages/model-family-list.test.tsx
@@ -7,6 +7,7 @@ import {
   findCatalogModel,
   familyDisplayName,
   formatTokenThreshold,
+  longContextWarningText,
 } from './model-family-list'
 import type { ModelDefinition } from '@shared/lib/llm-provider'
 import type { EffortLevel } from '@shared/lib/container/types'
@@ -20,8 +21,8 @@ const CATALOG: ModelDefinition[] = [
   { id: 'claude-opus-4-6', label: 'Opus 4.6', family: 'opus', icon: 'anthropic', supportedEfforts: ALL },
   { id: 'claude-opus-4-7', label: 'Opus 4.7', family: 'opus', icon: 'anthropic', supportedEfforts: ALL },
   { id: 'claude-opus-4-8', label: 'Opus 4.8', family: 'opus', isLatest: true, icon: 'anthropic', supportedEfforts: ALL },
-  { id: 'openai/gpt-5.4', label: 'GPT-5.4', family: 'gpt', icon: 'openai', supportedEfforts: STD, supportsWebSearch: false, longContextPriceCliff: { thresholdTokens: 272_000, inputMultiplier: 2, outputMultiplier: 1.5 } },
-  { id: 'openai/gpt-5.5', label: 'GPT-5.5', family: 'gpt', isLatest: true, icon: 'openai', supportedEfforts: STD, supportsWebSearch: false, longContextPriceCliff: { thresholdTokens: 272_000, inputMultiplier: 2, outputMultiplier: 1.5 } },
+  { id: 'openai/gpt-5.4', label: 'GPT-5.4', family: 'gpt', icon: 'openai', supportedEfforts: STD, supportsWebSearch: false, contextWindow: 1_050_000, longContextPriceCliff: { thresholdTokens: 272_000, inputMultiplier: 2, outputMultiplier: 1.5 } },
+  { id: 'openai/gpt-5.5', label: 'GPT-5.5', family: 'gpt', isLatest: true, icon: 'openai', supportedEfforts: STD, supportsWebSearch: false, contextWindow: 1_050_000, longContextPriceCliff: { thresholdTokens: 272_000, inputMultiplier: 2, outputMultiplier: 1.5 } },
 ]
 
 describe('familyDisplayName', () => {
@@ -38,6 +39,28 @@ describe('formatTokenThreshold', () => {
     expect(formatTokenThreshold(272_000)).toBe('272K')
     expect(formatTokenThreshold(1_050_000)).toBe('1.05M')
     expect(formatTokenThreshold(500)).toBe('500')
+  })
+})
+
+describe('longContextWarningText', () => {
+  const cliff = { thresholdTokens: 272_000, inputMultiplier: 2, outputMultiplier: 1.5 }
+
+  it('frames the threshold as a share of the context window when known', () => {
+    expect(longContextWarningText(cliff, 1_050_000)).toBe(
+      'Note: beyond about 26% of the context window, pricing increases by roughly 1.5–2×.',
+    )
+  })
+
+  it('falls back to a token count when the context window is unknown', () => {
+    expect(longContextWarningText(cliff)).toBe(
+      'Note: beyond ~272K tokens of context, pricing increases by roughly 1.5–2×.',
+    )
+  })
+
+  it('collapses equal multipliers to a single factor', () => {
+    expect(longContextWarningText({ thresholdTokens: 100_000, inputMultiplier: 2, outputMultiplier: 2 })).toContain(
+      'roughly 2×',
+    )
   })
 })
 
@@ -125,9 +148,9 @@ describe('ModelFamilyList', () => {
   it('warns about the long-context price cliff for GPT, and not for flat-priced Claude', () => {
     const { rerender } = render(<ModelFamilyList catalog={CATALOG} value="openai/gpt-5.5" onPick={vi.fn()} />)
     const warning = screen.getByTestId('model-long-context-cliff-warning')
-    expect(warning).toHaveTextContent('272K')
-    expect(warning).toHaveTextContent('2× input')
-    expect(warning).toHaveTextContent('1.5× output')
+    // 272K / 1.05M ≈ 26% of the context window; multipliers shown as a soft range.
+    expect(warning).toHaveTextContent('26% of the context window')
+    expect(warning).toHaveTextContent('1.5–2×')
 
     rerender(<ModelFamilyList catalog={CATALOG} value="claude-opus-4-8" onPick={vi.fn()} />)
     expect(screen.queryByTestId('model-long-context-cliff-warning')).not.toBeInTheDocument()

--- a/src/renderer/components/messages/model-family-list.test.tsx
+++ b/src/renderer/components/messages/model-family-list.test.tsx
@@ -47,19 +47,13 @@ describe('longContextWarningText', () => {
 
   it('frames the threshold as a share of the context window when known', () => {
     expect(longContextWarningText(cliff, 1_050_000)).toBe(
-      'Note: beyond about 26% of the context window, pricing increases by roughly 1.5–2×.',
+      'Note: beyond about 26% of the context window, input pricing rises 2× and output 1.5×.',
     )
   })
 
   it('falls back to a token count when the context window is unknown', () => {
     expect(longContextWarningText(cliff)).toBe(
-      'Note: beyond ~272K tokens of context, pricing increases by roughly 1.5–2×.',
-    )
-  })
-
-  it('collapses equal multipliers to a single factor', () => {
-    expect(longContextWarningText({ thresholdTokens: 100_000, inputMultiplier: 2, outputMultiplier: 2 })).toContain(
-      'roughly 2×',
+      'Note: beyond ~272K tokens of context, input pricing rises 2× and output 1.5×.',
     )
   })
 })
@@ -148,9 +142,9 @@ describe('ModelFamilyList', () => {
   it('warns about the long-context price cliff for GPT, and not for flat-priced Claude', () => {
     const { rerender } = render(<ModelFamilyList catalog={CATALOG} value="openai/gpt-5.5" onPick={vi.fn()} />)
     const warning = screen.getByTestId('model-long-context-cliff-warning')
-    // 272K / 1.05M ≈ 26% of the context window; multipliers shown as a soft range.
+    // 272K / 1.05M ≈ 26% of the context window; input/output multipliers spelled out.
     expect(warning).toHaveTextContent('26% of the context window')
-    expect(warning).toHaveTextContent('1.5–2×')
+    expect(warning).toHaveTextContent('input pricing rises 2× and output 1.5×')
 
     rerender(<ModelFamilyList catalog={CATALOG} value="claude-opus-4-8" onPick={vi.fn()} />)
     expect(screen.queryByTestId('model-long-context-cliff-warning')).not.toBeInTheDocument()

--- a/src/renderer/components/messages/model-family-list.test.tsx
+++ b/src/renderer/components/messages/model-family-list.test.tsx
@@ -2,7 +2,12 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { ModelFamilyList, findCatalogModel, familyDisplayName } from './model-family-list'
+import {
+  ModelFamilyList,
+  findCatalogModel,
+  familyDisplayName,
+  formatTokenThreshold,
+} from './model-family-list'
 import type { ModelDefinition } from '@shared/lib/llm-provider'
 import type { EffortLevel } from '@shared/lib/container/types'
 
@@ -15,8 +20,8 @@ const CATALOG: ModelDefinition[] = [
   { id: 'claude-opus-4-6', label: 'Opus 4.6', family: 'opus', icon: 'anthropic', supportedEfforts: ALL },
   { id: 'claude-opus-4-7', label: 'Opus 4.7', family: 'opus', icon: 'anthropic', supportedEfforts: ALL },
   { id: 'claude-opus-4-8', label: 'Opus 4.8', family: 'opus', isLatest: true, icon: 'anthropic', supportedEfforts: ALL },
-  { id: 'openai/gpt-5.4', label: 'GPT-5.4', family: 'gpt', icon: 'openai', supportedEfforts: STD, supportsWebSearch: false },
-  { id: 'openai/gpt-5.5', label: 'GPT-5.5', family: 'gpt', isLatest: true, icon: 'openai', supportedEfforts: STD, supportsWebSearch: false },
+  { id: 'openai/gpt-5.4', label: 'GPT-5.4', family: 'gpt', icon: 'openai', supportedEfforts: STD, supportsWebSearch: false, longContextPriceCliff: { thresholdTokens: 272_000, inputMultiplier: 2, outputMultiplier: 1.5 } },
+  { id: 'openai/gpt-5.5', label: 'GPT-5.5', family: 'gpt', isLatest: true, icon: 'openai', supportedEfforts: STD, supportsWebSearch: false, longContextPriceCliff: { thresholdTokens: 272_000, inputMultiplier: 2, outputMultiplier: 1.5 } },
 ]
 
 describe('familyDisplayName', () => {
@@ -25,6 +30,14 @@ describe('familyDisplayName', () => {
     expect(familyDisplayName('sonnet')).toBe('Sonnet')
     expect(familyDisplayName('gpt')).toBe('GPT')
     expect(familyDisplayName('glm')).toBe('GLM')
+  })
+})
+
+describe('formatTokenThreshold', () => {
+  it('formats thousands and millions compactly', () => {
+    expect(formatTokenThreshold(272_000)).toBe('272K')
+    expect(formatTokenThreshold(1_050_000)).toBe('1.05M')
+    expect(formatTokenThreshold(500)).toBe('500')
   })
 })
 
@@ -107,6 +120,17 @@ describe('ModelFamilyList', () => {
 
     rerender(<ModelFamilyList catalog={CATALOG} value="claude-opus-4-8" onPick={vi.fn()} />)
     expect(screen.queryByTestId('model-no-websearch-warning')).not.toBeInTheDocument()
+  })
+
+  it('warns about the long-context price cliff for GPT, and not for flat-priced Claude', () => {
+    const { rerender } = render(<ModelFamilyList catalog={CATALOG} value="openai/gpt-5.5" onPick={vi.fn()} />)
+    const warning = screen.getByTestId('model-long-context-cliff-warning')
+    expect(warning).toHaveTextContent('272K')
+    expect(warning).toHaveTextContent('2× input')
+    expect(warning).toHaveTextContent('1.5× output')
+
+    rerender(<ModelFamilyList catalog={CATALOG} value="claude-opus-4-8" onPick={vi.fn()} />)
+    expect(screen.queryByTestId('model-long-context-cliff-warning')).not.toBeInTheDocument()
   })
 
   it('offers a "latest" row only when offerLatest is set', async () => {

--- a/src/renderer/components/messages/model-family-list.tsx
+++ b/src/renderer/components/messages/model-family-list.tsx
@@ -25,11 +25,8 @@ export function formatTokenThreshold(tokens: number): string {
 
 type LongContextCliff = NonNullable<ModelDefinition['longContextPriceCliff']>
 
-/**
- * Gentle heads-up about the long-context price step. Frames the threshold as a
- * share of the context window when known (more intuitive than a raw token
- * count), and the multipliers as a soft range.
- */
+// Picker copy for a model's long-context price step; frames the threshold as a
+// share of the context window when known, else as a raw token count.
 export function longContextWarningText(cliff: LongContextCliff, contextWindow?: number): string {
   const where = contextWindow
     ? `beyond about ${Math.round((cliff.thresholdTokens / contextWindow) * 100)}% of the context window`

--- a/src/renderer/components/messages/model-family-list.tsx
+++ b/src/renderer/components/messages/model-family-list.tsx
@@ -31,13 +31,10 @@ type LongContextCliff = NonNullable<ModelDefinition['longContextPriceCliff']>
  * count), and the multipliers as a soft range.
  */
 export function longContextWarningText(cliff: LongContextCliff, contextWindow?: number): string {
-  const lo = Math.min(cliff.inputMultiplier, cliff.outputMultiplier)
-  const hi = Math.max(cliff.inputMultiplier, cliff.outputMultiplier)
-  const range = lo === hi ? `${hi}×` : `${lo}–${hi}×`
   const where = contextWindow
     ? `beyond about ${Math.round((cliff.thresholdTokens / contextWindow) * 100)}% of the context window`
     : `beyond ~${formatTokenThreshold(cliff.thresholdTokens)} tokens of context`
-  return `Note: ${where}, pricing increases by roughly ${range}.`
+  return `Note: ${where}, input pricing rises ${cliff.inputMultiplier}× and output ${cliff.outputMultiplier}×.`
 }
 
 /**

--- a/src/renderer/components/messages/model-family-list.tsx
+++ b/src/renderer/components/messages/model-family-list.tsx
@@ -16,6 +16,13 @@ export function familyDisplayName(family: string): string {
   return FAMILY_LABELS[family] ?? capitalize(family)
 }
 
+/** Compact token-count label for warnings, e.g. 272000 → "272K", 1_050_000 → "1.05M". */
+export function formatTokenThreshold(tokens: number): string {
+  if (tokens >= 1_000_000) return `${+(tokens / 1_000_000).toFixed(2)}M`
+  if (tokens >= 1_000) return `${+(tokens / 1_000).toFixed(0)}K`
+  return String(tokens)
+}
+
 /**
  * Resolve a stored selection to its catalog entry for display: an exact
  * concrete-id match first, then a bare family alias → that family's latest.
@@ -153,6 +160,19 @@ export function ModelFamilyList({
         >
           <TriangleAlert className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
           <span>Web search and fetch aren’t available on this model.</span>
+        </div>
+      )}
+      {resolved?.longContextPriceCliff && (
+        <div
+          data-testid="model-long-context-cliff-warning"
+          className="mx-1 mb-1 flex items-start gap-1.5 rounded-sm bg-amber-500/10 px-2 py-1 text-[11px] text-amber-600 dark:text-amber-500"
+        >
+          <TriangleAlert className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
+          <span>
+            Above {formatTokenThreshold(resolved.longContextPriceCliff.thresholdTokens)} tokens of
+            context, pricing jumps to {resolved.longContextPriceCliff.inputMultiplier}× input and{' '}
+            {resolved.longContextPriceCliff.outputMultiplier}× output for the whole request.
+          </span>
         </div>
       )}
       {families.map((group) => {

--- a/src/renderer/components/messages/model-family-list.tsx
+++ b/src/renderer/components/messages/model-family-list.tsx
@@ -23,6 +23,23 @@ export function formatTokenThreshold(tokens: number): string {
   return String(tokens)
 }
 
+type LongContextCliff = NonNullable<ModelDefinition['longContextPriceCliff']>
+
+/**
+ * Gentle heads-up about the long-context price step. Frames the threshold as a
+ * share of the context window when known (more intuitive than a raw token
+ * count), and the multipliers as a soft range.
+ */
+export function longContextWarningText(cliff: LongContextCliff, contextWindow?: number): string {
+  const lo = Math.min(cliff.inputMultiplier, cliff.outputMultiplier)
+  const hi = Math.max(cliff.inputMultiplier, cliff.outputMultiplier)
+  const range = lo === hi ? `${hi}×` : `${lo}–${hi}×`
+  const where = contextWindow
+    ? `beyond about ${Math.round((cliff.thresholdTokens / contextWindow) * 100)}% of the context window`
+    : `beyond ~${formatTokenThreshold(cliff.thresholdTokens)} tokens of context`
+  return `Note: ${where}, pricing increases by roughly ${range}.`
+}
+
 /**
  * Resolve a stored selection to its catalog entry for display: an exact
  * concrete-id match first, then a bare family alias → that family's latest.
@@ -168,11 +185,7 @@ export function ModelFamilyList({
           className="mx-1 mb-1 flex items-start gap-1.5 rounded-sm bg-amber-500/10 px-2 py-1 text-[11px] text-amber-600 dark:text-amber-500"
         >
           <TriangleAlert className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
-          <span>
-            Above {formatTokenThreshold(resolved.longContextPriceCliff.thresholdTokens)} tokens of
-            context, pricing jumps to {resolved.longContextPriceCliff.inputMultiplier}× input and{' '}
-            {resolved.longContextPriceCliff.outputMultiplier}× output for the whole request.
-          </span>
+          <span>{longContextWarningText(resolved.longContextPriceCliff, resolved.contextWindow)}</span>
         </div>
       )}
       {families.map((group) => {

--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -19,6 +19,14 @@ const STANDARD_EFFORTS: EffortLevel[] = ['low', 'medium', 'high']
 // xhigh/max are Anthropic-only reasoning tiers; non-Claude models get the standard three.
 const NON_CLAUDE_EFFORTS: EffortLevel[] = ['low', 'medium', 'high']
 
+// OpenAI GPT-5.x reprice the whole request 2x input / 1.5x output once prompt
+// input crosses 272K tokens. Shared by every GPT entry so the picker can warn.
+const GPT_LONG_CONTEXT_CLIFF = {
+  thresholdTokens: 272_000,
+  inputMultiplier: 2,
+  outputMultiplier: 1.5,
+} as const
+
 const ICON = 'anthropic'
 
 /** Anthropic / OpenRouter / Platform — bare Claude ids. */
@@ -157,6 +165,7 @@ const OPENROUTER_EXTRA_MODELS: ModelDefinition[] = [
     pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.4).
     contextWindow: 1_050_000,
+    longContextPriceCliff: GPT_LONG_CONTEXT_CLIFF,
     promptHints: GPT_TOOL_USE_PROMPT_HINTS,
   },
   {
@@ -175,6 +184,7 @@ const OPENROUTER_EXTRA_MODELS: ModelDefinition[] = [
     pricing: { inputPerMtok: 5, outputPerMtok: 30 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.5).
     contextWindow: 1_050_000,
+    longContextPriceCliff: GPT_LONG_CONTEXT_CLIFF,
     promptHints: GPT_TOOL_USE_PROMPT_HINTS,
   },
   {
@@ -216,6 +226,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.4).
     contextWindow: 1_050_000,
+    longContextPriceCliff: GPT_LONG_CONTEXT_CLIFF,
     promptHints: GPT_TOOL_USE_PROMPT_HINTS,
   },
   {
@@ -230,6 +241,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     pricing: { inputPerMtok: 5, outputPerMtok: 30 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.5).
     contextWindow: 1_050_000,
+    longContextPriceCliff: GPT_LONG_CONTEXT_CLIFF,
     promptHints: GPT_TOOL_USE_PROMPT_HINTS,
   },
 ]

--- a/src/shared/lib/llm-provider/model-catalog-schema.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.test.ts
@@ -53,6 +53,29 @@ describe('modelDefinitionSchema', () => {
     expect(() => modelDefinitionSchema.parse({ ...base, contextWindow: 1.5 })).toThrow()
   })
 
+  it('accepts an optional longContextPriceCliff and omits cleanly', () => {
+    const cliff = { thresholdTokens: 272_000, inputMultiplier: 2, outputMultiplier: 1.5 }
+    expect(modelDefinitionSchema.parse({ ...base, longContextPriceCliff: cliff })).toMatchObject({
+      longContextPriceCliff: cliff,
+    })
+    expect(modelDefinitionSchema.parse(base).longContextPriceCliff).toBeUndefined()
+  })
+
+  it('rejects a longContextPriceCliff with a non-positive threshold or multiplier', () => {
+    expect(() =>
+      modelDefinitionSchema.parse({
+        ...base,
+        longContextPriceCliff: { thresholdTokens: 0, inputMultiplier: 2, outputMultiplier: 1.5 },
+      }),
+    ).toThrow()
+    expect(() =>
+      modelDefinitionSchema.parse({
+        ...base,
+        longContextPriceCliff: { thresholdTokens: 272_000, inputMultiplier: 0, outputMultiplier: 1.5 },
+      }),
+    ).toThrow()
+  })
+
   it('accepts non-empty prompt hints and rejects empty hints', () => {
     expect(modelDefinitionSchema.parse({ ...base, promptHints: ['Use exact tool names.'] })).toMatchObject({
       promptHints: ['Use exact tool names.'],

--- a/src/shared/lib/llm-provider/model-catalog-schema.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.ts
@@ -52,6 +52,16 @@ export const modelDefinitionSchema = z.object({
   // generic 200K default for these, so the host prefers this over the SDK value
   // (see handleResultUsage). Claude entries omit it and use the SDK's real window.
   contextWindow: z.number().int().positive().optional(),
+  // Long-context pricing cliff: above `thresholdTokens` of input, the provider
+  // reprices the whole request by these multipliers (e.g. OpenAI's 272K cliff).
+  // Present ⇒ the picker warns. Omit for flat-priced models.
+  longContextPriceCliff: z
+    .object({
+      thresholdTokens: z.number().int().positive(),
+      inputMultiplier: z.number().positive(),
+      outputMultiplier: z.number().positive(),
+    })
+    .optional(),
 })
 
 export type ModelDefinition = z.infer<typeof modelDefinitionSchema>

--- a/src/shared/lib/services/model-pricing.json
+++ b/src/shared/lib/services/model-pricing.json
@@ -130,5 +130,57 @@
     "output": 15,
     "cacheCreation": 3.75,
     "cacheRead": 0.3
+  },
+  "gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheCreation": 2.5,
+    "cacheRead": 0.25,
+    "longContext": {
+      "thresholdTokens": 272000,
+      "input": 5,
+      "output": 22.5,
+      "cacheCreation": 5,
+      "cacheRead": 0.5
+    }
+  },
+  "gpt-5.5": {
+    "input": 5,
+    "output": 30,
+    "cacheCreation": 5,
+    "cacheRead": 0.5,
+    "longContext": {
+      "thresholdTokens": 272000,
+      "input": 10,
+      "output": 45,
+      "cacheCreation": 10,
+      "cacheRead": 1
+    }
+  },
+  "openai/gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheCreation": 2.5,
+    "cacheRead": 0.25,
+    "longContext": {
+      "thresholdTokens": 272000,
+      "input": 5,
+      "output": 22.5,
+      "cacheCreation": 5,
+      "cacheRead": 0.5
+    }
+  },
+  "openai/gpt-5.5": {
+    "input": 5,
+    "output": 30,
+    "cacheCreation": 5,
+    "cacheRead": 0.5,
+    "longContext": {
+      "thresholdTokens": 272000,
+      "input": 10,
+      "output": 45,
+      "cacheCreation": 10,
+      "cacheRead": 1
+    }
   }
 }

--- a/src/shared/lib/services/usage-service.test.ts
+++ b/src/shared/lib/services/usage-service.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import * as path from 'path'
 
-import { loadDailyUsageData as loadDailyUsageDataLightweight } from './usage-service'
+import { loadDailyUsageData as loadDailyUsageDataLightweight, calculateCost } from './usage-service'
 
 const FIXTURES_DIR = path.resolve(__dirname, '__fixtures__/usage-data')
 
@@ -258,6 +258,58 @@ describe('usage-service', () => {
       // costUSD was 0.0023 + 0.0045 = 0.0068
       // Hardcoded pricing would give a different number
       expect(dec5.totalCost).toBeCloseTo(0.0068, 6)
+    })
+  })
+
+  describe('calculateCost — GPT pricing + 272K long-context cliff', () => {
+    it('prices GPT models that are absent from the old Claude-only table (was $0)', () => {
+      // 100K input, 1K output, below the cliff: $5 input / $30 output per 1M.
+      expect(calculateCost('gpt-5.5', 100_000, 1_000, 0, 0)).toBeCloseTo(
+        (100_000 * 5 + 1_000 * 30) / 1_000_000,
+        9,
+      )
+      // OpenRouter-prefixed id resolves too.
+      expect(calculateCost('openai/gpt-5.4', 100_000, 1_000, 0, 0)).toBeCloseTo(
+        (100_000 * 2.5 + 1_000 * 15) / 1_000_000,
+        9,
+      )
+    })
+
+    it('reprices the whole request above 272K input (2x input / 1.5x output)', () => {
+      expect(calculateCost('gpt-5.5', 300_000, 2_000, 0, 0)).toBeCloseTo(
+        (300_000 * 10 + 2_000 * 45) / 1_000_000,
+        9,
+      )
+      expect(calculateCost('gpt-5.4', 300_000, 2_000, 0, 0)).toBeCloseTo(
+        (300_000 * 5 + 2_000 * 22.5) / 1_000_000,
+        9,
+      )
+    })
+
+    it('counts cache reads toward the threshold (cliff is on full prompt input)', () => {
+      // 50K fresh + 250K cache reads = 300K prompt input → over 272K.
+      expect(calculateCost('gpt-5.5', 50_000, 0, 0, 250_000)).toBeCloseTo(
+        (50_000 * 10 + 250_000 * 1) / 1_000_000,
+        9,
+      )
+    })
+
+    it('stays on the short rate exactly at 272K (cliff is strictly >)', () => {
+      expect(calculateCost('gpt-5.5', 272_000, 0, 0, 0)).toBeCloseTo(
+        (272_000 * 5) / 1_000_000,
+        9,
+      )
+    })
+
+    it('Claude models have no cliff — large prompts stay linear', () => {
+      expect(calculateCost('claude-opus-4-6', 500_000, 10_000, 0, 0)).toBeCloseTo(
+        (500_000 * 5 + 10_000 * 25) / 1_000_000,
+        9,
+      )
+    })
+
+    it('returns 0 for unknown models', () => {
+      expect(calculateCost('totally-unknown', 100_000, 1_000, 0, 0)).toBe(0)
     })
   })
 

--- a/src/shared/lib/services/usage-service.ts
+++ b/src/shared/lib/services/usage-service.ts
@@ -58,25 +58,45 @@ interface CountedUsage {
 // When costUSD is present in the JSONL entry, it takes precedence over this table.
 import MODEL_PRICING from './model-pricing.json'
 
+interface RateCard {
+  input: number
+  output: number
+  cacheCreation: number
+  cacheRead: number
+}
+
+interface PricingEntry extends RateCard {
+  // OpenAI GPT-5.x 272K cliff: above `thresholdTokens` of prompt input the whole
+  // request reprices at these rates. Mirror of the proxy's pricing table.
+  longContext?: RateCard & { thresholdTokens: number }
+}
+
 /**
  * Calculate cost from token counts using hardcoded pricing.
  * Returns 0 for unknown models.
  */
-function calculateCost(
+export function calculateCost(
   model: string,
   inputTokens: number,
   outputTokens: number,
   cacheCreationTokens: number,
   cacheReadTokens: number,
 ): number {
-  const pricing = (MODEL_PRICING as Record<string, { input: number; output: number; cacheCreation: number; cacheRead: number }>)[model]
+  const pricing = (MODEL_PRICING as Record<string, PricingEntry>)[model]
   if (!pricing) return 0
 
+  // Cliff triggers on full prompt input (input excludes cache reads in this
+  // shape, so add them back) and reprices the whole request once tripped.
+  const rates =
+    pricing.longContext && inputTokens + cacheReadTokens > pricing.longContext.thresholdTokens
+      ? pricing.longContext
+      : pricing
+
   return (
-    (inputTokens * pricing.input +
-      outputTokens * pricing.output +
-      cacheCreationTokens * pricing.cacheCreation +
-      cacheReadTokens * pricing.cacheRead) /
+    (inputTokens * rates.input +
+      outputTokens * rates.output +
+      cacheCreationTokens * rates.cacheCreation +
+      cacheReadTokens * rates.cacheRead) /
     1_000_000
   )
 }


### PR DESCRIPTION
Two related GPT-pricing gaps in SuperAgent, both stemming from OpenAI's **272K long-context cliff** (GPT-5.4/5.5 reprice the whole request ~1.5–2× once prompt input crosses 272K tokens). Billing itself is correct via the platform proxy (platform PR #104); this is the SuperAgent-side display.

## 1. Picker warning (new)

The model picker gave no signal, so a user could pick GPT for a large-context agent and silently pay more.

- `ModelDefinition` gains an optional, generic `longContextPriceCliff` (`thresholdTokens` + `inputMultiplier` + `outputMultiplier`) — no model id leaks into the component.
- Set on all four GPT catalog entries (Platform `gpt-5.4`/`gpt-5.5` + OpenRouter `openai/gpt-5.4`/`openai/gpt-5.5`) via a shared constant.
- The picker renders a soft, formal note when the selected model carries a cliff, mirroring the existing no-web-search warning. Data-driven, so Claude/GLM show nothing.
- Copy: *"Note: beyond about 26% of the context window, pricing increases by roughly 1.5–2×."* (threshold framed as a share of the context window when known.)

## 2. Usage dashboard cost (was $0 for GPT)

`usage-service` computes cost from `model-pricing.json` (`entry.costUSD` is present in only 2/130 transcript fixtures — normal assistant entries have none), but the table was Claude-only, so **every GPT run displayed $0**.

- Add `gpt-5.4`/`gpt-5.5` + `openai/gpt-5.*` to `model-pricing.json` with a `longContext` tier.
- `calculateCost` applies the same 272K cliff the proxy bills at (`inputTokens + cacheReadTokens > 272K` reprices the whole request); exported for direct unit testing.

## Tests

- `model-catalog-schema.test.ts`: accepts/omits `longContextPriceCliff`, rejects non-positive values.
- `model-family-list.test.tsx`: GPT shows the warning (26% / 1.5–2×), Claude doesn't; `longContextWarningText` percent + token-fallback paths; `formatTokenThreshold`.
- `usage-service.test.ts`: GPT priced (was $0), >272K reprice, cache-reads count toward threshold, exactly-272K stays short, Claude linear, unknown → 0.
- 55 touched tests pass; typecheck clean for touched files (pre-existing `tools/*` e2b errors unrelated).

## Known follow-up (out of scope)

`scripts/fetch-model-pricing.ts` regenerates `model-pricing.json` claude-only, so a regen would wipe these manual GPT entries (same as the proxy generator). Tracked separately.

## Test plan

- [ ] Picker: select GPT-5.5 → soft pricing note; select Claude → none.
- [ ] Usage dashboard: a GPT run shows non-zero cost; a >272K run shows the higher rate.