### PR TITLE
Harden request and streaming E2E flows

### DIFF
--- a/e2e/pages/session.page.ts
+++ b/e2e/pages/session.page.ts
@@ -221,9 +221,9 @@ export class SessionPage {
   /**
    * Assert that the assistant message contains expected text
    */
-  async expectAssistantMessage(text: string, index = 0) {
+  async expectAssistantMessage(text: string, index = 0, timeout = 10000) {
     const messages = this.getAssistantMessages()
-    await expect(messages.nth(index)).toContainText(text)
+    await expect(messages.nth(index)).toContainText(text, { timeout })
   }
 
   /**
@@ -273,6 +273,18 @@ export class SessionPage {
     if (!(await target.isVisible())) {
       throw new Error('paginateToCard: target never became visible in the stack')
     }
+  }
+
+  private async waitForVisibleRequestCard(testId: string, timeout = 15000) {
+    const card = this.page.locator(`[data-testid="${testId}"]`).first()
+    await expect(card).toBeAttached({ timeout })
+
+    await expect.poll(async () => {
+      if (await card.isVisible().catch(() => false)) return 'visible'
+
+      await this.paginateToCard(card, 1000).catch(() => undefined)
+      return await card.isVisible().catch(() => false) ? 'visible' : 'hidden'
+    }, { timeout }).toBe('visible')
   }
 
   /**
@@ -429,7 +441,7 @@ export class SessionPage {
   // --- Script Run Request Helpers ---
 
   async waitForScriptRunRequest(timeout = 15000) {
-    await expect(this.page.locator('[data-testid="script-run-request"]').first()).toBeVisible({ timeout })
+    await this.waitForVisibleRequestCard('script-run-request', timeout)
   }
 
   getScriptRunRequests() {
@@ -449,7 +461,7 @@ export class SessionPage {
   // --- Proxy Review Request Helpers ---
 
   async waitForProxyReviewRequest(timeout = 15000) {
-    await expect(this.page.locator('[data-testid="proxy-review-request"]').first()).toBeVisible({ timeout })
+    await this.waitForVisibleRequestCard('proxy-review-request', timeout)
   }
 
   getProxyReviewRequests() {
@@ -502,7 +514,7 @@ export class SessionPage {
   // --- X-Agent Review Request Helpers ---
 
   async waitForXAgentReviewRequest(timeout = 15000) {
-    await expect(this.page.locator('[data-testid="xagent-review-request"]').first()).toBeVisible({ timeout })
+    await this.waitForVisibleRequestCard('xagent-review-request', timeout)
   }
 
   getXAgentReviewRequests() {
@@ -526,7 +538,7 @@ export class SessionPage {
   // --- Computer Use Request Helpers ---
 
   async waitForComputerUseRequest(timeout = 15000) {
-    await expect(this.page.locator('[data-testid="computer-use-request"]').first()).toBeVisible({ timeout })
+    await this.waitForVisibleRequestCard('computer-use-request', timeout)
   }
 
   getComputerUseRequests() {

--- a/e2e/specs/background-bash.spec.ts
+++ b/e2e/specs/background-bash.spec.ts
@@ -35,36 +35,33 @@ test.describe('Background Bash Task Tracking', () => {
     // Should show background process count
     await expect(indicator).toContainText('background process', { timeout: 10000 })
 
-    // Wait for the background task to complete and agent to respond
-    // The BackgroundBashScenario has a 2s delay, then the agent processes the notification
-    await sessionPage.waitForInputEnabled(15000)
+    // Wait for the background task to complete and agent to respond.
+    // The BackgroundBashScenario has a 2s delay, then the agent processes the notification.
+    await sessionPage.expectAssistantMessage('Background command completed', 1, 30000)
+    await sessionPage.waitForInputEnabled(30000)
 
     // Agent should go back to idle after everything completes
     await agentPage.waitForStatus('idle', 15000)
   })
 
-  test('background process indicator disappears after completion', async ({ page }) => {
+  test('background process indicator disappears after completion', async () => {
     await sessionPage.sendMessage('run background command')
 
     // Wait for background process indicator to appear
     const indicator = sessionPage.getActivityIndicator()
     await expect(indicator).toContainText('background process', { timeout: 10000 })
 
-    // Wait for completion — the indicator should eventually disappear
-    await sessionPage.waitForInputEnabled(15000)
-
-    // Activity indicator should be gone (session is idle)
-    await expect(indicator).not.toBeVisible({ timeout: 10000 })
+    // Activity indicator should be gone once the background task has completed.
+    await expect(indicator).not.toBeVisible({ timeout: 30000 })
+    await sessionPage.waitForInputEnabled(30000)
   })
 
   test('agent responds with final output after background task completes', async () => {
     await sessionPage.sendMessage('run background command')
 
-    // Wait for the full flow to complete
-    await sessionPage.waitForInputEnabled(15000)
-
     // Should have the final response mentioning the command output
-    await sessionPage.expectAssistantMessage('Background command completed', 1)
+    await sessionPage.expectAssistantMessage('Background command completed', 1, 30000)
+    await sessionPage.waitForInputEnabled(30000)
   })
 
   test('shows both stop and send buttons while waiting for background task', async ({ page }) => {
@@ -81,6 +78,7 @@ test.describe('Background Bash Task Tracking', () => {
     await expect(sendButton).toBeVisible({ timeout: 5000 })
 
     // Wait for completion
-    await sessionPage.waitForInputEnabled(15000)
+    await expect(indicator).not.toBeVisible({ timeout: 30000 })
+    await sessionPage.waitForInputEnabled(30000)
   })
 })

--- a/e2e/specs/computer-use.spec.ts
+++ b/e2e/specs/computer-use.spec.ts
@@ -40,6 +40,7 @@ test.describe('Computer Use requests', () => {
 
     // Session should complete
     await sessionPage.waitForInputEnabled(15000)
+    await sessionPage.expectAssistantMessage('Thank you for providing the information.', 1, 15000)
   })
 
   test('computer use request: deny', async () => {
@@ -55,5 +56,6 @@ test.describe('Computer Use requests', () => {
 
     // Session should complete
     await sessionPage.waitForInputEnabled(15000)
+    await sessionPage.expectAssistantMessage('Thank you for providing the information.', 1, 15000)
   })
 })

--- a/e2e/specs/proxy-review.spec.ts
+++ b/e2e/specs/proxy-review.spec.ts
@@ -23,12 +23,12 @@ test.describe('Proxy Review Requests', () => {
     await agentPage.createAgent(testAgentName)
   })
 
-  test('proxy review: review prompt appears with correct details', async ({ page }) => {
+  test('proxy review: review prompt appears with correct details', async () => {
     // "proxy review" triggers ProxyReviewScenario
     await sessionPage.sendMessage('proxy review')
 
     // Wait for the review prompt to appear
-    await sessionPage.waitForProxyReviewRequest()
+    await sessionPage.waitForProxyReviewRequest(35000)
 
     // Verify the API details are shown
     const request = sessionPage.getProxyReviewRequests().first()
@@ -38,69 +38,69 @@ test.describe('Proxy Review Requests', () => {
     await expect(request).toContainText('slack')
   })
 
-  test('proxy review: user can allow the request', async ({ page }) => {
+  test('proxy review: user can allow the request', async () => {
     await sessionPage.sendMessage('proxy review')
 
-    await sessionPage.waitForProxyReviewRequest()
+    await sessionPage.waitForProxyReviewRequest(35000)
 
     // Allow the request
     await sessionPage.allowProxyReview()
 
-    // Review prompt should disappear
+    // Review prompt should disappear.
     await expect(sessionPage.getProxyReviewRequests()).toHaveCount(0, { timeout: 10000 })
 
     // Session should complete with approval message
     await sessionPage.waitForInputEnabled(15000)
-    await sessionPage.expectAssistantMessage('approved by user')
+    await sessionPage.expectAssistantMessage('approved by user', 0, 15000)
   })
 
-  test('proxy review: user can deny the request', async ({ page }) => {
+  test('proxy review: user can deny the request', async () => {
     await sessionPage.sendMessage('proxy review')
 
-    await sessionPage.waitForProxyReviewRequest()
+    await sessionPage.waitForProxyReviewRequest(35000)
 
     // Deny the request
     await sessionPage.denyProxyReview()
 
-    // Review prompt should disappear
+    // Review prompt should disappear.
     await expect(sessionPage.getProxyReviewRequests()).toHaveCount(0, { timeout: 10000 })
 
     // Session should complete with denial message
     await sessionPage.waitForInputEnabled(15000)
-    await sessionPage.expectAssistantMessage('denied by user')
+    await sessionPage.expectAssistantMessage('denied by user', 0, 15000)
   })
 
-  test('proxy review: remember always allow for scope', async ({ page }) => {
+  test('proxy review: remember always allow for scope', async () => {
     await sessionPage.sendMessage('proxy review')
 
-    await sessionPage.waitForProxyReviewRequest()
+    await sessionPage.waitForProxyReviewRequest(35000)
 
     // Click always allow for this scope (opens Allow popover, then clicks scope button)
     await sessionPage.alwaysAllowScope('chat:write')
 
-    // Review prompt should disappear
+    // Review prompt should disappear.
     await expect(sessionPage.getProxyReviewRequests()).toHaveCount(0, { timeout: 10000 })
 
     // Session should complete with approval message
     await sessionPage.waitForInputEnabled(15000)
-    await sessionPage.expectAssistantMessage('approved by user')
+    await sessionPage.expectAssistantMessage('approved by user', 0, 15000)
   })
 
-  test('proxy review: allow all requests for the minimal risk group', async ({ page }) => {
+  test('proxy review: allow all requests for the minimal risk group', async () => {
     await sessionPage.sendMessage('proxy review')
 
-    await sessionPage.waitForProxyReviewRequest()
+    await sessionPage.waitForProxyReviewRequest(35000)
 
     // chat.postMessage is satisfied by chat:write (a "write"-labelled scope), so the
     // minimal group offered is "write". Allowing it should approve and persist '*write'.
     await sessionPage.alwaysAllowLabelGroup('write')
 
-    // Review prompt should disappear
+    // Review prompt should disappear.
     await expect(sessionPage.getProxyReviewRequests()).toHaveCount(0, { timeout: 10000 })
 
     // Session should complete with approval message
     await sessionPage.waitForInputEnabled(15000)
-    await sessionPage.expectAssistantMessage('approved by user')
+    await sessionPage.expectAssistantMessage('approved by user', 0, 15000)
   })
 })
 
@@ -122,12 +122,12 @@ test.describe('X-Agent Review Requests', () => {
     await agentPage.createAgent(testAgentName, { waitForSidebarName: false })
   })
 
-  test('x-agent review: interrupt dismisses the review card', async ({ page }) => {
+  test('x-agent review: interrupt dismisses the review card', async () => {
     // "x-agent review" triggers XAgentReviewScenario
     await sessionPage.sendMessage('x-agent review')
 
     // Wait for the x-agent review prompt to appear
-    await sessionPage.waitForXAgentReviewRequest()
+    await sessionPage.waitForXAgentReviewRequest(35000)
 
     // Click the X (stop session) button on the card
     await sessionPage.stopSessionFromRequest()
@@ -136,10 +136,10 @@ test.describe('X-Agent Review Requests', () => {
     await expect(sessionPage.getXAgentReviewRequests()).toHaveCount(0, { timeout: 10000 })
   })
 
-  test('x-agent review: user can allow the request', async ({ page }) => {
+  test('x-agent review: user can allow the request', async () => {
     await sessionPage.sendMessage('x-agent review')
 
-    await sessionPage.waitForXAgentReviewRequest()
+    await sessionPage.waitForXAgentReviewRequest(35000)
 
     // Verify the card shows the right text
     const request = sessionPage.getXAgentReviewRequests().first()
@@ -148,27 +148,27 @@ test.describe('X-Agent Review Requests', () => {
     // Allow the request
     await sessionPage.allowXAgentReview()
 
-    // Review prompt should disappear
+    // Review prompt should disappear.
     await expect(sessionPage.getXAgentReviewRequests()).toHaveCount(0, { timeout: 10000 })
 
     // Session should complete with approval message
     await sessionPage.waitForInputEnabled(15000)
-    await sessionPage.expectAssistantMessage('approved by user')
+    await sessionPage.expectAssistantMessage('approved by user', 0, 15000)
   })
 
-  test('x-agent review: user can deny the request', async ({ page }) => {
+  test('x-agent review: user can deny the request', async () => {
     await sessionPage.sendMessage('x-agent review')
 
-    await sessionPage.waitForXAgentReviewRequest()
+    await sessionPage.waitForXAgentReviewRequest(35000)
 
     // Deny the request
     await sessionPage.denyXAgentReview()
 
-    // Review prompt should disappear
+    // Review prompt should disappear.
     await expect(sessionPage.getXAgentReviewRequests()).toHaveCount(0, { timeout: 10000 })
 
     // Session should complete with denial message
     await sessionPage.waitForInputEnabled(15000)
-    await sessionPage.expectAssistantMessage('denied by user')
+    await sessionPage.expectAssistantMessage('denied by user', 0, 15000)
   })
 })

--- a/src/renderer/components/messages/use-pending-requests.test.tsx
+++ b/src/renderer/components/messages/use-pending-requests.test.tsx
@@ -28,6 +28,7 @@ const mockStreamState = {
   pendingComputerUseRequests: [] as Array<{ toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string }>,
   streamingToolUses: [] as Array<{ id: string; name: string; partialInput: string; ready?: boolean }>,
   autoApprovedScriptRunIds: new Set<string>(),
+  autoApprovedComputerUseIds: new Set<string>(),
 }
 
 const mockRemovers = {
@@ -107,6 +108,7 @@ describe('usePendingRequests', () => {
       pendingComputerUseRequests: [],
       streamingToolUses: [],
       autoApprovedScriptRunIds: new Set<string>(),
+      autoApprovedComputerUseIds: new Set<string>(),
     })
   })
 
@@ -426,7 +428,7 @@ describe('usePendingRequests', () => {
     expect(matches[0].url).toBe('https://mcp.example.com')
   })
 
-  it('derives computer-use pending request from message history when active', () => {
+  it('derives computer-use pending request from message history when active and not auto-approved', () => {
     mockStreamState.isActive = true
     mockMessagesData.data = [
       createAssistantMessage({
@@ -454,6 +456,28 @@ describe('usePendingRequests', () => {
     })
   })
 
+  it('suppresses computer-use message-history fallback when the backend auto-approved it', () => {
+    mockStreamState.isActive = true
+    mockStreamState.autoApprovedComputerUseIds = new Set(['tc-cu-auto'])
+    mockMessagesData.data = [
+      createAssistantMessage({
+        content: { text: '' },
+        toolCalls: [
+          createToolCall({
+            id: 'tc-cu-auto',
+            name: 'mcp__computer-use__computer_apps',
+            input: { includeHidden: false },
+            result: undefined,
+          }),
+        ],
+      }),
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    expect(ofKind(result.current.items, 'computer_use')).toHaveLength(0)
+  })
+
   it('derives computer-use pending request from ready streaming tool use', () => {
     mockStreamState.isActive = true
     mockMessagesData.data = []
@@ -477,6 +501,24 @@ describe('usePendingRequests', () => {
       permissionLevel: 'use_application',
       appName: 'Safari',
     })
+  })
+
+  it('suppresses computer-use streaming fallback when the backend auto-approved it', () => {
+    mockStreamState.isActive = true
+    mockMessagesData.data = []
+    mockStreamState.autoApprovedComputerUseIds = new Set(['stream-cu-auto'])
+    mockStreamState.streamingToolUses = [
+      {
+        id: 'stream-cu-auto',
+        name: 'mcp__computer-use__computer_click',
+        partialInput: JSON.stringify({ app: 'Safari', x: 10, y: 20 }),
+        ready: true,
+      },
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    expect(ofKind(result.current.items, 'computer_use')).toHaveLength(0)
   })
 
   it('coerces a non-array requirements to [] (model emitted a bare string)', () => {

--- a/src/renderer/components/messages/use-pending-requests.test.tsx
+++ b/src/renderer/components/messages/use-pending-requests.test.tsx
@@ -26,6 +26,7 @@ const mockStreamState = {
   pendingBrowserInputRequests: [] as Array<{ toolUseId: string; message: string; requirements: string[] }>,
   pendingScriptRunRequests: [] as Array<{ toolUseId: string; script: string; explanation: string; scriptType: 'applescript' | 'shell' | 'powershell' }>,
   pendingComputerUseRequests: [] as Array<{ toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string }>,
+  streamingToolUses: [] as Array<{ id: string; name: string; partialInput: string; ready?: boolean }>,
   autoApprovedScriptRunIds: new Set<string>(),
 }
 
@@ -104,6 +105,7 @@ describe('usePendingRequests', () => {
       pendingBrowserInputRequests: [],
       pendingScriptRunRequests: [],
       pendingComputerUseRequests: [],
+      streamingToolUses: [],
       autoApprovedScriptRunIds: new Set<string>(),
     })
   })
@@ -211,6 +213,49 @@ describe('usePendingRequests', () => {
     expect(matches[0].secretName).toBe('DB_PASSWORD')
   })
 
+  it('derives pending secret request from ready streaming tool use when SSE event is missed', () => {
+    mockStreamState.isActive = true
+    mockMessagesData.data = []
+    mockStreamState.streamingToolUses = [
+      {
+        id: 'stream-secret',
+        name: 'mcp__user-input__request_secret',
+        partialInput: JSON.stringify({
+          secretName: 'OPENAI_API_KEY',
+          reason: 'Needed for API access',
+        }),
+        ready: true,
+      },
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    const matches = ofKind(result.current.items, 'secret')
+    expect(matches).toHaveLength(1)
+    expect(matches[0]).toMatchObject({
+      toolUseId: 'stream-secret',
+      secretName: 'OPENAI_API_KEY',
+      reason: 'Needed for API access',
+    })
+  })
+
+  it('ignores non-ready streaming request tool use until input is parseable', () => {
+    mockStreamState.isActive = true
+    mockMessagesData.data = []
+    mockStreamState.streamingToolUses = [
+      {
+        id: 'stream-secret',
+        name: 'mcp__user-input__request_secret',
+        partialInput: '{"secretName":"OPEN',
+        ready: false,
+      },
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    expect(result.current.count).toBe(0)
+  })
+
   it('does not derive pending requests from history when session is idle', () => {
     mockStreamState.isActive = false
     mockMessagesData.data = [
@@ -306,6 +351,35 @@ describe('usePendingRequests', () => {
     expect(matches).toHaveLength(1)
   })
 
+  it('derives question pending request from stringified history input without unsafe casts', () => {
+    mockStreamState.isActive = true
+    mockMessagesData.data = [
+      createAssistantMessage({
+        content: { text: '' },
+        toolCalls: [
+          createToolCall({
+            id: 'tc-q-string',
+            name: 'AskUserQuestion',
+            input: {
+              questions: JSON.stringify([
+                { question: 'Which env?', options: [{ label: 'Prod' }], multiSelect: false },
+              ]),
+            },
+            result: undefined,
+          }),
+        ],
+      }),
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    const matches = ofKind(result.current.items, 'question')
+    expect(matches).toHaveLength(1)
+    expect(matches[0].questions).toEqual([
+      { question: 'Which env?', header: '', options: [{ label: 'Prod', description: '' }], multiSelect: false },
+    ])
+  })
+
   it('derives file pending request from message history when active', () => {
     mockStreamState.isActive = true
     mockMessagesData.data = [
@@ -350,6 +424,59 @@ describe('usePendingRequests', () => {
     const matches = ofKind(result.current.items, 'remote_mcp')
     expect(matches).toHaveLength(1)
     expect(matches[0].url).toBe('https://mcp.example.com')
+  })
+
+  it('derives computer-use pending request from message history when active', () => {
+    mockStreamState.isActive = true
+    mockMessagesData.data = [
+      createAssistantMessage({
+        content: { text: '' },
+        toolCalls: [
+          createToolCall({
+            id: 'tc-cu',
+            name: 'mcp__computer-use__computer_apps',
+            input: { includeHidden: false },
+            result: undefined,
+          }),
+        ],
+      }),
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    const matches = ofKind(result.current.items, 'computer_use')
+    expect(matches).toHaveLength(1)
+    expect(matches[0]).toMatchObject({
+      toolUseId: 'tc-cu',
+      method: 'apps',
+      params: { includeHidden: false },
+      permissionLevel: 'list_apps_windows',
+    })
+  })
+
+  it('derives computer-use pending request from ready streaming tool use', () => {
+    mockStreamState.isActive = true
+    mockMessagesData.data = []
+    mockStreamState.streamingToolUses = [
+      {
+        id: 'stream-cu',
+        name: 'mcp__computer-use__computer_click',
+        partialInput: JSON.stringify({ app: 'Safari', x: 10, y: 20 }),
+        ready: true,
+      },
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    const matches = ofKind(result.current.items, 'computer_use')
+    expect(matches).toHaveLength(1)
+    expect(matches[0]).toMatchObject({
+      toolUseId: 'stream-cu',
+      method: 'click',
+      params: { app: 'Safari', x: 10, y: 20 },
+      permissionLevel: 'use_application',
+      appName: 'Safari',
+    })
   })
 
   it('coerces a non-array requirements to [] (model emitted a bare string)', () => {

--- a/src/renderer/components/messages/use-pending-requests.tsx
+++ b/src/renderer/components/messages/use-pending-requests.tsx
@@ -13,6 +13,8 @@ import {
 import { useMessages } from '@renderer/hooks/use-messages'
 import { usePendingProxyReviews, type PendingReview } from '@renderer/hooks/use-proxy-reviews'
 import { isTurnStartingUserMessage, type PendingMessage } from './pending-message'
+import { getRequiredPermissionLevel, resolveTargetApp } from '@shared/lib/computer-use/types'
+import { askUserQuestionDef } from '@shared/lib/tool-definitions/ask-user-question'
 
 interface UsePendingRequestsArgs {
   sessionId: string
@@ -25,6 +27,176 @@ type Question = {
   header: string
   options: Array<{ label: string; description: string }>
   multiSelect: boolean
+}
+
+type PendingRequestBuckets = {
+  secretRequests: { toolUseId: string; secretName: string; reason?: string }[]
+  connectedAccountRequests: { toolUseId: string; toolkit: string; reason?: string }[]
+  questionRequests: { toolUseId: string; questions: Question[] }[]
+  fileRequests: { toolUseId: string; description: string; fileTypes?: string }[]
+  remoteMcpRequests: { toolUseId: string; url: string; name?: string; reason?: string; authHint?: 'oauth' | 'bearer' }[]
+  browserInputRequests: { toolUseId: string; message: string; requirements: string[] }[]
+  scriptRunRequests: { toolUseId: string; script: string; explanation: string; scriptType: 'applescript' | 'shell' | 'powershell' }[]
+  computerUseRequests: { toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string }[]
+}
+
+type RequestToolCall = {
+  id: string
+  name: string
+  input: unknown
+}
+
+const COMPUTER_USE_METHODS: Record<string, string> = {
+  apps: 'apps',
+  windows: 'windows',
+  snapshot: 'snapshot',
+  find: 'find',
+  screenshot: 'screenshot',
+  read: 'read',
+  status: 'status',
+  displays: 'displays',
+  permissions: 'permissions',
+  click: 'click',
+  type: 'type',
+  fill: 'fill',
+  key: 'key',
+  scroll: 'scroll',
+  select: 'select',
+  hover: 'hover',
+  launch: 'launch',
+  quit: 'quit',
+  grab: 'grab',
+  ungrab: 'ungrab',
+  menu: 'menuClick',
+  dialog: 'dialog',
+  run: 'run',
+}
+
+function computerUseMethodFromToolName(toolName: string): string {
+  const suffix = toolName.replace('mcp__computer-use__computer_', '')
+  return COMPUTER_USE_METHODS[suffix] ?? suffix
+}
+
+function recordFromInput(input: unknown): Record<string, unknown> {
+  return input && typeof input === 'object' && !Array.isArray(input)
+    ? input as Record<string, unknown>
+    : {}
+}
+
+function createPendingRequestBuckets(): PendingRequestBuckets {
+  return {
+    secretRequests: [],
+    connectedAccountRequests: [],
+    questionRequests: [],
+    fileRequests: [],
+    remoteMcpRequests: [],
+    browserInputRequests: [],
+    scriptRunRequests: [],
+    computerUseRequests: [],
+  }
+}
+
+function isScriptType(value: unknown): value is 'applescript' | 'shell' | 'powershell' {
+  return value === 'applescript' || value === 'shell' || value === 'powershell'
+}
+
+function normalizePendingQuestions(input: Record<string, unknown>): Question[] {
+  const questions = askUserQuestionDef.parseInput(input).questions
+  if (!questions?.length) return []
+
+  return questions.flatMap((question) => {
+    if (typeof question.question !== 'string' || !question.question.trim()) return []
+
+    return [{
+      question: question.question,
+      header: typeof question.header === 'string' ? question.header : '',
+      options: Array.isArray(question.options)
+        ? question.options.flatMap((option) => (
+          typeof option.label === 'string'
+            ? [{ label: option.label, description: typeof option.description === 'string' ? option.description : '' }]
+            : []
+        ))
+        : [],
+      multiSelect: question.multiSelect === true,
+    }]
+  })
+}
+
+function addPendingRequestFromToolCall(buckets: PendingRequestBuckets, toolCall: RequestToolCall) {
+  const input = recordFromInput(toolCall.input)
+
+  if (toolCall.name === 'mcp__user-input__request_secret') {
+    if (typeof input.secretName === 'string') {
+      buckets.secretRequests.push({
+        toolUseId: toolCall.id,
+        secretName: input.secretName,
+        reason: typeof input.reason === 'string' ? input.reason : undefined,
+      })
+    }
+  } else if (toolCall.name === 'mcp__user-input__request_connected_account') {
+    if (typeof input.toolkit === 'string') {
+      buckets.connectedAccountRequests.push({
+        toolUseId: toolCall.id,
+        toolkit: input.toolkit,
+        reason: typeof input.reason === 'string' ? input.reason : undefined,
+      })
+    }
+  } else if (toolCall.name === 'AskUserQuestion') {
+    const questions = normalizePendingQuestions(input)
+    if (questions.length) {
+      buckets.questionRequests.push({
+        toolUseId: toolCall.id,
+        questions,
+      })
+    }
+  } else if (toolCall.name === 'mcp__user-input__request_remote_mcp') {
+    if (typeof input.url === 'string') {
+      buckets.remoteMcpRequests.push({
+        toolUseId: toolCall.id,
+        url: input.url,
+        name: typeof input.name === 'string' ? input.name : undefined,
+        reason: typeof input.reason === 'string' ? input.reason : undefined,
+        authHint: input.authHint === 'oauth' || input.authHint === 'bearer' ? input.authHint : undefined,
+      })
+    }
+  } else if (toolCall.name === 'mcp__user-input__request_file') {
+    if (typeof input.description === 'string') {
+      buckets.fileRequests.push({
+        toolUseId: toolCall.id,
+        description: input.description,
+        fileTypes: typeof input.fileTypes === 'string' ? input.fileTypes : undefined,
+      })
+    }
+  } else if (toolCall.name === 'mcp__user-input__request_browser_input') {
+    if (typeof input.message === 'string') {
+      buckets.browserInputRequests.push({
+        toolUseId: toolCall.id,
+        message: input.message,
+        // Model-controlled: coerce a non-array (e.g. a bare string) to []
+        // so downstream `.map()` can't crash the request card. `|| []`
+        // would let a non-empty string through.
+        requirements: Array.isArray(input.requirements) ? input.requirements : [],
+      })
+    }
+  } else if (toolCall.name === 'mcp__user-input__request_script_run') {
+    if (typeof input.script === 'string' && isScriptType(input.scriptType)) {
+      buckets.scriptRunRequests.push({
+        toolUseId: toolCall.id,
+        script: input.script,
+        explanation: typeof input.explanation === 'string' ? input.explanation : '',
+        scriptType: input.scriptType,
+      })
+    }
+  } else if (toolCall.name.startsWith('mcp__computer-use__computer_')) {
+    const method = computerUseMethodFromToolName(toolCall.name)
+    buckets.computerUseRequests.push({
+      toolUseId: toolCall.id,
+      method,
+      params: input,
+      permissionLevel: getRequiredPermissionLevel(method),
+      appName: resolveTargetApp(method, input),
+    })
+  }
 }
 
 export type PendingRequestDescriptor =
@@ -63,6 +235,7 @@ export function usePendingRequests({
     pendingBrowserInputRequests: sseBrowserInputRequests,
     pendingScriptRunRequests: sseScriptRunRequests,
     pendingComputerUseRequests: sseComputerUseRequests,
+    streamingToolUses,
     autoApprovedScriptRunIds,
   } = useMessageStream(sessionId, agentSlug)
 
@@ -73,15 +246,9 @@ export function usePendingRequests({
   // Tool calls without a result are still pending, but only if there are no
   // subsequent user messages (which would indicate user has moved past the request).
   const messagesBasedPendingRequests = useMemo(() => {
-    const secretRequests: { toolUseId: string; secretName: string; reason?: string }[] = []
-    const connectedAccountRequests: { toolUseId: string; toolkit: string; reason?: string }[] = []
-    const questionRequests: { toolUseId: string; questions: Question[] }[] = []
-    const fileRequests: { toolUseId: string; description: string; fileTypes?: string }[] = []
-    const remoteMcpRequests: { toolUseId: string; url: string; name?: string; reason?: string; authHint?: 'oauth' | 'bearer' }[] = []
-    const browserInputRequests: { toolUseId: string; message: string; requirements: string[] }[] = []
-    const scriptRunRequests: { toolUseId: string; script: string; explanation: string; scriptType: 'applescript' | 'shell' | 'powershell' }[] = []
+    const buckets = createPendingRequestBuckets()
 
-    if (!messages) return { secretRequests, connectedAccountRequests, questionRequests, fileRequests, remoteMcpRequests, browserInputRequests, scriptRunRequests }
+    if (!messages) return buckets
 
     for (let i = 0; i < messages.length; i++) {
       const message = messages[i]
@@ -95,81 +262,36 @@ export function usePendingRequests({
 
       for (const toolCall of message.toolCalls) {
         if (toolCall.result !== undefined) continue
-
-        if (toolCall.name === 'mcp__user-input__request_secret') {
-          const input = toolCall.input as { secretName?: string; reason?: string }
-          if (input.secretName) {
-            secretRequests.push({
-              toolUseId: toolCall.id,
-              secretName: input.secretName,
-              reason: input.reason,
-            })
-          }
-        } else if (toolCall.name === 'mcp__user-input__request_connected_account') {
-          const input = toolCall.input as { toolkit?: string; reason?: string }
-          if (input.toolkit) {
-            connectedAccountRequests.push({
-              toolUseId: toolCall.id,
-              toolkit: input.toolkit,
-              reason: input.reason,
-            })
-          }
-        } else if (toolCall.name === 'AskUserQuestion') {
-          const input = toolCall.input as { questions?: Question[] }
-          if (input.questions?.length) {
-            questionRequests.push({
-              toolUseId: toolCall.id,
-              questions: input.questions,
-            })
-          }
-        } else if (toolCall.name === 'mcp__user-input__request_remote_mcp') {
-          const input = toolCall.input as { url?: string; name?: string; reason?: string; authHint?: 'oauth' | 'bearer' }
-          if (input.url) {
-            remoteMcpRequests.push({
-              toolUseId: toolCall.id,
-              url: input.url,
-              name: input.name,
-              reason: input.reason,
-              authHint: input.authHint,
-            })
-          }
-        } else if (toolCall.name === 'mcp__user-input__request_file') {
-          const input = toolCall.input as { description?: string; fileTypes?: string }
-          if (input.description) {
-            fileRequests.push({
-              toolUseId: toolCall.id,
-              description: input.description,
-              fileTypes: input.fileTypes,
-            })
-          }
-        } else if (toolCall.name === 'mcp__user-input__request_browser_input') {
-          const input = toolCall.input as { message?: string; requirements?: unknown }
-          if (input.message) {
-            browserInputRequests.push({
-              toolUseId: toolCall.id,
-              message: input.message,
-              // Model-controlled: coerce a non-array (e.g. a bare string) to []
-              // so downstream `.map()` can't crash the request card. `|| []`
-              // would let a non-empty string through.
-              requirements: Array.isArray(input.requirements) ? input.requirements : [],
-            })
-          }
-        } else if (toolCall.name === 'mcp__user-input__request_script_run') {
-          const input = toolCall.input as { script?: string; explanation?: string; scriptType?: 'applescript' | 'shell' | 'powershell' }
-          if (input.script && input.scriptType) {
-            scriptRunRequests.push({
-              toolUseId: toolCall.id,
-              script: input.script,
-              explanation: input.explanation || '',
-              scriptType: input.scriptType,
-            })
-          }
-        }
+        addPendingRequestFromToolCall(buckets, toolCall)
       }
     }
 
-    return { secretRequests, connectedAccountRequests, questionRequests, fileRequests, remoteMcpRequests, browserInputRequests, scriptRunRequests }
+    return buckets
   }, [messages, hasPendingUserMessage])
+
+  // Derive pending requests from ready in-flight tool calls too. This closes the
+  // gap where the one-shot request SSE event is missed but the tool call has not
+  // reached the persisted message-history fallback yet.
+  const streamingBasedPendingRequests = useMemo(() => {
+    const buckets = createPendingRequestBuckets()
+
+    for (const toolUse of streamingToolUses) {
+      if (!toolUse.ready) continue
+
+      try {
+        addPendingRequestFromToolCall(buckets, {
+          id: toolUse.id,
+          name: toolUse.name,
+          input: JSON.parse(toolUse.partialInput || '{}'),
+        })
+      } catch {
+        // The ready event should mean parseable input, but skip defensively
+        // rather than risking a render crash from malformed streaming data.
+      }
+    }
+
+    return buckets
+  }, [streamingToolUses])
 
   // Track toolUseIds the user has already answered, so the message-based
   // recovery source doesn't re-surface them before the tool result is persisted.
@@ -191,85 +313,92 @@ export function usePendingRequests({
     const seen = new Set<string>()
     const merged: { toolUseId: string; secretName: string; reason?: string }[] = []
     const messageBased = isActive ? messagesBasedPendingRequests.secretRequests : []
-    for (const req of [...sseSecretRequests, ...messageBased]) {
+    const streamingBased = isActive ? streamingBasedPendingRequests.secretRequests : []
+    for (const req of [...sseSecretRequests, ...streamingBased, ...messageBased]) {
       if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseSecretRequests, messagesBasedPendingRequests.secretRequests, isActive])
+  }, [sseSecretRequests, streamingBasedPendingRequests.secretRequests, messagesBasedPendingRequests.secretRequests, isActive])
 
   const pendingConnectedAccountRequests = useMemo(() => {
     const seen = new Set<string>()
     const merged: { toolUseId: string; toolkit: string; reason?: string }[] = []
     const messageBased = isActive ? messagesBasedPendingRequests.connectedAccountRequests : []
-    for (const req of [...sseConnectedAccountRequests, ...messageBased]) {
+    const streamingBased = isActive ? streamingBasedPendingRequests.connectedAccountRequests : []
+    for (const req of [...sseConnectedAccountRequests, ...streamingBased, ...messageBased]) {
       if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseConnectedAccountRequests, messagesBasedPendingRequests.connectedAccountRequests, isActive])
+  }, [sseConnectedAccountRequests, streamingBasedPendingRequests.connectedAccountRequests, messagesBasedPendingRequests.connectedAccountRequests, isActive])
 
   const pendingQuestionRequests = useMemo(() => {
     const seen = new Set<string>()
     const merged: { toolUseId: string; questions: Question[] }[] = []
     const messageBased = isActive ? messagesBasedPendingRequests.questionRequests : []
-    for (const req of [...sseQuestionRequests, ...messageBased]) {
+    const streamingBased = isActive ? streamingBasedPendingRequests.questionRequests : []
+    for (const req of [...sseQuestionRequests, ...streamingBased, ...messageBased]) {
       if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseQuestionRequests, messagesBasedPendingRequests.questionRequests, isActive])
+  }, [sseQuestionRequests, streamingBasedPendingRequests.questionRequests, messagesBasedPendingRequests.questionRequests, isActive])
 
   const pendingFileRequests = useMemo(() => {
     const seen = new Set<string>()
     const merged: { toolUseId: string; description: string; fileTypes?: string }[] = []
     const messageBased = isActive ? messagesBasedPendingRequests.fileRequests : []
-    for (const req of [...sseFileRequests, ...messageBased]) {
+    const streamingBased = isActive ? streamingBasedPendingRequests.fileRequests : []
+    for (const req of [...sseFileRequests, ...streamingBased, ...messageBased]) {
       if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseFileRequests, messagesBasedPendingRequests.fileRequests, isActive])
+  }, [sseFileRequests, streamingBasedPendingRequests.fileRequests, messagesBasedPendingRequests.fileRequests, isActive])
 
   const pendingRemoteMcpRequests = useMemo(() => {
     const seen = new Set<string>()
     const merged: { toolUseId: string; url: string; name?: string; reason?: string; authHint?: 'oauth' | 'bearer' }[] = []
     const messageBased = isActive ? messagesBasedPendingRequests.remoteMcpRequests : []
-    for (const req of [...sseRemoteMcpRequests, ...messageBased]) {
+    const streamingBased = isActive ? streamingBasedPendingRequests.remoteMcpRequests : []
+    for (const req of [...sseRemoteMcpRequests, ...streamingBased, ...messageBased]) {
       if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseRemoteMcpRequests, messagesBasedPendingRequests.remoteMcpRequests, isActive])
+  }, [sseRemoteMcpRequests, streamingBasedPendingRequests.remoteMcpRequests, messagesBasedPendingRequests.remoteMcpRequests, isActive])
 
   const pendingBrowserInputRequests = useMemo(() => {
     const seen = new Set<string>()
     const merged: { toolUseId: string; message: string; requirements: string[] }[] = []
     const messageBased = isActive ? messagesBasedPendingRequests.browserInputRequests : []
-    for (const req of [...sseBrowserInputRequests, ...messageBased]) {
+    const streamingBased = isActive ? streamingBasedPendingRequests.browserInputRequests : []
+    for (const req of [...sseBrowserInputRequests, ...streamingBased, ...messageBased]) {
       if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseBrowserInputRequests, messagesBasedPendingRequests.browserInputRequests, isActive])
+  }, [sseBrowserInputRequests, streamingBasedPendingRequests.browserInputRequests, messagesBasedPendingRequests.browserInputRequests, isActive])
 
   const pendingScriptRunRequests = useMemo(() => {
     const seen = new Set<string>()
     const merged: { toolUseId: string; script: string; explanation: string; scriptType: 'applescript' | 'shell' | 'powershell' }[] = []
     const messageBased = isActive ? messagesBasedPendingRequests.scriptRunRequests : []
-    for (const req of [...sseScriptRunRequests, ...messageBased]) {
+    const streamingBased = isActive ? streamingBasedPendingRequests.scriptRunRequests : []
+    for (const req of [...sseScriptRunRequests, ...streamingBased, ...messageBased]) {
       if (autoApprovedScriptRunIds.has(req.toolUseId)) continue
       if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
         seen.add(req.toolUseId)
@@ -277,19 +406,21 @@ export function usePendingRequests({
       }
     }
     return merged
-  }, [sseScriptRunRequests, messagesBasedPendingRequests.scriptRunRequests, isActive, autoApprovedScriptRunIds])
+  }, [sseScriptRunRequests, streamingBasedPendingRequests.scriptRunRequests, messagesBasedPendingRequests.scriptRunRequests, isActive, autoApprovedScriptRunIds])
 
   const pendingComputerUseRequests = useMemo(() => {
     const seen = new Set<string>()
     const merged: { toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string }[] = []
-    for (const req of sseComputerUseRequests) {
+    const messageBased = isActive ? messagesBasedPendingRequests.computerUseRequests : []
+    const streamingBased = isActive ? streamingBasedPendingRequests.computerUseRequests : []
+    for (const req of [...sseComputerUseRequests, ...streamingBased, ...messageBased]) {
       if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseComputerUseRequests])
+  }, [sseComputerUseRequests, streamingBasedPendingRequests.computerUseRequests, messagesBasedPendingRequests.computerUseRequests, isActive])
 
   // Track arrival order so the stack is chronological. Each id gets a
   // monotonically increasing sequence number the first time it appears.

--- a/src/renderer/components/messages/use-pending-requests.tsx
+++ b/src/renderer/components/messages/use-pending-requests.tsx
@@ -13,7 +13,7 @@ import {
 import { useMessages } from '@renderer/hooks/use-messages'
 import { usePendingProxyReviews, type PendingReview } from '@renderer/hooks/use-proxy-reviews'
 import { isTurnStartingUserMessage, type PendingMessage } from './pending-message'
-import { getRequiredPermissionLevel, resolveTargetApp } from '@shared/lib/computer-use/types'
+import { computerUseMethodFromToolName, getRequiredPermissionLevel, resolveTargetApp } from '@shared/lib/computer-use/types'
 import { askUserQuestionDef } from '@shared/lib/tool-definitions/ask-user-question'
 
 interface UsePendingRequestsArgs {
@@ -44,37 +44,6 @@ type RequestToolCall = {
   id: string
   name: string
   input: unknown
-}
-
-const COMPUTER_USE_METHODS: Record<string, string> = {
-  apps: 'apps',
-  windows: 'windows',
-  snapshot: 'snapshot',
-  find: 'find',
-  screenshot: 'screenshot',
-  read: 'read',
-  status: 'status',
-  displays: 'displays',
-  permissions: 'permissions',
-  click: 'click',
-  type: 'type',
-  fill: 'fill',
-  key: 'key',
-  scroll: 'scroll',
-  select: 'select',
-  hover: 'hover',
-  launch: 'launch',
-  quit: 'quit',
-  grab: 'grab',
-  ungrab: 'ungrab',
-  menu: 'menuClick',
-  dialog: 'dialog',
-  run: 'run',
-}
-
-function computerUseMethodFromToolName(toolName: string): string {
-  const suffix = toolName.replace('mcp__computer-use__computer_', '')
-  return COMPUTER_USE_METHODS[suffix] ?? suffix
 }
 
 function recordFromInput(input: unknown): Record<string, unknown> {
@@ -237,6 +206,7 @@ export function usePendingRequests({
     pendingComputerUseRequests: sseComputerUseRequests,
     streamingToolUses,
     autoApprovedScriptRunIds,
+    autoApprovedComputerUseIds,
   } = useMessageStream(sessionId, agentSlug)
 
   const { data: proxyReviewsData, refetch: refetchProxyReviews } = usePendingProxyReviews(agentSlug)
@@ -414,13 +384,14 @@ export function usePendingRequests({
     const messageBased = isActive ? messagesBasedPendingRequests.computerUseRequests : []
     const streamingBased = isActive ? streamingBasedPendingRequests.computerUseRequests : []
     for (const req of [...sseComputerUseRequests, ...streamingBased, ...messageBased]) {
+      if (autoApprovedComputerUseIds.has(req.toolUseId)) continue
       if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseComputerUseRequests, streamingBasedPendingRequests.computerUseRequests, messagesBasedPendingRequests.computerUseRequests, isActive])
+  }, [sseComputerUseRequests, streamingBasedPendingRequests.computerUseRequests, messagesBasedPendingRequests.computerUseRequests, isActive, autoApprovedComputerUseIds])
 
   // Track arrival order so the stack is chronological. Each id gets a
   // monotonically increasing sequence number the first time it appears.

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -1963,6 +1963,54 @@ describe('useMessageStream', () => {
       expect(result.current.autoApprovedScriptRunIds.size).toBe(0)
     })
 
+    it('autoApproved:true computer-use request populates suppress-set and skips pendingComputerUseRequests', async () => {
+      const mod = await getHookModule()
+      const wrapper = createWrapper()
+
+      const { result } = renderHook(
+        () => mod.useMessageStream('session-auto-cu-1', 'agent-1'),
+        { wrapper }
+      )
+
+      await vi.waitFor(() => {
+        expect(MockEventSource.instances.length).toBeGreaterThan(0)
+      })
+      const es = MockEventSource.instances[MockEventSource.instances.length - 1]
+
+      act(() => {
+        es.simulateMessage({ type: 'connected', isActive: true })
+      })
+
+      act(() => {
+        es.simulateMessage({
+          type: 'computer_use_request',
+          toolUseId: 'tool-cu-auto',
+          method: 'apps',
+          params: {},
+          permissionLevel: 'list_apps_windows',
+          autoApproved: true,
+        })
+      })
+
+      await vi.waitFor(() => {
+        expect(result.current.autoApprovedComputerUseIds.has('tool-cu-auto')).toBe(true)
+      })
+
+      expect(result.current.pendingComputerUseRequests).toHaveLength(0)
+    })
+
+    it('default autoApprovedComputerUseIds is empty for a fresh session', async () => {
+      const mod = await getHookModule()
+      const wrapper = createWrapper()
+
+      const { result } = renderHook(
+        () => mod.useMessageStream('session-auto-cu-empty', 'agent-1'),
+        { wrapper }
+      )
+
+      expect(result.current.autoApprovedComputerUseIds.size).toBe(0)
+    })
+
     it('mixes autoApproved and prompt requests independently', async () => {
       const mod = await getHookModule()
       const wrapper = createWrapper()
@@ -2293,8 +2341,6 @@ describe('useMessageStream', () => {
           partialInput: '',
         })
       })
-
-      const toolUsesBefore = result.current.streamingToolUses
 
       // Send tool_use_ready for a non-existent tool
       act(() => {

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -240,6 +240,12 @@ const EMPTY_AUTO_APPROVED_SET: ReadonlySet<string> = new Set()
 // StreamState to avoid threading a new field through ~15 state-rebuild sites.
 const sessionAutoApprovedScriptRunIds = new Map<string, Set<string>>()
 
+// Same suppression set for computer-use requests. Unlike most user-input tools,
+// computer-use can be auto-executed when the agent already has a matching grant.
+// The server still broadcasts autoApproved:true so streaming/history recovery
+// can tell "in flight but granted" apart from "actually waiting for approval".
+const sessionAutoApprovedComputerUseIds = new Map<string, Set<string>>()
+
 
 // Singleton EventSource connections per session (prevents duplicates from StrictMode/re-renders)
 const eventSources = new Map<string, EventSource>()
@@ -985,8 +991,18 @@ function getOrCreateEventSource(
         }
       }
       else if (data.type === 'computer_use_request') {
-        // Agent is requesting computer use on the host
-        if (current && !current.pendingComputerUseRequests.some(r => r.toolUseId === data.toolUseId)) {
+        // Agent is requesting computer use on the host. When autoApproved is
+        // true the backend is already executing it; record the id so fallback
+        // recovery does not surface a stale Allow/Deny card.
+        if (data.autoApproved) {
+          let approved = sessionAutoApprovedComputerUseIds.get(sessionId)
+          if (!approved) {
+            approved = new Set()
+            sessionAutoApprovedComputerUseIds.set(sessionId, approved)
+          }
+          approved.add(data.toolUseId)
+          streamListeners.get(sessionId)?.forEach((l) => l())
+        } else if (current && !current.pendingComputerUseRequests.some(r => r.toolUseId === data.toolUseId)) {
           const newRequest: ComputerUseRequest = {
             toolUseId: data.toolUseId,
             method: data.method,
@@ -1467,6 +1483,7 @@ export function useMessageStream(sessionId: string | null, agentSlug: string | n
   const [slashCommands, setSlashCommands] = useState<SlashCommandInfo[]>([])
   const [thinking, setThinking] = useState<ThinkingState>(EMPTY_THINKING)
   const [autoApprovedScriptRunIds, setAutoApprovedScriptRunIds] = useState<ReadonlySet<string>>(EMPTY_AUTO_APPROVED_SET)
+  const [autoApprovedComputerUseIds, setAutoApprovedComputerUseIds] = useState<ReadonlySet<string>>(EMPTY_AUTO_APPROVED_SET)
   const [workflows, setWorkflows] = useState<WorkflowRunLive[]>(EMPTY_WORKFLOWS)
   const queryClient = useQueryClient()
 
@@ -1501,6 +1518,20 @@ export function useMessageStream(sessionId: string | null, agentSlug: string | n
         }
         return new Set(approved)
       })
+      const approvedComputerUse = sessionAutoApprovedComputerUseIds.get(sessionId)
+      setAutoApprovedComputerUseIds((prev) => {
+        if (!approvedComputerUse || approvedComputerUse.size === 0) {
+          return prev.size === 0 ? prev : EMPTY_AUTO_APPROVED_SET
+        }
+        if (prev.size === approvedComputerUse.size) {
+          let identical = true
+          for (const id of approvedComputerUse) {
+            if (!prev.has(id)) { identical = false; break }
+          }
+          if (identical) return prev
+        }
+        return new Set(approvedComputerUse)
+      })
       // Workflows are stored as immutable arrays (a new ref only on workflow events),
       // so a plain ref-equal set bails out of re-render on every other event.
       setWorkflows(sessionWorkflows.get(sessionId) ?? EMPTY_WORKFLOWS)
@@ -1515,6 +1546,8 @@ export function useMessageStream(sessionId: string | null, agentSlug: string | n
       setState(EMPTY_STREAM_STATE)
       setSlashCommands([])
       setThinking(EMPTY_THINKING)
+      setAutoApprovedScriptRunIds(EMPTY_AUTO_APPROVED_SET)
+      setAutoApprovedComputerUseIds(EMPTY_AUTO_APPROVED_SET)
       setWorkflows(EMPTY_WORKFLOWS)
       return
     }
@@ -1545,5 +1578,5 @@ export function useMessageStream(sessionId: string | null, agentSlug: string | n
     }
   }, [sessionId, agentSlug, updateState, queryClient])
 
-  return { ...state, slashCommands, autoApprovedScriptRunIds, workflows, isThinking: thinking.isThinking, thinkingText: thinking.text }
+  return { ...state, slashCommands, autoApprovedScriptRunIds, autoApprovedComputerUseIds, workflows, isThinking: thinking.isThinking, thinkingText: thinking.text }
 }

--- a/src/renderer/test/mock-stream.ts
+++ b/src/renderer/test/mock-stream.ts
@@ -19,6 +19,8 @@ export interface MockStreamState {
   pendingBrowserInputRequests: Array<{ toolUseId: string; message: string; requirements: string[] }>
   pendingScriptRunRequests: Array<{ toolUseId: string; script: string; explanation: string; scriptType: 'applescript' | 'shell' | 'powershell' }>
   pendingComputerUseRequests: Array<{ toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string }>
+  autoApprovedScriptRunIds: ReadonlySet<string>
+  autoApprovedComputerUseIds: ReadonlySet<string>
   error: string | null
   browserActive: boolean
   activeStartTime: number | null
@@ -41,6 +43,8 @@ export const DEFAULT_STREAM_STATE: MockStreamState = {
   pendingBrowserInputRequests: [],
   pendingScriptRunRequests: [],
   pendingComputerUseRequests: [],
+  autoApprovedScriptRunIds: new Set(),
+  autoApprovedComputerUseIds: new Set(),
   error: null,
   browserActive: false,
   activeStartTime: null,

--- a/src/shared/lib/computer-use/types.ts
+++ b/src/shared/lib/computer-use/types.ts
@@ -44,6 +44,7 @@ export interface ComputerUseRequestEvent {
   permissionLevel: ComputerUsePermissionLevel
   appName?: string
   agentSlug?: string
+  autoApproved?: boolean
 }
 
 /** Read-only AC methods that only need list_apps_windows permission */
@@ -57,6 +58,37 @@ export const READ_ONLY_METHODS = new Set([
 export function getRequiredPermissionLevel(method: string): ComputerUsePermissionLevel {
   if (READ_ONLY_METHODS.has(method)) return 'list_apps_windows'
   return 'use_application'
+}
+
+const COMPUTER_USE_METHODS: Record<string, string> = {
+  apps: 'apps',
+  windows: 'windows',
+  snapshot: 'snapshot',
+  find: 'find',
+  screenshot: 'screenshot',
+  read: 'read',
+  status: 'status',
+  displays: 'displays',
+  permissions: 'permissions',
+  click: 'click',
+  type: 'type',
+  fill: 'fill',
+  key: 'key',
+  scroll: 'scroll',
+  select: 'select',
+  hover: 'hover',
+  launch: 'launch',
+  quit: 'quit',
+  grab: 'grab',
+  ungrab: 'ungrab',
+  menu: 'menuClick',
+  dialog: 'dialog',
+  run: 'run',
+}
+
+export function computerUseMethodFromToolName(toolName: string): string {
+  const suffix = toolName.replace('mcp__computer-use__computer_', '')
+  return COMPUTER_USE_METHODS[suffix] ?? suffix
 }
 
 /** Duration of "timed" permission grants in milliseconds (15 minutes) */

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -69,7 +69,15 @@ vi.mock('@shared/lib/computer-use/permission-manager', () => ({
 }))
 
 vi.mock('@shared/lib/computer-use/types', () => ({
-  getRequiredPermissionLevel: vi.fn(() => 'use_application'),
+  computerUseMethodFromToolName: vi.fn((toolName: string) => {
+    const suffix = toolName.replace('mcp__computer-use__computer_', '')
+    return suffix === 'menu' ? 'menuClick' : suffix
+  }),
+  getRequiredPermissionLevel: vi.fn((method: string) => (
+    ['apps', 'windows', 'status', 'displays', 'permissions'].includes(method)
+      ? 'list_apps_windows'
+      : 'use_application'
+  )),
   resolveTargetApp: vi.fn(() => undefined),
   READ_ONLY_METHODS: new Set(['apps', 'windows', 'status', 'displays', 'permissions']),
   TIMED_GRANT_DURATION_MS: 15 * 60 * 1000,
@@ -2766,6 +2774,86 @@ describe('MessagePersister', () => {
       // what drives the orange agent-status indicator.
       expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
       vi.unstubAllGlobals()
+    })
+  })
+
+  // ============================================================================
+  // Computer use request detection
+  // ============================================================================
+
+  describe('Computer use request detection', () => {
+    function simulateToolUse(toolName: string, toolId: string, input: Record<string, unknown>) {
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          content_block: { type: 'tool_use', id: toolId, name: toolName },
+        },
+      })
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) },
+        },
+      })
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_stop' },
+      })
+    }
+
+    it('auto-executes AND broadcasts with autoApproved:true when computer-use permission is granted', async () => {
+      const { notificationManager } = await import('@shared/lib/notifications/notification-manager')
+      const originalE2eMock = process.env.E2E_MOCK
+      process.env.E2E_MOCK = 'true'
+      mockCheckPermission.mockReturnValue('granted')
+      sseEvents.length = 0
+      const fetchMock = vi.fn(() => Promise.resolve({ ok: true } as Response))
+      vi.stubGlobal('fetch', fetchMock)
+      const triggerSpy = vi.mocked(notificationManager.triggerSessionWaitingInput)
+      triggerSpy.mockClear()
+
+      try {
+        simulateToolUse('mcp__computer-use__computer_apps', 'tool-cu-granted', {
+          includeHidden: false,
+        })
+
+        await vi.waitFor(() => {
+          expect(fetchMock).toHaveBeenCalledTimes(1)
+        })
+
+        const computerUseEvents = sseEvents.filter(e => e.type === 'computer_use_request')
+        expect(computerUseEvents).toHaveLength(1)
+        expect(computerUseEvents[0]).toMatchObject({
+          type: 'computer_use_request',
+          toolUseId: 'tool-cu-granted',
+          method: 'apps',
+          params: { includeHidden: false },
+          permissionLevel: 'list_apps_windows',
+          agentSlug: AGENT_SLUG,
+          autoApproved: true,
+        })
+
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.getPendingComputerUseRequests(SESSION_ID)).toHaveLength(0)
+        expect(triggerSpy).not.toHaveBeenCalled()
+
+        const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+        expect(url).toContain(`/api/agents/${AGENT_SLUG}/sessions/_auto/computer-use`)
+        expect(init.method).toBe('POST')
+        const body = JSON.parse(init.body as string)
+        expect(body).toEqual({
+          toolUseId: 'tool-cu-granted',
+          method: 'apps',
+          params: { includeHidden: false },
+          permissionLevel: 'list_apps_windows',
+        })
+      } finally {
+        if (originalE2eMock === undefined) delete process.env.E2E_MOCK
+        else process.env.E2E_MOCK = originalE2eMock
+        vi.unstubAllGlobals()
+      }
     })
   })
 

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -39,7 +39,7 @@ import { VALID_SCRIPT_TYPES } from '@shared/lib/config/settings'
 import { getActiveLlmProvider, getModelContextWindow } from '@shared/lib/llm-provider'
 import { computerUsePermissionManager } from '@shared/lib/computer-use/permission-manager'
 import { resolveAppFromWindowRef } from '@shared/lib/computer-use/executor'
