### PR TITLE
fix(container): make MicroVM stop suspend-only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@analytics/mixpanel": "^0.4.0",
         "@anthropic-ai/bedrock-sdk": "^0.30.2",
         "@anthropic-ai/sdk": "^0.104.2",
+        "@aws-sdk/client-lambda-microvms": "^3.1075.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -889,34 +890,68 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/core": {
-      "version": "3.973.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.20.tgz",
-      "integrity": "sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==",
+    "node_modules/@aws-sdk/client-lambda-microvms": {
+      "version": "3.1075.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda-microvms/-/client-lambda-microvms-3.1075.0.tgz",
+      "integrity": "sha512-aRqc4fT/qwwsbhiiaTsY/rNtsZjZMWuDEIYBaWNgQcsGJ8BPQvz3uNq+O08vl8rnRhNf6NotMqXfqyW+byaPeQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/xml-builder": "^3.972.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-node": "^3.972.58",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/core/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
-      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+    "node_modules/@aws-sdk/client-lambda-microvms/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda-microvms/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda-microvms/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda-microvms/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -925,50 +960,59 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/core/node_modules/@smithy/protocol-http": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
-      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+    "node_modules/@aws-sdk/client-lambda-microvms/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda-microvms/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
+      "integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.31",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/core/node_modules/@smithy/signature-v4": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
-      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
+      "integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/core/node_modules/@smithy/smithy-client": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.5.tgz",
-      "integrity": "sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.11",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.19",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -976,25 +1020,11 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/core/node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1030,15 +1060,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.18.tgz",
-      "integrity": "sha512-X0B8AlQY507i5DwjLByeU2Af4ARsl9Vr84koDcXCbAkplmU+1xBFWxEPrWRAoh56waBne/yJqEloSwvRf4x6XA==",
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
+      "integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1046,9 +1076,9 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1058,61 +1088,27 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.20.tgz",
-      "integrity": "sha512-ey9Lelj001+oOfrbKmS6R2CJAiXX7QKY4Vj9VJv6L2eE6/VjD8DocHIoYqztTm70xDLR4E1jYPTKfIui+eRNDA==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
+      "integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.19",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/protocol-http": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
-      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/smithy-client": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.5.tgz",
-      "integrity": "sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.11",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.19",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1122,24 +1118,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.20.tgz",
-      "integrity": "sha512-5flXSnKHMloObNF+9N0cupKegnH1Z37cdVlpETVgx8/rAhCe+VNlkcZH3HDg2SDn9bI765S+rhNPXGDJJPfbtA==",
+      "version": "3.972.56",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
+      "integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-env": "^3.972.18",
-        "@aws-sdk/credential-provider-http": "^3.972.20",
-        "@aws-sdk/credential-provider-login": "^3.972.20",
-        "@aws-sdk/credential-provider-process": "^3.972.18",
-        "@aws-sdk/credential-provider-sso": "^3.972.20",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.20",
-        "@aws-sdk/nested-clients": "^3.996.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-login": "^3.972.55",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1147,9 +1142,9 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1159,41 +1154,26 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.20.tgz",
-      "integrity": "sha512-gEWo54nfqp2jABMu6HNsjVC4hDLpg9HC8IKSJnp0kqWtxIJYHTmiLSsIfI4ScQjxEwpB+jOOH8dOLax1+hy/Hw==",
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
+      "integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/nested-clients": "^3.996.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/protocol-http": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
-      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1203,22 +1183,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.21.tgz",
-      "integrity": "sha512-hah8if3/B/Q+LBYN5FukyQ1Mym6PLPDsBOBsIgNEYD6wLyZg0UmUF/OKIVC3nX9XH8TfTPuITK+7N/jenVACWA==",
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
+      "integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.18",
-        "@aws-sdk/credential-provider-http": "^3.972.20",
-        "@aws-sdk/credential-provider-ini": "^3.972.20",
-        "@aws-sdk/credential-provider-process": "^3.972.18",
-        "@aws-sdk/credential-provider-sso": "^3.972.20",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.20",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-ini": "^3.972.56",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1226,9 +1205,9 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1238,16 +1217,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.18.tgz",
-      "integrity": "sha512-Tpl7SRaPoOLT32jbTWchPsn52hYYgJ0kpiFgnwk8pxTANQdUymVSZkzFvv1+oOgZm1CrbQUP9MBeoMZ9IzLZjA==",
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
+      "integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1255,9 +1233,9 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1267,18 +1245,34 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.20.tgz",
-      "integrity": "sha512-p+R+PYR5Z7Gjqf/6pvbCnzEHcqPCpLzR7Yf127HjJ6EAb4hUcD+qsNRnuww1sB/RmSeCLxyay8FMyqREw4p1RA==",
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
+      "integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/nested-clients": "^3.996.10",
-        "@aws-sdk/token-providers": "3.1009.0",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/token-providers": "3.1074.0",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1074.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
+      "integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1286,9 +1280,9 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1298,17 +1292,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.20.tgz",
-      "integrity": "sha512-rWCmh8o7QY4CsUj63qopzMzkDq/yPpkrpb+CnjBEFSOg/02T/we7sSTVg4QsDiVS9uwZ8VyONhq98qt+pIh3KA==",
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
+      "integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/nested-clients": "^3.996.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1316,9 +1309,9 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1682,48 +1675,20 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.10.tgz",
-      "integrity": "sha512-SlDol5Z+C7Ivnc2rKGqiqfSUmUZzY1qHfVs9myt/nxVwswgfpjdKahyTzLTx802Zfq0NFRs7AejwKzzzl5Co2w==",
+      "version": "3.997.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
+      "integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1793,57 +1758,12 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/protocol-http": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
-      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/smithy-client": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.5.tgz",
-      "integrity": "sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.11",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.19",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1870,6 +1790,47 @@
       "version": "4.13.1",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
       "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/signature-v4": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
+      "integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1909,12 +1870,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1922,9 +1883,9 @@
       }
     },
     "node_modules/@aws-sdk/types/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2071,13 +2032,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.15.tgz",
-      "integrity": "sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
+      "integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "fast-xml-parser": "5.5.8",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2085,9 +2045,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -7771,31 +7731,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@smithy/abort-controller": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
-      "integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/config-resolver": {
       "version": "4.4.11",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.11.tgz",
@@ -7826,33 +7761,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.11",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.11.tgz",
-      "integrity": "sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
+      "integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.19",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/core/node_modules/@smithy/protocol-http": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
-      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7860,25 +7775,11 @@
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/core/node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7886,15 +7787,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
-      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
+      "integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7902,9 +7801,9 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -8104,28 +8003,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.15",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
-      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
+      "integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/protocol-http": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
-      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8133,25 +8017,11 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8448,28 +8318,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.16.tgz",
-      "integrity": "sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+      "integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/node-http-handler/node_modules/@smithy/protocol-http": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
-      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8477,9 +8332,9 @@
       }
     },
     "node_modules/@smithy/node-http-handler/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -15167,41 +15022,6 @@
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
     },
-    "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.1.3"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -19837,21 +19657,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -22345,18 +22150,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/strnum": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.1.tgz",
-      "integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@analytics/mixpanel": "^0.4.0",
     "@anthropic-ai/bedrock-sdk": "^0.30.2",
     "@anthropic-ai/sdk": "^0.104.2",
+    "@aws-sdk/client-lambda-microvms": "^3.1075.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -30,6 +30,7 @@ import adminUsersRouter from './routes/admin-users'
 import auditLogRouter from './routes/audit-log'
 import debugRouter from './routes/debug'
 import platformAuth from './routes/platform-auth'
+import agentBootstrap from './routes/agent-bootstrap'
 import { initializeServices } from '@shared/lib/startup'
 import { isAuthMode } from '@shared/lib/auth/mode'
 import { sql } from 'drizzle-orm'
@@ -175,6 +176,7 @@ app.route('/api/webhook-triggers', webhookTriggers)
 app.route('/api/chat-integrations', chatIntegrationsRouter)
 app.route('/api/notifications', notifications)
 app.route('/api/proxy', proxy)
+app.route('/api/agent-bootstrap', agentBootstrap)
 app.route('/api/mcp-proxy', mcpProxy)
 app.route('/api/browser', browser)
 app.route('/api/skillsets', skillsets)

--- a/src/api/middleware/local-mode-auth.ts
+++ b/src/api/middleware/local-mode-auth.ts
@@ -20,6 +20,7 @@ const LOCALHOST_ADDRS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1'])
  */
 const CONTAINER_FACING_PREFIXES = [
   '/api/proxy/',
+  '/api/agent-bootstrap/',
   '/api/mcp-proxy/',
   '/api/x-agent/', // covers /api/x-agent and /api/x-agent/chat
   '/api/browser/',

--- a/src/api/routes/agent-bootstrap.test.ts
+++ b/src/api/routes/agent-bootstrap.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const validateProxyToken = vi.fn(async (_token: string): Promise<string | null> => null)
+vi.mock('@shared/lib/proxy/token-store', () => ({
+  validateProxyToken: (t: string) => validateProxyToken(t),
+}))
+
+import agentBootstrap from './agent-bootstrap'
+import { setBootstrapEnv, resetBootstrapEnvStoreForTests } from '@shared/lib/container/agent-bootstrap-env-store'
+
+function get(path: string, headers: Record<string, string> = {}) {
+  return agentBootstrap.request(path, { headers })
+}
+
+beforeEach(() => {
+  validateProxyToken.mockReset().mockResolvedValue(null)
+  resetBootstrapEnvStoreForTests()
+})
+
+describe('GET /:agentSlug/env', () => {
+  it('returns the stashed env for a valid token matching the agent', async () => {
+    validateProxyToken.mockResolvedValue('agent-1')
+    setBootstrapEnv('agent-1', { FOO: 'bar', PROXY_TOKEN: 'synth_x' })
+    const res = await get('/agent-1/env', { Authorization: 'Bearer synth_x' })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ env: { FOO: 'bar', PROXY_TOKEN: 'synth_x' } })
+  })
+
+  it('401 when the Authorization header is missing', async () => {
+    setBootstrapEnv('agent-1', { FOO: 'bar' })
+    expect((await get('/agent-1/env')).status).toBe(401)
+  })
+
+  it('401 when the token is invalid', async () => {
+    validateProxyToken.mockResolvedValue(null)
+    setBootstrapEnv('agent-1', { FOO: 'bar' })
+    expect((await get('/agent-1/env', { Authorization: 'Bearer nope' })).status).toBe(401)
+  })
+
+  it('403 when the token resolves to a different agent', async () => {
+    validateProxyToken.mockResolvedValue('agent-2')
+    setBootstrapEnv('agent-1', { FOO: 'bar' })
+    expect((await get('/agent-1/env', { Authorization: 'Bearer synth_other' })).status).toBe(403)
+  })
+
+  it('404 when no env is stashed', async () => {
+    validateProxyToken.mockResolvedValue('agent-1')
+    expect((await get('/agent-1/env', { Authorization: 'Bearer synth_x' })).status).toBe(404)
+  })
+
+  it('is single-use: the second fetch gets 404', async () => {
+    validateProxyToken.mockResolvedValue('agent-1')
+    setBootstrapEnv('agent-1', { FOO: 'bar' })
+    expect((await get('/agent-1/env', { Authorization: 'Bearer synth_x' })).status).toBe(200)
+    expect((await get('/agent-1/env', { Authorization: 'Bearer synth_x' })).status).toBe(404)
+  })
+})

--- a/src/api/routes/agent-bootstrap.ts
+++ b/src/api/routes/agent-bootstrap.ts
@@ -1,0 +1,31 @@
+// Container-to-host endpoint a remote agent VM hits once at boot to fetch its full
+// env. Auth: Bearer PROXY_TOKEN whose resolved slug must match :agentSlug.
+
+import { Hono } from 'hono'
+import { validateProxyToken } from '@shared/lib/proxy/token-store'
+import { consumeBootstrapEnv } from '@shared/lib/container/agent-bootstrap-env-store'
+
+const agentBootstrap = new Hono()
+
+agentBootstrap.get('/:agentSlug/env', async (c) => {
+  const agentSlug = c.req.param('agentSlug')
+  const token = c.req.header('Authorization')?.replace('Bearer ', '')
+  if (!token) {
+    return c.json({ error: 'Unauthorized' }, 401)
+  }
+  const callerSlug = await validateProxyToken(token)
+  if (!callerSlug) {
+    return c.json({ error: 'Unauthorized' }, 401)
+  }
+  if (callerSlug !== agentSlug) {
+    return c.json({ error: 'Token does not match agent' }, 403)
+  }
+  // Single-use: a second fetch gets 404.
+  const env = consumeBootstrapEnv(agentSlug)
+  if (!env) {
+    return c.json({ error: 'No bootstrap env available' }, 404)
+  }
+  return c.json({ env })
+})
+
+export default agentBootstrap

