### PR TITLE
fix(usage): price GPT models incl. 272K cliff in usage dashboard

### DIFF
--- a/src/shared/lib/services/model-pricing.json
+++ b/src/shared/lib/services/model-pricing.json
@@ -130,5 +130,57 @@
     "output": 15,
     "cacheCreation": 3.75,
     "cacheRead": 0.3
+  },
+  "gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheCreation": 2.5,
+    "cacheRead": 0.25,
+    "longContext": {
+      "thresholdTokens": 272000,
+      "input": 5,
+      "output": 22.5,
+      "cacheCreation": 5,
+      "cacheRead": 0.5
+    }
+  },
+  "gpt-5.5": {
+    "input": 5,
+    "output": 30,
+    "cacheCreation": 5,
+    "cacheRead": 0.5,
+    "longContext": {
+      "thresholdTokens": 272000,
+      "input": 10,
+      "output": 45,
+      "cacheCreation": 10,
+      "cacheRead": 1
+    }
+  },
+  "openai/gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheCreation": 2.5,
+    "cacheRead": 0.25,
+    "longContext": {
+      "thresholdTokens": 272000,
+      "input": 5,
+      "output": 22.5,
+      "cacheCreation": 5,
+      "cacheRead": 0.5
+    }
+  },
+  "openai/gpt-5.5": {
+    "input": 5,
+    "output": 30,
+    "cacheCreation": 5,
+    "cacheRead": 0.5,
+    "longContext": {
+      "thresholdTokens": 272000,
+      "input": 10,
+      "output": 45,
+      "cacheCreation": 10,
+      "cacheRead": 1
+    }
   }
 }

--- a/src/shared/lib/services/usage-service.test.ts
+++ b/src/shared/lib/services/usage-service.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import * as path from 'path'
 
-import { loadDailyUsageData as loadDailyUsageDataLightweight } from './usage-service'
+import { loadDailyUsageData as loadDailyUsageDataLightweight, calculateCost } from './usage-service'
 
 const FIXTURES_DIR = path.resolve(__dirname, '__fixtures__/usage-data')
 
@@ -258,6 +258,58 @@ describe('usage-service', () => {
       // costUSD was 0.0023 + 0.0045 = 0.0068
       // Hardcoded pricing would give a different number
       expect(dec5.totalCost).toBeCloseTo(0.0068, 6)
+    })
+  })
+
+  describe('calculateCost — GPT pricing + 272K long-context cliff', () => {
+    it('prices GPT models that are absent from the old Claude-only table (was $0)', () => {
+      // 100K input, 1K output, below the cliff: $5 input / $30 output per 1M.
+      expect(calculateCost('gpt-5.5', 100_000, 1_000, 0, 0)).toBeCloseTo(
+        (100_000 * 5 + 1_000 * 30) / 1_000_000,
+        9,
+      )
+      // OpenRouter-prefixed id resolves too.
+      expect(calculateCost('openai/gpt-5.4', 100_000, 1_000, 0, 0)).toBeCloseTo(
+        (100_000 * 2.5 + 1_000 * 15) / 1_000_000,
+        9,
+      )
+    })
+
+    it('reprices the whole request above 272K input (2x input / 1.5x output)', () => {
+      expect(calculateCost('gpt-5.5', 300_000, 2_000, 0, 0)).toBeCloseTo(
+        (300_000 * 10 + 2_000 * 45) / 1_000_000,
+        9,
+      )
+      expect(calculateCost('gpt-5.4', 300_000, 2_000, 0, 0)).toBeCloseTo(
+        (300_000 * 5 + 2_000 * 22.5) / 1_000_000,
+        9,
+      )
+    })
+
+    it('counts cache reads toward the threshold (cliff is on full prompt input)', () => {
+      // 50K fresh + 250K cache reads = 300K prompt input → over 272K.
+      expect(calculateCost('gpt-5.5', 50_000, 0, 0, 250_000)).toBeCloseTo(
+        (50_000 * 10 + 250_000 * 1) / 1_000_000,
+        9,
+      )
+    })
+
+    it('stays on the short rate exactly at 272K (cliff is strictly >)', () => {
+      expect(calculateCost('gpt-5.5', 272_000, 0, 0, 0)).toBeCloseTo(
+        (272_000 * 5) / 1_000_000,
+        9,
+      )
+    })
+
+    it('Claude models have no cliff — large prompts stay linear', () => {
+      expect(calculateCost('claude-opus-4-6', 500_000, 10_000, 0, 0)).toBeCloseTo(
+        (500_000 * 5 + 10_000 * 25) / 1_000_000,
+        9,
+      )
+    })
+
+    it('returns 0 for unknown models', () => {
+      expect(calculateCost('totally-unknown', 100_000, 1_000, 0, 0)).toBe(0)
     })
   })
 

