### PR TITLE
feat(workflows): Tier-0 dynamic-workflow (Workflow tool) support

### DIFF
--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -436,6 +436,14 @@ export class ClaudeCodeProcess extends EventEmitter {
         permissionMode: 'bypassPermissions',
         includePartialMessages: true,
         agentProgressSummaries: true,
+        // Expose the dynamic-workflows `Workflow` tool. In headless/SDK mode the
+        // feature is hidden unless explicitly opted in (there is no interactive
+        // /config to record consent, so the SDK defaults it OFF). There is no
+        // enable env var — only CLAUDE_CODE_DISABLE_WORKFLOWS — so we set it via
+        // the `settings` flag layer (`enableWorkflows` is a Settings field, not a
+        // top-level Option). Without it the model can't see a Workflow tool at all
+        // and falls back to simulating with Agent subagents.
+        settings: { enableWorkflows: true },
         settingSources: ['user', 'project'],
         allowedTools: ['Skill', 'Task', 'Agent', ...remoteMcpToolPatterns],
         disallowedTools: [

--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -24,7 +24,7 @@ const mockStreamState = {
   activeSubagents: [] as any[],
   completedSubagents: null as Set<string> | null,
   slashCommands: [],
-  backgroundTasks: [] as Array<{ taskId: string; startedAt: number }>,
+  backgroundTasks: [] as Array<{ taskId: string; startedAt: number; isWorkflow?: boolean }>,
 }
 
 vi.mock('@renderer/hooks/use-message-stream', () => ({
@@ -603,6 +603,29 @@ describe('AgentActivityIndicator', () => {
 
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
     expect(screen.queryByText(/background process/)).not.toBeInTheDocument()
+  })
+
+  it('labels a background workflow as "workflow" instead of "process"', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockStreamState.backgroundTasks = [
+      { taskId: 'wf-1', startedAt: Date.now() - 4000, isWorkflow: true },
+    ]
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+    expect(screen.getByText('1 background workflow')).toBeInTheDocument()
+  })
+
+  it('pluralizes multiple background workflows as "workflows"', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockStreamState.backgroundTasks = [
+      { taskId: 'wf-1', startedAt: Date.now() - 5000, isWorkflow: true },
+      { taskId: 'wf-2', startedAt: Date.now() - 3000, isWorkflow: true },
+    ]
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+    expect(screen.getByText('2 background workflows')).toBeInTheDocument()
   })
 
   describe('subagent status', () => {

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -398,9 +398,14 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
   )
 }
 
-function BackgroundTasksSection({ tasks }: { tasks: Array<{ taskId: string; startedAt: number }> }) {
+function BackgroundTasksSection({ tasks }: { tasks: Array<{ taskId: string; startedAt: number; isWorkflow?: boolean }> }) {
   const earliest = Math.min(...tasks.map(t => t.startedAt))
   const elapsed = useElapsedTimer(new Date(earliest))
+  // Label as "workflow" when every active background task is a dynamic workflow;
+  // fall back to the generic "process" wording for backgrounded Bash (or a mix).
+  const allWorkflows = tasks.every(t => t.isWorkflow)
+  const noun = allWorkflows ? 'workflow' : 'process'
+  const label = `${tasks.length} background ${tasks.length === 1 ? noun : allWorkflows ? `${noun}s` : `${noun}es`}`
   return (
     <div className="mt-2 text-sm pl-5">
       <div className="flex items-center gap-2">
@@ -409,7 +414,7 @@ function BackgroundTasksSection({ tasks }: { tasks: Array<{ taskId: string; star
           <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
         </span>
         <span className="text-xs text-muted-foreground">
-          {tasks.length} background {tasks.length === 1 ? 'process' : 'processes'}
+          {label}
         </span>
         {elapsed && (
           <span className="text-xs text-muted-foreground tabular-nums">{elapsed}</span>

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -5,6 +5,9 @@ import { ProviderErrorCard } from '@renderer/components/ui/provider-error-card'
 import { InsufficientBalanceCard, usePlatformBillingUrl } from './insufficient-balance-card'
 import { ToolCallItem } from './tool-call-item'
 import { SubAgentBlock } from './subagent-block'
+import { WorkflowBlock } from './workflow-block'
+import { WorkflowResultCard } from './workflow-result-card'
+import { parseTaskNotifications } from '@shared/lib/utils/task-notifications'
 import { MessageContextMenu } from './message-context-menu'
 import { MessageErrorBoundary } from './message-error-boundary'
 import { FileDownloadPill } from '@renderer/components/ui/file-download-pill'
@@ -221,7 +224,12 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
   const rawText = message.content.text
   const { cleanText: textAfterFiles, attachedFiles } = isUser && rawText ? parseAttachedFiles(rawText) : { cleanText: rawText, attachedFiles: [] }
   const { cleanText, mountedFolders } = isUser && textAfterFiles ? parseMountedFolders(textAfterFiles) : { cleanText: textAfterFiles, mountedFolders: [] }
-  const text = cleanText
+  // Strip SDK-injected `<task-notification>` blocks that land in assistant text on
+  // the busy path; surface any `workflow-complete` result as a structured card.
+  const { cleanText: textAfterNotifs, workflowResults } = isAssistant && cleanText
+    ? parseTaskNotifications(cleanText)
+    : { cleanText, workflowResults: [] }
+  const text = textAfterNotifs
   const hasText = text && text.length > 0
   const toolCalls = message.toolCalls || []
 
@@ -365,6 +373,15 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
           </div>
         )}
 
+        {/* Workflow result cards parsed from inline task-notification blocks */}
+        {isAssistant && workflowResults.length > 0 && (
+          <div className="w-full space-y-2">
+            {workflowResults.map((wf, idx) => (
+              <WorkflowResultCard key={wf.runId ?? idx} notification={wf} />
+            ))}
+          </div>
+        )}
+
         {/* Tool calls - shown below assistant message */}
         {isAssistant && toolCalls.length > 0 && (
           <div className="w-full space-y-2">
@@ -378,6 +395,12 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
                         sessionId={sessionId}
                         agentSlug={agentSlug!}
                         isSessionActive={isSessionActive}
+                        activeSubagent={activeSubagents?.find(s => s.parentToolId === toolCall.id) ?? null}
+                        isCompleted={completedSubagents?.has(toolCall.id) ?? false}
+                      />
+                    ) : toolCall.name === 'Workflow' ? (
+                      <WorkflowBlock
+                        toolCall={toolCall}
                         activeSubagent={activeSubagents?.find(s => s.parentToolId === toolCall.id) ?? null}
                         isCompleted={completedSubagents?.has(toolCall.id) ?? false}
                       />

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -13,6 +13,7 @@ import { isTurnStartingUserMessage, type PendingMessage } from './pending-messag
 import { MessageItem } from './message-item'
 import { ToolCallItem, StreamingToolCallItem } from './tool-call-item'
 import { SubAgentBlock } from './subagent-block'
+import { WorkflowBlock } from './workflow-block'
 import { CompactBoundaryItem } from './compact-boundary-item'
 import { MemoryRecallItem } from './memory-recall-item'
 import { MessageErrorBoundary } from './message-error-boundary'
@@ -756,6 +757,14 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
                   sessionId={sessionId}
                   agentSlug={agentSlug}
                   isSessionActive={isActive}
+                  activeSubagent={activeSubagents?.find(s => s.parentToolId === tool.id) ?? null}
+                  isCompleted={completedSubagents?.has(tool.id) ?? false}
+                />
+              )
+            } else if (tool.name === 'Workflow') {
+              inner = (
+                <WorkflowBlock
+                  toolCall={syntheticToolCall}
                   activeSubagent={activeSubagents?.find(s => s.parentToolId === tool.id) ?? null}
                   isCompleted={completedSubagents?.has(tool.id) ?? false}
                 />

--- a/src/renderer/components/messages/workflow-block.test.tsx
+++ b/src/renderer/components/messages/workflow-block.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { WorkflowBlock } from './workflow-block'
+import { createToolCall } from '@renderer/test/factories'
+import type { SubagentInfo } from '@renderer/hooks/use-message-stream'
+
+// StatusIndicator → expose the status string for assertions
+vi.mock('./tool-call-item', () => ({
+  StatusIndicator: ({ status }: { status: string }) => (
+    <span data-testid="status-indicator">{status}</span>
+  ),
+}))
+
+vi.mock('@renderer/hooks/use-elapsed-timer', () => ({
+  formatElapsed: (ms: number) => `${Math.floor(ms / 1000)}s`,
+}))
+
+function makeActive(overrides: Partial<SubagentInfo>): SubagentInfo {
+  return {
+    parentToolId: 'wf-tool-1',
+    agentId: 'wk2hahfwt',
+    streamingMessage: null,
+    streamingToolUse: null,
+    progressSummary: null,
+    subagentType: null,
+    description: null,
+    usage: null,
+    lastToolName: null,
+    resultText: null,
+    ...overrides,
+  }
+}
+
+const SCRIPT = `export const meta = { name: 'capture-probe', phases: [] }\nphase('Scan')`
+
+describe('WorkflowBlock', () => {
+  it('stays running while the workflow is active even after the session goes idle', () => {
+    // Regression: a workflow is a background task that outlives the launch turn.
+    // session goes idle (isSessionActive=false) while the workflow keeps running —
+    // it must NOT flip to "completed" until subagent_completed (isCompleted) fires.
+    const tc = createToolCall({ id: 'wf-tool-1', name: 'Workflow', input: { script: SCRIPT } })
+    const active = makeActive({
+      description: 'Minimal 2-phase probe',
+      lastToolName: 'word-beta',
+      usage: { total_tokens: 8846, tool_uses: 0, duration_ms: 1600 },
+    })
+
+    render(
+      <WorkflowBlock toolCall={tc} activeSubagent={active} isCompleted={false} />
+    )
+
+    expect(screen.getByText('Minimal 2-phase probe')).toBeInTheDocument()
+    expect(screen.getByText('word-beta')).toBeInTheDocument() // current agent
+    expect(screen.getByTestId('status-indicator')).toHaveTextContent('running')
+    expect(screen.getByText(/8\.8k tokens/)).toBeInTheDocument()
+  })
+
+  it('renders a completed workflow once subagent_completed has fired', () => {
+    const tc = createToolCall({ id: 'wf-tool-1', name: 'Workflow', input: { script: SCRIPT } })
+    const active = makeActive({ description: 'Minimal 2-phase probe', lastToolName: 'concat' })
+
+    render(
+      <WorkflowBlock toolCall={tc} activeSubagent={active} isCompleted />
+    )
+
+    expect(screen.getByTestId('status-indicator')).toHaveTextContent('completed')
+    // current-agent pointer is only shown while running
+    expect(screen.queryByText('concat')).not.toBeInTheDocument()
+  })
+
+  it('falls back to the script meta.name when no live description is available (e.g. after reload)', () => {
+    const tc = createToolCall({ id: 'wf-tool-1', name: 'Workflow', input: { script: SCRIPT } })
+
+    render(
+      <WorkflowBlock toolCall={tc} activeSubagent={null} isCompleted={false} />
+    )
+
+    expect(screen.getByText('capture-probe')).toBeInTheDocument()
+    expect(screen.getByTestId('status-indicator')).toHaveTextContent('completed')
+  })
+})

--- a/src/renderer/components/messages/workflow-block.tsx
+++ b/src/renderer/components/messages/workflow-block.tsx
@@ -1,0 +1,111 @@
+import { Workflow } from 'lucide-react'
+import { cn } from '@shared/lib/utils/cn'
+import { StatusIndicator } from './tool-call-item'
+import { formatElapsed } from '@renderer/hooks/use-elapsed-timer'
+import type { ApiToolCall } from '@shared/lib/types/api'
+import type { SubagentInfo } from '@renderer/hooks/use-message-stream'
+
+/**
+ * Tier-0 status block for a dynamic-workflow (`Workflow` tool) run.
+ *
+ * A workflow runs as a background fan-out of subagents inside the CLI; only
+ * WORKFLOW-LEVEL lifecycle crosses the SDK stream (the per-agent transcripts
+ * live on disk, not on the wire — a full per-agent drawer is a planned follow-up).
+ * The persister maps the workflow's `task_*` events onto the existing subagent
+ * channel keyed by the Workflow tool's `tool_use_id`, so we can show a live
+ * running→done status, cumulative usage, and the currently-active agent label
+ * (`lastToolName`) with no extra plumbing. The Workflow tool itself returns an
+ * immediate `async_launched` result, so WITHOUT this block it renders as a
+ * generic tool call that looks "done" a second after launch — misleading while
+ * the workflow is still running.
+ */
+
+const LABEL_CLASS =
+  'font-sans font-normal shrink-0 text-sm text-foreground/65 group-hover:text-foreground leading-none transition-colors'
+
+type WorkflowStatus = 'running' | 'completed' | 'error'
+
+interface WorkflowBlockProps {
+  toolCall: ApiToolCall
+  activeSubagent?: SubagentInfo | null
+  isCompleted?: boolean // subagent_completed SSE fired for this tool
+  // NOTE: intentionally no `isSessionActive` (unlike SubAgentBlock). A workflow is a
+  // background task that outlives its launch turn, so its running state is driven by
+  // its own subagent lifecycle — see the status comment below.
+}
+
+function formatTokens(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`
+  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}k`
+  return `${tokens}`
+}
+
+/** Best-effort `meta.name` from the workflow script (input.script) — used only as a fallback label. */
+function parseWorkflowName(toolCall: ApiToolCall): string | null {
+  const input = toolCall.input as { script?: string; name?: string } | undefined
+  if (input?.name) return input.name
+  if (typeof input?.script === 'string') {
+    const m = input.script.match(/name\s*:\s*['"]([^'"]+)['"]/)
+    if (m) return m[1]
+  }
+  return null
+}
+
+export function WorkflowBlock({
+  toolCall,
+  activeSubagent,
+  isCompleted,
+}: WorkflowBlockProps) {
+  const isActive = activeSubagent?.parentToolId === toolCall.id
+
+  // A workflow is a BACKGROUND task that outlives the turn: the agent launches it
+  // (async_launched) and goes idle while it keeps running. So "running" is driven by
+  // the workflow's own lifecycle — its subagent state is still tracked and not yet
+  // completed — NOT by isSessionActive (which flips false the moment the launch turn
+  // ends, even though task_progress/subagent_completed keep flowing afterward).
+  let status: WorkflowStatus = 'completed'
+  if (isCompleted) {
+    status = toolCall.isError ? 'error' : 'completed'
+  } else if (isActive) {
+    status = 'running'
+  } else if (toolCall.isError) {
+    status = 'error'
+  }
+  const isRunning = status === 'running'
+
+  // Label: prefer the live workflow description (forwarded on subagent_started),
+  // fall back to the script's meta.name, then a generic label.
+  const label = activeSubagent?.description || parseWorkflowName(toolCall) || 'workflow'
+
+  // While running, lastToolName carries the currently-active agent label
+  // (from task_progress.last_tool_name, e.g. "word-beta" / "concat").
+  const currentAgent = isRunning && isActive ? activeSubagent?.lastToolName : null
+  const usage = isActive ? activeSubagent?.usage : null
+
+  return (
+    <div className="text-sm border border-border/70 rounded-md overflow-hidden">
+      <div className="flex w-full items-center gap-2 pl-2 pr-2 py-1.5 group">
+        <Workflow className="h-3.5 w-3.5 shrink-0 text-foreground/45" />
+        <span className={LABEL_CLASS}>Workflow:</span>
+        <span className="text-muted-foreground/80 truncate text-xs leading-none">{label}</span>
+        {currentAgent && (
+          <>
+            <span aria-hidden className="shrink-0 text-foreground/40 text-sm leading-none">→</span>
+            <span className="text-muted-foreground/70 truncate text-xs leading-none font-mono">
+              {currentAgent}
+            </span>
+          </>
+        )}
+        <span className="ml-auto flex h-4 w-4 shrink-0 items-center justify-center">
+          <StatusIndicator status={status} />
+        </span>
+      </div>
+      {isRunning && usage && (usage.total_tokens > 0 || usage.duration_ms > 0) && (
+        <div className={cn('border-t border-border/70 bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground italic')}>
+          {formatElapsed(usage.duration_ms)}
+          {' · '}{formatTokens(usage.total_tokens)} tokens
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/messages/workflow-result-card.tsx
+++ b/src/renderer/components/messages/workflow-result-card.tsx
@@ -1,0 +1,29 @@
+import { CheckCircle2 } from 'lucide-react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { markdownUrlTransform } from '@renderer/lib/markdown-url-transform'
+import type { WorkflowResultNotification } from '@shared/lib/utils/task-notifications'
+
+/**
+ * Renders the result of a completed dynamic workflow, parsed out of an inline
+ * `<task-notification type="workflow-complete">` block (see parseTaskNotifications).
+ * Used in place of the raw XML the SDK appends to assistant text on the busy path.
+ */
+export function WorkflowResultCard({ notification }: { notification: WorkflowResultNotification }) {
+  return (
+    <div className="text-sm border border-border/70 rounded-md overflow-hidden">
+      <div className="flex items-center gap-2 px-2 py-1.5 bg-muted/40">
+        <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-500" />
+        <span className="font-sans text-sm text-foreground/70 leading-none">Workflow completed</span>
+        {notification.title && (
+          <span className="text-muted-foreground/70 truncate text-xs leading-none">{notification.title}</span>
+        )}
+      </div>
+      <div className="px-3 py-2 prose prose-sm max-w-none min-w-0 break-words dark:prose-invert prose-strong:font-medium">
+        <ReactMarkdown remarkPlugins={[remarkGfm]} urlTransform={markdownUrlTransform}>
+          {notification.result}
+        </ReactMarkdown>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -124,7 +124,7 @@ interface StreamState {
   typingUser: { id: string; name?: string } | null // User currently typing (auth mode shared agents)
   peerUserMessages: PeerUserMessage[] // Messages from other users not yet seen in fetched messages
   apiRetry: ApiRetryInfo | null // Non-null while API is retrying a transient error
-  backgroundTasks: Array<{ taskId: string; startedAt: number }> // Active background Bash commands
+  backgroundTasks: Array<{ taskId: string; startedAt: number; isWorkflow?: boolean }> // Active background Bash commands + dynamic workflows
   isWaitingBackground: boolean // True when agent turn ended but background tasks are still running
 }
 
@@ -480,7 +480,7 @@ function getOrCreateEventSource(
           const existing = current.backgroundTasks.filter(t => t.taskId !== data.taskId)
           streamStates.set(sessionId, {
             ...current,
-            backgroundTasks: [...existing, { taskId: data.taskId, startedAt: data.startedAt }],
+            backgroundTasks: [...existing, { taskId: data.taskId, startedAt: data.startedAt, isWorkflow: data.isWorkflow }],
           })
         }
       }

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -619,6 +619,50 @@ describe('MessagePersister', () => {
       expect(sseEvents.filter(e => e.type === 'subagent_completed')).toHaveLength(1)
     })
 
+    // A dynamic workflow (task_type 'local_workflow') must get the same treatment as a
+    // backgrounded Bash command: registered as a background task, surfaced via
+    // session_waiting_background, and NOT phantom-cleared/finalized when the SDK fires a
+    // premature turn-end idle while it is still running. (Synthetic — mirrors the real
+    // background-bash-premature-idle capture shape; replace with a real workflow capture
+    // fixture when one is available.)
+    it('treats a local_workflow as a background task and survives a premature idle', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      // Make session_state_changed the idle authority (matches the container handshake).
+      mockClient._sendMessage({ type: 'system', subtype: 'capabilities', session_state_events: true })
+      sseEvents.length = 0
+
+      // Workflow launches mid-turn → registered as a background task.
+      mockClient._sendMessage({
+        type: 'system', subtype: 'task_started', task_type: 'local_workflow',
+        task_id: 'wf1', tool_use_id: 'wf-tool', workflow_name: 'demo', description: 'demo workflow',
+      })
+      expect(sseEvents.filter(e => e.type === 'background_task_started' && e.taskId === 'wf1')).toHaveLength(1)
+
+      // Launch turn ends, but the workflow keeps running in the background.
+      mockClient._sendMessage({
+        type: 'result', subtype: 'success', is_error: false, duration_ms: 100, num_turns: 1,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      })
+      expect(sseEvents.some(e => e.type === 'session_waiting_background')).toBe(true)
+
+      // Premature idle while the workflow is still running → must stay waiting-background.
+      sseEvents.length = 0
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+      expect(sseEvents.some(e => e.type === 'session_idle')).toBe(false)
+      expect(sseEvents.some(e => e.type === 'background_task_completed')).toBe(false)
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+
+      // Workflow settles → its terminal clears the background task exactly once.
+      mockClient._sendMessage({
+        type: 'system', subtype: 'task_notification', task_id: 'wf1', tool_use_id: 'wf-tool', status: 'completed',
+      })
+      expect(sseEvents.filter(e => e.type === 'background_task_completed' && e.taskId === 'wf1')).toHaveLength(1)
+
+      // The subsequent, truly-settled idle finalizes the session.
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+      expect(sseEvents.some(e => e.type === 'session_idle')).toBe(true)
+    })
+
     it('does not broadcast subagent_completed for non-matching tool_result', () => {
       // Set up Task tool tracking
       mockClient._sendMessage({

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -81,7 +81,7 @@ interface StreamingState {
   // /stream route replays them on (re)connect. Cleared at turn boundaries (session_active/idle).
   pendingInputRequests: Map<string, { type: string; toolUseId: string; [k: string]: unknown }>
   lastApiErrorCode: string | null // SDK error code from last assistant message (e.g., 'authentication_failed', 'rate_limit')
-  activeBackgroundTasks: Map<string, { startedAt: number }> // Background Bash commands still running (keyed by task ID)
+  activeBackgroundTasks: Map<string, { startedAt: number; isWorkflow?: boolean }> // Backgrounded Bash commands + dynamic workflows still running (keyed by task ID)
   pendingDeliverFiles: Map<string, { filePath: string; description?: string }> // deliver_file tool calls awaiting their tool_result, keyed by tool_use ID
   // True when the runtime publishes session_state_changed events — then IT is
   // the idle authority: a 'result' alone does not end the session (queued
@@ -372,12 +372,13 @@ class MessagePersister {
     }
   }
 
-  getActiveBackgroundTasks(sessionId: string): Array<{ taskId: string; startedAt: number }> {
+  getActiveBackgroundTasks(sessionId: string): Array<{ taskId: string; startedAt: number; isWorkflow?: boolean }> {
     const state = this.streamingStates.get(sessionId)
     if (!state) return []
     return Array.from(state.activeBackgroundTasks.entries()).map(([taskId, info]) => ({
       taskId,
       startedAt: info.startedAt,
+      isWorkflow: info.isWorkflow,
     }))
   }
 
@@ -923,6 +924,23 @@ class MessagePersister {
               description: content.description,
             })
           }
+          // A dynamic workflow (task_type 'local_workflow') is a background task that
+          // outlives its launch turn — register it exactly like a backgrounded Bash
+          // command so it surfaces in the same "N background processes" UI and holds the
+          // session in the waiting-background state. The idle handler already keeps the
+          // session alive whenever activeBackgroundTasks is non-empty (the SDK fires idle
+          // at turn-end while the work runs, then wakes on completion), and the terminal
+          // task_updated/task_notification handlers below clear it by task_id — so no
+          // workflow-specific handling is needed anywhere else.
+          if (content.task_type === 'local_workflow') {
+            const workflowTaskId = content.task_id as string | undefined
+            if (workflowTaskId && !state.activeBackgroundTasks.has(workflowTaskId)) {
+              const startedAt = Date.now()
+              state.activeBackgroundTasks.set(workflowTaskId, { startedAt, isWorkflow: true })
+              this.broadcastToSSE(sessionId, { type: 'background_task_started', taskId: workflowTaskId, startedAt, isWorkflow: true })
+              this.broadcastGlobal({ type: 'background_task_started', sessionId, agentSlug: state.agentSlug, taskId: workflowTaskId })
+            }
+          }
         } else if (content.subtype === 'task_progress') {
           // Subagent progress with usage stats (description intentionally omitted —
           // task_progress.description can change to reflect current action, but the
@@ -1019,11 +1037,12 @@ class MessagePersister {
             // session_idle (and a bogus completion notification).
             if (state.isActive && state.lastResultSubtype !== null) {
               if (state.activeBackgroundTasks.size > 0) {
-                // Idle here does NOT mean "settled". activeBackgroundTasks only
-                // ever holds backgrounded Bash commands (task_type=local_bash);
-                // for those the SDK fires `idle` at TURN-END while the command is
-                // still running, then re-fires `running` + task_notification when
-                // it actually finishes. Phantom-clearing + finalizing here would
+                // Idle here does NOT mean "settled". activeBackgroundTasks holds
+                // backgrounded Bash commands (task_type=local_bash) and dynamic
+                // workflows (local_workflow); for both the SDK fires `idle` at
+                // TURN-END while the work is still running, then re-fires `running`
+                // + task_notification when it actually finishes. Phantom-clearing
+                // + finalizing here would
                 // drop the indicator and un-gate auto-sleep mid-job — the exact
                 // failure run_in_background is meant to prevent. Keep the session
                 // alive and surface it as waiting-on-background; the per-task

--- a/src/shared/lib/utils/message-transform.ts
+++ b/src/shared/lib/utils/message-transform.ts
@@ -124,7 +124,9 @@ export function isTaskNotificationMessage(entry: JsonlMessageEntry): boolean {
   // TODO deprecate 2026-08-01: XML fallback for JSONL files written before SDK 0.3.144 added the origin field
   const content = entry.message.content
   if (typeof content !== 'string') return false
-  return content.trimStart().startsWith('<task-notification>')
+  // Match both the bare `<task-notification>` form and attributed variants
+  // (`<task-notification id="..." type="workflow-complete" ...>`).
+  return /^<task-notification[\s>]/.test(content.trimStart())
 }
 
 /**

--- a/src/shared/lib/utils/task-notifications.test.ts
+++ b/src/shared/lib/utils/task-notifications.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { parseTaskNotifications } from './task-notifications'
+
+describe('parseTaskNotifications', () => {
+  it('passes through text with no notifications', () => {
+    const { cleanText, workflowResults } = parseTaskNotifications('Just a normal reply.')
+    expect(cleanText).toBe('Just a normal reply.')
+    expect(workflowResults).toEqual([])
+  })
+
+  it('strips a bare status-only notification (real busy-path shape)', () => {
+    const input =
+      "The workflow is running — I'll report when it completes.\n\n<task-notification>Task wbvdjkgtn completed</task-notification>"
+    const { cleanText, workflowResults } = parseTaskNotifications(input)
+    expect(cleanText).toBe("The workflow is running — I'll report when it completes.")
+    expect(cleanText).not.toContain('task-notification')
+    expect(workflowResults).toEqual([])
+  })
+
+  it('extracts a workflow-complete result and strips the raw block (real shape)', () => {
+    const input =
+      'Working on it.\n\n<task-notification id="w77wo334c" type="workflow-complete" title="Workflow completed" runId="wf_1244fc66-44e">{"result":"Our solar system is wild.","completedAt":"2026-06-23T05:30:32.221Z"}</task-notification>'
+    const { cleanText, workflowResults } = parseTaskNotifications(input)
+    expect(cleanText).toBe('Working on it.')
+    expect(cleanText).not.toContain('task-notification')
+    expect(workflowResults).toEqual([
+      {
+        runId: 'wf_1244fc66-44e',
+        title: 'Workflow completed',
+        result: 'Our solar system is wild.',
+        completedAt: '2026-06-23T05:30:32.221Z',
+      },
+    ])
+  })
+
+  it('extracts an attribute-less JSON-body notification (workflow_completed / run_id shape)', () => {
+    // Real third-format shape: no XML attrs; type/run_id/result live in the JSON body.
+    const input =
+      'On it.\n\n<task-notification>{"task_id":"wbpoha88l","type":"workflow_completed","run_id":"wf_8914eb0b-603","result":"Our solar system is wild.","status":"completed"} </task-notification>'
+    const { cleanText, workflowResults } = parseTaskNotifications(input)
+    expect(cleanText).toBe('On it.')
+    expect(cleanText).not.toContain('task-notification')
+    expect(workflowResults).toEqual([
+      { runId: 'wf_8914eb0b-603', title: undefined, result: 'Our solar system is wild.', completedAt: undefined },
+    ])
+  })
+
+  it('drops a malformed workflow-complete payload without surfacing raw XML', () => {
+    const input = 'Hi.\n\n<task-notification type="workflow-complete">not json</task-notification>'
+    const { cleanText, workflowResults } = parseTaskNotifications(input)
+    expect(cleanText).toBe('Hi.')
+    expect(cleanText).not.toContain('task-notification')
+    expect(workflowResults).toEqual([])
+  })
+
+  it('handles multiple blocks and collapses leftover blank lines', () => {
+    const input =
+      'Start.\n\n<task-notification>Task a completed</task-notification>\n\n<task-notification type="workflow-complete" runId="wf_2">{"result":"done"}</task-notification>\n\nEnd.'
+    const { cleanText, workflowResults } = parseTaskNotifications(input)
+    expect(cleanText).toBe('Start.\n\nEnd.')
+    expect(workflowResults).toHaveLength(1)
+    expect(workflowResults[0]).toMatchObject({ runId: 'wf_2', result: 'done' })
+  })
+})

--- a/src/shared/lib/utils/task-notifications.ts
+++ b/src/shared/lib/utils/task-notifications.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod'
+
+/**
+ * `<task-notification>` blocks are SDK/CLI-injected background-task wakes. On the
+ * idle path they arrive as their own `user` message (filtered upstream by
+ * `isTaskNotificationMessage`), but on the **busy path** — when a background task
+ * (e.g. a dynamic workflow) settles while the agent is still mid-turn — the block
+ * is appended directly into the assistant's text content and would otherwise
+ * render as raw XML.
+ *
+ * Two shapes occur:
+ *   - status-only:   `<task-notification>Task abc123 completed</task-notification>` — pure noise, dropped.
+ *   - workflow result: `<task-notification ... type="workflow-complete" ...>{"result": "..."}</task-notification>`
+ *     — carries the workflow's return value; surfaced as a structured result instead of being lost.
+ *
+ * We parse at render time and leave the persisted JSONL untouched (it's the source of truth).
+ */
+
+// The result-bearing payload's shape varies by SDK version: ids may be `runId`
+// or `run_id`, the timestamp `completedAt` or `completed_at`, and a `type`/
+// `task_id`/`status` may or may not be present. Unknown keys are ignored.
+const WorkflowCompletePayloadSchema = z.object({
+  result: z.string(),
+  completedAt: z.string().optional(),
+  completed_at: z.string().optional(),
+  runId: z.string().optional(),
+  run_id: z.string().optional(),
+  title: z.string().optional(),
+})
+
+export interface WorkflowResultNotification {
+  runId?: string
+  title?: string
+  result: string
+  completedAt?: string
+}
+
+const TASK_NOTIFICATION_RE = /<task-notification(\s[^>]*)?>([\s\S]*?)<\/task-notification>/g
+
+function attr(attrs: string, name: string): string | undefined {
+  return attrs.match(new RegExp(`\\b${name}="([^"]*)"`))?.[1]
+}
+
+/**
+ * Strip `<task-notification>` blocks from a message's text and extract any
+ * `workflow-complete` results. Returns the cleaned text plus the parsed results
+ * (status-only and malformed blocks are dropped, never surfaced as raw text).
+ */
+export function parseTaskNotifications(text: string): {
+  cleanText: string
+  workflowResults: WorkflowResultNotification[]
+} {
+  if (!text.includes('<task-notification')) return { cleanText: text, workflowResults: [] }
+
+  const workflowResults: WorkflowResultNotification[] = []
+  const cleanText = text
+    .replace(TASK_NOTIFICATION_RE, (_full, attrs: string | undefined, body: string) => {
+      // A workflow-completion notification carries a JSON body with a string
+      // `result`. The discriminating `type` may be an XML attribute
+      // (`type="workflow-complete"`) OR a field inside the JSON body
+      // (`"type":"workflow_completed"`), and ids may be `runId` or `run_id` — so
+      // rather than match one shape, we treat ANY task-notification whose body is
+      // JSON with a string `result` as a workflow result. Everything else
+      // (status-only text like "Task abc completed", or malformed JSON) is dropped
+      // as noise. In all cases the raw block is stripped from the displayed text.
+      const a = attrs ?? ''
+      let payload: unknown
+      try {
+        payload = JSON.parse(body.trim())
+      } catch {
+        return '' // non-JSON body — status-only notification
+      }
+      const parsed = WorkflowCompletePayloadSchema.safeParse(payload)
+      if (parsed.success) {
+        const p = parsed.data
+        workflowResults.push({
+          runId: attr(a, 'runId') ?? p.runId ?? p.run_id,
+          title: attr(a, 'title') ?? p.title,
+          result: p.result,
+          completedAt: p.completedAt ?? p.completed_at,
+        })
+      }
+      return ''
+    })
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+
+  return { cleanText, workflowResults }
+}


### PR DESCRIPTION
## What

Adds first-class rendering for the Claude Agent SDK's **dynamic-workflow** (`Workflow` tool) runs. Today a workflow launches, returns an immediate `async_launched` result, and renders as a generic tool call that looks **done** a second after launch — while it's actually still fanning out subagents in the background. This makes it a real, tracked background task.

## Changes

- **Enable the tool** (`agent-container/src/claude-code.ts`) — in headless/SDK mode the workflows feature is hidden unless explicitly opted in (no interactive `/config` to record consent). There's no enable env var, only `CLAUDE_CODE_DISABLE_WORKFLOWS`, so we set it via the `settings` flag layer (`settings.enableWorkflows`). Without it the model can't see a `Workflow` tool at all and falls back to simulating one with `Agent` subagents.
- **`WorkflowBlock`** — live `running → done` status, the currently-active agent label, and cumulative usage. Running state is driven by the workflow's own background lifecycle (its subagent channel), **not** `isSessionActive` — which flips false the moment the launch turn ends even though `task_progress`/`subagent_completed` keep flowing afterward.
- **Background-task tracking** (`message-persister.ts`) — a `task_type: 'local_workflow'` task is registered exactly like a backgrounded Bash command, so it flows through the existing `session_waiting_background` path: it surfaces in the shared "N background workflow(s)" indicator and holds the session alive (no premature idle / auto-sleep) until its terminal `task_notification` clears it. Builds directly on the background-Bash idle fix from #322.
- **`isWorkflow` flag** threaded through the SSE event + `use-message-stream` so the indicator reads "N background **workflow(s)**" rather than the generic "process(es)".
- **`<task-notification>` handling** (`task-notifications.ts`) — on the busy path the SDK appends these blocks straight into assistant text. We strip them at render time and surface any workflow result as a structured `WorkflowResultCard` (shape-agnostic, Zod-validated parse). JSONL stays untouched (source of truth).

## Scope

This is **Tier-0**: workflow-level lifecycle only (status + result), which is all that crosses the SDK stream. The per-agent transcripts live on disk, not on the wire — a per-agent drawer is a planned follow-up.

## Ship note

The only container-side change is `settings.enableWorkflows`; it's baked into the agent-container image, so it needs a container rebuild (CI) to take effect — everything else is host-side.

## Test plan

- `tsc --noEmit` clean, `eslint` clean
- New unit suites: `task-notifications.test.ts` (6), `workflow-block.test.tsx` (3), persister + activity-indicator additions — 204 tests green across the touched suites
- Verified live against a real captured workflow run (sleep-based fan-out): running indicator + "1 background workflow" label + result card, no premature idle