### PR TITLE
Isolate auth e2e projects

### DIFF
--- a/e2e/auth/fixtures/multi-user.fixture.ts
+++ b/e2e/auth/fixtures/multi-user.fixture.ts
@@ -1,6 +1,8 @@
 import { test as base, type BrowserContext, type Page } from '@playwright/test'
 
-export function getAuthBaseUrl() {
+export function getAuthBaseUrl(projectBaseURL?: unknown) {
+  if (typeof projectBaseURL === 'string') return projectBaseURL
+
   const port = process.env.E2E_PORT ?? process.env.PORT ?? '3001'
   return process.env.E2E_BASE_URL ?? `http://localhost:${port}`
 }
@@ -23,39 +25,45 @@ export const test = base.extend<
     user3Page: Page
   }
 >({
-  user1Context: [async ({ browser }, use) => {
-    const context = await browser.newContext()
+  user1Context: [async ({ browser }, use, workerInfo) => {
+    const context = await browser.newContext({
+      baseURL: getAuthBaseUrl(workerInfo.project.use.baseURL),
+    })
     await use(context)
     await context.close()
   }, { scope: 'worker' }],
 
   user1Page: [async ({ user1Context }, use) => {
     const page = await user1Context.newPage()
-    await page.goto(getAuthBaseUrl())
+    await page.goto('/')
     await use(page)
   }, { scope: 'worker' }],
 
-  user2Context: [async ({ browser }, use) => {
-    const context = await browser.newContext()
+  user2Context: [async ({ browser }, use, workerInfo) => {
+    const context = await browser.newContext({
+      baseURL: getAuthBaseUrl(workerInfo.project.use.baseURL),
+    })
     await use(context)
     await context.close()
   }, { scope: 'worker' }],
 
   user2Page: [async ({ user2Context }, use) => {
     const page = await user2Context.newPage()
-    await page.goto(getAuthBaseUrl())
+    await page.goto('/')
     await use(page)
   }, { scope: 'worker' }],
 
-  user3Context: [async ({ browser }, use) => {
-    const context = await browser.newContext()
+  user3Context: [async ({ browser }, use, workerInfo) => {
+    const context = await browser.newContext({
+      baseURL: getAuthBaseUrl(workerInfo.project.use.baseURL),
+    })
     await use(context)
     await context.close()
   }, { scope: 'worker' }],
 
   user3Page: [async ({ user3Context }, use) => {
     const page = await user3Context.newPage()
-    await page.goto(getAuthBaseUrl())
+    await page.goto('/')
     await use(page)
   }, { scope: 'worker' }],
 })

--- a/e2e/auth/fixtures/multi-user.fixture.ts
+++ b/e2e/auth/fixtures/multi-user.fixture.ts
@@ -1,6 +1,6 @@
 import { test as base, type BrowserContext, type Page } from '@playwright/test'
 
-export function getAuthBaseUrl(projectBaseURL?: unknown) {
+function getAuthBaseUrl(projectBaseURL?: unknown) {
   if (typeof projectBaseURL === 'string') return projectBaseURL
 
   const port = process.env.E2E_PORT ?? process.env.PORT ?? '3001'

--- a/e2e/auth/pages/auth.page.ts
+++ b/e2e/auth/pages/auth.page.ts
@@ -6,6 +6,26 @@ import { Page, expect } from '@playwright/test'
 export class AuthPage {
   constructor(private page: Page) {}
 
+  private async waitForAuthPost(path: string, action: () => Promise<unknown>) {
+    const responsePromise = this.page.waitForResponse((response) =>
+      response.url().includes(path) &&
+      response.request().method() === 'POST'
+    )
+    await action()
+    return responsePromise
+  }
+
+  async resetToAuthPage() {
+    await this.page.context().clearCookies()
+    await this.page.goto('/')
+    await this.page.evaluate(() => {
+      localStorage.clear()
+      sessionStorage.clear()
+    })
+    await this.page.reload()
+    await this.expectVisible()
+  }
+
   /** Sign up a new user */
   async signUp(name: string, email: string, password: string) {
     // Switch to sign-up tab
@@ -18,7 +38,26 @@ export class AuthPage {
     await this.page.locator('#signup-confirm').fill(password)
 
     // Submit
-    await this.page.locator('[data-testid="signup-submit"]').click()
+    await this.waitForAuthPost('/api/auth/sign-up/email', () =>
+      this.page.locator('[data-testid="signup-submit"]').click()
+    )
+  }
+
+  /** Sign up, falling back to sign-in if the user already exists or no session was attached. */
+  async signUpOrSignIn(name: string, email: string, password: string) {
+    await this.signUp(name, email, password)
+
+    const appReady = this.page.locator('[data-testid="app-sidebar"], [data-testid="wizard-container"]').first()
+    try {
+      await appReady.waitFor({ state: 'visible', timeout: 5000 })
+      return
+    } catch {
+      // Stay on the auth page when signup hit an existing user or did not attach a session.
+    }
+
+    if (await this.page.locator('[data-testid="auth-page"]').isVisible().catch(() => false)) {
+      await this.signIn(email, password)
+    }
   }
 
   /** Sign in an existing user */
@@ -34,7 +73,9 @@ export class AuthPage {
     await this.page.locator('#signin-password').fill(password)
 
     // Submit
-    await this.page.locator('[data-testid="signin-submit"]').click()
+    await this.waitForAuthPost('/api/auth/sign-in/email', () =>
+      this.page.locator('[data-testid="signin-submit"]').click()
+    )
   }
 
   /** Assert the auth page is visible */

--- a/e2e/auth/specs/auth-flow.spec.ts
+++ b/e2e/auth/specs/auth-flow.spec.ts
@@ -37,7 +37,8 @@ test.describe('Auth Flow', () => {
     const settingsPage = new SettingsPage(user1Page)
 
     // Sign up User1 (first user becomes admin)
-    await authPage.signUp(user1.name, user1.email, user1.password)
+    await authPage.resetToAuthPage()
+    await authPage.signUpOrSignIn(user1.name, user1.email, user1.password)
 
     // App should load after signup
     await appPage.waitForAppLoaded()
@@ -62,7 +63,8 @@ test.describe('Auth Flow', () => {
     const settingsPage = new SettingsPage(user2Page)
 
     // Sign up User2 (second user is regular user)
-    await authPage.signUp(user2.name, user2.email, user2.password)
+    await authPage.resetToAuthPage()
+    await authPage.signUpOrSignIn(user2.name, user2.email, user2.password)
 
     // App should load
     await appPage.waitForAppLoaded()
@@ -192,7 +194,8 @@ test.describe('Auth Flow', () => {
     const appPage = new AppPage(user3Page)
     const userBar = new UserBarPage(user3Page)
 
-    await authPage.signUp(user3.name, user3.email, user3.password)
+    await authPage.resetToAuthPage()
+    await authPage.signUpOrSignIn(user3.name, user3.email, user3.password)
     await appPage.waitForAppLoaded()
     await appPage.dismissWizardIfVisible()
     await userBar.expectUserName(user3.name)

--- a/e2e/auth/specs/auth-settings.spec.ts
+++ b/e2e/auth/specs/auth-settings.spec.ts
@@ -49,7 +49,7 @@ test.describe('Auth Settings Enforcement', () => {
     if (config.hasUsers) {
       await authPage.signIn(admin.email, admin.password)
     } else {
-      await authPage.signUp(admin.name, admin.email, admin.password)
+      await authPage.signUpOrSignIn(admin.name, admin.email, admin.password)
     }
 
     await appPage.waitForAppLoaded()
@@ -134,7 +134,7 @@ test.describe('Auth Settings Enforcement', () => {
 
     await user3Page.reload()
     await authPage.expectVisible()
-    await authPage.signUp(user.name, user.email, user.password)
+    await authPage.signUpOrSignIn(user.name, user.email, user.password)
     await appPage.waitForAppLoaded()
     await appPage.dismissWizardIfVisible()
   })

--- a/e2e/auth/specs/auth-settings.spec.ts
+++ b/e2e/auth/specs/auth-settings.spec.ts
@@ -1,27 +1,23 @@
-import { getAuthBaseUrl, test, expect } from '../fixtures/multi-user.fixture'
+import { test, expect } from '../fixtures/multi-user.fixture'
 import { AuthPage } from '../pages/auth.page'
 import { SettingsPage } from '../pages/settings.page'
 import { AppPage } from '../../pages/app.page'
 
-// All tests run serially — each test builds on state from previous tests.
-// This spec runs AFTER auth-flow.spec.ts (alphabetical order).
-// The DB already has user1 (alice@test.com, admin) from the prior spec.
+// All tests run serially; this spec owns its auth server and data directory.
 test.describe.configure({ mode: 'serial' })
 
-const admin = { email: 'alice@test.com', password: 'password123' }
+const admin = { name: 'Settings Admin', email: 'settings-admin@test.com', password: 'password123' }
 const newUser = { name: 'Dave Domain', email: 'dave@allowed.com', password: 'password123' }
 const blockedUser = { name: 'Eve External', email: 'eve@blocked.com', password: 'password123' }
 const approvalUser = { name: 'Frank Pending', email: 'frank@test.com', password: 'password123' }
-const authBaseUrl = getAuthBaseUrl()
 
 test.describe('Auth Settings Enforcement', () => {
   // ── Setup: admin signs in ───────────────────────────────────────────
 
-  test('admin signs in', async ({ user1Page, user2Page, user3Page }) => {
+  test('admin signs in', async ({ request, user1Page, user2Page, user3Page }) => {
     const authPage = new AuthPage(user1Page)
     const appPage = new AppPage(user1Page)
 
-    // Users may still be signed in from auth-flow.spec.ts (shared worker).
     // Clear all cookies and navigate to the base URL so every context starts fresh.
     await Promise.all([
       user1Page.context().clearCookies(),
@@ -29,13 +25,22 @@ test.describe('Auth Settings Enforcement', () => {
       user3Page.context().clearCookies(),
     ])
     await Promise.all([
-      user1Page.goto(authBaseUrl),
-      user2Page.goto(authBaseUrl),
-      user3Page.goto(authBaseUrl),
+      user1Page.goto('/'),
+      user2Page.goto('/'),
+      user3Page.goto('/'),
     ])
 
     await authPage.expectVisible()
-    await authPage.signIn(admin.email, admin.password)
+
+    const configRes = await request.get('/api/auth-config')
+    expect(configRes.ok()).toBe(true)
+    const config = await configRes.json() as { hasUsers: boolean }
+    if (config.hasUsers) {
+      await authPage.signIn(admin.email, admin.password)
+    } else {
+      await authPage.signUp(admin.name, admin.email, admin.password)
+    }
+
     await appPage.waitForAppLoaded()
     await appPage.dismissWizardIfVisible()
   })

--- a/e2e/auth/specs/auth-settings.spec.ts
+++ b/e2e/auth/specs/auth-settings.spec.ts
@@ -10,6 +10,17 @@ const admin = { name: 'Settings Admin', email: 'settings-admin@test.com', passwo
 const newUser = { name: 'Dave Domain', email: 'dave@allowed.com', password: 'password123' }
 const blockedUser = { name: 'Eve External', email: 'eve@blocked.com', password: 'password123' }
 const approvalUser = { name: 'Frank Pending', email: 'frank@test.com', password: 'password123' }
+const authSettingsRunId = (process.env.GITHUB_RUN_ID ?? `${Date.now()}-${process.pid}`)
+  .replace(/[^a-zA-Z0-9]/g, '')
+  .slice(-12)
+
+function retryScopedUser(user: typeof newUser) {
+  const [localPart, domain] = user.email.split('@')
+  return {
+    ...user,
+    email: `${localPart}+${authSettingsRunId}-r${test.info().retry}@${domain}`,
+  }
+}
 
 test.describe('Auth Settings Enforcement', () => {
   // ── Setup: admin signs in ───────────────────────────────────────────
@@ -109,8 +120,9 @@ test.describe('Auth Settings Enforcement', () => {
 
   test('signup from wrong domain shows error', async ({ user2Page }) => {
     const authPage = new AuthPage(user2Page)
+    const user = retryScopedUser(blockedUser)
 
-    await authPage.signUp(blockedUser.name, blockedUser.email, blockedUser.password)
+    await authPage.signUp(user.name, user.email, user.password)
     await authPage.expectSignupError()
     await authPage.expectVisible()
   })
@@ -118,10 +130,11 @@ test.describe('Auth Settings Enforcement', () => {
   test('signup from allowed domain succeeds', async ({ user3Page }) => {
     const authPage = new AuthPage(user3Page)
     const appPage = new AppPage(user3Page)
+    const user = retryScopedUser(newUser)
 
     await user3Page.reload()
     await authPage.expectVisible()
-    await authPage.signUp(newUser.name, newUser.email, newUser.password)
+    await authPage.signUp(user.name, user.email, user.password)
     await appPage.waitForAppLoaded()
     await appPage.dismissWizardIfVisible()
   })
@@ -138,26 +151,28 @@ test.describe('Auth Settings Enforcement', () => {
 
   test('new user signs up and sees pending approval', async ({ user2Page }) => {
     const authPage = new AuthPage(user2Page)
+    const user = retryScopedUser(approvalUser)
 
     await user2Page.reload()
     await authPage.expectVisible()
-    await authPage.signUp(approvalUser.name, approvalUser.email, approvalUser.password)
+    await authPage.signUp(user.name, user.email, user.password)
     await authPage.expectPendingApproval()
   })
 
   test('admin unbans the pending user', async ({ user1Page }) => {
     const settingsPage = new SettingsPage(user1Page)
+    const user = retryScopedUser(approvalUser)
 
     await settingsPage.open()
     await settingsPage.navigateToTab('users')
 
     // The approval user should appear as pending approval
-    const userRow = user1Page.locator(`[data-testid="user-row-${approvalUser.email}"]`)
+    const userRow = user1Page.locator(`[data-testid="user-row-${user.email}"]`)
     await expect(userRow).toBeVisible()
     await expect(userRow.getByText('pending approval')).toBeVisible()
 
     // Click approve
-    await user1Page.locator(`[data-testid="user-approve-${approvalUser.email}"]`).click()
+    await user1Page.locator(`[data-testid="user-approve-${user.email}"]`).click()
 
     // The "pending approval" label should disappear
     await expect(userRow.getByText('pending approval')).not.toBeVisible()
@@ -168,10 +183,11 @@ test.describe('Auth Settings Enforcement', () => {
   test('approved user can now sign in', async ({ user2Page }) => {
     const authPage = new AuthPage(user2Page)
     const appPage = new AppPage(user2Page)
+    const user = retryScopedUser(approvalUser)
 
     await user2Page.reload()
     await authPage.expectVisible()
-    await authPage.signIn(approvalUser.email, approvalUser.password)
+    await authPage.signIn(user.email, user.password)
     await appPage.waitForAppLoaded()
     await appPage.dismissWizardIfVisible()
   })

--- a/e2e/pages/app.page.ts
+++ b/e2e/pages/app.page.ts
@@ -32,7 +32,11 @@ export class AppPage {
    */
   async dismissWizardIfVisible() {
     const wizard = this.page.locator('[data-testid="wizard-container"]')
-    if (await wizard.isVisible({ timeout: 1000 }).catch(() => false)) {
+    const createAgentHeading = this.page.getByRole('heading', { name: /create your first agent/i })
+    const wizardVisible = await wizard.isVisible({ timeout: 1000 }).catch(() => false)
+    const createAgentVisible = await createAgentHeading.isVisible({ timeout: 500 }).catch(() => false)
+
+    if (wizardVisible) {
       const manualSetup = this.page.locator('[data-testid="wizard-manual-setup"]')
 
       if (await manualSetup.isVisible({ timeout: 500 }).catch(() => false)) {
@@ -69,6 +73,9 @@ export class AppPage {
       }
 
       await expect(wizard).not.toBeVisible()
+    } else if (createAgentVisible) {
+      await this.page.getByRole('button', { name: /^skip$/i }).click()
+      await expect(createAgentHeading).not.toBeVisible({ timeout: 15000 })
     }
   }
 

--- a/e2e/pages/app.page.ts
+++ b/e2e/pages/app.page.ts
@@ -84,8 +84,8 @@ export class AppPage {
   async waitForAgentsLoaded() {
     // Wait for sidebar to be visible first
     await this.waitForAppLoaded()
-    // Dismiss wizard if it auto-opened (safety net for clean test state)
-    await this.dismissWizardIfVisible()
+    // Broad safety net: keep this short because the main suite seeds setup as complete.
+    await this.dismissWizardIfVisible(500)
     // Wait for the app to be interactive (create agent button visible).
     // If the wizard appeared after our check (race with parallel tests),
     // try dismissing it once more.
@@ -93,7 +93,7 @@ export class AppPage {
     try {
       await expect(createBtn).toBeVisible({ timeout: 3000 })
     } catch {
-      await this.dismissWizardIfVisible()
+      await this.dismissWizardIfVisible(500)
       await expect(createBtn).toBeVisible()
     }
   }

--- a/e2e/pages/app.page.ts
+++ b/e2e/pages/app.page.ts
@@ -20,7 +20,6 @@ export class AppPage {
     await expect(
       this.page
         .locator('[data-testid="app-sidebar"], [data-testid="wizard-container"]')
-        .or(this.page.getByRole('heading', { name: /create your first agent/i }))
         .first()
     ).toBeVisible({ timeout })
   }
@@ -30,53 +29,53 @@ export class AppPage {
    * Navigates through all steps using Next/Skip to close it.
    * Requires E2E mock mode (mock API key configured, runtime available).
    */
-  async dismissWizardIfVisible() {
+  async dismissWizardIfVisible(timeout = 2000) {
     const wizard = this.page.locator('[data-testid="wizard-container"]')
-    const createAgentHeading = this.page.getByRole('heading', { name: /create your first agent/i })
-    const wizardVisible = await wizard.isVisible({ timeout: 1000 }).catch(() => false)
-    const createAgentVisible = await createAgentHeading.isVisible({ timeout: 500 }).catch(() => false)
 
-    if (wizardVisible) {
-      const manualSetup = this.page.locator('[data-testid="wizard-manual-setup"]')
-
-      if (await manualSetup.isVisible({ timeout: 500 }).catch(() => false)) {
-        // Full wizard — walk through all steps
-        const stepContent = this.page.locator('[data-testid="wizard-step-content"]')
-        await manualSetup.click()
-        await expect(stepContent).toHaveAttribute('data-step', '0')
-
-        // LLM -> Browser
-        await this.page.locator('[data-testid="wizard-next"]').click()
-        await expect(stepContent).toHaveAttribute('data-step', '1')
-
-        // Browser -> Composio
-        await this.page.locator('[data-testid="wizard-next"]').click()
-        await expect(stepContent).toHaveAttribute('data-step', '2')
-
-        // Composio -> Runtime
-        await this.page.locator('[data-testid="wizard-skip"]').click()
-        await expect(stepContent).toHaveAttribute('data-step', '3')
-
-        // Runtime -> Privacy
-        await this.page.locator('[data-testid="wizard-next"]').click()
-        await expect(stepContent).toHaveAttribute('data-step', '4')
-
-        // Privacy -> Agent
-        await this.page.locator('[data-testid="wizard-next"]').click()
-        await expect(stepContent).toHaveAttribute('data-step', '5')
-
-        // Skip on Agent step finishes the wizard
-        await this.page.locator('[data-testid="wizard-skip"]').click()
-      } else {
-        // Agent-only wizard — just skip
-        await this.page.locator('[data-testid="wizard-skip"]').click()
-      }
-
-      await expect(wizard).not.toBeVisible()
-    } else if (createAgentVisible) {
-      await this.page.getByRole('button', { name: /^skip$/i }).click()
-      await expect(createAgentHeading).not.toBeVisible({ timeout: 15000 })
+    try {
+      await wizard.waitFor({ state: 'visible', timeout })
+    } catch {
+      return
     }
+
+    const manualSetup = this.page.locator('[data-testid="wizard-manual-setup"]')
+    const agentOnlyHeading = wizard.getByRole('heading', { name: /create your first agent/i })
+    await expect(manualSetup.or(agentOnlyHeading).first()).toBeVisible({ timeout: 5000 })
+
+    if (await manualSetup.isVisible()) {
+      // Full wizard — walk through all steps
+      const stepContent = this.page.locator('[data-testid="wizard-step-content"]')
+      await manualSetup.click()
+      await expect(stepContent).toHaveAttribute('data-step', '0')
+
+      // LLM -> Browser
+      await this.page.locator('[data-testid="wizard-next"]').click()
+      await expect(stepContent).toHaveAttribute('data-step', '1')
+
+      // Browser -> Composio
+      await this.page.locator('[data-testid="wizard-next"]').click()
+      await expect(stepContent).toHaveAttribute('data-step', '2')
+
+      // Composio -> Runtime
+      await this.page.locator('[data-testid="wizard-skip"]').click()
+      await expect(stepContent).toHaveAttribute('data-step', '3')
+
+      // Runtime -> Privacy
+      await this.page.locator('[data-testid="wizard-next"]').click()
+      await expect(stepContent).toHaveAttribute('data-step', '4')
+
+      // Privacy -> Agent
+      await this.page.locator('[data-testid="wizard-next"]').click()
+      await expect(stepContent).toHaveAttribute('data-step', '5')
+
+      // Skip on Agent step finishes the wizard
+      await this.page.locator('[data-testid="wizard-skip"]').click()
+    } else {
+      // Agent-only wizard — just skip
+      await this.page.locator('[data-testid="wizard-skip"]').click()
+    }
+
+    await expect(wizard).not.toBeVisible({ timeout: 15000 })
   }
 
   /**

--- a/playwright.auth.config.ts
+++ b/playwright.auth.config.ts
@@ -3,10 +3,37 @@ import path from 'path'
 
 // Use a separate data directory for auth E2E tests.
 const e2eDataDir = path.resolve(process.env.SUPERAGENT_DATA_DIR ?? path.join(__dirname, '.e2e-data-auth'))
-const e2ePort = process.env.E2E_PORT ?? process.env.PORT ?? '3001'
-const e2eBaseUrl = process.env.E2E_BASE_URL ?? `http://localhost:${e2ePort}`
+const configuredPort = Number(process.env.E2E_PORT ?? process.env.PORT ?? '3001')
+const e2ePort = Number.isFinite(configuredPort) ? configuredPort : 3001
 const playwrightOutputDir = process.env.PLAYWRIGHT_OUTPUT_DIR ?? 'test-results'
 const playwrightHtmlReportDir = process.env.PLAYWRIGHT_HTML_REPORT ?? 'playwright-report'
+const configuredWorkers = process.env.PLAYWRIGHT_WORKERS
+  ? Number(process.env.PLAYWRIGHT_WORKERS)
+  : undefined
+
+const authProjects = [
+  {
+    name: 'auth-flow',
+    testMatch: '**/auth-flow.spec.ts',
+    port: e2ePort,
+    dataDir: path.join(e2eDataDir, 'flow'),
+  },
+  {
+    name: 'auth-settings',
+    testMatch: '**/auth-settings.spec.ts',
+    port: e2ePort + 1,
+    dataDir: path.join(e2eDataDir, 'settings'),
+  },
+].map((project, index) => ({
+  ...project,
+  baseURL: index === 0 && process.env.E2E_BASE_URL
+    ? process.env.E2E_BASE_URL
+    : `http://localhost:${project.port}`,
+}))
+
+function buildAuthServerCommand(dataDir: string, port: number) {
+  return `SUPERAGENT_DATA_DIR="${dataDir}" AUTH_MODE=true node e2e/setup-e2e-data.js && SUPERAGENT_DATA_DIR="${dataDir}" E2E_MOCK=true AUTH_MODE=true ANTHROPIC_API_KEY=sk-ant-e2e-mock PORT=${port} npm run dev:web`
+}
 
 export default defineConfig({
   testDir: './e2e/auth/specs',
@@ -14,27 +41,25 @@ export default defineConfig({
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: 1,
+  workers: configuredWorkers && Number.isFinite(configuredWorkers) ? configuredWorkers : 2,
   reporter: [['list'], ['html', { open: 'never', outputFolder: playwrightHtmlReportDir }]],
 
   use: {
-    baseURL: e2eBaseUrl,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
 
-  projects: [
-    {
-      name: 'auth-chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
-  ],
+  projects: authProjects.map((project) => ({
+    name: project.name,
+    testMatch: project.testMatch,
+    use: { ...devices['Desktop Chrome'], baseURL: project.baseURL },
+  })),
 
-  webServer: {
-    command: `SUPERAGENT_DATA_DIR="${e2eDataDir}" AUTH_MODE=true node e2e/setup-e2e-data.js && SUPERAGENT_DATA_DIR="${e2eDataDir}" E2E_MOCK=true AUTH_MODE=true ANTHROPIC_API_KEY=sk-ant-e2e-mock PORT=${e2ePort} npm run dev:web`,
-    url: `${e2eBaseUrl}/api/settings`,
+  webServer: authProjects.map((project) => ({
+    command: buildAuthServerCommand(project.dataDir, project.port),
+    url: `${project.baseURL}/api/settings`,
     reuseExistingServer: false,
     timeout: 120000,
     stdout: 'pipe',
-  },
+  })),
 })

--- a/playwright.auth.config.ts
+++ b/playwright.auth.config.ts
@@ -17,12 +17,14 @@ const authProjects = [
     testMatch: '**/auth-flow.spec.ts',
     port: e2ePort,
     dataDir: path.join(e2eDataDir, 'flow'),
+    viteCacheDir: path.join(e2eDataDir, '.vite', 'flow'),
   },
   {
     name: 'auth-settings',
     testMatch: '**/auth-settings.spec.ts',
     port: e2ePort + 1,
     dataDir: path.join(e2eDataDir, 'settings'),
+    viteCacheDir: path.join(e2eDataDir, '.vite', 'settings'),
   },
 ].map((project, index) => ({
   ...project,
@@ -31,8 +33,8 @@ const authProjects = [
     : `http://localhost:${project.port}`,
 }))
 
-function buildAuthServerCommand(dataDir: string, port: number) {
-  return `SUPERAGENT_DATA_DIR="${dataDir}" AUTH_MODE=true node e2e/setup-e2e-data.js && SUPERAGENT_DATA_DIR="${dataDir}" E2E_MOCK=true AUTH_MODE=true ANTHROPIC_API_KEY=sk-ant-e2e-mock PORT=${port} npm run dev:web`
+function buildAuthServerCommand(dataDir: string, port: number, viteCacheDir: string) {
+  return `SUPERAGENT_DATA_DIR="${dataDir}" AUTH_MODE=true node e2e/setup-e2e-data.js && SUPERAGENT_DATA_DIR="${dataDir}" VITE_CACHE_DIR="${viteCacheDir}" E2E_MOCK=true AUTH_MODE=true ANTHROPIC_API_KEY=sk-ant-e2e-mock PORT=${port} npm run dev:web`
 }
 
 export default defineConfig({
@@ -56,7 +58,7 @@ export default defineConfig({
   })),
 
   webServer: authProjects.map((project) => ({
-    command: buildAuthServerCommand(project.dataDir, project.port),
+    command: buildAuthServerCommand(project.dataDir, project.port, project.viteCacheDir),
     url: `${project.baseURL}/api/settings`,
     reuseExistingServer: false,
     timeout: 120000,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,8 +6,10 @@ import { readFileSync } from 'fs'
 
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'))
 const analyticsConfig = JSON.parse(readFileSync(path.resolve(__dirname, 'src/shared/lib/analytics/config.json'), 'utf-8'))
+const viteCacheDir = process.env.VITE_CACHE_DIR ? path.resolve(__dirname, process.env.VITE_CACHE_DIR) : undefined
 
 export default defineConfig({
+  cacheDir: viteCacheDir,
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
     __AUTH_MODE__: JSON.stringify(process.env.AUTH_MODE === 'true'),


### PR DESCRIPTION
## Summary

This PR removes a cross-spec dependency in the auth E2E suite and lets the two auth narratives run independently.

- split `playwright.auth.config.ts` into `auth-flow` and `auth-settings` projects
- start each auth project with its own port, data directory, and Vite cache directory
- default the auth job to two workers while preserving serial execution inside each spec
- wire the multi-user fixture to the active project `baseURL`
- make `auth-settings.spec.ts` bootstrap/sign in its own admin instead of assuming `auth-flow.spec.ts` already created Alice
- make the settings-created users retry-scoped so serial retry replay does not collide with users from the previous attempt
- make the shared app page helper wait briefly for a late-opening onboarding wizard before deciding there is nothing to dismiss
- keep the longer wizard wait on explicit auth post-signup paths, while limiting the broad `waitForAgentsLoaded()` safety net to 500 ms so the main E2E suite does not pay a 2 s no-op wait on every setup
- make successful auth signup helpers wait for the actual Better Auth response and fall back to sign-in on replay, so serial auth-flow retries survive already-created users or missing signup sessions

## Why

`auth-settings.spec.ts` previously depended on `auth-flow.spec.ts` running first against the same database. That made the auth suite order-dependent, retry-hostile, and impossible to parallelize safely. The settings suite now owns its seed state, while keeping the existing signup-mode, domain, approval, and admin-settings assertions.

The first CI run on this PR also exposed a related auth-flow timing issue: `waitForAppLoaded()` can return on the app shell before the onboarding wizard auto-opens. The wizard helper now uses a real short wait for `[data-testid="wizard-container"]`, then handles the full and agent-only wizard paths through the existing test ids. This avoids the non-waiting `isVisible({ timeout })` snapshot race.

The longer 2 s wizard wait is preserved for direct auth post-signup calls, where the race can happen. The broad `waitForAgentsLoaded()` safety net uses a 500 ms budget because the main non-auth E2E seed marks setup complete and normally never opens the wizard.

The latest CI auth failure showed the serial auth-flow retry path replaying signup after the first attempt had already created users/sessions. The auth page object now waits for submit responses, clears per-user context before successful signup narratives, and falls back to sign-in when signup replays against an existing user or does not attach a session.

Because the auth config now starts two Vite dev servers concurrently, this also gives each server a separate `VITE_CACHE_DIR` to avoid concurrent `optimizeDeps` cache collisions on cold CI runners.

## Validation

- `npm exec eslint -- e2e/pages/app.page.ts`
- `npm exec eslint -- e2e/pages/app.page.ts playwright.auth.config.ts vite.config.ts e2e/auth/specs/auth-settings.spec.ts e2e/auth/fixtures/multi-user.fixture.ts` (passes with existing `vite.config.ts` warnings)
- `npm run lint:e2e` (passes with existing warnings)
- `npm run typecheck`
- `PORT=3261 SUPERAGENT_DATA_DIR=.e2e-data/main-wizard-budget-smoke PLAYWRIGHT_OUTPUT_DIR=test-results/main-wizard-budget-smoke PLAYWRIGHT_HTML_REPORT=playwright-report/main-wizard-budget-smoke npx playwright test --project=web-chromium --no-deps e2e/specs/agent-lifecycle.spec.ts -g "create a new agent"`
- `PORT=3271 SUPERAGENT_DATA_DIR=.e2e-data/auth-wizard-budget-smoke PLAYWRIGHT_OUTPUT_DIR=test-results/auth-wizard-budget-smoke PLAYWRIGHT_HTML_REPORT=playwright-report/auth-wizard-budget-smoke npx playwright test --config=playwright.auth.config.ts --project=auth-flow -g "user1 signs up and becomes admin"`
- `PORT=3281 SUPERAGENT_DATA_DIR=.e2e-data/auth-retry-harden-full PLAYWRIGHT_OUTPUT_DIR=test-results/auth-retry-harden-full PLAYWRIGHT_HTML_REPORT=playwright-report/auth-retry-harden-full npm run test:e2e:auth`
- `PORT=3241 SUPERAGENT_DATA_DIR=.e2e-data/auth-review-followup-settings PLAYWRIGHT_OUTPUT_DIR=test-results/auth-review-followup-settings PLAYWRIGHT_HTML_REPORT=playwright-report/auth-review-followup-settings npx playwright test --config=playwright.auth.config.ts --project=auth-settings`
- `PORT=3251 SUPERAGENT_DATA_DIR=.e2e-data/auth-review-followup-full PLAYWRIGHT_OUTPUT_DIR=test-results/auth-review-followup-full PLAYWRIGHT_HTML_REPORT=playwright-report/auth-review-followup-full npm run test:e2e:auth`
- confirmed separate auth Vite cache dirs were created at `.e2e-data/auth-review-followup-full/.vite/flow` and `.e2e-data/auth-review-followup-full/.vite/settings`
