### PR TITLE
fix(browser): keep control pill visible in Safari (SUP-338)

### DIFF
--- a/src/renderer/components/browser/browser-tray-content.tsx
+++ b/src/renderer/components/browser/browser-tray-content.tsx
@@ -169,8 +169,14 @@ export function BrowserTrayContent({
         )}
       </div>
 
-      {/* Browser controls pill */}
-      <div className="sticky bottom-2 z-20 flex justify-center pointer-events-none shrink-0 -mt-10">
+      {/* Browser controls pill. translateZ(0) forces this onto its own compositing
+          layer so it paints above the screencast <canvas> (which sets
+          will-change: transform). Without its own layer, Safari/WebKit composites
+          the canvas layer over the z-index'd pill and the controls disappear. */}
+      <div
+        className="sticky bottom-2 z-20 flex justify-center pointer-events-none shrink-0 -mt-10"
+        style={{ transform: 'translateZ(0)' }}
+      >
         <div className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-background px-2 py-1 shadow-md pointer-events-auto">
           {(isPaused || (isActive && !stream.needsAttention)) && (
             <button


### PR DESCRIPTION
## Problem

On the hosted web deployment, the browser drawer's **control pill** (pause / stop / expand) was missing — but only in **Safari**. It worked fine in the Electron app. Reported in SUP-338 as possibly auth-mode / Browserbase / "being in the browser" — all of which turned out to be red herrings.

## Root cause

A Safari/WebKit GPU **compositing-layer** bug:

- The screencast `<canvas>` sets `will-change: transform` (`browser-tray-content.tsx`), putting it on its own GPU layer that repaints every frame.
- The control pill relied only on `z-index: 20`, with no compositing layer of its own.
- In Safari's Metal compositor, the canvas layer paints **over** the non-promoted sticky pill. The pill is present, correctly positioned, and `visibility: visible` / `opacity: 1` in the DOM — it's just never painted.

Chromium (Electron, and even Playwright's bundled Chromium **and** WebKit) composites it correctly, which is why it only reproduced in real Safari and "worked in the Electron app."

## Fix

Force the pill onto its own compositing layer with `transform: translateZ(0)`, so the compositor orders it above the canvas by z-index. No-op in Chromium; restores the controls in Safari.

```diff
-      {/* Browser controls pill */}
-      <div className="sticky bottom-2 z-20 flex justify-center pointer-events-none shrink-0 -mt-10">
+      {/* Browser controls pill. translateZ(0) forces this onto its own compositing layer ... */}
+      <div
+        className="sticky bottom-2 z-20 flex justify-center pointer-events-none shrink-0 -mt-10"
+        style={{ transform: 'translateZ(0)' }}
+      >
```

## Testing

- ✅ Confirmed fix in **real Safari** on the deployment via DevTools (adding `translateZ(0)` to the pill makes the controls reappear).
- ✅ `tsc --noEmit` and `eslint` pass.
- ✅ Verified no regression in Chromium (pill renders identically with/without the change, across dev + production web builds and expanded/short viewports).

No automated test added: the bug only manifests in real Safari's GPU compositor — Playwright's WebKit does not reproduce it. A code comment documents why the `translateZ(0)` must stay.

Closes SUP-338.
