### PR TITLE
Harden MCP OAuth callback validation and delivery

### DIFF
--- a/src/api/routes/remote-mcps.test.ts
+++ b/src/api/routes/remote-mcps.test.ts
@@ -34,11 +34,14 @@ const mockInitiateOAuthFlow = vi.fn()
 const mockInitiateNewServerOAuth = vi.fn()
 const mockCompleteOAuthFlow = vi.fn()
 const mockDiscoverOAuthMetadata = vi.fn()
+const mockValidateAndConsumeOAuthErrorResponse = vi.fn()
 
 vi.mock('@shared/lib/mcp/oauth', () => ({
   initiateOAuthFlow: (...args: unknown[]) => mockInitiateOAuthFlow(...args),
   initiateNewServerOAuth: (...args: unknown[]) => mockInitiateNewServerOAuth(...args),
   completeOAuthFlow: (...args: unknown[]) => mockCompleteOAuthFlow(...args),
+  validateAndConsumeOAuthErrorResponse: (...args: unknown[]) =>
+    mockValidateAndConsumeOAuthErrorResponse(...args),
   discoverOAuthMetadata: (...args: unknown[]) => mockDiscoverOAuthMetadata(...args),
 }))
 
@@ -1066,14 +1069,53 @@ describe('OAuth callback — postMessage origin', () => {
   })
 
   it('uses window.location.origin (not wildcard) on error', async () => {
+    mockValidateAndConsumeOAuthErrorResponse.mockReturnValueOnce({ valid: true })
+
     const res = await app.request(
-      'http://localhost/api/remote-mcps/oauth-callback?error=access_denied'
+      'http://localhost/api/remote-mcps/oauth-callback?error=access_denied&state=xyz'
     )
 
     expect(res.status).toBe(200)
     const html = await res.text()
     expect(html).toContain('window.location.origin')
     expect(html).not.toContain("'*'")
+  })
+
+  it('escapes authorization-server error text once on the callback page', async () => {
+    mockValidateAndConsumeOAuthErrorResponse.mockReturnValueOnce({ valid: true })
+
+    const res = await app.request(
+      'http://localhost/api/remote-mcps/oauth-callback?error=%3Cbad%3E&state=xyz'
+    )
+
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain('OAuth error: &lt;bad&gt;. You can close this window.')
+    expect(html).not.toContain('&amp;lt;bad&amp;gt;')
+    expect(html).toContain('"error":"\\u003cbad\\u003e"')
+  })
+
+  it('does not display authorization-server error fields when issuer validation fails', async () => {
+    mockValidateAndConsumeOAuthErrorResponse.mockReturnValueOnce({
+      valid: false,
+      error: 'OAuth issuer validation failed',
+    })
+
+    const res = await app.request(
+      'http://localhost/api/remote-mcps/oauth-callback?error=access_denied&error_description=Do+not+show+me&error_uri=https%3A%2F%2Fevil.example.com%2Fdocs&state=xyz&iss=https%3A%2F%2Fevil.example.com'
+    )
+
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain('OAuth callback validation failed')
+    expect(html).not.toContain('access_denied')
+    expect(html).not.toContain('Do not show me')
+    expect(html).not.toContain('evil.example.com')
+    expect(mockValidateAndConsumeOAuthErrorResponse).toHaveBeenCalledWith(
+      'xyz',
+      'https://evil.example.com'
+    )
+    expect(mockCompleteOAuthFlow).not.toHaveBeenCalled()
   })
 
   it('uses window.location.origin (not wildcard) on token exchange failure', async () => {
@@ -1087,6 +1129,20 @@ describe('OAuth callback — postMessage origin', () => {
     const html = await res.text()
     expect(html).toContain('window.location.origin')
     expect(html).not.toContain("'*'")
+  })
+
+  it('passes iss through for successful authorization responses', async () => {
+    mockCompleteOAuthFlow.mockResolvedValue({ success: false })
+
+    await app.request(
+      'http://localhost/api/remote-mcps/oauth-callback?code=abc&state=xyz&iss=https%3A%2F%2Fauth.example.com'
+    )
+
+    expect(mockCompleteOAuthFlow).toHaveBeenCalledWith(
+      'xyz',
+      'abc',
+      'https://auth.example.com'
+    )
   })
 
   it('uses window.location.origin (not wildcard) on success', async () => {
@@ -1121,5 +1177,41 @@ describe('OAuth callback — postMessage origin', () => {
     const html = await res.text()
     expect(html).toContain('window.location.origin')
     expect(html).not.toContain("'*'")
+  })
+
+  it('emits callback fallbacks for web popups whose opener was severed', async () => {
+    mockCompleteOAuthFlow.mockResolvedValue({ success: true, mcpId: 'mcp-new' })
+    mockDbFrom.mockReturnValue({ where: mockWhere })
+    mockWhere.mockReturnValue({ limit: mockLimit })
+    mockLimit.mockResolvedValue([
+      { id: 'mcp-new', url: 'https://mcp.example.com', accessToken: 'tok' },
+    ])
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ jsonrpc: '2.0', result: {}, id: 1 }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }))
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ jsonrpc: '2.0', result: { tools: [] }, id: 2 }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) })
+
+    const res = await app.request(
+      'http://localhost/api/remote-mcps/oauth-callback?code=abc&state=xyz'
+    )
+
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain("new BroadcastChannel('mcp-oauth-callback')")
+    expect(html).toContain("localStorage.setItem('superagent.mcp-oauth-callback'")
+    expect(html).toContain('window.opener?.postMessage')
+    expect(html).toContain('setTimeout(() => window.close(), 0)')
+    expect(html).toContain('"success":true')
+    expect(html).toContain('"mcpId":"mcp-new"')
   })
 })

