### PR TITLE
Harden persistence E2E isolation

### DIFF
--- a/e2e/helpers/agents.ts
+++ b/e2e/helpers/agents.ts
@@ -1,4 +1,4 @@
-import { expect, type APIRequestContext, type Page } from '@playwright/test'
+import { expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
 
 export interface TestAgent {
   slug: string
@@ -13,6 +13,25 @@ export interface TestSession {
 export interface TestMessage {
   type: string
   content?: unknown
+}
+
+export function uniqueSuffix(
+  testInfo: Pick<TestInfo, 'workerIndex' | 'repeatEachIndex' | 'retry'>,
+) {
+  return [
+    testInfo.workerIndex,
+    testInfo.repeatEachIndex,
+    testInfo.retry,
+    Date.now(),
+    Math.random().toString(36).slice(2, 8),
+  ].join('-')
+}
+
+export function uniqueName(
+  testInfo: Pick<TestInfo, 'workerIndex' | 'repeatEachIndex' | 'retry'>,
+  label: string,
+) {
+  return `${label} ${uniqueSuffix(testInfo)}`
 }
 
 async function expectAgentInApi(
@@ -30,7 +49,7 @@ async function expectAgentInApi(
   }, { timeout: 15000 }).toBe(true)
 }
 
-function getAgentItem(page: Page, agent: Pick<TestAgent, 'slug' | 'name'>) {
+export function getAgentItem(page: Page, agent: Pick<TestAgent, 'slug' | 'name'>) {
   return page
     .locator(`[data-testid="agent-item-${agent.slug}"]`)
     .or(page.locator('[data-testid^="agent-item-"]', { hasText: agent.name }))
@@ -136,7 +155,7 @@ export async function listSessionMessages(
   return await response.json() as TestMessage[]
 }
 
-function messageContentIncludes(message: TestMessage, text: string) {
+export function messageContentIncludes(message: TestMessage, text: string) {
   if (typeof message.content === 'string') {
     return message.content.includes(text)
   }
@@ -157,9 +176,15 @@ export async function findSessionWithUserMessage(
   let found: TestSession | undefined
 
   await expect.poll(async () => {
-    const sessions = await listSessions(request, agent)
+    const sessionsResponse = await request.get(`/api/agents/${agent.slug}/sessions`)
+    if (!sessionsResponse.ok()) return false
+
+    const sessions = await sessionsResponse.json() as TestSession[]
     for (const session of sessions) {
-      const messages = await listSessionMessages(request, agent, session)
+      const messagesResponse = await request.get(`/api/agents/${agent.slug}/sessions/${session.id}/messages`)
+      if (!messagesResponse.ok()) continue
+
+      const messages = await messagesResponse.json() as TestMessage[]
       if (messages.some((message) => message.type === 'user' && messageContentIncludes(message, text))) {
         found = session
         return true

--- a/e2e/helpers/agents.ts
+++ b/e2e/helpers/agents.ts
@@ -10,6 +10,11 @@ export interface TestSession {
   name: string
 }
 
+export interface TestMessage {
+  type: string
+  content?: unknown
+}
+
 async function expectAgentInApi(
   request: APIRequestContext,
   agent: Pick<TestAgent, 'slug' | 'name'>,
@@ -46,6 +51,45 @@ export async function createAgent(request: APIRequestContext, name: string): Pro
   return agent
 }
 
+export async function findAgentByName(
+  request: APIRequestContext,
+  name: string,
+): Promise<TestAgent> {
+  let found: TestAgent | undefined
+
+  await expect.poll(async () => {
+    const response = await request.get('/api/agents')
+    if (!response.ok()) return false
+
+    const agents = await response.json() as TestAgent[]
+    found = agents.find((agent) => agent.name === name)
+    return Boolean(found)
+  }, { timeout: 15000 }).toBe(true)
+
+  return found!
+}
+
+export async function deleteAgentViaApi(
+  request: APIRequestContext,
+  agent: Pick<TestAgent, 'slug'>,
+) {
+  const response = await request.delete(`/api/agents/${agent.slug}`)
+  expect([204, 404]).toContain(response.status())
+}
+
+export async function expectAgentDeleted(
+  request: APIRequestContext,
+  agent: Pick<TestAgent, 'slug'>,
+) {
+  await expect.poll(async () => {
+    const response = await request.get('/api/agents')
+    if (!response.ok()) return false
+
+    const agents = await response.json() as TestAgent[]
+    return !agents.some((candidate) => candidate.slug === agent.slug)
+  }, { timeout: 15000 }).toBe(true)
+}
+
 export async function createSession(
   request: APIRequestContext,
   agent: Pick<TestAgent, 'slug'>,
@@ -69,6 +113,63 @@ export async function createSession(
   }, { timeout: 15000 }).toBe(true)
 
   return session
+}
+
+export async function listSessions(
+  request: APIRequestContext,
+  agent: Pick<TestAgent, 'slug'>,
+): Promise<TestSession[]> {
+  const response = await request.get(`/api/agents/${agent.slug}/sessions`)
+  expect(response.ok()).toBeTruthy()
+
+  return await response.json() as TestSession[]
+}
+
+export async function listSessionMessages(
+  request: APIRequestContext,
+  agent: Pick<TestAgent, 'slug'>,
+  session: Pick<TestSession, 'id'>,
+): Promise<TestMessage[]> {
+  const response = await request.get(`/api/agents/${agent.slug}/sessions/${session.id}/messages`)
+  expect(response.ok()).toBeTruthy()
+
+  return await response.json() as TestMessage[]
+}
+
+function messageContentIncludes(message: TestMessage, text: string) {
+  if (typeof message.content === 'string') {
+    return message.content.includes(text)
+  }
+
+  if (!message.content || typeof message.content !== 'object') {
+    return false
+  }
+
+  const content = message.content as Record<string, unknown>
+  return typeof content.text === 'string' && content.text.includes(text)
+}
+
+export async function findSessionWithUserMessage(
+  request: APIRequestContext,
+  agent: Pick<TestAgent, 'slug'>,
+  text: string,
+): Promise<TestSession> {
+  let found: TestSession | undefined
+
+  await expect.poll(async () => {
+    const sessions = await listSessions(request, agent)
+    for (const session of sessions) {
+      const messages = await listSessionMessages(request, agent, session)
+      if (messages.some((message) => message.type === 'user' && messageContentIncludes(message, text))) {
+        found = session
+        return true
+      }
+    }
+
+    return false
+  }, { timeout: 15000 }).toBe(true)
+
+  return found!
 }
 
 export async function waitForSessionIdle(
@@ -134,6 +235,33 @@ export async function gotoAgentHome(page: Page, agent: Pick<TestAgent, 'slug' | 
   throw lastError instanceof Error
     ? lastError
     : new Error(`Could not load agent "${agent.name}" (${agent.slug})`)
+}
+
+export async function gotoAgentSession(
+  page: Page,
+  agent: Pick<TestAgent, 'slug' | 'name'>,
+  session: Pick<TestSession, 'id'>,
+) {
+  let lastError: unknown
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      await page.goto(`/agents/${agent.slug}/sessions/${session.id}`)
+      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name, { timeout: 15000 })
+      await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
+      await expect(page.locator('[data-testid="message-input"]')).toBeVisible({ timeout: 15000 })
+      return
+    } catch (error) {
+      lastError = error
+      if (attempt === 1) break
+
+      await page.reload()
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`Could not load session "${session.id}" for agent "${agent.name}" (${agent.slug})`)
 }
 
 export async function openAgentSession(

--- a/e2e/specs/cross-session-messages.spec.ts
+++ b/e2e/specs/cross-session-messages.spec.ts
@@ -1,132 +1,131 @@
-import { test, expect } from '@playwright/test'
-import { AgentPage } from '../pages/agent.page'
+import { test, expect, type Page, type TestInfo } from '@playwright/test'
 import { SessionPage } from '../pages/session.page'
-import { createAgent as createAgentViaApi, gotoAgentHome, type TestAgent } from '../helpers/agents'
+import {
+  createAgent as createAgentViaApi,
+  gotoAgentHome,
+  gotoAgentSession,
+  waitForSessionIdle,
+  type TestAgent,
+  type TestSession,
+} from '../helpers/agents'
 
-// Run serially to avoid conflicts
-test.describe.configure({ mode: 'serial' })
+function uniqueSuffix(testInfo: TestInfo) {
+  return [
+    testInfo.workerIndex,
+    testInfo.repeatEachIndex,
+    testInfo.retry,
+    Date.now(),
+    Math.random().toString(36).slice(2, 8),
+  ].join('-')
+}
 
-test.describe('Cross-Session Message Isolation', () => {
-  let agentPage: AgentPage
-  let sessionPage: SessionPage
+function uniqueName(testInfo: TestInfo, label: string) {
+  return `${label} ${uniqueSuffix(testInfo)}`
+}
 
-  test.beforeEach(async ({ page }) => {
-    agentPage = new AgentPage(page)
-    sessionPage = new SessionPage(page)
-  })
+function userMessage(sessionPage: SessionPage, text: string) {
+  // `.first()` is deliberate: during reconciliation the optimistic
+  // pending-user-message ghost and the persisted message-user briefly coexist
+  // (both carry data-testid="message-user"), so a bare toBeVisible() on the
+  // unscoped match trips Playwright strict mode under CI load. These checks only
+  // assert the message is PRESENT; the isolation guarantee is asserted by the
+  // getMessageList().not.toContainText(...) lines below.
+  return sessionPage.getUserMessages().filter({ hasText: text }).first()
+}
 
-  function userMessage(text: string) {
-    // `.first()` is deliberate: during reconciliation the optimistic
-    // pending-user-message ghost and the persisted message-user briefly coexist
-    // (both carry data-testid="message-user"), so a bare toBeVisible() on the
-    // unscoped match trips Playwright strict mode under CI load. These checks only
-    // assert the message is PRESENT; the isolation guarantee is asserted by the
-    // getMessageList().not.toContainText(...) lines below.
-    return sessionPage.getUserMessages().filter({ hasText: text }).first()
+async function currentSession(page: Page, agent: Pick<TestAgent, 'slug'>): Promise<TestSession> {
+  await expect(page).toHaveURL(new RegExp(`/agents/${agent.slug}/sessions/[^/?#]+$`), { timeout: 15000 })
+
+  const match = page.url().match(new RegExp(`/agents/${agent.slug}/sessions/([^/?#]+)`))
+  expect(match, `expected current URL to include a session id for ${agent.slug}`).not.toBeNull()
+
+  return { id: match![1], name: '' }
+}
+
+async function waitForSessionsToSettle(
+  request: Parameters<typeof waitForSessionIdle>[0],
+  sessions: Array<{ agent: TestAgent; session: TestSession | undefined }>,
+) {
+  for (const { agent, session } of sessions) {
+    if (session) await waitForSessionIdle(request, agent, session).catch(() => {})
   }
+}
 
-  test('messages from one agent do not leak into another agent', async ({ page, request }) => {
-    const ts = Date.now()
-    const agentAName = `Agent A ${ts}`
-    const agentBName = `Agent B ${ts}`
-    const messageA = 'slow response for agent A'
-    const messageB = 'Hello from agent B'
-    const createdAgents: TestAgent[] = []
+// These tests leave their uniquely named agents in the per-run data dir and let
+// setup-e2e-data reset them before the next run. Deleting agents while sibling
+// workers list /api/agents can race session-summary file reads under load.
+test.describe('Cross-Session Message Isolation', () => {
+  test('messages from one agent do not leak into another agent', async ({ page, request }, testInfo) => {
+    const sessionPage = new SessionPage(page)
+    const agentA = await createAgentViaApi(request, uniqueName(testInfo, 'Isolation A'))
+    const agentB = await createAgentViaApi(request, uniqueName(testInfo, 'Isolation B'))
+    const messageA = `slow response for agent A ${uniqueSuffix(testInfo)}`
+    const messageB = `Hello from agent B ${uniqueSuffix(testInfo)}`
+    let sessionA: TestSession | undefined
+    let sessionB: TestSession | undefined
 
     try {
-      // Create two agents
-      const agentA = await createAgentViaApi(request, agentAName)
-      const agentB = await createAgentViaApi(request, agentBName)
-      createdAgents.push(agentA, agentB)
-
-      // 1. Go to Agent A and send a slow message (triggers 3s delay)
       await gotoAgentHome(page, agentA)
       await sessionPage.sendMessage(messageA)
+      sessionA = await currentSession(page, agentA)
 
-      // Wait for the message we just sent to appear.
-      await expect(userMessage(messageA)).toBeVisible({ timeout: 10000 })
-
-      // Verify Agent A is working (slow response takes 3s)
+      await expect(userMessage(sessionPage, messageA)).toBeVisible({ timeout: 10000 })
       await expect(sessionPage.getStopButton()).toBeVisible({ timeout: 5000 })
 
-      // 2. While Agent A is working, switch to Agent B
-      await agentPage.selectAgent(agentBName)
-      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agentBName, { timeout: 15000 })
-
-      // 3. Send a message to Agent B
+      await gotoAgentHome(page, agentB)
       await sessionPage.sendMessage(messageB)
-      await expect(userMessage(messageB)).toBeVisible({ timeout: 10000 })
+      sessionB = await currentSession(page, agentB)
 
-      // Verify Agent B's message list does NOT contain Agent A's message
-      const messageBList = sessionPage.getMessageList()
-      await expect(messageBList).not.toContainText(messageA)
+      await expect(userMessage(sessionPage, messageB)).toBeVisible({ timeout: 10000 })
+      await expect(sessionPage.getMessageList()).not.toContainText(messageA)
 
-      // 4. Switch back to Agent A and select its session
-      await agentPage.selectAgent(agentAName)
-      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agentAName, { timeout: 15000 })
-      // Need to click on the session in the sidebar since switching agent deselects it
-      await sessionPage.selectFirstSessionInSidebar(agentPage.getAgentLi(agentAName))
+      await gotoAgentSession(page, agentA, sessionA)
 
-      // Wait for message list to appear
       const messageAList = sessionPage.getMessageList()
       await expect(messageAList).toBeVisible({ timeout: 5000 })
-
-      // 5. Verify Agent A's messages do NOT contain Agent B's message
-      await expect(userMessage(messageA)).toBeVisible({ timeout: 10000 })
+      await expect(userMessage(sessionPage, messageA)).toBeVisible({ timeout: 10000 })
       await expect(messageAList).not.toContainText(messageB)
     } finally {
-      for (const agent of createdAgents) {
-        await request.delete(`/api/agents/${agent.slug}`).catch(() => {})
-      }
+      await waitForSessionsToSettle(request, [
+        { agent: agentA, session: sessionA },
+        { agent: agentB, session: sessionB },
+      ])
     }
   })
 
-  test('pending optimistic message is scoped to session', async ({ page, request }) => {
-    const ts = Date.now()
-    const agentAName = `Pending A ${ts}`
-    const agentBName = `Pending B ${ts}`
-    const messageA = 'slow response test'
-    const messageB = 'Quick message B'
-    const createdAgents: TestAgent[] = []
+  test('pending optimistic message is scoped to session', async ({ page, request }, testInfo) => {
+    const sessionPage = new SessionPage(page)
+    const agentA = await createAgentViaApi(request, uniqueName(testInfo, 'Pending A'))
+    const agentB = await createAgentViaApi(request, uniqueName(testInfo, 'Pending B'))
+    const messageA = `slow response test ${uniqueSuffix(testInfo)}`
+    const messageB = `Quick message B ${uniqueSuffix(testInfo)}`
+    let sessionA: TestSession | undefined
+    let sessionB: TestSession | undefined
 
     try {
-      // Create two agents
-      const agentA = await createAgentViaApi(request, agentAName)
-      const agentB = await createAgentViaApi(request, agentBName)
-      createdAgents.push(agentA, agentB)
-
-      // Send slow message to Agent A
       await gotoAgentHome(page, agentA)
       await sessionPage.sendMessage(messageA)
-      await expect(userMessage(messageA)).toBeVisible({ timeout: 10000 })
+      sessionA = await currentSession(page, agentA)
 
-      // Agent A should be working
+      await expect(userMessage(sessionPage, messageA)).toBeVisible({ timeout: 10000 })
       await expect(sessionPage.getStopButton()).toBeVisible({ timeout: 5000 })
 
-      // Switch to Agent B and send a message
-      await agentPage.selectAgent(agentBName)
-      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agentBName, { timeout: 15000 })
+      await gotoAgentHome(page, agentB)
       await sessionPage.sendMessage(messageB)
+      sessionB = await currentSession(page, agentB)
 
-      // Agent B should show its own message, not Agent A's
-      await expect(userMessage(messageB)).toBeVisible({ timeout: 10000 })
+      await expect(userMessage(sessionPage, messageB)).toBeVisible({ timeout: 10000 })
       await expect(sessionPage.getMessageList()).not.toContainText(messageA)
 
-      // Switch back to Agent A and select session
-      await agentPage.selectAgent(agentAName)
-      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agentAName, { timeout: 15000 })
-      await sessionPage.selectFirstSessionInSidebar(agentPage.getAgentLi(agentAName))
+      await gotoAgentSession(page, agentA, sessionA)
 
-      // Agent A should show its message
-      await expect(userMessage(messageA)).toBeVisible({ timeout: 10000 })
-
-      // And should NOT have messageB anywhere
-      const messageListA = sessionPage.getMessageList()
-      await expect(messageListA).not.toContainText(messageB)
+      await expect(userMessage(sessionPage, messageA)).toBeVisible({ timeout: 10000 })
+      await expect(sessionPage.getMessageList()).not.toContainText(messageB)
     } finally {
-      for (const agent of createdAgents) {
-        await request.delete(`/api/agents/${agent.slug}`).catch(() => {})
-      }
+      await waitForSessionsToSettle(request, [
+        { agent: agentA, session: sessionA },
+        { agent: agentB, session: sessionB },
+      ])
     }
   })
 })

--- a/e2e/specs/cross-session-messages.spec.ts
+++ b/e2e/specs/cross-session-messages.spec.ts
@@ -1,27 +1,16 @@
-import { test, expect, type Page, type TestInfo } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import { SessionPage } from '../pages/session.page'
 import {
   createAgent as createAgentViaApi,
+  getAgentItem,
   gotoAgentHome,
   gotoAgentSession,
+  uniqueName,
+  uniqueSuffix,
   waitForSessionIdle,
   type TestAgent,
   type TestSession,
 } from '../helpers/agents'
-
-function uniqueSuffix(testInfo: TestInfo) {
-  return [
-    testInfo.workerIndex,
-    testInfo.repeatEachIndex,
-    testInfo.retry,
-    Date.now(),
-    Math.random().toString(36).slice(2, 8),
-  ].join('-')
-}
-
-function uniqueName(testInfo: TestInfo, label: string) {
-  return `${label} ${uniqueSuffix(testInfo)}`
-}
 
 function userMessage(sessionPage: SessionPage, text: string) {
   // `.first()` is deliberate: during reconciliation the optimistic
@@ -34,12 +23,17 @@ function userMessage(sessionPage: SessionPage, text: string) {
 }
 
 async function currentSession(page: Page, agent: Pick<TestAgent, 'slug'>): Promise<TestSession> {
-  await expect(page).toHaveURL(new RegExp(`/agents/${agent.slug}/sessions/[^/?#]+$`), { timeout: 15000 })
+  let sessionId = ''
 
-  const match = page.url().match(new RegExp(`/agents/${agent.slug}/sessions/([^/?#]+)`))
-  expect(match, `expected current URL to include a session id for ${agent.slug}`).not.toBeNull()
+  await expect.poll(async () => {
+    const match = page.url().match(/\/agents\/([^/?#]+)\/sessions\/([^/?#]+)(?:[?#].*)?$/)
+    if (!match || !match[1].endsWith(agent.slug)) return ''
 
-  return { id: match![1], name: '' }
+    sessionId = match[2]
+    return sessionId
+  }, { timeout: 15000 }).not.toBe('')
+
+  return { id: sessionId, name: '' }
 }
 
 async function waitForSessionsToSettle(
@@ -49,6 +43,16 @@ async function waitForSessionsToSettle(
   for (const { agent, session } of sessions) {
     if (session) await waitForSessionIdle(request, agent, session).catch(() => {})
   }
+}
+
+async function switchAgentViaSidebar(page: Page, agent: TestAgent) {
+  const agentItem = getAgentItem(page, agent)
+
+  await expect(agentItem).toBeVisible({ timeout: 15000 })
+  await agentItem.scrollIntoViewIfNeeded({ timeout: 10000 })
+  await agentItem.click()
+  await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name, { timeout: 15000 })
+  await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible({ timeout: 15000 })
 }
 
 // These tests leave their uniquely named agents in the per-run data dir and let
@@ -72,7 +76,9 @@ test.describe('Cross-Session Message Isolation', () => {
       await expect(userMessage(sessionPage, messageA)).toBeVisible({ timeout: 10000 })
       await expect(sessionPage.getStopButton()).toBeVisible({ timeout: 5000 })
 
-      await gotoAgentHome(page, agentB)
+      await switchAgentViaSidebar(page, agentB)
+      await expect(page.locator('[data-testid="main-content"]')).not.toContainText(messageA)
+
       await sessionPage.sendMessage(messageB)
       sessionB = await currentSession(page, agentB)
 

--- a/e2e/specs/persistence.spec.ts
+++ b/e2e/specs/persistence.spec.ts
@@ -1,141 +1,160 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page, type TestInfo } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
+import {
+  createAgent as createAgentViaApi,
+  deleteAgentViaApi,
+  expectAgentDeleted,
+  findAgentByName,
+  findSessionWithUserMessage,
+  gotoAgentHome,
+  gotoAgentSession,
+  listSessionMessages,
+  waitForSessionIdle,
+  type TestAgent,
+  type TestMessage,
+  type TestSession,
+} from '../helpers/agents'
 
-// Serial: tests reload the page and verify DB state, sensitive to concurrent DB writes
-test.describe.configure({ mode: 'serial' })
+function uniqueSuffix(testInfo: TestInfo) {
+  return [
+    testInfo.workerIndex,
+    testInfo.repeatEachIndex,
+    testInfo.retry,
+    Date.now(),
+    Math.random().toString(36).slice(2, 8),
+  ].join('-')
+}
 
+function uniqueName(testInfo: TestInfo, label: string) {
+  return `${label} ${uniqueSuffix(testInfo)}`
+}
+
+function agentRow(page: Page, agent: Pick<TestAgent, 'slug' | 'name'>) {
+  return page
+    .locator(`[data-testid="agent-item-${agent.slug}"]`)
+    .or(page.locator('[data-testid^="agent-item-"]', { hasText: agent.name }))
+    .first()
+}
+
+function messageText(message: TestMessage) {
+  if (typeof message.content === 'string') return message.content
+  if (!message.content || typeof message.content !== 'object') return ''
+
+  const content = message.content as Record<string, unknown>
+  return typeof content.text === 'string' ? content.text : ''
+}
+
+function expectMessagesIncludeUserText(messages: TestMessage[], text: string) {
+  expect(
+    messages.some((message) => message.type === 'user' && messageText(message).includes(text)),
+  ).toBe(true)
+}
+
+async function openApp(page: Page) {
+  const appPage = new AppPage(page)
+  await appPage.goto()
+  await appPage.waitForAgentsLoaded()
+  return appPage
+}
+
+// Aside from the deletion case itself, these tests leave their uniquely named
+// agents in the per-run data dir and let setup-e2e-data reset them before the
+// next run. Deleting agents while sibling workers list /api/agents can race
+// session-summary file reads under load.
 test.describe('Persistence', () => {
-  let appPage: AppPage
-  let agentPage: AgentPage
-  let sessionPage: SessionPage
+  test('UI-created agent persists after page reload', async ({ page, request }, testInfo) => {
+    const appPage = await openApp(page)
+    const agentPage = new AgentPage(page)
+    const agentName = uniqueName(testInfo, 'Persist Agent')
 
-  test.beforeEach(async ({ page }) => {
-    appPage = new AppPage(page)
-    agentPage = new AgentPage(page)
-    sessionPage = new SessionPage(page)
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
-  })
-
-  test('agent persists after page reload', async ({ page }) => {
-    const agentName = `Persist Agent ${Date.now()}`
-
-    // Create agent
     await agentPage.createAgent(agentName)
-    await expect(agentPage.getAgentItem(agentName)).toBeVisible()
+    const agent = await findAgentByName(request, agentName)
 
-    // Reload page
+    await expect(agentRow(page, agent)).toBeVisible()
+
     await appPage.reload()
 
-    // Verify agent still exists
-    await expect(agentPage.getAgentItem(agentName)).toBeVisible()
+    await expect(agentRow(page, agent)).toBeVisible()
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name, { timeout: 15000 })
 
-    // Clean up
-    await agentPage.selectAgent(agentName)
-    await agentPage.deleteAgent()
+    const session = await findSessionWithUserMessage(request, agent, agentName)
+    await waitForSessionIdle(request, agent, session).catch(() => {})
   })
 
-  test('messages persist after page reload', async ({ page, request }) => {
-    const agentName = `Message Persist Agent ${Date.now()}`
-    await agentPage.createAgent(agentName)
+  test('UI-sent messages persist after page reload', async ({ page, request }, testInfo) => {
+    const agent = await createAgentViaApi(request, uniqueName(testInfo, 'Message Persist Agent'))
+    const sessionPage = new SessionPage(page)
+    const message = `Persistent message ${uniqueSuffix(testInfo)}`
+    let session: TestSession | undefined
 
-    // Send a message and wait for response
-    await sessionPage.sendMessage('Persistent message')
-    await sessionPage.waitForResponse()
-    await sessionPage.waitForInputEnabled()
-    await sessionPage.expectUserMessage('Persistent message')
+    await gotoAgentHome(page, agent)
 
-    // Verify assistant response is visible
+    await sessionPage.sendMessage(message)
+    await sessionPage.waitForResponse(15000)
+    await sessionPage.waitForInputEnabled(15000)
+    await sessionPage.expectUserMessage(message)
     await expect(sessionPage.getAssistantMessages().first()).toBeVisible()
 
-    // Get the agent slug from the agents list API
-    const agentsResponse = await request.get('/api/agents')
-    expect(agentsResponse.ok()).toBeTruthy()
-    const agents = await agentsResponse.json()
-    const agent = agents.find((a: { name: string }) => a.name === agentName)
-    expect(agent).toBeDefined()
-    const agentSlug = agent.slug
-
-    // Get sessions for this agent via API
-    const sessionsResponse = await request.get(`/api/agents/${agentSlug}/sessions`)
-    expect(sessionsResponse.ok()).toBeTruthy()
-    const sessions = await sessionsResponse.json()
-    expect(sessions.length).toBeGreaterThan(0)
-
-    const sessionId = sessions[0].id
-
-    // Get messages for the session via API
-    const messagesResponse = await request.get(
-      `/api/agents/${agentSlug}/sessions/${sessionId}/messages`
+    session = await findSessionWithUserMessage(request, agent, message)
+    expectMessagesIncludeUserText(
+      await listSessionMessages(request, agent, session),
+      message,
     )
-    expect(messagesResponse.ok()).toBeTruthy()
-    const messages = await messagesResponse.json()
 
-    // Verify messages are persisted
-    expect(messages.length).toBeGreaterThan(0)
-    const userMessage = messages.find((m: { type: string }) => m.type === 'user')
-    expect(userMessage).toBeDefined()
-    // content is { text: string } not a plain string
-    expect(userMessage.content.text).toContain('Persistent message')
-
-    // Reload page to verify data survives reload
+    const appPage = new AppPage(page)
     await appPage.reload()
 
-    // Verify via API that messages still exist after reload
-    const messagesAfterReload = await request.get(
-      `/api/agents/${agentSlug}/sessions/${sessionId}/messages`
+    await gotoAgentSession(page, agent, session)
+    await expect(sessionPage.getUserMessages().filter({ hasText: message }).first()).toBeVisible({ timeout: 10000 })
+    expectMessagesIncludeUserText(
+      await listSessionMessages(request, agent, session),
+      message,
     )
-    expect(messagesAfterReload.ok()).toBeTruthy()
-    const messagesAfter = await messagesAfterReload.json()
-    expect(messagesAfter.length).toBeGreaterThan(0)
-
-    // Clean up
-    await agentPage.selectAgent(agentName)
-    await agentPage.deleteAgent()
+    if (session) await waitForSessionIdle(request, agent, session).catch(() => {})
   })
 
-  test('deleted agent stays deleted after reload', async ({ page }) => {
-    const agentName = `Deletable Agent ${Date.now()}`
+  test('UI-deleted agent stays deleted after reload', async ({ page, request }, testInfo) => {
+    const appPage = await openApp(page)
+    const agentPage = new AgentPage(page)
+    const agent = await createAgentViaApi(request, uniqueName(testInfo, 'Deletable Agent'))
+    let deleted = false
 
-    // Create agent
-    await agentPage.createAgent(agentName)
-    await expect(agentPage.getAgentItem(agentName)).toBeVisible()
+    try {
+      await gotoAgentHome(page, agent)
+      await expect(agentRow(page, agent)).toBeVisible()
 
-    // Delete agent
-    await agentPage.deleteAgent()
-    await expect(agentPage.getAgentItem(agentName)).not.toBeVisible()
-
-    // Reload page
-    await appPage.reload()
-
-    // Verify agent is still gone
-    await expect(agentPage.getAgentItem(agentName)).not.toBeVisible()
-  })
-
-  test('multiple agents persist', async ({ page }) => {
-    const timestamp = Date.now()
-    const agents = [`Agent One ${timestamp}`, `Agent Two ${timestamp}`, `Agent Three ${timestamp}`]
-
-    // Create multiple agents
-    for (const name of agents) {
-      await agentPage.createAgent(name)
-      await expect(agentPage.getAgentItem(name)).toBeVisible()
-    }
-
-    // Reload page
-    await appPage.reload()
-
-    // Verify all agents still exist
-    for (const name of agents) {
-      await expect(agentPage.getAgentItem(name)).toBeVisible()
-    }
-
-    // Clean up - delete all agents
-    for (const name of agents) {
-      await agentPage.selectAgent(name)
       await agentPage.deleteAgent()
+      deleted = true
+      await expectAgentDeleted(request, agent)
+      await expect(agentRow(page, agent)).not.toBeVisible()
+
+      await appPage.reload()
+
+      await expect(agentRow(page, agent)).not.toBeVisible()
+    } finally {
+      if (!deleted) await deleteAgentViaApi(request, agent)
+    }
+  })
+
+  test('multiple API-created agents persist after reload', async ({ page, request }, testInfo) => {
+    const agents: TestAgent[] = []
+
+    for (const label of ['Agent One', 'Agent Two', 'Agent Three']) {
+      agents.push(await createAgentViaApi(request, uniqueName(testInfo, label)))
+    }
+
+    const appPage = await openApp(page)
+
+    for (const agent of agents) {
+      await expect(agentRow(page, agent)).toBeVisible()
+    }
+
+    await appPage.reload()
+
+    for (const agent of agents) {
+      await expect(agentRow(page, agent)).toBeVisible()
     }
   })
 })

--- a/e2e/specs/persistence.spec.ts
+++ b/e2e/specs/persistence.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page, type TestInfo } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
@@ -8,47 +8,24 @@ import {
   expectAgentDeleted,
   findAgentByName,
   findSessionWithUserMessage,
+  getAgentItem,
   gotoAgentHome,
   gotoAgentSession,
   listSessionMessages,
+  messageContentIncludes,
+  uniqueName,
+  uniqueSuffix,
   waitForSessionIdle,
   type TestAgent,
-  type TestMessage,
   type TestSession,
 } from '../helpers/agents'
 
-function uniqueSuffix(testInfo: TestInfo) {
-  return [
-    testInfo.workerIndex,
-    testInfo.repeatEachIndex,
-    testInfo.retry,
-    Date.now(),
-    Math.random().toString(36).slice(2, 8),
-  ].join('-')
-}
-
-function uniqueName(testInfo: TestInfo, label: string) {
-  return `${label} ${uniqueSuffix(testInfo)}`
-}
-
-function agentRow(page: Page, agent: Pick<TestAgent, 'slug' | 'name'>) {
-  return page
-    .locator(`[data-testid="agent-item-${agent.slug}"]`)
-    .or(page.locator('[data-testid^="agent-item-"]', { hasText: agent.name }))
-    .first()
-}
-
-function messageText(message: TestMessage) {
-  if (typeof message.content === 'string') return message.content
-  if (!message.content || typeof message.content !== 'object') return ''
-
-  const content = message.content as Record<string, unknown>
-  return typeof content.text === 'string' ? content.text : ''
-}
-
-function expectMessagesIncludeUserText(messages: TestMessage[], text: string) {
+function expectMessagesIncludeUserText(
+  messages: Awaited<ReturnType<typeof listSessionMessages>>,
+  text: string,
+) {
   expect(
-    messages.some((message) => message.type === 'user' && messageText(message).includes(text)),
+    messages.some((message) => message.type === 'user' && messageContentIncludes(message, text)),
   ).toBe(true)
 }
 
@@ -72,11 +49,11 @@ test.describe('Persistence', () => {
     await agentPage.createAgent(agentName)
     const agent = await findAgentByName(request, agentName)
 
-    await expect(agentRow(page, agent)).toBeVisible()
+    await expect(getAgentItem(page, agent)).toBeVisible()
 
     await appPage.reload()
 
-    await expect(agentRow(page, agent)).toBeVisible()
+    await expect(getAgentItem(page, agent)).toBeVisible()
     await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name, { timeout: 15000 })
 
     const session = await findSessionWithUserMessage(request, agent, agentName)
@@ -93,7 +70,6 @@ test.describe('Persistence', () => {
 
     await sessionPage.sendMessage(message)
     await sessionPage.waitForResponse(15000)
-    await sessionPage.waitForInputEnabled(15000)
     await sessionPage.expectUserMessage(message)
     await expect(sessionPage.getAssistantMessages().first()).toBeVisible()
 
@@ -123,16 +99,16 @@ test.describe('Persistence', () => {
 
     try {
       await gotoAgentHome(page, agent)
-      await expect(agentRow(page, agent)).toBeVisible()
+      await expect(getAgentItem(page, agent)).toBeVisible()
 
       await agentPage.deleteAgent()
       deleted = true
       await expectAgentDeleted(request, agent)
-      await expect(agentRow(page, agent)).not.toBeVisible()
+      await expect(getAgentItem(page, agent)).not.toBeVisible()
 
       await appPage.reload()
 
-      await expect(agentRow(page, agent)).not.toBeVisible()
+      await expect(getAgentItem(page, agent)).not.toBeVisible()
     } finally {
       if (!deleted) await deleteAgentViaApi(request, agent)
     }
@@ -148,13 +124,13 @@ test.describe('Persistence', () => {
     const appPage = await openApp(page)
 
     for (const agent of agents) {
-      await expect(agentRow(page, agent)).toBeVisible()
+      await expect(getAgentItem(page, agent)).toBeVisible()
     }
 
     await appPage.reload()
 
     for (const agent of agents) {
-      await expect(agentRow(page, agent)).toBeVisible()
+      await expect(getAgentItem(page, agent)).toBeVisible()
     }
   })
 })


### PR DESCRIPTION
## Summary

- Remove serial execution from the persistence and cross-session isolation specs by giving each test unique agent/session data and exact slug/session-id navigation.
- Add shared E2E helpers for finding agents, listing sessions/messages, direct session routes, API deletion checks, and message-based session lookup.
- Avoid deleting non-essential unique test agents mid-run; setup-e2e-data resets the per-run data dir, and this avoids /api/agents session-summary races while sibling workers are listing agents.
- Keep UI coverage where it matters: UI-created agent persistence, UI-sent message persistence, UI deletion persistence, and UI navigation between active sessions are still exercised.

## Validation

- npx eslint e2e/helpers/agents.ts e2e/specs/persistence.spec.ts e2e/specs/cross-session-messages.spec.ts
- npm run typecheck
- git diff --check
- PORT=3424 PLAYWRIGHT_WORKERS=4 npm run test:e2e -- e2e/specs/persistence.spec.ts e2e/specs/cross-session-messages.spec.ts — 6 passed
- PORT=3425 PLAYWRIGHT_WORKERS=4 npm run test:e2e -- e2e/specs/persistence.spec.ts e2e/specs/cross-session-messages.spec.ts — 6 passed
- PORT=3426 PLAYWRIGHT_WORKERS=4 npm run test:e2e -- e2e/specs/persistence.spec.ts e2e/specs/cross-session-messages.spec.ts — 6 passed

Saved E2E logs did not contain ENOENT, scandir, or Failed to fetch agents after the no-delete adjustment.