### PR TITLE
Make policy settings e2e independent

### DIFF
--- a/e2e/specs/policy-settings.spec.ts
+++ b/e2e/specs/policy-settings.spec.ts
@@ -1,7 +1,26 @@
 import { test, expect, type Page, type APIRequestContext } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 
-test.describe.configure({ mode: 'serial' })
+type ScopeDecision = 'allow' | 'review' | 'block'
+type ScopePolicy = { scope: string; decision: ScopeDecision }
+
+async function createSlackAccount(
+  request: APIRequestContext,
+  label: string,
+) {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const displayName = `E2E Policy ${label} ${unique}`
+  const res = await request.post('/api/connected-accounts', {
+    data: {
+      providerConnectionId: `e2e-policy-${unique}`,
+      toolkitSlug: 'slack',
+      displayName,
+    },
+  })
+  expect(res.ok()).toBe(true)
+  const body = await res.json()
+  return { id: body.account.id as string, name: displayName }
+}
 
 /**
  * Opens Global Settings → Connections and clicks through to the detail page
@@ -13,6 +32,10 @@ async function openConnectionDetail(page: Page, name: string) {
   await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
   await page.locator('[data-testid="settings-nav-connections"]').click()
 
+  await openConnectionRow(page, name)
+}
+
+async function openConnectionRow(page: Page, name: string) {
   const row = page.getByRole('button', { name: `Open ${name} connection details` })
   await expect(row).toBeVisible({ timeout: 5000 })
   await row.click()
@@ -24,61 +47,67 @@ async function openConnectionDetail(page: Page, name: string) {
   await expect(page).toHaveURL(/detail=account-/)
 }
 
+async function seedScopePolicies(
+  request: APIRequestContext,
+  accountId: string,
+  policies: ScopePolicy[],
+) {
+  const res = await request.put(`/api/policies/scope/${accountId}`, {
+    data: { policies },
+  })
+  expect(res.ok()).toBe(true)
+}
+
+async function scopePolicies(request: APIRequestContext, accountId: string) {
+  const res = await request.get(`/api/policies/scope/${accountId}`)
+  expect(res.ok()).toBe(true)
+  const body = await res.json()
+  return body.policies as ScopePolicy[]
+}
+
+function chatWriteRow(page: Page) {
+  return page.locator('[data-testid="scope-row-chat:write"]')
+}
+
+async function openChatWriteGroup(page: Page) {
+  await page.locator('[data-testid="scope-group-toggle-write"]').click()
+  const row = chatWriteRow(page)
+  await expect(row).toBeVisible({ timeout: 5000 })
+  return row
+}
+
 test.describe('Policy Settings', () => {
   let appPage: AppPage
-  let accountId: string
-  const accountName = 'E2E Slack Account'
 
-  test.beforeAll(async ({ request }) => {
-    // Unique per run so a retry (which re-runs beforeAll in a new worker) does
-    // not collide with the previously-seeded row on the unique connectionId.
-    const providerConnectionId = `e2e-test-connection-${Date.now()}`
-    const res = await request.post('/api/connected-accounts', {
-      data: {
-        providerConnectionId,
-        toolkitSlug: 'slack',
-        displayName: accountName,
-      },
-    })
-    const body = await res.json()
-    accountId = body.account.id
-  })
-
-  // The inline editor has no dialog-close to await after Save, so persistence
-  // is asserted against the API instead of pill text (the pill is gone).
-  const scopePolicies = async (request: APIRequestContext) => {
-    const res = await request.get(`/api/policies/scope/${accountId}`)
-    const body = await res.json()
-    return body.policies as Array<{ scope: string; decision: string }>
-  }
-
-  test('settings: connection row opens the detail page with the inline scope editor', async ({ page }) => {
+  const openPolicyEditor = async (page: Page, accountName: string) => {
     appPage = new AppPage(page)
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
-
     await openConnectionDetail(page, accountName)
+  }
+
+  test('settings: connection row opens the detail page with the inline scope editor', async ({ page, request }) => {
+    const account = await createSlackAccount(request, 'Open')
+
+    await openPolicyEditor(page, account.name)
 
     // The scope policy editor renders inline in the Permissions column.
+    await expect(page.getByRole('heading', { name: account.name })).toBeVisible()
     await expect(page.getByText('Permissions')).toBeVisible()
     await expect(page.locator('[data-testid="scope-group-write"]')).toBeVisible({ timeout: 5000 })
+    await expect(page.locator('[data-testid="scope-policy-save"]')).toBeVisible()
   })
 
   test('settings: can set a scope policy from the detail page', async ({ page, request }) => {
-    appPage = new AppPage(page)
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
-
-    await openConnectionDetail(page, accountName)
+    const account = await createSlackAccount(request, 'Allow')
+    await openPolicyEditor(page, account.name)
 
     // Find the chat:write scope row and set it to "allow".
     // The Write group is an accordion collapsed by default — expand it first.
-    await page.locator('[data-testid="scope-group-toggle-write"]').click()
-    const chatWriteRow = page.locator('[data-testid="scope-row-chat:write"]')
-    await expect(chatWriteRow).toBeVisible({ timeout: 5000 })
+    const chatWrite = await openChatWriteGroup(page)
 
     // The allow toggle should not be active
-    const allowToggle = chatWriteRow.locator('[data-testid="policy-toggle-allow"]')
+    const allowToggle = chatWrite.locator('[data-testid="policy-toggle-allow"]')
     await expect(allowToggle).toHaveAttribute('data-active', 'false')
 
     // Click the allow toggle
@@ -89,46 +118,52 @@ test.describe('Policy Settings', () => {
     await page.locator('[data-testid="scope-policy-save"]').click()
     await expect
       .poll(
-        async () => (await scopePolicies(request)).find((p) => p.scope === 'chat:write')?.decision,
+        async () => (await scopePolicies(request, account.id)).find((p) => p.scope === 'chat:write')?.decision,
         { timeout: 5000 },
       )
       .toBe('allow')
   })
 
-  test('settings: saved policy persists after reopening the editor', async ({ page }) => {
-    appPage = new AppPage(page)
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
+  test('settings: saved policy persists after reopening the editor', async ({ page, request }) => {
+    const account = await createSlackAccount(request, 'Reopen')
+    await openPolicyEditor(page, account.name)
 
-    await openConnectionDetail(page, accountName)
-
-    // The chat:write scope should still have allow active (from previous test)
-    // The Write group is an accordion collapsed by default — expand it first.
-    await page.locator('[data-testid="scope-group-toggle-write"]').click()
-    const chatWriteRow = page.locator('[data-testid="scope-row-chat:write"]')
-    await expect(chatWriteRow).toBeVisible({ timeout: 5000 })
-    const allowToggle = chatWriteRow.locator('[data-testid="policy-toggle-allow"]')
+    const chatWrite = await openChatWriteGroup(page)
+    const allowToggle = chatWrite.locator('[data-testid="policy-toggle-allow"]')
+    await expect(allowToggle).toHaveAttribute('data-active', 'false')
+    await allowToggle.click()
     await expect(allowToggle).toHaveAttribute('data-active', 'true')
+
+    await page.locator('[data-testid="scope-policy-save"]').click()
+    await expect
+      .poll(
+        async () => (await scopePolicies(request, account.id)).find((p) => p.scope === 'chat:write')?.decision,
+        { timeout: 5000 },
+      )
+      .toBe('allow')
+
+    // Reopen the editor so the UI refetches persisted policies, rather than
+    // only asserting the optimistic in-memory state from the first mount.
+    await page.locator('[data-testid="connection-detail-back"]').click()
+    await openConnectionRow(page, account.name)
+    const reopenedChatWrite = await openChatWriteGroup(page)
+    await expect(reopenedChatWrite.locator('[data-testid="policy-toggle-allow"]')).toHaveAttribute('data-active', 'true')
   })
 
   test('settings: can change policy from allow to block', async ({ page, request }) => {
-    appPage = new AppPage(page)
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
+    const account = await createSlackAccount(request, 'Block')
+    await seedScopePolicies(request, account.id, [{ scope: 'chat:write', decision: 'allow' }])
 
-    await openConnectionDetail(page, accountName)
+    await openPolicyEditor(page, account.name)
 
-    // The Write group is an accordion collapsed by default — expand it first.
-    await page.locator('[data-testid="scope-group-toggle-write"]').click()
-    const chatWriteRow = page.locator('[data-testid="scope-row-chat:write"]')
-    await expect(chatWriteRow).toBeVisible({ timeout: 5000 })
+    const chatWrite = await openChatWriteGroup(page)
 
-    // Allow should be active from previous test
-    const allowToggle = chatWriteRow.locator('[data-testid="policy-toggle-allow"]')
+    // Allow should be active from this test's seeded starting policy.
+    const allowToggle = chatWrite.locator('[data-testid="policy-toggle-allow"]')
     await expect(allowToggle).toHaveAttribute('data-active', 'true')
 
     // Click block toggle instead
-    const blockToggle = chatWriteRow.locator('[data-testid="policy-toggle-block"]')
+    const blockToggle = chatWrite.locator('[data-testid="policy-toggle-block"]')
     await blockToggle.click()
 
     // Allow should now be inactive, block active
@@ -139,26 +174,22 @@ test.describe('Policy Settings', () => {
     await page.locator('[data-testid="scope-policy-save"]').click()
     await expect
       .poll(
-        async () => (await scopePolicies(request)).find((p) => p.scope === 'chat:write')?.decision,
+        async () => (await scopePolicies(request, account.id)).find((p) => p.scope === 'chat:write')?.decision,
         { timeout: 5000 },
       )
       .toBe('block')
   })
 
   test('settings: can deselect to reset to default', async ({ page, request }) => {
-    appPage = new AppPage(page)
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
+    const account = await createSlackAccount(request, 'Default')
+    await seedScopePolicies(request, account.id, [{ scope: 'chat:write', decision: 'block' }])
 
-    await openConnectionDetail(page, accountName)
+    await openPolicyEditor(page, account.name)
 
-    // The Write group is an accordion collapsed by default — expand it first.
-    await page.locator('[data-testid="scope-group-toggle-write"]').click()
-    const chatWriteRow = page.locator('[data-testid="scope-row-chat:write"]')
-    await expect(chatWriteRow).toBeVisible({ timeout: 5000 })
+    const chatWrite = await openChatWriteGroup(page)
 
-    // Block should be active from previous test
-    const blockToggle = chatWriteRow.locator('[data-testid="policy-toggle-block"]')
+    // Block should be active from this test's seeded starting policy.
+    const blockToggle = chatWrite.locator('[data-testid="policy-toggle-block"]')
     await expect(blockToggle).toHaveAttribute('data-active', 'true')
 
     // Click block again to deselect (reset to default)
@@ -166,42 +197,18 @@ test.describe('Policy Settings', () => {
     await expect(blockToggle).toHaveAttribute('data-active', 'false')
 
     // All toggles should be inactive (= default)
-    await expect(chatWriteRow.locator('[data-testid="policy-toggle-allow"]')).toHaveAttribute('data-active', 'false')
-    await expect(chatWriteRow.locator('[data-testid="policy-toggle-review"]')).toHaveAttribute('data-active', 'false')
-    await expect(chatWriteRow.locator('[data-testid="policy-toggle-block"]')).toHaveAttribute('data-active', 'false')
+    await expect(chatWrite.locator('[data-testid="policy-toggle-allow"]')).toHaveAttribute('data-active', 'false')
+    await expect(chatWrite.locator('[data-testid="policy-toggle-review"]')).toHaveAttribute('data-active', 'false')
+    await expect(chatWrite.locator('[data-testid="policy-toggle-block"]')).toHaveAttribute('data-active', 'false')
 
     // Save and verify the per-scope row is gone from the persisted policies
     // (label-default rows may remain — only chat:write must be absent).
     await page.locator('[data-testid="scope-policy-save"]').click()
     await expect
       .poll(
-        async () => (await scopePolicies(request)).some((p) => p.scope === 'chat:write'),
+        async () => (await scopePolicies(request, account.id)).some((p) => p.scope === 'chat:write'),
         { timeout: 5000 },
       )
       .toBe(false)
-  })
-
-  test('settings: global default policy toggle works', async ({ page }) => {
-    appPage = new AppPage(page)
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
-
-    // Open settings → Accounts
-    await page.locator('[data-testid="settings-button"]').click()
-    await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
-    await page.locator('[data-testid="settings-nav-connections"]').click()
-
-    // The API default-policy row inside the "Default Policies" card.
-    const globalSection = page.locator('[data-testid="default-policy-api"]')
-    const reviewToggle = globalSection.locator('[data-testid="policy-toggle-review"]')
-    const allowToggle = globalSection.locator('[data-testid="policy-toggle-allow"]')
-
-    // Review is default, should be active
-    await expect(reviewToggle).toHaveAttribute('data-active', 'true')
-
-    // Switch to allow
-    await allowToggle.click()
-    await expect(allowToggle).toHaveAttribute('data-active', 'true')
-    await expect(reviewToggle).toHaveAttribute('data-active', 'false')
   })
 })

--- a/e2e/specs/settings.spec.ts
+++ b/e2e/specs/settings.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test'
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 
 test.describe.configure({ mode: 'serial' })
@@ -32,6 +32,18 @@ async function waitForSettingsSave(page: Page) {
   await page.waitForResponse(
     (res) => res.url().includes('/api/settings') && res.request().method() === 'PUT' && res.ok(),
   )
+}
+
+/** Wait for a PUT /api/user-settings request to complete. */
+async function waitForUserSettingsSave(page: Page) {
+  await page.waitForResponse(
+    (res) => res.url().includes('/api/user-settings') && res.request().method() === 'PUT' && res.ok(),
+  )
+}
+
+async function setDefaultApiPolicy(request: APIRequestContext, defaultApiPolicy: 'review' | 'allow') {
+  const res = await request.put('/api/user-settings', { data: { defaultApiPolicy } })
+  expect(res.ok()).toBe(true)
 }
 
 // ---------------------------------------------------------------------------