--- a/src/api/routes/remote-mcps.ts
+++ b/src/api/routes/remote-mcps.ts
@@ -3,7 +3,13 @@ import crypto from 'crypto'
 import { db } from '@shared/lib/db'
 import { remoteMcpServers, agentRemoteMcps } from '@shared/lib/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { initiateOAuthFlow, initiateNewServerOAuth, completeOAuthFlow, discoverOAuthMetadata } from '@shared/lib/mcp/oauth'
+import {
+  initiateOAuthFlow,
+  initiateNewServerOAuth,
+  completeOAuthFlow,
+  validateAndConsumeOAuthErrorResponse,
+  discoverOAuthMetadata,
+} from '@shared/lib/mcp/oauth'
 import type { McpToolInfo } from '@shared/lib/mcp/types'
 import { getAppBaseUrlFromRequest, getCurrentUserId } from '@shared/lib/auth/config'
 import { isAuthMode } from '@shared/lib/auth/mode'
@@ -43,6 +49,46 @@ function escapeHtml(str: string): string {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;')
+}
+
+type McpOAuthCallbackPayload = {
+  type: 'mcp-oauth-callback'
+  success: boolean
+  mcpId?: string
+  error?: string
+}
+
+function safeScriptJson(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+}
+
+function renderMcpOAuthCallbackHtml(payload: McpOAuthCallbackPayload, message: string): string {
+  const safeMessage = escapeHtml(message)
+  const payloadJson = safeScriptJson(payload)
+  const storageValueJson = safeScriptJson(JSON.stringify({
+    ...payload,
+    deliveredAt: Date.now(),
+  }))
+
+  return `
+    <html><body><script>
+      const payload = ${payloadJson};
+      window.opener?.postMessage(payload, window.location.origin);
+      try {
+        const channel = new BroadcastChannel('mcp-oauth-callback');
+        channel.postMessage(payload);
+        channel.close();
+      } catch {}
+      try {
+        localStorage.setItem('superagent.mcp-oauth-callback', ${storageValueJson});
+        localStorage.removeItem('superagent.mcp-oauth-callback');
+      } catch {}
+      setTimeout(() => window.close(), 0);
+    </script><p>${safeMessage}</p></body></html>
+  `
 }
 
 // Entry-path SSRF guard for the user-supplied MCP server URL. Delegates to the
