### PR TITLE
feat(stale-session): prompt to start a new conversation when one goes stale

### DIFF
--- a/e2e/helpers/stale-session.ts
+++ b/e2e/helpers/stale-session.ts
@@ -1,0 +1,111 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Resolve the data directory used by the E2E server process.
+ *
+ * The Playwright web-server command sets SUPERAGENT_DATA_DIR=.e2e-data on the
+ * *server* process, but that variable is NOT forwarded to the test-runner
+ * process by default.  We replicate the same defaulting logic as
+ * playwright.config.ts: honour the env var when present, otherwise assume the
+ * conventional .e2e-data directory relative to the project root (which is the
+ * CWD of the Playwright test runner).
+ */
+function getE2eDataDir(): string {
+  const env = process.env.SUPERAGENT_DATA_DIR
+  return env ? path.resolve(env) : path.resolve('.e2e-data')
+}
+
+/**
+ * Seed a session to satisfy the AND trigger (idle > 6 h AND context > 100 k tokens).
+ *
+ * Call AFTER the session has completed at least one turn — both the JSONL file
+ * and session-metadata.json must already exist on disk.
+ *
+ * Mechanism
+ *  1. Every JSONL entry timestamp → 7 h ago.
+ *     parseSessionInfo() reads `messages[last].timestamp` as lastActivityAt,
+ *     so this makes the single-session GET return lastActivityAt = 7 h ago.
+ *  2. JSONL file mtime → 7 h ago.
+ *     listSessions() uses stat.mtimeMs; keeping mtime aligned avoids confusion
+ *     between the list endpoint and the single-session endpoint.
+ *  3. session-metadata.json lastUsage.inputTokens = 110 000.
+ *     currentContextTokens(lastUsage) sums inputTokens + cacheReadInputTokens
+ *     + cacheCreationInputTokens. 110 000 > STALE_CONTEXT_TOKENS (100 000).
+ *
+ * The server reads these files on every request (no in-process cache for
+ * lastActivityAt / lastUsage), so the seeded values are visible immediately
+ * after the call.
+ */
+export function seedStaleSession(agentSlug: string, sessionId: string): void {
+  const dataDir = getE2eDataDir()
+
+  const jsonlPath = path.join(
+    dataDir,
+    'agents',
+    agentSlug,
+    'workspace',
+    '.claude',
+    'projects',
+    '-workspace',
+    `${sessionId}.jsonl`,
+  )
+  const metaPath = path.join(
+    dataDir,
+    'agents',
+    agentSlug,
+    'workspace',
+    'session-metadata.json',
+  )
+
+  const sevenHoursAgo = new Date(Date.now() - 7 * 60 * 60 * 1000)
+
+  // Step 1 + 2: rewrite JSONL timestamps and update file mtime
+  if (fs.existsSync(jsonlPath)) {
+    const rewritten =
+      fs
+        .readFileSync(jsonlPath, 'utf8')
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => {
+          try {
+            const entry = JSON.parse(line) as Record<string, unknown>
+            entry.timestamp = sevenHoursAgo.toISOString()
+            return JSON.stringify(entry)
+          } catch {
+            return line
+          }
+        })
+        .join('\n') + '\n'
+
+    fs.writeFileSync(jsonlPath, rewritten)
+    fs.utimesSync(jsonlPath, sevenHoursAgo, sevenHoursAgo)
+  }
+
+  // Step 3: inject large lastUsage into session metadata
+  let metadata: Record<string, Record<string, unknown>> = {}
+  if (fs.existsSync(metaPath)) {
+    try {
+      metadata = JSON.parse(
+        fs.readFileSync(metaPath, 'utf8'),
+      ) as typeof metadata
+    } catch {
+      /* start fresh on corrupt file */
+    }
+  }
+
+  metadata[sessionId] = {
+    ...(metadata[sessionId] ?? {}),
+    lastUsage: {
+      inputTokens: 110_000,         // sum > STALE_CONTEXT_TOKENS (100_000)
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      outputTokens: 1_000,
+      contextWindow: 200_000,
+    },
+  }
+  // Ensure the workspace directory exists before writing (registerSession
+  // normally creates it, but guard against edge-cases in test teardown timing)
+  fs.mkdirSync(path.dirname(metaPath), { recursive: true })
+  fs.writeFileSync(metaPath, JSON.stringify(metadata, null, 2))
+}

