### PR TITLE
feat(chat-integrations): honest AskUserQuestion in Telegram + cancel-on-message

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -105,6 +105,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
     subscribeToSession: vi.fn(),
     unsubscribeFromSession: vi.fn(),
     markSessionActive: vi.fn(),
+    cancelAwaitingInput: vi.fn(),
     broadcastSessionEvent: vi.fn(),
   },
 }))
@@ -2156,6 +2157,20 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
     expect(mockSendMessage).toHaveBeenCalledWith('sess-1', 'hello', expect.any(String), {
       model: 'claude-sonnet-4-6',
     })
+  })
+
+  it('cancels any awaiting-input request before forwarding the message to the container', async () => {
+    mockIsAuthMode.mockReturnValue(false)
+
+    const res = await postJson(app, URL, { content: 'never mind, do X instead' })
+    expect(res.status).toBe(201)
+
+    // The dispatch guard runs first so a message sent during an open request
+    // (e.g. AskUserQuestion) cancels it instead of deadlocking behind it.
+    expect(messagePersister.cancelAwaitingInput).toHaveBeenCalledWith('sess-1', 'test-agent')
+    const cancelOrder = vi.mocked(messagePersister.cancelAwaitingInput).mock.invocationCallOrder[0]
+    const sendOrder = mockSendMessage.mock.invocationCallOrder[0]
+    expect(cancelOrder).toBeLessThan(sendOrder)
   })
 
   it('strips model/effort when the session is already active (mid-turn send)', async () => {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1561,6 +1561,13 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
       await messagePersister.subscribeToSession(sessionId, client, sessionId, agentSlug)
     }
 
+    // If the session is awaiting user input (an open AskUserQuestion / secret / file
+    // request, etc.), cancel the pending request first so this message starts a fresh
+    // turn instead of deadlocking behind the blocked tool. No-op when not awaiting.
+    // Runs before the wasQueued capture so its state changes (interrupt for subagent
+    // requests) are reflected in the queue-vs-fresh-turn decision below.
+    await messagePersister.cancelAwaitingInput(sessionId, agentSlug)
+
     // Captured before markSessionActive: a message sent while the agent is
     // mid-turn is queued by the agent loop rather than starting a new turn.
     const wasQueued = messagePersister.isSessionActive(sessionId)

--- a/src/shared/lib/chat-integrations/base-connector.ts
+++ b/src/shared/lib/chat-integrations/base-connector.ts
@@ -100,6 +100,15 @@ export abstract class ChatClientConnector {
    */
   abstract sendUserRequestCard(chatId: string, event: UserRequestEvent): Promise<string>
 
+  /**
+   * Resolve an open single-question AskUserQuestion card with a free-typed message as the
+   * "Other" answer. Returns true only if a live card matching `toolUseId` is open for this chat,
+   * so the manager consumes the message only on a real resolve. Default: not supported (false).
+   */
+  async answerOpenQuestionWithText(_chatId: string, _toolUseId: string, _text: string): Promise<boolean> {
+    return false
+  }
+
   /** Whether the connection is healthy right now. */
   abstract isConnected(): boolean
 

--- a/src/shared/lib/chat-integrations/base-connector.ts
+++ b/src/shared/lib/chat-integrations/base-connector.ts
@@ -109,6 +109,14 @@ export abstract class ChatClientConnector {
     return false
   }
 
+  /**
+   * Dismiss every open request card for this chat: strip its inline keyboard and forget its
+   * callbacks, so a card abandoned by a cancelling message doesn't keep showing live buttons.
+   * Called on the cancel path when a new message starts a fresh turn. Default no-op for
+   * connectors without interactive cards.
+   */
+  async dismissOpenCards(_chatId: string): Promise<void> {}
+
   /** Whether the connection is healthy right now. */
   abstract isConnected(): boolean
 

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -824,6 +824,27 @@ class ChatIntegrationManager {
       // Revoke can land mid-flight (during the awaits above). Re-check before spending.
       if (!isChatAllowed(integrationId, chatId)) return
 
+      // If a single-question AskUserQuestion is open, a plain-text message is the free-form
+      // "Other" answer: resolve that question so the same turn continues, instead of cancelling.
+      // isSessionAwaitingInput is the source of truth (it reflects taps, cancels, and answers from
+      // other surfaces), so we consume the message only on a confirmed live resolve; a non-text
+      // message, a multi-question card, or any other awaiting type falls through to cancel.
+      const isPlainText = !!messageText.trim() && !(message.files && message.files.length > 0)
+      if (isPlainText && messagePersister.isSessionAwaitingInput(sessionId)) {
+        const pendingQuestion = messagePersister
+          .getPendingInputRequests(sessionId)
+          .find((r) => r.type === 'user_question_request')
+        if (pendingQuestion) {
+          const answered = await conn.connector.answerOpenQuestionWithText(chatId, pendingQuestion.toolUseId, messageText)
+          if (answered) return
+        }
+      }
+
+      // Otherwise: if the session is awaiting input, cancel the pending request first so this
+      // message starts a fresh turn instead of deadlocking behind the blocked tool. No-op
+      // when not awaiting. Mirrors the app send-message route.
+      await messagePersister.cancelAwaitingInput(sessionId, integration.agentSlug)
+
       await client.sendMessage(sessionId, messageText)
       messagePersister.markSessionActive(sessionId, integration.agentSlug)
       const now = Date.now()

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -834,6 +834,9 @@ class ChatIntegrationManager {
         agentSlug: integration.agentSlug,
         chatId,
         messageText,
+        // Resolve an open question with the RAW user text (no group sender-name prefix): the
+        // prefixed messageText is only for the fresh-turn forward below.
+        answerText: message.text ?? '',
         hasFiles: !!(message.files && message.files.length > 0),
         persister: messagePersister,
         connector: conn.connector,

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -17,6 +17,7 @@ import { getToolDefinition } from '@shared/lib/tool-definitions/registry'
 import { formatToolName } from '@shared/lib/tool-definitions/types'
 import { parseChatIntegrationConfig, type ChatProvider } from './config-schema'
 import { formatProviderName, formatSessionTimestamp } from './utils'
+import { consumeOrCancelAwaitingInput } from './resolve-awaiting-input'
 import {
   listStartupChatIntegrations,
   getChatIntegration,
@@ -824,26 +825,20 @@ class ChatIntegrationManager {
       // Revoke can land mid-flight (during the awaits above). Re-check before spending.
       if (!isChatAllowed(integrationId, chatId)) return
 
-      // If a single-question AskUserQuestion is open, a plain-text message is the free-form
-      // "Other" answer: resolve that question so the same turn continues, instead of cancelling.
-      // isSessionAwaitingInput is the source of truth (it reflects taps, cancels, and answers from
-      // other surfaces), so we consume the message only on a confirmed live resolve; a non-text
-      // message, a multi-question card, or any other awaiting type falls through to cancel.
-      const isPlainText = !!messageText.trim() && !(message.files && message.files.length > 0)
-      if (isPlainText && messagePersister.isSessionAwaitingInput(sessionId)) {
-        const pendingQuestion = messagePersister
-          .getPendingInputRequests(sessionId)
-          .find((r) => r.type === 'user_question_request')
-        if (pendingQuestion) {
-          const answered = await conn.connector.answerOpenQuestionWithText(chatId, pendingQuestion.toolUseId, messageText)
-          if (answered) return
-        }
-      }
-
-      // Otherwise: if the session is awaiting input, cancel the pending request first so this
-      // message starts a fresh turn instead of deadlocking behind the blocked tool. No-op
+      // A plain-text reply to an open single-question card continues the same turn as the
+      // free-form "Other" answer; anything else cancels the pending request (and strips its
+      // now-abandoned card) so this message starts a fresh turn instead of deadlocking. No-op
       // when not awaiting. Mirrors the app send-message route.
-      await messagePersister.cancelAwaitingInput(sessionId, integration.agentSlug)
+      const consumed = await consumeOrCancelAwaitingInput({
+        sessionId,
+        agentSlug: integration.agentSlug,
+        chatId,
+        messageText,
+        hasFiles: !!(message.files && message.files.length > 0),
+        persister: messagePersister,
+        connector: conn.connector,
+      })
+      if (consumed) return
 
       await client.sendMessage(sessionId, messageText)
       messagePersister.markSessionActive(sessionId, integration.agentSlug)

--- a/src/shared/lib/chat-integrations/finalize-streaming.test.ts
+++ b/src/shared/lib/chat-integrations/finalize-streaming.test.ts
@@ -290,12 +290,11 @@ describe('TelegramConnector.sendUserRequestCard (rich)', () => {
 
   it('escapes interpolated values so they cannot break the markdown', async () => {
     await connector.sendUserRequestCard('123', {
-      type: 'secret_request', toolUseId: 't3', secretName: 'weird`name', reason: 'needs **admin** rights',
+      type: 'user_question_request', toolUseId: 't3',
+      questions: [{ question: 'needs **admin** rights', options: [{ label: 'A' }] }],
     } as any)
     const md: string = mockSendRich.mock.calls[0][0].rich_message.markdown
-    // secretName with a backtick is fenced so it can't close the code span.
-    expect(md).toContain('``weird`name``')
-    // reason's asterisks are escaped, not rendered as bold.
+    // The interpolated question's asterisks are escaped, not rendered as bold.
     expect(md).toContain('needs \\*\\*admin\\*\\* rights')
   })
 })

--- a/src/shared/lib/chat-integrations/imessage-connector.test.ts
+++ b/src/shared/lib/chat-integrations/imessage-connector.test.ts
@@ -807,7 +807,7 @@ describe('IMessageConnector', () => {
       ws = wireUp(connector)
     })
 
-    it('sends secret request text', async () => {
+    it('sends secret request as a desktop-only fallback (secrets are unsafe to type in chat)', async () => {
       const event = {
         type: 'secret_request' as const,
         toolUseId: 'sec-1',
@@ -818,9 +818,8 @@ describe('IMessageConnector', () => {
       await connector.sendUserRequestCard('chat-1', event as any)
 
       const text = (parseSent(ws)[0].data as any).parts[0].value as string
-      expect(text).toContain('Secret requested: API_KEY')
-      expect(text).toContain('Reason: Needed for authentication')
-      expect(text).toContain('reply with the secret value')
+      expect(text).toContain('API_KEY')
+      expect(text).toContain('Open Gamut on your desktop')
     })
 
     it('sends tool status with correct emoji', async () => {

--- a/src/shared/lib/chat-integrations/imessage-connector.ts
+++ b/src/shared/lib/chat-integrations/imessage-connector.ts
@@ -344,15 +344,8 @@ export class IMessageConnector extends ChatClientConnector {
         return this.sendQuestionCard(event, targetChatId)
       }
 
-      case 'secret_request': {
-        const text = `Secret requested: ${event.secretName}${event.reason ? `\nReason: ${event.reason}` : ''}\n\nPlease reply with the secret value.`
-        return this.sendTextAndReturn(text, targetChatId)
-      }
-
-      case 'file_request': {
-        const text = `File requested:\n${event.description}${event.fileTypes ? `\n\nAccepted types: ${event.fileTypes}` : ''}\n\nPlease send the file.`
-        return this.sendTextAndReturn(text, targetChatId)
-      }
+      // secret_request / file_request are handled by the isUnsupportedInChat early-return above
+      // (desktop-only fallback); they intentionally have no prompt case here.
 
       case 'file_delivery': {
         const text = `File delivered: ${event.filePath}${event.description ? `\n${event.description}` : ''}`

--- a/src/shared/lib/chat-integrations/resolve-awaiting-input.test.ts
+++ b/src/shared/lib/chat-integrations/resolve-awaiting-input.test.ts
@@ -42,6 +42,26 @@ describe('consumeOrCancelAwaitingInput', () => {
     expect(rec.answerArgs).toEqual({ chatId: 'c1', toolUseId: 't1', text: 'my answer' })
   })
 
+  it('resolves with the raw answerText, not the group-prefixed messageText, when both are given', async () => {
+    const { rec, persister, connector } = makeDeps({
+      awaiting: true,
+      pending: [{ type: 'user_question_request', toolUseId: 't1' }],
+      answerResult: true,
+    })
+    // messageText carries the `\[Alice]: ` sender prefix (for the fresh-turn forward); the answer
+    // sent to the model must be the raw text only.
+    const consumed = await consumeOrCancelAwaitingInput({
+      ...base,
+      messageText: '\\[Alice]: option nobody listed',
+      answerText: 'option nobody listed',
+      hasFiles: false,
+      persister,
+      connector,
+    })
+    expect(consumed).toBe(true)
+    expect(rec.answerArgs?.text).toBe('option nobody listed')
+  })
+
   it('cancels and dismisses when the open question declines the typed text', async () => {
     const { rec, persister, connector } = makeDeps({
       awaiting: true,

--- a/src/shared/lib/chat-integrations/resolve-awaiting-input.test.ts
+++ b/src/shared/lib/chat-integrations/resolve-awaiting-input.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { consumeOrCancelAwaitingInput } from './resolve-awaiting-input'
+
+interface Recorder {
+  awaiting: boolean
+  pending: Array<{ type: string; toolUseId: string }>
+  answerResult: boolean
+  calls: string[]
+  answerArgs?: { chatId: string; toolUseId: string; text: string }
+}
+
+function makeDeps(over: Partial<Recorder> = {}) {
+  const rec: Recorder = { awaiting: false, pending: [], answerResult: false, calls: [], ...over }
+  const persister = {
+    isSessionAwaitingInput: () => rec.awaiting,
+    getPendingInputRequests: () => rec.pending,
+    cancelAwaitingInput: async () => { rec.calls.push('cancel') },
+  }
+  const connector = {
+    answerOpenQuestionWithText: async (chatId: string, toolUseId: string, text: string) => {
+      rec.calls.push('answer')
+      rec.answerArgs = { chatId, toolUseId, text }
+      return rec.answerResult
+    },
+    dismissOpenCards: async () => { rec.calls.push('dismiss') },
+  }
+  return { rec, persister, connector }
+}
+
+const base = { sessionId: 's1', agentSlug: 'agent', chatId: 'c1' }
+
+describe('consumeOrCancelAwaitingInput', () => {
+  it('resolves an open question with plain text and consumes the message (no cancel/dismiss)', async () => {
+    const { rec, persister, connector } = makeDeps({
+      awaiting: true,
+      pending: [{ type: 'user_question_request', toolUseId: 't1' }],
+      answerResult: true,
+    })
+    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'my answer', hasFiles: false, persister, connector })
+    expect(consumed).toBe(true)
+    expect(rec.calls).toEqual(['answer'])
+    expect(rec.answerArgs).toEqual({ chatId: 'c1', toolUseId: 't1', text: 'my answer' })
+  })
+
+  it('cancels and dismisses when the open question declines the typed text', async () => {
+    const { rec, persister, connector } = makeDeps({
+      awaiting: true,
+      pending: [{ type: 'user_question_request', toolUseId: 't1' }],
+      answerResult: false,
+    })
+    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'redirect me', hasFiles: false, persister, connector })
+    expect(consumed).toBe(false)
+    expect(rec.calls).toEqual(['answer', 'cancel', 'dismiss'])
+  })
+
+  it('does not attempt to answer with a file/non-text message — cancels and dismisses', async () => {
+    const { rec, persister, connector } = makeDeps({
+      awaiting: true,
+      pending: [{ type: 'user_question_request', toolUseId: 't1' }],
+    })
+    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'caption', hasFiles: true, persister, connector })
+    expect(consumed).toBe(false)
+    expect(rec.calls).toEqual(['cancel', 'dismiss'])
+  })
+
+  it('cancels and dismisses when awaiting a non-question request (e.g. secret)', async () => {
+    const { rec, persister, connector } = makeDeps({
+      awaiting: true,
+      pending: [{ type: 'secret_request', toolUseId: 't9' }],
+    })
+    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'hello', hasFiles: false, persister, connector })
+    expect(consumed).toBe(false)
+    expect(rec.calls).toEqual(['cancel', 'dismiss'])
+  })
+
+  it('cancels and dismisses (both no-ops downstream) when not awaiting input', async () => {
+    const { rec, persister, connector } = makeDeps({ awaiting: false })
+    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'hi', hasFiles: false, persister, connector })
+    expect(consumed).toBe(false)
+    expect(rec.calls).toEqual(['cancel', 'dismiss'])
+  })
+
+  it('treats a whitespace-only message as non-text and does not answer', async () => {
+    const { rec, persister, connector } = makeDeps({
+      awaiting: true,
+      pending: [{ type: 'user_question_request', toolUseId: 't1' }],
+    })
+    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: '   ', hasFiles: false, persister, connector })
+    expect(consumed).toBe(false)
+    expect(rec.calls).toEqual(['cancel', 'dismiss'])
+  })
+})

--- a/src/shared/lib/chat-integrations/resolve-awaiting-input.ts
+++ b/src/shared/lib/chat-integrations/resolve-awaiting-input.ts
@@ -1,0 +1,59 @@
+/**
+ * On an inbound chat message while a session may be awaiting user input, decide whether the
+ * message answers an open question or cancels the pending request.
+ *
+ * If it is a plain-text reply (no attachments) and a single-question AskUserQuestion card is open,
+ * resolve that question as the free-form "Other" answer so the same turn continues. Otherwise
+ * cancel the pending request and dismiss its now-abandoned card, so the caller forwards the
+ * message as a fresh turn. Returns true when the message was consumed as an answer (the caller
+ * should stop), false when the caller should forward it.
+ *
+ * Extracted from the manager's inbound handler so the answer-vs-cancel decision (and the
+ * dismiss-on-cancel wiring) is unit-testable without the full container/session harness.
+ */
+
+interface AwaitingInputPersister {
+  isSessionAwaitingInput(sessionId: string): boolean
+  getPendingInputRequests(sessionId: string): Array<{ type: string; toolUseId: string }>
+  cancelAwaitingInput(sessionId: string, agentSlug: string): Promise<void>
+}
+
+interface DismissibleConnector {
+  answerOpenQuestionWithText(chatId: string, toolUseId: string, text: string): Promise<boolean>
+  dismissOpenCards(chatId: string): Promise<void>
+}
+
+export async function consumeOrCancelAwaitingInput(opts: {
+  sessionId: string
+  agentSlug: string
+  chatId: string
+  messageText: string
+  hasFiles: boolean
+  persister: AwaitingInputPersister
+  connector: DismissibleConnector
+}): Promise<boolean> {
+  const { sessionId, agentSlug, chatId, messageText, hasFiles, persister, connector } = opts
+
+  // A plain-text message during an open single-question card is the free-form "Other" answer:
+  // resolve that question so the same turn continues. isSessionAwaitingInput is the source of
+  // truth (it reflects taps, cancels, and answers from other surfaces), so we consume the message
+  // only on a confirmed live resolve; a non-text message, a multi-question card, or any other
+  // awaiting type falls through to cancel.
+  const isPlainText = !!messageText.trim() && !hasFiles
+  if (isPlainText && persister.isSessionAwaitingInput(sessionId)) {
+    const pendingQuestion = persister
+      .getPendingInputRequests(sessionId)
+      .find((r) => r.type === 'user_question_request')
+    if (pendingQuestion) {
+      const answered = await connector.answerOpenQuestionWithText(chatId, pendingQuestion.toolUseId, messageText)
+      if (answered) return true
+    }
+  }
+
+  // Not an answer: cancel the pending request so the message starts a fresh turn instead of
+  // deadlocking behind the blocked tool (no-op when not awaiting), and strip the now-abandoned
+  // card so it does not keep showing live buttons.
+  await persister.cancelAwaitingInput(sessionId, agentSlug)
+  await connector.dismissOpenCards(chatId)
+  return false
+}

--- a/src/shared/lib/chat-integrations/resolve-awaiting-input.ts
+++ b/src/shared/lib/chat-integrations/resolve-awaiting-input.ts
@@ -28,11 +28,16 @@ export async function consumeOrCancelAwaitingInput(opts: {
   agentSlug: string
   chatId: string
   messageText: string
+  // The raw user text to resolve an open question with as the "Other" answer. Distinct from
+  // messageText, which may carry a group sender-name prefix (e.g. `\[Alice]: `) meant only for the
+  // fresh-turn forward path — that prefix must not leak into the answer sent to the model. Falls
+  // back to messageText when not supplied.
+  answerText?: string
   hasFiles: boolean
   persister: AwaitingInputPersister
   connector: DismissibleConnector
 }): Promise<boolean> {
-  const { sessionId, agentSlug, chatId, messageText, hasFiles, persister, connector } = opts
+  const { sessionId, agentSlug, chatId, messageText, answerText, hasFiles, persister, connector } = opts
 
   // A plain-text message during an open single-question card is the free-form "Other" answer:
   // resolve that question so the same turn continues. isSessionAwaitingInput is the source of
@@ -45,7 +50,7 @@ export async function consumeOrCancelAwaitingInput(opts: {
       .getPendingInputRequests(sessionId)
       .find((r) => r.type === 'user_question_request')
     if (pendingQuestion) {
-      const answered = await connector.answerOpenQuestionWithText(chatId, pendingQuestion.toolUseId, messageText)
+      const answered = await connector.answerOpenQuestionWithText(chatId, pendingQuestion.toolUseId, answerText ?? messageText)
       if (answered) return true
     }
   }

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -708,25 +708,8 @@ export class SlackConnector extends ChatClientConnector {
         return lastTs
       }
 
-      case 'secret_request': {
-        const result = await this.app.client.chat.postMessage({
-          channel,
-          text: `*Secret requested:* \`${event.secretName}\`${event.reason ? `\nReason: ${event.reason}` : ''}\n\nPlease reply with the secret value.`,
-          mrkdwn: true,
-          ...threadOpt,
-        })
-        return result.ts || ''
-      }
-
-      case 'file_request': {
-        const result = await this.app.client.chat.postMessage({
-          channel,
-          text: `*File requested:*\n${event.description}${event.fileTypes ? `\n\nAccepted types: ${event.fileTypes}` : ''}\n\nPlease upload the file.`,
-          mrkdwn: true,
-          ...threadOpt,
-        })
-        return result.ts || ''
-      }
+      // secret_request / file_request are handled by the isUnsupportedInChat early-return above
+      // (desktop-only fallback); they intentionally have no prompt case here.
 
       case 'file_delivery': {
         // File transfer from container to chat is not yet supported — show metadata only

--- a/src/shared/lib/chat-integrations/telegram-connector.test.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.test.ts
@@ -69,6 +69,40 @@ function collectEmits(connector: TelegramConnector): IncomingMessage[] {
   return msgs
 }
 
+interface CapturedResponse { toolUseId: string; response: any; chatId?: string }
+
+function collectInteractiveResponses(connector: TelegramConnector): CapturedResponse[] {
+  const out: CapturedResponse[] = []
+  connector.onInteractiveResponse((toolUseId, response, chatId) => out.push({ toolUseId, response, chatId }))
+  return out
+}
+
+/** Attach a fake grammY bot that captures rich sends/edits, so sendUserRequestCard works. */
+function attachFakeBot(connector: TelegramConnector): { sent: any[] } {
+  const sent: any[] = []
+  ;(connector as any).bot = {
+    api: {
+      raw: {
+        sendRichMessage: vi.fn(async (args: any) => { sent.push(args); return { message_id: 1000 + sent.length } }),
+        editMessageText: vi.fn(async () => ({})),
+      },
+      sendMessage: vi.fn(async () => ({ message_id: 1 })),
+      editMessageText: vi.fn(async () => ({})),
+    },
+  }
+  return { sent }
+}
+
+/** A callback_query ctx. Rich messages carry no `.text`, so we omit it by default. */
+function makeCbCtx(data: string, opts: { messageId?: number; chatId?: number; text?: string } = {}): any {
+  return {
+    callbackQuery: { data, message: { message_id: opts.messageId ?? 1001, text: opts.text } },
+    chat: { id: opts.chatId ?? 123 },
+    answerCallbackQuery: vi.fn(async () => {}),
+    editMessageReplyMarkup: vi.fn(async () => {}),
+  }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('TelegramConnector — chatType propagation', () => {
@@ -270,5 +304,166 @@ describe('startWorking (dumb, no self-heartbeat)', () => {
     const { connector } = makeDmConnector()
     await connector.startWorking('999', 'working')
     await expect(connector.stopWorking('999')).resolves.toBeUndefined()
+  })
+})
+
+describe('TelegramConnector — AskUserQuestion multi-select', () => {
+  let connector: TelegramConnector
+  let sent: any[]
+  let responses: CapturedResponse[]
+
+  beforeEach(() => {
+    connector = makeConnector()
+    responses = collectInteractiveResponses(connector)
+    sent = attachFakeBot(connector).sent
+  })
+
+  function multiSelectEvent(): any {
+    return {
+      type: 'user_question_request',
+      toolUseId: 'tu-multi',
+      questions: [{
+        question: 'Pick your stack',
+        multiSelect: true,
+        options: [{ label: 'Redis' }, { label: 'S3' }, { label: 'Postgres' }],
+      }],
+    }
+  }
+
+  it('renders one option button per choice plus a Done button for a multiSelect question', async () => {
+    await (connector as any).sendUserRequestCard('123', multiSelectEvent())
+    const kb = sent[0].reply_markup.inline_keyboard
+    expect(kb).toHaveLength(4) // 3 options + Done
+    expect(kb.slice(0, 3).map((row: any) => row[0].text)).toEqual(['Redis', 'S3', 'Postgres'])
+    expect(kb[3][0].text).toBe('Done')
+  })
+
+  it('single-select question renders tap-to-resolve buttons with no Done (unchanged)', async () => {
+    await (connector as any).sendUserRequestCard('123', {
+      type: 'user_question_request',
+      toolUseId: 'tu-single',
+      questions: [{ question: 'Which one?', options: [{ label: 'A' }, { label: 'B' }] }],
+    })
+    const kb = sent[0].reply_markup.inline_keyboard
+    expect(kb.map((row: any) => row[0].text)).toEqual(['A', 'B'])
+  })
+
+  it('tapping a multiSelect option toggles a checkmark and does not resolve', async () => {
+    await (connector as any).sendUserRequestCard('123', multiSelectEvent())
+    const kb = sent[0].reply_markup.inline_keyboard
+    const ctx = makeCbCtx(kb[0][0].callback_data) // Redis
+    await (connector as any).handleCallbackQuery(ctx)
+    expect(ctx.editMessageReplyMarkup).toHaveBeenCalled()
+    const newKb = ctx.editMessageReplyMarkup.mock.calls[0][0].reply_markup.inline_keyboard
+    expect(newKb[0][0].text).toBe('✅ Redis')
+    expect(responses).toHaveLength(0)
+  })
+
+  it('Done resolves with the checked options joined by ", "', async () => {
+    await (connector as any).sendUserRequestCard('123', multiSelectEvent())
+    const kb = sent[0].reply_markup.inline_keyboard
+    await (connector as any).handleCallbackQuery(makeCbCtx(kb[0][0].callback_data)) // Redis
+    await (connector as any).handleCallbackQuery(makeCbCtx(kb[1][0].callback_data)) // S3
+    await (connector as any).handleCallbackQuery(makeCbCtx(kb[3][0].callback_data)) // Done
+    expect(responses).toHaveLength(1)
+    expect(responses[0].toolUseId).toBe('tu-multi')
+    expect(responses[0].response.answer).toBe('Redis, S3')
+  })
+
+  it('re-tapping a checked option unchecks it (callback is not consumed on tap)', async () => {
+    await (connector as any).sendUserRequestCard('123', multiSelectEvent())
+    const kb = sent[0].reply_markup.inline_keyboard
+    const redisCb = kb[0][0].callback_data
+    await (connector as any).handleCallbackQuery(makeCbCtx(redisCb)) // check
+    const ctx2 = makeCbCtx(redisCb)
+    await (connector as any).handleCallbackQuery(ctx2) // uncheck
+    const newKb = ctx2.editMessageReplyMarkup.mock.calls[0][0].reply_markup.inline_keyboard
+    expect(newKb[0][0].text).toBe('Redis') // ✅ removed
+    expect(responses).toHaveLength(0)
+  })
+
+  it('Done with nothing checked shows a toast and does not resolve', async () => {
+    await (connector as any).sendUserRequestCard('123', multiSelectEvent())
+    const kb = sent[0].reply_markup.inline_keyboard
+    const doneCtx = makeCbCtx(kb[3][0].callback_data)
+    await (connector as any).handleCallbackQuery(doneCtx)
+    expect(responses).toHaveLength(0)
+    expect(doneCtx.answerCallbackQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('at least one') }),
+    )
+  })
+
+  it('text overrides checked boxes on a multiSelect single-question card', async () => {
+    await (connector as any).sendUserRequestCard('123', multiSelectEvent())
+    const kb = sent[0].reply_markup.inline_keyboard
+    await (connector as any).handleCallbackQuery(makeCbCtx(kb[0][0].callback_data)) // check Redis
+    const ok = await (connector as any).answerOpenQuestionWithText('123', 'tu-multi', 'use whatever you think best')
+    expect(ok).toBe(true)
+    expect(responses).toHaveLength(1)
+    expect(responses[0].response.answer).toBe('use whatever you think best') // text wins, not 'Redis'
+  })
+})
+
+describe('TelegramConnector — typed message answers an open question (Other)', () => {
+  let connector: TelegramConnector
+  let sent: any[]
+  let responses: CapturedResponse[]
+
+  beforeEach(() => {
+    connector = makeConnector()
+    responses = collectInteractiveResponses(connector)
+    sent = attachFakeBot(connector).sent
+  })
+
+  function singleQuestionEvent(toolUseId = 'tu-q'): any {
+    return {
+      type: 'user_question_request',
+      toolUseId,
+      questions: [{ question: 'Which database?', options: [{ label: 'Postgres' }, { label: 'MySQL' }] }],
+    }
+  }
+
+  it('resolves a single-question card with the typed text as the answer and returns true', async () => {
+    await (connector as any).sendUserRequestCard('123', singleQuestionEvent())
+    const ok = await (connector as any).answerOpenQuestionWithText('123', 'tu-q', 'actually use SQLite')
+    expect(ok).toBe(true)
+    expect(responses).toHaveLength(1)
+    expect(responses[0].toolUseId).toBe('tu-q')
+    expect(responses[0].response.answer).toBe('actually use SQLite')
+  })
+
+  it('returns false when no question card is open for the chat', async () => {
+    const ok = await (connector as any).answerOpenQuestionWithText('123', 'tu-q', 'hi')
+    expect(ok).toBe(false)
+    expect(responses).toHaveLength(0)
+  })
+
+  it('returns false when the toolUseId does not match the open card (race / stale)', async () => {
+    await (connector as any).sendUserRequestCard('123', singleQuestionEvent('tu-q'))
+    const ok = await (connector as any).answerOpenQuestionWithText('123', 'a-different-tooluse', 'hi')
+    expect(ok).toBe(false)
+    expect(responses).toHaveLength(0)
+  })
+
+  it('returns false for a multi-question card (v1 falls through to cancel)', async () => {
+    await (connector as any).sendUserRequestCard('123', {
+      type: 'user_question_request',
+      toolUseId: 'tu-mq',
+      questions: [
+        { question: 'Q1', options: [{ label: 'A' }] },
+        { question: 'Q2', options: [{ label: 'B' }] },
+      ],
+    })
+    const ok = await (connector as any).answerOpenQuestionWithText('123', 'tu-mq', 'hi')
+    expect(ok).toBe(false)
+    expect(responses).toHaveLength(0)
+  })
+
+  it('a tapped single-select answer clears the open card so a later text is not consumed', async () => {
+    await (connector as any).sendUserRequestCard('123', singleQuestionEvent('tu-q'))
+    const kb = sent[0].reply_markup.inline_keyboard
+    await (connector as any).handleCallbackQuery(makeCbCtx(kb[0][0].callback_data)) // tap Postgres
+    const ok = await (connector as any).answerOpenQuestionWithText('123', 'tu-q', 'too late')
+    expect(ok).toBe(false) // card already resolved by the tap
   })
 })

--- a/src/shared/lib/chat-integrations/telegram-connector.test.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.test.ts
@@ -460,6 +460,42 @@ describe('TelegramConnector — typed message answers an open question (Other)',
     expect(md).toContain('Postgres')
   })
 
+  it('multi-question sub-card tap rebuilds its confirmation from the stored sub-card question text', async () => {
+    await (connector as any).sendUserRequestCard('123', {
+      type: 'user_question_request',
+      toolUseId: 'tu-mq2',
+      questions: [
+        { question: 'Q1 pick', options: [{ label: 'A' }, { label: 'B' }] },
+        { question: 'Q2 pick', options: [{ label: 'C' }, { label: 'D' }] },
+      ],
+    })
+    const q1 = sent[0].reply_markup.inline_keyboard
+    const editSpy = vi.spyOn(connector as any, 'editRichOrHtml')
+    await (connector as any).handleCallbackQuery(makeCbCtx(q1[0][0].callback_data, { messageId: 1001 })) // Q1 = A
+    expect(editSpy).toHaveBeenCalled()
+    const md = editSpy.mock.calls[0][2] as string
+    expect(md).toContain('Q1 pick') // the sub-card's own question, not blank
+    expect(md).toContain('A')
+  })
+
+  it('resolving a multi-question sub-card does not wipe a concurrent single-question card', async () => {
+    // Card A: single-question (lives in openQuestionCard). Card B: multi-question (pendingQuestions).
+    await (connector as any).sendUserRequestCard('123', singleQuestionEvent('tu-a')) // sent[0], msg 1001
+    await (connector as any).sendUserRequestCard('123', {
+      type: 'user_question_request',
+      toolUseId: 'tu-b',
+      questions: [
+        { question: 'B1', options: [{ label: 'X' }] }, // sent[1], msg 1002
+        { question: 'B2', options: [{ label: 'Y' }] }, // sent[2], msg 1003
+      ],
+    })
+    const bKb = sent[1].reply_markup.inline_keyboard
+    await (connector as any).handleCallbackQuery(makeCbCtx(bKb[0][0].callback_data, { messageId: 1002 })) // tap B1
+    // Card A must still be answerable via typed "Other" — resolving B must not clear A's tracking.
+    const ok = await (connector as any).answerOpenQuestionWithText('123', 'tu-a', 'other for A')
+    expect(ok).toBe(true)
+  })
+
   it('returns false when no question card is open for the chat', async () => {
     const ok = await (connector as any).answerOpenQuestionWithText('123', 'tu-q', 'hi')
     expect(ok).toBe(false)

--- a/src/shared/lib/chat-integrations/telegram-connector.test.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.test.ts
@@ -433,6 +433,33 @@ describe('TelegramConnector — typed message answers an open question (Other)',
     expect(responses[0].response.answer).toBe('actually use SQLite')
   })
 
+  it('resolves an options-less (free-form) single question typed as the Other answer', async () => {
+    // No options -> no keyboard, but openQuestionCard is still set (cbIds:[]) so a typed message
+    // is the only way to answer. This is the core "honest Other" path.
+    await (connector as any).sendUserRequestCard('123', {
+      type: 'user_question_request',
+      toolUseId: 'tu-open',
+      questions: [{ question: 'What should I name the file?' }],
+    })
+    const ok = await (connector as any).answerOpenQuestionWithText('123', 'tu-open', 'report.csv')
+    expect(ok).toBe(true)
+    expect(responses).toHaveLength(1)
+    expect(responses[0].response.answer).toBe('report.csv')
+  })
+
+  it('single-select tap rebuilds the confirmation from the stored question text (rich path has no message.text)', async () => {
+    await (connector as any).sendUserRequestCard('123', singleQuestionEvent('tu-q'))
+    const kb = sent[0].reply_markup.inline_keyboard
+    const editSpy = vi.spyOn(connector as any, 'editRichOrHtml')
+    // makeCbCtx omits .text (rich messages carry none) — the confirmation must come from storage,
+    // not ctx.callbackQuery.message.text, or the question is dropped.
+    await (connector as any).handleCallbackQuery(makeCbCtx(kb[0][0].callback_data)) // tap Postgres
+    expect(editSpy).toHaveBeenCalled()
+    const md = editSpy.mock.calls[0][2] as string
+    expect(md).toContain('Which database?')
+    expect(md).toContain('Postgres')
+  })
+
   it('returns false when no question card is open for the chat', async () => {
     const ok = await (connector as any).answerOpenQuestionWithText('123', 'tu-q', 'hi')
     expect(ok).toBe(false)

--- a/src/shared/lib/chat-integrations/telegram-connector.test.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.test.ts
@@ -88,6 +88,7 @@ function attachFakeBot(connector: TelegramConnector): { sent: any[] } {
       },
       sendMessage: vi.fn(async () => ({ message_id: 1 })),
       editMessageText: vi.fn(async () => ({})),
+      editMessageReplyMarkup: vi.fn(async () => ({})),
     },
   }
   return { sent }
@@ -465,5 +466,149 @@ describe('TelegramConnector — typed message answers an open question (Other)',
     await (connector as any).handleCallbackQuery(makeCbCtx(kb[0][0].callback_data)) // tap Postgres
     const ok = await (connector as any).answerOpenQuestionWithText('123', 'tu-q', 'too late')
     expect(ok).toBe(false) // card already resolved by the tap
+  })
+
+  it('a single-select tap claims the card synchronously so a racing typed answer is rejected', async () => {
+    await (connector as any).sendUserRequestCard('123', singleQuestionEvent('tu-q'))
+    const kb = sent[0].reply_markup.inline_keyboard
+    // Kick off the tap WITHOUT awaiting, then race a typed "Other" answer during its awaits.
+    const tap = (connector as any).handleCallbackQuery(makeCbCtx(kb[0][0].callback_data)) // Postgres
+    const racingText = await (connector as any).answerOpenQuestionWithText('123', 'tu-q', 'racing other')
+    await tap
+    expect(racingText).toBe(false) // the tap already owns the resolution
+    expect(responses).toHaveLength(1) // exactly one resolution, not two
+    expect(responses[0].response.answer).toBe('Postgres')
+  })
+
+  it('a fast tap on two different single-select options resolves only once (siblings invalidated)', async () => {
+    await (connector as any).sendUserRequestCard('123', singleQuestionEvent('tu-q')) // Postgres / MySQL
+    const kb = sent[0].reply_markup.inline_keyboard
+    await (connector as any).handleCallbackQuery(makeCbCtx(kb[0][0].callback_data)) // Postgres
+    await (connector as any).handleCallbackQuery(makeCbCtx(kb[1][0].callback_data)) // MySQL (stale sibling)
+    expect(responses).toHaveLength(1)
+    expect(responses[0].response.answer).toBe('Postgres')
+  })
+
+  it('a stale sibling tap on the last sub-question of a multi-question card does not double-emit', async () => {
+    await (connector as any).sendUserRequestCard('123', {
+      type: 'user_question_request',
+      toolUseId: 'tu-mq',
+      questions: [
+        { question: 'Q1', options: [{ label: 'A' }, { label: 'B' }] },
+        { question: 'Q2', options: [{ label: 'C' }, { label: 'D' }] },
+      ],
+    })
+    const q1 = sent[0].reply_markup.inline_keyboard
+    const q2 = sent[1].reply_markup.inline_keyboard
+    await (connector as any).handleCallbackQuery(makeCbCtx(q1[0][0].callback_data, { messageId: 1001 })) // Q1 = A
+    await (connector as any).handleCallbackQuery(makeCbCtx(q2[0][0].callback_data, { messageId: 1002 })) // Q2 = C → completes
+    await (connector as any).handleCallbackQuery(makeCbCtx(q2[1][0].callback_data, { messageId: 1002 })) // Q2 = D (stale)
+    expect(responses).toHaveLength(1) // only the combined _all emit
+  })
+})
+
+describe('TelegramConnector — dismissOpenCards (cancel strips abandoned cards)', () => {
+  let connector: TelegramConnector
+  let sent: any[]
+  let responses: CapturedResponse[]
+
+  beforeEach(() => {
+    connector = makeConnector()
+    responses = collectInteractiveResponses(connector)
+    sent = attachFakeBot(connector).sent
+  })
+
+  function singleQuestionEvent(toolUseId = 'tu-q'): any {
+    return {
+      type: 'user_question_request',
+      toolUseId,
+      questions: [{ question: 'Which database?', options: [{ label: 'Postgres' }, { label: 'MySQL' }] }],
+    }
+  }
+  function multiSelectEvent(): any {
+    return {
+      type: 'user_question_request',
+      toolUseId: 'tu-multi',
+      questions: [{ question: 'Pick your stack', multiSelect: true, options: [{ label: 'Redis' }, { label: 'S3' }] }],
+    }
+  }
+
+  it('strips a single-question card and clears it so a later tap/text cannot resolve', async () => {
+    await (connector as any).sendUserRequestCard('123', singleQuestionEvent('tu-q'))
+    const kb = sent[0].reply_markup.inline_keyboard
+    await (connector as any).dismissOpenCards('123')
+    expect((connector as any).bot.api.editMessageReplyMarkup).toHaveBeenCalledWith(123, 1001, { reply_markup: { inline_keyboard: [] } })
+    expect(await (connector as any).answerOpenQuestionWithText('123', 'tu-q', 'late')).toBe(false)
+    await (connector as any).handleCallbackQuery(makeCbCtx(kb[0][0].callback_data)) // stale tap
+    expect(responses).toHaveLength(0)
+  })
+
+  it('strips a multiSelect single-question card and clears its toggle state', async () => {
+    await (connector as any).sendUserRequestCard('123', multiSelectEvent())
+    const kb = sent[0].reply_markup.inline_keyboard // [Redis, S3, Done]
+    await (connector as any).dismissOpenCards('123')
+    expect((connector as any).bot.api.editMessageReplyMarkup).toHaveBeenCalled()
+    // Toggle state + callbacks are gone: a stale toggle or Done tap resolves nothing.
+    await (connector as any).handleCallbackQuery(makeCbCtx(kb[0][0].callback_data)) // stale Redis toggle
+    await (connector as any).handleCallbackQuery(makeCbCtx(kb[2][0].callback_data)) // stale Done
+    expect(responses).toHaveLength(0)
+    expect(await (connector as any).answerOpenQuestionWithText('123', 'tu-multi', 'late')).toBe(false)
+  })
+
+  it('strips every sub-card of a multi-question card and invalidates their callbacks', async () => {
+    await (connector as any).sendUserRequestCard('123', {
+      type: 'user_question_request',
+      toolUseId: 'tu-mq',
+      questions: [
+        { question: 'Q1', options: [{ label: 'A' }, { label: 'B' }] },
+        { question: 'Q2', options: [{ label: 'C' }, { label: 'D' }] },
+      ],
+    })
+    const q1 = sent[0].reply_markup.inline_keyboard
+    await (connector as any).dismissOpenCards('123')
+    const strippedIds = (connector as any).bot.api.editMessageReplyMarkup.mock.calls.map((c: any) => c[1])
+    expect(strippedIds).toContain(1001)
+    expect(strippedIds).toContain(1002)
+    // Callbacks invalidated: a stale tap on a sub-card option resolves nothing (no deadlocked re-answer).
+    await (connector as any).handleCallbackQuery(makeCbCtx(q1[0][0].callback_data, { messageId: 1001 }))
+    expect(responses).toHaveLength(0)
+  })
+
+  it('is a no-op when no card is open for the chat', async () => {
+    await (connector as any).dismissOpenCards('123')
+    expect((connector as any).bot.api.editMessageReplyMarkup).not.toHaveBeenCalled()
+    expect(responses).toHaveLength(0)
+  })
+
+  it('only dismisses cards for the given chat, leaving other chats intact', async () => {
+    await (connector as any).sendUserRequestCard('123', singleQuestionEvent('tu-a'))
+    await (connector as any).sendUserRequestCard('999', singleQuestionEvent('tu-b'))
+    await (connector as any).dismissOpenCards('123')
+    expect(await (connector as any).answerOpenQuestionWithText('999', 'tu-b', 'ok')).toBe(true)
+  })
+})
+
+describe('TelegramConnector — secret/file requests route to the desktop-only fallback', () => {
+  let connector: TelegramConnector
+  let sent: any[]
+
+  beforeEach(() => {
+    connector = makeConnector()
+    sent = attachFakeBot(connector).sent
+  })
+
+  it('renders a secret_request as the desktop-only fallback, not a "reply with the secret" prompt', async () => {
+    await (connector as any).sendUserRequestCard('123', { type: 'secret_request', toolUseId: 'tu-s', secretName: 'OPENAI_API_KEY' })
+    const md = sent[0].rich_message.markdown as string
+    expect(md).toContain("isn't safe to provide in chat")
+    expect(md).not.toMatch(/reply with the secret value/i)
+    expect(sent[0].reply_markup).toBeUndefined() // no prompt keyboard — the secret can't be typed in
+  })
+
+  it('renders a file_request as the desktop-only fallback', async () => {
+    await (connector as any).sendUserRequestCard('123', { type: 'file_request', toolUseId: 'tu-f', description: 'a CSV export' })
+    const md = sent[0].rich_message.markdown as string
+    expect(md).toContain("isn't supported in chat")
+    expect(md).not.toMatch(/please (upload|send) the file/i)
   })
 })

--- a/src/shared/lib/chat-integrations/telegram-connector.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.ts
@@ -629,23 +629,26 @@ export class TelegramConnector extends ChatClientConnector {
     // can't double-resolve (matching answerOpenQuestionWithText / handleMultiSelectDone).
     const chatId = String(ctx.chat?.id ?? '')
     const messageId = String(ctx.callbackQuery?.message?.message_id ?? '')
-    const card = this.openQuestionCard.get(chatId)
-    const cardCbIds =
-      card && card.toolUseId === mapping.toolUseId
-        ? card.cbIds
-        : this.pendingQuestions.get(mapping.toolUseId)?.cards.find((c) => c.messageId === messageId)?.cbIds
+    // Resolve the source card ONCE: the single-question card in openQuestionCard if this tap is its,
+    // else the multi-question sub-card in pendingQuestions matching this message.
+    const openCard = this.openQuestionCard.get(chatId)
+    const currentCard = openCard && openCard.toolUseId === mapping.toolUseId ? openCard : undefined
+    const subCard = currentCard
+      ? undefined
+      : this.pendingQuestions.get(mapping.toolUseId)?.cards.find((c) => c.messageId === messageId)
+    const cardCbIds = currentCard ? currentCard.cbIds : subCard?.cbIds
     for (const cb of cardCbIds ?? [data]) this.callbackDataMap.delete(cb)
-    this.openQuestionCard.delete(chatId)
+    // Only clear the per-chat openQuestionCard when THIS tap resolved it — a tap on a concurrent
+    // multi-question sub-card must not wipe a different single-question card's tracking.
+    if (currentCard) this.openQuestionCard.delete(chatId)
 
     await ctx.answerCallbackQuery()
     // Rebuild the confirmation from the STORED question text: on the default rich-message path
     // ctx.callbackQuery.message.text is empty, so reading it would drop the question (only the
     // richMessages=false HTML fallback carries readable text).
-    const questionText =
-      card && card.toolUseId === mapping.toolUseId
-        ? card.questionText
-        : this.pendingQuestions.get(mapping.toolUseId)?.cards.find((c) => c.messageId === messageId)?.questionText
-          ?? escapeMarkdown(ctx.callbackQuery?.message?.text || '')
+    const questionText = currentCard
+      ? currentCard.questionText
+      : subCard?.questionText ?? escapeMarkdown(ctx.callbackQuery?.message?.text || '')
     await this.confirmAndEmit(chatId, messageId, questionText, mapping.toolUseId, val.question, val.answer ?? '')
   }
 
@@ -685,7 +688,11 @@ export class TelegramConnector extends ChatClientConnector {
     for (const o of state.options) this.callbackDataMap.delete(o.cbId)
     this.callbackDataMap.delete(state.doneCbId)
     this.pendingMultiSelect.delete(this.multiSelectKey(toolUseId, question))
-    this.openQuestionCard.delete(state.chatId)
+    // Only clear the per-chat card when THIS multiSelect card owns it (a single-question multiSelect
+    // card populates openQuestionCard; a multi-question sub-card does not) — don't wipe a concurrent
+    // card's tracking.
+    const openCard = this.openQuestionCard.get(state.chatId)
+    if (openCard && openCard.toolUseId === toolUseId) this.openQuestionCard.delete(state.chatId)
 
     await ctx.answerCallbackQuery()
 

--- a/src/shared/lib/chat-integrations/telegram-connector.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.ts
@@ -128,6 +128,10 @@ export class TelegramConnector extends ChatClientConnector {
   private pendingQuestions: Map<string, {
     totalQuestions: number
     answers: Record<string, string> // { questionText: selectedAnswer }
+    chatId: string
+    // Single-select sub-cards of this multi-question card (multiSelect sub-cards live in
+    // pendingMultiSelect); tracked so dismissOpenCards can strip every keyboard on cancel.
+    cards: Array<{ messageId: string; cbIds: string[] }>
   }> = new Map()
 
   // Track open multiSelect questions: the redraw state + the accumulating checked set,
@@ -512,6 +516,8 @@ export class TelegramConnector extends ChatClientConnector {
           this.pendingQuestions.set(event.toolUseId, {
             totalQuestions: event.questions.length,
             answers: {},
+            chatId,
+            cards: [],
           })
         }
 
@@ -569,6 +575,10 @@ export class TelegramConnector extends ChatClientConnector {
               toolUseId: event.toolUseId, question: q.question, questionText: text,
               messageId: lastMessageId, multiSelect: false, cbIds,
             })
+          } else if (hasOptions) {
+            // Multi-question single-select sub-card: track its message + callbacks so a cancel can
+            // strip the keyboard (multiSelect sub-cards are tracked in pendingMultiSelect instead).
+            this.pendingQuestions.get(event.toolUseId)?.cards.push({ messageId: lastMessageId, cbIds })
           }
         }
 
@@ -611,19 +621,29 @@ export class TelegramConnector extends ChatClientConnector {
     if (val.kind === 'multiToggle') { await this.handleMultiSelectToggle(ctx, mapping.toolUseId, val.question, val.label ?? ''); return }
     if (val.kind === 'multiDone') { await this.handleMultiSelectDone(ctx, mapping.toolUseId, val.question); return }
 
-    // Single-select: confirm the choice, strip the keyboard, and emit the answer.
-    await ctx.answerCallbackQuery()
-    const originalText = ctx.callbackQuery?.message?.text || ''
+    // Single-select: confirm the choice, strip the keyboard, and emit the answer. Claim the card
+    // synchronously (before the first await) so a racing typed "Other" answer can't also resolve it.
+    // Delete the WHOLE card's callbacks, not just the tapped one, so a fast tap on a sibling option
+    // can't double-resolve (matching answerOpenQuestionWithText / handleMultiSelectDone).
     const chatId = String(ctx.chat?.id ?? '')
     const messageId = String(ctx.callbackQuery?.message?.message_id ?? '')
+    const card = this.openQuestionCard.get(chatId)
+    const cardCbIds =
+      card && card.toolUseId === mapping.toolUseId
+        ? card.cbIds
+        : this.pendingQuestions.get(mapping.toolUseId)?.cards.find((c) => c.messageId === messageId)?.cbIds
+    for (const cb of cardCbIds ?? [data]) this.callbackDataMap.delete(cb)
+    this.callbackDataMap.delete(data)
+    this.openQuestionCard.delete(chatId)
+
+    await ctx.answerCallbackQuery()
+    const originalText = ctx.callbackQuery?.message?.text || ''
     const confirmation = `${escapeMarkdown(originalText)}\n\n✅ **${escapeMarkdown(val.answer ?? '')}**`
     try {
       await this.editRichOrHtml(chatId, messageId, confirmation)
     } catch {
       try { await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }) } catch { /* ignore */ }
     }
-    this.callbackDataMap.delete(data)
-    this.openQuestionCard.delete(chatId)
     this.emitAnswer(mapping.toolUseId, val.question, val.answer ?? '', chatId)
   }
 
@@ -657,6 +677,14 @@ export class TelegramConnector extends ChatClientConnector {
       return
     }
     const answer = [...state.checked].join(', ')
+
+    // Claim the card synchronously (before any await) so a racing typed "Other" answer or a
+    // second Done tap can't also resolve it.
+    for (const o of state.options) this.callbackDataMap.delete(o.cbId)
+    this.callbackDataMap.delete(state.doneCbId)
+    this.pendingMultiSelect.delete(this.multiSelectKey(toolUseId, question))
+    this.openQuestionCard.delete(state.chatId)
+
     await ctx.answerCallbackQuery()
 
     // Build the confirmation from the stored question text — rich messages carry no `.text`.
@@ -666,10 +694,6 @@ export class TelegramConnector extends ChatClientConnector {
     } catch { /* ignore */ }
     try { await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }) } catch { /* ignore */ }
 
