### PR TITLE
Harden navigation E2E for parallel runs

### DIFF
--- a/e2e/specs/dashboard-and-tasks.spec.ts
+++ b/e2e/specs/dashboard-and-tasks.spec.ts
@@ -1,7 +1,43 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
+
+async function openAgentHome(page: Page, agentPage: AgentPage, agentName: string) {
+  await agentPage.selectAgent(agentName)
+  await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible({ timeout: 10000 })
+  await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agentName, { timeout: 10000 })
+}
+
+function getDailyIssueSummaryTaskRow(appPage: AppPage) {
+  return appPage
+    .getMainContent()
+    .getByRole('button')
+    .filter({ hasText: 'Daily Issue Summary' })
+    .filter({ hasText: /cron/i })
+    .first()
+}
+
+function getCurrentAgentSlug(page: Page) {
+  const match = page.url().match(/\/agents\/([^/?#]+)/)
+  expect(match).toBeTruthy()
+  return match![1]
+}
+
+async function waitForDailyIssueSummaryTask(request: APIRequestContext, agentSlug: string) {
+  let task: { id: string; name?: string } | undefined
+
+  await expect.poll(async () => {
+    const response = await request.get(`/api/agents/${agentSlug}/scheduled-tasks`)
+    if (!response.ok()) return false
+
+    const tasks = await response.json() as Array<{ id: string; name?: string }>
+    task = tasks.find((candidate) => candidate.name === 'Daily Issue Summary')
+    return Boolean(task)
+  }, { timeout: 20000 }).toBe(true)
+
+  return task!
+}
 
 test.describe('Dashboard & Scheduled Task Tool Rendering', () => {
   let appPage: AppPage
@@ -17,7 +53,7 @@ test.describe('Dashboard & Scheduled Task Tool Rendering', () => {
     await appPage.waitForAgentsLoaded()
   })
 
-  test('schedule task tool renders with cron and task details', async ({ page }) => {
+  test('schedule task tool renders with cron and task details', async () => {
     const agentName = `Schedule Agent ${Date.now()}`
     await agentPage.createAgent(agentName)
 
@@ -34,7 +70,7 @@ test.describe('Dashboard & Scheduled Task Tool Rendering', () => {
     await expect(toolCall).toContainText('Daily Issue Summary')
   })
 
-  test('schedule task tool call can be expanded', async ({ page }) => {
+  test('schedule task tool call can be expanded', async () => {
     const agentName = `Schedule Expand ${Date.now()}`
     await agentPage.createAgent(agentName)
 
@@ -54,41 +90,44 @@ test.describe('Dashboard & Scheduled Task Tool Rendering', () => {
     await expect(toolCall).toContainText('America/New York')
   })
 
-  test('scheduled task is created in the database and appears on agent home', async ({ page: _page }) => {
+  test('scheduled task is created in the database and appears on agent home', async ({ page, request }) => {
     const agentName = `Schedule DB ${Date.now()}`
     await agentPage.createAgent(agentName)
+    const agentSlug = getCurrentAgentSlug(page)
 
     await sessionPage.sendMessage('schedule task for daily issues')
     await sessionPage.waitForResponse(15000)
 
     // Wait for the tool call to complete
     await sessionPage.expectToolCall('mcp__user-input__schedule_task', 15000)
+    await waitForDailyIssueSummaryTask(request, agentSlug)
 
     // Scheduled tasks live on the agent home page (under the "Triggers"
-    // section), not in the sidebar. Click the agent row to clear the session
-    // selection and land on AgentHome.
-    await agentPage.selectAgent(agentName)
+    // section), not in the session transcript. Use the canonical sidebar link
+    // so we do not land on the stale pre-rename slug.
+    await openAgentHome(page, agentPage, agentName)
 
     const main = appPage.getMainContent()
     // Role-scoped: the section's empty state ("No triggers yet" / "Triggers
     // fire your agent…") also contains the word "Triggers", and bare
     // getByText trips strict mode while the task is still being created.
     await expect(main.getByRole('button', { name: 'Triggers' })).toBeVisible({ timeout: 5000 })
-    await expect(main.getByText('Daily Issue Summary')).toBeVisible({ timeout: 10000 })
+    await expect(getDailyIssueSummaryTaskRow(appPage)).toBeVisible({ timeout: 10000 })
   })
 
-  test('opening a scheduled task navigates to its own route and back returns home', async ({ page }) => {
+  test('opening a scheduled task navigates to its own route and back returns home', async ({ page, request }) => {
     const agentName = `Task Route ${Date.now()}`
     await agentPage.createAgent(agentName)
+    const agentSlug = getCurrentAgentSlug(page)
 
     await sessionPage.sendMessage('schedule task for daily issues')
     await sessionPage.waitForResponse(15000)
     await sessionPage.expectToolCall('mcp__user-input__schedule_task', 15000)
+    await waitForDailyIssueSummaryTask(request, agentSlug)
 
     // Land on agent home where the task lives under "Triggers"
-    await agentPage.selectAgent(agentName)
-    const main = appPage.getMainContent()
-    const taskRow = main.getByText('Daily Issue Summary')
+    await openAgentHome(page, agentPage, agentName)
+    const taskRow = getDailyIssueSummaryTaskRow(appPage)
     await expect(taskRow).toBeVisible({ timeout: 10000 })
 
     // Open the task → it has its own URL route
@@ -107,19 +146,21 @@ test.describe('Dashboard & Scheduled Task Tool Rendering', () => {
     await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
   })
 
-  test('a cross-agent task deep-link canonicalizes to the task\'s true agent (P1-b)', async ({ page }) => {
+  test('a cross-agent task deep-link canonicalizes to the task\'s true agent (P1-b)', async ({ page, request }) => {
     // Tasks are addressed globally by id, so /agents/<other>/tasks/<id> would
     // otherwise render the task under the WRONG agent's shell (mismatched chrome,
     // back-links, permission gating). The view redirects to the task's true agent.
     const ownerName = `Task Owner ${Date.now()}`
     await agentPage.createAgent(ownerName)
+    const ownerApiSlug = getCurrentAgentSlug(page)
     await sessionPage.sendMessage('schedule task for daily issues')
     await sessionPage.waitForResponse(15000)
     await sessionPage.expectToolCall('mcp__user-input__schedule_task', 15000)
+    await waitForDailyIssueSummaryTask(request, ownerApiSlug)
 
     // Open the task to capture its id + the owner's slug from the URL.
-    await agentPage.selectAgent(ownerName)
-    const taskRow = appPage.getMainContent().getByText('Daily Issue Summary')
+    await openAgentHome(page, agentPage, ownerName)
+    const taskRow = getDailyIssueSummaryTaskRow(appPage)
     await expect(taskRow).toBeVisible({ timeout: 10000 })
     await taskRow.click()
     await expect(page).toHaveURL(/\/tasks\/[^/]+$/)

--- a/e2e/specs/navigation.spec.ts
+++ b/e2e/specs/navigation.spec.ts
@@ -1,601 +1,557 @@
 /**
- * Navigation invariants — exercises the discriminated-union AgentView model
- * (SUP-161). Verifies that switching between every kind of agent view (home,
- * session, connections, API logs, dashboard, scheduled task) leaves exactly
- * one view active and never flickers two views at once.
+ * Navigation invariants - exercises the discriminated-union AgentView model
+ * (SUP-161). Verifies that switching between every kind of agent view leaves
+ * exactly one view active and that durable routes restore from the URL.
  *
- * The old parallel-boolean model produced "two views true at once" bugs when
- * a new selector forgot to clear an existing field. The discriminated union
- * makes that impossible by construction, but it's worth pinning the behavior
- * end-to-end so any regression in the consumer wiring (sidebar highlights,
- * breadcrumb crumbs, render switch) is caught.
+ * Keep at least one test for each user-facing navigation flow as a real UI
+ * click path. API setup is used only to create independent, deterministic
+ * state for route/durability cases where creation itself is not under test.
  */
-import { test, expect } from '@playwright/test'
+import { test, expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
-import { createAgent as createAgentViaApi } from '../helpers/agents'
+import {
+  createAgent as createAgentViaApi,
+  createSession,
+  gotoAgentHome,
+  openAgentSession,
+  type TestAgent,
+  type TestSession,
+} from '../helpers/agents'
 
-// Serial: each test creates and deletes one agent — overlapping creates
-// in mock mode share state on the server side and can flake.
-test.describe.configure({ mode: 'serial' })
+interface TestConnectedAccount {
+  id: string
+  name: string
+}
 
-test.describe('Navigation — discriminated AgentView', () => {
+function uniqueSuffix(testInfo: TestInfo) {
+  return [
+    testInfo.workerIndex,
+    testInfo.repeatEachIndex,
+    testInfo.retry,
+    Date.now(),
+    Math.random().toString(36).slice(2, 8),
+  ].join('-')
+}
+
+function uniqueName(testInfo: TestInfo, label: string) {
+  return `${label} ${uniqueSuffix(testInfo)}`
+}
+
+function collectPageErrors(page: Page) {
+  const errors: string[] = []
+  page.on('pageerror', (error) => errors.push(error.message))
+  return errors
+}
+
+async function createNavAgent(
+  request: APIRequestContext,
+  testInfo: TestInfo,
+  label: string,
+) {
+  return createAgentViaApi(request, uniqueName(testInfo, label))
+}
+
+async function findAgentByName(
+  request: APIRequestContext,
+  name: string,
+): Promise<TestAgent> {
+  let found: TestAgent | undefined
+
+  await expect.poll(async () => {
+    const response = await request.get('/api/agents')
+    if (!response.ok()) return false
+
+    const agents = await response.json() as TestAgent[]
+    found = agents.find((agent) => agent.name === name)
+    return Boolean(found)
+  }, { timeout: 15000 }).toBe(true)
+
+  return found!
+}
+
+function cleanupAgents(_request: APIRequestContext, _agents: Array<TestAgent | undefined>) {
+  // Intentionally defer cleanup to the next setup-e2e-data run. This spec runs
+  // fully parallel against a file-backed agent store; deleting agents mid-run
+  // can race sibling tests that are listing agents and scanning session files.
+}
+
+async function expectGlobalHome(page: Page) {
+  await expect(page).toHaveURL(/\/$/)
+  await expect(page.locator('[data-testid="home-button"]')).toHaveAttribute('data-active', 'true')
+  await expect(page.locator('[data-testid="agent-breadcrumb"]')).not.toBeVisible()
+}
+
+async function expectAgentHome(page: Page, agent?: Pick<TestAgent, 'name'>) {
+  if (agent) {
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name, { timeout: 15000 })
+  } else {
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toBeVisible({ timeout: 15000 })
+  }
+  await expect(page).toHaveURL(/\/agents\/[^/]+$/)
+  await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible({ timeout: 15000 })
+  await expect(page.locator('[data-testid="message-list"]')).not.toBeVisible()
+}
+
+async function expectSessionView(page: Page, session?: Pick<TestSession, 'id'>) {
+  if (session) {
+    await expect(page).toHaveURL(new RegExp(`/sessions/${session.id}$`))
+  } else {
+    await expect(page).toHaveURL(/\/sessions\/[^/]+$/)
+  }
+  await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
+  await expect(page.locator('[data-testid="agent-breadcrumb"]')).toBeVisible({ timeout: 15000 })
+}
+
+test.describe('Navigation - discriminated AgentView', () => {
   let appPage: AppPage
   let agentPage: AgentPage
   let sessionPage: SessionPage
-
-  // Seeded once for the connections-detail deep-link tests below. The global
-  // /api/connected-accounts list is agent-independent, so a freshly-created
-  // agent still surfaces this row in its connections list (just not granted).
-  let accountId: string
+  let connectionAccount: TestConnectedAccount
 
   test.beforeAll(async ({ request }) => {
-    // Unique per run so a retry (which re-runs beforeAll in a new worker) does
-    // not collide with the previously-seeded row on the unique connectionId.
-    const providerConnectionId = `e2e-nav-conn-detail-${Date.now()}`
+    // Each worker gets an account, because fullyParallel runs beforeAll per
+    // worker. The account list is global, but tests target their worker's id.
+    const unique = [
+      process.pid,
+      Date.now(),
+      Math.random().toString(36).slice(2, 8),
+    ].join('-')
+    const displayName = `E2E Nav Detail ${unique}`
     const res = await request.post('/api/connected-accounts', {
       data: {
-        providerConnectionId,
+        providerConnectionId: `e2e-nav-conn-detail-${unique}`,
         toolkitSlug: 'slack',
-        displayName: 'E2E Nav Detail Account',
+        displayName,
       },
     })
+    expect(res.ok()).toBe(true)
     const body = await res.json()
-    accountId = body.account.id
+    connectionAccount = { id: body.account.id as string, name: displayName }
   })
 
   test.beforeEach(async ({ page }) => {
     appPage = new AppPage(page)
     agentPage = new AgentPage(page)
     sessionPage = new SessionPage(page)
+  })
+
+  async function loadApp() {
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
-  })
-
-  test('Home → Agent → Home returns to global home (no agent breadcrumb)', async ({ page }) => {
-    const agentName = `Nav Home ${Date.now()}`
-    await agentPage.createAgent(agentName)
-    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toBeVisible()
-    await expect(page).toHaveURL(/\/agents\/[^/]+$/)
-
-    // Go back to global Home — should not render the agent breadcrumb anymore
-    await page.locator('[data-testid="home-button"]').click()
-    await expect(page.locator('[data-testid="agent-breadcrumb"]')).not.toBeVisible()
-    await expect(page).toHaveURL(/\/$/)
-
-    // Cleanup
-    await agentPage.selectAgent(agentName)
-    await agentPage.deleteAgent()
-  })
-
-  test('Agent → API Logs → back returns to agent home (and not to a session)', async ({ page }) => {
-    const agentName = `Nav APILogs ${Date.now()}`
-    await agentPage.createAgent(agentName)
-
-    // Open API Logs from agent-home extras
-    await page.getByTestId('home-api-logs-open-page').click()
-    await expect(page).toHaveURL(/\/api-logs$/)
-    await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
-
-    // Back → agent home (large composer visible, no message-list)
-    await page.locator('[data-testid="api-logs-back-button"]').click()
-    await expect(page).toHaveURL(/\/agents\/[^/]+$/)
-    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
-    await expect(page.locator('[data-testid="message-list"]')).not.toBeVisible()
-
-    // Cleanup
-    await agentPage.deleteAgent()
-  })
-
-  test('Agent → Connections → back returns to agent home', async ({ page }) => {
-    const agentName = `Nav Conn ${Date.now()}`
-    await agentPage.createAgent(agentName)
-
-    // The "Manage Connections"/"Add Connection" button on agent home opens connections view
-    const manageBtn = page.locator('[data-testid="home-connections-open-page"]')
-    await expect(manageBtn).toBeVisible()
-    await manageBtn.click()
-
-    await expect(page).toHaveURL(/\/connections$/)
-    await expect(page.locator('[data-testid="connections-back-button"]')).toBeVisible()
-
-    // Back → agent home
-    await page.locator('[data-testid="connections-back-button"]').click()
-    await expect(page).toHaveURL(/\/agents\/[^/]+$/)
-    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
-
-    // Cleanup
-    await agentPage.deleteAgent()
-  })
-
-  test('API Logs → Connections → API Logs: only one view at a time', async ({ page }) => {
-    // Mutual exclusion: you should never see two end-views simultaneously.
-    const agentName = `Nav Mutex ${Date.now()}`
-    await agentPage.createAgent(agentName)
-
-    // Open API Logs — the URL itself enforces mutual exclusion (one leaf path).
-    await page.getByTestId('home-api-logs-open-page').click()
-    await expect(page).toHaveURL(/\/api-logs$/)
-    await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
-
-    // Switch to Connections via the sidebar's agent-home (back first, then connections)
-    await page.locator('[data-testid="api-logs-back-button"]').click()
-    await page.locator('[data-testid="home-connections-open-page"]').click()
-    await expect(page).toHaveURL(/\/connections$/)
-    await expect(page.locator('[data-testid="connections-back-button"]')).toBeVisible()
-    // API Logs back-button must not be present at the same time
-    await expect(page.locator('[data-testid="api-logs-back-button"]')).not.toBeVisible()
-
-    // Switch back to API Logs
-    await page.locator('[data-testid="connections-back-button"]').click()
-    await page.getByTestId('home-api-logs-open-page').click()
-    await expect(page).toHaveURL(/\/api-logs$/)
-    await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
-    await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
-
-    // Cleanup
-    await page.locator('[data-testid="api-logs-back-button"]').click()
-    await agentPage.deleteAgent()
-  })
-
-  test('Browser back/forward walks agent sub-view transitions in lockstep with the URL', async ({ page }) => {
-    // Each sub-view nav is a real history PUSH, so the browser back/forward
-    // buttons replay them in order. A navigate() that mistakenly used
-    // `replace: true`, or a sub-view that double-pushed, would break this
-    // silently while every forward-nav test still passed — so this is the only
-    // e2e that drives page.goBack()/goForward().
-    const errors: string[] = []
-    page.on('pageerror', (e) => errors.push(e.message))
-
-    const agentName = `Nav BackFwd ${Date.now()}`
-    await agentPage.createAgent(agentName)
-    // createAgent lands on agent-home (this is history entry [0] for our walk).
-    await expect(page).toHaveURL(/\/agents\/[^/]+$/)
-    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
-
-    // [1] Push API Logs.
-    await page.getByTestId('home-api-logs-open-page').click()
-    await expect(page).toHaveURL(/\/api-logs$/)
-    await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
-
-    // Back to agent-home via the in-app back button (this is its own push of the
-    // home route, NOT a history pop) so the subsequent Connections push sits
-    // after a clean home entry.
-    await page.locator('[data-testid="api-logs-back-button"]').click()
-    await expect(page).toHaveURL(/\/agents\/[^/]+$/)
-    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
-
-    // [2] Push Connections.
-    await page.locator('[data-testid="home-connections-open-page"]').click()
-    await expect(page).toHaveURL(/\/connections$/)
-    await expect(page.locator('[data-testid="connections-back-button"]')).toBeVisible()
-    // Mutual exclusion: only the Connections back-button is present.
-    await expect(page.locator('[data-testid="api-logs-back-button"]')).not.toBeVisible()
-
-    // ── Walk backward through the pushed history ──────────────────────────────
-
-    // goBack → the home entry pushed by the API-Logs back-button.
-    await page.goBack()
-    await expect(page).toHaveURL(/\/agents\/[^/]+$/)
-    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
-    await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
-    await expect(page.locator('[data-testid="api-logs-back-button"]')).not.toBeVisible()
-
-    // goBack → API Logs.
-    await page.goBack()
-    await expect(page).toHaveURL(/\/api-logs$/)
-    await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
-    await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
-
-    // goBack → agent home (the original entry from createAgent).
-    await page.goBack()
-    await expect(page).toHaveURL(/\/agents\/[^/]+$/)
-    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
-    await expect(page.locator('[data-testid="api-logs-back-button"]')).not.toBeVisible()
-    await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
-
-    // ── Walk forward, replaying the same stops ────────────────────────────────
-
-    // goForward → API Logs.
-    await page.goForward()
-    await expect(page).toHaveURL(/\/api-logs$/)
-    await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
-    await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
-
-    // goForward → the home entry, then goForward → Connections.
-    await page.goForward()
-    await expect(page).toHaveURL(/\/agents\/[^/]+$/)
-    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
-
-    await page.goForward()
-    await expect(page).toHaveURL(/\/connections$/)
-    await expect(page.locator('[data-testid="connections-back-button"]')).toBeVisible()
-    await expect(page.locator('[data-testid="api-logs-back-button"]')).not.toBeVisible()
-
-    // No uncaught render errors anywhere across the whole back/forward walk.
-    expect(errors).toEqual([])
-
-    // Cleanup — return to agent-home (where agent-settings-button lives) before
-    // deleting. We're on Connections, so use its in-app back button.
-    await page.locator('[data-testid="connections-back-button"]').click()
-    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
-    await agentPage.deleteAgent()
-  })
-
-  test('Switching agents resets view to that agent\'s home', async ({ page }) => {
-    // The view is per-(agent + view) — when the user switches agents while
-    // looking at API Logs of agent A, they should land on agent B's home, not
-    // see B's API Logs.
-    const a = `Nav SwitchA ${Date.now()}`
-    const b = `Nav SwitchB ${Date.now()}`
-    await agentPage.createAgent(a)
-    await agentPage.createAgent(b)
-
-    // On agent B, open API Logs
-    await agentPage.selectAgent(b)
-    await page.getByTestId('home-api-logs-open-page').click()
-    await expect(page).toHaveURL(/\/api-logs$/)
-    await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
-
-    // Switch to agent A — should land on A's home, not on API Logs
-    await agentPage.selectAgent(a)
-    await expect(page).toHaveURL(/\/agents\/[^/]+$/)
-    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
-    await expect(page.locator('[data-testid="api-logs-back-button"]')).not.toBeVisible()
-
-    // Cleanup
-    await agentPage.deleteAgent()
-    await agentPage.selectAgent(b)
-    await agentPage.deleteAgent()
-  })
-
-  test('Session → agent breadcrumb returns to agent home', async ({ page }) => {
-    const agentName = `Nav Crumb ${Date.now()}`
-    await agentPage.createAgent(agentName)
-
-    // The createAgent flow creates a session, navigates to it, then goes back
-    // to agent-home. Send a message to make sure we have a session row in the
-    // sidebar.
-    await sessionPage.sendMessage('hi')
-    await sessionPage.waitForResponse(15000)
-    await expect(page).toHaveURL(/\/sessions\/[^/]+$/)
-
-    // Click the agent breadcrumb → should return to agent home
-    await page.locator('[data-testid="agent-breadcrumb"]').click()
-    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
-    await expect(page.locator('[data-testid="message-list"]')).not.toBeVisible()
-    await expect(page).toHaveURL(/\/agents\/[^/]+$/)
-
-    // Cleanup
-    await agentPage.deleteAgent()
-  })
-
-  test('Session is a durable URL route — a hard reload restores it', async ({ page }) => {
-    const agentName = `Nav Session Reload ${Date.now()}`
-    await agentPage.createAgent(agentName)
-
-    // Send from agent-home → creates a session and navigates to its OWN route.
-    await sessionPage.sendMessage('hello session route')
-    await expect(page).toHaveURL(/\/sessions\/[^/]+$/)
-    await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
-
-    // Reload — the router restores the session straight from the path, no Selection.
-    await appPage.reload()
-    await expect(page).toHaveURL(/\/sessions\/[^/]+$/)
-    await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
-    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toBeVisible()
-
-    // Cleanup
-    await page.locator('[data-testid="agent-breadcrumb"]').click()
-    await agentPage.deleteAgent()
-  })
-
-  test('Cold reload restores the Selection-driven session sub-crumb', async ({ page }) => {
-    // On the INITIAL mount the URL→Selection bridge rehydrates `view` from the
-    // path. The header crumbs are Selection-driven (which crumb shows reads
-    // `view`), so without that rehydration the session-name crumb goes MISSING
-    // on a cold reload (view snaps to the `home` default) even though the
-    // message list — which is route-driven — still renders. This pins the crumb.
-    const agentName = `Nav Crumb Restore ${Date.now()}`
-    await agentPage.createAgent(agentName)
-
-    await sessionPage.sendMessage('restore my crumb')
-    await expect(page).toHaveURL(/\/sessions\/[^/]+$/)
-    await expect(page.locator('[data-testid="session-breadcrumb"]')).toBeVisible({ timeout: 15000 })
-
-    // Hard reload — the bridge restores view.kind='session' from the URL, so the
-    // Selection-driven session crumb comes back (not just the route-driven body).
-    await appPage.reload()
-    await expect(page).toHaveURL(/\/sessions\/[^/]+$/)
-    await expect(page.locator('[data-testid="session-breadcrumb"]')).toBeVisible({ timeout: 15000 })
-
-    // Cleanup
-    await page.locator('[data-testid="agent-breadcrumb"]').click()
-    await agentPage.deleteAgent()
-  })
-
-  test('Session survives a sibling round-trip with the agent shell mounted', async ({ page }) => {
-    // Leaving the session leaf for a sibling (agent home) and returning must NOT
-    // unmount AgentShell — it anchors the chat/SSE stream and the optimistic
-    // pendingMessagesRef. The session re-renders its persisted messages on
-    // return with no page crash.
-    const errors: string[] = []
-    page.on('pageerror', (e) => errors.push(e.message))
-
-    const agentName = `Nav Session Survive ${Date.now()}`
-    await agentPage.createAgent(agentName)
-
-    await sessionPage.sendMessage('survive me')
-    await expect(page).toHaveURL(/\/sessions\/[^/]+$/)
-    await sessionPage.waitForResponse(15000)
-    await sessionPage.expectUserMessage('survive me')
-
-    // Leave for the agent-home sibling leaf…
-    await page.locator('[data-testid="agent-breadcrumb"]').click()
-    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
-    await expect(page).toHaveURL(/\/agents\/[^/]+$/)
-
-    // …then return to the same session via the sidebar.
-    await agentPage.expandAgent(agentName)
-    await sessionPage.selectFirstSessionInSidebar(agentPage.getAgentLi(agentName))
-    await expect(page).toHaveURL(/\/sessions\/[^/]+$/)
-    await sessionPage.expectUserMessage('survive me')
-    expect(errors).toEqual([])
-
-    // Cleanup
-    await page.locator('[data-testid="agent-breadcrumb"]').click()
-    await agentPage.deleteAgent()
-  })
-
-  test('Page reload retains the deep-linked sub-view (URL is the source of truth)', async ({ page }) => {
-    // Every agent sub-view is its own route, so a hard reload restores it from
-    // the path.
-    const agentName = `Nav Reload ${Date.now()}`
-    await agentPage.createAgent(agentName)
-
-    // Navigate into API Logs (durable in the URL)
-    await page.getByTestId('home-api-logs-open-page').click()
-    await expect(page).toHaveURL(/\/api-logs$/)
-    await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
-
-    // Reload — the URL is durable, so API Logs is restored, not reset to home.
-    await appPage.reload()
-    await expect(page).toHaveURL(/\/api-logs$/)
-    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toBeVisible()
-    await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
-
-    // Cleanup
-    await agentPage.selectAgent(agentName)
-    await agentPage.deleteAgent()
-  })
-
-  test('Dashboard leaf route resolves on a cold deep-link without crashing', async ({ page }) => {
-    // Mock mode has no real dashboards (artifacts=[]), so we can't click a card —
-    // but we can verify the dashboard leaf route resolves into the shared agent
-    // shell and renders DashboardView's fallback without a page crash.
-    const errors: string[] = []
-    page.on('pageerror', (e) => errors.push(e.message))
-
-    const agentName = `Nav Dash ${Date.now()}`
-    await agentPage.createAgent(agentName)
-    const slug = page.url().match(/\/agents\/([^/?#]+)/)?.[1]
-    expect(slug).toBeTruthy()
-
-    await page.goto(`/agents/${slug}/dashboards/sample-dashboard`)
-    await expect(page).toHaveURL(/\/dashboards\/sample-dashboard$/)
-    // The shared agent header rendered → the route matched AgentShell, no crash.
-    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toBeVisible()
-    expect(errors).toEqual([])
-
-    // Cleanup
-    await agentPage.selectAgent(agentName)
-    await agentPage.deleteAgent()
-  })
-
-  test('Chat leaf route resolves on a cold deep-link with ?session= search', async ({ page }) => {
-    // Mock mode has no chat integrations, so we can't click one — but we can
-    // verify the chat leaf route (path param + ?session= search) resolves into
-    // the shared agent shell and renders its fallback without a page crash.
-    const errors: string[] = []
-    page.on('pageerror', (e) => errors.push(e.message))
-
-    const agentName = `Nav Chat ${Date.now()}`
-    await agentPage.createAgent(agentName)
-    const slug = page.url().match(/\/agents\/([^/?#]+)/)?.[1]
-    expect(slug).toBeTruthy()
-
-    await page.goto(`/agents/${slug}/chat/sample-integration?session=sample-session`)
-    await expect(page).toHaveURL(/\/chat\/sample-integration\?session=sample-session$/)
-    // The shared agent header rendered → the route matched AgentShell, no crash.
-    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toBeVisible()
-    expect(errors).toEqual([])
-
-    // Cleanup
-    await agentPage.selectAgent(agentName)
-    await agentPage.deleteAgent()
-  })
-
-  test('Sidebar highlights the agent on a cold reload (route-driven active)', async ({ page }) => {
-    // The sidebar active state is route-derived (useParams/pathname), so it
-    // reflects the URL immediately on a hard reload — it never depended on the
-    // Selection bridge.
-    const agentName = `Nav Sidebar Active ${Date.now()}`
-    await agentPage.createAgent(agentName)
-    const slug = page.url().match(/\/agents\/([^/?#]+)/)?.[1]
-    expect(slug).toBeTruthy()
-
-    await appPage.reload()
-    await expect(page).toHaveURL(/\/agents\/[^/]+$/)
-    // The sidebar row testid keys on the agent's stable id, while the URL carries
-    // the display slug — match by the (unique, timestamped) name instead.
-    await expect(page.locator('[data-testid^="agent-item-"]', { hasText: agentName })).toHaveAttribute('data-active', 'true')
-    await expect(page.locator('[data-testid="home-button"]')).toHaveAttribute('data-active', 'false')
-
-    // Cleanup
-    await agentPage.deleteAgent()
-  })
-
-  test('Notifications route lights up only the Notifications nav item', async ({ page }) => {
-    const agentName = `Nav Notif Active ${Date.now()}`
-    await agentPage.createAgent(agentName)
-
-    await page.locator('[data-testid="notifications-button"]').click()
-    await expect(page).toHaveURL(/\/notifications$/)
-    await expect(page.locator('[data-testid="notifications-button"]')).toHaveAttribute('data-active', 'true')
-    await expect(page.locator('[data-testid="home-button"]')).toHaveAttribute('data-active', 'false')
-    await expect(page.locator('[data-testid^="agent-item-"]', { hasText: agentName })).toHaveAttribute('data-active', 'false')
-
-    // Cleanup
-    await agentPage.selectAgent(agentName)
-    await agentPage.deleteAgent()
-  })
-
-  test('Notifications is a durable top-level route — survives a hard reload', async ({ page }) => {
-    // /notifications is its own top-level route, and all entry points (sidebar,
-    // OS/tray) navigate to it. A hard reload restores the notifications page
-    // straight from the URL, and the back button still navigates out (to global
-    // home — no agent scope after a cold reload, since /notifications carries no
-    // slug).
-    const agentName = `Nav Notif Reload ${Date.now()}`
-    await agentPage.createAgent(agentName)
-
-    await page.locator('[data-testid="notifications-button"]').click()
-    await expect(page).toHaveURL(/\/notifications$/)
-    await expect(page.locator('[data-testid="notifications-back-button"]')).toBeVisible()
-
-    await appPage.reload()
-    await expect(page).toHaveURL(/\/notifications$/)
-    await expect(page.locator('[data-testid="notifications-back-button"]')).toBeVisible()
-
-    // Back leaves the notifications route.
-    await page.locator('[data-testid="notifications-back-button"]').click()
-    await expect(page).not.toHaveURL(/\/notifications/)
-
-    // Cleanup
-    await agentPage.selectAgent(agentName)
-    await agentPage.deleteAgent()
-  })
-
-  test('Deep-linking an unknown agent shows the ambiguous not-found screen', async ({ page }) => {
-    // The agent loader maps 404 (unknown) — and, in auth mode, 403 (forbidden) —
-    // to ONE ambiguous not-found screen (anti-enumeration). Mock mode returns
-    // 404 for an unknown slug, so this exercises the 404 → notFound path.
-    const errors: string[] = []
-    page.on('pageerror', (e) => errors.push(e.message))
-
-    await page.goto('/agents/does-not-exist-r15')
-    await expect(page).toHaveURL(/\/agents\/does-not-exist-r15$/)
-    await expect(page.locator('[data-testid="agent-not-found"]')).toBeVisible()
-    // The persistent app shell (sidebar) stays mounted around the fallback.
-    await expect(page.locator('[data-testid="home-button"]')).toBeVisible()
-    expect(errors).toEqual([])
-  })
-
-  test('Home is a durable route — a hard reload stays on global home', async ({ page }) => {
-    // The root route restores from the URL like every other route: a hard reload
-    // on '/' returns to global home, not a blank screen or an error.
-    await appPage.reload()
-    await expect(page).toHaveURL(/\/$/)
-    await expect(page.locator('[data-testid="home-button"]')).toBeVisible()
-    await expect(page.locator('[data-testid="agent-breadcrumb"]')).not.toBeVisible()
-  })
-
-  test('Deep-linking a non-existent session shows the not-found leaf', async ({ page }) => {
-    // A session deep-link within an ACCESSIBLE agent that doesn't exist → the
-    // session leaf shows the ambiguous not-found (guarded so a just-created
-    // session's optimistic ghost never flashes it). The agent shell stays.
-    const errors: string[] = []
-    page.on('pageerror', (e) => errors.push(e.message))
-
-    const agentName = `Nav SessionNF ${Date.now()}`
-    await agentPage.createAgent(agentName)
-    const slug = page.url().match(/\/agents\/([^/?#]+)/)?.[1]
-    expect(slug).toBeTruthy()
-
-    await page.goto(`/agents/${slug}/sessions/does-not-exist-r17`)
-    // The not-found surfaces only after useSession's retries are exhausted (it
-    // doesn't skip 404, to avoid false-firing on a still-settling new session).
-    await expect(page.locator('[data-testid="session-not-found"]')).toBeVisible({ timeout: 15000 })
-    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toBeVisible()
-    expect(errors).toEqual([])
-
-    // Cleanup
-    await agentPage.selectAgent(agentName)
-    await agentPage.deleteAgent()
-  })
-
-  test('Connections detail overlay is deep-linkable and reload-durable; source=list back returns to the list', async ({ page, request }) => {
-    // The detail overlay travels in the URL search (`?detail&source`,
-    // ConnectionsRoute decodes it). A cold deep-link must restore the overlay
-    // (connection-detail-back), hide the bare list back-button, and survive a
-    // hard reload. For source=list, Back returns to the connections list.
-    const errors: string[] = []
-    page.on('pageerror', (e) => errors.push(e.message))
-
-    const agent = await createAgentViaApi(request, `Nav Conn Detail ${Date.now()}`)
-    const slug = agent.slug
+  }
+
+  test('UI: create/select agent and global Home route stay in sync', async ({ page, request }, testInfo) => {
+    const agentName = uniqueName(testInfo, 'Nav Home')
+    let createdAgent: TestAgent | undefined
 
     try {
-      // Cold deep-link straight to the open overlay.
-      await page.goto(`/agents/${slug}/connections?detail=account-${accountId}&source=list`)
+      await loadApp()
 
-      // The URL keeps both search params (param order isn't guaranteed, so assert
-      // each independently).
-      await expect(page).toHaveURL(new RegExp(`/agents/${slug}/connections\\?`))
-      await expect(page).toHaveURL(new RegExp(`detail=account-${accountId}`))
+      // Real UI creation is intentionally covered once in this spec. The rest
+      // of the suite can API-seed agents without losing create/select coverage.
+      await agentPage.createAgent(agentName)
+      createdAgent = await findAgentByName(request, agentName)
+      await expectAgentHome(page, createdAgent)
+      await expect(agentPage.getAgentItem(agentName)).toBeVisible()
+
+      await page.locator('[data-testid="home-button"]').click()
+      await expectGlobalHome(page)
+
+      // Sidebar agent selection is also a real UI navigation flow.
+      await agentPage.selectAgent(agentName)
+      await expectAgentHome(page, createdAgent)
+
+      await page.locator('[data-testid="home-button"]').click()
+      await expectGlobalHome(page)
+    } finally {
+      await cleanupAgents(request, [createdAgent])
+    }
+  })
+
+  test('UI: Agent -> API Logs -> back returns to agent home', async ({ page, request }, testInfo) => {
+    const agent = await createNavAgent(request, testInfo, 'Nav API Logs')
+
+    try {
+      await gotoAgentHome(page, agent)
+
+      await page.getByTestId('home-api-logs-open-page').click()
+      await expect(page).toHaveURL(/\/api-logs$/)
+      await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
+
+      await page.locator('[data-testid="api-logs-back-button"]').click()
+      await expectAgentHome(page, agent)
+    } finally {
+      await cleanupAgents(request, [agent])
+    }
+  })
+
+  test('UI: Agent -> Connections -> detail row -> back returns through list to home', async ({ page, request }, testInfo) => {
+    const agent = await createNavAgent(request, testInfo, 'Nav Connections')
+
+    try {
+      await gotoAgentHome(page, agent)
+
+      await page.locator('[data-testid="home-connections-open-page"]').click()
+      await expect(page).toHaveURL(/\/connections$/)
+      await expect(page.locator('[data-testid="connections-back-button"]')).toBeVisible()
+
+      const row = page.getByRole('button', {
+        name: `Open ${connectionAccount.name} connection details`,
+      })
+      await expect(row).toBeVisible({ timeout: 15000 })
+      await row.click()
+
+      await expect(page).toHaveURL(new RegExp(`detail=account-${connectionAccount.id}`))
       await expect(page).toHaveURL(/source=list/)
-
-      // Overlay renders; the bare connections-list back-button is NOT present
-      // (PageTitle is suppressed while a detail is open).
       await expect(page.locator('[data-testid="connection-detail-back"]')).toBeVisible({ timeout: 15000 })
       await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
 
-      // Reload — the overlay is restored straight from the URL, no Selection.
-      await appPage.reload()
-      await expect(page).toHaveURL(new RegExp(`detail=account-${accountId}`))
-      await expect(page).toHaveURL(/source=list/)
-      await expect(page.locator('[data-testid="connection-detail-back"]')).toBeVisible({ timeout: 15000 })
-      await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
-
-      // source=list → Back returns to the connections list (the bare list
-      // back-button reappears, overlay gone).
       await page.locator('[data-testid="connection-detail-back"]').click()
       await expect(page).toHaveURL(/\/connections$/)
       await expect(page.locator('[data-testid="connections-back-button"]')).toBeVisible()
       await expect(page.locator('[data-testid="connection-detail-back"]')).not.toBeVisible()
 
-      expect(errors).toEqual([])
+      await page.locator('[data-testid="connections-back-button"]').click()
+      await expectAgentHome(page, agent)
     } finally {
-      await request.delete(`/api/agents/${slug}`).catch(() => {})
+      await cleanupAgents(request, [agent])
     }
   })
 
-  test('Connections detail overlay with source=home: Back returns to agent home', async ({ page, request }) => {
-    // The agent-scoped overlay's `source` decides the back-target: source=home
-    // routes Back to agent home, not to the connections list — an invariant that
-    // can silently regress.
-    const errors: string[] = []
-    page.on('pageerror', (e) => errors.push(e.message))
-
-    const agent = await createAgentViaApi(request, `Nav Conn Detail Home ${Date.now()}`)
-    const slug = agent.slug
+  test('UI: API Logs -> Connections -> API Logs leaves only one sub-view active', async ({ page, request }, testInfo) => {
+    const agent = await createNavAgent(request, testInfo, 'Nav Mutex')
 
     try {
-      await page.goto(`/agents/${slug}/connections?detail=account-${accountId}&source=home`)
-      await expect(page).toHaveURL(new RegExp(`detail=account-${accountId}`))
-      await expect(page).toHaveURL(/source=home/)
-      await expect(page.locator('[data-testid="connection-detail-back"]')).toBeVisible({ timeout: 15000 })
+      await gotoAgentHome(page, agent)
 
-      // source=home → Back returns to agent home (large composer visible).
-      await page.locator('[data-testid="connection-detail-back"]').click()
-      await expect(page).toHaveURL(/\/agents\/[^/]+$/)
-      await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
-      await expect(page.locator('[data-testid="connection-detail-back"]')).not.toBeVisible()
+      await page.getByTestId('home-api-logs-open-page').click()
+      await expect(page).toHaveURL(/\/api-logs$/)
+      await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
+
+      await page.locator('[data-testid="api-logs-back-button"]').click()
+      await page.locator('[data-testid="home-connections-open-page"]').click()
+      await expect(page).toHaveURL(/\/connections$/)
+      await expect(page.locator('[data-testid="connections-back-button"]')).toBeVisible()
+      await expect(page.locator('[data-testid="api-logs-back-button"]')).not.toBeVisible()
+
+      await page.locator('[data-testid="connections-back-button"]').click()
+      await page.getByTestId('home-api-logs-open-page').click()
+      await expect(page).toHaveURL(/\/api-logs$/)
+      await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
+      await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
+    } finally {
+      await cleanupAgents(request, [agent])
+    }
+  })
+
+  test('UI: browser back/forward walks agent sub-view transitions with the URL', async ({ page, request }, testInfo) => {
+    const errors = collectPageErrors(page)
+    const agent = await createNavAgent(request, testInfo, 'Nav BackFwd')
+
+    try {
+      await gotoAgentHome(page, agent)
+
+      await page.getByTestId('home-api-logs-open-page').click()
+      await expect(page).toHaveURL(/\/api-logs$/)
+      await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
+
+      // In-app back pushes an agent-home entry before the next leaf route.
+      await page.locator('[data-testid="api-logs-back-button"]').click()
+      await expectAgentHome(page, agent)
+
+      await page.locator('[data-testid="home-connections-open-page"]').click()
+      await expect(page).toHaveURL(/\/connections$/)
+      await expect(page.locator('[data-testid="connections-back-button"]')).toBeVisible()
+      await expect(page.locator('[data-testid="api-logs-back-button"]')).not.toBeVisible()
+
+      await page.goBack()
+      await expectAgentHome(page, agent)
+
+      await page.goBack()
+      await expect(page).toHaveURL(/\/api-logs$/)
+      await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
+      await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
+
+      await page.goBack()
+      await expectAgentHome(page, agent)
+
+      await page.goForward()
+      await expect(page).toHaveURL(/\/api-logs$/)
+      await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
+      await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
+
+      await page.goForward()
+      await expectAgentHome(page, agent)
+
+      await page.goForward()
+      await expect(page).toHaveURL(/\/connections$/)
+      await expect(page.locator('[data-testid="connections-back-button"]')).toBeVisible()
+      await expect(page.locator('[data-testid="api-logs-back-button"]')).not.toBeVisible()
 
       expect(errors).toEqual([])
     } finally {
-      await request.delete(`/api/agents/${slug}`).catch(() => {})
+      await cleanupAgents(request, [agent])
+    }
+  })
+
+  test('UI: switching agents resets the selected agent to home', async ({ page, request }, testInfo) => {
+    const agentA = await createNavAgent(request, testInfo, 'Nav Switch A')
+    const agentB = await createNavAgent(request, testInfo, 'Nav Switch B')
+
+    try {
+      await loadApp()
+
+      await agentPage.selectAgent(agentB.name)
+      await expectAgentHome(page, agentB)
+      await page.getByTestId('home-api-logs-open-page').click()
+      await expect(page).toHaveURL(/\/api-logs$/)
+      await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
+
+      await agentPage.selectAgent(agentA.name)
+      await expectAgentHome(page, agentA)
+      await expect(page.locator('[data-testid="api-logs-back-button"]')).not.toBeVisible()
+    } finally {
+      await cleanupAgents(request, [agentA, agentB])
+    }
+  })
+
+  test('UI: session breadcrumb returns to agent home', async ({ page, request }, testInfo) => {
+    const agent = await createNavAgent(request, testInfo, 'Nav Crumb')
+    const session = await createSession(request, agent, 'breadcrumb route')
+
+    try {
+      await page.goto(`/agents/${agent.slug}/sessions/${session.id}`)
+      await expectSessionView(page, session)
+
+      await page.locator('[data-testid="agent-breadcrumb"]').click()
+      await expectAgentHome(page, agent)
+    } finally {
+      await cleanupAgents(request, [agent])
+    }
+  })
+
+  test('Session URL route survives a hard reload', async ({ page, request }, testInfo) => {
+    const agent = await createNavAgent(request, testInfo, 'Nav Session Reload')
+    const session = await createSession(request, agent, 'hello session route')
+
+    try {
+      await page.goto(`/agents/${agent.slug}/sessions/${session.id}`)
+      await expectSessionView(page, session)
+
+      await appPage.reload()
+      await expectSessionView(page, session)
+    } finally {
+      await cleanupAgents(request, [agent])
+    }
+  })
+
+  test('Cold reload restores the Selection-driven session sub-crumb', async ({ page, request }, testInfo) => {
+    const agent = await createNavAgent(request, testInfo, 'Nav Crumb Restore')
+    const session = await createSession(request, agent, 'restore my crumb')
+
+    try {
+      await page.goto(`/agents/${agent.slug}/sessions/${session.id}`)
+      await expectSessionView(page, session)
+      await expect(page.locator('[data-testid="session-breadcrumb"]')).toBeVisible({ timeout: 15000 })
+
+      await appPage.reload()
+      await expectSessionView(page, session)
+      await expect(page.locator('[data-testid="session-breadcrumb"]')).toBeVisible({ timeout: 15000 })
+    } finally {
+      await cleanupAgents(request, [agent])
+    }
+  })
+
+  test('UI: session survives a sibling round-trip with the agent shell mounted', async ({ page, request }, testInfo) => {
+    const errors = collectPageErrors(page)
+    const agent = await createNavAgent(request, testInfo, 'Nav Session Survive')
+    const session = await createSession(request, agent, 'survive me')
+
+    try {
+      await loadApp()
+      await openAgentSession(page, agent, session)
+      await sessionPage.expectUserMessage('survive me')
+
+      await page.locator('[data-testid="agent-breadcrumb"]').click()
+      await expectAgentHome(page, agent)
+
+      await agentPage.expandAgent(agent.name)
+      await sessionPage.selectFirstSessionInSidebar(agentPage.getAgentLi(agent.name))
+      await expectSessionView(page, session)
+      await sessionPage.expectUserMessage('survive me')
+      expect(errors).toEqual([])
+    } finally {
+      await cleanupAgents(request, [agent])
+    }
+  })
+
+  test('API Logs deep-link survives reload', async ({ page, request }, testInfo) => {
+    const agent = await createNavAgent(request, testInfo, 'Nav API Logs Reload')
+
+    try {
+      await page.goto(`/agents/${agent.slug}/api-logs`)
+      await expect(page).toHaveURL(/\/api-logs$/)
+      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name, { timeout: 15000 })
+      await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
+
+      await appPage.reload()
+      await expect(page).toHaveURL(/\/api-logs$/)
+      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name, { timeout: 15000 })
+      await expect(page.locator('[data-testid="api-logs-back-button"]')).toBeVisible()
+    } finally {
+      await cleanupAgents(request, [agent])
+    }
+  })
+
+  test('Dashboard leaf route resolves on a cold deep-link without crashing', async ({ page, request }, testInfo) => {
+    const errors = collectPageErrors(page)
+    const agent = await createNavAgent(request, testInfo, 'Nav Dash')
+
+    try {
+      await page.goto(`/agents/${agent.slug}/dashboards/sample-dashboard`)
+      await expect(page).toHaveURL(/\/dashboards\/sample-dashboard$/)
+      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name, { timeout: 15000 })
+      expect(errors).toEqual([])
+    } finally {
+      await cleanupAgents(request, [agent])
+    }
+  })
+
+  test('Chat leaf route resolves on a cold deep-link with ?session= search', async ({ page, request }, testInfo) => {
+    const errors = collectPageErrors(page)
+    const agent = await createNavAgent(request, testInfo, 'Nav Chat')
+
+    try {
+      await page.goto(`/agents/${agent.slug}/chat/sample-integration?session=sample-session`)
+      await expect(page).toHaveURL(/\/chat\/sample-integration\?session=sample-session$/)
+      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name, { timeout: 15000 })
+      expect(errors).toEqual([])
+    } finally {
+      await cleanupAgents(request, [agent])
+    }
+  })
+
+  test('Sidebar highlights the agent on a cold reload', async ({ page, request }, testInfo) => {
+    const agent = await createNavAgent(request, testInfo, 'Nav Sidebar Active')
+
+    try {
+      await page.goto(`/agents/${agent.slug}`)
+      await appPage.reload()
+      await expectAgentHome(page, agent)
+      await expect(page.locator('[data-testid^="agent-item-"]', { hasText: agent.name })).toHaveAttribute('data-active', 'true')
+      await expect(page.locator('[data-testid="home-button"]')).toHaveAttribute('data-active', 'false')
+    } finally {
+      await cleanupAgents(request, [agent])
+    }
+  })
+
+  test('UI: Notifications route lights up only the Notifications nav item', async ({ page, request }, testInfo) => {
+    const agent = await createNavAgent(request, testInfo, 'Nav Notif Active')
+
+    try {
+      await loadApp()
+
+      await page.locator('[data-testid="notifications-button"]').click()
+      await expect(page).toHaveURL(/\/notifications$/)
+      await expect(page.locator('[data-testid="notifications-button"]')).toHaveAttribute('data-active', 'true')
+      await expect(page.locator('[data-testid="home-button"]')).toHaveAttribute('data-active', 'false')
+      await expect(page.locator('[data-testid^="agent-item-"]', { hasText: agent.name })).toHaveAttribute('data-active', 'false')
+    } finally {
+      await cleanupAgents(request, [agent])
+    }
+  })
+
+  test('UI: Notifications route survives reload and Back leaves it', async ({ page }) => {
+    await loadApp()
+
+    await page.locator('[data-testid="notifications-button"]').click()
+    await expect(page).toHaveURL(/\/notifications$/)
+    await expect(page.locator('[data-testid="notifications-back-button"]')).toBeVisible()
+
+    await appPage.reload()
+    await expect(page).toHaveURL(/\/notifications$/)
+    await expect(page.locator('[data-testid="notifications-back-button"]')).toBeVisible()
+
+    await page.locator('[data-testid="notifications-back-button"]').click()
+    await expect(page).not.toHaveURL(/\/notifications/)
+  })
+
+  test('Deep-linking an unknown agent shows the ambiguous not-found screen', async ({ page }) => {
+    const errors = collectPageErrors(page)
+
+    await page.goto('/agents/does-not-exist-r15')
+    await expect(page).toHaveURL(/\/agents\/does-not-exist-r15$/)
+    await expect(page.locator('[data-testid="agent-not-found"]')).toBeVisible()
+    await expect(page.locator('[data-testid="home-button"]')).toBeVisible()
+    expect(errors).toEqual([])
+  })
+
+  test('Home is a durable route and reload stays on global home', async ({ page }) => {
+    await loadApp()
+    await appPage.reload()
+    await expectGlobalHome(page)
+  })
+
+  test('Deep-linking a non-existent session shows the not-found leaf', async ({ page, request }, testInfo) => {
+    const errors = collectPageErrors(page)
+    const agent = await createNavAgent(request, testInfo, 'Nav Session Not Found')
+
+    try {
+      await page.goto(`/agents/${agent.slug}/sessions/does-not-exist-r17`)
+      await expect(page.locator('[data-testid="session-not-found"]')).toBeVisible({ timeout: 15000 })
+      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name, { timeout: 15000 })
+      expect(errors).toEqual([])
+    } finally {
+      await cleanupAgents(request, [agent])
+    }
+  })
+
+  test('Connections detail overlay is deep-linkable and reload-durable; source=list back returns to the list', async ({ page, request }, testInfo) => {
+    const errors = collectPageErrors(page)
+    const agent = await createNavAgent(request, testInfo, 'Nav Conn Detail')
+
+    try {
+      await page.goto(`/agents/${agent.slug}/connections?detail=account-${connectionAccount.id}&source=list`)
+      await expect(page).toHaveURL(new RegExp(`/agents/${agent.slug}/connections\\?`))
+      await expect(page).toHaveURL(new RegExp(`detail=account-${connectionAccount.id}`))
+      await expect(page).toHaveURL(/source=list/)
+      await expect(page.locator('[data-testid="connection-detail-back"]')).toBeVisible({ timeout: 15000 })
+      await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
+
+      await appPage.reload()
+      await expect(page).toHaveURL(new RegExp(`detail=account-${connectionAccount.id}`))
+      await expect(page).toHaveURL(/source=list/)
+      await expect(page.locator('[data-testid="connection-detail-back"]')).toBeVisible({ timeout: 15000 })
+      await expect(page.locator('[data-testid="connections-back-button"]')).not.toBeVisible()
+
+      await page.locator('[data-testid="connection-detail-back"]').click()
+      await expect(page).toHaveURL(/\/connections$/)
+      await expect(page.locator('[data-testid="connections-back-button"]')).toBeVisible()
+      await expect(page.locator('[data-testid="connection-detail-back"]')).not.toBeVisible()
+      expect(errors).toEqual([])
+    } finally {
+      await cleanupAgents(request, [agent])
+    }
+  })
+
+  test('Connections detail overlay with source=home: Back returns to agent home', async ({ page, request }, testInfo) => {
+    const errors = collectPageErrors(page)
+    const agent = await createNavAgent(request, testInfo, 'Nav Conn Detail Home')
+
+    try {
+      await page.goto(`/agents/${agent.slug}/connections?detail=account-${connectionAccount.id}&source=home`)
+      await expect(page).toHaveURL(new RegExp(`detail=account-${connectionAccount.id}`))
+      await expect(page).toHaveURL(/source=home/)
+      await expect(page.locator('[data-testid="connection-detail-back"]')).toBeVisible({ timeout: 15000 })
+
+      await page.locator('[data-testid="connection-detail-back"]').click()
+      await expectAgentHome(page, agent)
+      await expect(page.locator('[data-testid="connection-detail-back"]')).not.toBeVisible()
+      expect(errors).toEqual([])
+    } finally {
+      await cleanupAgents(request, [agent])
     }
   })
 })


### PR DESCRIPTION
## Summary

- Remove the serial dependency from `navigation.spec.ts` and make the navigation cases independent for higher parallelism.
- Preserve real UI coverage for the core navigation flows: creating/selecting agents, agent subviews, back/forward history, sidebar switching, session breadcrumb/sidebar navigation, and notification routing.
- Use API setup only for supporting state and route durability cases where the UI flow is already exercised elsewhere in the spec.
- Harden the dashboard scheduled-task assertions discovered during 4-worker validation by scoping the task row selector and waiting for API persistence before asserting the UI trigger row.

## Notes

- Navigation agent cleanup is intentionally deferred to the next E2E data setup run. Deleting agents mid-run can race sibling tests that list agents and scan session files in the file-backed store.
- The dashboard/task change is included because it was the remaining flake exposed while proving the main suite under 4 workers.

## Validation

- `npx eslint e2e/specs/navigation.spec.ts e2e/specs/dashboard-and-tasks.spec.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `PORT=3372 SUPERAGENT_DATA_DIR=.e2e-data/web-navigation-pr-dashboard PLAYWRIGHT_OUTPUT_DIR=test-results/web-navigation-pr-dashboard PLAYWRIGHT_HTML_REPORT=playwright-report/web-navigation-pr-dashboard PLAYWRIGHT_WORKERS=4 npm run test:e2e -- e2e/specs/dashboard-and-tasks.spec.ts` -> 6 passed
- `PORT=3373 SUPERAGENT_DATA_DIR=.e2e-data/web-navigation-pr-focused PLAYWRIGHT_OUTPUT_DIR=test-results/web-navigation-pr-focused PLAYWRIGHT_HTML_REPORT=playwright-report/web-navigation-pr-focused PLAYWRIGHT_WORKERS=4 npm run test:e2e -- e2e/specs/navigation.spec.ts e2e/specs/dashboard-and-tasks.spec.ts` -> 27 passed
- Full suite, `PLAYWRIGHT_WORKERS=4`, run #1 -> 200 passed, 21 skipped
- Full suite, `PLAYWRIGHT_WORKERS=4`, run #2 -> 200 passed, 21 skipped
- Full suite, `PLAYWRIGHT_WORKERS=4`, run #3 -> 200 passed, 21 skipped