### PR TITLE
fix(browser): contenteditable read-back so type/fill don't duplicate text (SUP-340)

### DIFF
--- a/agent-container/src/field-value-readback.test.ts
+++ b/agent-container/src/field-value-readback.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { resolveCommittedValue, type FieldRead } from './field-value-readback'
+
+const read = (text: string): FieldRead => ({ ok: true, text })
+const failed: FieldRead = { ok: false, text: '' }
+
+describe('resolveCommittedValue', () => {
+  it('uses the form-control value when it is non-empty (input/textarea)', () => {
+    // The common case: `get value` returns the value, no text fallback needed.
+    expect(resolveCommittedValue(read('hello'), null)).toBe('hello')
+  })
+
+  it('does not consult text when value is non-empty', () => {
+    // Even if a (hypothetical) text read would differ, value wins.
+    expect(resolveCommittedValue(read('hello'), read('ignored'))).toBe('hello')
+  })
+
+  it('falls back to text content for contenteditable when value is empty', () => {
+    // LinkedIn's message box: `get value` is "" but `get text` has the content.
+    // Returning "" here is exactly what drove agents to re-type "hellohello".
+    expect(resolveCommittedValue(read(''), read('hello'))).toBe('hello')
+  })
+
+  it('falls back to text when the value read failed but text succeeded', () => {
+    expect(resolveCommittedValue(failed, read('hello'))).toBe('hello')
+  })
+
+  it('reports "" for a genuinely empty form control', () => {
+    expect(resolveCommittedValue(read(''), read(''))).toBe('')
+  })
+
+  it('reports "" when value read failed but text read returned empty', () => {
+    expect(resolveCommittedValue(failed, read(''))).toBe('')
+  })
+
+  it('returns null when nothing could be read back', () => {
+    expect(resolveCommittedValue(failed, failed)).toBeNull()
+  })
+
+  it('returns null when value is empty/unreadable and no text read was done', () => {
+    // Defensive: caller should perform the text read on an empty value, but if
+    // it passes null we cannot claim the field is empty without evidence.
+    expect(resolveCommittedValue(failed, null)).toBeNull()
+  })
+})

--- a/agent-container/src/field-value-readback.ts
+++ b/agent-container/src/field-value-readback.ts
@@ -1,0 +1,57 @@
+/**
+ * Contenteditable-aware field value read-back for browser_fill / browser_type.
+ *
+ * Both handlers verify what landed in a field by reading it back after the
+ * action. They used agent-browser's `get value`, which reads the element's
+ * `.value` property. Form controls (<input>/<textarea>/<select>) expose
+ * `.value`, but contenteditable widgets do NOT — `get value` returns "" for
+ * them even when text is present.
+ *
+ * LinkedIn's message composer (and rich-text editors generally) is a
+ * contenteditable <div>. So the read-back reported an empty field even after a
+ * successful type, and that false-empty value was fed straight to the agent
+ * ("field value is now ''"). The agent concluded its keystrokes had not landed
+ * and typed again — `keyboard type` appends, so the field accumulated
+ * "hellohello", "hellohellohello", ... and the agent then struggled to delete
+ * the extras. Because the compose box is always contenteditable, this happened
+ * on every send.
+ *
+ * Fix: when `get value` is empty, fall back to the element's text content
+ * (`get text`), which IS populated for contenteditables. Form controls keep
+ * their existing behaviour because a non-empty `get value` short-circuits.
+ */
+
+export interface FieldRead {
+  /** The CLI read succeeded (exit code 0). */
+  ok: boolean
+  /** Trimmed stdout from the read (only meaningful when `ok`). */
+  text: string
+}
+
+/**
+ * Resolve the committed value of a field from its `get value` read and, when
+ * that is empty/unreadable, its `get text` read.
+ *
+ * @param valueRead  result of `get value <ref>`
+ * @param textRead   result of `get text <ref>`, or null when it was not
+ *                   performed (the caller skips it when `valueRead` already
+ *                   yielded a non-empty value)
+ * @returns the committed value, "" when the field is genuinely empty, or null
+ *          when nothing could be read back
+ */
+export function resolveCommittedValue(
+  valueRead: FieldRead,
+  textRead: FieldRead | null
+): string | null {
+  // Form control with content: trust `.value` directly.
+  if (valueRead.ok && valueRead.text !== '') return valueRead.text
+
+  // Empty or unreadable `.value`: a contenteditable exposes its content as
+  // text, not value, so prefer a non-empty text read.
+  if (textRead && textRead.ok && textRead.text !== '') return textRead.text
+
+  // Nothing has content. Report "" if either read succeeded (genuinely empty
+  // field), otherwise null (could not read the field at all).
+  if (valueRead.ok || (textRead && textRead.ok)) return ''
+  return null
+}

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -608,6 +608,7 @@ import { resolveRunCommandArgs } from './browser-command-args';
 import { validatePressKey } from './press-key';
 import { prepareEvalScript, finalizeEvalOutput, evalErrorHint } from './eval-script';
 import { judgeSelectCommit, SELECT_COMMIT_SETTLE_MS } from './select-verify';
