### PR TITLE
fix(nav): don't hijack Option+Arrow on macOS for history nav

### DIFF
--- a/src/renderer/components/history-navigation-handler.test.tsx
+++ b/src/renderer/components/history-navigation-handler.test.tsx
@@ -92,6 +92,21 @@ describe('HistoryNavigationHandler', () => {
     expect(mockForward).toHaveBeenCalledTimes(1)
   })
 
+  it('ignores Alt+Arrow on macOS so Option+Arrow word-jump still works', () => {
+    vi.stubGlobal('__WEB__', false)
+    mockIsElectron.mockReturnValue(true)
+    mockGetPlatform.mockReturnValue('darwin')
+    render(<HistoryNavigationHandler />)
+
+    const backEvent = dispatchKeyboardEvent({ key: 'ArrowLeft', altKey: true })
+    const forwardEvent = dispatchKeyboardEvent({ key: 'ArrowRight', altKey: true })
+
+    expect(backEvent.defaultPrevented).toBe(false)
+    expect(forwardEvent.defaultPrevented).toBe(false)
+    expect(mockBack).not.toHaveBeenCalled()
+    expect(mockForward).not.toHaveBeenCalled()
+  })
+
   it('handles Electron auxiliary mouse buttons', () => {
     vi.stubGlobal('__WEB__', false)
     mockIsElectron.mockReturnValue(true)

--- a/src/renderer/components/history-navigation-handler.tsx
+++ b/src/renderer/components/history-navigation-handler.tsx
@@ -22,7 +22,17 @@ function getKeyboardNavigationCommand(event: KeyboardEvent): HistoryNavigationCo
     if (isBracketKey(event, ']')) return 'forward'
   }
 
-  if (event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
+  // Alt+Arrow is the native back/forward gesture on Windows/Linux (word-jump
+  // there is Ctrl+Arrow, so no conflict). On macOS, Option+Arrow is reserved
+  // for word-jump in text fields and was never a nav gesture — Mac uses
+  // Cmd+[ / Cmd+] instead — so we skip it there to avoid hijacking editing.
+  if (
+    getPlatform() !== 'darwin' &&
+    event.altKey &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey
+  ) {
     if (event.key === 'ArrowLeft') return 'back'
     if (event.key === 'ArrowRight') return 'forward'
   }


### PR DESCRIPTION
## Problem

We added Alt/Option + Left/Right as a back/forward history shortcut. On macOS, **Option+Arrow is the system word-jump gesture in text fields** — so our global handler was calling `preventDefault()` and navigating instead of letting the cursor jump by word. A real regression for anyone editing in the composer.

The deeper issue: Alt+Arrow-for-nav was never a macOS idiom — that's a Windows/Linux convention. We applied it globally by accident.

## Fix

Gate the Alt+Arrow back/forward branch in `history-navigation-handler.tsx` to **non-darwin** platforms:

| | Word-jump in text | History back/forward |
|---|---|---|
| **macOS** | Option+Arrow *(restored)* | Cmd-[ / Cmd-] |
| **Win/Linux** | Ctrl+Arrow | Alt+Arrow *(kept — native, no conflict)* |

Cmd-[ / Cmd-], mouse buttons, and native app-command forwarding are untouched, so macOS keeps full history nav.

## Tests

- Added a test asserting Alt+Arrow does **not** `preventDefault` or navigate on `darwin`.
- Existing `win32` Alt+Arrow test still covers the keep-it-on-Windows path.
- `tsc --noEmit` clean, `eslint` clean, `vitest` 6/6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)