-    for (const o of state.options) this.callbackDataMap.delete(o.cbId)
-    this.callbackDataMap.delete(state.doneCbId)
-    this.pendingMultiSelect.delete(this.multiSelectKey(toolUseId, question))
-    this.openQuestionCard.delete(state.chatId)
     this.emitAnswer(toolUseId, question, answer, state.chatId)
   }
 
@@ -699,6 +723,46 @@ export class TelegramConnector extends ChatClientConnector {
 
     this.emitAnswer(card.toolUseId, card.question, text, chatId)
     return true
+  }
+
+  /**
+   * Strip and clear every open question card for this chat: remove its inline keyboard and forget
+   * its callbacks, so a card abandoned by a cancelling message doesn't keep showing live buttons
+   * (a later tap would otherwise resolve an already-rejected request). Best-effort: edit failures
+   * are swallowed (the card may already have been edited/answered).
+   */
+  async dismissOpenCards(chatId: string): Promise<void> {
+    const messageIds = new Set<string>()
+
+    const single = this.openQuestionCard.get(chatId)
+    if (single) {
+      messageIds.add(single.messageId)
+      for (const cb of single.cbIds) this.callbackDataMap.delete(cb)
+      this.openQuestionCard.delete(chatId)
+    }
+
+    for (const [key, state] of this.pendingMultiSelect) {
+      if (state.chatId !== chatId) continue
+      messageIds.add(state.messageId)
+      for (const o of state.options) this.callbackDataMap.delete(o.cbId)
+      this.callbackDataMap.delete(state.doneCbId)
+      this.pendingMultiSelect.delete(key)
+    }
+
+    for (const [toolUseId, pending] of this.pendingQuestions) {
+      if (pending.chatId !== chatId) continue
+      for (const card of pending.cards) {
+        messageIds.add(card.messageId)
+        for (const cb of card.cbIds) this.callbackDataMap.delete(cb)
+      }
+      this.pendingQuestions.delete(toolUseId)
+    }
+
+    for (const messageId of messageIds) {
+      try {
+        await this.bot?.api.editMessageReplyMarkup(Number(chatId), Number(messageId), { reply_markup: { inline_keyboard: [] } })
+      } catch { /* best-effort */ }
+    }
   }
 
   /** Emit one question's answer, accumulating across a multi-question card before resolving. */

