### PR TITLE
chore: exclude tools/ from typecheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     }
   },
   "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "agent-container", "dist"]
+  "exclude": ["node_modules", "agent-container", "dist", "tools"]
 }


### PR DESCRIPTION
## What was broken

`npm run typecheck` (`tsc --noEmit`) failed with ~12 errors, all in `tools/*.ts` — standalone POC/verify scripts for storage experiments (S3 Files / e2b / daytona). They import optional SDKs (`e2b`, `@daytonaio/sdk`) that aren't project dependencies, plus a few implicit-any params.

## What changed

Add `tools` to the `tsconfig.json` `exclude` list.

- These are throwaway scripts run via `tsx`, not part of the app (`src/`) or the build.
- Verified nothing in `src/` imports `tools/`.
- After the change, `tsc --noEmit` exits 0.

No app code touched.

Made with [Cursor](https://cursor.com)