--- a/src/shared/lib/services/usage-service.ts
+++ b/src/shared/lib/services/usage-service.ts
@@ -58,25 +58,45 @@ interface CountedUsage {
 // When costUSD is present in the JSONL entry, it takes precedence over this table.
 import MODEL_PRICING from './model-pricing.json'
 
+interface RateCard {
+  input: number
+  output: number
+  cacheCreation: number
+  cacheRead: number
+}
+
+interface PricingEntry extends RateCard {
+  // OpenAI GPT-5.x 272K cliff: above `thresholdTokens` of prompt input the whole
+  // request reprices at these rates. Mirror of the proxy's pricing table.
+  longContext?: RateCard & { thresholdTokens: number }
+}
+
 /**
  * Calculate cost from token counts using hardcoded pricing.
  * Returns 0 for unknown models.
  */
-function calculateCost(
+export function calculateCost(
   model: string,
   inputTokens: number,
   outputTokens: number,
   cacheCreationTokens: number,
   cacheReadTokens: number,
 ): number {
-  const pricing = (MODEL_PRICING as Record<string, { input: number; output: number; cacheCreation: number; cacheRead: number }>)[model]
+  const pricing = (MODEL_PRICING as Record<string, PricingEntry>)[model]
   if (!pricing) return 0
 
+  // Cliff triggers on full prompt input (input excludes cache reads in this
+  // shape, so add them back) and reprices the whole request once tripped.
+  const rates =
+    pricing.longContext && inputTokens + cacheReadTokens > pricing.longContext.thresholdTokens
+      ? pricing.longContext
+      : pricing
+
   return (
-    (inputTokens * pricing.input +
-      outputTokens * pricing.output +
-      cacheCreationTokens * pricing.cacheCreation +
-      cacheReadTokens * pricing.cacheRead) /
+    (inputTokens * rates.input +
+      outputTokens * rates.output +
+      cacheCreationTokens * rates.cacheCreation +
+      cacheReadTokens * rates.cacheRead) /
     1_000_000
   )
 }


### PR DESCRIPTION
## What was broken

The local **usage dashboard** (`usage-service.ts`) shows $0 for every GPT run.

`loadDailyUsageData` uses `entry.costUSD` when present, else computes cost from `model-pricing.json`. But `costUSD` is **almost never in the transcripts** — only **2 of 130** fixture files carry it; normal assistant entries have just `{ timestamp, type, requestId, message }`. So `calculateCost(model, …)` keyed off `model-pricing.json` is the *actual* cost path — and that table was **Claude-only**. GPT models (`gpt-5.4`, `gpt-5.5`, `openai/gpt-5.*`) miss the lookup → cost `0`.

## What changed

- Add `gpt-5.4` / `gpt-5.5` (Platform bare ids) and `openai/gpt-5.4` / `openai/gpt-5.5` (OpenRouter ids) to `model-pricing.json`.
- Apply the **same 272K long-context cliff the proxy bills at** (platform PR #104): once a request's prompt input (`inputTokens + cacheReadTokens`, since input excludes cache reads in this shape) crosses 272K, the whole request reprices **2× input / 1.5× output**.
- Export `calculateCost` and unit-test it directly (the cliff is pure logic).
- Claude and unknown models are unchanged.

### Rates (mirror of the proxy table)

| Model | input ≤272K | input >272K | output ≤272K | output >272K |
|---|---|---|---|---|
| gpt-5.4 | $2.50 | $5.00 | $15.00 | $22.50 |
| gpt-5.5 | $5.00 | $10.00 | $30.00 | $45.00 |

## Tests

`usage-service.test.ts` adds: GPT priced (was $0), >272K reprice, cache-reads-count-toward-threshold, exactly-272K stays short, Claude stays linear, unknown → 0. All 27 tests pass; typecheck clean for touched files.

## Known follow-up (out of scope)

`scripts/fetch-model-pricing.ts` regenerates `model-pricing.json` from LiteLLM **claude-only**, so a regen would wipe these manual GPT entries (same as the proxy's generator). Tracked separately.

## Test plan

- [ ] Run a GPT-5.5 agent, open the usage dashboard → non-zero cost.
- [ ] A GPT run with >272K context shows the doubled rate.

Made with [Cursor](https://cursor.com)