### PR TITLE
Harden E2E suite for workers 4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
         env:
           PORT: '3000'
           SUPERAGENT_DATA_DIR: .e2e-data/web
-          PLAYWRIGHT_WORKERS: '2'
+          PLAYWRIGHT_WORKERS: '4'
           PLAYWRIGHT_OUTPUT_DIR: test-results/web
           PLAYWRIGHT_HTML_REPORT: playwright-report/web
         run: npm run test:e2e

--- a/e2e/helpers/agents.ts
+++ b/e2e/helpers/agents.ts
@@ -114,6 +114,28 @@ export async function openAgentHome(page: Page, agent: Pick<TestAgent, 'slug' | 
     : new Error(`Could not open agent "${agent.name}" (${agent.slug})`)
 }
 
+export async function gotoAgentHome(page: Page, agent: Pick<TestAgent, 'slug' | 'name'>) {
+  let lastError: unknown
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      await page.goto(`/agents/${agent.slug}`)
+      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name, { timeout: 15000 })
+      await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible({ timeout: 15000 })
+      return
+    } catch (error) {
+      lastError = error
+      if (attempt === 1) break
+
+      await page.reload()
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`Could not load agent "${agent.name}" (${agent.slug})`)
+}
+
 export async function openAgentSession(
   page: Page,
   agent: Pick<TestAgent, 'slug' | 'name'>,

--- a/e2e/pages/session.page.ts
+++ b/e2e/pages/session.page.ts
@@ -73,14 +73,18 @@ export class SessionPage {
     return enabledInput ?? this.page.locator('[data-testid="message-input"]').first()
   }
 
-  private async getVisibleSendButton(timeout = 10000) {
-    let visibleButton: Locator | undefined
+  private async clickEnabledSendButton(timeout = 10000) {
     await expect.poll(async () => {
-      visibleButton = await this.findMatchingLocator(this.getSendButtonLocators())
-      return visibleButton ? 'found' : 'none'
-    }, { timeout }).not.toBe('none')
+      const button = await this.findMatchingLocator(this.getSendButtonLocators(), { enabled: true })
+      if (!button) return 'waiting'
 
-    return visibleButton ?? this.page.locator('[data-testid="send-button"]').first()
+      try {
+        await button.click({ timeout: 1000 })
+        return 'clicked'
+      } catch {
+        return 'retry'
+      }
+    }, { timeout }).toBe('clicked')
   }
 
   /**
@@ -132,9 +136,7 @@ export class SessionPage {
    */
   async sendMessage(content: string) {
     await this.typeMessage(content)
-    const sendButton = await this.getVisibleSendButton()
-    await expect(sendButton).toBeEnabled({ timeout: 10000 })
-    await sendButton.click()
+    await this.clickEnabledSendButton()
   }
 
   /**

--- a/e2e/specs/connected-accounts.spec.ts
+++ b/e2e/specs/connected-accounts.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
-import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
-import { createAgent, openAgentHome, type TestAgent } from '../helpers/agents'
+import { createAgent, gotoAgentHome, type TestAgent } from '../helpers/agents'
 import {
   createRemoteMcp,
   expectAgentHasRemoteMcp,
@@ -81,10 +80,7 @@ async function createAndOpenAgent(
   label: string,
 ): Promise<TestAgent> {
   const agent = await createAgent(request, uniqueName(testInfo, label))
-  const appPage = new AppPage(page)
-  await appPage.goto()
-  await appPage.waitForAgentsLoaded()
-  await openAgentHome(page, agent)
+  await gotoAgentHome(page, agent)
   return agent
 }
 

--- a/e2e/specs/cross-session-messages.spec.ts
+++ b/e2e/specs/cross-session-messages.spec.ts
@@ -1,18 +1,16 @@
 import { test, expect } from '@playwright/test'
-import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
+import { createAgent as createAgentViaApi, gotoAgentHome, type TestAgent } from '../helpers/agents'
 
 // Run serially to avoid conflicts
 test.describe.configure({ mode: 'serial' })
 
 test.describe('Cross-Session Message Isolation', () => {
-  let appPage: AppPage
   let agentPage: AgentPage
   let sessionPage: SessionPage
 
   test.beforeEach(async ({ page }) => {
-    appPage = new AppPage(page)
     agentPage = new AgentPage(page)
     sessionPage = new SessionPage(page)
   })
@@ -27,107 +25,108 @@ test.describe('Cross-Session Message Isolation', () => {
     return sessionPage.getUserMessages().filter({ hasText: text }).first()
   }
 
-  test('messages from one agent do not leak into another agent', async ({ page }) => {
+  test('messages from one agent do not leak into another agent', async ({ page, request }) => {
     const ts = Date.now()
     const agentAName = `Agent A ${ts}`
     const agentBName = `Agent B ${ts}`
     const messageA = 'slow response for agent A'
     const messageB = 'Hello from agent B'
+    const createdAgents: TestAgent[] = []
 
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
+    try {
+      // Create two agents
+      const agentA = await createAgentViaApi(request, agentAName)
+      const agentB = await createAgentViaApi(request, agentBName)
+      createdAgents.push(agentA, agentB)
 
-    // Create two agents
-    await agentPage.createAgent(agentAName)
-    await agentPage.createAgent(agentBName)
+      // 1. Go to Agent A and send a slow message (triggers 3s delay)
+      await gotoAgentHome(page, agentA)
+      await sessionPage.sendMessage(messageA)
 
-    // 1. Go to Agent A and send a slow message (triggers 3s delay)
-    await agentPage.selectAgent(agentAName)
-    await sessionPage.sendMessage(messageA)
+      // Wait for the message we just sent to appear.
+      await expect(userMessage(messageA)).toBeVisible({ timeout: 10000 })
 
-    // Wait for the message we just sent to appear; the create-agent prompt may
-    // also be present in this first session.
-    await expect(userMessage(messageA)).toBeVisible({ timeout: 10000 })
+      // Verify Agent A is working (slow response takes 3s)
+      await expect(sessionPage.getStopButton()).toBeVisible({ timeout: 5000 })
 
-    // Verify Agent A is working (slow response takes 3s)
-    await expect(sessionPage.getStopButton()).toBeVisible({ timeout: 5000 })
+      // 2. While Agent A is working, switch to Agent B
+      await agentPage.selectAgent(agentBName)
+      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agentBName, { timeout: 15000 })
 
-    // 2. While Agent A is working, switch to Agent B
-    await agentPage.selectAgent(agentBName)
+      // 3. Send a message to Agent B
+      await sessionPage.sendMessage(messageB)
+      await expect(userMessage(messageB)).toBeVisible({ timeout: 10000 })
 
-    // 3. Send a message to Agent B
-    await sessionPage.sendMessage(messageB)
-    await expect(userMessage(messageB)).toBeVisible({ timeout: 10000 })
+      // Verify Agent B's message list does NOT contain Agent A's message
+      const messageBList = sessionPage.getMessageList()
+      await expect(messageBList).not.toContainText(messageA)
 
-    // Verify Agent B's message list does NOT contain Agent A's message
-    const messageBList = sessionPage.getMessageList()
-    await expect(messageBList).not.toContainText(messageA)
+      // 4. Switch back to Agent A and select its session
+      await agentPage.selectAgent(agentAName)
+      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agentAName, { timeout: 15000 })
+      // Need to click on the session in the sidebar since switching agent deselects it
+      await sessionPage.selectFirstSessionInSidebar(agentPage.getAgentLi(agentAName))
 
-    // 4. Switch back to Agent A and select its session
-    await agentPage.selectAgent(agentAName)
-    // Need to click on the session in the sidebar since switching agent deselects it
-    await sessionPage.selectFirstSessionInSidebar(agentPage.getAgentLi(agentAName))
+      // Wait for message list to appear
+      const messageAList = sessionPage.getMessageList()
+      await expect(messageAList).toBeVisible({ timeout: 5000 })
 
-    // Wait for message list to appear
-    const messageAList = sessionPage.getMessageList()
-    await expect(messageAList).toBeVisible({ timeout: 5000 })
-
-    // 5. Verify Agent A's messages do NOT contain Agent B's message
-    await expect(userMessage(messageA)).toBeVisible({ timeout: 10000 })
-    await expect(messageAList).not.toContainText(messageB)
-
-    // Cleanup: delete both agents
-    await agentPage.selectAgent(agentAName)
-    try { await agentPage.deleteAgent() } catch { /* ignore */ }
-    await agentPage.selectAgent(agentBName)
-    try { await agentPage.deleteAgent() } catch { /* ignore */ }
+      // 5. Verify Agent A's messages do NOT contain Agent B's message
+      await expect(userMessage(messageA)).toBeVisible({ timeout: 10000 })
+      await expect(messageAList).not.toContainText(messageB)
+    } finally {
+      for (const agent of createdAgents) {
+        await request.delete(`/api/agents/${agent.slug}`).catch(() => {})
+      }
+    }
   })
 
