### PR TITLE
Make settings e2e independent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,9 +109,7 @@ jobs:
       - name: Run Playwright E2E suites
         env:
           PLAYWRIGHT_WORKERS: '2'
-        run: |
-          PORT=3000 SUPERAGENT_DATA_DIR=.e2e-data PLAYWRIGHT_WORKERS=1 PLAYWRIGHT_OUTPUT_DIR=test-results/stateful PLAYWRIGHT_HTML_REPORT=playwright-report/stateful npm run test:e2e:stateful
-          PORT=3000 SUPERAGENT_DATA_DIR=.e2e-data PLAYWRIGHT_WORKERS=$PLAYWRIGHT_WORKERS PLAYWRIGHT_OUTPUT_DIR=test-results/web PLAYWRIGHT_HTML_REPORT=playwright-report/web npm run test:e2e:web
+        run: PORT=3000 SUPERAGENT_DATA_DIR=.e2e-data PLAYWRIGHT_WORKERS=$PLAYWRIGHT_WORKERS PLAYWRIGHT_OUTPUT_DIR=test-results/web PLAYWRIGHT_HTML_REPORT=playwright-report/web npm run test:e2e
 
       - name: Upload Playwright artifacts
         if: always()

--- a/e2e/specs/settings.spec.ts
+++ b/e2e/specs/settings.spec.ts
@@ -1,11 +1,29 @@
-import { test, expect, type APIRequestContext, type Page } from '@playwright/test'
+import { test, expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
-
-test.describe.configure({ mode: 'serial' })
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+type DefaultApiPolicy = 'allow' | 'review' | 'block'
+type SttProvider = 'deepgram' | 'openai' | 'platform'
+
+interface GlobalSettingsSnapshot {
+  app: {
+    maxBrowserTabs?: number
+    autoSleepTimeoutMinutes?: number
+  }
+  accountProviderUserId?: string
+  customEnvVars: Record<string, string>
+  shareAnalytics: boolean
+  voice?: {
+    sttProvider?: SttProvider
+  }
+}
+
+interface UserSettingsSnapshot {
+  defaultApiPolicy: DefaultApiPolicy
+}
 
 async function openSettings(page: Page) {
   await page.locator('[data-testid="settings-button"]').click()
@@ -41,9 +59,56 @@ async function waitForUserSettingsSave(page: Page) {
   )
 }
 
-async function setDefaultApiPolicy(request: APIRequestContext, defaultApiPolicy: 'review' | 'allow') {
-  const res = await request.put('/api/user-settings', { data: { defaultApiPolicy } })
+async function settings(request: APIRequestContext) {
+  const res = await request.get('/api/settings')
   expect(res.ok()).toBe(true)
+  return await res.json() as GlobalSettingsSnapshot
+}
+
+async function saveSettings(request: APIRequestContext, data: Record<string, unknown>) {
+  const res = await request.put('/api/settings', { data })
+  expect(res.ok()).toBe(true)
+  return await res.json() as GlobalSettingsSnapshot
+}
+
+async function userSettings(request: APIRequestContext) {
+  const res = await request.get('/api/user-settings')
+  expect(res.ok()).toBe(true)
+  return await res.json() as UserSettingsSnapshot
+}
+
+async function saveUserSettings(request: APIRequestContext, data: Record<string, unknown>) {
+  const res = await request.put('/api/user-settings', { data })
+  expect(res.ok()).toBe(true)
+  return await res.json() as UserSettingsSnapshot
+}
+
+async function ensureSetupCompleted(request: APIRequestContext) {
+  await saveUserSettings(request, { setupCompleted: true })
+}
+
+async function setDefaultApiPolicy(request: APIRequestContext, defaultApiPolicy: DefaultApiPolicy) {
+  await saveUserSettings(request, { defaultApiPolicy })
+}
+
+async function deleteCustomEnvVar(request: APIRequestContext, key: string) {
+  const current = await settings(request)
+  const customEnvVars = { ...current.customEnvVars }
+  delete customEnvVars[key]
+  await saveSettings(request, { customEnvVars })
+}
+
+function uniqueEnvKey(testInfo: TestInfo, prefix: string) {
+  return `${prefix}_${testInfo.workerIndex}_${testInfo.parallelIndex}_${testInfo.retry}_${Date.now()}`
+}
+
+function uniqueAgentName(testInfo: TestInfo, name: string) {
+  return `${name} ${testInfo.workerIndex}-${testInfo.parallelIndex}-${testInfo.retry}-${Date.now()}`
+}
+
+async function deleteAgent(request: APIRequestContext, slug: string | undefined) {
+  if (!slug) return
+  await request.delete(`/api/agents/${slug}`)
 }
 
 // ---------------------------------------------------------------------------
@@ -53,7 +118,8 @@ async function setDefaultApiPolicy(request: APIRequestContext, defaultApiPolicy:
 test.describe('Settings Page', () => {
   let appPage: AppPage
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, request }) => {
+    await ensureSetupCompleted(request)
     appPage = new AppPage(page)
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
@@ -193,153 +259,167 @@ test.describe('Settings Page', () => {
 test.describe('Settings persistence', () => {
   let appPage: AppPage
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, request }) => {
+    await ensureSetupCompleted(request)
     appPage = new AppPage(page)
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
   })
 
-  test('General tab: share analytics toggle persists', async ({ page }) => {
-    await openSettings(page)
-    await goToTab(page, 'general')
+  test('General tab: share analytics toggle persists', async ({ page, request }) => {
+    await saveSettings(request, { shareAnalytics: true })
+    await appPage.reload()
 
-    const toggle = page.locator('#share-analytics')
-    await expect(toggle).toBeVisible()
+    try {
+      await openSettings(page)
+      await goToTab(page, 'general')
 
-    // Read the current state, then toggle and verify persistence
-    const initialState = await toggle.getAttribute('data-state')
-    const oppositeState = initialState === 'checked' ? 'unchecked' : 'checked'
+      const toggle = page.locator('#share-analytics')
+      await expect(toggle).toBeVisible()
+      await expect(toggle).toHaveAttribute('data-state', 'checked')
 
-    // Toggle and wait for save
-    const savePromise = waitForSettingsSave(page)
-    await toggle.click()
-    await savePromise
-    await expect(toggle).toHaveAttribute('data-state', oppositeState)
+      const savePromise = waitForSettingsSave(page)
+      await toggle.click()
+      await savePromise
+      await expect(toggle).toHaveAttribute('data-state', 'unchecked')
 
-    // Close, reopen, verify the toggled state persisted
-    await closeSettings(page)
-    await openSettings(page)
-    await goToTab(page, 'general')
-    await expect(page.locator('#share-analytics')).toHaveAttribute('data-state', oppositeState)
+      await closeSettings(page)
+      await openSettings(page)
+      await goToTab(page, 'general')
+      await expect(page.locator('#share-analytics')).toHaveAttribute('data-state', 'unchecked')
 
-    // Toggle back for cleanup
-    const savePromise2 = waitForSettingsSave(page)
-    await page.locator('#share-analytics').click()
-    await savePromise2
-  })
-
-  test('Voice tab: STT provider selection persists', async ({ page }) => {
-    await openSettings(page)
-    await goToTab(page, 'voice')
-
-    // If Deepgram is already selected (from a previous run), reset to OpenAI first
-    const currentText = await page.locator('#stt-provider').textContent()
-    if (currentText?.includes('Deepgram')) {
-      const resetPromise = waitForSettingsSave(page)
-      await pickSelectOption(page, 'stt-provider', 'OpenAI')
-      await resetPromise
+      const persisted = await settings(request)
+      expect(persisted.shareAnalytics).toBe(false)
+    } finally {
+      await saveSettings(request, { shareAnalytics: true })
     }
-
-    // Select Deepgram
-    const savePromise = waitForSettingsSave(page)
-    await pickSelectOption(page, 'stt-provider', 'Deepgram')
-    await savePromise
-
-    // The provider trigger should now show Deepgram
-    await expect(page.locator('#stt-provider')).toContainText('Deepgram')
-
-    // After selecting a provider, the API key section should appear
-    await expect(page.locator('#deepgram-api-key')).toBeVisible()
-
-    // Close, reopen, verify
-    await closeSettings(page)
-    await openSettings(page)
-    await goToTab(page, 'voice')
-    await expect(page.locator('#stt-provider')).toContainText('Deepgram')
-    await expect(page.locator('#deepgram-api-key')).toBeVisible()
   })
 
-  test('Browser tab: max browser tabs change persists', async ({ page }) => {
-    await openSettings(page)
-    await goToTab(page, 'browser')
+  test('Voice tab: STT provider selection persists', async ({ page, request }) => {
+    await saveSettings(request, { voice: { sttProvider: 'openai' } })
+    await appPage.reload()
 
-    // Change max browser tabs from default (10) to 5
-    const input = page.locator('#max-browser-tabs')
-    await expect(input).toHaveValue('10')
+    try {
+      await openSettings(page)
+      await goToTab(page, 'voice')
 
-    const savePromise = waitForSettingsSave(page)
-    await input.fill('5')
-    await savePromise
+      await expect(page.locator('#stt-provider')).toContainText('OpenAI')
 
-    // Close, reopen, verify
-    await closeSettings(page)
-    await openSettings(page)
-    await goToTab(page, 'browser')
-    await expect(page.locator('#max-browser-tabs')).toHaveValue('5')
+      const savePromise = waitForSettingsSave(page)
+      await pickSelectOption(page, 'stt-provider', 'Deepgram')
+      await savePromise
 
-    // Restore default
-    const restorePromise = waitForSettingsSave(page)
-    await page.locator('#max-browser-tabs').fill('10')
-    await restorePromise
+      await expect(page.locator('#stt-provider')).toContainText('Deepgram')
+      await expect(page.locator('#deepgram-api-key')).toBeVisible()
+
+      await closeSettings(page)
+      await openSettings(page)
+      await goToTab(page, 'voice')
+      await expect(page.locator('#stt-provider')).toContainText('Deepgram')
+      await expect(page.locator('#deepgram-api-key')).toBeVisible()
+
+      const persisted = await settings(request)
+      expect(persisted.voice?.sttProvider).toBe('deepgram')
+    } finally {
+      await saveSettings(request, { voice: { sttProvider: 'openai' } })
+    }
   })
 
-  test('Runtime tab: idle timeout change persists', async ({ page }) => {
-    await openSettings(page)
-    await goToTab(page, 'runtime')
+  test('Browser tab: max browser tabs change persists', async ({ page, request }) => {
+    await saveSettings(request, { app: { maxBrowserTabs: 10 } })
+    await appPage.reload()
 
-    const input = page.locator('#auto-sleep-timeout')
-    // Default is 30
-    await expect(input).toHaveValue('30')
+    try {
+      await openSettings(page)
+      await goToTab(page, 'browser')
 
-    // Change to 15 — saves on blur
-    await input.fill('15')
-    const savePromise = waitForSettingsSave(page)
-    await input.blur()
-    await savePromise
+      const input = page.locator('#max-browser-tabs')
+      await expect(input).toHaveValue('10')
 
-    // Close, reopen, verify
-    await closeSettings(page)
-    await openSettings(page)
-    await goToTab(page, 'runtime')
-    await expect(page.locator('#auto-sleep-timeout')).toHaveValue('15')
+      const savePromise = waitForSettingsSave(page)
+      await input.fill('5')
+      await savePromise
+      await expect(input).toHaveValue('5')
 
-    // Restore
-    const restoreInput = page.locator('#auto-sleep-timeout')
-    await restoreInput.fill('30')
-    const restorePromise = waitForSettingsSave(page)
-    await restoreInput.blur()
-    await restorePromise
+      await closeSettings(page)
+      await openSettings(page)
+      await goToTab(page, 'browser')
+      await expect(page.locator('#max-browser-tabs')).toHaveValue('5')
+
+      const persisted = await settings(request)
+      expect(persisted.app.maxBrowserTabs).toBe(5)
+    } finally {
+      await saveSettings(request, { app: { maxBrowserTabs: 10 } })
+    }
   })
 
-  test('Composio tab: user ID save persists', async ({ page }) => {
-    await openSettings(page)
-    await goToTab(page, 'account-provider')
+  test('Runtime tab: idle timeout change persists', async ({ page, request }) => {
+    await saveSettings(request, { app: { autoSleepTimeoutMinutes: 30 } })
+    await appPage.reload()
 
-    // Type a user ID
-    await page.locator('#provider-user-id').fill('test-user-123')
+    try {
+      await openSettings(page)
+      await goToTab(page, 'runtime')
 
-    // Save button should appear
-    const saveBtn = page.getByRole('button', { name: 'Save User ID' })
-    await expect(saveBtn).toBeVisible()
+      const input = page.locator('#auto-sleep-timeout')
+      await expect(input).toHaveValue('30')
 
-    const savePromise = waitForSettingsSave(page)
-    await saveBtn.click()
-    await savePromise
+      await input.fill('15')
+      const savePromise = waitForSettingsSave(page)
+      await input.blur()
+      await savePromise
 
-    // After save, "Configured" badge should appear
-    await expect(page.getByText('Configured', { exact: true })).toBeVisible()
+      await closeSettings(page)
+      await openSettings(page)
+      await goToTab(page, 'runtime')
+      await expect(page.locator('#auto-sleep-timeout')).toHaveValue('15')
 
-    // Close, reopen, verify the badge is still there
-    await closeSettings(page)
-    await openSettings(page)
-    await goToTab(page, 'account-provider')
-    await expect(page.getByText('Configured', { exact: true })).toBeVisible()
+      const persisted = await settings(request)
+      expect(persisted.app.autoSleepTimeoutMinutes).toBe(15)
+    } finally {
+      await saveSettings(request, { app: { autoSleepTimeoutMinutes: 30 } })
+    }
+  })
 
-    // Clean up: remove user ID
-    const removeBtn = page.getByRole('button', { name: 'Remove User ID' })
-    const removePromise = waitForSettingsSave(page)
-    await removeBtn.click()
-    await removePromise
+  test('Composio tab: user ID save persists', async ({ page, request }, testInfo) => {
+    const userId = `settings-user-${testInfo.workerIndex}-${testInfo.parallelIndex}-${testInfo.retry}-${Date.now()}`
+    await saveSettings(request, { apiKeys: { accountProviderUserId: '' } })
+    await appPage.reload()
+
+    try {
+      await openSettings(page)
+      await goToTab(page, 'account-provider')
+
+      await page.locator('#provider-user-id').fill(userId)
+
+      const saveBtn = page.getByRole('button', { name: 'Save User ID' })
+      await expect(saveBtn).toBeVisible()
+
+      const savePromise = waitForSettingsSave(page)
+      await saveBtn.click()
+      await savePromise
+
+      await expect(page.getByText('Configured', { exact: true })).toBeVisible()
+
+      await closeSettings(page)
+      await openSettings(page)
+      await goToTab(page, 'account-provider')
+      await expect(page.getByText('Configured', { exact: true })).toBeVisible()
+
+      const persisted = await settings(request)
+      expect(persisted.accountProviderUserId).toBe(userId)
+
+      const removeBtn = page.getByRole('button', { name: 'Remove User ID' })
+      const removePromise = waitForSettingsSave(page)
+      await removeBtn.click()
+      await removePromise
+      await expect(page.getByText('Configured', { exact: true })).not.toBeVisible()
+
+      const cleaned = await settings(request)
+      expect(cleaned.accountProviderUserId).toBeUndefined()
+    } finally {
+      await saveSettings(request, { apiKeys: { accountProviderUserId: '' } })
+    }
   })
 
   test('Connections tab: global default API policy toggle persists', async ({ page, request }) => {
@@ -374,10 +454,8 @@ test.describe('Settings persistence', () => {
       await expect(reopenedSection.locator('[data-testid="policy-toggle-allow"]')).toHaveAttribute('data-active', 'true')
       await expect(reopenedSection.locator('[data-testid="policy-toggle-review"]')).toHaveAttribute('data-active', 'false')
 
-      const settingsRes = await request.get('/api/user-settings')
-      expect(settingsRes.ok()).toBe(true)
-      const settings = await settingsRes.json()
-      expect(settings.defaultApiPolicy).toBe('allow')
+      const persisted = await userSettings(request)
+      expect(persisted.defaultApiPolicy).toBe('allow')
     } finally {
       await setDefaultApiPolicy(request, 'review')
     }
@@ -389,82 +467,64 @@ test.describe('Settings persistence', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('Custom environment variables', () => {
-  let appPage: AppPage
-
-  test.beforeEach(async ({ page }) => {
-    appPage = new AppPage(page)
+  test.beforeEach(async ({ page, request }) => {
+    await ensureSetupCompleted(request)
+    const appPage = new AppPage(page)
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
   })
 
-  test('add and delete a custom env var', async ({ page }) => {
-    await openSettings(page)
-    await goToTab(page, 'runtime')
+  test('add, edit, persist, and delete a custom env var', async ({ page, request }, testInfo) => {
+    const envKey = uniqueEnvKey(testInfo, 'SETTINGS_TEST_VAR')
+    await deleteCustomEnvVar(request, envKey)
 
-    await page.getByRole('button', { name: 'Add Variable' }).click()
-    const dialog = page.getByRole('dialog').filter({ hasText: 'Add Custom Environment Variable' })
-    await expect(dialog).toBeVisible()
-    await dialog.getByLabel('Variable Name').fill('MY_TEST_VAR')
+    try {
+      await openSettings(page)
+      await goToTab(page, 'runtime')
 
-    const savePromise = waitForSettingsSave(page)
-    await dialog.getByRole('button', { name: 'Add Variable' }).click()
-    await savePromise
+      await page.getByRole('button', { name: 'Add Variable' }).click()
+      const dialog = page.getByRole('dialog').filter({ hasText: 'Add Custom Environment Variable' })
+      await expect(dialog).toBeVisible()
+      await dialog.getByLabel('Variable Name').fill(envKey)
 
-    // The variable should appear in the list (key input is disabled, shows the name)
-    const keyInput = page.locator('input[disabled][value="MY_TEST_VAR"]')
-    await expect(keyInput).toBeVisible()
+      const addPromise = waitForSettingsSave(page)
+      await dialog.getByRole('button', { name: 'Add Variable' }).click()
+      await addPromise
 
-    // Close, reopen, verify it persisted
-    await closeSettings(page)
-    await openSettings(page)
-    await goToTab(page, 'runtime')
-    await expect(page.locator('input[disabled][value="MY_TEST_VAR"]')).toBeVisible()
+      const row = page.locator(`[data-testid="custom-env-var-row"][data-env-var-key="${envKey}"]`)
+      await expect(row.getByTestId('custom-env-var-key')).toHaveValue(envKey)
 
-    // Delete the variable via the X button next to it
-    const row = page.locator('[data-testid="custom-env-var-row"][data-env-var-key="MY_TEST_VAR"]')
-    const deletePromise = waitForSettingsSave(page)
-    await row.getByTestId('custom-env-var-delete').click()
-    await deletePromise
+      await closeSettings(page)
+      await openSettings(page)
+      await goToTab(page, 'runtime')
+      const reopenedRow = page.locator(`[data-testid="custom-env-var-row"][data-env-var-key="${envKey}"]`)
+      await expect(reopenedRow.getByTestId('custom-env-var-key')).toHaveValue(envKey)
 
-    // Variable should be gone
-    await expect(page.locator('input[disabled][value="MY_TEST_VAR"]')).not.toBeVisible()
-  })
+      const valueInput = reopenedRow.getByTestId('custom-env-var-value')
+      await valueInput.fill('hello-world')
+      const editPromise = waitForSettingsSave(page)
+      await valueInput.blur()
+      await editPromise
 
-  test('edit a custom env var value', async ({ page }) => {
-    await openSettings(page)
-    await goToTab(page, 'runtime')
+      const edited = await settings(request)
+      expect(edited.customEnvVars[envKey]).toBe('hello-world')
 
-    await page.getByRole('button', { name: 'Add Variable' }).click()
-    const dialog = page.getByRole('dialog').filter({ hasText: 'Add Custom Environment Variable' })
-    await expect(dialog).toBeVisible()
-    await dialog.getByLabel('Variable Name').fill('EDIT_TEST_VAR')
+      await closeSettings(page)
+      await openSettings(page)
+      await goToTab(page, 'runtime')
+      const persistedRow = page.locator(`[data-testid="custom-env-var-row"][data-env-var-key="${envKey}"]`)
+      await expect(persistedRow.getByTestId('custom-env-var-value')).toHaveValue('hello-world')
 
-    const addPromise = waitForSettingsSave(page)
-    await dialog.getByRole('button', { name: 'Add Variable' }).click()
-    await addPromise
+      const deletePromise = waitForSettingsSave(page)
+      await persistedRow.getByTestId('custom-env-var-delete').click()
+      await deletePromise
 
-    // Find the value input (sibling of the key input)
-    const row = page.locator('[data-testid="custom-env-var-row"][data-env-var-key="EDIT_TEST_VAR"]')
-    const valueInput = row.getByTestId('custom-env-var-value')
-
-    // Persist on blur, matching the runtime tab behavior.
-    await valueInput.fill('hello-world')
-    const fillPromise = waitForSettingsSave(page)
-    await valueInput.blur()
-    await fillPromise
-
-    // Close, reopen, verify value persisted
-    await closeSettings(page)
-    await openSettings(page)
-    await goToTab(page, 'runtime')
-    const persistedRow = page.locator('[data-testid="custom-env-var-row"][data-env-var-key="EDIT_TEST_VAR"]')
-    const persistedValue = persistedRow.getByTestId('custom-env-var-value')
-    await expect(persistedValue).toHaveValue('hello-world')
-
-    // Clean up: delete the variable
-    const deletePromise = waitForSettingsSave(page)
-    await persistedRow.getByTestId('custom-env-var-delete').click()
-    await deletePromise
+      await expect(page.locator(`[data-testid="custom-env-var-row"][data-env-var-key="${envKey}"]`)).not.toBeVisible()
+      const cleaned = await settings(request)
+      expect(cleaned.customEnvVars[envKey]).toBeUndefined()
+    } finally {
+      await deleteCustomEnvVar(request, envKey)
+    }
   })
 })
 
@@ -475,7 +535,8 @@ test.describe('Custom environment variables', () => {
 test.describe('Settings validation errors', () => {
   let appPage: AppPage
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, request }) => {
+    await ensureSetupCompleted(request)
     appPage = new AppPage(page)
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
@@ -591,39 +652,38 @@ test.describe('Settings validation errors', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('Settings deep-link reset', () => {
-  test('voice-button deep link does not stick after close', async ({ page, request }) => {
-    // Skip the first-launch wizard so the app renders straight to the agent view.
-    await request.put('/api/user-settings', {
-      data: { setupCompleted: true },
-    })
-    // Seed an agent via API so the home message-input (which hosts the voice button) renders.
-    const createRes = await request.post('/api/agents', {
-      data: { name: 'Voice Deep Link Test' },
-    })
-    const agent = await createRes.json() as { slug: string; displaySlug: string }
+  test('voice-button deep link does not stick after close', async ({ page, request }, testInfo) => {
+    await ensureSetupCompleted(request)
+    let agent: { slug: string; displaySlug: string } | undefined
 
-    const appPage = new AppPage(page)
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
-    await page.locator(`[data-testid="agent-item-${agent.slug}"]`).click()
-    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
+    try {
+      const createRes = await request.post('/api/agents', {
+        data: { name: uniqueAgentName(testInfo, 'Voice Deep Link Test') },
+      })
+      agent = await createRes.json() as { slug: string; displaySlug: string }
 
-    // Voice provider is unconfigured in mock mode → clicking the mic deep-links to the Voice section.
-    await page.locator('[data-testid="voice-input-button"]').click()
-    await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
-    await expect(page.locator('[data-testid="settings-nav-voice"]')).toHaveAttribute('data-active', 'true')
+      const appPage = new AppPage(page)
+      await appPage.goto()
+      await appPage.waitForAgentsLoaded()
+      await page.locator(`[data-testid="agent-item-${agent.slug}"]`).click()
+      await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
 
-    // Close, then reopen via the plain Settings button (no tab argument).
-    await page.locator('[data-testid="settings-back"]').click()
-    await page.locator('[data-testid="settings-button"]').click()
-    await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
+      // Voice provider is unconfigured in mock mode → clicking the mic deep-links to the Voice section.
+      await page.locator('[data-testid="voice-input-button"]').click()
+      await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
+      await expect(page.locator('[data-testid="settings-nav-voice"]')).toHaveAttribute('data-active', 'true')
 
-    // Should land on the default first section, NOT remember 'voice'.
-    await expect(page.locator('[data-testid="settings-nav-general"]')).toHaveAttribute('data-active', 'true')
-    await expect(page.locator('[data-testid="settings-nav-voice"]')).toHaveAttribute('data-active', 'false')
+      // Close, then reopen via the plain Settings button (no tab argument).
+      await page.locator('[data-testid="settings-back"]').click()
+      await page.locator('[data-testid="settings-button"]').click()
+      await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
 
-    // Clean up: delete the seeded agent via API so other tests aren't affected.
-    await request.delete(`/api/agents/${agent.slug}`)
+      // Should land on the default first section, NOT remember 'voice'.
+      await expect(page.locator('[data-testid="settings-nav-general"]')).toHaveAttribute('data-active', 'true')
+      await expect(page.locator('[data-testid="settings-nav-voice"]')).toHaveAttribute('data-active', 'false')
+    } finally {
+      await deleteAgent(request, agent?.slug)
+    }
   })
 })
 
@@ -633,29 +693,33 @@ test.describe('Settings deep-link reset', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('Settings ?from= close-target', () => {
-  test('close pushes to the captured ?from origin', async ({ page, request }) => {
-    await request.put('/api/user-settings', { data: { setupCompleted: true } })
-    const createRes = await request.post('/api/agents', { data: { name: 'Settings From Origin' } })
-    const agent = await createRes.json() as { slug: string; displaySlug: string }
+  test('close pushes to the captured ?from origin', async ({ page, request }, testInfo) => {
+    await ensureSetupCompleted(request)
+    let agent: { slug: string; displaySlug: string } | undefined
 
-    const appPage = new AppPage(page)
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
-    await page.locator(`[data-testid="agent-item-${agent.slug}"]`).click()
-    // The URL carries the display slug ({name}-{id}), not the bare canonical id.
-    await expect(page).toHaveURL(new RegExp(`/agents/${agent.displaySlug}$`))
-    const origin = page.url()
+    try {
+      const createRes = await request.post('/api/agents', { data: { name: uniqueAgentName(testInfo, 'Settings From Origin') } })
+      agent = await createRes.json() as { slug: string; displaySlug: string }
 
-    await page.locator('[data-testid="settings-button"]').click()
-    await expect(page).toHaveURL(/\/settings(\/|\?|$)/)
-    await page.locator('[data-testid="settings-back"]').click()
-    await expect(page).toHaveURL(origin)
+      const appPage = new AppPage(page)
+      await appPage.goto()
+      await appPage.waitForAgentsLoaded()
+      await page.locator(`[data-testid="agent-item-${agent.slug}"]`).click()
+      // The URL carries the display slug ({name}-{id}), not the bare canonical id.
+      await expect(page).toHaveURL(new RegExp(`/agents/${agent.displaySlug}$`))
+      const origin = page.url()
 
-    await request.delete(`/api/agents/${agent.slug}`)
+      await page.locator('[data-testid="settings-button"]').click()
+      await expect(page).toHaveURL(/\/settings(\/|\?|$)/)
+      await page.locator('[data-testid="settings-back"]').click()
+      await expect(page).toHaveURL(origin)
+    } finally {
+      await deleteAgent(request, agent?.slug)
+    }
   })
 
   test('cold deep-link to /settings/general closes to home (no ?from)', async ({ page, request }) => {
-    await request.put('/api/user-settings', { data: { setupCompleted: true } })
+    await ensureSetupCompleted(request)
     await page.goto('/settings/general')
     await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
     await expect(page.locator('[data-testid="settings-nav-general"]')).toHaveAttribute('data-active', 'true')
@@ -663,26 +727,30 @@ test.describe('Settings ?from= close-target', () => {
     await expect(page).toHaveURL(/\/$/)
   })
 
-  test('settings survives a refresh and still closes to origin (?from= is durable)', async ({ page, request }) => {
-    await request.put('/api/user-settings', { data: { setupCompleted: true } })
-    const createRes = await request.post('/api/agents', { data: { name: 'Settings Refresh From' } })
-    const agent = await createRes.json() as { slug: string; displaySlug: string }
+  test('settings survives a refresh and still closes to origin (?from= is durable)', async ({ page, request }, testInfo) => {
+    await ensureSetupCompleted(request)
+    let agent: { slug: string; displaySlug: string } | undefined
 
-    const appPage = new AppPage(page)
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
-    await page.locator(`[data-testid="agent-item-${agent.slug}"]`).click()
-    // The URL carries the display slug ({name}-{id}), not the bare canonical id.
-    await expect(page).toHaveURL(new RegExp(`/agents/${agent.displaySlug}$`))
-    const origin = page.url()
+    try {
+      const createRes = await request.post('/api/agents', { data: { name: uniqueAgentName(testInfo, 'Settings Refresh From') } })
+      agent = await createRes.json() as { slug: string; displaySlug: string }
 
-    await page.locator('[data-testid="settings-button"]').click()
-    await expect(page).toHaveURL(/\/settings(\/|\?|$)/)
-    await page.reload()
-    await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
-    await page.locator('[data-testid="settings-back"]').click()
-    await expect(page).toHaveURL(origin)
+      const appPage = new AppPage(page)
+      await appPage.goto()
+      await appPage.waitForAgentsLoaded()
+      await page.locator(`[data-testid="agent-item-${agent.slug}"]`).click()
+      // The URL carries the display slug ({name}-{id}), not the bare canonical id.
+      await expect(page).toHaveURL(new RegExp(`/agents/${agent.displaySlug}$`))
+      const origin = page.url()
 
-    await request.delete(`/api/agents/${agent.slug}`)
+      await page.locator('[data-testid="settings-button"]').click()
+      await expect(page).toHaveURL(/\/settings(\/|\?|$)/)
+      await page.reload()
+      await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
+      await page.locator('[data-testid="settings-back"]').click()
+      await expect(page).toHaveURL(origin)
+    } finally {
+      await deleteAgent(request, agent?.slug)
+    }
   })
 })

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "test:container": "npm --prefix agent-container test",
     "test:e2e": "E2E_MOCK=true playwright test --project=web-chromium",
     "test:e2e:web": "E2E_MOCK=true playwright test --project=web-chromium --no-deps",
-    "test:e2e:stateful": "E2E_MOCK=true playwright test --project=global-state",
     "test:e2e:a11y": "E2E_MOCK=true E2E_INCLUDE_A11Y=true playwright test e2e/specs/a11y-audit.spec.ts --project=web-chromium --no-deps",
     "test:e2e:headed": "E2E_MOCK=true playwright test --project=web-chromium --headed",
     "test:e2e:ui": "E2E_MOCK=true playwright test --ui",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,14 +12,9 @@ const configuredWorkers = process.env.PLAYWRIGHT_WORKERS
   ? Number(process.env.PLAYWRIGHT_WORKERS)
   : undefined
 
-const statefulTestMatch = [
-  '**/settings.spec.ts',
-]
-
 const webTestIgnore = [
   '**/auth/**',
   '**/getting-started-wizard.spec.ts',
-  ...statefulTestMatch,
 ]
 
 if (process.env.E2E_INCLUDE_A11Y !== 'true') {
@@ -81,19 +76,10 @@ export default defineConfig({
       fullyParallel: false,
     },
     {
-      // Settings tests modify global settings but don't toggle setupCompleted.
-      // Safe to run after wizard tests complete.
-      name: 'global-state',
-      testMatch: statefulTestMatch,
-      use: { ...devices['Desktop Chrome'] },
-      fullyParallel: false,
-      dependencies: ['wizard'],
-    },
-    {
       name: 'web-chromium',
       testIgnore: webTestIgnore,
       use: { ...devices['Desktop Chrome'] },
-      dependencies: ['global-state'],
+      dependencies: ['wizard'],
     },
   ],
 


### PR DESCRIPTION
## Summary
- run `settings.spec.ts` in the normal `web-chromium` project instead of the serialized `global-state` project
- seed and restore shared settings explicitly in persistence tests, with API assertions for the saved state
- make custom env var and settings deep-link tests use unique data and cleanup so they can run independently
- remove the now-unused `global-state` project and make `web-chromium` depend directly on `wizard`
- remove the stale `test:e2e:stateful` CI path so the workflow no longer targets the deleted `global-state` project

## Validation
- `npm exec eslint -- e2e/specs/settings.spec.ts playwright.config.ts`
- `npx playwright test --list --project=web-chromium e2e/specs/settings.spec.ts`
- `PORT=3321 SUPERAGENT_DATA_DIR=.e2e-data/settings-independence-stress PLAYWRIGHT_OUTPUT_DIR=test-results/settings-independence-stress PLAYWRIGHT_HTML_REPORT=playwright-report/settings-independence-stress npx playwright test --project=web-chromium --no-deps e2e/specs/settings.spec.ts --workers=4 --repeat-each=2` (`52 passed`)
- `npm run typecheck`
- `git diff --check`
- `PORT=3322 SUPERAGENT_DATA_DIR=.e2e-data/main-settings-independence PLAYWRIGHT_OUTPUT_DIR=test-results/main-settings-independence PLAYWRIGHT_HTML_REPORT=playwright-report/main-settings-independence npm run test:e2e` (`207 passed`, `21 skipped`)
- `rg "test:e2e:stateful|global-state" package.json .github playwright.config.ts e2e` (no matches)
- `PORT=3323 SUPERAGENT_DATA_DIR=.e2e-data/ci-command-check PLAYWRIGHT_OUTPUT_DIR=test-results/ci-command-check PLAYWRIGHT_HTML_REPORT=playwright-report/ci-command-check npm run test:e2e -- --list` (`228 tests in 43 files`)
- CI `Tests` workflow passed on `b8c3a9b1`, including `e2e-tests`