--- a/e2e/stale-session-prompt.spec.ts
+++ b/e2e/stale-session-prompt.spec.ts
@@ -1,0 +1,323 @@
+/**
+ * E2E tests for the stale-session surface (toast + popovers).
+ *
+ * Trigger: idle > 6 h  AND  context > 100 k tokens (AND logic). Detection is
+ * continuous (not send-gated): the toast surfaces at rest, above the composer.
+ *
+ * Seeding mechanism (see e2e/helpers/stale-session.ts):
+ *  - JSONL entry timestamps are rewritten to 7 h ago →  lastActivityAt is old
+ *  - session-metadata.json lastUsage.inputTokens = 110 000  →  contextTokens > threshold
+ *
+ * Run:
+ *   E2E_MOCK=true npx playwright test e2e/stale-session-prompt.spec.ts 2>&1 | tee /tmp/e2e-stale.txt
+ */
+
+import { test, expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
+import { AppPage } from './pages/app.page'
+import { SessionPage } from './pages/session.page'
+import { createAgent, openAgentHome } from './helpers/agents'
+import { seedStaleSession } from './helpers/stale-session'
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+type TestAgent = { slug: string; name: string }
+
+/** Fetch the most-recently-created session ID for an agent via the API. */
+async function getFirstSessionId(
+  request: APIRequestContext,
+  agentSlug: string,
+): Promise<string> {
+  const resp = await request.get(`/api/agents/${agentSlug}/sessions`)
+  expect(resp.ok()).toBeTruthy()
+  const sessions = (await resp.json()) as Array<{ id: string }>
+  expect(sessions.length).toBeGreaterThan(0)
+  return sessions[0].id
+}
+
+/**
+ * Navigate to a specific session by clicking its sidebar item.
+ *
+ * Session sub-items live inside a Radix CollapsibleContent and are UNMOUNTED
+ * while the agent row is collapsed — clicking one before expanding auto-waits
+ * for an element that never attaches and hangs until the test times out. Wait
+ * for the (collapsed-state) Expand chevron to render before clicking it.
+ */
+async function openSessionById(
+  page: Page,
+  agent: TestAgent,
+  sessionId: string,
+): Promise<void> {
+  const agentLi = page
+    .locator('li')
+    .filter({ has: page.locator(`[data-testid="agent-item-${agent.slug}"]`) })
+    .or(
+      page
+        .locator('li')
+        .filter({ has: page.locator('[data-testid^="agent-item-"]', { hasText: agent.name }) }),
+    )
+    .first()
+
+  const expandChevron = agentLi.locator('button[aria-label="Expand"]').first()
+  await expandChevron.waitFor({ state: 'visible', timeout: 15000 }).catch(() => {})
+  if (await expandChevron.isVisible().catch(() => false)) {
+    await expandChevron.click()
+  }
+
+  await page.locator(`[data-testid="session-item-${sessionId}"]`).click()
+  await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 20000 })
+}
+
+/**
+ * Standard setup: create an agent + send one message so the JSONL and
+ * session-metadata files exist on disk.  Returns the agent + its session ID.
+ */
+async function setupWithSession(
+  page: Page,
+  request: APIRequestContext,
+  testInfo: TestInfo,
+  label: string,
+): Promise<{ agent: TestAgent; sessionId: string }> {
+  const appPage = new AppPage(page)
+  const sessionPage = new SessionPage(page)
+  const agentName = `Stale ${label} ${testInfo.workerIndex}-${testInfo.repeatEachIndex}-${Date.now()}`
+
+  const agent = await createAgent(request, agentName)
+
+  await appPage.goto()
+  await appPage.waitForAgentsLoaded()
+  await openAgentHome(page, agent)
+
+  // First message → creates the JSONL file + session-metadata entry on disk
+  await sessionPage.sendMessage('Hello')
+  await sessionPage.waitForResponse(30000)
+  await sessionPage.waitForInputEnabled(15000)
+
+  const sessionId = await getFirstSessionId(request, agent.slug)
+  return { agent, sessionId }
+}
+
+/**
+ * Seed the session stale, return to agent home (so navigating back forces a
+ * fresh useSession fetch with the seeded data), then open it at rest and wait
+ * for the seeded context to land in the UI.
+ */
+async function openStaleAtRest(
+  page: Page,
+  sessionPage: SessionPage,
+  agent: TestAgent,
+  sessionId: string,
+): Promise<void> {
+  await page.locator('[data-testid="agent-breadcrumb"]').click()
+  await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
+
+  seedStaleSession(agent.slug, sessionId)
+
+  // "Context Usage" renders only once useSession has refetched with the seeded
+  // lastUsage, so it doubles as a settle point before asserting on the toast.
+  await openSessionById(page, agent, sessionId)
+  await expect(page.getByText('Context Usage')).toBeVisible({ timeout: 20000 })
+  await sessionPage.waitForInputEnabled(15000)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Stale Session Surface', () => {
+  // -------------------------------------------------------------------------
+  // Scenario 1 — the toast surfaces at rest on an idle + large conversation
+  // -------------------------------------------------------------------------
+  test('stale session: the toast appears at rest, no send required', async (
+    { page, request },
+    testInfo,
+  ) => {
+    const sessionPage = new SessionPage(page)
+    const { agent, sessionId } = await setupWithSession(page, request, testInfo, 'Toast')
+
+    await openStaleAtRest(page, sessionPage, agent, sessionId)
+
+    const toast = page.locator('[data-testid="stale-toast"]')
+    await expect(toast).toBeVisible({ timeout: 20000 })
+    await expect(toast).toContainText('Start a new conversation?')
+  })
+
+  // -------------------------------------------------------------------------
+  // Scenario 2 — Ignore hides the toast (local state, no persistence)
+  // -------------------------------------------------------------------------
+  test('stale session: Ignore hides the toast', async ({ page, request }, testInfo) => {
+    const sessionPage = new SessionPage(page)
+    const { agent, sessionId } = await setupWithSession(page, request, testInfo, 'Ignore')
+
+    await openStaleAtRest(page, sessionPage, agent, sessionId)
+
+    const toast = page.locator('[data-testid="stale-toast"]')
+    await expect(toast).toBeVisible({ timeout: 20000 })
+
+    await page.locator('[data-testid="stale-toast-ignore"]').click()
+    await expect(toast).not.toBeVisible({ timeout: 15000 })
+  })
+
+  // -------------------------------------------------------------------------
+  // Scenario 3 — the toast offers Ignore and New conversation
+  // -------------------------------------------------------------------------
+  test('stale session: the toast offers Ignore and New conversation', async (
+    { page, request },
+    testInfo,
+  ) => {
+    const sessionPage = new SessionPage(page)
+    const { agent, sessionId } = await setupWithSession(page, request, testInfo, 'NewChat')
+
+    await openStaleAtRest(page, sessionPage, agent, sessionId)
+    await expect(page.locator('[data-testid="stale-toast"]')).toBeVisible({ timeout: 20000 })
+
+    await expect(page.locator('[data-testid="stale-toast-ignore"]')).toBeVisible()
+    const newChat = page.locator('[data-testid="stale-new-chat"]')
+    await expect(newChat).toBeVisible()
+    await expect(newChat).toContainText('New conversation')
+  })
+
+  // -------------------------------------------------------------------------
+  // Scenario 4 — the Learn more popover shows the two teaching points
+  // -------------------------------------------------------------------------
+  test('stale session: Learn more popover shows the two teaching points', async (
+    { page, request },
+    testInfo,
+  ) => {
+    const sessionPage = new SessionPage(page)
+    const { agent, sessionId } = await setupWithSession(page, request, testInfo, 'LearnMore')
+
+    await openStaleAtRest(page, sessionPage, agent, sessionId)
+    await expect(page.locator('[data-testid="stale-toast"]')).toBeVisible({ timeout: 20000 })
+
+    await page.locator('[data-testid="stale-learn-more-trigger"]').click()
+
+    const learnMore = page.locator('[data-testid="stale-learn-more-popover"]')
+    await expect(learnMore).toBeVisible({ timeout: 15000 })
+    await expect(learnMore).toContainText('Your agent can handle many conversations at once.')
+    await expect(learnMore).toContainText('Agents re-read everything each time they reply.')
+  })
+
+  // -------------------------------------------------------------------------
+  // Scenario 5 — "Start fresh" carries the composer into a new chat (no send)
+  //
+  // No session is created until the user actually sends. Start fresh snapshots the
+  // composer (text + model + effort + files) and lands the user on the agent's
+  // new-chat composer with it carried over, ready to edit — nothing is sent.
+  // -------------------------------------------------------------------------
+  test('stale session: Start fresh carries the typed draft into the new-chat composer without sending', async (
+    { page, request },
+    testInfo,
+  ) => {
+    const sessionPage = new SessionPage(page)
+    const { agent, sessionId } = await setupWithSession(page, request, testInfo, 'Fresh')
+
+    await openStaleAtRest(page, sessionPage, agent, sessionId)
+    await expect(page.locator('[data-testid="stale-toast"]')).toBeVisible({ timeout: 20000 })
+
+    // Type into the in-session composer, then start a new conversation.
+    await page.locator('[data-testid="message-input"]').fill('A brand new conversation')
+
+    await page.locator('[data-testid="stale-new-chat"]').click()
+
+    // Lands on the agent's new-chat composer — no session created, nothing sent —
+    // with the draft carried verbatim and ready to edit.
+    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('[data-testid="message-input"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="home-message-input"]')).toHaveValue('A brand new conversation')
+  })
+
+  // -------------------------------------------------------------------------
+  // Scenario 6 — a plain send is never intercepted (detection is not send-gated)
+  // -------------------------------------------------------------------------
+  test('stale session: a plain send lands in the same conversation and is not intercepted', async (
+    { page, request },
+    testInfo,
+  ) => {
+    const sessionPage = new SessionPage(page)
+    const { agent, sessionId } = await setupWithSession(page, request, testInfo, 'Send')
+
+    await openStaleAtRest(page, sessionPage, agent, sessionId)
+    await expect(page.locator('[data-testid="stale-toast"]')).toBeVisible({ timeout: 20000 })
+
+    // Sending goes straight through to the current conversation — no gate, no modal.
+    await sessionPage.sendMessage('Send into this one')
+    await sessionPage.waitForUserMessageCount(2, 25000) // "Hello" + "Send into this one"
+  })
+
+  // -------------------------------------------------------------------------
+  // Scenario 8 — Awaiting-input suppression
+  //
+  // When a session has a pending input request the message input is replaced by
+  // the PendingRequestStack, so the toast slot is not in play and no toast fires.
+  // The isAwaitingInput branch is exercised at unit level in
+  // stale-session-trigger.test.ts.
+  // -------------------------------------------------------------------------
+  test('awaiting-input session: message input is hidden and no toast fires', async (
+    { page, request },
+    testInfo,
+  ) => {
+    const appPage = new AppPage(page)
+    const sessionPage = new SessionPage(page)
+    const agentName = `Stale AwaitInput ${testInfo.workerIndex}-${testInfo.repeatEachIndex}-${Date.now()}`
+
+    const agent = await createAgent(request, agentName)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+    await openAgentHome(page, agent)
+
+    // 'ask secret' triggers the UserInputRequest scenario in MockContainerClient,
+    // putting the session into awaiting_input state with a pending secret request
+    await sessionPage.sendMessage('ask secret')
+    await sessionPage.waitForSecretRequest('OPENAI_API_KEY', 15000)
+
+    const sessionId = await getFirstSessionId(request, agent.slug)
+
+    // Seed stale state on top of the awaiting-input session: it now satisfies
+    // idle > 6 h AND context > 100 k tokens, but isAwaitingInput suppresses it.
+    seedStaleSession(agent.slug, sessionId)
+
+    // Reload — SSE reconnects and the server replays pending input requests.
+    await page.reload()
+    await appPage.waitForAgentsLoaded()
+    await openSessionById(page, agent, sessionId)
+
+    await expect(
+      page.locator('[data-testid="secret-request"]').first(),
+    ).toBeAttached({ timeout: 20000 })
+
+    // The message input is NOT rendered (pending request stack takes its slot)
+    await expect(page.locator('[data-testid="message-input"]')).not.toBeVisible()
+    // And no stale toast is shown.
+    await expect(page.locator('[data-testid="stale-toast"]')).not.toBeVisible()
+  })
+
+  // -------------------------------------------------------------------------
+  // Scenario 9 — Fresh small session: no toast
+  // -------------------------------------------------------------------------
+  test('fresh small session: no toast appears', async ({ page, request }, testInfo) => {
+    const appPage = new AppPage(page)
+    const sessionPage = new SessionPage(page)
+    const agentName = `Stale Fresh ${testInfo.workerIndex}-${testInfo.repeatEachIndex}-${Date.now()}`
+
+    const agent = await createAgent(request, agentName)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+    await openAgentHome(page, agent)
+
+    // First message creates a fresh session — idle ≈ 0 ms, context ≈ 0 tokens
+    await sessionPage.sendMessage('First message')
+    await sessionPage.waitForResponse(30000)
+    await sessionPage.waitForInputEnabled(15000)
+
+    // Immediately send a second message — neither threshold is met
+    await sessionPage.sendMessage('Second message right away')
+
+    await sessionPage.waitForUserMessageCount(2, 25000)
+    // No stale toast ever appeared (neither threshold met).
+    await expect(page.locator('[data-testid="stale-toast"]')).not.toBeVisible()
+  })
+})

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -25,6 +25,7 @@ import { useMessageComposer } from '@renderer/hooks/use-message-composer'
 import { ChatComposerBox } from '@renderer/components/messages/chat-composer-box'
 import { useIsMobile } from '@renderer/hooks/use-mobile'
 import { ComposerOptions, useComposerOptions } from '@renderer/components/messages/composer-options'
+import { useNewChatCarryover, carryoverToComposerInit } from '@renderer/lib/composer-carryover'
 import { InlineEditableTitle } from '@renderer/components/ui/inline-editable-title'
 import { HomeTriggers } from './home-triggers'
 import { HomeSkills } from './home-skills'