--- a/src/shared/lib/chat-integrations/telegram-connector.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.ts
@@ -130,6 +130,30 @@ export class TelegramConnector extends ChatClientConnector {
     answers: Record<string, string> // { questionText: selectedAnswer }
   }> = new Map()
 
+  // Track open multiSelect questions: the redraw state + the accumulating checked set,
+  // keyed by `${toolUseId} ${question}` (toolUseId has no spaces, so the join is unambiguous).
+  // In-memory only — never encoded into callback_data, which Telegram caps at 64 bytes.
+  private pendingMultiSelect: Map<string, {
+    chatId: string
+    messageId: string
+    questionText: string
+    options: Array<{ label: string; cbId: string }>
+    doneCbId: string
+    checked: Set<string>
+  }> = new Map()
+
+  // Track the open single-question AskUserQuestion card per chat, so a free-typed message can
+  // be resolved as the "Other" answer. Set only for single-question cards (multi-question falls
+  // through to cancel); cleared synchronously when the card is answered by any path.
+  private openQuestionCard: Map<string, {
+    toolUseId: string
+    question: string
+    questionText: string
+    messageId: string
+    multiSelect: boolean
+    cbIds: string[]
+  }> = new Map()
+
   // Animated DM draft streaming: per-chat non-zero draft id.
   private nextDraftId = 1
   private activeDrafts: Map<string, number> = new Map()
