### PR TITLE
refactor(chat): project session activity onto the working indicator

### DIFF
--- a/src/api/routes/x-agent-chat.test.ts
+++ b/src/api/routes/x-agent-chat.test.ts
@@ -248,7 +248,7 @@ describe('x-agent chat route', () => {
     expect(await res.json()).toEqual({ chatId: 'chat-1', provider: 'slack' })
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('getConnector returned undefined'))
     expect(mockAddIntegration).toHaveBeenCalledWith('integration-1')
-    expect(connector.startWorking).toHaveBeenCalledWith('chat-1')
+    expect(connector.startWorking).toHaveBeenCalledWith('chat-1', 'working')
     expect(connector.sendMessage).toHaveBeenCalledWith('chat-1', { text: 'Ship the update' })
     expect(mockEnsureSession).toHaveBeenCalledWith('integration-1', 'chat-1')
     expect(mockEnsureRunning).toHaveBeenCalledWith('agent-one')

--- a/src/api/routes/x-agent-chat.ts
+++ b/src/api/routes/x-agent-chat.ts
@@ -225,7 +225,7 @@ xAgentChat.post('/send', async (c) => {
     }
 
     const typingDelay = 100 + Math.random() * 1100
-    await connector.startWorking(resolvedChatId).catch(() => {})
+    await connector.startWorking(resolvedChatId, 'working').catch(() => {})
     await new Promise((resolve) => setTimeout(resolve, typingDelay))
 
     await connector.sendMessage(resolvedChatId, { text: message })

--- a/src/shared/lib/chat-integrations/base-connector.test.ts
+++ b/src/shared/lib/chat-integrations/base-connector.test.ts
@@ -219,8 +219,8 @@ describe('MockChatClientConnector', () => {
   it('records working indicators', async () => {
     const mock = new MockChatClientConnector()
 
-    await mock.startWorking('chat-1')
-    await mock.startWorking('chat-2')
+    await mock.startWorking('chat-1', 'working')
+    await mock.startWorking('chat-2', 'working')
 
     expect(mock.typingIndicators).toEqual(['chat-1', 'chat-2'])
   })
@@ -256,7 +256,7 @@ describe('MockChatClientConnector', () => {
     await mock.sendMessage('chat-1', { text: 'hello' })
     await mock.sendStreamingUpdate('chat-1', 'partial')
     await mock.finalizeStreamingMessage('chat-1', 'msg-1', 'final')
-    await mock.startWorking('chat-1')
+    await mock.startWorking('chat-1', 'working')
     await mock.sendUserRequestCard('chat-1', { type: 'secret_request', toolUseId: 'tu-1', secretName: 'KEY' } as any)
 
     mock.reset()

--- a/src/shared/lib/chat-integrations/base-connector.ts
+++ b/src/shared/lib/chat-integrations/base-connector.ts
@@ -6,6 +6,7 @@
  */
 
 import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
+import type { SessionActivity } from '@shared/lib/types/agent'
 import type { ChatProvider } from './config-schema'
 import { captureException } from '@shared/lib/error-reporting'
 
@@ -67,11 +68,13 @@ export abstract class ChatClientConnector {
   abstract finalizeStreamingMessage(chatId: string, messageId: string, finalText: string): Promise<void>
 
   /**
-   * Signal that the agent is working (processing, no output yet). The connector
-   * owns the representation AND any keep-alive needed to survive provider-side
-   * expiry. Idempotent — safe to call repeatedly for the same chat.
+   * Signal that the agent is busy, labeled by what it is doing (`activity`). The
+   * connector owns how that maps to its surface (Telegram labels a draft, Slack
+   * reacts) AND any keep-alive needed to survive provider-side expiry. Called
+   * again with a new activity when the label changes mid-turn. Idempotent — safe
+   * to call repeatedly for the same chat.
    */
-  abstract startWorking(chatId: string): Promise<void>
+  abstract startWorking(chatId: string, activity: SessionActivity): Promise<void>
 
   /**
    * Stop the working indicator as the response takes over. Idempotent — safe to

--- a/src/shared/lib/chat-integrations/chat-integration-e2e.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-e2e.test.ts
@@ -509,6 +509,15 @@ describe('Chat integration E2E', () => {
       expect(mockConnector.typingIndicators).toContain('chat-1')
     })
 
+    it('reconciles the indicator from the snapshot on subscribe (cold-start)', async () => {
+      const integrationId = createTestIntegration()
+      await chatIntegrationManager.addIntegration(integrationId)
+      mockConnector.simulateIncomingMessage('hi', 'chat-1', 'user-1')
+      await waitForCondition(() => MockContainerClient.createSessionCalls.length > 0)
+      await waitForCondition(() => mockConnector.typingIndicators.includes('chat-1'), 2000)
+      expect(mockConnector.typingIndicators).toContain('chat-1') // came up via snapshot or event
+    })
+
     it('stops the working indicator when the integration is torn down', async () => {
       const integrationId = createTestIntegration()
       await chatIntegrationManager.addIntegration(integrationId)

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -12,6 +12,7 @@
 
 import type { ChatClientConnector, IncomingMessage } from './base-connector'
 import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
+import type { SessionActivity } from '@shared/lib/types/agent'
 import { getToolDefinition } from '@shared/lib/tool-definitions/registry'
 import { formatToolName } from '@shared/lib/tool-definitions/types'
 import { parseChatIntegrationConfig, type ChatProvider } from './config-schema'
@@ -523,6 +524,11 @@ class ChatIntegrationManager {
       this.enqueueSSEEvent(integrationId, chatId, event)
     })
     session.sseUnsubscribe = unsubscribe
+    // Reconcile from the current state so a cold/late subscriber matches reality
+    // instead of waiting for the next session_activity event. The snapshot reads
+    // live state, and awaiting/idle are set synchronously with their broadcast,
+    // so a stale 'working' can't outlive the real state.
+    reconcileIndicator(session, messagePersister.getSessionActivity(sessionId))
   }
 
   private enqueueSSEEvent(integrationId: string, chatId: string, event: unknown): void {
@@ -842,7 +848,7 @@ class ChatIntegrationManager {
       return
     }
 
-    // Show the "Thinking…" indicator (the connector keeps it alive) until the first token streams.
+    // The working indicator now arms via session_activity (markSessionActive above), not here.
     const dispatched = this.chatSessions.get(this.getChatSessionKey(integrationId, chatId))
     if (dispatched) {
       // New user turn: re-allow exactly one terminal notice (the watchdog stall
@@ -850,8 +856,6 @@ class ChatIntegrationManager {
       // than on every stream_start, so a single multi-stall turn can't emit
       // repeated notices.
       dispatched.turnNotified = false
-      dispatched.connector.startWorking(dispatched.chatId).catch(() => {})
-      armWorkingWatchdog(dispatched)
     }
   }
 
@@ -1431,23 +1435,21 @@ class ChatIntegrationManager {
   }
 }
 
-// ── Working-indicator teardown + idle watchdog ─────────────────────────
+// ── Turn finalize + idle watchdog (watchdog force-settles the indicator) ──
 
 /**
- * Tear down a turn's live UI: stop the working indicator (kills the keep-alive
- * heartbeat), commit any streamed text, and settle pending tool pills. Shared by
- * session_idle, session_error, and the idle watchdog so every terminal path
- * clears the indicator the same way. Idempotent.
+ * Commit a turn's streamed text + settle pending tool pills. Indicator-free: the
+ * working indicator is reconcile-driven off session_activity (the persister emits
+ * a non-busy activity immediately before a terminal event), so the terminal
+ * cases no longer own indicator teardown — they only finalize. Idempotent.
  */
-async function settleTurn(managed: ManagedConnector): Promise<void> {
-  clearWorkingWatchdog(managed)
-  managed.connector.stopWorking(managed.chatId).catch(() => {})
+async function finalizeTurn(managed: ManagedConnector): Promise<void> {
   try {
     await finalizeStreaming(managed)
     await resolvePendingToolMessages(managed)
   } catch (err) {
     console.error('[ChatIntegrationManager] Failed to finalize turn:', err)
-    reportError(err, 'settle-turn', { integrationId: managed.integration.id, chatId: managed.chatId })
+    reportError(err, 'finalize-turn', { integrationId: managed.integration.id, chatId: managed.chatId })
   }
 }
 
@@ -1460,10 +1462,10 @@ function clearWorkingWatchdog(managed: ManagedConnector): void {
 }
 
 /**
- * (Re)arm the idle watchdog. Called when the working indicator is shown (dispatch
- * / stream_start) and reset on every subsequent SSE event, so it fires only after
- * a full WORKING_WATCHDOG_MS of total silence — a stalled turn that never emits a
- * terminal event.
+ * (Re)arm the idle watchdog. Called when the working indicator is shown (via
+ * reconcileIndicator off session_activity) and reset on every subsequent SSE event,
+ * so it fires only after a full WORKING_WATCHDOG_MS of total silence — a stalled
+ * turn that never emits a terminal event.
  */
 function armWorkingWatchdog(managed: ManagedConnector): void {
   clearWorkingWatchdog(managed)
@@ -1498,7 +1500,10 @@ async function onWorkingWatchdogFired(managed: ManagedConnector): Promise<void> 
     },
     'warning',
   )
-  await settleTurn(managed)
+  // Force the indicator off: this is a stall, so session state may still say
+  // working and a plain reconcile would re-arm. Override directly, then finalize.
+  reconcileIndicator(managed, 'idle')
+  await finalizeTurn(managed)
   // Notify at most once per turn: if a near-simultaneous session_error already
   // surfaced its message, don't pile a second notice on top. Softened copy — the
   // watchdog can be a false positive on a slow-but-alive turn, so it must not
@@ -1533,6 +1538,32 @@ function friendlyErrorMessage(apiErrorCode: string | null | undefined): string {
   return '⚠️ The assistant hit an error and stopped. Please try again.'
 }
 
+/**
+ * Activities that show a placeholder ("busy"). 'idle' | 'awaiting' | 'streaming'
+ * show none — the surface is owned by the reply or a request card, or there is
+ * nothing to show.
+ */
+const BUSY_ACTIVITIES: ReadonlySet<SessionActivity> = new Set([
+  'working', 'thinking', 'compacting', 'retrying',
+])
+
+/**
+ * The ONE thing that drives the working indicator: project the agent's activity
+ * onto the connector. Busy activities show a labeled placeholder; the rest tear
+ * it down. Idempotent on both connector and watchdog, so the subscribe snapshot
+ * and the event stream cannot conflict. The connector owns how each activity is
+ * rendered (Telegram labels it, Slack reacts, the app draws its own indicator).
+ */
+function reconcileIndicator(managed: ManagedConnector, activity: SessionActivity): void {
+  if (BUSY_ACTIVITIES.has(activity)) {
+    managed.connector.startWorking(managed.chatId, activity).catch(() => {})
+    armWorkingWatchdog(managed)
+  } else {
+    managed.connector.stopWorking(managed.chatId).catch(() => {})
+    clearWorkingWatchdog(managed)
+  }
+}
+
 // ── SSE event processing (exported for testing) ────────────────────────
 
 /**
@@ -1555,13 +1586,6 @@ export async function processSSEEvent(
     case 'stream_delta': {
       const text = data.text as string
       if (!text) break
-      // First token of this segment: the response is streaming now, so drop "Thinking…".
-      // Guard on the empty accumulator so stopWorking fires once on the transition,
-      // not on every streamed token.
-      if (managed.streamingState.accumulatedText === '') {
-        managed.connector.stopWorking(managed.chatId).catch(() => {})
-        clearWorkingWatchdog(managed)
-      }
       managed.streamingState.accumulatedText += text
 
       const now = Date.now()
@@ -1589,10 +1613,6 @@ export async function processSSEEvent(
       } catch (err) {
         console.error('[ChatIntegrationManager] Failed to finalize on stream_start:', err)
       }
-      // "Thinking…" again for the next segment. startWorking self-keep-alives, so a
-      // long gap before the next token no longer drops it; the first token replaces it.
-      managed.connector.startWorking(managed.chatId).catch(() => {})
-      armWorkingWatchdog(managed)
       break
     }
 
@@ -1671,9 +1691,9 @@ export async function processSSEEvent(
     case 'browser_input_request':
     case 'script_run_request':
     case 'computer_use_request': {
-      // The agent is now waiting on the user, so the silence that follows is the
-      // human, not a stall — pause the idle watchdog until the next turn re-arms it.
-      clearWorkingWatchdog(managed)
+      // The agent is now waiting on the user. The persister flips isAwaitingInput
+      // and emits a non-busy session_activity, which settles the indicator + watchdog;
+      // here we only surface the request card.
       try {
         await managed.connector.sendUserRequestCard(managed.chatId, data as UserRequestEvent)
       } catch (err) {
@@ -1683,8 +1703,13 @@ export async function processSSEEvent(
       break
     }
 
+    case 'session_activity': {
+      reconcileIndicator(managed, (data as { activity: SessionActivity }).activity)
+      break
+    }
+
     case 'session_idle': {
-      await settleTurn(managed)
+      await finalizeTurn(managed)
       break
     }
 
@@ -1692,9 +1717,9 @@ export async function processSSEEvent(
       // An errored turn emits session_error (NOT session_idle), and the host
       // suppresses the later authoritative idle. Without this case the working
       // indicator's keep-alive heartbeat is never torn down and re-stamps
-      // "Thinking…" forever. Settle the turn the same way session_idle does, then
+      // "Thinking…" forever. Finalize the turn the same way session_idle does, then
       // surface the error so the user isn't left staring at a frozen indicator.
-      await settleTurn(managed)
+      await finalizeTurn(managed)
       if (!managed.turnNotified) {
         managed.turnNotified = true
         try {

--- a/src/shared/lib/chat-integrations/finalize-streaming.test.ts
+++ b/src/shared/lib/chat-integrations/finalize-streaming.test.ts
@@ -410,7 +410,7 @@ describe('TelegramConnector.startWorking / stopWorking', () => {
     const sendChatAction = vi.fn().mockResolvedValue(true)
     ;(connector as any).bot = { api: { raw: { sendRichMessageDraft }, sendChatAction } }
 
-    await connector.startWorking('999')
+    await connector.startWorking('999', 'thinking')
     expect(sendRichMessageDraft).toHaveBeenCalledWith(expect.objectContaining({
       chat_id: 999,
       rich_message: { html: '<tg-thinking>✨ Thinking…</tg-thinking>' },
@@ -427,7 +427,7 @@ describe('TelegramConnector.startWorking / stopWorking', () => {
       const sendRichMessageDraft = vi.fn().mockResolvedValue(true)
       ;(connector as any).bot = { api: { raw: { sendRichMessageDraft }, sendChatAction: vi.fn() } }
 
-      await connector.startWorking('999')
+      await connector.startWorking('999', 'working')
       expect(sendRichMessageDraft).toHaveBeenCalledTimes(1) // sent right away
 
       await vi.advanceTimersByTimeAsync(1000)
@@ -452,7 +452,7 @@ describe('TelegramConnector.startWorking / stopWorking', () => {
     const sendChatAction = vi.fn().mockResolvedValue(true)
     ;(connector as any).bot = { api: { raw: { sendRichMessageDraft }, sendChatAction } }
 
-    await connector.startWorking('-1001')
+    await connector.startWorking('-1001', 'working')
     expect(sendChatAction).toHaveBeenCalledWith('-1001', 'typing')
     expect(sendRichMessageDraft).not.toHaveBeenCalled()
     await connector.stopWorking('-1001') // clear the keep-alive timer

--- a/src/shared/lib/chat-integrations/imessage-connector.test.ts
+++ b/src/shared/lib/chat-integrations/imessage-connector.test.ts
@@ -861,7 +861,7 @@ describe('IMessageConnector', () => {
       const connector = createConnector()
       const ws = wireUp(connector)
 
-      await connector.startWorking('chat-1')
+      await connector.startWorking('chat-1', 'working')
 
       const messages = parseSent(ws)
       expect(messages).toHaveLength(1)

--- a/src/shared/lib/chat-integrations/imessage-connector.ts
+++ b/src/shared/lib/chat-integrations/imessage-connector.ts
@@ -8,6 +8,7 @@
 
 import WebSocket from 'ws'
 import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
+import type { SessionActivity } from '@shared/lib/types/agent'
 import { ChatClientConnector, type OutgoingMessage } from './base-connector'
 import { describeUnsupportedRequest, isUnsupportedInChat } from './utils'
 import { captureException } from '@shared/lib/error-reporting'
@@ -248,7 +249,8 @@ export class IMessageConnector extends ChatClientConnector {
     await this.sendMessage(chatId, { text: finalText })
   }
 
-  async startWorking(chatId: string): Promise<void> {
+  async startWorking(chatId: string, _activity: SessionActivity): Promise<void> {
+    // iMessage shows only a typing indicator, so the activity label is unused.
     const targetChatId = chatId || this.lastChatId || undefined
     this.send({ type: 'start_typing', data: { chatId: targetChatId } })
   }

--- a/src/shared/lib/chat-integrations/mock-connector.ts
+++ b/src/shared/lib/chat-integrations/mock-connector.ts
@@ -6,6 +6,7 @@
  */
 
 import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
+import type { SessionActivity } from '@shared/lib/types/agent'
 import { ChatClientConnector, type OutgoingMessage } from './base-connector'
 
 export class MockChatClientConnector extends ChatClientConnector {
@@ -22,6 +23,7 @@ export class MockChatClientConnector extends ChatClientConnector {
   finalizedMessages: { chatId: string; messageId: string; finalText: string }[] = []
   typingIndicators: string[] = []
   stoppedWorking: string[] = []
+  workingActivities: SessionActivity[] = [] // activity passed to each startWorking call
 
   private nextMessageId = 1
 
@@ -112,8 +114,9 @@ export class MockChatClientConnector extends ChatClientConnector {
     this.finalizedMessages.push({ chatId, messageId, finalText })
   }
 
-  async startWorking(chatId: string): Promise<void> {
+  async startWorking(chatId: string, activity: SessionActivity): Promise<void> {
     this.typingIndicators.push(chatId)
+    this.workingActivities.push(activity)
   }
 
   async stopWorking(chatId: string): Promise<void> {

--- a/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
+++ b/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
@@ -25,6 +25,7 @@ import { processSSEEvent, finalizeStreaming, type ManagedConnector } from './cha
 import { TelegramConnector } from './telegram-connector'
 import { MockChatClientConnector } from './mock-connector'
 import type { ChatIntegration } from '@shared/lib/db/schema'
+import type { SessionActivity } from '@shared/lib/types/agent'
 
 function makeManaged(connector: ManagedConnector['connector'], chatId: string): ManagedConnector {
   return {
@@ -74,7 +75,7 @@ describe('REPRO: perpetual "Thinking…" after a non-idle terminal event', () =>
       const managed = makeManaged(connector, DM_CHAT)
 
       // 1) A message arrives → the manager arms the indicator (dispatch site).
-      await connector.startWorking(DM_CHAT)
+      await connector.startWorking(DM_CHAT, 'working')
 
       // 2) The agent streams a full answer. The first token clears the bubble and
       //    the user SEES the response ("it finished its response").
@@ -88,9 +89,11 @@ describe('REPRO: perpetual "Thinking…" after a non-idle terminal event', () =>
       // Let the (un-awaited) startWorking inside processSSEEvent arm its interval.
       await vi.advanceTimersByTimeAsync(1)
 
-      // 4) ...but the turn ends in an ERROR (e.g. API overloaded / rate limit), so
-      //    the host broadcasts `session_error`, NOT `session_idle`. processSSEEvent
-      //    has no case for it → stopWorking is never called.
+      // 4) ...but the turn ends in an ERROR (e.g. API overloaded / rate limit). In
+      //    production the persister sets isActive=false → emits session_activity('idle')
+      //    → THEN broadcasts session_error. The idle activity tears the
+      //    indicator down; session_error only finalizes + surfaces the message.
+      await processSSEEvent(managed, { type: 'session_activity', activity: 'idle' })
       await processSSEEvent(managed, {
         type: 'session_error',
         error: 'Overloaded (API 529)',
@@ -121,7 +124,10 @@ describe('REPRO: perpetual "Thinking…" after a non-idle terminal event', () =>
 
       // Message arrives → indicator armed. Agent errors immediately (no stream_delta
       // ever clears it). e.g. rate-limit / auth / context-overflow on the first turn.
-      await connector.startWorking(DM_CHAT)
+      // In production the persister emits session_activity('idle') before session_error;
+      // that signal — not the terminal case — tears the indicator down.
+      await connector.startWorking(DM_CHAT, 'working')
+      await processSSEEvent(managed, { type: 'session_activity', activity: 'idle' })
       await processSSEEvent(managed, {
         type: 'session_error',
         error: 'rate_limit',
@@ -149,7 +155,7 @@ describe('REPRO: perpetual "Thinking…" after a non-idle terminal event', () =>
       // a terminal stopWorking that runs in that window finds no timer, and the late
       // startWorking installs one after teardown — "Thinking…" leaks. The fix
       // registers the interval synchronously, before the await.
-      void connector.startWorking(DM_CHAT)
+      void connector.startWorking(DM_CHAT, 'working')
       // A terminal event settles the turn immediately, before the initial send resolves.
       await connector.stopWorking(DM_CHAT)
       // Let the in-flight startWorking send resolve.
@@ -170,14 +176,16 @@ describe('REPRO: perpetual "Thinking…" after a non-idle terminal event', () =>
       const { connector, sendRichMessageDraft } = makeRealDmConnector()
       const managed = makeManaged(connector, DM_CHAT)
 
-      await connector.startWorking(DM_CHAT)
+      await connector.startWorking(DM_CHAT, 'working')
       await processSSEEvent(managed, { type: 'stream_start' })
       managed.streamingState.lastUpdateTime = 0
       await processSSEEvent(managed, { type: 'stream_delta', text: 'Here is your answer.' })
       await processSSEEvent(managed, { type: 'stream_start' })
       await vi.advanceTimersByTimeAsync(1)
 
-      // Proper terminal event → stopWorking → timer cleared.
+      // Proper terminal flow: the persister emits session_activity('idle') (which stops
+      // the indicator + clears the timer) right before the authoritative session_idle.
+      await processSSEEvent(managed, { type: 'session_activity', activity: 'idle' })
       await processSSEEvent(managed, { type: 'session_idle' })
       const sendsAtIdle = sendRichMessageDraft.mock.calls.length
 
@@ -208,8 +216,8 @@ describe('REPRO: idle-silence watchdog', () => {
       const connector = new MockChatClientConnector()
       const managed = makeManaged(connector, 'chat-watch')
 
-      // A turn begins (stream_start arms the indicator + the watchdog), then total silence.
-      await processSSEEvent(managed, { type: 'stream_start' })
+      // A turn begins (a busy session_activity arms the indicator + the watchdog), then total silence.
+      await processSSEEvent(managed, { type: 'session_activity', activity: 'working' })
       await vi.advanceTimersByTimeAsync(WATCHDOG_MS + 1000)
 
       expect(connector.stoppedWorking).toContain('chat-watch')
@@ -225,7 +233,7 @@ describe('REPRO: idle-silence watchdog', () => {
       const connector = new MockChatClientConnector()
       const managed = makeManaged(connector, 'chat-watch')
 
-      await processSSEEvent(managed, { type: 'stream_start' }) // arm
+      await processSSEEvent(managed, { type: 'session_activity', activity: 'working' }) // arm
       await vi.advanceTimersByTimeAsync(2 * 60 * 1000) // 2 min — still alive
       await processSSEEvent(managed, { type: 'tool_use_start', toolId: 't1', toolName: 'Bash' }) // activity → reset
       await vi.advanceTimersByTimeAsync(2 * 60 * 1000) // 2 min since reset (< threshold)
@@ -243,7 +251,11 @@ describe('REPRO: idle-silence watchdog', () => {
       const connector = new MockChatClientConnector()
       const managed = makeManaged(connector, 'chat-watch')
 
-      await processSSEEvent(managed, { type: 'stream_start' }) // arm
+      await processSSEEvent(managed, { type: 'session_activity', activity: 'working' }) // arm
+      // In production a *_request makes the persister flip isAwaitingInput → emit
+      // session_activity('awaiting'), which clears the watchdog before the card is shown.
+      // Model that paired signal here so the silence below is a genuine human wait.
+      await processSSEEvent(managed, { type: 'session_activity', activity: 'awaiting' })
       await processSSEEvent(managed, {
         type: 'user_question_request',
         toolUseId: 'tu-1',
@@ -263,9 +275,11 @@ describe('REPRO: idle-silence watchdog', () => {
       const connector = new MockChatClientConnector()
       const managed = makeManaged(connector, 'chat-watch')
 
-      // A turn arms the indicator + watchdog, then errors. session_error settles
-      // the turn (clearing the watchdog) and sends ONE curated error message.
-      await processSSEEvent(managed, { type: 'stream_start' })
+      // A turn arms the indicator + watchdog, then errors. In production the persister
+      // emits session_activity('idle') before session_error: the idle activity clears
+      // the watchdog, and session_error sends ONE curated error message.
+      await processSSEEvent(managed, { type: 'session_activity', activity: 'working' })
+      await processSSEEvent(managed, { type: 'session_activity', activity: 'idle' })
       await processSSEEvent(managed, {
         type: 'session_error',
         error: 'boom',
@@ -302,7 +316,7 @@ describe('REPRO: idle-silence watchdog', () => {
       const managed = makeManaged(connector, 'chat-watch')
 
       // Arm, then total silence trips the watchdog — whose notice send throws.
-      await processSSEEvent(managed, { type: 'stream_start' })
+      await processSSEEvent(managed, { type: 'session_activity', activity: 'working' })
       await vi.advanceTimersByTimeAsync(WATCHDOG_MS + 1000)
 
       // A genuine error then arrives. It must NOT be suppressed by the failed notice.
@@ -327,13 +341,13 @@ describe('REPRO: idle-silence watchdog', () => {
       const managed = makeManaged(connector, 'chat-watch')
 
       // Segment 1 of the turn: arm, then total silence trips the watchdog → notice #1.
-      await processSSEEvent(managed, { type: 'stream_start' })
+      await processSSEEvent(managed, { type: 'session_activity', activity: 'working' })
       await vi.advanceTimersByTimeAsync(WATCHDOG_MS + 1000)
 
       // Same turn continues (a new segment, NO new user dispatch in between) and
       // stalls again. The once-per-turn latch — reset at dispatch, not per
       // segment — must suppress a second notice.
-      await processSSEEvent(managed, { type: 'stream_start' })
+      await processSSEEvent(managed, { type: 'session_activity', activity: 'working' })
       await vi.advanceTimersByTimeAsync(WATCHDOG_MS + 1000)
 
       const stallNotices = connector.sentMessages.filter((m) =>
@@ -384,6 +398,32 @@ describe('finalizeStreaming: concurrent calls send the final text exactly once',
   })
 })
 
+describe('reconcileIndicator via session_activity', () => {
+  it('a busy activity starts the indicator + arms the watchdog', async () => {
+    const connector = new MockChatClientConnector()
+    const managed = makeManaged(connector, 'chat-w')
+    await processSSEEvent(managed, { type: 'session_activity', activity: 'working' })
+    expect(connector.typingIndicators).toContain('chat-w')
+  })
+
+  it('a non-busy activity stops the indicator', async () => {
+    const connector = new MockChatClientConnector()
+    const managed = makeManaged(connector, 'chat-w')
+    await processSSEEvent(managed, { type: 'session_activity', activity: 'working' })
+    await processSSEEvent(managed, { type: 'session_activity', activity: 'idle' })
+    expect(connector.stoppedWorking).toContain('chat-w')
+  })
+
+  it('projects the activity-specific label onto the connector (working/thinking/compacting/retrying)', async () => {
+    const connector = new MockChatClientConnector()
+    const managed = makeManaged(connector, 'chat-w')
+    for (const activity of ['working', 'thinking', 'compacting', 'retrying'] as const) {
+      await processSSEEvent(managed, { type: 'session_activity', activity })
+    }
+    expect(connector.workingActivities).toEqual(['working', 'thinking', 'compacting', 'retrying'])
+  })
+})
+
 describe('session_error: curated message by apiErrorCode, raw error never leaked', () => {
   const RAW_LEAK = '/Users/secret/path tok-abc123 stack-trace-line'
   const cases: Array<{ code: string | null; expect: RegExp }> = [
@@ -400,6 +440,9 @@ describe('session_error: curated message by apiErrorCode, raw error never leaked
       const connector = new MockChatClientConnector()
       const managed = makeManaged(connector, 'chat-err')
 
+      // The persister emits session_activity('idle') before session_error; that signal
+      // settles the indicator, session_error only surfaces the curated message.
+      await processSSEEvent(managed, { type: 'session_activity', activity: 'idle' })
       await processSSEEvent(managed, {
         type: 'session_error',
         error: RAW_LEAK,
@@ -415,4 +458,63 @@ describe('session_error: curated message by apiErrorCode, raw error never leaked
       expect(connector.stoppedWorking).toContain('chat-err')
     })
   }
+})
+
+// ── Task 5: settleTurn split into indicator-free finalizeTurn ──────────────
+// Terminal cases (session_idle / session_error) now ONLY finalize the turn; the
+// indicator is reconcile-driven off session_activity. In production the persister
+// emits a non-busy session_activity immediately BEFORE the terminal broadcast, so the
+// manager stops the indicator on that signal — not on the terminal case itself.
+// The watchdog is the one exception: a stall means state still says working, so
+// it must force the indicator off directly.
+
+describe('Task 5: finalizeTurn split — terminal cases finalize, indicator is reconcile-driven', () => {
+  it('session_idle finalizes streamed text but does not itself stop the indicator (session_activity does)', async () => {
+    const connector = new MockChatClientConnector()
+    const managed = makeManaged(connector, 'chat-i')
+    await processSSEEvent(managed, { type: 'session_activity', activity: 'working' })
+    await processSSEEvent(managed, { type: 'stream_delta', text: 'Answer.' })
+    connector.stoppedWorking = []
+    await processSSEEvent(managed, { type: 'session_idle' })
+    // idle commits the streamed text…
+    expect(connector.finalizedMessages.some((m) => /Answer\./.test(m.finalText))).toBe(true)
+    // …but does NOT itself tear down the indicator — that is session_activity's job now.
+    expect(connector.stoppedWorking).not.toContain('chat-i')
+    // The indicator settles via the session_activity('idle') the persister emits on idle:
+    await processSSEEvent(managed, { type: 'session_activity', activity: 'idle' })
+    expect(connector.stoppedWorking).toContain('chat-i')
+  })
+})
+
+// ── Honest, activity-specific Telegram label ───────────────────────────────
+// The native draft is labeled by what the agent is actually doing, not a single
+// hardcoded "Thinking…". The label tracks the latest activity even mid-turn.
+
+describe('Telegram: the native draft is labeled by activity', () => {
+  const cases: Array<{ activity: SessionActivity; label: string }> = [
+    { activity: 'working', label: '✨ Working…' },
+    { activity: 'thinking', label: '✨ Thinking…' },
+    { activity: 'compacting', label: '🗜 Compacting…' },
+    { activity: 'retrying', label: '🔄 Retrying…' },
+  ]
+  for (const { activity, label } of cases) {
+    it(`${activity} → "${label}"`, async () => {
+      const { connector, sendRichMessageDraft } = makeRealDmConnector()
+      await connector.startWorking(DM_CHAT, activity)
+      expect(sendRichMessageDraft).toHaveBeenLastCalledWith(expect.objectContaining({
+        rich_message: { html: `<tg-thinking>${label}</tg-thinking>` },
+      }))
+      await connector.stopWorking(DM_CHAT)
+    })
+  }
+
+  it('relabels in place when the activity changes mid-turn (working → compacting)', async () => {
+    const { connector, sendRichMessageDraft } = makeRealDmConnector()
+    await connector.startWorking(DM_CHAT, 'working')
+    await connector.startWorking(DM_CHAT, 'compacting')
+    expect(sendRichMessageDraft).toHaveBeenLastCalledWith(expect.objectContaining({
+      rich_message: { html: '<tg-thinking>🗜 Compacting…</tg-thinking>' },
+    }))
+    await connector.stopWorking(DM_CHAT)
+  })
 })

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -9,6 +9,7 @@
 
 import { App as SlackApp } from '@slack/bolt'
 import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
+import type { SessionActivity } from '@shared/lib/types/agent'
 import { ChatClientConnector, type OutgoingMessage } from './base-connector'
 import { describeUnsupportedRequest, isUnsupportedInChat, splitChatMessage } from './utils'
 import { captureException } from '@shared/lib/error-reporting'
@@ -588,9 +589,11 @@ export class SlackConnector extends ChatClientConnector {
     await this.clearThinkingReaction(chatId)
   }
 
-  async startWorking(chatId: string): Promise<void> {
+  async startWorking(chatId: string, _activity: SessionActivity): Promise<void> {
     if (!this.app) return
 
+    // Slack's surface is a single reaction, so it can't show distinct labels —
+    // the activity is intentionally ignored here (coarse "busy" fidelity).
     // Slack doesn't support typing indicators for bots.
     // Workaround: add a :thinking_face: reaction to the user's last message.
     // The reaction persists until removed, so no keep-alive timer is needed.

--- a/src/shared/lib/chat-integrations/sse-error-resilience.test.ts
+++ b/src/shared/lib/chat-integrations/sse-error-resilience.test.ts
@@ -164,10 +164,7 @@ describe('stream_start error resilience', () => {
     mock.sendMessage = async () => { throw new Error('fallback also failed') }
 
     // Should not throw
-    await processSSEEvent(managed, { type: 'stream_start' })
-
-    // Typing indicator should still be sent
-    expect(mock.typingIndicators.length).toBe(1)
+    await expect(processSSEEvent(managed, { type: 'stream_start' })).resolves.toBeUndefined()
   })
 })
 

--- a/src/shared/lib/chat-integrations/sse-event-processing.test.ts
+++ b/src/shared/lib/chat-integrations/sse-event-processing.test.ts
@@ -55,29 +55,10 @@ async function processEvents(
 
 // ── Tests ───────────────────────────────────────────────────────────────
 
-describe('working indicator', () => {
-  it('stops the indicator once, on the first streamed token of a segment', async () => {
-    const managed = createManagedConnector()
-    const mock = getMock(managed)
-
-    await processSSEEvent(managed, { type: 'stream_delta', text: 'Hello' })
-    expect(mock.stoppedWorking).toEqual(['chat-123']) // fired on the thinking→streaming transition
-
-    // Later tokens in the same segment must not re-fire stopWorking (no API call per token).
-    await processSSEEvent(managed, { type: 'stream_delta', text: ' world' })
-    expect(mock.stoppedWorking).toEqual(['chat-123'])
-  })
-
-  it('re-shows the indicator at the start of a new segment', async () => {
-    const managed = createManagedConnector()
-    const mock = getMock(managed)
-
-    await processSSEEvent(managed, { type: 'stream_delta', text: 'first segment' })
-    const before = mock.typingIndicators.length
-    await processSSEEvent(managed, { type: 'stream_start' })
-    expect(mock.typingIndicators.length).toBe(before + 1) // startWorking re-shown for the next segment
-  })
-})
+// NOTE: indicator arming/settling is no longer driven by stream_start / stream_delta —
+// session_activity is the sole driver. New-model coverage (a busy activity arms,
+// a non-busy one settles) lives in perpetual-thinking.repro.test.ts under
+// 'reconcileIndicator via session_activity'.
 
 describe('processSSEEvent', () => {
   let managed: ManagedConnector
@@ -162,13 +143,6 @@ describe('processSSEEvent', () => {
       // State should be reset
       expect(managed.streamingState.accumulatedText).toBe('')
       expect(managed.streamingState.currentMessageId).toBeNull()
-    })
-
-    it('shows typing indicator', async () => {
-      await processSSEEvent(managed, { type: 'stream_start' })
-
-      const mock = getMock(managed)
-      expect(mock.typingIndicators.length).toBe(1)
     })
   })
 
@@ -352,11 +326,6 @@ describe('processSSEEvent', () => {
   // ── Typing indicator ────────────────────────────────────────────
 
   describe('typing indicator', () => {
-    it('sends typing on stream_start', async () => {
-      await processSSEEvent(managed, { type: 'stream_start' })
-      expect(getMock(managed).typingIndicators.length).toBe(1)
-    })
-
     it('does not re-show "Thinking…" on messages_updated (would clobber the streaming draft)', async () => {
       // Even mid-stream, messages_updated must not re-send the thinking draft over
       // already-streamed content — the thinking indicator is a pre-stream-only state.
@@ -370,7 +339,7 @@ describe('processSSEEvent', () => {
         { type: 'tool_use_start', toolId: 't1', toolName: 'Bash' },
         { type: 'tool_use_ready', toolId: 't1', toolName: 'Bash' },
       ])
-      // No typing from tool_use_ready (only from stream_start)
+      // No typing from tool_use_ready
       expect(getMock(managed).typingIndicators.length).toBe(0)
     })
   })
@@ -721,7 +690,6 @@ describe('edge cases', () => {
 
     const mock = getMock(managed)
     expect(mock.finalizedMessages.length).toBe(1) // Only one finalization
-    expect(mock.typingIndicators.length).toBe(2) // Typing sent for both
   })
 
   it('handles session_idle followed by more streaming', async () => {
@@ -1052,14 +1020,6 @@ describe('no-streaming connector (iMessage-style)', () => {
 
     expect(outputLog.some(t => t.includes('Let me check...'))).toBe(true)
     expect(outputLog.some(t => t.includes('Here are the results.'))).toBe(true)
-  })
-
-  it('shows typing indicator on stream_start', async () => {
-    const managed = createNoStreamManaged()
-    await processSSEEvent(managed, { type: 'stream_start' })
-
-    const mock = managed.connector as MockChatClientConnector
-    expect(mock.typingIndicators.length).toBe(1)
   })
 })
 

--- a/src/shared/lib/chat-integrations/telegram-connector.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.ts
@@ -11,6 +11,7 @@
 import { Bot, type Context as GrammyContext } from 'grammy'
 import { Marked, Renderer } from 'marked'
 import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
+import type { SessionActivity } from '@shared/lib/types/agent'
 import { ChatClientConnector, type OutgoingMessage } from './base-connector'
 import { describeUnsupportedRequest, isUnsupportedInChat } from './utils'
 import { captureException } from '@shared/lib/error-reporting'
@@ -138,6 +139,9 @@ export class TelegramConnector extends ChatClientConnector {
   private activeDrafts: Map<string, number> = new Map()
   // Keep-alive timers re-sending the "working" indicator, one per chat.
   private workingTimers: Map<string, ReturnType<typeof setInterval>> = new Map()
+  // Latest activity per chat, so the keep-alive heartbeat re-sends the current
+  // label even when it changes mid-turn (working → thinking → compacting …).
+  private workingActivity: Map<string, SessionActivity> = new Map()
 
   constructor(private config: TelegramConfig) {
     super()
@@ -283,6 +287,7 @@ export class TelegramConnector extends ChatClientConnector {
     this.activeDrafts.clear()
     for (const timer of this.workingTimers.values()) clearInterval(timer)
     this.workingTimers.clear()
+    this.workingActivity.clear()
 
     if (this.bot) {
       await this.bot.stop()
@@ -423,13 +428,16 @@ export class TelegramConnector extends ChatClientConnector {
     }
   }
 
-  async startWorking(chatId: string): Promise<void> {
+  async startWorking(chatId: string, activity: SessionActivity): Promise<void> {
     if (!this.bot) return
+    // Record the latest activity first, so both the immediate send below AND the
+    // keep-alive heartbeat render the current label (it can change mid-turn).
+    this.workingActivity.set(chatId, activity)
     // Register the keep-alive heartbeat synchronously BEFORE the first awaited send.
     // stopWorking() is fire-and-forget and can run while this initial send is still
     // in flight; if the interval were registered only after the await, that
     // stopWorking would find no timer and this call would install one *after*
-    // teardown, leaking "Thinking…" forever. Registering first means a concurrent
+    // teardown, leaking the indicator forever. Registering first means a concurrent
     // stopWorking always sees (and clears) the timer. Idempotent: one timer per chat.
     if (!this.workingTimers.has(chatId)) {
       this.workingTimers.set(chatId, setInterval(() => {
@@ -445,8 +453,19 @@ export class TelegramConnector extends ChatClientConnector {
       clearInterval(timer)
       this.workingTimers.delete(chatId)
     }
+    this.workingActivity.delete(chatId)
     // The streaming response shares the draft_id and replaces the draft in place,
     // so there is nothing else to tear down.
+  }
+
+  /** The native-draft label for a busy activity (`<tg-thinking>` inner HTML). */
+  private workingLabel(activity: SessionActivity | undefined): string {
+    switch (activity) {
+      case 'compacting': return '🗜 Compacting…'
+      case 'retrying': return '🔄 Retrying…'
+      case 'thinking': return '✨ Thinking…'
+      default: return '✨ Working…' // 'working' and any non-busy fallback
+    }
   }
 
   /** Post the "working" indicator once: a native draft in rich DMs, else typing. */
@@ -454,16 +473,17 @@ export class TelegramConnector extends ChatClientConnector {
     if (!this.bot) return
     try {
       if (this.useRich && this.config.draftStreaming !== false && this.isPrivateChat(chatId)) {
-        // Native Telegram "Thinking…" placeholder (RichBlockThinking / <tg-thinking>).
-        // Draft-only, so DM-only. Static ✨: the animated AIActions custom emoji only
-        // render when the bot's owner has Telegram Premium (otherwise Telegram strips the
-        // entity), so we use a plain sparkle that renders for everyone. The keep-alive
-        // timer re-sends it (drafts expire ~30s) and it shares the streaming draft_id, so
-        // the response replaces it.
+        // Native Telegram placeholder (RichBlockThinking / <tg-thinking>), labeled
+        // by the agent's current activity. Draft-only, so DM-only. Static glyph:
+        // the animated AIActions custom emoji only render when the bot's owner has
+        // Telegram Premium (otherwise Telegram strips the entity), so we use plain
+        // glyphs that render for everyone. The keep-alive timer re-sends it (drafts
+        // expire ~30s) and it shares the streaming draft_id, so the response replaces it.
+        const label = this.workingLabel(this.workingActivity.get(chatId))
         await this.bot.api.raw.sendRichMessageDraft({
           chat_id: Number(chatId),
           draft_id: this.draftIdFor(chatId),
-          rich_message: { html: '<tg-thinking>✨ Thinking…</tg-thinking>' },
+          rich_message: { html: `<tg-thinking>${label}</tg-thinking>` },
         })
         return
       }

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -364,6 +364,21 @@ describe('MessagePersister', () => {
       const compactStarts = sseEvents.filter(e => e.type === 'compact_start')
       expect(compactStarts).toHaveLength(1)
     })
+
+    it('emits a non-compacting session_activity when compaction completes (no stale "Compacting…")', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // active → 'working'
+      mockClient._sendMessage({ type: 'system', subtype: 'status', status: 'compacting', session_id: SESSION_ID, uuid: 's1' })
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('compacting')
+      sseEvents.length = 0 // isolate the completion transition
+
+      // The compact-summary user message clears isCompacting (state.isCompacting was true).
+      mockClient._sendMessage({ type: 'user', session_id: SESSION_ID, uuid: 'summary-1' })
+
+      const activity = sseEvents.filter(e => e.type === 'session_activity')
+      expect(activity.length).toBeGreaterThan(0) // the clear must emit, or the chat stays stale "Compacting…"
+      expect(activity.at(-1).activity).not.toBe('compacting')
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('working')
+    })
   })
 
   // ============================================================================
@@ -2385,6 +2400,64 @@ describe('MessagePersister', () => {
   })
 
   // ============================================================================
+  // getSessionActivity
+  // ============================================================================
+
+  describe('getSessionActivity', () => {
+    it('projects the streaming-state flags onto an activity label', () => {
+      // helper sets the three lifecycle flags on the session's streaming state
+      const setFlags = (a: boolean, aw: boolean, s: boolean) => {
+        const st = (messagePersister as any).streamingStates.get(SESSION_ID)
+        st.isActive = a; st.isAwaitingInput = aw; st.isStreaming = s
+      }
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // ensures a state exists
+
+      setFlags(true, false, false);  expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('working')   // nothing more specific
+      setFlags(true, false, true);   expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('streaming') // assistant text owns the surface
+      setFlags(true, true, false);   expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('awaiting')  // waiting on the user
+      setFlags(false, false, false); expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('idle')      // not active
+    })
+
+    it('honors the busy precedence (compacting > retrying > thinking > streaming), even with isStreaming set', () => {
+      // isStreaming stale-true throughout (the api_retry-mid-stream case): the busy
+      // states must still win, so chat shows "Compacting…/Retrying…/Thinking…" like the
+      // app rather than dishonestly yielding to 'streaming'. As each clears, the next
+      // down the ladder shows, and once all clear, streamed text owns the surface.
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      const st = (messagePersister as any).streamingStates.get(SESSION_ID)
+      st.isActive = true; st.isAwaitingInput = false; st.currentToolUse = null
+      st.isStreaming = true
+
+      st.isCompacting = true; st.isRetrying = true; st.currentThinking = true
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('compacting')
+      st.isCompacting = false
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('retrying')
+      st.isRetrying = false
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('thinking')
+      st.currentThinking = false
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('streaming')
+    })
+
+    it('a new turn (markSessionActive) clears a stale isCompacting/currentThinking from an abnormally-ended prior turn', () => {
+      // The desktop app resets these on session_active/idle/error; chat must too, or a
+      // turn that ended mid-compaction (error/interrupt before the compact summary)
+      // wedges the next turn's label to "Compacting…". The state object is reused across turns.
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      const st = (messagePersister as any).streamingStates.get(SESSION_ID)
+      st.isActive = false; st.isCompacting = true; st.currentThinking = true
+
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // next user message
+      expect(st.isCompacting).toBe(false)
+      expect(st.currentThinking).toBe(false)
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('working')
+    })
+
+    it('is idle for an unknown session', () => {
+      expect(messagePersister.getSessionActivity('nope')).toBe('idle')
+    })
+  })
+
+  // ============================================================================
   // Automated session promotion
   // ============================================================================
 
@@ -4029,6 +4102,71 @@ describe('MessagePersister', () => {
 
       expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
       expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)[0].taskId).toBe('snake-1')
+    })
+  })
+
+  // ============================================================================
+  // session_activity emission
+  // ============================================================================
+
+  describe('session_activity emission', () => {
+    const BUSY = new Set(['working', 'thinking', 'compacting', 'retrying'])
+
+    it('emits session_activity on the per-session stream when the activity flips', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // isActive true → 'working'
+
+      const perSession = sseEvents.filter(e => e.type === 'session_activity')
+      expect(perSession.at(-1)).toMatchObject({ activity: 'working', sessionId: SESSION_ID })
+    })
+
+    it('does not re-emit session_activity when the activity is unchanged', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      const before = sseEvents.filter(e => e.type === 'session_activity').length
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // still 'working' → no change
+      const after = sseEvents.filter(e => e.type === 'session_activity').length
+      expect(after).toBe(before)
+    })
+
+    // Regression: a mid-stream error must NOT emit a spurious busy activity right
+    // before settling. The terminal transition has to settle in a SINGLE non-busy
+    // emit reflecting the final state — an intermediate "isActive still true,
+    // streaming just cleared" snapshot would briefly read 'working' and race
+    // connectors (Slack's async reaction add/remove) into a stuck indicator.
+    it('emits no spurious busy session_activity on a mid-stream error result', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // active → 'working'
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'message_start' } }) // → 'streaming'
+      sseEvents.length = 0 // isolate the terminal transition
+
+      mockClient._sendMessage({ type: 'result', subtype: 'error', error: 'boom' })
+
+      const activity = sseEvents.filter(e => e.type === 'session_activity')
+      // Old code emitted a busy state (isActive still true) before settling.
+      expect(activity.filter(e => BUSY.has(e.activity))).toHaveLength(0)
+      // The session settles to idle.
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('idle')
+    })
+
+    // Same invariant for the connection-closed → markSessionInactive terminal
+    // path: finalizeIdle's single non-busy emit covers the settle; clearing
+    // streaming/awaiting must not emit a busy activity first.
+    it('emits no spurious busy session_activity when markSessionInactive finalizes a streaming session', async () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // active → 'working'
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'message_start' } }) // → 'streaming'
+      sseEvents.length = 0 // isolate the terminal transition
+
+      // Default mock getSession() resolves null → handleConnectionClosed marks inactive.
+      mockClient._messageCallback!({
+        type: 'connection_closed',
+        content: { type: 'connection_closed' },
+        timestamp: new Date(),
+        sessionId: SESSION_ID,
+      })
+      // Let getSession().then(...) settle.
+      await new Promise((r) => setTimeout(r, 0))
+
+      const activity = sseEvents.filter(e => e.type === 'session_activity')
+      expect(activity.filter(e => BUSY.has(e.activity))).toHaveLength(0)
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('idle')
     })
   })
 })

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -4127,6 +4127,42 @@ describe('MessagePersister', () => {
       expect(after).toBe(before)
     })
 
+    // Iddo (review): message_start must NOT optimistically project 'streaming' before
+    // the first content block's type is known. A message that opens directly with a
+    // tool call (no preamble text) would otherwise flip streaming→working here, and
+    // reconcileIndicator turns that non-busy→busy flip into stopWorking()+startWorking()
+    // — Slack removes+re-adds its reaction and iMessage blinks the typing bubble, once
+    // per tool-first assistant message in an agentic turn. 'streaming' is deferred to the
+    // first text token instead.
+    it('keeps a tool-first message on "working" without flipping through "streaming"', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // active → 'working'
+      sseEvents.length = 0 // isolate the assistant message
+
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'message_start' } })
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_start', content_block: { type: 'tool_use', id: 't1', name: 'Bash' } },
+      })
+
+      const activities = sseEvents.filter(e => e.type === 'session_activity').map(e => e.activity)
+      expect(activities).not.toContain('streaming')
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('working')
+    })
+
+    it('projects "streaming" only when real text starts (first text_delta), not at message_start', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // active → 'working'
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'message_start' } })
+      // No content yet: the agent is honestly 'working', not optimistically 'streaming'.
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('working')
+
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Hello' } },
+      })
+      // The first token yields the reply surface to the streamed text.
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('streaming')
+    })
+
     // Regression: a mid-stream error must NOT emit a spurious busy activity right
     // before settling. The terminal transition has to settle in a SINGLE non-busy
     // emit reflecting the final state — an intermediate "isActive still true,
@@ -4134,7 +4170,8 @@ describe('MessagePersister', () => {
     // connectors (Slack's async reaction add/remove) into a stuck indicator.
     it('emits no spurious busy session_activity on a mid-stream error result', () => {
       messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // active → 'working'
-      mockClient._sendMessage({ type: 'stream_event', event: { type: 'message_start' } }) // → 'streaming'
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'message_start' } })
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'hi' } } }) // → 'streaming'
       sseEvents.length = 0 // isolate the terminal transition
 
       mockClient._sendMessage({ type: 'result', subtype: 'error', error: 'boom' })
@@ -4151,7 +4188,8 @@ describe('MessagePersister', () => {
     // streaming/awaiting must not emit a busy activity first.
     it('emits no spurious busy session_activity when markSessionInactive finalizes a streaming session', async () => {
       messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // active → 'working'
-      mockClient._sendMessage({ type: 'stream_event', event: { type: 'message_start' } }) // → 'streaming'
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'message_start' } })
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'hi' } } }) // → 'streaming'
       sseEvents.length = 0 // isolate the terminal transition
 
       // Default mock getSession() resolves null → handleConnectionClosed marks inactive.

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1749,12 +1749,14 @@ class MessagePersister {
     switch (event.type) {
       case 'message_start':
         state.currentText = ''
-        state.isStreaming = true
+        state.isStreaming = false // text hasn't started; set true at the first text token below
         state.currentToolUse = null
         state.currentThinking = false
-        state.isRetrying = false // a streaming message means any retry resolved
-        // Emit after the resets so the activity reads 'streaming' (text owns the
-        // reply surface), not a stale 'thinking'/'working' from the prior block.
+        state.isRetrying = false // the response is flowing now, so any retry resolved
+        // Emit after the resets. Activity reads 'working' (active, nothing surfaced
+        // yet) — 'streaming' is deferred to the first text token (content_block_delta)
+        // so a message that opens with a tool call doesn't flip streaming→working and
+        // churn connectors (Slack reaction remove+re-add, iMessage typing-bubble blink).
         this.emitActivityState(sessionId)
         this.broadcastToSSE(sessionId, { type: 'stream_start' })
         break
@@ -1780,8 +1782,8 @@ class MessagePersister {
           state.currentThinking = true
           this.broadcastToSSE(sessionId, { type: 'thinking_start' })
         }
-        // A tool block projects 'working'; a thinking block 'thinking' — both
-        // differ from the 'streaming' set at message_start, so re-project.
+        // A tool block projects 'working', a thinking block 'thinking'. A text block
+        // keeps 'working' (deduped) until its first token sets 'streaming' below.
         this.emitActivityState(sessionId)
         break
 
@@ -1792,6 +1794,11 @@ class MessagePersister {
             type: 'stream_delta',
             text: event.delta.text,
           })
+          // The streamed reply now owns the surface → project 'streaming' (deferred
+          // from message_start so a tool-first message never churns connectors).
+          // Idempotent + deduped, so the per-token cost is one cheap compare.
+          state.isStreaming = true
+          this.emitActivityState(sessionId)
         } else if (event.delta?.type === 'thinking_delta' && event.delta.thinking) {
           // Stream summarized reasoning text so the UI can accumulate it for "View thinking"
           this.broadcastToSSE(sessionId, {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1,5 +1,5 @@
 import type { ContainerClient, StreamMessage, SlashCommandInfo } from './types'
-import type { SessionUsage } from '@shared/lib/types/agent'
+import type { SessionUsage, SessionActivity } from '@shared/lib/types/agent'
 import type { AskUserQuestionInput } from '@shared/lib/tool-definitions/ask-user-question'
 import type { RequestSecretInput } from '@shared/lib/tool-definitions/request-secret'
 import type { RequestFileInput } from '@shared/lib/tool-definitions/request-file'
@@ -105,6 +105,8 @@ interface StreamingState {
   // Subtype of the most recent result — gates the completion notification when
   // idle arrives via session_state_changed (resume-exits pause, not finish).
   lastResultSubtype: string | null
+  isRetrying: boolean // True while an API retry is in progress, cleared when the next message starts
+  lastEmittedActivity?: SessionActivity // Deduplication guard — undefined = not yet emitted
 }
 
 // Lazy import to break circular dependency: container-manager -> message-persister
@@ -201,6 +203,7 @@ class MessagePersister {
       pendingDeliverFiles: new Map(),
       stateEventsAuthority: prior?.stateEventsAuthority ?? false,
       lastResultSubtype: null,
+      isRetrying: false,
     })
 
     // Store container client for reconnection checks
@@ -240,6 +243,7 @@ class MessagePersister {
   // session_state_changed handler (authoritative idle), and markSessionInactive.
   private finalizeIdle(sessionId: string, state: StreamingState): void {
     state.isActive = false
+    this.emitActivityState(sessionId)
     this.broadcastToSSE(sessionId, { type: 'session_idle', isActive: false })
     this.broadcastGlobal({
       type: 'session_idle',
@@ -334,6 +338,47 @@ class MessagePersister {
   isSessionAwaitingInput(sessionId: string): boolean {
     const state = this.streamingStates.get(sessionId)
     return state?.isAwaitingInput ?? false
+  }
+
+  /**
+   * Project the session's streaming state onto a single activity label, using
+   * the same precedence as the app's activity indicator. Streamed assistant
+   * TEXT (not a thinking or tool block) owns the reply surface, so it yields the
+   * placeholder; a thinking/tool block does not. See {@link SessionActivity}.
+   */
+  private computeActivity(state: StreamingState): SessionActivity {
+    if (!state.isActive) return 'idle'
+    if (state.isAwaitingInput) return 'awaiting'
+    // Mirror the app's busy precedence exactly: compacting > retrying > thinking
+    // > working. Checked BEFORE 'streaming' so a stale isStreaming (e.g. an
+    // api_retry mid-stream) can't make chat yield the placeholder while the app
+    // honestly shows "Compacting…"/"Retrying…" for the same underlying state.
+    if (state.isCompacting) return 'compacting'
+    if (state.isRetrying) return 'retrying'
+    if (state.currentThinking) return 'thinking'
+    // Assistant TEXT streaming (not a tool block) owns the reply surface, so it
+    // yields the placeholder. Thinking is already handled above.
+    if (state.isStreaming && !state.currentToolUse) return 'streaming'
+    return 'working'
+  }
+
+  // Public snapshot of the activity — the chat manager reads it for the
+  // subscribe-time reconcile (cold-start), alongside the session_activity event.
+  getSessionActivity(sessionId: string): SessionActivity {
+    const state = this.streamingStates.get(sessionId)
+    return state ? this.computeActivity(state) : 'idle'
+  }
+
+  /** Recompute the activity and broadcast session_activity iff it changed. */
+  private emitActivityState(sessionId: string): void {
+    const state = this.streamingStates.get(sessionId)
+    if (!state) return
+    const activity = this.computeActivity(state)
+    if (activity === state.lastEmittedActivity) return
+    state.lastEmittedActivity = activity
+    // Per-session only: the chat manager subscribes per session and is the sole
+    // consumer. (No global broadcast — nothing listens for session_activity there.)
+    this.broadcastToSSE(sessionId, { type: 'session_activity', sessionId, activity, agentSlug: state.agentSlug })
   }
 
   // Get pending computer use requests for a session (for SSE replay on reconnect)
@@ -492,6 +537,7 @@ class MessagePersister {
       state.isStreaming = false
       state.isActive = false
       state.isAwaitingInput = false
+      this.emitActivityState(sessionId)
       state.currentText = ''
       state.currentToolUse = null
       state.currentToolInput = ''
@@ -563,6 +609,7 @@ class MessagePersister {
         pendingDeliverFiles: new Map(),
         stateEventsAuthority: false,
         lastResultSubtype: null,
+        isRetrying: false,
       }
       this.streamingStates.set(sessionId, state)
       if (this.capture && agentSlug) {
@@ -574,6 +621,13 @@ class MessagePersister {
     state.isActive = true
     state.isInterrupted = false // Reset interrupted flag on new message
     state.isAwaitingInput = false // Reset awaiting input on new message
+    state.isRetrying = false // Reset retry flag on new message
+    // Reset compaction/thinking too, mirroring the app's session_active reset: a
+    // turn that ended mid-compaction/-thinking (error/interrupt before the clearing
+    // event) must not wedge the next turn's label. State is reused across turns.
+    state.isCompacting = false
+    state.currentThinking = false
+    this.emitActivityState(sessionId)
     state.lastApiErrorCode = null // Clear previous API error on new message
     // Clear the previous turn's result subtype so a late idle from an
     // already-finished (or interrupted) run can't fire a stale "success"
@@ -600,6 +654,7 @@ class MessagePersister {
     const state = this.streamingStates.get(sessionId)
     if (state && !state.isAwaitingInput) {
       state.isAwaitingInput = true
+      this.emitActivityState(sessionId)
       this.broadcastGlobal({
         type: 'session_awaiting_input',
         sessionId,
@@ -846,6 +901,7 @@ class MessagePersister {
         // may not always carry the isCompactSummary metadata flag.
         if (state.isCompacting || content.isCompactSummary) {
           state.isCompacting = false
+          this.emitActivityState(sessionId) // re-project: the indicator must leave 'compacting' now, not at the next token
           // Compaction complete — broadcast so frontend transitions from spinner to boundary
           this.broadcastToSSE(sessionId, { type: 'compact_complete' })
           this.broadcastToSSE(sessionId, { type: 'messages_updated' })
@@ -854,6 +910,7 @@ class MessagePersister {
         // Clear awaiting input when tool results arrive (user provided input)
         if (state.isAwaitingInput) {
           state.isAwaitingInput = false
+          this.emitActivityState(sessionId)
           this.broadcastGlobal({
             type: 'session_input_provided',
             sessionId,
@@ -887,6 +944,7 @@ class MessagePersister {
           if (content.status === 'compacting' && !state.isCompacting) {
             state.isCompacting = true
             this.broadcastToSSE(sessionId, { type: 'compact_start' })
+            this.emitActivityState(sessionId)
           }
           if (content.status === 'requesting') {
             // The CLI is composing the next model request — the moment it
@@ -901,9 +959,11 @@ class MessagePersister {
           if (!state.isCompacting) {
             state.isCompacting = true
             this.broadcastToSSE(sessionId, { type: 'compact_start' })
+            this.emitActivityState(sessionId)
           }
         } else if (content.subtype === 'api_retry') {
           // API retry in progress — broadcast details so the UI can show retry state
+          state.isRetrying = true
           this.broadcastToSSE(sessionId, {
             type: 'api_retry',
             attempt: content.attempt,
@@ -911,6 +971,7 @@ class MessagePersister {
             delayMs: content.delay_ms,
             errorStatus: content.error_status,
           })
+          this.emitActivityState(sessionId)
         } else if (content.subtype === 'task_started') {
           // Subagent started — set agentId deterministically from task_id (SDK 0.3.142+
           // guarantees task_id === subagent session ID === JSONL filename).
@@ -1092,6 +1153,7 @@ class MessagePersister {
             // The runtime started a turn we didn't initiate via POST (e.g. a
             // queued message picked up after an out-of-order idle) — self-heal.
             state.isActive = true
+            this.emitActivityState(sessionId)
             this.broadcastToSSE(sessionId, { type: 'session_active', isActive: true })
             this.broadcastGlobal({
               type: 'session_active',
@@ -1111,8 +1173,16 @@ class MessagePersister {
 
       case 'result': {
         // Query completed
+        const isError = content.subtype === 'error_during_execution' || content.subtype === 'error'
         state.isStreaming = false
         state.isAwaitingInput = false
+        // On error the turn ends here, so settle isActive too BEFORE the single
+        // emit. Collapsing every terminal flag change into ONE emit (reflecting
+        // the final state) avoids a spurious working(true)→(false) pair — the
+        // intermediate "isActive still true, streaming just cleared" snapshot
+        // would read working=true and race connectors into a stuck indicator.
+        if (isError) state.isActive = false
+        this.emitActivityState(sessionId)
         state.currentText = ''
         state.lastResultSubtype = typeof content.subtype === 'string' ? content.subtype : null
 
@@ -1120,9 +1190,9 @@ class MessagePersister {
         this.handleResultUsage(sessionId, state, content)
 
         // Check if this is an error result. Errors end the user-visible work
-        // immediately in both lifecycle modes.
-        if (content.subtype === 'error_during_execution' || content.subtype === 'error') {
-          state.isActive = false
+        // immediately in both lifecycle modes. (isActive + the working emit were
+        // already settled above, before the session_error broadcasts below.)
+        if (isError) {
           const errorMessage = content.error || content.message || 'An error occurred during execution'
           // Use SDK error code from the preceding assistant message (e.g., 'authentication_failed', 'rate_limit')
           const apiErrorCode = state.lastApiErrorCode || null
@@ -1282,6 +1352,10 @@ class MessagePersister {
     state.activeSubagents.clear()
     state.activeBackgroundTasks.clear()
     this.stopAllWorkflowTailers(sessionId)
+    // finalizeIdle clears isActive and emits the single settling working(false).
+    // Don't emit here first: clearing streaming while isActive is still true
+    // would read working=true and emit a spurious working(true)→(false) pair
+    // that races connectors into a stuck indicator.
     this.finalizeIdle(sessionId, state)
   }
 
@@ -1678,6 +1752,10 @@ class MessagePersister {
         state.isStreaming = true
         state.currentToolUse = null
         state.currentThinking = false
+        state.isRetrying = false // a streaming message means any retry resolved
+        // Emit after the resets so the activity reads 'streaming' (text owns the
+        // reply surface), not a stale 'thinking'/'working' from the prior block.
+        this.emitActivityState(sessionId)
         this.broadcastToSSE(sessionId, { type: 'stream_start' })
         break
 
@@ -1702,6 +1780,9 @@ class MessagePersister {
           state.currentThinking = true
           this.broadcastToSSE(sessionId, { type: 'thinking_start' })
         }
+        // A tool block projects 'working'; a thinking block 'thinking' — both
+        // differ from the 'streaming' set at message_start, so re-project.
+        this.emitActivityState(sessionId)
         break
 
       case 'content_block_delta':
@@ -1735,6 +1816,8 @@ class MessagePersister {
         if (state.currentThinking) {
           state.currentThinking = false
           this.broadcastToSSE(sessionId, { type: 'thinking_stop' })
+          // Thinking ended → re-project ('thinking' → 'streaming'/'working').
+          this.emitActivityState(sessionId)
         }
         // Tool use block finished streaming
         if (state.currentToolUse) {
@@ -1969,6 +2052,7 @@ class MessagePersister {
       case 'message_stop':
         // Don't save here - JSONL is the source of truth
         state.isStreaming = false
+        this.emitActivityState(sessionId)
         state.currentToolUse = null
         state.currentToolInput = ''
         // Defensive: ensure thinking state is cleared if a stop was missed

--- a/src/shared/lib/types/agent.ts
+++ b/src/shared/lib/types/agent.ts
@@ -233,6 +233,28 @@ export interface JsonlFileHistoryEntry {
 export type JsonlEntry = JsonlMessageEntry | JsonlFileHistoryEntry | JsonlSystemEntry | JsonlAttachmentEntry
 
 // ============================================================================
+// Session activity (working-indicator projection)
+// ============================================================================
+
+/**
+ * What the agent is doing right now, projected from a session's streaming state.
+ * Mirrors the app activity-indicator precedence so chat connectors can surface
+ * the same honest label instead of a single hardcoded "Thinking…".
+ *
+ * 'idle' | 'awaiting' | 'streaming' show NO placeholder — the surface is owned
+ * by the reply (streaming) or a request card (awaiting), or there is nothing to
+ * show (idle). The rest are "busy" states that drive a labeled placeholder.
+ */
+export type SessionActivity =
+  | 'idle'        // not active
+  | 'awaiting'    // waiting on the user (question / secret / file / etc.)
+  | 'streaming'   // assistant TEXT is streaming into the reply — it owns the surface
+  | 'compacting'  // context compaction in progress
+  | 'retrying'    // API retry in progress
+  | 'thinking'    // an extended-thinking block is streaming
+  | 'working'     // active with nothing more specific to show
+
+// ============================================================================
 // Content Block Types (from Anthropic API)
 // ============================================================================
 


### PR DESCRIPTION
## What & why

The chat "working" indicator showed a single hardcoded **"Thinking…"** no matter what the agent was actually doing, even while running a tool or compacting context. This replaces it with a labeled projection of the real activity, mirroring the desktop app's activity indicator so the chat surfaces stay honest.

There is now **one source of truth for chat**: the persister computes a single `SessionActivity` from a session's streaming state (`computeActivity`) and emits one `session_activity` signal. The manager reconciles one indicator off that signal; each connector only *renders* it. Telegram labels its native draft, Slack reacts coarsely (ignores the label by design), the desktop app keeps its own richer indicator.

## What the indicator shows (state -> activity -> label)

| Session state (checked in order) | Activity | Telegram draft | Desktop app |
|---|---|---|---|
| `!isActive` | `idle` | (none) | (hidden) |
| `isAwaitingInput` | `awaiting` | (none; question card is the surface) | "Waiting for input…" |
| `isCompacting` | `compacting` | 🗜 Compacting… | "Compacting…" |
| `isRetrying` | `retrying` | 🔄 Retrying… | "Retrying…" |
| `currentThinking` | `thinking` | ✨ Thinking… | "Thinking…" |
| `isStreaming && !currentToolUse` | `streaming` | (none; streamed reply is the surface) | (indicator stays; text streams below) |
| otherwise (active; tool run / gap) | `working` | ✨ Working… | "Working…" / todo activeForm |

Busy precedence (`awaiting > compacting > retrying > thinking > working`) matches the app exactly. `idle` / `awaiting` / `streaming` are surface-yield states that show no placeholder. The only app/chat divergence is *which widget* each surface uses during `streaming` and `awaiting`, not what they claim the agent is doing.

## Notable fixes

- **Cold-start:** a first message that makes the agent ask via `AskUserQuestion` no longer leaves "Thinking…" stuck under the question card (`awaiting` yields the placeholder).
- **Compaction lifecycle:** the chat indicator now leaves "🗜 Compacting…" the moment compaction finishes (it previously stayed stale until the next token), and a turn that ends mid-compaction no longer wedges the next turn's label to "Compacting…". Both are brought in line with the desktop app's reset behavior.

## Test plan

- **Unit, full suite green (5775 passed).** Persister projection precedence (including the streaming-vs-`compacting`/`retrying` ordering that would otherwise contradict the app); manager reconcile off `session_activity`; Telegram per-activity label + mid-turn relabel; the existing PR #308 watchdog / error-settle invariants migrated to `session_activity`.
- **Manual Telegram smoke (DM).** Working/streaming/idle; tool-gap shows "Working…" (not "Thinking…"); cold-start `AskUserQuestion` shows the card with no lingering placeholder; "Thinking…" only during actual extended thinking. All pass.

## Out of scope

Sending a *new* message while a question is awaiting still deadlocks the session ("Working…" forever, message lost). That is a separate session-cancel fix on `fix/message-cancels-awaiting-input`, not this PR. The indicator here is honest about that state (the session genuinely is stuck), so the fix belongs in message dispatch, not the indicator.

## Follow-ups: connector label fidelity

The `session_activity` signal is connector-agnostic and reaches every integration; the `startWorking(chatId, activity)` seam is already in place. Today only Telegram renders the activity as a visible label. Slack and iMessage act on the same signal (their reaction / typing indicator turns on and off from it, so they get the cold-start and streaming-yield fixes too) but do not vary by status.

- **Slack: deferred to a follow-up.** Could map activity to a reaction emoji, but a per-activity swap churns reactions (remove + re-add), so it should be scoped to the slow, notable states (Compacting, Retrying) with working/thinking folded into one generic busy reaction. Not in this PR.
- **iMessage: intentionally not planned.** The indicator is the native typing bubble, which is binary by protocol (no label to vary). Reflecting status would require sending status text (5-edit limit, intrusive), a worse UX than the clean typing indicator. Left binary by design.