-  test('pending optimistic message is scoped to session', async ({ page }) => {
+  test('pending optimistic message is scoped to session', async ({ page, request }) => {
     const ts = Date.now()
     const agentAName = `Pending A ${ts}`
     const agentBName = `Pending B ${ts}`
     const messageA = 'slow response test'
     const messageB = 'Quick message B'
+    const createdAgents: TestAgent[] = []
 
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
+    try {
+      // Create two agents
+      const agentA = await createAgentViaApi(request, agentAName)
+      const agentB = await createAgentViaApi(request, agentBName)
+      createdAgents.push(agentA, agentB)
 
-    // Create two agents
-    await agentPage.createAgent(agentAName)
-    await agentPage.createAgent(agentBName)
+      // Send slow message to Agent A
+      await gotoAgentHome(page, agentA)
+      await sessionPage.sendMessage(messageA)
+      await expect(userMessage(messageA)).toBeVisible({ timeout: 10000 })
 
-    // Send slow message to Agent A
-    await agentPage.selectAgent(agentAName)
-    await sessionPage.sendMessage(messageA)
-    await expect(userMessage(messageA)).toBeVisible({ timeout: 10000 })
+      // Agent A should be working
+      await expect(sessionPage.getStopButton()).toBeVisible({ timeout: 5000 })
 
-    // Agent A should be working
-    await expect(sessionPage.getStopButton()).toBeVisible({ timeout: 5000 })
+      // Switch to Agent B and send a message
+      await agentPage.selectAgent(agentBName)
+      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agentBName, { timeout: 15000 })
+      await sessionPage.sendMessage(messageB)
 
-    // Switch to Agent B and send a message
-    await agentPage.selectAgent(agentBName)
-    await sessionPage.sendMessage(messageB)
+      // Agent B should show its own message, not Agent A's
+      await expect(userMessage(messageB)).toBeVisible({ timeout: 10000 })
+      await expect(sessionPage.getMessageList()).not.toContainText(messageA)
 
-    // Agent B should show its own message, not Agent A's
-    await expect(userMessage(messageB)).toBeVisible({ timeout: 10000 })
-    await expect(sessionPage.getMessageList()).not.toContainText(messageA)
+      // Switch back to Agent A and select session
+      await agentPage.selectAgent(agentAName)
+      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agentAName, { timeout: 15000 })
+      await sessionPage.selectFirstSessionInSidebar(agentPage.getAgentLi(agentAName))
 
-    // Switch back to Agent A and select session
-    await agentPage.selectAgent(agentAName)
-    await sessionPage.selectFirstSessionInSidebar(agentPage.getAgentLi(agentAName))
+      // Agent A should show its message
+      await expect(userMessage(messageA)).toBeVisible({ timeout: 10000 })
 
-    // Agent A should show its message
-    await expect(userMessage(messageA)).toBeVisible({ timeout: 10000 })
-
-    // And should NOT have messageB anywhere
-    const messageListA = sessionPage.getMessageList()
-    await expect(messageListA).not.toContainText(messageB)
-
-    // Cleanup
-    await agentPage.selectAgent(agentAName)
-    try { await agentPage.deleteAgent() } catch { /* ignore */ }
-    await agentPage.selectAgent(agentBName)
-    try { await agentPage.deleteAgent() } catch { /* ignore */ }
+      // And should NOT have messageB anywhere
+      const messageListA = sessionPage.getMessageList()
+      await expect(messageListA).not.toContainText(messageB)
+    } finally {
+      for (const agent of createdAgents) {
+        await request.delete(`/api/agents/${agent.slug}`).catch(() => {})
+      }
+    }
   })
 })

