### PR TITLE
Per-task overlap guard: at most one live run per recurring schedule (SUP-329)

### DIFF
--- a/src/api/routes/scheduled-tasks.test.ts
+++ b/src/api/routes/scheduled-tasks.test.ts
@@ -56,6 +56,7 @@ vi.mock('@shared/lib/container/container-manager', () => ({
 
 const mockMessagePersister = vi.hoisted(() => ({
   isSessionActive: vi.fn(),
+  isSessionAwaitingInput: vi.fn(),
   subscribeToSession: vi.fn(),
   markSessionActive: vi.fn(),
 }))
@@ -149,6 +150,7 @@ function createTask(overrides: Record<string, unknown> = {}) {
     scheduleExpression: '0 9 * * 1-5',
     status: 'pending',
     isRecurring: true,
+    lastSessionId: null,
     model: null,
     effort: null,
     ...overrides,
@@ -170,6 +172,7 @@ describe('scheduled-tasks route', () => {
       { id: 'session-idle', name: 'Idle session' },
     ])
     mockMessagePersister.isSessionActive.mockImplementation((sessionId: string) => sessionId === 'session-active')
+    mockMessagePersister.isSessionAwaitingInput.mockReturnValue(false)
     mockCreateSession.mockResolvedValue({ id: 'container-session-1' })
     mockEnsureRunning.mockResolvedValue({ createSession: mockCreateSession })
     mockGetSecretEnvVars.mockResolvedValue(['GITHUB_TOKEN'])
@@ -249,6 +252,35 @@ describe('scheduled-tasks route', () => {
     expect(mockRegisterSession).toHaveBeenCalledWith('agent-one', 'container-session-1', 'Scheduled Task (Run Now)')
     expect(mockMarkTaskExecuted).toHaveBeenCalledWith('task-1', 'container-session-1')
     expect(mockRecordManualExecution).not.toHaveBeenCalled()
+  })
+
+  it('returns 409 for run-now while the previous run of a recurring task is still active', async () => {
+    // Same occupied predicate as the scheduler's overlap guard: a held task
+    // shows a stale past "next run", making Run Now the natural user response —
+    // it must not spawn a session concurrent with the run being held against.
+    task = createTask({ lastSessionId: 'session-active' })
+
+    const res = await app.request('http://localhost/api/scheduled-tasks/task-1/run-now', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(409)
+    expect(await res.json()).toEqual({ error: 'Previous run of this task is still in progress' })
+    expect(mockEnsureRunning).not.toHaveBeenCalled()
+    expect(mockCreateSession).not.toHaveBeenCalled()
+    expect(mockRecordManualExecution).not.toHaveBeenCalled()
+  })
+
+  it('allows run-now when the previous run is parked awaiting user input', async () => {
+    task = createTask({ lastSessionId: 'session-active' })
+    mockMessagePersister.isSessionAwaitingInput.mockReturnValue(true)
+
+    const res = await app.request('http://localhost/api/scheduled-tasks/task-1/run-now', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(201)
+    expect(mockRecordManualExecution).toHaveBeenCalledWith('task-1', 'container-session-1')
   })
 
   it('does not start a container for non-runnable task statuses', async () => {

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -270,6 +270,20 @@ scheduledTasksRouter.post('/:taskId/run-now', TaskAgentRole('user'), async (c) =
       return c.json({ error: 'Task is not pending' }, 400)
     }
 
+    // Per-task overlap guard, same predicate as the scheduler's: a manual run
+    // must not overlap a still-active previous run either. A held task shows a
+    // stale past "next run" timestamp, making Run Now the natural user response —
+    // an unguarded spawn here would create exactly the concurrent overlap the
+    // scheduler is holding back.
+    if (task.isRecurring && task.lastSessionId) {
+      const occupied =
+        messagePersister.isSessionActive(task.lastSessionId) &&
+        !messagePersister.isSessionAwaitingInput(task.lastSessionId)
+      if (occupied) {
+        return c.json({ error: 'Previous run of this task is still in progress' }, 409)
+      }
+    }
+
     const client = await containerManager.ensureRunning(task.agentSlug)
     const availableEnvVars = await getSecretEnvVars(task.agentSlug)
     const models = getEffectiveModels()

--- a/src/shared/lib/db/migrations/0026_volatile_aaron_stack.sql
+++ b/src/shared/lib/db/migrations/0026_volatile_aaron_stack.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `scheduled_tasks` ADD `consecutive_skips` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `scheduled_tasks` ADD `last_skipped_at` integer;

--- a/src/shared/lib/db/migrations/meta/0026_snapshot.json
+++ b/src/shared/lib/db/migrations/meta/0026_snapshot.json
@@ -1,0 +1,2356 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6aeb1a7c-7394-47f4-ad34-fae8e0bdc06b",
+  "prevId": "9a935307-ac89-48b1-af57-9a1b34542c5c",
+  "tables": {
+    "agent_acl": {
+      "name": "agent_acl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_acl_user_agent_unique": {
+          "name": "agent_acl_user_agent_unique",
+          "columns": [
+            "user_id",
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "agent_acl_agent_slug_idx": {
+          "name": "agent_acl_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_acl_user_id_user_id_fk": {
+          "name": "agent_acl_user_id_user_id_fk",
+          "tableFrom": "agent_acl",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_connected_accounts": {
+      "name": "agent_connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_connected_accounts_unique": {
+          "name": "agent_connected_accounts_unique",
+          "columns": [
+            "agent_slug",
+            "connected_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_connected_accounts_connected_account_id_connected_accounts_id_fk": {
+          "name": "agent_connected_accounts_connected_account_id_connected_accounts_id_fk",
+          "tableFrom": "agent_connected_accounts",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "connected_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_remote_mcps": {
+      "name": "agent_remote_mcps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_remote_mcps_unique": {
+          "name": "agent_remote_mcps_unique",
+          "columns": [
+            "agent_slug",
+            "remote_mcp_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "agent_remote_mcps",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "remote_mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_scope_policies": {
+      "name": "api_scope_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_scope_policies_unique": {
+          "name": "api_scope_policies_unique",
+          "columns": [
+            "account_id",
+            "scope"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_scope_policies_account_id_connected_accounts_id_fk": {
+          "name": "api_scope_policies_account_id_connected_accounts_id_fk",
+          "tableFrom": "api_scope_policies",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_log_object_idx": {
+          "name": "audit_log_object_idx",
+          "columns": [
+            "object"
+          ],
+          "isUnique": false
+        },
+        "audit_log_user_id_idx": {
+          "name": "audit_log_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integration_access": {
+      "name": "chat_integration_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "approval_source": {
+          "name": "approval_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_id": {
+          "name": "first_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_name": {
+          "name": "first_user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message_preview": {
+          "name": "first_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_notice_sent_at": {
+          "name": "request_notice_sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_access_unique": {
+          "name": "chat_integration_access_unique",
+          "columns": [
+            "integration_id",
+            "external_chat_id"
+          ],
+          "isUnique": true
+        },
+        "chat_integration_access_status_idx": {
+          "name": "chat_integration_access_status_idx",
+          "columns": [
+            "integration_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_access_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_access_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_access",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chat_integration_access_status_check": {
+          "name": "chat_integration_access_status_check",
+          "value": "\"chat_integration_access\".\"status\" in ('pending','allowed','denied')"
+        },
+        "chat_integration_access_chat_type_check": {
+          "name": "chat_integration_access_chat_type_check",
+          "value": "\"chat_integration_access\".\"chat_type\" is null or \"chat_integration_access\".\"chat_type\" in ('private','group','supergroup')"
+        },
+        "chat_integration_access_source_check": {
+          "name": "chat_integration_access_source_check",
+          "value": "\"chat_integration_access\".\"approval_source\" is null or \"chat_integration_access\".\"approval_source\" in ('auto_first_contact','owner','migration')"
+        }
+      }
+    },
+    "chat_integration_sessions": {
+      "name": "chat_integration_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_sessions_integration_id_idx": {
+          "name": "chat_integration_sessions_integration_id_idx",
+          "columns": [
+            "integration_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_sessions_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_sessions_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_sessions",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integrations": {
+      "name": "chat_integrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "show_tool_calls": {
+          "name": "show_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "require_approval": {
+          "name": "require_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_timeout": {
+          "name": "session_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integrations_agent_slug_idx": {
+          "name": "chat_integrations_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "chat_integrations_status_idx": {
+          "name": "chat_integrations_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connected_accounts": {
+      "name": "connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_connection_id": {
+          "name": "provider_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "toolkit_slug": {
+          "name": "toolkit_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connected_accounts_provider_connection_id_unique": {
+          "name": "connected_accounts_provider_connection_id_unique",
+          "columns": [
+            "provider_connection_id"
+          ],
+          "isUnique": true
+        },
+        "connected_accounts_userId_idx": {
+          "name": "connected_accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connected_accounts_user_id_user_id_fk": {
+          "name": "connected_accounts_user_id_user_id_fk",
+          "tableFrom": "connected_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_name": {
+          "name": "remote_mcp_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_tool": {
+          "name": "matched_tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_policies": {
+      "name": "mcp_tool_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_tool_policies_unique": {
+          "name": "mcp_tool_policies_unique",
+          "columns": [
+            "mcp_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_policies",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message_author": {
+      "name": "message_author",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "message_author_session_idx": {
+          "name": "message_author_session_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_author_user_id_user_id_fk": {
+          "name": "message_author_user_id_user_id_fk",
+          "tableFrom": "message_author",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_agent_slug_is_read_idx": {
+          "name": "notifications_agent_slug_is_read_idx",
+          "columns": [
+            "agent_slug",
+            "is_read"
+          ],
+          "isUnique": false
+        },
+        "notifications_session_id_idx": {
+          "name": "notifications_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_audit_log": {
+      "name": "proxy_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_scopes": {
+          "name": "matched_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_tokens": {
+      "name": "proxy_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_tokens_agent_slug_unique": {
+          "name": "proxy_tokens_agent_slug_unique",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "proxy_tokens_token_unique": {
+          "name": "proxy_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_mcp_servers": {
+      "name": "remote_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token_endpoint": {
+          "name": "oauth_token_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_resource": {
+          "name": "oauth_resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_discovered_at": {
+          "name": "tools_discovered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "remote_mcp_servers_user_id_user_id_fk": {
+          "name": "remote_mcp_servers_user_id_user_id_fk",
+          "tableFrom": "remote_mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_expression": {
+          "name": "schedule_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "next_execution_at": {
+          "name": "next_execution_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "execution_count": {
+          "name": "execution_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "consecutive_skips": {
+          "name": "consecutive_skips",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_skipped_at": {
+          "name": "last_skipped_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_triggers": {
+      "name": "webhook_triggers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "composio_trigger_id": {
+          "name": "composio_trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fire_count": {
+          "name": "fire_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_triggers_agent_slug_idx": {
+          "name": "webhook_triggers_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_status_idx": {
+          "name": "webhook_triggers_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_composio_idx": {
+          "name": "webhook_triggers_composio_idx",
+          "columns": [
+            "composio_trigger_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "x_agent_policies": {
+      "name": "x_agent_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_agent_slug": {
+          "name": "caller_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_agent_slug": {
+          "name": "target_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "x_agent_policies_unique": {
+          "name": "x_agent_policies_unique",
+          "columns": [
+            "caller_agent_slug",
+            "target_agent_slug",
+            "operation"
+          ],
+          "isUnique": true
+        },
+        "x_agent_policies_caller_idx": {
+          "name": "x_agent_policies_caller_idx",
+          "columns": [
+            "caller_agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/shared/lib/db/migrations/meta/_journal.json
+++ b/src/shared/lib/db/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1782496663785,
       "tag": "0025_orange_secret_warriors",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1782868296091,
+      "tag": "0026_volatile_aaron_stack",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/lib/db/schema.ts
+++ b/src/shared/lib/db/schema.ts
@@ -159,8 +159,10 @@ export const scheduledTasks = sqliteTable('scheduled_tasks', {
 
   // Overlap guard (recurring tasks): number of consecutive poll cycles this task
   // was held because its previous run was still actively progressing, and when it
-  // was last held. Reset to 0/null on a successful fire. Consumed by skip
-  // observability (surfacing skipped & wedged recurring tasks).
+  // was last held. Reset to 0/null on any fire (scheduled or manual) and whenever
+  // the schedule is re-anchored (resume/reset); preserved across failed fire
+  // attempts. Written for skip observability (surfacing skipped & wedged
+  // recurring tasks) — no consumer reads them yet.
   consecutiveSkips: integer('consecutive_skips').notNull().default(0),
   lastSkippedAt: integer('last_skipped_at', { mode: 'timestamp_ms' }),
 

--- a/src/shared/lib/db/schema.ts
+++ b/src/shared/lib/db/schema.ts
@@ -157,6 +157,13 @@ export const scheduledTasks = sqliteTable('scheduled_tasks', {
   isRecurring: integer('is_recurring', { mode: 'boolean' }).notNull().default(false),
   executionCount: integer('execution_count').notNull().default(0),
 
+  // Overlap guard (recurring tasks): number of consecutive poll cycles this task
+  // was held because its previous run was still actively progressing, and when it
+  // was last held. Reset to 0/null on a successful fire. Consumed by skip
+  // observability (surfacing skipped & wedged recurring tasks).
+  consecutiveSkips: integer('consecutive_skips').notNull().default(0),
+  lastSkippedAt: integer('last_skipped_at', { mode: 'timestamp_ms' }),
+
   // Session tracking
   lastSessionId: text('last_session_id'),
   createdBySessionId: text('created_by_session_id'),

--- a/src/shared/lib/scheduler/task-scheduler.overlap-guard-replay.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.overlap-guard-replay.test.ts
@@ -4,7 +4,7 @@ import { promises as fs } from 'fs'
 import type { ContainerClient, StreamMessage } from '@shared/lib/container/types'
 import type { ScheduledTask } from '@shared/lib/services/scheduled-task-service'
 
-// COMPOSITION test for the per-task overlap guard (SUP-329).
+// COMPOSITION test for the per-task overlap guard.
 //
 // The scheduler unit test (task-scheduler.overlap-guard.test.ts) mocks the
 // occupied predicate, and the message-persister suite proves the predicate's
@@ -36,6 +36,7 @@ const mockMarkTaskExecuted = vi.fn()
 const mockMarkTaskFailed = vi.fn()
 const mockUpdateNextExecution = vi.fn()
 const mockRecordTaskSkip = vi.fn()
+const mockRescheduleAfterFailure = vi.fn()
 
 vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   // Scheduler side
@@ -44,6 +45,7 @@ vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   markTaskFailed: (...a: unknown[]) => mockMarkTaskFailed(...a),
   updateNextExecution: (...a: unknown[]) => mockUpdateNextExecution(...a),
   recordTaskSkip: (...a: unknown[]) => mockRecordTaskSkip(...a),
+  rescheduleAfterFailure: (...a: unknown[]) => mockRescheduleAfterFailure(...a),
   // Persister side
   createScheduledTask: vi.fn(),
   listPendingScheduledTasks: vi.fn(() => Promise.resolve([])),

--- a/src/shared/lib/scheduler/task-scheduler.overlap-guard-replay.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.overlap-guard-replay.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as path from 'path'
+import { promises as fs } from 'fs'
+import type { ContainerClient, StreamMessage } from '@shared/lib/container/types'
+import type { ScheduledTask } from '@shared/lib/services/scheduled-task-service'
+
+// COMPOSITION test for the per-task overlap guard (SUP-329).
+//
+// The scheduler unit test (task-scheduler.overlap-guard.test.ts) mocks the
+// occupied predicate, and the message-persister suite proves the predicate's
+// runtime semantics from real captures — but nothing tests the SEAM between
+// them. This test closes that gap: it drives the REAL messagePersister with a
+// REAL SUPERAGENT_CAPTURE_DIR stream (the background-bash-premature-idle capture,
+// the ac23bdd8 regression) and then invokes the REAL taskScheduler guard against
+// that live streaming state. No mock stands between the captured SDK events and
+// the hold/fire decision.
+//
+// A run_in_background Bash keeps the session isActive=true / isAwaitingInput=false
+// (it emits session_waiting_background at the premature turn-end idle), so the
+// guard must HOLD while the bash is pending and FIRE once the session truly
+// settles. Both halves are asserted against the same real persister instance the
+// scheduler reads from.
+
+// ---------------------------------------------------------------------------
+// Mock surface. The message-persister and its transitive deps are mocked exactly
+// as the existing capture-replay suites do (queued-message-idle-replay /
+// subagent-task-events-replay) so the REAL persister imports cleanly — EXCEPT we
+// never mock message-persister itself. On top of that we mock the scheduler's own
+// dependencies. Where a module is imported by BOTH (scheduled-task-service,
+// session-service, notification-manager, config/settings, schedule-parser) the
+// mock exports the union of what each side needs.
+// ---------------------------------------------------------------------------
+
+const mockGetDueTasks = vi.fn()
+const mockMarkTaskExecuted = vi.fn()
+const mockMarkTaskFailed = vi.fn()
+const mockUpdateNextExecution = vi.fn()
+const mockRecordTaskSkip = vi.fn()
+
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  // Scheduler side
+  getDueTasks: (...a: unknown[]) => mockGetDueTasks(...a),
+  markTaskExecuted: (...a: unknown[]) => mockMarkTaskExecuted(...a),
+  markTaskFailed: (...a: unknown[]) => mockMarkTaskFailed(...a),
+  updateNextExecution: (...a: unknown[]) => mockUpdateNextExecution(...a),
+  recordTaskSkip: (...a: unknown[]) => mockRecordTaskSkip(...a),
+  // Persister side
+  createScheduledTask: vi.fn(),
+  listPendingScheduledTasks: vi.fn(() => Promise.resolve([])),
+  getScheduledTask: vi.fn(() => Promise.resolve(null)),
+  cancelScheduledTask: vi.fn(),
+  pauseScheduledTask: vi.fn(),
+  resumeScheduledTask: vi.fn(),
+}))
+
+const mockGetSessionForScheduledExecution = vi.fn()
+const mockRegisterSession = vi.fn()
+
+vi.mock('@shared/lib/services/session-service', () => ({
+  // Scheduler side
+  getSessionForScheduledExecution: (...a: unknown[]) => mockGetSessionForScheduledExecution(...a),
+  registerSession: (...a: unknown[]) => mockRegisterSession(...a),
+  // Persister side
+  getSessionMetadata: vi.fn(() => Promise.resolve(null)),
+  updateSessionMetadata: vi.fn(() => Promise.resolve()),
+}))
+
+const mockTriggerScheduledSessionStarted = vi.fn()
+
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    // Scheduler side
+    triggerScheduledSessionStarted: (...a: unknown[]) => mockTriggerScheduledSessionStarted(...a),
+    // Persister side
+    triggerSessionComplete: vi.fn(() => Promise.resolve()),
+    triggerSessionWaitingInput: vi.fn(() => Promise.resolve()),
+  },
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  // Scheduler side
+  getEffectiveModels: () => ({
+    agentModel: 'claude-sonnet-4-20250514',
+    browserModel: 'claude-sonnet-4-20250514',
+    dashboardBuilderModel: 'claude-sonnet-4-20250514',
+  }),
+  // Persister side
+  getSettings: () => ({}),
+  VALID_SCRIPT_TYPES: { darwin: ['applescript', 'shell'], linux: ['shell'], win32: ['powershell'] },
+}))
+
+const mockGetNextCronTime = vi.fn()
+
+vi.mock('@shared/lib/services/schedule-parser', () => ({
+  // Scheduler side
+  getNextCronTime: (...a: unknown[]) => mockGetNextCronTime(...a),
+  // Persister side
+  getFrequencyWarning: vi.fn(() => null),
+  getScheduleCountWarning: vi.fn(() => null),
+  validateScheduleExpression: vi.fn(() => ({ valid: true })),
+}))
+
+// Scheduler-only deps
+const mockEnsureRunning = vi.fn()
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: { ensureRunning: (...a: unknown[]) => mockEnsureRunning(...a) },
+}))
+
+const mockAgentExists = vi.fn()
+vi.mock('@shared/lib/services/agent-service', () => ({
+  agentExists: (...a: unknown[]) => mockAgentExists(...a),
+}))
+
+const mockGetSecretEnvVars = vi.fn()
+vi.mock('@shared/lib/services/secrets-service', () => ({
+  getSecretEnvVars: (...a: unknown[]) => mockGetSecretEnvVars(...a),
+}))
+
+vi.mock('@shared/lib/platform-attribution', () => ({
+  runWithOptionalUser: (_u: string | null | undefined, fn: () => unknown) => fn(),
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({ captureException: vi.fn() }))
+
+// Persister-only transitive deps (mirrors the existing replay suites).
+vi.mock('@shared/lib/computer-use/permission-manager', () => ({
+  computerUsePermissionManager: {
+    checkPermission: vi.fn(() => 'prompt_needed'),
+    getGrabbedApp: vi.fn(() => undefined),
+    setGrabbedApp: vi.fn(),
+    clearGrabbedApp: vi.fn(),
+    consumeOnceGrant: vi.fn(),
+  },
+}))
+vi.mock('@shared/lib/computer-use/types', () => ({
+  getRequiredPermissionLevel: vi.fn(() => 'use_application'),
+  resolveTargetApp: vi.fn(() => undefined),
+  READ_ONLY_METHODS: new Set(['apps', 'windows', 'status', 'displays', 'permissions']),
+  TIMED_GRANT_DURATION_MS: 15 * 60 * 1000,
+}))
+vi.mock('@shared/lib/computer-use/executor', () => ({
+  resolveAppFromWindowRef: vi.fn(() => undefined),
+}))
+vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
+  createWebhookTrigger: vi.fn(() => Promise.resolve('trigger_new_id')),
+  listActiveWebhookTriggers: vi.fn(() => Promise.resolve([])),
+  cancelWebhookTriggerWithCleanup: vi.fn(() => Promise.resolve(true)),
+}))
+vi.mock('@shared/lib/composio/triggers', () => ({
+  getAvailableTriggers: vi.fn(() => Promise.resolve([])),
+  enableComposioTrigger: vi.fn(() => Promise.resolve('composio_trigger_id')),
+  deleteComposioTrigger: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('@shared/lib/composio/client', () => ({
+  isPlatformComposioActive: vi.fn(() => true),
+}))
+vi.mock('@shared/lib/services/timezone-resolver', () => ({
+  resolveTimezoneForAgent: vi.fn(() => Promise.resolve('UTC')),
+}))
+vi.mock('@shared/lib/analytics/server-analytics', () => ({ trackServerEvent: vi.fn() }))
+vi.mock('@shared/lib/db', () => ({ db: {} }))
+vi.mock('@shared/lib/db/schema', () => ({ connectedAccounts: {} }))
+vi.mock('drizzle-orm', () => ({ eq: vi.fn() }))
+vi.mock('@shared/lib/utils/file-storage', () => ({
+  getAgentSessionsDir: (_agentSlug: string) => '/nonexistent',
+}))
+
+// Real modules under test — same registry, so the scheduler's
+// `import { messagePersister }` resolves to THIS instance.
+import { messagePersister } from '@shared/lib/container/message-persister'
+import { taskScheduler } from '@shared/lib/scheduler/task-scheduler'
+
+// ---------------------------------------------------------------------------
+// Fixture + replay plumbing (mirrors queued-message-idle-replay.test.ts)
+// ---------------------------------------------------------------------------
+
+interface FixtureEntry {
+  t: number
+  message: StreamMessage
+}
+
+async function loadFixture(): Promise<{ sessionId: string; agentSlug: string; entries: FixtureEntry[] }> {
+  const fixtureDir = path.join(
+    __dirname,
+    '..',
+    'container',
+    '__fixtures__',
+    'background-bash-premature-idle',
+  )
+  const meta = JSON.parse(await fs.readFile(path.join(fixtureDir, 'metadata.json'), 'utf8'))
+  const raw = await fs.readFile(path.join(fixtureDir, 'stream-input.jsonl'), 'utf8')
+  const entries = raw
+    .split('\n')
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l))
+  return { sessionId: meta.sessionId, agentSlug: meta.agentSlug, entries }
+}
+
+function createReplayClient(): { client: ContainerClient; send: (m: StreamMessage) => void } {
+  let callback: ((message: StreamMessage) => void) | null = null
+  const client = {
+    subscribeToStream: vi.fn((_sid: string, cb: (message: StreamMessage) => void) => {
+      callback = cb
+      return { unsubscribe: vi.fn(), ready: Promise.resolve() }
+    }),
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopSync: vi.fn(),
+    getInfoFromRuntime: vi.fn(),
+    getInfo: vi.fn(),
+    fetch: vi.fn(),
+    waitForHealthy: vi.fn(),
+    isHealthy: vi.fn(),
+    getStats: vi.fn(),
+    createSession: vi.fn(),
+    getSession: vi.fn(() => Promise.resolve(null)),
+    deleteSession: vi.fn(),
+    sendMessage: vi.fn(),
+    getMessages: vi.fn(),
+    interruptSession: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  } as unknown as ContainerClient
+  return { client, send: (m) => callback?.(m) }
+}
+
+const tick = () => new Promise((r) => setImmediate(r))
+
+const reanchoredAt = new Date('2026-06-26T17:05:00.000Z')
+
+function dueRecurringTask(lastSessionId: string): ScheduledTask {
+  return {
+    id: 'task-1',
+    agentSlug: 'agent-one',
+    scheduleType: 'cron',
+    scheduleExpression: '*/5 * * * *',
+    prompt: 'Run the recurring report',
+    name: 'Recurring report',
+    status: 'pending',
+    nextExecutionAt: new Date('2026-06-26T17:00:00.000Z'),
+    lastExecutedAt: null,
+    isRecurring: true,
+    executionCount: 3,
+    consecutiveSkips: 0,
+    lastSkippedAt: null,
+    lastSessionId,
+    createdBySessionId: null,
+    createdByUserId: 'user-1',
+    timezone: null,
+    model: null,
+    effort: null,
+    createdAt: new Date('2026-06-26T16:00:00.000Z'),
+    cancelledAt: null,
+    pausedAt: null,
+  }
+}
+
+describe('overlap guard against a real background-bash capture (persister ↔ scheduler seam)', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+  let fixtureSessionId: string
+
+  beforeEach(() => {
+    taskScheduler.stop()
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    vi.clearAllMocks()
+    mockGetDueTasks.mockResolvedValue([])
+    mockGetSessionForScheduledExecution.mockResolvedValue(null)
+    mockAgentExists.mockResolvedValue(true)
+    mockGetSecretEnvVars.mockResolvedValue([])
+    mockRegisterSession.mockResolvedValue(undefined)
+    mockTriggerScheduledSessionStarted.mockResolvedValue(undefined)
+    mockUpdateNextExecution.mockResolvedValue(undefined)
+    mockRecordTaskSkip.mockResolvedValue(undefined)
+    mockMarkTaskExecuted.mockResolvedValue(undefined)
+    mockGetNextCronTime.mockReturnValue(reanchoredAt)
+    // The freshly-fired session uses a mocked container client whose stream
+    // subscription resolves immediately (subscribeToSession awaits `ready`).
+    mockEnsureRunning.mockResolvedValue({
+      createSession: vi.fn(() => Promise.resolve({ id: 'fired-session-new' })),
+      subscribeToStream: vi.fn(() => ({ unsubscribe: vi.fn(), ready: Promise.resolve() })),
+    })
+  })
+
+  afterEach(() => {
+    taskScheduler.stop()
+    if (fixtureSessionId) messagePersister.unsubscribeFromSession(fixtureSessionId)
+    messagePersister.unsubscribeFromSession('fired-session-new')
+    consoleLogSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('HOLDS while the backgrounded bash is live, then FIRES once the session truly settles', async () => {
+    const { sessionId, agentSlug, entries } = await loadFixture()
+    fixtureSessionId = sessionId
+    const { client, send } = createReplayClient()
+
+    // Wire the REAL persister to the replay stream, exactly like the POST
+    // /messages route: subscribe, then mark active on the first user message.
+    await messagePersister.subscribeToSession(sessionId, client, sessionId, agentSlug)
+    messagePersister.markSessionActive(sessionId, agentSlug)
+
+    // ---- Replay until the first "backgrounded bash pending" checkpoint ----
+    // We stop at the first moment the persister reports the occupied shape from
+    // the real stream: active, not awaiting input, with a live background task.
+    let occupiedIdx = -1
+    for (let i = 0; i < entries.length; i++) {
+      send(entries[i].message)
+      await tick()
+      if (
+        messagePersister.isSessionActive(sessionId) &&
+        !messagePersister.isSessionAwaitingInput(sessionId) &&
+        messagePersister.getActiveBackgroundTasks(sessionId).length > 0
+      ) {
+        occupiedIdx = i
+        break
+      }
+    }
+    expect(occupiedIdx).toBeGreaterThan(-1)
+    // Sanity: this is the exact predicate the guard evaluates, sourced from the
+    // real persister rather than a mock.
+    expect(messagePersister.isSessionActive(sessionId)).toBe(true)
+    expect(messagePersister.isSessionAwaitingInput(sessionId)).toBe(false)
+
+    // ---- Invoke the REAL scheduler guard against that live state ----
+    mockGetDueTasks.mockResolvedValue([dueRecurringTask(sessionId)])
+    await taskScheduler.triggerExecution()
+
+    // HELD: no second session spun up, schedule not advanced, skip recorded.
+    expect(mockEnsureRunning).not.toHaveBeenCalled()
+    expect(mockAgentExists).not.toHaveBeenCalled()
+    expect(mockUpdateNextExecution).not.toHaveBeenCalled()
+    expect(mockRecordTaskSkip).toHaveBeenCalledTimes(1)
+    expect(mockRecordTaskSkip).toHaveBeenCalledWith('task-1')
+
+    // ---- Replay the remainder of the capture to the truly-settled idle ----
+    for (let i = occupiedIdx + 1; i < entries.length; i++) {
+      send(entries[i].message)
+      await tick()
+    }
+    // The real capture ends with the authoritative settled idle once both
+    // backgrounded bashes have reported completion.
+    expect(messagePersister.isSessionActive(sessionId)).toBe(false)
+    expect(messagePersister.getActiveBackgroundTasks(sessionId)).toHaveLength(0)
+
+    // ---- Invoke the guard again now that the slot is free ----
+    await taskScheduler.triggerExecution()
+
+    // FIRES exactly once: a new session is created and the schedule re-anchors
+    // forward. No additional skip was recorded (still just the one hold).
+    expect(mockEnsureRunning).toHaveBeenCalledTimes(1)
+    expect(mockRecordTaskSkip).toHaveBeenCalledTimes(1)
+    expect(mockUpdateNextExecution).toHaveBeenCalledTimes(1)
+    expect(mockUpdateNextExecution).toHaveBeenCalledWith('task-1', reanchoredAt, 'fired-session-new')
+  })
+})

--- a/src/shared/lib/scheduler/task-scheduler.overlap-guard.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.overlap-guard.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { ScheduledTask } from '@shared/lib/services/scheduled-task-service'
+
+// Per-task overlap guard: a recurring task must not spawn a second concurrent
+// session while its previous run is still actively progressing. See the guard in
+// executeTaskInner. Occupied predicate:
+//   isSessionActive(lastSessionId) && !isSessionAwaitingInput(lastSessionId)
+
+const mockGetDueTasks = vi.fn()
+const mockMarkTaskExecuted = vi.fn()
+const mockMarkTaskFailed = vi.fn()
+const mockUpdateNextExecution = vi.fn()
+const mockRecordTaskSkip = vi.fn()
+
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  getDueTasks: (...args: unknown[]) => mockGetDueTasks(...args),
+  markTaskExecuted: (...args: unknown[]) => mockMarkTaskExecuted(...args),
+  markTaskFailed: (...args: unknown[]) => mockMarkTaskFailed(...args),
+  updateNextExecution: (...args: unknown[]) => mockUpdateNextExecution(...args),
+  recordTaskSkip: (...args: unknown[]) => mockRecordTaskSkip(...args),
+}))
+
+const mockCreateSession = vi.fn()
+const mockEnsureRunning = vi.fn()
+
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: {
+    ensureRunning: (...args: unknown[]) => mockEnsureRunning(...args),
+  },
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getEffectiveModels: () => ({
+    agentModel: 'claude-sonnet-4-20250514',
+    browserModel: 'claude-sonnet-4-20250514',
+    dashboardBuilderModel: 'claude-sonnet-4-20250514',
+  }),
+}))
+
+const mockSubscribeToSession = vi.fn()
+const mockMarkSessionActive = vi.fn()
+const mockIsSessionActive = vi.fn()
+const mockIsSessionAwaitingInput = vi.fn()
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    subscribeToSession: (...args: unknown[]) => mockSubscribeToSession(...args),
+    markSessionActive: (...args: unknown[]) => mockMarkSessionActive(...args),
+    isSessionActive: (...args: unknown[]) => mockIsSessionActive(...args),
+    isSessionAwaitingInput: (...args: unknown[]) => mockIsSessionAwaitingInput(...args),
+  },
+}))
+
+const mockTriggerScheduledSessionStarted = vi.fn()
+
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerScheduledSessionStarted: (...args: unknown[]) =>
+      mockTriggerScheduledSessionStarted(...args),
+  },
+}))
+
+const mockGetSessionForScheduledExecution = vi.fn()
+const mockRegisterSession = vi.fn()
+
+vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionForScheduledExecution: (...args: unknown[]) =>
+    mockGetSessionForScheduledExecution(...args),
+  registerSession: (...args: unknown[]) => mockRegisterSession(...args),
+}))
+
+const mockGetSecretEnvVars = vi.fn()
+
+vi.mock('@shared/lib/services/secrets-service', () => ({
+  getSecretEnvVars: (...args: unknown[]) => mockGetSecretEnvVars(...args),
+}))
+
+const mockAgentExists = vi.fn()
+
+vi.mock('@shared/lib/services/agent-service', () => ({
+  agentExists: (...args: unknown[]) => mockAgentExists(...args),
+}))
+
+const mockGetNextCronTime = vi.fn()
+
+vi.mock('@shared/lib/services/schedule-parser', () => ({
+  getNextCronTime: (...args: unknown[]) => mockGetNextCronTime(...args),
+}))
+
+vi.mock('@shared/lib/platform-attribution', () => ({
+  runWithOptionalUser: (_userId: string | null | undefined, fn: () => unknown) => fn(),
+}))
+
+const mockCaptureException = vi.fn()
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}))
+
+import { taskScheduler } from './task-scheduler'
+
+const nextExecutionAt = new Date('2026-06-26T17:00:00.000Z')
+const reanchoredAt = new Date('2026-06-26T17:05:00.000Z')
+
+function createRecurringTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
+  return {
+    id: 'task-1',
+    agentSlug: 'agent-one',
+    scheduleType: 'cron',
+    scheduleExpression: '*/5 * * * *',
+    prompt: 'Run the recurring report',
+    name: 'Recurring report',
+    status: 'pending',
+    nextExecutionAt,
+    lastExecutedAt: null,
+    isRecurring: true,
+    executionCount: 3,
+    consecutiveSkips: 0,
+    lastSkippedAt: null,
+    lastSessionId: 'prev-session-1',
+    createdBySessionId: null,
+    createdByUserId: 'user-1',
+    timezone: null,
+    model: null,
+    effort: null,
+    createdAt: new Date('2026-06-26T16:00:00.000Z'),
+    cancelledAt: null,
+    pausedAt: null,
+    ...overrides,
+  }
+}
+
+describe('TaskScheduler per-task overlap guard', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    taskScheduler.stop()
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    vi.clearAllMocks()
+    mockGetDueTasks.mockResolvedValue([])
+    mockEnsureRunning.mockResolvedValue({ createSession: mockCreateSession })
+    mockCreateSession.mockResolvedValue({ id: 'new-session-1' })
+    mockSubscribeToSession.mockResolvedValue(undefined)
+    mockTriggerScheduledSessionStarted.mockResolvedValue(undefined)
+    mockRegisterSession.mockResolvedValue(undefined)
+    mockGetSecretEnvVars.mockResolvedValue([])
+    mockAgentExists.mockResolvedValue(true)
+    mockGetSessionForScheduledExecution.mockResolvedValue(null)
+    mockMarkTaskExecuted.mockResolvedValue(undefined)
+    mockMarkTaskFailed.mockResolvedValue(undefined)
+    mockUpdateNextExecution.mockResolvedValue(undefined)
+    mockRecordTaskSkip.mockResolvedValue(undefined)
+    mockGetNextCronTime.mockReturnValue(reanchoredAt)
+    // Default: previous run is idle (not occupied) so tasks fire normally.
+    mockIsSessionActive.mockReturnValue(false)
+    mockIsSessionAwaitingInput.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    taskScheduler.stop()
+    consoleErrorSpy.mockRestore()
+    consoleLogSpy.mockRestore()
+  })
+
+  it('holds a recurring task whose previous run is still actively running (no second session)', async () => {
+    mockGetDueTasks.mockResolvedValue([createRecurringTask()])
+    mockIsSessionActive.mockReturnValue(true)
+    mockIsSessionAwaitingInput.mockReturnValue(false)
+
+    await taskScheduler.triggerExecution()
+
+    // Held: no new container/session spun up.
+    expect(mockEnsureRunning).not.toHaveBeenCalled()
+    expect(mockCreateSession).not.toHaveBeenCalled()
+    // nextExecutionAt is NOT advanced — the task stays due.
+    expect(mockUpdateNextExecution).not.toHaveBeenCalled()
+    // The occupied predicate was evaluated against the previous run's session.
+    expect(mockIsSessionActive).toHaveBeenCalledWith('prev-session-1')
+    // The hold is recorded for skip observability.
+    expect(mockRecordTaskSkip).toHaveBeenCalledTimes(1)
+    expect(mockRecordTaskSkip).toHaveBeenCalledWith('task-1')
+  })
+
+  it('fires a recurring task whose previous run is parked on user input', async () => {
+    // A parked run has nobody to answer an offline scheduled question, so it must
+    // not wedge the task: active=true but awaitingInput=true => NOT occupied.
+    mockGetDueTasks.mockResolvedValue([createRecurringTask()])
+    mockIsSessionActive.mockReturnValue(true)
+    mockIsSessionAwaitingInput.mockReturnValue(true)
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    expect(mockRecordTaskSkip).not.toHaveBeenCalled()
+    // Fires and re-anchors forward.
+    expect(mockUpdateNextExecution).toHaveBeenCalledWith('task-1', reanchoredAt, 'new-session-1')
+  })
+
+  it('holds a recurring task whose previous run has a backgrounded task still executing', async () => {
+    // A run with a run_in_background Bash/workflow stays active=true and
+    // awaitingInput=false (it emits session_waiting_background), so it counts as
+    // occupied exactly like a foreground-busy run.
+    mockGetDueTasks.mockResolvedValue([createRecurringTask()])
+    mockIsSessionActive.mockReturnValue(true)
+    mockIsSessionAwaitingInput.mockReturnValue(false)
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockCreateSession).not.toHaveBeenCalled()
+    expect(mockUpdateNextExecution).not.toHaveBeenCalled()
+    expect(mockRecordTaskSkip).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires a recurring task whose previous run has gone idle', async () => {
+    mockGetDueTasks.mockResolvedValue([createRecurringTask()])
+    mockIsSessionActive.mockReturnValue(false)
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    expect(mockRecordTaskSkip).not.toHaveBeenCalled()
+    expect(mockUpdateNextExecution).toHaveBeenCalledWith('task-1', reanchoredAt, 'new-session-1')
+  })
+
+  it('holds then fires once and re-anchors when the slot frees on a later poll', async () => {
+    const task = createRecurringTask()
+    // The task remains due across both polls because a held cycle does not advance
+    // nextExecutionAt.
+    mockGetDueTasks.mockResolvedValue([task])
+    // Poll 1: previous run busy -> hold. Poll 2: previous run idle -> fire.
+    mockIsSessionActive.mockReturnValueOnce(true).mockReturnValue(false)
+
+    await taskScheduler.triggerExecution()
+    await taskScheduler.triggerExecution()
+
+    // Exactly one session spawned across the two polls — capped at 1 concurrent.
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    expect(mockRecordTaskSkip).toHaveBeenCalledTimes(1)
+    // Re-anchors forward via getNextCronTime(now) on the successful fire.
+    expect(mockUpdateNextExecution).toHaveBeenCalledTimes(1)
+    expect(mockUpdateNextExecution).toHaveBeenCalledWith('task-1', reanchoredAt, 'new-session-1')
+  })
+
+  it('does not apply the overlap guard to a recurring task with no prior session', async () => {
+    mockGetDueTasks.mockResolvedValue([createRecurringTask({ lastSessionId: null })])
+    // Even if some stale streaming state is somehow active, a null lastSessionId
+    // means there is nothing to guard against — the task fires.
+    mockIsSessionActive.mockReturnValue(true)
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockIsSessionActive).not.toHaveBeenCalled()
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    expect(mockRecordTaskSkip).not.toHaveBeenCalled()
+  })
+
+  it('does not apply the overlap guard to one-time (at) tasks', async () => {
+    // Crons only: a one-time task fires once and is marked executed, so it can
+    // never overlap. Guard must be skipped even if a prior session is active.
+    mockGetDueTasks.mockResolvedValue([
+      createRecurringTask({
+        scheduleType: 'at',
+        isRecurring: false,
+        lastSessionId: 'prev-session-1',
+      }),
+    ])
+    mockIsSessionActive.mockReturnValue(true)
+    mockIsSessionAwaitingInput.mockReturnValue(false)
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockIsSessionActive).not.toHaveBeenCalled()
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    expect(mockRecordTaskSkip).not.toHaveBeenCalled()
+    expect(mockMarkTaskExecuted).toHaveBeenCalledWith('task-1', 'new-session-1')
+  })
+})

--- a/src/shared/lib/scheduler/task-scheduler.overlap-guard.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.overlap-guard.test.ts
@@ -11,6 +11,7 @@ const mockMarkTaskExecuted = vi.fn()
 const mockMarkTaskFailed = vi.fn()
 const mockUpdateNextExecution = vi.fn()
 const mockRecordTaskSkip = vi.fn()
+const mockRescheduleAfterFailure = vi.fn()
 
 vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   getDueTasks: (...args: unknown[]) => mockGetDueTasks(...args),
@@ -18,6 +19,7 @@ vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   markTaskFailed: (...args: unknown[]) => mockMarkTaskFailed(...args),
   updateNextExecution: (...args: unknown[]) => mockUpdateNextExecution(...args),
   recordTaskSkip: (...args: unknown[]) => mockRecordTaskSkip(...args),
+  rescheduleAfterFailure: (...args: unknown[]) => mockRescheduleAfterFailure(...args),
 }))
 
 const mockCreateSession = vi.fn()
@@ -153,6 +155,7 @@ describe('TaskScheduler per-task overlap guard', () => {
     mockMarkTaskFailed.mockResolvedValue(undefined)
     mockUpdateNextExecution.mockResolvedValue(undefined)
     mockRecordTaskSkip.mockResolvedValue(undefined)
+    mockRescheduleAfterFailure.mockResolvedValue(undefined)
     mockGetNextCronTime.mockReturnValue(reanchoredAt)
     // Default: previous run is idle (not occupied) so tasks fire normally.
     mockIsSessionActive.mockReturnValue(false)
@@ -245,13 +248,10 @@ describe('TaskScheduler per-task overlap guard', () => {
   })
 
   it('still holds when the skip bookkeeping write fails — the schedule must not advance', async () => {
-    // Regression (PR #363 review, P1): recordTaskSkip rejecting must NOT escape
-    // executeTaskInner as an execution failure. The outer recurring-task catch
-    // responds to failures with updateNextExecution(task.id, nextTime, '') —
-    // advancing the schedule, resetting skip state, and blanking lastSessionId,
-    // which disarms the guard on the next poll and allows the exact overlap the
-    // guard exists to prevent. The skip counter is best-effort observability;
-    // the hold itself must not depend on it.
+    // Regression: recordTaskSkip rejecting must NOT escape executeTaskInner as
+    // an execution failure. A hold is not a failure — the failure path advances
+    // the schedule, abandoning the pending fire a held task is entitled to. The
+    // skip counter is best-effort observability; the hold must not depend on it.
     mockGetDueTasks.mockResolvedValue([createRecurringTask()])
     mockIsSessionActive.mockReturnValue(true)
     mockIsSessionAwaitingInput.mockReturnValue(false)
@@ -261,10 +261,49 @@ describe('TaskScheduler per-task overlap guard', () => {
 
     // Still held: no second session.
     expect(mockCreateSession).not.toHaveBeenCalled()
-    // THE regression assertions: the failure path must not run.
+    // THE regression assertions: neither the fire record nor the failure
+    // reschedule may run — the task must stay due and untouched.
     expect(mockUpdateNextExecution).not.toHaveBeenCalled()
+    expect(mockRescheduleAfterFailure).not.toHaveBeenCalled()
     expect(mockMarkTaskFailed).not.toHaveBeenCalled()
     // The bookkeeping failure is still reported, just not escalated.
+    expect(mockCaptureException).toHaveBeenCalled()
+  })
+
+  it('a transient pre-guard failure reschedules without touching the guard state', async () => {
+    // A throw before the guard (the reconcile lookup does disk I/O every held
+    // poll) must not blank lastSessionId or wipe the hold streak — that would
+    // disarm the guard and allow the overlap it exists to prevent. The failure
+    // path uses rescheduleAfterFailure (advance-only), never the fire record.
+    mockGetDueTasks.mockResolvedValue([createRecurringTask()])
+    mockGetSessionForScheduledExecution.mockRejectedValue(new Error('transient FS error'))
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockCreateSession).not.toHaveBeenCalled()
+    // Advance-only reschedule; the fire record (which rewrites lastSessionId
+    // and resets the streak) must not run.
+    expect(mockRescheduleAfterFailure).toHaveBeenCalledTimes(1)
+    expect(mockRescheduleAfterFailure).toHaveBeenCalledWith('task-1', reanchoredAt)
+    expect(mockUpdateNextExecution).not.toHaveBeenCalled()
+    expect(mockCaptureException).toHaveBeenCalled()
+  })
+
+  it('records the real session when the fire fails after session creation', async () => {
+    // createSession succeeded — the prompt is already executing in the container.
+    // A subsequent registration failure must still record that session as the
+    // fire's session so the overlap guard arms against the orphan, rather than
+    // going through the failure path which records no session at all.
+    mockGetDueTasks.mockResolvedValue([createRecurringTask()])
+    mockIsSessionActive.mockReturnValue(false)
+    mockRegisterSession.mockRejectedValue(new Error('metadata write failed'))
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    // The orphan is recorded as this fire's session (real id, not '').
+    expect(mockUpdateNextExecution).toHaveBeenCalledWith('task-1', reanchoredAt, 'new-session-1')
+    // The error still surfaces through the failure accounting.
     expect(mockCaptureException).toHaveBeenCalled()
   })
 

--- a/src/shared/lib/scheduler/task-scheduler.overlap-guard.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.overlap-guard.test.ts
@@ -244,6 +244,45 @@ describe('TaskScheduler per-task overlap guard', () => {
     expect(mockUpdateNextExecution).toHaveBeenCalledWith('task-1', reanchoredAt, 'new-session-1')
   })
 
+  it('still holds when the skip bookkeeping write fails — the schedule must not advance', async () => {
+    // Regression (PR #363 review, P1): recordTaskSkip rejecting must NOT escape
+    // executeTaskInner as an execution failure. The outer recurring-task catch
+    // responds to failures with updateNextExecution(task.id, nextTime, '') —
+    // advancing the schedule, resetting skip state, and blanking lastSessionId,
+    // which disarms the guard on the next poll and allows the exact overlap the
+    // guard exists to prevent. The skip counter is best-effort observability;
+    // the hold itself must not depend on it.
+    mockGetDueTasks.mockResolvedValue([createRecurringTask()])
+    mockIsSessionActive.mockReturnValue(true)
+    mockIsSessionAwaitingInput.mockReturnValue(false)
+    mockRecordTaskSkip.mockRejectedValue(new Error('SQLite write failed'))
+
+    await taskScheduler.triggerExecution()
+
+    // Still held: no second session.
+    expect(mockCreateSession).not.toHaveBeenCalled()
+    // THE regression assertions: the failure path must not run.
+    expect(mockUpdateNextExecution).not.toHaveBeenCalled()
+    expect(mockMarkTaskFailed).not.toHaveBeenCalled()
+    // The bookkeeping failure is still reported, just not escalated.
+    expect(mockCaptureException).toHaveBeenCalled()
+  })
+
+  it('fires normally on a later poll after a failed skip write, once the slot frees', async () => {
+    mockGetDueTasks.mockResolvedValue([createRecurringTask()])
+    // Poll 1: occupied + skip write fails. Poll 2: slot freed.
+    mockIsSessionActive.mockReturnValueOnce(true).mockReturnValue(false)
+    mockRecordTaskSkip.mockRejectedValueOnce(new Error('SQLite write failed'))
+
+    await taskScheduler.triggerExecution()
+    await taskScheduler.triggerExecution()
+
+    // The guard stayed armed through the failed write: exactly one fire.
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    expect(mockUpdateNextExecution).toHaveBeenCalledTimes(1)
+    expect(mockUpdateNextExecution).toHaveBeenCalledWith('task-1', reanchoredAt, 'new-session-1')
+  })
+
   it('does not apply the overlap guard to a recurring task with no prior session', async () => {
     mockGetDueTasks.mockResolvedValue([createRecurringTask({ lastSessionId: null })])
     // Even if some stale streaming state is somehow active, a null lastSessionId

--- a/src/shared/lib/scheduler/task-scheduler.sup243.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.sup243.test.ts
@@ -111,6 +111,8 @@ function createTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     lastExecutedAt: null,
     isRecurring: false,
     executionCount: 0,
+    consecutiveSkips: 0,
+    lastSkippedAt: null,
     lastSessionId: null,
     createdBySessionId: null,
     createdByUserId: 'user-1',

--- a/src/shared/lib/scheduler/task-scheduler.sup243.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.sup243.test.ts
@@ -5,12 +5,16 @@ const mockGetDueTasks = vi.fn()
 const mockMarkTaskExecuted = vi.fn()
 const mockMarkTaskFailed = vi.fn()
 const mockUpdateNextExecution = vi.fn()
+const mockRecordTaskSkip = vi.fn()
+const mockRescheduleAfterFailure = vi.fn()
 
 vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   getDueTasks: (...args: unknown[]) => mockGetDueTasks(...args),
   markTaskExecuted: (...args: unknown[]) => mockMarkTaskExecuted(...args),
   markTaskFailed: (...args: unknown[]) => mockMarkTaskFailed(...args),
   updateNextExecution: (...args: unknown[]) => mockUpdateNextExecution(...args),
+  recordTaskSkip: (...args: unknown[]) => mockRecordTaskSkip(...args),
+  rescheduleAfterFailure: (...args: unknown[]) => mockRescheduleAfterFailure(...args),
 }))
 
 const mockCreateSession = vi.fn()
@@ -158,6 +162,8 @@ describe('TaskScheduler duplicate execution guard (SUP-243)', () => {
     mockMarkTaskExecuted.mockResolvedValue(undefined)
     mockMarkTaskFailed.mockResolvedValue(undefined)
     mockUpdateNextExecution.mockResolvedValue(undefined)
+    mockRecordTaskSkip.mockResolvedValue(undefined)
+    mockRescheduleAfterFailure.mockResolvedValue(undefined)
     mockGetNextCronTime.mockReturnValue(nextExecutionAt)
   })
 
@@ -222,23 +228,27 @@ describe('TaskScheduler duplicate execution guard (SUP-243)', () => {
       .mockResolvedValueOnce(existingScheduledSession())
     mockUpdateNextExecution
       .mockRejectedValueOnce(new Error('lost durable advance'))
-      .mockRejectedValueOnce(new Error('same SQLite outage'))
       .mockResolvedValueOnce(undefined)
+    mockRescheduleAfterFailure.mockRejectedValue(new Error('same SQLite outage'))
     mockMarkTaskFailed.mockRejectedValue(new Error('same SQLite outage'))
 
     await taskScheduler.triggerExecution()
     await taskScheduler.triggerExecution()
 
     expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    // Fire attempt: the durable advance carries the real session id.
     expect(mockUpdateNextExecution).toHaveBeenNthCalledWith(
       1,
       'task-1',
       nextExecutionAt,
       'container-session-1',
     )
-    expect(mockUpdateNextExecution).toHaveBeenNthCalledWith(2, 'task-1', nextExecutionAt, '')
+    // Failure path: advance-only reschedule — never a fire record with a
+    // blank session id (that would disarm the overlap guard).
+    expect(mockRescheduleAfterFailure).toHaveBeenCalledWith('task-1', nextExecutionAt)
+    // Retry poll reconciles with the existing session and records it.
     expect(mockUpdateNextExecution).toHaveBeenNthCalledWith(
-      3,
+      2,
       'task-1',
       nextExecutionAt,
       'container-session-1',

--- a/src/shared/lib/scheduler/task-scheduler.ts
+++ b/src/shared/lib/scheduler/task-scheduler.ts
@@ -14,6 +14,7 @@ import {
   getDueTasks,
   markTaskExecuted,
   markTaskFailed,
+  recordTaskSkip,
   updateNextExecution,
 } from '@shared/lib/services/scheduled-task-service'
 import type { ScheduledTask } from '@shared/lib/services/scheduled-task-service'
@@ -180,6 +181,34 @@ class TaskScheduler {
       )
       await this.recordTaskExecution(task, existingSession.id)
       return
+    }
+
+    // Per-task overlap guard (recurring crons only): if the previous run of THIS
+    // task is still actively progressing, hold this fire instead of spawning a
+    // second concurrent session. "Actively progressing" means busy AND not parked
+    // on user input — a parked run has nobody to answer an offline scheduled
+    // question, so it must not wedge the task forever, whereas a run with a
+    // backgrounded task still executing stays isActive=true / isAwaitingInput=false
+    // and correctly counts as occupied.
+    //
+    // Hold semantics: we do NOT advance nextExecutionAt, leaving the task due so
+    // the next poll re-checks and fires the freshest run the moment the slot frees
+    // (re-anchoring forward via getNextCronTime(now) in recordTaskExecution).
+    // Because nextExecutionAt is a single scalar, at most one pending fire exists
+    // per task — coalesce-to-latest is automatic. Each held cycle bumps
+    // consecutiveSkips / lastSkippedAt for skip observability.
+    if (task.isRecurring && task.lastSessionId) {
+      const lastSessionId = task.lastSessionId
+      const occupied =
+        messagePersister.isSessionActive(lastSessionId) &&
+        !messagePersister.isSessionAwaitingInput(lastSessionId)
+      if (occupied) {
+        console.log(
+          `[TaskScheduler] Task ${task.id} held: previous run ${lastSessionId} still active; leaving task due`
+        )
+        await recordTaskSkip(task.id)
+        return
+      }
     }
 
     // Verify agent still exists

--- a/src/shared/lib/scheduler/task-scheduler.ts
+++ b/src/shared/lib/scheduler/task-scheduler.ts
@@ -15,6 +15,7 @@ import {
   markTaskExecuted,
   markTaskFailed,
   recordTaskSkip,
+  rescheduleAfterFailure,
   updateNextExecution,
 } from '@shared/lib/services/scheduled-task-service'
 import type { ScheduledTask } from '@shared/lib/services/scheduled-task-service'
@@ -130,12 +131,15 @@ class TaskScheduler {
             tags: { component: 'task-scheduler', phase: 'execute-task' },
             extra: { taskId: task.id, agentSlug: task.agentSlug, isRecurring: task.isRecurring },
           })
-          // For recurring tasks, schedule next execution even on failure
-          // For one-time tasks, mark as failed
+          // For recurring tasks, schedule the next attempt without recording an
+          // execution: rescheduleAfterFailure advances nextExecutionAt only,
+          // preserving lastSessionId (blanking it would disarm the overlap
+          // guard) and the consecutiveSkips hold streak.
+          // For one-time tasks, mark as failed.
           if (task.isRecurring) {
             try {
               const nextTime = getNextCronTime(task.scheduleExpression, task.timezone || undefined)
-              await updateNextExecution(task.id, nextTime, '')
+              await rescheduleAfterFailure(task.id, nextTime)
               console.log(
                 `[TaskScheduler] Recurring task ${task.id} failed but scheduled next: ${nextTime.toISOString()}`
               )
@@ -206,13 +210,9 @@ class TaskScheduler {
         console.log(
           `[TaskScheduler] Task ${task.id} held: previous run ${lastSessionId} still active; leaving task due`
         )
-        // The skip counter is best-effort observability — a failed write must
-        // NOT escape as an execution failure. The recurring-task catch in
-        // executeOverdueTasks responds to failures with
-        // updateNextExecution(task.id, nextTime, ''), which advances the
-        // schedule, resets the skip streak, and blanks lastSessionId — disarming
-        // this guard on the next poll and allowing the exact overlap it exists
-        // to prevent. Report and hold regardless.
+        // Best-effort bookkeeping: a hold is not a failure, so a failed skip
+        // write must not escape into the failure path (which would advance the
+        // schedule and abandon the pending fire). Report and hold regardless.
         try {
           await recordTaskSkip(task.id)
         } catch (error) {
@@ -260,21 +260,40 @@ class TaskScheduler {
     const sessionId = containerSession.id
     const sessionName = task.name || 'Scheduled Task'
 
-    await registerSession(task.agentSlug, sessionId, sessionName, {
-      isScheduledExecution: true,
-      scheduledTaskId: task.id,
-      scheduledTaskName: task.name || undefined,
-      scheduledExecutionAt: task.nextExecutionAt.toISOString(),
-    })
+    try {
+      await registerSession(task.agentSlug, sessionId, sessionName, {
+        isScheduledExecution: true,
+        scheduledTaskId: task.id,
+        scheduledTaskName: task.name || undefined,
+        scheduledExecutionAt: task.nextExecutionAt.toISOString(),
+      })
 
-    // Subscribe to the session for SSE updates
-    await messagePersister.subscribeToSession(
-      sessionId,
-      client,
-      sessionId,
-      task.agentSlug
-    )
-    messagePersister.markSessionActive(sessionId, task.agentSlug)
+      // Subscribe to the session for SSE updates
+      await messagePersister.subscribeToSession(
+        sessionId,
+        client,
+        sessionId,
+        task.agentSlug
+      )
+      messagePersister.markSessionActive(sessionId, task.agentSlug)
+    } catch (error) {
+      // The session already exists and is executing the prompt (initialMessage),
+      // even though registration/subscription failed. Record it as this fire's
+      // session before propagating so the schedule advances pointing at the real
+      // session — arming the overlap guard against the orphan — instead of going
+      // through the failure path, which records no session at all.
+      await this.recordTaskExecution(task, sessionId).catch((recordError) => {
+        console.error(
+          `[TaskScheduler] Failed to record orphaned session ${sessionId} for task ${task.id}:`,
+          recordError
+        )
+        captureException(recordError, {
+          tags: { component: 'task-scheduler', phase: 'record-orphan' },
+          extra: { taskId: task.id, agentSlug: task.agentSlug, sessionId },
+        })
+      })
+      throw error
+    }
 
     console.log(
       `[TaskScheduler] Task ${task.id} started, session: ${sessionId}`

--- a/src/shared/lib/scheduler/task-scheduler.ts
+++ b/src/shared/lib/scheduler/task-scheduler.ts
@@ -206,7 +206,25 @@ class TaskScheduler {
         console.log(
           `[TaskScheduler] Task ${task.id} held: previous run ${lastSessionId} still active; leaving task due`
         )
-        await recordTaskSkip(task.id)
+        // The skip counter is best-effort observability — a failed write must
+        // NOT escape as an execution failure. The recurring-task catch in
+        // executeOverdueTasks responds to failures with
+        // updateNextExecution(task.id, nextTime, ''), which advances the
+        // schedule, resets the skip streak, and blanks lastSessionId — disarming
+        // this guard on the next poll and allowing the exact overlap it exists
+        // to prevent. Report and hold regardless.
+        try {
+          await recordTaskSkip(task.id)
+        } catch (error) {
+          console.error(
+            `[TaskScheduler] Failed to record skip for task ${task.id}:`,
+            error
+          )
+          captureException(error, {
+            tags: { component: 'task-scheduler', phase: 'record-skip' },
+            extra: { taskId: task.id, agentSlug: task.agentSlug },
+          })
+        }
         return
       }
     }

--- a/src/shared/lib/services/scheduled-task-service.test.ts
+++ b/src/shared/lib/services/scheduled-task-service.test.ts
@@ -35,6 +35,7 @@ import {
   cancelScheduledTask,
   markTaskExecuted,
   updateNextExecution,
+  recordTaskSkip,
   markTaskFailed,
   resetScheduledTask,
   updateTaskName,
@@ -442,6 +443,71 @@ describe('scheduled-task-service', () => {
       expect(updatedTask!.lastSessionId).toBe('session-xyz')
       expect(updatedTask!.executionCount).toBe(initialCount + 1)
       expect(updatedTask!.status).toBe('pending') // Should stay pending for recurring
+    })
+  })
+
+  // ============================================================================
+  // recordTaskSkip / overlap-guard skip counters
+  // ============================================================================
+
+  describe('recordTaskSkip', () => {
+    it('increments consecutiveSkips and stamps lastSkippedAt without advancing the schedule', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'cron',
+        scheduleExpression: '*/15 * * * *',
+        prompt: 'Recurring test',
+      })
+
+      const before = await getScheduledTask(taskId)
+      expect(before!.consecutiveSkips).toBe(0)
+      expect(before!.lastSkippedAt).toBeNull()
+      const originalNext = before!.nextExecutionAt.getTime()
+
+      await recordTaskSkip(taskId)
+
+      const afterOne = await getScheduledTask(taskId)
+      expect(afterOne!.consecutiveSkips).toBe(1)
+      expect(afterOne!.lastSkippedAt).not.toBeNull()
+      // Held cycle must NOT advance the schedule — the task stays due.
+      expect(afterOne!.nextExecutionAt.getTime()).toBe(originalNext)
+      // A hold is not an execution.
+      expect(afterOne!.executionCount).toBe(0)
+      expect(afterOne!.lastExecutedAt).toBeNull()
+
+      await recordTaskSkip(taskId)
+      const afterTwo = await getScheduledTask(taskId)
+      expect(afterTwo!.consecutiveSkips).toBe(2)
+    })
+
+    it('is a no-op for a nonexistent task', async () => {
+      await expect(recordTaskSkip('nonexistent-id')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('updateNextExecution skip reset', () => {
+    it('resets consecutiveSkips and lastSkippedAt on a successful fire', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'cron',
+        scheduleExpression: '*/15 * * * *',
+        prompt: 'Recurring test',
+      })
+
+      // Accumulate a hold streak.
+      await recordTaskSkip(taskId)
+      await recordTaskSkip(taskId)
+      const held = await getScheduledTask(taskId)
+      expect(held!.consecutiveSkips).toBe(2)
+      expect(held!.lastSkippedAt).not.toBeNull()
+
+      // A successful fire clears the streak.
+      await updateNextExecution(taskId, new Date('2024-06-15T13:00:00.000Z'), 'session-xyz')
+
+      const fired = await getScheduledTask(taskId)
+      expect(fired!.consecutiveSkips).toBe(0)
+      expect(fired!.lastSkippedAt).toBeNull()
+      expect(fired!.executionCount).toBe(1)
     })
   })
 

--- a/src/shared/lib/services/scheduled-task-service.test.ts
+++ b/src/shared/lib/services/scheduled-task-service.test.ts
@@ -36,6 +36,10 @@ import {
   markTaskExecuted,
   updateNextExecution,
   recordTaskSkip,
+  rescheduleAfterFailure,
+  recordManualExecution,
+  pauseScheduledTask,
+  resumeScheduledTask,
   markTaskFailed,
   resetScheduledTask,
   updateTaskName,
@@ -508,6 +512,108 @@ describe('scheduled-task-service', () => {
       expect(fired!.consecutiveSkips).toBe(0)
       expect(fired!.lastSkippedAt).toBeNull()
       expect(fired!.executionCount).toBe(1)
+    })
+  })
+
+  // ============================================================================
+  // rescheduleAfterFailure Tests
+  // ============================================================================
+
+  describe('rescheduleAfterFailure', () => {
+    it('advances the schedule but preserves the guard pointer, hold streak, and execution stats', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'cron',
+        scheduleExpression: '*/15 * * * *',
+        prompt: 'Recurring test',
+      })
+
+      // Establish a real prior fire, then a hold streak on top of it.
+      await updateNextExecution(taskId, new Date('2024-06-15T12:15:00.000Z'), 'prev-session')
+      await recordTaskSkip(taskId)
+      await recordTaskSkip(taskId)
+      const before = await getScheduledTask(taskId)
+      expect(before!.lastSessionId).toBe('prev-session')
+      expect(before!.consecutiveSkips).toBe(2)
+      const beforeExecutedAt = before!.lastExecutedAt
+
+      const nextTime = new Date('2024-06-15T12:30:00.000Z')
+      await rescheduleAfterFailure(taskId, nextTime)
+
+      const after = await getScheduledTask(taskId)
+      // Schedule advanced (failure must not hot-loop the same slot)...
+      expect(after!.nextExecutionAt.getTime()).toBe(nextTime.getTime())
+      // ...but nothing else: the failure is not an execution, and blanking
+      // lastSessionId here is what disarms the overlap guard.
+      expect(after!.lastSessionId).toBe('prev-session')
+      expect(after!.consecutiveSkips).toBe(2)
+      expect(after!.lastSkippedAt).not.toBeNull()
+      expect(after!.executionCount).toBe(1)
+      expect(after!.lastExecutedAt?.getTime()).toBe(beforeExecutedAt?.getTime())
+      expect(after!.status).toBe('pending')
+    })
+
+    it('is a no-op for a nonexistent task', async () => {
+      await expect(
+        rescheduleAfterFailure('nonexistent-id', new Date('2024-06-15T13:00:00.000Z'))
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  // ============================================================================
+  // Skip-streak reset on re-anchor and manual run
+  // ============================================================================
+
+  describe('skip-streak reset on re-anchor and manual run', () => {
+    async function createHeldTask(): Promise<string> {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'cron',
+        scheduleExpression: '*/15 * * * *',
+        prompt: 'Recurring test',
+      })
+      await recordTaskSkip(taskId)
+      await recordTaskSkip(taskId)
+      await recordTaskSkip(taskId)
+      const held = await getScheduledTask(taskId)
+      expect(held!.consecutiveSkips).toBe(3)
+      return taskId
+    }
+
+    it('resumeScheduledTask clears the streak (the held fire is abandoned by the re-anchor)', async () => {
+      const taskId = await createHeldTask()
+      await pauseScheduledTask(taskId)
+
+      const resumed = await resumeScheduledTask(taskId)
+      expect(resumed).toBe(true)
+
+      const task = await getScheduledTask(taskId)
+      expect(task!.consecutiveSkips).toBe(0)
+      expect(task!.lastSkippedAt).toBeNull()
+    })
+
+    it('resetScheduledTask clears the streak', async () => {
+      const taskId = await createHeldTask()
+      await markTaskFailed(taskId, 'boom')
+
+      const reset = await resetScheduledTask(taskId)
+      expect(reset).toBe(true)
+
+      const task = await getScheduledTask(taskId)
+      expect(task!.consecutiveSkips).toBe(0)
+      expect(task!.lastSkippedAt).toBeNull()
+    })
+
+    it('recordManualExecution clears the streak (manual run becomes the guarded previous run)', async () => {
+      const taskId = await createHeldTask()
+
+      await recordManualExecution(taskId, 'manual-session')
+
+      const task = await getScheduledTask(taskId)
+      expect(task!.consecutiveSkips).toBe(0)
+      expect(task!.lastSkippedAt).toBeNull()
+      expect(task!.lastSessionId).toBe('manual-session')
+      expect(task!.executionCount).toBe(1)
     })
   })
 

--- a/src/shared/lib/services/scheduled-task-service.ts
+++ b/src/shared/lib/services/scheduled-task-service.ts
@@ -7,7 +7,7 @@
 
 import { db } from '@shared/lib/db'
 import { scheduledTasks, type ScheduledTask, type NewScheduledTask } from '@shared/lib/db/schema'
-import { eq, and, lte, inArray } from 'drizzle-orm'
+import { eq, and, lte, inArray, sql } from 'drizzle-orm'
 import { getNextCronTime, parseAtSyntax } from './schedule-parser'
 import { trackServerEvent } from '../analytics/server-analytics'
 
@@ -249,6 +249,10 @@ export async function resumeScheduledTask(taskId: string): Promise<boolean> {
       status: 'pending',
       nextExecutionAt,
       pausedAt: null,
+      // Re-anchoring abandons any held fire — clear the hold streak that was
+      // counting it, or the task reads as wedged until its next scheduled fire.
+      consecutiveSkips: 0,
+      lastSkippedAt: null,
     })
     .where(eq(scheduledTasks.id, taskId))
 
@@ -304,17 +308,37 @@ export async function updateNextExecution(
  * and stamps lastSkippedAt WITHOUT advancing nextExecutionAt, so the task stays
  * due and re-fires on the first poll after the slot frees. Both fields are reset
  * on the next successful fire (see updateNextExecution).
+ *
+ * SQL-side increment (same pattern as webhook-trigger-service's fireCount):
+ * one atomic statement, no read-modify-write. A nonexistent task is a natural
+ * no-op (the UPDATE matches zero rows).
  */
 export async function recordTaskSkip(taskId: string): Promise<void> {
-  const task = await getScheduledTask(taskId)
-  if (!task) return
-
   await db
     .update(scheduledTasks)
     .set({
-      consecutiveSkips: task.consecutiveSkips + 1,
+      consecutiveSkips: sql`${scheduledTasks.consecutiveSkips} + 1`,
       lastSkippedAt: new Date(),
     })
+    .where(eq(scheduledTasks.id, taskId))
+}
+
+/**
+ * Advance a recurring task's schedule after a FAILED fire attempt — without
+ * recording an execution. Deliberately preserves lastSessionId (the overlap
+ * guard's pointer to the previous run: blanking it would disarm the guard and
+ * allow the overlap it exists to prevent), the consecutiveSkips/lastSkippedAt
+ * hold streak (a failure is not a fire; wiping the streak would erase the
+ * wedge-observability signal), executionCount, and lastExecutedAt (nothing
+ * executed). Contrast with updateNextExecution, which records a real fire.
+ */
+export async function rescheduleAfterFailure(
+  taskId: string,
+  nextTime: Date
+): Promise<void> {
+  await db
+    .update(scheduledTasks)
+    .set({ nextExecutionAt: nextTime })
     .where(eq(scheduledTasks.id, taskId))
 }
 
@@ -353,6 +377,10 @@ export async function resetScheduledTask(taskId: string): Promise<boolean> {
     .set({
       status: 'pending',
       nextExecutionAt,
+      // Same re-anchor semantics as resume: the held fire (if any) is abandoned,
+      // so the streak counting it must go too.
+      consecutiveSkips: 0,
+      lastSkippedAt: null,
     })
     .where(eq(scheduledTasks.id, taskId))
 
@@ -466,6 +494,11 @@ export async function recordManualExecution(
       lastExecutedAt: new Date(),
       lastSessionId: sessionId,
       executionCount: task.executionCount + 1,
+      // A manual run rebinds lastSessionId (above), making it "the previous run"
+      // for the overlap guard — reset the streak to match. If the scheduled slot
+      // is genuinely still blocked, recordTaskSkip rebuilds it on the next poll.
+      consecutiveSkips: 0,
+      lastSkippedAt: null,
     })
     .where(eq(scheduledTasks.id, taskId))
 }

--- a/src/shared/lib/services/scheduled-task-service.ts
+++ b/src/shared/lib/services/scheduled-task-service.ts
@@ -291,6 +291,29 @@ export async function updateNextExecution(
       lastExecutedAt: new Date(),
       lastSessionId: sessionId,
       executionCount: task.executionCount + 1,
+      // A fire (successful or failed-then-rescheduled) breaks any hold streak.
+      consecutiveSkips: 0,
+      lastSkippedAt: null,
+    })
+    .where(eq(scheduledTasks.id, taskId))
+}
+
+/**
+ * Record that a recurring task's fire was held this cycle because its previous
+ * run is still actively progressing (overlap guard). Increments consecutiveSkips
+ * and stamps lastSkippedAt WITHOUT advancing nextExecutionAt, so the task stays
+ * due and re-fires on the first poll after the slot frees. Both fields are reset
+ * on the next successful fire (see updateNextExecution).
+ */
+export async function recordTaskSkip(taskId: string): Promise<void> {
+  const task = await getScheduledTask(taskId)
+  if (!task) return
+
+  await db
+    .update(scheduledTasks)
+    .set({
+      consecutiveSkips: task.consecutiveSkips + 1,
+      lastSkippedAt: new Date(),
     })
     .where(eq(scheduledTasks.id, taskId))
 }


### PR DESCRIPTION
## Summary

Part of **SUP-326** (cron hardening). A recurring task whose run outlasts its interval currently accumulates overlapping sessions — every poll spawns a fresh session without checking whether the previous run of the *same task* is still in flight. This is the root cause of the "pile of parallel tasks → exhaust resources" failure in the parent.

This adds a per-task overlap guard: before firing a recurring task, if its previous run is still **actively progressing**, hold the fire instead of spawning a second concurrent session.

## How it works

**Occupied predicate** (in `executeTaskInner`, crons only):

```
isSessionActive(lastSessionId) && !isSessionAwaitingInput(lastSessionId)
```

- A run parked on **user input** is *not* occupied — it re-fires. An offline scheduled run has nobody to answer a question, so a parked run must not wedge the task forever.
- A run with a `run_in_background` Bash/workflow still executing stays `isActive=true / isAwaitingInput=false` (it emits `session_waiting_background`), so it **is** occupied and blocks a new run.

**Hold semantics:** when occupied we do **not** advance `nextExecutionAt` — the task stays due, the next poll re-checks, and it fires the freshest run the moment the slot frees (re-anchoring forward via `getNextCronTime(now)`). Because `nextExecutionAt` is a single scalar, at most one pending fire can exist per task — coalesce-to-latest is automatic, no queue.

**Skip tracking:** each held cycle bumps `consecutiveSkips` / `lastSkippedAt`; a successful fire resets both. Consumed by the observability sub-task (**SUP-333**, which this blocks).

## Scope

Crons only. Webhooks/triggers are out of scope — they need buffer-not-skip semantics (dropping a webhook = data loss), tracked separately.

## Changes

- **`db/schema.ts`** + **migration `0026`** — additive `consecutive_skips` (int, notNull, default 0) and `last_skipped_at` (nullable) columns on `scheduled_tasks`. `ADD COLUMN` with defaults, safe on existing rows.
- **`scheduled-task-service.ts`** — new `recordTaskSkip(taskId)`; `updateNextExecution` resets the skip counters on a fire.
- **`task-scheduler.ts`** — the overlap guard, gated on `isRecurring && lastSessionId`.

## Tests

- **`task-scheduler.overlap-guard.test.ts`** — control-flow unit tests (overlap-skip, awaiting-input-fires, background-occupied-skips, hold-then-fire re-anchor, crons-only, no-prior-session).
- **`task-scheduler.overlap-guard-replay.test.ts`** — **composition test**: drives the *real* `messagePersister` with the real `background-bash-premature-idle` capture, then invokes the *real* scheduler guard against that live state (HOLD while bash pending → FIRE once settled). Mutation-verified: disabling the guard makes it fail.
- **`scheduled-task-service.test.ts`** — skip increment/reset through a real in-memory SQLite DB + the real migration.

Full scheduler + service + persister suites: **276/276 green**. Typecheck + lint clean.

## Accepted residuals (per ticket)

- After an app restart, in-memory streaming state is empty → the task fires fresh. Correct: the prior container session is gone too, no zombie.
- A genuine runaway loop (busy, never awaiting input) blocks its task indefinitely — surfaced by the skip-threshold notification in SUP-333.