@@ -495,15 +519,42 @@ export class TelegramConnector extends ChatClientConnector {
         for (const q of event.questions) {
           const header = q.header ? `**${escapeMarkdown(q.header)}**\n` : ''
           const text = `${header}${escapeMarkdown(q.question)}`
+          const hasOptions = !!(q.options && q.options.length > 0)
+
+          const singleQuestionCard = event.questions.length === 1
+
+          if (hasOptions && q.multiSelect) {
+            // Multi-select: each tap toggles a ✅; a Done button resolves the checked set.
+            const options = q.options!.map((opt) => ({
+              label: opt.label,
+              cbId: this.registerCallback(event.toolUseId, { kind: 'multiToggle', question: q.question, label: opt.label }),
+            }))
+            const doneCbId = this.registerCallback(event.toolUseId, { kind: 'multiDone', question: q.question })
+            const keyboard = options.map((o) => [{ text: o.label, callback_data: o.cbId }])
+            keyboard.push([{ text: 'Done', callback_data: doneCbId }])
+            lastMessageId = await this.sendRichOrHtml(chatId, text, { reply_markup: { inline_keyboard: keyboard } })
+            this.pendingMultiSelect.set(this.multiSelectKey(event.toolUseId, q.question), {
+              chatId, messageId: lastMessageId, questionText: text, options, doneCbId, checked: new Set(),
+            })
+            if (singleQuestionCard) {
+              this.openQuestionCard.set(chatId, {
+                toolUseId: event.toolUseId, question: q.question, questionText: text,
+                messageId: lastMessageId, multiSelect: true, cbIds: [...options.map((o) => o.cbId), doneCbId],
+              })
+            }
+            continue
+          }
 
           const keyboard: Array<Array<{ text: string; callback_data: string }>> = []
-          if (q.options && q.options.length > 0) {
-            for (const opt of q.options) {
-              // Store the full answer payload: { question, answer }
+          const cbIds: string[] = []
+          if (hasOptions) {
+            for (const opt of q.options!) {
+              // Single-select: store the full answer payload { question, answer }; first tap resolves.
               const cbId = this.registerCallback(event.toolUseId, {
                 question: q.question,
                 answer: opt.label,
               })
+              cbIds.push(cbId)
               keyboard.push([{ text: opt.label, callback_data: cbId }])
             }
           }
@@ -513,20 +564,19 @@ export class TelegramConnector extends ChatClientConnector {
             text,
             keyboard.length > 0 ? { reply_markup: { inline_keyboard: keyboard } } : undefined,
           )
+          if (singleQuestionCard) {
+            this.openQuestionCard.set(chatId, {
+              toolUseId: event.toolUseId, question: q.question, questionText: text,
+              messageId: lastMessageId, multiSelect: false, cbIds,
+            })
+          }
         }
 
         return lastMessageId
       }
 
-      case 'secret_request': {
-        const text = `**Secret requested:** ${codeSpan(event.secretName)}\n${event.reason ? `\nReason: ${escapeMarkdown(event.reason)}` : ''}\n\nPlease reply with the secret value.`
-        return this.sendRichOrHtml(chatId, text)
-      }
-
-      case 'file_request': {
-        const text = `**File requested:**\n${escapeMarkdown(event.description)}${event.fileTypes ? `\n\nAccepted types: ${escapeMarkdown(event.fileTypes)}` : ''}\n\nPlease upload the file.`
-        return this.sendRichOrHtml(chatId, text)
-      }
+      // secret_request / file_request are handled by the isUnsupportedInChat early-return above
+      // (desktop-only fallback); they intentionally have no prompt case here.
 
       case 'file_delivery': {
         // File transfer from container to chat is not yet supported — show metadata only
@@ -544,46 +594,124 @@ export class TelegramConnector extends ChatClientConnector {
     }
   }
 
-  /** Handle an inline-keyboard button click: confirm the choice and emit the answer. */
-  private async handleCallbackQuery(ctx: GrammyContext): Promise<void> {
-    await ctx.answerCallbackQuery()
-    const data = ctx.callbackQuery?.data
-    if (!data) return
-    const mapping = this.callbackDataMap.get(data)
-    if (!mapping) return
-    const val = mapping.value as { question: string; answer: string }
+  private multiSelectKey(toolUseId: string, question: string): string {
+    return `${toolUseId} ${question}`
+  }
 
-    // Update the message to show the selected answer and remove the keyboard.
-    // Route through editRichOrHtml so the edit matches the connector's mode
-    // (a rich edit in rich mode, HTML otherwise) instead of always HTML.
+  /** Handle an inline-keyboard button click. Single-select resolves on tap; multi-select toggles
+   *  and only resolves on Done. The callback is answered inside each branch so the empty-Done
+   *  toast can fire (a callback can be answered exactly once). */
+  private async handleCallbackQuery(ctx: GrammyContext): Promise<void> {
+    const data = ctx.callbackQuery?.data
+    if (!data) { await ctx.answerCallbackQuery(); return }
+    const mapping = this.callbackDataMap.get(data)
+    if (!mapping) { await ctx.answerCallbackQuery(); return }
+    const val = mapping.value as { kind?: 'multiToggle' | 'multiDone'; question: string; answer?: string; label?: string }
+
+    if (val.kind === 'multiToggle') { await this.handleMultiSelectToggle(ctx, mapping.toolUseId, val.question, val.label ?? ''); return }
+    if (val.kind === 'multiDone') { await this.handleMultiSelectDone(ctx, mapping.toolUseId, val.question); return }
+
+    // Single-select: confirm the choice, strip the keyboard, and emit the answer.
+    await ctx.answerCallbackQuery()
     const originalText = ctx.callbackQuery?.message?.text || ''
     const chatId = String(ctx.chat?.id ?? '')
     const messageId = String(ctx.callbackQuery?.message?.message_id ?? '')
-    const confirmation = `${escapeMarkdown(originalText)}\n\n✅ **${escapeMarkdown(val.answer)}**`
+    const confirmation = `${escapeMarkdown(originalText)}\n\n✅ **${escapeMarkdown(val.answer ?? '')}**`
     try {
       await this.editRichOrHtml(chatId, messageId, confirmation)
     } catch {
       try { await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }) } catch { /* ignore */ }
     }
-
     this.callbackDataMap.delete(data)
+    this.openQuestionCard.delete(chatId)
+    this.emitAnswer(mapping.toolUseId, val.question, val.answer ?? '', chatId)
+  }
 
-    // Accumulate answer for multi-question requests
-    const pending = this.pendingQuestions.get(mapping.toolUseId)
+  /** Toggle a multiSelect option's ✅ and redraw the keyboard; does not resolve. */
+  private async handleMultiSelectToggle(ctx: GrammyContext, toolUseId: string, question: string, label: string): Promise<void> {
+    const state = this.pendingMultiSelect.get(this.multiSelectKey(toolUseId, question))
+    if (!state) { await ctx.answerCallbackQuery(); return }
+    if (state.checked.has(label)) state.checked.delete(label)
+    else state.checked.add(label)
+
+    const keyboard = state.options.map((o) => [{
+      text: state.checked.has(o.label) ? `✅ ${o.label}` : o.label,
+      callback_data: o.cbId,
+    }])
+    keyboard.push([{ text: 'Done', callback_data: state.doneCbId }])
+    try {
+      await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: keyboard } })
+    } catch (err) {
+      const m = err instanceof Error ? err.message : String(err)
+      if (!m.includes('message is not modified')) console.error('[TelegramConnector] multi-select redraw failed:', err)
+    }
+    await ctx.answerCallbackQuery()
+  }
+
+  /** Resolve a multiSelect question with the checked options, joined by ", ". */
+  private async handleMultiSelectDone(ctx: GrammyContext, toolUseId: string, question: string): Promise<void> {
+    const state = this.pendingMultiSelect.get(this.multiSelectKey(toolUseId, question))
+    if (!state) { await ctx.answerCallbackQuery(); return }
+    if (state.checked.size === 0) {
+      await ctx.answerCallbackQuery({ text: 'Select at least one option, then tap Done.' })
+      return
+    }
+    const answer = [...state.checked].join(', ')
+    await ctx.answerCallbackQuery()
+
+    // Build the confirmation from the stored question text — rich messages carry no `.text`.
+    const confirmation = `${state.questionText}\n\n✅ **${escapeMarkdown(answer)}**`
+    try {
+      await this.editRichOrHtml(state.chatId, state.messageId, confirmation)
+    } catch { /* ignore */ }
+    try { await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }) } catch { /* ignore */ }
+
+    for (const o of state.options) this.callbackDataMap.delete(o.cbId)
+    this.callbackDataMap.delete(state.doneCbId)
+    this.pendingMultiSelect.delete(this.multiSelectKey(toolUseId, question))
+    this.openQuestionCard.delete(state.chatId)
+    this.emitAnswer(toolUseId, question, answer, state.chatId)
+  }
+
+  /**
+   * Resolve an open single-question card with free-typed text as the "Other" answer (the text
+   * overrides any checked boxes, mirroring the app). Returns true only if a live card matching
+   * `toolUseId` is open for this chat — so the manager consumes the message only on a real resolve
+   * and otherwise sends it as a fresh turn.
+   */
+  async answerOpenQuestionWithText(chatId: string, toolUseId: string, text: string): Promise<boolean> {
+    const card = this.openQuestionCard.get(chatId)
+    if (!card || card.toolUseId !== toolUseId) return false
+
+    this.openQuestionCard.delete(chatId)
+    if (card.multiSelect) this.pendingMultiSelect.delete(this.multiSelectKey(card.toolUseId, card.question))
+    for (const cb of card.cbIds) this.callbackDataMap.delete(cb)
+
+    // Confirm + strip the keyboard. Build the confirmation from the stored question text, since
+    // rich messages carry no readable `.text`.
+    const confirmation = `${card.questionText}\n\n✅ **${escapeMarkdown(text)}**`
+    try {
+      await this.editRichOrHtml(chatId, card.messageId, confirmation)
+    } catch { /* best-effort */ }
+    try {
+      await this.bot?.api.editMessageReplyMarkup(Number(chatId), Number(card.messageId), { reply_markup: { inline_keyboard: [] } })
+    } catch { /* best-effort */ }
+
+    this.emitAnswer(card.toolUseId, card.question, text, chatId)
+    return true
+  }
+
+  /** Emit one question's answer, accumulating across a multi-question card before resolving. */
+  private emitAnswer(toolUseId: string, question: string, answer: string, chatId: string): void {
+    const pending = this.pendingQuestions.get(toolUseId)
     if (pending) {
-      pending.answers[val.question] = val.answer
+      pending.answers[question] = answer
       if (Object.keys(pending.answers).length >= pending.totalQuestions) {
-        // All questions answered — emit the combined response
-        this.emitInteractiveResponse(mapping.toolUseId, {
-          question: '_all',
-          answer: '_all',
-          answers: pending.answers,
-        }, chatId)
-        this.pendingQuestions.delete(mapping.toolUseId)
+        this.emitInteractiveResponse(toolUseId, { question: '_all', answer: '_all', answers: pending.answers }, chatId)
+        this.pendingQuestions.delete(toolUseId)
       }
     } else {
-      // Single question — emit immediately
-      this.emitInteractiveResponse(mapping.toolUseId, mapping.value, chatId)
+      this.emitInteractiveResponse(toolUseId, { question, answer }, chatId)
     }
   }
 

