### PR TITLE
Soft cap: warn the agent when it accumulates many schedules (SUP-332)

### DIFF
--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -3499,6 +3499,98 @@ describe('MessagePersister', () => {
         expect(mockCreateScheduledTask).toHaveBeenCalled()
         expect(findFetchCall('/inputs/tool-sched-deliver-fail/reject')).toBeUndefined()
       })
+
+      // Soft-cap (SUP-332): the result always carries the active-schedule count +
+      // list; a warning is appended above the warn band and a critical warning
+      // above the critical band. We never block creation.
+      function makeActiveTasks(n: number): unknown[] {
+        return Array.from({ length: n }, (_, i) => ({
+          id: `task_${i}`,
+          name: `Task ${i}`,
+          scheduleType: 'cron',
+          scheduleExpression: '0 9 * * 1-5',
+          status: 'pending',
+          nextExecutionAt: new Date('2026-06-04T09:00:00Z'),
+          timezone: 'America/New_York',
+          prompt: 'do a thing',
+        }))
+      }
+
+      it('always returns the active-schedule count and list with no warning at or below the warn band', async () => {
+        mockListPendingScheduledTasks.mockResolvedValue(makeActiveTasks(4))
+
+        simulateToolUse('mcp__user-input__schedule_task', 'tool-sched-band-ok', {
+          scheduleType: 'cron',
+          scheduleExpression: '0 9 * * 1-5',
+          prompt: 'Send the daily report',
+        })
+
+        await flushHandlers()
+
+        const resolveCall = findFetchCall('/inputs/tool-sched-band-ok/resolve')
+        expect(resolveCall).toBeDefined()
+        const value = JSON.parse(resolveCall![1].body).value
+        expect(value).toContain('Active schedules for this agent: 4')
+        expect(value).toContain('task_0') // full list is present
+        expect(value).toContain('task_3')
+        expect(value).not.toContain('Schedule count warning')
+        expect(value).not.toContain('CRITICAL')
+      })
+
+      it('appends a (non-critical) warning above the warn band', async () => {
+        mockListPendingScheduledTasks.mockResolvedValue(makeActiveTasks(5))
+
+        simulateToolUse('mcp__user-input__schedule_task', 'tool-sched-band-warn', {
+          scheduleType: 'cron',
+          scheduleExpression: '0 9 * * 1-5',
+          prompt: 'Send the daily report',
+        })
+
+        await flushHandlers()
+
+        const value = JSON.parse(findFetchCall('/inputs/tool-sched-band-warn/resolve')![1].body).value
+        expect(value).toContain('Active schedules for this agent: 5')
+        expect(value).toContain('Schedule count warning')
+        expect(value).not.toContain('CRITICAL')
+        expect(value).toContain('task_4') // full list still included
+      })
+
+      it('appends a critical warning above the critical band', async () => {
+        mockListPendingScheduledTasks.mockResolvedValue(makeActiveTasks(7))
+
+        simulateToolUse('mcp__user-input__schedule_task', 'tool-sched-band-crit', {
+          scheduleType: 'cron',
+          scheduleExpression: '0 9 * * 1-5',
+          prompt: 'Send the daily report',
+        })
+
+        await flushHandlers()
+
+        const value = JSON.parse(findFetchCall('/inputs/tool-sched-band-crit/resolve')![1].body).value
+        expect(value).toContain('Active schedules for this agent: 7')
+        expect(value).toContain('CRITICAL')
+      })
+
+      it('still resolves with the base success when the active-list lookup fails', async () => {
+        // Enrichment is best-effort: a failure reading the active list must not
+        // block resolving the already-persisted (blocking) tool.
+        mockListPendingScheduledTasks.mockRejectedValue(new Error('db unavailable'))
+
+        simulateToolUse('mcp__user-input__schedule_task', 'tool-sched-band-fail', {
+          scheduleType: 'cron',
+          scheduleExpression: '0 9 * * 1-5',
+          prompt: 'Send the daily report',
+        })
+
+        await flushHandlers()
+
+        const resolveCall = findFetchCall('/inputs/tool-sched-band-fail/resolve')
+        expect(resolveCall).toBeDefined()
+        const value = JSON.parse(resolveCall![1].body).value
+        expect(value).toContain('task_new_id') // base success preserved
+        expect(value).not.toContain('Active schedules for this agent') // enrichment skipped
+        expect(findFetchCall('/inputs/tool-sched-band-fail/reject')).toBeUndefined()
+      })
     })
 
     describe('list_scheduled_tasks', () => {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -14,6 +14,7 @@ import {
   cancelScheduledTask,
   pauseScheduledTask,
   resumeScheduledTask,
+  type ScheduledTask,
 } from '@shared/lib/services/scheduled-task-service'
 import {
   createWebhookTrigger,
@@ -30,7 +31,7 @@ import { db } from '@shared/lib/db'
 import { connectedAccounts } from '@shared/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { resolveTimezoneForAgent } from '@shared/lib/services/timezone-resolver'
-import { getFrequencyWarning, validateScheduleExpression } from '@shared/lib/services/schedule-parser'
+import { getFrequencyWarning, getScheduleCountWarning, validateScheduleExpression } from '@shared/lib/services/schedule-parser'
 import { getSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
@@ -2254,12 +2255,22 @@ class MessagePersister {
           agentSlug,
         })
 
-        // Resolve the blocking tool with a success message (plus any frequency warning).
-        await this.resolveContainerInput(
-          agentSlug,
-          toolUseId,
-          this.formatScheduleTaskResult(input, taskId, timezone)
-        )
+        // Build the agent-facing result: base success + any frequency warning,
+        // then enrich with the agent's active-schedule count, a soft-cap warning,
+        // and the full active list so a runaway loop or duplicate schedules are
+        // visible. The enrichment is best-effort — if reading the active list
+        // throws we still resolve with the base success so the blocking tool never
+        // hangs.
+        let resultMessage = this.formatScheduleTaskResult(input, taskId, timezone)
+        try {
+          const activeTasks = await listPendingScheduledTasks(agentSlug)
+          resultMessage += this.formatActiveScheduleSummary(activeTasks)
+        } catch (summaryError) {
+          console.error('[MessagePersister] Failed to build active-schedule summary:', summaryError)
+        }
+
+        // Resolve the blocking tool with the (possibly enriched) success message.
+        await this.resolveContainerInput(agentSlug, toolUseId, resultMessage)
       } catch (deliveryError) {
         console.error('[MessagePersister] Schedule persisted but result delivery failed:', deliveryError)
       }
@@ -2302,6 +2313,37 @@ ${continuation}`
     }
 
     return result
+  }
+
+  /**
+   * Build the active-schedule summary appended to a schedule_task result: the
+   * agent's current count of active schedules (pending + paused), a soft-cap
+   * warning when the count is high, and the full list (id, name, schedule
+   * expression, next run) so the agent can spot duplicates/overlaps and
+   * self-correct. Always returns the count + list; the warning is conditional.
+   */
+  private formatActiveScheduleSummary(tasks: ScheduledTask[]): string {
+    const count = tasks.length
+    let summary = `\n\nActive schedules for this agent: ${count}`
+
+    const warning = getScheduleCountWarning(count)
+    if (warning) {
+      summary += `\n\n${warning}`
+    }
+
+    if (count > 0) {
+      const list = tasks
+        .map((t) => {
+          const kind = t.scheduleType === 'cron' ? 'recurring' : 'one-time'
+          const next = t.nextExecutionAt ? t.nextExecutionAt.toISOString() : 'unknown'
+          const status = t.status === 'paused' ? ' [PAUSED]' : ''
+          return `- **${t.name || 'Scheduled Task'}** (ID: ${t.id})${status} — ${kind} (${t.scheduleExpression}), next run ${next}${t.timezone ? ` (${t.timezone})` : ''}`
+        })
+        .join('\n')
+      summary += `\n\n${list}`
+    }
+
+    return summary
   }
 
   // Handle list_scheduled_tasks - blocking: read from SQLite and resolve

--- a/src/shared/lib/services/schedule-parser.test.ts
+++ b/src/shared/lib/services/schedule-parser.test.ts
@@ -10,6 +10,9 @@ import {
   getMinCronIntervalMs,
   getFrequencyWarning,
   MIN_RECURRING_INTERVAL_MS,
+  getScheduleCountWarning,
+  SCHEDULE_COUNT_WARN_THRESHOLD,
+  SCHEDULE_COUNT_CRITICAL_THRESHOLD,
 } from './schedule-parser'
 
 // ============================================================================
@@ -298,6 +301,46 @@ describe('getFrequencyWarning', () => {
   it('warns for a bursty schedule whose tightest gap is below the threshold', () => {
     // ":00 and :05 every hour" — the 5-minute burst gap is under 15 min.
     expect(getFrequencyWarning('cron', '0,5 * * * *')).toContain('Frequent schedule warning')
+  })
+})
+
+// ============================================================================
+// getScheduleCountWarning Tests
+// ============================================================================
+
+describe('getScheduleCountWarning', () => {
+  it('exposes conservative warn/critical threshold constants', () => {
+    expect(SCHEDULE_COUNT_WARN_THRESHOLD).toBe(4)
+    expect(SCHEDULE_COUNT_CRITICAL_THRESHOLD).toBe(6)
+  })
+
+  it('does not warn at or below the warn threshold', () => {
+    expect(getScheduleCountWarning(0)).toBeNull()
+    expect(getScheduleCountWarning(1)).toBeNull()
+    expect(getScheduleCountWarning(SCHEDULE_COUNT_WARN_THRESHOLD)).toBeNull() // exactly 4
+  })
+
+  it('warns just above the warn threshold (but not critical)', () => {
+    const warning = getScheduleCountWarning(5)
+    expect(warning).toBeTruthy()
+    expect(warning).toContain('Schedule count warning')
+    expect(warning).toContain('5 active schedules')
+    expect(warning).not.toContain('CRITICAL')
+  })
+
+  it('still only warns (not critical) at the critical threshold itself', () => {
+    const warning = getScheduleCountWarning(SCHEDULE_COUNT_CRITICAL_THRESHOLD) // exactly 6
+    expect(warning).toContain('Schedule count warning')
+    expect(warning).not.toContain('CRITICAL')
+  })
+
+  it('escalates to a critical warning above the critical threshold', () => {
+    const warning = getScheduleCountWarning(7)
+    expect(warning).toBeTruthy()
+    expect(warning).toContain('CRITICAL')
+    expect(warning).toContain('7 active schedules')
+    // The critical band mentions the runaway / self-replicating failure mode.
+    expect(warning).toContain('self-replicating')
   })
 })
 

--- a/src/shared/lib/services/schedule-parser.ts
+++ b/src/shared/lib/services/schedule-parser.ts
@@ -202,6 +202,47 @@ export function getFrequencyWarning(
 }
 
 /**
+ * Soft-cap thresholds for how many active schedules a single agent holds. These
+ * are purely informational — we never block creation, only warn so the agent (or
+ * a human reading the tool result) can spot a runaway loop or a self-replicating
+ * scheduled prompt (a cron whose prompt schedules another task). The per-task
+ * overlap guard can't catch this because each task has a distinct ID.
+ *
+ *   count > SCHEDULE_COUNT_WARN_THRESHOLD     → warning
+ *   count > SCHEDULE_COUNT_CRITICAL_THRESHOLD → critical warning
+ *
+ * The warn threshold is intentionally conservative; since nothing is prevented,
+ * the occasional false alarm is acceptable.
+ */
+export const SCHEDULE_COUNT_WARN_THRESHOLD = 4
+export const SCHEDULE_COUNT_CRITICAL_THRESHOLD = 6
+
+/**
+ * Build a soft-cap warning for an agent that holds many active schedules. Returns
+ * null at or below the warn threshold (no warning), a warning above it, and a
+ * critical warning above the critical threshold. Non-blocking by design — the
+ * caller still creates the schedule and returns the full active list so the agent
+ * can judge whether the count is legitimate.
+ */
+export function getScheduleCountWarning(activeCount: number): string | null {
+  if (activeCount > SCHEDULE_COUNT_CRITICAL_THRESHOLD) {
+    return (
+      `🚨 CRITICAL: this agent now has ${activeCount} active schedules. ` +
+      `This is unusually high and often means a runaway loop or a self-replicating scheduled prompt ` +
+      `(a recurring task whose prompt schedules yet another task). ` +
+      `Review the active schedules listed below and cancel any duplicates, overlaps, or tasks you did not intend to create.`
+    )
+  }
+  if (activeCount > SCHEDULE_COUNT_WARN_THRESHOLD) {
+    return (
+      `⚠️ Schedule count warning: this agent now has ${activeCount} active schedules. ` +
+      `If you did not mean to accumulate this many, review the list below for duplicates or overlapping schedules and cancel any that are unneeded.`
+    )
+  }
+  return null
+}
+
+/**
  * Validate a cron expression and return the next execution time.
  */
 export function validateCronExpression(cronExpression: string, timezone?: string): ParseResult {


### PR DESCRIPTION
## Summary

Part of [SUP-326](https://linear.app/datawizz/issue/SUP-326) (schedule/cron hardening). Builds on SUP-331 (#333), which made `schedule_task` a blocking, host-resolved tool. Closes SUP-332.

Nothing currently bounds how many schedules an agent can create. A runaway loop, or a self-replicating scheduled prompt (a cron whose prompt schedules another task), can pile up unlimited tasks — the per-task overlap guard doesn't catch this because each task has a distinct ID.

This adds a **soft, non-blocking** signal: when `schedule_task` creates a task, the (now blocking) tool result is enriched with the agent's active-schedule count, a warning when the count is high, and the full active list so the agent can spot duplicates/overlaps and self-correct. We deliberately **do not block** creation — the agent judges whether the count is legitimate.

## Behavior

After persisting, the result always appends:
- **Active-schedule count** (pending + paused — everything on the schedule, same set `list_scheduled_tasks` shows).
- **> 4 active** → ⚠️ warning.
- **> 6 active** → 🚨 critical warning (calls out the runaway / self-replicating failure mode).
- **The full active list** (id, name, schedule expression, next run) in every case.

The warn threshold of 4 is intentionally conservative; since it's purely informational, the occasional false alarm is acceptable.

## Implementation

- `src/shared/lib/services/schedule-parser.ts` — named constants `SCHEDULE_COUNT_WARN_THRESHOLD = 4` / `SCHEDULE_COUNT_CRITICAL_THRESHOLD = 6` and a pure `getScheduleCountWarning(activeCount)` band helper, mirroring the existing `getFrequencyWarning` from SUP-331.
- `src/shared/lib/container/message-persister.ts` — the host `schedule_task` handler now reads the active set via the existing `listPendingScheduledTasks` and appends the summary via a new `formatActiveScheduleSummary`. The enrichment is **best-effort**: if the lookup throws, it still resolves with the base success so the blocking tool never hangs.

I reused `listPendingScheduledTasks` rather than adding a redundant count/list helper to `scheduled-task-service.ts` — it already returns exactly the active set, and the count is `.length`.

## Tests

- `schedule-parser.test.ts` — thresholds; no-warn at ≤4; warn at 5–6; critical at 7+.
- `message-persister.test.ts` — count+list always present with no warning at the warn band, warning above it, critical above the critical band, and graceful degradation when the active-list lookup fails.

`tsc --noEmit` clean, eslint clean, **240 tests pass** across both files.