### PR TITLE
Allow deleting skills in the UI

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -270,6 +270,7 @@ vi.mock('@shared/lib/services/skillset-service', () => ({
   publishSkillToSkillset: vi.fn(),
   refreshAgentSkills: vi.fn(),
   exportSkill: vi.fn(),
+  deleteSkill: vi.fn(),
   importSkillFromZip: vi.fn(),
   SKILL_MAX_COMPRESSED_SIZE: 100 * 1024 * 1024,
 }))
@@ -400,6 +401,7 @@ import {
   hasOnboardingSkill,
 } from '@shared/lib/services/agent-template-service'
 import {
+  deleteSkill,
   exportSkill,
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
@@ -3154,6 +3156,38 @@ describe('POST /api/agents/:id/skills/:dir/export', () => {
 
     const res = await app.request('http://localhost/api/agents/my-agent/skills/bad-skill/export', {
       method: 'POST',
+    })
+
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toBe('Skill directory not found')
+  })
+})
+
+describe('DELETE /api/agents/:id/skills/:dir', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+  })
+
+  it('deletes the skill and returns 204', async () => {
+    vi.mocked(deleteSkill).mockResolvedValue()
+
+    const res = await app.request('http://localhost/api/agents/my-agent/skills/my-skill', {
+      method: 'DELETE',
+    })
+
+    expect(res.status).toBe(204)
+    expect(deleteSkill).toHaveBeenCalledWith('my-agent', 'my-skill')
+  })
+
+  it('returns 500 when service throws', async () => {
+    vi.mocked(deleteSkill).mockRejectedValue(new Error('Skill directory not found'))
+
+    const res = await app.request('http://localhost/api/agents/my-agent/skills/bad-skill', {
+      method: 'DELETE',
     })
 
     expect(res.status).toBe(500)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -76,6 +76,7 @@ import {
   publishSkillToSkillset,
   refreshAgentSkills,
   exportSkill,
+  deleteSkill,
   importSkillFromZip,
   SKILL_MAX_COMPRESSED_SIZE,
 } from '@shared/lib/services/skillset-service'
@@ -3667,6 +3668,22 @@ agents.post('/:id/skills/:dir/export', AgentAdmin(), async (c) => {
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to export skill'
     console.error('Failed to export skill:', error)
+    return c.json({ error: message }, 500)
+  }
+})
+
+// DELETE /api/agents/:id/skills/:dir - Delete an installed skill from an agent
+agents.delete('/:id/skills/:dir', AgentAdmin(), async (c) => {
+  try {
+    const agentSlug = getAgentId(c)
+    const dir = c.req.param('dir')
+    await deleteSkill(agentSlug, dir)
+
+    logAuditEvent({ userId: getCurrentUserId(c), object: 'skill', objectId: `${agentSlug}/${dir}`, action: 'deleted' })
+    return c.body(null, 204)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to delete skill'
+    console.error('Failed to delete skill:', error)
     return c.json({ error: message }, 500)
   }
 })

--- a/src/renderer/components/agents/agent-home/home-skills.tsx
+++ b/src/renderer/components/agents/agent-home/home-skills.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useRef, useCallback } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
-import { MoreVertical, FileCode, CloudUpload, GitPullRequest, Send, RefreshCw, Loader2, Plus, Play, Upload, Download, FileArchive } from 'lucide-react'
+import { MoreVertical, FileCode, CloudUpload, GitPullRequest, Send, RefreshCw, Loader2, Plus, Play, Upload, Download, FileArchive, Trash2 } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -15,6 +15,7 @@ import { StatusBadge } from '../status-badge'
 import { SkillFilesDialog } from '../skill-files-dialog'
 import { SkillPublishDialog } from '../skill-publish-dialog'
 import { SkillPRDialog } from '../skill-pr-dialog'
+import { SkillDeleteDialog } from '../skill-delete-dialog'
 import { HomeCollapsible } from './home-collapsible'
 import { HomeSkillsBrowseDialog } from './home-skills-browse-dialog'
 import { useAgentSkills, useDiscoverableSkills, useUpdateSkill, useExportSkill, useImportSkillZip } from '@renderer/hooks/use-agent-skills'