@@ -240,32 +286,34 @@ remoteMcps.get('/oauth-callback', async (c) => {
   const code = c.req.query('code')
   const state = c.req.query('state')
   const error = c.req.query('error')
+  const iss = c.req.query('iss')
 
   if (error) {
-    const safeError = escapeHtml(error)
-    const errorPayload = JSON.stringify({ type: 'mcp-oauth-callback', success: false, error: safeError })
-    return c.html(`
-      <html><body><script>
-        window.opener?.postMessage(${errorPayload}, window.location.origin);
-        window.close();
-      </script><p>OAuth error: ${safeError}. You can close this window.</p></body></html>
-    `)
+    const issuerValidation = validateAndConsumeOAuthErrorResponse(state, iss)
+    if (!issuerValidation.valid) {
+      return c.html(renderMcpOAuthCallbackHtml(
+        { type: 'mcp-oauth-callback', success: false, error: 'OAuth callback validation failed' },
+        'OAuth callback validation failed. You can close this window.',
+      ))
+    }
+
+    return c.html(renderMcpOAuthCallbackHtml(
+      { type: 'mcp-oauth-callback', success: false, error },
+      `OAuth error: ${error}. You can close this window.`,
+    ))
   }
 
   if (!code || !state) {
     return c.json({ error: 'Missing code or state parameter' }, 400)
   }
 
-  const result = await completeOAuthFlow(state, code)
+  const result = await completeOAuthFlow(state, code, iss)
 
   if (!result.success || !result.mcpId) {
-    const failPayload = JSON.stringify({ type: 'mcp-oauth-callback', success: false, error: 'Token exchange failed' })
-    return c.html(`
-      <html><body><script>
-        window.opener?.postMessage(${failPayload}, window.location.origin);
-        window.close();
-      </script><p>OAuth failed. You can close this window.</p></body></html>
-    `)
+    return c.html(renderMcpOAuthCallbackHtml(
+      { type: 'mcp-oauth-callback', success: false, error: 'Token exchange failed' },
+      'OAuth failed. You can close this window.',
+    ))
   }
 
   // Discover tools to verify the connection works
@@ -293,23 +341,21 @@ remoteMcps.get('/oauth-callback', async (c) => {
     // Tool discovery failed — delete the server so we don't leave a broken entry
     await db.delete(remoteMcpServers).where(eq(remoteMcpServers.id, result.mcpId))
     const errorMsg = err.message || 'Tool discovery failed'
-    const payload = JSON.stringify({ type: 'mcp-oauth-callback', success: false, error: `Connected but failed to discover tools: ${errorMsg}` })
-    return c.html(`
-      <html><body><script>
-        window.opener?.postMessage(${payload}, window.location.origin);
-        window.close();
-      </script><p>OAuth succeeded but tool discovery failed. You can close this window.</p></body></html>
-    `)
+    return c.html(renderMcpOAuthCallbackHtml(
+      {
+        type: 'mcp-oauth-callback',
+        success: false,
+        error: `Connected but failed to discover tools: ${errorMsg}`,
+      },
+      'OAuth succeeded but tool discovery failed. You can close this window.',
+    ))
   }
 
   trackServerEvent('mcp_oauth_succeeded', { url: serverUrl, mcpId: result.mcpId })
-  const successPayload = JSON.stringify({ type: 'mcp-oauth-callback', success: true, mcpId: result.mcpId })
-  return c.html(`
-    <html><body><script>
-      window.opener?.postMessage(${successPayload}, window.location.origin);
-      window.close();
-    </script><p>OAuth successful! You can close this window.</p></body></html>
-  `)
+  return c.html(renderMcpOAuthCallbackHtml(
+    { type: 'mcp-oauth-callback', success: true, mcpId: result.mcpId },
+    'OAuth successful! You can close this window.',
+  ))
 })
 
 // Get a single MCP server

--- a/src/renderer/components/messages/remote-mcp-request-item.test.tsx
+++ b/src/renderer/components/messages/remote-mcp-request-item.test.tsx
@@ -1,11 +1,14 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { RemoteMcpRequestItem } from './remote-mcp-request-item'
 import { renderWithProviders } from '@renderer/test/test-utils'
 
 const mockApiFetch = vi.fn()
+const mockInitiateOAuthMutateAsync = vi.hoisted(() => vi.fn())
+const mockUseMcpOAuthListener = vi.hoisted(() => vi.fn())
+
 vi.mock('@renderer/lib/api', () => ({
   apiFetch: (...args: unknown[]) => mockApiFetch(...args),
 }))
@@ -19,9 +22,13 @@ vi.mock('@renderer/lib/oauth-popup', () => ({
 
 vi.mock('@renderer/hooks/use-remote-mcps', () => ({
   useInitiateMcpOAuth: () => ({
-    mutateAsync: vi.fn(),
+    mutateAsync: mockInitiateOAuthMutateAsync,
     isPending: false,
   }),
+}))
+
+vi.mock('@renderer/hooks/use-mcp-oauth-listener', () => ({
+  useMcpOAuthListener: (...args: unknown[]) => mockUseMcpOAuthListener(...args),
 }))
 
 vi.mock('./pending-request-stack', () => ({
@@ -69,6 +76,7 @@ const defaultServer = {
 describe('RemoteMcpRequestItem', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockInitiateOAuthMutateAsync.mockReset()
     mockServerListResponse([defaultServer])
   })
 
@@ -158,6 +166,38 @@ describe('RemoteMcpRequestItem', () => {
     // When no servers match, the component shows an inline Connect button
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Connect/i })).toBeInTheDocument()
+    })
+  })
+
+  it('uses the shared OAuth callback listener while waiting for web OAuth', async () => {
+    const user = userEvent.setup()
+    mockServerListResponse([])
+    mockInitiateOAuthMutateAsync.mockResolvedValue({ redirectUrl: 'https://auth.example.com/oauth' })
+
+    renderWithProviders(
+      <RemoteMcpRequestItem
+        {...defaultProps}
+        url="https://new-server.example.com/sse"
+        authHint="oauth"
+      />
+    )
+
+    await user.click(await screen.findByRole('button', { name: /Connect/i }))
+
+    await waitFor(() => {
+      expect(mockUseMcpOAuthListener).toHaveBeenCalledWith(true, expect.any(Function))
+    })
+
+    const activeCall = mockUseMcpOAuthListener.mock.calls.find(([active]) => active === true)
+    const onOAuthComplete = activeCall?.[1] as ((result: { success: boolean; error?: string }) => void) | undefined
+    expect(onOAuthComplete).toBeDefined()
+
+    act(() => {
+      onOAuthComplete?.({ success: false, error: 'OAuth failed in popup' })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(/Error:.*OAuth failed in popup/)).toBeInTheDocument()
     })
   })
 

--- a/src/renderer/components/messages/remote-mcp-request-item.tsx
+++ b/src/renderer/components/messages/remote-mcp-request-item.tsx
@@ -17,6 +17,7 @@ import { RequestItemActions } from './request-item-actions'
 import { cn } from '@shared/lib/utils/cn'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useInitiateMcpOAuth } from '@renderer/hooks/use-remote-mcps'
+import { useMcpOAuthListener } from '@renderer/hooks/use-mcp-oauth-listener'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { type RemoteMcpServer, getMcpServiceKey, McpSourceIcon, McpServerCard } from './mcp-server-card'
 import { McpServicePicker } from './mcp-service-picker'
