### PR TITLE
fix(telegram): stop the "Thinking…" indicator leaking on errored/stalled turns

### DIFF
--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -1502,11 +1502,15 @@ async function onWorkingWatchdogFired(managed: ManagedConnector): Promise<void> 
   // flatly assert the agent died.
   if (!managed.turnNotified) {
     managed.turnNotified = true
-    await managed.connector
-      .sendMessage(managed.chatId, {
+    try {
+      await managed.connector.sendMessage(managed.chatId, {
         text: "⚠️ This is taking longer than expected. If you don't see a reply soon, send your message again.",
       })
-      .catch(() => {})
+    } catch {
+      // Delivery failed — release the latch so a later terminal notice (e.g. a real
+      // session_error) can still reach the user instead of being suppressed.
+      managed.turnNotified = false
+    }
   }
 }
 
@@ -1690,11 +1694,13 @@ export async function processSSEEvent(
       await settleTurn(managed)
       if (!managed.turnNotified) {
         managed.turnNotified = true
-        await managed.connector
-          .sendMessage(managed.chatId, { text: friendlyErrorMessage(data.apiErrorCode as string | null) })
-          .catch((err) => {
-            console.error('[ChatIntegrationManager] Failed to send error message:', err)
-          })
+        try {
+          await managed.connector.sendMessage(managed.chatId, { text: friendlyErrorMessage(data.apiErrorCode as string | null) })
+        } catch (err) {
+          // Delivery failed — release the latch so a later notice isn't suppressed.
+          managed.turnNotified = false
+          console.error('[ChatIntegrationManager] Failed to send error message:', err)
+        }
       }
       break
     }
@@ -1728,14 +1734,25 @@ export async function finalizeStreaming(managed: ManagedConnector): Promise<void
     lastUpdateTime: 0,
   }
 