--- a/src/shared/lib/chat-integrations/telegram-connector.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.ts
@@ -130,8 +130,9 @@ export class TelegramConnector extends ChatClientConnector {
     answers: Record<string, string> // { questionText: selectedAnswer }
     chatId: string
     // Single-select sub-cards of this multi-question card (multiSelect sub-cards live in
-    // pendingMultiSelect); tracked so dismissOpenCards can strip every keyboard on cancel.
-    cards: Array<{ messageId: string; cbIds: string[] }>
+    // pendingMultiSelect); tracked so dismissOpenCards can strip every keyboard on cancel and so
+    // a tap can rebuild its confirmation from the stored question text (rich messages carry none).
+    cards: Array<{ messageId: string; cbIds: string[]; questionText: string }>
   }> = new Map()
 
   // Track open multiSelect questions: the redraw state + the accumulating checked set,
@@ -577,8 +578,9 @@ export class TelegramConnector extends ChatClientConnector {
             })
           } else if (hasOptions) {
             // Multi-question single-select sub-card: track its message + callbacks so a cancel can
-            // strip the keyboard (multiSelect sub-cards are tracked in pendingMultiSelect instead).
-            this.pendingQuestions.get(event.toolUseId)?.cards.push({ messageId: lastMessageId, cbIds })
+            // strip the keyboard (multiSelect sub-cards are tracked in pendingMultiSelect instead),
+            // and its question text so a tap can rebuild the confirmation on the rich-message path.
+            this.pendingQuestions.get(event.toolUseId)?.cards.push({ messageId: lastMessageId, cbIds, questionText: text })
           }
         }
 
