### PR TITLE
debug(microvm): bootstrap env lifecycle logging

### DIFF
--- a/src/api/routes/agent-bootstrap.ts
+++ b/src/api/routes/agent-bootstrap.ts
@@ -7,24 +7,42 @@ import { readBootstrapEnv } from '@shared/lib/container/agent-bootstrap-env-stor
 
 const agentBootstrap = new Hono()
 
+// TEMP debug (debug/microvm-bootstrap-env-logging): trace the boot fetch outcome
+// without leaking token/env. Remove before merge.
+function bootstrapRouteDebug(agentSlug: string, outcome: string, extra?: Record<string, unknown>): void {
+  try {
+    console.log(
+      `[bootstrap-debug] ${JSON.stringify({ ts: new Date().toISOString(), event: 'route', agentSlug, outcome, pid: process.pid, ...extra })}`,
+    )
+  } catch {
+    // never let logging break the route
+  }
+}
+
 agentBootstrap.get('/:agentSlug/env', async (c) => {
   const agentSlug = c.req.param('agentSlug')
   const token = c.req.header('Authorization')?.replace('Bearer ', '')
+  bootstrapRouteDebug(agentSlug, 'enter', { hasToken: Boolean(token) })
   if (!token) {
+    bootstrapRouteDebug(agentSlug, '401-no-token')
     return c.json({ error: 'Unauthorized' }, 401)
   }
   const callerSlug = await validateProxyToken(token)
   if (!callerSlug) {
+    bootstrapRouteDebug(agentSlug, '401-bad-token')
     return c.json({ error: 'Unauthorized' }, 401)
   }
   if (callerSlug !== agentSlug) {
+    bootstrapRouteDebug(agentSlug, '403-slug-mismatch', { callerSlug })
     return c.json({ error: 'Token does not match agent' }, 403)
   }
   // Idempotent: re-fetchable until the agent tears down (boot fetch may retry).
   const env = readBootstrapEnv(agentSlug)
   if (!env) {
+    bootstrapRouteDebug(agentSlug, '404-no-env')
     return c.json({ error: 'No bootstrap env available' }, 404)
   }
+  bootstrapRouteDebug(agentSlug, '200-ok', { envKeyCount: Object.keys(env).length })
   return c.json({ env })
 })
 

--- a/src/shared/lib/container/agent-bootstrap-env-store.ts
+++ b/src/shared/lib/container/agent-bootstrap-env-store.ts
@@ -7,19 +7,49 @@ export type BootstrapEnv = z.infer<typeof bootstrapEnvSchema>
 
 const store = new Map<string, BootstrapEnv>()
 