@@ -86,7 +87,11 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   const [sessionSearch, setSessionSearch] = useState('')
   const [sessionSort, setSessionSort] = useState<SortOrder>('newest')
   const { data: sessionsData } = useSessions(agent.slug)
-  const composerOptions = useComposerOptions()
+  // A pending "Start fresh" carry-over pre-fills this composer exactly once: text
+  // arrives via the agent draft key, attachments + model + effort come from here.
+  const carryover = useNewChatCarryover(agent.slug)
+  const { initialAttachments, initialModel, initialEffort } = carryoverToComposerInit(carryover)
+  const composerOptions = useComposerOptions({ initialModel, initialEffort })
   const sessionSearchRef = useRef<HTMLInputElement>(null)
   const composerTextareaRef = useRef<HTMLTextAreaElement>(null)
   const isMobile = useIsMobile()
@@ -177,6 +182,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
     submitDisabled: createSession.isPending || !isRuntimeReady,
     keepMessageUntilComplete: true,
     draftKey: `agent:${agent.slug}`,
+    initialAttachments,
   })
 
   // Reset the manual-collapse flag once the message clears.

--- a/src/renderer/components/layout/session-chat-column.test.tsx
+++ b/src/renderer/components/layout/session-chat-column.test.tsx
@@ -139,3 +139,42 @@ describe('SessionChatColumn composer swap', () => {
     expect(screen.queryByText('New line')).not.toBeInTheDocument()
   })
 })