@@ -154,7 +155,7 @@ export function RemoteMcpRequestItem({
     }
   }, [servers, targetServiceServers, targetUrl])
 
-  // Handle OAuth completion (shared by Electron IPC and web postMessage)
+  // Handle OAuth completion from Electron IPC, postMessage, BroadcastChannel, or storage fallback.
   const handleOAuthComplete = useCallback((success: boolean, errorMessage?: string) => {
     if (success) {
       setError(null)
@@ -175,33 +176,9 @@ export function RemoteMcpRequestItem({
     }
   }, [refetch, targetUrl])
 
-  // Listen for MCP OAuth callback from Electron main process
-  useEffect(() => {
-    if (!window.electronAPI || status !== 'oauth_pending') return
-
-    const unsubscribe = window.electronAPI.onMcpOAuthCallback((params) => {
-      handleOAuthComplete(params.success, params.error ?? undefined)
-    })
-
-    return () => {
-      unsubscribe?.()
-    }
-  }, [status, handleOAuthComplete])
-
-  // Listen for MCP OAuth callback via postMessage (web mode)
-  useEffect(() => {
-    if (status !== 'oauth_pending') return
-
-    const handleMessage = (event: MessageEvent) => {
-      if (event.origin !== window.location.origin) return
-      if (event.data?.type === 'mcp-oauth-callback') {
-        handleOAuthComplete(event.data.success, event.data.error)
-      }
-    }
-
-    window.addEventListener('message', handleMessage)
-    return () => window.removeEventListener('message', handleMessage)
-  }, [status, handleOAuthComplete])
+  useMcpOAuthListener(status === 'oauth_pending', ({ success, error: oauthError }) => {
+    handleOAuthComplete(success, oauthError)
+  })
 
   const startOAuthFlow = async (popup: ReturnType<typeof prepareOAuthPopup>) => {
     try {

--- a/src/renderer/hooks/use-mcp-oauth-listener.test.ts
+++ b/src/renderer/hooks/use-mcp-oauth-listener.test.ts
@@ -7,13 +7,52 @@ import { useMcpOAuthListener } from './use-mcp-oauth-listener'
 vi.stubGlobal('electronAPI', undefined)
 Object.defineProperty(window, 'electronAPI', { value: undefined, writable: true })
 
+const broadcastChannels: FakeBroadcastChannel[] = []
+
+class FakeBroadcastChannel {
+  listeners = new Set<(event: MessageEvent) => void>()
+  close = vi.fn()
+
+  constructor(public name: string) {
+    broadcastChannels.push(this)
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    if (type === 'message') {
+      this.listeners.add(listener as (event: MessageEvent) => void)
+    }
+  }
+
+  removeEventListener(type: string, listener: EventListener) {
+    if (type === 'message') {
+      this.listeners.delete(listener as (event: MessageEvent) => void)
+    }
+  }
+
+  dispatch(data: unknown) {
+    for (const listener of this.listeners) {
+      listener(new MessageEvent('message', { data }))
+    }
+  }
+}
+
+vi.stubGlobal('BroadcastChannel', FakeBroadcastChannel)
+
 function firePostMessage(data: unknown, origin: string) {
   const event = new MessageEvent('message', { data, origin })
   window.dispatchEvent(event)
 }
 
+function fireStorageMessage(data: unknown) {
+  window.dispatchEvent(new StorageEvent('storage', {
+    key: 'superagent.mcp-oauth-callback',
+    newValue: JSON.stringify(data),
+  }))
+}
+
 describe('useMcpOAuthListener', () => {
   afterEach(() => {
+    broadcastChannels.length = 0
     vi.restoreAllMocks()
   })
 
@@ -27,6 +66,41 @@ describe('useMcpOAuthListener', () => {
     )
 
     expect(onComplete).toHaveBeenCalledWith({ success: true, error: undefined })
+  })
+
+  it('calls onComplete for BroadcastChannel mcp-oauth-callback messages', () => {
+    const onComplete = vi.fn()
+    renderHook(() => useMcpOAuthListener(true, onComplete))
+
+    broadcastChannels[0].dispatch(
+      { type: 'mcp-oauth-callback', success: true },
+    )
+
+    expect(broadcastChannels[0].name).toBe('mcp-oauth-callback')
+    expect(onComplete).toHaveBeenCalledWith({ success: true, error: undefined })
+  })
+
+  it('calls onComplete for localStorage storage fallback messages', () => {
+    const onComplete = vi.fn()
+    renderHook(() => useMcpOAuthListener(true, onComplete))
+
+    fireStorageMessage(
+      { type: 'mcp-oauth-callback', success: true },
+    )
+
+    expect(onComplete).toHaveBeenCalledWith({ success: true, error: undefined })
+  })
+
+  it('only completes once if multiple callback delivery mechanisms fire', () => {
+    const onComplete = vi.fn()
+    renderHook(() => useMcpOAuthListener(true, onComplete))
+
+    const payload = { type: 'mcp-oauth-callback', success: true }
+    broadcastChannels[0].dispatch(payload)
+    firePostMessage(payload, window.location.origin)
+    fireStorageMessage(payload)
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
   })
 
   it('ignores mcp-oauth-callback messages from a different origin', () => {

--- a/src/renderer/hooks/use-mcp-oauth-listener.ts
+++ b/src/renderer/hooks/use-mcp-oauth-listener.ts
@@ -1,12 +1,32 @@
 import { useEffect, useRef } from 'react'
 
 type McpOAuthResult = { success: boolean; error?: string }
+type McpOAuthCallbackMessage = {
+  type?: unknown
+  success?: unknown
+  error?: unknown
+}
+
+const MCP_OAUTH_CALLBACK_CHANNEL = 'mcp-oauth-callback'
+const MCP_OAUTH_CALLBACK_STORAGE_KEY = 'superagent.mcp-oauth-callback'
+
+function parseMcpOAuthResult(data: unknown): McpOAuthResult | null {
+  if (!data || typeof data !== 'object') return null
+
+  const message = data as McpOAuthCallbackMessage
+  if (message.type !== 'mcp-oauth-callback') return null
+
+  return {
+    success: !!message.success,
+    error: typeof message.error === 'string' ? message.error : undefined,
+  }
+}
 
 /**
  * Listen for MCP OAuth completion from the OS browser (Electron IPC) or the
- * popup window (web postMessage). Only listens while `active` is true; the
- * callback ref is kept fresh so a changing closure does not trigger
- * re-registration.
+ * popup window. Some providers isolate the popup with Cross-Origin-Opener-Policy
+ * and sever `window.opener`, so web mode listens on postMessage, BroadcastChannel,
+ * and localStorage's cross-window storage event.
  */
 export function useMcpOAuthListener(active: boolean, onComplete: (result: McpOAuthResult) => void): void {
   const callbackRef = useRef(onComplete)
@@ -15,24 +35,55 @@ export function useMcpOAuthListener(active: boolean, onComplete: (result: McpOAu
   useEffect(() => {
     if (!active) return
 
+    let completed = false
+    const completeOnce = (data: unknown) => {
+      const result = parseMcpOAuthResult(data)
+      if (!result || completed) return
+
+      completed = true
+      callbackRef.current(result)
+    }
+
     const handleMessage = (event: MessageEvent) => {
       if (event.origin !== window.location.origin) return
-      if (event.data?.type === 'mcp-oauth-callback') {
-        callbackRef.current({ success: !!event.data.success, error: event.data.error })
+      completeOnce(event.data)
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== MCP_OAUTH_CALLBACK_STORAGE_KEY || !event.newValue) return
+      try {
+        completeOnce(JSON.parse(event.newValue))
+      } catch {
+        // Ignore unrelated or malformed storage writes.
       }
     }
 
     window.addEventListener('message', handleMessage)
+    window.addEventListener('storage', handleStorage)
+
+    let broadcastChannel: BroadcastChannel | null = null
+    if (typeof BroadcastChannel !== 'undefined') {
+      broadcastChannel = new BroadcastChannel(MCP_OAUTH_CALLBACK_CHANNEL)
+      broadcastChannel.addEventListener('message', (event) => {
+        completeOnce(event.data)
+      })
+    }
 
     let unsubscribe: (() => void) | undefined
     if (window.electronAPI) {
       unsubscribe = window.electronAPI.onMcpOAuthCallback((params) => {
-        callbackRef.current({ success: !!params.success, error: params.error ?? undefined })
+        completeOnce({
+          type: 'mcp-oauth-callback',
+          success: params.success,
+          error: params.error ?? undefined,
+        })
       })
     }
 
     return () => {
       window.removeEventListener('message', handleMessage)
+      window.removeEventListener('storage', handleStorage)
+      broadcastChannel?.close()
       unsubscribe?.()
     }
   }, [active])

--- a/src/shared/lib/mcp/oauth.test.ts
+++ b/src/shared/lib/mcp/oauth.test.ts
@@ -34,6 +34,7 @@ import {
   initiateOAuthFlow,
   initiateNewServerOAuth,
   completeOAuthFlow,
+  validateAndConsumeOAuthErrorResponse,
   refreshMcpToken,
 } from './oauth'
 
@@ -401,7 +402,10 @@ describe('oauth', () => {
   // initiateOAuthFlow — authorization URL construction
   // =========================================================================
   describe('initiateOAuthFlow', () => {
-    function setupDiscoveryMocks() {
+    function setupDiscoveryMocks(options: {
+      issuer?: string
+      supportsIss?: boolean
+    } = {}) {
       // Probe: 401 with resource_metadata
       mockFetch.mockResolvedValueOnce(
         new Response(null, {
@@ -429,6 +433,10 @@ describe('oauth', () => {
             authorization_endpoint: 'https://auth.example.com/authorize',
             token_endpoint: 'https://auth.example.com/token',
             scopes_supported: ['read', 'write'],
+            ...(options.issuer ? { issuer: options.issuer } : {}),
+            ...(options.supportsIss === undefined
+              ? {}
+              : { authorization_response_iss_parameter_supported: options.supportsIss }),
           }),
           { status: 200 }
         )
@@ -473,6 +481,45 @@ describe('oauth', () => {
       // WWW-Authenticate, request all advertised scopes_supported — regardless
       // of whether the client was freshly registered or pre-existing.
       expect(url.searchParams.get('scope')).toBe('read write')
+    })
+
+    it('records issuer metadata for existing-server re-auth flows', async () => {
+      setupDiscoveryMocks({
+        issuer: 'https://auth.example.com',
+        supportsIss: true,
+      })
+
+      mockDbFrom.mockReturnValue({ where: mockWhere })
+      mockWhere.mockReturnValue({ limit: mockLimit })
+      mockLimit.mockResolvedValue([
+        { oauthClientId: 'existing-client-id', oauthClientSecret: null },
+      ])
+      mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) })
+
+      const initiated = await initiateOAuthFlow(
+        'mcp-1',
+        'https://mcp.example.com/mcp',
+        'http://localhost:3000/callback'
+      )
+      expect(initiated).not.toBeNull()
+
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'access-tok-123',
+            token_type: 'Bearer',
+          }),
+          { status: 200 }
+        )
+      )
+
+      const result = await completeOAuthFlow(
+        initiated!.state,
+        'auth-code-xyz',
+        'https://auth.example.com'
+      )
+
+      expect(result).toEqual({ success: true, mcpId: 'mcp-1' })
     })
 
     it('sends scopes_supported from the resource metadata when DCR returns no scope (Robinhood case)', async () => {
@@ -855,7 +902,10 @@ describe('oauth', () => {
     // We need to first initiate a flow to populate the pendingOAuthFlows map,
     // then complete it. We'll use initiateNewServerOAuth to set up state.
 
-    async function setupFlowAndGetState(): Promise<string> {
+    async function setupFlowAndGetState(options: {
+      issuer?: string
+      supportsIss?: boolean
+    } = {}): Promise<string> {
       // Full discovery + registration
       mockFetch.mockResolvedValueOnce(
         new Response(null, {
@@ -881,6 +931,10 @@ describe('oauth', () => {
             authorization_endpoint: 'https://auth.example.com/authorize',
             token_endpoint: 'https://auth.example.com/token',
             registration_endpoint: 'https://auth.example.com/register',
+            ...(options.issuer ? { issuer: options.issuer } : {}),
+            ...(options.supportsIss === undefined
+              ? {}
+              : { authorization_response_iss_parameter_supported: options.supportsIss }),
           }),
           { status: 200 }
         )
@@ -936,6 +990,243 @@ describe('oauth', () => {
       expect(body.get('grant_type')).toBe('authorization_code')
       expect(body.get('code')).toBe('auth-code-xyz')
       expect(body.get('redirect_uri')).toBe('http://localhost/callback')
+    })
+
+    it('stores issuer metadata and accepts a matching iss when advertised as supported', async () => {
+      const state = await setupFlowAndGetState({
+        issuer: 'https://auth.example.com',
+        supportsIss: true,
+      })
+
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'access-tok-123',
+            token_type: 'Bearer',
+          }),
+          { status: 200 }
+        )
+      )
+      mockInsertValues.mockResolvedValue(undefined)
+
+      const result = await completeOAuthFlow(
+        state,
+        'auth-code-xyz',
+        'https://auth.example.com'
+      )
+
+      expect(result.success).toBe(true)
+      expect(mockFetch.mock.calls[mockFetch.mock.calls.length - 1][0]).toBe(
+        'https://auth.example.com/token'
+      )
+    })
+
+    it('rejects a missing iss before token exchange when metadata advertises support', async () => {
+      const state = await setupFlowAndGetState({
+        issuer: 'https://auth.example.com',
+        supportsIss: true,
+      })
+      const fetchCallsBefore = mockFetch.mock.calls.length
+
+      const result = await completeOAuthFlow(state, 'auth-code-xyz')
+
+      expect(result.success).toBe(false)
+      expect(mockFetch).toHaveBeenCalledTimes(fetchCallsBefore)
+      expect(mockInsertValues).not.toHaveBeenCalled()
+      expect(
+        validateAndConsumeOAuthErrorResponse(state, 'https://auth.example.com').valid
+      ).toBe(true)
+    })
+
+    it('rejects a mismatched iss before token exchange when metadata advertises support', async () => {
+      const state = await setupFlowAndGetState({
+        issuer: 'https://auth.example.com',
+        supportsIss: true,
+      })
+      const fetchCallsBefore = mockFetch.mock.calls.length
+
+      const result = await completeOAuthFlow(
+        state,
+        'auth-code-xyz',
+        'https://evil.example.com'
+      )
+
+      expect(result.success).toBe(false)
+      expect(mockFetch).toHaveBeenCalledTimes(fetchCallsBefore)
+      expect(mockInsertValues).not.toHaveBeenCalled()
+      expect(
+        validateAndConsumeOAuthErrorResponse(state, 'https://auth.example.com').valid
+      ).toBe(true)
+    })
+
+    it('compares iss with simple string comparison without URI normalization', async () => {
+      const state = await setupFlowAndGetState({
+        issuer: 'https://auth.example.com',
+        supportsIss: true,
+      })
+      const fetchCallsBefore = mockFetch.mock.calls.length
+
+      const result = await completeOAuthFlow(
+        state,
+        'auth-code-xyz',
+        'https://AUTH.example.com/'
+      )
+
+      expect(result.success).toBe(false)
+      expect(mockFetch).toHaveBeenCalledTimes(fetchCallsBefore)
+      expect(
+        validateAndConsumeOAuthErrorResponse(state, 'https://auth.example.com').valid
+      ).toBe(true)
+    })
+
+    it('accepts a matching iss even when metadata does not advertise support', async () => {
+      const state = await setupFlowAndGetState({
+        issuer: 'https://auth.example.com',
+        supportsIss: false,
+      })
+
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'access-tok-123',
+            token_type: 'Bearer',
+          }),
+          { status: 200 }
+        )
+      )
+      mockInsertValues.mockResolvedValue(undefined)
+
+      const result = await completeOAuthFlow(
+        state,
+        'auth-code-xyz',
+        'https://auth.example.com'
+      )
+
+      expect(result.success).toBe(true)
+    })
+
+    it('compares a present iss when the support flag is absent', async () => {
+      const state = await setupFlowAndGetState({
+        issuer: 'https://auth.example.com',
+      })
+      const fetchCallsBefore = mockFetch.mock.calls.length
+
+      const result = await completeOAuthFlow(
+        state,
+        'auth-code-xyz',
+        'https://evil.example.com'
+      )
+
+      expect(result.success).toBe(false)
+      expect(mockFetch).toHaveBeenCalledTimes(fetchCallsBefore)
+      expect(
+        validateAndConsumeOAuthErrorResponse(state, 'https://auth.example.com').valid
+      ).toBe(true)
+    })
+
+    it('rejects a mismatched iss even when metadata does not advertise support', async () => {
+      const state = await setupFlowAndGetState({
+        issuer: 'https://auth.example.com',
+        supportsIss: false,
+      })
+      const fetchCallsBefore = mockFetch.mock.calls.length
+
+      const result = await completeOAuthFlow(
+        state,
+        'auth-code-xyz',
+        'https://evil.example.com'
+      )
+
+      expect(result.success).toBe(false)
+      expect(mockFetch).toHaveBeenCalledTimes(fetchCallsBefore)
+      expect(
+        validateAndConsumeOAuthErrorResponse(state, 'https://auth.example.com').valid
+      ).toBe(true)
+    })
+
+    it('does not consume a pending flow when issuer validation fails', async () => {
+      const state = await setupFlowAndGetState({
+        issuer: 'https://auth.example.com',
+        supportsIss: true,
+      })
+
+      const invalid = await completeOAuthFlow(
+        state,
+        'auth-code-xyz',
+        'https://evil.example.com'
+      )
+      expect(invalid.success).toBe(false)
+
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'access-tok-123',
+            token_type: 'Bearer',
+          }),
+          { status: 200 }
+        )
+      )
+      mockInsertValues.mockResolvedValue(undefined)
+
+      const valid = await completeOAuthFlow(
+        state,
+        'auth-code-xyz',
+        'https://auth.example.com'
+      )
+      expect(valid.success).toBe(true)
+    })
+
+    it('validates and consumes trusted authorization error responses', async () => {
+      const state = await setupFlowAndGetState({
+        issuer: 'https://auth.example.com',
+        supportsIss: true,
+      })
+
+      const validation = validateAndConsumeOAuthErrorResponse(
+        state,
+        'https://auth.example.com'
+      )
+
+      expect(validation.valid).toBe(true)
+
+      const result = await completeOAuthFlow(
+        state,
+        'auth-code-xyz',
+        'https://auth.example.com'
+      )
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects untrusted authorization error responses without consuming the pending flow', async () => {
+      const state = await setupFlowAndGetState({
+        issuer: 'https://auth.example.com',
+        supportsIss: true,
+      })
+
+      const validation = validateAndConsumeOAuthErrorResponse(
+        state,
+        'https://evil.example.com'
+      )
+
+      expect(validation.valid).toBe(false)
+
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'access-tok-123',
+            token_type: 'Bearer',
+          }),
+          { status: 200 }
+        )
+      )
+      mockInsertValues.mockResolvedValue(undefined)
+
+      const result = await completeOAuthFlow(
+        state,
+        'auth-code-xyz',
+        'https://auth.example.com'
+      )
+      expect(result.success).toBe(true)
     })
 
     it('calculates expiry correctly from expires_in', async () => {

--- a/src/shared/lib/mcp/oauth.ts
+++ b/src/shared/lib/mcp/oauth.ts
@@ -205,21 +205,89 @@ export async function registerDynamicClient(
   }
 }
 
+type PendingOAuthFlow = {
+  codeVerifier: string
+  redirectUri: string
+  resource: string
+  tokenEndpoint: string
+  expectedIssuer?: string
+  authorizationResponseIssParameterSupported: boolean
+  clientId: string
+  clientSecret?: string
+  mcpId?: string
+  newServer?: { name: string; url: string }
+  userId?: string
+}
+
+type OAuthIssuerValidationResult =
+  | { valid: true }
+  | { valid: false; error: string }
+
 // In-memory store for pending OAuth flows
-const pendingOAuthFlows = new Map<
-  string,
-  {
-    codeVerifier: string
-    redirectUri: string
-    resource: string
-    tokenEndpoint: string
-    clientId: string
-    clientSecret?: string
-    mcpId?: string
-    newServer?: { name: string; url: string }
-    userId?: string
+const pendingOAuthFlows = new Map<string, PendingOAuthFlow>()
+
+function validateAuthorizationResponseIssuer(
+  flow: PendingOAuthFlow,
+  iss: string | null | undefined,
+): OAuthIssuerValidationResult {
+  const hasIss = iss !== undefined && iss !== null
+
+  if (flow.authorizationResponseIssParameterSupported && !hasIss) {
+    return {
+      valid: false,
+      error: 'Missing OAuth issuer parameter',
+    }
   }
->()
+
+  if (!hasIss) {
+    return { valid: true }
+  }
+
+  if (!flow.expectedIssuer) {
+    return {
+      valid: false,
+      error: 'Missing expected OAuth issuer',
+    }
+  }
+
+  if (iss !== flow.expectedIssuer) {
+    return {
+      valid: false,
+      error: 'OAuth issuer mismatch',
+    }
+  }
+
+  return { valid: true }
+}
+
+export function validateAndConsumeOAuthErrorResponse(
+  state: string | null | undefined,
+  iss: string | null | undefined,
+): OAuthIssuerValidationResult {
+  if (!state) {
+    return {
+      valid: false,
+      error: 'Missing OAuth state parameter',
+    }
+  }
+
+  const flow = pendingOAuthFlows.get(state)
+  if (!flow) {
+    return {
+      valid: false,
+      error: 'No pending OAuth flow for state',
+    }
+  }
+
+  const validation = validateAuthorizationResponseIssuer(flow, iss)
+  if (!validation.valid) {
+    console.error('[mcp/oauth] Authorization error issuer validation failed:', validation.error)
+    return validation
+  }
+
+  pendingOAuthFlows.delete(state)
+  return { valid: true }
+}
 
 /**
  * Initiate an OAuth flow for a remote MCP server.
@@ -307,6 +375,9 @@ export async function initiateOAuthFlow(
     redirectUri,
     resource,
     tokenEndpoint: metadata.token_endpoint,
+    expectedIssuer: metadata.issuer,
+    authorizationResponseIssParameterSupported:
+      metadata.authorization_response_iss_parameter_supported === true,
     clientId,
     clientSecret,
     mcpId,
@@ -408,6 +479,9 @@ export async function initiateNewServerOAuth(
     redirectUri,
     resource,
     tokenEndpoint: metadata.token_endpoint,
+    expectedIssuer: metadata.issuer,
+    authorizationResponseIssParameterSupported:
+      metadata.authorization_response_iss_parameter_supported === true,
     clientId,
     clientSecret,
     newServer: { name, url: mcpUrl },
@@ -453,10 +527,17 @@ export async function initiateNewServerOAuth(
 export async function completeOAuthFlow(
   state: string,
   code: string,
+  iss?: string | null,
 ): Promise<{ success: boolean; mcpId?: string }> {
   const flow = pendingOAuthFlows.get(state)
   if (!flow) {
     console.error('[mcp/oauth] No pending flow for state:', state)
+    return { success: false }
+  }
+
+  const issuerValidation = validateAuthorizationResponseIssuer(flow, iss)
+  if (!issuerValidation.valid) {
+    console.error('[mcp/oauth] Authorization response issuer validation failed:', issuerValidation.error)
     return { success: false }
   }
 

--- a/src/shared/lib/mcp/types.ts
+++ b/src/shared/lib/mcp/types.ts
@@ -12,11 +12,13 @@ export interface RemoteMcpConfig {
 }
 
 export interface OAuthMetadata {
+  issuer?: string
   authorization_endpoint: string
   token_endpoint: string
   registration_endpoint?: string
   code_challenge_methods_supported?: string[]
   scopes_supported?: string[]
+  authorization_response_iss_parameter_supported?: boolean
 }
 
 export interface OAuthTokenResponse {


### PR DESCRIPTION
## Summary
- Record the OAuth authorization server issuer in pending MCP OAuth flows.
- Validate callback iss before token exchange, including error responses.
- Deliver web MCP OAuth callbacks through postMessage, BroadcastChannel, and localStorage fallback for providers that sever window.opener.

## Why
SUP-263 requires RFC 9207 issuer validation before exchanging authorization codes. While testing Sentry MCP in web dev mode, Sentry also exposed a latent callback delivery issue: its OAuth pages send Cross-Origin-Opener-Policy: same-origin, which can sever window.opener and leave the app stuck waiting for OAuth.

## Validation
- /Users/iddogino/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/.bin/vitest run src/shared/lib/mcp/oauth.test.ts src/api/routes/remote-mcps.test.ts src/renderer/hooks/use-mcp-oauth-listener.test.ts
- node_modules/.bin/eslint src/shared/lib/mcp/oauth.ts src/shared/lib/mcp/types.ts src/shared/lib/mcp/oauth.test.ts src/api/routes/remote-mcps.ts src/api/routes/remote-mcps.test.ts src/renderer/hooks/use-mcp-oauth-listener.ts src/renderer/hooks/use-mcp-oauth-listener.test.ts --ext .ts
- git diff --check