### PR TITLE
fix(agent-container): disable DesignSync tool

### DIFF
--- a/agent-container/src/claude-code-effort.test.ts
+++ b/agent-container/src/claude-code-effort.test.ts
@@ -273,3 +273,21 @@ describe('ClaudeCodeProcess model prompt hints', () => {
     expect(calls[0].options.systemPrompt).toContain('- Do not send pages as an empty string.')
   })
 })
+
+describe('ClaudeCodeProcess static tool bans', () => {
+  beforeEach(() => {
+    calls.length = 0
+  })
+
+  it('blocks DesignSync globally', async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-designsync-disabled',
+      workingDirectory: '/tmp',
+    })
+
+    await process.start()
+    expect(calls).toHaveLength(1)
+    const disallowed = calls[0].options.disallowedTools as string[]
+    expect(disallowed).toContain('DesignSync')
+  })
+})

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -447,7 +447,7 @@ export class ClaudeCodeProcess extends EventEmitter {
         settingSources: ['user', 'project'],
         allowedTools: ['Skill', 'Task', 'Agent', ...remoteMcpToolPatterns],
         disallowedTools: [
-          'TaskOutput', 'Monitor',
+          'TaskOutput', 'Monitor', 'DesignSync',
           'CronCreate', 'CronDelete', 'CronList',
           'ScheduleWakeup', 'RemoteTrigger', 'PushNotification',
           'EnterWorktree', 'ExitWorktree',


### PR DESCRIPTION
## Summary
- Blocks the SDK-provided `DesignSync` tool via static `disallowedTools` so it is not exposed to agent sessions.
- Adds a regression test that verifies `DesignSync` remains globally disallowed.

## Test plan
- `npm test -- claude-code-effort.test.ts` from `agent-container/`
- Prompt drift capture: `0.3.181` snapshot for `claude-opus-4-7`; verified current deferred tools no longer include `DesignSync`


Made with [Cursor](https://cursor.com)