+
+// Detection logic lives in useStaleSession (unit-tested there). This just verifies
+// SessionChatColumn wires showToast → the toast in the at-rest footer.
+describe('SessionChatColumn stale toast', () => {
+  const staleProps = {
+    ...baseProps,
+    lastActivityAt: new Date(Date.now() - 7 * 60 * 60 * 1000),
+    contextUsage: {
+      inputTokens: 5000,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 130_000,
+      contextWindow: 200_000,
+    },
+  }
+
+  beforeEach(() => {
+    mockPendingResult.items = []
+    mockPendingResult.count = 0
+  })
+
+  it('renders the stale toast when the conversation is idle + large, at rest', () => {
+    renderWithProviders(<SessionChatColumn {...staleProps} />)
+    expect(screen.getByTestId('stale-toast')).toBeInTheDocument()
+    expect(screen.getByTestId('stale-new-chat')).toBeInTheDocument()
+  })
+
+  it('does not render the stale toast for a fresh conversation', () => {
+    renderWithProviders(<SessionChatColumn {...baseProps} />)
+    expect(screen.queryByTestId('stale-toast')).not.toBeInTheDocument()
+  })
+
+  it('does not render the stale toast while a request is pending', () => {
+    mockPendingResult.items = [secretDescriptor]
+    mockPendingResult.count = 1
+    renderWithProviders(<SessionChatColumn {...staleProps} />)
+    expect(screen.queryByTestId('stale-toast')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/layout/session-chat-column.tsx
+++ b/src/renderer/components/layout/session-chat-column.tsx
@@ -4,13 +4,16 @@ import { PendingRequestStack } from '@renderer/components/messages/pending-reque
 import { renderPendingRequest, type RenderContext } from '@renderer/components/messages/pending-request-renderer'
 import { PendingRequestErrorBoundary } from '@renderer/components/messages/pending-request-error-boundary'
 import { usePendingRequests } from '@renderer/components/messages/use-pending-requests'
+import { StaleSessionToast } from '@renderer/components/messages/stale-session-notice'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useScreenWakeLock } from '@renderer/hooks/use-screen-wake-lock'
 import { useFileDeliveryWatcher } from '@renderer/hooks/use-file-delivery-watcher'
+import { useStaleSession } from '@renderer/hooks/use-stale-session'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
 import { DonutChart } from '@renderer/components/ui/donut-chart'
 import type { EffortLevel } from '@shared/lib/container/types'
 import type { PendingMessage } from '@renderer/components/messages/pending-message'
+import type { SessionUsage } from '@shared/lib/types/agent'
 
 interface SessionChatColumnProps {
   sessionId: string
@@ -24,6 +27,8 @@ interface SessionChatColumnProps {
   onMessageSent: (content: string, localId: string, queued: boolean) => void
   onMessageUuidAssigned: (localId: string, uuid: string, queued: boolean) => void
   onMessageFailed: (localId: string) => void
+  lastActivityAt?: Date | null
+  contextUsage?: SessionUsage | null
 }
 
 export function SessionChatColumn({
@@ -38,8 +43,20 @@ export function SessionChatColumn({
   onMessageSent,
   onMessageUuidAssigned,
   onMessageFailed,
+  lastActivityAt,
+  contextUsage,
 }: SessionChatColumnProps) {
-  const { isActive, browserActive, isWaitingBackground } = useMessageStream(sessionId, agentSlug)
+  const {
+    isActive,
+    browserActive,
+    isWaitingBackground,
+    pendingSecretRequests,
+    pendingConnectedAccountRequests,
+    pendingQuestionRequests,
+    pendingFileRequests,
+    pendingRemoteMcpRequests,
+    pendingBrowserInputRequests,
+  } = useMessageStream(sessionId, agentSlug)
   // Keep the phone awake (PWA only) while this session is actively working.
   useScreenWakeLock(isActive || isWaitingBackground)
   useFileDeliveryWatcher(sessionId, agentSlug)
@@ -51,6 +68,28 @@ export function SessionChatColumn({
 
   const renderCtx: RenderContext = { sessionId, agentSlug, readOnly: isViewOnly }
 
+  const isAwaitingInput = isActive && (
+    pendingSecretRequests.length > 0 ||
+    pendingConnectedAccountRequests.length > 0 ||
+    pendingQuestionRequests.length > 0 ||
+    pendingFileRequests.length > 0 ||
+    pendingRemoteMcpRequests.length > 0 ||
+    pendingBrowserInputRequests.length > 0
+  )
+
+  // Continuous stale-session detection + "Start fresh" handoff, off the send path
+  // (so sending is never interrupted). See useStaleSession.
+  const stale = useStaleSession({
+    sessionId,
+    agentSlug,
+    isActive,
+    isWaitingBackground,
+    isAwaitingInput,
+    isViewOnly,
+    lastActivityAt,
+    contextUsage,
+  })
+
   return (
     <SessionThread
       sessionId={sessionId}
@@ -59,6 +98,7 @@ export function SessionChatColumn({
       pendingUserMessages={pendingUserMessages}
       pendingRequestCount={pendingRequestCount}
       onPendingMessageAppeared={onPendingMessageAppeared}
+      suppressScrollToBottom={stale.menuOpen}
       footerClassName="bg-background max-w-[740px] mx-auto w-full"
       footer={
         pendingRequestCount > 0 ? (
@@ -80,6 +120,13 @@ export function SessionChatColumn({
           </div>
         ) : (
           <>
+            {stale.showToast && (
+              <StaleSessionToast
+                onIgnore={stale.ignore}
+                onStartFresh={stale.startFresh}
+                onMenuOpenChange={stale.setMenuOpen}
+              />
+            )}
             <MessageInput
               key={sessionId}
               sessionId={sessionId}
@@ -89,6 +136,7 @@ export function SessionChatColumn({
               onMessageFailed={onMessageFailed}
               initialEffort={effort}
               initialModel={model}
+              registerSnapshot={stale.registerSnapshot}
             />
             <div className="flex justify-between items-center gap-1.5 px-6 py-3">
               {contextPercent != null ? (

--- a/src/renderer/components/layout/session-view.tsx
+++ b/src/renderer/components/layout/session-view.tsx
@@ -145,6 +145,8 @@ export function SessionView({ agentSlug, sessionId }: SessionViewProps) {
               onMessageSent={onMessageSent}
               onMessageUuidAssigned={onMessageUuidAssigned}
               onMessageFailed={onPendingMessageAppeared}
+              lastActivityAt={session?.lastActivityAt ? new Date(session.lastActivityAt) : null}
+              contextUsage={contextUsage}
             />
           </div>
         </WorkflowProvider>

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -17,6 +17,7 @@ import { useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
 import { ChatComposerBox } from './chat-composer-box'
 import { ComposerOptions, useComposerOptions } from './composer-options'
 import { useRenderTracker } from '@renderer/lib/perf'
+import type { ComposerSnapshot } from '@renderer/lib/composer-carryover'
 import type { EffortLevel } from '@shared/lib/container/types'
 
 interface MessageInputProps {
@@ -32,9 +33,13 @@ interface MessageInputProps {
   initialEffort?: EffortLevel
   /** Model last used on this session; seeds the composer selector. Defaults to provider's agent default. */
   initialModel?: string
+  /** Register a getter for the live composer state (text + attachments + model + effort).
+   *  Lets a sibling (the stale-session "Start fresh" action) snapshot the composer to
+   *  carry it into a new chat. Called with null on unmount to deregister. */
+  registerSnapshot?: (getSnapshot: (() => ComposerSnapshot) | null) => void
 }
 
-export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUuidAssigned, onMessageFailed, initialEffort, initialModel }: MessageInputProps) {
+export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUuidAssigned, onMessageFailed, initialEffort, initialModel, registerSnapshot }: MessageInputProps) {
   useRenderTracker('MessageInput')
   const { canUseAgent, isAuthMode } = useUser()
   const isViewOnly = !canUseAgent(agentSlug)
@@ -101,6 +106,22 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
     submitDisabled: sendMessage.isPending || isOffline || !isRuntimeReady,
     draftKey: `session:${sessionId}`,
   })
+
+  // Mirror the live composer state into a ref so the registered getter always reads
+  // the latest (text + attachments + model + effort) without re-registering on every
+  // keystroke. "Start fresh" calls the getter to carry the composer into a new chat.
+  const snapshotRef = useRef<ComposerSnapshot>({ text: '', attachments: [], model: undefined, effort: composerOptions.effort })
+  snapshotRef.current = {
+    text: composer.message,
+    attachments: composer.attachments,
+    model: composerOptions.model,
+    effort: composerOptions.effort,
+  }
+  useEffect(() => {
+    if (!registerSnapshot) return
+    registerSnapshot(() => snapshotRef.current)
+    return () => registerSnapshot(null)
+  }, [registerSnapshot])
 
   // Extract the slash command prefix being typed (e.g. "co" from "/co")
   const slashFilter = useMemo(() => {

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -59,9 +59,11 @@ interface MessageListProps {
   pendingRequestCount?: number
   /** The pending message materialized (or was restored to the composer) — remove it. */
   onPendingMessageAppeared?: (localId: string) => void
+  /** Hide the scroll-to-bottom FAB while a footer overlay (the stale-session popover) covers it. */
+  suppressScrollToBottom?: boolean
 }
 
-export function MessageList({ sessionId, agentSlug, pendingUserMessages, pendingRequestCount = 0, onPendingMessageAppeared }: MessageListProps) {
+export function MessageList({ sessionId, agentSlug, pendingUserMessages, pendingRequestCount = 0, onPendingMessageAppeared, suppressScrollToBottom = false }: MessageListProps) {
   useRenderTracker('MessageList')
   const { data: messages, isLoading, error } = useMessages(sessionId, agentSlug)
   const deleteMessage = useDeleteMessage()
@@ -852,7 +854,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
         {/* Pending interactive requests render in the composer slot — see SessionChatColumn. */}
         </div>
       </div>
-      {showScrollToBottom && (
+      {showScrollToBottom && !suppressScrollToBottom && (
         <button
           onClick={scrollToBottom}
           className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5 rounded-full bg-primary text-primary-foreground px-3 py-1.5 text-xs font-medium shadow-lg hover:bg-primary/90 transition-opacity cursor-pointer"

--- a/src/renderer/components/messages/session-thread.tsx
+++ b/src/renderer/components/messages/session-thread.tsx
@@ -17,6 +17,8 @@ interface SessionThreadProps {
   pendingUserMessages?: PendingMessage[]
   pendingRequestCount?: number
   onPendingMessageAppeared?: (localId: string) => void
+  /** Hide the scroll-to-bottom FAB (e.g. while a footer popover overlays it). */
+  suppressScrollToBottom?: boolean
 }
 
 /**
@@ -37,6 +39,7 @@ export function SessionThread({
   pendingUserMessages,
   pendingRequestCount,
   onPendingMessageAppeared,
+  suppressScrollToBottom,
 }: SessionThreadProps) {
   return (
     <div className="relative flex-1 flex min-h-0">
@@ -49,6 +52,7 @@ export function SessionThread({
           pendingUserMessages={pendingUserMessages}
           pendingRequestCount={pendingRequestCount}
           onPendingMessageAppeared={onPendingMessageAppeared}
+          suppressScrollToBottom={suppressScrollToBottom}
         />
         <div className={`${footerClassName} pb-[env(safe-area-inset-bottom)]`}>
           <AgentActivityIndicator sessionId={sessionId} agentSlug={agentSlug} />

--- a/src/renderer/components/messages/stale-session-notice.test.tsx
+++ b/src/renderer/components/messages/stale-session-notice.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders, userEvent } from '@renderer/test/test-utils'
+import { StaleSessionToast, type StaleSessionToastProps } from './stale-session-notice'
+
+function makeProps(overrides: Partial<StaleSessionToastProps> = {}): StaleSessionToastProps {
+  return {
+    onIgnore: vi.fn(),
+    onStartFresh: vi.fn(),
+    onMenuOpenChange: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('StaleSessionToast', () => {
+  it('renders the toast, title, and action buttons', () => {
+    renderWithProviders(<StaleSessionToast {...makeProps()} />)
+    expect(screen.getByTestId('stale-toast')).toBeInTheDocument()
+    expect(screen.getByText('Start a new conversation?')).toBeInTheDocument()
+    expect(screen.getByTestId('stale-toast-ignore')).toBeInTheDocument()
+    expect(screen.getByTestId('stale-new-chat')).toBeInTheDocument()
+  })
+
+  it('calls onIgnore when Ignore is clicked', async () => {
+    const user = userEvent.setup()
+    const props = makeProps()
+    renderWithProviders(<StaleSessionToast {...props} />)
+    await user.click(screen.getByTestId('stale-toast-ignore'))
+    expect(props.onIgnore).toHaveBeenCalledOnce()
+  })
+
+  it('calls onStartFresh when New conversation is clicked', async () => {
+    const user = userEvent.setup()
+    const props = makeProps()
+    renderWithProviders(<StaleSessionToast {...props} />)
+    await user.click(screen.getByTestId('stale-new-chat'))
+    expect(props.onStartFresh).toHaveBeenCalledOnce()
+  })
+
+  it('calls onMenuOpenChange(true) when the Learn more popover opens', async () => {
+    const user = userEvent.setup()
+    const props = makeProps()
+    renderWithProviders(<StaleSessionToast {...props} />)
+    await user.click(screen.getByTestId('stale-learn-more-trigger'))
+    expect(props.onMenuOpenChange).toHaveBeenCalledWith(true)
+  })
+
+  it('reports onMenuOpenChange(false) on unmount so the scroll-to-bottom FAB is not left suppressed', async () => {
+    const user = userEvent.setup()
+    const props = makeProps()
+    const { unmount } = renderWithProviders(<StaleSessionToast {...props} />)
+    await user.click(screen.getByTestId('stale-learn-more-trigger'))
+    expect(props.onMenuOpenChange).toHaveBeenCalledWith(true)
+    unmount()
+    expect(props.onMenuOpenChange).toHaveBeenLastCalledWith(false)
+  })
+})

--- a/src/renderer/components/messages/stale-session-notice.tsx
+++ b/src/renderer/components/messages/stale-session-notice.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import { Button } from '@renderer/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+
+export interface StaleSessionToastProps {
+  /** Local hide (no persistence). */
+  onIgnore: () => void
+  /** Snapshot the live composer into a new chat under this agent and navigate there.
+   *  Instant — no session is created until the user actually sends. */
+  onStartFresh: () => void
+  /** Fires when the Learn more popover opens or closes, so the parent can hide UI
+   *  it overlaps (the centered scroll-to-bottom FAB). */
+  onMenuOpenChange?: (open: boolean) => void
+}
+
+function TeachingPoint({ lead, children }: { lead: string; children: ReactNode }) {
+  return (
+    <div className="text-xs">
+      <p className="font-semibold text-foreground">{lead}</p>
+      <p className="text-muted-foreground">{children}</p>
+    </div>
+  )
+}
+
+/**
+ * Ambient, non-blocking toast shown in the footer when a returning user lands on
+ * an idle + large conversation, at rest. Educate-first, deliberately qualitative
+ * (no token/dollar figures). Ignore hides it locally; a plain send clears it as
+ * the idle gate resets.
+ *
+ * Layout (per spec): a single row — title + description stacked on the left with a
+ * generous gap before the Ignore / New conversation buttons, which sit vertically
+ * centered on the right. "New conversation" starts fresh immediately (the live
+ * composer carries over; no session is created until the user sends). Learn more
+ * opens an educational popover above its inline link (left-aligned).
+ */
+export function StaleSessionToast({ onIgnore, onStartFresh, onMenuOpenChange }: StaleSessionToastProps) {
+  const [learnOpen, setLearnOpen] = useState(false)
+
+  // Report whether the Learn more popover is open. Cleanup resets to closed so the
+  // parent never gets stuck suppressing the FAB if the toast unmounts mid-open.
+  useEffect(() => {
+    onMenuOpenChange?.(learnOpen)
+    return () => onMenuOpenChange?.(false)
+  }, [learnOpen, onMenuOpenChange])
+
+  // -mb-1 (−4px) trims the composer's pt-3 (12px) below us down to an 8px gap.
+  return (
+    <div data-testid="stale-toast" className="mx-auto -mb-1 w-full max-w-[740px] px-4">
+      <div className="flex items-center justify-between gap-4 rounded-2xl border bg-muted/50 p-4">
+        <div className="flex min-w-0 max-w-[60%] flex-col gap-1.5">
+          <p className="text-sm font-medium">Start a new conversation?</p>
+          <p className="text-xs text-muted-foreground">
+            This conversation is getting pretty long. It may be cheaper, faster, and more effective to
+            start a new conversation.{' '}
+            <Popover open={learnOpen} onOpenChange={setLearnOpen}>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  data-testid="stale-learn-more-trigger"
+                  className="text-foreground underline underline-offset-2 transition-colors hover:text-foreground/80"
+                >
+                  Learn more
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                side="top"
+                align="start"
+                onOpenAutoFocus={(e) => e.preventDefault()}
+                onCloseAutoFocus={(e) => e.preventDefault()}
+                className="flex w-80 flex-col gap-1.5 rounded-lg px-4 py-3"
+                data-testid="stale-learn-more-popover"
+              >
+                <TeachingPoint lead="Your agent can handle many conversations at once.">
+                  It works better and smarter with focused conversations. We recommend starting a new
+                  conversation with your agent for each task so it isn&apos;t wasting time or tokens on
+                  unrelated chat history.
+                </TeachingPoint>
+                <TeachingPoint lead="Agents re-read everything each time they reply.">
+                  That&apos;s why long conversations slow down and get expensive. Start fresh to keep the
+                  agent fast and sharp.
+                </TeachingPoint>
+              </PopoverContent>
+            </Popover>
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onIgnore}
+            data-testid="stale-toast-ignore"
+          >
+            Ignore
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={onStartFresh}
+            data-testid="stale-new-chat"
+          >
+            New conversation
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/hooks/use-attachments.test.tsx
+++ b/src/renderer/hooks/use-attachments.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useAttachments } from './use-attachments'
+import type { Attachment } from '@renderer/components/messages/attachment-preview'
+
+beforeEach(() => {
+  // jsdom doesn't implement object URLs; the hook mints previews for carried images.
+  global.URL.createObjectURL = vi.fn(() => 'blob:fresh-url')
+  global.URL.revokeObjectURL = vi.fn()
+})
+
+describe('useAttachments initialAttachments hydration', () => {
+  it('starts empty when nothing is carried over', () => {
+    const { result } = renderHook(() => useAttachments())
+    expect(result.current.attachments).toEqual([])
+  })
+
+  it('mints a fresh preview for a carried image whose preview was stripped', () => {
+    const initial: Attachment[] = [
+      { type: 'file', id: 'img', file: new File(['x'], 'a.png', { type: 'image/png' }) },
+    ]
+    const { result } = renderHook(() => useAttachments({ initialAttachments: initial }))
+    const a = result.current.attachments[0]
+    expect(a.type === 'file' && a.preview).toBe('blob:fresh-url')
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not mint previews for non-image files', () => {
+    const initial: Attachment[] = [
+      { type: 'file', id: 'txt', file: new File(['x'], 'b.txt', { type: 'text/plain' }) },
+    ]
+    const { result } = renderHook(() => useAttachments({ initialAttachments: initial }))
+    const a = result.current.attachments[0]
+    expect(a.type === 'file' && a.preview).toBeUndefined()
+    expect(URL.createObjectURL).not.toHaveBeenCalled()
+  })
+
+  it('carries folders and mounts through untouched', () => {
+    const initial: Attachment[] = [
+      { type: 'folder', id: 'fld', folderName: 'docs', folderPath: '/host/docs', files: [], totalSize: 0 },
+      { type: 'mount', id: 'mnt', folderName: 'repo', hostPath: '/host/repo' },
+    ]
+    const { result } = renderHook(() => useAttachments({ initialAttachments: initial }))
+    expect(result.current.attachments).toEqual(initial)
+    expect(URL.createObjectURL).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/hooks/use-attachments.ts
+++ b/src/renderer/hooks/use-attachments.ts
@@ -7,10 +7,27 @@ const MAX_WEB_FOLDER_SIZE = 500 * 1024 * 1024
 
 interface UseAttachmentsOptions {
   onFoldersReceived?: (folders: FolderGroup[]) => void
+  /** Pre-fill the composer with carried-over attachments (e.g. "Start fresh"). */
+  initialAttachments?: Attachment[]
+}
+
+/**
+ * Carried-over image attachments arrive with their object-URL preview stripped
+ * (the source composer revokes it on unmount), so mint a fresh one from the
+ * still-valid File. Other attachment kinds carry no preview to rebuild.
+ */
+function rehydratePreviews(initial: Attachment[]): Attachment[] {
+  return initial.map((a) =>
+    a.type === 'file' && a.file.type.startsWith('image/') && !a.preview
+      ? { ...a, preview: URL.createObjectURL(a.file) }
+      : a
+  )
 }
 
 export function useAttachments(options?: UseAttachmentsOptions) {
-  const [attachments, setAttachments] = useState<Attachment[]>([])
+  const [attachments, setAttachments] = useState<Attachment[]>(
+    () => rehydratePreviews(options?.initialAttachments ?? [])
+  )
   const [isDragOver, setIsDragOver] = useState(false)
 
   const addFiles = useCallback((files: FileWithPath[]) => {

--- a/src/renderer/hooks/use-message-composer.ts
+++ b/src/renderer/hooks/use-message-composer.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { captureRendererException } from '@renderer/lib/error-reporting'
 import { useAttachments } from './use-attachments'
+import type { Attachment } from '@renderer/components/messages/attachment-preview'
 import { useVoiceInput } from './use-voice-input'
 import { useAddMount } from './use-mounts'
 import { useDraft } from '@renderer/context/drafts-context'
@@ -21,6 +22,8 @@ interface UseMessageComposerOptions {
   keepMessageUntilComplete?: boolean
   /** If provided, the composer persists its draft under this key via DraftsContext so it survives unmount. */
   draftKey?: string
+  /** Seed the composer with carried-over attachments (e.g. "Start fresh"). One-shot: read at mount only. */
+  initialAttachments?: Attachment[]
 }
 
 export function useMessageComposer(options: UseMessageComposerOptions) {
@@ -74,7 +77,10 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     handleFileSelect,
     handleFolderSelect,
     dragHandlers,
-  } = useAttachments({ onFoldersReceived: isElectron ? handleFoldersReceived : undefined })
+  } = useAttachments({
+    onFoldersReceived: isElectron ? handleFoldersReceived : undefined,
+    initialAttachments: options.initialAttachments,
+  })
 
   const voiceInput = useVoiceInput({
     onTranscriptUpdate: useCallback((text: string) => {

--- a/src/renderer/hooks/use-stale-session.test.ts
+++ b/src/renderer/hooks/use-stale-session.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
+import { useStaleSession, type UseStaleSessionArgs } from './use-stale-session'
+import { DraftsProvider, useDraftsStore } from '@renderer/context/drafts-context'
+import { carryoverKey, type ComposerSnapshot, type NewChatCarryover } from '@renderer/lib/composer-carryover'
+import type { SessionUsage } from '@shared/lib/types/agent'
+
+// Override setup.ts's global no-op useNavigate with a spy so we can assert that
+// "Start fresh" navigates to the agent's new-chat composer.
+const { navigateSpy } = vi.hoisted(() => ({ navigateSpy: vi.fn() }))
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return { ...actual, useNavigate: () => navigateSpy }
+})
+
+// Idle > 6h AND current context > 100k → trips the stale gate.
+const staleUsage: SessionUsage = {
+  inputTokens: 5000,
+  outputTokens: 0,
+  cacheCreationInputTokens: 0,
+  cacheReadInputTokens: 130_000,
+  contextWindow: 200_000,
+}
+const idle7h = () => new Date(Date.now() - 7 * 60 * 60 * 1000)
+
+function baseArgs(over: Partial<UseStaleSessionArgs> = {}): UseStaleSessionArgs {
+  return {
+    sessionId: 's-1',
+    agentSlug: 'agent-1',
+    isActive: false,
+    isWaitingBackground: false,
+    isAwaitingInput: false,
+    isViewOnly: false,
+    lastActivityAt: idle7h(),
+    contextUsage: staleUsage,
+    ...over,
+  }
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => createElement(DraftsProvider, null, children)
+
+// Render the hook alongside the drafts store so tests can assert what Start fresh wrote.
+function renderStale(args: UseStaleSessionArgs) {
+  return renderHook(({ a }: { a: UseStaleSessionArgs }) => ({ stale: useStaleSession(a), store: useDraftsStore() }), {
+    wrapper,
+    initialProps: { a: args },
+  })
+}
+
+describe('useStaleSession detection', () => {
+  it('does not prompt for a fresh (not idle, small context) conversation', () => {
+    const { result } = renderStale(baseArgs({ lastActivityAt: new Date(), contextUsage: null }))
+    expect(result.current.stale.showToast).toBe(false)
+  })
+
+  it('prompts when idle long enough AND context is large, at rest', () => {
+    const { result } = renderStale(baseArgs())
+    expect(result.current.stale.showToast).toBe(true)
+  })
+
+  it('never prompts while the session is active', () => {
+    const { result } = renderStale(baseArgs({ isActive: true }))
+    expect(result.current.stale.showToast).toBe(false)
+  })
+
+  it('never prompts while awaiting input', () => {
+    const { result } = renderStale(baseArgs({ isActive: true, isAwaitingInput: true }))
+    expect(result.current.stale.showToast).toBe(false)
+  })
+
+  it('never prompts for view-only users (they cannot start fresh)', () => {
+    const { result } = renderStale(baseArgs({ isViewOnly: true }))
+    expect(result.current.stale.showToast).toBe(false)
+  })
+
+  it('hides the toast after Ignore (local, no persistence)', () => {
+    const { result } = renderStale(baseArgs())
+    expect(result.current.stale.showToast).toBe(true)
+    act(() => result.current.stale.ignore())
+    expect(result.current.stale.showToast).toBe(false)
+  })
+})
+
+describe('useStaleSession active->idle clock', () => {
+  it('does not re-trip immediately after a turn finishes (active -> idle resets the idle clock)', () => {
+    const { result, rerender } = renderStale(baseArgs({ isActive: true }))
+    // Turn just completed: active -> idle. The live signal stamps "now", so even
+    // though lastActivityAt is 7h old, the conversation is not treated as idle.
+    rerender({ a: baseArgs({ isActive: false }) })
+    expect(result.current.stale.showToast).toBe(false)
+  })
+})
+
+describe('useStaleSession conversation change', () => {
+  it('clears local Ignore when the conversation changes (Ignore is per-conversation)', () => {
+    const { result, rerender } = renderStale(baseArgs())
+    act(() => result.current.stale.ignore())
+    expect(result.current.stale.showToast).toBe(false)
+    rerender({ a: baseArgs({ sessionId: 's-2' }) })
+    expect(result.current.stale.showToast).toBe(true)
+  })
+})
+
+describe('useStaleSession Start fresh', () => {
+  beforeEach(() => navigateSpy.mockClear())
+
+  function startFreshWith(snapshot: ComposerSnapshot, result: ReturnType<typeof renderStale>['result']) {
+    act(() => result.current.stale.registerSnapshot(() => snapshot))
+    act(() => result.current.stale.startFresh())
+  }
+
+  it('carries text + model/effort into the agent draft + carry-over, clears the source, then navigates', () => {
+    const { result } = renderStale(baseArgs())
+    startFreshWith({ text: 'pick this up later', attachments: [], model: 'sonnet', effort: 'low' }, result)
+
+    expect(result.current.store.get('agent:agent-1')).toBe('pick this up later')
+    expect(result.current.store.get<NewChatCarryover>(carryoverKey('agent-1'))).toEqual({
+      attachments: [],
+      model: 'sonnet',
+      effort: 'low',
+    })
+    // Source session draft is cleared — Start fresh is a move, not a copy.
+    expect(result.current.store.get('session:s-1')).toBeUndefined()
+    expect(navigateSpy).toHaveBeenCalledWith({ to: '/agents/$slug', params: { slug: 'agent-1' } })
+  })
+
+  it('carries model/effort but leaves the agent draft untouched when the composer is empty', () => {
+    const { result } = renderStale(baseArgs())
+    startFreshWith({ text: '   ', attachments: [], model: 'opus', effort: 'high' }, result)
+
+    // A blank composer must not clobber an existing agent-home draft.
+    expect(result.current.store.get('agent:agent-1')).toBeUndefined()
+    expect(result.current.store.get<NewChatCarryover>(carryoverKey('agent-1'))).toEqual({
+      attachments: [],
+      model: 'opus',
+      effort: 'high',
+    })
+    expect(navigateSpy).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/hooks/use-stale-session.ts
+++ b/src/renderer/hooks/use-stale-session.ts
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { useDraftsStore } from '@renderer/context/drafts-context'
+import { splitSnapshotForHandoff, carryoverKey, type ComposerSnapshot } from '@renderer/lib/composer-carryover'
+import { evaluateStalePrompt } from '@shared/lib/stale-session/stale-session-trigger'
+import { currentContextTokens } from '@shared/lib/stale-session/message-cost'
+import type { SessionUsage } from '@shared/lib/types/agent'
+
+export interface UseStaleSessionArgs {
+  sessionId: string
+  agentSlug: string
+  /** Session is mid-turn (running or awaiting input). */
+  isActive: boolean
+  /** Active only because a background task is in flight (not a foreground turn). */
+  isWaitingBackground: boolean
+  /** Active and blocked on a pending interactive request (secret, question, file, ...). */
+  isAwaitingInput: boolean
+  /** View-only users cannot start a new conversation, so they never see the prompt. */
+  isViewOnly: boolean
+  /** Last activity time from the session-detail query (may lag a just-finished turn). */
+  lastActivityAt?: Date | null
+  contextUsage?: SessionUsage | null
+}
+
+export interface UseStaleSessionResult {
+  /** Whether the stale-session toast should render right now. */
+  showToast: boolean
+  /** Hide the toast for this mount (no persistence). */
+  ignore: () => void
+  /** True while the toast's Learn more popover is open; the caller suppresses the
+   *  scroll-to-bottom FAB it would otherwise overlap. */
+  menuOpen: boolean
+  setMenuOpen: (open: boolean) => void
+  /** Registered by MessageInput so "Start fresh" can read the live composer state. */
+  registerSnapshot: (getSnapshot: (() => ComposerSnapshot) | null) => void
+  /** Snapshot the composer into the agent's new-chat composer and navigate there.
+   *  No session is created until the user actually sends. */
+  startFresh: () => void
+}
+
+/**
+ * Stale-session detection + "Start fresh" handoff, extracted from SessionChatColumn.
+ *
+ * Detection is continuous (not gated on the send path): a conversation is stale
+ * when it has been idle long enough AND carries enough context to be costly, and
+ * isn't mid-turn or awaiting input. Dismissal is a local hide, not a persisted
+ * property — see evaluateStalePrompt.
+ *
+ * SessionChatColumn is a persistent holder that is NOT keyed by sessionId, so all
+ * mutable state here is reset when the conversation changes; otherwise a previous
+ * conversation's Ignore / activity signal would bleed into the next one and wrongly
+ * suppress a prompt it independently earns.
+ */
+export function useStaleSession({
+  sessionId,
+  agentSlug,
+  isActive,
+  isWaitingBackground,
+  isAwaitingInput,
+  isViewOnly,
+  lastActivityAt,
+  contextUsage,
+}: UseStaleSessionArgs): UseStaleSessionResult {
+  const navigate = useNavigate()
+  const draftStore = useDraftsStore()
+
+  // `lastActivityAt` comes from the session-detail query, which only refreshes on
+  // metadata changes / remount — not when a turn completes. So after the user sends
+  // and the agent replies, it still reads the pre-send time, and the prompt would
+  // immediately re-trip the moment the session goes idle. Track the live active->idle
+  // transition as a fresher activity signal (set while active and at the instant it
+  // goes idle) so a just-finished turn resets the idle clock.
+  const [liveActivityAt, setLiveActivityAt] = useState<number | null>(null)
+  const wasActiveRef = useRef(isActive)
+  useEffect(() => {
+    if (isActive || wasActiveRef.current) setLiveActivityAt(Date.now())
+    wasActiveRef.current = isActive
+  }, [isActive])
+
+  const isRunning = isActive && !isWaitingBackground
+  const shouldPrompt = useMemo(() => {
+    const activityMs = Math.max(lastActivityAt?.getTime() ?? 0, liveActivityAt ?? 0)
+    return evaluateStalePrompt({
+      idleMs: activityMs ? Date.now() - activityMs : 0,
+      contextTokens: currentContextTokens(contextUsage),
+      isAwaitingInput,
+      isRunning,
+    }).shouldPrompt
+  }, [lastActivityAt, liveActivityAt, contextUsage, isAwaitingInput, isRunning])
+
+  // Local Ignore (no persistence) + Learn more popover open-state (drives FAB suppression).
+  const [ignored, setIgnored] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  // Reset all stale-prompt state when the conversation changes (see the holder note above).
+  useEffect(() => {
+    setIgnored(false)
+    setMenuOpen(false)
+    setLiveActivityAt(null)
+    wasActiveRef.current = isActive
+  }, [sessionId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Getter for the in-session composer's live state, registered by MessageInput.
+  // "Start fresh" reads it to carry text + files + model + effort into the new chat.
+  const composerSnapshotRef = useRef<(() => ComposerSnapshot) | null>(null)
+  const registerSnapshot = useCallback((getSnapshot: (() => ComposerSnapshot) | null) => {
+    composerSnapshotRef.current = getSnapshot
+  }, [])
+
+  // Move the live composer (text + files + model + effort) into the agent's new-chat
+  // composer and clear the source draft — a move, not a copy.
+  const startFresh = useCallback(() => {
+    const { draftText, carryover } = splitSnapshotForHandoff(composerSnapshotRef.current?.())
+    if (draftText !== undefined) draftStore.set(`agent:${agentSlug}`, draftText)
+    draftStore.set(carryoverKey(agentSlug), carryover)
+    draftStore.set(`session:${sessionId}`, undefined)
+    void navigate({ to: '/agents/$slug', params: { slug: agentSlug } })
+  }, [agentSlug, sessionId, draftStore, navigate])
+
+  // The toast owns the footer slot only at rest; once active, the activity indicator
+  // owns it instead. View-only users can't start fresh, so they never see it. Ignore
+  // is a local hide; it can return on a later qualifying mount, and a plain send
+  // clears it as the idle gate resets.
+  const showToast = shouldPrompt && !isActive && !isViewOnly && !ignored
+
+  return {
+    showToast,
+    ignore: useCallback(() => setIgnored(true), []),
+    menuOpen,
+    setMenuOpen,
+    registerSnapshot,
+    startFresh,
+  }
+}

--- a/src/renderer/lib/composer-carryover.test.tsx
+++ b/src/renderer/lib/composer-carryover.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { useState } from 'react'
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import {
+  carryoverKey,
+  splitSnapshotForHandoff,
+  carryoverToComposerInit,
+  useNewChatCarryover,
+  type ComposerSnapshot,
+  type NewChatCarryover,
+} from './composer-carryover'
+import { DraftsProvider, useDraftsStore } from '@renderer/context/drafts-context'
+import type { Attachment } from '@renderer/components/messages/attachment-preview'
+
+// "Run this side effect once during the initial render" helper for the seeder
+// below — sets up a pending carry-over before the consumer component reads it.
+function useStateOnce(fn: () => void) {
+  useState(() => {
+    fn()
+    return null
+  })
+}
+
+const imageFile = (): Attachment => ({
+  type: 'file',
+  id: 'img',
+  file: new File(['x'], 'a.png', { type: 'image/png' }),
+  preview: 'blob:stale-url',
+})
+const textFile = (): Attachment => ({
+  type: 'file',
+  id: 'txt',
+  file: new File(['x'], 'b.txt', { type: 'text/plain' }),
+})
+const folder = (): Attachment => ({
+  type: 'folder',
+  id: 'fld',
+  folderName: 'docs',
+  folderPath: '/host/docs',
+  files: [],
+  totalSize: 0,
+})
+const mount = (): Attachment => ({
+  type: 'mount',
+  id: 'mnt',
+  folderName: 'repo',
+  hostPath: '/host/repo',
+})
+
+const snapshot = (over: Partial<ComposerSnapshot> = {}): ComposerSnapshot => ({
+  text: '',
+  attachments: [],
+  model: 'opus',
+  effort: 'high',
+  ...over,
+})
+
+describe('splitSnapshotForHandoff', () => {
+  it('returns nothing for a missing snapshot (no live composer to read)', () => {
+    expect(splitSnapshotForHandoff(undefined)).toEqual({ draftText: undefined, carryover: undefined })
+  })
+
+  it('carries model + effort even when the composer is otherwise empty', () => {
+    const { draftText, carryover } = splitSnapshotForHandoff(snapshot())
+    expect(draftText).toBeUndefined()
+    expect(carryover).toEqual({ attachments: [], model: 'opus', effort: 'high' })
+  })
+
+  it('treats whitespace-only text as empty', () => {
+    const { draftText } = splitSnapshotForHandoff(snapshot({ text: '   \n  ' }))
+    expect(draftText).toBeUndefined()
+  })
+
+  it('carries non-blank text verbatim (preserving surrounding spaces)', () => {
+    const { draftText } = splitSnapshotForHandoff(snapshot({ text: '  hi there ' }))
+    expect(draftText).toBe('  hi there ')
+  })
+
+  it('carries files with the image preview stripped', () => {
+    const { draftText, carryover } = splitSnapshotForHandoff(snapshot({ attachments: [imageFile()] }))
+    expect(draftText).toBeUndefined()
+    expect(carryover?.attachments).toHaveLength(1)
+    const a = carryover!.attachments[0]
+    expect(a.type === 'file' && a.preview).toBeUndefined()
+  })
+
+  it('leaves non-image files, folders, and mounts untouched', () => {
+    const { carryover } = splitSnapshotForHandoff(
+      snapshot({ attachments: [textFile(), folder(), mount()] })
+    )
+    expect(carryover?.attachments).toEqual([textFile(), folder(), mount()])
+  })
+
+  it('does not mutate the source snapshot when stripping previews', () => {
+    const src = snapshot({ attachments: [imageFile()] })
+    splitSnapshotForHandoff(src)
+    expect(src.attachments[0]).toEqual(imageFile()) // preview still present on the original
+  })
+
+  it('carries text + files + model + effort together', () => {
+    const { draftText, carryover } = splitSnapshotForHandoff(
+      snapshot({ text: 'continue this', attachments: [textFile()], model: 'sonnet', effort: 'medium' })
+    )
+    expect(draftText).toBe('continue this')
+    expect(carryover).toEqual({ attachments: [textFile()], model: 'sonnet', effort: 'medium' })
+  })
+
+  it('passes through an undefined model (settings still loading)', () => {
+    const { carryover } = splitSnapshotForHandoff(snapshot({ model: undefined }))
+    expect(carryover?.model).toBeUndefined()
+  })
+})
+
+describe('carryoverToComposerInit', () => {
+  it('yields empty defaults for a missing carry-over', () => {
+    expect(carryoverToComposerInit(undefined)).toEqual({
+      initialAttachments: [],
+      initialModel: undefined,
+      initialEffort: undefined,
+    })
+  })
+
+  it('maps a carry-over onto the composer init props', () => {
+    const carryover: NewChatCarryover = { attachments: [mount()], model: 'haiku', effort: 'low' }
+    expect(carryoverToComposerInit(carryover)).toEqual({
+      initialAttachments: [mount()],
+      initialModel: 'haiku',
+      initialEffort: 'low',
+    })
+  })
+})
+
+describe('useNewChatCarryover', () => {
+  let store: ReturnType<typeof useDraftsStore> | undefined
+  function Grab() {
+    store = useDraftsStore()
+    return null
+  }
+  function Seeder({ slug, value }: { slug: string; value: NewChatCarryover }) {
+    const s = useDraftsStore()
+    // Seed during render (before the consumer below mounts and reads it).
+    useStateOnce(() => s.set(carryoverKey(slug), value))
+    return null
+  }
+
+  it('returns undefined when nothing is pending', () => {
+    const seen: (NewChatCarryover | undefined)[] = []
+    function Consumer() {
+      seen.push(useNewChatCarryover('agent-x'))
+      return null
+    }
+    render(
+      <DraftsProvider>
+        <Consumer />
+      </DraftsProvider>
+    )
+    expect(seen[0]).toBeUndefined()
+  })
+
+  it('reads the pending carry-over once and clears the slot', () => {
+    const value: NewChatCarryover = { attachments: [textFile()], model: 'opus', effort: 'high' }
+    const seen: (NewChatCarryover | undefined)[] = []
+    function Consumer() {
+      seen.push(useNewChatCarryover('agent-y'))
+      return null
+    }
+    render(
+      <DraftsProvider>
+        <Grab />
+        <Seeder slug="agent-y" value={value} />
+        <Consumer />
+      </DraftsProvider>
+    )
+    expect(seen[0]).toEqual(value)
+    // The mount effect consumes the slot so a later home-view mount starts clean.
+    expect(store?.get(carryoverKey('agent-y'))).toBeUndefined()
+  })
+})

--- a/src/renderer/lib/composer-carryover.ts
+++ b/src/renderer/lib/composer-carryover.ts
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react'
+import { useDraftsStore } from '@renderer/context/drafts-context'
+import type { Attachment } from '@renderer/components/messages/attachment-preview'
+import type { EffortLevel } from '@shared/lib/container/types'
+
+/**
+ * "Start fresh" carry-over: when a user leaves a stale conversation for a new one
+ * under the same agent, their in-progress composer (text, attachments, selected
+ * model + effort) follows them into the new-chat composer instead of being lost.
+ *
+ * No session is created here — the snapshot only pre-fills the new-chat composer;
+ * the session is born when the user actually sends, via the normal AgentHome path.
+ *
+ * Text travels through the agent's existing text draft key; the rest rides in a
+ * one-shot carry-over slot in the drafts store, keyed by agent slug.
+ */
+
+/** Live composer state captured at the moment the user chooses "Start fresh". */
+export interface ComposerSnapshot {
+  text: string
+  attachments: Attachment[]
+  /** Family alias, or undefined while settings are still loading. */
+  model: string | undefined
+  effort: EffortLevel
+}
+
+/** The non-text part of a snapshot, stashed for the new-chat composer to pick up. */
+export interface NewChatCarryover {
+  attachments: Attachment[]
+  model: string | undefined
+  effort: EffortLevel
+}
+
+/** Drafts-store key under which a pending carry-over for an agent lives. */
+export const carryoverKey = (agentSlug: string) => `newchat-carryover:${agentSlug}`
+
+/**
+ * Image previews are object URLs owned by the source composer; they get revoked
+ * when it unmounts on navigation. Drop them here so a dead URL never travels —
+ * the target composer recreates fresh ones from the still-valid File on hydrate.
+ */
+function stripPreviews(attachments: Attachment[]): Attachment[] {
+  return attachments.map((a) => (a.type === 'file' && a.preview ? { ...a, preview: undefined } : a))
+}
+
+/**
+ * Split a composer snapshot into its two handoff channels:
+ *   - `draftText`: the agent's text draft. Omitted when blank so an empty
+ *     "Start fresh" never clobbers an existing agent-home draft.
+ *   - `carryover`: attachments + selected model + effort, stashed under
+ *     `carryoverKey`. Model and effort are always carried (even for an otherwise
+ *     empty composer) so the user's current selection follows them.
+ *
+ * Returns both as undefined when there is no snapshot (e.g. a view-only column
+ * with no live composer to read).
+ */
+export function splitSnapshotForHandoff(snapshot: ComposerSnapshot | undefined): {
+  draftText: string | undefined
+  carryover: NewChatCarryover | undefined
+} {
+  if (!snapshot) return { draftText: undefined, carryover: undefined }
+  const draftText = snapshot.text.trim() ? snapshot.text : undefined
+  const carryover: NewChatCarryover = {
+    attachments: stripPreviews(snapshot.attachments),
+    model: snapshot.model,
+    effort: snapshot.effort,
+  }
+  return { draftText, carryover }
+}
+
+/** Map a consumed carry-over into the initial props the new-chat composer seeds from. */
+export function carryoverToComposerInit(carryover: NewChatCarryover | undefined): {
+  initialAttachments: Attachment[]
+  initialModel: string | undefined
+  initialEffort: EffortLevel | undefined
+} {
+  return {
+    initialAttachments: carryover?.attachments ?? [],
+    initialModel: carryover?.model,
+    initialEffort: carryover?.effort,
+  }
+}
+
+/**
+ * Read and clear a pending carry-over for an agent, exactly once. The value is
+ * captured at mount so the composer can seed from it on first render, and the
+ * store slot is cleared in an effect — so navigating back to the home view later
+ * starts clean rather than re-applying a stale carry-over.
+ */
+export function useNewChatCarryover(agentSlug: string): NewChatCarryover | undefined {
+  const store = useDraftsStore()
+  const key = carryoverKey(agentSlug)
+  const [value] = useState(() => store.get<NewChatCarryover>(key))
+  useEffect(() => {
+    if (store.get(key) !== undefined) store.set(key, undefined)
+  }, [store, key])
+  return value
+}

--- a/src/shared/lib/stale-session/message-cost.test.ts
+++ b/src/shared/lib/stale-session/message-cost.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { currentContextTokens } from './message-cost'
+
+describe('currentContextTokens', () => {
+  it('returns 0 for null usage', () => {
+    expect(currentContextTokens(null)).toBe(0)
+  })
+
+  it('returns 0 for undefined usage', () => {
+    expect(currentContextTokens(undefined)).toBe(0)
+  })
+
+  it('sums inputTokens, cacheReadInputTokens, and cacheCreationInputTokens', () => {
+    expect(
+      currentContextTokens({
+        inputTokens: 1000,
+        cacheReadInputTokens: 5000,
+        cacheCreationInputTokens: 2000,
+      }),
+    ).toBe(8000)
+  })
+})

--- a/src/shared/lib/stale-session/message-cost.ts
+++ b/src/shared/lib/stale-session/message-cost.ts
@@ -1,0 +1,9 @@
+import type { SessionUsage } from '../types/agent'
+
+/** Current context occupancy ≈ what the next message re-reads (last turn's input side). */
+export function currentContextTokens(
+  usage: Pick<SessionUsage, 'inputTokens' | 'cacheReadInputTokens' | 'cacheCreationInputTokens'> | null | undefined,
+): number {
+  if (!usage) return 0
+  return (usage.inputTokens ?? 0) + (usage.cacheReadInputTokens ?? 0) + (usage.cacheCreationInputTokens ?? 0)
+}

--- a/src/shared/lib/stale-session/stale-session-config.ts
+++ b/src/shared/lib/stale-session/stale-session-config.ts
@@ -1,0 +1,9 @@
+// Tunable in code only (not user settings, not UI). Calibrate from real usage.
+// See docs/superpowers/specs/2026-06-15-stale-session-prompt-design.md.
+
+/** Idle gap after which a returning user is prompted. Default 6h. */
+export const STALE_TIME_GAP_MS = 6 * 60 * 60 * 1000
+
+/** Current context occupancy (tokens) above which the session is "expensive now".
+ *  Only fires in combination with the idle gate (AND). */
+export const STALE_CONTEXT_TOKENS = 100_000

--- a/src/shared/lib/stale-session/stale-session-trigger.test.ts
+++ b/src/shared/lib/stale-session/stale-session-trigger.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { evaluateStalePrompt } from './stale-session-trigger'
+import { STALE_TIME_GAP_MS, STALE_CONTEXT_TOKENS } from './stale-session-config'
+
+const base = { idleMs: 0, contextTokens: 0, isAwaitingInput: false, isRunning: false }
+
+const stale = { idleMs: STALE_TIME_GAP_MS + 1, contextTokens: STALE_CONTEXT_TOKENS + 1 }
+
+describe('evaluateStalePrompt', () => {
+  it('does not prompt a fresh, small, active session', () => {
+    expect(evaluateStalePrompt(base).shouldPrompt).toBe(false)
+  })
+  it('does NOT prompt on idle alone when the context is small', () => {
+    expect(evaluateStalePrompt({ ...base, idleMs: STALE_TIME_GAP_MS + 1 }).shouldPrompt).toBe(false)
+  })
+  it('does NOT prompt on size alone when recently active', () => {
+    expect(evaluateStalePrompt({ ...base, contextTokens: STALE_CONTEXT_TOKENS + 1 }).shouldPrompt).toBe(false)
+  })
+  it('prompts only when BOTH idle past the gap AND large', () => {
+    expect(evaluateStalePrompt({ ...base, ...stale }).shouldPrompt).toBe(true)
+  })
+  it('suppresses while awaiting a permission/tool decision, even when stale', () => {
+    expect(evaluateStalePrompt({ ...base, ...stale, isAwaitingInput: true }).shouldPrompt).toBe(false)
+  })
+  it('suppresses while actively running', () => {
+    expect(evaluateStalePrompt({ ...base, ...stale, isRunning: true }).shouldPrompt).toBe(false)
+  })
+})

--- a/src/shared/lib/stale-session/stale-session-trigger.ts
+++ b/src/shared/lib/stale-session/stale-session-trigger.ts
@@ -1,0 +1,24 @@
+import { STALE_TIME_GAP_MS, STALE_CONTEXT_TOKENS } from './stale-session-config'
+
+export interface StaleInput {
+  idleMs: number          // now - lastActivityAt
+  contextTokens: number   // currentContextTokens(lastUsage)
+  isAwaitingInput: boolean
+  isRunning: boolean
+}
+
+export interface StaleDecision {
+  shouldPrompt: boolean
+}
+
+// Pure staleness predicate: "is this conversation stale right now". Dismissal is
+// no longer an input here — it is a UI suppression (local Ignore in the chat
+// column), not a persisted property of staleness.
+export function evaluateStalePrompt(i: StaleInput): StaleDecision {
+  if (i.isAwaitingInput || i.isRunning) return { shouldPrompt: false }
+  // Both must hold (AND): idle long enough that the prompt isn't mid-flow,
+  // AND large enough that continuing is genuinely costly. A small session is
+  // cheap to continue; a large-but-active one is bounded by auto-compact.
+  const shouldPrompt = i.idleMs > STALE_TIME_GAP_MS && i.contextTokens > STALE_CONTEXT_TOKENS
+  return { shouldPrompt }
+}


### PR DESCRIPTION
## What this does

When a conversation goes stale (idle 6h+ AND context over ~100k), a footer toast appears at rest offering to start a new conversation under the same agent:

- **New conversation** snapshots the live composer (text + attachments + model + effort) and lands the user on the agent's new-chat composer with it carried over. No session is created until they actually send.
- **Ignore** hides the toast locally; a plain send clears it as the idle gate resets.
- **Learn more** explains why long conversations get slow and expensive.

Keeps long-running agents fast and cheap without losing the user's in-progress draft.

## Why this PR is small

This is the focused split of #276 that @iddogino asked for. #276 bundled three things; this PR is just the first:

- **A (this PR):** the stale-session prompt + "start a new conversation" flow.
- **B (follow-up):** "Start with Summary" - summarize the old conversation and seed the new one. This is the bulk of #276's complexity (summarizer service, transcript pruning, the `/sessions/summarize` endpoint, the carried-summary card, the transcript splitter). It will land as its own focused PR on top of this one.
- **C (dropped):** a "first-session defaults to Opus" change that had ridden along unrelated. It used the model-*family* API that was deprecated when GPT support landed, so it is removed here entirely rather than carried forward.

#276 will be closed as superseded by this PR plus the B follow-up.

## Review notes from #276 addressed here

- Split into a small, reviewable unit (23 files, +1445/-7, client-side only - no server routes, no API/type changes, no migrations).
- The detection logic is extracted out of `SessionChatColumn` into a standalone, unit-tested `useStaleSession` hook.
- `SessionView` no longer threads an `onStartFresh` prop - the hook owns navigation via `useNavigate` and the agent slug it already has.
- The deprecated model-family logic (C) is gone.

## Test plan

- `typecheck` clean, `lint` 0 errors.
- 231 unit tests across the touched + adjacent suites (`useStaleSession`, the toast, composer carry-over, `SessionChatColumn`, `AgentHome`, `MessageList`, `MessageInput`).
- e2e (`stale-session-prompt.spec.ts`): toast appears at rest, Ignore hides it, New conversation carries the draft without sending, Learn more shows the teaching points, a plain send is never intercepted, and no toast fires for awaiting-input or fresh-small sessions.