+// TEMP debug instrumentation (debug/microvm-bootstrap-env-logging). Logs the
+// lifecycle of the in-memory bootstrap env stash WITHOUT printing values, so we
+// can align set/read/clear against the MicroVM boot fetch timeline. Remove before
+// merge.
+function bootstrapDebug(event: string, agentSlug: string, extra?: Record<string, unknown>): void {
+  try {
+    const payload = {
+      ts: new Date().toISOString(),
+      event,
+      agentSlug,
+      pid: process.pid,
+      keys: Array.from(store.keys()),
+      ...extra,
+    }
+    console.log(`[bootstrap-debug] ${JSON.stringify(payload)}`)
+  } catch {
+    // never let logging break the store
+  }
+}
+
 export function setBootstrapEnv(agentSlug: string, env: BootstrapEnv): void {
   store.set(agentSlug, bootstrapEnvSchema.parse(env))
+  bootstrapDebug('set', agentSlug, { envKeyCount: Object.keys(env).length })
 }
 
 // Returns the stashed env WITHOUT removing it. Re-fetchable so a VM whose boot
 // fetch is retried (lost response, re-boot before resume) still gets its env;
 // the entry is dropped on agent teardown via clearBootstrapEnv. Null if cleared.
 export function readBootstrapEnv(agentSlug: string): BootstrapEnv | null {
-  return store.get(agentSlug) ?? null
+  const env = store.get(agentSlug) ?? null
+  bootstrapDebug(env ? 'read-hit' : 'read-miss', agentSlug, {
+    envKeyCount: env ? Object.keys(env).length : 0,
+  })
+  return env
 }
 
 export function clearBootstrapEnv(agentSlug: string): void {
+  const existed = store.has(agentSlug)
   store.delete(agentSlug)
+  // Capture WHO cleared it (which code path), since a premature clear in the boot
+  // window would explain a 404 even though set ran.
+  const caller = new Error().stack?.split('\n').slice(2, 6).join(' <- ').trim()
+  bootstrapDebug('clear', agentSlug, { existed, caller })
 }
 
 export function resetBootstrapEnvStoreForTests(): void {

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -411,7 +411,21 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   }
 
   async start(options?: StartOptions): Promise<void> {
-    if ((await this.getInfoFromRuntime()).status === 'running') return
+    // TEMP debug (debug/microvm-bootstrap-env-logging). Remove before merge.
+    const startDebug = (event: string, extra?: Record<string, unknown>) => {
+      try {
+        console.log(
+          `[bootstrap-debug] ${JSON.stringify({ ts: new Date().toISOString(), event: `start.${event}`, agentSlug: this.config.agentId, pid: process.pid, ...extra })}`,
+        )
+      } catch {
+        // no-op
+      }
+    }
+    startDebug('enter')
+    if ((await this.getInfoFromRuntime()).status === 'running') {
+      startDebug('early-return-running')
+      return
+    }
 
     const config = getMicrovmRuntimeConfig()
     const client = getMicrovmClient(config.region)
@@ -443,6 +457,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
       )
     }
 
+    startDebug('before-RunMicrovm', { hasEnv })
     const run = await client.send(
       new RunMicrovmCommand({
         imageIdentifier: config.imageArn,
@@ -478,8 +493,10 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     const proxyPort = await proxy.start()
     // Stop any stale proxy before overwriting state (no leaked port/listener); stash
     // env after the cleanup (which clears stale stashes) so it isn't wiped.
+    startDebug('after-RunMicrovm', { microvmId: run.microvmId })
     this.cleanupLocal()
     if (hasEnv) setBootstrapEnv(this.config.agentId, env)
+    startDebug('stashed-bootstrap-env', { hasEnv })
     agentStates.set(this.config.agentId, { microvmId: run.microvmId, endpoint: run.endpoint, proxy, proxyPort })
 
     try {


### PR DESCRIPTION
## What

Temporary, value-free `[bootstrap-debug]` instrumentation to root-cause why a MicroVM agent's boot-time `GET /api/agent-bootstrap/:slug/env` returns **404** on an ECS Fargate host-app, while a later `curl` with the same `PROXY_TOKEN` returns **200** with a full env.

## Why

On the ECS+Fargate host-app POC (gamut-infra Milestone 0), every fresh MicroVM agent logs:
```
bootstrap env fetch error: HTTP Error 404
spawning agent with 0 env overrides
```
So the agent starts with no env (no `CLAUDE_CONFIG_DIR`, `PROXY_BASE_URL`, etc.) → transcript not persisted to S3, UI stuck on "Working...". Verified the route/token/slug/store are all correct *after the fact* (200 on manual curl), so the failure is timing/lifecycle, not static config. These logs align `set` / `read-hit` / `read-miss` / `clear(+caller)` against the boot fetch.

## Changes (all temporary; remove before merge)

- `agent-bootstrap-env-store.ts`: log set / read-hit / read-miss / clear (with caller stack), incl. `pid` + current store keys. No env values.
- `routes/agent-bootstrap.ts`: log enter / 401 / 403 / 404-no-env / 200.
- `lambda-microvm-runtime.ts` `start()`: log enter / before+after RunMicrovm / stashed-bootstrap-env.

## Not for merge

Pure diagnostics for `debug/microvm-bootstrap-env-logging`. Will be reverted once the root cause is confirmed.

Made with [Cursor](https://cursor.com)