@@ -328,6 +340,47 @@ test.describe('Settings persistence', () => {
     const removePromise = waitForSettingsSave(page)
     await removeBtn.click()
     await removePromise
+  })
+
+  test('Connections tab: global default API policy toggle persists', async ({ page, request }) => {
+    await setDefaultApiPolicy(request, 'review')
+    await appPage.reload()
+
+    try {
+      await openSettings(page)
+      await goToTab(page, 'connections')
+
+      // The API default-policy row inside the "Default Policies" card.
+      const globalSection = page.locator('[data-testid="default-policy-api"]')
+      const reviewToggle = globalSection.locator('[data-testid="policy-toggle-review"]')
+      const allowToggle = globalSection.locator('[data-testid="policy-toggle-allow"]')
+
+      // Review is default, should be active.
+      await expect(reviewToggle).toHaveAttribute('data-active', 'true')
+      await expect(allowToggle).toHaveAttribute('data-active', 'false')
+
+      // Switch to allow and wait for the user-settings mutation.
+      const savePromise = waitForUserSettingsSave(page)
+      await allowToggle.click()
+      await savePromise
+      await expect(allowToggle).toHaveAttribute('data-active', 'true')
+      await expect(reviewToggle).toHaveAttribute('data-active', 'false')
+
+      // Close, reopen, verify the persisted setting is reflected by the UI.
+      await closeSettings(page)
+      await openSettings(page)
+      await goToTab(page, 'connections')
+      const reopenedSection = page.locator('[data-testid="default-policy-api"]')
+      await expect(reopenedSection.locator('[data-testid="policy-toggle-allow"]')).toHaveAttribute('data-active', 'true')
+      await expect(reopenedSection.locator('[data-testid="policy-toggle-review"]')).toHaveAttribute('data-active', 'false')
+
+      const settingsRes = await request.get('/api/user-settings')
+      expect(settingsRes.ok()).toBe(true)
+      const settings = await settingsRes.json()
+      expect(settings.defaultApiPolicy).toBe('allow')
+    } finally {
+      await setDefaultApiPolicy(request, 'review')
+    }
   })
 })
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,6 @@ const configuredWorkers = process.env.PLAYWRIGHT_WORKERS
 
 const statefulTestMatch = [
   '**/settings.spec.ts',
-  '**/policy-settings.spec.ts',
 ]
 
 const webTestIgnore = [
@@ -82,7 +81,7 @@ export default defineConfig({
       fullyParallel: false,
     },
     {
-      // Settings/policy tests modify global settings but don't toggle setupCompleted.
+      // Settings tests modify global settings but don't toggle setupCompleted.
       // Safe to run after wizard tests complete.
       name: 'global-state',
       testMatch: statefulTestMatch,


### PR DESCRIPTION
## Summary
- Give each policy-settings E2E test its own Slack connected account and explicit starting policy state.
- Move the global default API policy persistence coverage into `settings.spec.ts`, where global user-settings mutations are already serialized.
- Remove `policy-settings.spec.ts` from the `global-state` project so it can run under normal `web-chromium` parallelism.

## Why
`policy-settings.spec.ts` depended on prior tests to seed account/policy state and was quarantined with global settings tests. This made it unsafe for higher parallelism and hid real ordering assumptions. The rewritten tests keep the same user-facing coverage while making each test own its setup, and the persistence test now reopens the editor after saving to verify fetched state rather than only optimistic UI state.

## Validation
- `npm exec eslint -- e2e/specs/policy-settings.spec.ts e2e/specs/settings.spec.ts playwright.config.ts`
- `git diff --check`
- `PORT=3312 SUPERAGENT_DATA_DIR=.e2e-data/policy-settings-parallel-rerun PLAYWRIGHT_OUTPUT_DIR=test-results/policy-settings-parallel-rerun PLAYWRIGHT_HTML_REPORT=playwright-report/policy-settings-parallel-rerun npx playwright test --project=web-chromium --no-deps e2e/specs/policy-settings.spec.ts --workers=4 --repeat-each=3` (`15 passed`)
- `PORT=3315 SUPERAGENT_DATA_DIR=.e2e-data/settings-policy-default-final PLAYWRIGHT_OUTPUT_DIR=test-results/settings-policy-default-final PLAYWRIGHT_HTML_REPORT=playwright-report/settings-policy-default-final npx playwright test --project=global-state --no-deps e2e/specs/settings.spec.ts -g "Connections tab: global default API policy toggle persists"` (`1 passed`)
- `npm run typecheck`
- `npm run lint:e2e` (passes with existing warnings)
- `npx playwright test --list --project=global-state`
- `PORT=3316 SUPERAGENT_DATA_DIR=.e2e-data/main-policy-config-final PLAYWRIGHT_OUTPUT_DIR=test-results/main-policy-config-final PLAYWRIGHT_HTML_REPORT=playwright-report/main-policy-config-final npm run test:e2e` (`18 skipped, 211 passed`)