--- a/src/shared/lib/container/agent-bootstrap-env-store.ts
+++ b/src/shared/lib/container/agent-bootstrap-env-store.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+// In-memory, single-use stash of the full agent env (keyed by slug) for runtimes
+// whose start transport can't carry it; the VM fetches it once via /api/agent-bootstrap.
+export const bootstrapEnvSchema = z.record(z.string(), z.string())
+export type BootstrapEnv = z.infer<typeof bootstrapEnvSchema>
+
+const store = new Map<string, BootstrapEnv>()
+
+export function setBootstrapEnv(agentSlug: string, env: BootstrapEnv): void {
+  store.set(agentSlug, bootstrapEnvSchema.parse(env))
+}
+
+// Returns the stashed env and deletes it (single-use). Null if absent/consumed.
+export function consumeBootstrapEnv(agentSlug: string): BootstrapEnv | null {
+  const env = store.get(agentSlug)
+  if (!env) return null
+  store.delete(agentSlug)
+  return env
+}
+
+export function clearBootstrapEnv(agentSlug: string): void {
+  store.delete(agentSlug)
+}
+
+export function resetBootstrapEnvStoreForTests(): void {
+  store.clear()
+}

--- a/src/shared/lib/container/base-container-client.test.ts
+++ b/src/shared/lib/container/base-container-client.test.ts
@@ -5,6 +5,14 @@ import * as os from 'os'
 import { writeEnvFile, parseMemoryValue, shellQuote, isConnectionError, getEnhancedPath, BaseContainerClient } from './base-container-client'
 import type { ContainerInfo, ContainerConfig, StreamMessage } from './types'
 