@@ -633,18 +635,18 @@ export class TelegramConnector extends ChatClientConnector {
         ? card.cbIds
         : this.pendingQuestions.get(mapping.toolUseId)?.cards.find((c) => c.messageId === messageId)?.cbIds
     for (const cb of cardCbIds ?? [data]) this.callbackDataMap.delete(cb)
-    this.callbackDataMap.delete(data)
     this.openQuestionCard.delete(chatId)
 
     await ctx.answerCallbackQuery()
-    const originalText = ctx.callbackQuery?.message?.text || ''
-    const confirmation = `${escapeMarkdown(originalText)}\n\n✅ **${escapeMarkdown(val.answer ?? '')}**`
-    try {
-      await this.editRichOrHtml(chatId, messageId, confirmation)
-    } catch {
-      try { await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }) } catch { /* ignore */ }
-    }
-    this.emitAnswer(mapping.toolUseId, val.question, val.answer ?? '', chatId)
+    // Rebuild the confirmation from the STORED question text: on the default rich-message path
+    // ctx.callbackQuery.message.text is empty, so reading it would drop the question (only the
+    // richMessages=false HTML fallback carries readable text).
+    const questionText =
+      card && card.toolUseId === mapping.toolUseId
+        ? card.questionText
+        : this.pendingQuestions.get(mapping.toolUseId)?.cards.find((c) => c.messageId === messageId)?.questionText
+          ?? escapeMarkdown(ctx.callbackQuery?.message?.text || '')
+    await this.confirmAndEmit(chatId, messageId, questionText, mapping.toolUseId, val.question, val.answer ?? '')
   }
 
   /** Toggle a multiSelect option's ✅ and redraw the keyboard; does not resolve. */
@@ -687,14 +689,7 @@ export class TelegramConnector extends ChatClientConnector {
 
     await ctx.answerCallbackQuery()
 
-    // Build the confirmation from the stored question text — rich messages carry no `.text`.
-    const confirmation = `${state.questionText}\n\n✅ **${escapeMarkdown(answer)}**`
-    try {
-      await this.editRichOrHtml(state.chatId, state.messageId, confirmation)
-    } catch { /* ignore */ }
-    try { await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }) } catch { /* ignore */ }
-
-    this.emitAnswer(toolUseId, question, answer, state.chatId)
+    await this.confirmAndEmit(state.chatId, state.messageId, state.questionText, toolUseId, question, answer)
   }
 
   /**
@@ -711,18 +706,32 @@ export class TelegramConnector extends ChatClientConnector {
     if (card.multiSelect) this.pendingMultiSelect.delete(this.multiSelectKey(card.toolUseId, card.question))
     for (const cb of card.cbIds) this.callbackDataMap.delete(cb)
 
-    // Confirm + strip the keyboard. Build the confirmation from the stored question text, since
-    // rich messages carry no readable `.text`.
-    const confirmation = `${card.questionText}\n\n✅ **${escapeMarkdown(text)}**`
-    try {
-      await this.editRichOrHtml(chatId, card.messageId, confirmation)
-    } catch { /* best-effort */ }
-    try {
-      await this.bot?.api.editMessageReplyMarkup(Number(chatId), Number(card.messageId), { reply_markup: { inline_keyboard: [] } })
-    } catch { /* best-effort */ }
-
-    this.emitAnswer(card.toolUseId, card.question, text, chatId)
+    await this.confirmAndEmit(chatId, card.messageId, card.questionText, card.toolUseId, card.question, text)
     return true
