### PR TITLE
Make schedule_task blocking & warn on too-frequent recurring schedules (SUP-331)

### DIFF
--- a/agent-container/src/tools/schedule-task.ts
+++ b/agent-container/src/tools/schedule-task.ts
@@ -11,6 +11,15 @@ import { z } from 'zod'
 import { inputManager } from '../input-manager'
 
 /**
+ * How long to wait for the host to confirm the schedule before giving up.
+ * Unlike user-input tools (secret/question) that legitimately block on a human,
+ * schedule_task waits only on a fast automated host operation (a DB write), so a
+ * host that never responds means something is wrong — fail loud instead of
+ * hanging the agent session forever.
+ */
+const SCHEDULE_TASK_HOST_TIMEOUT_MS = 60_000
+
+/**
  * Basic validation for cron expression (5-6 space-separated fields)
  */
 function isValidCronFormat(expression: string): boolean {
@@ -48,7 +57,9 @@ For recurring tasks, use cron syntax (5 fields: minute hour day-of-month month d
 The prompt you provide will be sent to the agent as a new conversation at the scheduled time.
 The task will be executed in a new session, and the agent will have full access to tools and capabilities.
 
-Note: One-time tasks ('at') will execute once and complete. Recurring tasks ('cron') will continue executing on schedule indefinitely until cancelled — there is no expiration or time limit.`,
+Note: One-time tasks ('at') will execute once and complete. Recurring tasks ('cron') will continue executing on schedule indefinitely until cancelled — there is no expiration or time limit.
+
+Avoid recurring intervals shorter than 15 minutes unless truly necessary: frequent runs can pile up and are costly, especially on Opus or at high effort.`,
   {
     scheduleType: z
       .enum(['at', 'cron'])
@@ -131,28 +142,45 @@ Note: One-time tasks ('at') will execute once and complete. Recurring tasks ('cr
       }
     }
 
-    // Return success - the API server will intercept this and handle the actual scheduling
-    const taskType = args.scheduleType === 'cron' ? 'recurring' : 'one-time'
-    const taskName = args.name || 'Scheduled Task'
+    // Blocking: the host persists the task and resolves this tool only after the
+    // schedule is actually saved. This avoids the false-success bug where the
+    // tool reported "scheduled" while host persistence happened (and could fail)
+    // in the background. The host's resolved message also carries any
+    // too-frequent-interval warning.
+    const toolUseId = inputManager.consumeCurrentToolUseId()
+    if (!toolUseId) {
+      return {
+        content: [{ type: 'text' as const, text: 'Unable to process request — no tool use ID available.' }],
+        isError: true,
+      }
+    }
 
-    console.log(`[schedule_task] Task "${taskName}" scheduled successfully`)
+    // Bound the wait so a host that never resolves/rejects (e.g. a handler that
+    // bails before reaching the container) surfaces an error instead of hanging
+    // the session indefinitely.
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+    try {
+      const result = await Promise.race([
+        inputManager.createPendingWithType<string>(toolUseId, 'schedule_task'),
+        new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(
+            () => reject(new Error('Timed out waiting for the host to confirm the schedule')),
+            SCHEDULE_TASK_HOST_TIMEOUT_MS,
+          )
+        }),
+      ])
 
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: `Scheduled ${taskType} task "${taskName}".
-
-Schedule: ${args.scheduleExpression}
-Task: ${args.prompt.substring(0, 100)}${args.prompt.length > 100 ? '...' : ''}
-
-The task has been registered and will be executed according to the schedule. ${
-            args.scheduleType === 'cron'
-              ? 'This recurring task will continue until cancelled.'
-              : 'This one-time task will be removed after execution.'
-          }`,
-        },
-      ],
+      return {
+        content: [{ type: 'text' as const, text: result }],
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'Unknown error'
+      return {
+        content: [{ type: 'text' as const, text: `Failed to schedule task: ${msg}` }],
+        isError: true,
+      }
+    } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle)
     }
   }
 )

--- a/src/api/routes/scheduled-tasks.test.ts
+++ b/src/api/routes/scheduled-tasks.test.ts
@@ -75,9 +75,11 @@ vi.mock('@shared/lib/config/settings', () => ({
 }))
 
 const mockValidateCronExpression = vi.fn()
+const mockGetFrequencyWarning = vi.fn()
 
 vi.mock('@shared/lib/services/schedule-parser', () => ({
   validateCronExpression: (...args: unknown[]) => mockValidateCronExpression(...args),
+  getFrequencyWarning: (...args: unknown[]) => mockGetFrequencyWarning(...args),
 }))
 
 const mockMessagesCreate = vi.fn()
@@ -177,6 +179,7 @@ describe('scheduled-tasks route', () => {
       summarizerModel: 'claude-haiku-4-5',
     })
     mockValidateCronExpression.mockReturnValue({ valid: true })