@@ -101,11 +102,14 @@ function SkillRow({ skill, agentSlug, onRunSkill }: { skill: ApiSkillWithStatus;
   const [filesOpen, setFilesOpen] = useState(false)
   const [publishOpen, setPublishOpen] = useState(false)
   const [reviewOpen, setReviewOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [actionsOpen, setActionsOpen] = useState(false)
   const updateSkill = useUpdateSkill()
   const exportSkill = useExportSkill()
   const publishMode = useSkillsetPublishMode(skill.status.skillsetId)
   const ReviewIcon = isPullRequestPublishMode(publishMode) ? GitPullRequest : Send
   const actionLabel = getReviewActionLabel(publishMode)
+  const skillName = skill.name ?? skill.path
 
   return (
     <>
@@ -130,7 +134,7 @@ function SkillRow({ skill, agentSlug, onRunSkill }: { skill: ApiSkillWithStatus;
               <Play className="h-3 w-3" />
             </Button>
           )}
-          <Popover>
+          <Popover open={actionsOpen} onOpenChange={setActionsOpen}>
             <PopoverTrigger asChild>
               <Button
                 type="button"
@@ -146,7 +150,7 @@ function SkillRow({ skill, agentSlug, onRunSkill }: { skill: ApiSkillWithStatus;
             <PopoverContent align="end" className="w-36 p-1" onClick={(e) => e.stopPropagation()}>
               <button
                 className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
-                onClick={(e) => { e.stopPropagation(); setFilesOpen(true) }}
+                onClick={(e) => { e.stopPropagation(); setActionsOpen(false); setFilesOpen(true) }}
               >
                 <FileCode className="h-3.5 w-3.5" />
                 View Files
@@ -156,8 +160,9 @@ function SkillRow({ skill, agentSlug, onRunSkill }: { skill: ApiSkillWithStatus;
                 disabled={exportSkill.isPending}
                 onClick={(e) => {
                   e.stopPropagation()
+                  setActionsOpen(false)
                   exportSkill.mutate(
-                    { agentSlug, skillDir: skill.path, skillName: skill.name ?? skill.path },
+                    { agentSlug, skillDir: skill.path, skillName },
                     { onError: (err) => toast.error('Export failed', { description: err.message }) },
                   )
                 }}
@@ -172,7 +177,7 @@ function SkillRow({ skill, agentSlug, onRunSkill }: { skill: ApiSkillWithStatus;
               {skill.status.type === 'local' && skill.status.publishable !== false && publishMode !== 'none' && (
                 <button
                   className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
-                  onClick={(e) => { e.stopPropagation(); setPublishOpen(true) }}
+                  onClick={(e) => { e.stopPropagation(); setActionsOpen(false); setPublishOpen(true) }}
                 >
                   <CloudUpload className="h-3.5 w-3.5" />
                   Publish Skill
@@ -182,7 +187,7 @@ function SkillRow({ skill, agentSlug, onRunSkill }: { skill: ApiSkillWithStatus;
                 <button
                   className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
                   disabled={updateSkill.isPending}
-                  onClick={(e) => { e.stopPropagation(); updateSkill.mutate({ agentSlug, skillDir: skill.path }) }}
+                  onClick={(e) => { e.stopPropagation(); setActionsOpen(false); updateSkill.mutate({ agentSlug, skillDir: skill.path }) }}
                 >
                   {updateSkill.isPending ? (
                     <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -195,12 +200,19 @@ function SkillRow({ skill, agentSlug, onRunSkill }: { skill: ApiSkillWithStatus;
               {skill.status.type === 'locally_modified' && publishMode !== 'none' && (
                 <button
                   className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
-                  onClick={(e) => { e.stopPropagation(); setReviewOpen(true) }}
+                  onClick={(e) => { e.stopPropagation(); setActionsOpen(false); setReviewOpen(true) }}
                 >
                   <ReviewIcon className="h-3.5 w-3.5" />
                   {actionLabel}
                 </button>
               )}
+              <button
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-destructive hover:bg-destructive/10 transition-colors"
+                onClick={(e) => { e.stopPropagation(); setActionsOpen(false); setDeleteOpen(true) }}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                Delete Skill
+              </button>
             </PopoverContent>
           </Popover>
         </div>
@@ -227,6 +239,13 @@ function SkillRow({ skill, agentSlug, onRunSkill }: { skill: ApiSkillWithStatus;
         agentSlug={agentSlug}
         skillDir={skill.path}
         publishMode={publishMode}
+      />
+      <SkillDeleteDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        agentSlug={agentSlug}
+        skillDir={skill.path}
+        skillName={skillName}
       />
     </>
   )

--- a/src/renderer/components/agents/skill-context-menu.tsx
+++ b/src/renderer/components/agents/skill-context-menu.tsx
@@ -1,13 +1,15 @@
 import { useState } from 'react'
-import { FileCode, Upload } from 'lucide-react'
+import { FileCode, Trash2, Upload } from 'lucide-react'
 import { toast } from 'sonner'
 import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuSeparator,
   ContextMenuTrigger,
 } from '@renderer/components/ui/context-menu'
 import { SkillFilesDialog } from './skill-files-dialog'
+import { SkillDeleteDialog } from './skill-delete-dialog'
 import { useExportSkill } from '@renderer/hooks/use-agent-skills'
 import type { ApiSkillWithStatus } from '@shared/lib/types/api'
 
@@ -19,7 +21,9 @@ interface SkillContextMenuProps {
 
 export function SkillContextMenu({ skill, agentSlug, children }: SkillContextMenuProps) {
   const [filesDialogOpen, setFilesDialogOpen] = useState(false)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const exportSkill = useExportSkill()
+  const skillName = skill.name ?? skill.path
 
   return (
     <>
@@ -36,13 +40,21 @@ export function SkillContextMenu({ skill, agentSlug, children }: SkillContextMen
             disabled={exportSkill.isPending}
             onClick={() => {
               exportSkill.mutate(
-                { agentSlug, skillDir: skill.path, skillName: skill.name ?? skill.path },
+                { agentSlug, skillDir: skill.path, skillName },
                 { onError: (err) => toast.error('Export failed', { description: err.message }) },
               )
             }}
           >
             <Upload className="h-4 w-4 mr-2" />
             Export Skill
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={() => setDeleteDialogOpen(true)}
+          >
+            <Trash2 className="h-4 w-4 mr-2" />
+            Delete Skill
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
@@ -53,6 +65,13 @@ export function SkillContextMenu({ skill, agentSlug, children }: SkillContextMen
         agentSlug={agentSlug}
         skillDir={skill.path}
         skillName={skill.name}
+      />
+      <SkillDeleteDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        agentSlug={agentSlug}
+        skillDir={skill.path}
+        skillName={skillName}
       />
     </>
   )

--- a/src/renderer/components/agents/skill-delete-dialog.tsx
+++ b/src/renderer/components/agents/skill-delete-dialog.tsx
@@ -1,0 +1,72 @@
+import { toast } from 'sonner'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@renderer/components/ui/alert-dialog'
+import { useDeleteSkill } from '@renderer/hooks/use-agent-skills'
+
+interface SkillDeleteDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  agentSlug: string
+  skillDir: string
+  skillName?: string | null
+}
+
+export function SkillDeleteDialog({
+  open,
+  onOpenChange,
+  agentSlug,
+  skillDir,
+  skillName,
+}: SkillDeleteDialogProps) {
+  const deleteSkill = useDeleteSkill()
+  const displayName = skillName || skillDir
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!deleteSkill.isPending) onOpenChange(nextOpen)
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete Skill</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will remove {displayName} from this agent. You can add it again
+            from your team skills if it is still available.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleteSkill.isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            disabled={deleteSkill.isPending}
+            onClick={(event) => {
+              event.preventDefault()
+              deleteSkill.mutate(
+                { agentSlug, skillDir },
+                {
+                  onSuccess: () => {
+                    onOpenChange(false)
+                    toast.success(`Deleted skill "${displayName}"`)
+                  },
+                  onError: (err) => toast.error('Delete failed', { description: err.message }),
+                },
+              )
+            }}
+          >
+            {deleteSkill.isPending ? 'Deleting...' : 'Delete Skill'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/renderer/hooks/use-agent-skills.ts
+++ b/src/renderer/hooks/use-agent-skills.ts
@@ -259,6 +259,28 @@ export function useExportSkill() {
   })
 }
 
+export function useDeleteSkill() {
+  const queryClient = useQueryClient()
+
+  return useMutation<void, Error, { agentSlug: string; skillDir: string }>({
+    meta: { skipGlobalErrorToast: true },
+    mutationFn: async ({ agentSlug, skillDir }) => {
+      const res = await apiFetch(
+        `/api/agents/${encodeURIComponent(agentSlug)}/skills/${encodeURIComponent(skillDir)}`,
+        { method: 'DELETE' },
+      )
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Failed to delete skill')
+      }
+    },
+    onSuccess: (_, vars) => {
+      queryClient.invalidateQueries({ queryKey: ['agent-skills', vars.agentSlug] })
+      queryClient.invalidateQueries({ queryKey: ['discoverable-skills', vars.agentSlug] })
+    },
+  })
+}
+
 export function useImportSkillZip() {
   const queryClient = useQueryClient()
 

--- a/src/shared/lib/services/audit-log-service.ts
+++ b/src/shared/lib/services/audit-log-service.ts
@@ -12,7 +12,7 @@ export const AUDIT_EVENT_MAP = {
   trigger:          ['created', 'updated', 'deleted', 'paused', 'resumed'],
   task:             ['created', 'updated', 'deleted', 'paused', 'resumed'],
   chat_integration: ['created', 'updated', 'deleted'],
-  skill:            ['created', 'updated', 'exported'],
+  skill:            ['created', 'updated', 'deleted', 'exported'],
   secret:           ['created', 'updated', 'deleted'],
   file:             ['uploaded'],
   mount:            ['created', 'deleted'],
@@ -117,4 +117,3 @@ export async function getDistinctAuditUsers(): Promise<Array<{ id: string; name:
     .from(user)
     .where(inArray(user.id, userIds))
 }
-

--- a/src/shared/lib/services/skillset-service.test.ts
+++ b/src/shared/lib/services/skillset-service.test.ts
@@ -104,6 +104,7 @@ import {
   getSkillsetRepoDir,
   isCacheReady,
   isGitAvailable,
+  deleteSkill,
   exportSkill,
   validateSkillZip,
   importSkillFromZip,
@@ -2318,6 +2319,28 @@ metadata:
 
     it('rejects path traversal in skillDirName', async () => {
       await expect(exportSkill('test-agent', '../etc')).rejects.toThrow('Invalid directory name')
+    })
+  })
+
+  describe('deleteSkill', () => {
+    it('removes a skill directory recursively', async () => {
+      const agentSlug = 'test-agent'
+      const skillDir = makeSkillDir(agentSlug, 'delete-me')
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), MINIMAL_SKILL_MD)
+      fs.mkdirSync(path.join(skillDir, 'lib'))
+      fs.writeFileSync(path.join(skillDir, 'lib', 'helper.py'), 'print("hello")')
+
+      await deleteSkill(agentSlug, 'delete-me')
+
+      expect(fs.existsSync(skillDir)).toBe(false)
+    })
+
+    it('throws when skill directory does not exist', async () => {
+      await expect(deleteSkill('test-agent', 'missing-skill')).rejects.toThrow('Skill directory not found')
+    })
+
+    it('rejects path traversal in skillDirName', async () => {
+      await expect(deleteSkill('test-agent', '../etc')).rejects.toThrow('Invalid directory name')
     })
   })
 

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -23,6 +23,7 @@ import {
   readFileOrNull,
   ensureDirectory,
   directoryExists,
+  removeDirectory,
 } from '@shared/lib/utils/file-storage'
 import type {
   SkillsetIndex,
@@ -1737,6 +1738,20 @@ export async function exportSkill(agentSlug: string, skillDirName: string): Prom
 
   const { createZipBuffer } = await import('@shared/lib/utils/zip')
   return createZipBuffer(files)
+}
+
+/**
+ * Delete a skill from an agent's installed skills directory.
+ */
+export async function deleteSkill(agentSlug: string, skillDirName: string): Promise<void> {
+  sanitizeDirName(skillDirName)
+  const skillDir = path.join(getAgentSkillsDir(agentSlug), skillDirName)
+
+  if (!(await directoryExists(skillDir))) {
+    throw new Error('Skill directory not found')
+  }
+
+  await removeDirectory(skillDir)
 }
 
 export interface SkillValidationResult {


### PR DESCRIPTION
## Summary

- Add a backend endpoint and service method for deleting installed agent skills.
- Add a reusable delete confirmation dialog and wire it into the skill actions menus.
- Refresh installed/discoverable skill queries after deletion and cover the new route/service behavior with tests.

## Validation

- `npm run test:run -- src/shared/lib/services/skillset-service.test.ts src/api/routes/agents.test.ts`
- `npm run typecheck`
- `./node_modules/.bin/eslint src/api/routes/agents.ts src/api/routes/agents.test.ts src/shared/lib/services/audit-log-service.ts src/shared/lib/services/skillset-service.ts src/shared/lib/services/skillset-service.test.ts src/renderer/hooks/use-agent-skills.ts src/renderer/components/agents/agent-home/home-skills.tsx src/renderer/components/agents/skill-context-menu.tsx src/renderer/components/agents/skill-delete-dialog.tsx --ext .ts,.tsx`