### PR TITLE
perf(web): tune Cache-Control for the static web build

### DIFF
--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -9,11 +9,39 @@ const app = new Hono()
 // Mount API routes
 app.route('/', api)
 
+// Cache policy for the static web build. Vite emits content-hashed JS/CSS into
+// `/assets/*`, so the filename itself changes whenever the bytes change — those
+// can be cached permanently and a new deploy is picked up automatically (new
+// URLs, nothing to invalidate). `index.html` is the un-hashed entry that points
+// at the hashed bundles, so it must always be revalidated or clients pin to a
+// stale build. Stable-named `public/` assets (icons, manifest) have no hash to
+// bust them, so they revalidate too rather than caching forever.
+function staticCacheControl(filePath: string): string {
+  const p = filePath.replace(/\\/g, '/')
+  if (p.includes('/assets/')) return 'public, max-age=31536000, immutable'
+  if (p.endsWith('index.html')) return 'no-cache'
+  return 'public, max-age=3600, must-revalidate'
+}
+
 // Only serve static files in production (when dist/renderer exists)
 // In development, Vite dev server handles the frontend
 if (existsSync('./dist/renderer')) {
-  app.use('/*', serveStatic({ root: './dist/renderer' }))
-  app.get('*', serveStatic({ path: './dist/renderer/index.html' }))
+  app.use(
+    '/*',
+    serveStatic({
+      root: './dist/renderer',
+      onFound: (filePath, c) => c.header('Cache-Control', staticCacheControl(filePath)),
+    }),
+  )
+  // SPA fallback: any unmatched route serves the HTML entry, which must never be
+  // cached so a reload always discovers the latest hashed bundles.
+  app.get(
+    '*',
+    serveStatic({
+      path: './dist/renderer/index.html',
+      onFound: (_filePath, c) => c.header('Cache-Control', 'no-cache'),
+    }),
+  )
 }
 
 let server: BoundServer['server']


### PR DESCRIPTION
## What

The production web server (`src/web/server.ts`) served `dist/renderer` with **no `Cache-Control` headers**, so even Vite's content-hashed bundles were revalidated on every load. This adds a hash-aware cache policy via `serveStatic`'s `onFound`.

## Policy

| Path | Cache-Control | Why |
|---|---|---|
| `/assets/*` (hashed JS/CSS) | `public, max-age=31536000, immutable` | the content hash is the cache key — a new build always means new filenames, so it can never serve stale code |
| `index.html` + SPA `*` fallback | `no-cache` | the un-hashed entry points at the hashed bundles; it must revalidate so a reload always discovers the latest build |
| `public/` (icons, manifest) | `public, max-age=3600, must-revalidate` | stable-named, no hash to bust — revalidate rather than pin a stale copy forever |

The hash-based busting is what makes the long `immutable` cache safe: changed bytes → new filename → the browser fetches a URL it has never seen, while `index.html` (always revalidated) is what hands out the new references. Result: warm loads serve all JS/CSS straight from disk, cold loads cost one small `index.html` revalidation.

## Scope / safety

- **Web-only.** The static branch is guarded by `existsSync('./dist/renderer')`, which is false in dev (Vite serves the frontend) and in Electron (`file://`). Desktop is unaffected.
- **No Service Worker** — this is purely HTTP-cache tuning. A SW (precache / offline app-shell) is tracked separately and is larger because it must stay network-only for SSE + `/api/*`.

## Test plan

- `tsc --noEmit` clean, `eslint` clean
- `onFound` receives the joined fs path (e.g. `dist/renderer/assets/x.js`), so the `/assets/` and `index.html` checks match (separator-normalized for safety; prod runs on Linux)
