### PR TITLE
fix(dashboard-builder): catch client-side absolute URLs in generated dashboards

### DIFF
--- a/agent-container/src/dashboard-builder-agent-prompt.md
+++ b/agent-container/src/dashboard-builder-agent-prompt.md
@@ -78,7 +78,7 @@ Bun.serve({
   port,
   async fetch(req) {
     const url = new URL(req.url);
-    if (url.pathname === '/api/data') {
+    if (url.pathname === '/api/data') {       // server route: leading slash REQUIRED here
       const data = await fetchExternalData();
       return Response.json(data);
     }
@@ -92,7 +92,7 @@ Bun.serve({
 **Client-side periodic refresh:**
 ```javascript
 async function refreshData() {
-  const res = await fetch('api/data');
+  const res = await fetch('api/data');      // client: relative, NOT '/api/data' (absolute bypasses the proxy and 404s)
   const data = await res.json();
   renderChart(data);
 }
@@ -252,7 +252,7 @@ Rate limited to 100 req/min. This is the full Anthropic JS SDK (lazy-loaded) —
 - **Inspect the screenshot carefully.** It is your only visual feedback. Look for layout issues, missing content, broken styling.
 - **Install dependencies before starting.** If you add npm packages to `package.json`, run `bun install` in the dashboard directory, or just use `bun add <package>` which both installs and updates package.json.
 - **Use the DASHBOARD_PORT environment variable.** Never hardcode a port number.
-- **Always use relative URLs in client-side code.** Dashboards are served under a subpath (`/api/agents/:id/artifacts/:slug/`), so absolute paths like `fetch('/api/data')` bypass the proxy and 404. Use `fetch('api/data')` or `fetch('./api/data')` instead. This applies to all fetch calls, image sources, link hrefs, etc.
+- **Always use relative URLs in client-side code, never absolute.** Dashboards are served under a subpath (`/api/agents/:id/artifacts/:slug/`), so `fetch('/api/data')` bypasses the proxy and 404s - write `fetch('api/data')` instead. Applies to every fetch, `img src`, and `href`.
 
 ## Response Format
 

--- a/agent-container/src/dashboard-url-lint.test.ts
+++ b/agent-container/src/dashboard-url-lint.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { lintDashboardSource, lintDashboardDir, formatUrlFindings } from './dashboard-url-lint'
+
+describe('lintDashboardSource - flags client-side absolute URLs (the patterns that matter)', () => {
+  it('flags fetch with single quotes, double quotes, and template literals', () => {
+    expect(lintDashboardSource(`const r = await fetch('/api/data')`, 'index.js')).toHaveLength(1)
+    expect(lintDashboardSource(`fetch("/x")`, 'a.js')).toHaveLength(1)
+    expect(lintDashboardSource('fetch(`/x`)', 'a.js')).toHaveLength(1)
+  })
+
+  it('flags axios methods and direct axios calls', () => {
+    expect(lintDashboardSource(`axios.get('/api/x')`, 'a.js')).toHaveLength(1)
+    expect(lintDashboardSource(`axios.post('/api/x', body)`, 'a.js')).toHaveLength(1)
+    expect(lintDashboardSource(`axios('/api/x')`, 'a.js')).toHaveLength(1)
+  })
+
+  it('flags EventSource streams', () => {
+    expect(lintDashboardSource(`const es = new EventSource('/events')`, 'a.js')).toHaveLength(1)
+  })
+
+  it('flags absolute src and href attributes (single and double quoted)', () => {
+    expect(lintDashboardSource(`<img src="/logo.png">`, 'i.html')).toHaveLength(1)
+    expect(lintDashboardSource(`<link href="/style.css">`, 'i.html')).toHaveLength(1)
+    expect(lintDashboardSource(`<a href='/page'>x</a>`, 'i.html')).toHaveLength(1)
+  })
+
+  it('flags absolute CSS url() incl. quotes and @font-face', () => {
+    expect(lintDashboardSource(`background: url(/bg.png)`, 's.css')).toHaveLength(1)
+    expect(lintDashboardSource(`background: url('/bg.png')`, 's.css')).toHaveLength(1)
+    expect(lintDashboardSource(`@font-face { src: url("/f.woff2") }`, 's.css')).toHaveLength(1)
+  })
+
+  it('reports the correct 1-based line number and file', () => {
+    const f = lintDashboardSource(`line1\nfetch('/api/x')\nline3`, 'a.js')
+    expect(f).toHaveLength(1)
+    expect(f[0]).toMatchObject({ file: 'a.js', line: 2 })
+  })
+
+  it('flags uppercase HTML attributes (attribute names are case-insensitive)', () => {
+    expect(lintDashboardSource(`<IMG SRC="/logo.png">`, 'i.html')).toHaveLength(1)
+    expect(lintDashboardSource(`<a HREF="/page">x</a>`, 'i.html')).toHaveLength(1)
+  })
+
+  it('counts every site on a line, not just the first', () => {
+    expect(lintDashboardSource(`fetch('/a'); fetch('/b')`, 'a.js')).toHaveLength(2)
+  })
+})
+
+describe('lintDashboardSource - does NOT flag correct code (no crying wolf)', () => {
+  it('ignores server-side route declarations and URL parsing', () => {
+    expect(lintDashboardSource(`if (url.pathname === '/api/data') {}`, 'srv.js')).toHaveLength(0)
+    expect(lintDashboardSource(`const url = new URL(req.url)`, 'srv.js')).toHaveLength(0)
+  })
+
+  it('does not treat non-listed calls (app.get, http.get) as client fetches', () => {
+    expect(lintDashboardSource(`app.get('/api/data', handler)`, 'srv.js')).toHaveLength(0)
+    expect(lintDashboardSource(`http.get('/api/data', cb)`, 'srv.js')).toHaveLength(0)
+  })
+
+  it('ignores relative URLs', () => {
+    expect(lintDashboardSource(`fetch('api/data')`, 'a.js')).toHaveLength(0)
+    expect(lintDashboardSource(`fetch('./api/data')`, 'a.js')).toHaveLength(0)
+    expect(lintDashboardSource(`<img src="logo.png">`, 'i.html')).toHaveLength(0)
+  })
+
+  it('ignores absolute external URLs and protocol-relative URLs', () => {
+    expect(lintDashboardSource(`fetch('https://api.example.com/x')`, 'a.js')).toHaveLength(0)
+    expect(lintDashboardSource(`<script src="//cdn.example.com/lib.js"></script>`, 'i.html')).toHaveLength(0)
+    expect(lintDashboardSource(`background: url(https://cdn/x.png)`, 's.css')).toHaveLength(0)
+  })
+
+  it('ignores anchors and data URIs', () => {
+    expect(lintDashboardSource(`<a href="#top">x</a>`, 'i.html')).toHaveLength(0)
+    expect(lintDashboardSource(`<img src="data:image/png;base64,AAA">`, 'i.html')).toHaveLength(0)
+  })
+
+  it('does not fire inside identifiers like curl() or the JS new URL() constructor', () => {
+    expect(lintDashboardSource(`const r = curl('/api/data')`, 'a.js')).toHaveLength(0)
+    expect(lintDashboardSource(`const u = new URL('/api/x', location.href)`, 'a.js')).toHaveLength(0)
+  })
+})
+
+describe('lintDashboardSource - documented heuristic limitations (locked intentionally)', () => {
+  it('keeps CSS url() case-sensitive to avoid flagging new URL(), so uppercase CSS URL() is a known miss', () => {
+    expect(lintDashboardSource(`.hero { background: URL(/bg.png); }`, 's.css')).toHaveLength(0)
+  })
+})
+
+describe('lintDashboardDir', () => {
+  const mkdir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'dashlint-'))
+
+  it('scans source files and skips node_modules + non-source files', () => {
+    const dir = mkdir()
+    fs.writeFileSync(path.join(dir, 'index.js'), `fetch('/api/x')`)
+    fs.mkdirSync(path.join(dir, 'node_modules'))
+    fs.writeFileSync(path.join(dir, 'node_modules', 'dep.js'), `fetch('/api/y')`)
+    fs.writeFileSync(path.join(dir, 'package.json'), `{"name":"x"}`)
+    const f = lintDashboardDir(dir)
+    expect(f).toHaveLength(1)
+    expect(f[0].file).toBe('index.js')
+  })
+
+  it('reports nested files with a relative path', () => {
+    const dir = mkdir()
+    fs.mkdirSync(path.join(dir, 'src'))
+    fs.writeFileSync(path.join(dir, 'src', 'app.js'), `fetch('/api/x')`)
+    const f = lintDashboardDir(dir)
+    expect(f).toHaveLength(1)
+    expect(f[0].file).toBe(path.join('src', 'app.js'))
+  })
+
+  it('returns empty for a clean dashboard', () => {
+    const dir = mkdir()
+    fs.writeFileSync(path.join(dir, 'index.js'), `fetch('api/x')`)
+    expect(lintDashboardDir(dir)).toHaveLength(0)
+  })
+})
+
+describe('formatUrlFindings', () => {
+  it('names each file:line, mentions 404, and exempts server routes', () => {
+    const out = formatUrlFindings([
+      { file: 'index.js', line: 417, kind: 'network-call', snippet: `fetch('/api/test-write')` },
+    ])
+    expect(out).toContain('index.js:417')
+    expect(out).toContain('404')
+    expect(out.toLowerCase()).toContain('relative')
+    expect(out).toContain('url.pathname')
+  })
+})

--- a/agent-container/src/dashboard-url-lint.ts
+++ b/agent-container/src/dashboard-url-lint.ts
@@ -1,0 +1,130 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+export interface UrlLintFinding {
+  /** Path relative to the dashboard directory, e.g. "index.js" or "src/app.js". */
+  file: string
+  /** 1-based line number. */
+  line: number
+  /** 1-based column of the match start. */
+  column?: number
+  /** Which matcher fired: "network-call" | "attribute" | "css-url". */
+  kind: string
+  /** The trimmed source line, for context in the warning. */
+  snippet: string
+}
+
+// Only inspect *consumption* sites - the places a leading-slash path is actually
+// requested by the browser. Server-side route declarations
+// (`url.pathname === '/api/data'`, `app.get('/api/data')`) are deliberately NOT
+// in these patterns, so correct server code is never flagged. Each pattern also
+// excludes `//` (protocol-relative) and anything with a scheme (`https://`,
+// `data:`) because those don't start with a single leading slash.
+//
+// This is a deliberately lightweight lexical scan, not a parser. Known, accepted
+// limitations: it can flag a matching string sitting inside a comment or string
+// literal; it treats a bare `src`/`href` assignment (e.g. `el.src = '/x'`) like
+// an attribute (usually a real bug anyway); it misses calls split across multiple
+// lines and uppercase CSS `URL(` (network/CSS forms stay case-sensitive so
+// `new URL('/x')` and `FETCH` are never mistaken for matches); symlinked source
+// files are skipped. The goal is to catch the common literal mistake cheaply.
+const MATCHERS: { kind: string; re: RegExp }[] = [
+  // fetch('/...'), axios('/...'), axios.get('/...'), new EventSource('/...').
+  // Case-sensitive on purpose: JS identifiers are (FETCH is not a real call).
+  {
+    kind: 'network-call',
+    re: /\b(?:fetch|EventSource|axios(?:\.(?:get|post|put|patch|delete|head|request))?)\s*\(\s*['"`]\/(?!\/)/g,
+  },
+  // <img src="/...">, <link href="/...">, <a href='/...'>. Case-insensitive:
+  // HTML attribute names are.
+  { kind: 'attribute', re: /\b(?:src|href)\s*=\s*['"]\/(?!\/)/gi },
+  // CSS url(/...), url('/...'), @font-face { src: url("/...") }. The lookbehind
+  // stops it firing inside identifiers like `curl(`. Case-sensitive to avoid
+  // matching the JS `new URL('/x')` constructor.
+  { kind: 'css-url', re: /(?<![\w-])url\(\s*['"]?\/(?!\/)/g },
+]
+
+const SOURCE_EXTENSIONS = new Set([
+  '.js',
+  '.jsx',
+  '.ts',
+  '.tsx',
+  '.mjs',
+  '.cjs',
+  '.html',
+  '.htm',
+  '.css',
+])
+
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', '.next', 'coverage'])
+
+const MAX_LISTED = 20
+
+/** Scan a single source string. Pure - this is the precision contract. */
+export function lintDashboardSource(source: string, file: string): UrlLintFinding[] {
+  const findings: UrlLintFinding[] = []
+  const lines = source.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    for (const m of MATCHERS) {
+      // matchAll (regexes are /g) so every site on a line is counted, not just
+      // the first - the warning's "(N)" must reflect the real total.
+      for (const hit of line.matchAll(m.re)) {
+        findings.push({
+          file,
+          line: i + 1,
+          column: (hit.index ?? 0) + 1,
+          kind: m.kind,
+          snippet: line.trim().slice(0, 160),
+        })
+      }
+    }
+  }
+  return findings
+}
+
+/** Recursively scan a dashboard directory's source files. Best-effort: unreadable entries are skipped. */
+export function lintDashboardDir(dir: string): UrlLintFinding[] {
+  const findings: UrlLintFinding[] = []
+  const walk = (current: string): void => {
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      const full = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) walk(full)
+      } else if (entry.isFile() && SOURCE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
+        let content: string
+        try {
+          content = fs.readFileSync(full, 'utf8')
+        } catch {
+          continue
+        }
+        findings.push(...lintDashboardSource(content, path.relative(dir, full)))
+      }
+    }
+  }
+  walk(dir)
+  return findings
+}
+
+/** Render findings into the warning block prepended to the start_dashboard response. */
+export function formatUrlFindings(findings: UrlLintFinding[]): string {
+  const shown = findings.slice(0, MAX_LISTED)
+  const bullets = shown.map((f) => `  - ${f.file}:${f.line}  ${f.snippet}`).join('\n')
+  const more =
+    findings.length > shown.length ? `\n  ...and ${findings.length - shown.length} more` : ''
+  return (
+    `⚠ ABSOLUTE URLS DETECTED (${findings.length}) - these will 404 once the dashboard is ` +
+    `served under its /api/agents/.../artifacts/<slug>/ subpath. Make each one relative (drop the ` +
+    `leading slash, e.g. fetch('/api/x') -> fetch('api/x')) and call start_dashboard again:\n\n` +
+    bullets +
+    more +
+    `\n\nServer-side route declarations (e.g. url.pathname === '/api/data') are correct and ` +
+    `intentionally not listed.`
+  )
+}

--- a/agent-container/src/tools/start-dashboard.ts
+++ b/agent-container/src/tools/start-dashboard.ts
@@ -1,8 +1,10 @@
 import * as fs from 'fs'
+import * as path from 'path'
 import { tool } from '@anthropic-ai/claude-agent-sdk'
 import { z } from 'zod'
-import { dashboardManager } from '../dashboard-manager'
+import { dashboardManager, ARTIFACTS_DIR } from '../dashboard-manager'
 import { resizeScreenshot } from '../image-utils'
+import { lintDashboardDir, formatUrlFindings } from '../dashboard-url-lint'
 
 type ToolContentBlock =
   | { type: 'text'; text: string }
@@ -47,6 +49,19 @@ The dashboard must exist at /workspace/artifacts/<slug>/ with a valid package.js
           }
         } else {
           text += `\n\n(Screenshot unavailable: ${shot.reason})`
+        }
+
+        // Catch client-side absolute URLs that will 404 once the dashboard is
+        // served under its /api/agents/.../artifacts/<slug>/ subpath. Surfaced
+        // here (the agent's verification touchpoint) with exact file:line so it
+        // self-corrects. Best-effort: a lint failure must never break start.
+        try {
+          const urlFindings = lintDashboardDir(path.join(ARTIFACTS_DIR, args.slug))
+          if (urlFindings.length > 0) {
+            text = `${formatUrlFindings(urlFindings)}\n\n${text}`
+          }
+        } catch {
+          // ignore lint errors
         }
       } else if (info.status === 'crashed' || info.status === 'stopped') {
         // Include recent logs so the agent can debug without a separate tool call


### PR DESCRIPTION
## What & why

Agent-generated dashboards are served under a path prefix (`/api/agents/:id/artifacts/:slug/`), so any client-side request must use a **relative** URL. An **absolute** one like `fetch('/api/data')` resolves against the host root, bypasses the artifact proxy, and 404s.

The builder prompt already stated the rule, but an agent ignored it and shipped a dashboard whose button silently 404s. Root cause is a real trap: the agent writes the correct absolute path for its **server route** (`url.pathname === '/api/data'` - leading slash required there) and then copies that same literal into the **client fetch** (`fetch('/api/data')` - leading slash fatal there). One string, mandatory on one side, broken on the other.

This breaks the dashboard identically **in-app and via Telegram** - it is a dashboard-generation issue, not specific to either surface.

## Not part of #307

Surfaced while smoke-testing #307 (Telegram Mini App dashboards), but it predates #307 and reproduces in the in-app view too. Separate branch off `main`, zero file overlap with #307 - independent, merge in any order.

## What changed

Two tiers, because the rule was *requested* but never *enforced*:

1. **Prompt hardening** (`dashboard-builder-agent-prompt.md`) - anchors the lesson in the example the model imitates: inline comments on the server route (`leading slash REQUIRED`) vs the client fetch (`relative, NOT '/api/x'`), plus a tightened DO/DON'T in the Critical Rules. Zero net new lines.

2. **A deterministic check at `start_dashboard`** (`dashboard-url-lint.ts`) - the real guarantee. The agent must call `start_dashboard` to verify its work; this scans the source and, if it finds client-side absolute URLs, **leads the tool response with the exact `file:line`** so the agent self-corrects. It is **non-blocking**: the dashboard still starts and the screenshot still returns; the warning rides the verification loop the agent already runs.

### Precision (the part that matters)

The check only inspects **consumption sites** - `fetch`/`axios`/`EventSource` calls, `src`/`href` attributes, and CSS `url(...)`. It never matches server route declarations (`url.pathname === '/api/data'`, `app.get('/api/data')`), relative URLs, external `https://`, or protocol-relative `//cdn`. That is what keeps it from crying wolf - a check that flagged correct server code would be ignored within a day.

It is a deliberately lightweight lexical scan, not a parser. Known limitations (comments/strings, multiline-split calls, uppercase CSS `URL(`, symlinks) are documented in the module - it is a guardrail for the common literal mistake, not a fortress.

## How it was verified

- **19 unit tests** pin the precision contract (must-flag vs must-not-flag).
- **Real-data check** - scanned the actual generated dashboard on disk: 0 false positives; catches an injected absolute URL at the right line.
- **End-to-end live smoke in a real container**: rebuilt the agent image, had the agent build a dashboard with `fetch('/api/time')` → `start_dashboard` surfaced the warning at `index.js:24` (non-blocking, dashboard still ran) → the agent understood it, explained the mechanism, and on go-ahead switched to relative and re-ran → clean, no warning.
- **Adversarial regex review** (codex) hardened it: lookbehind stops the CSS matcher firing inside `curl(`; the attribute matcher is case-insensitive (HTML attrs are) while network/CSS stay case-sensitive so `new URL('/x')` and `FETCH` are never mismatched; `matchAll` makes the warning's `(N)` count accurate.

## Rollout note

This is `agent-container` code, baked into the agent image. It reaches agents on the **next image release + container recreate** - existing dashboards are unaffected until then. No host/server changes; no migration.
