### PR TITLE
fix(messages): don't show a user their own typing indicator in auth mode (SUP-158)

### DIFF
--- a/e2e/auth/specs/typing-indicator.spec.ts
+++ b/e2e/auth/specs/typing-indicator.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test'
+import { AuthPage } from '../pages/auth.page'
+import { AppPage } from '../../pages/app.page'
+import { SessionPage } from '../../pages/session.page'
+
+/**
+ * Regression test for SUP-158:
+ * "Auth mode — sometimes will show own user's typing indicator while they type
+ *  (should not show self)".
+ *
+ * The typing indicator is a shared-session (auth mode) feature: when a peer is
+ * typing in the same session, the others see a "..." bubble. The server
+ * broadcasts the `user_typing` event to EVERY SSE client of the session —
+ * including the user who triggered it — so the sender's own browser receives an
+ * echo of its own typing event. Peer *messages* are self-filtered on the client
+ * (sender.id === user.id), but the typing indicator is not, so the sender ends
+ * up rendering a typing bubble for themselves.
+ *
+ * This test runs with a single user: they type into their own session composer
+ * and must NOT see a typing indicator. With the bug present, the self-echo makes
+ * the indicator appear; with the fix, it stays hidden.
+ *
+ * Uses a fresh isolated context (base `test`, not the multi-user fixture) so it
+ * doesn't couple to the serial auth-flow / auth-settings narratives. The auth
+ * suite leaves signup in "open" mode, and a fresh DB makes the first signup an
+ * admin — either way a unique-email signup lands in the app.
+ */
+test('auth mode: a user does not see their own typing indicator', async ({ page }) => {
+  const authPage = new AuthPage(page)
+  const appPage = new AppPage(page)
+  const sessionPage = new SessionPage(page)
+
+  const unique = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+  const user = {
+    name: 'Typing Tester',
+    email: `typing-${unique}@test.com`,
+    password: 'password123',
+  }
+
+  // Sign up a fresh user and land in the app.
+  await page.goto('/')
+  await authPage.expectVisible()
+  await authPage.signUp(user.name, user.email, user.password)
+  await appPage.waitForAppLoaded()
+  await appPage.dismissWizardIfVisible()
+
+  // Create an agent and open its first session (the typing indicator only
+  // renders inside the session chat view, and the typing POST only fires once a
+  // sessionId exists). The home composer creates the session and navigates to it.
+  await page.locator('[data-testid="new-agent-button"]').click()
+  await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText('Untitled', { timeout: 10000 })
+  await page.locator('[data-testid="home-message-input"]').fill('Hello from the typing test')
+  await page.locator('[data-testid="home-send-button"]').click()
+
+  // We're now in the session chat view: wait for it to settle.
+  await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
+  await sessionPage.waitForUserMessageCount(1)
+  await sessionPage.waitForResponse(15000)
+
+  // Type into the per-session composer WITHOUT sending. The first keystroke fires
+  // the debounced typing notification, which the server echoes back to us over SSE.
+  const composer = page.locator('[data-testid="message-input"]')
+  await expect(composer).toBeVisible()
+
+  const typingPosted = page.waitForResponse(
+    (res) => res.url().includes('/typing') && res.request().method() === 'POST',
+    { timeout: 10000 }
+  )
+  await composer.click()
+  // Typing spans ~0.5s; the first keystroke fires the (debounced) typing POST
+  // immediately, so the server's self-echo round-trips and is processed before
+  // pressSequentially even returns.
+  await composer.pressSequentially('typing a message…', { delay: 30 })
+
+  // Confirm the typing event reached the server and broadcast (proves the
+  // pipeline ran — otherwise the assertion below could pass vacuously).
+  await typingPosted
+
+  // The bug: the self-echo renders the user's OWN typing indicator. With the bug
+  // present it is already visible by now and stays up for a 5s auto-clear window;
+  // toBeHidden therefore keeps failing until it gives up. The 3s timeout is
+  // deliberately shorter than that 5s auto-clear, so the auto-clear cannot turn
+  // this into a false pass. With the fix, the indicator is never rendered.
+  const indicator = page.locator('[data-testid="typing-indicator"]')
+  await expect(indicator, 'a user must never see their OWN typing indicator').toBeHidden({ timeout: 3000 })
+})

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -727,10 +727,12 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
         {visiblePeerMessages.filter((p) => !p.queued).map(renderPeerGhost)}
         {pendingUserMessages?.filter((p) => !p.queued).map(renderPendingGhost)}
 