-  if (messageId) {
-    try {
-      await managed.connector.finalizeStreamingMessage(managed.chatId, messageId, finalText)
-    } catch {
+  try {
+    if (messageId) {
+      try {
+        await managed.connector.finalizeStreamingMessage(managed.chatId, messageId, finalText)
+      } catch {
+        await managed.connector.sendMessage(managed.chatId, { text: finalText })
+      }
+    } else {
       await managed.connector.sendMessage(managed.chatId, { text: finalText })
     }
-  } else {
-    await managed.connector.sendMessage(managed.chatId, { text: finalText })
+  } catch (err) {
+    // Both delivery attempts failed (chat unreachable). Restore the claimed buffer so
+    // a later terminal path can retry — but only if no concurrent finalize has since
+    // claimed a new one, so we never resurrect already-sent text. Re-throw so callers
+    // log/handle the failure exactly as before.
+    if (!managed.streamingState.accumulatedText) {
+      managed.streamingState = { currentMessageId: messageId, accumulatedText: finalText, lastUpdateTime: 0 }
+    }
+    throw err
   }
 }
 

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -102,8 +102,12 @@ const HEALTH_CHECK_ERROR_THRESHOLD_MS = 5 * 60 * 1000
 // completely silent (no SSE events) for this long, assume it stalled and tear
 // the indicator down. The backstop for any missing-terminal-event path (SDK
 // stall, dropped stream, an event type nobody handles). Reset on any activity,
-// so a healthy long turn never trips it.
-const WORKING_WATCHDOG_MS = 3 * 60 * 1000
+// so a healthy long turn never trips it. Set generously: a single silent tool
+// call (a long build / install / search that streams nothing) is legitimate
+// work, so the threshold must clear that before it assumes a stall — and even
+// then the notice is softened (see onWorkingWatchdogFired) because it can be a
+// false positive on slow-but-alive work.
+const WORKING_WATCHDOG_MS = 5 * 60 * 1000
 const HEALTH_CHECK_MAX_CONSECUTIVE_FAILURES = 15
 const MAX_FILE_DOWNLOAD_SIZE = 50 * 1024 * 1024 // 50 MB
 
@@ -141,6 +145,11 @@ export interface ManagedConnector {
   // Idle-silence watchdog timer (see WORKING_WATCHDOG_MS). Armed when the
   // working indicator is shown, reset on every SSE event, cleared on teardown.
   watchdogTimer?: ReturnType<typeof setTimeout> | null
+  // True once a terminal user-facing notice (the session_error message or the
+  // watchdog stall notice) has gone out for the current turn, so a watchdog /
+  // session_error overlap can't double-notify. Reset whenever the indicator is
+  // (re)armed for a new turn or segment.
+  turnNotified?: boolean
 }
 
 // ── Manager ─────────────────────────────────────────────────────────────
@@ -1453,9 +1462,17 @@ function clearWorkingWatchdog(managed: ManagedConnector): void {
  */
 function armWorkingWatchdog(managed: ManagedConnector): void {
   clearWorkingWatchdog(managed)
-  managed.watchdogTimer = setTimeout(() => {
+  // A freshly-shown indicator is a fresh turn/segment: allow one terminal notice.
+  managed.turnNotified = false
+  const timer = setTimeout(() => {
+    // Ignore a stale fire. If the watchdog was cleared or re-armed after this
+    // timer was scheduled (clearTimeout can't un-queue an already-fired timer),
+    // managed.watchdogTimer no longer points at us — do nothing.
+    if (managed.watchdogTimer !== timer) return
+    managed.watchdogTimer = null
     void onWorkingWatchdogFired(managed)
   }, WORKING_WATCHDOG_MS)
+  managed.watchdogTimer = timer
 }
 
 /** Reset the watchdog only if it is currently armed — any SSE event proves liveness. */
@@ -1464,7 +1481,6 @@ function resetWatchdogIfRunning(managed: ManagedConnector): void {
 }
 
 async function onWorkingWatchdogFired(managed: ManagedConnector): Promise<void> {
-  managed.watchdogTimer = null
   console.warn(
     `[ChatIntegrationManager] Working-indicator watchdog fired after ${WORKING_WATCHDOG_MS}ms of silence (chat ${managed.chatId})`,
   )
@@ -1480,11 +1496,18 @@ async function onWorkingWatchdogFired(managed: ManagedConnector): Promise<void> 
     'warning',
   )
   await settleTurn(managed)
-  await managed.connector
-    .sendMessage(managed.chatId, {
-      text: '⚠️ The assistant stopped responding. Send your message again to retry.',
-    })
-    .catch(() => {})
+  // Notify at most once per turn: if a near-simultaneous session_error already
+  // surfaced its message, don't pile a second notice on top. Softened copy — the
+  // watchdog can be a false positive on a slow-but-alive turn, so it must not
+  // flatly assert the agent died.
+  if (!managed.turnNotified) {
+    managed.turnNotified = true
+    await managed.connector
+      .sendMessage(managed.chatId, {
+        text: "⚠️ This is taking longer than expected. If you don't see a reply soon, send your message again.",
+      })
+      .catch(() => {})
+  }
 }
 
 /**
@@ -1665,11 +1688,14 @@ export async function processSSEEvent(
       // "Thinking…" forever. Settle the turn the same way session_idle does, then
       // surface the error so the user isn't left staring at a frozen indicator.
       await settleTurn(managed)
-      await managed.connector
-        .sendMessage(managed.chatId, { text: friendlyErrorMessage(data.apiErrorCode as string | null) })
-        .catch((err) => {
-          console.error('[ChatIntegrationManager] Failed to send error message:', err)
-        })
+      if (!managed.turnNotified) {
+        managed.turnNotified = true
+        await managed.connector
+          .sendMessage(managed.chatId, { text: friendlyErrorMessage(data.apiErrorCode as string | null) })
+          .catch((err) => {
+            console.error('[ChatIntegrationManager] Failed to send error message:', err)
+          })
+      }
       break
     }
   }

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -1745,10 +1745,10 @@ export async function finalizeStreaming(managed: ManagedConnector): Promise<void
       await managed.connector.sendMessage(managed.chatId, { text: finalText })
     }
   } catch (err) {
-    // Both delivery attempts failed (chat unreachable). Restore the claimed buffer so
-    // a later terminal path can retry — but only if no concurrent finalize has since
-    // claimed a new one, so we never resurrect already-sent text. Re-throw so callers
-    // log/handle the failure exactly as before.
+    // Both delivery attempts failed (chat unreachable) — nothing reached the user.
+    // Restore the claimed buffer so a later terminal path can retry, but only if it
+    // is still empty, so we never overwrite newer streamed text (a later stream_delta
+    // repopulated it). Re-throw so callers log/handle the failure exactly as before.
     if (!managed.streamingState.accumulatedText) {
       managed.streamingState = { currentMessageId: messageId, accumulatedText: finalText, lastUpdateTime: 0 }
     }

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -98,6 +98,12 @@ const IMESSAGE_SYSTEM_PROMPT = `This is an iMessage-based conversation. Follow t
 
 const HEALTH_CHECK_INTERVAL_MS = 5 * 60 * 1000
 const HEALTH_CHECK_ERROR_THRESHOLD_MS = 5 * 60 * 1000
+// Idle-silence watchdog: if a turn shows the working indicator and then goes
+// completely silent (no SSE events) for this long, assume it stalled and tear
+// the indicator down. The backstop for any missing-terminal-event path (SDK
+// stall, dropped stream, an event type nobody handles). Reset on any activity,
+// so a healthy long turn never trips it.
+const WORKING_WATCHDOG_MS = 3 * 60 * 1000
 const HEALTH_CHECK_MAX_CONSECUTIVE_FAILURES = 15
 const MAX_FILE_DOWNLOAD_SIZE = 50 * 1024 * 1024 // 50 MB
 
@@ -132,6 +138,9 @@ export interface ManagedConnector {
   }
   currentToolInput: string
   pendingToolMessages: Array<{ messageId: string; text: string }>
+  // Idle-silence watchdog timer (see WORKING_WATCHDOG_MS). Armed when the
+  // working indicator is shown, reset on every SSE event, cleared on teardown.
+  watchdogTimer?: ReturnType<typeof setTimeout> | null
 }
 
 // ── Manager ─────────────────────────────────────────────────────────────
@@ -826,7 +835,10 @@ class ChatIntegrationManager {
 
     // Show the "Thinking…" indicator (the connector keeps it alive) until the first token streams.
     const dispatched = this.chatSessions.get(this.getChatSessionKey(integrationId, chatId))
-    if (dispatched) dispatched.connector.startWorking(dispatched.chatId).catch(() => {})
+    if (dispatched) {
+      dispatched.connector.startWorking(dispatched.chatId).catch(() => {})
+      armWorkingWatchdog(dispatched)
+    }
   }
 
   /**
@@ -908,6 +920,7 @@ class ChatIntegrationManager {
   private stopSession(session: ManagedConnector): void {
     session.sseUnsubscribe?.()
     session.connector.stopWorking(session.chatId).catch(() => {})
+    clearWorkingWatchdog(session)
   }
 
   private teardownManagedSession(integrationId: string, chatId: string, opts?: { archive?: string }): void {
@@ -1404,6 +1417,92 @@ class ChatIntegrationManager {
   }
 }
 
+// ── Working-indicator teardown + idle watchdog ─────────────────────────
+
+/**
+ * Tear down a turn's live UI: stop the working indicator (kills the keep-alive
+ * heartbeat), commit any streamed text, and settle pending tool pills. Shared by
+ * session_idle, session_error, and the idle watchdog so every terminal path
+ * clears the indicator the same way. Idempotent.
+ */
+async function settleTurn(managed: ManagedConnector): Promise<void> {
+  clearWorkingWatchdog(managed)
+  managed.connector.stopWorking(managed.chatId).catch(() => {})
+  try {
+    await finalizeStreaming(managed)
+    await resolvePendingToolMessages(managed)
+  } catch (err) {
+    console.error('[ChatIntegrationManager] Failed to finalize turn:', err)
+    reportError(err, 'settle-turn', { integrationId: managed.integration.id, chatId: managed.chatId })
+  }
+}
+
+/** Clear the idle watchdog timer (if armed). */
+function clearWorkingWatchdog(managed: ManagedConnector): void {
+  if (managed.watchdogTimer) {
+    clearTimeout(managed.watchdogTimer)
+    managed.watchdogTimer = null
+  }
+}
+
+/**
+ * (Re)arm the idle watchdog. Called when the working indicator is shown (dispatch
+ * / stream_start) and reset on every subsequent SSE event, so it fires only after
+ * a full WORKING_WATCHDOG_MS of total silence — a stalled turn that never emits a
+ * terminal event.
+ */
+function armWorkingWatchdog(managed: ManagedConnector): void {
+  clearWorkingWatchdog(managed)
+  managed.watchdogTimer = setTimeout(() => {
+    void onWorkingWatchdogFired(managed)
+  }, WORKING_WATCHDOG_MS)
+}
+
+/** Reset the watchdog only if it is currently armed — any SSE event proves liveness. */
+function resetWatchdogIfRunning(managed: ManagedConnector): void {
+  if (managed.watchdogTimer) armWorkingWatchdog(managed)
+}
+
+async function onWorkingWatchdogFired(managed: ManagedConnector): Promise<void> {
+  managed.watchdogTimer = null
+  console.warn(
+    `[ChatIntegrationManager] Working-indicator watchdog fired after ${WORKING_WATCHDOG_MS}ms of silence (chat ${managed.chatId})`,
+  )
+  reportError(
+    new Error('working-indicator watchdog fired after SSE silence'),
+    'working-indicator-watchdog',
+    {
+      integrationId: managed.integration.id,
+      chatId: managed.chatId,
+      agentSlug: managed.integration.agentSlug,
+      silenceMs: WORKING_WATCHDOG_MS,
+    },
+    'warning',
+  )
+  await settleTurn(managed)
+  await managed.connector
+    .sendMessage(managed.chatId, {
+      text: '⚠️ The assistant stopped responding. Send your message again to retry.',
+    })
+    .catch(() => {})
+}
+
+/**
+ * A short, user-facing message for a turn that ended in an error. Curated by the
+ * SDK error code; never echoes the raw internal error (which can leak file paths,
+ * tokens, or stack text into the chat).
+ */
+function friendlyErrorMessage(apiErrorCode: string | null | undefined): string {
+  const code = (apiErrorCode ?? '').toLowerCase()
+  if (code.includes('overload')) return '⚠️ The assistant is overloaded right now. Please try again in a moment.'
+  if (code.includes('rate') || code.includes('429')) return '⚠️ Hit a rate limit. Please wait a few seconds and try again.'
+  if (code.includes('auth') || code.includes('permission')) return '⚠️ The assistant could not authenticate. Please check the integration settings.'
+  if (code.includes('context') || code.includes('too_long') || code.includes('too_large') || code.includes('length')) {
+    return '⚠️ This conversation got too long for the assistant. Try starting a new conversation.'
+  }
+  return '⚠️ The assistant hit an error and stopped. Please try again.'
+}
+
 // ── SSE event processing (exported for testing) ────────────────────────
 
 /**
@@ -1418,6 +1517,10 @@ export async function processSSEEvent(
   const data = event as Record<string, unknown>
   const eventType = data.type as string
 
+  // Any agent activity proves the turn is alive: push the idle watchdog out.
+  // No-op when the indicator isn't currently armed.
+  resetWatchdogIfRunning(managed)
+
   switch (eventType) {
     case 'stream_delta': {
       const text = data.text as string
@@ -1427,6 +1530,7 @@ export async function processSSEEvent(
       // not on every streamed token.
       if (managed.streamingState.accumulatedText === '') {
         managed.connector.stopWorking(managed.chatId).catch(() => {})
+        clearWorkingWatchdog(managed)
       }
       managed.streamingState.accumulatedText += text
 
@@ -1458,6 +1562,7 @@ export async function processSSEEvent(
       // "Thinking…" again for the next segment. startWorking self-keep-alives, so a
       // long gap before the next token no longer drops it; the first token replaces it.
       managed.connector.startWorking(managed.chatId).catch(() => {})
+      armWorkingWatchdog(managed)
       break
     }
 
@@ -1536,6 +1641,9 @@ export async function processSSEEvent(
     case 'browser_input_request':
     case 'script_run_request':
     case 'computer_use_request': {
+      // The agent is now waiting on the user, so the silence that follows is the
+      // human, not a stall — pause the idle watchdog until the next turn re-arms it.
+      clearWorkingWatchdog(managed)
       try {
         await managed.connector.sendUserRequestCard(managed.chatId, data as UserRequestEvent)
       } catch (err) {
@@ -1546,14 +1654,22 @@ export async function processSSEEvent(
     }
 
     case 'session_idle': {
-      managed.connector.stopWorking(managed.chatId).catch(() => {})
-      try {
-        await finalizeStreaming(managed)
-        await resolvePendingToolMessages(managed)
-      } catch (err) {
-        console.error('[ChatIntegrationManager] Failed to finalize on session_idle:', err)
-        reportError(err, 'session-idle-finalize', { integrationId: managed.integration.id, chatId: managed.chatId })
-      }
+      await settleTurn(managed)
+      break
+    }
+
+    case 'session_error': {
+      // An errored turn emits session_error (NOT session_idle), and the host
+      // suppresses the later authoritative idle. Without this case the working
+      // indicator's keep-alive heartbeat is never torn down and re-stamps
+      // "Thinking…" forever. Settle the turn the same way session_idle does, then
+      // surface the error so the user isn't left staring at a frozen indicator.
+      await settleTurn(managed)
+      await managed.connector
+        .sendMessage(managed.chatId, { text: friendlyErrorMessage(data.apiErrorCode as string | null) })
+        .catch((err) => {
+          console.error('[ChatIntegrationManager] Failed to send error message:', err)
+        })
       break
     }
   }

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -1716,25 +1716,26 @@ export async function resolvePendingToolMessages(managed: ManagedConnector): Pro
 export async function finalizeStreaming(managed: ManagedConnector): Promise<void> {
   const finalText = managed.streamingState.accumulatedText
   if (!finalText) return
+  const messageId = managed.streamingState.currentMessageId
 
-  if (managed.streamingState.currentMessageId) {
+  // Claim the buffer synchronously, before the first await, so a concurrent
+  // finalize (e.g. the idle watchdog tearing down while a late stream event is
+  // processed) reads an empty buffer and can't double-send the same text. The
+  // reset previously ran only after the await, leaving that window open.
+  managed.streamingState = {
+    currentMessageId: null,
+    accumulatedText: '',
+    lastUpdateTime: 0,
+  }
+
+  if (messageId) {
     try {
-      await managed.connector.finalizeStreamingMessage(
-        managed.chatId,
-        managed.streamingState.currentMessageId,
-        finalText,
-      )
+      await managed.connector.finalizeStreamingMessage(managed.chatId, messageId, finalText)
     } catch {
       await managed.connector.sendMessage(managed.chatId, { text: finalText })
     }
   } else {
     await managed.connector.sendMessage(managed.chatId, { text: finalText })
-  }
-
-  managed.streamingState = {
-    currentMessageId: null,
-    accumulatedText: '',
-    lastUpdateTime: 0,
   }
 }
 

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -146,9 +146,9 @@ export interface ManagedConnector {
   // working indicator is shown, reset on every SSE event, cleared on teardown.
   watchdogTimer?: ReturnType<typeof setTimeout> | null
   // True once a terminal user-facing notice (the session_error message or the
-  // watchdog stall notice) has gone out for the current turn, so a watchdog /
-  // session_error overlap can't double-notify. Reset whenever the indicator is
-  // (re)armed for a new turn or segment.
+  // watchdog stall notice) has gone out for the current turn, so a turn can't
+  // emit repeated/duplicate notices. Reset once per turn at dispatch (not per
+  // segment), so a multi-stall turn still yields at most one notice.
   turnNotified?: boolean
 }
 
@@ -845,6 +845,11 @@ class ChatIntegrationManager {
     // Show the "Thinking…" indicator (the connector keeps it alive) until the first token streams.
     const dispatched = this.chatSessions.get(this.getChatSessionKey(integrationId, chatId))
     if (dispatched) {
+      // New user turn: re-allow exactly one terminal notice (the watchdog stall
+      // notice OR the session_error message). Reset here, once per turn, rather
+      // than on every stream_start, so a single multi-stall turn can't emit
+      // repeated notices.
+      dispatched.turnNotified = false
       dispatched.connector.startWorking(dispatched.chatId).catch(() => {})
       armWorkingWatchdog(dispatched)
     }
@@ -1462,8 +1467,6 @@ function clearWorkingWatchdog(managed: ManagedConnector): void {
  */
 function armWorkingWatchdog(managed: ManagedConnector): void {
   clearWorkingWatchdog(managed)
-  // A freshly-shown indicator is a fresh turn/segment: allow one terminal notice.
-  managed.turnNotified = false
   const timer = setTimeout(() => {
     // Ignore a stale fire. If the watchdog was cleared or re-armed after this
     // timer was scheduled (clearTimeout can't un-queue an already-fired timer),

--- a/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
+++ b/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
@@ -139,6 +139,31 @@ describe('REPRO: perpetual "Thinking…" after a non-idle terminal event', () =>
     }
   })
 
+  it('LEAKS (race): a fire-and-forget startWorking must register the heartbeat before its send, so a racing stopWorking clears it', async () => {
+    vi.useFakeTimers()
+    try {
+      const { connector, sendRichMessageDraft } = makeRealDmConnector()
+
+      // Real dispatch / stream_start call startWorking fire-and-forget (un-awaited).
+      // If the keep-alive interval is registered only AFTER the initial awaited send,
+      // a terminal stopWorking that runs in that window finds no timer, and the late
+      // startWorking installs one after teardown — "Thinking…" leaks. The fix
+      // registers the interval synchronously, before the await.
+      void connector.startWorking(DM_CHAT)
+      // A terminal event settles the turn immediately, before the initial send resolves.
+      await connector.stopWorking(DM_CHAT)
+      // Let the in-flight startWorking send resolve.
+      await vi.advanceTimersByTimeAsync(1)
+      const sendsAfterStop = sendRichMessageDraft.mock.calls.length
+
+      // No heartbeat should remain after the racing stop.
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(sendRichMessageDraft.mock.calls.length).toBe(sendsAfterStop)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('CONTROL: the same flow ending in session_idle correctly stops the heartbeat', async () => {
     vi.useFakeTimers()
     try {

--- a/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
+++ b/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
@@ -1,0 +1,234 @@
+/**
+ * REPRODUCTION: Telegram "Thinking…" bubble runs forever after a turn that ends
+ * on a non-idle terminal event (an error result, or any path where the host
+ * never broadcasts `session_idle`).
+ *
+ * Root cause (verified end-to-end):
+ *  - The working indicator is a 1s keep-alive `setInterval` in TelegramConnector
+ *    (`workingTimers`) that re-sends `<tg-thinking>✨ Thinking…</tg-thinking>` to
+ *    the shared draft_id until `stopWorking` clears it.
+ *  - On the streaming path, `stopWorking` is reached ONLY via the first
+ *    `stream_delta` of a segment (guarded by an empty accumulator) or `session_idle`.
+ *  - When a turn ends in an error, message-persister broadcasts `session_error`
+ *    (NOT `session_idle`) and suppresses the later authoritative idle. But
+ *    `processSSEEvent` has NO `session_error` case — so nothing ever calls
+ *    `stopWorking`. The heartbeat re-stamps "Thinking…" forever (until the
+ *    connector disconnects / the server restarts).
+ *
+ * These tests assert the DESIRED behavior (the heartbeat stops). On current
+ * code the error/missing-idle cases FAIL — that failure IS the reproduction.
+ * The `session_idle` case is the positive control and passes today.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { processSSEEvent, type ManagedConnector } from './chat-integration-manager'
+import { TelegramConnector } from './telegram-connector'
+import { MockChatClientConnector } from './mock-connector'
+import type { ChatIntegration } from '@shared/lib/db/schema'
+
+function makeManaged(connector: ManagedConnector['connector'], chatId: string): ManagedConnector {
+  return {
+    connector,
+    integration: {
+      id: 'repro-integration',
+      agentSlug: 'repro-agent',
+      provider: 'telegram',
+      name: 'Repro Bot',
+      config: '{}',
+      showToolCalls: false,
+      status: 'active',
+      errorMessage: null,
+      createdByUserId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as ChatIntegration,
+    chatId,
+    sseUnsubscribe: null,
+    messageUnsubscribe: null,
+    interactiveUnsubscribe: null,
+    errorUnsubscribe: null,
+    streamingState: { currentMessageId: null, accumulatedText: '', lastUpdateTime: 0 },
+    currentToolInput: '',
+    pendingToolMessages: [],
+  }
+}
+
+/** A real TelegramConnector with a stubbed grammy bot that records draft sends. */
+function makeRealDmConnector() {
+  const connector = new TelegramConnector({ botToken: 'fake:token' })
+  const sendRichMessageDraft = vi.fn().mockResolvedValue(true)
+  const sendRichMessage = vi.fn().mockResolvedValue({ message_id: 1 })
+  ;(connector as unknown as { bot: unknown }).bot = {
+    api: { raw: { sendRichMessageDraft, sendRichMessage }, sendChatAction: vi.fn() },
+  }
+  return { connector, sendRichMessageDraft }
+}
+
+const DM_CHAT = '999' // positive id → private DM → native <tg-thinking> draft path
+
+describe('REPRO: perpetual "Thinking…" after a non-idle terminal event', () => {
+  it('LEAKS: an error-terminal turn (after a finished response) keeps re-sending "Thinking…" forever', async () => {
+    vi.useFakeTimers()
+    try {
+      const { connector, sendRichMessageDraft } = makeRealDmConnector()
+      const managed = makeManaged(connector, DM_CHAT)
+
+      // 1) A message arrives → the manager arms the indicator (dispatch site).
+      await connector.startWorking(DM_CHAT)
+
+      // 2) The agent streams a full answer. The first token clears the bubble and
+      //    the user SEES the response ("it finished its response").
+      await processSSEEvent(managed, { type: 'stream_start' })
+      managed.streamingState.lastUpdateTime = 0
+      await processSSEEvent(managed, { type: 'stream_delta', text: 'Here is your answer.' })
+
+      // 3) The agent begins one more segment (very common: text → tool → text, or
+      //    a trailing assistant block). stream_start RE-ARMS the keep-alive timer.
+      await processSSEEvent(managed, { type: 'stream_start' })
+      // Let the (un-awaited) startWorking inside processSSEEvent arm its interval.
+      await vi.advanceTimersByTimeAsync(1)
+
+      // 4) ...but the turn ends in an ERROR (e.g. API overloaded / rate limit), so
+      //    the host broadcasts `session_error`, NOT `session_idle`. processSSEEvent
+      //    has no case for it → stopWorking is never called.
+      await processSSEEvent(managed, {
+        type: 'session_error',
+        error: 'Overloaded (API 529)',
+        apiErrorCode: 'overloaded_error',
+        isActive: false,
+      })
+
+      const sendsAtError = sendRichMessageDraft.mock.calls.length
+
+      // No further events arrive. Any draft send in this idle window is the
+      // keep-alive heartbeat re-stamping "Thinking…".
+      await vi.advanceTimersByTimeAsync(30_000)
+      const sendsAfter30s = sendRichMessageDraft.mock.calls.length
+
+      // DESIRED: the indicator is torn down on the terminal event → no more sends.
+      // ACTUAL (bug): ~30 extra sends — "Thinking…" forever until restart.
+      expect(sendsAfter30s).toBe(sendsAtError)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('LEAKS: a turn that errors before any text streams strands the bubble immediately', async () => {
+    vi.useFakeTimers()
+    try {
+      const { connector, sendRichMessageDraft } = makeRealDmConnector()
+      const managed = makeManaged(connector, DM_CHAT)
+
+      // Message arrives → indicator armed. Agent errors immediately (no stream_delta
+      // ever clears it). e.g. rate-limit / auth / context-overflow on the first turn.
+      await connector.startWorking(DM_CHAT)
+      await processSSEEvent(managed, {
+        type: 'session_error',
+        error: 'rate_limit',
+        apiErrorCode: 'rate_limit_error',
+        isActive: false,
+      })
+
+      const sendsAtError = sendRichMessageDraft.mock.calls.length
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      // DESIRED: stopped. ACTUAL (bug): keeps firing forever.
+      expect(sendRichMessageDraft.mock.calls.length).toBe(sendsAtError)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('CONTROL: the same flow ending in session_idle correctly stops the heartbeat', async () => {
+    vi.useFakeTimers()
+    try {
+      const { connector, sendRichMessageDraft } = makeRealDmConnector()
+      const managed = makeManaged(connector, DM_CHAT)
+
+      await connector.startWorking(DM_CHAT)
+      await processSSEEvent(managed, { type: 'stream_start' })
+      managed.streamingState.lastUpdateTime = 0
+      await processSSEEvent(managed, { type: 'stream_delta', text: 'Here is your answer.' })
+      await processSSEEvent(managed, { type: 'stream_start' })
+      await vi.advanceTimersByTimeAsync(1)
+
+      // Proper terminal event → stopWorking → timer cleared.
+      await processSSEEvent(managed, { type: 'session_idle' })
+      const sendsAtIdle = sendRichMessageDraft.mock.calls.length
+
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(sendRichMessageDraft.mock.calls.length).toBe(sendsAtIdle)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+// ── Idle-silence watchdog (backstop for stalls / missing terminal events) ──
+// Even when NO terminal event ever arrives (a true SDK stall, a dropped stream,
+// a future event type nobody wired up), "Thinking…" must not run forever. The
+// watchdog clears the indicator after a stretch of total SSE silence, and resets
+// on any activity so a healthy long turn is never cut off.
+
+const WATCHDOG_MS = 3 * 60 * 1000
+
+function stalledMessageSent(connector: MockChatClientConnector): boolean {
+  return connector.sentMessages.some((m) => /stopped responding|try again/i.test(m.message.text))
+}
+
+describe('REPRO: idle-silence watchdog', () => {
+  it('fires after the silence threshold: clears the indicator and tells the user', async () => {
+    vi.useFakeTimers()
+    try {
+      const connector = new MockChatClientConnector()
+      const managed = makeManaged(connector, 'chat-watch')
+
+      // A turn begins (stream_start arms the indicator + the watchdog), then total silence.
+      await processSSEEvent(managed, { type: 'stream_start' })
+      await vi.advanceTimersByTimeAsync(WATCHDOG_MS + 1000)
+
+      expect(connector.stoppedWorking).toContain('chat-watch')
+      expect(stalledMessageSent(connector)).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does NOT fire on a healthy long turn: any SSE event resets the silence clock', async () => {
+    vi.useFakeTimers()
+    try {
+      const connector = new MockChatClientConnector()
+      const managed = makeManaged(connector, 'chat-watch')
+
+      await processSSEEvent(managed, { type: 'stream_start' }) // arm
+      await vi.advanceTimersByTimeAsync(2 * 60 * 1000) // 2 min — still alive
+      await processSSEEvent(managed, { type: 'tool_use_start', toolId: 't1', toolName: 'Bash' }) // activity → reset
+      await vi.advanceTimersByTimeAsync(2 * 60 * 1000) // 2 min since reset (< threshold)
+
+      expect(connector.stoppedWorking).not.toContain('chat-watch')
+      expect(stalledMessageSent(connector)).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('is paused while a user-request card is outstanding (silence is the user, not a stall)', async () => {
+    vi.useFakeTimers()
+    try {
+      const connector = new MockChatClientConnector()
+      const managed = makeManaged(connector, 'chat-watch')
+
+      await processSSEEvent(managed, { type: 'stream_start' }) // arm
+      await processSSEEvent(managed, {
+        type: 'user_question_request',
+        toolUseId: 'tu-1',
+        questions: [{ question: 'Which DB?' }],
+      })
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000) // long human wait
+
+      expect(stalledMessageSent(connector)).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
+++ b/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
@@ -170,10 +170,10 @@ describe('REPRO: perpetual "Thinking…" after a non-idle terminal event', () =>
 // watchdog clears the indicator after a stretch of total SSE silence, and resets
 // on any activity so a healthy long turn is never cut off.
 
-const WATCHDOG_MS = 3 * 60 * 1000
+const WATCHDOG_MS = 5 * 60 * 1000
 
 function stalledMessageSent(connector: MockChatClientConnector): boolean {
-  return connector.sentMessages.some((m) => /stopped responding|try again/i.test(m.message.text))
+  return connector.sentMessages.some((m) => /taking longer|send your message again/i.test(m.message.text))
 }
 
 describe('REPRO: idle-silence watchdog', () => {
@@ -224,11 +224,78 @@ describe('REPRO: idle-silence watchdog', () => {
         toolUseId: 'tu-1',
         questions: [{ question: 'Which DB?' }],
       })
-      await vi.advanceTimersByTimeAsync(5 * 60 * 1000) // long human wait
+      await vi.advanceTimersByTimeAsync(WATCHDOG_MS + 60 * 1000) // long human wait, past threshold
 
       expect(stalledMessageSent(connector)).toBe(false)
     } finally {
       vi.useRealTimers()
     }
   })
+
+  it('does NOT fire after session_error already settled the turn (and never double-notifies)', async () => {
+    vi.useFakeTimers()
+    try {
+      const connector = new MockChatClientConnector()
+      const managed = makeManaged(connector, 'chat-watch')
+
+      // A turn arms the indicator + watchdog, then errors. session_error settles
+      // the turn (clearing the watchdog) and sends ONE curated error message.
+      await processSSEEvent(managed, { type: 'stream_start' })
+      await processSSEEvent(managed, {
+        type: 'session_error',
+        error: 'boom',
+        apiErrorCode: 'overloaded_error',
+        isActive: false,
+      })
+      const messagesAfterError = connector.sentMessages.length
+
+      // Well past the watchdog threshold: the watchdog must NOT also fire (no
+      // stall notice, no second message piled on the error).
+      await vi.advanceTimersByTimeAsync(WATCHDOG_MS + 60 * 1000)
+
+      expect(stalledMessageSent(connector)).toBe(false)
+      expect(connector.sentMessages.length).toBe(messagesAfterError)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+// ── session_error → curated, code-specific message (and NEVER the raw error) ──
+// The headline fix: an errored turn settles the indicator AND surfaces a short,
+// sanitized message keyed off apiErrorCode. The producer puts the raw internal
+// error (which can carry file paths / tokens) in `data.error`; the consumer must
+// read only `apiErrorCode` and never echo `data.error` into the chat.
+
+describe('session_error: curated message by apiErrorCode, raw error never leaked', () => {
+  const RAW_LEAK = '/Users/secret/path tok-abc123 stack-trace-line'
+  const cases: Array<{ code: string | null; expect: RegExp }> = [
+    { code: 'overloaded_error', expect: /overloaded/i },
+    { code: 'rate_limit_error', expect: /rate limit/i },
+    { code: 'authentication_failed', expect: /authenticate/i },
+    { code: 'context_length_exceeded', expect: /too long|new conversation/i },
+    { code: 'some_unknown_code', expect: /hit an error/i },
+    { code: null, expect: /hit an error/i },
+  ]
+
+  for (const c of cases) {
+    it(`apiErrorCode=${c.code ?? 'null'} → curated message, no raw error`, async () => {
+      const connector = new MockChatClientConnector()
+      const managed = makeManaged(connector, 'chat-err')
+
+      await processSSEEvent(managed, {
+        type: 'session_error',
+        error: RAW_LEAK,
+        apiErrorCode: c.code,
+        isActive: false,
+      })
+
+      const text = connector.sentMessages.at(-1)?.message.text ?? ''
+      expect(text).toMatch(c.expect)
+      expect(text).not.toContain('/Users/secret/path')
+      expect(text).not.toContain('tok-abc123')
+      // The indicator is also torn down on the error path.
+      expect(connector.stoppedWorking).toContain('chat-err')
+    })
+  }
 })

--- a/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
+++ b/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest'
-import { processSSEEvent, type ManagedConnector } from './chat-integration-manager'
+import { processSSEEvent, finalizeStreaming, type ManagedConnector } from './chat-integration-manager'
 import { TelegramConnector } from './telegram-connector'
 import { MockChatClientConnector } from './mock-connector'
 import type { ChatIntegration } from '@shared/lib/db/schema'
@@ -291,6 +291,25 @@ describe('REPRO: idle-silence watchdog', () => {
 // sanitized message keyed off apiErrorCode. The producer puts the raw internal
 // error (which can carry file paths / tokens) in `data.error`; the consumer must
 // read only `apiErrorCode` and never echo `data.error` into the chat.
+
+// ── finalizeStreaming is synchronously idempotent ──────────────────────────
+// The watchdog tears down off the per-chat SSE queue, so its settleTurn can race
+// a late stream event that also finalizes. finalizeStreaming must claim its buffer
+// before its first await, so two concurrent calls send the final text only once.
+
+describe('finalizeStreaming: concurrent calls send the final text exactly once', () => {
+  it('claims the buffer synchronously, so a racing finalize is a no-op', async () => {
+    const connector = new MockChatClientConnector()
+    const managed = makeManaged(connector, 'chat-fin')
+    managed.streamingState = { currentMessageId: null, accumulatedText: 'final answer', lastUpdateTime: 0 }
+
+    await Promise.all([finalizeStreaming(managed), finalizeStreaming(managed)])
+
+    const finalSends = connector.sentMessages.filter((m) => m.message.text === 'final answer')
+    expect(finalSends.length).toBe(1)
+    expect(managed.streamingState.accumulatedText).toBe('')
+  })
+})
 
 describe('session_error: curated message by apiErrorCode, raw error never leaked', () => {
   const RAW_LEAK = '/Users/secret/path tok-abc123 stack-trace-line'

--- a/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
+++ b/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
@@ -284,6 +284,41 @@ describe('REPRO: idle-silence watchdog', () => {
       vi.useRealTimers()
     }
   })
+
+  it('a FAILED watchdog notice releases the latch, so a later real session_error still reaches the user', async () => {
+    vi.useFakeTimers()
+    try {
+      const connector = new MockChatClientConnector()
+      // The watchdog notice send fails (transient), every later send succeeds.
+      let failNext = true
+      const realSend = connector.sendMessage.bind(connector)
+      connector.sendMessage = async (chatId, message) => {
+        if (failNext) {
+          failNext = false
+          throw new Error('transient send failure')
+        }
+        return realSend(chatId, message)
+      }
+      const managed = makeManaged(connector, 'chat-watch')
+
+      // Arm, then total silence trips the watchdog — whose notice send throws.
+      await processSSEEvent(managed, { type: 'stream_start' })
+      await vi.advanceTimersByTimeAsync(WATCHDOG_MS + 1000)
+
+      // A genuine error then arrives. It must NOT be suppressed by the failed notice.
+      await processSSEEvent(managed, {
+        type: 'session_error',
+        error: 'boom',
+        apiErrorCode: 'rate_limit_error',
+        isActive: false,
+      })
+
+      const errorDelivered = connector.sentMessages.some((m) => /rate limit/i.test(m.message.text))
+      expect(errorDelivered).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })
 
 // ── session_error → curated, code-specific message (and NEVER the raw error) ──
@@ -308,6 +343,19 @@ describe('finalizeStreaming: concurrent calls send the final text exactly once',
     const finalSends = connector.sentMessages.filter((m) => m.message.text === 'final answer')
     expect(finalSends.length).toBe(1)
     expect(managed.streamingState.accumulatedText).toBe('')
+  })
+
+  it('restores the buffer if delivery fails, so a later finalize can retry (does not silently drop)', async () => {
+    const connector = new MockChatClientConnector()
+    connector.sendMessage = async () => {
+      throw new Error('chat unreachable')
+    }
+    const managed = makeManaged(connector, 'chat-fin')
+    managed.streamingState = { currentMessageId: null, accumulatedText: 'answer', lastUpdateTime: 0 }
+
+    await expect(finalizeStreaming(managed)).rejects.toThrow()
+    // The claimed text is restored (not lost) so a later terminal path can resend.
+    expect(managed.streamingState.accumulatedText).toBe('answer')
   })
 })
 

--- a/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
+++ b/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
@@ -319,6 +319,31 @@ describe('REPRO: idle-silence watchdog', () => {
       vi.useRealTimers()
     }
   })
+
+  it('emits at most ONE stall notice per turn, even if it stalls again in a later segment', async () => {
+    vi.useFakeTimers()
+    try {
+      const connector = new MockChatClientConnector()
+      const managed = makeManaged(connector, 'chat-watch')
+
+      // Segment 1 of the turn: arm, then total silence trips the watchdog → notice #1.
+      await processSSEEvent(managed, { type: 'stream_start' })
+      await vi.advanceTimersByTimeAsync(WATCHDOG_MS + 1000)
+
+      // Same turn continues (a new segment, NO new user dispatch in between) and
+      // stalls again. The once-per-turn latch — reset at dispatch, not per
+      // segment — must suppress a second notice.
+      await processSSEEvent(managed, { type: 'stream_start' })
+      await vi.advanceTimersByTimeAsync(WATCHDOG_MS + 1000)
+
+      const stallNotices = connector.sentMessages.filter((m) =>
+        /taking longer|send your message again/i.test(m.message.text),
+      )
+      expect(stallNotices.length).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })
 
 // ── session_error → curated, code-specific message (and NEVER the raw error) ──

--- a/src/shared/lib/chat-integrations/telegram-connector.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.ts
@@ -425,13 +425,18 @@ export class TelegramConnector extends ChatClientConnector {
 
   async startWorking(chatId: string): Promise<void> {
     if (!this.bot) return
-    // Send once now, then keep it alive on a heartbeat (drafts/typing self-expire)
-    // until stopWorking. Idempotent: one timer per chat.
+    // Register the keep-alive heartbeat synchronously BEFORE the first awaited send.
+    // stopWorking() is fire-and-forget and can run while this initial send is still
+    // in flight; if the interval were registered only after the await, that
+    // stopWorking would find no timer and this call would install one *after*
+    // teardown, leaking "Thinking…" forever. Registering first means a concurrent
+    // stopWorking always sees (and clears) the timer. Idempotent: one timer per chat.
+    if (!this.workingTimers.has(chatId)) {
+      this.workingTimers.set(chatId, setInterval(() => {
+        void this.sendWorkingIndicator(chatId)
+      }, WORKING_REFRESH_MS))
+    }
     await this.sendWorkingIndicator(chatId)
-    if (this.workingTimers.has(chatId)) return
-    this.workingTimers.set(chatId, setInterval(() => {
-      void this.sendWorkingIndicator(chatId)
-    }, WORKING_REFRESH_MS))
   }
 
   async stopWorking(chatId: string): Promise<void> {


### PR DESCRIPTION
## What

Fixes the Telegram bot showing "Thinking..." forever and going deaf to later messages after a turn that ended in an error, until the server was restarted.

The working indicator is a 1-second keep-alive heartbeat in `TelegramConnector` that re-sends until `stopWorking()` clears it. The chat-integration SSE consumer (`processSSEEvent`) tore the indicator down on `session_idle` but had no case for `session_error` - and an errored turn emits `session_error` (the host suppresses the later authoritative idle). So nothing ever called `stopWorking` and the heartbeat re-stamped "Thinking..." indefinitely.

## How it's fixed

- Shared `settleTurn()` teardown (stop indicator + finalize streamed text + settle tool pills), reused by `session_idle`, the new `session_error` case, and the watchdog, so every terminal path settles the same way.
- New `session_error` case: settle the turn, then surface a short message curated by `apiErrorCode`. It never echoes the raw internal error (which can carry file paths), and it tells the user the conversation got too long when that's the cause.
- Idle-silence watchdog as a backstop for any path that emits no terminal event at all (SDK stall, dropped stream, an event nobody handles): if the indicator is up and SSE goes fully silent for 5 minutes, settle and post a soft notice. It re-arms on any activity (so a healthy long turn never trips it) and fires at most once per turn.
- `TelegramConnector.startWorking()` now registers the keep-alive interval before its first awaited send, so a racing `stopWorking()` can't miss the timer and re-leak the indicator.
- Failure-path robustness: `finalizeStreaming` claims its buffer synchronously (no double-send if a late event races the watchdog) and restores it if delivery fails; the user-notice latch releases on a failed send, so a transient send failure can't swallow a later real error.

## How it was verified

- New regression tests (`perpetual-thinking.repro.test.ts`) drive the real `TelegramConnector` heartbeat with fake timers: they fail on the old code (the heartbeat keeps firing) and pass now. They cover the error-after-response leak, the error-before-any-text leak, the `startWorking` race, the `session_idle` control, the watchdog (fires on true silence, resets on activity, paused while a user-request card is outstanding, one notice per turn, no fire after `session_error` already settled), the `friendlyErrorMessage` branch table, and the guarantee that the raw error is never sent to the chat.
- Full `chat-integrations` suite green (485 tests), typecheck and lint clean.
- Manually verified on a live Telegram bot: the happy path (indicator clears, response renders) and the watchdog (the soft notice appears on a slow turn and the real answer still streams in afterward - the notice is reversible). The `session_error` teardown is covered by the real-connector unit tests above.

## Notes for the reviewer

- Scope is the chat-integration consumer plus a small `TelegramConnector.startWorking()` ordering fix. No host SSE-contract / message-persister or renderer changes, and no agent-container change.
- The watchdog deliberately does not cancel the agent's turn - only the host-side indicator. Canceling would make any operation longer than the threshold impossible to complete (killed, resent, killed again), so a long-but-alive turn is left to finish and deliver its answer, with the soft notice in between. The 5-minute threshold is a tunable constant.