+    mockGetFrequencyWarning.mockReturnValue(null)
     mockMessagesCreate.mockResolvedValue({ content: [{ type: 'text', text: 'Every weekday at 9:00 AM' }] })
     mockExtractTextFromLlmResponse.mockReturnValue('Every weekday at 9:00 AM')
     mockPauseScheduledTask.mockResolvedValue(true)
@@ -272,6 +275,37 @@ describe('scheduled-tasks route', () => {
     expect(res.status).toBe(400)
     expect(await res.json()).toEqual({ error: 'Invalid cron expression' })
     expect(mockUpdateScheduleExpression).not.toHaveBeenCalled()
+  })
+
+  it('appends a frequency warning when the new schedule is too frequent', async () => {
+    mockGetFrequencyWarning.mockReturnValue('⚠️ Frequent schedule warning: every 1 minute')
+
+    const res = await app.request('http://localhost/api/scheduled-tasks/task-1/schedule', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scheduleExpression: '* * * * *' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockGetFrequencyWarning).toHaveBeenCalledWith('cron', '* * * * *', undefined)
+    expect(await res.json()).toMatchObject({
+      id: 'task-1',
+      warning: '⚠️ Frequent schedule warning: every 1 minute',
+    })
+  })
+
+  it('omits the warning when the new schedule is not too frequent', async () => {
+    mockGetFrequencyWarning.mockReturnValue(null)
+
+    const res = await app.request('http://localhost/api/scheduled-tasks/task-1/schedule', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scheduleExpression: '0 9 * * 1-5' }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).not.toHaveProperty('warning')
   })
 
   it('renames a scheduled task title', async () => {

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -32,7 +32,7 @@ import { getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { containerManager } from '@shared/lib/container/container-manager'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { getEffectiveModels } from '@shared/lib/config/settings'
-import { validateCronExpression } from '@shared/lib/services/schedule-parser'
+import { validateCronExpression, getFrequencyWarning } from '@shared/lib/services/schedule-parser'
 import { RuntimeOptionsSchema } from '@shared/lib/container/runtime-options'
 import type { EffortLevel } from '@shared/lib/container/types'
 import { withRetry } from '@shared/lib/utils/retry'
@@ -444,7 +444,11 @@ scheduledTasksRouter.patch('/:taskId/schedule', TaskAgentRole('user'), async (c)
 
     const refreshed = await getScheduledTask(task.id)
     logAuditEvent({ userId: getCurrentUserId(c), object: 'task', objectId: task!.id, action: 'updated', details: { field: 'schedule' } })
-    return c.json(refreshed)
+
+    // Surface the same too-frequent-interval warning as the agent path. The edit
+    // still succeeds — the warning is advisory.
+    const warning = getFrequencyWarning('cron', body.scheduleExpression.trim(), task.timezone || undefined)
+    return c.json(warning ? { ...refreshed, warning } : refreshed)
   } catch (error) {
     console.error('Failed to update schedule:', error)
     return c.json({ error: 'Failed to update schedule' }, 500)

--- a/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
+++ b/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
@@ -197,16 +197,25 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
     if (!canSaveSchedule) return
 
     try {
+      let frequencyWarning: string | undefined
       if (parsedExpression) {
-        await updateSchedule.mutateAsync({
+        const result = await updateSchedule.mutateAsync({
           taskId,
           scheduleExpression: parsedExpression,
         })
+        frequencyWarning = result.warning
       }
       if (timezoneChanged) {
         await updateTimezone.mutateAsync({ taskId, timezone: pendingTimezone })
       }
       setEditScheduleOpen(false)
+      // Advisory only — the edit succeeded. Surface the too-frequent-interval
+      // note so it isn't silently dropped when the dialog closes.
+      if (frequencyWarning) {
+        toast.warning('Frequent schedule', {
+          description: <span className="whitespace-pre-line">{frequencyWarning}</span>,
+        })
+      }
     } catch (err) {
       console.error('Failed to update schedule:', err)
     }

--- a/src/renderer/hooks/use-scheduled-tasks.ts
+++ b/src/renderer/hooks/use-scheduled-tasks.ts
@@ -279,7 +279,9 @@ export function useUpdateSchedule() {
         body: JSON.stringify({ scheduleExpression }),
       })
       if (!res.ok) throw new Error('Failed to update schedule')
-      return res.json() as Promise<ApiScheduledTask>
+      // The route appends a top-level `warning` when the new cadence is below the
+      // recommended minimum interval; surface it to the caller.
+      return res.json() as Promise<ApiScheduledTask & { warning?: string }>
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['scheduled-task', data.id] })

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -8,10 +8,11 @@ const mockGetScheduledTask = vi.fn<SchedMockFn>(() => Promise.resolve(null))
 const mockCancelScheduledTask = vi.fn<SchedMockFn>(() => Promise.resolve(true))
 const mockPauseScheduledTask = vi.fn<SchedMockFn>(() => Promise.resolve(true))
 const mockResumeScheduledTask = vi.fn<SchedMockFn>(() => Promise.resolve(true))
+const mockCreateScheduledTask = vi.fn<SchedMockFn>(() => Promise.resolve('task_new_id'))
 
 // Mock external dependencies before importing
 vi.mock('@shared/lib/services/scheduled-task-service', () => ({
-  createScheduledTask: vi.fn(),
+  createScheduledTask: (...args: unknown[]) => mockCreateScheduledTask(...args),
   listPendingScheduledTasks: (...args: unknown[]) => mockListPendingScheduledTasks(...args),
   getScheduledTask: (...args: unknown[]) => mockGetScheduledTask(...args),
   cancelScheduledTask: (...args: unknown[]) => mockCancelScheduledTask(...args),
@@ -21,6 +22,9 @@ vi.mock('@shared/lib/services/scheduled-task-service', () => ({
 vi.mock('@shared/lib/services/session-service', () => ({
   updateSessionMetadata: vi.fn(() => Promise.resolve()),
   getSessionMetadata: vi.fn(() => Promise.resolve(null)),
+}))
+vi.mock('@shared/lib/services/timezone-resolver', () => ({
+  resolveTimezoneForAgent: vi.fn(() => 'UTC'),
 }))
 vi.mock('@shared/lib/notifications/notification-manager', () => ({
   notificationManager: {
@@ -3247,6 +3251,7 @@ describe('MessagePersister', () => {
       mockCancelScheduledTask.mockClear()
       mockPauseScheduledTask.mockClear()
       mockResumeScheduledTask.mockClear()
+      mockCreateScheduledTask.mockReset()
 
       mockContainerClientFetch.mockResolvedValue({ ok: true })
       mockListPendingScheduledTasks.mockResolvedValue([])
@@ -3254,6 +3259,137 @@ describe('MessagePersister', () => {
       mockCancelScheduledTask.mockResolvedValue(true)
       mockPauseScheduledTask.mockResolvedValue(true)
       mockResumeScheduledTask.mockResolvedValue(true)
+      mockCreateScheduledTask.mockResolvedValue('task_new_id')
+    })
+
+    describe('schedule_task (blocking)', () => {
+      function findFetchCall(suffix: string) {
+        return mockContainerClientFetch.mock.calls.find((c) => c[0] === suffix)
+      }
+
+      it('persists then resolves the tool with a success message', async () => {
+        simulateToolUse('mcp__user-input__schedule_task', 'tool-sched-create-1', {
+          scheduleType: 'cron',
+          scheduleExpression: '0 9 * * 1-5',
+          prompt: 'Send the daily report',
+          name: 'Daily report',
+        })
+
+        await flushHandlers()
+
+        expect(mockCreateScheduledTask).toHaveBeenCalledWith(
+          expect.objectContaining({
+            agentSlug: AGENT_SLUG,
+            scheduleType: 'cron',
+            scheduleExpression: '0 9 * * 1-5',
+            prompt: 'Send the daily report',
+          })
+        )
+
+        const resolveCall = findFetchCall('/inputs/tool-sched-create-1/resolve')
+        expect(resolveCall).toBeDefined()
+        const body = JSON.parse(resolveCall![1].body)
+        expect(body.value).toContain('Daily report')
+        expect(body.value).toContain('task_new_id')
+        // Daily (well above threshold) — no frequency warning.
+        expect(body.value).not.toContain('Frequent schedule warning')
+      })
+
+      it('rejects (no false success) when persistence throws', async () => {
+        mockCreateScheduledTask.mockRejectedValue(new Error('disk full'))
+
+        simulateToolUse('mcp__user-input__schedule_task', 'tool-sched-create-fail', {
+          scheduleType: 'cron',
+          scheduleExpression: '0 9 * * 1-5',
+          prompt: 'Send the daily report',
+        })
+
+        await flushHandlers()
+
+        expect(findFetchCall('/inputs/tool-sched-create-fail/resolve')).toBeUndefined()
+        const rejectCall = findFetchCall('/inputs/tool-sched-create-fail/reject')
+        expect(rejectCall).toBeDefined()
+        expect(JSON.parse(rejectCall![1].body).reason).toContain('disk full')
+      })
+
+      it('appends a frequency warning for sub-threshold recurring schedules', async () => {
+        simulateToolUse('mcp__user-input__schedule_task', 'tool-sched-create-freq', {
+          scheduleType: 'cron',
+          scheduleExpression: '* * * * *',
+          prompt: 'Poll something',
+        })
+
+        await flushHandlers()
+
+        const resolveCall = findFetchCall('/inputs/tool-sched-create-freq/resolve')
+        expect(resolveCall).toBeDefined()
+        expect(JSON.parse(resolveCall![1].body).value).toContain('Frequent schedule warning')
+      })
+
+      it('does not warn for one-time (at) schedules', async () => {
+        simulateToolUse('mcp__user-input__schedule_task', 'tool-sched-create-at', {
+          scheduleType: 'at',
+          scheduleExpression: 'at now + 1 hour',
+          prompt: 'One-off reminder',
+        })
+
+        await flushHandlers()
+
+        const resolveCall = findFetchCall('/inputs/tool-sched-create-at/resolve')
+        expect(resolveCall).toBeDefined()
+        expect(JSON.parse(resolveCall![1].body).value).not.toContain('Frequent schedule warning')
+      })
+
+      it('rejects when required fields are missing', async () => {
+        simulateToolUse('mcp__user-input__schedule_task', 'tool-sched-create-missing', {
+          scheduleType: 'cron',
+        })
+
+        await flushHandlers()
+
+        expect(mockCreateScheduledTask).not.toHaveBeenCalled()
+        const rejectCall = findFetchCall('/inputs/tool-sched-create-missing/reject')
+        expect(rejectCall).toBeDefined()
+        expect(JSON.parse(rejectCall![1].body).reason).toContain('Missing required fields')
+      })
+
+      it('rejects a whitespace-only prompt without persisting', async () => {
+        simulateToolUse('mcp__user-input__schedule_task', 'tool-sched-create-ws', {
+          scheduleType: 'cron',
+          scheduleExpression: '0 9 * * 1-5',
+          prompt: '   ',
+        })
+
+        await flushHandlers()
+
+        // Container and host must agree: a blank prompt is rejected, never persisted.
+        expect(mockCreateScheduledTask).not.toHaveBeenCalled()
+        const rejectCall = findFetchCall('/inputs/tool-sched-create-ws/reject')
+        expect(rejectCall).toBeDefined()
+        expect(JSON.parse(rejectCall![1].body).reason).toContain('Missing required fields')
+      })
+
+      it('does not reject (no false failure) when result delivery fails after persistence', async () => {
+        // Persistence succeeds, but the resolve fetch to the container fails. The
+        // agent must NOT be told the schedule failed — otherwise it retries into a
+        // duplicate recurring task.
+        mockContainerClientFetch.mockImplementation((url: string) =>
+          url.endsWith('/resolve')
+            ? Promise.reject(new Error('container unreachable'))
+            : Promise.resolve({ ok: true })
+        )
+
+        simulateToolUse('mcp__user-input__schedule_task', 'tool-sched-deliver-fail', {
+          scheduleType: 'cron',
+          scheduleExpression: '0 9 * * 1-5',
+          prompt: 'Send the daily report',
+        })
+
+        await flushHandlers()
+
+        expect(mockCreateScheduledTask).toHaveBeenCalled()
+        expect(findFetchCall('/inputs/tool-sched-deliver-fail/reject')).toBeUndefined()
+      })
     })
 
     describe('list_scheduled_tasks', () => {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -30,6 +30,7 @@ import { db } from '@shared/lib/db'
 import { connectedAccounts } from '@shared/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { resolveTimezoneForAgent } from '@shared/lib/services/timezone-resolver'
+import { getFrequencyWarning, validateScheduleExpression } from '@shared/lib/services/schedule-parser'
 import { getSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
@@ -1905,49 +1906,63 @@ class MessagePersister {
     }
   }
 
-  // Handle schedule task tool - save to database and broadcast to SSE clients
+  // Handle schedule task tool - blocking: persist to database, then resolve the
+  // container tool only after the task is actually saved (fixes the false-success
+  // bug where the tool reported success while persistence ran/failed in the
+  // background). Also appends a warning for too-frequent recurring schedules.
   private handleScheduleTaskTool(
     sessionId: string,
     toolUseId: string,
     toolInput: string,
     agentSlug?: string
   ): void {
-    // Use async IIFE since we need to await database operations
     ;(async () => {
+      if (!agentSlug) {
+        // Without an agentSlug we can't reach the container to resolve/reject.
+        console.error('[MessagePersister] Schedule task missing agentSlug')
+        return
+      }
+
+      // Parse the tool input
+      let input: {
+        scheduleType: 'at' | 'cron'
+        scheduleExpression: string
+        prompt: string
+        name?: string
+        timezone?: string
+        model?: string
+        effort?: string
+      }
       try {
-        // Parse the tool input
-        let input: {
-          scheduleType: 'at' | 'cron'
-          scheduleExpression: string
-          prompt: string
-          name?: string
-          timezone?: string
-          model?: string
-          effort?: string
-        }
-        try {
-          input = JSON.parse(toolInput)
-        } catch {
-          console.error('[MessagePersister] Failed to parse schedule task input:', toolInput)
-          return
-        }
+        input = JSON.parse(toolInput)
+      } catch {
+        console.error('[MessagePersister] Failed to parse schedule task input:', toolInput)
+        await this.rejectContainerInput(agentSlug, toolUseId, 'Invalid tool input').catch(console.error)
+        return
+      }
 
-        if (!input.scheduleType || !input.scheduleExpression || !input.prompt) {
-          console.error('[MessagePersister] Schedule task missing required fields')
-          return
-        }
+      // Trim-aware required-field check, matching the container tool's own
+      // validation (a whitespace-only prompt/expression is empty). Without the
+      // trim the host would persist a task the container already told the agent
+      // was rejected.
+      if (!input.scheduleType || !input.scheduleExpression?.trim() || !input.prompt?.trim()) {
+        await this.rejectContainerInput(
+          agentSlug,
+          toolUseId,
+          'Missing required fields: scheduleType, scheduleExpression, and prompt are required'
+        ).catch(console.error)
+        return
+      }
 
-        if (!agentSlug) {
-          console.error('[MessagePersister] Schedule task missing agentSlug')
-          return
-        }
-
+      // Persist the task. A failure here must reject — the agent is never told a
+      // false success.
+      let taskId: string
+      let timezone: string | undefined
+      try {
         // Resolve timezone: agent tool override > agent owner's timezone
-        const timezone = input.timezone || resolveTimezoneForAgent(agentSlug)
-
-        // Create the scheduled task in the database
+        timezone = input.timezone || resolveTimezoneForAgent(agentSlug)
         const sessionOwnerId = (await getSessionMetadata(agentSlug, sessionId))?.createdByUserId
-        const taskId = await createScheduledTask({
+        taskId = await createScheduledTask({
           agentSlug,
           scheduleType: input.scheduleType,
           scheduleExpression: input.scheduleExpression,
@@ -1959,7 +1974,17 @@ class MessagePersister {
           model: input.model,
           effort: input.effort,
         })
+      } catch (error) {
+        console.error('[MessagePersister] Error handling schedule task:', error)
+        const msg = error instanceof Error ? error.message : String(error)
+        await this.rejectContainerInput(agentSlug, toolUseId, `Failed to schedule task: ${msg}`).catch(console.error)
+        return
+      }
 
+      // The task is persisted. Everything past here is best-effort: a failure
+      // delivering the result must NOT reject the tool, or the agent could be told
+      // a real success failed and retry into a duplicate schedule.
+      try {
         // Broadcast the scheduled task created event to session-specific SSE clients
         this.broadcastToSSE(sessionId, {
           type: 'scheduled_task_created',
@@ -1977,10 +2002,55 @@ class MessagePersister {
           taskId,
           agentSlug,
         })
-      } catch (error) {
-        console.error('[MessagePersister] Error handling schedule task:', error)
+
+        // Resolve the blocking tool with a success message (plus any frequency warning).
+        await this.resolveContainerInput(
+          agentSlug,
+          toolUseId,
+          this.formatScheduleTaskResult(input, taskId, timezone)
+        )
+      } catch (deliveryError) {
+        console.error('[MessagePersister] Schedule persisted but result delivery failed:', deliveryError)
       }
     })()
+  }
+
+  /**
+   * Build the success message returned to the agent after a schedule is persisted,
+   * appending a too-frequent-interval warning for recurring schedules below the
+   * recommended minimum.
+   */
+  private formatScheduleTaskResult(
+    input: {
+      scheduleType: 'at' | 'cron'
+      scheduleExpression: string
+      prompt: string
+      name?: string
+    },
+    taskId: string,
+    timezone?: string
+  ): string {
+    const taskType = input.scheduleType === 'cron' ? 'recurring' : 'one-time'
+    const taskName = input.name || 'Scheduled Task'
+    const parsed = validateScheduleExpression(input.scheduleType, input.scheduleExpression, timezone)
+    const nextRun = parsed.nextTime ? `\nNext run: ${parsed.nextTime.toISOString()}` : ''
+    const continuation =
+      input.scheduleType === 'cron'
+        ? 'This recurring task will continue until cancelled.'
+        : 'This one-time task will be removed after execution.'
+
+    let result = `Scheduled ${taskType} task "${taskName}" (ID: ${taskId}).
+
+Schedule: ${input.scheduleExpression}${timezone ? ` (${timezone})` : ''}${nextRun}
+
+${continuation}`
+
+    const warning = getFrequencyWarning(input.scheduleType, input.scheduleExpression, timezone)
+    if (warning) {
+      result += `\n\n${warning}`
+    }
+
+    return result
   }
 
   // Handle list_scheduled_tasks - blocking: read from SQLite and resolve

--- a/src/shared/lib/services/schedule-parser.test.ts
+++ b/src/shared/lib/services/schedule-parser.test.ts
@@ -7,6 +7,9 @@ import {
   validateScheduleExpression,
   formatScheduleDescription,
   ianaToOffsetMinutes,
+  getCronIntervalMs,
+  getFrequencyWarning,
+  MIN_RECURRING_INTERVAL_MS,
 } from './schedule-parser'
 
 // ============================================================================
@@ -217,6 +220,62 @@ describe('validateCronExpression', () => {
       expect(result.valid).toBe(false)
       expect(result.error).toBeDefined()
     }
+  })
+})
+
+// ============================================================================
+// getCronIntervalMs Tests
+// ============================================================================
+
+describe('getCronIntervalMs', () => {
+  it('computes a 1-minute interval for every-minute cron', () => {
+    expect(getCronIntervalMs('* * * * *')).toBe(60_000)
+  })
+
+  it('computes a 5-minute interval for */5', () => {
+    expect(getCronIntervalMs('*/5 * * * *')).toBe(5 * 60_000)
+  })
+
+  it('computes a 1-hour interval for hourly cron', () => {
+    expect(getCronIntervalMs('0 * * * *')).toBe(60 * 60_000)
+  })
+
+  it('returns null for an invalid cron expression', () => {
+    expect(getCronIntervalMs('not a cron')).toBeNull()
+  })
+})
+
+// ============================================================================
+// getFrequencyWarning Tests
+// ============================================================================
+
+describe('getFrequencyWarning', () => {
+  it('exposes a 15-minute threshold constant', () => {
+    expect(MIN_RECURRING_INTERVAL_MS).toBe(15 * 60 * 1000)
+  })
+
+  it('warns when the interval is below the threshold', () => {
+    const warning = getFrequencyWarning('cron', '*/5 * * * *')
+    expect(warning).toBeTruthy()
+    expect(warning).toContain('Frequent schedule warning')
+    expect(warning).toContain('skipped') // mentions overlap auto-skip
+    expect(warning).toContain('cost') // mentions cost
+  })
+
+  it('does not warn at exactly the threshold (15 minutes)', () => {
+    expect(getFrequencyWarning('cron', '*/15 * * * *')).toBeNull()
+  })
+
+  it('does not warn above the threshold', () => {
+    expect(getFrequencyWarning('cron', '0 9 * * 1-5')).toBeNull()
+  })
+
+  it('never warns for one-time (at) schedules', () => {
+    expect(getFrequencyWarning('at', 'at now + 1 minute')).toBeNull()
+  })
+
+  it('does not warn for an unparseable cron expression', () => {
+    expect(getFrequencyWarning('cron', 'not a cron')).toBeNull()
   })
 })
 

--- a/src/shared/lib/services/schedule-parser.test.ts
+++ b/src/shared/lib/services/schedule-parser.test.ts
@@ -7,7 +7,7 @@ import {
   validateScheduleExpression,
   formatScheduleDescription,
   ianaToOffsetMinutes,
-  getCronIntervalMs,
+  getMinCronIntervalMs,
   getFrequencyWarning,
   MIN_RECURRING_INTERVAL_MS,
 } from './schedule-parser'
@@ -224,24 +224,41 @@ describe('validateCronExpression', () => {
 })
 
 // ============================================================================
-// getCronIntervalMs Tests
+// getMinCronIntervalMs Tests
 // ============================================================================
 
-describe('getCronIntervalMs', () => {
+describe('getMinCronIntervalMs', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('computes a 1-minute interval for every-minute cron', () => {
-    expect(getCronIntervalMs('* * * * *')).toBe(60_000)
+    expect(getMinCronIntervalMs('* * * * *')).toBe(60_000)
   })
 
   it('computes a 5-minute interval for */5', () => {
-    expect(getCronIntervalMs('*/5 * * * *')).toBe(5 * 60_000)
+    expect(getMinCronIntervalMs('*/5 * * * *')).toBe(5 * 60_000)
   })
 
   it('computes a 1-hour interval for hourly cron', () => {
-    expect(getCronIntervalMs('0 * * * *')).toBe(60 * 60_000)
+    expect(getMinCronIntervalMs('0 * * * *')).toBe(60 * 60_000)
   })
 
   it('returns null for an invalid cron expression', () => {
-    expect(getCronIntervalMs('not a cron')).toBeNull()
+    expect(getMinCronIntervalMs('not a cron')).toBeNull()
+  })
+
+  // Bursty schedule: "0,5 * * * *" fires at :00 and :05 each hour. The tightest
+  // gap (5 min) must be found regardless of the current time — comparing only the
+  // next two occurrences would report ~55 min near the top of the hour.
+  it('finds the tightest gap of a bursty schedule independent of current time', () => {
+    vi.useFakeTimers()
+
+    vi.setSystemTime(new Date('2024-06-15T00:02:00.000Z')) // next two are :05 then 01:00
+    expect(getMinCronIntervalMs('0,5 * * * *')).toBe(5 * 60_000)
+
+    vi.setSystemTime(new Date('2024-06-15T00:58:00.000Z')) // next two are 01:00 then 01:05
+    expect(getMinCronIntervalMs('0,5 * * * *')).toBe(5 * 60_000)
   })
 })
 
@@ -276,6 +293,11 @@ describe('getFrequencyWarning', () => {
 
   it('does not warn for an unparseable cron expression', () => {
     expect(getFrequencyWarning('cron', 'not a cron')).toBeNull()
+  })
+
+  it('warns for a bursty schedule whose tightest gap is below the threshold', () => {
+    // ":00 and :05 every hour" — the 5-minute burst gap is under 15 min.
+    expect(getFrequencyWarning('cron', '0,5 * * * *')).toContain('Frequent schedule warning')
   })
 })
 

--- a/src/shared/lib/services/schedule-parser.ts
+++ b/src/shared/lib/services/schedule-parser.ts
@@ -124,21 +124,36 @@ export function getNextCronTime(cronExpression: string, timezone?: string): Date
 export const MIN_RECURRING_INTERVAL_MS = 15 * 60 * 1000
 
 /**
- * Compute the interval (in milliseconds) between the next two occurrences of a
- * cron expression. Returns null if the expression is invalid.
- *
- * Note: cron intervals aren't always constant (e.g. "0 0 1 * *" varies 28–31
- * days), so this is the gap between the *next* two runs — a good-enough proxy
- * for "is this schedule too frequent?".
+ * Number of upcoming occurrences to scan when measuring how frequently a cron
+ * fires. Comparing only the next two runs is time-dependent for bursty schedules
+ * (e.g. "0,5 * * * *" looks like a 55-minute gap at :02 but a 5-minute gap at
+ * :58), so we scan a small horizon and take the smallest gap. 32 covers
+ * intra-hour bursts and any realistic daily/weekly burst while staying cheap.
  */
-export function getCronIntervalMs(cronExpression: string, timezone?: string): number | null {
+const CRON_OCCURRENCE_SCAN_COUNT = 32
+
+/**
+ * Compute the smallest gap (in milliseconds) between consecutive runs of a cron
+ * expression over the next CRON_OCCURRENCE_SCAN_COUNT occurrences. Returns null
+ * if the expression is invalid.
+ *
+ * Scanning a horizon (rather than just the next two runs) makes the result
+ * independent of the current time and catches bursty schedules whose tightest
+ * gap isn't between the immediate next two occurrences.
+ */
+export function getMinCronIntervalMs(cronExpression: string, timezone?: string): number | null {
   try {
     const interval = CronExpressionParser.parse(cronExpression, {
       tz: timezone || 'UTC',
     })
-    const first = interval.next().toDate()
-    const second = interval.next().toDate()
-    return second.getTime() - first.getTime()
+    let prev = interval.next().toDate().getTime()
+    let minGap = Infinity
+    for (let i = 0; i < CRON_OCCURRENCE_SCAN_COUNT; i++) {
+      const next = interval.next().toDate().getTime()
+      minGap = Math.min(minGap, next - prev)
+      prev = next
+    }
+    return Number.isFinite(minGap) ? minGap : null
   } catch {
     return null
   }
@@ -172,7 +187,7 @@ export function getFrequencyWarning(
 ): string | null {
   if (scheduleType !== 'cron') return null
 
-  const intervalMs = getCronIntervalMs(scheduleExpression, timezone)
+  const intervalMs = getMinCronIntervalMs(scheduleExpression, timezone)
   if (intervalMs === null || intervalMs >= MIN_RECURRING_INTERVAL_MS) return null
 
   const thresholdMinutes = Math.round(MIN_RECURRING_INTERVAL_MS / 60_000)

--- a/src/shared/lib/services/schedule-parser.ts
+++ b/src/shared/lib/services/schedule-parser.ts
@@ -116,6 +116,77 @@ export function getNextCronTime(cronExpression: string, timezone?: string): Date
 }
 
 /**
+ * Recommended minimum interval for recurring (cron) schedules. Recurring tasks
+ * more frequent than this can pile up if a run outlasts the interval and rack up
+ * cost on expensive models — so we surface a warning below this threshold (the
+ * schedule is still allowed). 15 minutes.
+ */
+export const MIN_RECURRING_INTERVAL_MS = 15 * 60 * 1000
+
+/**
+ * Compute the interval (in milliseconds) between the next two occurrences of a
+ * cron expression. Returns null if the expression is invalid.
+ *
+ * Note: cron intervals aren't always constant (e.g. "0 0 1 * *" varies 28–31
+ * days), so this is the gap between the *next* two runs — a good-enough proxy
+ * for "is this schedule too frequent?".
+ */
+export function getCronIntervalMs(cronExpression: string, timezone?: string): number | null {
+  try {
+    const interval = CronExpressionParser.parse(cronExpression, {
+      tz: timezone || 'UTC',
+    })
+    const first = interval.next().toDate()
+    const second = interval.next().toDate()
+    return second.getTime() - first.getTime()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Format a millisecond interval as a short human-readable string (e.g. "1 minute",
+ * "30 seconds", "10 minutes").
+ */
+function formatInterval(ms: number): string {
+  if (ms < 60_000) {
+    const seconds = Math.max(1, Math.round(ms / 1000))
+    return `${seconds} second${seconds === 1 ? '' : 's'}`
+  }
+  const minutes = Math.round(ms / 60_000)
+  return `${minutes} minute${minutes === 1 ? '' : 's'}`
+}
+
+/**
+ * Build a warning for recurring schedules that fire more often than
+ * MIN_RECURRING_INTERVAL_MS. Returns null for one-time ("at") schedules,
+ * unparseable expressions, or intervals at/above the threshold.
+ *
+ * Shared by the agent tool path (message-persister) and the manual API path
+ * (scheduled-tasks route) so both surface identical guidance.
+ */
+export function getFrequencyWarning(
+  scheduleType: 'at' | 'cron',
+  scheduleExpression: string,
+  timezone?: string
+): string | null {
+  if (scheduleType !== 'cron') return null
+
+  const intervalMs = getCronIntervalMs(scheduleExpression, timezone)
+  if (intervalMs === null || intervalMs >= MIN_RECURRING_INTERVAL_MS) return null
+
+  const thresholdMinutes = Math.round(MIN_RECURRING_INTERVAL_MS / 60_000)
+  return (
+    `⚠️ Frequent schedule warning: this recurring task runs about every ${formatInterval(intervalMs)}, ` +
+    `under the recommended ${thresholdMinutes}-minute minimum.\n` +
+    `- Runs can pile up if a single execution takes longer than the interval. Overlapping runs are automatically skipped ` +
+    `(a new run won't start while the previous one is still active), so the effective rate may be lower than requested.\n` +
+    `- Frequent runs add up in cost — especially on Opus or at high effort.\n` +
+    `Consider a longer interval unless this frequency is genuinely required.`
+  )
+}
+
+/**
  * Validate a cron expression and return the next execution time.
  */
 export function validateCronExpression(cronExpression: string, timezone?: string): ParseResult {


### PR DESCRIPTION
## Summary

Part of **SUP-326** (schedule-task cron hardening). Fixes two problems on the schedule-creation path:

1. **False-success bug** — `schedule_task` was fire-and-forget: the container tool returned "Scheduled successfully" immediately while the host persisted in the background. If `createScheduledTask` threw, the agent was told a success that never happened.
2. **No frequency feedback** — the agent could create arbitrarily frequent recurring schedules (e.g. every minute) with no warning.

### Changes

- **Blocking, host-resolved `schedule_task`** — converted to the existing `list_scheduled_tasks` pattern (container `createPendingWithType` → host `resolveContainerInput`/`rejectContainerInput`). The agent is told success only after the task is actually persisted; a persistence failure surfaces as an error.
- **Too-frequent warning** — new `MIN_RECURRING_INTERVAL_MS` (15 min), `getCronIntervalMs`, and `getFrequencyWarning` in `schedule-parser.ts`. A labeled warning is appended for recurring schedules below the threshold — on both the agent path and the manual schedule-edit API route (`PATCH /scheduled-tasks/:id/schedule`). The warning notes pile-up, that overlapping runs are auto-skipped, and cost.
- **Tool-description nudge** discouraging sub-15-min intervals.

### Hardening (from self-review)

- Result delivery is **best-effort after persistence** — a transient container error can't report a real success as a failure (which would cause the agent to retry into a duplicate schedule).
- **Trim-aware host validation** matching the container tool — no phantom task on a whitespace-only prompt.
- **60s timeout** on the container tool's host wait — avoids an indefinite session hang if the host never responds.

## Acceptance criteria

- [x] `schedule_task` returns only after the task is persisted; persistence failure → error result, not a false success
- [x] Recurring schedule with interval < threshold returns a labeled warning; ≥ threshold returns none
- [x] Manual creation/edit via the API route surfaces the same warning
- [x] Threshold is a named constant
- [x] Tests: blocking resolve/reject, false-success path, warning below vs at/above threshold

## Test plan

- New unit tests: blocking resolve, reject-on-persistence-failure, warning below/at/above the 15-min boundary, one-time schedules never warn, whitespace-only prompt rejected, best-effort delivery doesn't false-fail.
- `tsc` + eslint clean (root and agent-container).
- **230 passing** across the 3 affected suites; full agent-container suite **381 passing / 1 skipped**.

## Note

`scheduled-tasks.ts` has no POST-create route — tasks are created only via the agent tool — so the "manual" warning is applied to the schedule-**edit** PATCH (the only user-supplied cron path in that file).

Closes SUP-331.