-        {/* Typing indicator - shown when another user is typing (gated on the
-            sender-filtered peer list — our own echo must not suppress it) */}
-        {typingUser && visiblePeerMessages.length === 0 && (
-          <div className="flex gap-3 flex-row-reverse">
+        {/* Typing indicator - shown when ANOTHER user is typing. The server echoes
+            user_typing back to the sender too, so exclude our own id (mirrors the
+            peer-message self-filter); the peer-list gate keeps our own echoed
+            message from suppressing a real peer's indicator. */}
+        {typingUser && typingUser.id !== user?.id && visiblePeerMessages.length === 0 && (
+          <div data-testid="typing-indicator" className="flex gap-3 flex-row-reverse">
             <div className="h-8 w-8 rounded-full items-center justify-center shrink-0 hidden md:flex bg-primary text-primary-foreground">
               <span className="text-xs font-medium">
                 {typingUser.name?.split(' ').map(w => w[0]).join('').toUpperCase().slice(0, 2) || '?'}


### PR DESCRIPTION
## What

In **auth mode** (shared agents), a user could see **their own** typing indicator while typing. It should only ever show *other* users typing.

Fixes **SUP-158**.

## Root cause

The typing indicator has no self-filter, unlike peer *messages* (which are self-filtered at `message-list.tsx:201` and `:534`):

1. **Server** (`src/api/routes/agents.ts:1653`) — the `/typing` endpoint broadcasts `user_typing` to *every* SSE client of the session, including the sender (`broadcastToSSE` has no per-user exclusion).
2. **Client receive** (`src/renderer/hooks/use-message-stream.ts:801`) — sets `typingUser = data.sender` unconditionally; the hook has no notion of "self".
3. **Render** (`src/renderer/components/messages/message-list.tsx:732`) — showed the bubble whenever `typingUser` was set, with no `typingUser.id !== user?.id` check.

So your own echoed typing event set `typingUser = you` and rendered your own bubble.

### Why it looked "sometimes"
It's actually deterministic, but feels intermittent: the typing POST is debounced to once per 3s, the bubble auto-clears 5s after the last echo, and it's suppressed whenever a peer ghost message is on screen (the `visiblePeerMessages.length === 0` gate). So you only catch it while typing with no ghost message showing.

## Fix

One-line self-filter in the render gate, mirroring the existing peer-message pattern (`message-list` already has `user` from `useUser()`):

```tsx
{typingUser && typingUser.id !== user?.id && visiblePeerMessages.length === 0 && (
```

The server can't easily exclude the sender (SSE callbacks carry no user identity), so client-side filtering is the established pattern here.

## Test plan

New auth-mode E2E regression test `e2e/auth/specs/typing-indicator.spec.ts`: a user types into their own session composer and asserts they never see a typing indicator. Verified **red before / green after** the fix. (Also added a `data-testid="typing-indicator"` hook.)

- `npx playwright test --config=playwright.auth.config.ts typing-indicator` → ✅ passes (fails without the fix)
- `message-list.test.tsx` + `use-message-stream.test.ts` → ✅ 172/172 (peer typing still renders)
- `tsc --noEmit` ✅ · `eslint` ✅

> Note: a more thorough variant would filter at the receive side (`use-message-stream.ts`) so a self-echo never enters `typingUser` state at all (it can briefly overwrite a real peer's indicator). Not needed for this bug; deferred to keep the change minimal.