--- a/e2e/specs/navigation.spec.ts
+++ b/e2e/specs/navigation.spec.ts
@@ -14,6 +14,7 @@ import { test, expect } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
+import { createAgent as createAgentViaApi } from '../helpers/agents'
 
 // Serial: each test creates and deletes one agent — overlapping creates
 // in mock mode share state on the server side and can flake.
@@ -524,7 +525,7 @@ test.describe('Navigation — discriminated AgentView', () => {
     await agentPage.deleteAgent()
   })
 
-  test('Connections detail overlay is deep-linkable and reload-durable; source=list back returns to the list', async ({ page }) => {
+  test('Connections detail overlay is deep-linkable and reload-durable; source=list back returns to the list', async ({ page, request }) => {
     // The detail overlay travels in the URL search (`?detail&source`,
     // ConnectionsRoute decodes it). A cold deep-link must restore the overlay
     // (connection-detail-back), hide the bare list back-button, and survive a
@@ -532,73 +533,69 @@ test.describe('Navigation — discriminated AgentView', () => {
     const errors: string[] = []
     page.on('pageerror', (e) => errors.push(e.message))
 
-    const agentName = `Nav Conn Detail ${Date.now()}`
-    await agentPage.createAgent(agentName)
-    const slug = page.url().match(/\/agents\/([^/?#]+)/)?.[1]
-    expect(slug).toBeTruthy()
+    const agent = await createAgentViaApi(request, `Nav Conn Detail ${Date.now()}`)
+    const slug = agent.slug
 
-    // Cold deep-link straight to the open overlay.
-    await page.goto(`/agents/${slug}/connections?detail=account-${accountId}&source=list`)
+    try {
+      // Cold deep-link straight to the open overlay.
+      await page.goto(`/agents/${slug}/connections?detail=account-${accountId}&source=list`)
 
-    // The URL keeps both search params (param order isn't guaranteed, so assert
-    // each independently).
-    await expect(page).toHaveURL(new RegExp(`/agents/${slug}/connections\\?`))
-    await expect(page).toHaveURL(new RegExp(`detail=account-${accountId}`))
-    await expect(page).toHaveURL(/source=list/)
+      // The URL keeps both search params (param order isn't guaranteed, so assert
+      // each independently).
+      await expect(page).toHaveURL(new RegExp(`/agents/${slug}/connections\\?`))
+      await expect(page).toHaveURL(new RegExp(`detail=account-${accountId}`))
+      await expect(page).toHaveURL(/source=list/)
 
-    // Overlay renders; the bare connections-list back-button is NOT present
-    // (PageTitle is suppressed while a detail is open).
-    await expect(page.locator('[data-testid="connection-detail-back"]')).toBeVisible({ timeout: 15000 })
-    await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
+      // Overlay renders; the bare connections-list back-button is NOT present
+      // (PageTitle is suppressed while a detail is open).
+      await expect(page.locator('[data-testid="connection-detail-back"]')).toBeVisible({ timeout: 15000 })
+      await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
 
-    // Reload — the overlay is restored straight from the URL, no Selection.
-    await appPage.reload()
-    await expect(page).toHaveURL(new RegExp(`detail=account-${accountId}`))
-    await expect(page).toHaveURL(/source=list/)
-    await expect(page.locator('[data-testid="connection-detail-back"]')).toBeVisible({ timeout: 15000 })
-    await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
+      // Reload — the overlay is restored straight from the URL, no Selection.
+      await appPage.reload()
+      await expect(page).toHaveURL(new RegExp(`detail=account-${accountId}`))
+      await expect(page).toHaveURL(/source=list/)
+      await expect(page.locator('[data-testid="connection-detail-back"]')).toBeVisible({ timeout: 15000 })
+      await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
 
-    // source=list → Back returns to the connections list (the bare list
-    // back-button reappears, overlay gone).
-    await page.locator('[data-testid="connection-detail-back"]').click()
-    await expect(page).toHaveURL(/\/connections$/)
-    await expect(page.locator('[data-testid="connections-back-button"]')).toBeVisible()
-    await expect(page.locator('[data-testid="connection-detail-back"]')).not.toBeVisible()
+      // source=list → Back returns to the connections list (the bare list
+      // back-button reappears, overlay gone).
+      await page.locator('[data-testid="connection-detail-back"]').click()
+      await expect(page).toHaveURL(/\/connections$/)
+      await expect(page.locator('[data-testid="connections-back-button"]')).toBeVisible()
+      await expect(page.locator('[data-testid="connection-detail-back"]')).not.toBeVisible()
 
-    expect(errors).toEqual([])
-
-    // Cleanup
-    await agentPage.selectAgent(agentName)
-    await agentPage.deleteAgent()
+      expect(errors).toEqual([])
+    } finally {
+      await request.delete(`/api/agents/${slug}`).catch(() => {})
+    }
   })
 
-  test('Connections detail overlay with source=home: Back returns to agent home', async ({ page }) => {
+  test('Connections detail overlay with source=home: Back returns to agent home', async ({ page, request }) => {
     // The agent-scoped overlay's `source` decides the back-target: source=home
     // routes Back to agent home, not to the connections list — an invariant that
     // can silently regress.
     const errors: string[] = []
     page.on('pageerror', (e) => errors.push(e.message))
 
-    const agentName = `Nav Conn Detail Home ${Date.now()}`
-    await agentPage.createAgent(agentName)
-    const slug = page.url().match(/\/agents\/([^/?#]+)/)?.[1]
-    expect(slug).toBeTruthy()
+    const agent = await createAgentViaApi(request, `Nav Conn Detail Home ${Date.now()}`)
+    const slug = agent.slug
 
-    await page.goto(`/agents/${slug}/connections?detail=account-${accountId}&source=home`)
-    await expect(page).toHaveURL(new RegExp(`detail=account-${accountId}`))
-    await expect(page).toHaveURL(/source=home/)
-    await expect(page.locator('[data-testid="connection-detail-back"]')).toBeVisible({ timeout: 15000 })
+    try {
+      await page.goto(`/agents/${slug}/connections?detail=account-${accountId}&source=home`)
+      await expect(page).toHaveURL(new RegExp(`detail=account-${accountId}`))
+      await expect(page).toHaveURL(/source=home/)
+      await expect(page.locator('[data-testid="connection-detail-back"]')).toBeVisible({ timeout: 15000 })
 
-    // source=home → Back returns to agent home (large composer visible).
-    await page.locator('[data-testid="connection-detail-back"]').click()
-    await expect(page).toHaveURL(/\/agents\/[^/]+$/)
-    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
-    await expect(page.locator('[data-testid="connection-detail-back"]')).not.toBeVisible()
+      // source=home → Back returns to agent home (large composer visible).
+      await page.locator('[data-testid="connection-detail-back"]').click()
+      await expect(page).toHaveURL(/\/agents\/[^/]+$/)
+      await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
+      await expect(page.locator('[data-testid="connection-detail-back"]')).not.toBeVisible()
 
-    expect(errors).toEqual([])
-
-    // Cleanup
-    await agentPage.selectAgent(agentName)
-    await agentPage.deleteAgent()
+      expect(errors).toEqual([])
+    } finally {
+      await request.delete(`/api/agents/${slug}`).catch(() => {})
+    }
   })
 })

--- a/e2e/specs/skill-export-import.spec.ts
+++ b/e2e/specs/skill-export-import.spec.ts
@@ -11,6 +11,10 @@ test.describe('Skill Export & Import', () => {
   let agentPage: AgentPage
   let tmpDir: string
 
+  async function createSkillTestAgent(name: string) {
+    await agentPage.createAgent(name, { waitForSidebarName: false })
+  }
+
   test.beforeEach(async ({ page }) => {
     appPage = new AppPage(page)
     agentPage = new AgentPage(page)
@@ -34,7 +38,7 @@ test.describe('Skill Export & Import', () => {
       { name: skillName },
     )
 
-    await agentPage.createAgent(`Skill Imp ${Date.now()}`)
+    await createSkillTestAgent(`Skill Imp ${Date.now()}`)
 
     const importButton = page.locator('[data-testid="import-skill-button"]')
     await expect(importButton).toBeVisible({ timeout: 10000 })
@@ -63,7 +67,7 @@ test.describe('Skill Export & Import', () => {
     const { writeZipFile } = await import('../../src/shared/lib/utils/zip')
     await writeZipFile(badZipPath, { 'README.md': '# Not a skill' })
 
-    await agentPage.createAgent(`Bad Imp ${Date.now()}`)
+    await createSkillTestAgent(`Bad Imp ${Date.now()}`)
 
     const importButton = page.locator('[data-testid="import-skill-button"]')
     await expect(importButton).toBeVisible({ timeout: 10000 })
@@ -79,7 +83,7 @@ test.describe('Skill Export & Import', () => {
   })
 
   test('export a skill via three-dot menu', async ({ page }) => {
-    await agentPage.createAgent(`Skill Exp ${Date.now()}`)
+    await createSkillTestAgent(`Skill Exp ${Date.now()}`)
 
     const addSkillButton = page.locator('[data-testid="add-skill-button"]')
     await expect(addSkillButton).toBeVisible({ timeout: 10000 })
@@ -112,7 +116,7 @@ test.describe('Skill Export & Import', () => {
   })
 
   test('round-trip: export from one agent, import into another', async ({ page }) => {
-    await agentPage.createAgent(`RT Exp ${Date.now()}`)
+    await createSkillTestAgent(`RT Exp ${Date.now()}`)
 
     const addSkillButton = page.locator('[data-testid="add-skill-button"]')
     await expect(addSkillButton).toBeVisible({ timeout: 10000 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -62,7 +62,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: configuredWorkers && Number.isFinite(configuredWorkers) ? configuredWorkers : 2,
+  workers: configuredWorkers && Number.isFinite(configuredWorkers) ? configuredWorkers : 4,
   reporter: [['list'], ['html', { open: 'never', outputFolder: playwrightHtmlReportDir }]],
 
   use: {

--- a/src/shared/lib/services/skillset-service.test.ts
+++ b/src/shared/lib/services/skillset-service.test.ts
@@ -15,7 +15,8 @@ import type {
 
 const { mockExecFile, mockAnthropicCreate, mockGetApiKey, mockGetModels } = vi.hoisted(() => {
   const mockExecFile = vi.fn<
-    (cmd: string, args: string[], opts?: unknown) => { stdout: string; stderr: string }
+    (cmd: string, args: string[], opts?: unknown) =>
+      { stdout: string; stderr: string } | Promise<{ stdout: string; stderr: string }>
   >()
   const mockAnthropicCreate = vi.fn()
   const mockGetApiKey = vi.fn((): string | undefined => undefined)
@@ -37,19 +38,21 @@ vi.mock('child_process', () => {
       stderr?: string,
     ) => void
     const callArgs = args.slice(0, -1) as [string, string[], unknown?]
-    try {
-      const result = mockExecFile(...callArgs)
-      callback(null, result?.stdout ?? '', result?.stderr ?? '')
-    } catch (err) {
-      callback(err as Error)
-    }
+    Promise.resolve()
+      .then(() => mockExecFile(...callArgs))
+      .then((result) => {
+        callback(null, result?.stdout ?? '', result?.stderr ?? '')
+      })
+      .catch((err) => {
+        callback(err as Error)
+      })
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(execFileFn as any)[Symbol.for('nodejs.util.promisify.custom')] = async (
     ...args: unknown[]
   ) => {
     const callArgs = args as [string, string[], unknown?]
-    const result = mockExecFile(...callArgs)
+    const result = await mockExecFile(...callArgs)
     return { stdout: result?.stdout ?? '', stderr: result?.stderr ?? '' }
   }
   return { execFile: execFileFn }
@@ -94,6 +97,7 @@ import {
   parseSkillFrontmatter,
   urlToSkillsetId,
   getAgentSkillsWithStatus,
+  refreshSkillset,
   refreshAgentSkills,
   publishSkillToSkillset,
   getSkillPublishInfo,
@@ -766,6 +770,52 @@ Instructions here`
       // No brittle hardcoded master fallback and no full-history reset by name.
       expect(cmdline).not.toContain('git checkout master')
       expect(cmdline.some((c) => c.startsWith('git reset --hard origin/'))).toBe(false)
+    })
+
+    it('coalesces concurrent refreshes for the same cache directory', async () => {
+      const config = buildSkillsetConfig()
+      const index = buildIndex()
+      await createSkillsetCache(config.id, index)
+
+      const ref = {
+        skillsetId: config.id,
+        skillsetUrl: config.url,
+        provider: config.provider,
+        providerData: config.providerData,
+      }
+
+      let setUrlCalls = 0
+      let releaseSetUrl!: () => void
+      let notifySetUrlStarted!: () => void
+      const setUrlStarted = new Promise<void>((resolve) => {
+        notifySetUrlStarted = resolve
+      })
+      const setUrlCanFinish = new Promise<void>((resolve) => {
+        releaseSetUrl = resolve
+      })
+
+      mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'remote' && args[1] === 'set-url') {
+          setUrlCalls += 1
+          notifySetUrlStarted()
+          return setUrlCanFinish.then(() => ({ stdout: '', stderr: '' }))
+        }
+        if (cmd === 'git' && args[0] === 'symbolic-ref') {
+          return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      })
+
+      const firstRefresh = refreshSkillset(ref)
+      await setUrlStarted
+      const secondRefresh = refreshSkillset(ref)
+      releaseSetUrl()
+
+      await expect(Promise.all([firstRefresh, secondRefresh])).resolves.toEqual([index, index])
+      expect(setUrlCalls).toBe(1)
+
+      await expect(refreshSkillset(ref)).resolves.toEqual(index)
+      expect(setUrlCalls).toBe(2)
     })
 
     it('gitPull swallows expected drift errors from fetch+reset without throwing', async () => {

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -56,6 +56,8 @@ const GIT_ENV = {
   LANG: 'C',
 }
 
+const activeSkillsetRefreshes = new Map<string, Promise<SkillsetIndex>>()
+
 // ============================================================================
 // Path Helpers
 // ============================================================================
@@ -669,6 +671,25 @@ export async function refreshSkillset(ref: SkillsetRef): Promise<SkillsetIndex> 
   const hostingProvider = getSkillsetProvider(ref.provider)
   const repoDir = getSkillsetRepoDir(hostingProvider.getEffectiveRepoId(ref))
 
+  const inFlight = activeSkillsetRefreshes.get(repoDir)
+  if (inFlight) return inFlight
+
+  const refresh = refreshSkillsetCache(ref, hostingProvider, repoDir)
+  activeSkillsetRefreshes.set(repoDir, refresh)
+  try {
+    return await refresh
+  } finally {
+    if (activeSkillsetRefreshes.get(repoDir) === refresh) {
+      activeSkillsetRefreshes.delete(repoDir)
+    }
+  }
+}
+
+async function refreshSkillsetCache(
+  ref: SkillsetRef,
+  hostingProvider: ReturnType<typeof getSkillsetProvider>,
+  repoDir: string,
+): Promise<SkillsetIndex> {
   if (!hostingProvider.usesGitCache) {
     await hostingProvider.refreshCache(repoDir, ref)
     return readIndexJson(repoDir)


### PR DESCRIPTION
## Summary
- Raise the main web E2E worker default and CI worker setting from 2 to 4.
- Harden fragile UI setup paths by using API-created agents and direct agent navigation where appropriate.
- Coalesce concurrent skillset refreshes for the same local cache directory to avoid git lock collisions under higher parallelism.
- Add coverage for concurrent skillset refresh coalescing and make session send-button clicks resilient to remounts.

## Validation
- npm run test:run -- src/shared/lib/services/skillset-service.test.ts
- Targeted skill export/import at PLAYWRIGHT_WORKERS=4
- Targeted navigation overlay at PLAYWRIGHT_WORKERS=4
- Targeted connected-accounts + cross-session at PLAYWRIGHT_WORKERS=4
- Full main E2E workers=4 run 1: 200 passed, 21 skipped, 3.9m
- Full main E2E workers=4 run 2: 200 passed, 21 skipped, 3.9m
- Full main E2E workers=4 run 3: 200 passed, 21 skipped, 3.8m