+  }
+
+  /**
+   * Confirm a resolved question card and emit its answer. Rebuilds the confirmation from the STORED
+   * question text (rich messages carry no readable `.text`), best-effort edits the card + strips its
+   * inline keyboard, then emits. Shared by every resolve path (single-select tap, multiSelect Done,
+   * typed "Other") so the confirmation stays consistent and can't drift.
+   */
+  private async confirmAndEmit(
+    chatId: string,
+    messageId: string,
+    questionText: string,
+    toolUseId: string,
+    question: string,
+    answer: string,
+  ): Promise<void> {
+    const confirmation = `${questionText}\n\n✅ **${escapeMarkdown(answer)}**`
+    try {
+      await this.editRichOrHtml(chatId, messageId, confirmation)
+    } catch { /* best-effort */ }
+    try {
+      await this.bot?.api.editMessageReplyMarkup(Number(chatId), Number(messageId), { reply_markup: { inline_keyboard: [] } })
+    } catch { /* best-effort */ }
+    this.emitAnswer(toolUseId, question, answer, chatId)
   }
 
   /**

--- a/src/shared/lib/chat-integrations/utils.test.ts
+++ b/src/shared/lib/chat-integrations/utils.test.ts
@@ -42,4 +42,18 @@ describe('isUnsupportedInChat / describeUnsupportedRequest', () => {
     expect(isUnsupportedInChat(event)).toBe(true)
     expect(describeUnsupportedRequest(event)).toContain('Acme MCP')
   })
+
+  it('flags secret_request as unsupported (secrets are unsafe to type into chat) and names the secret', () => {
+    const event: UserRequestEvent = { type: 'secret_request', toolUseId: 't4', secretName: 'OPENAI_API_KEY' }
+    expect(isUnsupportedInChat(event)).toBe(true)
+    expect(describeUnsupportedRequest(event)).toContain('OPENAI_API_KEY')
+    expect(describeUnsupportedRequest(event)).toContain('desktop')
+  })
+
+  it('flags file_request as unsupported and mentions uploading', () => {
+    const event: UserRequestEvent = { type: 'file_request', toolUseId: 't5', description: 'a CSV export' }
+    expect(isUnsupportedInChat(event)).toBe(true)
+    expect(describeUnsupportedRequest(event)).toContain('upload')
+    expect(describeUnsupportedRequest(event)).toContain('desktop')
+  })
 })

--- a/src/shared/lib/chat-integrations/utils.ts
+++ b/src/shared/lib/chat-integrations/utils.ts
@@ -25,12 +25,17 @@ export function formatProviderName(provider: string): string {
 }
 
 // Event types that need the desktop app (OAuth callbacks, browser input, script approval, etc.).
+// secret_request / file_request are here too: neither is wired to complete in chat, and a secret
+// typed into a chat thread leaks into the provider's cloud and the transcript - the vault path is
+// the desktop app's job.
 const UNSUPPORTED_IN_CHAT: ReadonlySet<UserRequestEvent['type']> = new Set([
   'connected_account_request',
   'remote_mcp_request',
   'browser_input_request',
   'script_run_request',
   'computer_use_request',
+  'secret_request',
+  'file_request',
 ])
 
 export function isUnsupportedInChat(event: UserRequestEvent): boolean {
@@ -82,6 +87,10 @@ export function describeUnsupportedRequest(event: UserRequestEvent): string {
       return `The agent wants to run a script, which needs your approval.${tail}`
     case 'computer_use_request':
       return `The agent wants to use your computer, which isn't supported in chat.${tail}`
+    case 'secret_request':
+      return `The agent needs the secret ${event.secretName}, which isn't safe to provide in chat.${tail}`
+    case 'file_request':
+      return `The agent wants you to upload a file${event.description ? ` (${event.description})` : ''}, which isn't supported in chat.${tail}`
     default:
       return `The agent sent a "${event.type}" request that isn't supported in chat.${tail}`
   }

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -2410,9 +2410,10 @@ describe('MessagePersister', () => {
     // ------------------------------------------------------------------
     // cancelAwaitingInput: when a new message arrives while the session is
     // awaiting input, cancel the pending request(s) so the message isn't
-    // queued behind a blocked tool (the deadlock). Top-level requests are
-    // rejected (the main loop unblocks directly); subagent requests are
-    // additionally interrupted to unwind the parked Task.
+    // queued behind a blocked tool (the deadlock). EVERY cancel interrupts
+    // first — aborting the parked query so it can't resume into a filler
+    // reply — then cleanup-rejects each pending id (the reason is never read
+    // by the model, since the turn was already aborted).
     // ------------------------------------------------------------------
     describe('cancelAwaitingInput', () => {
       const rejectCallFor = (toolUseId: string) =>
@@ -2420,7 +2421,7 @@ describe('MessagePersister', () => {
       const interruptCall = () =>
         mockContainerClientFetch.mock.calls.find((c) => c[0] === `/sessions/${SESSION_ID}/interrupt`)
 
-      it('rejects a top-level AskUserQuestion without interrupting', async () => {
+      it('interrupts a top-level AskUserQuestion BEFORE cleanup-rejecting it (aborted turn cannot resume into a filler reply)', async () => {
         messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
         simulateToolUse('AskUserQuestion', 'q-1', {
           questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
@@ -2430,11 +2431,16 @@ describe('MessagePersister', () => {
 
         await messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)
 
-        const reject = rejectCallFor('q-1')
-        expect(reject).toBeDefined()
-        expect(JSON.parse((reject![1] as { body: string }).body).reason).toBeTruthy()
-        // Top-level: reject only — the main loop unblocks without an interrupt.
-        expect(interruptCall()).toBeUndefined()
+        const calls = mockContainerClientFetch.mock.calls
+        const interruptIdx = calls.findIndex((c) => c[0] === `/sessions/${SESSION_ID}/interrupt`)
+        const rejectIdx = calls.findIndex((c) => c[0] === `/inputs/q-1/reject`)
+        // Top-level now interrupts too, and the interrupt must land BEFORE the reject:
+        // rejecting first would resume the parked turn and let the model emit a filler
+        // ("Go ahead") that the next message then anchors to.
+        expect(interruptIdx).toBeGreaterThanOrEqual(0)
+        expect(rejectIdx).toBeGreaterThan(interruptIdx)
+        // markSessionInterrupted ran, clearing the awaiting state.
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
       })
 
       it('rejects AND interrupts for a subagent browser_input request', async () => {
@@ -2505,11 +2511,11 @@ describe('MessagePersister', () => {
         try {
           // Must resolve, not reject — a failed cancel must never block the incoming message.
           await expect(messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)).resolves.toBeUndefined()
-          // Both container calls were attempted (and rejected): reject + the subagent interrupt.
+          // Both container calls were attempted (and rejected): the interrupt + the cleanup reject.
           expect(rejectCallFor('bi-err')).toBeDefined()
           expect(interruptCall()).toBeDefined()
-          // The interrupt fetch rejected, but markSessionInterrupted runs after the swallowed
-          // interrupt, so the subagent path still clears the awaiting state.
+          // The interrupt fetch rejected, but markSessionInterrupted runs right after the swallowed
+          // interrupt, so the cancel still clears the awaiting state.
           expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
         } finally {
           mockContainerClientFetch.mockImplementation(() => Promise.resolve({ ok: true }))

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -2492,6 +2492,29 @@ describe('MessagePersister', () => {
 
         expect(mockContainerClientFetch).not.toHaveBeenCalled()
       })
+
+      it('swallows reject/interrupt failures so a best-effort cancel never throws', async () => {
+        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+        simulateToolUse('mcp__user-input__request_browser_input', 'bi-err', {
+          message: 'Please log in',
+          requirements: ['Enter credentials'],
+        })
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        mockContainerClientFetch.mockClear()
+        mockContainerClientFetch.mockRejectedValue(new Error('container unreachable'))
+        try {
+          // Must resolve, not reject — a failed cancel must never block the incoming message.
+          await expect(messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)).resolves.toBeUndefined()
+          // Both container calls were attempted (and rejected): reject + the subagent interrupt.
+          expect(rejectCallFor('bi-err')).toBeDefined()
+          expect(interruptCall()).toBeDefined()
+          // The interrupt fetch rejected, but markSessionInterrupted runs after the swallowed
+          // interrupt, so the subagent path still clears the awaiting state.
+          expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        } finally {
+          mockContainerClientFetch.mockImplementation(() => Promise.resolve({ ok: true }))
+        }
+      })
     })
   })
 

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -2406,6 +2406,93 @@ describe('MessagePersister', () => {
     it('returns false for unknown session IDs', () => {
       expect(messagePersister.isSessionAwaitingInput('nonexistent-session')).toBe(false)
     })
+
+    // ------------------------------------------------------------------
+    // cancelAwaitingInput: when a new message arrives while the session is
+    // awaiting input, cancel the pending request(s) so the message isn't
+    // queued behind a blocked tool (the deadlock). Top-level requests are
+    // rejected (the main loop unblocks directly); subagent requests are
+    // additionally interrupted to unwind the parked Task.
+    // ------------------------------------------------------------------
+    describe('cancelAwaitingInput', () => {
+      const rejectCallFor = (toolUseId: string) =>
+        mockContainerClientFetch.mock.calls.find((c) => c[0] === `/inputs/${toolUseId}/reject`)
+      const interruptCall = () =>
+        mockContainerClientFetch.mock.calls.find((c) => c[0] === `/sessions/${SESSION_ID}/interrupt`)
+
+      it('rejects a top-level AskUserQuestion without interrupting', async () => {
+        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+        simulateToolUse('AskUserQuestion', 'q-1', {
+          questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
+        })
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        mockContainerClientFetch.mockClear()
+
+        await messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)
+
+        const reject = rejectCallFor('q-1')
+        expect(reject).toBeDefined()
+        expect(JSON.parse((reject![1] as { body: string }).body).reason).toBeTruthy()
+        // Top-level: reject only — the main loop unblocks without an interrupt.
+        expect(interruptCall()).toBeUndefined()
+      })
+
+      it('rejects AND interrupts for a subagent browser_input request', async () => {
+        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+        simulateToolUse('mcp__user-input__request_browser_input', 'bi-1', {
+          message: 'Please log in',
+          requirements: ['Enter credentials'],
+        })
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        mockContainerClientFetch.mockClear()
+
+        await messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)
+
+        expect(rejectCallFor('bi-1')).toBeDefined()
+        expect(interruptCall()).toBeDefined()
+        // The interrupt path marks the session interrupted (awaiting cleared).
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      })
+
+      it('sweeps pendingComputerUseRequests (the separate map) and interrupts', async () => {
+        vi.stubEnv('E2E_MOCK', 'true') // skip the host platform gate so the request goes pending
+        try {
+          messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+          simulateToolUse('mcp__computer-use__computer_click', 'cu-1', { ref: 'win:1' })
+          expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+          expect(messagePersister.getPendingComputerUseRequests(SESSION_ID)).toHaveLength(1)
+          mockContainerClientFetch.mockClear()
+
+          await messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)
+
+          expect(rejectCallFor('cu-1')).toBeDefined()
+          expect(interruptCall()).toBeDefined()
+        } finally {
+          vi.unstubAllEnvs()
+        }
+      })
+
+      it('rejects every pending request when several are open', async () => {
+        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+        simulateToolUse('mcp__user-input__request_secret', 's-1', { secretName: 'KEY1' })
+        simulateToolUse('mcp__user-input__request_file', 'f-1', { description: 'CSV' })
+        mockContainerClientFetch.mockClear()
+
+        await messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)
+
+        expect(rejectCallFor('s-1')).toBeDefined()
+        expect(rejectCallFor('f-1')).toBeDefined()
+      })
+
+      it('is a no-op when the session is not awaiting input', async () => {
+        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+        mockContainerClientFetch.mockClear()
+
+        await messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)
+
+        expect(mockContainerClientFetch).not.toHaveBeenCalled()
+      })
+    })
   })
 
   // ============================================================================

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -2473,6 +2473,9 @@ describe('MessagePersister', () => {
 
           expect(rejectCallFor('cu-1')).toBeDefined()
           expect(interruptCall()).toBeDefined()
+          // Host-side computer_use bookkeeping is cleared too (session_idle only clears
+          // pendingInputRequests), so a reconnect can't replay a phantom approval card.
+          expect(messagePersister.getPendingComputerUseRequests(SESSION_ID)).toHaveLength(0)
         } finally {
           vi.unstubAllEnvs()
         }

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -414,54 +414,42 @@ class MessagePersister {
   // pending request(s) so the message starts a fresh turn instead of deadlocking behind
   // the blocked tool.
   //
-  // Top-level requests (question / secret / file / connected_account / remote_mcp) block the
-  // main loop, so rejecting them is enough — the loop unblocks and the queued message runs.
-  // Subagent requests (browser_input / script_run / computer_use) block a subagent while the
-  // main loop is parked on the Task tool, so we additionally interrupt to unwind it (mirroring
-  // the shipped `complete-browser-input` decline recipe).
+  // We interrupt FIRST — aborting the parked query outright — then cleanup-reject each
+  // pending request. Order matters: rejecting first returns a tool result and RESUMES the
+  // turn, letting the model emit a filler reply ("Go ahead …") that the user's forwarded
+  // message then anchors to (it reads as a reply to the filler, not to the original ask).
+  // Aborting at the parked point means the model never receives a tool result and never
+  // speaks. The abort also unwinds a subagent's parked Task, so every awaiting type —
+  // top-level (question / secret / file / connected_account / remote_mcp) and subagent
+  // (browser_input / script_run / computer_use) — takes this one path. After the abort the
+  // reject is pure cleanup: its reason is never read by the model.
   //
   // No-op when the session is not awaiting input (also makes rapid double-messages idempotent).
-  // Reject/interrupt failures are swallowed: a best-effort cancel must never block the message.
+  // Interrupt/reject failures are swallowed: a best-effort cancel must never block the message.
   async cancelAwaitingInput(sessionId: string, agentSlug: string): Promise<void> {
     if (!this.isSessionAwaitingInput(sessionId)) return
 
-    // Requests in pendingInputRequests that block a running subagent (vs the main loop).
-    // INVARIANT: any input type that blocks a subagent while the main loop is parked on the Task
-    // tool MUST be listed here, so the cancel path interrupts to unwind it. A type left out
-    // defaults to top-level (reject only), which deadlocks; a type wrongly added just triggers a
-    // harmless extra interrupt. computer_use is swept separately below (its own pending map).
-    const SUBAGENT_INPUT_TYPES = new Set(['browser_input_request', 'script_run_request'])
-    const topLevelReason =
-      'The user sent a new message instead of answering. Do not respond to this — their next message contains how to proceed.'
-    const subagentReason =
-      'The user sent a new message; stopping so they can redirect you. Their next message contains how to proceed.'
+    // Snapshot the pending tool ids from BOTH maps before interrupting (pendingInputRequests
+    // holds the broadcast types; computer_use lives in its own pendingComputerUseRequests map):
+    // the reject below is only cleanup, and the interrupt/markSessionInterrupted clears state.
+    const pendingToolUseIds = [
+      ...this.getPendingInputRequests(sessionId).map((r) => r.toolUseId),
+      ...this.getPendingComputerUseRequests(sessionId).map((r) => r.toolUseId),
+    ]
 
-    let sawSubagent = false
+    // Interrupt FIRST: abort the parked query so it can never resume into a filler reply.
+    await this.interruptContainerSession(agentSlug, sessionId).catch(
+      (e) => console.error(`[MessagePersister] cancelAwaitingInput interrupt failed for ${sessionId}:`, e),
+    )
+    await this.markSessionInterrupted(sessionId)
 
-    // Sweep BOTH maps: pendingInputRequests holds the 7 broadcast types; computer_use is
-    // excluded from INPUT_REQUEST_TYPES and lives in its own pendingComputerUseRequests map.
-    for (const req of this.getPendingInputRequests(sessionId)) {
-      const isSubagent = SUBAGENT_INPUT_TYPES.has(req.type)
-      sawSubagent = sawSubagent || isSubagent
-      await this.rejectContainerInput(agentSlug, req.toolUseId, isSubagent ? subagentReason : topLevelReason).catch(
-        (e) => console.error(`[MessagePersister] cancelAwaitingInput reject failed for ${req.toolUseId}:`, e),
+    // Cleanup-reject each pending request: the query is already aborted, so the reason is never
+    // read by the model — this just clears the container-side pending entry (and its host
+    // bookkeeping) so a late resolve/tap can't land on an abandoned request.
+    for (const toolUseId of pendingToolUseIds) {
+      await this.rejectContainerInput(agentSlug, toolUseId, 'Superseded: the user sent a new message.').catch(
+        (e) => console.error(`[MessagePersister] cancelAwaitingInput reject failed for ${toolUseId}:`, e),
       )
-    }
-    for (const req of this.getPendingComputerUseRequests(sessionId)) {
-      sawSubagent = true
-      await this.rejectContainerInput(agentSlug, req.toolUseId, subagentReason).catch(
-        (e) => console.error(`[MessagePersister] cancelAwaitingInput reject failed for ${req.toolUseId}:`, e),
-      )
-    }
-
-    // Subagent requests leave the main loop parked on the Task tool — reject alone doesn't
-    // unwind it, so interrupt. Top-level requests unblock on reject alone, so they skip the
-    // interrupt (and its abort/resume), keeping the common path provably race-free.
-    if (sawSubagent) {
-      await this.interruptContainerSession(agentSlug, sessionId).catch(
-        (e) => console.error(`[MessagePersister] cancelAwaitingInput interrupt failed for ${sessionId}:`, e),
-      )
-      await this.markSessionInterrupted(sessionId)
     }
   }
 

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -424,18 +424,18 @@ class MessagePersister {
   // (browser_input / script_run / computer_use) — takes this one path. After the abort the
   // reject is pure cleanup: its reason is never read by the model.
   //
-  // No-op when the session is not awaiting input (also makes rapid double-messages idempotent).
+  // No-op when the session is not awaiting input. (This guard also makes rapid double-messages
+  // idempotent when sends are serialized — the chat path serializes per chat via messageQueues;
+  // the app send route does not, so two truly concurrent sends there can both pass it.)
   // Interrupt/reject failures are swallowed: a best-effort cancel must never block the message.
   async cancelAwaitingInput(sessionId: string, agentSlug: string): Promise<void> {
     if (!this.isSessionAwaitingInput(sessionId)) return
 
-    // Snapshot the pending tool ids from BOTH maps before interrupting (pendingInputRequests
-    // holds the broadcast types; computer_use lives in its own pendingComputerUseRequests map):
-    // the reject below is only cleanup, and the interrupt/markSessionInterrupted clears state.
-    const pendingToolUseIds = [
-      ...this.getPendingInputRequests(sessionId).map((r) => r.toolUseId),
-      ...this.getPendingComputerUseRequests(sessionId).map((r) => r.toolUseId),
-    ]
+    // Snapshot the pending tool ids from BOTH maps before interrupting. pendingInputRequests holds
+    // the broadcast types (cleared by markSessionInterrupted's session_idle); computer_use lives in
+    // its own pendingComputerUseRequests map, which that broadcast does NOT clear.
+    const inputRequestIds = this.getPendingInputRequests(sessionId).map((r) => r.toolUseId)
+    const computerUseIds = this.getPendingComputerUseRequests(sessionId).map((r) => r.toolUseId)
 
     // Interrupt FIRST: abort the parked query so it can never resume into a filler reply.
     await this.interruptContainerSession(agentSlug, sessionId).catch(
@@ -443,10 +443,15 @@ class MessagePersister {
     )
     await this.markSessionInterrupted(sessionId)
 
-    // Cleanup-reject each pending request: the query is already aborted, so the reason is never
-    // read by the model — this just clears the container-side pending entry (and its host
-    // bookkeeping) so a late resolve/tap can't land on an abandoned request.
-    for (const toolUseId of pendingToolUseIds) {
+    // Clear the host-side computer_use bookkeeping explicitly — session_idle only clears
+    // pendingInputRequests, so a leftover entry would replay a phantom approval card on reconnect.
+    const state = this.streamingStates.get(sessionId)
+    for (const id of computerUseIds) state?.pendingComputerUseRequests.delete(id)
+
+    // Cleanup-reject each pending request on the CONTAINER: the query is already aborted, so the
+    // reason is never read by the model — this just clears the container-side pending entry so a
+    // late resolve/tap can't land on an abandoned request.
+    for (const toolUseId of [...inputRequestIds, ...computerUseIds]) {
       await this.rejectContainerInput(agentSlug, toolUseId, 'Superseded: the user sent a new message.').catch(
         (e) => console.error(`[MessagePersister] cancelAwaitingInput reject failed for ${toolUseId}:`, e),
       )

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -417,7 +417,11 @@ class MessagePersister {
   async cancelAwaitingInput(sessionId: string, agentSlug: string): Promise<void> {
     if (!this.isSessionAwaitingInput(sessionId)) return
 
-    // Requests in pendingInputRequests that belong to a running subagent (vs the main loop).
+    // Requests in pendingInputRequests that block a running subagent (vs the main loop).
+    // INVARIANT: any input type that blocks a subagent while the main loop is parked on the Task
+    // tool MUST be listed here, so the cancel path interrupts to unwind it. A type left out
+    // defaults to top-level (reject only), which deadlocks; a type wrongly added just triggers a
+    // harmless extra interrupt. computer_use is swept separately below (its own pending map).
     const SUBAGENT_INPUT_TYPES = new Set(['browser_input_request', 'script_run_request'])
     const topLevelReason =
       'The user sent a new message instead of answering. Do not respond to this — their next message contains how to proceed.'
@@ -2572,8 +2576,10 @@ ${continuation}`
   }
 
   /**
-   * Interrupt the running query in the container (abort + resume), mirroring the
-   * `/sessions/:id/interrupt` endpoint the explicit interrupt route uses.
+   * Interrupt the running query in the container (abort + resume) by POSTing the same
+   * `/sessions/:id/interrupt` endpoint the explicit interrupt route hits. Uses `client.fetch`
+   * (not the `client.interruptSession` helper that route calls) to stay on the proxy-routed path
+   * the rest of MessagePersister's container calls use, e.g. `rejectContainerInput`.
    */
   private async interruptContainerSession(agentSlug: string, sessionId: string): Promise<void> {
     const cm = await getContainerManager()

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -402,6 +402,57 @@ class MessagePersister {
     }
   }
 