+const enableToolSearch = vi.fn((): boolean | undefined => true)
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({ enableToolSearch: enableToolSearch() }),
+}))
+vi.mock('@shared/lib/llm-provider', () => ({
+  getActiveLlmProvider: () => ({ getContainerEnvVars: () => ({ ANTHROPIC_API_KEY: 'provider-key' }) }),
+}))
+
 /** Minimal concrete subclass to exercise protected run-error classification. */
 class TestContainerClient extends BaseContainerClient {
   protected getRunnerCommand(): string {
@@ -17,7 +25,33 @@ class TestContainerClient extends BaseContainerClient {
   public testExtractInaccessibleMountPath(error: unknown): string | null {
     return this.extractInaccessibleMountPath(error)
   }
+  public testBuildAgentEnv(extra?: Record<string, string>): Record<string, string> {
+    return this.buildAgentEnv(extra)
+  }
 }
+
+describe('buildAgentEnv', () => {
+  afterEach(() => enableToolSearch.mockReturnValue(true))
+
+  it('merges provider env, constants, config.envVars and per-start extra (later wins)', () => {
+    const client = new TestContainerClient({
+      agentId: 'a',
+      envVars: { FROM_CONFIG: 'c', ANTHROPIC_API_KEY: 'from-config' }, // config beats provider
+    })
+    const env = client.testBuildAgentEnv({ FROM_EXTRA: 'e', FROM_CONFIG: 'from-extra' }) // extra beats config
+    expect(env.ANTHROPIC_API_KEY).toBe('from-config')
+    expect(env.FROM_CONFIG).toBe('from-extra')
+    expect(env.FROM_EXTRA).toBe('e')
+    expect(env.CLAUDE_CONFIG_DIR).toBe('/workspace/.claude')
+    expect(env.ENABLE_TOOL_SEARCH).toBe('true')
+  })
+
+  it('sets ENABLE_TOOL_SEARCH=false only when the setting is explicitly false', () => {
+    enableToolSearch.mockReturnValue(false)
+    const env = new TestContainerClient({ agentId: 'a', envVars: {} }).testBuildAgentEnv()
+    expect(env.ENABLE_TOOL_SEARCH).toBe('false')
+  })
+})
 
 describe('writeEnvFile', () => {
   const cleanups: (() => void)[] = []

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -1420,20 +1420,32 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   }
 
   /**
-   * Write env vars to a temp file and return the --env-file flag.
-   * This avoids shell quoting issues and Windows command length limits.
-   * The caller must clean up the file after the container starts.
+   * The env every agent gets, independent of how a runtime delivers it (docker
+   * env-file, k8s pod env, MicroVM runHookPayload). Defined once here; subclasses
+   * only serialize the result into their transport. Merge order:
+   * provider defaults < runtime constants < config.envVars < per-start extra.
    */
-  protected buildEnvFile(additionalEnvVars?: Record<string, string>): { flag: string; cleanup: () => void } {
+  protected buildAgentEnv(extra?: Record<string, string>): Record<string, string> {
     const settings = getSettings()
-    const envVars: Record<string, string | undefined> = {
+    const merged: Record<string, string | undefined> = {
       ...getActiveLlmProvider().getContainerEnvVars(),
       CLAUDE_CONFIG_DIR: '/workspace/.claude',
       ENABLE_TOOL_SEARCH: settings.enableToolSearch !== false ? 'true' : 'false',
       ...this.config.envVars,
-      ...additionalEnvVars,
+      ...extra,
     }
+    const out: Record<string, string> = {}
+    for (const [key, value] of Object.entries(merged)) {
+      if (value !== undefined) out[key] = value
+    }
+    return out
+  }
 
-    return writeEnvFile(envVars, this.config.agentId)
+  /**
+   * Serialize the agent env to a temp --env-file (avoids shell-quoting issues and
+   * Windows command-length limits). Caller cleans up the file after start.
+   */
+  protected buildEnvFile(additionalEnvVars?: Record<string, string>): { flag: string; cleanup: () => void } {
+    return writeEnvFile(this.buildAgentEnv(additionalEnvVars), this.config.agentId)
   }
 }

--- a/src/shared/lib/container/client-factory.test.ts
+++ b/src/shared/lib/container/client-factory.test.ts
@@ -70,6 +70,14 @@ vi.mock('./platform-k8s-runtime', () => ({
   },
 }))
 
+vi.mock('./lambda-microvm-runtime', () => ({
+  LambdaMicroVmRuntimeClient: class {
+    static isEligible() { return false }
+    static async isAvailable() { return false }
+    static async isRunning() { return false }
+  },
+}))
+
 const mockExecWithPath = vi.fn()
 const mockSpawnWithPath = vi.fn()
 vi.mock('./base-container-client', () => ({

--- a/src/shared/lib/container/client-factory.ts
+++ b/src/shared/lib/container/client-factory.ts
@@ -6,6 +6,7 @@ import { AppleContainerClient } from './apple-container-client'
 import { LimaContainerClient, getNerdctlWrapperPath, ensureLimaReady, stopLimaVm } from './lima-container-client'
 import { WSL2ContainerClient, getWSL2NerdctlWrapperPath, ensureWSL2Ready, stopWSL2Distro } from './wsl2-container-client'
 import { PlatformK8sRuntimeClient } from './platform-k8s-runtime'
+import { LambdaMicroVmRuntimeClient } from './lambda-microvm-runtime'
 import { RunnerSetupError, type RunnerSetupRemediation } from './wsl2-setup-errors'
 import { MockContainerClient } from './mock-container-client'
 import { getSettings } from '@shared/lib/config/settings'
@@ -13,7 +14,7 @@ import { BaseContainerClient, execWithPath, spawnWithPath, AGENT_CONTAINER_PATH 
 import { platform } from 'os'
 import * as fs from 'fs'
 
-export type ContainerRunner = 'docker' | 'podman' | 'apple-container' | 'lima' | 'wsl2' | 'kubernetes'
+export type ContainerRunner = 'docker' | 'podman' | 'apple-container' | 'lima' | 'wsl2' | 'kubernetes' | 'lambda-microvm'
 
 export interface RunnerAvailability {
   runner: ContainerRunner
@@ -55,6 +56,7 @@ const ALL_RUNNERS: {
   { name: 'lima', cliCommand: () => getNerdctlWrapperPath(), isEligible: () => LimaContainerClient.isEligible(), isAvailable: () => LimaContainerClient.isAvailable(), reconcileRuntimeState: () => LimaContainerClient.reconcileRuntimeState(), isRunning: () => LimaContainerClient.isRunning(), shutdownRuntime: () => stopLimaVm() },
   { name: 'wsl2', cliCommand: () => getWSL2NerdctlWrapperPath(), isEligible: () => WSL2ContainerClient.isEligible(), isAvailable: () => WSL2ContainerClient.isAvailable(), isRunning: () => WSL2ContainerClient.isRunning(), shutdownRuntime: () => stopWSL2Distro() },
   { name: 'kubernetes', cliCommand: 'kubernetes', isEligible: () => PlatformK8sRuntimeClient.isEligible(), isAvailable: () => PlatformK8sRuntimeClient.isAvailable(), isRunning: () => PlatformK8sRuntimeClient.isRunning() },
+  { name: 'lambda-microvm', cliCommand: 'lambda-microvm', isEligible: () => LambdaMicroVmRuntimeClient.isEligible(), isAvailable: () => LambdaMicroVmRuntimeClient.isAvailable(), isRunning: () => LambdaMicroVmRuntimeClient.isRunning() },
 ]
 
 /**
@@ -75,6 +77,7 @@ const RUNNER_DISPLAY_NAMES: Record<ContainerRunner, string> = {
   lima: 'Built-in Runtime',
   wsl2: 'Built-in Runtime',
   kubernetes: 'Kubernetes',
+  'lambda-microvm': 'AWS Lambda MicroVM',
 }
 
 export function getRunnerDisplayName(runner: ContainerRunner): string {
@@ -592,6 +595,8 @@ export function getContainerClientClass(runner: ContainerRunner): ConcreteContai
       return WSL2ContainerClient
     case 'kubernetes':
       return PlatformK8sRuntimeClient
+    case 'lambda-microvm':
+      return LambdaMicroVmRuntimeClient
     default:
       console.warn(`Unknown container runner "${runner}", falling back to docker`)
       return DockerContainerClient

--- a/src/shared/lib/container/lambda-microvm-runtime.e2e.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.e2e.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Real-AWS end-to-end check. Gated by RUN_MICROVM_E2E=1 so it never runs in CI.
+// Drives the actual client against a live MicroVM image. Requires AWS creds +
+// MICROVM_* env pointing at a runnable agent image (e.g. the poc2 scaffolding):
+//
+//   RUN_MICROVM_E2E=1 \
+//   MICROVM_AWS_REGION=us-east-2 \
+//   MICROVM_AGENT_IMAGE_ARN=arn:aws:lambda:us-east-2:<acct>:microvm-image:poc2-agent \
+//   MICROVM_AGENT_IMAGE_VERSION=1.0 \
+//   MICROVM_EXECUTION_ROLE_ARN=arn:aws:iam::<acct>:role/poc2-mvm-exec \
+//   MICROVM_EGRESS_CONNECTOR_ARN=arn:aws:lambda:us-east-2:<acct>:network-connector:nc-... \
+//   HOST_PUBLIC_URL=https://dummy \
+//   npx vitest run src/shared/lib/container/lambda-microvm-runtime.e2e.test.ts
+
+vi.mock('@shared/lib/llm-provider', () => ({ getActiveLlmProvider: () => ({ getContainerEnvVars: () => ({}) }) }))
+vi.mock('@shared/lib/error-reporting', () => ({ captureException: vi.fn(), addErrorBreadcrumb: vi.fn() }))
+
+import { LambdaMicroVmRuntimeClient } from './lambda-microvm-runtime'
+
+const enabled = process.env.RUN_MICROVM_E2E === '1'
+
+describe.skipIf(!enabled)('LambdaMicroVmRuntimeClient e2e (real AWS)', () => {
+  it('runs a real MicroVM, serves /health through the proxy, then terminates', async () => {
+    const client = new LambdaMicroVmRuntimeClient({ agentId: `e2e-${Date.now()}` })
+    try {
+      await client.start()
+      const info = await client.getInfoFromRuntime()
+      expect(info.status).toBe('running')
+      const res = await client.fetch('/health')
+      expect(res.ok).toBe(true)
+      expect(await res.text()).toContain('ok')
+    } finally {
+      await client.stop()
+    }
+  }, 360_000)
+
+  // First-touch / steady-state regression guard. Prints per-stage timing so a
+  // future slow path (like the once-seen ~17s) is caught and bisected by stage,
+  // not just felt. Set MICROVM_E2E_COLD_RUNS to change the sample count.
+  it('cold-start series stays in the steady band (start -> /health)', async () => {
+    const runs = Number(process.env.MICROVM_E2E_COLD_RUNS || 3)
+    const timings: number[] = []
+    for (let i = 0; i < runs; i++) {
+      const client = new LambdaMicroVmRuntimeClient({ agentId: `e2e-cold-${Date.now()}-${i}` })
+      const t0 = Date.now()
+      try {
+        await client.start()
+        const elapsed = Date.now() - t0
+        timings.push(elapsed)
+        const res = await client.fetch('/health')
+        expect(res.ok).toBe(true)
+        console.log(`[E2E-COLD ${i}] start -> /health ok: ${elapsed}ms`)
+      } finally {
+        await client.stop()
+      }
+    }
+    const max = Math.max(...timings)
+    console.log(`[E2E-COLD] runs=${timings.join(',')}ms max=${max}ms`)
+    // Steady cold start to agent /health is ~5-11s; 30s is a generous regression
+    // ceiling (image-version first-touch warmup can be slower — run once after a
+    // publish to pre-warm, then this guards the steady path).
+    expect(max).toBeLessThan(30_000)
+  }, 600_000)
+
+  // Verifies the auto-sleep contract end-to-end: idle stop suspends (not
+  // terminates), and the SAME VM auto-resumes on demand far faster than a cold
+  // start would.
+  //
+  // Two deliberate choices keep this faithful to production rather than to a
+  // worst-case race:
+  //  1. Wait for the VM to settle into SUSPENDED before resuming. stop() issues
+  //     SuspendMicrovm and returns without waiting, so an immediate request races
+  //     a still-SUSPENDING VM — a worst case that never happens in production,
+  //     where requests arrive long after the VM has settled.
+  //  2. Measure time-to-healthy via waitForHealthy (kick + poll), not a single
+  //     fetch. The first request to a suspended VM triggers the async resume and
+  //     may itself 502 before the agent is back; what matters is how quickly the
+  //     agent becomes serveable, which is what a real caller (and the host) sees.
+  it('auto-sleep suspends, then auto-resumes faster than cold start', async () => {
+    const client = new LambdaMicroVmRuntimeClient({ agentId: `e2e-resume-${Date.now()}` })
+    try {
+      await client.start()
+      expect((await client.getInfoFromRuntime()).status).toBe('running')
+
+      await client.stop({ escalateToForceStop: false }) // auto-sleep -> suspend
+      // Let the suspend settle (SuspendMicrovm completes in ~1s); the client maps
+      // SUSPENDED/SUSPENDING to 'running' since the VM auto-resumes on demand.
+      await new Promise((r) => setTimeout(r, 10_000))
+      expect((await client.getInfoFromRuntime()).status).toBe('running')
+
+      const t0 = Date.now()
+      const healthy = await client.waitForHealthy(30_000) // kick + poll until agent serveable
+      const resumeMs = Date.now() - t0
+      expect(healthy).toBe(true)
+      console.log(`[E2E-RESUME] suspend -> agent healthy (auto-resume): ${resumeMs}ms`)
+      expect(resumeMs).toBeLessThan(15_000)
+    } finally {
+      await client.stop() // explicit terminate to free the VM
+    }
+  }, 600_000)
+})

--- a/src/shared/lib/container/lambda-microvm-runtime.e2e.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.e2e.test.ts
@@ -21,7 +21,7 @@ import { LambdaMicroVmRuntimeClient } from './lambda-microvm-runtime'
 const enabled = process.env.RUN_MICROVM_E2E === '1'
 
 describe.skipIf(!enabled)('LambdaMicroVmRuntimeClient e2e (real AWS)', () => {
-  it('runs a real MicroVM, serves /health through the proxy, then terminates', async () => {
+  it('runs a real MicroVM, serves /health through the proxy, then suspends', async () => {
     const client = new LambdaMicroVmRuntimeClient({ agentId: `e2e-${Date.now()}` })
     try {
       await client.start()
@@ -63,40 +63,28 @@ describe.skipIf(!enabled)('LambdaMicroVmRuntimeClient e2e (real AWS)', () => {
     expect(max).toBeLessThan(30_000)
   }, 600_000)
 
-  // Verifies the auto-sleep contract end-to-end: idle stop suspends (not
-  // terminates), and the SAME VM auto-resumes on demand far faster than a cold
-  // start would.
-  //
-  // Two deliberate choices keep this faithful to production rather than to a
-  // worst-case race:
-  //  1. Wait for the VM to settle into SUSPENDED before resuming. stop() issues
-  //     SuspendMicrovm and returns without waiting, so an immediate request races
-  //     a still-SUSPENDING VM — a worst case that never happens in production,
-  //     where requests arrive long after the VM has settled.
-  //  2. Measure time-to-healthy via waitForHealthy (kick + poll), not a single
-  //     fetch. The first request to a suspended VM triggers the async resume and
-  //     may itself 502 before the agent is back; what matters is how quickly the
-  //     agent becomes serveable, which is what a real caller (and the host) sees.
-  it('auto-sleep suspends, then auto-resumes faster than cold start', async () => {
+  // Stop means suspend; the next plain request resumes the same VM warmly.
+  it('auto-sleep suspends, then a plain request transparently auto-resumes (warm)', async () => {
     const client = new LambdaMicroVmRuntimeClient({ agentId: `e2e-resume-${Date.now()}` })
     try {
       await client.start()
       expect((await client.getInfoFromRuntime()).status).toBe('running')
 
-      await client.stop({ escalateToForceStop: false }) // auto-sleep -> suspend
+      await client.stop() // plain stop -> suspend (default)
       // Let the suspend settle (SuspendMicrovm completes in ~1s); the client maps
       // SUSPENDED/SUSPENDING to 'running' since the VM auto-resumes on demand.
       await new Promise((r) => setTimeout(r, 10_000))
       expect((await client.getInfoFromRuntime()).status).toBe('running')
 
+      // No waitForHealthy kick: a normal request resumes + succeeds via the proxy.
       const t0 = Date.now()
-      const healthy = await client.waitForHealthy(30_000) // kick + poll until agent serveable
+      const res = await client.fetch('/health')
       const resumeMs = Date.now() - t0
-      expect(healthy).toBe(true)
-      console.log(`[E2E-RESUME] suspend -> agent healthy (auto-resume): ${resumeMs}ms`)
+      expect(res.ok).toBe(true)
+      console.log(`[E2E-RESUME] suspend -> /health ok (transparent auto-resume): ${resumeMs}ms`)
       expect(resumeMs).toBeLessThan(15_000)
     } finally {
-      await client.stop() // explicit terminate to free the VM
+      await client.stop()
     }
   }, 600_000)
 })

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -57,6 +57,7 @@ import {
   getMicrovmRuntimeConfig,
   resolveIdleSeconds,
 } from './lambda-microvm-runtime'
+import { consumeBootstrapEnv, resetBootstrapEnvStoreForTests } from './agent-bootstrap-env-store'
 
 const REQUIRED_ENV = {
   MICROVM_AWS_REGION: 'us-east-2',
@@ -88,6 +89,7 @@ beforeEach(() => {
   })
   vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true }) as Response))
   resetMicrovmRuntimeForTests()
+  resetBootstrapEnvStoreForTests()
 })
 
 afterEach(() => {
@@ -242,8 +244,19 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(typeof input.clientToken).toBe('string')
     expect(input.clientToken.length).toBeGreaterThan(0)
     const payload = JSON.parse(input.runHookPayload)
-    expect(payload.env.FOO).toBe('bar') // the agent's configured env is delivered
+    // Env no longer rides the payload (4096 cap); only a small bootstrap credential does.
+    expect(payload.env).toBeUndefined()
+    expect(payload.bootstrap.url).toBe('https://host.example/api/agent-bootstrap/agent-xyz/env')
     expect(payload.mount).toBeUndefined() // no mount configured here
+    // The full env is stashed host-side for the VM to fetch at boot.
+    expect(consumeBootstrapEnv('agent-xyz')).toMatchObject({ FOO: 'bar' })
+  })
+
+  it('the bootstrap credential carries the agent PROXY_TOKEN for the boot fetch', async () => {
+    const client = new LambdaMicroVmRuntimeClient({ agentId: 'agent-tok', envVars: { PROXY_TOKEN: 'synth_abc' } })
+    await client.start()
+    const input = sendMock.mock.calls.find((c) => c[0].type === 'Run')![0].input
+    expect(JSON.parse(input.runHookPayload).bootstrap.token).toBe('synth_abc')
   })
 
   it('uses a unique clientToken per start (fixed tokens collide on idempotency → InternalFailure)', async () => {
@@ -266,7 +279,7 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     await newClient().start()
     const input = sendMock.mock.calls.find((c) => c[0].type === 'Run')![0].input
     const payload = JSON.parse(input.runHookPayload)
-    expect(payload.env.FOO).toBe('bar')
+    expect(payload.bootstrap.url).toContain('/api/agent-bootstrap/agent-xyz/env')
     expect(payload.mount).toEqual({ fsId: 'fs-1', accessPoint: 'fsap-1', mountTargetIp: '10.0.0.5' })
   })
 
@@ -297,11 +310,55 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect((await client.getInfoFromRuntime()).status).toBe('running')
   })
 
-  it('getInfoFromRuntime reports stopped when the VM is TERMINATED', async () => {
+  it('getInfoFromRuntime reports stopped when the VM is TERMINATED and cleans up local state', async () => {
     const client = newClient()
     await client.start()
     responses.getState = 'TERMINATED'
     expect(await client.getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
+
+    // Terminal state must drop local state (mirror NotFound): a subsequent start()
+    // re-runs a fresh VM rather than reusing the dead one's proxy.
+    responses.getState = 'RUNNING'
+    sendMock.mockClear()
+    await client.start()
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(true)
+  })
+
+  it('getInfoFromRuntime keeps last known running state on a transient (non-NotFound) error', async () => {
+    const client = newClient()
+    await client.start()
+    const port = (await client.getInfoFromRuntime()).port
+
+    // A throttling/network blip must not be reported as stopped (which would orphan
+    // the live VM when start()/ensureRunning react to it).
+    sendMock.mockImplementationOnce(async () => { throw new Error('ThrottlingException') })
+    const info = await client.getInfoFromRuntime()
+    expect(info.status).toBe('running')
+    expect(info.port).toBe(port)
+
+    // State is retained: the next start() short-circuits (no new RunMicrovm).
+    sendMock.mockClear()
+    await client.start()
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
+  })
+
+  it('start stops the prior proxy across a terminate→restart cycle (no leaked listener)', async () => {
+    const stopSpy = vi.spyOn(LocalAuthForwardProxy.prototype, 'stop')
+    const client = newClient()
+    await client.start()
+    expect((await client.getInfoFromRuntime()).status).toBe('running')
+
+    // VM dies → getInfo cleans up the old proxy; the next request restarts it.
+    responses.getState = 'TERMINATED'
+    expect(await client.getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
+    expect(stopSpy).toHaveBeenCalled() // old loopback server was closed, not leaked
+
+    responses.getState = 'RUNNING'
+    await client.start()
+    const info = await client.getInfoFromRuntime()
+    expect(info.status).toBe('running')
+    expect(typeof info.port).toBe('number')
+    stopSpy.mockRestore()
   })
 
   it('stop terminates the MicroVM', async () => {

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -1,0 +1,457 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import http from 'http'
+import net from 'net'
+import { PassThrough } from 'stream'
+
+const sendMock = vi.fn()
+const responses: Record<string, unknown> = {}
+
+// Upstream transports are mocked so the proxy's real loopback server can be
+// driven by real http/net clients while we capture what it forwards upstream.
+const httpsRequestMock = vi.fn()
+const tlsConnectMock = vi.fn()
+vi.mock('https', () => ({
+  default: { request: (...a: unknown[]) => httpsRequestMock(...a) },
+  request: (...a: unknown[]) => httpsRequestMock(...a),
+}))
+vi.mock('tls', () => ({
+  default: { connect: (...a: unknown[]) => tlsConnectMock(...a) },
+  connect: (...a: unknown[]) => tlsConnectMock(...a),
+}))
+
+vi.mock('@aws-sdk/client-lambda-microvms', () => {
+  class RunMicrovmCommand { type = 'Run'; constructor(public input: unknown) {} }
+  class GetMicrovmCommand { type = 'Get'; constructor(public input: unknown) {} }
+  class SuspendMicrovmCommand { type = 'Suspend'; constructor(public input: unknown) {} }
+  class TerminateMicrovmCommand { type = 'Terminate'; constructor(public input: unknown) {} }
+  class CreateMicrovmAuthTokenCommand { type = 'Token'; constructor(public input: unknown) {} }
+  return {
+    LambdaMicrovmsClient: class { send = (cmd: { type: string }) => sendMock(cmd) },
+    RunMicrovmCommand,
+    GetMicrovmCommand,
+    SuspendMicrovmCommand,
+    TerminateMicrovmCommand,
+    CreateMicrovmAuthTokenCommand,
+  }
+})
+
+vi.mock('@shared/lib/error-reporting', () => ({ captureException: vi.fn(), addErrorBreadcrumb: vi.fn() }))
+// Inert: the env builder reaches for the active provider; we don't assert its
+// output here (that's the builder's concern), we only verify the runtime
+// delivers the agent's own config.envVars through runHookPayload.
+vi.mock('@shared/lib/llm-provider', () => ({
+  getActiveLlmProvider: () => ({ getContainerEnvVars: () => ({}) }),
+}))
+
+const autoSleepTimeoutMinutes = vi.fn((): number | undefined => 30)
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({ app: { autoSleepTimeoutMinutes: autoSleepTimeoutMinutes() }, enableToolSearch: true }),
+}))
+
+import {
+  LambdaMicroVmRuntimeClient,
+  LocalAuthForwardProxy,
+  resetMicrovmRuntimeForTests,
+  resolveMicrovmRuntimeConfigOrNull,
+  isMicrovmRuntimeConfigured,
+  getMicrovmRuntimeConfig,
+  resolveIdleSeconds,
+} from './lambda-microvm-runtime'
+
+const REQUIRED_ENV = {
+  MICROVM_AWS_REGION: 'us-east-2',
+  MICROVM_AGENT_IMAGE_ARN: 'arn:img',
+  MICROVM_EXECUTION_ROLE_ARN: 'arn:exec',
+  MICROVM_EGRESS_CONNECTOR_ARN: 'arn:egress',
+}
+const FULL_ENV = { ...REQUIRED_ENV, HOST_PUBLIC_URL: 'https://host.example' }
+
+const TOUCHED = [
+  ...Object.keys(FULL_ENV),
+  'AWS_REGION', 'AWS_DEFAULT_REGION', 'MICROVM_AGENT_IMAGE_VERSION', 'MICROVM_INGRESS_CONNECTOR_ARN',
+  'MICROVM_AGENT_PORT', 'MICROVM_MAX_DURATION_SECONDS', 'MICROVM_IDLE_SECONDS', 'MICROVM_SUSPENDED_SECONDS', 'MICROVM_LOG_GROUP',
+  'MICROVM_FS_ID', 'MICROVM_ACCESS_POINT', 'MICROVM_MOUNT_TARGET_IP',
+]
+
+beforeEach(() => {
+  for (const k of TOUCHED) delete process.env[k]
+  for (const k in responses) delete responses[k]
+  autoSleepTimeoutMinutes.mockReturnValue(30)
+  sendMock.mockReset()
+  httpsRequestMock.mockReset()
+  tlsConnectMock.mockReset()
+  sendMock.mockImplementation(async (cmd: { type: string }) => {
+    if (cmd.type === 'Run') return { microvmId: 'mvm-1', endpoint: 'ep.lambda-microvm.aws' }
+    if (cmd.type === 'Get') return { state: responses.getState ?? 'RUNNING' }
+    if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
+    return {}
+  })
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true }) as Response))
+  resetMicrovmRuntimeForTests()
+})
+
+afterEach(() => {
+  for (const k of TOUCHED) delete process.env[k]
+  resetMicrovmRuntimeForTests()
+  vi.unstubAllGlobals()
+})
+
+describe('microvm runtime config', () => {
+  it('returns null and isConfigured=false when required env is absent', () => {
+    expect(resolveMicrovmRuntimeConfigOrNull()).toBeNull()
+    expect(isMicrovmRuntimeConfigured()).toBe(false)
+  })
+
+  it('drops the config when one required field is missing', () => {
+    Object.assign(process.env, REQUIRED_ENV)
+    delete process.env.MICROVM_EGRESS_CONNECTOR_ARN
+    expect(resolveMicrovmRuntimeConfigOrNull()).toBeNull()
+  })
+
+  it('parses a fully configured env and applies defaults', () => {
+    Object.assign(process.env, REQUIRED_ENV)
+    const config = getMicrovmRuntimeConfig()
+    expect(config.region).toBe('us-east-2')
+    expect(config.imageArn).toBe('arn:img')
+    expect(config.agentPort).toBe(3000)
+    // Lifetime + suspend default to the AWS 8h cap: a suspended VM survives
+    // "until killed" and only the ceiling force-terminates an untouched one.
+    expect(config.maxDurationSeconds).toBe(28_800)
+    expect(config.suspendedSeconds).toBe(28_800)
+    // idle has no static default — it's resolved from the app setting at start().
+    expect(config.idleSeconds).toBeUndefined()
+  })
+
+  it('defaults the ingress connector to the AWS well-known ALL_INGRESS for the region', () => {
+    Object.assign(process.env, REQUIRED_ENV)
+    expect(getMicrovmRuntimeConfig().ingressConnectorArn).toBe(
+      'arn:aws:lambda:us-east-2:aws:network-connector:aws-network-connector:ALL_INGRESS',
+    )
+  })
+
+  it('honors an explicit ingress connector', () => {
+    Object.assign(process.env, REQUIRED_ENV, { MICROVM_INGRESS_CONNECTOR_ARN: 'arn:custom:ingress' })
+    expect(getMicrovmRuntimeConfig().ingressConnectorArn).toBe('arn:custom:ingress')
+  })
+
+  it('falls back to AWS_REGION then AWS_DEFAULT_REGION', () => {
+    Object.assign(process.env, REQUIRED_ENV)
+    delete process.env.MICROVM_AWS_REGION
+    process.env.AWS_DEFAULT_REGION = 'eu-west-1'
+    expect(getMicrovmRuntimeConfig().region).toBe('eu-west-1')
+  })
+
+  it('coerces numeric overrides from strings', () => {
+    Object.assign(process.env, REQUIRED_ENV, {
+      MICROVM_AGENT_PORT: '8080',
+      MICROVM_IDLE_SECONDS: '60',
+      MICROVM_SUSPENDED_SECONDS: '120',
+      MICROVM_MAX_DURATION_SECONDS: '600',
+    })
+    const config = getMicrovmRuntimeConfig()
+    expect(config.agentPort).toBe(8080)
+    expect(config.idleSeconds).toBe(60)
+    expect(config.suspendedSeconds).toBe(120)
+    expect(config.maxDurationSeconds).toBe(600)
+  })
+
+  it('memoizes the resolved config across calls', () => {
+    Object.assign(process.env, REQUIRED_ENV)
+    expect(resolveMicrovmRuntimeConfigOrNull()).toBe(resolveMicrovmRuntimeConfigOrNull())
+  })
+
+  it('getMicrovmRuntimeConfig throws when unconfigured', () => {
+    expect(() => getMicrovmRuntimeConfig()).toThrow(/not configured/)
+  })
+})
+
+describe('resolveIdleSeconds', () => {
+  beforeEach(() => {
+    Object.assign(process.env, REQUIRED_ENV)
+  })
+
+  it('derives the idle window from the app auto-sleep setting when no env override', () => {
+    autoSleepTimeoutMinutes.mockReturnValue(30)
+    expect(resolveIdleSeconds(getMicrovmRuntimeConfig())).toBe(1_800)
+  })
+
+  it('an explicit MICROVM_IDLE_SECONDS env overrides the app setting', () => {
+    process.env.MICROVM_IDLE_SECONDS = '60'
+    resetMicrovmRuntimeForTests()
+    autoSleepTimeoutMinutes.mockReturnValue(30)
+    expect(resolveIdleSeconds(getMicrovmRuntimeConfig())).toBe(60)
+  })
+
+  it('never idle-suspends (falls back to the lifetime cap) when auto-sleep is disabled', () => {
+    autoSleepTimeoutMinutes.mockReturnValue(0)
+    const config = getMicrovmRuntimeConfig()
+    expect(resolveIdleSeconds(config)).toBe(config.maxDurationSeconds)
+  })
+
+  it('clamps an app setting longer than the lifetime cap to maxDurationSeconds', () => {
+    autoSleepTimeoutMinutes.mockReturnValue(600) // 10h > 8h cap
+    const config = getMicrovmRuntimeConfig()
+    expect(resolveIdleSeconds(config)).toBe(config.maxDurationSeconds)
+  })
+})
+
+describe('LambdaMicroVmRuntimeClient eligibility', () => {
+  it('isEligible only when runtime env is configured', () => {
+    Object.assign(process.env, FULL_ENV)
+    resetMicrovmRuntimeForTests()
+    expect(LambdaMicroVmRuntimeClient.isEligible()).toBe(true)
+    for (const k of TOUCHED) delete process.env[k]
+    resetMicrovmRuntimeForTests()
+    expect(LambdaMicroVmRuntimeClient.isEligible()).toBe(false)
+  })
+
+  it('isAvailable requires HOST_PUBLIC_URL', async () => {
+    Object.assign(process.env, FULL_ENV)
+    resetMicrovmRuntimeForTests()
+    expect(await LambdaMicroVmRuntimeClient.isAvailable()).toBe(true)
+    delete process.env.HOST_PUBLIC_URL
+    expect(await LambdaMicroVmRuntimeClient.isAvailable()).toBe(false)
+  })
+})
+
+describe('LambdaMicroVmRuntimeClient lifecycle', () => {
+  beforeEach(() => {
+    Object.assign(process.env, FULL_ENV)
+    resetMicrovmRuntimeForTests()
+  })
+
+  function newClient() {
+    // envVars is the public seam: whatever the agent is configured with must
+    // arrive inside runHookPayload.env, regardless of how the env is built.
+    return new LambdaMicroVmRuntimeClient({ agentId: 'agent-xyz', envVars: { FOO: 'bar' } })
+  }
+
+  it('start runs a MicroVM with image/role/connectors and becomes healthy', async () => {
+    await newClient().start()
+    const runCall = sendMock.mock.calls.find((c) => c[0].type === 'Run')
+    expect(runCall).toBeTruthy()
+    const input = runCall![0].input
+    expect(input.imageIdentifier).toBe('arn:img')
+    expect(input.executionRoleArn).toBe('arn:exec')
+    expect(input.egressNetworkConnectors).toEqual(['arn:egress'])
+    expect(input.idlePolicy.autoResumeEnabled).toBe(true)
+    // idle tracks the app auto-sleep setting (30m); suspend/lifetime hit the 8h cap.
+    expect(input.idlePolicy.maxIdleDurationSeconds).toBe(1_800)
+    expect(input.idlePolicy.suspendedDurationSeconds).toBe(28_800)
+    expect(input.maximumDurationInSeconds).toBe(28_800)
+    expect(typeof input.clientToken).toBe('string')
+    expect(input.clientToken.length).toBeGreaterThan(0)
+    const payload = JSON.parse(input.runHookPayload)
+    expect(payload.env.FOO).toBe('bar') // the agent's configured env is delivered
+    expect(payload.mount).toBeUndefined() // no mount configured here
+  })
+
+  it('uses a unique clientToken per start (fixed tokens collide on idempotency → InternalFailure)', async () => {
+    await new LambdaMicroVmRuntimeClient({ agentId: 'a' }).start()
+    resetMicrovmRuntimeForTests()
+    Object.assign(process.env, FULL_ENV)
+    await new LambdaMicroVmRuntimeClient({ agentId: 'a' }).start()
+    const tokens = sendMock.mock.calls.filter((c) => c[0].type === 'Run').map((c) => c[0].input.clientToken)
+    expect(tokens).toHaveLength(2)
+    expect(tokens[0]).not.toBe(tokens[1])
+  })
+
+  it('includes the workspace mount in runHookPayload when fs/ap/mtip are configured', async () => {
+    Object.assign(process.env, {
+      MICROVM_FS_ID: 'fs-1',
+      MICROVM_ACCESS_POINT: 'fsap-1',
+      MICROVM_MOUNT_TARGET_IP: '10.0.0.5',
+    })
+    resetMicrovmRuntimeForTests()
+    await newClient().start()
+    const input = sendMock.mock.calls.find((c) => c[0].type === 'Run')![0].input
+    const payload = JSON.parse(input.runHookPayload)
+    expect(payload.env.FOO).toBe('bar')
+    expect(payload.mount).toEqual({ fsId: 'fs-1', accessPoint: 'fsap-1', mountTargetIp: '10.0.0.5' })
+  })
+
+  it('omits mount when the mount params are not fully configured', async () => {
+    Object.assign(process.env, { MICROVM_FS_ID: 'fs-1' }) // accessPoint/mtip missing
+    resetMicrovmRuntimeForTests()
+    await newClient().start()
+    const input = sendMock.mock.calls.find((c) => c[0].type === 'Run')![0].input
+    expect(JSON.parse(input.runHookPayload).mount).toBeUndefined()
+  })
+
+  it('getInfoFromRuntime reports running with the proxy port after start', async () => {
+    const client = newClient()
+    await client.start()
+    const info = await client.getInfoFromRuntime()
+    expect(info.status).toBe('running')
+    expect(typeof info.port).toBe('number')
+  })
+
+  it('getInfoFromRuntime reports stopped before any start (no state)', async () => {
+    expect(await newClient().getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
+  })
+
+  it('getInfoFromRuntime treats SUSPENDED as running (auto-resume on request)', async () => {
+    const client = newClient()
+    await client.start()
+    responses.getState = 'SUSPENDED'
+    expect((await client.getInfoFromRuntime()).status).toBe('running')
+  })
+
+  it('getInfoFromRuntime reports stopped when the VM is TERMINATED', async () => {
+    const client = newClient()
+    await client.start()
+    responses.getState = 'TERMINATED'
+    expect(await client.getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
+  })
+
+  it('stop terminates the MicroVM', async () => {
+    const client = newClient()
+    await client.start()
+    const result = await client.stop()
+    expect(result).toEqual({ forceStopUsed: false, stopped: true })
+    const terminateCall = sendMock.mock.calls.find((c) => c[0].type === 'Terminate')
+    expect(terminateCall![0].input).toEqual({ microvmIdentifier: 'mvm-1' })
+  })
+
+  it('auto-sleep stop (escalateToForceStop:false) suspends and preserves state for resume', async () => {
+    const client = newClient()
+    await client.start()
+    sendMock.mockClear()
+
+    const result = await client.stop({ escalateToForceStop: false })
+
+    expect(result).toEqual({ forceStopUsed: false, stopped: true })
+    const suspendCall = sendMock.mock.calls.find((c) => c[0].type === 'Suspend')
+    expect(suspendCall![0].input).toEqual({ microvmIdentifier: 'mvm-1' })
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
+
+    // State is preserved: a subsequent start() short-circuits (no new RunMicrovm).
+    sendMock.mockClear()
+    responses.getState = 'SUSPENDED'
+    await client.start()
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
+  })
+
+  it('auto-sleep stop is a no-op suspend when already SUSPENDED', async () => {
+    const client = newClient()
+    await client.start()
+    responses.getState = 'SUSPENDED'
+    sendMock.mockClear()
+    await client.stop({ escalateToForceStop: false })
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Suspend')).toBe(false)
+  })
+
+  it('start is a no-op when the agent is already running', async () => {
+    const client = newClient()
+    await client.start()
+    sendMock.mockClear()
+    await client.start()
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
+  })
+})
+
+describe('LocalAuthForwardProxy', () => {
+  let capturedRequest: { host?: string; path?: string; headers?: Record<string, string> }
+  const proxies: LocalAuthForwardProxy[] = []
+
+  beforeEach(() => {
+    capturedRequest = {}
+    httpsRequestMock.mockImplementation((options: typeof capturedRequest, cb: (res: PassThrough) => void) => {
+      capturedRequest = options
+      const upstreamRes = new PassThrough() as PassThrough & { statusCode: number; headers: Record<string, string> }
+      upstreamRes.statusCode = 200
+      upstreamRes.headers = {}
+      cb(upstreamRes)
+      upstreamRes.end('UPSTREAM_OK')
+      return new PassThrough() // stands in for the upstream client request (req.pipe target)
+    })
+  })
+
+  afterEach(() => {
+    for (const p of proxies.splice(0)) p.stop()
+  })
+
+  function makeProxy(mintToken: () => Promise<Record<string, string>>) {
+    const proxy = new LocalAuthForwardProxy({ endpoint: 'mvm.lambda-microvm.aws', agentPort: 3000, mintToken })
+    proxies.push(proxy)
+    return proxy
+  }
+
+  function httpGet(port: number, path: string, headers: Record<string, string> = {}): Promise<{ status: number; body: string }> {
+    return new Promise((resolve, reject) => {
+      const req = http.request({ host: '127.0.0.1', port, path, headers }, (res) => {
+        let body = ''
+        res.on('data', (d) => (body += d))
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body }))
+      })
+      req.on('error', reject)
+      req.end()
+    })
+  }
+
+  it('injects auth + proxy-port headers, sets upstream host, and drops hop-by-hop headers', async () => {
+    const proxy = makeProxy(async () => ({ 'X-aws-proxy-auth': 'tok1' }))
+    const port = await proxy.start()
+    const res = await httpGet(port, '/sessions', { connection: 'keep-alive', 'x-custom': 'v' })
+    expect(res.body).toBe('UPSTREAM_OK')
+    expect(capturedRequest.host).toBe('mvm.lambda-microvm.aws')
+    expect(capturedRequest.path).toBe('/sessions')
+    expect(capturedRequest.headers!['X-aws-proxy-auth']).toBe('tok1')
+    expect(capturedRequest.headers!['x-aws-proxy-port']).toBe('3000')
+    expect(capturedRequest.headers!.host).toBe('mvm.lambda-microvm.aws')
+    expect(capturedRequest.headers!['x-custom']).toBe('v')
+    expect(capturedRequest.headers!.connection).toBeUndefined()
+  })
+
+  it('caches the auth token across requests (mints once)', async () => {
+    const mint = vi.fn(async () => ({ 'X-aws-proxy-auth': 'tok' }))
+    const port = await makeProxy(mint).start()
+    await httpGet(port, '/a')
+    await httpGet(port, '/b')
+    expect(mint).toHaveBeenCalledTimes(1)
+  })
+
+  it('single-flights concurrent token refreshes (mints once)', async () => {
+    const mint = vi.fn(() => new Promise<Record<string, string>>((r) => setTimeout(() => r({ 'X-aws-proxy-auth': 'tok' }), 20)))
+    const port = await makeProxy(mint).start()
+    await Promise.all([httpGet(port, '/a'), httpGet(port, '/b'), httpGet(port, '/c')])
+    expect(mint).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 502 when minting the auth token fails', async () => {
+    const port = await makeProxy(async () => { throw new Error('token unavailable') }).start()
+    const res = await httpGet(port, '/sessions')
+    expect(res.status).toBe(502)
+  })
+
+  it('forwards WebSocket upgrades to TLS upstream with sec-websocket + injected auth headers', async () => {
+    let capturedTls: { host?: string } = {}
+    let written = ''
+    const ready = new Promise<void>((resolve) => {
+      tlsConnectMock.mockImplementation((opts: { host?: string }, cb: () => void) => {
+        capturedTls = opts
+        const sock = new PassThrough()
+        sock.on('data', (d: Buffer) => {
+          written += d.toString()
+          if (written.includes('\r\n\r\n')) resolve()
+        })
+        process.nextTick(cb)
+        return sock
+      })
+    })
+    const port = await makeProxy(async () => ({ 'X-aws-proxy-auth': 'tokws' })).start()
+    const client = net.connect(port, '127.0.0.1', () => {
+      client.write(
+        'GET /sessions/s1/stream HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n' +
+          'Sec-WebSocket-Key: thekey\r\nSec-WebSocket-Version: 13\r\n\r\n',
+      )
+    })
+    await ready
+    client.destroy()
+    expect(capturedTls.host).toBe('mvm.lambda-microvm.aws')
+    expect(written).toContain('GET /sessions/s1/stream HTTP/1.1')
+    expect(written.toLowerCase()).toContain('sec-websocket-key: thekey')
+    expect(written.toLowerCase()).toContain('x-aws-proxy-auth: tokws')
+    expect(written.toLowerCase()).toContain('x-aws-proxy-port: 3000')
+  })
+})

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -70,7 +70,7 @@ const FULL_ENV = { ...REQUIRED_ENV, HOST_PUBLIC_URL: 'https://host.example' }
 const TOUCHED = [
   ...Object.keys(FULL_ENV),
   'AWS_REGION', 'AWS_DEFAULT_REGION', 'MICROVM_AGENT_IMAGE_VERSION', 'MICROVM_INGRESS_CONNECTOR_ARN',
-  'MICROVM_AGENT_PORT', 'MICROVM_MAX_DURATION_SECONDS', 'MICROVM_IDLE_SECONDS', 'MICROVM_SUSPENDED_SECONDS', 'MICROVM_LOG_GROUP',
+  'MICROVM_AGENT_PORT', 'MICROVM_MAX_DURATION_SECONDS', 'MICROVM_SUSPENDED_SECONDS', 'MICROVM_LOG_GROUP',
   'MICROVM_FS_ID', 'MICROVM_ACCESS_POINT', 'MICROVM_MOUNT_TARGET_IP',
 ]
 
@@ -120,8 +120,6 @@ describe('microvm runtime config', () => {
     // "until killed" and only the ceiling force-terminates an untouched one.
     expect(config.maxDurationSeconds).toBe(28_800)
     expect(config.suspendedSeconds).toBe(28_800)
-    // idle has no static default — it's resolved from the app setting at start().
-    expect(config.idleSeconds).toBeUndefined()
   })
 
   it('defaults the ingress connector to the AWS well-known ALL_INGRESS for the region', () => {
@@ -146,13 +144,11 @@ describe('microvm runtime config', () => {
   it('coerces numeric overrides from strings', () => {
     Object.assign(process.env, REQUIRED_ENV, {
       MICROVM_AGENT_PORT: '8080',
-      MICROVM_IDLE_SECONDS: '60',
       MICROVM_SUSPENDED_SECONDS: '120',
       MICROVM_MAX_DURATION_SECONDS: '600',
     })
     const config = getMicrovmRuntimeConfig()
     expect(config.agentPort).toBe(8080)
-    expect(config.idleSeconds).toBe(60)
     expect(config.suspendedSeconds).toBe(120)
     expect(config.maxDurationSeconds).toBe(600)
   })
@@ -172,16 +168,9 @@ describe('resolveIdleSeconds', () => {
     Object.assign(process.env, REQUIRED_ENV)
   })
 
-  it('derives the idle window from the app auto-sleep setting when no env override', () => {
+  it('derives the idle window from the app auto-sleep setting (single source of truth)', () => {
     autoSleepTimeoutMinutes.mockReturnValue(30)
     expect(resolveIdleSeconds(getMicrovmRuntimeConfig())).toBe(1_800)
-  })
-
-  it('an explicit MICROVM_IDLE_SECONDS env overrides the app setting', () => {
-    process.env.MICROVM_IDLE_SECONDS = '60'
-    resetMicrovmRuntimeForTests()
-    autoSleepTimeoutMinutes.mockReturnValue(30)
-    expect(resolveIdleSeconds(getMicrovmRuntimeConfig())).toBe(60)
   })
 
   it('never idle-suspends (falls back to the lifetime cap) when auto-sleep is disabled', () => {
@@ -280,7 +269,7 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     const input = sendMock.mock.calls.find((c) => c[0].type === 'Run')![0].input
     const payload = JSON.parse(input.runHookPayload)
     expect(payload.bootstrap.url).toContain('/api/agent-bootstrap/agent-xyz/env')
-    expect(payload.mount).toEqual({ fsId: 'fs-1', accessPoint: 'fsap-1', mountTargetIp: '10.0.0.5' })
+    expect(payload.mount).toEqual({ fsId: 'fs-1', accessPoint: 'fsap-1', mountTargetIp: '10.0.0.5', subPath: 'agents/agent-xyz/workspace' })
   })
 
   it('omits mount when the mount params are not fully configured', async () => {
@@ -361,21 +350,21 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     stopSpy.mockRestore()
   })
 
-  it('stop terminates the MicroVM', async () => {
+  it('background auto-sleep (escalateToForceStop:false) is a no-op — idlePolicy owns idle', async () => {
     const client = newClient()
     await client.start()
-    const result = await client.stop()
-    expect(result).toEqual({ forceStopUsed: false, stopped: true })
-    const terminateCall = sendMock.mock.calls.find((c) => c[0].type === 'Terminate')
-    expect(terminateCall![0].input).toEqual({ microvmIdentifier: 'mvm-1' })
+    sendMock.mockClear()
+    await client.stop({ escalateToForceStop: false })
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Suspend')).toBe(false)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
   })
 
-  it('auto-sleep stop (escalateToForceStop:false) suspends and preserves state for resume', async () => {
+  it('a plain stop() suspends (preserves state for warm resume), not terminate', async () => {
     const client = newClient()
     await client.start()
     sendMock.mockClear()
 
-    const result = await client.stop({ escalateToForceStop: false })
+    const result = await client.stop()
 
     expect(result).toEqual({ forceStopUsed: false, stopped: true })
     const suspendCall = sendMock.mock.calls.find((c) => c[0].type === 'Suspend')
@@ -389,12 +378,12 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
   })
 
-  it('auto-sleep stop is a no-op suspend when already SUSPENDED', async () => {
+  it('a plain stop() is a no-op suspend when already SUSPENDED', async () => {
     const client = newClient()
     await client.start()
     responses.getState = 'SUSPENDED'
     sendMock.mockClear()
-    await client.stop({ escalateToForceStop: false })
+    await client.stop()
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Suspend')).toBe(false)
   })
 

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -24,6 +24,11 @@ import { setBootstrapEnv, clearBootstrapEnv } from './agent-bootstrap-env-store'
 // env-delivery note in start().
 const RUN_HOOK_PAYLOAD_MAX_BYTES = 4_096
 const AUTH_TOKEN_EXPIRATION_MINUTES = 60
+// Max wait to kick a (possibly suspended) VM back to a serveable agent before a real
+// request. Covers auto-resume (~2-10s) with headroom; returns as soon as /health is ok.
+const RESUME_KICK_TIMEOUT_MS = 60_000
+// Gap between proxy retries while a suspended VM wakes (it 502s for ~2-3s).
+const RESUME_RETRY_DELAY_MS = 400
 
 // ---------------------------------------------------------------------------
 // Runtime config (env-driven, zod-validated, memoized)
@@ -46,9 +51,6 @@ const microvmRuntimeSchema = z.object({
   // suspended VM survives "until killed" — the next request auto-resumes it and
   // only the 8h ceiling force-terminates an untouched VM.
   maxDurationSeconds: z.coerce.number().int().positive().max(28_800).default(28_800),
-  // Idle→suspend window. Optional: an explicit env override wins, otherwise it's
-  // derived from the app's autoSleepTimeoutMinutes at start() (see resolveIdleSeconds).
-  idleSeconds: z.coerce.number().int().positive().optional(),
   // How long a suspended VM is kept before AWS terminates it. Maxed so suspend
   // lasts "until killed" within the 8h lifetime cap.
   suspendedSeconds: z.coerce.number().int().positive().max(28_800).default(28_800),
@@ -77,7 +79,6 @@ function computeConfigOrNull(): MicrovmRuntimeConfig | null {
     ingressConnectorArn: process.env.MICROVM_INGRESS_CONNECTOR_ARN,
     agentPort: process.env.MICROVM_AGENT_PORT,
     maxDurationSeconds: process.env.MICROVM_MAX_DURATION_SECONDS,
-    idleSeconds: process.env.MICROVM_IDLE_SECONDS,
     suspendedSeconds: process.env.MICROVM_SUSPENDED_SECONDS,
     logGroup: process.env.MICROVM_LOG_GROUP,
     fsId: process.env.MICROVM_FS_ID,
@@ -113,13 +114,8 @@ export function isMicrovmRuntimeConfigured(): boolean {
   return resolveMicrovmRuntimeConfigOrNull() !== null
 }
 
-// Single source of truth for "when does an idle VM suspend": an explicit
-// MICROVM_IDLE_SECONDS override wins; otherwise it tracks the app's auto-sleep
-// setting (read live so a UI change applies on the next start). When auto-sleep
-// is disabled (<= 0) we never idle-suspend — fall back to the lifetime cap.
-// Clamped to maxDurationSeconds since idle can't outlast the VM.
+// Idle→suspend window: app settings are the single source of truth.
 export function resolveIdleSeconds(config: MicrovmRuntimeConfig): number {
-  if (config.idleSeconds !== undefined) return Math.min(config.idleSeconds, config.maxDurationSeconds)
   const minutes = getSettings().app?.autoSleepTimeoutMinutes ?? 30
   if (minutes <= 0) return config.maxDurationSeconds
   return Math.min(minutes * 60, config.maxDurationSeconds)
@@ -208,36 +204,73 @@ export class LocalAuthForwardProxy {
     return out
   }
 
+  private readBody(req: http.IncomingMessage): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = []
+      req.on('data', (c) => chunks.push(c as Buffer))
+      req.on('end', () => resolve(Buffer.concat(chunks)))
+      req.on('error', reject)
+    })
+  }
+
+  private forwardOnce(method: string, path: string, headers: Record<string, string>, body: Buffer): Promise<http.IncomingMessage> {
+    return new Promise((resolve, reject) => {
+      const upstream = https.request(
+        { host: this.options.endpoint, port: 443, method, path, servername: this.options.endpoint, headers },
+        resolve,
+      )
+      upstream.on('error', reject)
+      if (body.length) upstream.write(body)
+      upstream.end()
+    })
+  }
+
+  // Replay requests across the brief resume window, where AWS may 502/refuse.
   private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-    let auth: Record<string, string>
+    let body: Buffer
     try {
-      auth = await this.authHeaders()
-    } catch (error) {
-      captureException(error, { tags: { area: 'container', op: 'microvm.proxy.token' }, extra: { endpoint: this.options.endpoint } })
-      res.writeHead(502)
-      res.end('microvm auth token unavailable')
-      return
-    }
-    const upstream = https.request(
-      {
-        host: this.options.endpoint,
-        port: 443,
-        method: req.method,
-        path: req.url,
-        servername: this.options.endpoint,
-        headers: { ...this.forwardableHeaders(req.headers), host: this.options.endpoint, ...auth },
-      },
-      (upstreamRes) => {
-        res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers)
-        upstreamRes.pipe(res)
-      },
-    )
-    upstream.on('error', (error) => {
-      captureException(error, { tags: { area: 'container', op: 'microvm.proxy.request' }, extra: { endpoint: this.options.endpoint, path: req.url } })
+      body = await this.readBody(req)
+    } catch {
       if (!res.headersSent) res.writeHead(502)
       res.end()
-    })
-    req.pipe(upstream)
+      return
+    }
+    const deadline = Date.now() + RESUME_KICK_TIMEOUT_MS
+    for (;;) {
+      let auth: Record<string, string>
+      try {
+        auth = await this.authHeaders()
+      } catch (error) {
+        captureException(error, { tags: { area: 'container', op: 'microvm.proxy.token' }, extra: { endpoint: this.options.endpoint } })
+        if (!res.headersSent) res.writeHead(502)
+        res.end('microvm auth token unavailable')
+        return
+      }
+      const headers = { ...this.forwardableHeaders(req.headers), host: this.options.endpoint, ...auth }
+      let upstreamRes: http.IncomingMessage
+      try {
+        upstreamRes = await this.forwardOnce(req.method ?? 'GET', req.url ?? '/', headers, body)
+      } catch (error) {
+        // Connection error = VM still waking; retry within the resume budget.
+        if (Date.now() < deadline) {
+          await new Promise((r) => setTimeout(r, RESUME_RETRY_DELAY_MS))
+          continue
+        }
+        captureException(error, { tags: { area: 'container', op: 'microvm.proxy.request' }, extra: { endpoint: this.options.endpoint, path: req.url } })
+        if (!res.headersSent) res.writeHead(502)
+        res.end()
+        return
+      }
+      // 502 from the endpoint = VM resuming; drain and retry within the budget.
+      if (upstreamRes.statusCode === 502 && Date.now() < deadline) {
+        upstreamRes.resume()
+        await new Promise((r) => setTimeout(r, RESUME_RETRY_DELAY_MS))
+        continue
+      }
+      res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers)
+      upstreamRes.pipe(res)
+      return
+    }
   }
 
   private async handleUpgrade(req: http.IncomingMessage, socket: net.Socket, head: Buffer): Promise<void> {
@@ -334,8 +367,14 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     // VM only a small bootstrap credential to fetch it at boot via /api/agent-bootstrap.
     const env = this.buildAgentEnv(options?.envVars)
     const hasEnv = Object.keys(env).length > 0
+    // Mount the same per-agent workspace path the k8s runtime uses.
     const mount = config.fsId && config.accessPoint && config.mountTargetIp
-      ? { fsId: config.fsId, accessPoint: config.accessPoint, mountTargetIp: config.mountTargetIp }
+      ? {
+          fsId: config.fsId,
+          accessPoint: config.accessPoint,
+          mountTargetIp: config.mountTargetIp,
+          subPath: `${process.env.K8S_WORKSPACES_SUBPATH_PREFIX || 'agents'}/${this.config.agentId}/workspace`,
+        }
       : undefined
     const bootstrap = hasEnv
       ? {
@@ -402,17 +441,15 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     }
   }
 
+  // Proxy-level retry handles the suspend→resume 502 window for all HTTP calls.
+
   async stop(options?: StopOptions): Promise<StopResult> {
     this.terminateWebSocketConnections()
-    // Background auto-sleep passes escalateToForceStop:false. For MicroVMs that
-    // means "go idle, keep state" — suspend (preserving memory+disk) instead of
-    // terminating, so the next request resumes (~2s) rather than cold-starts.
-    // A user-initiated / shutdown stop (default) still terminates to free the VM.
+    // Auto-sleep is handled by AWS idlePolicy; the host-app sweep is a no-op.
     if (options?.escalateToForceStop === false) {
-      await this.suspendForAutoSleep()
       return { forceStopUsed: false, stopped: true }
     }
-    await this.teardown()
+    await this.suspend()
     return { forceStopUsed: false, stopped: true }
   }
 
@@ -495,10 +532,8 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     throw new Error(`Timed out waiting for MicroVM ${microvmId} to become RUNNING`)
   }
 
-  // Idle (auto-sleep) suspend: keep agentStates + proxy so the next start()
-  // short-circuits and traffic auto-resumes the VM. Lost VM is reclaimed by the
-  // idlePolicy's suspendedDurationSeconds. Never throws into the sweep loop.
-  private async suspendForAutoSleep(): Promise<void> {
+  // Keep local proxy state so the next request auto-resumes the same VM.
+  private async suspend(): Promise<void> {
     const state = agentStates.get(this.config.agentId)
     if (!state) return
     const config = getMicrovmRuntimeConfig()

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -1,0 +1,539 @@
+import http from 'http'
+import https from 'https'
+import tls from 'tls'
+import net, { AddressInfo } from 'net'
+import { randomUUID } from 'crypto'
+import { z } from 'zod'
+import {
+  LambdaMicrovmsClient,
+  RunMicrovmCommand,
+  GetMicrovmCommand,
+  SuspendMicrovmCommand,
+  TerminateMicrovmCommand,
+  CreateMicrovmAuthTokenCommand,
+} from '@aws-sdk/client-lambda-microvms'
+import { BaseContainerClient, CONTAINER_INTERNAL_PORT } from './base-container-client'
+import type { ContainerConfig, ContainerInfo, ContainerStats, StartOptions, StopOptions, StopResult } from './types'
+import { getSettings } from '@shared/lib/config/settings'
+import { captureException } from '@shared/lib/error-reporting'
+
+// RunMicrovm caps runHookPayload at 4096 bytes (API constraint; the prose "16KB"
+// in some docs is wrong). It's meant for small per-agent data (session ids /
+// secret references), NOT the full agent env — which exceeds 4096. See the
+// env-delivery note in start().
+const RUN_HOOK_PAYLOAD_MAX_BYTES = 4_096
+const AUTH_TOKEN_EXPIRATION_MINUTES = 60
+
+// ---------------------------------------------------------------------------
+// Runtime config (env-driven, zod-validated, memoized)
+// ---------------------------------------------------------------------------
+
+function allIngressConnectorArn(region: string): string {
+  return `arn:aws:lambda:${region}:aws:network-connector:aws-network-connector:ALL_INGRESS`
+}
+
+const microvmRuntimeSchema = z.object({
+  region: z.string().min(1),
+  imageArn: z.string().min(1),
+  imageVersion: z.string().min(1).optional(),
+  executionRoleArn: z.string().min(1),
+  // Per-org egress connector (gates "agent A only talks to app A" via its SG).
+  egressConnectorArn: z.string().min(1),
+  ingressConnectorArn: z.string().min(1).optional(),
+  agentPort: z.coerce.number().int().positive().default(CONTAINER_INTERNAL_PORT),
+  // Total VM lifetime cap (AWS hard max 28_800 = 8h). Default to the max so a
+  // suspended VM survives "until killed" — the next request auto-resumes it and
+  // only the 8h ceiling force-terminates an untouched VM.
+  maxDurationSeconds: z.coerce.number().int().positive().max(28_800).default(28_800),
+  // Idle→suspend window. Optional: an explicit env override wins, otherwise it's
+  // derived from the app's autoSleepTimeoutMinutes at start() (see resolveIdleSeconds).
+  idleSeconds: z.coerce.number().int().positive().optional(),
+  // How long a suspended VM is kept before AWS terminates it. Maxed so suspend
+  // lasts "until killed" within the 8h lifetime cap.
+  suspendedSeconds: z.coerce.number().int().positive().max(28_800).default(28_800),
+  logGroup: z.string().min(1).optional(),
+  // Per-org S3 Files workspace mount, passed to the image's run hook so the
+  // supervisor mounts /workspace. All three required together or none (no mount).
+  fsId: z.string().min(1).optional(),
+  accessPoint: z.string().min(1).optional(),
+  mountTargetIp: z.string().min(1).optional(),
+})
+
+export type MicrovmRuntimeConfig = Omit<z.infer<typeof microvmRuntimeSchema>, 'ingressConnectorArn'> & {
+  ingressConnectorArn: string
+}
+
+let memoizedConfig: MicrovmRuntimeConfig | null = null
+let configComputed = false
+
+function computeConfigOrNull(): MicrovmRuntimeConfig | null {
+  const parsed = microvmRuntimeSchema.safeParse({
+    region: process.env.MICROVM_AWS_REGION || process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION,
+    imageArn: process.env.MICROVM_AGENT_IMAGE_ARN,
+    imageVersion: process.env.MICROVM_AGENT_IMAGE_VERSION,
+    executionRoleArn: process.env.MICROVM_EXECUTION_ROLE_ARN,
+    egressConnectorArn: process.env.MICROVM_EGRESS_CONNECTOR_ARN,
+    ingressConnectorArn: process.env.MICROVM_INGRESS_CONNECTOR_ARN,
+    agentPort: process.env.MICROVM_AGENT_PORT,
+    maxDurationSeconds: process.env.MICROVM_MAX_DURATION_SECONDS,
+    idleSeconds: process.env.MICROVM_IDLE_SECONDS,
+    suspendedSeconds: process.env.MICROVM_SUSPENDED_SECONDS,
+    logGroup: process.env.MICROVM_LOG_GROUP,
+    fsId: process.env.MICROVM_FS_ID,
+    accessPoint: process.env.MICROVM_ACCESS_POINT,
+    mountTargetIp: process.env.MICROVM_MOUNT_TARGET_IP,
+  })
+  if (!parsed.success) return null
+  return {
+    ...parsed.data,
+    ingressConnectorArn: parsed.data.ingressConnectorArn ?? allIngressConnectorArn(parsed.data.region),
+  }
+}
+
+export function resolveMicrovmRuntimeConfigOrNull(): MicrovmRuntimeConfig | null {
+  if (!configComputed) {
+    memoizedConfig = computeConfigOrNull()
+    configComputed = true
+  }
+  return memoizedConfig
+}
+
+export function getMicrovmRuntimeConfig(): MicrovmRuntimeConfig {
+  const config = resolveMicrovmRuntimeConfigOrNull()
+  if (!config) {
+    throw new Error(
+      'MicroVM runtime is not configured: MICROVM_AGENT_IMAGE_ARN, MICROVM_EXECUTION_ROLE_ARN, MICROVM_EGRESS_CONNECTOR_ARN and an AWS region are required',
+    )
+  }
+  return config
+}
+
+export function isMicrovmRuntimeConfigured(): boolean {
+  return resolveMicrovmRuntimeConfigOrNull() !== null
+}
+
+// Single source of truth for "when does an idle VM suspend": an explicit
+// MICROVM_IDLE_SECONDS override wins; otherwise it tracks the app's auto-sleep
+// setting (read live so a UI change applies on the next start). When auto-sleep
+// is disabled (<= 0) we never idle-suspend — fall back to the lifetime cap.
+// Clamped to maxDurationSeconds since idle can't outlast the VM.
+export function resolveIdleSeconds(config: MicrovmRuntimeConfig): number {
+  if (config.idleSeconds !== undefined) return Math.min(config.idleSeconds, config.maxDurationSeconds)
+  const minutes = getSettings().app?.autoSleepTimeoutMinutes ?? 30
+  if (minutes <= 0) return config.maxDurationSeconds
+  return Math.min(minutes * 60, config.maxDurationSeconds)
+}
+
+// ---------------------------------------------------------------------------
+// Local auth-forward proxy: injects the MicroVM auth-proxy headers into every
+// HTTP request and WebSocket upgrade, so BaseContainerClient can talk to a
+// MicroVM as if it were a local container without knowing about auth tokens.
+// ---------------------------------------------------------------------------
+
+const PROXY_PORT_HEADER = 'x-aws-proxy-port'
+// Auth tokens last max 60min; refresh well before so in-flight requests never 401.
+const TOKEN_TTL_MS = 50 * 60 * 1000
+// Hop-by-hop headers must not be forwarded (RFC 7230 §6.1).
+const HOP_BY_HOP = new Set([
+  'connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization',
+  'te', 'trailer', 'transfer-encoding', 'upgrade', 'host',
+])
+
+export type MicrovmAuthToken = Record<string, string>
+
+export interface ProxyOptions {
+  /** MicroVM HTTPS endpoint host (no scheme), from RunMicrovm/GetMicrovm. */
+  endpoint: string
+  /** Port inside the MicroVM the auth-proxy should forward to (agent server). */
+  agentPort: number
+  /** Mints a fresh auth-token map ({ "X-aws-proxy-auth": "<jwe>", ... }). */
+  mintToken: () => Promise<MicrovmAuthToken>
+}
+
+export class LocalAuthForwardProxy {
+  private server: http.Server | null = null
+  private port: number | null = null
+  private tokenCache: { token: MicrovmAuthToken; expiresAt: number } | null = null
+  private refreshing: Promise<MicrovmAuthToken> | null = null
+
+  constructor(private readonly options: ProxyOptions) {}
+
+  async start(): Promise<number> {
+    if (this.port !== null) return this.port
+    const server = http.createServer((req, res) => this.handleRequest(req, res))
+    server.on('upgrade', (req, socket, head) => this.handleUpgrade(req, socket as net.Socket, head))
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', () => resolve())
+    })
+    this.server = server
+    this.port = (server.address() as AddressInfo).port
+    return this.port
+  }
+
+  stop(): void {
+    this.server?.close()
+    this.server = null
+    this.port = null
+    this.tokenCache = null
+  }
+
+  // Single-flight token refresh so a burst of requests can't trigger a token storm.
+  private async authHeaders(): Promise<Record<string, string>> {
+    const now = Date.now()
+    if (!this.tokenCache || now >= this.tokenCache.expiresAt) {
+      if (!this.refreshing) {
+        this.refreshing = this.options
+          .mintToken()
+          .then((token) => {
+            this.tokenCache = { token, expiresAt: Date.now() + TOKEN_TTL_MS }
+            return token
+          })
+          .finally(() => {
+            this.refreshing = null
+          })
+      }
+      await this.refreshing
+    }
+    return { ...this.tokenCache!.token, [PROXY_PORT_HEADER]: String(this.options.agentPort) }
+  }
+
+  private forwardableHeaders(headers: http.IncomingHttpHeaders): Record<string, string> {
+    const out: Record<string, string> = {}
+    for (const [key, value] of Object.entries(headers)) {
+      if (value === undefined || HOP_BY_HOP.has(key.toLowerCase())) continue
+      out[key] = Array.isArray(value) ? value.join(', ') : value
+    }
+    return out
+  }
+
+  private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    let auth: Record<string, string>
+    try {
+      auth = await this.authHeaders()
+    } catch (error) {
+      captureException(error, { tags: { area: 'container', op: 'microvm.proxy.token' }, extra: { endpoint: this.options.endpoint } })
+      res.writeHead(502)
+      res.end('microvm auth token unavailable')
+      return
+    }
+    const upstream = https.request(
+      {
+        host: this.options.endpoint,
+        port: 443,
+        method: req.method,
+        path: req.url,
+        servername: this.options.endpoint,
+        headers: { ...this.forwardableHeaders(req.headers), host: this.options.endpoint, ...auth },
+      },
+      (upstreamRes) => {
+        res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers)
+        upstreamRes.pipe(res)
+      },
+    )
+    upstream.on('error', (error) => {
+      captureException(error, { tags: { area: 'container', op: 'microvm.proxy.request' }, extra: { endpoint: this.options.endpoint, path: req.url } })
+      if (!res.headersSent) res.writeHead(502)
+      res.end()
+    })
+    req.pipe(upstream)
+  }
+
+  private async handleUpgrade(req: http.IncomingMessage, socket: net.Socket, head: Buffer): Promise<void> {
+    let auth: Record<string, string>
+    try {
+      auth = await this.authHeaders()
+    } catch (error) {
+      captureException(error, { tags: { area: 'container', op: 'microvm.proxy.token' }, extra: { endpoint: this.options.endpoint } })
+      socket.destroy()
+      return
+    }
+    const upstream = tls.connect({ host: this.options.endpoint, port: 443, servername: this.options.endpoint }, () => {
+      const headerLines = [`GET ${req.url} HTTP/1.1`, `Host: ${this.options.endpoint}`]
+      for (const [key, value] of Object.entries(req.headers)) {
+        const lower = key.toLowerCase()
+        if (lower.startsWith('sec-websocket') || lower === 'upgrade' || lower === 'connection' || lower === 'origin') {
+          headerLines.push(`${key}: ${Array.isArray(value) ? value.join(', ') : value}`)
+        }
+      }
+      for (const [key, value] of Object.entries(auth)) headerLines.push(`${key}: ${value}`)
+      upstream.write(headerLines.join('\r\n') + '\r\n\r\n')
+      if (head?.length) upstream.write(head)
+      upstream.pipe(socket)
+      socket.pipe(upstream)
+    })
+    const onError = (error: Error) => {
+      captureException(error, { tags: { area: 'container', op: 'microvm.proxy.upgrade' }, extra: { endpoint: this.options.endpoint } })
+      upstream.destroy()
+      socket.destroy()
+    }
+    upstream.on('error', onError)
+    socket.on('error', onError)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Runtime client
+// ---------------------------------------------------------------------------
+
+// MicroVM ids are AWS-generated (no deterministic name, no tag-filtered lookup),
+// so the agentId→microvm mapping + its loopback proxy live in process memory.
+// Lost on host-app restart: the orphaned VM is reclaimed by its idlePolicy
+// (idle→suspend→suspended-timeout→terminate) and the next start() re-runs.
+interface AgentMicrovmState {
+  microvmId: string
+  endpoint: string
+  proxy: LocalAuthForwardProxy
+  proxyPort: number
+}
+const agentStates = new Map<string, AgentMicrovmState>()
+
+let memoizedClient: LambdaMicrovmsClient | null = null
+function getMicrovmClient(region: string): LambdaMicrovmsClient {
+  if (!memoizedClient) memoizedClient = new LambdaMicrovmsClient({ region })
+  return memoizedClient
+}
+
+function isNotFound(error: unknown): boolean {
+  return (error as { name?: string })?.name === 'ResourceNotFoundException'
+}
+
+export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
+  static readonly runnerName = 'lambda-microvm'
+  // Image is built once via create-microvm-image and run by AWS; nothing local.
+  static readonly requiresLocalImage = false
+
+  constructor(config: ContainerConfig) {
+    super(config)
+  }
+
+  protected getRunnerCommand(): string {
+    return 'lambda-microvm'
+  }
+
+  static isEligible(): boolean {
+    return isMicrovmRuntimeConfigured()
+  }
+
+  static async isAvailable(): Promise<boolean> {
+    // HOST_PUBLIC_URL is required: agents talk back to host-app via getHostApiBaseUrl().
+    return isMicrovmRuntimeConfigured() && Boolean(process.env.HOST_PUBLIC_URL?.trim())
+  }
+
+  static async isRunning(): Promise<boolean> {
+    return this.isAvailable()
+  }
+
+  async start(options?: StartOptions): Promise<void> {
+    if ((await this.getInfoFromRuntime()).status === 'running') return
+
+    const config = getMicrovmRuntimeConfig()
+    const client = getMicrovmClient(config.region)
+    // runHookPayload (env + workspace mount) requires the image to declare a run
+    // hook; omit it entirely when there's nothing to pass so hook-less images still run.
+    const env = this.buildAgentEnv(options?.envVars)
+    const mount = config.fsId && config.accessPoint && config.mountTargetIp
+      ? { fsId: config.fsId, accessPoint: config.accessPoint, mountTargetIp: config.mountTargetIp }
+      : undefined
+    const runHookPayload = Object.keys(env).length > 0 || mount
+      ? JSON.stringify(mount ? { env, mount } : { env })
+      : undefined
+    const payloadBytes = runHookPayload ? Buffer.byteLength(runHookPayload, 'utf8') : 0
+    if (payloadBytes > RUN_HOOK_PAYLOAD_MAX_BYTES) {
+      const keys = Object.keys(env).sort((a, b) => env[b].length - env[a].length).slice(0, 5)
+      throw new Error(
+        `MicroVM runHookPayload is ${payloadBytes} bytes, over the ${RUN_HOOK_PAYLOAD_MAX_BYTES} limit. ` +
+          `${Object.keys(env).length} env keys; largest: ${keys.map((k) => `${k}=${env[k].length}b`).join(', ')}`,
+      )
+    }
+
+    const run = await client.send(
+      new RunMicrovmCommand({
+        imageIdentifier: config.imageArn,
+        imageVersion: config.imageVersion,
+        executionRoleArn: config.executionRoleArn,
+        ingressNetworkConnectors: [config.ingressConnectorArn],
+        egressNetworkConnectors: [config.egressConnectorArn],
+        idlePolicy: {
+          maxIdleDurationSeconds: resolveIdleSeconds(config),
+          suspendedDurationSeconds: config.suspendedSeconds,
+          autoResumeEnabled: true,
+        },
+        logging: config.logGroup
+          ? { cloudWatch: { logGroup: config.logGroup, logStream: this.config.agentId } }
+          : undefined,
+        maximumDurationInSeconds: config.maxDurationSeconds,
+        runHookPayload,
+        // Unique per start() — dedupes this call's SDK retries, but never collides
+        // with a prior start (a fixed token reused with changed params makes
+        // RunMicrovm return InternalFailure on the idempotency conflict).
+        clientToken: randomUUID(),
+      }),
+    )
+    if (!run.microvmId || !run.endpoint) {
+      throw new Error('RunMicrovm returned no microvmId/endpoint')
+    }
+
+    const proxy = new LocalAuthForwardProxy({
+      endpoint: run.endpoint,
+      agentPort: config.agentPort,
+      mintToken: () => this.mintToken(run.microvmId!),
+    })
+    const proxyPort = await proxy.start()
+    agentStates.set(this.config.agentId, { microvmId: run.microvmId, endpoint: run.endpoint, proxy, proxyPort })
+
+    try {
+      await this.waitForRunning(client, run.microvmId, 300_000)
+      if (!(await this.waitForHealthy(120_000, proxyPort))) {
+        throw new Error(`MicroVM agent ${run.microvmId} failed to become healthy`)
+      }
+    } catch (error) {
+      await this.teardown()
+      throw error
+    }
+  }
+
+  async stop(options?: StopOptions): Promise<StopResult> {
+    this.terminateWebSocketConnections()
+    // Background auto-sleep passes escalateToForceStop:false. For MicroVMs that
+    // means "go idle, keep state" — suspend (preserving memory+disk) instead of
+    // terminating, so the next request resumes (~2s) rather than cold-starts.
+    // A user-initiated / shutdown stop (default) still terminates to free the VM.
+    if (options?.escalateToForceStop === false) {
+      await this.suspendForAutoSleep()
+      return { forceStopUsed: false, stopped: true }
+    }
+    await this.teardown()
+    return { forceStopUsed: false, stopped: true }
+  }
+
+  stopSync(): void {
+    // Terminate uses the async AWS API; sync shutdown only tears down WS + proxy.
+    // The VM itself is reclaimed by its idlePolicy.
+    this.terminateWebSocketConnections()
+    this.cleanupLocal()
+  }
+
+  async getInfoFromRuntime(): Promise<ContainerInfo> {
+    const state = agentStates.get(this.config.agentId)
+    if (!state) return { status: 'stopped', port: null }
+    const config = getMicrovmRuntimeConfig()
+    try {
+      const mvm = await getMicrovmClient(config.region).send(
+        new GetMicrovmCommand({ microvmIdentifier: state.microvmId }),
+      )
+      // SUSPENDED is "running on demand": idlePolicy.autoResumeEnabled wakes it
+      // on the next request through the proxy.
+      if (mvm.state === 'RUNNING' || mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
+        return { status: 'running', port: state.proxyPort }
+      }
+      return { status: 'stopped', port: null }
+    } catch (error) {
+      if (isNotFound(error)) {
+        this.cleanupLocal()
+        return { status: 'stopped', port: null }
+      }
+      captureException(error, { tags: { area: 'container', op: 'microvm.getInfo' }, extra: { microvmId: state.microvmId } })
+      return { status: 'stopped', port: null }
+    }
+  }
+
+  async getStats(): Promise<ContainerStats | null> {
+    // lambda-microvms exposes no per-VM resource metrics; surface none.
+    return null
+  }
+
+  public buildVolumeFlag(_hostPath: string, _containerPath: string): string {
+    // Workspace is an S3 Files mount performed inside the VM, not a host bind.
+    return ''
+  }
+
+  public getHostApiBaseUrl(): string {
+    const publicUrl = process.env.HOST_PUBLIC_URL?.replace(/\/+$/, '')
+    if (!publicUrl) {
+      throw new Error('HOST_PUBLIC_URL is required for the MicroVM runtime')
+    }
+    return publicUrl
+  }
+
+  private async mintToken(microvmId: string): Promise<MicrovmAuthToken> {
+    const config = getMicrovmRuntimeConfig()
+    const out = await getMicrovmClient(config.region).send(
+      new CreateMicrovmAuthTokenCommand({
+        microvmIdentifier: microvmId,
+        expirationInMinutes: AUTH_TOKEN_EXPIRATION_MINUTES,
+        allowedPorts: [{ port: config.agentPort }],
+      }),
+    )
+    if (!out.authToken) throw new Error('CreateMicrovmAuthToken returned no token')
+    return out.authToken
+  }
+
+  private async waitForRunning(client: LambdaMicrovmsClient, microvmId: string, timeoutMs: number): Promise<void> {
+    const startedAt = Date.now()
+    while (Date.now() - startedAt < timeoutMs) {
+      const mvm = await client.send(new GetMicrovmCommand({ microvmIdentifier: microvmId }))
+      if (mvm.state === 'RUNNING') return
+      if (mvm.state === 'TERMINATED' || mvm.state === 'TERMINATING') {
+        throw new Error(`MicroVM ${microvmId} entered ${mvm.state} before becoming ready`)
+      }
+      await new Promise((resolve) => setTimeout(resolve, 2_000))
+    }
+    throw new Error(`Timed out waiting for MicroVM ${microvmId} to become RUNNING`)
+  }
+
+  // Idle (auto-sleep) suspend: keep agentStates + proxy so the next start()
+  // short-circuits and traffic auto-resumes the VM. Lost VM is reclaimed by the
+  // idlePolicy's suspendedDurationSeconds. Never throws into the sweep loop.
+  private async suspendForAutoSleep(): Promise<void> {
+    const state = agentStates.get(this.config.agentId)
+    if (!state) return
+    const config = getMicrovmRuntimeConfig()
+    try {
+      const mvm = await getMicrovmClient(config.region).send(
+        new GetMicrovmCommand({ microvmIdentifier: state.microvmId }),
+      )
+      if (mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') return
+      if (mvm.state === 'TERMINATED' || mvm.state === 'TERMINATING') {
+        this.cleanupLocal()
+        return
+      }
+      await getMicrovmClient(config.region).send(new SuspendMicrovmCommand({ microvmIdentifier: state.microvmId }))
+    } catch (error) {
+      if (isNotFound(error)) {
+        this.cleanupLocal()
+        return
+      }
+      captureException(error, { tags: { area: 'container', op: 'microvm.suspend' }, extra: { microvmId: state.microvmId } })
+    }
+  }
+
+  private async teardown(): Promise<void> {
+    const state = agentStates.get(this.config.agentId)
+    if (state) {
+      const config = getMicrovmRuntimeConfig()
+      try {
+        await getMicrovmClient(config.region).send(new TerminateMicrovmCommand({ microvmIdentifier: state.microvmId }))
+      } catch (error) {
+        if (!isNotFound(error)) {
+          captureException(error, { tags: { area: 'container', op: 'microvm.terminate' }, extra: { microvmId: state.microvmId } })
+        }
+      }
+    }
+    this.cleanupLocal()
+  }
+
+  private cleanupLocal(): void {
+    const state = agentStates.get(this.config.agentId)
+    state?.proxy.stop()
+    agentStates.delete(this.config.agentId)
+  }
+}
+
+export function resetMicrovmRuntimeForTests(): void {
+  for (const state of agentStates.values()) state.proxy.stop()
+  agentStates.clear()
+  memoizedClient = null
+  memoizedConfig = null
+  configComputed = false
+}

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -16,6 +16,7 @@ import { BaseContainerClient, CONTAINER_INTERNAL_PORT } from './base-container-c
 import type { ContainerConfig, ContainerInfo, ContainerStats, StartOptions, StopOptions, StopResult } from './types'
 import { getSettings } from '@shared/lib/config/settings'
 import { captureException } from '@shared/lib/error-reporting'
+import { setBootstrapEnv, clearBootstrapEnv } from './agent-bootstrap-env-store'
 
 // RunMicrovm caps runHookPayload at 4096 bytes (API constraint; the prose "16KB"
 // in some docs is wrong). It's meant for small per-agent data (session ids /
@@ -329,21 +330,25 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
 
     const config = getMicrovmRuntimeConfig()
     const client = getMicrovmClient(config.region)
-    // runHookPayload (env + workspace mount) requires the image to declare a run
-    // hook; omit it entirely when there's nothing to pass so hook-less images still run.
+    // Full env exceeds the 4096-byte payload cap, so stash it host-side and pass the
+    // VM only a small bootstrap credential to fetch it at boot via /api/agent-bootstrap.
     const env = this.buildAgentEnv(options?.envVars)
+    const hasEnv = Object.keys(env).length > 0
     const mount = config.fsId && config.accessPoint && config.mountTargetIp
       ? { fsId: config.fsId, accessPoint: config.accessPoint, mountTargetIp: config.mountTargetIp }
       : undefined
-    const runHookPayload = Object.keys(env).length > 0 || mount
-      ? JSON.stringify(mount ? { env, mount } : { env })
+    const bootstrap = hasEnv
+      ? {
+          url: `${this.getHostApiBaseUrl()}/api/agent-bootstrap/${this.config.agentId}/env`,
+          token: env.PROXY_TOKEN ?? '',
+        }
       : undefined
+    const payloadObj = { ...(bootstrap ? { bootstrap } : {}), ...(mount ? { mount } : {}) }
+    const runHookPayload = bootstrap || mount ? JSON.stringify(payloadObj) : undefined
     const payloadBytes = runHookPayload ? Buffer.byteLength(runHookPayload, 'utf8') : 0
     if (payloadBytes > RUN_HOOK_PAYLOAD_MAX_BYTES) {
-      const keys = Object.keys(env).sort((a, b) => env[b].length - env[a].length).slice(0, 5)
       throw new Error(
-        `MicroVM runHookPayload is ${payloadBytes} bytes, over the ${RUN_HOOK_PAYLOAD_MAX_BYTES} limit. ` +
-          `${Object.keys(env).length} env keys; largest: ${keys.map((k) => `${k}=${env[k].length}b`).join(', ')}`,
+        `MicroVM runHookPayload is ${payloadBytes} bytes, over the ${RUN_HOOK_PAYLOAD_MAX_BYTES} limit.`,
       )
     }
 
@@ -380,6 +385,10 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
       mintToken: () => this.mintToken(run.microvmId!),
     })
     const proxyPort = await proxy.start()
+    // Stop any stale proxy before overwriting state (no leaked port/listener); stash
+    // env after the cleanup (which clears stale stashes) so it isn't wiped.
+    this.cleanupLocal()
+    if (hasEnv) setBootstrapEnv(this.config.agentId, env)
     agentStates.set(this.config.agentId, { microvmId: run.microvmId, endpoint: run.endpoint, proxy, proxyPort })
 
     try {
@@ -427,14 +436,18 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
       if (mvm.state === 'RUNNING' || mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
         return { status: 'running', port: state.proxyPort }
       }
+      // Terminal: VM is gone — drop state + proxy (mirror NotFound) so it isn't leaked.
+      this.cleanupLocal()
       return { status: 'stopped', port: null }
     } catch (error) {
       if (isNotFound(error)) {
         this.cleanupLocal()
         return { status: 'stopped', port: null }
       }
+      // Transient (throttling/network): keep last known state so we don't orphan a live
+      // VM; container-manager's TTL /health re-probe backstops a genuinely dead one.
       captureException(error, { tags: { area: 'container', op: 'microvm.getInfo' }, extra: { microvmId: state.microvmId } })
-      return { status: 'stopped', port: null }
+      return { status: 'running', port: state.proxyPort }
     }
   }
 
@@ -527,6 +540,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     const state = agentStates.get(this.config.agentId)
     state?.proxy.stop()
     agentStates.delete(this.config.agentId)
+    clearBootstrapEnv(this.config.agentId)
   }
 }
 

