### PR TITLE
feat(file-preview): video preview with timestamped + positional comments (SUP-318)

### DIFF
--- a/e2e/specs/file-preview.spec.ts
+++ b/e2e/specs/file-preview.spec.ts
@@ -185,6 +185,42 @@ test.describe('File Preview', () => {
     await expect(page.getByText('At cell 1:Email', { exact: false })).toBeVisible({ timeout: 10000 })
   })
 
+  test('renders a video and pins a timestamped comment via the Add Comment button', async ({ page }) => {
+    await agentPage.createAgent(`VideoComment ${Date.now()}`)
+    const agentSlug = await getLatestAgentSlug(page)
+    // A handful of bytes is enough: the comment flow keys off the default frame
+    // (timestamp 0) and never depends on the file actually decoding.
+    seedWorkspaceFile(agentSlug, 'output/clip.mp4', Buffer.from('00000018667479706d70343200000000', 'hex'))
+
+    await sessionPage.sendMessage('deliver video')
+    await sessionPage.waitForResponse(15000)
+
+    const filePill = getFilePill(page, 'clip.mp4').first()
+    await expect(filePill).toBeVisible({ timeout: 10000 })
+    await filePill.click()
+
+    await expect(page.getByTestId('file-preview-header')).toBeVisible({ timeout: 5000 })
+    await expect(page.getByTestId('video-renderer')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByTestId('video-element')).toBeVisible()
+
+    // The Add Comment button opens the editor directly and pins the timestamp.
+    await page.getByTestId('video-add-comment').click()
+    const overlay = page.locator('[data-comment-overlay]')
+    await expect(overlay.getByText('At 0:00', { exact: false })).toBeVisible({ timeout: 5000 })
+
+    await page.getByPlaceholder('Add your comment...').fill('Trim the intro here')
+    await overlay.getByRole('button', { name: 'Add' }).click()
+
+    // The comment bar lists the timestamped comment.
+    const tray = page.getByTestId('file-preview-tray')
+    await expect(tray.getByText('At 0:00', { exact: false })).toBeVisible({ timeout: 5000 })
+    await expect(tray.getByText('Trim the intro here')).toBeVisible()
+
+    // Submitting posts the formatted feedback back into the conversation.
+    await tray.getByRole('button', { name: 'Submit' }).click()
+    await expect(page.getByText('At 0:00', { exact: false }).first()).toBeVisible({ timeout: 10000 })
+  })
+
   test('multiple file tabs, switching, and image rendering', async ({ page }) => {
     await agentPage.createAgent(`MultiFile ${Date.now()}`)
     const agentSlug = await getLatestAgentSlug(page)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -23,6 +23,7 @@ import { listWebhookTriggers, listActiveWebhookTriggers, listCancelledWebhookTri
 import { listChatIntegrations, listChatIntegrationsByAgents } from '@shared/lib/services/chat-integration-service'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
 import { guessMimeType } from '@shared/lib/utils/mime'
+import { parseByteRange } from '@shared/lib/utils/http-range'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import {
   listSessions,
@@ -4139,9 +4140,6 @@ agents.get('/:id/files/*', AgentRead(), async (c) => {
     }
 
     const filename = path.basename(filePath)
-    const fileStream = fs.createReadStream(fullPath)
-    const webStream = Readable.toWeb(fileStream) as ReadableStream
-
     const encodedFilename = encodeURIComponent(filename)
     const inline = new URL(c.req.url).searchParams.get('inline') === 'true'
     if (inline) {
@@ -4151,8 +4149,32 @@ agents.get('/:id/files/*', AgentRead(), async (c) => {
       c.header('Content-Disposition', `attachment; filename="${encodedFilename}"; filename*=UTF-8''${encodedFilename}`)
       c.header('Content-Type', 'application/octet-stream')
     }
-    c.header('Content-Length', stat.size.toString())
 
+    // Advertise range support so media players (e.g. <video>) can seek. When the
+    // client requests a byte range, serve just that slice as 206 Partial
+    // Content; otherwise stream the whole file. Only the stream we actually
+    // return is opened, so we never leak a dangling read descriptor.
+    c.header('Accept-Ranges', 'bytes')
+    const size = stat.size
+    const rangeHeader = c.req.header('range')
+    const parsedRange = rangeHeader ? parseByteRange(rangeHeader, size) : null
+
+    if (rangeHeader && !parsedRange) {
+      // Unsatisfiable range → 416 with the valid extent so the client can retry.
+      c.header('Content-Range', `bytes */${size}`)
+      return c.body(null, 416)
+    }
+
+    if (parsedRange) {
+      const { start, end } = parsedRange
+      const chunk = Readable.toWeb(fs.createReadStream(fullPath, { start, end })) as ReadableStream
+      c.header('Content-Range', `bytes ${start}-${end}/${size}`)
+      c.header('Content-Length', (end - start + 1).toString())
+      return c.body(chunk, 206)
+    }
+
+    const webStream = Readable.toWeb(fs.createReadStream(fullPath)) as ReadableStream
+    c.header('Content-Length', size.toString())
     return c.body(webStream)
   } catch (error) {
     console.error('Failed to download file:', error)

--- a/src/renderer/components/file-preview/comments/comment-bar.test.ts
+++ b/src/renderer/components/file-preview/comments/comment-bar.test.ts
@@ -23,6 +23,25 @@ describe('formatComments', () => {
     expect(result).toContain('Button misaligned')
   })
 
+  it('formats video comments with a timestamp and in-frame position', () => {
+    const comments: FileComment[] = [
+      { id: '1', filePath: '/workspace/clip.mp4', text: 'Cut this scene', timestamp: 75.4, x: 30.2, y: 60.9 },
+    ]
+    const result = formatComments('/workspace/clip.mp4', comments)
+    expect(result).toContain('File feedback on `clip.mp4`')
+    expect(result).toContain('At 1:15 at position (30%, 61%):')
+    expect(result).toContain('Cut this scene')
+  })
+
+  it('formats a video comment with a timestamp but no in-frame position', () => {
+    const comments: FileComment[] = [
+      { id: '1', filePath: '/workspace/clip.mp4', text: 'Audio drops out', timestamp: 5 },
+    ]
+    const result = formatComments('/workspace/clip.mp4', comments)
+    expect(result).toContain('At 0:05:')
+    expect(result).not.toContain('position')
+  })
+
   it('formats multiple comments with blank line separators', () => {
     const comments: FileComment[] = [
       { id: '1', filePath: '/workspace/doc.md', text: 'Fix typo', selectedText: 'teh' },

--- a/src/renderer/components/file-preview/comments/comment-bar.tsx
+++ b/src/renderer/components/file-preview/comments/comment-bar.tsx
@@ -3,6 +3,7 @@ import { MessageSquare, X, Trash2 } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { useFilePreview, type FileComment } from '@renderer/context/file-preview-context'
 import { useSendMessage } from '@renderer/hooks/use-messages'
+import { formatMediaTime } from './format-media-time'
 
 interface CommentBarProps {
   comments: FileComment[]
@@ -45,6 +46,14 @@ export function formatComments(filePath: string, comments: FileComment[]): strin
       lines.push(comment.text)
     } else if (comment.selectedText) {
       lines.push(`> "${comment.selectedText}"`)
+      lines.push(comment.text)
+    } else if (comment.timestamp != null) {
+      // Video comment: tie the feedback to the frame time and, when present, the
+      // in-frame position the user marked.
+      const pos = comment.x != null && comment.y != null
+        ? ` at position (${Math.round(comment.x)}%, ${Math.round(comment.y)}%)`
+        : ''
+      lines.push(`At ${formatMediaTime(comment.timestamp)}${pos}:`)
       lines.push(comment.text)
     } else if (comment.x != null && comment.y != null) {
       lines.push(`At position (${Math.round(comment.x)}%, ${Math.round(comment.y)}%):`)
@@ -94,7 +103,13 @@ export function CommentBar({ comments, filePath, agentSlug, sessionId }: Comment
               {comment.selectedText && (
                 <div className="text-muted-foreground/70 italic truncate">&ldquo;{comment.selectedText}&rdquo;</div>
               )}
-              {comment.x != null && comment.y != null && (
+              {comment.timestamp != null && (
+                <div className="text-muted-foreground/70">
+                  At {formatMediaTime(comment.timestamp)}
+                  {comment.x != null && comment.y != null && <span> &middot; ({Math.round(comment.x)}%, {Math.round(comment.y)}%)</span>}
+                </div>
+              )}
+              {comment.timestamp == null && comment.x != null && comment.y != null && (
                 <div className="text-muted-foreground/70">({Math.round(comment.x)}%, {Math.round(comment.y)}%)</div>
               )}
               <div className="text-foreground">{comment.text}</div>

--- a/src/renderer/components/file-preview/comments/comment-overlay.tsx
+++ b/src/renderer/components/file-preview/comments/comment-overlay.tsx
@@ -3,15 +3,18 @@ import { MessageSquarePlus } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { useFilePreview } from '@renderer/context/file-preview-context'
 import type { TextSelectionInfo } from './use-text-selection'
+import { formatMediaTime } from './format-media-time'
 
 interface CommentOverlayProps {
   selection: TextSelectionInfo
   filePath: string
   onClose: () => void
+  /** Skip the intermediate "Comment" button and open the editor immediately. */
+  autoEdit?: boolean
 }
 
-export function CommentOverlay({ selection, filePath, onClose }: CommentOverlayProps) {
-  const [isEditing, setIsEditing] = useState(false)
+export function CommentOverlay({ selection, filePath, onClose, autoEdit = false }: CommentOverlayProps) {
+  const [isEditing, setIsEditing] = useState(autoEdit)
   const [commentText, setCommentText] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const { addComment } = useFilePreview()
@@ -31,6 +34,7 @@ export function CommentOverlay({ selection, filePath, onClose }: CommentOverlayP
       x: selection.x,
       y: selection.y,
       cell: selection.cell,
+      timestamp: selection.timestamp,
     })
     setCommentText('')
     setIsEditing(false)
@@ -78,7 +82,15 @@ export function CommentOverlay({ selection, filePath, onClose }: CommentOverlayP
             &ldquo;{selection.text}&rdquo;
           </div>
         )}
-        {selection.x != null && selection.y != null && (
+        {selection.timestamp != null && (
+          <div className="text-xs text-muted-foreground bg-muted/50 rounded p-1.5">
+            At {formatMediaTime(selection.timestamp)}
+            {selection.x != null && selection.y != null && (
+              <span> &middot; ({Math.round(selection.x)}%, {Math.round(selection.y)}%)</span>
+            )}
+          </div>
+        )}
+        {selection.timestamp == null && selection.x != null && selection.y != null && (
           <div className="text-xs text-muted-foreground bg-muted/50 rounded p-1.5">
             Point at ({Math.round(selection.x)}%, {Math.round(selection.y)}%)
           </div>

--- a/src/renderer/components/file-preview/comments/format-media-time.test.ts
+++ b/src/renderer/components/file-preview/comments/format-media-time.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { formatMediaTime } from './format-media-time'
+
+describe('formatMediaTime', () => {
+  it('formats sub-minute times as m:ss', () => {
+    expect(formatMediaTime(0)).toBe('0:00')
+    expect(formatMediaTime(5)).toBe('0:05')
+    expect(formatMediaTime(59)).toBe('0:59')
+  })
+
+  it('formats minutes with zero-padded seconds', () => {
+    expect(formatMediaTime(60)).toBe('1:00')
+    expect(formatMediaTime(75)).toBe('1:15')
+    expect(formatMediaTime(629)).toBe('10:29')
+  })
+
+  it('adds an hours field past an hour', () => {
+    expect(formatMediaTime(3600)).toBe('1:00:00')
+    expect(formatMediaTime(3661)).toBe('1:01:01')
+  })
+
+  it('floors fractional seconds', () => {
+    expect(formatMediaTime(12.9)).toBe('0:12')
+  })
+
+  it('collapses negative or non-finite input to 0:00', () => {
+    expect(formatMediaTime(-4)).toBe('0:00')
+    expect(formatMediaTime(NaN)).toBe('0:00')
+    expect(formatMediaTime(Infinity)).toBe('0:00')
+  })
+})

--- a/src/renderer/components/file-preview/comments/format-media-time.ts
+++ b/src/renderer/components/file-preview/comments/format-media-time.ts
@@ -1,0 +1,16 @@
+/**
+ * Format a playback position (in seconds) as a clock-style `m:ss` string, or
+ * `h:mm:ss` once past an hour. Shared by the video renderer, the comment
+ * overlay, and the comment bar so a timestamp reads identically everywhere.
+ * Negative or non-finite inputs collapse to `0:00`.
+ */
+export function formatMediaTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) seconds = 0
+  const total = Math.floor(seconds)
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  const ss = s.toString().padStart(2, '0')
+  if (h > 0) return `${h}:${m.toString().padStart(2, '0')}:${ss}`
+  return `${m}:${ss}`
+}

--- a/src/renderer/components/file-preview/comments/use-text-selection.ts
+++ b/src/renderer/components/file-preview/comments/use-text-selection.ts
@@ -8,6 +8,8 @@ export interface TextSelectionInfo {
   x?: number
   y?: number
   cell?: CellRef
+  /** Playback position in seconds, set for video-frame comments. */
+  timestamp?: number
 }
 
 export function useTextSelection(containerRef: RefObject<HTMLElement | null>) {

--- a/src/renderer/components/file-preview/renderers/file-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/file-renderer.tsx
@@ -5,6 +5,7 @@ import { MarkdownRenderer } from './markdown-renderer'
 import { TextRenderer } from './text-renderer'
 import { CsvRenderer } from './csv-renderer'
 import { ImageRenderer } from './image-renderer'
+import { VideoRenderer } from './video-renderer'
 import { HtmlRenderer } from './html-renderer'
 import { UnsupportedRenderer } from './unsupported-renderer'
 
@@ -20,6 +21,7 @@ const TEXT_EXTS = new Set([
   'c', 'cpp', 'h', 'hpp', 'r',
 ])
 const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'ico'])
+const VIDEO_EXTS = new Set(['mp4', 'mov', 'webm', 'm4v', 'ogv'])
 
 interface FileRendererProps {
   filePath: string
@@ -48,6 +50,10 @@ export function FileRenderer({ filePath, fileUrl, agentSlug }: FileRendererProps
 
   if (IMAGE_EXTS.has(ext)) {
     return <ImageRenderer url={fileUrl} filePath={filePath} />
+  }
+
+  if (VIDEO_EXTS.has(ext)) {
+    return <VideoRenderer url={fileUrl} filePath={filePath} />
   }
 
   if (ext === 'pdf') {

--- a/src/renderer/components/file-preview/renderers/video-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/video-renderer.tsx
@@ -1,0 +1,239 @@
+import { useState, useRef, useCallback } from 'react'
+import { Play, Pause, MessageSquarePlus } from 'lucide-react'
+import { useFilePreview, type FileComment } from '@renderer/context/file-preview-context'
+import { CommentPin } from '../comments/comment-pin'
+import { CommentOverlay } from '../comments/comment-overlay'
+import { formatMediaTime } from '../comments/format-media-time'
+
+interface VideoRendererProps {
+  url: string
+  filePath: string
+}
+
+/** An in-progress comment: a locked frame time plus a draggable in-frame point. */
+interface PendingComment {
+  timestamp: number
+  /** Horizontal position as a 0–100 percentage of the frame width. */
+  x: number
+  /** Vertical position as a 0–100 percentage of the frame height. */
+  y: number
+  /** Where to anchor the comment editor, in frame-local pixels. */
+  rect: DOMRect
+}
+
+/** A video comment always carries a timestamp; x/y are present when placed in-frame. */
+type VideoComment = FileComment & { timestamp: number }
+
+/** How close (in seconds) the playhead must be to a comment to show its pin. */
+const PIN_VISIBLE_WINDOW = 0.4
+
+function clampPct(value: number): number {
+  return Math.min(100, Math.max(0, value))
+}
+
+export function VideoRenderer({ url, filePath }: VideoRendererProps) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const frameRef = useRef<HTMLDivElement>(null)
+  const draggingRef = useRef(false)
+
+  const [playing, setPlaying] = useState(false)
+  const [currentTime, setCurrentTime] = useState(0)
+  const [duration, setDuration] = useState(0)
+  const [pending, setPending] = useState<PendingComment | null>(null)
+
+  const { comments } = useFilePreview()
+  const fileComments = comments.get(filePath) || []
+  const videoComments = fileComments.filter((c): c is VideoComment => c.timestamp != null)
+
+  const togglePlay = useCallback(() => {
+    const v = videoRef.current
+    if (!v) return
+    if (v.paused) void v.play().catch(() => {})
+    else v.pause()
+  }, [])
+
+  const seekTo = useCallback((time: number) => {
+    const v = videoRef.current
+    if (!v) return
+    v.currentTime = time
+    setCurrentTime(time)
+  }, [])
+
+  // Start a comment at the current frame: pause, lock the timestamp, drop the
+  // draggable point. `xy` is the click position (frame %), or null to centre it.
+  const beginComment = useCallback((xy: { x: number; y: number } | null) => {
+    const v = videoRef.current
+    const frame = frameRef.current
+    if (!v || !frame) return
+    v.pause()
+    const frameRect = frame.getBoundingClientRect()
+    const x = xy ? clampPct(xy.x) : 50
+    const y = xy ? clampPct(xy.y) : 50
+    setPending({
+      timestamp: v.currentTime,
+      x,
+      y,
+      rect: new DOMRect((x / 100) * frameRect.width, (y / 100) * frameRect.height, 0, 0),
+    })
+  }, [])
+
+  const handleFrameClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement
+    // Clicks inside the editor or on the draggable point are handled there.
+    if (target.closest('[data-comment-overlay]') || target.closest('[data-comment-box]')) return
+    const frame = frameRef.current
+    if (!frame) return
+    const rect = frame.getBoundingClientRect()
+    const x = clampPct(((e.clientX - rect.left) / rect.width) * 100)
+    const y = clampPct(((e.clientY - rect.top) / rect.height) * 100)
+    // While a comment is being placed, a frame click just repositions the point;
+    // otherwise it opens a new comment at the click.
+    if (pending) setPending(p => (p ? { ...p, x, y } : p))
+    else beginComment({ x, y })
+  }, [pending, beginComment])
+
+  const handleBoxPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    draggingRef.current = true
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }, [])
+
+  const handleBoxPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!draggingRef.current) return
+    const frame = frameRef.current
+    if (!frame) return
+    const rect = frame.getBoundingClientRect()
+    const x = clampPct(((e.clientX - rect.left) / rect.width) * 100)
+    const y = clampPct(((e.clientY - rect.top) / rect.height) * 100)
+    setPending(p => (p ? { ...p, x, y } : p))
+  }, [])
+
+  const handleBoxPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    draggingRef.current = false
+    e.currentTarget.releasePointerCapture?.(e.pointerId)
+  }, [])
+
+  const maxSeek = duration > 0 ? duration : 0
+
+  return (
+    <div className="flex flex-col items-center gap-3 p-4" data-testid="video-renderer">
+      {/* Video frame — clicking anywhere starts a comment at that point. */}
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
+      <div
+        ref={frameRef}
+        className="relative inline-block max-w-full cursor-crosshair"
+        onClick={handleFrameClick}
+      >
+        {/* Agent-delivered videos have no caption track to offer. */}
+        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+        <video
+          ref={videoRef}
+          src={url}
+          playsInline
+          preload="metadata"
+          className="max-w-full max-h-[60vh] rounded bg-black block"
+          data-testid="video-element"
+          onLoadedMetadata={e => setDuration(e.currentTarget.duration || 0)}
+          onTimeUpdate={e => setCurrentTime(e.currentTarget.currentTime)}
+          onPlay={() => setPlaying(true)}
+          onPause={() => setPlaying(false)}
+          onEnded={() => setPlaying(false)}
+        />
+
+        {/* Pins for comments anchored near the current frame. */}
+        {videoComments.map((comment, i) =>
+          comment.x != null && comment.y != null && Math.abs(comment.timestamp - currentTime) <= PIN_VISIBLE_WINDOW ? (
+            <CommentPin key={comment.id} x={comment.x} y={comment.y} number={i + 1} />
+          ) : null,
+        )}
+
+        {/* Draggable point for the comment being placed. */}
+        {pending && (
+          <div
+            data-comment-box
+            role="presentation"
+            onPointerDown={handleBoxPointerDown}
+            onPointerMove={handleBoxPointerMove}
+            onPointerUp={handleBoxPointerUp}
+            className="absolute w-9 h-9 -translate-x-1/2 -translate-y-1/2 rounded-md border-2 border-primary bg-primary/20 shadow-md cursor-move touch-none flex items-center justify-center"
+            style={{ left: `${pending.x}%`, top: `${pending.y}%` }}
+            title="Drag to position the comment"
+          >
+            <span className="w-1.5 h-1.5 rounded-full bg-primary" />
+          </div>
+        )}
+
+        {pending && (
+          <CommentOverlay
+            selection={{
+              text: '',
+              rect: pending.rect,
+              x: pending.x,
+              y: pending.y,
+              timestamp: pending.timestamp,
+            }}
+            filePath={filePath}
+            autoEdit
+            onClose={() => setPending(null)}
+          />
+        )}
+      </div>
+
+      {/* Controls */}
+      <div className="w-full max-w-[640px] space-y-2">
+        {/* Scrubber with comment markers above the track. */}
+        <div className="space-y-1">
+          <div className="relative h-2">
+            {maxSeek > 0 &&
+              videoComments.map(comment => (
+                <button
+                  key={comment.id}
+                  type="button"
+                  onClick={() => seekTo(comment.timestamp)}
+                  style={{ left: `${(comment.timestamp / maxSeek) * 100}%` }}
+                  className="absolute top-0 h-2 w-1 -translate-x-1/2 rounded-sm bg-primary hover:scale-y-150 transition-transform"
+                  title={`Comment at ${formatMediaTime(comment.timestamp)}`}
+                />
+              ))}
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={maxSeek}
+            step={0.01}
+            value={Math.min(currentTime, maxSeek)}
+            onChange={e => seekTo(Number(e.target.value))}
+            aria-label="Seek"
+            className="w-full accent-primary cursor-pointer"
+          />
+        </div>
+
+        {/* Transport + add-comment affordance. */}
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={togglePlay}
+            className="flex items-center justify-center w-8 h-8 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 transition-colors shrink-0"
+            title={playing ? 'Pause' : 'Play'}
+            aria-label={playing ? 'Pause' : 'Play'}
+          >
+            {playing ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4 translate-x-px" />}
+          </button>
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {formatMediaTime(currentTime)} / {formatMediaTime(duration)}
+          </span>
+          <button
+            type="button"
+            onClick={() => beginComment(null)}
+            disabled={pending != null}
+            className="ml-auto flex items-center gap-1 px-2.5 py-1 text-xs rounded-md border border-border bg-background hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-default"
+            data-testid="video-add-comment"
+          >
+            <MessageSquarePlus className="h-3.5 w-3.5" />
+            Add Comment
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/context/file-preview-context.tsx
+++ b/src/renderer/context/file-preview-context.tsx
@@ -29,6 +29,8 @@ export interface FileComment {
   x?: number
   y?: number
   cell?: CellRef
+  /** Playback position in seconds for video comments (paired with x/y in-frame). */
+  timestamp?: number
 }
 
 interface FilePreviewContextType {

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1225,6 +1225,12 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
       'File delivered successfully (size: 256 bytes)',
       'Here is the contacts export.'
     )],
+    ['deliver video', new ToolUseScenario(
+      'mcp__user-input__deliver_file',
+      { filePath: '/workspace/output/clip.mp4', description: 'Demo clip' },
+      'File delivered successfully (size: 4096 bytes)',
+      'Here is the demo clip.'
+    )],
     // API error scenarios
     ['auth error', new ApiErrorScenario('authentication_failed', 'Invalid API key')],
     ['rate limit error', new ApiErrorScenario('rate_limit', 'Rate limit exceeded, please try again later')],

--- a/src/shared/lib/utils/http-range.test.ts
+++ b/src/shared/lib/utils/http-range.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { parseByteRange } from './http-range'
+
+describe('parseByteRange', () => {
+  const SIZE = 1000
+
+  it('parses a fully-specified range', () => {
+    expect(parseByteRange('bytes=0-499', SIZE)).toEqual({ start: 0, end: 499 })
+    expect(parseByteRange('bytes=200-999', SIZE)).toEqual({ start: 200, end: 999 })
+  })
+
+  it('treats an open-ended range as running to the last byte', () => {
+    expect(parseByteRange('bytes=500-', SIZE)).toEqual({ start: 500, end: 999 })
+  })
+
+  it('clamps an end past the file size', () => {
+    expect(parseByteRange('bytes=0-5000', SIZE)).toEqual({ start: 0, end: 999 })
+  })
+
+  it('resolves a suffix range to the last N bytes', () => {
+    expect(parseByteRange('bytes=-100', SIZE)).toEqual({ start: 900, end: 999 })
+  })
+
+  it('clamps a suffix range larger than the file to the whole file', () => {
+    expect(parseByteRange('bytes=-5000', SIZE)).toEqual({ start: 0, end: 999 })
+  })
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseByteRange('  bytes=0-9 ', SIZE)).toEqual({ start: 0, end: 9 })
+  })
+
+  it('rejects malformed headers', () => {
+    expect(parseByteRange('bytes=', SIZE)).toBeNull()
+    expect(parseByteRange('bytes=abc-def', SIZE)).toBeNull()
+    expect(parseByteRange('items=0-10', SIZE)).toBeNull()
+    expect(parseByteRange('0-10', SIZE)).toBeNull()
+  })
+
+  it('rejects multi-range requests (unsupported)', () => {
+    expect(parseByteRange('bytes=0-10,20-30', SIZE)).toBeNull()
+  })
+
+  it('rejects an unsatisfiable start at or beyond the file size', () => {
+    expect(parseByteRange('bytes=1000-1100', SIZE)).toBeNull()
+    expect(parseByteRange('bytes=2000-', SIZE)).toBeNull()
+  })
+
+  it('rejects an inverted range', () => {
+    expect(parseByteRange('bytes=500-100', SIZE)).toBeNull()
+  })
+
+  it('rejects a zero-length suffix range', () => {
+    expect(parseByteRange('bytes=-0', SIZE)).toBeNull()
+  })
+
+  it('treats every range against an empty file as unsatisfiable', () => {
+    expect(parseByteRange('bytes=0-0', 0)).toBeNull()
+    expect(parseByteRange('bytes=-100', 0)).toBeNull()
+  })
+})

--- a/src/shared/lib/utils/http-range.ts
+++ b/src/shared/lib/utils/http-range.ts
@@ -1,0 +1,29 @@
+/**
+ * Parse a single-range HTTP `Range: bytes=…` header against a known resource
+ * size. Returns inclusive { start, end } byte offsets, or null when the header
+ * is malformed, multi-range (unsupported), or unsatisfiable. Supports suffix
+ * ranges (`bytes=-500` → last 500 bytes), which media players use to probe the
+ * tail of a file (e.g. an mp4 moov atom) before seeking.
+ */
+export function parseByteRange(header: string, size: number): { start: number; end: number } | null {
+  const match = /^bytes=(\d*)-(\d*)$/.exec(header.trim())
+  if (!match) return null
+  const [, startRaw, endRaw] = match
+  if (startRaw === '' && endRaw === '') return null
+
+  let start: number
+  let end: number
+  if (startRaw === '') {
+    // Suffix range: the last N bytes.
+    const suffix = parseInt(endRaw, 10)
+    if (Number.isNaN(suffix) || suffix <= 0) return null
+    start = Math.max(0, size - suffix)
+    end = size - 1
+  } else {
+    start = parseInt(startRaw, 10)
+    end = endRaw === '' ? size - 1 : parseInt(endRaw, 10)
+  }
+  if (Number.isNaN(start) || Number.isNaN(end)) return null
+  if (start > end || start >= size) return null
+  return { start, end: Math.min(end, size - 1) }
+}


### PR DESCRIPTION
## What & why

[SUP-318](https://linear.app/datawizz/issue/SUP-318) — the file preview tray renders images, CSVs, markdown, and PDFs, but videos fell through to the "Preview is not available" renderer. This adds a proper video preview with the same comment-back-to-the-agent flow images have, extended for the time dimension.

## Changes

**Video preview** — `mp4 / mov / webm / m4v / ogv` now render with a native `<video>` element and custom play / pause / seek controls, routed alongside the existing renderers in `file-renderer.tsx`.

**Timestamped + positional comments** — mirrors the image commenting flow, but each comment is tied to a frame **timestamp** plus a draggable in-frame **x/y point**:
- **Click anywhere in the frame** → pauses, captures the timestamp + x/y, opens the comment editor.
- **[+ Add Comment] button** under the frame → pauses and opens the editor at the current timestamp with a centered, draggable point (discoverable entry point).
- A **draggable box** lets you fine-tune the x/y placement; the scrubber shows clickable markers for each pending comment's time.
- Adding a comment always pauses playback so you can type.
- Comments are sent to the agent formatted as e.g. `At 1:15 at position (30%, 61%): <text>`.

**Backend — HTTP Range support** (`GET /api/agents/:id/files/*`): the route streamed the whole file with no `Accept-Ranges`, which breaks `<video>` seeking. Added `206 Partial Content` / `Content-Range`, `Accept-Ranges: bytes`, `416` for unsatisfiable ranges, and suffix-range (`bytes=-N`) handling. Only the served stream is opened now, fixing a read-fd leak in the original handler. Range parsing is extracted to a unit-tested `http-range.ts` util.

## Test plan

- `tsc --noEmit` ✅ · `eslint` on all touched files ✅
- Unit: `http-range` (12), `format-media-time` (5), `formatComments` video cases (2) — **31 passing**
- `agents.test.ts` **163 passing** (range refactor doesn't regress the file route)
- E2E (`file-preview.spec.ts`, mock mode) **green**, including a new test that delivers an mp4, opens it, pins a `0:00` comment via the button, and submits it back into the conversation
- Manually validated in the running app (real `.mp4`)

## Notes

- Playwright's bundled Chromium lacks proprietary codecs, so the E2E exercises the comment flow at the default frame (`timestamp 0`) rather than asserting decode/playback. Real playback was verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
