### PR TITLE
feat(agents): opaque agent ids with recomputed display slugs (SUP-271)

### DIFF
--- a/e2e/auth/specs/auth-flow.spec.ts
+++ b/e2e/auth/specs/auth-flow.spec.ts
@@ -144,6 +144,35 @@ test.describe('Auth Flow', () => {
     expect(agentSlug).toBeTruthy()
   })
 
+  // Regression guard for the SUP-271 view-only bug: the URL carries the pretty
+  // display slug (`{name}-{id}`), which no longer equals the agent's canonical id,
+  // and `agent-shell` derives the header's view-only state from
+  // `canUseAgent(routeSlug)` while the role map is keyed by the id. Without
+  // resolving the route slug → id, an OWNER was wrongly forced view-only (no
+  // start/stop controls). This is the discriminating case the rest of the suite
+  // misses — the home composer keys on the canonical id and the `sendMessage`
+  // helper falls back to it, so neither exercises the route-slug path.
+  test('owner viewing via the display-slug route keeps agent controls', async ({ user2Page }) => {
+    const agentPage = new AgentPage(user2Page)
+
+    // Click the sidebar entry → navigates to the pretty display-slug URL.
+    await agentPage.selectAgent(agentName)
+    await expect(user2Page.locator('[data-testid="agent-breadcrumb"]')).toBeVisible()
+
+    // Sanity-gate: assert the route really carries the display-slug form
+    // (`{name}-{id}`), not a bare id — otherwise this wouldn't exercise the
+    // slug→id resolution the fix added.
+    const routeSlug = new URL(user2Page.url()).pathname.split('/')[2] ?? ''
+    expect(routeSlug).toMatch(/-[a-z0-9]{10}$/)
+    expect(routeSlug).not.toMatch(/^[a-z0-9]{10}$/)
+
+    // The owner must NOT be view-only: header start/stop controls (gated on
+    // `canUseAgent(routeSlug)` in agent-shell) render, and the agent-home
+    // view-only banner stays absent.
+    await expect(user2Page.locator('[data-testid="agent-power-controls"]')).toBeVisible()
+    await expect(user2Page.locator('[data-testid="view-only-banner"]')).not.toBeVisible()
+  })
+
   test('user1 does NOT see user2 agent', async ({ user1Page }) => {
     const appPage = new AppPage(user1Page)
     const agentPage = new AgentPage(user1Page)

--- a/e2e/specs/dashboard-and-tasks.spec.ts
+++ b/e2e/specs/dashboard-and-tasks.spec.ts
@@ -174,6 +174,10 @@ test.describe('Dashboard & Scheduled Task Tool Rendering', () => {
     expect(integrations.length).toBeGreaterThan(0)
     const integrationId = integrations[0].id
     expect(integrationId).toBeTruthy()
+    // The integration is stored under the canonical agent id; the canonicalize
+    // redirect lands there (the same id form the app uses for chat routes). The
+    // captured `aSlug` from the URL is a stale display slug (deferred URL rewrite).
+    const trueAgentSlug = integrations[0].agentSlug
 
     // Create agent B and deep-link A's integration under ITS slug, with a sub-session.
     const otherName = `Chat Canon Other ${Date.now()}`
@@ -185,7 +189,7 @@ test.describe('Dashboard & Scheduled Task Tool Rendering', () => {
     await page.goto(`/agents/${bSlug}/chat/${integrationId}?session=sample`)
 
     // Canonicalizes to A (the integration's true agent), preserving ?session=sample.
-    await expect(page).toHaveURL(new RegExp(`/agents/${aSlug}/chat/${integrationId}\\?session=sample$`))
+    await expect(page).toHaveURL(new RegExp(`/agents/${trueAgentSlug}/chat/${integrationId}\\?session=sample$`))
 
     // The owner's shell renders: agent breadcrumb + the integration header name.
     // Scope the name to main-content — the sidebar also lists integration.name,

--- a/e2e/specs/navigation.spec.ts
+++ b/e2e/specs/navigation.spec.ts
@@ -426,7 +426,9 @@ test.describe('Navigation — discriminated AgentView', () => {
 
     await appPage.reload()
     await expect(page).toHaveURL(/\/agents\/[^/]+$/)
-    await expect(page.locator(`[data-testid="agent-item-${slug}"]`)).toHaveAttribute('data-active', 'true')
+    // The sidebar row testid keys on the agent's stable id, while the URL carries
+    // the display slug — match by the (unique, timestamped) name instead.
+    await expect(page.locator('[data-testid^="agent-item-"]', { hasText: agentName })).toHaveAttribute('data-active', 'true')
     await expect(page.locator('[data-testid="home-button"]')).toHaveAttribute('data-active', 'false')
 
     // Cleanup
@@ -436,13 +438,12 @@ test.describe('Navigation — discriminated AgentView', () => {
   test('Notifications route lights up only the Notifications nav item', async ({ page }) => {
     const agentName = `Nav Notif Active ${Date.now()}`
     await agentPage.createAgent(agentName)
-    const slug = page.url().match(/\/agents\/([^/?#]+)/)?.[1]
 
     await page.locator('[data-testid="notifications-button"]').click()
     await expect(page).toHaveURL(/\/notifications$/)
     await expect(page.locator('[data-testid="notifications-button"]')).toHaveAttribute('data-active', 'true')
     await expect(page.locator('[data-testid="home-button"]')).toHaveAttribute('data-active', 'false')
-    await expect(page.locator(`[data-testid="agent-item-${slug}"]`)).toHaveAttribute('data-active', 'false')
+    await expect(page.locator('[data-testid^="agent-item-"]', { hasText: agentName })).toHaveAttribute('data-active', 'false')
 
     // Cleanup
     await agentPage.selectAgent(agentName)

--- a/e2e/specs/settings.spec.ts
+++ b/e2e/specs/settings.spec.ts
@@ -547,7 +547,7 @@ test.describe('Settings deep-link reset', () => {
     const createRes = await request.post('/api/agents', {
       data: { name: 'Voice Deep Link Test' },
     })
-    const agent = await createRes.json() as { slug: string }
+    const agent = await createRes.json() as { slug: string; displaySlug: string }
 
     const appPage = new AppPage(page)
     await appPage.goto()
@@ -583,13 +583,14 @@ test.describe('Settings ?from= close-target', () => {
   test('close pushes to the captured ?from origin', async ({ page, request }) => {
     await request.put('/api/user-settings', { data: { setupCompleted: true } })
     const createRes = await request.post('/api/agents', { data: { name: 'Settings From Origin' } })
-    const agent = await createRes.json() as { slug: string }
+    const agent = await createRes.json() as { slug: string; displaySlug: string }
 
     const appPage = new AppPage(page)
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
     await page.locator(`[data-testid="agent-item-${agent.slug}"]`).click()
-    await expect(page).toHaveURL(new RegExp(`/agents/${agent.slug}$`))
+    // The URL carries the display slug ({name}-{id}), not the bare canonical id.
+    await expect(page).toHaveURL(new RegExp(`/agents/${agent.displaySlug}$`))
     const origin = page.url()
 
     await page.locator('[data-testid="settings-button"]').click()
@@ -612,13 +613,14 @@ test.describe('Settings ?from= close-target', () => {
   test('settings survives a refresh and still closes to origin (?from= is durable)', async ({ page, request }) => {
     await request.put('/api/user-settings', { data: { setupCompleted: true } })
     const createRes = await request.post('/api/agents', { data: { name: 'Settings Refresh From' } })
-    const agent = await createRes.json() as { slug: string }
+    const agent = await createRes.json() as { slug: string; displaySlug: string }
 
     const appPage = new AppPage(page)
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
     await page.locator(`[data-testid="agent-item-${agent.slug}"]`).click()
-    await expect(page).toHaveURL(new RegExp(`/agents/${agent.slug}$`))
+    // The URL carries the display slug ({name}-{id}), not the bare canonical id.
+    await expect(page).toHaveURL(new RegExp(`/agents/${agent.displaySlug}$`))
     const origin = page.url()
 
     await page.locator('[data-testid="settings-button"]').click()

--- a/src/api/middleware/auth.ts
+++ b/src/api/middleware/auth.ts
@@ -5,6 +5,7 @@ import { runWithRequestUser } from '@shared/lib/platform-attribution'
 import { db } from '@shared/lib/db'
 import { agentAcl, connectedAccounts, remoteMcpServers, notifications } from '@shared/lib/db/schema'
 import { validateProxyToken } from '@shared/lib/proxy/token-store'
+import { resolveAgentId } from '@shared/lib/utils/file-storage'
 
 // Lazy import to avoid pulling in better-auth ESM at import time
 let _getAuth: (() => ReturnType<typeof import('@shared/lib/auth/index').getAuth>) | null = null
@@ -62,6 +63,42 @@ function isAdmin(user: { role?: string }): boolean {
   return user.role === 'admin'
 }
 
+/**
+ * ResolveAgent — resolve the `:id` route param (which may be a decorative
+ * display slug, a bare id, or a legacy compound folder name) to the canonical
+ * agent id, stash it on the context as `agentId`, and 404 if no such agent
+ * exists.
+ *
+ * Runs in BOTH auth and non-auth modes (the URL form is independent of auth)
+ * and MUST run before any AgentRead/AgentUser/AgentAdmin check, since the ACL
+ * tables are keyed on the canonical id. Subsumes the old agent-existence guard.
+ */
+export function ResolveAgent(): MiddlewareHandler {
+  return async (c: Context, next: Next) => {
+    const id = await resolveAgentId(c.req.param('id') ?? '')
+    if (!id) return c.json({ error: 'Agent not found' }, 404)
+    c.set('agentId' as never, id as never)
+    return next()
+  }
+}
+
+/**
+ * Read the canonical agent id resolved by {@link ResolveAgent}. Route handlers
+ * under a `:id` path should use this instead of `c.req.param('id')`, which may
+ * be a decorative display slug. Throws if ResolveAgent() did not run.
+ */
+export function getAgentId(c: Context): string {
+  const id = c.get('agentId' as never) as string | undefined
+  if (!id) throw new Error('agentId not resolved — ResolveAgent() middleware missing?')
+  return id
+}
+
+// Resolved id if ResolveAgent() ran, else the raw param (preserves behavior for
+// any ACL middleware mounted without ResolveAgent in front).
+function resolvedAgentSlug(c: Context): string {
+  return (c.get('agentId' as never) as string | undefined) ?? c.req.param('id')!
+}
+
 
 /**
  * AgentRead — user has any role on the agent (viewer+).
@@ -73,7 +110,7 @@ export function AgentRead(): MiddlewareHandler {
 
     const user = getUser(c)
     if (isAdmin(user)) return next()
-    const agentSlug = c.req.param('id')!
+    const agentSlug = resolvedAgentSlug(c)
     const role = await getUserAgentRole(user.id, agentSlug)
     if (!hasMinRole(role, 'viewer')) {
       return c.json({ error: 'Forbidden' }, 403)
@@ -92,7 +129,7 @@ export function AgentUser(): MiddlewareHandler {
 
     const user = getUser(c)
     if (isAdmin(user)) return next()
-    const agentSlug = c.req.param('id')!
+    const agentSlug = resolvedAgentSlug(c)
     const role = await getUserAgentRole(user.id, agentSlug)
     if (!hasMinRole(role, 'user')) {
       return c.json({ error: 'Forbidden' }, 403)
@@ -111,7 +148,7 @@ export function AgentAdmin(): MiddlewareHandler {
 
     const user = getUser(c)
     if (isAdmin(user)) return next()
-    const agentSlug = c.req.param('id')!
+    const agentSlug = resolvedAgentSlug(c)
     const role = await getUserAgentRole(user.id, agentSlug)
     if (!hasMinRole(role, 'owner')) {
       return c.json({ error: 'Forbidden' }, 403)

--- a/src/api/routes/agents-owner-acl-rollback.sup207.test.ts
+++ b/src/api/routes/agents-owner-acl-rollback.sup207.test.ts
@@ -129,6 +129,8 @@ vi.mock('../middleware/auth', () => ({
   OwnsAccount: () => async (_c: unknown, next: () => Promise<void>) => next(),
   IsAdmin: () => async (_c: unknown, next: () => Promise<void>) => next(),
   Or: (..._mw: unknown[]) => async (_c: unknown, next: () => Promise<void>) => next(),
+  ResolveAgent: () => async (c: any, next: () => Promise<void>) => { c.set('agentId', c.req.param('id')); return next() },
+  getAgentId: (c: any) => c.get('agentId') ?? c.req.param('id'),
 }))
 
 vi.mock('@shared/lib/analytics/server-analytics', () => ({ trackServerEvent: vi.fn() }))

--- a/src/api/routes/agents.delete-ordering.sup208.test.ts
+++ b/src/api/routes/agents.delete-ordering.sup208.test.ts
@@ -123,6 +123,8 @@ vi.mock('../middleware/auth', () => ({
   AgentRead: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
   AgentUser: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
   AgentAdmin: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
+  ResolveAgent: () => async (c: any, next: () => Promise<void>) => { c.set('agentId', c.req.param('id')); return next() },
+  getAgentId: (c: any) => c.get('agentId') ?? c.req.param('id'),
 }))
 
 vi.mock('@shared/lib/auth/config', () => ({

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -53,6 +53,16 @@ vi.mock('../middleware/auth', () => ({
   AgentRead: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
   AgentUser: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
   AgentAdmin: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
+  // Mirrors the real ResolveAgent: 404 on a missing agent (via the agentExists
+  // mock) and stash the resolved id, which getAgentId reads back. For test slugs
+  // (already canonical), resolution is the identity.
+  ResolveAgent: () => async (c: any, next: () => Promise<void>) => {
+    const slug = c.req.param('id')
+    if (!(await mockAgentExists(slug))) return c.json({ error: 'Agent not found' }, 404)
+    c.set('agentId', slug)
+    return next()
+  },
+  getAgentId: (c: any) => c.get('agentId') ?? c.req.param('id'),
 }))
 
 // Container manager
@@ -348,6 +358,11 @@ vi.mock('@shared/lib/proxy/token-store', () => ({
 
 const mockGetAgentWorkspaceDir = vi.fn((_slug?: string) => '/mock/workspace')
 vi.mock('@shared/lib/utils/file-storage', () => ({
+  // ResolveAgent() resolves the :id param via resolveAgentId. Delegate to the
+  // existing agentExists mock so the legacy 404-on-missing behavior is preserved:
+  // returns the slug verbatim when it "exists", else null.
+  resolveAgentId: async (slug: string) => ((await mockAgentExists(slug)) ? slug : null),
+  displaySlug: (_name: string, id: string) => id,
   getSessionJsonlPath: vi.fn(),
   readFileOrNull: vi.fn(),
   writeFile: vi.fn(),
@@ -2410,6 +2425,7 @@ describe('GET /api/agents (enriched summary)', () => {
 
   const baseAgent = {
     slug: 'agent-1',
+    displaySlug: 'agent-one-agent-1',
     name: 'Agent One',
     description: 'Test agent',
     createdAt: new Date('2026-01-01'),

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -48,6 +48,10 @@ vi.mock('stream', () => ({
 
 // Auth middleware — passthrough (sets mock user on context for auth mode tests)
 const mockAuthUser = { id: 'test-user-id', name: 'Test User', email: 'test@example.com' }
+// Display-slug -> canonical-id resolution applied by the ResolveAgent mock. Defaults
+// to identity (test slugs are already canonical); a test can override it to exercise
+// routes where the URL display slug differs from the resolved id.
+let mockResolveSlug: (slug: string) => string = (slug) => slug
 vi.mock('../middleware/auth', () => ({
   Authenticated: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
   AgentRead: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
@@ -59,7 +63,7 @@ vi.mock('../middleware/auth', () => ({
   ResolveAgent: () => async (c: any, next: () => Promise<void>) => {
     const slug = c.req.param('id')
     if (!(await mockAgentExists(slug))) return c.json({ error: 'Agent not found' }, 404)
-    c.set('agentId', slug)
+    c.set('agentId', mockResolveSlug(slug))
     return next()
   },
   getAgentId: (c: any) => c.get('agentId') ?? c.req.param('id'),
@@ -2650,6 +2654,38 @@ describe('GET /api/agents (enriched summary)', () => {
     expect(body[0]).toHaveProperty('dashboardCount')
   })
 
+  it('sorts the auth-mode list newest-first', async () => {
+    mockIsAuthMode.mockReturnValue(true)
+    // The ACL query has no ORDER BY, so rows arrive in index-scan order — i.e. by
+    // the opaque agent slug, NOT by createdAt. Feed them slug-sorted (a, m, z) with
+    // a different creation order so the response order can only be right if the
+    // route sorts: without the sort this returns the slug order and the test fails.
+    mockDbSelectFrom.mockReturnValue({
+      where: vi.fn().mockResolvedValue([
+        { agentSlug: 'aaaaaaaaaa' },
+        { agentSlug: 'mmmmmmmmmm' },
+        { agentSlug: 'zzzzzzzzzz' },
+      ]),
+    })
+    const bySlug: Record<string, typeof baseAgent> = {
+      aaaaaaaaaa: { ...baseAgent, slug: 'aaaaaaaaaa', createdAt: new Date('2026-01-01') }, // oldest
+      mmmmmmmmmm: { ...baseAgent, slug: 'mmmmmmmmmm', createdAt: new Date('2026-01-03') }, // newest
+      zzzzzzzzzz: { ...baseAgent, slug: 'zzzzzzzzzz', createdAt: new Date('2026-01-02') },
+    }
+    const { getAgentWithStatus } = await import('@shared/lib/services/agent-service')
+    vi.mocked(getAgentWithStatus).mockImplementation(async (slug: string) => bySlug[slug])
+
+    const res = await getReq(app, '/api/agents')
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.map((a: { slug: string }) => a.slug)).toEqual([
+      'mmmmmmmmmm', // 2026-01-03 newest
+      'zzzzzzzzzz', // 2026-01-02
+      'aaaaaaaaaa', // 2026-01-01 oldest
+    ])
+  })
+
   it('returns lastActivityAt as null when agent has no sessions', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
 
@@ -2674,6 +2710,42 @@ describe('GET /api/agents (enriched summary)', () => {
     expect(getSessionSummary).toHaveBeenCalledTimes(2)
     expect(getSessionSummary).toHaveBeenCalledWith('agent-1')
     expect(getSessionSummary).toHaveBeenCalledWith('agent-2')
+  })
+})
+
+// ============================================================================
+// Artifact proxy — container subPath construction
+// ============================================================================
+
+describe('artifact proxy — subPath uses the raw display-slug URL', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    mockIsAuthMode.mockReturnValue(false)
+    mockAgentExists.mockResolvedValue(true)
+    // Resolution maps the display slug to a DIFFERENT canonical id (trailing
+    // segment), so the proxy must slice subPath against the URL (display slug),
+    // not the resolved id.
+    mockResolveSlug = (slug: string) => slug.slice(slug.lastIndexOf('-') + 1)
+  })
+
+  afterEach(() => {
+    mockResolveSlug = (slug: string) => slug // restore identity for other suites
+  })
+
+  it('proxies a nested asset to the correct container path on a display-slug route', async () => {
+    mockContainerFetch.mockResolvedValue(
+      new Response('ok', { headers: { 'content-type': 'application/javascript' } }),
+    )
+
+    const res = await getReq(app, '/api/agents/my-dash-abc1234567/artifacts/dash/static/app.js')
+
+    expect(res.status).toBe(200)
+    expect(mockContainerFetch).toHaveBeenCalledTimes(1)
+    // Bug repro: an id-based prefix yields indexOf(prefix) === -1, corrupting this path.
+    expect(mockContainerFetch.mock.calls[0]?.[0]).toBe('/artifacts/dash/static/app.js')
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -4115,9 +4115,13 @@ agents.delete('/:id/mounts/:mountId', AgentUser(), async (c) => {
 agents.get('/:id/files/*', AgentRead(), async (c) => {
   try {
     const agentSlug = getAgentId(c)
-    // Extract file path from URL - wildcard param can be unreliable in sub-routers
+    // Extract file path from URL - wildcard param can be unreliable in sub-routers.
+    // The prefix must use the RAW :id route param (the display slug as it appears in
+    // the URL), NOT the resolved canonical agentSlug — otherwise startsWith() fails on
+    // a display-slug route and the path comes back empty (400). The resolved id is
+    // only for locating the workspace dir below.
     const urlPath = new URL(c.req.url).pathname
-    const filesPrefix = `/api/agents/${agentSlug}/files/`
+    const filesPrefix = `/api/agents/${c.req.param('id')}/files/`
     const filePath = urlPath.startsWith(filesPrefix)
       ? decodeURIComponent(urlPath.slice(filesPrefix.length))
       : ''
@@ -4519,10 +4523,15 @@ async function proxyArtifactRequest(c: any) {
     return c.json({ error: 'Agent is not running. Start the agent to view this dashboard.' }, 503)
   }
 
-  // Build the container path
+  // Build the container path. The prefix must use the RAW :id route param (the
+  // display slug as it appears in the URL), NOT the resolved canonical agentSlug:
+  // url.pathname still carries the display slug, so an id-based prefix would not be
+  // found (indexOf → -1) and corrupt subPath. The resolved id is only for the
+  // container lookup above.
   // eslint-disable-next-line local-rules/no-unhandled-throwing-builtins -- c.req.url is always a valid URL
   const url = new URL(c.req.url)
-  const prefix = `/api/agents/${agentSlug}/artifacts/${artifactSlug}`
+  const routeSlug = c.req.param('id')
+  const prefix = `/api/agents/${routeSlug}/artifacts/${artifactSlug}`
   const subPath = url.pathname.slice(url.pathname.indexOf(prefix) + prefix.length) || '/'
   const containerPath = `/artifacts/${artifactSlug}${subPath}${url.search}`
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -6,7 +6,7 @@ import { z } from 'zod'
 import { zValidator } from '@hono/zod-validator'
 import { getPolyfillJs } from '../speech-recognition-polyfill'
 import { getLlmPolyfillJs } from '../llm-polyfill'
-import { Authenticated, AgentRead, AgentUser, AgentAdmin } from '../middleware/auth'
+import { Authenticated, AgentRead, AgentUser, AgentAdmin, ResolveAgent, getAgentId } from '../middleware/auth'
 import {
   listAgentsWithStatus,
   createAgent,
@@ -39,7 +39,7 @@ import {
   removeMessage,
   removeToolCall,
 } from '@shared/lib/services/session-service'
-import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, getTempUploadsDir, ensureDirectory, removeDirectory, writeJsonFileAtomic } from '@shared/lib/utils/file-storage'
+import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, getTempUploadsDir, ensureDirectory, removeDirectory, writeJsonFileAtomic, displaySlug } from '@shared/lib/utils/file-storage'
 import { getMountsWithHealth, addMount, removeMount } from '@shared/lib/services/mount-service'
 import {
   listUserSecrets,
@@ -576,14 +576,10 @@ Respond with ONLY the agent name, nothing else. No quotes, no explanation.`,
   }
 })
 
-// Middleware: verify agent exists for all /:id/* routes
-agents.use('/:id/*', async (c, next) => {
-  const slug = c.req.param('id')
-  if (!(await agentExists(slug))) {
-    return c.json({ error: 'Agent not found' }, 404)
-  }
-  await next()
-})
+// Middleware: resolve the :id param (display slug / bare id / legacy compound)
+// to the canonical agent id for all /:id/* routes, stashing it for getAgentId(c).
+// 404s if it doesn't resolve — subsumes the old existence check.
+agents.use('/:id/*', ResolveAgent())
 
 // Create owner ACL entry when an agent is created in auth mode
 async function createOwnerAcl(c: Context, agentSlug: string) {
@@ -705,6 +701,12 @@ agents.get('/', async (c) => {
         rows.map((r) => agentLimit(() => getAgentWithStatus(r.agentSlug)))
       )
       agentList = agents.filter((a): a is ApiAgent => a !== null)
+      // The ACL query has no ORDER BY, so rows arrive in index-scan order — i.e.
+      // by agentSlug, which is now an opaque random id (it used to embed the name,
+      // so the scan was incidentally name-ish). Sort newest-first to match the
+      // non-auth listAgentsWithStatus() ordering, so a freshly created agent lands
+      // at the top of the sidebar (the client's applyAgentOrder floats new agents up).
+      agentList.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
     } else {
       agentList = await listAgentsWithStatus()
     }
@@ -742,9 +744,9 @@ agents.post('/', async (c) => {
 })
 
 // GET /api/agents/:id - Get a single agent
-agents.get('/:id', AgentRead(), async (c) => {
+agents.get('/:id', ResolveAgent(), AgentRead(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const agent = await getAgentWithStatus(slug)
 
     if (!agent) {
@@ -760,9 +762,9 @@ agents.get('/:id', AgentRead(), async (c) => {
 })
 
 // PUT /api/agents/:id - Update an agent
-agents.put('/:id', AgentAdmin(), async (c) => {
+agents.put('/:id', ResolveAgent(), AgentAdmin(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const body = await c.req.json()
     const { name, description, instructions } = body
 
@@ -786,9 +788,9 @@ agents.put('/:id', AgentAdmin(), async (c) => {
 })
 
 // DELETE /api/agents/:id - Delete an agent
-agents.delete('/:id', AgentAdmin(), async (c) => {
+agents.delete('/:id', ResolveAgent(), AgentAdmin(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
 
     // Existence check up front so we never start the destructive flow for a
     // missing agent. We rely on getAgent (not deleteAgent's return value)
@@ -852,7 +854,7 @@ agents.delete('/:id', AgentAdmin(), async (c) => {
 // GET /api/agents/:id/preferences - Get agent preferences
 agents.get('/:id/preferences', AgentRead(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     if (!(await agentExists(slug))) {
       return c.json({ error: 'Agent not found' }, 404)
     }
@@ -867,7 +869,7 @@ agents.get('/:id/preferences', AgentRead(), async (c) => {
 // PUT /api/agents/:id/preferences - Update agent preferences
 agents.put('/:id/preferences', AgentAdmin(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     if (!(await agentExists(slug))) {
       return c.json({ error: 'Agent not found' }, 404)
     }
@@ -901,7 +903,7 @@ agents.put('/:id/preferences', AgentAdmin(), async (c) => {
 // GET /api/agents/:id/access - List users with roles on this agent
 agents.get('/:id/access', AgentAdmin(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const rows = await db
       .select({
         userId: agentAcl.userId,
@@ -923,7 +925,7 @@ agents.get('/:id/access', AgentAdmin(), async (c) => {
 // POST /api/agents/:id/access - Invite user (assign role)
 agents.post('/:id/access', AgentAdmin(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const { userId, role } = await c.req.json()
 
     if (!userId || !role) {
@@ -972,7 +974,7 @@ agents.post('/:id/access', AgentAdmin(), async (c) => {
 // PATCH /api/agents/:id/access/:userId - Change user's role
 agents.patch('/:id/access/:userId', AgentAdmin(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const targetUserId = c.req.param('userId')
     const { role } = await c.req.json()
 
@@ -1025,7 +1027,7 @@ agents.patch('/:id/access/:userId', AgentAdmin(), async (c) => {
 // DELETE /api/agents/:id/access/:userId - Remove user's access
 agents.delete('/:id/access/:userId', AgentAdmin(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const targetUserId = c.req.param('userId')
 
     // Transaction to prevent TOCTOU race on last-owner check
@@ -1072,7 +1074,7 @@ agents.delete('/:id/access/:userId', AgentAdmin(), async (c) => {
 // POST /api/agents/:id/leave - Remove yourself from an agent's ACL
 agents.post('/:id/leave', AgentRead(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const userId = getCurrentUserId(c)
 
     const error = db.transaction((tx) => {
@@ -1121,7 +1123,7 @@ agents.get('/:id/access/search-users', AgentAdmin(), async (c) => {
       return c.json([])
     }
 
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
 
     // Get users who already have access
     const existingUserIds = await db
@@ -1150,7 +1152,7 @@ agents.get('/:id/access/search-users', AgentAdmin(), async (c) => {
 // POST /api/agents/:id/start - Start an agent's container
 agents.post('/:id/start', AgentUser(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
 
 
     await containerManager.ensureRunning(slug)
@@ -1169,7 +1171,7 @@ agents.post('/:id/start', AgentUser(), async (c) => {
 // POST /api/agents/:id/stop - Stop an agent's container
 agents.post('/:id/stop', AgentUser(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const agent = await getAgent(slug)
 
     if (!agent) {
@@ -1182,6 +1184,7 @@ agents.post('/:id/stop', AgentUser(), async (c) => {
     if (info.status === 'stopped') {
       return c.json({
         slug: agent.slug,
+        displaySlug: displaySlug(agent.frontmatter.name, agent.slug),
         name: agent.frontmatter.name,
         description: agent.frontmatter.description,
         createdAt: agent.frontmatter.createdAt,
@@ -1195,6 +1198,7 @@ agents.post('/:id/stop', AgentUser(), async (c) => {
 
     return c.json({
       slug: agent.slug,
+      displaySlug: displaySlug(agent.frontmatter.name, agent.slug),
       name: agent.frontmatter.name,
       description: agent.frontmatter.description,
       createdAt: agent.frontmatter.createdAt,
@@ -1209,7 +1213,7 @@ agents.post('/:id/stop', AgentUser(), async (c) => {
 
 // POST /api/agents/:id/keep-alive - Prevent auto-sleep (e.g. dashboard is open)
 agents.post('/:id/keep-alive', AgentRead(), async (c) => {
-  const slug = c.req.param('id')
+  const slug = getAgentId(c)
   containerManager.keepAlive(slug)
   return c.json({ ok: true })
 })
@@ -1219,7 +1223,7 @@ const OpenDirectoryBody = z.object({ open: z.boolean().optional() })
 
 agents.post('/:id/open-directory', AgentAdmin(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const workspaceDir = getAgentWorkspaceDir(slug)
 
     // Ensure directory exists
@@ -1250,7 +1254,7 @@ agents.post('/:id/open-directory', AgentAdmin(), async (c) => {
 // GET /api/agents/:id/sessions - List sessions for an agent
 agents.get('/:id/sessions', AgentRead(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
 
 
     const sessionList = await listSessions(slug, { excludeAutomated: true })
@@ -1276,7 +1280,7 @@ agents.get('/:id/sessions', AgentRead(), async (c) => {
 // POST /api/agents/:id/sessions - Create a new session with initial message
 agents.post('/:id/sessions', AgentUser(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const body = await c.req.json()
     const { message } = body
 
@@ -1381,7 +1385,7 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
 // GET /api/agents/:id/sessions/:sessionId/messages - Get messages for a session
 agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
 
     // No JSONL transcript on disk — e.g. it was deleted by the CLI's retention
@@ -1442,7 +1446,7 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
 // DELETE /api/agents/:id/sessions/:sessionId/messages/:messageId - Remove a message from history
 agents.delete('/:id/sessions/:sessionId/messages/:messageId', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
     const messageId = c.req.param('messageId')
 
@@ -1462,7 +1466,7 @@ agents.delete('/:id/sessions/:sessionId/messages/:messageId', AgentUser(), async
 // DELETE /api/agents/:id/sessions/:sessionId/tool-calls/:toolCallId - Remove a tool call from history
 agents.delete('/:id/sessions/:sessionId/tool-calls/:toolCallId', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
     const toolCallId = c.req.param('toolCallId')
 
@@ -1482,7 +1486,7 @@ agents.delete('/:id/sessions/:sessionId/tool-calls/:toolCallId', AgentUser(), as
 // GET /api/agents/:id/sessions/:sessionId/subagent/:agentId/messages - Get subagent messages
 agents.get('/:id/sessions/:sessionId/subagent/:agentId/messages', AgentRead(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
     const subagentId = c.req.param('agentId')
 
@@ -1504,7 +1508,7 @@ agents.get('/:id/sessions/:sessionId/subagent/:agentId/messages', AgentRead(), a
 // GET /api/agents/:id/sessions/:sessionId/raw-log - Get raw JSONL log for a session
 agents.get('/:id/sessions/:sessionId/raw-log', AgentRead(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
 
 
@@ -1525,7 +1529,7 @@ agents.get('/:id/sessions/:sessionId/raw-log', AgentRead(), async (c) => {
 // POST /api/agents/:id/sessions/:sessionId/messages - Send a message
 agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
     const body = await c.req.json()
     const { content } = body
@@ -1621,7 +1625,7 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
 // picked up (or the session isn't live) — the message will materialize normally.
 agents.delete('/:id/sessions/:sessionId/queued-messages/:uuid', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
     const uuidParam = z.string().uuid().safeParse(c.req.param('uuid'))
     if (!uuidParam.success) {
@@ -1655,7 +1659,7 @@ agents.post('/:id/sessions/:sessionId/typing', AgentUser(), async (c) => {
 // GET /api/agents/:id/sessions/:sessionId - Get a single session
 agents.get('/:id/sessions/:sessionId', AgentRead(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
 
 
@@ -1693,7 +1697,7 @@ agents.get('/:id/sessions/:sessionId', AgentRead(), async (c) => {
 // PATCH /api/agents/:id/sessions/:sessionId - Update a session (e.g., rename)
 agents.patch('/:id/sessions/:sessionId', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
     const body = await c.req.json()
     const { name } = body
@@ -1728,7 +1732,7 @@ agents.patch('/:id/sessions/:sessionId', AgentUser(), async (c) => {
 // DELETE /api/agents/:id/sessions/:sessionId - Delete a session
 agents.delete('/:id/sessions/:sessionId', AgentAdmin(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
 
     messagePersister.unsubscribeFromSession(sessionId)
@@ -1783,7 +1787,7 @@ agents.get('/:id/sessions/:sessionId/stream', AgentRead(), async (c) => {
       })
 
       // Send initial connection message (include slash commands for late-joining clients)
-      const agentSlug = c.req.param('id')
+      const agentSlug = getAgentId(c)
       const isActive = messagePersister.isSessionActive(sessionId)
       let slashCommands = messagePersister.getSlashCommands(sessionId)
       // Fall back to persisted metadata (e.g. after container restart)
@@ -1829,7 +1833,7 @@ agents.get('/:id/sessions/:sessionId/stream', AgentRead(), async (c) => {
       }
 
       // Replay current computer use grab state (with icon if cached)
-      const agentSlugForStream = c.req.param('id')
+      const agentSlugForStream = getAgentId(c)
       const grabbedApp = computerUsePermissionManager.getGrabbedApp(agentSlugForStream)
       if (grabbedApp) {
         const { getAppIconBase64 } = await import('@shared/lib/computer-use/app-icon')
@@ -1869,7 +1873,7 @@ agents.get('/:id/sessions/:sessionId/stream', AgentRead(), async (c) => {
 // POST /api/agents/:id/sessions/:sessionId/interrupt - Interrupt an active session
 agents.post('/:id/sessions/:sessionId/interrupt', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
 
 
@@ -1904,7 +1908,7 @@ agents.post('/:id/sessions/:sessionId/interrupt', AgentUser(), async (c) => {
     // Even on error, try to mark session as interrupted to fix UI state
     try {
       const sessionId = c.req.param('sessionId')
-      const agentSlugFallback = c.req.param('id')
+      const agentSlugFallback = getAgentId(c)
       await messagePersister.markSessionInterrupted(sessionId)
       reviewManager.denyAllForAgent(agentSlugFallback)
       return c.json({ success: true, note: 'Error during interrupt, but session marked inactive' })
@@ -1917,7 +1921,7 @@ agents.post('/:id/sessions/:sessionId/interrupt', AgentUser(), async (c) => {
 // POST /api/agents/:id/sessions/:sessionId/provide-secret - Provide or decline a secret request
 agents.post('/:id/sessions/:sessionId/provide-secret', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const body = await c.req.json()
     const { toolUseId, secretName, value, decline, declineReason } = body
 
@@ -2025,7 +2029,7 @@ agents.post('/:id/sessions/:sessionId/provide-secret', AgentUser(), async (c) =>
 // POST /api/agents/:id/sessions/:sessionId/provide-connected-account - Provide or decline a connected account request
 agents.post('/:id/sessions/:sessionId/provide-connected-account', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const body = await c.req.json()
     const { toolUseId, toolkit, accountIds, decline, declineReason } = body
 
@@ -2211,7 +2215,7 @@ agents.post('/:id/sessions/:sessionId/provide-connected-account', AgentUser(), a
 // POST /api/agents/:id/sessions/:sessionId/answer-question - Answer or decline a question request
 agents.post('/:id/sessions/:sessionId/answer-question', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const body = await c.req.json()
     const { toolUseId, answers, decline, declineReason } = body
 
@@ -2282,7 +2286,7 @@ agents.post('/:id/sessions/:sessionId/answer-question', AgentUser(), async (c) =
 // POST /api/agents/:id/sessions/:sessionId/complete-browser-input - Complete or cancel a browser input request
 agents.post('/:id/sessions/:sessionId/complete-browser-input', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const body = await c.req.json()
     const { toolUseId, decline, declineReason } = body
 
@@ -2361,7 +2365,7 @@ agents.post('/:id/sessions/:sessionId/complete-browser-input', AgentUser(), asyn
 // POST /api/agents/:id/sessions/:sessionId/run-script - Run or deny a script execution request
 agents.post('/:id/sessions/:sessionId/run-script', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const body = await c.req.json()
     const { toolUseId, script, scriptType, decline, declineReason } = body
 
@@ -2492,7 +2496,7 @@ agents.post('/:id/sessions/:sessionId/run-script', AgentUser(), async (c) => {
 // POST /api/agents/:id/sessions/:sessionId/computer-use - Execute or deny a computer use request
 agents.post('/:id/sessions/:sessionId/computer-use', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
     const body = await c.req.json()
     const { toolUseId, method, params, permissionLevel, appName, grantType, decline, declineReason } = body
@@ -2656,7 +2660,7 @@ agents.post('/:id/sessions/:sessionId/computer-use', AgentUser(), async (c) => {
 // POST /api/agents/:id/sessions/:sessionId/computer-use/revoke - Ungrab window and revoke permission for the app
 agents.post('/:id/sessions/:sessionId/computer-use/revoke', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
 
     const session = await getSession(agentSlug, sessionId)
@@ -2690,7 +2694,7 @@ agents.post('/:id/sessions/:sessionId/computer-use/revoke', AgentUser(), async (
 // GET /api/agents/:id/scheduled-tasks - List scheduled tasks for an agent
 agents.get('/:id/scheduled-tasks', AgentRead(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const status = c.req.query('status') // Optional: filter by status (e.g., 'pending')
 
 
@@ -2713,7 +2717,7 @@ agents.get('/:id/scheduled-tasks', AgentRead(), async (c) => {
 // GET /api/agents/:id/webhook-triggers - List webhook triggers for an agent
 agents.get('/:id/webhook-triggers', AgentRead(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const status = c.req.query('status')
 
     const triggers = status === 'active'
@@ -2731,7 +2735,7 @@ agents.get('/:id/webhook-triggers', AgentRead(), async (c) => {
 // GET /api/agents/:id/chat-integrations - List chat integrations for an agent
 agents.get('/:id/chat-integrations', AgentRead(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const status = c.req.query('status')
 
     const integrations = listChatIntegrations(slug, status || undefined)
@@ -2745,7 +2749,7 @@ agents.get('/:id/chat-integrations', AgentRead(), async (c) => {
 // GET /api/agents/:id/secrets - List secrets for an agent
 agents.get('/:id/secrets', AgentRead(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
 
     // Only user-managed secrets — reserved runtime vars (e.g. CONNECTED_ACCOUNTS)
     // that the container writes into the same .env are system-managed and must
@@ -2768,7 +2772,7 @@ agents.get('/:id/secrets', AgentRead(), async (c) => {
 // POST /api/agents/:id/secrets - Create or update a secret
 agents.post('/:id/secrets', AgentUser(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const body = await c.req.json()
     const { key, value } = body
 
@@ -2812,7 +2816,7 @@ agents.post('/:id/secrets', AgentUser(), async (c) => {
 // PUT /api/agents/:id/secrets/:secretId - Update a secret
 agents.put('/:id/secrets/:secretId', AgentUser(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const envVar = c.req.param('secretId')
     const body = await c.req.json()
     const { key, value } = body
@@ -2856,7 +2860,7 @@ agents.put('/:id/secrets/:secretId', AgentUser(), async (c) => {
 // DELETE /api/agents/:id/secrets/:secretId - Delete a secret
 agents.delete('/:id/secrets/:secretId', AgentUser(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const envVar = c.req.param('secretId')
 
 
@@ -2877,7 +2881,7 @@ agents.delete('/:id/secrets/:secretId', AgentUser(), async (c) => {
 // GET /api/agents/:id/connected-accounts - List agent's connected accounts
 agents.get('/:id/connected-accounts', AgentRead(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
 
 
     const mappings = await db
@@ -2909,7 +2913,7 @@ agents.get('/:id/connected-accounts', AgentRead(), async (c) => {
 // POST /api/agents/:id/connected-accounts - Map account(s) to agent
 agents.post('/:id/connected-accounts', AgentUser(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const body = await c.req.json()
     const { accountIds } = body as { accountIds: string[] }
 
@@ -2986,7 +2990,7 @@ agents.post('/:id/connected-accounts', AgentUser(), async (c) => {
 // DELETE /api/agents/:id/connected-accounts/:accountId - Remove account mapping from agent
 agents.delete('/:id/connected-accounts/:accountId', AgentUser(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const accountId = c.req.param('accountId')
 
     const filtered = await db
@@ -3015,7 +3019,7 @@ agents.delete('/:id/connected-accounts/:accountId', AgentUser(), async (c) => {
 // GET /api/agents/:id/remote-mcps - List remote MCP servers assigned to this agent
 agents.get('/:id/remote-mcps', AgentRead(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const mappings = await db
       .select({ mcp: remoteMcpServers, mapping: agentRemoteMcps })
       .from(agentRemoteMcps)
@@ -3047,7 +3051,7 @@ agents.get('/:id/remote-mcps', AgentRead(), async (c) => {
 // POST /api/agents/:id/remote-mcps - Assign remote MCP server(s) to agent
 agents.post('/:id/remote-mcps', AgentUser(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const body = await c.req.json<{ mcpIds: string[] }>()
 
     if (!Array.isArray(body.mcpIds) || body.mcpIds.length === 0) {
@@ -3104,7 +3108,7 @@ agents.post('/:id/remote-mcps', AgentUser(), async (c) => {
 // DELETE /api/agents/:id/remote-mcps/:mcpId - Remove remote MCP from agent
 agents.delete('/:id/remote-mcps/:mcpId', AgentUser(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const mcpId = c.req.param('mcpId')
 
     const [mapping] = await db
@@ -3134,7 +3138,7 @@ agents.delete('/:id/remote-mcps/:mcpId', AgentUser(), async (c) => {
 // POST /api/agents/:id/sessions/:sessionId/provide-remote-mcp - Handle user approval of runtime MCP request
 agents.post('/:id/sessions/:sessionId/provide-remote-mcp', AgentUser(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const body = await c.req.json<{
       toolUseId: string
       remoteMcpId?: string
@@ -3272,7 +3276,7 @@ agents.post('/:id/sessions/:sessionId/provide-remote-mcp', AgentUser(), async (c
 // GET /api/agents/:id/mcp-audit-log - Get MCP audit log for an agent
 agents.get('/:id/mcp-audit-log', AgentAdmin(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const limit = Math.min(parseInt(c.req.query('limit') || '50', 10), 100)
     const offset = parseInt(c.req.query('offset') || '0', 10)
 
@@ -3304,7 +3308,7 @@ agents.get('/:id/mcp-audit-log', AgentAdmin(), async (c) => {
 // GET /api/agents/:id/skills - Get skills for an agent (with status info)
 agents.get('/:id/skills', AgentRead(), async (c) => {
   try {
-    const id = c.req.param('id')
+    const id = getAgentId(c)
     const skills = await getAgentSkillsWithStatus(id, getConfiguredSkillsets())
     return c.json({ skills })
   } catch (error) {
@@ -3316,7 +3320,7 @@ agents.get('/:id/skills', AgentRead(), async (c) => {
 // GET /api/agents/:id/discoverable-skills - Get available skills from skillsets
 agents.get('/:id/discoverable-skills', AgentRead(), async (c) => {
   try {
-    const id = c.req.param('id')
+    const id = getAgentId(c)
     const skills = await getDiscoverableSkills(id, getConfiguredSkillsets())
     return c.json({ skills })
   } catch (error) {
@@ -3328,7 +3332,7 @@ agents.get('/:id/discoverable-skills', AgentRead(), async (c) => {
 // POST /api/agents/:id/skills/install - Install a skill from a skillset
 agents.post('/:id/skills/install', AgentAdmin(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const { skillsetId, skillPath, skillName, skillVersion } = await c.req.json()
 
     if (!skillsetId || !skillPath) {
@@ -3360,7 +3364,7 @@ agents.post('/:id/skills/install', AgentAdmin(), async (c) => {
 // POST /api/agents/:id/skills/:dir/update - Update an installed skill
 agents.post('/:id/skills/:dir/update', AgentAdmin(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const skillDir = c.req.param('dir')
     const result = await updateSkillFromSkillset(agentSlug, skillDir)
     logAuditEvent({ userId: getCurrentUserId(c), object: 'skill', objectId: `${agentSlug}/${skillDir}`, action: 'updated' })
@@ -3375,7 +3379,7 @@ agents.post('/:id/skills/:dir/update', AgentAdmin(), async (c) => {
 // GET /api/agents/:id/skills/:dir/pr-info - Get info for PR dialog
 agents.get('/:id/skills/:dir/pr-info', AgentAdmin(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const skillDir = c.req.param('dir')
     const info = await getSkillPRInfo(agentSlug, skillDir)
     return c.json(info)
@@ -3389,7 +3393,7 @@ agents.get('/:id/skills/:dir/pr-info', AgentAdmin(), async (c) => {
 // POST /api/agents/:id/skills/:dir/create-pr - Create PR for local changes
 agents.post('/:id/skills/:dir/create-pr', AgentAdmin(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const skillDir = c.req.param('dir')
     const { title, body, newVersion } = await c.req.json()
 
@@ -3410,7 +3414,7 @@ agents.post('/:id/skills/:dir/create-pr', AgentAdmin(), async (c) => {
 // GET /api/agents/:id/skills/:dir/publish-info - Get info for publishing a local skill
 agents.get('/:id/skills/:dir/publish-info', AgentAdmin(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const skillDir = c.req.param('dir')
     const skillsetId = c.req.query('skillsetId')
 
@@ -3435,7 +3439,7 @@ agents.get('/:id/skills/:dir/publish-info', AgentAdmin(), async (c) => {
 // POST /api/agents/:id/skills/:dir/publish - Publish a local skill to a skillset
 agents.post('/:id/skills/:dir/publish', AgentAdmin(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const skillDir = c.req.param('dir')
     const { skillsetId, title, body, newVersion } = await c.req.json()
 
@@ -3467,7 +3471,7 @@ agents.post('/:id/skills/:dir/publish', AgentAdmin(), async (c) => {
 // POST /api/agents/:id/export-template - Export agent as ZIP download
 agents.post('/:id/export-template', AgentAdmin(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const zipBuffer = await exportAgentTemplate(slug)
 
     logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: slug, action: 'exported', details: { type: 'template' } })
@@ -3489,7 +3493,7 @@ agents.post('/:id/export-template', AgentAdmin(), async (c) => {
 // POST /api/agents/:id/export-full - Export full agent as ZIP download (includes .env, data, etc.)
 agents.post('/:id/export-full', AgentAdmin(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const zipBuffer = await exportAgentFull(slug)
 
     logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: slug, action: 'exported', details: { type: 'full' } })
@@ -3511,7 +3515,7 @@ agents.post('/:id/export-full', AgentAdmin(), async (c) => {
 // GET /api/agents/:id/template-status - Get skillset status
 agents.get('/:id/template-status', AgentRead(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const status = await getAgentTemplateStatus(slug, getConfiguredSkillsets())
     return c.json(status)
   } catch (error) {
@@ -3523,7 +3527,7 @@ agents.get('/:id/template-status', AgentRead(), async (c) => {
 // POST /api/agents/:id/template-update - Update from skillset
 agents.post('/:id/template-update', AgentAdmin(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const result = await updateAgentFromSkillset(slug)
     return c.json(result)
   } catch (error) {
@@ -3536,7 +3540,7 @@ agents.post('/:id/template-update', AgentAdmin(), async (c) => {
 // GET /api/agents/:id/template-pr-info - Get AI-suggested PR info
 agents.get('/:id/template-pr-info', AgentRead(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const info = await getAgentPRInfo(slug)
     return c.json(info)
   } catch (error) {
@@ -3549,7 +3553,7 @@ agents.get('/:id/template-pr-info', AgentRead(), async (c) => {
 // POST /api/agents/:id/template-create-pr - Create PR for modifications
 agents.post('/:id/template-create-pr', AgentAdmin(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const { title, body, newVersion } = await c.req.json()
 
     if (!title || !body) {
@@ -3568,7 +3572,7 @@ agents.post('/:id/template-create-pr', AgentAdmin(), async (c) => {
 // GET /api/agents/:id/template-publish-info - Get publish info
 agents.get('/:id/template-publish-info', AgentRead(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const skillsetId = c.req.query('skillsetId')
 
     if (!skillsetId) {
@@ -3592,7 +3596,7 @@ agents.get('/:id/template-publish-info', AgentRead(), async (c) => {
 // POST /api/agents/:id/template-publish - Publish to skillset
 agents.post('/:id/template-publish', AgentAdmin(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const { skillsetId, title, body, newVersion } = await c.req.json()
 
     if (!skillsetId || !title || !body) {
@@ -3618,7 +3622,7 @@ agents.post('/:id/template-refresh', AgentUser(), async (c) => {
   try {
     const skillsets = getConfiguredSkillsets()
     await refreshAgentTemplates(skillsets)
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const status = await getAgentTemplateStatus(slug, skillsets)
     return c.json(status)
   } catch (error) {
@@ -3631,7 +3635,7 @@ agents.post('/:id/template-refresh', AgentUser(), async (c) => {
 // POST /api/agents/:id/skills/refresh - Refresh skillset caches and reconcile skill status
 agents.post('/:id/skills/refresh', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const skillsets = getConfiguredSkillsets()
     await refreshAgentSkills(agentSlug, skillsets)
     const skills = await getAgentSkillsWithStatus(agentSlug, skillsets)
@@ -3646,7 +3650,7 @@ agents.post('/:id/skills/refresh', AgentUser(), async (c) => {
 // POST /api/agents/:id/skills/:dir/export - Export a skill as ZIP download
 agents.post('/:id/skills/:dir/export', AgentAdmin(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const dir = c.req.param('dir')
     const zipBuffer = await exportSkill(agentSlug, dir)
 
@@ -3669,7 +3673,7 @@ agents.post('/:id/skills/:dir/export', AgentAdmin(), async (c) => {
 // POST /api/agents/:id/skills/import-zip - Import a skill from uploaded ZIP
 agents.post('/:id/skills/import-zip', AgentAdmin(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const formData = await c.req.formData()
     const file = formData.get('file') as File | null
 
@@ -3697,7 +3701,7 @@ agents.post('/:id/skills/import-zip', AgentAdmin(), async (c) => {
 // GET /api/agents/:id/skills/:dir/files - List all files in a skill directory
 agents.get('/:id/skills/:dir/files', AgentAdmin(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const dir = c.req.param('dir')
 
     if (!dir || dir.includes('/') || dir.includes('\\') || dir.includes('..')) {
@@ -3741,7 +3745,7 @@ agents.get('/:id/skills/:dir/files', AgentAdmin(), async (c) => {
 // GET /api/agents/:id/skills/:dir/files/content - Read a skill file
 agents.get('/:id/skills/:dir/files/content', AgentAdmin(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const dir = c.req.param('dir')
     const filePath = c.req.query('path')
 
@@ -3773,7 +3777,7 @@ agents.get('/:id/skills/:dir/files/content', AgentAdmin(), async (c) => {
 // PUT /api/agents/:id/skills/:dir/files/content - Write a skill file
 agents.put('/:id/skills/:dir/files/content', AgentAdmin(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const dir = c.req.param('dir')
     const { path: filePath, content } = await c.req.json()
 
@@ -3802,7 +3806,7 @@ agents.put('/:id/skills/:dir/files/content', AgentAdmin(), async (c) => {
 // GET /api/agents/:id/audit-log - Get combined proxy + MCP audit log for agent
 agents.get('/:id/audit-log', AgentAdmin(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
 
     const offset = parseInt(c.req.query('offset') ?? '0', 10)
     const limit = Math.min(parseInt(c.req.query('limit') ?? '20', 10), 100)
@@ -3948,7 +3952,7 @@ async function handleChunkedFileUpload(c: Context, agentSlug: string, formData: 
 // <100MB slices.
 async function respondUploadFile(c: Context) {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     if (!agentSlug) return c.json({ error: 'Missing agent id' }, 400)
     const formData = await c.req.formData()
 
@@ -3972,7 +3976,7 @@ async function respondUploadFile(c: Context) {
     return c.json(result)
   } catch (error) {
     console.error('Failed to upload file:', error)
-    captureException(error, { tags: { component: 'agents', operation: 'upload-file' }, extra: { agentSlug: c.req.param('id') } })
+    captureException(error, { tags: { component: 'agents', operation: 'upload-file' }, extra: { agentSlug: getAgentId(c) } })
     return c.json({ error: 'Failed to upload file' }, 500)
   }
 }
@@ -4011,7 +4015,7 @@ async function handleFolderUpload(agentSlug: string, sourcePath: string) {
 // POST /api/agents/:id/upload-folder - Copy a local folder to the agent workspace (Electron only)
 agents.post('/:id/upload-folder', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const { sourcePath } = await c.req.json<{ sourcePath: string }>()
     if (!sourcePath) return c.json({ error: 'No source path provided' }, 400)
     const result = await handleFolderUpload(agentSlug, sourcePath)
@@ -4019,7 +4023,7 @@ agents.post('/:id/upload-folder', AgentUser(), async (c) => {
     return c.json(result)
   } catch (error) {
     console.error('Failed to upload folder:', error)
-    captureException(error, { tags: { component: 'agents', operation: 'upload-folder' }, extra: { agentSlug: c.req.param('id') } })
+    captureException(error, { tags: { component: 'agents', operation: 'upload-folder' }, extra: { agentSlug: getAgentId(c) } })
     return c.json({ error: 'Failed to upload folder' }, 500)
   }
 })
@@ -4027,7 +4031,7 @@ agents.post('/:id/upload-folder', AgentUser(), async (c) => {
 // POST /api/agents/:id/sessions/:sessionId/upload-folder - Copy a local folder to the agent workspace (Electron only)
 agents.post('/:id/sessions/:sessionId/upload-folder', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const { sourcePath } = await c.req.json<{ sourcePath: string }>()
     if (!sourcePath) return c.json({ error: 'No source path provided' }, 400)
     const result = await handleFolderUpload(agentSlug, sourcePath)
@@ -4035,7 +4039,7 @@ agents.post('/:id/sessions/:sessionId/upload-folder', AgentUser(), async (c) => 
     return c.json(result)
   } catch (error) {
     console.error('Failed to upload folder:', error)
-    captureException(error, { tags: { component: 'agents', operation: 'upload-folder' }, extra: { agentSlug: c.req.param('id') } })
+    captureException(error, { tags: { component: 'agents', operation: 'upload-folder' }, extra: { agentSlug: getAgentId(c) } })
     return c.json({ error: 'Failed to upload folder' }, 500)
   }
 })
@@ -4045,7 +4049,7 @@ agents.post('/:id/sessions/:sessionId/upload-folder', AgentUser(), async (c) => 
 // GET /api/agents/:id/mounts - List mounts with health status
 agents.get('/:id/mounts', AgentRead(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const mounts = getMountsWithHealth(agentSlug)
     return c.json(mounts)
   } catch (error) {
@@ -4057,7 +4061,7 @@ agents.get('/:id/mounts', AgentRead(), async (c) => {
 // POST /api/agents/:id/mounts - Add a mount
 agents.post('/:id/mounts', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const { hostPath, restart } = await c.req.json<{ hostPath: string; restart?: boolean }>()
     if (!hostPath) return c.json({ error: 'hostPath is required' }, 400)
 
@@ -4086,7 +4090,7 @@ agents.post('/:id/mounts', AgentUser(), async (c) => {
 // DELETE /api/agents/:id/mounts/:mountId - Remove a mount
 agents.delete('/:id/mounts/:mountId', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const mountId = c.req.param('mountId')
     const restart = c.req.query('restart') === 'true'
 
@@ -4110,7 +4114,7 @@ agents.delete('/:id/mounts/:mountId', AgentUser(), async (c) => {
 // GET /api/agents/:id/files/* - Download a file from the agent workspace
 agents.get('/:id/files/*', AgentRead(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     // Extract file path from URL - wildcard param can be unreliable in sub-routers
     const urlPath = new URL(c.req.url).pathname
     const filesPrefix = `/api/agents/${agentSlug}/files/`
@@ -4185,7 +4189,7 @@ agents.get('/:id/files/*', AgentRead(), async (c) => {
 // POST /api/agents/:id/sessions/:sessionId/provide-file - Provide or decline a file request
 agents.post('/:id/sessions/:sessionId/provide-file', AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const body = await c.req.json()
     const { toolUseId, filePath, decline, declineReason } = body
 
@@ -4260,7 +4264,7 @@ agents.post('/:id/sessions/:sessionId/provide-file', AgentUser(), async (c) => {
 // GET /api/agents/:id/artifacts - List dashboards for an agent
 agents.get('/:id/artifacts', AgentRead(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
 
 
     // Always read name/description from host filesystem (source of truth for metadata)
@@ -4308,7 +4312,7 @@ agents.get('/:id/artifacts', AgentRead(), async (c) => {
 // DELETE /api/agents/:id/artifacts/:artifactSlug - Delete a dashboard
 agents.delete('/:id/artifacts/:artifactSlug', AgentAdmin(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const artifactSlug = c.req.param('artifactSlug')
 
     // Stop the dashboard process in the container (if running), then delete files
@@ -4333,7 +4337,7 @@ agents.delete('/:id/artifacts/:artifactSlug', AgentAdmin(), async (c) => {
 // PATCH /api/agents/:id/artifacts/:artifactSlug - Rename a dashboard
 agents.patch('/:id/artifacts/:artifactSlug', AgentAdmin(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const artifactSlug = c.req.param('artifactSlug')
     const { name } = await c.req.json()
 
@@ -4354,7 +4358,7 @@ agents.patch('/:id/artifacts/:artifactSlug', AgentAdmin(), async (c) => {
 // regardless of whether the container is running. Must be registered before
 // the catch-all artifact proxy below.
 agents.get('/:id/artifacts/:artifactSlug/screenshot.png', AgentRead(), async (c) => {
-  const agentSlug = c.req.param('id')
+  const agentSlug = getAgentId(c)
   const artifactSlug = c.req.param('artifactSlug')
 
   const workspaceDir = getAgentWorkspaceDir(agentSlug)
@@ -4390,7 +4394,7 @@ agents.get('/:id/artifacts/:artifactSlug/screenshot.png', AgentRead(), async (c)
 // GET /api/agents/:id/artifacts/:artifactSlug/view - Standalone dashboard wrapper
 // Serves a self-contained HTML page that handles agent lifecycle (auto-start, wait, then load dashboard)
 agents.get('/:id/artifacts/:artifactSlug/view', AgentRead(), async (c) => {
-  const agentSlug = c.req.param('id')
+  const agentSlug = getAgentId(c)
   const artifactSlug = c.req.param('artifactSlug')
   const basePath = `/api/agents/${agentSlug}`
 
@@ -4504,7 +4508,7 @@ const skipProxyRequestHeaders = new Set([
 ])
 
 async function proxyArtifactRequest(c: any) {
-  const agentSlug = c.req.param('id')
+  const agentSlug = getAgentId(c)
   const artifactSlug = c.req.param('artifactSlug')
 
   const client = containerManager.getClient(agentSlug)
@@ -4587,7 +4591,7 @@ agents.all('/:id/artifacts/:artifactSlug', AgentRead(), async (c) => {
 // GET /api/agents/:id/browser/status - Check browser state
 agents.get('/:id/browser/status', AgentRead(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
 
 
     const client = containerManager.getClient(slug)
@@ -4609,7 +4613,7 @@ agents.get('/:id/browser/status', AgentRead(), async (c) => {
 // POST /api/agents/:id/browser/:action - Proxy browser tool actions
 agents.post('/:id/browser/:action', AgentUser(), async (c) => {
   try {
-    const slug = c.req.param('id')
+    const slug = getAgentId(c)
     const action = c.req.param('action')
 
 
@@ -4669,14 +4673,14 @@ setInterval(cleanupStaleUploads, 30 * 60 * 1000).unref()
 
 // GET /api/agents/:id/proxy-reviews - List pending reviews for this agent
 agents.get('/:id/proxy-reviews', AgentRead(), async (c) => {
-  const slug = c.req.param('id')
+  const slug = getAgentId(c)
   const reviews = reviewManager.getPendingReviewsForAgent(slug)
   return c.json({ reviews })
 })
 
 // POST /api/agents/:id/proxy-review/:reviewId - Submit a review decision
 agents.post('/:id/proxy-review/:reviewId', AgentUser(), async (c) => {
-  const slug = c.req.param('id')
+  const slug = getAgentId(c)
   const reviewId = c.req.param('reviewId')
   const body = await c.req.json<{ decision: 'allow' | 'deny' }>()
 
@@ -4698,7 +4702,7 @@ agents.post('/:id/proxy-review/:reviewId', AgentUser(), async (c) => {
 // POST /api/agents/:id/proxy-review/:reviewId/always - Submit decision and save as policy
 agents.post('/:id/proxy-review/:reviewId/always', AgentUser(), async (c) => {
   const reviewId = c.req.param('reviewId')
-  const slug = c.req.param('id')
+  const slug = getAgentId(c)
   const body = await c.req.json<{
     decision: 'allow' | 'deny'
     scope: string
@@ -4833,7 +4837,7 @@ agents.post('/:id/proxy-review/:reviewId/always', AgentUser(), async (c) => {
 
 // GET /api/agents/:id/x-agent-policies - List policies where this agent is the caller
 agents.get('/:id/x-agent-policies', AgentRead(), async (c) => {
-  const slug = c.req.param('id')
+  const slug = getAgentId(c)
   const rows = listPoliciesForCaller(slug)
   // Enrich with target agent display name (best-effort; null target means "list" op)
   const targetSlugs = Array.from(
@@ -4875,7 +4879,7 @@ agents.get('/:id/x-agent-policies', AgentRead(), async (c) => {
 
 // PUT /api/agents/:id/x-agent-policies - Replace all policies for this caller (batch)
 agents.put('/:id/x-agent-policies', AgentAdmin(), async (c) => {
-  const slug = c.req.param('id')
+  const slug = getAgentId(c)
   // AgentAdmin checks role but not existence (and is a no-op in non-auth mode);
   // assert here so a typo'd slug doesn't write phantom rows that nothing references.
   const callerAgent = await getAgent(slug)
@@ -4900,7 +4904,7 @@ agents.put('/:id/x-agent-policies', AgentAdmin(), async (c) => {
 // GET /api/agents/:id/bookmarks - Read bookmarks from agent workspace
 agents.get('/:id/bookmarks', AgentRead(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const bookmarksPath = path.join(getAgentWorkspaceDir(agentSlug), 'bookmarks.json')
     const content = await fs.promises.readFile(bookmarksPath, 'utf-8').catch(() => null)
     if (!content) {
@@ -4919,7 +4923,7 @@ agents.get('/:id/bookmarks', AgentRead(), async (c) => {
 // PUT /api/agents/:id/bookmarks - Write bookmarks to agent workspace
 agents.put('/:id/bookmarks', AgentAdmin(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const bookmarks = await c.req.json()
     if (!Array.isArray(bookmarks)) {
       return c.json({ error: 'Bookmarks must be an array' }, 400)

--- a/src/api/routes/chat-integrations.access.test.ts
+++ b/src/api/routes/chat-integrations.access.test.ts
@@ -40,6 +40,8 @@ vi.mock('../middleware/auth', () => {
       if (RANK[mockAuthRole.current] < RANK.user) return c.json({ error: 'Forbidden' }, 403)
       c.set('user', mockAuthUser); return next()
     },
+    ResolveAgent: () => async (c: any, next: () => Promise<void>) => { c.set('agentId', c.req.param('id')); return next() },
+    getAgentId: (c: any) => c.get('agentId') ?? c.req.param('id'),
     EntityAgentRole: (opts: any) => (minRole: string) => async (c: any, next: () => Promise<void>) => {
       const id = c.req.param(opts.paramName)
       const entity = await opts.lookupFn(id)

--- a/src/api/routes/chat-integrations.sup229.test.ts
+++ b/src/api/routes/chat-integrations.sup229.test.ts
@@ -32,6 +32,8 @@ const mockAuthUser = { id: 'attacker-user', name: 'Attacker', email: 'attacker@e
 vi.mock('../middleware/auth', () => ({
   Authenticated: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
   AgentUser: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
+  ResolveAgent: () => async (c: any, next: () => Promise<void>) => { c.set('agentId', c.req.param('id')); return next() },
+  getAgentId: (c: any) => c.get('agentId') ?? c.req.param('id'),
   EntityAgentRole: (opts: any) => (_minRole: string) => async (c: any, next: () => Promise<void>) => {
     const id = c.req.param(opts.paramName)
     const entity = await opts.lookupFn(id)

--- a/src/api/routes/chat-integrations.ts
+++ b/src/api/routes/chat-integrations.ts
@@ -28,7 +28,7 @@ import { chatIntegrationManager } from '@shared/lib/chat-integrations/chat-integ
 import { validateChatIntegrationConfig, CHAT_PROVIDERS, IMESSAGE_GATEWAY_URL, imessageSetupSchema, type ChatProvider } from '@shared/lib/chat-integrations/config-schema'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
-import { Authenticated, AgentUser, EntityAgentRole } from '../middleware/auth'
+import { Authenticated, AgentUser, EntityAgentRole, ResolveAgent, getAgentId } from '../middleware/auth'
 import { captureException } from '@shared/lib/error-reporting'
 
 const SENTRY_TAGS = { component: 'chat-integration' } as const
@@ -122,10 +122,13 @@ chatIntegrationsRouter.post('/test-credentials', Authenticated(), async (c) => {
 })
 
 // POST /api/chat-integrations - Create a new integration
-// AgentUser validates the user has 'user' role on the agent identified by :id param
-chatIntegrationsRouter.post('/:id', AgentUser(), async (c) => {
+// ResolveAgent maps the :id route param (which may be a display slug) to the
+// canonical id BEFORE AgentUser checks the ACL — otherwise auth mode denies valid
+// owners (ACL is id-keyed) and non-auth mode persists the display slug, splitting
+// the row from the canonical id. AgentUser then validates the 'user' role.
+chatIntegrationsRouter.post('/:id', ResolveAgent(), AgentUser(), async (c) => {
   try {
-    const agentSlug = c.req.param('id')
+    const agentSlug = getAgentId(c)
     const body = await c.req.json()
     const { provider, name, config, showToolCalls, sessionTimeout, model, effort } = body
     // requireApproval is intentionally NOT accepted here: making a bot public is

--- a/src/api/routes/chat-session-scope.sup202.test.ts
+++ b/src/api/routes/chat-session-scope.sup202.test.ts
@@ -31,6 +31,8 @@ const mockAuthUser = { id: 'attacker-user', name: 'Attacker', email: 'attacker@e
 vi.mock('../middleware/auth', () => ({
   Authenticated: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
   AgentUser: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
+  ResolveAgent: () => async (c: any, next: () => Promise<void>) => { c.set('agentId', c.req.param('id')); return next() },
+  getAgentId: (c: any) => c.get('agentId') ?? c.req.param('id'),
   EntityAgentRole: (opts: any) => (_minRole: string) => async (c: any, next: () => Promise<void>) => {
     const id = c.req.param(opts.paramName)
     const entity = await opts.lookupFn(id)

--- a/src/api/routes/provide-connected-account.test.ts
+++ b/src/api/routes/provide-connected-account.test.ts
@@ -11,6 +11,8 @@ vi.mock('../middleware/auth', () => ({
   AgentRead: () => async (_c: unknown, next: () => Promise<void>) => next(),
   AgentUser: () => async (_c: unknown, next: () => Promise<void>) => next(),
   AgentAdmin: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  ResolveAgent: () => async (c: any, next: () => Promise<void>) => { c.set('agentId', c.req.param('id')); return next() },
+  getAgentId: (c: any) => c.get('agentId') ?? c.req.param('id'),
 }))
 
 // Container manager

--- a/src/api/routes/resolve-interrupted-subagents.test.ts
+++ b/src/api/routes/resolve-interrupted-subagents.test.ts
@@ -93,6 +93,8 @@ vi.mock('../middleware/auth', () => ({
   AgentRead: () => vi.fn((_c: unknown, next: () => Promise<void>) => next()),
   AgentUser: () => vi.fn((_c: unknown, next: () => Promise<void>) => next()),
   AgentAdmin: () => vi.fn((_c: unknown, next: () => Promise<void>) => next()),
+  ResolveAgent: () => async (c: any, next: () => Promise<void>) => { c.set('agentId', c.req.param('id')); return next() },
+  getAgentId: (c: any) => c.get('agentId') ?? c.req.param('id'),
 }))
 
 // Import after mocks

--- a/src/api/routes/security-repro.test.ts
+++ b/src/api/routes/security-repro.test.ts
@@ -155,6 +155,8 @@ vi.mock('../middleware/auth', () => ({
   OwnsAccount: () => async (_c: unknown, next: () => Promise<void>) => next(),
   IsAdmin: () => async (_c: unknown, next: () => Promise<void>) => next(),
   Or: (..._mw: unknown[]) => async (_c: unknown, next: () => Promise<void>) => next(),
+  ResolveAgent: () => async (c: any, next: () => Promise<void>) => { c.set('agentId', c.req.param('id')); return next() },
+  getAgentId: (c: any) => c.get('agentId') ?? c.req.param('id'),
 }))
 
 vi.mock('@shared/lib/analytics/server-analytics', () => ({

--- a/src/api/routes/x-agent-policies.test.ts
+++ b/src/api/routes/x-agent-policies.test.ts
@@ -52,6 +52,8 @@ vi.mock('../middleware/auth', () => {
     AgentRead: passthrough,
     AgentUser: passthrough,
     AgentAdmin: passthrough,
+    ResolveAgent: () => async (c: any, next: () => Promise<void>) => { c.set('agentId', c.req.param('id')); return next() },
+    getAgentId: (c: any) => c.get('agentId') ?? c.req.param('id'),
     EntityAgentRole: () => () => passthrough(),
     OwnsAccount: passthrough,
     OwnsAccountByParam: () => passthrough(),

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -31,6 +31,7 @@ vi.hoisted(() => {
 let testDir: string
 let testDb: ReturnType<typeof drizzle>
 let testSqlite: InstanceType<typeof Database>
+let prevDataDir: string | undefined
 
 vi.mock('@shared/lib/db', async () => ({
   get db() {
@@ -169,6 +170,13 @@ function authedFetch(path: string, body: unknown, token = CALLER_TOKEN) {
 
 beforeEach(async () => {
   testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'xagent-test-'))
+  // Point the data dir at testDir so the REAL resolveAgentId (not mocked) finds
+  // agent folders on disk. Caller/target are seeded as bare folders matching the
+  // legacy-style test slugs (resolveAgentId returns them via exact-folder match).
+  prevDataDir = process.env.SUPERAGENT_DATA_DIR
+  process.env.SUPERAGENT_DATA_DIR = testDir
+  await fs.promises.mkdir(path.join(testDir, 'agents', CALLER_SLUG), { recursive: true })
+  await fs.promises.mkdir(path.join(testDir, 'agents', TARGET_SLUG), { recursive: true })
   testSqlite = new Database(':memory:')
   testDb = drizzle(testSqlite, { schema })
   const migrationsFolder = path.join(process.cwd(), 'src/shared/lib/db/migrations')
@@ -216,6 +224,8 @@ beforeEach(async () => {
 afterEach(async () => {
   testSqlite?.close()
   await fs.promises.rm(testDir, { recursive: true, force: true })
+  if (prevDataDir === undefined) delete process.env.SUPERAGENT_DATA_DIR
+  else process.env.SUPERAGENT_DATA_DIR = prevDataDir
 })
 
 // ============================================================================
@@ -317,7 +327,7 @@ describe('/create', () => {
 
   it('creates and returns slug on allow', async () => {
     reviewDecisions.push('allow')
-    mockCreateAgent.mockResolvedValue({ slug: 'new-helper', name: 'New Helper' })
+    mockCreateAgent.mockResolvedValue({ slug: 'new-helper', displaySlug: 'new-helper', name: 'New Helper' })
     const res = await authedFetch('/x-agent/create', { name: 'New Helper' })
     expect(res.status).toBe(200)
     const body = await res.json()
@@ -334,7 +344,7 @@ describe('/create', () => {
   it('inherits owner ACL from caller in auth mode', async () => {
     authModeEnabled = true
     reviewDecisions.push('allow')
-    mockCreateAgent.mockResolvedValue({ slug: 'new-helper', name: 'New' })
+    mockCreateAgent.mockResolvedValue({ slug: 'new-helper', displaySlug: 'new-helper', name: 'New' })
     const res = await authedFetch('/x-agent/create', { name: 'New' })
     expect(res.status).toBe(200)
     const aclRows = testDb
@@ -789,6 +799,71 @@ describe('/get-transcript', () => {
     expect(mockWaitForIdle).toHaveBeenCalledWith('sess-1')
     const body = await res.json()
     expect(body.status).toBe('idle')
+  })
+})
+
+// ============================================================================
+// Display-slug resolution: model-facing slugs resolve to the canonical id,
+// and every ACL / policy / runtime call below keys on the id (not the prefix).
+// ============================================================================
+
+describe('display-slug resolution', () => {
+  const TARGET_ID = 't1234567ab' // 10-char minted id
+  const DISPLAY_SLUG = `pretty-target-${TARGET_ID}`
+
+  beforeEach(async () => {
+    await fs.promises.mkdir(path.join(testDir, 'agents', TARGET_ID), { recursive: true })
+    mockGetAgent.mockResolvedValue({
+      slug: TARGET_ID,
+      frontmatter: { name: 'Pretty Target', createdAt: '2024-01-01' },
+      instructions: '',
+    })
+    mockCreateSession.mockResolvedValue({ id: 'sess-id' })
+  })
+
+  it('/list projects {slug(name)}-{id} for a minted agent', async () => {
+    const { setPolicy } = await import('@shared/lib/services/x-agent-policy-service')
+    await setPolicy(CALLER_SLUG, 'list', null, 'allow')
+    mockListAgents.mockResolvedValue([{ slug: TARGET_ID, frontmatter: { name: 'Pretty Target' } }])
+    const res = await authedFetch('/x-agent/list', {})
+    const body = await res.json()
+    expect(body.agents).toEqual([{ slug: DISPLAY_SLUG, name: 'Pretty Target' }])
+  })
+
+  it('/invoke accepts the display slug and keys runtime calls on the id', async () => {
+    const { setPolicy } = await import('@shared/lib/services/x-agent-policy-service')
+    await setPolicy(CALLER_SLUG, 'invoke', TARGET_ID, 'allow')
+    const res = await authedFetch('/x-agent/invoke', { slug: DISPLAY_SLUG, prompt: 'hello' })
+    expect(res.status).toBe(200)
+    expect(mockRegisterSession).toHaveBeenCalledWith(TARGET_ID, expect.any(String), expect.any(String))
+  })
+
+  it('/invoke accepts a wrong-prefix slug (the prefix is decorative)', async () => {
+    const { setPolicy } = await import('@shared/lib/services/x-agent-policy-service')
+    await setPolicy(CALLER_SLUG, 'invoke', TARGET_ID, 'allow')
+    const res = await authedFetch('/x-agent/invoke', { slug: `anything-${TARGET_ID}`, prompt: 'hi' })
+    expect(res.status).toBe(200)
+  })
+
+  it('policy is keyed on the resolved id — a block on the id blocks a display-slug invoke', async () => {
+    const { setPolicy } = await import('@shared/lib/services/x-agent-policy-service')
+    await setPolicy(CALLER_SLUG, 'invoke', TARGET_ID, 'block')
+    const res = await authedFetch('/x-agent/invoke', { slug: DISPLAY_SLUG, prompt: 'hi' })
+    expect(res.status).toBe(403)
+  })
+
+  it('/get-sessions accepts the display slug and lists by id', async () => {
+    const { setPolicy } = await import('@shared/lib/services/x-agent-policy-service')
+    await setPolicy(CALLER_SLUG, 'read', TARGET_ID, 'allow')
+    mockListSessions.mockResolvedValue([])
+    const res = await authedFetch('/x-agent/get-sessions', { slug: DISPLAY_SLUG })
+    expect(res.status).toBe(200)
+    expect(mockListSessions).toHaveBeenCalledWith(TARGET_ID)
+  })
+
+  it('returns 404 for a well-formed display slug whose id does not exist', async () => {
+    const res = await authedFetch('/x-agent/invoke', { slug: 'ghost-zzzzzzzzzz', prompt: 'hi' })
+    expect(res.status).toBe(404)
   })
 })
 

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -26,6 +26,7 @@ import {
   listAgents,
   getAgent,
 } from '@shared/lib/services/agent-service'
+import { resolveAgentId, displaySlug } from '@shared/lib/utils/file-storage'
 import {
   listSessions,
   getSessionMessagesWithCompact,
@@ -196,7 +197,9 @@ xAgent.post('/list', async (c) => {
     .filter((a) => a.slug !== callerSlug)
     .filter((a) => (visible ? visible.has(a.slug) : true))
     .map((a) => ({
-      slug: a.slug,
+      // Project the decorative display slug for the model; resolveAgentId tolerates
+      // it (and the bare id / legacy form) on the way back in via invoke/get-*.
+      slug: displaySlug(a.frontmatter.name, a.slug),
       name: a.frontmatter.name,
       description: a.frontmatter.description,
     }))
@@ -240,7 +243,7 @@ xAgent.post('/create', zValidator('json', createBodySchema), async (c) => {
       })
     }
   }
-  return c.json({ slug: agent.slug, name: agent.name })
+  return c.json({ slug: agent.displaySlug, name: agent.name })
 })
 
 // ----------------------------------------------------------------------------
@@ -255,7 +258,12 @@ const getSessionsBodySchema = z.object({
 
 xAgent.post('/get-sessions', zValidator('json', getSessionsBodySchema), async (c) => {
   const callerSlug = getCallerSlug(c)
-  const { slug: targetSlug, limit = 50, offset = 0 } = c.req.valid('json')
+  const { slug: rawTargetSlug, limit = 50, offset = 0 } = c.req.valid('json')
+
+  // Resolve the model-supplied display slug to the canonical id and rebind, so
+  // every downstream ACL / policy / fs use below keys on the id, not the prefix.
+  const targetSlug = await resolveAgentId(rawTargetSlug)
+  if (!targetSlug) return c.json({ error: 'Target agent not found' }, 404)
 
   const target = await getAgent(targetSlug)
   if (!target) return c.json({ error: 'Target agent not found' }, 404)
@@ -399,7 +407,11 @@ async function readLastAssistantMessage(
 
 xAgent.post('/get-transcript', zValidator('json', getTranscriptBodySchema), async (c) => {
   const callerSlug = getCallerSlug(c)
-  const { slug: targetSlug, sessionId, sync } = c.req.valid('json')
+  const { slug: rawTargetSlug, sessionId, sync } = c.req.valid('json')
+
+  // Resolve the model-supplied display slug to the canonical id and rebind.
+  const targetSlug = await resolveAgentId(rawTargetSlug)
+  if (!targetSlug) return c.json({ error: 'Target agent not found' }, 404)
 
   const target = await getAgent(targetSlug)
   if (!target) return c.json({ error: 'Target agent not found' }, 404)
@@ -456,7 +468,12 @@ const invokeBodySchema = z.object({
 
 xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
   const callerSlug = getCallerSlug(c)
-  const { slug: targetSlug, prompt, sessionId: existingSessionId, sync, _callerSessionId } = c.req.valid('json')
+  const { slug: rawTargetSlug, prompt, sessionId: existingSessionId, sync, _callerSessionId } = c.req.valid('json')
+
+  // Resolve the model-supplied display slug to the canonical id and rebind, so
+  // the self-invoke guard and every ACL / policy / runtime call below use ids.
+  const targetSlug = await resolveAgentId(rawTargetSlug)
+  if (!targetSlug) return c.json({ error: 'Target agent not found' }, 404)
 
   if (targetSlug === callerSlug) {
     return c.json({ error: 'Agent cannot invoke itself' }, 400)

--- a/src/main/browser-stream-proxy.ts
+++ b/src/main/browser-stream-proxy.ts
@@ -10,6 +10,7 @@ import type { Duplex } from 'stream'
 import type { ServerType } from '@hono/node-server'
 import { WebSocketServer, WebSocket } from 'ws'
 import { containerManager } from '@shared/lib/container/container-manager'
+import { resolveAgentId } from '@shared/lib/utils/file-storage'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
 import { getSettings } from '@shared/lib/config/settings'
 import { isAuthMode } from '@shared/lib/auth/mode'
@@ -79,33 +80,44 @@ export function setupBrowserStreamProxy(server: ServerType): void {
       return
     }
 
-    const agentSlug = match[1]
-
-    // Authenticate before upgrading — viewer+ can watch, but input is filtered per-role below
-    authenticateWs(request, agentSlug, 'viewer').then((allowed) => {
-      if (!allowed) {
-        socket.write('HTTP/1.1 403 Forbidden\r\n\r\n')
+    // The URL carries the display slug ({name}-{id}); resolve to the canonical id
+    // before any ACL check or container lookup. This WS upgrade bypasses the Hono
+    // /:id/* ResolveAgent middleware, so it must resolve itself. Stash the resolved
+    // id for the connection handler below.
+    resolveAgentId(match[1]).then((agentSlug) => {
+      if (!agentSlug) {
+        socket.write('HTTP/1.1 404 Not Found\r\n\r\n')
         socket.destroy()
         return
       }
+      ;(request as any)._agentId = agentSlug
 
-      // Check if user has 'user' role (can send input) — stash on the request object
-      authenticateWs(request, agentSlug, 'user').then((canInput) => {
-        ;(request as any)._canInput = canInput
-        browserWss.handleUpgrade(request, socket, head, (ws) => {
-          browserWss.emit('connection', ws, request)
+      // Authenticate before upgrading — viewer+ can watch, but input is filtered per-role below
+      authenticateWs(request, agentSlug, 'viewer').then((allowed) => {
+        if (!allowed) {
+          socket.write('HTTP/1.1 403 Forbidden\r\n\r\n')
+          socket.destroy()
+          return
+        }
+
+        // Check if user has 'user' role (can send input) — stash on the request object
+        authenticateWs(request, agentSlug, 'user').then((canInput) => {
+          ;(request as any)._canInput = canInput
+          browserWss.handleUpgrade(request, socket, head, (ws) => {
+            browserWss.emit('connection', ws, request)
+          })
         })
       })
+    }).catch(() => {
+      socket.destroy()
     })
   })
 
   browserWss.on('connection', async (ws: WebSocket, request: IncomingMessage) => {
-    // eslint-disable-next-line local-rules/no-unhandled-throwing-builtins -- request.url from HTTP server is always valid
-    const url = new URL(request.url || '', `http://${request.headers.host}`)
-    const match = url.pathname.match(/^\/api\/agents\/([^/]+)\/browser\/stream$/)
-    if (!match) { ws.close(1011, 'Invalid path'); return }
-
-    const agentSlug = match[1]
+    // Canonical id resolved during the upgrade handshake above (the URL slug is the
+    // display slug; container lookups are keyed by the canonical id).
+    const agentSlug = (request as any)._agentId as string | undefined
+    if (!agentSlug) { ws.close(1011, 'Invalid path'); return }
     const canInput = (request as any)._canInput === true
 
     try {

--- a/src/renderer/components/agents/agent-context-menu.tsx
+++ b/src/renderer/components/agents/agent-context-menu.tsx
@@ -18,8 +18,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@renderer/components/ui/alert-dialog'
-import { useDeleteAgent, type ApiAgent } from '@renderer/hooks/use-agents'
-import { useNavigate, useParams } from '@tanstack/react-router'
+import { useDeleteAgent, useRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
+import { useNavigate } from '@tanstack/react-router'
 import { useUser } from '@renderer/context/user-context'
 import { AgentSettingsDialog } from './agent-settings-dialog'
 import { apiFetch } from '@renderer/lib/api'
@@ -45,10 +45,10 @@ export function AgentContextMenu({
   const [isLeaving, setIsLeaving] = useState(false)
   const deleteAgent = useDeleteAgent()
   const navigate = useNavigate()
-  // strict:false → undefined when the menu is opened off the agent route (e.g.
-  // from the sidebar list), so the up-nav only fires when we're actually viewing
-  // the agent being deleted/left.
-  const params = useParams({ strict: false }) as { slug?: string }
+  // undefined when the menu is opened off the agent route (e.g. from the sidebar
+  // list), so the up-nav only fires when we're actually viewing the agent being
+  // deleted/left. Resolves the URL display slug to the canonical id to compare.
+  const routeAgentId = useRouteAgentId()
   const { canAdminAgent, isAuthMode } = useUser()
   const queryClient = useQueryClient()
   const isOwner = canAdminAgent(agent.slug)
@@ -75,7 +75,7 @@ export function AgentContextMenu({
     try {
       await deleteAgent.mutateAsync(agent.slug)
       setShowDeleteDialog(false)
-      if (params.slug === agent.slug) {
+      if (routeAgentId === agent.slug) {
         void navigate({ to: '/' })
       }
     } catch (error) {
@@ -96,7 +96,7 @@ export function AgentContextMenu({
         return
       }
       setShowLeaveDialog(false)
-      if (params.slug === agent.slug) {
+      if (routeAgentId === agent.slug) {
         void navigate({ to: '/' })
       }
       queryClient.invalidateQueries({ queryKey: ['agents'] })

--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -10,6 +10,7 @@ import type { ApiAgent } from '@renderer/hooks/use-agents'
 
 const testAgent: ApiAgent = {
   slug: 'test-agent',
+  displaySlug: 'test-agent',
   name: 'Test Agent',
   description: 'A test agent',
   createdAt: new Date('2025-01-01'),

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -46,8 +46,6 @@ import { useRenameUntitledAgent } from '@renderer/hooks/use-rename-untitled-agen
 import { useRenderTracker } from '@renderer/lib/perf'
 import { formatDistanceToNow } from 'date-fns'
 
-const INTRO_ANIMATION_MS = 2200
-
 interface AgentHomeProps {
   agent: ApiAgent
   onSessionCreated: (sessionId: string, initialMessage: string, messageUuid: string) => void
@@ -70,10 +68,13 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
     const t = setTimeout(() => setIntroPlaying(true), 1000)
     return () => clearTimeout(t)
   }, [introStagger])
+  // One-shot: consume the morph tag immediately once introStagger has captured it
+  // at mount, so it can't replay if AgentHome unmounts mid-animation — e.g. the
+  // user sends the first message within ~2s, the index leaf unmounts, and a
+  // deferred clear would be cancelled, stranding the tag and re-animating on
+  // return. The animation runs off local introStagger/introPlaying state.
   useEffect(() => {
-    if (!introStagger) return
-    const t = setTimeout(() => setJustCreatedSlug(null), INTRO_ANIMATION_MS)
-    return () => clearTimeout(t)
+    if (introStagger) setJustCreatedSlug(null)
   }, [introStagger, setJustCreatedSlug])
   const startOnboardingSession = useStartOnboardingSession()
   const { canUseAgent, canAdminAgent } = useUser()

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -58,7 +58,7 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
   const finishCreatedAgent = useCallback(
     async (agent: ApiAgent, source: 'new' | 'import' | 'skillset', hasOnboarding?: boolean) => {
       track('agent_created', { source, num_skills_added_at_creation: 0 })
-      void navigate({ to: '/agents/$slug', params: { slug: agent.slug } })
+      void navigate({ to: '/agents/$slug', params: { slug: agent.displaySlug } })
       if (hasOnboarding) {
         await startOnboardingSession(agent.slug)
       }
@@ -87,7 +87,7 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
           model: 'opus',
         })
         track('agent_created', { source: 'new', num_skills_added_at_creation: 0 })
-        void navigate({ to: '/agents/$slug/sessions/$sessionId', params: { slug: newAgent.slug, sessionId: session.id } })
+        void navigate({ to: '/agents/$slug/sessions/$sessionId', params: { slug: newAgent.displaySlug, sessionId: session.id } })
         await onAgentCreated?.()
       } catch (error) {
         console.error('Failed to create agent:', error)

--- a/src/renderer/components/agents/settings/general-tab.tsx
+++ b/src/renderer/components/agents/settings/general-tab.tsx
@@ -16,10 +16,10 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@renderer/components/ui/alert-dialog'
-import { useDeleteAgent } from '@renderer/hooks/use-agents'
+import { useDeleteAgent, useRouteAgentId } from '@renderer/hooks/use-agents'
 import { useAgentPreferences, useUpdateAgentPreferences } from '@renderer/hooks/use-agent-preferences'
 import { useSettings } from '@renderer/hooks/use-settings'
-import { useNavigate, useParams } from '@tanstack/react-router'
+import { useNavigate } from '@tanstack/react-router'
 import {
   useForceSyncAgentTemplate,
   useAgentTemplateStatus,
@@ -52,7 +52,7 @@ export function GeneralTab({ name, agentSlug, onNameChange, onDialogClose }: Gen
   const updatePrefs = useUpdateAgentPreferences(agentSlug)
   const { data: settings } = useSettings()
   const navigate = useNavigate()
-  const routeSlug = useParams({ strict: false }).slug ?? null
+  const routeAgentId = useRouteAgentId()
   const { data: templateStatus } = useAgentTemplateStatus(agentSlug)
   const refreshTemplateStatus = useRefreshAgentTemplateStatus()
   const forceSyncTemplate = useForceSyncAgentTemplate()
@@ -69,7 +69,7 @@ export function GeneralTab({ name, agentSlug, onNameChange, onDialogClose }: Gen
     try {
       await deleteAgent.mutateAsync(agentSlug)
       onDialogClose()
-      if (routeSlug === agentSlug) void navigate({ to: '/' })
+      if (routeAgentId === agentSlug) void navigate({ to: '/' })
     } catch (error) {
       console.error('Failed to delete agent:', error)
       toast.error(error instanceof Error ? error.message : 'Failed to delete agent')

--- a/src/renderer/components/agents/settings/x-agent-policies-tab.tsx
+++ b/src/renderer/components/agents/settings/x-agent-policies-tab.tsx
@@ -261,7 +261,7 @@ export function XAgentPoliciesTab({ agentSlug }: XAgentPoliciesTabProps) {
                 >
                   <div className="min-w-0">
                     <div className="truncate text-sm font-medium">{agent.name}</div>
-                    <div className="truncate text-[10px] font-mono text-muted-foreground">{agent.slug}</div>
+                    <div className="truncate text-[10px] font-mono text-muted-foreground">{agent.displaySlug}</div>
                   </div>
                   <div className="w-[120px] flex justify-center">
                     <PolicyDecisionToggle

--- a/src/renderer/components/chat-integrations/chat-integration-view.tsx
+++ b/src/renderer/components/chat-integrations/chat-integration-view.tsx
@@ -28,6 +28,7 @@ import {
 } from '@renderer/hooks/use-chat-integrations'
 import { formatSessionTimestamp } from '@shared/lib/chat-integrations/utils'
 import { useNavigate } from '@tanstack/react-router'
+import { useAgents, resolveRouteAgentId } from '@renderer/hooks/use-agents'
 import { useUser } from '@renderer/context/user-context'
 import {
   Dialog,
@@ -271,16 +272,22 @@ export function ChatIntegrationView({ integrationId, agentSlug, chatSessionId }:
   // agent's shell (mismatched chrome and canManage gating, and the SessionThread
   // below fetches messages scoped to the URL slug → empty/404). Redirect to the
   // integration's true agent, preserving the `?session=` sub-session.
+  //
+  // Compare RESOLVED ids: the route param may be the display slug ({name}-{id})
+  // while integration.agentSlug is the canonical id, so a raw `!==` would fire on
+  // every correct-agent visit. Wait for the agents list, then redirect to the
+  // canonical id (the same form the app uses for chat routes).
+  const { data: agents } = useAgents()
   useEffect(() => {
-    if (integration && integration.agentSlug !== agentSlug) {
-      void navigate({
-        to: '/agents/$slug/chat/$integrationId',
-        params: { slug: integration.agentSlug, integrationId },
-        search: (prev) => prev,
-        replace: true,
-      })
-    }
-  }, [integration, agentSlug, integrationId, navigate])
+    if (!integration || !agents) return
+    if (integration.agentSlug === resolveRouteAgentId(agentSlug, agents)) return
+    void navigate({
+      to: '/agents/$slug/chat/$integrationId',
+      params: { slug: integration.agentSlug, integrationId },
+      search: (prev) => prev,
+      replace: true,
+    })
+  }, [integration, agents, agentSlug, integrationId, navigate])
 
   const [clearError, setClearError] = useState<string | null>(null)
   const [renameOpen, setRenameOpen] = useState(false)
@@ -316,7 +323,8 @@ export function ChatIntegrationView({ integrationId, agentSlug, chatSessionId }:
 
   // Mismatched shell → the effect above is redirecting; don't render B's
   // integration (or its wrong-slug message fetches) under A's chrome meanwhile.
-  if (integration.agentSlug !== agentSlug) {
+  // Resolve first and only block once the agents list is loaded (see the effect).
+  if (agents && integration.agentSlug !== resolveRouteAgentId(agentSlug, agents)) {
     return (
       <div className="flex-1 flex items-center justify-center text-muted-foreground">
         <Loader2 className="h-4 w-4 animate-spin mr-2" />

--- a/src/renderer/components/connections/connection-agents-list.tsx
+++ b/src/renderer/components/connections/connection-agents-list.tsx
@@ -151,7 +151,7 @@ export function ConnectionAgentsList({ type, id, name, sectioned = false }: Conn
       >
         <div className="min-w-0 flex-1">
           <div className="text-xs font-medium truncate">{agent.name}</div>
-          <div className="text-[11px] text-muted-foreground truncate">{agent.slug}</div>
+          <div className="text-[11px] text-muted-foreground truncate">{agent.displaySlug}</div>
         </div>
         {pending ? (
           <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />

--- a/src/renderer/components/home/home-page.test.tsx
+++ b/src/renderer/components/home/home-page.test.tsx
@@ -93,6 +93,7 @@ import { HomePage } from './home-page'
 function makeAgent(overrides = {}) {
   return {
     slug: 'test-agent',
+    displaySlug: 'test-agent',
     name: 'Test Agent',
     description: 'A test description',
     createdAt: new Date('2026-01-01'),

--- a/src/renderer/components/home/home-page.tsx
+++ b/src/renderer/components/home/home-page.tsx
@@ -153,7 +153,7 @@ function AgentCard({ agent, dailyUsage }: { agent: ApiAgent; dailyUsage?: DailyU
       <AgentContextMenu agent={agent}>
         <AppLink
           to="/agents/$slug"
-          params={{ slug: agent.slug }}
+          params={{ slug: agent.displaySlug }}
           className="relative text-left p-4 rounded-lg border bg-card hover:border-accent-foreground/20 transition-colors flex flex-col gap-3 z-10 h-24 overflow-hidden"
         >
           {/* Spark chart background */}
@@ -263,7 +263,7 @@ function AgentCard({ agent, dailyUsage }: { agent: ApiAgent; dailyUsage?: DailyU
         >
           <AppLink
             to="/agents/$slug"
-            params={{ slug: agent.slug }}
+            params={{ slug: agent.displaySlug }}
             className="w-full flex items-center gap-2 px-3 py-1.5 pt-3 text-left text-xs border rounded-b-lg transition-colors hover:brightness-95 bg-blue-50 border-blue-200 dark:bg-blue-950 dark:border-blue-800"
           >
             <span className="h-2 w-2 shrink-0 rounded-full bg-blue-500" />

--- a/src/renderer/components/layout/agent-header.tsx
+++ b/src/renderer/components/layout/agent-header.tsx
@@ -129,7 +129,7 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
             </div>
           )
         })()}
-        {sessionId && session?.agentSlug === slug && (
+        {sessionId && session?.agentSlug === agent?.slug && (
           <div className="flex items-center gap-1.5 min-w-0">
             <span aria-hidden="true" className="text-sm font-light text-muted-foreground shrink-0 hidden md:block">/</span>
             <SessionContextMenu
@@ -164,7 +164,7 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
         {!isViewOnly && (
           <>
             <Separator orientation="vertical" className="h-5 hidden md:block ml-2" />
-            <div className="hidden md:flex items-center gap-2">
+            <div className="hidden md:flex items-center gap-2" data-testid="agent-power-controls">
               {agent?.status === 'running' ? (
                 <TooltipProvider delayDuration={0}>
                   <Tooltip>

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -31,6 +31,14 @@ const mockUseAgents = vi.fn()
 vi.mock('@renderer/hooks/use-agents', () => ({
   useAgents: () => mockUseAgents(),
   useDeleteAgent: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  // Resolve the route param to the canonical id the way the real hook does,
+  // using the mocked params + agents so active-state tests behave faithfully.
+  useRouteAgentId: () => {
+    const slug = mockRouteParams.slug
+    if (!slug) return undefined
+    const agents = mockUseAgents()?.data as Array<{ slug: string; displaySlug: string }> | undefined
+    return agents?.find((a) => a.slug === slug || a.displaySlug === slug)?.slug ?? slug
+  },
 }))
 
 const mockCreateUntitledAgent = vi.fn()
@@ -278,6 +286,7 @@ vi.mock('@dnd-kit/modifiers', () => ({
 function makeAgent(overrides: Record<string, any> = {}) {
   return {
     slug: 'test-agent',
+    displaySlug: 'test-agent',
     name: 'Test Agent',
     status: 'running',
     containerPort: 3000,

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -38,7 +38,7 @@ import {
   RuntimePullingSidebarBanner,
   SidebarBannerStack,
 } from '@renderer/components/runtime/runtime-status-banners'
-import { useAgents, type ApiAgent } from '@renderer/hooks/use-agents'
+import { useAgents, useRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
 import { useSessions, type ApiSession } from '@renderer/hooks/use-sessions'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useSettings } from '@renderer/hooks/use-settings'
@@ -128,8 +128,9 @@ function SessionSubItem({
   // Active state is route-derived (URL is authoritative, read from useParams) so
   // the highlight + the stream subscription are correct on a cold reload, with no
   // in-memory selection state to wait on.
-  const { slug: routeSlug, sessionId: routeSessionId } = useParams({ strict: false }) as { slug?: string; sessionId?: string }
-  const isSelected = routeSlug === agentSlug && routeSessionId === session.id
+  const { sessionId: routeSessionId } = useParams({ strict: false }) as { sessionId?: string }
+  const routeAgentId = useRouteAgentId()
+  const isSelected = routeAgentId === agentSlug && routeSessionId === session.id
   const { isStreaming } = useMessageStream(isSelected ? session.id : null, isSelected ? agentSlug : null)
   const isWorking = (session.isActive || isStreaming) && !session.isAwaitingInput
   const isAwaitingInput = session.isAwaitingInput
@@ -179,9 +180,10 @@ function ChatIntegrationSubItem({
 }) {
   const { data: sessions } = useChatIntegrationSessions(integration.id)
   // Route-derived active state (URL-authoritative; correct on cold reload).
-  const { slug: routeSlug, integrationId: routeIntegrationId } = useParams({ strict: false }) as { slug?: string; integrationId?: string }
+  const { integrationId: routeIntegrationId } = useParams({ strict: false }) as { integrationId?: string }
+  const routeAgentId = useRouteAgentId()
   const chatSearch = useRouteSearch({ strict: false }) as { session?: unknown }
-  const viewingThisIntegration = routeSlug === agentSlug && routeIntegrationId === integration.id
+  const viewingThisIntegration = routeAgentId === agentSlug && routeIntegrationId === integration.id
   const selectedChatSessionId = viewingThisIntegration && typeof chatSearch.session === 'string' ? chatSearch.session : null
   const isSelected = viewingThisIntegration && !selectedChatSessionId
   const hasSelectedSession = viewingThisIntegration && selectedChatSessionId != null
@@ -330,8 +332,9 @@ function DashboardSubItem({
   artifact: ArtifactInfo
   agentSlug: string
 }) {
-  const { slug: routeSlug, dashSlug: routeDashSlug } = useParams({ strict: false }) as { slug?: string; dashSlug?: string }
-  const isSelected = routeSlug === agentSlug && routeDashSlug === artifact.slug
+  const { dashSlug: routeDashSlug } = useParams({ strict: false }) as { dashSlug?: string }
+  const routeAgentId = useRouteAgentId()
+  const isSelected = routeAgentId === agentSlug && routeDashSlug === artifact.slug
   const [isRenaming, setIsRenaming] = useState(false)
 
   const handleDoubleClick = () => {
@@ -502,8 +505,8 @@ export const AgentMenuItem = React.forwardRef<
   // Route-derived selection (URL is authoritative — correct on a cold reload,
   // and inherently false on the global notifications/home views since they carry
   // no slug). Drives the highlight AND the submenu auto-expand below.
-  const { slug: routeSlug } = useParams({ strict: false }) as { slug?: string }
-  const isSelected = agent.slug === routeSlug
+  const routeAgentId = useRouteAgentId()
+  const isSelected = agent.slug === routeAgentId
   // Auto-expand on selection only if the agent has content to show. Brand-new
   // agents (no sessions / dashboards / chat integrations yet) start collapsed
   // — the empty submenu would just be visual noise.
@@ -597,7 +600,7 @@ export const AgentMenuItem = React.forwardRef<
               className="justify-between pl-7"
               data-testid={`agent-item-${agent.slug}`}
             >
-              <AppLink to="/agents/$slug" params={{ slug: agent.slug }}>
+              <AppLink to="/agents/$slug" params={{ slug: agent.displaySlug }}>
                 <span className="flex items-center gap-1.5 min-w-0">
                   <span className="truncate text-[13px] font-normal text-sidebar-foreground">{agent.name}</span>
                   {isShared && <Users className="h-3 w-3 shrink-0 text-muted-foreground" />}

--- a/src/renderer/components/messages/remote-mcp-request-item.tsx
+++ b/src/renderer/components/messages/remote-mcp-request-item.tsx
@@ -386,7 +386,9 @@ export function RemoteMcpRequestItem({
       }
 
       setStatus('provided')
-      queryClient.invalidateQueries({ queryKey: ['agent-remote-mcps', agentSlug] })
+      // Bare prefix: agentSlug here is the session's display-slug route form, but the
+      // agent-home Connections card keys on the canonical id — a targeted key misses it.
+      queryClient.invalidateQueries({ queryKey: ['agent-remote-mcps'] })
       onComplete()
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to provide MCP access')

--- a/src/renderer/components/messages/tool-renderers/deliver-session.tsx
+++ b/src/renderer/components/messages/tool-renderers/deliver-session.tsx
@@ -1,7 +1,7 @@
 import { ArrowDownToLine, ArrowRight, MessageSquare } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { useNavigate } from '@tanstack/react-router'
-import { useAgents } from '@renderer/hooks/use-agents'
+import { useAgents, resolveRouteAgentId } from '@renderer/hooks/use-agents'
 import { useSession } from '@renderer/hooks/use-sessions'
 import type { ToolRenderer, ToolRendererProps, StreamingToolRendererProps, CollapsedContentProps } from './types'
 import { deliverSessionDef, shortSessionId, type DeliverSessionInput } from '@shared/lib/tool-definitions/deliver-session'
@@ -9,7 +9,11 @@ import { deliverSessionDef, shortSessionId, type DeliverSessionInput } from '@sh
 function useAgentName(slug: string | undefined): string | undefined {
   const { data: agents } = useAgents()
   if (!slug) return undefined
-  return agents?.find((a) => a.slug === slug)?.name ?? slug
+  // `slug` arrives as the x-agent display slug (model-facing) or the route slug —
+  // resolve to the canonical id before matching, else the name falls back to the
+  // raw slug string. `agent.slug` is the id, so compare against the resolved id.
+  const id = resolveRouteAgentId(slug, agents)
+  return agents?.find((a) => a.slug === id)?.name ?? slug
 }
 
 // Resolve session name via the same query the rest of the app uses.

--- a/src/renderer/components/scheduled-tasks/scheduled-task-view.test.tsx
+++ b/src/renderer/components/scheduled-tasks/scheduled-task-view.test.tsx
@@ -9,6 +9,8 @@ const mockUpdateScheduledTaskName = vi.fn()
 const mockCancelScheduledTask = vi.fn()
 let mockCanUseAgent = true
 let mockTask: ApiScheduledTask
+let mockAgents: Array<{ slug: string; displaySlug: string; name: string }>
+const mockNavigate = vi.fn()
 
 vi.mock('@renderer/context/selection-context', () => ({
   useSelection: () => ({
@@ -26,6 +28,17 @@ vi.mock('@renderer/context/user-context', () => ({
   }),
   UserProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
+
+vi.mock('@renderer/hooks/use-agents', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/hooks/use-agents')>()
+  // Keep the real resolveRouteAgentId; only stub the agents list it reads.
+  return { ...actual, useAgents: () => ({ data: mockAgents }) }
+})
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
 
 vi.mock('@renderer/hooks/use-humanized-cron', () => ({
   useHumanizedCron: () => 'Every day at 9:00 AM',
@@ -108,6 +121,7 @@ describe('ScheduledTaskView', () => {
     vi.clearAllMocks()
     mockTask = createTask()
     mockCanUseAgent = true
+    mockAgents = [{ slug: 'agent-one', displaySlug: 'agent-one', name: 'Agent One' }]
     mockUpdateScheduledTaskName.mockResolvedValue(createTask({ name: 'Weekly report' }))
   })
 
@@ -139,5 +153,37 @@ describe('ScheduledTaskView', () => {
 
     expect(screen.queryByText('Rename Cron')).not.toBeInTheDocument()
     expect(screen.getByText('Edit Schedule')).toBeInTheDocument()
+  })
+
+  it('does not redirect when viewing the task via the agent display slug', async () => {
+    // Regression: the route param is the display slug while task.agentSlug is the
+    // canonical id, so a raw `!==` would fire a spurious redirect on the correct
+    // agent (downgrading the pretty URL to a bare id).
+    mockTask = createTask({ agentSlug: 'abc1234567' })
+    mockAgents = [{ slug: 'abc1234567', displaySlug: 'daily-report-abc1234567', name: 'Daily Report' }]
+
+    renderWithProviders(<ScheduledTaskView taskId="task-1" agentSlug="daily-report-abc1234567" />)
+
+    await screen.findByTestId('scheduled-task-title')
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it("redirects to the task's true agent when the URL is for a different agent", async () => {
+    mockTask = createTask({ agentSlug: 'abc1234567' })
+    mockAgents = [
+      { slug: 'abc1234567', displaySlug: 'daily-report-abc1234567', name: 'Daily Report' },
+      { slug: 'zzz9999999', displaySlug: 'other-agent-zzz9999999', name: 'Other Agent' },
+    ]
+
+    renderWithProviders(<ScheduledTaskView taskId="task-1" agentSlug="other-agent-zzz9999999" />)
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: '/agents/$slug/tasks/$taskId',
+        // Redirects to the canonical id (same form agent-home uses to open tasks).
+        params: { slug: 'abc1234567', taskId: 'task-1' },
+        replace: true,
+      })
+    })
   })
 })

--- a/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
+++ b/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
@@ -36,6 +36,7 @@ import {
 } from '@renderer/hooks/use-scheduled-tasks'
 import { useNavigate } from '@tanstack/react-router'
 import { useUser } from '@renderer/context/user-context'
+import { useAgents, resolveRouteAgentId } from '@renderer/hooks/use-agents'
 import { useRenderTracker } from '@renderer/lib/perf'
 import {
   AlertDialog,
@@ -79,19 +80,26 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
   const navigate = useNavigate()
   const { canUseAgent } = useUser()
   const canCancel = canUseAgent(agentSlug)
+  const { data: agents } = useAgents()
 
   // Canonicalize: tasks are addressed globally by id, so /agents/<wrong>/tasks/<id>
   // would render this task under the wrong agent's shell (mismatched chrome,
   // back-links, and canUseAgent gating). Redirect to the task's true agent.
+  //
+  // Compare RESOLVED ids: the route param is the display slug (`{name}-{id}`) while
+  // task.agentSlug is the canonical id, so a raw `!==` would fire on every
+  // correct-agent visit. Wait for the agents list before deciding (an unresolved
+  // slug must not trigger a spurious redirect). Redirect to the canonical id — the
+  // same form agent-home uses to open a task (`params.slug = agent.slug`).
   useEffect(() => {
-    if (task && task.agentSlug !== agentSlug) {
-      void navigate({
-        to: '/agents/$slug/tasks/$taskId',
-        params: { slug: task.agentSlug, taskId },
-        replace: true,
-      })
-    }
-  }, [task, agentSlug, taskId, navigate])
+    if (!task || !agents) return
+    if (task.agentSlug === resolveRouteAgentId(agentSlug, agents)) return
+    void navigate({
+      to: '/agents/$slug/tasks/$taskId',
+      params: { slug: task.agentSlug, taskId },
+      replace: true,
+    })
+  }, [task, agents, agentSlug, taskId, navigate])
   const humanizedCron = useHumanizedCron(task?.isRecurring ? task.scheduleExpression : null)
   const isActive = task?.status === 'pending' || task?.status === 'paused'
   const isPaused = task?.status === 'paused'
@@ -229,8 +237,11 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
   }
 
   // Mismatched shell → the effect above is redirecting; don't render B's task
-  // (or its wrong-slug nested fetches) under A's chrome in the meantime.
-  if (task.agentSlug !== agentSlug) {
+  // (or its wrong-slug nested fetches) under A's chrome in the meantime. Resolve
+  // the route slug first (it's the display slug; task.agentSlug is the id) and only
+  // block once the agents list is loaded — otherwise a correct display-slug visit
+  // would render "Loading…" forever (the effect can't redirect away from it).
+  if (agents && task.agentSlug !== resolveRouteAgentId(agentSlug, agents)) {
     return (
       <div className="flex-1 flex items-center justify-center text-muted-foreground">
         Loading scheduled task...

--- a/src/renderer/components/search/filter.test.ts
+++ b/src/renderer/components/search/filter.test.ts
@@ -10,6 +10,7 @@ function agent(
 ): ApiAgent {
   return {
     slug,
+    displaySlug: slug,
     name,
     createdAt: new Date(0),
     status: 'stopped',

--- a/src/renderer/components/webhook-triggers/webhook-trigger-view.tsx
+++ b/src/renderer/components/webhook-triggers/webhook-trigger-view.tsx
@@ -20,6 +20,7 @@ import {
   useUpdateWebhookTriggerRuntimeOptions,
 } from '@renderer/hooks/use-webhook-triggers'
 import { useNavigate } from '@tanstack/react-router'
+import { useAgents, resolveRouteAgentId } from '@renderer/hooks/use-agents'
 import { useUser } from '@renderer/context/user-context'
 import { useSettings } from '@renderer/hooks/use-settings'
 import { usePlatformAuthStatus } from '@renderer/hooks/use-platform-auth'
@@ -59,19 +60,25 @@ export function WebhookTriggerView({ triggerId, agentSlug }: WebhookTriggerViewP
   const { data: settings } = useSettings()
   const { data: platformAuth } = usePlatformAuthStatus()
   const canCancel = canUseAgent(agentSlug)
+  const { data: agents } = useAgents()
 
   // Canonicalize: triggers are addressed globally by id, so /agents/<wrong>/webhooks/<id>
   // would render this trigger under the wrong agent's shell (mismatched chrome,
   // back-links, and canUseAgent gating). Redirect to the trigger's true agent.
+  //
+  // Compare RESOLVED ids: the route param may be the display slug ({name}-{id})
+  // while trigger.agentSlug is the canonical id, so a raw `!==` would fire on every
+  // correct-agent visit. Wait for the agents list, then redirect to the canonical
+  // id (the same form agent-home uses to open a webhook).
   useEffect(() => {
-    if (trigger && trigger.agentSlug !== agentSlug) {
-      void navigate({
-        to: '/agents/$slug/webhooks/$webhookId',
-        params: { slug: trigger.agentSlug, webhookId: triggerId },
-        replace: true,
-      })
-    }
-  }, [trigger, agentSlug, triggerId, navigate])
+    if (!trigger || !agents) return
+    if (trigger.agentSlug === resolveRouteAgentId(agentSlug, agents)) return
+    void navigate({
+      to: '/agents/$slug/webhooks/$webhookId',
+      params: { slug: trigger.agentSlug, webhookId: triggerId },
+      replace: true,
+    })
+  }, [trigger, agents, agentSlug, triggerId, navigate])
 
   const isActive = trigger?.status === 'active' || trigger?.status === 'paused'
   const isPaused = trigger?.status === 'paused'
@@ -136,8 +143,9 @@ export function WebhookTriggerView({ triggerId, agentSlug }: WebhookTriggerViewP
   }
 
   // Mismatched shell → the effect above is redirecting; don't render B's trigger
-  // (or its wrong-slug nested fetches) under A's chrome in the meantime.
-  if (trigger.agentSlug !== agentSlug) {
+  // (or its wrong-slug nested fetches) under A's chrome in the meantime. Resolve
+  // first and only block once the agents list is loaded (see the effect).
+  if (agents && trigger.agentSlug !== resolveRouteAgentId(agentSlug, agents)) {
     return (
       <div className="flex-1 flex items-center justify-center text-muted-foreground">
         Loading webhook trigger...

--- a/src/renderer/context/user-context.tsx
+++ b/src/renderer/context/user-context.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useCallback, useEffect, useMemo, useRef, typ
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useSession, signOut as authSignOut } from '@renderer/lib/auth-client'
 import { apiFetch, clearRedirectStash } from '@renderer/lib/api'
+import { useAgents, resolveRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
 import type { AgentRole } from '@shared/lib/types/agent'
 
 interface AgentRoleInfo {
@@ -63,6 +64,25 @@ function useAuthSession() {
   return { data: null, isPending: false } as ReturnType<typeof useSession>
 }
 
+// The agents list is consulted only to resolve a display slug → canonical id for
+// the role lookups below, which short-circuit when auth is off — so only subscribe
+// in auth mode (same compile-time gate as useAuthSession). Outside auth mode this
+// avoids a wasted /api/agents fetch on every UserProvider mount.
+//
+// Project to just {slug, displaySlug} — all the resolver reads. React Query
+// structurally shares the `select` result, so this reference stays STABLE across the
+// frequent status-only `['agents']` refetches (every session state change invalidates
+// that query). Subscribing to the full list here would re-run the role callbacks and
+// re-render every `useUser()` consumer on each status tick.
+const selectAgentIndex = (agents: ApiAgent[]): Pick<ApiAgent, 'slug' | 'displaySlug'>[] =>
+  agents.map(({ slug, displaySlug }) => ({ slug, displaySlug }))
+
+function useResolverAgents(): { data: Pick<ApiAgent, 'slug' | 'displaySlug'>[] | undefined } {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  if (__AUTH_MODE__) return useAgents({ select: selectAgentIndex })
+  return { data: undefined }
+}
+
 export function UserProvider({ children }: { children: ReactNode }) {
   // Better Auth session (only active in auth mode)
   const session = useAuthSession()
@@ -100,20 +120,27 @@ export function UserProvider({ children }: { children: ReactNode }) {
   const { data: agentRoles, isFetched: rolesFetched } = useAgentRoles(isAuthenticated)
   const rolesReady = !isAuthMode || !isAuthenticated || rolesFetched
 
+  // `agentRoles` is keyed by the canonical agent id, but callers pass whatever
+  // slug they have on hand — frequently the URL **display slug** (`{name}-{id}`),
+  // which never matches an id-keyed entry. Resolve to the canonical id first so a
+  // route-derived slug doesn't silently read as "no role" (false view-only).
+  const { data: agents } = useResolverAgents()
   const agentRole = useCallback(
     (agentSlug: string): AgentRole | null => {
       if (!isAuthMode) return null
-      return agentRoles?.[agentSlug]?.role ?? null
+      const id = resolveRouteAgentId(agentSlug, agents) ?? agentSlug
+      return agentRoles?.[id]?.role ?? null
     },
-    [agentRoles],
+    [agentRoles, agents],
   )
 
   const agentMemberCount = useCallback(
     (agentSlug: string): number => {
       if (!isAuthMode) return 0
-      return agentRoles?.[agentSlug]?.memberCount ?? 0
+      const id = resolveRouteAgentId(agentSlug, agents) ?? agentSlug
+      return agentRoles?.[id]?.memberCount ?? 0
     },
-    [agentRoles],
+    [agentRoles, agents],
   )
 
   const canAccessAgent = useCallback(

--- a/src/renderer/hooks/query-options.ts
+++ b/src/renderer/hooks/query-options.ts
@@ -10,6 +10,11 @@ import { apiJson } from '@renderer/lib/api'
  *   - agent:   `['agents', slug]`            (use-agents.ts `useAgent`)
  *   - session: `['session', id, agentSlug]`  (use-sessions.ts `useSession`)
  *
+ * NOTE: `useSession` resolves `agentSlug` to the canonical agent id before keying
+ * (a display slug and the bare id must share one entry). `sessionQuery` below is
+ * currently unused by any loader; a future session loader must resolve the slug
+ * the same way (via the cached agents list) to land on `useSession`'s entry.
+ *
  * The loader uses `apiJson` (throws `HttpError`) rather than the hooks' own
  * `apiFetch` queryFn so a 403/404 surfaces as a throw the loader can map to
  * `notFound()`. Both queryFns hit the same endpoint and shape, so they coexist

--- a/src/renderer/hooks/use-agents.test.ts
+++ b/src/renderer/hooks/use-agents.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import type { ApiAgent } from '@shared/lib/types/api'
+import { resolveRouteAgentId } from './use-agents'
+
+// Minimal agent factory — only the id/displaySlug fields the resolver reads.
+function agent(slug: string, displaySlug: string): ApiAgent {
+  return { slug, displaySlug, name: displaySlug, createdAt: new Date(), status: 'stopped', containerPort: null }
+}
+
+describe('resolveRouteAgentId', () => {
+  const ID = 'abcd123456' // 10-char minted id
+  const renamed = agent(ID, `greeting-assistant-${ID}`)
+
+  it('resolves the bare id', () => {
+    expect(resolveRouteAgentId(ID, [renamed])).toBe(ID)
+  })
+
+  it('resolves the current display slug', () => {
+    expect(resolveRouteAgentId(`greeting-assistant-${ID}`, [renamed])).toBe(ID)
+  })
+
+  it('resolves a STALE display slug after an auto-rename (the deselect bug)', () => {
+    // URL still says untitled-{id} from creation; agent is now greeting-assistant-{id}.
+    expect(resolveRouteAgentId(`untitled-${ID}`, [renamed])).toBe(ID)
+  })
+
+  it('resolves a wrong-prefix slug (prefix is decorative)', () => {
+    expect(resolveRouteAgentId(`literally-anything-${ID}`, [renamed])).toBe(ID)
+  })
+
+  it('resolves a legacy compound folder id exactly', () => {
+    const legacy = agent('untitled-h45k3n', 'untitled-h45k3n')
+    expect(resolveRouteAgentId('untitled-h45k3n', [legacy])).toBe('untitled-h45k3n')
+  })
+
+  it('picks the right agent when several are loaded', () => {
+    const other = agent('zzzz999999', 'other-zzzz999999')
+    expect(resolveRouteAgentId(`untitled-${ID}`, [other, renamed])).toBe(ID)
+  })
+
+  it('falls back to the raw slug when nothing matches', () => {
+    expect(resolveRouteAgentId('unknown-9999999999', [renamed])).toBe('unknown-9999999999')
+  })
+
+  it('falls back to the raw slug while the agents list is still loading', () => {
+    expect(resolveRouteAgentId(`untitled-${ID}`, undefined)).toBe(`untitled-${ID}`)
+  })
+
+  it('returns undefined for no slug', () => {
+    expect(resolveRouteAgentId(undefined, [renamed])).toBeUndefined()
+  })
+})

--- a/src/renderer/hooks/use-agents.ts
+++ b/src/renderer/hooks/use-agents.ts
@@ -98,8 +98,13 @@ export function useCreateAgent() {
       // Seed the per-slug cache so consumers reading useAgent(slug) right
       // after navigation (e.g. AgentHome via MainContent) render synchronously
       // instead of flashing through an undefined state while the list query
-      // refetches.
+      // refetches. Create flows navigate to agent.displaySlug, so the loader /
+      // useAgent read keys on THAT form — seed it too, or the canonical-id seed
+      // is a dead entry and the loader does a cold blocking fetch.
       queryClient.setQueryData(['agents', agent.slug], agent)
+      if (agent.displaySlug !== agent.slug) {
+        queryClient.setQueryData(['agents', agent.displaySlug], agent)
+      }
       queryClient.invalidateQueries({ queryKey: ['agents'] })
       queryClient.invalidateQueries({ queryKey: ['my-agent-roles'] })
     },

--- a/src/renderer/hooks/use-agents.ts
+++ b/src/renderer/hooks/use-agents.ts
@@ -1,19 +1,66 @@
 import { apiFetch } from '@renderer/lib/api'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useParams } from '@tanstack/react-router'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import type { ApiAgent } from '@shared/lib/types/api'
 
 // Re-export for convenience
 export type { ApiAgent }
 
-export function useAgents() {
-  return useQuery<ApiAgent[]>({
+// Mirrors the host's minted-id shape ([a-z0-9]{10}). Kept local because the
+// shared file-storage module pulls in `fs` and can't be imported in the renderer.
+const MINTED_AGENT_ID_RE = /^[a-z0-9]{10}$/
+
+/**
+ * Resolve an agent route param — which may be a display slug (`{name}-{id}`), a
+ * bare id, or a legacy folder id — to the canonical agent id, using the loaded
+ * agents list. The URL carries the decorative display slug, but every in-app
+ * comparison keys on the stable id, so route-derived active/selection state must
+ * be resolved through here rather than comparing the raw param to `agent.slug`.
+ *
+ * Matches on the trailing minted id (not just the exact current displaySlug) so
+ * selection stays stable when the URL slug goes stale — e.g. a brand-new agent
+ * navigated to as `untitled-{id}` and then auto-renamed to `{name}-{id}` (the URL
+ * isn't canonicalized). Mirrors the host `resolveAgentId`. Falls back to the raw
+ * input when the list isn't ready or nothing matches.
+ */
+export function resolveRouteAgentId(
+  slug: string | undefined,
+  agents: Pick<ApiAgent, 'slug' | 'displaySlug'>[] | undefined,
+): string | undefined {
+  if (!slug) return undefined
+  const dash = slug.lastIndexOf('-')
+  const tail = dash === -1 ? slug : slug.slice(dash + 1)
+  const trailingId = MINTED_AGENT_ID_RE.test(tail) ? tail : undefined
+  const match = agents?.find(
+    (a) => a.slug === slug || a.displaySlug === slug || a.slug === trailingId,
+  )
+  return match?.slug ?? slug
+}
+
+/** Hook form of {@link resolveRouteAgentId}, reading the active `:slug` route param. */
+export function useRouteAgentId(): string | undefined {
+  const { slug } = useParams({ strict: false }) as { slug?: string }
+  const { data: agents } = useAgents()
+  return resolveRouteAgentId(slug, agents)
+}
+
+export function useAgents<TData = ApiAgent[]>(options?: {
+  select?: (agents: ApiAgent[]) => TData
+}) {
+  return useQuery<ApiAgent[], Error, TData>({
     queryKey: ['agents'],
     queryFn: async () => {
       const res = await apiFetch('/api/agents')
       if (!res.ok) throw new Error('Failed to fetch agents')
       return res.json()
     },
+    // React Query structurally shares the `select` result, so a narrow projection
+    // (e.g. just {slug, displaySlug} for UserProvider's slug→id resolver) keeps a
+    // STABLE reference across the frequent status-only `['agents']` refetches. Without
+    // it, every agent-status tick would change `data` identity and re-render every
+    // consumer of that projection.
+    select: options?.select,
     // Real-time updates via GlobalNotificationHandler, poll as fallback only
     refetchInterval: 60000,
   })

--- a/src/renderer/hooks/use-connected-accounts.ts
+++ b/src/renderer/hooks/use-connected-accounts.ts
@@ -179,8 +179,11 @@ export function useAssignAccountsToAgent() {
         throw new Error(error.error || 'Failed to assign accounts to agent')
       }
     },
-    onSuccess: (_, { agentSlug, accountIds }) => {
-      queryClient.invalidateQueries({ queryKey: ['agent-connected-accounts', agentSlug] })
+    onSuccess: (_, { accountIds }) => {
+      // Bare prefix (not keyed on agentSlug): the agent-home Connections card keys
+      // on the canonical id, but this mutation fires from the display-slug route, so
+      // a targeted key would miss it. Matches the delete/rename mutations above.
+      queryClient.invalidateQueries({ queryKey: ['agent-connected-accounts'] })
       queryClient.invalidateQueries({ queryKey: ['connected-accounts'] })
       for (const id of accountIds) {
         queryClient.invalidateQueries({ queryKey: ['account-agents', id] })
@@ -203,8 +206,9 @@ export function useRemoveAgentConnectedAccount() {
       })
       if (!res.ok) throw new Error('Failed to remove account from agent')
     },
-    onSuccess: (_, { agentSlug, accountId }) => {
-      queryClient.invalidateQueries({ queryKey: ['agent-connected-accounts', agentSlug] })
+    onSuccess: (_, { accountId }) => {
+      // Bare prefix — see useAssignAccountsToAgent: reaches the id-keyed home card too.
+      queryClient.invalidateQueries({ queryKey: ['agent-connected-accounts'] })
       queryClient.invalidateQueries({ queryKey: ['connected-accounts'] })
       queryClient.invalidateQueries({ queryKey: ['account-agents', accountId] })
     },

--- a/src/renderer/hooks/use-create-untitled-agent.ts
+++ b/src/renderer/hooks/use-create-untitled-agent.ts
@@ -20,8 +20,10 @@ export function useCreateUntitledAgent() {
       const agent = await createAgent.mutateAsync({ name: UNTITLED_AGENT_NAME })
       track('agent_created', { source: 'new', num_skills_added_at_creation: 0 })
 
+      // Morph tag keys on the canonical id (AgentHome compares against agent.slug);
+      // navigate with the pretty display slug so the URL reflects the name.
       setJustCreatedSlug(agent.slug)
-      void navigate({ to: '/agents/$slug', params: { slug: agent.slug } })
+      void navigate({ to: '/agents/$slug', params: { slug: agent.displaySlug } })
 
       return agent
     } catch (error) {

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -107,6 +107,23 @@ describe('useMessageStream', () => {
     expect(MockEventSource.instances[0].url).toBe('/api/agents/agent-1/sessions/session-1/stream')
   })
 
+  it('shares ONE EventSource when the same session is subscribed with different agent-slug forms', async () => {
+    // The sidebar subscribes with the canonical agent id while the session view
+    // uses the URL display slug — both for the same session. Keying the singleton
+    // by sessionId keeps it to one connection; otherwise both streams write the
+    // same session state and the assistant response renders doubled.
+    const { useMessageStream } = await getHookModule()
+    renderHook(
+      () => {
+        useMessageStream('session-1', 'greeting-assistant-abcd123456') // session view: display slug
+        useMessageStream('session-1', 'abcd123456') // sidebar: canonical id
+      },
+      { wrapper: createWrapper() }
+    )
+
+    expect(MockEventSource.instances).toHaveLength(1)
+  })
+
   it('handles connected event', async () => {
     const { useMessageStream } = await getHookModule()
     const { result } = renderHook(

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -267,7 +267,13 @@ function getOrCreateEventSource(
   agentSlug: string,
   queryClient: QueryClient
 ): EventSource {
-  const key = `${agentSlug}:${sessionId}`
+  // Key the singleton by sessionId alone: a session id is globally unique and
+  // belongs to exactly one agent, so subscribers that pass different slug forms
+  // for the same session (the sidebar uses the canonical id; the session view
+  // uses the URL display slug) must still share ONE EventSource — otherwise both
+  // streams write the same session state and the response renders doubled.
+  // agentSlug is only used to build the URL below (the host resolves any form).
+  const key = sessionId
   let es = eventSources.get(key)
   if (es && es.readyState !== EventSource.CLOSED) {
     // Increment ref count
@@ -1170,8 +1176,8 @@ function getOrCreateEventSource(
   return es
 }
 
-function releaseEventSource(sessionId: string, agentSlug: string): void {
-  const key = `${agentSlug}:${sessionId}`
+function releaseEventSource(sessionId: string): void {
+  const key = sessionId
   const count = (refCounts.get(key) || 1) - 1
   refCounts.set(key, count)
 
@@ -1416,7 +1422,7 @@ export function useMessageStream(sessionId: string | null, agentSlug: string | n
       if (listeners?.size === 0) {
         streamListeners.delete(sessionId)
       }
-      releaseEventSource(sessionId, agentSlug)
+      releaseEventSource(sessionId)
     }
   }, [sessionId, agentSlug, updateState, queryClient])
 

--- a/src/renderer/hooks/use-mount-warnings.test.tsx
+++ b/src/renderer/hooks/use-mount-warnings.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useMountWarnings, setMountWarning } from './use-mount-warnings'
+
+// useMountWarnings resolves the route (display) slug to the canonical id via the
+// agents list before keying its query; stub the list so the resolver maps
+// `my-agent-abc1234567` (display) -> `abc1234567` (canonical). The real
+// resolveRouteAgentId is kept.
+vi.mock('@renderer/hooks/use-agents', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/hooks/use-agents')>()
+  return {
+    ...actual,
+    useAgents: () => ({ data: [{ slug: 'abc1234567', displaySlug: 'my-agent-abc1234567', name: 'My Agent' }] }),
+  }
+})
+
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useMountWarnings', () => {
+  it('surfaces a warning written under the canonical id when subscribed via the display slug', () => {
+    const client = new QueryClient()
+    // The SSE handler writes under the canonical id (data.agentSlug).
+    setMountWarning(client, {
+      agentSlug: 'abc1234567',
+      missingMounts: [{ folderName: 'data', hostPath: '/host/data' }],
+    })
+
+    // The banner subscribes with the route DISPLAY slug — it must still see it.
+    const { result } = renderHook(() => useMountWarnings('my-agent-abc1234567'), {
+      wrapper: makeWrapper(client),
+    })
+
+    expect(result.current.warning?.missingMounts[0]?.folderName).toBe('data')
+  })
+
+  it('dismiss clears the canonical-id entry', () => {
+    const client = new QueryClient()
+    setMountWarning(client, {
+      agentSlug: 'abc1234567',
+      missingMounts: [{ folderName: 'data', hostPath: '/host/data' }],
+    })
+
+    const { result } = renderHook(() => useMountWarnings('my-agent-abc1234567'), {
+      wrapper: makeWrapper(client),
+    })
+    expect(result.current.warning).not.toBeNull()
+
+    // dismiss must clear the CANONICAL-id entry (what the SSE handler wrote), not a
+    // display-slug-keyed one — assert the cache directly to avoid the async observer
+    // re-render under act().
+    act(() => result.current.dismiss())
+    expect(client.getQueryData(['mount-warnings', 'abc1234567'])).toBeNull()
+  })
+})

--- a/src/renderer/hooks/use-mount-warnings.ts
+++ b/src/renderer/hooks/use-mount-warnings.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { useQueryClient, useQuery } from '@tanstack/react-query'
+import { useAgents, resolveRouteAgentId } from '@renderer/hooks/use-agents'
 
 interface MountWarning {
   agentSlug: string
@@ -13,18 +14,25 @@ const QUERY_KEY_PREFIX = 'mount-warnings'
 export function useMountWarnings(agentSlug: string | null) {
   const queryClient = useQueryClient()
 
+  // The caller passes the route param (a display slug), but the SSE handler writes
+  // warnings under the canonical id (setMountWarning ← data.agentSlug). Resolve so
+  // the subscription keys on the same id — otherwise the missing-mount banner
+  // silently never shows on a pretty display-slug route.
+  const { data: agents } = useAgents()
+  const resolvedSlug = agentSlug ? resolveRouteAgentId(agentSlug, agents) ?? agentSlug : null
+
   const { data: warning } = useQuery<MountWarning | null>({
-    queryKey: [QUERY_KEY_PREFIX, agentSlug],
+    queryKey: [QUERY_KEY_PREFIX, resolvedSlug],
     queryFn: () => null,
     enabled: false, // Never fetches — data is set manually from SSE
     staleTime: Infinity,
   })
 
   const dismiss = useCallback(() => {
-    if (agentSlug) {
-      queryClient.setQueryData([QUERY_KEY_PREFIX, agentSlug], null)
+    if (resolvedSlug) {
+      queryClient.setQueryData([QUERY_KEY_PREFIX, resolvedSlug], null)
     }
-  }, [queryClient, agentSlug])
+  }, [queryClient, resolvedSlug])
 
   return { warning: warning ?? null, dismiss }
 }

--- a/src/renderer/hooks/use-mounts.ts
+++ b/src/renderer/hooks/use-mounts.ts
@@ -38,8 +38,11 @@ export function useAddMount() {
       if (!res.ok) throw new Error(await parseErrorMessage(res, 'Failed to add mount'))
       return res.json() as Promise<AgentMount>
     },
-    onSuccess: (_, { agentSlug }) => {
-      queryClient.invalidateQueries({ queryKey: ['mounts', agentSlug] })
+    onSuccess: () => {
+      // Bare prefix (not keyed on agentSlug): the agent-home Volumes card keys on the
+      // canonical id, but this mutation can fire from the session composer's
+      // display-slug route, so a targeted key would miss it.
+      queryClient.invalidateQueries({ queryKey: ['mounts'] })
     },
   })
 }
@@ -53,8 +56,9 @@ export function useRemoveMount() {
       const res = await apiFetch(url, { method: 'DELETE' })
       if (!res.ok) throw new Error(await parseErrorMessage(res, 'Failed to remove mount'))
     },
-    onSuccess: (_, { agentSlug }) => {
-      queryClient.invalidateQueries({ queryKey: ['mounts', agentSlug] })
+    onSuccess: () => {
+      // Bare prefix — see useAddMount: reaches the id-keyed home Volumes card too.
+      queryClient.invalidateQueries({ queryKey: ['mounts'] })
     },
   })
 }

--- a/src/renderer/hooks/use-proxy-reviews.ts
+++ b/src/renderer/hooks/use-proxy-reviews.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { apiFetch } from '@renderer/lib/api'
+import { useAgents, resolveRouteAgentId } from '@renderer/hooks/use-agents'
 
 export interface PendingReview {
   id: string
@@ -20,10 +21,18 @@ export interface PendingReview {
 }
 
 export function usePendingProxyReviews(agentSlug: string) {
+  // Key on the CANONICAL agent id, not the raw slug. The URL carries the display
+  // slug (`{name}-{id}`) but GlobalNotificationHandler's SSE invalidations target
+  // `['proxy-reviews', <server agentSlug = id>]`. Keyed on the display slug those
+  // invalidations MISS, so a freshly-created review card only surfaces on the 30s
+  // poll (status flips to "needs input" instantly via the agents invalidation,
+  // but the card lags). Resolving collapses both forms onto one id-keyed entry.
+  const { data: agents } = useAgents()
+  const resolvedSlug = resolveRouteAgentId(agentSlug, agents) ?? agentSlug
   return useQuery<{ reviews: PendingReview[] }>({
-    queryKey: ['proxy-reviews', agentSlug],
+    queryKey: ['proxy-reviews', resolvedSlug],
     queryFn: async () => {
-      const res = await apiFetch(`/api/agents/${agentSlug}/proxy-reviews`)
+      const res = await apiFetch(`/api/agents/${resolvedSlug}/proxy-reviews`)
       if (!res.ok) return { reviews: [] }
       return res.json()
     },

--- a/src/renderer/hooks/use-remote-mcps.ts
+++ b/src/renderer/hooks/use-remote-mcps.ts
@@ -152,8 +152,11 @@ export function useAssignMcpToAgent() {
         throw new Error(error.error || 'Failed to assign MCP to agent')
       }
     },
-    onSuccess: (_, { agentSlug, mcpIds }) => {
-      queryClient.invalidateQueries({ queryKey: ['agent-remote-mcps', agentSlug] })
+    onSuccess: (_, { mcpIds }) => {
+      // Bare prefix (not keyed on agentSlug): the agent-home Connections card keys
+      // on the canonical id, but this mutation fires from the display-slug route, so
+      // a targeted key would miss it. Matches the rename/delete mutations above.
+      queryClient.invalidateQueries({ queryKey: ['agent-remote-mcps'] })
       for (const id of mcpIds) {
         queryClient.invalidateQueries({ queryKey: ['mcp-agents', id] })
       }
@@ -178,8 +181,9 @@ export function useRemoveMcpFromAgent() {
         throw new Error(error.error || 'Failed to remove MCP from agent')
       }
     },
-    onSuccess: (_, { agentSlug, mcpId }) => {
-      queryClient.invalidateQueries({ queryKey: ['agent-remote-mcps', agentSlug] })
+    onSuccess: (_, { mcpId }) => {
+      // Bare prefix — see useAssignMcpToAgent: reaches the id-keyed home card too.
+      queryClient.invalidateQueries({ queryKey: ['agent-remote-mcps'] })
       queryClient.invalidateQueries({ queryKey: ['mcp-agents', mcpId] })
     },
   })

--- a/src/renderer/hooks/use-sessions.ts
+++ b/src/renderer/hooks/use-sessions.ts
@@ -1,32 +1,54 @@
 import { apiFetch, apiJson } from '@renderer/lib/api'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
+import { useAgents, resolveRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
 import type { ApiSession } from '@shared/lib/types/api'
 import type { EffortLevel } from '@shared/lib/container/types'
 
 // Re-export for convenience
 export type { ApiSession }
 
+// Session caches are keyed by the CANONICAL agent id so a given agent's sessions
+// land on ONE cache entry — the URL carries the decorative display slug
+// (`{name}-{id}`) while the sidebar, mutations and SSE invalidations all key on
+// the bare id. Resolving every slug form through the loaded agents list before it
+// reaches a query key is what stops the same session list/entry from splitting in
+// two (one stale half that invalidations never reach). `useAgents` is shared
+// (deduped) so this adds no real fetch cost.
+function useResolvedAgentSlug(agentSlug: string | null): string | null {
+  const { data: agents } = useAgents()
+  if (!agentSlug) return null
+  return resolveRouteAgentId(agentSlug, agents) ?? agentSlug
+}
+
+/** One-shot resolution for mutation invalidations, reading the cached agents list. */
+function resolveAgentSlugFromCache(queryClient: QueryClient, agentSlug: string): string {
+  const agents = queryClient.getQueryData<ApiAgent[]>(['agents'])
+  return resolveRouteAgentId(agentSlug, agents) ?? agentSlug
+}
+
 export function useSessions(agentSlug: string | null, options?: { staleTime?: number }) {
+  const resolvedSlug = useResolvedAgentSlug(agentSlug)
   return useQuery<ApiSession[]>({
-    queryKey: ['sessions', agentSlug],
+    queryKey: ['sessions', resolvedSlug],
     queryFn: async () => {
-      const res = await apiFetch(`/api/agents/${agentSlug}/sessions`)
+      const res = await apiFetch(`/api/agents/${resolvedSlug}/sessions`)
       if (!res.ok) throw new Error('Failed to fetch sessions')
       return res.json()
     },
-    enabled: !!agentSlug,
+    enabled: !!resolvedSlug,
     staleTime: options?.staleTime,
   })
 }
 
 export function useSession(id: string | null, agentSlug: string | null = null) {
+  const resolvedSlug = useResolvedAgentSlug(agentSlug)
   return useQuery<ApiSession>({
-    queryKey: ['session', id, agentSlug],
+    queryKey: ['session', id, resolvedSlug],
     // `apiJson` throws `HttpError` carrying the status, so the session leaf can
     // distinguish a 404 (missing session) from a 5xx/network error.
-    queryFn: () => apiJson<ApiSession>(`/api/agents/${agentSlug}/sessions/${id}`),
-    enabled: !!id && !!agentSlug,
+    queryFn: () => apiJson<ApiSession>(`/api/agents/${resolvedSlug}/sessions/${id}`),
+    enabled: !!id && !!resolvedSlug,
     // A 404 here means the session is genuinely missing: the backend's
     // getSession is metadata-authoritative, so a just-created session — which is
     // registered in metadata synchronously as part of the create response — is
@@ -58,7 +80,9 @@ export function useCreateSession() {
     onSuccess: (_, variables) => {
       track('session_created')
       track('message_sent')
-      queryClient.invalidateQueries({ queryKey: ['sessions', variables.agentSlug] })
+      queryClient.invalidateQueries({
+        queryKey: ['sessions', resolveAgentSlugFromCache(queryClient, variables.agentSlug)],
+      })
     },
   })
 }
@@ -73,7 +97,9 @@ export function useDeleteSession() {
       // 204 No Content - no body to parse
     },
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['sessions', variables.agentSlug] })
+      queryClient.invalidateQueries({
+        queryKey: ['sessions', resolveAgentSlugFromCache(queryClient, variables.agentSlug)],
+      })
     },
   })
 }
@@ -92,7 +118,9 @@ export function useUpdateSessionName() {
       return res.json() as Promise<ApiSession>
     },
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['sessions', variables.agentSlug] })
+      queryClient.invalidateQueries({
+        queryKey: ['sessions', resolveAgentSlugFromCache(queryClient, variables.agentSlug)],
+      })
     },
   })
 }

--- a/src/renderer/lib/agent-ordering.test.ts
+++ b/src/renderer/lib/agent-ordering.test.ts
@@ -5,6 +5,7 @@ import type { ApiAgent } from '@renderer/hooks/use-agents'
 function makeAgent(slug: string, createdAt: string): ApiAgent {
   return {
     slug,
+    displaySlug: slug,
     name: slug,
     createdAt: new Date(createdAt),
     status: 'stopped',

--- a/src/shared/lib/services/agent-service.test.ts
+++ b/src/shared/lib/services/agent-service.test.ts
@@ -270,7 +270,9 @@ Instructions`
       const agent = await createAgent({ name: 'New Agent' })
 
       expect(agent.name).toBe('New Agent')
-      expect(agent.slug).toMatch(/^new-agent-[a-z0-9]{6}$/)
+      // Identity is now an opaque minted id; the name lives in the projected displaySlug.
+      expect(agent.slug).toMatch(/^[a-z0-9]{10}$/)
+      expect(agent.displaySlug).toMatch(/^new-agent-[a-z0-9]{10}$/)
       expect(agent.status).toBe('stopped')
       expect(agent.containerPort).toBeNull()
       expect(agent.instructions).toContain('You are a helpful AI assistant')

--- a/src/shared/lib/services/agent-service.ts
+++ b/src/shared/lib/services/agent-service.ts
@@ -18,7 +18,8 @@ import {
   writeFileAtomic,
   parseMarkdownWithFrontmatter,
   serializeMarkdownWithFrontmatter,
-  generateUniqueAgentSlug,
+  generateAgentId,
+  displaySlug,
 } from '@shared/lib/utils/file-storage'
 import {
   AgentFrontmatter,
@@ -48,6 +49,7 @@ function toApiAgent(
   const healthWarnings = containerManager.getHealthWarnings(agent.slug)
   return {
     slug: agent.slug,
+    displaySlug: displaySlug(agent.frontmatter.name, agent.slug),
     name: agent.frontmatter.name,
     description: agent.frontmatter.description,
     instructions: agent.instructions,
@@ -204,8 +206,9 @@ export async function createAgent(input: CreateAgentInput): Promise<ApiAgent> {
   const { name: rawName, description, instructions } = input
   const name = String(rawName)
 
-  // Generate unique slug
-  const slug = await generateUniqueAgentSlug(name)
+  // Mint an opaque id — the name no longer feeds the folder, so the "Untitled"
+  // promptless-create flow can't poison it.
+  const slug = await generateAgentId()
 
   // Create directory structure
   const workspaceDir = getAgentWorkspaceDir(slug)
@@ -228,6 +231,7 @@ export async function createAgent(input: CreateAgentInput): Promise<ApiAgent> {
   // Return in API format (new agents are always stopped)
   return {
     slug,
+    displaySlug: displaySlug(name, slug),
     name,
     description,
     instructions: body,
@@ -276,6 +280,7 @@ export async function updateAgent(
 
   return {
     slug,
+    displaySlug: displaySlug(newFrontmatter.name, slug),
     name: newFrontmatter.name,
     description: newFrontmatter.description,
     instructions: newInstructions,
@@ -347,7 +352,7 @@ export async function deleteAgent(slug: string): Promise<boolean> {
  */
 export async function createAgentFromExistingWorkspace(rawName: string): Promise<ApiAgent> {
   const name = String(rawName)
-  const slug = await generateUniqueAgentSlug(name)
+  const slug = await generateAgentId()
 
   const workspaceDir = getAgentWorkspaceDir(slug)
   await ensureDirectory(workspaceDir)
@@ -365,6 +370,7 @@ export async function createAgentFromExistingWorkspace(rawName: string): Promise
 
   return {
     slug,
+    displaySlug: displaySlug(name, slug),
     name,
     createdAt: new Date(frontmatter.createdAt),
     status: 'stopped',

--- a/src/shared/lib/services/agent-template-service.test.ts
+++ b/src/shared/lib/services/agent-template-service.test.ts
@@ -2097,7 +2097,7 @@ describe('installAgentFromSkillset', () => {
     const installTime = new Date()
     const oldTemplateTime = '2020-01-01T00:00:00.000Z'
 
-    const agent = { slug, name: 'My Agent', createdAt: installTime, status: 'stopped' as const, containerPort: null }
+    const agent = { slug, displaySlug: slug, name: 'My Agent', createdAt: installTime, status: 'stopped' as const, containerPort: null }
     mockCreateAgent.mockResolvedValue(agent)
     mockGetAgentWithStatus.mockResolvedValue(agent)
 

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -16,7 +16,10 @@ import type { SessionUsage } from '@shared/lib/types/agent'
  * Agent response from API - flattened format
  */
 export interface ApiAgent {
+  /** Canonical opaque id — folder name, DB key, URL resolution key. Never changes. */
   slug: string
+  /** Decorative `{slug(name)}-{id}` projection for URLs/links; recomputed from the current name. */
+  displaySlug: string
   name: string
   description?: string
   instructions?: string // Only included in single-agent response

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -1,9 +1,14 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
 import {
-  generateAgentSlug,
+  nameToSlugBase,
+  generateAgentId,
+  displaySlug,
+  resolveAgentId,
+  isMintedAgentId,
+  AGENT_ID_LENGTH,
   parseMarkdownWithFrontmatter,
   serializeMarkdownWithFrontmatter,
   listDirectories,
@@ -47,71 +52,133 @@ afterEach(async () => {
 // Slug Generation Tests
 // ============================================================================
 
-describe('generateAgentSlug', () => {
-  it('converts name to lowercase slug with random suffix', () => {
-    const slug = generateAgentSlug('My Cool Agent')
-    expect(slug).toMatch(/^my-cool-agent-[a-z0-9]{6}$/)
+describe('nameToSlugBase', () => {
+  it('lowercases and hyphenates a name', () => {
+    expect(nameToSlugBase('My Cool Agent')).toBe('my-cool-agent')
   })
 
-  it('replaces special characters with hyphens', () => {
-    const slug = generateAgentSlug('Test @#$ Agent!!!')
-    expect(slug).toMatch(/^test-agent-[a-z0-9]{6}$/)
+  it('collapses runs of special characters to single hyphens and trims edges', () => {
+    expect(nameToSlugBase('Test @#$ Agent!!!')).toBe('test-agent')
+    expect(nameToSlugBase('---Test---')).toBe('test')
+    expect(nameToSlugBase('Tëst Àgènt')).toBe('t-st-g-nt')
   })
 
-  it('removes leading and trailing hyphens', () => {
-    const slug = generateAgentSlug('---Test---')
-    expect(slug).toMatch(/^test-[a-z0-9]{6}$/)
+  it('keeps digits and only ever emits [a-z0-9-]', () => {
+    expect(nameToSlugBase('GPT 4 Bot')).toBe('gpt-4-bot')
+    expect(nameToSlugBase('Agent 007')).toBe('agent-007')
   })
 
-  it('handles empty name', () => {
-    const slug = generateAgentSlug('')
-    expect(slug).toMatch(/^[a-z0-9]{6}$/)
+  it('returns an empty string when nothing alphanumeric survives', () => {
+    expect(nameToSlugBase('')).toBe('')
+    expect(nameToSlugBase('@#$%^&*()')).toBe('')
   })
 
-  it('handles name with only special characters', () => {
-    const slug = generateAgentSlug('@#$%^&*()')
-    expect(slug).toMatch(/^[a-z0-9]{6}$/)
-  })
-
-  it('truncates long names to 50 characters', () => {
-    const longName = 'a'.repeat(100)
-    const slug = generateAgentSlug(longName)
-    // Base should be truncated to 50, plus hyphen and 6-char suffix
-    expect(slug.length).toBeLessThanOrEqual(50 + 1 + 6)
-  })
-
-  it('generates different slugs for same name (random suffix)', () => {
-    const slug1 = generateAgentSlug('Test')
-    const slug2 = generateAgentSlug('Test')
-    // Very unlikely to be the same due to random suffix
-    expect(slug1).not.toBe(slug2)
-  })
-
-  it('handles unicode characters', () => {
-    const slug = generateAgentSlug('Tëst Àgènt')
-    expect(slug).toMatch(/^t-st-g-nt-[a-z0-9]{6}$/)
-  })
-
-  it('handles numbers in name', () => {
-    const slug = generateAgentSlug('Agent 007')
-    expect(slug).toMatch(/^agent-007-[a-z0-9]{6}$/)
+  it('truncates the base to 50 characters', () => {
+    expect(nameToSlugBase('a'.repeat(100))).toHaveLength(50)
   })
 })
 
-describe('generateUniqueAgentSlug', () => {
-  it('generates a unique slug when no collision', async () => {
-    // Mock getDataDir to use our test directory
-    vi.mock('@/lib/config/data-dir', () => ({
-      getDataDir: () => testDir,
-    }))
-
-    // Dynamically re-import to pick up the mock
-    const { generateUniqueAgentSlug: genSlug } = await import('./file-storage')
-    const slug = await genSlug('Test Agent')
-    expect(slug).toMatch(/^test-agent-[a-z0-9]{6}$/)
-
-    vi.resetModules()
+describe('isMintedAgentId', () => {
+  it('accepts a bare 10-char [a-z0-9] id', () => {
+    expect(isMintedAgentId('k7x9m2ab3c')).toBe(true)
   })
+
+  it('rejects legacy / wrong-length / out-of-charset strings', () => {
+    expect(isMintedAgentId('abc123')).toBe(false) // 6-char legacy suffix
+    expect(isMintedAgentId('untitled-h45k3n')).toBe(false) // legacy compound
+    expect(isMintedAgentId('k7x9m2ab3')).toBe(false) // 9 chars
+    expect(isMintedAgentId('K7X9M2AB3C')).toBe(false) // uppercase
+    expect(isMintedAgentId('')).toBe(false)
+  })
+})
+
+describe('displaySlug', () => {
+  const id = 'k7x9m2ab3c' // 10-char minted id
+
+  it('projects {base}-{id} for a named, minted agent', () => {
+    expect(displaySlug('GPT 4 Bot', id)).toBe(`gpt-4-bot-${id}`)
+  })
+
+  it('returns the bare id when the name slugifies to empty', () => {
+    expect(displaySlug('', id)).toBe(id)
+    expect(displaySlug('🙂', id)).toBe(id)
+  })
+
+  it('returns legacy folder ids verbatim — never re-prettified (would break resolution)', () => {
+    expect(displaySlug('Renamed Agent', 'untitled-h45k3n')).toBe('untitled-h45k3n')
+    expect(displaySlug('Renamed Agent', 'abc123')).toBe('abc123')
+  })
+})
+
+describe('generateAgentId + resolveAgentId (filesystem-backed)', () => {
+  // Point the data dir at the per-test temp dir so getAgentDir() lands there.
+  let prevDataDir: string | undefined
+
+  beforeEach(async () => {
+    prevDataDir = process.env.SUPERAGENT_DATA_DIR
+    process.env.SUPERAGENT_DATA_DIR = testDir
+    await ensureDirectory(getAgentsDir())
+  })
+
+  afterEach(() => {
+    if (prevDataDir === undefined) delete process.env.SUPERAGENT_DATA_DIR
+    else process.env.SUPERAGENT_DATA_DIR = prevDataDir
+  })
+
+  const makeAgentFolder = (id: string) => ensureDirectory(getAgentDir(id))
+
+  it('mints a bare [a-z0-9]{10} id, not derived from any name', async () => {
+    const id = await generateAgentId()
+    expect(id).toMatch(new RegExp(`^[a-z0-9]{${AGENT_ID_LENGTH}}$`))
+  })
+
+  it('mints distinct ids across calls', async () => {
+    expect(await generateAgentId()).not.toBe(await generateAgentId())
+  })
+
+  it('resolves a bare minted id (exact folder match)', async () => {
+    const id = await generateAgentId()
+    await makeAgentFolder(id)
+    expect(await resolveAgentId(id)).toBe(id)
+  })
+
+  it('resolves a {name}-{id} display slug to the id', async () => {
+    const id = await generateAgentId()
+    await makeAgentFolder(id)
+    expect(await resolveAgentId(`gpt-4-bot-${id}`)).toBe(id)
+  })
+
+  it('resolves a wrong-prefix {anything}-{id} to the same id (prefix is decorative)', async () => {
+    const id = await generateAgentId()
+    await makeAgentFolder(id)
+    expect(await resolveAgentId(`literally-anything-${id}`)).toBe(id)
+    expect(await resolveAgentId(`beta-${id}`)).toBe(id)
+  })
+
+  it('resolves a legacy compound folder id to itself', async () => {
+    await makeAgentFolder('untitled-h45k3n')
+    expect(await resolveAgentId('untitled-h45k3n')).toBe('untitled-h45k3n')
+  })
+
+  it('resolves a bare legacy id to itself', async () => {
+    await makeAgentFolder('abc123')
+    expect(await resolveAgentId('abc123')).toBe('abc123')
+  })
+
+  it('returns null for an unknown slug', async () => {
+    expect(await resolveAgentId('does-not-exist')).toBeNull()
+  })
+
+  it('returns null for a well-formed but non-existent minted id', async () => {
+    expect(await resolveAgentId('zzzzzzzzzz')).toBeNull()
+  })
+
+  it.each(['../foo', 'a/b', 'a_b', '..', '.', 'foo/../bar', 'UPPER', ''])(
+    'rejects unsafe / out-of-charset input %j with no filesystem access',
+    async (bad) => {
+      expect(await resolveAgentId(bad)).toBeNull()
+    },
+  )
 })
 
 // ============================================================================

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -13,6 +13,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import type { ZodType } from 'zod'
 import { getDataDir } from '@shared/lib/config/data-dir'
+import { assertPathWithinDir } from '@shared/lib/utils/path-safety'
 
 // ============================================================================
 // Slug Generation
@@ -34,7 +35,7 @@ function generateRandomSuffix(length: number = 6): string {
  * Convert a name to a URL-safe slug
  * "My Cool Agent" -> "my-cool-agent"
  */
-function nameToSlugBase(name: string): string {
+export function nameToSlugBase(name: string): string {
   return name
     .toLowerCase()
     .trim()
@@ -44,35 +45,86 @@ function nameToSlugBase(name: string): string {
 }
 
 /**
- * Generate a URL-safe slug with unique suffix
- * "My Cool Agent" -> "my-cool-agent-k7x9m2"
- *
- * Note: Display name always comes from CLAUDE.md frontmatter, not the slug.
- * The slug is only used for directory names and URLs.
+ * Length of a minted agent id. Deliberately distinct from the legacy 6-char
+ * name-suffix: that length gap is what lets resolveAgentId() tell a minted id
+ * apart from a legacy compound folder name (see resolveAgentId).
  */
-export function generateAgentSlug(name: string): string {
-  const base = nameToSlugBase(name)
-  const suffix = generateRandomSuffix()
-  return base ? `${base}-${suffix}` : suffix
+export const AGENT_ID_LENGTH = 10
+
+const MINTED_ID_RE = new RegExp(`^[a-z0-9]{${AGENT_ID_LENGTH}}$`)
+
+/**
+ * Path-safety gate for any externally-supplied agent identifier. nameToSlugBase
+ * only ever emits [a-z0-9-] and minted ids are [a-z0-9], so a legitimate display
+ * slug or folder name never contains anything else. Rejecting everything else
+ * also forbids '/', '.', and therefore '..' path traversal.
+ */
+const SAFE_AGENT_INPUT_RE = /^[a-z0-9-]+$/
+
+/**
+ * Whether an id is a freshly-minted opaque id (vs a legacy name-derived folder).
+ */
+export function isMintedAgentId(id: string): boolean {
+  return MINTED_ID_RE.test(id)
 }
 
 /**
- * Generate a unique agent slug, checking for collisions
- * Regenerates random suffix if directory already exists
+ * Mint an opaque agent id: a bare random [a-z0-9]{AGENT_ID_LENGTH} string.
+ *
+ * This is the agent's permanent identity — folder name, DB key, URL key, and
+ * x-agent target. It is NOT derived from the name, so renaming never moves it.
+ * Keeps the FS-collision loop (checked against ALL existing folders, legacy
+ * included); the timestamp fallback is still a bare [a-z0-9] id.
  */
-export async function generateUniqueAgentSlug(name: string): Promise<string> {
+export async function generateAgentId(): Promise<string> {
   const maxAttempts = 10
   for (let i = 0; i < maxAttempts; i++) {
-    const slug = generateAgentSlug(name)
-    const agentDir = getAgentDir(slug)
-    if (!await directoryExists(agentDir)) {
-      return slug
+    const id = generateRandomSuffix(AGENT_ID_LENGTH)
+    if (!await directoryExists(getAgentDir(id))) {
+      return id
     }
   }
-  // Fallback: use timestamp for uniqueness
+  // Fallback: timestamp + random, still a bare [a-z0-9] string.
+  return `${Date.now().toString(36)}${generateRandomSuffix(4)}`
+}
+
+/**
+ * Project the decorative display slug shown to models and placed in URLs:
+ *   {nameToSlugBase(name)}-{id}   (or bare {id} when the name slugifies to empty)
+ *
+ * Legacy folders (non-minted ids, e.g. "untitled-h45k3n") are returned VERBATIM:
+ * prettifying them would break resolution, since the folder still embeds the old
+ * name and there is no reverse lookup from a name-prefix back to the folder.
+ */
+export function displaySlug(name: string, id: string): string {
+  if (!isMintedAgentId(id)) return id
   const base = nameToSlugBase(name)
-  const timestamp = Date.now().toString(36)
-  return base ? `${base}-${timestamp}` : timestamp
+  return base ? `${base}-${id}` : id
+}
+
+/**
+ * Resolve any agent identifier — bare id, {name}-{id} display slug, wrong-prefix
+ * {anything}-{id}, or a legacy compound folder name — to the canonical folder
+ * id, or null if no such agent exists. The trailing minted id is the only
+ * authoritative part; the prefix is ignored.
+ *
+ * Path-safety: rejects anything outside [a-z0-9-] before any fs access.
+ */
+export async function resolveAgentId(input: string): Promise<string | null> {
+  if (!input || !SAFE_AGENT_INPUT_RE.test(input)) return null
+  // Defense-in-depth: the charset gate already forbids '/' and '.', so this can
+  // never escape, but assert before touching the filesystem regardless.
+  assertPathWithinDir(getAgentsDir(), getAgentDir(input))
+  // Exact match handles a bare minted id AND a legacy compound folder name.
+  if (await directoryExists(getAgentDir(input))) return input
+  // Otherwise the id is the final hyphen-delimited segment (ids have no hyphen).
+  const dash = input.lastIndexOf('-')
+  if (dash === -1) return null
+  const candidate = input.slice(dash + 1)
+  if (MINTED_ID_RE.test(candidate) && await directoryExists(getAgentDir(candidate))) {
+    return candidate
+  }
+  return null
 }
 
 // ============================================================================


### PR DESCRIPTION
## What & why

Agents historically minted their folder slug from the name at create time. But the UX now creates an **unnamed** agent first, so folders froze as `untitled-h45k3n` forever, and renaming only rewrote the CLAUDE.md frontmatter — never the slug/folder.

This adopts the Notion/Linear/GitHub pattern: an authoritative **opaque id** with a *decorative, recomputed* pretty prefix.

- **Identity = a bare random id `[a-z0-9]{10}`** — the folder name, every `agent_slug` DB value, the proxy-token subject, and the URL resolution key. It never changes.
- **Display string = `{slug(name)}-{id}`** — projected on read wherever an agent is shown to a model or placed in a URL.
- **Resolution ignores the prefix** — only the trailing id is authoritative. Bare `{id}`, `anything-{id}`, `{slug(name)}-{id}`, and legacy compound folder ids all resolve to the same agent.
- **No DB migration.** Existing folders stay; the folder name *is* their id and already matches every row. The tolerant resolver handles legacy compound ids (the 10-char minted id is deliberately distinct from the legacy 6-char suffix).

**Outcome:** rename is a pure display recompute (zero rename surface), the displayed slug tracks the current name, old URLs keep resolving, and the `Untitled` folder-poisoning dissolves.

## Shape

- **Shared/host** (`file-storage.ts`, `agent-service.ts`): `generateAgentId` / `displaySlug` / `resolveAgentId`; `ApiAgent.displaySlug`. Legacy (non-minted) ids project verbatim.
- **API** (`middleware/auth.ts`, `routes/agents.ts`, `routes/x-agent.ts`): `ResolveAgent()` + `getAgentId()` resolve `:id` once and fail closed; x-agent rebinds `targetSlug → id`; `/list` & `/create` return display slugs.
- **Renderer**: `resolveRouteAgentId()` maps a route display slug → canonical id; session/proxy-review query keys normalized to the id so SSE invalidations land; mounts/MCPs/accounts use slug-form-agnostic bare-prefix invalidation.

## Review hardening (post-implementation sweep)

- Hunted sibling "slug-representation-split" bugs (a slug string used as a dedup/map/query/equality key receiving both id and display forms). Fixed: session caches, proxy-review card lag (SSE-miss), x-agent name lookup, role resolution.
- **Auth-mode regression:** the ACL list query has no `ORDER BY`, so rows came back in index-scan order — i.e. by the now-random slug, scattering new agents. Sorted newest-first to match the non-auth path.
- **Auth-mode perf:** `UserContext` slug→id resolution uses a structurally-shared `{slug, displaySlug}` projection, so it no longer re-renders every `useUser()` consumer on each agent-status tick.

## Deferred (resolve & don't auto-rewrite)

- URL canonicalization redirect (display→canonical on mismatch).
- `scheduled-task-view` redirect now fires on every visit (downgrades pretty URL → bare id) — pre-existing, low priority.

## Testing

- `tsc --noEmit` clean, `eslint` clean.
- Unit (resolver contract incl. traversal + legacy), x-agent integration (resolve by display/wrong-prefix slug), renderer deep-link, auth E2E (owner view-only via the display-slug route).
- Full suites green at implementation; targeted suites re-run green through the review sweep.