--- a/src/shared/lib/container/platform-k8s-runtime.test.ts
+++ b/src/shared/lib/container/platform-k8s-runtime.test.ts
@@ -103,7 +103,15 @@ describe('PlatformK8sRuntimeClient manifests', () => {
       envVars: { EXTRA_ENV: 'extra' },
     }
 
-    const pod = buildAgentPodManifest(kube, 'superagent-agent-with-spaces-12345678', config, { RUNTIME_ENV: 'runtime' })
+    // buildAgentPodManifest is a pure serializer now: it maps the FINAL env
+    // (built by the client via buildAgentEnv) into pod env entries. Pass the
+    // already-merged env and assert it round-trips.
+    const pod = buildAgentPodManifest(kube, 'superagent-agent-with-spaces-12345678', config, {
+      ANTHROPIC_API_KEY: 'test-key',
+      EXTRA_ENV: 'extra',
+      RUNTIME_ENV: 'runtime',
+      CLAUDE_CONFIG_DIR: '/workspace/.claude',
+    })
 
     expect(pod.metadata.labels).toEqual({
       'app.kubernetes.io/managed-by': 'superagent',

--- a/src/shared/lib/container/platform-k8s-runtime.ts
+++ b/src/shared/lib/container/platform-k8s-runtime.ts
@@ -5,7 +5,6 @@ import { z } from 'zod'
 import { BaseContainerClient, CONTAINER_INTERNAL_PORT } from './base-container-client'
 import type { ContainerConfig, ContainerInfo, ContainerStats, StartOptions, StopOptions, StopResult } from './types'
 import { getSettings } from '@shared/lib/config/settings'
-import { getActiveLlmProvider } from '@shared/lib/llm-provider'
 import { captureException } from '@shared/lib/error-reporting'
 import { isRunningInKubernetes } from './runtime-env'
 
@@ -118,7 +117,7 @@ export class PlatformK8sRuntimeClient extends BaseContainerClient {
     await deleteResource(`/api/v1/namespaces/${kube.namespace}/pods/${this.podName()}`)
     await deleteResource(`/api/v1/namespaces/${kube.namespace}/services/${this.serviceName()}`)
     await createResource(`/api/v1/namespaces/${kube.namespace}/services`, buildAgentServiceManifest(kube, this.serviceName(), this.podName(), ownerRef))
-    await createResource(`/api/v1/namespaces/${kube.namespace}/pods`, buildAgentPodManifest(kube, this.podName(), this.config, options?.envVars ?? {}, ownerRef))
+    await createResource(`/api/v1/namespaces/${kube.namespace}/pods`, buildAgentPodManifest(kube, this.podName(), this.config, this.buildAgentEnv(options?.envVars), ownerRef))
 
     await waitForPodReady(kube.namespace, this.podName(), 300_000)
 
@@ -285,16 +284,9 @@ export function buildAgentPodManifest(
 ): KubeResource {
   const settings = getSettings()
   const image = process.env.K8S_AGENT_IMAGE || settings.container.agentImage
-  const mergedEnvVars: Record<string, string | undefined> = {
-    ...getActiveLlmProvider().getContainerEnvVars(),
-    CLAUDE_CONFIG_DIR: '/workspace/.claude',
-    ENABLE_TOOL_SEARCH: settings.enableToolSearch !== false ? 'true' : 'false',
-    ...config.envVars,
-    ...envVars,
-  }
-  const env = Object.entries(mergedEnvVars)
-    .filter((entry): entry is [string, string] => entry[1] !== undefined)
-    .map(([name, value]) => ({ name, value }))
+  // envVars is already the final agent env (built by the client via buildAgentEnv);
+  // this builder only serializes it into pod env entries.
+  const env = Object.entries(envVars).map(([name, value]) => ({ name, value }))
   const resources = buildAgentContainerResources(settings.container.resourceLimits)
 
   const spec: Record<string, unknown> = {


### PR DESCRIPTION
## Summary
- Makes MicroVM stop semantics suspend-only so stopped agents can resume warmly.
- Uses app auto-sleep settings as the sole source for AWS idlePolicy timing.
- Retries proxy HTTP requests across the brief suspend-to-resume 502 window.

## Test plan
- `npx vitest run src/shared/lib/container/lambda-microvm-runtime.test.ts`


Made with [Cursor](https://cursor.com)