### PR TITLE
Stabilize global connections E2E test

### DIFF
--- a/e2e/specs/global-connections.spec.ts
+++ b/e2e/specs/global-connections.spec.ts
@@ -1,90 +1,120 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page, type TestInfo } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 import { startMockMcpServer, type MockMcpServer } from '../helpers/mock-mcp-server'
-
-// Serial: cross-checks DB state via the API; sensitive to concurrent writes.
-test.describe.configure({ mode: 'serial' })
+import { expectRemoteMcpByUrl, type TestRemoteMcp } from '../helpers/connections'
 
 const API = ''
 
-test.describe('Global Settings → Connections — Add MCP flow', () => {
-  let appPage: AppPage
-  let mockMcp: MockMcpServer
-  // 9878 avoids colliding with connected-accounts.spec.ts (9876) and
-  // connections-management.spec.ts (9877).
-  const MCP_PORT = 9878
-
-  test.beforeAll(async () => {
-    mockMcp = await startMockMcpServer(MCP_PORT)
-  })
-
-  test.afterAll(async () => {
+async function withMockMcp<T>(run: (mockMcp: MockMcpServer) => Promise<T>): Promise<T> {
+  const mockMcp = await startMockMcpServer(0)
+  try {
+    return await run(mockMcp)
+  } finally {
     await mockMcp.close()
-  })
+  }
+}
 
+function uniqueName(testInfo: TestInfo, label: string) {
+  const suffix = [
+    testInfo.workerIndex,
+    testInfo.repeatEachIndex,
+    testInfo.retry,
+    Date.now(),
+    Math.random().toString(36).slice(2, 8),
+  ].join('-')
+
+  return `${label} ${suffix}`
+}
+
+function connectionRow(page: Page, name: string) {
+  return page.getByRole('button', {
+    name: `Open ${name} connection details`,
+    exact: true,
+  })
+}
+
+test.describe('Global Settings → Connections — Add MCP flow', () => {
   test.beforeEach(async ({ page }) => {
-    appPage = new AppPage(page)
+    const appPage = new AppPage(page)
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
   })
 
-  test('adding a custom MCP from the global Connections tab closes the dialog and shows the row', async ({ page, request }) => {
-    const mcpName = `Global Add MCP ${Date.now()}`
+  test('adding a custom MCP from the global Connections tab closes the dialog and shows the row', async ({ page, request }, testInfo) => {
+    await withMockMcp(async (mockMcp) => {
+      const mcpName = uniqueName(testInfo, 'Global Add MCP')
+      let created: TestRemoteMcp | undefined
 
-    // 1. Open Global Settings → Connections.
-    await page.locator('[data-testid="settings-button"]').click()
-    await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
-    await page.locator('[data-testid="settings-nav-connections"]').click()
+      try {
+        // 1. Open Global Settings → Connections.
+        await page.locator('[data-testid="settings-button"]').click()
+        await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
+        await page.locator('[data-testid="settings-nav-connections"]').click()
 
-    // The "+ New connection" button is hoisted into the page-level title row
-    // via SettingsPageSection.headerActions. Same component as the agent-page
-    // button, so it shares the `connections-add-button` test-id.
-    const addButton = page.locator('[data-testid="connections-add-button"]')
-    await expect(addButton).toBeVisible()
+        // The "+ New connection" button is hoisted into the page-level title row
+        // via SettingsPageSection.headerActions. Same component as the agent-page
+        // button, so it shares the `connections-add-button` test-id.
+        const addButton = page.locator('[data-testid="connections-add-button"]').first()
+        await expect(addButton).toBeVisible()
 
-    // 2. Open the directory dialog and switch to the MCPs tab.
-    await addButton.click()
-    const dialog = page.getByRole('dialog', { name: 'Add New Connection' })
-    await expect(dialog).toBeVisible()
-    await page.locator('[data-testid="directory-tab-mcps"]').click()
+        // 2. Open the directory dialog and switch to the MCPs tab.
+        await addButton.click()
+        const dialog = page.getByRole('dialog', { name: 'Add New Connection' })
+        await expect(dialog).toBeVisible()
+        await page.locator('[data-testid="directory-tab-mcps"]').click()
 
-    // 3. Expand the Custom MCP tile and fill in the no-auth form.
-    await page.locator('[data-testid="directory-connect-mcp-custom"]').click()
-    await page.locator('[data-testid="mcp-form-name"]').fill(mcpName)
-    await page.locator('[data-testid="mcp-form-url"]').fill(mockMcp.url)
-    // authType defaults to "No Authentication" — leave it.
+        // 3. Expand the Custom MCP tile and fill in the no-auth form.
+        await page.locator('[data-testid="directory-connect-mcp-custom"]').click()
+        await page.locator('[data-testid="mcp-form-name"]').fill(mcpName)
+        await page.locator('[data-testid="mcp-form-url"]').fill(mockMcp.url)
+        // authType defaults to "No Authentication" — leave it.
 
-    // 4. Submit. The directory dialog closes and the Tool Policy editor opens.
-    await page.locator('[data-testid="mcp-form-submit"]').click()
-    await expect(dialog).toBeHidden({ timeout: 10000 })
+        // 4. Submit. The directory dialog closes and the Tool Policy editor opens.
+        await page.locator('[data-testid="mcp-form-submit"]').click()
+        await expect(dialog).toBeHidden({ timeout: 10000 })
 
-    // Dismiss the Tool Policy editor that opens for the new MCP.
-    const policyDialog = page.getByText('Tool Policies')
-    await expect(policyDialog).toBeVisible({ timeout: 10000 })
-    await page.getByRole('button', { name: 'Cancel' }).click()
-    await expect(policyDialog).not.toBeVisible({ timeout: 5000 })
+        // 5. Cross-check that the global MCP record landed in the DB with
+        // the tool metadata discovered from this test's mock server.
+        created = await expectRemoteMcpByUrl(request, mockMcp.url, mcpName)
+        expect(created.name).toBe(mcpName)
+        expect(created.status).toBe('active')
+        expect(created.authType).toBe('none')
+        expect(created.tools.map((tool) => tool.name).sort()).toEqual(['get_weather', 'hello_world'])
+        expect(created.tools.find((tool) => tool.name === 'hello_world')).toMatchObject({
+          description: 'Returns a greeting message',
+          inputSchema: { properties: { name: { type: 'string' } } },
+        })
 
-    // 5. The new row shows up in the global Connections list.
-    //    The unified row has no per-agent Switch — match by name instead.
-    const newRow = page.getByText(mcpName, { exact: true }).first()
-    await expect(newRow).toBeVisible({ timeout: 10000 })
+        // Dismiss the Tool Policy editor that opens for the new MCP.
+        const policyDialog = page.getByRole('dialog', { name: `${mcpName} Tool Policies` })
+        await expect(policyDialog).toBeVisible({ timeout: 10000 })
+        await policyDialog.getByRole('button', { name: 'Cancel' }).click()
+        await expect(policyDialog).not.toBeVisible({ timeout: 5000 })
 
-    // 6. The row subtitle shows the agent-count snippet and reads "Not in use"
-    //    — the server has the MCP but it's not mapped to anyone yet.
-    const allMcps = await (await request.get(`${API}/api/remote-mcps`)).json()
-    const created = (allMcps.servers as Array<{ id: string; name: string; url: string }>).find(
-      (m) => m.url === mockMcp.url,
-    )
-    expect(created, 'newly added MCP missing from /api/remote-mcps').toBeDefined()
-    expect(created!.name).toBe(mcpName)
+        // 6. The new row shows up in the global Connections list. Scope to the
+        // interactive row so other tests' connections cannot satisfy this check.
+        const newRow = connectionRow(page, mcpName)
+        await expect(newRow).toBeVisible({ timeout: 10000 })
+        await expect(newRow).toContainText(mcpName)
+        await expect(newRow).toContainText('MCP')
+        await expect(newRow).toContainText(mockMcp.url)
 
-    const agentCount = page.locator(`[data-testid="connection-agent-count-mcp-${created!.id}"]`)
-    await expect(agentCount).toBeVisible()
-    await expect(agentCount).toContainText('Not in use')
+        // 7. The row subtitle shows the agent-count snippet and reads "Not in
+        // use" — the server has the MCP but it's not mapped to anyone yet.
+        const agentCount = page.locator(`[data-testid="connection-agent-count-mcp-${created.id}"]`)
+        await expect(agentCount).toBeVisible()
+        await expect(agentCount).toContainText('Not in use')
+        await expect(newRow).toContainText('Not in use')
 
-    // 7. Backend cross-check: the new /:id/agents endpoint returns an empty list.
-    const agentsRes = await request.get(`${API}/api/remote-mcps/${created!.id}/agents`)
-    expect(agentsRes.ok()).toBeTruthy()
-    expect(await agentsRes.json()).toEqual({ agentSlugs: [] })
+        // 8. Backend cross-check: the new /:id/agents endpoint returns an empty list.
+        const agentsRes = await request.get(`${API}/api/remote-mcps/${created.id}/agents`)
+        expect(agentsRes.ok()).toBeTruthy()
+        expect(await agentsRes.json()).toEqual({ agentSlugs: [] })
+      } finally {
+        if (created) {
+          await request.delete(`${API}/api/remote-mcps/${created.id}`).catch(() => {})
+        }
+      }
+    })
   })
 })


### PR DESCRIPTION
## Summary

Hardens the global Connections -> custom MCP E2E test so it is safer to run independently and alongside other connection tests.

- Removes serial mode from `global-connections.spec.ts`.
- Replaces the shared fixed-port mock MCP server with a per-test ephemeral server.
- Uses worker/retry-aware MCP names to avoid collisions in repeated or parallel runs.
- Scopes the created-row assertion to the interactive connection row instead of page-wide text.
- Handles the duplicate `connections-add-button` clean-database case by selecting the header action.
- Adds backend checks for discovered tool metadata, active/no-auth status, empty agent mapping, and cleans up the created MCP record.

## Why

The old test used a suite-level mock MCP server on hard-coded port `9878` and carried `serial` mode even though the test can be independent. It also left the created global MCP behind and used selectors that could be ambiguous when the database was empty or polluted by other tests. This change makes the test less coupled to suite order, fixed ports, and leftover global state while increasing assertion depth.

## Validation

- `npm exec eslint -- e2e/specs/global-connections.spec.ts`
- `npm run lint:e2e` (passes with existing warnings elsewhere)
- `E2E_MOCK=true PLAYWRIGHT_WORKERS=3 npx playwright test e2e/specs/global-connections.spec.ts --project=web-chromium --no-deps --workers=3`
- `E2E_MOCK=true PLAYWRIGHT_WORKERS=4 npx playwright test e2e/specs/global-connections.spec.ts e2e/specs/connections-management.spec.ts --project=web-chromium --no-deps --workers=4 --repeat-each=3`
- `E2E_MOCK=true PLAYWRIGHT_WORKERS=3 npx playwright test e2e/specs/global-connections.spec.ts --project=web-chromium --workers=3`