-import { getRequiredPermissionLevel, resolveTargetApp, type ComputerUsePermissionLevel } from '@shared/lib/computer-use/types'
+import { computerUseMethodFromToolName, getRequiredPermissionLevel, resolveTargetApp, type ComputerUsePermissionLevel } from '@shared/lib/computer-use/types'
 import { getAgentSessionsDir } from '@shared/lib/utils/file-storage'
 import { WorkflowJournalTailer } from './workflow-journal-tailer'
 import { SubagentCapture } from './subagent-capture'
@@ -3063,19 +3063,8 @@ ${continuation}`
     agentSlug?: string,
   ): Promise<void> {
     try {
-      // Extract AC method from tool name: mcp__computer-use__computer_launch → launch
-      // Tool names follow the pattern: mcp__computer-use__computer_{method}
-      const toolSuffix = toolName.replace('mcp__computer-use__computer_', '')
-      // Map tool suffixes to AC method names
-      const methodMap: Record<string, string> = {
-        apps: 'apps', windows: 'windows', snapshot: 'snapshot', find: 'find',
-        screenshot: 'screenshot', read: 'read', status: 'status', displays: 'displays',
-        permissions: 'permissions', click: 'click', type: 'type', fill: 'fill',
-        key: 'key', scroll: 'scroll', select: 'select', hover: 'hover',
-        launch: 'launch', quit: 'quit', grab: 'grab', ungrab: 'ungrab',
-        menu: 'menuClick', dialog: 'dialog', run: 'run',
-      }
-      const method = methodMap[toolSuffix] || toolSuffix
+      // Extract AC method from tool name: mcp__computer-use__computer_launch -> launch.
+      const method = computerUseMethodFromToolName(toolName)
 
       // The toolInput is the raw MCP tool input (e.g., { name: "Calculator" } for computer_launch)
       // Empty input is valid for tools like screenshot, apps, ungrab that take no required params
@@ -3114,7 +3103,19 @@ ${continuation}`
         const permissionResult = computerUsePermissionManager.checkPermission(agentSlug, permissionLevel, appName)
 
         if (permissionResult === 'granted') {
-          // Auto-execute: permission already granted
+          // Auto-execute: permission already granted. Broadcast with autoApproved
+          // so clients can suppress streaming/message-history fallback prompts
+          // during the window before the tool result is persisted.
+          this.broadcastToSSE(sessionId, {
+            type: 'computer_use_request',
+            toolUseId,
+            method,
+            params,
+            permissionLevel,
+            appName,
+            agentSlug,
+            autoApproved: true,
+          })
           this.autoExecuteComputerUseCommand(sessionId, agentSlug, toolUseId, method, params, permissionLevel, appName)
           return
         }