+import { resolveCommittedValue } from './field-value-readback';
 import { capBrowserOutput, redactCdpUrls, MAX_BROWSER_OUTPUT_CHARS, MAX_BROWSER_ERROR_CHARS } from './browser-output';
 import { capSnapshot, formatIframePlaceholders, parseIframeInfo, IFRAME_ENUM_SCRIPT } from './snapshot-format';
 import {
@@ -706,6 +707,26 @@ async function observeUrlDigest(): Promise<UrlDigest | null> {
   const r = await execBrowser(['get', 'url'], browserState.cdpUrl || undefined);
   if (r.exitCode !== 0 || !r.stdout.trim()) return null;
   return observeUrl(r.stdout.trim());
+}
+
+/**
+ * Read back the committed value of a field after fill/type.
+ *
+ * `get value` reads `.value`, which contenteditable widgets (LinkedIn's message
+ * box, rich-text editors) do not expose — it returns "" for them even when text
+ * is present. The false-empty read-back made agents believe their keystrokes
+ * had not landed and re-type, duplicating text. When `get value` is empty we
+ * fall back to `get text`, which IS populated for contenteditables.
+ */
+async function readCommittedFieldValue(ref: string): Promise<string | null> {
+  const value = await execBrowser(['get', 'value', ref], browserState.cdpUrl || undefined);
+  const valueRead = { ok: value.exitCode === 0, text: value.stdout.trim() };
+  if (valueRead.ok && valueRead.text !== '') return valueRead.text;
+
+  // Empty/unreadable `.value`: read text content to catch contenteditables.
+  const text = await execBrowser(['get', 'text', ref], browserState.cdpUrl || undefined);
+  const textRead = { ok: text.exitCode === 0, text: text.stdout.trim() };
+  return resolveCommittedValue(valueRead, textRead);
 }
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
@@ -1165,8 +1186,7 @@ app.post('/browser/fill', async (c) => {
     // of what the page kept (maxlength truncation, JS reformatting,
     // keystroke-only widgets — audit F6).
     await sleep(FILL_SETTLE_MS);
-    const read = await execBrowser(['get', 'value', body.ref], browserState.cdpUrl || undefined);
-    const committedValue = read.exitCode === 0 ? read.stdout.trim() : null;
+    const committedValue = await readCommittedFieldValue(body.ref);
 
     notifyBrowserAction();
     return c.json({ success: true, ...(committedValue !== null && { committedValue }) });
@@ -1482,8 +1502,7 @@ app.post('/browser/type', async (c) => {
     // target by definition (e.g. cross-origin payment iframes).
     let committedValue: string | null = null;
     if (body.ref) {
-      const read = await execBrowser(['get', 'value', body.ref], browserState.cdpUrl || undefined);
-      if (read.exitCode === 0) committedValue = read.stdout.trim();
+      committedValue = await readCommittedFieldValue(body.ref);
     }
 
     notifyBrowserAction();


### PR DESCRIPTION
Fixes SUP-340 — on LinkedIn (and any contenteditable composer) the agent typed `Hello Hello Hello` instead of a single `Hello`, then struggled to delete the extras. Reproduced reliably across two attached sessions.

## Root cause (in our code, not agent-browser)

`browser_type` / `browser_fill` verify what landed by reading the field back with agent-browser `get value`, which reads the DOM `.value` property. **Contenteditable widgets (LinkedIn's message composer, rich-text editors) have no `.value`**, so `get value` returns `""` for them even when the text is present.

That false-empty read-back was handed to the agent verbatim (`field value is now: ""`). The agent concluded its keystrokes hadn't registered and re-typed — and `keyboard type` **appends** — so the box accumulated `hello` → `hellohello` → `hellohellohello`. It's reliable because the compose box is *always* contenteditable.

Verified against the real `agent-browser` 0.27.2 that `keyboard type "hello"` inserts exactly once (`beforeinput:5 / input:5`); the duplication was entirely the misleading read-back, not the typing.

## Fix

When `get value` is empty, fall back to `get text` (which **is** populated for contenteditables).

- **`field-value-readback.ts`** (new) — pure, unit-tested `resolveCommittedValue(valueRead, textRead)` decision function (mirrors the `select-verify.ts` pattern).
- **`server.ts`** — new `readCommittedFieldValue(ref)` helper (value → `get text` fallback) wired into **both** `/browser/type` and `/browser/fill`.
- Form controls are unchanged — a non-empty `get value` short-circuits before the text read. `/browser/select` is untouched (native `<select>` only). `browser_type` without a `ref` (payment-iframe focus typing) is unchanged — it never had a read-back.

### What the agent now sees (contenteditable, after one `type "hello"`)

| Tool | Before | After |
|---|---|---|
| `browser_fill(ref, "hello")` | `⚠ Field value is now "" — differs from the requested "hello"…` | `Field value verified: "hello".` |
| `browser_type(text:"hello", ref)` | `…field value is now: ""` | `…field value is now: "hello"` |

## Validation

- New unit tests: **8/8** (`field-value-readback.test.ts`).
- Full `agent-container` suite: **389 passed**, 1 pre-existing skip.
- `tsc --noEmit` clean; ESLint on changed files: 0 errors.
- **End-to-end against live agent-browser** — contenteditable now reads back `"hello"` (was `""`); normal input → `"abc"`; empty field → `""`.

Deterministic root-cause repro (no app, no model):

```bash
cat > /tmp/ce.html <<'HTML'
<!doctype html><meta charset="utf-8">
<div id="composer" contenteditable="true" role="textbox" aria-label="Write a message…"></div>
HTML
agent-browser close --all
agent-browser open "file:///tmp/ce.html"
agent-browser snapshot            # composer is @e1 in this single-element page
agent-browser focus @e1
agent-browser keyboard type hello # ONE type
agent-browser get value @e1       # "" (old read-back -> the bug)
agent-browser get text  @e1       # "hello" (the fix)
```
