### PR TITLE
feat(messages): auto-expand wide tables beyond the readable column (SUP-319)

### DIFF
--- a/e2e/specs/table-expand.spec.ts
+++ b/e2e/specs/table-expand.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * Table breakout (SUP-319) — wide, many-column tables in agent responses should
+ * expand beyond the narrow readable text column (Notion-style) instead of being
+ * crammed into it, while ordinary prose keeps its constrained reading width.
+ *
+ * The 'wide table' mock scenario streams a 10-column markdown table preceded by
+ * an intro paragraph. The intro stays inside the readable column; the table is
+ * expected to break out wider than (and to the left of) that column.
+ */
+import { test, expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { SessionPage } from '../pages/session.page'
+import { createAgent, createSession, openAgentSession, waitForSessionIdle } from '../helpers/agents'
+
+async function setupSessionView(page: Page, request: APIRequestContext, testInfo: TestInfo) {
+  const appPage = new AppPage(page)
+  const sessionPage = new SessionPage(page)
+  const agentName = `Table Agent ${testInfo.workerIndex}-${testInfo.repeatEachIndex}-${Date.now()}`
+  const agent = await createAgent(request, agentName)
+  const session = await createSession(
+    request,
+    agent,
+    `setup table ${testInfo.workerIndex}-${testInfo.repeatEachIndex}`,
+  )
+  await waitForSessionIdle(request, agent, session)
+
+  await appPage.goto()
+  await appPage.waitForAgentsLoaded()
+  await openAgentSession(page, agent, session)
+  await sessionPage.waitForInputEnabled(15000)
+
+  return { sessionPage }
+}
+
+test.describe('Agent response table breakout (SUP-319)', () => {
+  test('wide table expands beyond the readable column', async ({ page, request }, testInfo) => {
+    const { sessionPage } = await setupSessionView(page, request, testInfo)
+
+    await sessionPage.sendMessage('wide table')
+    await sessionPage.waitForInputEnabled(20000)
+
+    const lastAssistant = sessionPage.getAssistantMessages().last()
+    const table = lastAssistant.getByTestId('markdown-table')
+    await expect(table).toBeVisible({ timeout: 20000 })
+    // All 10 header cells render — confirms the wide table is fully present.
+    await expect(lastAssistant.locator('th')).toHaveCount(10)
+
+    // The intro paragraph stays inside the constrained reading column; it is our
+    // reference for "the narrow column".
+    const intro = lastAssistant.getByText('Here is the quarterly breakdown:')
+    await expect(intro).toBeVisible()
+
+    const tableBox = await table.boundingBox()
+    const introBox = await intro.boundingBox()
+    expect(tableBox).not.toBeNull()
+    expect(introBox).not.toBeNull()
+
+    // The table is wider than the readable column...
+    expect(tableBox!.width).toBeGreaterThan(introBox!.width + 40)
+    // ...and breaks out past the column's left edge (it didn't just scroll in place).
+    expect(tableBox!.x).toBeLessThan(introBox!.x - 8)
+    // ...and extends past the column's right edge too.
+    expect(tableBox!.x + tableBox!.width).toBeGreaterThan(introBox!.x + introBox!.width + 8)
+
+    // The breakout stays inside the chat content area (no full-page horizontal scroll).
+    const contentArea = page.locator('[data-message-content-area]')
+    const areaBox = await contentArea.boundingBox()
+    expect(areaBox).not.toBeNull()
+    expect(tableBox!.x).toBeGreaterThanOrEqual(areaBox!.x - 1)
+    expect(tableBox!.x + tableBox!.width).toBeLessThanOrEqual(areaBox!.x + areaBox!.width + 1)
+  })
+})

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@shared/lib/utils/cn'
-import { useState, useCallback, memo, type ReactNode } from 'react'
+import { useState, useCallback, useRef, useLayoutEffect, memo, type ReactNode } from 'react'
 import { Check, Copy, Link2 } from 'lucide-react'
 import { ProviderErrorCard } from '@renderer/components/ui/provider-error-card'
 import { InsufficientBalanceCard, usePlatformBillingUrl } from './insufficient-balance-card'
@@ -63,6 +63,76 @@ function extractText(node: ReactNode): string {
 
 const REMARK_PLUGINS = [remarkGfm]
 
+// Side breathing room kept between an expanded table and the chat edges.
+const TABLE_BREAKOUT_GUTTER = 16
+
+// A wide (many-column) table shouldn't be crammed into the narrow readable text
+// column. Like Notion, we let a table that's wider than the column break out and
+// centre itself across the available chat width, scrolling horizontally only
+// once it still exceeds that. Narrow tables are left untouched in the normal
+// text flow. The breakout is measured rather than pure-CSS because the table is
+// nested several constrained, off-centre ancestors deep, so there is no static
+// containing block to anchor a symmetric breakout to. Only assistant messages
+// opt in (via `data-allow-table-breakout`); elsewhere the table just scrolls
+// inside its own column.
+function ExpandingTable({ children }: { children: ReactNode }) {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const scrollerRef = useRef<HTMLDivElement>(null)
+
+  useLayoutEffect(() => {
+    const wrapper = wrapperRef.current
+    const scroller = scrollerRef.current
+    if (!wrapper || !scroller) return
+
+    const contentArea = wrapper.closest('[data-message-content-area]') as HTMLElement | null
+    const canBreakOut = !!wrapper.closest('[data-allow-table-breakout]')
+
+    const measure = () => {
+      // Always start from the natural in-flow geometry before deciding.
+      wrapper.style.width = ''
+      wrapper.style.marginLeft = ''
+
+      if (!contentArea || !canBreakOut) return
+
+      const columnWidth = wrapper.clientWidth
+      const naturalWidth = scroller.scrollWidth
+      // Only break out when the table genuinely wants more than the column.
+      if (naturalWidth <= columnWidth + 1) return
+
+      const available = contentArea.clientWidth - TABLE_BREAKOUT_GUTTER * 2
+      if (available <= columnWidth) return // window too narrow to gain anything
+
+      const target = Math.min(naturalWidth, available)
+      const areaLeft = contentArea.getBoundingClientRect().left + TABLE_BREAKOUT_GUTTER
+      const currentLeft = wrapper.getBoundingClientRect().left
+      const desiredLeft = areaLeft + (available - target) / 2
+
+      wrapper.style.width = `${target}px`
+      wrapper.style.marginLeft = `${desiredLeft - currentLeft}px`
+    }
+
+    measure()
+
+    if (!contentArea || typeof ResizeObserver === 'undefined') return
+    // Re-centre when the chat area resizes. Content changes (e.g. a table still
+    // streaming) re-run this effect via the `children` dependency, so we don't
+    // observe the table itself — that would risk a resize-observer feedback loop.
+    const observer = new ResizeObserver(() => measure())
+    observer.observe(contentArea)
+    return () => observer.disconnect()
+  }, [children])
+
+  return (
+    <div ref={wrapperRef} className="my-3" data-testid="markdown-table">
+      <div ref={scrollerRef} className="code-scrollbar overflow-x-auto">
+        <table className="w-max min-w-full border-collapse text-sm">
+          {children}
+        </table>
+      </div>
+    </div>
+  )
+}
+
 // Hoisted to a stable module-level reference. The memoized <MarkdownBlock> below
 // must NOT be handed a fresh `components`/`remarkPlugins` object each render, or
 // its memo would never bail and every settled streaming block would re-parse.
@@ -82,28 +152,24 @@ const MARKDOWN_COMPONENTS: Components = {
       <code className={cn(className, 'text-foreground')}>{children}</code>
     )
   },
-  // Style tables with borders and horizontal scroll
-  table: ({ children }) => (
-    <div className="overflow-x-auto">
-      <table className="w-full border-collapse text-sm">
-        {children}
-      </table>
-    </div>
-  ),
+  // Wide tables expand beyond the readable column and scroll; see ExpandingTable.
+  table: ({ children }) => <ExpandingTable>{children}</ExpandingTable>,
+  // Cap individual cell width so prose-heavy cells wrap instead of stretching the
+  // table to one giant line, while many short columns still drive the breakout.
   th: ({ children }) => (
     <th className={cn(
-      'border-b-2 px-3 py-1.5 text-left font-semibold',
+      'border-b-2 px-3 py-1.5 text-left font-semibold align-top',
       'border-border'
     )}>
-      {children}
+      <div className="max-w-[32rem]">{children}</div>
     </th>
   ),
   td: ({ children }) => (
     <td className={cn(
-      'border-b px-3 py-1.5',
+      'border-b px-3 py-1.5 align-top',
       'border-border'
     )}>
-      {children}
+      <div className="max-w-[32rem]">{children}</div>
     </td>
   ),
   // Ensure links open in new tab
@@ -210,8 +276,11 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
           <MessageContextMenu text={text || ''} onRemove={onRemoveMessage ? () => onRemoveMessage(message.id) : undefined}>
             <div
               dir="auto"
+              // Assistant bubbles opt into table breakout and must not clip it.
+              data-allow-table-breakout={isAssistant ? '' : undefined}
               className={cn(
-                'rounded-lg max-w-full overflow-hidden text-foreground',
+                'rounded-lg max-w-full text-foreground',
+                !isAssistant && 'overflow-hidden',
                 isUser && 'bg-zinc-100 dark:bg-zinc-800/70 px-4 py-2',
                 isAssistant && 'py-1'
               )}

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -661,7 +661,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
 
   return (
     <div className="relative flex-1 min-h-0 overflow-hidden">
-      <div className="overflow-y-auto h-full" style={{ overflowAnchor: 'none' }} ref={scrollRef} onScroll={handleScroll} data-testid="message-list">
+      <div className="overflow-y-auto h-full" style={{ overflowAnchor: 'none' }} ref={scrollRef} onScroll={handleScroll} data-testid="message-list" data-message-content-area>
         <div className="mx-auto w-full max-w-[720px] px-4 pb-4 pt-14 space-y-4">
         {hiddenCount > 0 && (
           <div className="flex items-center justify-center py-3 text-xs text-muted-foreground">

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1241,6 +1241,16 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
       'Task scheduled successfully. ID: task_123',
       'I\'ve scheduled the daily issue summary task.'
     )],
+    // Wide, many-column markdown table to exercise table breakout (SUP-319).
+    ['wide table', new SimpleTextResponseScenario(
+      'Here is the quarterly breakdown:\n\n' +
+      '| Region | Q1 Revenue | Q2 Revenue | Q3 Revenue | Q4 Revenue | Headcount | Churn % | NPS | CAC | LTV |\n' +
+      '| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |\n' +
+      '| North America | $1,240,000 | $1,380,000 | $1,510,000 | $1,720,000 | 142 | 3.2% | 48 | $310 | $4,200 |\n' +
+      '| Europe | $980,000 | $1,050,000 | $1,190,000 | $1,330,000 | 118 | 4.1% | 41 | $290 | $3,800 |\n' +
+      '| Asia Pacific | $720,000 | $860,000 | $1,020,000 | $1,240,000 | 96 | 5.0% | 39 | $265 | $3,500 |\n' +
+      '| Latin America | $410,000 | $470,000 | $540,000 | $620,000 | 54 | 6.3% | 35 | $240 | $3,100 |\n'
+    )],
   ])
   static defaultScenario: MockScenario = new SimpleTextResponseScenario(
     'This is a mock response from the E2E test container.'


### PR DESCRIPTION
## SUP-319 — Auto-expand tables in agent responses

Agent responses keep a small max-width for readable prose, but wide (many-column) tables were cramped into that narrow column. They now break out — Notion-style — to use the available chat width.

### Behavior
- Ordinary prose keeps its constrained reading width.
- A table wider than that column breaks out and **centers across the available chat width**, scrolling horizontally only once it still exceeds that.
- Narrow tables are untouched (stay in the normal text flow).
- Works while streaming, too (re-measures per delta).

### How it works
- **`ExpandingTable`** (`message-item.tsx`) measures the table's natural width vs. the readable column and the chat content-area width, then sets an explicit width + centering margin. Measured rather than pure-CSS because the table sits several constrained, off-center ancestors deep, so there's no static containing block to anchor a symmetric breakout to. Re-centers on resize (`ResizeObserver` on the content area) and on streaming deltas (effect dep), and deliberately does **not** observe the table itself to avoid a resize-observer feedback loop.
- The scroll viewport is tagged **`data-message-content-area`** (`message-list.tsx`) as the breakout boundary.
- Only assistant bubbles opt in via **`data-allow-table-breakout`** and drop `overflow-hidden` so the breakout isn't clipped. User/other bubbles keep clipping and just scroll in-column.
- Cells gain a `max-w-[32rem]` cap so prose-heavy cells wrap instead of stretching the table to one giant line, while many short columns still drive the breakout.

### Verification
- New `e2e/specs/table-expand.spec.ts` (+ a `wide table` mock scenario) drives a real 10-column response and asserts the table is wider than, and breaks out past both edges of, the readable column while staying inside the chat content area. **Passing** (real Chromium layout). Local capture confirmed the intro text + user bubble stay in the ~720px column while the 10-column table extends past both edges, centered in the chat area.
- `tsc --noEmit` + `eslint` clean on all changed files.

### Note for reviewers
Breakout is **symmetric/centered** in the content area (matches Notion's full-width blocks). If left-anchored to the text column is preferred, it's a one-line change in `ExpandingTable` (drop the `(available - target) / 2` centering term).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
