### PR TITLE
ci: don't fail e2e job on retry-recovered flakes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,8 +110,8 @@ jobs:
         env:
           PLAYWRIGHT_WORKERS: '2'
         run: |
-          PORT=3000 SUPERAGENT_DATA_DIR=.e2e-data PLAYWRIGHT_WORKERS=1 PLAYWRIGHT_OUTPUT_DIR=test-results/stateful PLAYWRIGHT_HTML_REPORT=playwright-report/stateful npm run test:e2e:stateful -- --fail-on-flaky-tests
-          PORT=3000 SUPERAGENT_DATA_DIR=.e2e-data PLAYWRIGHT_WORKERS=$PLAYWRIGHT_WORKERS PLAYWRIGHT_OUTPUT_DIR=test-results/web PLAYWRIGHT_HTML_REPORT=playwright-report/web npm run test:e2e:web -- --fail-on-flaky-tests
+          PORT=3000 SUPERAGENT_DATA_DIR=.e2e-data PLAYWRIGHT_WORKERS=1 PLAYWRIGHT_OUTPUT_DIR=test-results/stateful PLAYWRIGHT_HTML_REPORT=playwright-report/stateful npm run test:e2e:stateful
+          PORT=3000 SUPERAGENT_DATA_DIR=.e2e-data PLAYWRIGHT_WORKERS=$PLAYWRIGHT_WORKERS PLAYWRIGHT_OUTPUT_DIR=test-results/web PLAYWRIGHT_HTML_REPORT=playwright-report/web npm run test:e2e:web
 
       - name: Upload Playwright artifacts
         if: always()
@@ -151,7 +151,7 @@ jobs:
           SUPERAGENT_DATA_DIR: .e2e-data/auth
           PLAYWRIGHT_OUTPUT_DIR: test-results/auth
           PLAYWRIGHT_HTML_REPORT: playwright-report/auth
-        run: npm run test:e2e:auth -- --fail-on-flaky-tests
+        run: npm run test:e2e:auth
 
       - name: Upload auth Playwright artifacts
         if: always()
@@ -193,7 +193,7 @@ jobs:
           PLAYWRIGHT_WORKERS: '1'
           PLAYWRIGHT_OUTPUT_DIR: test-results/a11y
           PLAYWRIGHT_HTML_REPORT: playwright-report/a11y
-        run: npm run test:e2e:a11y -- --fail-on-flaky-tests
+        run: npm run test:e2e:a11y
 
       - name: Upload a11y Playwright artifacts
         if: always()


### PR DESCRIPTION
## Problem

The `e2e-tests` job has been red on most runs since **Jun 15** — not because tests fail, but because of `--fail-on-flaky-tests`. The actual result in nearly every failure is `~164 passed, 2 flaky, exit code 1`: a "flaky" test is one that failed attempt 1 but **passed on retry** (`retries: 2`), and that flag turns a single retry-recovered test out of ~200 into a hard build failure.

The trigger was `a327df05` ("split e2e infra lanes"), which added `--fail-on-flaky-tests` to all four suites *and* moved the job to a shared self-hosted runner with 2 workers. Before that, plain `npm run test:e2e` let `retries: 2` absorb the same flakes and stay green.

The residual flakes are broad and timing-shaped (spread across ~22 distinct tests — `waitForResponse`/input-re-enable 15s waits and 30s test-timeouts, i.e. the SSE late-join/refetch races retries exist to absorb), not one broken test. With ~200 tests, even a ~1% first-attempt flake rate makes the job red ~85%+ of runs while ~99.5% of tests pass and all eventually pass on retry.

## Change

Remove `--fail-on-flaky-tests` from all four e2e suites (stateful, web, auth, a11y). `retries: 2` now absorbs infra flakes → the job goes green; flakes remain visible in the uploaded `playwright-report` artifact. Restores pre-`a327df05` behavior.

## Follow-up (not in this PR)

The residual timing flakes are real and were always masked by retries. If we want to drive the flake rate down, the levers are the web suite's 2-workers-on-one-dev-server contention and the streaming wait ceilings.