### PR TITLE
fix(agents): play new-agent intro morph reliably (flushSync before navigate)

### DIFF
--- a/e2e/specs/new-agent-intro.spec.ts
+++ b/e2e/specs/new-agent-intro.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+
+/**
+ * Regression guard for the new-agent intro ("morph") animation.
+ *
+ * Clicking "New Agent" mints an Untitled agent, stamps the morph tag
+ * (`justCreatedSlug`) into NavTransientContext, and navigates to the fresh
+ * AgentHome, which plays a one-shot staggered slide-in: a brief "Creating"
+ * overlay, then the sections fan in. The AgentHome root reflects this via
+ * `data-intro` (absent → 'pending' → 'playing').
+ *
+ * The tag is React state in a provider mounted above the router; the producer
+ * must commit it BEFORE `navigate`, because the router renders AgentHome
+ * synchronously within the same tick and AgentHome reads the tag once in a
+ * mount-time initializer. A prior change made AgentHome resolve from cache and
+ * mount during that synchronous navigate — so without a synchronous commit it
+ * captured the pre-set `null`, the intro state stayed absent, and nothing
+ * animated. This test pins that the intro actually fires end-to-end.
+ */
+test.describe('New-agent intro animation', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+
+  test.beforeEach(async ({ page }) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+  })
+
+  test('plays the staggered intro on a freshly created agent', async ({ page }) => {
+    await agentPage.clickCreateAgent()
+
+    // Landed on the fresh Untitled agent's AgentHome.
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText('Untitled', { timeout: 10000 })
+
+    // The morph fired: AgentHome captured the tag at mount and entered the intro.
+    // Absent `data-intro`, the tag read as null and nothing animated — the bug.
+    const home = page.locator('[data-testid="agent-home"]')
+    await expect(home).toHaveAttribute('data-intro', /pending|playing/)
+
+    // The "Initializing" overlay covers the page during the paused first beat.
+    await expect(page.getByText('Creating', { exact: true })).toBeVisible()
+
+    // The 1s gate fires and the steps animate: state advances to 'playing' and
+    // the overlay clears. Proves the animation actually runs, not just mounts.
+    await expect(home).toHaveAttribute('data-intro', 'playing', { timeout: 5000 })
+    await expect(page.getByText('Creating', { exact: true })).toHaveCount(0)
+  })
+
+  test('does not replay the one-shot when re-opening the same agent', async ({ page }) => {
+    await agentPage.clickCreateAgent()
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText('Untitled', { timeout: 10000 })
+    await expect(page.locator('[data-testid="agent-home"]')).toHaveAttribute('data-intro', /pending|playing/)
+
+    // Capture the agent's in-app route, leave to Home, then return via the
+    // sidebar (no hard reload) — the morph tag was consumed on first mount, so
+    // the intro must NOT play again.
+    let agentPath = ''
+    try {
+      agentPath = new URL(page.url()).pathname
+    } catch {
+      agentPath = ''
+    }
+    const agentId = agentPath.split('-').pop() ?? ''
+    expect(agentId).not.toBe('')
+
+    await page.locator('[data-testid="home-button"]').click()
+    await expect(page.locator('[data-testid="new-agent-button"]')).toBeVisible()
+
+    await page.locator(`[data-testid="agent-item-${agentId}"]`).click()
+
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText('Untitled', { timeout: 10000 })
+    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
+    await expect(page.locator('[data-testid="agent-home"]')).not.toHaveAttribute('data-intro', /pending|playing/)
+  })
+})

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -244,6 +244,11 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   return (
     <>
     <div
+      data-testid="agent-home"
+      // Surfaces the one-shot new-agent intro state for tests/debugging without
+      // coupling to CSS classes: absent when no morph, 'pending' while the
+      // "Creating" beat holds, 'playing' once the staggered slide-in runs.
+      data-intro={introStagger ? (introPlaying ? 'playing' : 'pending') : undefined}
       className={cn(
         'flex-1 flex flex-col overflow-y-auto px-10 py-10 bg-background',
         introStagger && 'agent-home-intro relative',

--- a/src/renderer/hooks/use-create-untitled-agent.ts
+++ b/src/renderer/hooks/use-create-untitled-agent.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { flushSync } from 'react-dom'
 import { toast } from 'sonner'
 import { useCreateAgent } from '@renderer/hooks/use-agents'
 import { useNavigate } from '@tanstack/react-router'
@@ -22,7 +23,13 @@ export function useCreateUntitledAgent() {
 
       // Morph tag keys on the canonical id (AgentHome compares against agent.slug);
       // navigate with the pretty display slug so the URL reflects the name.
-      setJustCreatedSlug(agent.slug)
+      //
+      // Commit the tag SYNCHRONOUSLY before navigating: `navigate` renders the
+      // destination route (mounting AgentHome) within the same tick, and AgentHome
+      // reads `justCreatedSlug` once in a mount-time initializer. Without flushSync
+      // the router's synchronous render runs before React commits this context
+      // update, so AgentHome captures the pre-set `null` and the intro never plays.
+      flushSync(() => setJustCreatedSlug(agent.slug))
       void navigate({ to: '/agents/$slug', params: { slug: agent.displaySlug } })
 
       return agent


### PR DESCRIPTION
## Problem

The new-agent intro **morph** animation — AgentHome's staggered slide-in plus the brief "Creating" overlay, shown when you click **New Agent** — silently stopped playing.

## Root cause (a render-ordering race)

`AgentHome` reads the `justCreatedSlug` morph tag **once**, in a mount-time `useState` initializer:

```ts
const [introStagger] = useState(() => {
  if (justCreatedSlug !== agent.slug) return false
  return !window.matchMedia('(prefers-reduced-motion: reduce)').matches
})
```

`useCreateUntitledAgent` set the tag and then navigated:

```ts
setJustCreatedSlug(agent.slug)
void navigate({ to: '/agents/$slug', params: { slug: agent.displaySlug } })
```

TanStack Router renders the destination route — **mounting `AgentHome` synchronously within the same tick** — *before* React commits the `setJustCreatedSlug` context update (the provider lives above the router). So `AgentHome` captured the pre-set `null`, `introStagger` stayed `false`, and nothing animated.

Console-probe order confirmed it:

```
[PRODUCER]  set justCreatedSlug = "dnx50higib"
[INTRO]     AgentHome reads justCreatedSlug = null   ← stale
[PROVIDER]  re-render with justCreatedSlug = "dnx50higib"   ← too late
```

**Why it regressed:** the race was latent until **SUP-271** (#332). Its "seed both `['agents', slug]` and `['agents', displaySlug]` cache forms" change made `useAgent(displaySlug)` resolve synchronously, so `AgentHome` now mounts *during* the navigate. Previously it missed the cache → cold fetch → mounted *later*, after the provider had already flushed the tag (it worked by accident).

## Fix

Commit the morph tag synchronously before navigating:

```ts
flushSync(() => setJustCreatedSlug(agent.slug))
void navigate({ to: '/agents/$slug', params: { slug: agent.displaySlug } })
```

`useCreateUntitledAgent` is the only producer of `justCreatedSlug`, so the one-site fix is complete.

Also exposes the intro state on `AgentHome`'s root as `data-testid="agent-home"` + `data-intro` (`absent | pending | playing`) so the test asserts it without brittle CSS-class selectors (the repo lints against class selectors in Playwright).

## Regression test

`e2e/specs/new-agent-intro.spec.ts` (2 tests):
- intro fires on a freshly created agent (`data-intro` → `pending` → `playing`; "Creating" overlay shows then clears)
- the one-shot does **not** replay when re-opening the same agent in-app

**Verified red without the fix, green with it.**

## Verification

- New e2e: 2/2 pass; fails without the fix (confirmed by temporarily reverting)
- `tsc --noEmit` clean; `eslint` clean on changed files
- Related unit suites green: `agent-home` (27), `home-page` (13), `app-sidebar` (26)