@@ -3138,6 +3139,7 @@ ${continuation}`
         permissionLevel,
         appName,
         agentSlug,
+        autoApproved: false,
       })
 
       // Renderer-side gate handles suppression; see session_complete trigger.

--- a/src/shared/lib/tool-definitions/types.ts
+++ b/src/shared/lib/tool-definitions/types.ts
@@ -110,6 +110,7 @@ export type UserRequestEvent =
       permissionLevel: string
       appName?: string
       agentSlug?: string
+      autoApproved?: boolean
     }
   | {
       type: 'tool_status'


### PR DESCRIPTION
## Summary
- Make request-card E2E waits stack-aware so mounted-but-hidden pending cards are paginated into view before assertions continue.
- Recover pending request cards from ready in-flight streaming tool calls before message-history fallback catches up.
- Suppress computer-use fallback cards for backend auto-approved commands, and share the computer-use tool-name method mapping between backend and client.
- Strengthen background bash, computer-use, proxy review, and question-request coverage around completion, transcript assertions, and malformed/stringified request input.

## Why
Under higher parallelism, a request card can be present in the stream before the one-shot request event or persisted message fallback is observed. That made request-family specs vulnerable to timing gaps even when the product was correctly waiting for input.

Computer-use has an extra wrinkle: calls can already be granted by once, timed, or always permissions. The backend now broadcasts autoApproved:true for those calls so the client can suppress streaming/history recovery prompts while the command is executing.

## Validation
- git diff --check
- npx eslint src/shared/lib/computer-use/types.ts src/shared/lib/tool-definitions/types.ts src/shared/lib/container/message-persister.ts src/shared/lib/container/message-persister.test.ts src/renderer/hooks/use-message-stream.ts src/renderer/hooks/use-message-stream.test.ts src/renderer/components/messages/use-pending-requests.tsx src/renderer/components/messages/use-pending-requests.test.tsx src/renderer/test/mock-stream.ts
- npx vitest run src/renderer/components/messages/use-pending-requests.test.tsx src/renderer/hooks/use-message-stream.test.ts src/shared/lib/container/message-persister.test.ts (324 passed)
- npm run typecheck
- PORT=3418 PLAYWRIGHT_WORKERS=4 npm run test:e2e -- e2e/specs/background-bash.spec.ts e2e/specs/computer-use.spec.ts e2e/specs/proxy-review.spec.ts e2e/specs/user-input-requests.spec.ts e2e/specs/awaiting-input-status.spec.ts e2e/specs/pending-request-reconnect.spec.ts (37 passed)