### PR TITLE
Fix scheduled task duplicate execution

### DIFF
--- a/src/shared/lib/scheduler/task-scheduler.sup243.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.sup243.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { ScheduledTask } from '@shared/lib/services/scheduled-task-service'
+
+const mockGetDueTasks = vi.fn()
+const mockMarkTaskExecuted = vi.fn()
+const mockMarkTaskFailed = vi.fn()
+const mockUpdateNextExecution = vi.fn()
+
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  getDueTasks: (...args: unknown[]) => mockGetDueTasks(...args),
+  markTaskExecuted: (...args: unknown[]) => mockMarkTaskExecuted(...args),
+  markTaskFailed: (...args: unknown[]) => mockMarkTaskFailed(...args),
+  updateNextExecution: (...args: unknown[]) => mockUpdateNextExecution(...args),
+}))
+
+const mockCreateSession = vi.fn()
+const mockEnsureRunning = vi.fn()
+
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: {
+    ensureRunning: (...args: unknown[]) => mockEnsureRunning(...args),
+  },
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getEffectiveModels: () => ({
+    agentModel: 'claude-sonnet-4-20250514',
+    browserModel: 'claude-sonnet-4-20250514',
+    dashboardBuilderModel: 'claude-sonnet-4-20250514',
+  }),
+}))
+
+const mockSubscribeToSession = vi.fn()
+const mockMarkSessionActive = vi.fn()
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    subscribeToSession: (...args: unknown[]) => mockSubscribeToSession(...args),
+    markSessionActive: (...args: unknown[]) => mockMarkSessionActive(...args),
+  },
+}))
+
+const mockTriggerScheduledSessionStarted = vi.fn()
+
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerScheduledSessionStarted: (...args: unknown[]) =>
+      mockTriggerScheduledSessionStarted(...args),
+  },
+}))
+
+const mockGetSessionForScheduledExecution = vi.fn()
+const mockRegisterSession = vi.fn()
+const mockUpdateSessionMetadata = vi.fn()
+
+vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionForScheduledExecution: (...args: unknown[]) =>
+    mockGetSessionForScheduledExecution(...args),
+  registerSession: (...args: unknown[]) => mockRegisterSession(...args),
+  updateSessionMetadata: (...args: unknown[]) => mockUpdateSessionMetadata(...args),
+}))
+
+const mockGetSecretEnvVars = vi.fn()
+
+vi.mock('@shared/lib/services/secrets-service', () => ({
+  getSecretEnvVars: (...args: unknown[]) => mockGetSecretEnvVars(...args),
+}))
+
+const mockAgentExists = vi.fn()
+
+vi.mock('@shared/lib/services/agent-service', () => ({
+  agentExists: (...args: unknown[]) => mockAgentExists(...args),
+}))
+
+const mockGetNextCronTime = vi.fn()
+
+vi.mock('@shared/lib/services/schedule-parser', () => ({
+  getNextCronTime: (...args: unknown[]) => mockGetNextCronTime(...args),
+}))
+
+const mockRunWithOptionalUser = vi.fn(
+  (_userId: string | null | undefined, fn: () => unknown) => fn(),
+)
+
+vi.mock('@shared/lib/platform-attribution', () => ({
+  runWithOptionalUser: (userId: string | null | undefined, fn: () => unknown) =>
+    mockRunWithOptionalUser(userId, fn),
+}))
+
+const mockCaptureException = vi.fn()
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}))
+
+import { taskScheduler } from './task-scheduler'
+
+const scheduledExecutionAt = new Date('2026-06-26T17:00:00.000Z')
+const nextExecutionAt = new Date('2026-06-26T17:05:00.000Z')
+
+function createTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
+  return {
+    id: 'task-1',
+    agentSlug: 'agent-one',
+    scheduleType: 'at',
+    scheduleExpression: 'at 2026-06-26 10:00',
+    prompt: 'Run the scheduled report',
+    name: 'Daily report',
+    status: 'pending',
+    nextExecutionAt: scheduledExecutionAt,
+    lastExecutedAt: null,
+    isRecurring: false,
+    executionCount: 0,
+    lastSessionId: null,
+    createdBySessionId: null,
+    createdByUserId: 'user-1',
+    timezone: 'America/Los_Angeles',
+    model: null,
+    effort: null,
+    createdAt: new Date('2026-06-26T16:00:00.000Z'),
+    cancelledAt: null,
+    pausedAt: null,
+    ...overrides,
+  }
+}
+
+function existingScheduledSession(sessionId = 'container-session-1') {
+  return {
+    id: sessionId,
+    agentSlug: 'agent-one',
+    name: 'Daily report',
+    createdAt: scheduledExecutionAt,
+    lastActivityAt: scheduledExecutionAt,
+    messageCount: 0,
+  }
+}
+
+describe('TaskScheduler duplicate execution guard (SUP-243)', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    taskScheduler.stop()
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    vi.clearAllMocks()
+    mockGetDueTasks.mockResolvedValue([])
+    mockEnsureRunning.mockResolvedValue({ createSession: mockCreateSession })
+    mockCreateSession.mockResolvedValue({ id: 'container-session-1' })
+    mockSubscribeToSession.mockResolvedValue(undefined)
+    mockTriggerScheduledSessionStarted.mockResolvedValue(undefined)
+    mockRegisterSession.mockResolvedValue(undefined)
+    mockUpdateSessionMetadata.mockResolvedValue(undefined)
+    mockGetSecretEnvVars.mockResolvedValue([])
+    mockAgentExists.mockResolvedValue(true)
+    mockGetSessionForScheduledExecution.mockResolvedValue(null)
+    mockMarkTaskExecuted.mockResolvedValue(undefined)
+    mockMarkTaskFailed.mockResolvedValue(undefined)
+    mockUpdateNextExecution.mockResolvedValue(undefined)
+    mockGetNextCronTime.mockReturnValue(nextExecutionAt)
+  })
+
+  afterEach(() => {
+    taskScheduler.stop()
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('reconciles a retried one-time task with the existing scheduled session instead of creating a duplicate', async () => {
+    const task = createTask()
+    mockGetDueTasks.mockResolvedValue([task])
+    mockGetSessionForScheduledExecution
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(existingScheduledSession())
+    mockMarkTaskExecuted
+      .mockRejectedValueOnce(new Error('lost durable mark'))
+      .mockResolvedValueOnce(undefined)
+    mockMarkTaskFailed.mockRejectedValue(new Error('same SQLite outage'))
+
+    await taskScheduler.triggerExecution()
+    await taskScheduler.triggerExecution()
+
+    expect(mockGetSessionForScheduledExecution).toHaveBeenNthCalledWith(
+      1,
+      'agent-one',
+      'task-1',
+      scheduledExecutionAt,
+    )
+    expect(mockGetSessionForScheduledExecution).toHaveBeenNthCalledWith(
+      2,
+      'agent-one',
+      'task-1',
+      scheduledExecutionAt,
+    )
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    expect(mockEnsureRunning).toHaveBeenCalledTimes(1)
+    expect(mockRegisterSession).toHaveBeenCalledWith(
+      'agent-one',
+      'container-session-1',
+      'Daily report',
+      expect.objectContaining({
+        isScheduledExecution: true,
+        scheduledTaskId: 'task-1',
+        scheduledTaskName: 'Daily report',
+        scheduledExecutionAt: scheduledExecutionAt.toISOString(),
+      }),
+    )
+    expect(mockUpdateSessionMetadata).not.toHaveBeenCalled()
+    expect(mockMarkTaskExecuted).toHaveBeenNthCalledWith(1, 'task-1', 'container-session-1')
+    expect(mockMarkTaskExecuted).toHaveBeenNthCalledWith(2, 'task-1', 'container-session-1')
+  })
+
+  it('reconciles a retried recurring task with the existing scheduled session and advances the schedule', async () => {
+    const task = createTask({
+      scheduleType: 'cron',
+      scheduleExpression: '*/5 * * * *',
+      isRecurring: true,
+    })
+    mockGetDueTasks.mockResolvedValue([task])
+    mockGetSessionForScheduledExecution
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(existingScheduledSession())
+    mockUpdateNextExecution
+      .mockRejectedValueOnce(new Error('lost durable advance'))
+      .mockRejectedValueOnce(new Error('same SQLite outage'))
+      .mockResolvedValueOnce(undefined)
+    mockMarkTaskFailed.mockRejectedValue(new Error('same SQLite outage'))
+
+    await taskScheduler.triggerExecution()
+    await taskScheduler.triggerExecution()
+
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    expect(mockUpdateNextExecution).toHaveBeenNthCalledWith(
+      1,
+      'task-1',
+      nextExecutionAt,
+      'container-session-1',
+    )
+    expect(mockUpdateNextExecution).toHaveBeenNthCalledWith(2, 'task-1', nextExecutionAt, '')
+    expect(mockUpdateNextExecution).toHaveBeenNthCalledWith(
+      3,
+      'task-1',
+      nextExecutionAt,
+      'container-session-1',
+    )
+  })
+})

