### PR TITLE
feat(models): model-specific disallowed tools + capability warnings

### DIFF
--- a/agent-container/src/claude-code-effort.test.ts
+++ b/agent-container/src/claude-code-effort.test.ts
@@ -279,7 +279,7 @@ describe('ClaudeCodeProcess unsupported tools', () => {
     calls.length = 0
   })
 
-  it('merges host-resolved unsupportedTools into the SDK disallowedTools', async () => {
+  it('keeps host-resolved unsupportedTools out of global SDK disallowedTools', async () => {
     const process = new ClaudeCodeProcess({
       sessionId: 'test-unsupported-tools',
       workingDirectory: '/tmp',
@@ -289,29 +289,55 @@ describe('ClaudeCodeProcess unsupported tools', () => {
     await process.start()
     expect(calls).toHaveLength(1)
     const disallowed = calls[0].options.disallowedTools as string[]
-    expect(disallowed).toContain('WebSearch')
-    expect(disallowed).toContain('WebFetch')
+    expect(disallowed).not.toContain('WebSearch')
+    expect(disallowed).not.toContain('WebFetch')
     // Static bans remain alongside the model-specific ones.
     expect(disallowed).toContain('TaskOutput')
   })
 
-  it('merges host-resolved image-emitting tools into the SDK disallowedTools', async () => {
+  it('denies unsupported tools only on the main thread', async () => {
     const process = new ClaudeCodeProcess({
-      sessionId: 'test-unsupported-image-tools',
+      sessionId: 'test-main-only-unsupported-tools',
       workingDirectory: '/tmp',
-      unsupportedTools: [
-        'mcp__browser__browser_screenshot',
-        'mcp__computer-use__computer_screenshot',
-      ],
+      unsupportedTools: ['WebSearch'],
     })
 
     await process.start()
     expect(calls).toHaveLength(1)
-    const disallowed = calls[0].options.disallowedTools as string[]
-    expect(disallowed).toContain('mcp__browser__browser_screenshot')
-    expect(disallowed).toContain('mcp__computer-use__computer_screenshot')
-    // Static bans remain alongside the model-specific ones.
-    expect(disallowed).toContain('TaskOutput')
+
+    const hooks = calls[0].options.hooks as {
+      PreToolUse: Array<{
+        hooks: Array<(input: Record<string, unknown>, toolUseId?: string) => Promise<Record<string, unknown>>>
+      }>
+    }
+    const mainOnlyHook = hooks.PreToolUse[0].hooks[0]
+    const mainResult = await mainOnlyHook({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'WebSearch',
+      tool_input: {},
+      tool_use_id: 'main-tool',
+      session_id: 'test-main-only-unsupported-tools',
+      transcript_path: '/tmp/transcript.jsonl',
+      cwd: '/tmp',
+    })
+    expect(mainResult).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+      },
+    })
+
+    const subagentResult = await mainOnlyHook({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'WebSearch',
+      tool_input: {},
+      tool_use_id: 'subagent-tool',
+      session_id: 'test-main-only-unsupported-tools',
+      transcript_path: '/tmp/transcript.jsonl',
+      cwd: '/tmp',
+      agent_id: 'web-browser-1',
+    })
+    expect(subagentResult).toEqual({})
   })
 
   it('leaves the static disallowedTools untouched when no unsupportedTools are set', async () => {

--- a/agent-container/src/claude-code-effort.test.ts
+++ b/agent-container/src/claude-code-effort.test.ts
@@ -273,3 +273,58 @@ describe('ClaudeCodeProcess model prompt hints', () => {
     expect(calls[0].options.systemPrompt).toContain('- Do not send pages as an empty string.')
   })
 })
+
+describe('ClaudeCodeProcess unsupported tools', () => {
+  beforeEach(() => {
+    calls.length = 0
+  })
+
+  it('merges host-resolved unsupportedTools into the SDK disallowedTools', async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-unsupported-tools',
+      workingDirectory: '/tmp',
+      unsupportedTools: ['WebSearch', 'WebFetch'],
+    })
+
+    await process.start()
+    expect(calls).toHaveLength(1)
+    const disallowed = calls[0].options.disallowedTools as string[]
+    expect(disallowed).toContain('WebSearch')
+    expect(disallowed).toContain('WebFetch')
+    // Static bans remain alongside the model-specific ones.
+    expect(disallowed).toContain('TaskOutput')
+  })
+
+  it('merges host-resolved image-emitting tools into the SDK disallowedTools', async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-unsupported-image-tools',
+      workingDirectory: '/tmp',
+      unsupportedTools: [
+        'mcp__browser__browser_screenshot',
+        'mcp__computer-use__computer_screenshot',
+      ],
+    })
+
+    await process.start()
+    expect(calls).toHaveLength(1)
+    const disallowed = calls[0].options.disallowedTools as string[]
+    expect(disallowed).toContain('mcp__browser__browser_screenshot')
+    expect(disallowed).toContain('mcp__computer-use__computer_screenshot')
+    // Static bans remain alongside the model-specific ones.
+    expect(disallowed).toContain('TaskOutput')
+  })
+
+  it('leaves the static disallowedTools untouched when no unsupportedTools are set', async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-no-unsupported-tools',
+      workingDirectory: '/tmp',
+    })
+
+    await process.start()
+    expect(calls).toHaveLength(1)
+    const disallowed = calls[0].options.disallowedTools as string[]
+    expect(disallowed).not.toContain('WebSearch')
+    expect(disallowed).not.toContain('mcp__browser__browser_screenshot')
+    expect(disallowed).toContain('TaskOutput')
+  })
+})

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -299,6 +299,8 @@ export interface ClaudeCodeProcessOptions {
   claudeSessionId?: string;
   userSystemPrompt?: string;
   modelPromptHints?: string[];
+  /** Host-resolved tools this model can't use (e.g. WebSearch/WebFetch when web search is unsupported). */
+  unsupportedTools?: string[];
   availableEnvVars?: string[];
   model?: string;
   browserModel?: string;
@@ -322,6 +324,7 @@ export class ClaudeCodeProcess extends EventEmitter {
   private model: string | undefined;
   private browserModel: string | undefined;
   private dashboardBuilderModel: string | undefined;
+  private unsupportedTools: string[];
   private maxOutputTokens: number | undefined;
   private maxThinkingTokens: number | undefined;
   private maxTurns: number | undefined;
@@ -346,6 +349,7 @@ export class ClaudeCodeProcess extends EventEmitter {
     this.model = options.model;
     this.browserModel = options.browserModel;
     this.dashboardBuilderModel = options.dashboardBuilderModel;
+    this.unsupportedTools = options.unsupportedTools ?? [];
     this.maxOutputTokens = options.maxOutputTokens;
     this.maxThinkingTokens = options.maxThinkingTokens;
     this.maxTurns = options.maxTurns;
@@ -451,6 +455,9 @@ export class ClaudeCodeProcess extends EventEmitter {
           'CronCreate', 'CronDelete', 'CronList',
           'ScheduleWakeup', 'RemoteTrigger', 'PushNotification',
           'EnterWorktree', 'ExitWorktree',
+          // Host-resolved tools the selected model can't use (e.g.
+          // WebSearch/WebFetch without web-search support). Applies query-wide.
+          ...this.unsupportedTools,
         ],
         // Request summarized thinking so reasoning text streams to the UI. Without an
         // explicit `display`, Opus 4.8/4.7 default to `omitted` — thinking_delta events

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -1,4 +1,4 @@
-import { query, Query, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import { query, Query, SDKUserMessage, type HookInput } from '@anthropic-ai/claude-agent-sdk';
 import type { UUID } from 'crypto';
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
@@ -40,6 +40,12 @@ function mcpToolNames(
     .filter(t => !excludeSet || !excludeSet.has(t.name))
     .map(t => `mcp__${serverName}__${t.name}`)
 }
+
+function shouldDenyMainModelTool(input: HookInput, unsupportedTools: string[]): boolean {
+  if (input.hook_event_name !== 'PreToolUse') return false;
+  return !input.agent_id && unsupportedTools.includes(input.tool_name);
+}
+
 import { inputManager } from './input-manager';
 import { sanitizeMcpName } from './sanitize-mcp-name';
 
@@ -455,9 +461,6 @@ export class ClaudeCodeProcess extends EventEmitter {
           'CronCreate', 'CronDelete', 'CronList',
           'ScheduleWakeup', 'RemoteTrigger', 'PushNotification',
           'EnterWorktree', 'ExitWorktree',
-          // Host-resolved tools the selected model can't use (e.g.
-          // WebSearch/WebFetch without web-search support). Applies query-wide.
-          ...this.unsupportedTools,
         ],
         // Request summarized thinking so reasoning text streams to the UI. Without an
         // explicit `display`, Opus 4.8/4.7 default to `omitted` — thinking_delta events
@@ -605,6 +608,23 @@ export class ClaudeCodeProcess extends EventEmitter {
         },
         hooks: {
           PreToolUse: [
+            {
+              matcher: '.*',
+              hooks: [
+                async (input) => {
+                  if (shouldDenyMainModelTool(input, this.unsupportedTools)) {
+                    return {
+                      hookSpecificOutput: {
+                        hookEventName: 'PreToolUse' as const,
+                        permissionDecision: 'deny' as const,
+                        permissionDecisionReason: 'The selected main model does not support this tool.',
+                      },
+                    };
+                  }
+                  return {};
+                },
+              ],
+            },
             {
               matcher: 'mcp__user-input__.*',
               hooks: [

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -106,6 +106,7 @@ export class SessionManager extends EventEmitter {
       workingDirectory,
       userSystemPrompt: request.systemPrompt,
       modelPromptHints: request.modelPromptHints,
+      unsupportedTools: request.unsupportedTools,
       availableEnvVars: request.availableEnvVars,
       model: request.model,
       browserModel: request.browserModel,
@@ -164,6 +165,7 @@ export class SessionManager extends EventEmitter {
       envVars: request.envVars,
       systemPrompt: request.systemPrompt,
       modelPromptHints: request.modelPromptHints,
+      unsupportedTools: request.unsupportedTools,
       availableEnvVars: request.availableEnvVars,
       slashCommands: process.slashCommands,
     };
@@ -197,6 +199,7 @@ export class SessionManager extends EventEmitter {
       lastActivity: session.lastActivity.toISOString(),
       systemPrompt: request.systemPrompt,
       modelPromptHints: request.modelPromptHints,
+      unsupportedTools: request.unsupportedTools,
       availableEnvVars: request.availableEnvVars,
       model: request.model,
       browserModel: request.browserModel,
@@ -232,6 +235,7 @@ export class SessionManager extends EventEmitter {
         claudeSessionId: persisted.claudeSessionId,
         userSystemPrompt: persisted.systemPrompt,
         modelPromptHints: persisted.modelPromptHints,
+        unsupportedTools: persisted.unsupportedTools,
         availableEnvVars: persisted.availableEnvVars,
         model: persisted.model,
         browserModel: persisted.browserModel,
@@ -251,6 +255,7 @@ export class SessionManager extends EventEmitter {
         workingDirectory: persisted.workingDirectory,
         systemPrompt: persisted.systemPrompt,
         modelPromptHints: persisted.modelPromptHints,
+        unsupportedTools: persisted.unsupportedTools,
         availableEnvVars: persisted.availableEnvVars,
       };
 

--- a/agent-container/src/session-persistence.ts
+++ b/agent-container/src/session-persistence.ts
@@ -10,6 +10,7 @@ interface SessionMetadata {
   lastActivity: string;
   systemPrompt?: string;
   modelPromptHints?: string[];
+  unsupportedTools?: string[];
   availableEnvVars?: string[];
   model?: string;
   browserModel?: string;

--- a/agent-container/src/types.ts
+++ b/agent-container/src/types.ts
@@ -32,6 +32,7 @@ export interface Session {
   envVars?: Record<string, string>;
   systemPrompt?: string;
   modelPromptHints?: string[];
+  unsupportedTools?: string[];
   availableEnvVars?: string[];
   slashCommands?: SlashCommandInfo[];
 }
@@ -57,6 +58,7 @@ export interface CreateSessionRequest {
   envVars?: Record<string, string>;
   systemPrompt?: string; // Custom system prompt to append to default
   modelPromptHints?: string[];
+  unsupportedTools?: string[]; // Host-resolved tools this model can't use (e.g. WebSearch/WebFetch when web search is unsupported); merged into disallowedTools
   availableEnvVars?: string[]; // List of env var names available to the agent
   initialMessage: string; // Required: first message to send (triggers session ID generation)
   initialMessageUuid?: UUID; // Optional UUID for message author attribution

--- a/agent-container/src/types.ts
+++ b/agent-container/src/types.ts
@@ -58,7 +58,7 @@ export interface CreateSessionRequest {
   envVars?: Record<string, string>;
   systemPrompt?: string; // Custom system prompt to append to default
   modelPromptHints?: string[];
-  unsupportedTools?: string[]; // Host-resolved tools this model can't use (e.g. WebSearch/WebFetch when web search is unsupported); merged into disallowedTools
+  unsupportedTools?: string[]; // Host-resolved tools denied for the main model only
   availableEnvVars?: string[]; // List of env var names available to the agent
   initialMessage: string; // Required: first message to send (triggers session ID generation)
   initialMessageUuid?: UUID; // Optional UUID for message author attribution

--- a/src/renderer/components/messages/model-family-list.test.tsx
+++ b/src/renderer/components/messages/model-family-list.test.tsx
@@ -139,6 +139,18 @@ describe('ModelFamilyList', () => {
     expect(screen.queryByTestId('model-no-websearch-warning')).not.toBeInTheDocument()
   })
 
+  it('warns when the selected model cannot read images, and not otherwise', () => {
+    const catalog = [
+      { id: 'text-only-1', label: 'Text Only', family: 'textonly', isLatest: true, supportedEfforts: STD, supportsImageInput: false },
+      ...CATALOG,
+    ]
+    const { rerender } = render(<ModelFamilyList catalog={catalog} value="text-only-1" onPick={vi.fn()} />)
+    expect(screen.getByTestId('model-no-image-warning')).toBeInTheDocument()
+
+    rerender(<ModelFamilyList catalog={catalog} value="claude-opus-4-8" onPick={vi.fn()} />)
+    expect(screen.queryByTestId('model-no-image-warning')).not.toBeInTheDocument()
+  })
+
   it('warns about the long-context price cliff for GPT, and not for flat-priced Claude', () => {
     const { rerender } = render(<ModelFamilyList catalog={CATALOG} value="openai/gpt-5.5" onPick={vi.fn()} />)
     const warning = screen.getByTestId('model-long-context-cliff-warning')

--- a/src/renderer/components/messages/model-family-list.tsx
+++ b/src/renderer/components/messages/model-family-list.tsx
@@ -173,6 +173,15 @@ export function ModelFamilyList({
           <span>Web search and fetch aren’t available on this model.</span>
         </div>
       )}
+      {resolved?.supportsImageInput === false && (
+        <div
+          data-testid="model-no-image-warning"
+          className="mx-1 mb-1 flex items-start gap-1.5 rounded-sm bg-amber-500/10 px-2 py-1 text-[11px] text-amber-600 dark:text-amber-500"
+        >
+          <TriangleAlert className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
+          <span>This model can’t read images, so screenshots and other image results may not work.</span>
+        </div>
+      )}
       {resolved?.longContextPriceCliff && (
         <div
           data-testid="model-long-context-cliff-warning"

--- a/src/renderer/components/messages/model-family-list.tsx
+++ b/src/renderer/components/messages/model-family-list.tsx
@@ -113,6 +113,18 @@ function Row({
   )
 }
 
+function PickerWarning({ testId, children }: { testId: string; children: ReactNode }) {
+  return (
+    <div
+      data-testid={testId}
+      className="mx-1 mb-1 flex items-start gap-1.5 rounded-sm bg-amber-500/10 px-2 py-1 text-[11px] text-amber-600 dark:text-amber-500"
+    >
+      <TriangleAlert className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
+      <span>{children}</span>
+    </div>
+  )
+}
+
 /**
  * Grouped model picker shared by the saved-setting selector and the per-message
  * composer. Layer 1 lists each family (and any family-less models); picking a
@@ -165,31 +177,19 @@ export function ModelFamilyList({
   return (
     <div className="flex flex-col gap-0.5">
       {resolved?.supportsWebSearch === false && (
-        <div
-          data-testid="model-no-websearch-warning"
-          className="mx-1 mb-1 flex items-start gap-1.5 rounded-sm bg-amber-500/10 px-2 py-1 text-[11px] text-amber-600 dark:text-amber-500"
-        >
-          <TriangleAlert className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
-          <span>Web search and fetch aren’t available on this model.</span>
-        </div>
+        <PickerWarning testId="model-no-websearch-warning">
+          Web search and fetch aren’t available on this model.
+        </PickerWarning>
       )}
       {resolved?.supportsImageInput === false && (
-        <div
-          data-testid="model-no-image-warning"
-          className="mx-1 mb-1 flex items-start gap-1.5 rounded-sm bg-amber-500/10 px-2 py-1 text-[11px] text-amber-600 dark:text-amber-500"
-        >
-          <TriangleAlert className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
-          <span>This model can’t read images, so screenshots and other image results may not work.</span>
-        </div>
+        <PickerWarning testId="model-no-image-warning">
+          This model can’t read images, so screenshots and other image results may not work.
+        </PickerWarning>
       )}
       {resolved?.longContextPriceCliff && (
-        <div
-          data-testid="model-long-context-cliff-warning"
-          className="mx-1 mb-1 flex items-start gap-1.5 rounded-sm bg-amber-500/10 px-2 py-1 text-[11px] text-amber-600 dark:text-amber-500"
-        >
-          <TriangleAlert className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
-          <span>{longContextWarningText(resolved.longContextPriceCliff, resolved.contextWindow)}</span>
-        </div>
+        <PickerWarning testId="model-long-context-cliff-warning">
+          {longContextWarningText(resolved.longContextPriceCliff, resolved.contextWindow)}
+        </PickerWarning>
       )}
       {families.map((group) => {
         const isOpen = openFamily === group.family

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -23,7 +23,11 @@ import { getAgentWorkspaceDir } from '@shared/lib/config/data-dir'
 import { getContainerHostUrl, getAppPort } from '@shared/lib/proxy/host-url'
 import { getSettings } from '@shared/lib/config/settings'
 import { getActiveLlmProvider } from '@shared/lib/llm-provider'
-import { resolveContainerModel, getContainerModelPromptHints } from './resolve-model'
+import {
+  resolveContainerModel,
+  getContainerModelPromptHints,
+  getContainerUnsupportedTools,
+} from './resolve-model'
 import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 
 const execAsync = promisify(exec)
@@ -999,6 +1003,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     const resolvedBrowserModel = resolveContainerModel(options.browserModel, 'browser')
     const resolvedDashboardBuilderModel = resolveContainerModel(options.dashboardBuilderModel, 'dashboard')
     const modelPromptHints = getContainerModelPromptHints(resolvedModel)
+    const unsupportedTools = getContainerUnsupportedTools(resolvedModel)
 
     try {
       const controller = new AbortController()
@@ -1011,6 +1016,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
           metadata: options.metadata,
           systemPrompt: options.systemPrompt,
           modelPromptHints: modelPromptHints.length > 0 ? modelPromptHints : undefined,
+          unsupportedTools: unsupportedTools.length > 0 ? unsupportedTools : undefined,
           availableEnvVars: options.availableEnvVars,
           initialMessage: options.initialMessage,
           initialMessageUuid: options.initialMessageUuid,

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -25,8 +25,7 @@ import { getSettings } from '@shared/lib/config/settings'
 import { getActiveLlmProvider } from '@shared/lib/llm-provider'
 import {
   resolveContainerModel,
-  getContainerModelPromptHints,
-  getContainerUnsupportedTools,
+  getContainerModelRuntimeConfig,
 } from './resolve-model'
 import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 
@@ -1002,8 +1001,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     const resolvedModel = resolveContainerModel(options.model, 'agent')
     const resolvedBrowserModel = resolveContainerModel(options.browserModel, 'browser')
     const resolvedDashboardBuilderModel = resolveContainerModel(options.dashboardBuilderModel, 'dashboard')
-    const modelPromptHints = getContainerModelPromptHints(resolvedModel)
-    const unsupportedTools = getContainerUnsupportedTools(resolvedModel)
+    const modelRuntimeConfig = getContainerModelRuntimeConfig(resolvedModel, 'agent')
 
     try {
       const controller = new AbortController()
@@ -1015,8 +1013,8 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
         body: JSON.stringify({
           metadata: options.metadata,
           systemPrompt: options.systemPrompt,
-          modelPromptHints: modelPromptHints.length > 0 ? modelPromptHints : undefined,
-          unsupportedTools: unsupportedTools.length > 0 ? unsupportedTools : undefined,
+          modelPromptHints: modelRuntimeConfig.modelPromptHints.length > 0 ? modelRuntimeConfig.modelPromptHints : undefined,
+          unsupportedTools: modelRuntimeConfig.unsupportedTools.length > 0 ? modelRuntimeConfig.unsupportedTools : undefined,
           availableEnvVars: options.availableEnvVars,
           initialMessage: options.initialMessage,
           initialMessageUuid: options.initialMessageUuid,

--- a/src/shared/lib/container/resolve-model.test.ts
+++ b/src/shared/lib/container/resolve-model.test.ts
@@ -9,34 +9,32 @@ vi.mock('../config/settings', () => ({
 }))
 
 import {
-  getContainerModelPromptHints,
-  getContainerUnsupportedTools,
+  getContainerModelRuntimeConfig,
   WEB_SEARCH_TOOLS,
-  IMAGE_EMITTING_TOOLS,
 } from './resolve-model'
 
 beforeEach(() => {
   settingsMock.mockReturnValue({ llmProvider: 'platform' })
 })
 
-describe('getContainerModelPromptHints', () => {
+describe('getContainerModelRuntimeConfig modelPromptHints', () => {
   it('returns GPT tool-use hints for a resolved Platform GPT id', () => {
-    const hints = getContainerModelPromptHints('gpt-5.5')
+    const hints = getContainerModelRuntimeConfig('gpt-5.5').modelPromptHints
     expect(hints.some((h) => h.includes('ToolSearch'))).toBe(true)
     expect(hints.some((h) => h.includes('pages as an empty string'))).toBe(true)
   })
 
   it('returns no hints for a Claude model on the active provider', () => {
-    expect(getContainerModelPromptHints('claude-opus-4-8')).toEqual([])
+    expect(getContainerModelRuntimeConfig('claude-opus-4-8').modelPromptHints).toEqual([])
   })
 
   it('returns no hints for an undefined or unknown model', () => {
-    expect(getContainerModelPromptHints(undefined)).toEqual([])
-    expect(getContainerModelPromptHints('nope')).toEqual([])
+    expect(getContainerModelRuntimeConfig(undefined).modelPromptHints).toEqual([])
+    expect(getContainerModelRuntimeConfig('nope').modelPromptHints).toEqual([])
   })
 })
 
-describe('getContainerUnsupportedTools', () => {
+describe('getContainerModelRuntimeConfig unsupportedTools', () => {
   it('returns the web tools for a model that does not support web search', () => {
     // Inject a no-web-search model via catalog overrides for the active provider.
     settingsMock.mockReturnValue({
@@ -49,10 +47,10 @@ describe('getContainerUnsupportedTools', () => {
         },
       },
     })
-    expect(getContainerUnsupportedTools('no-web-1')).toEqual([...WEB_SEARCH_TOOLS])
+    expect(getContainerModelRuntimeConfig('no-web-1').unsupportedTools).toEqual([...WEB_SEARCH_TOOLS])
   })
 
-  it('returns the image-emitting tools for a model that does not support image input', () => {
+  it('does not globally ban image-emitting tools for a model that does not support image input', () => {
     settingsMock.mockReturnValue({
       llmProvider: 'platform',
       modelCatalog: {
@@ -63,10 +61,10 @@ describe('getContainerUnsupportedTools', () => {
         },
       },
     })
-    expect(getContainerUnsupportedTools('no-image-1')).toEqual([...IMAGE_EMITTING_TOOLS])
+    expect(getContainerModelRuntimeConfig('no-image-1').unsupportedTools).toEqual([])
   })
 
-  it('combines web and image bans when the model supports neither', () => {
+  it('bans only web tools when the model supports neither web search nor image input', () => {
     settingsMock.mockReturnValue({
       llmProvider: 'platform',
       modelCatalog: {
@@ -83,16 +81,19 @@ describe('getContainerUnsupportedTools', () => {
         },
       },
     })
-    expect(getContainerUnsupportedTools('no-web-no-image')).toEqual([
-      ...WEB_SEARCH_TOOLS,
-      ...IMAGE_EMITTING_TOOLS,
-    ])
+    expect(getContainerModelRuntimeConfig('no-web-no-image').unsupportedTools).toEqual([...WEB_SEARCH_TOOLS])
   })
 
-  it('returns nothing when the model supports both or capability is unknown', () => {
+  it('returns nothing when the model supports web tools or capability is unknown', () => {
     // Built-in Claude entry leaves both flags unset (assume supported).
-    expect(getContainerUnsupportedTools('claude-opus-4-8')).toEqual([])
-    expect(getContainerUnsupportedTools('nope')).toEqual([])
-    expect(getContainerUnsupportedTools(undefined)).toEqual([])
+    expect(getContainerModelRuntimeConfig('claude-opus-4-8').unsupportedTools).toEqual([])
+    expect(getContainerModelRuntimeConfig('nope').unsupportedTools).toEqual([])
+    expect(getContainerModelRuntimeConfig(undefined).unsupportedTools).toEqual([])
+  })
+
+  it('conservatively bans web tools for unknown non-Claude OpenRouter pins', () => {
+    settingsMock.mockReturnValue({ llmProvider: 'openrouter' })
+    expect(getContainerModelRuntimeConfig('openai/gpt-6.0-preview').unsupportedTools).toEqual([...WEB_SEARCH_TOOLS])
+    expect(getContainerModelRuntimeConfig('anthropic/claude-sonnet-4.6').unsupportedTools).toEqual([])
   })
 })

--- a/src/shared/lib/container/resolve-model.test.ts
+++ b/src/shared/lib/container/resolve-model.test.ts
@@ -8,7 +8,12 @@ vi.mock('../config/settings', () => ({
   getModelCatalogSettings: () => settingsMock().modelCatalog ?? {},
 }))
 
-import { getContainerModelPromptHints } from './resolve-model'
+import {
+  getContainerModelPromptHints,
+  getContainerUnsupportedTools,
+  WEB_SEARCH_TOOLS,
+  IMAGE_EMITTING_TOOLS,
+} from './resolve-model'
 
 beforeEach(() => {
   settingsMock.mockReturnValue({ llmProvider: 'platform' })
@@ -28,5 +33,66 @@ describe('getContainerModelPromptHints', () => {
   it('returns no hints for an undefined or unknown model', () => {
     expect(getContainerModelPromptHints(undefined)).toEqual([])
     expect(getContainerModelPromptHints('nope')).toEqual([])
+  })
+})
+
+describe('getContainerUnsupportedTools', () => {
+  it('returns the web tools for a model that does not support web search', () => {
+    // Inject a no-web-search model via catalog overrides for the active provider.
+    settingsMock.mockReturnValue({
+      llmProvider: 'platform',
+      modelCatalog: {
+        platform: {
+          overrides: [
+            { id: 'no-web-1', label: 'No Web', supportedEfforts: ['low'], supportsWebSearch: false },
+          ],
+        },
+      },
+    })
+    expect(getContainerUnsupportedTools('no-web-1')).toEqual([...WEB_SEARCH_TOOLS])
+  })
+
+  it('returns the image-emitting tools for a model that does not support image input', () => {
+    settingsMock.mockReturnValue({
+      llmProvider: 'platform',
+      modelCatalog: {
+        platform: {
+          overrides: [
+            { id: 'no-image-1', label: 'No Image', supportedEfforts: ['low'], supportsImageInput: false },
+          ],
+        },
+      },
+    })
+    expect(getContainerUnsupportedTools('no-image-1')).toEqual([...IMAGE_EMITTING_TOOLS])
+  })
+
+  it('combines web and image bans when the model supports neither', () => {
+    settingsMock.mockReturnValue({
+      llmProvider: 'platform',
+      modelCatalog: {
+        platform: {
+          overrides: [
+            {
+              id: 'no-web-no-image',
+              label: 'Text Only',
+              supportedEfforts: ['low'],
+              supportsWebSearch: false,
+              supportsImageInput: false,
+            },
+          ],
+        },
+      },
+    })
+    expect(getContainerUnsupportedTools('no-web-no-image')).toEqual([
+      ...WEB_SEARCH_TOOLS,
+      ...IMAGE_EMITTING_TOOLS,
+    ])
+  })
+
+  it('returns nothing when the model supports both or capability is unknown', () => {
+    // Built-in Claude entry leaves both flags unset (assume supported).
+    expect(getContainerUnsupportedTools('claude-opus-4-8')).toEqual([])
+    expect(getContainerUnsupportedTools('nope')).toEqual([])
+    expect(getContainerUnsupportedTools(undefined)).toEqual([])
   })
 })

--- a/src/shared/lib/container/resolve-model.ts
+++ b/src/shared/lib/container/resolve-model.ts
@@ -1,32 +1,20 @@
 import {
   getActiveLlmProvider,
-  getModelDefinition,
-  getModelPromptHints,
+  getEffectiveCatalog,
+  hasVersionSegment,
   resolveActiveProviderModel,
+  type LlmProviderId,
+  type ModelDefinition,
   type ModelPurpose,
 } from '@shared/lib/llm-provider'
 
-/**
- * Anthropic-native web tools the agent invokes directly. Banned for a model
- * with `supportsWebSearch === false`.
- */
+// Anthropic-native web tools the main agent invokes directly.
 export const WEB_SEARCH_TOOLS: readonly string[] = ['WebSearch', 'WebFetch']
 
-/**
- * Tools whose results carry image content blocks. Banned for a model with
- * `supportsImageInput === false`.
- *
- * This is the MAIN model's disallow list, so it only removes these from the
- * main agent's context. The browser/dashboard/computer subagents have their
- * own model + tool list and are unaffected, so dashboards/browsing keep working
- * on the subagents' (vision-capable) models.
- */
-export const IMAGE_EMITTING_TOOLS: readonly string[] = [
-  'mcp__browser__browser_screenshot',
-  'mcp__browser__browser_get_state',
-  'mcp__computer-use__computer_screenshot',
-  'mcp__dashboards__start_dashboard',
-]
+export interface ContainerModelRuntimeConfig {
+  modelPromptHints: string[]
+  unsupportedTools: string[]
+}
 
 /**
  * Resolve a stored model selection (bare family alias or concrete id) to the
@@ -51,39 +39,49 @@ export function resolveContainerModel(
   }
 }
 
-/**
- * Catalog prompt hints for an already-resolved wire model id (the value
- * resolveContainerModel produced), looked up in the active provider's catalog.
- * Empty for Claude/unknown models.
- */
-export function getContainerModelPromptHints(resolvedModel: string | undefined): string[] {
-  if (!resolvedModel) return []
-  try {
-    return getModelPromptHints(resolvedModel, getActiveLlmProvider().id)
-  } catch {
-    // Same test-context fallback as resolveContainerModel: settings/provider
-    // registry may be unmocked, in which case there are no hints to apply.
-    return []
-  }
+function findCatalogModel(catalog: ModelDefinition[], selection: string): ModelDefinition | undefined {
+  return (
+    catalog.find(model => model.id === selection) ??
+    catalog.find(model => model.family === selection && model.isLatest)
+  )
 }
 
-/**
- * Tools the given (already-resolved) wire model can't use, based on the active
- * provider's catalog capabilities: web tools when web search is unsupported,
- * image-emitting tools when image input is unsupported. Empty for a model that
- * supports both or whose capabilities are unknown (assume supported).
- */
-export function getContainerUnsupportedTools(resolvedModel: string | undefined): string[] {
-  if (!resolvedModel) return []
+function isLikelyClaudeModel(model: string): boolean {
+  const normalized = model.toLowerCase()
+  return normalized.includes('claude') || normalized.includes('anthropic')
+}
+
+function shouldDisableWebTools(
+  providerId: LlmProviderId,
+  resolvedModel: string,
+  modelDefinition: ModelDefinition | undefined,
+): boolean {
+  if (modelDefinition?.supportsWebSearch === false) return true
+  if (modelDefinition?.supportsWebSearch === true) return false
+  if (modelDefinition) return false
+  return providerId !== 'anthropic' && hasVersionSegment(resolvedModel) && !isLikelyClaudeModel(resolvedModel)
+}
+
+export function getContainerModelRuntimeConfig(
+  resolvedModel: string | undefined,
+  purpose: ModelPurpose = 'agent',
+): ContainerModelRuntimeConfig {
   try {
-    const def = getModelDefinition(resolvedModel, getActiveLlmProvider().id)
-    if (!def) return []
-    const tools: string[] = []
-    if (def.supportsWebSearch === false) tools.push(...WEB_SEARCH_TOOLS)
-    if (def.supportsImageInput === false) tools.push(...IMAGE_EMITTING_TOOLS)
-    return tools
+    const provider = getActiveLlmProvider()
+    const catalog = getEffectiveCatalog(provider.id)
+    const fallback = provider.getDefaultModel(purpose)
+    const selectedModel = resolvedModel ?? fallback
+    const modelDefinition = findCatalogModel(catalog, selectedModel)
+    const effectiveModel = modelDefinition?.id ?? selectedModel
+    const unsupportedTools = shouldDisableWebTools(provider.id, effectiveModel, modelDefinition)
+      ? [...WEB_SEARCH_TOOLS]
+      : []
+
+    return {
+      modelPromptHints: modelDefinition?.promptHints ?? [],
+      unsupportedTools,
+    }
   } catch {
-    // Same test-context fallback as getContainerModelPromptHints.
-    return []
+    return { modelPromptHints: [], unsupportedTools: [] }
   }
 }

--- a/src/shared/lib/container/resolve-model.ts
+++ b/src/shared/lib/container/resolve-model.ts
@@ -1,9 +1,32 @@
 import {
   getActiveLlmProvider,
+  getModelDefinition,
   getModelPromptHints,
   resolveActiveProviderModel,
   type ModelPurpose,
 } from '@shared/lib/llm-provider'
+
+/**
+ * Anthropic-native web tools the agent invokes directly. Banned for a model
+ * with `supportsWebSearch === false`.
+ */
+export const WEB_SEARCH_TOOLS: readonly string[] = ['WebSearch', 'WebFetch']
+
+/**
+ * Tools whose results carry image content blocks. Banned for a model with
+ * `supportsImageInput === false`.
+ *
+ * This is the MAIN model's disallow list, so it only removes these from the
+ * main agent's context. The browser/dashboard/computer subagents have their
+ * own model + tool list and are unaffected, so dashboards/browsing keep working
+ * on the subagents' (vision-capable) models.
+ */
+export const IMAGE_EMITTING_TOOLS: readonly string[] = [
+  'mcp__browser__browser_screenshot',
+  'mcp__browser__browser_get_state',
+  'mcp__computer-use__computer_screenshot',
+  'mcp__dashboards__start_dashboard',
+]
 
 /**
  * Resolve a stored model selection (bare family alias or concrete id) to the
@@ -40,6 +63,27 @@ export function getContainerModelPromptHints(resolvedModel: string | undefined):
   } catch {
     // Same test-context fallback as resolveContainerModel: settings/provider
     // registry may be unmocked, in which case there are no hints to apply.
+    return []
+  }
+}
+
+/**
+ * Tools the given (already-resolved) wire model can't use, based on the active
+ * provider's catalog capabilities: web tools when web search is unsupported,
+ * image-emitting tools when image input is unsupported. Empty for a model that
+ * supports both or whose capabilities are unknown (assume supported).
+ */
+export function getContainerUnsupportedTools(resolvedModel: string | undefined): string[] {
+  if (!resolvedModel) return []
+  try {
+    const def = getModelDefinition(resolvedModel, getActiveLlmProvider().id)
+    if (!def) return []
+    const tools: string[] = []
+    if (def.supportsWebSearch === false) tools.push(...WEB_SEARCH_TOOLS)
+    if (def.supportsImageInput === false) tools.push(...IMAGE_EMITTING_TOOLS)
+    return tools
+  } catch {
+    // Same test-context fallback as getContainerModelPromptHints.
     return []
   }
 }


### PR DESCRIPTION
## What & why

Some models don't support certain capabilities (e.g. web search, image input). Today the picker only *warns* about missing web search and doesn't actually stop the agent from calling the tool, and there's no signal at all for image-only gaps. This wires model capability flags from the catalog through to the agent container so unsupported tools are disallowed, and surfaces capability gaps in the picker.

## What changed

- **Mechanism**: the host resolves per-model banned tools from the active provider's catalog and sends them on session create; the container merges them into the SDK `disallowedTools`. This mirrors the existing `modelPromptHints` plumbing (host computes → `/sessions` body → `session-manager` → `ClaudeCodeProcess`).
- **Web search enforcement**: `supportsWebSearch === false` → ban `WebSearch` / `WebFetch` (the main agent's Anthropic-native web tools).
- **UI warnings**: the model picker warns when the selected model lacks web search (existing) or image input (new).

## Deliberately scoped out (follow-up)

Image-emitting tools — `browser_screenshot`, `browser_get_state`, `computer_screenshot`, `start_dashboard` — are **not** banned here. They belong to the browser/dashboard/computer **subagents**, and their image results target the *subagent's own model* (e.g. dashboard-builder runs on Opus), not the main model. Banning them by main-model capability would needlessly break dashboards/browsing. Image input is therefore **warning-only** in this PR; per-subagent image-tool gating is a separate follow-up.

## Test plan

- [x] `agent-container` suite green (incl. new `bannedTools` → `disallowedTools` merge test)
- [x] app tests green: `resolve-model` (web-search ban), `model-family-list` (image warning)
- [x] typecheck clean (app + agent-container), lint clean

Draft: opening for early review of the mechanism + scope before the subagent follow-up.

Made with [Cursor](https://cursor.com)