+  // When a new message arrives while the session is awaiting user input, cancel the
+  // pending request(s) so the message starts a fresh turn instead of deadlocking behind
+  // the blocked tool.
+  //
+  // Top-level requests (question / secret / file / connected_account / remote_mcp) block the
+  // main loop, so rejecting them is enough — the loop unblocks and the queued message runs.
+  // Subagent requests (browser_input / script_run / computer_use) block a subagent while the
+  // main loop is parked on the Task tool, so we additionally interrupt to unwind it (mirroring
+  // the shipped `complete-browser-input` decline recipe).
+  //
+  // No-op when the session is not awaiting input (also makes rapid double-messages idempotent).
+  // Reject/interrupt failures are swallowed: a best-effort cancel must never block the message.
+  async cancelAwaitingInput(sessionId: string, agentSlug: string): Promise<void> {
+    if (!this.isSessionAwaitingInput(sessionId)) return
+
+    // Requests in pendingInputRequests that belong to a running subagent (vs the main loop).
+    const SUBAGENT_INPUT_TYPES = new Set(['browser_input_request', 'script_run_request'])
+    const topLevelReason =
+      'The user sent a new message instead of answering. Do not respond to this — their next message contains how to proceed.'
+    const subagentReason =
+      'The user sent a new message; stopping so they can redirect you. Their next message contains how to proceed.'
+
+    let sawSubagent = false
+
+    // Sweep BOTH maps: pendingInputRequests holds the 7 broadcast types; computer_use is
+    // excluded from INPUT_REQUEST_TYPES and lives in its own pendingComputerUseRequests map.
+    for (const req of this.getPendingInputRequests(sessionId)) {
+      const isSubagent = SUBAGENT_INPUT_TYPES.has(req.type)
+      sawSubagent = sawSubagent || isSubagent
+      await this.rejectContainerInput(agentSlug, req.toolUseId, isSubagent ? subagentReason : topLevelReason).catch(
+        (e) => console.error(`[MessagePersister] cancelAwaitingInput reject failed for ${req.toolUseId}:`, e),
+      )
+    }
+    for (const req of this.getPendingComputerUseRequests(sessionId)) {
+      sawSubagent = true
+      await this.rejectContainerInput(agentSlug, req.toolUseId, subagentReason).catch(
+        (e) => console.error(`[MessagePersister] cancelAwaitingInput reject failed for ${req.toolUseId}:`, e),
+      )
+    }
+
+    // Subagent requests leave the main loop parked on the Task tool — reject alone doesn't
+    // unwind it, so interrupt. Top-level requests unblock on reject alone, so they skip the
+    // interrupt (and its abort/resume), keeping the common path provably race-free.
+    if (sawSubagent) {
+      await this.interruptContainerSession(agentSlug, sessionId).catch(
+        (e) => console.error(`[MessagePersister] cancelAwaitingInput interrupt failed for ${sessionId}:`, e),
+      )
+      await this.markSessionInterrupted(sessionId)
+    }
+  }
+
   // Get available slash commands for a session
   getSlashCommands(sessionId: string): SlashCommandInfo[] {
     return this.streamingStates.get(sessionId)?.slashCommands ?? []
@@ -2517,6 +2568,18 @@ ${continuation}`
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ reason }),
+    })
+  }
+
+  /**
+   * Interrupt the running query in the container (abort + resume), mirroring the
+   * `/sessions/:id/interrupt` endpoint the explicit interrupt route uses.
+   */
+  private async interruptContainerSession(agentSlug: string, sessionId: string): Promise<void> {
+    const cm = await getContainerManager()
+    const client = cm.getClient(agentSlug)
+    await client.fetch(`/sessions/${encodeURIComponent(sessionId)}/interrupt`, {
+      method: 'POST',
     })
   }
 

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -113,9 +113,17 @@ interface StreamingState {
 // Lazy import to break circular dependency: container-manager -> message-persister
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let _containerManagerModule: any = null
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let _containerManagerImport: Promise<any> | null = null
 async function getContainerManager() {
   if (!_containerManagerModule) {
-    _containerManagerModule = await import('./container-manager')
+    // Cache the in-flight import promise, not just the resolved module: concurrent
+    // callers (e.g. a fire-and-forget tool handler resolving while cancelAwaitingInput
+    // rejects) would otherwise each see a null module and start their own
+    // import('./container-manager'), racing redundant dynamic imports of a module
+    // that sits on the container-manager <-> message-persister circular edge.
+    if (!_containerManagerImport) _containerManagerImport = import('./container-manager')
+    _containerManagerModule = await _containerManagerImport
   }
   return _containerManagerModule.containerManager
 }


### PR DESCRIPTION
## What

Telegram's AskUserQuestion was a lossy subset of the app's question card: it only rendered option buttons, mishandled multi-select, and had no honest path for a free-form answer. And sending any message while the agent was awaiting input deadlocked (the message queued behind the blocked tool forever).

This makes Telegram's AskUserQuestion honest and consistent with the app UI, and removes the deadlock.

## Before -> after

| Scenario | Before | After |
|---|---|---|
| Multi-select question | one tap resolved immediately, no way to pick multiple | toggle buttons (tap = checkmark on/off) plus a Done button; resolves with the full set |
| Type a message on an open single question | deadlocked | resolves the question as the free-form "Other" answer; the turn continues |
| Send any message while awaiting input (multi-question, a photo, secret, etc.) | deadlocked | cancels the pending request; the message starts a fresh turn |
| Agent asks for a secret / file in chat | showed a prompt it couldn't complete (and a typed secret would leak into the transcript) | routes to the "open on desktop" fallback |

## Changes

- **Multi-select** renders toggle buttons plus a Done button (`telegram-connector.ts`). Empty Done prompts to pick at least one. Long labels use the existing 64-byte `cb_N` callback-data indirection.
- **Typed "Other"** on an open single-question card resolves it with the raw user text, mirroring the app's "type something else" affordance. The three resolve paths (tap, multi-select Done, typed Other) share one `confirmAndEmit` helper and always rebuild the confirmation from the stored question text (rich messages carry no readable `.text`).
- **Cancel-on-message** (`cancelAwaitingInput` in `message-persister.ts`, wired via `resolve-awaiting-input.ts`): a message that does not resolve an open single question cancels the pending request so it starts a fresh turn. Shared by the app send route and every chat connector.
- **secret / file requests** route to the existing desktop fallback (`utils.ts` `UNSUPPORTED_IN_CHAT`), across all connectors.

## Implementation note: interrupt-first cancel

`cancelAwaitingInput` **interrupts (aborts the parked query) before rejecting**, then cleanup-rejects each pending request. Rejecting first would return a tool result and resume the parked turn, letting the model emit a filler reply ("Go ahead ...") that the user's forwarded message then anchored to (reading as a reply to the filler, not the original ask). Aborting at the parked point means the model never receives a tool result and never speaks. The abort also unwinds a subagent's parked Task, so top-level and subagent requests collapse into one path (the old `SUBAGENT_INPUT_TYPES` / two-reason machinery is gone).

## Testing

- **Unit:** new + updated coverage across `telegram-connector.test.ts`, `resolve-awaiting-input.test.ts`, `message-persister.test.ts`, `utils.test.ts` (multi-select toggle/Done, typed-Other incl. options-less question, cancel-on-message interrupt-first ordering, computer_use host-map cleanup, concurrent-card guard, secret/file fallback). Full suite green.
- **Manual smoke (real Telegram + Docker):** multi-question cancel, non-text (photo) cancel, secret-then-type, subagent cancel - all clean (no filler reply, no dangling tool_use, no stall). Multi-select Done, typed-Other, single-select confirmation display verified.
- **Adversarial review:** a multi-agent council (correctness x3 lenses + simplicity + tests, each finding adversarially verified) ran to convergence over three rounds; all confirmed findings addressed.

## Known gaps (follow-ups, not blockers)

- **Multi-question deadlock on identical question text.** When one AskUserQuestion call has two questions with byte-identical text, the answers map (keyed by question text end-to-end, including the container `/inputs/:id/resolve` payload) collides and the tool blocks. A correct fix needs index-based keys on both the Telegram side and the container resolve contract, which is out of this PR's scope; the deadlock is recoverable via cancel-on-message meanwhile.
- **Slack leaves live buttons after cancel-on-message.** Slack inherits the base no-op `dismissOpenCards`, so a Slack question card's buttons stay clickable after a cancel (a later tap resolves an already-rejected id). Not a regression (pre-PR the same interleave deadlocked). Deferred to a dedicated Slack AskUserQuestion-parity PR (which also needs typed-Other), since both need the same new card-tracking state.

## Related

- #366 - subagent-originated `request_secret` / `request_file` / `AskUserQuestion` never surface to any UI (found while smoking this PR; separate container-stream-layer bug, own branch).

## Scope

Telegram only for v1. Slack/iMessage get the connector-agnostic cancel wiring but no new Slack/iMessage-specific card behavior.
