### PR TITLE
feat(slack): seed agents with recent channel context on mentions and DMs

### DIFF
--- a/src/shared/lib/chat-integrations/base-connector.ts
+++ b/src/shared/lib/chat-integrations/base-connector.ts
@@ -22,6 +22,12 @@ export interface IncomingMessage {
   userName?: string            // Display name of the user (for session naming)
   chatName?: string            // Display name of the chat/channel (for session naming)
   files?: { name: string; url: string; mimeType?: string }[]
+  /**
+   * Historical attachments from seeded channel context (Slack only for now).
+   * Distinct from `files` (current-message attachments): best-effort, capped,
+   * and de-duplicated by the manager so re-seeds never re-download.
+   */
+  contextFiles?: { name: string; url: string; mimeType?: string }[]
   timestamp: Date
 }
 

--- a/src/shared/lib/chat-integrations/chat-integration-manager-context-files.sup-channel-context.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager-context-files.sup-channel-context.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { chatIntegrationManager, extractSlackFileId } from './chat-integration-manager'
+import { getAgentWorkspaceDir } from '@shared/lib/config/data-dir'
+
+const AGENT_A = 'ctx-agent-a'
+const AGENT_B = 'ctx-agent-b'
+let tempDataDir: string
+let prevDataDir: string | undefined
+
+function integration(agentSlug: string): any {
+  return { provider: 'slack', agentSlug, config: { botToken: 'xoxb-x' } }
+}
+function hostUploads(agentSlug: string) {
+  return path.resolve(getAgentWorkspaceDir(agentSlug), 'uploads')
+}
+
+beforeEach(async () => {
+  prevDataDir = process.env.SUPERAGENT_DATA_DIR
+  tempDataDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ctx-files-'))
+  process.env.SUPERAGENT_DATA_DIR = tempDataDir
+  ;(chatIntegrationManager as any).slackFileCache = new Map()
+})
+afterEach(async () => {
+  if (prevDataDir === undefined) delete process.env.SUPERAGENT_DATA_DIR
+  else process.env.SUPERAGENT_DATA_DIR = prevDataDir
+  await fs.promises.rm(tempDataDir, { recursive: true, force: true }).catch(() => {})
+  vi.restoreAllMocks()
+})
+
+describe('extractSlackFileId', () => {
+  it('extracts the file id from a Slack files-pri URL', () => {
+    expect(extractSlackFileId('https://files.slack.com/files-pri/T123-F456/secret.pdf')).toBe('F456')
+  })
+  it('returns null for a non-Slack host', () => {
+    expect(extractSlackFileId('https://evil.example.test/files-pri/T1-F1/x')).toBeNull()
+  })
+  it('returns null for a Slack URL that is not a files-pri path', () => {
+    expect(extractSlackFileId('https://files.slack.com/archives/C1/p123')).toBeNull()
+  })
+  it('returns null for a malformed URL', () => {
+    expect(extractSlackFileId('not a url')).toBeNull()
+  })
+})
+
+describe('downloadContextFile caching', () => {
+  it('downloads a file once and reuses the cached path on re-seed', async () => {
+    const buf = vi.fn(async () => Buffer.from('pdf-bytes'))
+    ;(chatIntegrationManager as any).downloadFileBuffer = buf
+    const file = { name: 'report.pdf', url: 'https://files.slack.com/files-pri/T1-F1/report.pdf' }
+    const p1 = await (chatIntegrationManager as any).downloadContextFile(integration(AGENT_A), file)
+    const p2 = await (chatIntegrationManager as any).downloadContextFile(integration(AGENT_A), file)
+    expect(p1).toMatch(/^\/workspace\/uploads\/\d+-report\.pdf$/)
+    expect(p2).toBe(p1)
+    expect(buf).toHaveBeenCalledTimes(1)
+    expect(fs.readdirSync(hostUploads(AGENT_A))).toHaveLength(1)
+  })
+  it('re-downloads when the cached file is gone (wiped workspace)', async () => {
+    const buf = vi.fn(async () => Buffer.from('bytes'))
+    ;(chatIntegrationManager as any).downloadFileBuffer = buf
+    const file = { name: 'a.pdf', url: 'https://files.slack.com/files-pri/T1-F1/a.pdf' }
+    await (chatIntegrationManager as any).downloadContextFile(integration(AGENT_A), file)
+    fs.rmSync(hostUploads(AGENT_A), { recursive: true, force: true })
+    await (chatIntegrationManager as any).downloadContextFile(integration(AGENT_A), file)
+    expect(buf).toHaveBeenCalledTimes(2)
+  })
+  it('scopes the cache per agent (no cross-agent reuse)', async () => {
+    const buf = vi.fn(async () => Buffer.from('bytes'))
+    ;(chatIntegrationManager as any).downloadFileBuffer = buf
+    const file = { name: 'a.pdf', url: 'https://files.slack.com/files-pri/T1-F1/a.pdf' }
+    await (chatIntegrationManager as any).downloadContextFile(integration(AGENT_A), file)
+    await (chatIntegrationManager as any).downloadContextFile(integration(AGENT_B), file)
+    expect(buf).toHaveBeenCalledTimes(2)
+    expect(fs.readdirSync(hostUploads(AGENT_B))).toHaveLength(1)
+  })
+  it('does not cache when no Slack file id is extractable', async () => {
+    const buf = vi.fn(async () => Buffer.from('bytes'))
+    ;(chatIntegrationManager as any).downloadFileBuffer = buf
+    const file = { name: 'a.pdf', url: 'https://example.test/not-a-slack-file' }
+    await (chatIntegrationManager as any).downloadContextFile(integration(AGENT_A), file)
+    await (chatIntegrationManager as any).downloadContextFile(integration(AGENT_A), file)
+    expect(buf).toHaveBeenCalledTimes(2)
+  })
+  it('returns null when the download fails', async () => {
+    ;(chatIntegrationManager as any).downloadFileBuffer = vi.fn(async () => null)
+    const file = { name: 'a.pdf', url: 'https://files.slack.com/files-pri/T1-F1/a.pdf' }
+    expect(await (chatIntegrationManager as any).downloadContextFile(integration(AGENT_A), file)).toBeNull()
+  })
+})
+
+describe('buildMessageContent context-file branching', () => {
+  const message = (over: any = {}) => ({ text: 'hi', chatId: 'C1', userId: 'U1', externalMessageId: '1', timestamp: new Date(), ...over })
+
+  it('returns plain text when there are no files of either kind', async () => {
+    const out = await (chatIntegrationManager as any).buildMessageContent(integration(AGENT_A), message())
+    expect(out.text).toContain('hi')
+    expect(out.failedFiles).toEqual([])
+  })
+  it('downloads context files and appends them (no contextFiles in failedFiles on success)', async () => {
+    ;(chatIntegrationManager as any).downloadFileBuffer = vi.fn(async () => Buffer.from('bytes'))
+    const msg = message({ contextFiles: [{ name: 'c.pdf', url: 'https://files.slack.com/files-pri/T1-F9/c.pdf' }] })
+    const out = await (chatIntegrationManager as any).buildMessageContent(integration(AGENT_A), msg)
+    expect(out.text).toContain('c.pdf')
+    expect(out.failedFiles).toEqual([])
+  })
+  it('keeps context-file failures silent (not surfaced in failedFiles)', async () => {
+    ;(chatIntegrationManager as any).downloadFileBuffer = vi.fn(async () => null)
+    const msg = message({ contextFiles: [{ name: 'c.pdf', url: 'https://files.slack.com/files-pri/T1-F9/c.pdf' }] })
+    const out = await (chatIntegrationManager as any).buildMessageContent(integration(AGENT_A), msg)
+    expect(out.failedFiles).toEqual([])
+  })
+  it('still surfaces current-mention file failures in failedFiles', async () => {
+    ;(chatIntegrationManager as any).downloadFileBuffer = vi.fn(async () => null)
+    const msg = message({ files: [{ name: 'now.pdf', url: 'https://files.slack.com/files-pri/T1-F2/now.pdf' }] })
+    const out = await (chatIntegrationManager as any).buildMessageContent(integration(AGENT_A), msg)
+    expect(out.failedFiles).toContain('now.pdf')
+  })
+})

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -472,7 +472,7 @@ class ChatIntegrationManager {
       }
       case 'slack': {
         const { SlackConnector } = await import('./slack-connector')
-        return new SlackConnector(config as import('./slack-connector').SlackConfig)
+        return new SlackConnector(config as import('./slack-connector').SlackConfig, integration.id)
       }
       case 'imessage': {
         const { IMessageConnector } = await import('./imessage-connector')

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -16,6 +16,7 @@ import { getToolDefinition } from '@shared/lib/tool-definitions/registry'
 import { formatToolName } from '@shared/lib/tool-definitions/types'
 import { parseChatIntegrationConfig, type ChatProvider } from './config-schema'
 import { formatProviderName, formatSessionTimestamp } from './utils'
+import { touchAndCapMap } from './collection-utils'
 import {
   listStartupChatIntegrations,
   getChatIntegration,
@@ -110,6 +111,20 @@ const HEALTH_CHECK_ERROR_THRESHOLD_MS = 5 * 60 * 1000
 const WORKING_WATCHDOG_MS = 5 * 60 * 1000
 const HEALTH_CHECK_MAX_CONSECUTIVE_FAILURES = 15
 const MAX_FILE_DOWNLOAD_SIZE = 50 * 1024 * 1024 // 50 MB
+const MAX_SLACK_FILE_CACHE = 500
+
+/**
+ * Extract the Slack file id from a private download URL, requiring a Slack host
+ * and an anchored /files-pri/<team>-<fileId>/ path. Returns null otherwise, so a
+ * stray URL cannot forge a cache key or a files.info lookup.
+ */
+export function extractSlackFileId(url: string): string | null {
+  let parsed: URL
+  try { parsed = new URL(url) } catch { return null }
+  if (!/(^|\.)slack\.com$/.test(parsed.hostname)) return null
+  const m = parsed.pathname.match(/^\/files-pri\/[A-Z0-9]+-([A-Z0-9]+)(?:\/|$)/)
+  return m ? m[1] : null
+}
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -168,6 +183,9 @@ class ChatIntegrationManager {
   // chain settles (see scheduleQueueEviction), so the map stays bounded.
   private messageQueues: Map<string, Promise<void>> = new Map()
   private lastSessionTouch: Map<string, number> = new Map()
+  // Slack context-file cache: `${agentSlug}:${fileId}` -> container workspace path.
+  // Lets re-seeded window files reuse one download instead of re-fetching.
+  private slackFileCache: Map<string, string> = new Map()
 
   // ── Lifecycle ───────────────────────────────────────────────────────
 
@@ -1048,7 +1066,9 @@ class ChatIntegrationManager {
     const prefix = message.chatName && message.userName ? `\\[${message.userName}]: ` : ''
     const text = prefix + (message.text || '')
 
-    if (!message.files || message.files.length === 0) {
+    const hasFiles = (message.files?.length ?? 0) > 0
+    const hasContextFiles = (message.contextFiles?.length ?? 0) > 0
+    if (!hasFiles && !hasContextFiles) {
       return { text, failedFiles: [] }
     }
 
@@ -1057,7 +1077,7 @@ class ChatIntegrationManager {
     const failedFiles: string[] = []
 
     let transcribedText = text
-    for (const file of message.files) {
+    for (const file of message.files ?? []) {
       if (!file.url) {
         failedFiles.push(file.name)
         continue
@@ -1087,7 +1107,51 @@ class ChatIntegrationManager {
       }
     }
 
+    for (const file of message.contextFiles ?? []) {
+      try {
+        const ctxPath = await this.downloadContextFile(integration, file)
+        if (ctxPath) uploadedPaths.push(ctxPath)
+      } catch (err) {
+        console.warn(`[ChatIntegrationManager] Context file download failed (non-critical) for ${file.name}:`, err instanceof Error ? err.message : err)
+      }
+    }
+
     return { text: appendAttachedFiles(transcribedText, uploadedPaths), failedFiles }
+  }
+
+  /**
+   * Download a seeded context file once, then serve it from a per-agent cache on
+   * re-seed. Returns the container workspace path, or null on failure.
+   */
+  private async downloadContextFile(
+    integration: ChatIntegration,
+    file: { name: string; url: string; mimeType?: string },
+  ): Promise<string | null> {
+    if (!file.url) return null
+    const { getAgentWorkspaceDir } = await import('@shared/lib/config/data-dir')
+    const path = await import('path')
+    const fs = await import('fs')
+
+    const fileId = extractSlackFileId(file.url)
+    const cacheKey = fileId ? `${integration.agentSlug}:${fileId}` : null
+
+    if (cacheKey) {
+      const cached = this.slackFileCache.get(cacheKey)
+      if (cached) {
+        // `cached` is a container path; the bytes live under the host uploads dir.
+        const hostPath = path.resolve(getAgentWorkspaceDir(integration.agentSlug), 'uploads', path.basename(cached))
+        if (fs.existsSync(hostPath)) {
+          touchAndCapMap(this.slackFileCache, cacheKey, cached, MAX_SLACK_FILE_CACHE)
+          return cached
+        }
+      }
+    }
+
+    const data = await this.downloadFileBuffer(integration, file.url)
+    if (!data) return null
+    const workspacePath = await this.writeToWorkspace(integration.agentSlug, file.name, data)
+    if (cacheKey) touchAndCapMap(this.slackFileCache, cacheKey, workspacePath, MAX_SLACK_FILE_CACHE)
+    return workspacePath
   }
 
   /** Download a file from the chat platform, returning a Buffer. */
@@ -1117,14 +1181,11 @@ class ChatIntegrationManager {
 
   /** Download a Slack file using the Web API (requires files:read scope). */
   private async downloadSlackFile(botToken: string, fileUrl: string): Promise<Buffer | null> {
-    // Extract file ID from Slack URL: .../files-pri/TEAM-FILEID/...
-    const fileIdMatch = fileUrl.match(/files-pri\/[A-Z0-9]+-([A-Z0-9]+)/)
-    if (!fileIdMatch) {
+    const fileId = extractSlackFileId(fileUrl)
+    if (!fileId) {
       // Fallback: try direct download with auth
       return this.downloadWithAuth(fileUrl, botToken)
     }
-
-    const fileId = fileIdMatch[1]
 
     // Use files.info API to get a proper download URL
     const infoRes = await fetch(`https://slack.com/api/files.info?file=${fileId}`, {

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -24,6 +24,7 @@ import {
 } from '@shared/lib/services/chat-integration-service'
 import {
   getChatIntegrationSession,
+  getChatIntegrationSessionById,
   getChatIntegrationSessionBySessionId,
   createChatIntegrationSession,
   updateChatIntegrationSessionName,
@@ -33,6 +34,7 @@ import {
   listActiveChatIntegrationSessions,
   resolveActiveSession,
   getLastDisplayName,
+  setLastSeenTs,
 } from '@shared/lib/services/chat-integration-session-service'
 import { assertPathWithinDir, isPathWithinDir, sanitizeUploadFilename } from '@shared/lib/utils/path-safety'
 import { isHostOrSubdomain, tryParseUrl } from '@shared/lib/utils/url-safety'
@@ -816,6 +818,10 @@ class ChatIntegrationManager {
       if (!isChatAllowed(integrationId, chatId)) return
 
       await client.sendMessage(sessionId, messageText)
+      if (integration.provider === 'slack') {
+        try { advanceConversationMarker(chatSession.id, message.externalMessageId) }
+        catch (err) { console.warn('[ChatIntegrationManager] marker advance failed (non-critical):', err instanceof Error ? err.message : err) }
+      }
       messagePersister.markSessionActive(sessionId, integration.agentSlug)
       const now = Date.now()
       const lastTouch = this.lastSessionTouch.get(chatSession.id) ?? 0
@@ -922,12 +928,16 @@ class ChatIntegrationManager {
       ...(integration.createdByUserId ? { createdByUserId: integration.createdByUserId } : {}),
     })
 
-    createChatIntegrationSession({
+    const newRowId = createChatIntegrationSession({
       integrationId: integration.id,
       externalChatId: chatId,
       sessionId,
       displayName,
     })
+    if (integration.provider === 'slack') {
+      try { advanceConversationMarker(newRowId, message.externalMessageId) }
+      catch (err) { console.warn('[ChatIntegrationManager] marker advance failed (non-critical):', err instanceof Error ? err.message : err) }
+    }
 
     await messagePersister.subscribeToSession(sessionId, client, sessionId, integration.agentSlug)
     messagePersister.markSessionActive(sessionId, integration.agentSlug)
@@ -1923,6 +1933,18 @@ export function buildSessionName(
     return `${baseName} — ${formatSessionTimestamp(now)}`
   }
   return baseName
+}
+
+/**
+ * Advance a conversation's marker to a processed Slack message's ts, never
+ * backward (out-of-order/duplicate deliveries must not rewind the gap window).
+ * Slack-only: callers gate on provider, so externalMessageId is always a numeric ts.
+ */
+export function advanceConversationMarker(sessionRowId: string, externalMessageId: string): void {
+  if (!externalMessageId) return
+  const row = getChatIntegrationSessionById(sessionRowId)
+  if (row?.lastSeenTs != null && Number(row.lastSeenTs) >= Number(externalMessageId)) return
+  setLastSeenTs(sessionRowId, externalMessageId)
 }
 
 // ── Singleton (globalThis for HMR persistence) ─────────────────────────

--- a/src/shared/lib/chat-integrations/chat-integration-marker-advance.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-marker-advance.test.ts
@@ -1,0 +1,38 @@
+// src/shared/lib/chat-integrations/chat-integration-marker-advance.test.ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { db } from '@shared/lib/db'
+import { chatIntegrations, chatIntegrationSessions } from '@shared/lib/db/schema'
+import { createChatIntegrationSession, getLastSeenTs } from '@shared/lib/services/chat-integration-session-service'
+import { advanceConversationMarker } from './chat-integration-manager'
+
+const INT = 'int-advance-test'
+beforeEach(() => {
+  db.delete(chatIntegrationSessions).run()
+  db.delete(chatIntegrations).run()
+  db.insert(chatIntegrations).values({
+    id: INT, agentSlug: 'a', provider: 'slack', name: 'n', config: '{}',
+    showToolCalls: false, status: 'active', requireApproval: true,
+    createdAt: new Date(), updatedAt: new Date(),
+  } as any).run()
+})
+
+describe('advanceConversationMarker', () => {
+  it('records externalMessageId as the marker for the row', () => {
+    const id = createChatIntegrationSession({ integrationId: INT, externalChatId: 'C1', sessionId: 's1' })
+    advanceConversationMarker(id, '123.45')
+    expect(getLastSeenTs(INT, 'C1')).toBe('123.45')
+  })
+
+  it('only advances forward (ignores an older externalMessageId)', () => {
+    const id = createChatIntegrationSession({ integrationId: INT, externalChatId: 'C1', sessionId: 's1' })
+    advanceConversationMarker(id, '200.0')
+    advanceConversationMarker(id, '100.0') // out-of-order/duplicate delivery
+    expect(getLastSeenTs(INT, 'C1')).toBe('200.0')
+  })
+
+  it('is a no-op for an empty external id', () => {
+    const id = createChatIntegrationSession({ integrationId: INT, externalChatId: 'C1', sessionId: 's1' })
+    advanceConversationMarker(id, '')
+    expect(getLastSeenTs(INT, 'C1')).toBeNull()
+  })
+})

--- a/src/shared/lib/chat-integrations/collection-utils.ts
+++ b/src/shared/lib/chat-integrations/collection-utils.ts
@@ -1,0 +1,27 @@
+/**
+ * Insert `key` at the most-recently-used position of an insertion-ordered Set,
+ * evicting the oldest entries once size exceeds `max`. Keeps long-lived tracking
+ * sets bounded so a connector that touches more and more threads over a
+ * long-running process can't leak memory. Re-inserting an existing key refreshes
+ * its recency (delete + re-add).
+ */
+export function touchAndCapSet(set: Set<string>, key: string, max: number): void {
+  set.delete(key)
+  set.add(key)
+  while (set.size > max) {
+    const oldest = set.values().next().value
+    if (oldest === undefined) break
+    set.delete(oldest)
+  }
+}
+
+/** Map counterpart of {@link touchAndCapSet}: (re)inserts `key` as MRU and evicts the oldest beyond `max`. */
+export function touchAndCapMap<V>(map: Map<string, V>, key: string, value: V, max: number): void {
+  map.delete(key)
+  map.set(key, value)
+  while (map.size > max) {
+    const oldest = map.keys().next().value
+    if (oldest === undefined) break
+    map.delete(oldest)
+  }
+}

--- a/src/shared/lib/chat-integrations/finalize-streaming.test.ts
+++ b/src/shared/lib/chat-integrations/finalize-streaming.test.ts
@@ -10,7 +10,7 @@ describe('SlackConnector.finalizeStreamingMessage', () => {
   let mockPostMessage: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    connector = new SlackConnector({ botToken: 'xoxb-fake', appToken: 'xapp-fake' })
+    connector = new SlackConnector({ botToken: 'xoxb-fake', appToken: 'xapp-fake' }, 'int-test')
     mockUpdate = vi.fn().mockResolvedValue({ ok: true })
     mockPostMessage = vi.fn().mockResolvedValue({ ok: true, ts: '1234.5678' })
     // Inject mock Slack app

--- a/src/shared/lib/chat-integrations/slack-channel-behavior.test.ts
+++ b/src/shared/lib/chat-integrations/slack-channel-behavior.test.ts
@@ -387,31 +387,6 @@ describe('routeSlackMessage', () => {
   })
 })
 
-describe('shouldSeedChannelContext', () => {
-  it('is true for a top-level channel mention when onlyMentioned is on', () => {
-    const result = routeSlackMessage(makeParams({ rawText: '<@U_BOT> can you log that', config: { onlyMentioned: true } }))
-    expect(result.shouldProcess).toBe(true)
-    expect(result.shouldSeedChannelContext).toBe(true)
-  })
-  it('is false when onlyMentioned is off (session already sees everything)', () => {
-    const result = routeSlackMessage(makeParams({ rawText: '<@U_BOT> hi', config: { onlyMentioned: false } }))
-    expect(result.shouldSeedChannelContext).toBe(false)
-  })
-  it('is false for an in-thread mention (thread path handles context)', () => {
-    const result = routeSlackMessage(makeParams({ rawText: '<@U_BOT> hi', threadTs: '900.000', config: { onlyMentioned: true } }))
-    expect(result.shouldSeedChannelContext).toBe(false)
-  })
-  it('is false for DMs', () => {
-    const result = routeSlackMessage(makeParams({ rawText: 'hi', channelType: 'im', config: { onlyMentioned: true } }))
-    expect(result.shouldSeedChannelContext).toBe(false)
-  })
-  it('is false on a filtered (non-process) message', () => {
-    const result = routeSlackMessage(makeParams({ rawText: 'no mention here', config: { onlyMentioned: true } }))
-    expect(result.shouldProcess).toBe(false)
-    expect(result.shouldSeedChannelContext).toBe(false)
-  })
-})
-
 // ── resolveSlackChannel ────────────────────────────────────────────────
 
 describe('resolveSlackChannel', () => {

--- a/src/shared/lib/chat-integrations/slack-channel-behavior.test.ts
+++ b/src/shared/lib/chat-integrations/slack-channel-behavior.test.ts
@@ -387,6 +387,31 @@ describe('routeSlackMessage', () => {
   })
 })
 
+describe('shouldSeedChannelContext', () => {
+  it('is true for a top-level channel mention when onlyMentioned is on', () => {
+    const result = routeSlackMessage(makeParams({ rawText: '<@U_BOT> can you log that', config: { onlyMentioned: true } }))
+    expect(result.shouldProcess).toBe(true)
+    expect(result.shouldSeedChannelContext).toBe(true)
+  })
+  it('is false when onlyMentioned is off (session already sees everything)', () => {
+    const result = routeSlackMessage(makeParams({ rawText: '<@U_BOT> hi', config: { onlyMentioned: false } }))
+    expect(result.shouldSeedChannelContext).toBe(false)
+  })
+  it('is false for an in-thread mention (thread path handles context)', () => {
+    const result = routeSlackMessage(makeParams({ rawText: '<@U_BOT> hi', threadTs: '900.000', config: { onlyMentioned: true } }))
+    expect(result.shouldSeedChannelContext).toBe(false)
+  })
+  it('is false for DMs', () => {
+    const result = routeSlackMessage(makeParams({ rawText: 'hi', channelType: 'im', config: { onlyMentioned: true } }))
+    expect(result.shouldSeedChannelContext).toBe(false)
+  })
+  it('is false on a filtered (non-process) message', () => {
+    const result = routeSlackMessage(makeParams({ rawText: 'no mention here', config: { onlyMentioned: true } }))
+    expect(result.shouldProcess).toBe(false)
+    expect(result.shouldSeedChannelContext).toBe(false)
+  })
+})
+
 // ── resolveSlackChannel ────────────────────────────────────────────────
 
 describe('resolveSlackChannel', () => {

--- a/src/shared/lib/chat-integrations/slack-channel-behavior.test.ts
+++ b/src/shared/lib/chat-integrations/slack-channel-behavior.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { routeSlackMessage, resolveSlackChannel, touchAndCapSet, touchAndCapMap, type SlackMessageRoutingParams } from './slack-connector'
+import { routeSlackMessage, resolveSlackChannel, type SlackMessageRoutingParams } from './slack-connector'
+import { touchAndCapSet, touchAndCapMap } from './collection-utils'
 
 // ── Helpers ────────────────────────────────────────────────────────────
 

--- a/src/shared/lib/chat-integrations/slack-channel-context.test.ts
+++ b/src/shared/lib/chat-integrations/slack-channel-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { selectChannelContextMessages, type SlackHistoryMessage } from './slack-connector'
+import { selectChannelContextMessages, SlackConnector, type SlackHistoryMessage } from './slack-connector'
 
 const BOT_USER = 'U_BOT'
 const BOT_ID = 'B_BOT'
@@ -44,5 +44,66 @@ describe('selectChannelContextMessages', () => {
   it('returns chronological order from newest-first input', () => {
     const kept = run([{ ts: '300.0', user: 'U1', text: 'c' }, { ts: '100.0', user: 'U1', text: 'a' }, { ts: '200.0', user: 'U1', text: 'b' }])
     expect(kept.map(m => m.text)).toEqual(['a', 'b', 'c'])
+  })
+})
+
+function makeConnector() {
+  const c = new SlackConnector({ botToken: 'xoxb-x', appToken: 'xapp-x' } as any)
+  ;(c as any).botUserId = 'U_BOT'
+  ;(c as any).botId = 'B_BOT'
+  ;(c as any).userNameCache = new Map([
+    ['U1', { value: 'Alice', ts: Date.now() }],
+    ['U2', { value: 'Bob', ts: Date.now() }],
+  ])
+  return c
+}
+
+describe('fetchChannelHistory', () => {
+  it('builds a channel-context block, skips the bot, and surfaces file presence', async () => {
+    const c = makeConnector()
+    ;(c as any).app = { client: { conversations: { history: async () => ({
+      ok: true,
+      messages: [
+        { ts: '1003.0', user: 'U_BOT', text: 'on it' },
+        { ts: '1002.0', user: 'U2', files: [{ name: 'report.pdf', url_private_download: 'https://files.slack.com/files-pri/T1-F1/report.pdf', mimetype: 'application/pdf' }] },
+        { ts: '1001.0', user: 'U1', text: 'the deploy is broken' },
+      ],
+    }) } } }
+    const result = await (c as any).fetchChannelHistory('C1', '1004.0')
+    expect(result).not.toBeNull()
+    expect(result.text).toContain('[Channel context')
+    expect(result.text).toContain('Alice: the deploy is broken')
+    expect(result.text).toContain('Bob: [shared file: report.pdf]')
+    expect(result.text).not.toContain('on it')
+    expect(result.files).toHaveLength(1)
+    expect(result.files[0].name).toBe('report.pdf')
+  })
+
+  it('caps downloaded files to the 3 newest and ignores non-downloadable (permalink-only) files', async () => {
+    const c = makeConnector()
+    const fileMsg = (ts: string, n: string) => ({ ts, user: 'U1', files: [{ name: n, url_private_download: `https://files.slack.com/files-pri/T1-F${n}/${n}` }] })
+    ;(c as any).app = { client: { conversations: { history: async () => ({
+      ok: true,
+      messages: [
+        fileMsg('105.0', 'e'), fileMsg('104.0', 'd'), fileMsg('103.0', 'c'), fileMsg('102.0', 'b'),
+        { ts: '101.0', user: 'U1', files: [{ name: 'permalink-only', permalink: 'https://slack.com/archives/x' }] },
+      ],
+    }) } } }
+    const result = await (c as any).fetchChannelHistory('C1', '999.0')
+    // Newest 3 downloadable by ts: c, d, e. permalink-only is surfaced in text but not queued.
+    expect(result.files.map((f: any) => f.name)).toEqual(['c', 'd', 'e'])
+    expect(result.text).toContain('[shared file: permalink-only]')
+  })
+
+  it('returns null on API failure (missing scope, etc.)', async () => {
+    const c = makeConnector()
+    ;(c as any).app = { client: { conversations: { history: async () => { throw new Error('missing_scope') } } } }
+    expect(await (c as any).fetchChannelHistory('C1', '999.0')).toBeNull()
+  })
+
+  it('returns null when nothing survives selection', async () => {
+    const c = makeConnector()
+    ;(c as any).app = { client: { conversations: { history: async () => ({ ok: true, messages: [{ ts: '1.0', user: 'U_BOT', text: 'mine' }] }) } } }
+    expect(await (c as any).fetchChannelHistory('C1', '999.0')).toBeNull()
   })
 })

--- a/src/shared/lib/chat-integrations/slack-channel-context.test.ts
+++ b/src/shared/lib/chat-integrations/slack-channel-context.test.ts
@@ -62,7 +62,7 @@ describe('selectChannelContextMessages', () => {
 })
 
 function makeConnector() {
-  const c = new SlackConnector({ botToken: 'xoxb-x', appToken: 'xapp-x' } as any)
+  const c = new SlackConnector({ botToken: 'xoxb-x', appToken: 'xapp-x' } as any, 'int-test')
   ;(c as any).botUserId = 'U_BOT'
   ;(c as any).botId = 'B_BOT'
   ;(c as any).userNameCache = new Map([
@@ -72,7 +72,7 @@ function makeConnector() {
   return c
 }
 
-describe('fetchChannelHistory', () => {
+describe('fetchHistorySince', () => {
   it('builds a channel-context block, skips the bot, and surfaces file presence', async () => {
     const c = makeConnector()
     ;(c as any).app = { client: { conversations: { history: async () => ({
@@ -83,7 +83,7 @@ describe('fetchChannelHistory', () => {
         { ts: '1001.0', user: 'U1', text: 'the deploy is broken' },
       ],
     }) } } }
-    const result = await (c as any).fetchChannelHistory('C1', '1004.0')
+    const result = await (c as any).fetchHistorySince('C1', null, '1004.0', 15)
     expect(result).not.toBeNull()
     expect(result.text).toContain('[Channel context - 2 previous messages]')
     expect(result.text).toContain('Alice: the deploy is broken')
@@ -93,50 +93,71 @@ describe('fetchChannelHistory', () => {
     expect(result.files[0].name).toBe('report.pdf')
   })
 
-  it('caps downloaded files to the 3 newest and ignores non-downloadable (permalink-only) files', async () => {
+  it('passes oldest when a marker is given and downloads ALL files (no cap)', async () => {
     const c = makeConnector()
+    const calls: any[] = []
     const fileMsg = (ts: string, n: string) => ({ ts, user: 'U1', files: [{ name: n, url_private_download: `https://files.slack.com/files-pri/T1-F${n}/${n}` }] })
-    ;(c as any).app = { client: { conversations: { history: async () => ({
+    ;(c as any).app = { client: { conversations: { history: async (args: any) => { calls.push(args); return {
       ok: true,
-      messages: [
-        fileMsg('105.0', 'e'), fileMsg('104.0', 'd'), fileMsg('103.0', 'c'), fileMsg('102.0', 'b'),
-        { ts: '101.0', user: 'U1', files: [{ name: 'permalink-only', permalink: 'https://slack.com/archives/x' }] },
-      ],
-    }) } } }
-    const result = await (c as any).fetchChannelHistory('C1', '999.0')
-    // Newest 3 downloadable by ts: c, d, e. permalink-only is surfaced in text but not queued.
-    expect(result.files.map((f: any) => f.name)).toEqual(['c', 'd', 'e'])
-    expect(result.text).toContain('[shared file: permalink-only]')
+      messages: [fileMsg('105.0', 'e'), fileMsg('104.0', 'd'), fileMsg('103.0', 'c'), fileMsg('102.0', 'b'), fileMsg('101.0', 'a')],
+    } } } } }
+    const result = await (c as any).fetchHistorySince('C1', '100.0', '999.0', 15)
+    expect(calls[0].oldest).toBe('100.0')
+    expect(calls[0].latest).toBe('999.0')
+    expect(calls[0].limit).toBe(15)
+    expect(result.files.map((f: any) => f.name)).toEqual(['a', 'b', 'c', 'd', 'e']) // all five, chronological, no cap
+  })
+
+  it('omits oldest on a cold start (null marker)', async () => {
+    const c = makeConnector()
+    const calls: any[] = []
+    ;(c as any).app = { client: { conversations: { history: async (args: any) => { calls.push(args); return { ok: true, messages: [{ ts: '100.0', user: 'U1', text: 'hi' }] } } } } }
+    await (c as any).fetchHistorySince('C1', null, '999.0', 15)
+    expect(calls[0].oldest).toBeUndefined()
+    expect(calls[0].limit).toBe(15)
+  })
+
+  it('drops this bot\'s own messages but keeps other bots', async () => {
+    const c = makeConnector()
+    ;(c as any).app = { client: { conversations: { history: async () => ({ ok: true, messages: [
+      { ts: '103.0', user: 'U_BOT', text: 'on it' },                                              // our bot -> dropped
+      { ts: '102.0', bot_id: 'B_OTHER', subtype: 'bot_message', text: 'deploy done' },            // other bot -> kept
+      { ts: '101.0', user: 'U1', text: 'the deploy is broken' },                                  // human -> kept
+    ] }) } } }
+    const result = await (c as any).fetchHistorySince('C1', null, '104.0', 15)
+    expect(result.text).toContain('the deploy is broken')
+    expect(result.text).toContain('deploy done')
+    expect(result.text).not.toContain('on it') // our bot's own line dropped
   })
 
   it('returns null on API failure (missing scope, etc.)', async () => {
     const c = makeConnector()
     ;(c as any).app = { client: { conversations: { history: async () => { throw new Error('missing_scope') } } } }
-    expect(await (c as any).fetchChannelHistory('C1', '999.0')).toBeNull()
+    expect(await (c as any).fetchHistorySince('C1', null, '999.0', 15)).toBeNull()
   })
 
   it('returns null when nothing survives selection', async () => {
     const c = makeConnector()
     ;(c as any).app = { client: { conversations: { history: async () => ({ ok: true, messages: [{ ts: '1.0', user: 'U_BOT', text: 'mine' }] }) } } }
-    expect(await (c as any).fetchChannelHistory('C1', '999.0')).toBeNull()
+    expect(await (c as any).fetchHistorySince('C1', null, '999.0', 15)).toBeNull()
   })
 
   it('returns null when the API responds not-ok (missing scope without throwing)', async () => {
     const c = makeConnector()
     ;(c as any).app = { client: { conversations: { history: async () => ({ ok: false, error: 'missing_scope' }) } } }
-    expect(await (c as any).fetchChannelHistory('C1', '999.0')).toBeNull()
+    expect(await (c as any).fetchHistorySince('C1', null, '999.0', 15)).toBeNull()
   })
 
   it('returns null when the API response omits messages', async () => {
     const c = makeConnector()
     ;(c as any).app = { client: { conversations: { history: async () => ({ ok: true }) } } }
-    expect(await (c as any).fetchChannelHistory('C1', '999.0')).toBeNull()
+    expect(await (c as any).fetchHistorySince('C1', null, '999.0', 15)).toBeNull()
   })
 
   it('uses singular wording for a single previous message', async () => {
     const c = makeConnector()
     ;(c as any).app = { client: { conversations: { history: async () => ({ ok: true, messages: [{ ts: '100.0', user: 'U1', text: 'just one' }] }) } } }
-    const result = await (c as any).fetchChannelHistory('C1', '999.0')
+    const result = await (c as any).fetchHistorySince('C1', null, '999.0', 15)
     expect(result.text).toContain('[Channel context - 1 previous message]')
   })
 })

--- a/src/shared/lib/chat-integrations/slack-channel-context.test.ts
+++ b/src/shared/lib/chat-integrations/slack-channel-context.test.ts
@@ -25,9 +25,13 @@ describe('selectChannelContextMessages', () => {
     const kept = run([{ ts: '100.0', user: 'U1', text: 'human' }, { ts: '101.0', bot_id: 'B_OTHER', subtype: 'bot_message', text: 'deploy done' }])
     expect(kept.map(m => m.text)).toEqual(['human', 'deploy done'])
   })
-  it('keeps me_message and thread_broadcast', () => {
-    const kept = run([{ ts: '100.0', user: 'U1', subtype: 'me_message', text: 'waves' }, { ts: '101.0', user: 'U2', subtype: 'thread_broadcast', text: 'also here' }])
-    expect(kept.map(m => m.text)).toEqual(['waves', 'also here'])
+  it('keeps the content subtypes on the allowlist (me_message, thread_broadcast, file_share)', () => {
+    const kept = run([
+      { ts: '100.0', user: 'U1', subtype: 'me_message', text: 'waves' },
+      { ts: '101.0', user: 'U2', subtype: 'thread_broadcast', text: 'also here' },
+      { ts: '102.0', user: 'U3', subtype: 'file_share', text: 'sharing', files: [{ name: 'x.pdf' }] },
+    ])
+    expect(kept.map(m => m.text)).toEqual(['waves', 'also here', 'sharing'])
   })
   it('drops system subtypes not on the allowlist (channel_join has text)', () => {
     const kept = run([{ ts: '100.0', user: 'U1', text: 'real' }, { ts: '101.0', subtype: 'channel_join', text: 'has joined' }])
@@ -41,9 +45,19 @@ describe('selectChannelContextMessages', () => {
     const kept = run([{ ts: '100.0', user: 'U1', text: '   ' }])
     expect(kept).toHaveLength(0)
   })
-  it('returns chronological order from newest-first input', () => {
-    const kept = run([{ ts: '300.0', user: 'U1', text: 'c' }, { ts: '100.0', user: 'U1', text: 'a' }, { ts: '200.0', user: 'U1', text: 'b' }])
-    expect(kept.map(m => m.text)).toEqual(['a', 'b', 'c'])
+  it('drops a message with no ts', () => {
+    const kept = run([{ user: 'U1', text: 'no ts' }, { ts: '100.0', user: 'U1', text: 'has ts' }])
+    expect(kept.map(m => m.text)).toEqual(['has ts'])
+  })
+  it('returns chronological order by NUMERIC ts (not lexical) from newest-first input', () => {
+    // A lexical string sort would order these '10.0' < '100.0' < '9.0' < '90.0'; numeric is 9 < 10 < 90 < 100.
+    const kept = run([
+      { ts: '100.0', user: 'U1', text: 'd' },
+      { ts: '9.0', user: 'U1', text: 'a' },
+      { ts: '10.0', user: 'U1', text: 'b' },
+      { ts: '90.0', user: 'U1', text: 'c' },
+    ])
+    expect(kept.map(m => m.text)).toEqual(['a', 'b', 'c', 'd'])
   })
 })
 
@@ -71,7 +85,7 @@ describe('fetchChannelHistory', () => {
     }) } } }
     const result = await (c as any).fetchChannelHistory('C1', '1004.0')
     expect(result).not.toBeNull()
-    expect(result.text).toContain('[Channel context')
+    expect(result.text).toContain('[Channel context - 2 previous messages]')
     expect(result.text).toContain('Alice: the deploy is broken')
     expect(result.text).toContain('Bob: [shared file: report.pdf]')
     expect(result.text).not.toContain('on it')
@@ -105,5 +119,24 @@ describe('fetchChannelHistory', () => {
     const c = makeConnector()
     ;(c as any).app = { client: { conversations: { history: async () => ({ ok: true, messages: [{ ts: '1.0', user: 'U_BOT', text: 'mine' }] }) } } }
     expect(await (c as any).fetchChannelHistory('C1', '999.0')).toBeNull()
+  })
+
+  it('returns null when the API responds not-ok (missing scope without throwing)', async () => {
+    const c = makeConnector()
+    ;(c as any).app = { client: { conversations: { history: async () => ({ ok: false, error: 'missing_scope' }) } } }
+    expect(await (c as any).fetchChannelHistory('C1', '999.0')).toBeNull()
+  })
+
+  it('returns null when the API response omits messages', async () => {
+    const c = makeConnector()
+    ;(c as any).app = { client: { conversations: { history: async () => ({ ok: true }) } } }
+    expect(await (c as any).fetchChannelHistory('C1', '999.0')).toBeNull()
+  })
+
+  it('uses singular wording for a single previous message', async () => {
+    const c = makeConnector()
+    ;(c as any).app = { client: { conversations: { history: async () => ({ ok: true, messages: [{ ts: '100.0', user: 'U1', text: 'just one' }] }) } } }
+    const result = await (c as any).fetchChannelHistory('C1', '999.0')
+    expect(result.text).toContain('[Channel context - 1 previous message]')
   })
 })

--- a/src/shared/lib/chat-integrations/slack-channel-context.test.ts
+++ b/src/shared/lib/chat-integrations/slack-channel-context.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { selectChannelContextMessages, type SlackHistoryMessage } from './slack-connector'
+
+const BOT_USER = 'U_BOT'
+const BOT_ID = 'B_BOT'
+
+function run(messages: SlackHistoryMessage[], currentTs = '9999.0') {
+  return selectChannelContextMessages(messages, currentTs, BOT_USER, BOT_ID)
+}
+
+describe('selectChannelContextMessages', () => {
+  it('excludes the current (triggering) message', () => {
+    const kept = run([{ ts: '100.0', user: 'U1', text: 'a' }, { ts: '9999.0', user: 'U1', text: 'b' }])
+    expect(kept.map(m => m.ts)).toEqual(['100.0'])
+  })
+  it("excludes the bot's own messages by user id", () => {
+    const kept = run([{ ts: '101.0', user: BOT_USER, text: 'on it' }, { ts: '100.0', user: 'U1', text: 'hi' }])
+    expect(kept.map(m => m.text)).toEqual(['hi'])
+  })
+  it("excludes the bot's own messages by bot_id when user is absent", () => {
+    const kept = run([{ ts: '101.0', bot_id: BOT_ID, subtype: 'bot_message', text: 'mine' }, { ts: '100.0', user: 'U1', text: 'hi' }])
+    expect(kept.map(m => m.text)).toEqual(['hi'])
+  })
+  it('keeps other integrations (bot_message with a different bot_id)', () => {
+    const kept = run([{ ts: '100.0', user: 'U1', text: 'human' }, { ts: '101.0', bot_id: 'B_OTHER', subtype: 'bot_message', text: 'deploy done' }])
+    expect(kept.map(m => m.text)).toEqual(['human', 'deploy done'])
+  })
+  it('keeps me_message and thread_broadcast', () => {
+    const kept = run([{ ts: '100.0', user: 'U1', subtype: 'me_message', text: 'waves' }, { ts: '101.0', user: 'U2', subtype: 'thread_broadcast', text: 'also here' }])
+    expect(kept.map(m => m.text)).toEqual(['waves', 'also here'])
+  })
+  it('drops system subtypes not on the allowlist (channel_join has text)', () => {
+    const kept = run([{ ts: '100.0', user: 'U1', text: 'real' }, { ts: '101.0', subtype: 'channel_join', text: 'has joined' }])
+    expect(kept.map(m => m.text)).toEqual(['real'])
+  })
+  it('keeps a file-only message (no text, has files)', () => {
+    const kept = run([{ ts: '100.0', user: 'U1', files: [{ name: 'a.pdf' }] }])
+    expect(kept).toHaveLength(1)
+  })
+  it('drops an empty message with no text and no files', () => {
+    const kept = run([{ ts: '100.0', user: 'U1', text: '   ' }])
+    expect(kept).toHaveLength(0)
+  })
+  it('returns chronological order from newest-first input', () => {
+    const kept = run([{ ts: '300.0', user: 'U1', text: 'c' }, { ts: '100.0', user: 'U1', text: 'a' }, { ts: '200.0', user: 'U1', text: 'b' }])
+    expect(kept.map(m => m.text)).toEqual(['a', 'b', 'c'])
+  })
+})

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -141,6 +141,12 @@ export interface SlackMessageRoutingResult {
    * passed in — i.e. before the caller marks this thread active.
    */
   isNewThreadEntry: boolean
+  /**
+   * True only for a genuinely top-level channel mention while `onlyMentioned`
+   * is on. The caller seeds recent channel history in this case. Mutually
+   * exclusive with `isNewThreadEntry` (which requires a threadTs).
+   */
+  shouldSeedChannelContext: boolean
 }
 
 export function routeSlackMessage(params: SlackMessageRoutingParams): SlackMessageRoutingResult {
@@ -151,7 +157,7 @@ export function routeSlackMessage(params: SlackMessageRoutingParams): SlackMessa
     const isMentioned = botUserId ? rawText.includes(`<@${botUserId}>`) : false
     if (!isMentioned) {
       if (!threadTs || !activeThreads.has(`${chatId}|${threadTs}`)) {
-        return { shouldProcess: false, effectiveChatId: chatId, isNewThreadEntry: false }
+        return { shouldProcess: false, effectiveChatId: chatId, isNewThreadEntry: false, shouldSeedChannelContext: false }
       }
     }
   }
@@ -188,8 +194,12 @@ export function routeSlackMessage(params: SlackMessageRoutingParams): SlackMessa
   // when the message is itself in a thread (threadTs) and we haven't tracked
   // that thread yet — a brand-new top-level message has no history to fetch.
   const isNewThreadEntry = !!(threadKey && threadTs && !activeThreads.has(threadKey))
+  // Top-level channel mention with onlyMentioned on: no thread to backfill, so
+  // seed recent channel history instead. !threadTs makes this exclusive with
+  // isNewThreadEntry.
+  const shouldSeedChannelContext = isChannel && !!config.onlyMentioned && !threadTs
 
-  return { shouldProcess: true, effectiveChatId, threadContext, threadKey, isNewThreadEntry }
+  return { shouldProcess: true, effectiveChatId, threadContext, threadKey, isNewThreadEntry, shouldSeedChannelContext }
 }
 
 export function resolveSlackChannel(

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -13,6 +13,7 @@ import { ChatClientConnector, type OutgoingMessage } from './base-connector'
 import { describeUnsupportedRequest, isUnsupportedInChat, splitChatMessage } from './utils'
 import { captureException } from '@shared/lib/error-reporting'
 import { touchAndCapSet, touchAndCapMap } from './collection-utils'
+import { getLastSeenTs } from '@shared/lib/services/chat-integration-session-service'
 
 // ── Config ──────────────────────────────────────────────────────────────
 
@@ -141,12 +142,6 @@ export interface SlackMessageRoutingResult {
    * passed in — i.e. before the caller marks this thread active.
    */
   isNewThreadEntry: boolean
-  /**
-   * True only for a genuinely top-level channel mention while `onlyMentioned`
-   * is on. The caller seeds recent channel history in this case. Mutually
-   * exclusive with `isNewThreadEntry` (which requires a threadTs).
-   */
-  shouldSeedChannelContext: boolean
 }
 
 export function routeSlackMessage(params: SlackMessageRoutingParams): SlackMessageRoutingResult {
@@ -157,7 +152,7 @@ export function routeSlackMessage(params: SlackMessageRoutingParams): SlackMessa
     const isMentioned = botUserId ? rawText.includes(`<@${botUserId}>`) : false
     if (!isMentioned) {
       if (!threadTs || !activeThreads.has(`${chatId}|${threadTs}`)) {
-        return { shouldProcess: false, effectiveChatId: chatId, isNewThreadEntry: false, shouldSeedChannelContext: false }
+        return { shouldProcess: false, effectiveChatId: chatId, isNewThreadEntry: false }
       }
     }
   }
@@ -194,12 +189,8 @@ export function routeSlackMessage(params: SlackMessageRoutingParams): SlackMessa
   // when the message is itself in a thread (threadTs) and we haven't tracked
   // that thread yet — a brand-new top-level message has no history to fetch.
   const isNewThreadEntry = !!(threadKey && threadTs && !activeThreads.has(threadKey))
-  // Top-level channel mention with onlyMentioned on: no thread to backfill, so
-  // seed recent channel history instead. !threadTs makes this exclusive with
-  // isNewThreadEntry.
-  const shouldSeedChannelContext = isChannel && !!config.onlyMentioned && !threadTs
 
-  return { shouldProcess: true, effectiveChatId, threadContext, threadKey, isNewThreadEntry, shouldSeedChannelContext }
+  return { shouldProcess: true, effectiveChatId, threadContext, threadKey, isNewThreadEntry }
 }
 
 export interface SlackHistoryMessage {
@@ -297,11 +288,9 @@ export class SlackConnector extends ChatClientConnector {
   // requires a re-mention if it ever resurfaces.
   private static readonly MAX_TRACKED_THREADS = 1000
   // Recent top-level channel messages seeded as context on a top-level mention.
-  private static readonly CHANNEL_CONTEXT_LIMIT = 10
-  // Newest historical files eagerly downloaded per seeded window.
-  private static readonly CHANNEL_CONTEXT_FILE_LIMIT = 3
+  private static readonly CHANNEL_CONTEXT_LIMIT = 15
 
-  constructor(private config: SlackConfig) {
+  constructor(private config: SlackConfig, private integrationId: string) {
     super()
   }
 
@@ -381,14 +370,16 @@ export class SlackConnector extends ChatClientConnector {
         if (history) text = history + '\n\n' + text
       }
 
-      // Top-level channel mention with onlyMentioned on: seed recent channel
-      // history (mutually exclusive with the thread block above).
+      // Non-thread (top-level channel or DM): backfill the gap since the
+      // conversation's marker. Thread messages keep the fetchThreadHistory path
+      // above. Setting-independent - the marker, not onlyMentioned, decides.
       let contextFiles: { name: string; url: string; mimeType?: string }[] | undefined
-      if (routing.shouldSeedChannelContext) {
-        const channelCtx = await this.fetchChannelHistory(chatId, ts)
-        if (channelCtx) {
-          text = channelCtx.text + '\n\n' + text
-          contextFiles = channelCtx.files.length ? channelCtx.files : undefined
+      if (!threadTs) {
+        const marker = getLastSeenTs(this.integrationId, chatId)
+        const ctx = await this.fetchHistorySince(chatId, marker, ts, SlackConnector.CHANNEL_CONTEXT_LIMIT)
+        if (ctx) {
+          text = ctx.text + '\n\n' + text
+          contextFiles = ctx.files.length ? ctx.files : undefined
         }
       }
 
@@ -823,7 +814,7 @@ export class SlackConnector extends ChatClientConnector {
       if (lines.length === 0) return null
 
       const label = lines.length === 1 ? '1 previous message' : `${lines.length} previous messages`
-      return `[Thread context — ${label}]\n${lines.join('\n')}`
+      return `[Thread context - ${label}]\n${lines.join('\n')}`
     } catch (err) {
       console.warn('[SlackConnector] Failed to fetch thread history (non-critical):', err instanceof Error ? err.message : err)
       return null
@@ -831,28 +822,34 @@ export class SlackConnector extends ChatClientConnector {
   }
 
   /**
-   * Build a channel-context block for a top-level mention, mirroring
-   * fetchThreadHistory but over conversations.history. Returns the prepend text
-   * plus metadata for the newest downloadable files (capped) so the manager can
-   * fetch them. Null on failure or when nothing is worth seeding (graceful).
+   * Backfill the gap between `sinceTs` (exclusive; null = cold start) and
+   * `latestTs` (exclusive) for a channel or DM, capped at the newest `limit`
+   * messages. Slack returns messages newest-first, so the most recent
+   * messages in the (oldest, latest) window come first; `limit` yields the
+   * newest `limit`. Drops this bot's own messages (selector), keeps other
+   * senders, surfaces every file, queues ALL downloadable files. Null on
+   * failure or when nothing survives.
    */
-  private async fetchChannelHistory(
+  private async fetchHistorySince(
     channel: string,
-    beforeTs: string,
+    sinceTs: string | null,
+    latestTs: string,
+    limit: number,
   ): Promise<{ text: string; files: { name: string; url: string; mimeType?: string }[] } | null> {
     if (!this.app) return null
     try {
       const result = await this.app.client.conversations.history({
         channel,
-        latest: beforeTs,
+        latest: latestTs,
+        ...(sinceTs != null ? { oldest: sinceTs } : {}),
         inclusive: false,
-        limit: SlackConnector.CHANNEL_CONTEXT_LIMIT,
+        limit,
       })
       if (!result.ok || !result.messages) return null
 
       const selected = selectChannelContextMessages(
         result.messages as SlackHistoryMessage[],
-        beforeTs,
+        latestTs,
         this.botUserId,
         this.botId,
       )
@@ -877,10 +874,8 @@ export class SlackConnector extends ChatClientConnector {
       }
       if (lines.length === 0) return null
 
-      // selected is chronological, so the newest downloadable files are at the tail.
-      const capped = files.slice(-SlackConnector.CHANNEL_CONTEXT_FILE_LIMIT)
       const label = lines.length === 1 ? '1 previous message' : `${lines.length} previous messages`
-      return { text: `[Channel context - ${label}]\n${lines.join('\n')}`, files: capped }
+      return { text: `[Channel context - ${label}]\n${lines.join('\n')}`, files }
     } catch (err) {
       console.warn('[SlackConnector] Failed to fetch channel history (non-critical):', err instanceof Error ? err.message : err)
       return null

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -373,13 +373,24 @@ export class SlackConnector extends ChatClientConnector {
       // Non-thread (top-level channel or DM): backfill the gap since the
       // conversation's marker. Thread messages keep the fetchThreadHistory path
       // above. Setting-independent - the marker, not onlyMentioned, decides.
+      // Read the marker by effectiveChatId (the key the manager advances the row
+      // under); the history fetch still targets the real channel (chatId). Wrapped
+      // best-effort: the marker read is a synchronous DB query and must never block
+      // the reply (fetchHistorySince already degrades internally). This runs before
+      // the manager's per-chat queue, so concurrent messages may re-seed overlapping
+      // windows - bounded (<=15 msgs, files deduped) and the forward-only marker
+      // guard prevents any skip, so it is accepted best-effort.
       let contextFiles: { name: string; url: string; mimeType?: string }[] | undefined
       if (!threadTs) {
-        const marker = getLastSeenTs(this.integrationId, chatId)
-        const ctx = await this.fetchHistorySince(chatId, marker, ts, SlackConnector.CHANNEL_CONTEXT_LIMIT)
-        if (ctx) {
-          text = ctx.text + '\n\n' + text
-          contextFiles = ctx.files.length ? ctx.files : undefined
+        try {
+          const marker = getLastSeenTs(this.integrationId, effectiveChatId)
+          const ctx = await this.fetchHistorySince(chatId, marker, ts, SlackConnector.CHANNEL_CONTEXT_LIMIT)
+          if (ctx) {
+            text = ctx.text + '\n\n' + text
+            contextFiles = ctx.files.length ? ctx.files : undefined
+          }
+        } catch (err) {
+          console.warn('[SlackConnector] channel-context seed failed (non-critical):', err instanceof Error ? err.message : err)
         }
       }
 

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -266,6 +266,9 @@ export class SlackConnector extends ChatClientConnector {
   private app: SlackApp | null = null
   private connected = false
   private botUserId: string | null = null
+  // Bot id from auth.test (xoxb tokens). Used to drop the bot's OWN historical
+  // messages even when they carry only a bot_id and no user field.
+  private botId: string | null = null
 
   // Track action_id → toolUseId mappings for interactive responses
   private actionDataMap: Map<string, { toolUseId: string; value: unknown; ts: number }> = new Map()
@@ -293,6 +296,10 @@ export class SlackConnector extends ChatClientConnector {
   // least-recently-touched threads; an evicted thread just re-fetches history /
   // requires a re-mention if it ever resurfaces.
   private static readonly MAX_TRACKED_THREADS = 1000
+  // Recent top-level channel messages seeded as context on a top-level mention.
+  private static readonly CHANNEL_CONTEXT_LIMIT = 10
+  // Newest historical files eagerly downloaded per seeded window.
+  private static readonly CHANNEL_CONTEXT_FILE_LIMIT = 3
 
   constructor(private config: SlackConfig) {
     super()
@@ -374,6 +381,17 @@ export class SlackConnector extends ChatClientConnector {
         if (history) text = history + '\n\n' + text
       }
 
+      // Top-level channel mention with onlyMentioned on: seed recent channel
+      // history (mutually exclusive with the thread block above).
+      let contextFiles: { name: string; url: string; mimeType?: string }[] | undefined
+      if (routing.shouldSeedChannelContext) {
+        const channelCtx = await this.fetchChannelHistory(chatId, ts)
+        if (channelCtx) {
+          text = channelCtx.text + '\n\n' + text
+          contextFiles = channelCtx.files.length ? channelCtx.files : undefined
+        }
+      }
+
       // Handle file uploads
       const files = msg.files?.map((f: any) => ({
         name: f.name || 'file',
@@ -389,6 +407,7 @@ export class SlackConnector extends ChatClientConnector {
         userName,
         chatName,
         files: files?.length ? files : undefined,
+        contextFiles,
         timestamp: new Date(Number(ts) * 1000),
       })
     })
@@ -450,6 +469,7 @@ export class SlackConnector extends ChatClientConnector {
         throw new Error(`Slack auth.test failed: ${authResult.error}`)
       }
       this.botUserId = authResult.user_id || null
+      this.botId = authResult.bot_id || null
       console.log(`[SlackConnector] Authenticated as ${authResult.user} in workspace ${authResult.team}`)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
@@ -806,6 +826,63 @@ export class SlackConnector extends ChatClientConnector {
       return `[Thread context — ${label}]\n${lines.join('\n')}`
     } catch (err) {
       console.warn('[SlackConnector] Failed to fetch thread history (non-critical):', err instanceof Error ? err.message : err)
+      return null
+    }
+  }
+
+  /**
+   * Build a channel-context block for a top-level mention, mirroring
+   * fetchThreadHistory but over conversations.history. Returns the prepend text
+   * plus metadata for the newest downloadable files (capped) so the manager can
+   * fetch them. Null on failure or when nothing is worth seeding (graceful).
+   */
+  private async fetchChannelHistory(
+    channel: string,
+    beforeTs: string,
+  ): Promise<{ text: string; files: { name: string; url: string; mimeType?: string }[] } | null> {
+    if (!this.app) return null
+    try {
+      const result = await this.app.client.conversations.history({
+        channel,
+        latest: beforeTs,
+        inclusive: false,
+        limit: SlackConnector.CHANNEL_CONTEXT_LIMIT,
+      })
+      if (!result.ok || !result.messages) return null
+
+      const selected = selectChannelContextMessages(
+        result.messages as SlackHistoryMessage[],
+        beforeTs,
+        this.botUserId,
+        this.botId,
+      )
+      if (selected.length === 0) return null
+
+      const lines: string[] = []
+      const files: { name: string; url: string; mimeType?: string }[] = []
+      for (const m of selected) {
+        const name = m.user ? (await this.resolveUserName(m.user) || m.user) : 'Unknown'
+        const textPart = m.text ? await this.resolveMentionsInText(m.text) : ''
+        const fileObjs = Array.isArray(m.files) ? (m.files as any[]) : []
+        const fileNames = fileObjs.map((f) => f?.name || 'file')
+        const filePart = fileNames.length ? `[shared file: ${fileNames.join(', ')}]` : ''
+        const combined = [textPart, filePart].filter(Boolean).join(' ')
+        if (combined) lines.push(`${name}: ${combined}`)
+        // Only queue downloadable files (private URLs). Permalink-only files are
+        // surfaced in the text above but cannot be fetched by the private path.
+        for (const f of fileObjs) {
+          const url = f?.url_private_download || f?.url_private || ''
+          if (url) files.push({ name: f?.name || 'file', url, mimeType: f?.mimetype })
+        }
+      }
+      if (lines.length === 0) return null
+
+      // selected is chronological, so the newest downloadable files are at the tail.
+      const capped = files.slice(-SlackConnector.CHANNEL_CONTEXT_FILE_LIMIT)
+      const label = lines.length === 1 ? '1 previous message' : `${lines.length} previous messages`
+      return { text: `[Channel context - ${label}]\n${lines.join('\n')}`, files: capped }
+    } catch (err) {
+      console.warn('[SlackConnector] Failed to fetch channel history (non-critical):', err instanceof Error ? err.message : err)
       return null
     }
   }

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -202,6 +202,44 @@ export function routeSlackMessage(params: SlackMessageRoutingParams): SlackMessa
   return { shouldProcess: true, effectiveChatId, threadContext, threadKey, isNewThreadEntry, shouldSeedChannelContext }
 }
 
+export interface SlackHistoryMessage {
+  ts?: string
+  user?: string
+  bot_id?: string
+  subtype?: string
+  text?: string
+  files?: unknown[]
+}
+
+// Content-bearing subtypes to keep. A message with NO subtype is kept too.
+// Everything else (channel_join, topic/purpose/name changes, message_changed,
+// message_deleted, etc.) is system noise and dropped.
+const KEEP_HISTORY_SUBTYPES = new Set(['bot_message', 'me_message', 'file_share', 'thread_broadcast'])
+
+/**
+ * Filter raw `conversations.history` messages down to the ones worth seeding as
+ * channel context, in chronological (oldest-first) order. Drops the triggering
+ * message, the bot's own messages (by user id or bot id), non-content subtypes,
+ * and empty messages. Threaded replies never appear here - history is top-level.
+ */
+export function selectChannelContextMessages(
+  messages: SlackHistoryMessage[],
+  currentTs: string,
+  botUserId: string | null,
+  botId: string | null,
+): SlackHistoryMessage[] {
+  const kept = messages.filter((m) => {
+    if (!m.ts || m.ts === currentTs) return false
+    if (botUserId && m.user === botUserId) return false
+    if (botId && m.bot_id && m.bot_id === botId) return false
+    if (m.subtype && !KEEP_HISTORY_SUBTYPES.has(m.subtype)) return false
+    const hasText = !!(m.text && m.text.trim())
+    const hasFiles = Array.isArray(m.files) && m.files.length > 0
+    return hasText || hasFiles
+  })
+  return kept.sort((a, b) => Number(a.ts) - Number(b.ts))
+}
+
 export function resolveSlackChannel(
   effectiveChatId: string,
   threadContextMap: ReadonlyMap<string, { channel: string; threadTs: string }>,

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -12,6 +12,7 @@ import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
 import { ChatClientConnector, type OutgoingMessage } from './base-connector'
 import { describeUnsupportedRequest, isUnsupportedInChat, splitChatMessage } from './utils'
 import { captureException } from '@shared/lib/error-reporting'
+import { touchAndCapSet, touchAndCapMap } from './collection-utils'
 
 // ── Config ──────────────────────────────────────────────────────────────
 
@@ -207,34 +208,6 @@ export function resolveSlackChannel(
   }
 
   return { channel: effectiveChatId }
-}
-
-/**
- * Insert `key` at the most-recently-used position of an insertion-ordered Set,
- * evicting the oldest entries once size exceeds `max`. Keeps long-lived tracking
- * sets bounded so a connector that touches more and more threads over a
- * long-running process can't leak memory. Re-inserting an existing key refreshes
- * its recency (delete + re-add).
- */
-export function touchAndCapSet(set: Set<string>, key: string, max: number): void {
-  set.delete(key)
-  set.add(key)
-  while (set.size > max) {
-    const oldest = set.values().next().value
-    if (oldest === undefined) break
-    set.delete(oldest)
-  }
-}
-
-/** Map counterpart of {@link touchAndCapSet}: (re)inserts `key` as MRU and evicts the oldest beyond `max`. */
-export function touchAndCapMap<V>(map: Map<string, V>, key: string, value: V, max: number): void {
-  map.delete(key)
-  map.set(key, value)
-  while (map.size > max) {
-    const oldest = map.keys().next().value
-    if (oldest === undefined) break
-    map.delete(oldest)
-  }
 }
 
 // ── Connector ───────────────────────────────────────────────────────────

--- a/src/shared/lib/db/migrations/0025_chilly_rumiko_fujikawa.sql
+++ b/src/shared/lib/db/migrations/0025_chilly_rumiko_fujikawa.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `chat_integration_sessions` ADD `last_seen_ts` text;

--- a/src/shared/lib/db/migrations/last-seen-ts-migration.test.ts
+++ b/src/shared/lib/db/migrations/last-seen-ts-migration.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+
+describe('last_seen_ts migration', () => {
+  it('adds a nullable last_seen_ts column to chat_integration_sessions', () => {
+    const sqlite = new Database(':memory:')
+    migrate(drizzle(sqlite), { migrationsFolder: 'src/shared/lib/db/migrations' })
+    const cols = sqlite.prepare(`PRAGMA table_info(chat_integration_sessions)`).all() as Array<{ name: string; notnull: number }>
+    const col = cols.find((c) => c.name === 'last_seen_ts')
+    expect(col).toBeDefined()
+    expect(col!.notnull).toBe(0) // nullable
+  })
+})

--- a/src/shared/lib/db/migrations/meta/0025_snapshot.json
+++ b/src/shared/lib/db/migrations/meta/0025_snapshot.json
@@ -1,0 +1,2341 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2c48a65b-21ce-4eb8-8083-8cc7b54d86e8",
+  "prevId": "73c89111-c165-4b74-afe6-36c10341e68f",
+  "tables": {
+    "agent_acl": {
+      "name": "agent_acl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_acl_user_agent_unique": {
+          "name": "agent_acl_user_agent_unique",
+          "columns": [
+            "user_id",
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "agent_acl_agent_slug_idx": {
+          "name": "agent_acl_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_acl_user_id_user_id_fk": {
+          "name": "agent_acl_user_id_user_id_fk",
+          "tableFrom": "agent_acl",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_connected_accounts": {
+      "name": "agent_connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_connected_accounts_unique": {
+          "name": "agent_connected_accounts_unique",
+          "columns": [
+            "agent_slug",
+            "connected_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_connected_accounts_connected_account_id_connected_accounts_id_fk": {
+          "name": "agent_connected_accounts_connected_account_id_connected_accounts_id_fk",
+          "tableFrom": "agent_connected_accounts",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "connected_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_remote_mcps": {
+      "name": "agent_remote_mcps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_remote_mcps_unique": {
+          "name": "agent_remote_mcps_unique",
+          "columns": [
+            "agent_slug",
+            "remote_mcp_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "agent_remote_mcps",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "remote_mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_scope_policies": {
+      "name": "api_scope_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_scope_policies_unique": {
+          "name": "api_scope_policies_unique",
+          "columns": [
+            "account_id",
+            "scope"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_scope_policies_account_id_connected_accounts_id_fk": {
+          "name": "api_scope_policies_account_id_connected_accounts_id_fk",
+          "tableFrom": "api_scope_policies",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_log_object_idx": {
+          "name": "audit_log_object_idx",
+          "columns": [
+            "object"
+          ],
+          "isUnique": false
+        },
+        "audit_log_user_id_idx": {
+          "name": "audit_log_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integration_access": {
+      "name": "chat_integration_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "approval_source": {
+          "name": "approval_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_id": {
+          "name": "first_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_name": {
+          "name": "first_user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message_preview": {
+          "name": "first_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_notice_sent_at": {
+          "name": "request_notice_sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_access_unique": {
+          "name": "chat_integration_access_unique",
+          "columns": [
+            "integration_id",
+            "external_chat_id"
+          ],
+          "isUnique": true
+        },
+        "chat_integration_access_status_idx": {
+          "name": "chat_integration_access_status_idx",
+          "columns": [
+            "integration_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_access_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_access_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_access",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chat_integration_access_status_check": {
+          "name": "chat_integration_access_status_check",
+          "value": "\"chat_integration_access\".\"status\" in ('pending','allowed','denied')"
+        },
+        "chat_integration_access_chat_type_check": {
+          "name": "chat_integration_access_chat_type_check",
+          "value": "\"chat_integration_access\".\"chat_type\" is null or \"chat_integration_access\".\"chat_type\" in ('private','group','supergroup')"
+        },
+        "chat_integration_access_source_check": {
+          "name": "chat_integration_access_source_check",
+          "value": "\"chat_integration_access\".\"approval_source\" is null or \"chat_integration_access\".\"approval_source\" in ('auto_first_contact','owner','migration')"
+        }
+      }
+    },
+    "chat_integration_sessions": {
+      "name": "chat_integration_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_ts": {
+          "name": "last_seen_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_sessions_integration_id_idx": {
+          "name": "chat_integration_sessions_integration_id_idx",
+          "columns": [
+            "integration_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_sessions_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_sessions_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_sessions",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integrations": {
+      "name": "chat_integrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "show_tool_calls": {
+          "name": "show_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "require_approval": {
+          "name": "require_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_timeout": {
+          "name": "session_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integrations_agent_slug_idx": {
+          "name": "chat_integrations_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "chat_integrations_status_idx": {
+          "name": "chat_integrations_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connected_accounts": {
+      "name": "connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_connection_id": {
+          "name": "provider_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "toolkit_slug": {
+          "name": "toolkit_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connected_accounts_provider_connection_id_unique": {
+          "name": "connected_accounts_provider_connection_id_unique",
+          "columns": [
+            "provider_connection_id"
+          ],
+          "isUnique": true
+        },
+        "connected_accounts_userId_idx": {
+          "name": "connected_accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connected_accounts_user_id_user_id_fk": {
+          "name": "connected_accounts_user_id_user_id_fk",
+          "tableFrom": "connected_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_name": {
+          "name": "remote_mcp_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_tool": {
+          "name": "matched_tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_policies": {
+      "name": "mcp_tool_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_tool_policies_unique": {
+          "name": "mcp_tool_policies_unique",
+          "columns": [
+            "mcp_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_policies",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message_author": {
+      "name": "message_author",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "message_author_session_idx": {
+          "name": "message_author_session_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_author_user_id_user_id_fk": {
+          "name": "message_author_user_id_user_id_fk",
+          "tableFrom": "message_author",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_agent_slug_is_read_idx": {
+          "name": "notifications_agent_slug_is_read_idx",
+          "columns": [
+            "agent_slug",
+            "is_read"
+          ],
+          "isUnique": false
+        },
+        "notifications_session_id_idx": {
+          "name": "notifications_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_audit_log": {
+      "name": "proxy_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_scopes": {
+          "name": "matched_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_tokens": {
+      "name": "proxy_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_tokens_agent_slug_unique": {
+          "name": "proxy_tokens_agent_slug_unique",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "proxy_tokens_token_unique": {
+          "name": "proxy_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_mcp_servers": {
+      "name": "remote_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token_endpoint": {
+          "name": "oauth_token_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_resource": {
+          "name": "oauth_resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_discovered_at": {
+          "name": "tools_discovered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "remote_mcp_servers_user_id_user_id_fk": {
+          "name": "remote_mcp_servers_user_id_user_id_fk",
+          "tableFrom": "remote_mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_expression": {
+          "name": "schedule_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "next_execution_at": {
+          "name": "next_execution_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "execution_count": {
+          "name": "execution_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_triggers": {
+      "name": "webhook_triggers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "composio_trigger_id": {
+          "name": "composio_trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fire_count": {
+          "name": "fire_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_triggers_agent_slug_idx": {
+          "name": "webhook_triggers_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_status_idx": {
+          "name": "webhook_triggers_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_composio_idx": {
+          "name": "webhook_triggers_composio_idx",
+          "columns": [
+            "composio_trigger_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "x_agent_policies": {
+      "name": "x_agent_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_agent_slug": {
+          "name": "caller_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_agent_slug": {
+          "name": "target_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "x_agent_policies_unique": {
+          "name": "x_agent_policies_unique",
+          "columns": [
+            "caller_agent_slug",
+            "target_agent_slug",
+            "operation"
+          ],
+          "isUnique": true
+        },
+        "x_agent_policies_caller_idx": {
+          "name": "x_agent_policies_caller_idx",
+          "columns": [
+            "caller_agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/shared/lib/db/migrations/meta/_journal.json
+++ b/src/shared/lib/db/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1781000000000,
       "tag": "0024_seed_chat_access",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1782339535562,
+      "tag": "0025_chilly_rumiko_fujikawa",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/lib/db/schema.ts
+++ b/src/shared/lib/db/schema.ts
@@ -444,6 +444,7 @@ export const chatIntegrationSessions = sqliteTable('chat_integration_sessions', 
   externalChatId: text('external_chat_id').notNull(), // Telegram chat_id or Slack channel_id
   sessionId: text('session_id').notNull(),
   displayName: text('display_name'), // e.g. "John's DM", "#general"
+  lastSeenTs: text('last_seen_ts'), // newest Slack ts this conversation's session has ingested; null until first ingest
   archivedAt: integer('archived_at', { mode: 'timestamp_ms' }), // Set when session is cleared; null = active
   createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
   updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),

--- a/src/shared/lib/services/chat-integration-session-service.marker.test.ts
+++ b/src/shared/lib/services/chat-integration-session-service.marker.test.ts
@@ -1,0 +1,66 @@
+// src/shared/lib/services/chat-integration-session-service.marker.test.ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { db } from '@shared/lib/db'
+import { chatIntegrations, chatIntegrationSessions } from '@shared/lib/db/schema'
+import {
+  createChatIntegrationSession,
+  archiveChatIntegrationSession,
+  getLastSeenTs,
+  setLastSeenTs,
+} from './chat-integration-session-service'
+
+const INT = 'int-marker-test'
+
+beforeEach(() => {
+  db.delete(chatIntegrationSessions).run()
+  db.delete(chatIntegrations).run()
+  db.insert(chatIntegrations).values({
+    id: INT, agentSlug: 'a', provider: 'slack', name: 'n', config: '{}',
+    showToolCalls: false, status: 'active', requireApproval: true,
+    createdAt: new Date(), updatedAt: new Date(),
+  } as any).run()
+})
+
+describe('getLastSeenTs / setLastSeenTs', () => {
+  it('returns null when no session exists', () => {
+    expect(getLastSeenTs(INT, 'C1')).toBeNull()
+  })
+
+  it('returns null when sessions exist but no marker is set', () => {
+    createChatIntegrationSession({ integrationId: INT, externalChatId: 'C1', sessionId: 's1' })
+    expect(getLastSeenTs(INT, 'C1')).toBeNull()
+  })
+
+  it('sets and reads the marker for the active row', () => {
+    const id = createChatIntegrationSession({ integrationId: INT, externalChatId: 'C1', sessionId: 's1' })
+    setLastSeenTs(id, '100.5')
+    expect(getLastSeenTs(INT, 'C1')).toBe('100.5')
+  })
+
+  it('compares numerically, not lexically', () => {
+    const id = createChatIntegrationSession({ integrationId: INT, externalChatId: 'C1', sessionId: 's1' })
+    // lexically "9.0" > "10.0"; numerically 9 < 10. Max must be "10.0".
+    setLastSeenTs(id, '9.0')
+    const id2 = createChatIntegrationSession({ integrationId: INT, externalChatId: 'C1', sessionId: 's2' })
+    setLastSeenTs(id2, '10.0')
+    expect(getLastSeenTs(INT, 'C1')).toBe('10.0')
+  })
+
+  it('carries forward across rotation: reads the max even from an archived row', () => {
+    const oldId = createChatIntegrationSession({ integrationId: INT, externalChatId: 'C1', sessionId: 's-old' })
+    setLastSeenTs(oldId, '500.0')
+    archiveChatIntegrationSession(oldId)
+    // New (active) row has no marker yet.
+    createChatIntegrationSession({ integrationId: INT, externalChatId: 'C1', sessionId: 's-new' })
+    expect(getLastSeenTs(INT, 'C1')).toBe('500.0')
+  })
+
+  it('scopes by conversation (integrationId + externalChatId)', () => {
+    const a = createChatIntegrationSession({ integrationId: INT, externalChatId: 'C1', sessionId: 's1' })
+    setLastSeenTs(a, '100.0')
+    const b = createChatIntegrationSession({ integrationId: INT, externalChatId: 'C2', sessionId: 's2' })
+    setLastSeenTs(b, '200.0')
+    expect(getLastSeenTs(INT, 'C1')).toBe('100.0')
+    expect(getLastSeenTs(INT, 'C2')).toBe('200.0')
+  })
+})

--- a/src/shared/lib/services/chat-integration-session-service.marker.test.ts
+++ b/src/shared/lib/services/chat-integration-session-service.marker.test.ts
@@ -46,13 +46,16 @@ describe('getLastSeenTs / setLastSeenTs', () => {
     expect(getLastSeenTs(INT, 'C1')).toBe('10.0')
   })
 
-  it('carries forward across rotation: reads the max even from an archived row', () => {
+  it('is session-scoped: a refreshed session starts cold (archived marker is ignored)', () => {
     const oldId = createChatIntegrationSession({ integrationId: INT, externalChatId: 'C1', sessionId: 's-old' })
     setLastSeenTs(oldId, '500.0')
     archiveChatIntegrationSession(oldId)
-    // New (active) row has no marker yet.
+    // Once the session is refreshed, its marker lives on the archived row and is
+    // no longer read - the next message must cold-start (seed recent history).
+    expect(getLastSeenTs(INT, 'C1')).toBeNull()
+    // A fresh active row also starts with no marker -> still null (cold start).
     createChatIntegrationSession({ integrationId: INT, externalChatId: 'C1', sessionId: 's-new' })
-    expect(getLastSeenTs(INT, 'C1')).toBe('500.0')
+    expect(getLastSeenTs(INT, 'C1')).toBeNull()
   })
 
   it('scopes by conversation (integrationId + externalChatId)', () => {

--- a/src/shared/lib/services/chat-integration-session-service.ts
+++ b/src/shared/lib/services/chat-integration-session-service.ts
@@ -190,11 +190,18 @@ export function deleteChatIntegrationSessionsByIntegration(integrationId: string
 // ── Marker (last seen message) ────────────────────────────────────────────
 
 /**
- * Newest ingested Slack ts for a conversation, across ALL rows (active +
- * archived). Reading across rows is what carries the marker forward when a
- * session rotates: a fresh row starts with a null marker, so the max comes
- * from the archived predecessor. Compared numerically (Slack ts are decimal
- * strings; a lexical sort would order "9.0" after "10.0").
+ * Newest ingested Slack ts for a conversation's ACTIVE session row (archived
+ * rows are ignored). The marker is session-scoped: a fresh session has no active
+ * marker, so this returns null and the connector cold-starts - seeds recent
+ * channel history so the agent is never context-blind on a new session. Within a
+ * live session the marker advances, so only the unseen gap is seeded instead of
+ * re-dumping recent history on every message. An explicit clear archives the row
+ * (its marker moves to the archived row this read skips), so the next message
+ * cold-starts with no reset code. (Auto-delete removes only the agent transcript,
+ * not this mapping row, so its next message self-heals first - gap-fills once,
+ * then cold-starts; after a multi-day idle that gap is ~the newest 15 anyway.)
+ * Compared numerically (Slack ts are decimal strings; a lexical sort would order
+ * "9.0" after "10.0").
  */
 export function getLastSeenTs(integrationId: string, externalChatId: string): string | null {
   const rows = db.select({ lastSeenTs: chatIntegrationSessions.lastSeenTs })
@@ -202,6 +209,7 @@ export function getLastSeenTs(integrationId: string, externalChatId: string): st
     .where(and(
       eq(chatIntegrationSessions.integrationId, integrationId),
       eq(chatIntegrationSessions.externalChatId, externalChatId),
+      isNull(chatIntegrationSessions.archivedAt),
     ))
     .all()
   let best: string | null = null

--- a/src/shared/lib/services/chat-integration-session-service.ts
+++ b/src/shared/lib/services/chat-integration-session-service.ts
@@ -186,3 +186,37 @@ export function deleteChatIntegrationSessionsByIntegration(integrationId: string
     .run()
   return result.changes
 }
+
+// ── Marker (last seen message) ────────────────────────────────────────────
+
+/**
+ * Newest ingested Slack ts for a conversation, across ALL rows (active +
+ * archived). Reading across rows is what carries the marker forward when a
+ * session rotates: a fresh row starts with a null marker, so the max comes
+ * from the archived predecessor. Compared numerically (Slack ts are decimal
+ * strings; a lexical sort would order "9.0" after "10.0").
+ */
+export function getLastSeenTs(integrationId: string, externalChatId: string): string | null {
+  const rows = db.select({ lastSeenTs: chatIntegrationSessions.lastSeenTs })
+    .from(chatIntegrationSessions)
+    .where(and(
+      eq(chatIntegrationSessions.integrationId, integrationId),
+      eq(chatIntegrationSessions.externalChatId, externalChatId),
+    ))
+    .all()
+  let best: string | null = null
+  for (const r of rows) {
+    if (r.lastSeenTs == null) continue
+    if (best == null || Number(r.lastSeenTs) > Number(best)) best = r.lastSeenTs
+  }
+  return best
+}
+
+/** Record the newest ingested Slack ts on a single session row. */
+export function setLastSeenTs(sessionRowId: string, ts: string): boolean {
+  const result = db.update(chatIntegrationSessions)
+    .set({ lastSeenTs: ts })
+    .where(eq(chatIntegrationSessions.id, sessionRowId))
+    .run()
+  return result.changes > 0
+}


### PR DESCRIPTION
## What

When a Slack agent is pulled into a conversation, it now sees the recent channel/DM messages it has not already ingested - so it can resolve references like "@bot can you log that" without the user re-explaining. On each processed top-level channel message or DM, the connector backfills the gap since a per-conversation marker (`last_seen_ts`), capped at the newest 15, with attached files downloaded. The bot's own messages are dropped; other bots are kept. Threads are unchanged (they keep the existing thread-history path).

## Why

Agents were blind to channel context outside their own session. A top-level mention handed the agent only the mention text, so "summarize what they said above" or "log that" had nothing to work with.

## Behavior

- A fresh agent session always cold-starts: it seeds the newest 15 messages so it is never context-blind. Within a live session the marker advances, so only the unseen gap is seeded - no re-dumping the same history on every message.
- The marker is scoped to the active session. Clearing a conversation re-orients the fresh agent with recent context on its next message; an ongoing session keeps its accumulated context and only fills new gaps.
- Setting-independent: "only respond on mentions" gates whether a message is processed, not whether context is seeded.
- Best-effort throughout: any history fetch or marker read/write failure logs a warning and the message still processes - no path blocks a reply.

## Scope

Host-side only: `src/shared/lib/chat-integrations/` (Slack connector + manager), the chat-integration session service, and one additive nullable column (`last_seen_ts` on `chat_integration_sessions`, migration 0025). No new OAuth scopes - channel/group/DM history scopes are already in the standard setup manifest. No agent-container changes.

## Key parameters

- Channel/DM: newest **15** messages per seed (`CHANNEL_CONTEXT_LIMIT`); no per-file-count cap - every file in the window downloads, deduped per-agent by Slack file-id (re-seeds reuse the on-disk copy instead of re-downloading).
- Per-file download limit **50 MB**; empty files and HTML error pages (a missing `files:read` scope) are skipped, not saved.
- Threads (unchanged path): up to **50** prior replies, **text only**.

## How verified

- Unit: marker helpers (active-row scoping, numeric compare), the migration, connector gap-fill (cold-start, between-mention gap, all-files, own-bot-drop, singular/plural label), and marker advance (forward-only, Slack-gated, best-effort). Full chat-integrations + services + db suites green; typecheck and lint clean.
- Manual Slack smoke against a real workspace: cold-start backfill, between-mention gap, steady-state no-seed, own-bot-not-reseeded, file download to `uploads/`, large gap capped at the newest 15, and clear -> cold-start re-seed.

## Known limitations / follow-ups

- **Deep context is lost on reset.** Cold-start restores only the newest 15, so after a clear or an auto-delete a fresh session lacks anything older - an agent can seem to "forget" history it held in the prior session. Cost trade-off; candidate follow-up: an on-demand history reach-back tool so the agent pulls older messages only when a question needs them.
- **Thread history is text-only** - files shared earlier in a thread aren't surfaced or downloaded (the thread path is pre-existing and unchanged here). Follow-up candidate.
- **answer-in-thread on + new-session-per-thread off:** thread replies share the channel session and can nudge the channel marker, so a later top-level seed may under-seed by a message or two. Narrow, config-specific, bounded, never blocks a reply. Follow-up candidate.
- **Concurrency:** the marker read precedes the manager's per-chat queue, so two near-simultaneous messages can double-seed an overlapping window - bounded (<=15, files deduped), no data loss; accepted as best-effort.
