### PR TITLE
Harden agent lifecycle E2E tests

### DIFF
--- a/e2e/helpers/agents.ts
+++ b/e2e/helpers/agents.ts
@@ -88,6 +88,25 @@ export async function findAgentByName(
   return found!
 }
 
+export async function expectAgentNamed(
+  request: APIRequestContext,
+  agent: Pick<TestAgent, 'slug'>,
+  name: string,
+): Promise<TestAgent> {
+  let found: TestAgent | undefined
+
+  await expect.poll(async () => {
+    const response = await request.get('/api/agents')
+    if (!response.ok()) return undefined
+
+    const agents = await response.json() as TestAgent[]
+    found = agents.find((candidate) => candidate.slug === agent.slug)
+    return found?.name
+  }, { timeout: 15000 }).toBe(name)
+
+  return found!
+}
+
 export async function deleteAgentViaApi(
   request: APIRequestContext,
   agent: Pick<TestAgent, 'slug'>,
@@ -142,6 +161,26 @@ export async function listSessions(
   expect(response.ok()).toBeTruthy()
 
   return await response.json() as TestSession[]
+}
+
+export async function expectSessionNamed(
+  request: APIRequestContext,
+  agent: Pick<TestAgent, 'slug'>,
+  session: Pick<TestSession, 'id'>,
+  name: string,
+): Promise<TestSession> {
+  let found: TestSession | undefined
+
+  await expect.poll(async () => {
+    const response = await request.get(`/api/agents/${agent.slug}/sessions`)
+    if (!response.ok()) return undefined
+
+    const sessions = await response.json() as TestSession[]
+    found = sessions.find((candidate) => candidate.id === session.id)
+    return found?.name
+  }, { timeout: 15000 }).toBe(name)
+
+  return found!
 }
 
 export async function listSessionMessages(

--- a/e2e/specs/agent-lifecycle.spec.ts
+++ b/e2e/specs/agent-lifecycle.spec.ts
@@ -1,7 +1,15 @@
 import { test, expect } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
-
+import {
+  createAgent,
+  expectAgentDeleted,
+  expectAgentNamed,
+  findAgentByName,
+  getAgentItem,
+  gotoAgentHome,
+  uniqueName,
+} from '../helpers/agents'
 
 test.describe('Agent Lifecycle', () => {
   let appPage: AppPage
@@ -14,66 +22,50 @@ test.describe('Agent Lifecycle', () => {
     await appPage.waitForAgentsLoaded()
   })
 
-  test('create a new agent', async ({ page }) => {
-    const agentName = `Test Agent ${Date.now()}`
-
-    // Create agent
+  test('creates a new agent through the UI', async ({ page, request }, testInfo) => {
+    const agentName = uniqueName(testInfo, 'Lifecycle Create')
     await agentPage.createAgent(agentName)
 
-    // Verify agent appears in sidebar
-    await expect(agentPage.getAgentItem(agentName)).toBeVisible()
-
-    // Verify main content is visible
+    const agent = await findAgentByName(request, agentName)
+    await expect(getAgentItem(page, agent)).toBeVisible()
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agentName)
     await expect(appPage.getMainContent()).toBeVisible()
-
-    // Clean up
-    await agentPage.deleteAgent()
+    await expectAgentNamed(request, agent, agentName)
   })
 
-  test('select an agent', async ({ page }) => {
-    const agentName = `Selectable Agent ${Date.now()}`
+  test('selects an existing agent from the sidebar', async ({ page, request }, testInfo) => {
+    const agent = await createAgent(request, uniqueName(testInfo, 'Lifecycle Select'))
 
-    // Create agent first
-    await agentPage.createAgent(agentName)
-
-    // Click somewhere else (the sidebar header), then select the agent again
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
     await page.locator('[data-testid="home-button"]').click()
-    await agentPage.selectAgent(agentName)
+    await getAgentItem(page, agent).click()
 
-    // Verify main content shows the agent
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name)
+    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
     await expect(appPage.getMainContent()).toBeVisible()
-
-    // Clean up
-    await agentPage.deleteAgent()
   })
 
-  test('delete an agent', async ({ page }) => {
-    const agentName = `Deletable Agent ${Date.now()}`
+  test('deletes an existing agent from settings', async ({ page, request }, testInfo) => {
+    const agent = await createAgent(request, uniqueName(testInfo, 'Lifecycle Delete'))
 
-    // Create agent first
-    await agentPage.createAgent(agentName)
-
-    // Verify it exists
-    await expect(agentPage.getAgentItem(agentName)).toBeVisible()
-
-    // Delete via settings
+    await gotoAgentHome(page, agent)
+    await expect(getAgentItem(page, agent)).toBeVisible()
     await agentPage.deleteAgent()
 
-    // Verify agent is removed from sidebar
-    await expect(agentPage.getAgentItem(agentName)).not.toBeVisible()
+    await expectAgentDeleted(request, agent)
+    await expect(getAgentItem(page, agent)).not.toBeVisible()
   })
 
-  test('create and delete agent end-to-end', async ({ page }) => {
-    const agentName = `E2E Test Agent ${Date.now()}`
-
-    // Create agent
+  test('creates and deletes an agent end-to-end through the UI', async ({ page, request }, testInfo) => {
+    const agentName = uniqueName(testInfo, 'Lifecycle E2E')
     await agentPage.createAgent(agentName)
-    await expect(agentPage.getAgentItem(agentName)).toBeVisible()
 
-    // Delete via settings
+    const agent = await findAgentByName(request, agentName)
+    await expect(getAgentItem(page, agent)).toBeVisible()
     await agentPage.deleteAgent()
 
-    // Verify agent is gone
-    await expect(agentPage.getAgentItem(agentName)).not.toBeVisible()
+    await expectAgentDeleted(request, agent)
+    await expect(getAgentItem(page, agent)).not.toBeVisible()
   })
 })

--- a/e2e/specs/agent-rename.spec.ts
+++ b/e2e/specs/agent-rename.spec.ts
@@ -1,6 +1,13 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
+import {
+  createAgent,
+  expectAgentNamed,
+  getAgentItem,
+  gotoAgentHome,
+  uniqueName,
+} from '../helpers/agents'
 
 test.describe('Agent Rename', () => {
   let appPage: AppPage
@@ -13,72 +20,67 @@ test.describe('Agent Rename', () => {
     await appPage.waitForAgentsLoaded()
   })
 
-  test('can type spaces in agent name input when settings opened via context menu', async ({ page }) => {
-    const agentName = `RenameTest${Date.now()}`
+  async function createAndOpenAgent(
+    request: APIRequestContext,
+    page: Page,
+    testInfo: TestInfo,
+    label: string,
+  ) {
+    const agent = await createAgent(request, uniqueName(testInfo, label))
+    await gotoAgentHome(page, agent)
+    await expect(getAgentItem(page, agent)).toBeVisible()
+    return agent
+  }
 
-    // Create an agent
-    await agentPage.createAgent(agentName)
-    await expect(agentPage.getAgentItem(agentName)).toBeVisible()
+  test('can type and save spaces in agent name input when settings opened via context menu', async ({ page, request }, testInfo) => {
+    const agent = await createAndOpenAgent(request, page, testInfo, 'Rename Context')
+    const newName = uniqueName(testInfo, 'Context Name With Spaces')
 
-    // Right-click the agent to open context menu
-    await agentPage.getAgentItem(agentName).click({ button: 'right' })
-
-    // Click "Settings" in the context menu
+    await getAgentItem(page, agent).click({ button: 'right' })
     await page.locator('[data-testid="agent-settings-item"]').click()
 
-    // Wait for the settings dialog
-    await expect(page.locator('[data-testid="agent-settings-dialog"]')).toBeVisible()
+    const dialog = page.locator('[data-testid="agent-settings-dialog"]')
+    await expect(dialog).toBeVisible()
 
-    // Find the agent name input
     const nameInput = page.locator('#agent-name')
     await expect(nameInput).toBeVisible()
 
-    // Type with actual keyboard (pressSequentially sends real key events)
     await nameInput.clear()
     await nameInput.click()
-    await nameInput.pressSequentially('Hello World')
-    await expect(nameInput).toHaveValue('Hello World')
+    await nameInput.pressSequentially(newName)
+    await expect(nameInput).toHaveValue(newName)
 
-    // Close dialog and clean up
-    await page.keyboard.press('Escape')
-    await agentPage.deleteAgent()
+    await dialog.getByRole('button', { name: /^Save$/ }).click()
+    await expect(dialog).not.toBeVisible({ timeout: 10000 })
+
+    const renamedAgent = await expectAgentNamed(request, agent, newName)
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(newName)
+    await expect(getAgentItem(page, renamedAgent)).toBeVisible()
   })
 
-  test('can rename agent inline from agent home by pressing Enter', async ({ page }) => {
-    const agentName = `InlineEnter${Date.now()}`
-    const newName = `${agentName}-Renamed`
+  test('can rename agent inline from agent home by pressing Enter', async ({ page, request }, testInfo) => {
+    const agent = await createAndOpenAgent(request, page, testInfo, 'Inline Enter')
+    const newName = uniqueName(testInfo, 'Inline Enter Renamed')
 
-    await agentPage.createAgent(agentName)
-    await expect(agentPage.getAgentItem(agentName)).toBeVisible()
-
-    // Click the agent name heading to enter edit mode
     const nameHeading = page.locator('[data-testid="agent-name"]')
     await expect(nameHeading).toBeVisible()
     await nameHeading.click()
 
-    // Input should be focused; replace value and press Enter to save
     const nameInput = page.locator('[data-testid="agent-name-input"]')
     await expect(nameInput).toBeVisible()
     await nameInput.fill(newName)
     await nameInput.press('Enter')
 
-    // Input should collapse back to the heading with the updated name
     await expect(nameInput).not.toBeVisible()
     await expect(page.locator('[data-testid="agent-name"]')).toHaveText(newName)
-
-    // Sidebar + breadcrumb should reflect the new name as well
     await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(newName)
-    await expect(agentPage.getAgentItem(newName)).toBeVisible()
-
-    await agentPage.deleteAgent()
+    const renamedAgent = await expectAgentNamed(request, agent, newName)
+    await expect(getAgentItem(page, renamedAgent)).toBeVisible()
   })
 
-  test('can rename agent inline from agent home by clicking save button', async ({ page }) => {
-    const agentName = `InlineSave${Date.now()}`
-    const newName = `${agentName}-Renamed`
-
-    await agentPage.createAgent(agentName)
-    await expect(agentPage.getAgentItem(agentName)).toBeVisible()
+  test('can rename agent inline from agent home by clicking save button', async ({ page, request }, testInfo) => {
+    const agent = await createAndOpenAgent(request, page, testInfo, 'Inline Save')
+    const newName = uniqueName(testInfo, 'Inline Save Renamed')
 
     await page.locator('[data-testid="agent-name"]').click()
 
@@ -91,51 +93,47 @@ test.describe('Agent Rename', () => {
     await expect(nameInput).not.toBeVisible()
     await expect(page.locator('[data-testid="agent-name"]')).toHaveText(newName)
     await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(newName)
-
-    await agentPage.deleteAgent()
+    const renamedAgent = await expectAgentNamed(request, agent, newName)
+    await expect(getAgentItem(page, renamedAgent)).toBeVisible()
   })
 
-  test('pressing Escape cancels inline rename without saving', async ({ page }) => {
-    const agentName = `InlineEscape${Date.now()}`
-
-    await agentPage.createAgent(agentName)
-    await expect(agentPage.getAgentItem(agentName)).toBeVisible()
+  test('pressing Escape cancels inline rename without saving', async ({ page, request }, testInfo) => {
+    const agent = await createAndOpenAgent(request, page, testInfo, 'Inline Escape')
+    const unsavedName = uniqueName(testInfo, 'Should Not Save')
 
     await page.locator('[data-testid="agent-name"]').click()
 
     const nameInput = page.locator('[data-testid="agent-name-input"]')
     await expect(nameInput).toBeVisible()
-    await nameInput.fill('Should Not Save')
+    await nameInput.fill(unsavedName)
     await nameInput.press('Escape')
 
     await expect(nameInput).not.toBeVisible()
-    await expect(page.locator('[data-testid="agent-name"]')).toHaveText(agentName)
-
-    await agentPage.deleteAgent()
+    await expect(page.locator('[data-testid="agent-name"]')).toHaveText(agent.name)
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name)
+    await expectAgentNamed(request, agent, agent.name)
+    await expect(page.locator('[data-testid^="agent-item-"]', { hasText: unsavedName })).toHaveCount(0)
   })
 
-  test('control: can type spaces in agent name input when settings opened via button', async ({ page }) => {
-    const agentName = `RenameCtrl${Date.now()}`
+  test('control: can type spaces in agent name input when settings opened via button without saving', async ({ page, request }, testInfo) => {
+    const agent = await createAndOpenAgent(request, page, testInfo, 'Rename Button')
+    const unsavedName = uniqueName(testInfo, 'Button Name With Spaces')
 
-    // Create an agent
-    await agentPage.createAgent(agentName)
-    await expect(agentPage.getAgentItem(agentName)).toBeVisible()
-
-    // Open settings via the button (not context menu)
     await agentPage.openSettings()
 
-    // Find the agent name input
+    const dialog = page.locator('[data-testid="agent-settings-dialog"]')
     const nameInput = page.locator('#agent-name')
     await expect(nameInput).toBeVisible()
 
-    // Type with actual keyboard (pressSequentially sends real key events)
     await nameInput.clear()
     await nameInput.click()
-    await nameInput.pressSequentially('Hello World')
-    await expect(nameInput).toHaveValue('Hello World')
+    await nameInput.pressSequentially(unsavedName)
+    await expect(nameInput).toHaveValue(unsavedName)
 
-    // Close dialog and clean up
-    await page.keyboard.press('Escape')
-    await agentPage.deleteAgent()
+    await dialog.getByRole('button', { name: /^Cancel$/ }).click()
+    await expect(dialog).not.toBeVisible()
+
+    await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name)
+    await expectAgentNamed(request, agent, agent.name)
   })
 })

--- a/e2e/specs/session-rename.spec.ts
+++ b/e2e/specs/session-rename.spec.ts
@@ -1,6 +1,15 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
-import { AgentPage } from '../pages/agent.page'
+import {
+  createAgent,
+  createSession,
+  expectSessionNamed,
+  openAgentSession,
+  uniqueName,
+  waitForSessionIdle,
+  type TestAgent,
+  type TestSession,
+} from '../helpers/agents'
 
 /**
  * Session names are persisted to `session-metadata.json` via
@@ -11,68 +20,75 @@ import { AgentPage } from '../pages/agent.page'
  * which is what regressed in production.
  */
 test.describe('Session Rename (names must persist)', () => {
-  let appPage: AppPage
-  let agentPage: AgentPage
-  let agentName: string
+  async function createSessionFixture(
+    page: Page,
+    request: APIRequestContext,
+    testInfo: TestInfo,
+    label: string,
+  ): Promise<{ agent: TestAgent; session: TestSession }> {
+    const agent = await createAgent(request, uniqueName(testInfo, label))
+    const session = await createSession(
+      request,
+      agent,
+      `Create a renameable session for ${uniqueName(testInfo, 'Session Message')}`,
+    )
+    await waitForSessionIdle(request, agent, session)
 
-  test.beforeEach(async ({ page }, testInfo) => {
-    appPage = new AppPage(page)
-    agentPage = new AgentPage(page)
-
+    const appPage = new AppPage(page)
     await appPage.goto()
     await appPage.waitForAgentsLoaded()
+    await openAgentSession(page, agent, session)
 
-    agentName = `Session Rename ${testInfo.workerIndex}-${Date.now()}`
-    await agentPage.createAgent(agentName)
-  })
+    return { agent, session }
+  }
 
-  async function renameFirstSession(page: import('@playwright/test').Page, newName: string) {
-    await agentPage.expandAgent(agentName)
-    const sessionItem = page.locator('[data-testid^="session-item-"]').first()
+  async function renameSessionInSidebar(page: Page, session: Pick<TestSession, 'id'>, newName: string) {
+    const sessionItem = page.locator(`[data-testid="session-item-${session.id}"]`)
     await expect(sessionItem).toBeVisible({ timeout: 15000 })
 
     await sessionItem.click({ button: 'right' })
     await page.locator('[data-testid="rename-session-item"]').click()
 
-    const dialog = page.getByRole('dialog')
+    const dialog = page.getByRole('dialog', { name: 'Rename Session' })
     await expect(dialog).toBeVisible()
     await dialog.getByPlaceholder('Session name').fill(newName)
-    await dialog.locator('button[type="submit"]').click()
+    await dialog.getByRole('button', { name: /^Rename$/ }).click()
     await expect(dialog).not.toBeVisible()
+    await expect(sessionItem).toContainText(newName, { timeout: 10000 })
   }
 
-  test('renames a session and the new name survives a reload', async ({ page }) => {
-    const newName = `Renamed-${Date.now()}`
+  test('renames a session and the new name survives a reload', async ({ page, request }, testInfo) => {
+    const { agent, session } = await createSessionFixture(page, request, testInfo, 'Session Rename Once')
+    const newName = uniqueName(testInfo, 'Renamed Session')
 
-    await renameFirstSession(page, newName)
+    await renameSessionInSidebar(page, session, newName)
+    await expectSessionNamed(request, agent, session, newName)
 
-    // Immediately reflected in the sidebar.
-    await expect(
-      page.locator('[data-testid^="session-item-"]', { hasText: newName })
-    ).toBeVisible({ timeout: 10000 })
-
-    // Reload: the name must be read back from session-metadata.json. Before the
-    // fix, a non-atomic write + swallow-to-{} read could wipe it here.
+    // Reload: the name must be read back from session-metadata.json for the
+    // exact session, not whichever session happens to render first.
     await page.reload()
+    const appPage = new AppPage(page)
     await appPage.waitForAgentsLoaded()
-    await agentPage.expandAgent(agentName)
-    await expect(
-      page.locator('[data-testid^="session-item-"]', { hasText: newName })
-    ).toBeVisible({ timeout: 15000 })
+    await openAgentSession(page, agent, session)
+    await expect(page.locator(`[data-testid="session-item-${session.id}"]`)).toContainText(newName, { timeout: 15000 })
+    await expectSessionNamed(request, agent, session, newName)
   })
 
-  test('a second rename overwrites the first and also persists', async ({ page }) => {
+  test('a second rename overwrites the first and also persists', async ({ page, request }, testInfo) => {
+    const { agent, session } = await createSessionFixture(page, request, testInfo, 'Session Rename Twice')
+
     // Two successive read-modify-write cycles on the same metadata file — the
     // second must not be lost and must not clobber the file.
-    await renameFirstSession(page, `First-${Date.now()}`)
-    const finalName = `Second-${Date.now()}`
-    await renameFirstSession(page, finalName)
+    await renameSessionInSidebar(page, session, uniqueName(testInfo, 'First Session Name'))
+    const finalName = uniqueName(testInfo, 'Second Session Name')
+    await renameSessionInSidebar(page, session, finalName)
+    await expectSessionNamed(request, agent, session, finalName)
 
     await page.reload()
+    const appPage = new AppPage(page)
     await appPage.waitForAgentsLoaded()
-    await agentPage.expandAgent(agentName)
-    await expect(
-      page.locator('[data-testid^="session-item-"]', { hasText: finalName })
-    ).toBeVisible({ timeout: 15000 })
+    await openAgentSession(page, agent, session)
+    await expect(page.locator(`[data-testid="session-item-${session.id}"]`)).toContainText(finalName, { timeout: 15000 })
+    await expectSessionNamed(request, agent, session, finalName)
   })
 })


### PR DESCRIPTION
## Summary

- Harden agent lifecycle, agent rename, and session rename specs for higher parallelism.
- Keep core UI coverage intact: creating/deleting agents still runs through the UI, and agent/session rename behavior is still exercised through the UI.
- Move repeated setup to API-created unique agents/sessions so tests stop depending on sidebar ordering or cleanup timing.
- Add API-backed persistence assertions for agent names, session names, and agent deletion.
- Target exact agent/session test IDs instead of first/partial-match rows where possible.

## Validation

- `npx eslint e2e/helpers/agents.ts e2e/specs/agent-lifecycle.spec.ts e2e/specs/agent-rename.spec.ts e2e/specs/session-rename.spec.ts`
- `npm run typecheck`
- `git diff --check`
- Focused workers=4 runs: 4 consecutive green runs of `PORT=<port> PLAYWRIGHT_WORKERS=4 npm run test:e2e -- e2e/specs/agent-lifecycle.spec.ts e2e/specs/agent-rename.spec.ts e2e/specs/session-rename.spec.ts` (`11 passed` each run)
- Main web workers=6 probe: `PORT=3446 PLAYWRIGHT_WORKERS=6 npm run test:e2e:web` produced `200 passed`, `21 skipped`, `2 failed`. The failures were request-card/input-request waits in `awaiting-input-status.spec.ts` and `proxy-review.spec.ts`, which points to the next concurrency bottleneck being request-card/SSE state rather than this lifecycle batch.