--- a/src/shared/lib/scheduler/task-scheduler.ts
+++ b/src/shared/lib/scheduler/task-scheduler.ts
@@ -20,8 +20,8 @@ import type { ScheduledTask } from '@shared/lib/services/scheduled-task-service'
 import type { EffortLevel } from '@shared/lib/container/types'
 import { getNextCronTime } from '@shared/lib/services/schedule-parser'
 import {
+  getSessionForScheduledExecution,
   registerSession,
-  updateSessionMetadata,
 } from '@shared/lib/services/session-service'
 import { getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { agentExists } from '@shared/lib/services/agent-service'
@@ -168,6 +168,20 @@ class TaskScheduler {
       `[TaskScheduler] Executing task ${task.id} for agent ${task.agentSlug}`
     )
 
+    const existingSession = await getSessionForScheduledExecution(
+      task.agentSlug,
+      task.id,
+      task.nextExecutionAt,
+    )
+
+    if (existingSession) {
+      console.log(
+        `[TaskScheduler] Task ${task.id} already has session ${existingSession.id}; reconciling task status`
+      )
+      await this.recordTaskExecution(task, existingSession.id)
+      return
+    }
+
     // Verify agent still exists
     if (!(await agentExists(task.agentSlug))) {
       console.error(
@@ -199,14 +213,11 @@ class TaskScheduler {
     const sessionId = containerSession.id
     const sessionName = task.name || 'Scheduled Task'
 
-    // Register the session
-    await registerSession(task.agentSlug, sessionId, sessionName)
-
-    // Update session metadata to mark it as created from a scheduled task
-    await updateSessionMetadata(task.agentSlug, sessionId, {
+    await registerSession(task.agentSlug, sessionId, sessionName, {
       isScheduledExecution: true,
       scheduledTaskId: task.id,
       scheduledTaskName: task.name || undefined,
+      scheduledExecutionAt: task.nextExecutionAt.toISOString(),
     })
 
     // Subscribe to the session for SSE updates
@@ -232,7 +243,10 @@ class TaskScheduler {
       console.error('[TaskScheduler] Failed to trigger scheduled notification:', err)
     })
 
-    // Update task status
+    await this.recordTaskExecution(task, sessionId)
+  }
+
+  private async recordTaskExecution(task: ScheduledTask, sessionId: string): Promise<void> {
     if (task.isRecurring) {
       // Update next execution time for recurring tasks
       const nextTime = getNextCronTime(task.scheduleExpression, task.timezone || undefined)

--- a/src/shared/lib/services/session-metadata-schema.ts
+++ b/src/shared/lib/services/session-metadata-schema.ts
@@ -42,6 +42,7 @@ export const sessionMetadataSchema = z
     isScheduledExecution: z.boolean().optional(),
     scheduledTaskId: z.string().optional(),
     scheduledTaskName: z.string().optional(),
+    scheduledExecutionAt: z.string().optional(),
     isWebhookExecution: z.boolean().optional(),
     webhookTriggerId: z.string().optional(),
     webhookTriggerName: z.string().optional(),

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -27,6 +27,7 @@ import {
   removeMessage,
   removeToolCall,
   getSessionsByScheduledTask,
+  getSessionForScheduledExecution,
   getSessionsByWebhookTrigger,
 } from './session-service'
 
@@ -128,6 +129,30 @@ describe('session-service', () => {
 
       const metadata = await getSessionMetadata('test-agent', 'session-123')
       expect(metadata?.name).toBe('New Session')
+    })
+
+    it('stores initial metadata in the same registration write', async () => {
+      await fs.promises.mkdir(
+        path.join(testDir, 'agents', 'test-agent', 'workspace'),
+        { recursive: true }
+      )
+
+      await registerSession('test-agent', 'session-123', 'Scheduled Run', {
+        isScheduledExecution: true,
+        scheduledTaskId: 'task-abc',
+        scheduledTaskName: 'Daily report',
+        scheduledExecutionAt: '2026-01-24T02:00:00.000Z',
+      })
+
+      const metadata = await getSessionMetadata('test-agent', 'session-123')
+      expect(metadata).toMatchObject({
+        name: 'Scheduled Run',
+        isScheduledExecution: true,
+        scheduledTaskId: 'task-abc',
+        scheduledTaskName: 'Daily report',
+        scheduledExecutionAt: '2026-01-24T02:00:00.000Z',
+      })
+      expect(metadata?.createdAt).toBeDefined()
     })
   })
 
@@ -2303,6 +2328,70 @@ describe('session-service', () => {
       const sessions = await getSessionsByScheduledTask('test-agent', 'task-abc')
       expect(sessions.length).toBe(1)
       expect(sessions[0].id).toBe('sess-1')
+    })
+  })
+
+  // ============================================================================
+  // getSessionForScheduledExecution Tests
+  // ============================================================================
+
+  describe('getSessionForScheduledExecution', () => {
+    it('returns the session for the exact scheduled task execution time', async () => {
+      await createSessionFile('test-agent', 'sess-1', SAMPLE_JSONL_ENTRIES)
+      await createSessionFile('test-agent', 'sess-2', SAMPLE_JSONL_ENTRIES)
+      await createSessionFile('test-agent', 'sess-3', SAMPLE_JSONL_ENTRIES)
+      await createSessionMetadata('test-agent', {
+        'sess-1': {
+          name: 'Earlier Run',
+          createdAt: '2026-01-24T01:00:00.000Z',
+          scheduledTaskId: 'task-abc',
+          scheduledExecutionAt: '2026-01-24T01:00:00.000Z',
+          isScheduledExecution: true,
+        },
+        'sess-2': {
+          name: 'Target Run',
+          createdAt: '2026-01-24T02:00:00.000Z',
+          scheduledTaskId: 'task-abc',
+          scheduledExecutionAt: '2026-01-24T02:00:00.000Z',
+          isScheduledExecution: true,
+        },
+        'sess-3': {
+          name: 'Different Task Same Time',
+          createdAt: '2026-01-24T02:00:00.000Z',
+          scheduledTaskId: 'task-xyz',
+          scheduledExecutionAt: '2026-01-24T02:00:00.000Z',
+          isScheduledExecution: true,
+        },
+      })
+
+      const session = await getSessionForScheduledExecution(
+        'test-agent',
+        'task-abc',
+        new Date('2026-01-24T02:00:00.000Z'),
+      )
+
+      expect(session?.id).toBe('sess-2')
+    })
+
+    it('returns null when the task matches but the execution time does not', async () => {
+      await createSessionFile('test-agent', 'sess-1', SAMPLE_JSONL_ENTRIES)
+      await createSessionMetadata('test-agent', {
+        'sess-1': {
+          name: 'Earlier Run',
+          createdAt: '2026-01-24T01:00:00.000Z',
+          scheduledTaskId: 'task-abc',
+          scheduledExecutionAt: '2026-01-24T01:00:00.000Z',
+          isScheduledExecution: true,
+        },
+      })
+
+      const session = await getSessionForScheduledExecution(
+        'test-agent',
+        'task-abc',
+        new Date('2026-01-24T02:00:00.000Z'),
+      )
+
+      expect(session).toBeNull()
     })
   })
 

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -143,10 +143,12 @@ export async function getSessionMetadata(
 export async function registerSession(
   agentSlug: string,
   sessionId: string,
-  name?: string
+  name?: string,
+  initialMetadata?: Partial<SessionMetadata>,
 ): Promise<void> {
   await mutateSessionMetadata(agentSlug, (metadata) => {
     metadata[sessionId] = {
+      ...initialMetadata,
       name: name || 'New Session',
       createdAt: new Date().toISOString(),
     }
@@ -864,6 +866,26 @@ export async function getSessionsByScheduledTask(
   scheduledTaskId: string
 ): Promise<SessionInfo[]> {
   return getSessionsByMetadata(agentSlug, (meta) => meta.scheduledTaskId === scheduledTaskId)
+}
+
+/**
+ * Get the session for a specific scheduled task execution slot.
+ */
+export async function getSessionForScheduledExecution(
+  agentSlug: string,
+  scheduledTaskId: string,
+  scheduledExecutionAt: Date,
+): Promise<SessionInfo | null> {
+  const executionAt = scheduledExecutionAt.toISOString()
+  const sessions = await getSessionsByMetadata(
+    agentSlug,
+    (meta) =>
+      meta.isScheduledExecution === true &&
+      meta.scheduledTaskId === scheduledTaskId &&
+      meta.scheduledExecutionAt === executionAt,
+  )
+
+  return sessions[0] ?? null
 }
 
 /**

--- a/src/shared/lib/types/agent.ts
+++ b/src/shared/lib/types/agent.ts
@@ -84,6 +84,7 @@ export interface SessionMetadata {
   isScheduledExecution?: boolean
   scheduledTaskId?: string
   scheduledTaskName?: string
+  scheduledExecutionAt?: string
   // Webhook trigger fields - present when session was created from a webhook trigger
   isWebhookExecution?: boolean
   webhookTriggerId?: string


### PR DESCRIPTION
## Summary

Fixes SUP-243 by adding host-side idempotency for scheduled task execution slots. The scheduler now records the scheduled execution timestamp in session metadata and checks for an existing `(scheduledTaskId, scheduledExecutionAt)` session before creating a new container session. If a prior session exists because the process crashed or the durable task mark failed after session creation, the scheduler reconciles the task status using that existing session instead of launching a duplicate.

The session registration path now accepts initial metadata so scheduled-session provenance and the dedupe key are written in the same metadata mutation as registration.

## Impact

This preserves at-least-once retry behavior while preventing duplicate agent sessions for the same scheduled execution slot once the session metadata write has succeeded. Recurring tasks remain able to run future slots because the dedupe key includes the scheduled execution timestamp, not just the task ID.

## Validation

- `/Users/iddogino/.nvm/versions/node/v22.22.3/bin/node ./node_modules/vitest/vitest.mjs run src/shared/lib/scheduler/task-scheduler.sup243.test.ts src/shared/lib/services/session-service.test.ts`
- `/Users/iddogino/.nvm/versions/node/v22.22.3/bin/node ./node_modules/vitest/vitest.mjs run src/shared/lib/scheduler/task-scheduler.sup224.test.ts src/shared/lib/scheduler/task-scheduler.sup243.test.ts`
- `/Users/iddogino/.nvm/versions/node/v22.22.3/bin/node ./node_modules/typescript/bin/tsc --noEmit`
- `/Users/iddogino/.nvm/versions/node/v22.22.3/bin/node ./node_modules/eslint/bin/eslint.js src/shared/lib/scheduler/task-scheduler.ts src/shared/lib/scheduler/task-scheduler.sup243.test.ts src/shared/lib/services/session-service.ts src/shared/lib/services/session-service.test.ts src/shared/lib/services/session-metadata-schema.ts src/shared/lib/types/agent.ts`