### PR TITLE
fix(mcp): fall back to http loopback OAuth redirect when the AS rejects the custom scheme (SUP-350)

### DIFF
--- a/scripts/verify-mcp-server.ts
+++ b/scripts/verify-mcp-server.ts
@@ -139,7 +139,7 @@ async function verifyOAuth(url: string, name: string, ev: Record<string, unknown
 
   // Full path: discover -> (DCR or fail) -> build the real authorization URL.
   const initiated = await withTimeout(
-    initiateNewServerOAuth(url, name, REDIRECT_URI),
+    initiateNewServerOAuth(url, name, [REDIRECT_URI]),
     NET_TIMEOUT_MS,
     'initiate-oauth',
   ).catch((e) => { ev.initiateError = classifyError(e).message; return null })

--- a/src/api/routes/remote-mcps.test.ts
+++ b/src/api/routes/remote-mcps.test.ts
@@ -962,6 +962,49 @@ describe('SSRF protection', () => {
     })
   })
 
+  describe('POST /initiate-oauth — redirect candidates', () => {
+    it('offers the custom app scheme then an http loopback for Electron (so strict AS like cal.com can fall back)', async () => {
+      mockInitiateNewServerOAuth.mockResolvedValue({
+        authorizationUrl: 'https://auth.example.com/auth',
+        state: 'state-xyz',
+      })
+
+      const res = await app.request('http://localhost/api/remote-mcps/initiate-oauth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Cal.com', url: 'https://mcp.cal.com/mcp', electron: true }),
+      })
+
+      expect(res.status).toBe(200)
+      const [url, name, candidates, electron] = mockInitiateNewServerOAuth.mock.calls[0]
+      expect(url).toBe('https://mcp.cal.com/mcp')
+      expect(name).toBe('Cal.com')
+      expect(electron).toBe(true)
+      // Custom scheme is preferred; the loopback comes from the request origin.
+      expect(candidates).toEqual([
+        'superagent://mcp-oauth-callback',
+        'http://localhost/api/remote-mcps/oauth-callback',
+      ])
+    })
+
+    it('offers only the http redirect for the web app', async () => {
+      mockInitiateNewServerOAuth.mockResolvedValue({
+        authorizationUrl: 'https://auth.example.com/auth',
+        state: 'state-xyz',
+      })
+
+      await app.request('http://localhost/api/remote-mcps/initiate-oauth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Cal.com', url: 'https://mcp.cal.com/mcp' }),
+      })
+
+      const [, , candidates, electron] = mockInitiateNewServerOAuth.mock.calls[0]
+      expect(electron).toBe(false)
+      expect(candidates).toEqual(['http://localhost:3000/api/remote-mcps/oauth-callback'])
+    })
+  })
+
   describe('PATCH /:id — rejects unsafe URL updates', () => {
     it('rejects private host URL in update', async () => {
       mockDbFrom.mockReturnValue({ where: mockWhere })
@@ -1213,5 +1256,47 @@ describe('OAuth callback — postMessage origin', () => {
     expect(html).toContain('setTimeout(() => window.close(), 0)')
     expect(html).toContain('"success":true')
     expect(html).toContain('"mcpId":"mcp-new"')
+  })
+
+  it('hands the result back to the app via the custom scheme for the Electron http-loopback flow', async () => {
+    // Electron flow whose redirect was the http loopback (redirectWasScheme:false):
+    // this callback loads in the external browser, so it must bounce into the app.
+    mockCompleteOAuthFlow.mockResolvedValue({
+      success: true,
+      mcpId: 'mcp-new',
+      electron: true,
+      redirectWasScheme: false,
+    })
+    mockDbFrom.mockReturnValue({ where: mockWhere })
+    mockWhere.mockReturnValue({ limit: mockLimit })
+    mockLimit.mockResolvedValue([
+      { id: 'mcp-new', url: 'https://mcp.example.com', accessToken: 'tok' },
+    ])
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ jsonrpc: '2.0', result: {}, id: 1 }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }))
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ jsonrpc: '2.0', result: { tools: [] }, id: 2 }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) })
+
+    const res = await app.request(
+      'http://localhost/api/remote-mcps/oauth-callback?code=abc&state=xyz'
+    )
+
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain('window.location.replace')
+    expect(html).toContain('superagent://mcp-oauth-callback?success=true')
+    expect(html).toContain('mcpId=mcp-new')
+    // NOT the web postMessage/BroadcastChannel bridge.
+    expect(html).not.toContain("new BroadcastChannel('mcp-oauth-callback')")
   })
 })

--- a/src/api/routes/remote-mcps.ts
+++ b/src/api/routes/remote-mcps.ts
@@ -91,6 +91,52 @@ function renderMcpOAuthCallbackHtml(payload: McpOAuthCallbackPayload, message: s
   `
 }
 
+/**
+ * Callback page for the Electron http-loopback OAuth path. Unlike the custom
+ * scheme path (where the Electron main process fetches this route directly), this
+ * page is loaded in the user's external browser after the token exchange has
+ * already completed server-side. It hands the result back into the app via the
+ * custom scheme so the main process can notify the renderer over IPC.
+ */
+function renderMcpOAuthHandoffHtml(payload: McpOAuthCallbackPayload): string {
+  const protocol = process.env.SUPERAGENT_PROTOCOL || 'superagent'
+  const params = new URLSearchParams()
+  params.set('success', payload.success ? 'true' : 'false')
+  if (payload.mcpId) params.set('mcpId', payload.mcpId)
+  if (payload.error) params.set('error', payload.error)
+  const deepLink = `${protocol}://mcp-oauth-callback?${params.toString()}`
+
+  const message = payload.success
+    ? 'Authentication successful! Returning to the app…'
+    : `Authentication failed${payload.error ? `: ${payload.error}` : ''}. Returning to the app…`
+
+  return `
+    <html><body><script>
+      window.location.replace(${safeScriptJson(deepLink)});
+    </script>
+    <p>${escapeHtml(message)}</p>
+    <p><a href="${escapeHtml(deepLink)}">Click here if you are not returned automatically.</a></p>
+    </body></html>
+  `
+}
+
+/**
+ * Pick the right callback response. The Electron http-loopback path (loaded in
+ * the external browser) hands back via the custom scheme; every other case (web,
+ * or the Electron custom-scheme path fetched by the main process) uses the
+ * postMessage/BroadcastChannel/localStorage bridge.
+ */
+function mcpOAuthCallbackBody(
+  payload: McpOAuthCallbackPayload,
+  message: string,
+  delivery: { electron?: boolean; redirectWasScheme?: boolean },
+): string {
+  if (delivery.electron && delivery.redirectWasScheme === false) {
+    return renderMcpOAuthHandoffHtml(payload)
+  }
+  return renderMcpOAuthCallbackHtml(payload, message)
+}
+
 // Entry-path SSRF guard for the user-supplied MCP server URL. Delegates to the
 // shared policy so it cannot drift from the OAuth-discovery checks, which must
 // reject the same private/loopback hosts on every server-supplied metadata URL.
@@ -225,10 +271,24 @@ remoteMcps.post('/initiate-oauth', async (c) => {
       ? body.clientSecret.trim()
       : undefined
 
+  // Ordered redirect candidates. In Electron we prefer the custom app scheme
+  // (port-independent, no external-browser hand-off needed) but fall back to an
+  // http loopback URL for authorization servers that reject non-http(s) redirects
+  // during dynamic client registration (e.g. cal.com). Web only has the http URL.
+  //
+  // The loopback base must come from the request URL's origin (http://localhost:<apiPort>),
+  // not getAppBaseUrlFromRequest: the packaged renderer is served from file://, so its
+  // fetches carry `Origin: null`. The AS redirects the external browser here to complete
+  // the flow, so the URL must be one the local API server actually answers on.
   const protocol = process.env.SUPERAGENT_PROTOCOL || 'superagent'
-  const redirectUri = body.electron
-    ? `${protocol}://mcp-oauth-callback`
+  // eslint-disable-next-line local-rules/no-unhandled-throwing-builtins -- c.req.url is always a valid URL
+  const loopbackRedirect = `${new URL(c.req.url).origin}/api/remote-mcps/oauth-callback`
+  const httpRedirect = body.electron
+    ? loopbackRedirect
     : `${getAppBaseUrlFromRequest(c)}/api/remote-mcps/oauth-callback`
+  const redirectCandidates = body.electron
+    ? [`${protocol}://mcp-oauth-callback`, httpRedirect]
+    : [httpRedirect]
 
   if (body.mcpId) {
     // Existing server re-auth
@@ -246,7 +306,7 @@ remoteMcps.post('/initiate-oauth', async (c) => {
       return c.json({ error: 'MCP server not found' }, 404)
     }
 
-    const result = await initiateOAuthFlow(body.mcpId, server.url, redirectUri, clientNameOverride, clientIdOverride, clientSecretOverride)
+    const result = await initiateOAuthFlow(body.mcpId, server.url, redirectCandidates, !!body.electron, clientNameOverride, clientIdOverride, clientSecretOverride)
 
     if (!result) {
       const discoveryResult = await discoverOAuthMetadata(server.url)
@@ -265,7 +325,7 @@ remoteMcps.post('/initiate-oauth', async (c) => {
     }
 
     // New server: OAuth-first flow (no DB insert yet)
-    const result = await initiateNewServerOAuth(body.url.trim(), body.name.trim(), redirectUri, getCurrentUserId(c), clientNameOverride, clientIdOverride, clientSecretOverride)
+    const result = await initiateNewServerOAuth(body.url.trim(), body.name.trim(), redirectCandidates, !!body.electron, getCurrentUserId(c), clientNameOverride, clientIdOverride, clientSecretOverride)
 
     if (!result) {
       const discoveryResult = await discoverOAuthMetadata(body.url.trim())
@@ -291,15 +351,17 @@ remoteMcps.get('/oauth-callback', async (c) => {
   if (error) {
     const issuerValidation = validateAndConsumeOAuthErrorResponse(state, iss)
     if (!issuerValidation.valid) {
-      return c.html(renderMcpOAuthCallbackHtml(
+      return c.html(mcpOAuthCallbackBody(
         { type: 'mcp-oauth-callback', success: false, error: 'OAuth callback validation failed' },
         'OAuth callback validation failed. You can close this window.',
+        issuerValidation,
       ))
     }
 
-    return c.html(renderMcpOAuthCallbackHtml(
+    return c.html(mcpOAuthCallbackBody(
       { type: 'mcp-oauth-callback', success: false, error },
       `OAuth error: ${error}. You can close this window.`,
+      issuerValidation,
     ))
   }
 
@@ -308,11 +370,13 @@ remoteMcps.get('/oauth-callback', async (c) => {
   }
 
   const result = await completeOAuthFlow(state, code, iss)
+  const delivery = { electron: result.electron, redirectWasScheme: result.redirectWasScheme }
 
   if (!result.success || !result.mcpId) {
-    return c.html(renderMcpOAuthCallbackHtml(
+    return c.html(mcpOAuthCallbackBody(
       { type: 'mcp-oauth-callback', success: false, error: 'Token exchange failed' },
       'OAuth failed. You can close this window.',
+      delivery,
     ))
   }
 
@@ -341,20 +405,22 @@ remoteMcps.get('/oauth-callback', async (c) => {
     // Tool discovery failed — delete the server so we don't leave a broken entry
     await db.delete(remoteMcpServers).where(eq(remoteMcpServers.id, result.mcpId))
     const errorMsg = err.message || 'Tool discovery failed'
-    return c.html(renderMcpOAuthCallbackHtml(
+    return c.html(mcpOAuthCallbackBody(
       {
         type: 'mcp-oauth-callback',
         success: false,
         error: `Connected but failed to discover tools: ${errorMsg}`,
       },
       'OAuth succeeded but tool discovery failed. You can close this window.',
+      delivery,
     ))
   }
 
   trackServerEvent('mcp_oauth_succeeded', { url: serverUrl, mcpId: result.mcpId })
-  return c.html(renderMcpOAuthCallbackHtml(
+  return c.html(mcpOAuthCallbackBody(
     { type: 'mcp-oauth-callback', success: true, mcpId: result.mcpId },
     'OAuth successful! You can close this window.',
+    delivery,
   ))
 })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -993,34 +993,50 @@ function handleDeepLinkUrl(url: string, fromQueue = false) {
     }
   }
 
-  // MCP OAuth callback — forward to the local API server to complete token exchange
+  // MCP OAuth callback
   if (url.startsWith(`${PROTOCOL_SCHEME}://mcp-oauth-callback`)) {
     try {
       const callbackUrl = new URL(url)
-      const queryString = callbackUrl.search
-      const apiUrl = `http://localhost:${actualApiPort}/api/remote-mcps/oauth-callback${queryString}`
-      fetch(apiUrl)
-        .then(async (res) => {
-          const text = await res.text()
-          const success = text.includes('OAuth successful')
-          const mcpIdMatch = text.match(/mcpId:\s*'([^']+)'/)
-          mainWindow?.webContents.send('mcp-oauth-callback', {
-            success,
-            mcpId: mcpIdMatch?.[1] || null,
-            error: success ? null : 'OAuth failed',
-          })
+      const params = callbackUrl.searchParams
+
+      if (params.has('success')) {
+        // http-loopback path: the local API server already completed the token
+        // exchange (and any error/issuer validation) in the external browser and
+        // bounced the result back here — the hand-off page always carries
+        // `success`. Notify the renderer directly; no second exchange needed.
+        const success = params.get('success') === 'true'
+        mainWindow?.webContents.send('mcp-oauth-callback', {
+          success,
+          mcpId: params.get('mcpId') || null,
+          error: success ? null : (params.get('error') || 'OAuth failed'),
         })
-        .catch((err) => {
-          console.error('Failed to complete MCP OAuth callback:', err)
-          mainWindow?.webContents.send('mcp-oauth-callback', {
-            success: false,
-            error: err.message || 'Failed to complete OAuth',
+      } else {
+        // Custom-scheme path: the app received the raw code/state, so forward to
+        // the local API server to complete the token exchange.
+        const apiUrl = `http://localhost:${actualApiPort}/api/remote-mcps/oauth-callback${callbackUrl.search}`
+        fetch(apiUrl)
+          .then(async (res) => {
+            const text = await res.text()
+            const success = text.includes('OAuth successful')
+            const mcpIdMatch = text.match(/mcpId:\s*'([^']+)'/)
+            mainWindow?.webContents.send('mcp-oauth-callback', {
+              success,
+              mcpId: mcpIdMatch?.[1] || null,
+              error: success ? null : 'OAuth failed',
+            })
           })
-        })
-      mainWindow.focus()
+          .catch((err) => {
+            console.error('Failed to complete MCP OAuth callback:', err)
+            mainWindow?.webContents.send('mcp-oauth-callback', {
+              success: false,
+              error: err.message || 'Failed to complete OAuth',
+            })
+          })
+      }
+      mainWindow?.focus()
     } catch (error) {
       console.error('Failed to parse MCP OAuth callback URL:', error)
-      mainWindow.webContents.send('mcp-oauth-callback', {
+      mainWindow?.webContents.send('mcp-oauth-callback', {
         success: false,
         error: 'Invalid callback URL',
       })

--- a/src/shared/lib/mcp/oauth.test.ts
+++ b/src/shared/lib/mcp/oauth.test.ts
@@ -93,7 +93,8 @@ describe('oauth', () => {
       const result = await initiateNewServerOAuth(
         'https://mcp.example.com/mcp',
         'Test Server',
-        'http://localhost:3000/callback',
+        ['http://localhost:3000/callback'],
+        false,
         'user-1'
       )
 
@@ -458,7 +459,7 @@ describe('oauth', () => {
       const result = await initiateOAuthFlow(
         'mcp-1',
         'https://mcp.example.com/mcp',
-        'http://localhost:3000/callback'
+        ['http://localhost:3000/callback']
       )
 
       expect(result).not.toBeNull()
@@ -499,7 +500,7 @@ describe('oauth', () => {
       const initiated = await initiateOAuthFlow(
         'mcp-1',
         'https://mcp.example.com/mcp',
-        'http://localhost:3000/callback'
+        ['http://localhost:3000/callback']
       )
       expect(initiated).not.toBeNull()
 
@@ -519,7 +520,7 @@ describe('oauth', () => {
         'https://auth.example.com'
       )
 
-      expect(result).toEqual({ success: true, mcpId: 'mcp-1' })
+      expect(result).toMatchObject({ success: true, mcpId: 'mcp-1' })
     })
 
     it('sends scopes_supported from the resource metadata when DCR returns no scope (Robinhood case)', async () => {
@@ -572,7 +573,7 @@ describe('oauth', () => {
       const result = await initiateOAuthFlow(
         'mcp-1',
         'https://mcp.example.com/mcp',
-        'http://localhost:3000/callback'
+        ['http://localhost:3000/callback']
       )
 
       expect(result).not.toBeNull()
@@ -624,7 +625,7 @@ describe('oauth', () => {
       const result = await initiateOAuthFlow(
         'mcp-1',
         'https://mcp.example.com/mcp',
-        'http://localhost:3000/callback'
+        ['http://localhost:3000/callback']
       )
 
       expect(result).not.toBeNull()
@@ -642,7 +643,7 @@ describe('oauth', () => {
       const result = await initiateOAuthFlow(
         'mcp-1',
         'https://mcp.example.com/mcp',
-        'http://localhost:3000/callback'
+        ['http://localhost:3000/callback']
       )
       expect(result).toBeNull()
     })
@@ -663,7 +664,8 @@ describe('oauth', () => {
       const result = await initiateOAuthFlow(
         'mcp-1',
         'https://mcp.example.com/mcp',
-        'http://localhost:3000/callback',
+        ['http://localhost:3000/callback'],
+        false,
         undefined,
         'override-client-id',
         'override-client-secret'
@@ -712,7 +714,7 @@ describe('oauth', () => {
       const result = await initiateOAuthFlow(
         'mcp-1',
         'https://mcp.example.com/mcp',
-        'http://localhost:3000/callback'
+        ['http://localhost:3000/callback']
       )
       expect(result).toBeNull()
     })
@@ -731,7 +733,7 @@ describe('oauth', () => {
       const result = await initiateOAuthFlow(
         'mcp-1',
         'https://mcp.example.com/mcp',
-        'http://localhost:3000/callback'
+        ['http://localhost:3000/callback']
       )
       expect(result).toBeNull()
     })
@@ -782,7 +784,8 @@ describe('oauth', () => {
       const result = await initiateNewServerOAuth(
         'https://mcp.example.com/mcp',
         'New MCP',
-        'http://localhost/callback',
+        ['http://localhost/callback'],
+        false,
         'user-1'
       )
 
@@ -797,6 +800,108 @@ describe('oauth', () => {
       expect(url.searchParams.get('scope')).toBe('mcp:read mcp:write')
       expect(result!.state).toBeTruthy()
       expect(result!.state).toHaveLength(32) // 16 bytes hex
+    })
+
+    // Discovery mocks (probe → resource metadata → auth-server metadata with a
+    // registration endpoint) shared by the redirect-candidate fallback tests.
+    function setupNewServerDcrDiscovery() {
+      mockFetch.mockResolvedValueOnce(
+        new Response(null, {
+          status: 401,
+          headers: {
+            'WWW-Authenticate':
+              'Bearer resource_metadata="https://mcp.example.com/.well-known/res"',
+          },
+        })
+      )
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            resource: 'https://mcp.example.com',
+            authorization_servers: ['https://auth.example.com'],
+          }),
+          { status: 200 }
+        )
+      )
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            registration_endpoint: 'https://auth.example.com/register',
+          }),
+          { status: 200 }
+        )
+      )
+    }
+
+    it('falls back to the http loopback redirect when DCR rejects the custom app scheme (cal.com case)', async () => {
+      setupNewServerDcrDiscovery()
+      // DCR #1: custom scheme rejected — cal.com allows only http(s) redirects.
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: 'invalid_request',
+            error_description: 'Invalid redirect_uri: invalid scheme: superagent:',
+          }),
+          { status: 400 }
+        )
+      )
+      // DCR #2: http loopback redirect accepted.
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ client_id: 'dyn-loopback' }), { status: 201 })
+      )
+
+      const loopback = 'http://localhost:47891/api/remote-mcps/oauth-callback'
+      const result = await initiateNewServerOAuth(
+        'https://mcp.example.com/mcp',
+        'Cal.com',
+        ['superagent://mcp-oauth-callback', loopback],
+        true,
+        'user-1'
+      )
+
+      expect(result).not.toBeNull()
+      const url = new URL(result!.authorizationUrl)
+      // The authorization request must use the redirect the AS actually accepted.
+      expect(url.searchParams.get('redirect_uri')).toBe(loopback)
+      expect(url.searchParams.get('client_id')).toBe('dyn-loopback')
+
+      // Registration was attempted with the custom scheme first, then the loopback.
+      const registerCalls = mockFetch.mock.calls.filter(
+        ([reqUrl]) => reqUrl === 'https://auth.example.com/register'
+      )
+      expect(registerCalls).toHaveLength(2)
+      expect(JSON.parse(registerCalls[0][1].body).redirect_uris).toEqual([
+        'superagent://mcp-oauth-callback',
+      ])
+      expect(JSON.parse(registerCalls[1][1].body).redirect_uris).toEqual([loopback])
+    })
+
+    it('uses the preferred (custom scheme) redirect when DCR accepts it', async () => {
+      setupNewServerDcrDiscovery()
+      // DCR #1: custom scheme accepted — no fallback needed.
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ client_id: 'dyn-scheme' }), { status: 201 })
+      )
+
+      const result = await initiateNewServerOAuth(
+        'https://mcp.example.com/mcp',
+        'Scheme OK',
+        ['superagent://mcp-oauth-callback', 'http://localhost:47891/api/remote-mcps/oauth-callback'],
+        true,
+        'user-1'
+      )
+
+      expect(result).not.toBeNull()
+      const url = new URL(result!.authorizationUrl)
+      expect(url.searchParams.get('redirect_uri')).toBe('superagent://mcp-oauth-callback')
+      expect(url.searchParams.get('client_id')).toBe('dyn-scheme')
+      // Only one registration attempt was made (the loopback was never tried).
+      const registerCalls = mockFetch.mock.calls.filter(
+        ([reqUrl]) => reqUrl === 'https://auth.example.com/register'
+      )
+      expect(registerCalls).toHaveLength(1)
     })
 
     it('uses provided clientId/clientSecret without dynamic registration', async () => {
@@ -821,7 +926,8 @@ describe('oauth', () => {
       const result = await initiateNewServerOAuth(
         'https://mcp.example.com/mcp',
         'New MCP',
-        'http://localhost/callback',
+        ['http://localhost/callback'],
+        false,
         'user-1',
         undefined,
         'byo-client-id',
@@ -856,7 +962,8 @@ describe('oauth', () => {
       const result = await initiateNewServerOAuth(
         'https://mcp.example.com/mcp',
         'New MCP',
-        'http://localhost/callback',
+        ['http://localhost/callback'],
+        false,
         'user-1',
         undefined,
         'manual-client-id'
@@ -889,7 +996,7 @@ describe('oauth', () => {
       const result = await initiateNewServerOAuth(
         'https://mcp.example.com/mcp',
         'New MCP',
-        'http://localhost/callback'
+        ['http://localhost/callback']
       )
       expect(result).toBeNull()
     })
@@ -949,7 +1056,8 @@ describe('oauth', () => {
       const result = await initiateNewServerOAuth(
         'https://mcp.example.com/mcp',
         'Test Server',
-        'http://localhost/callback',
+        ['http://localhost/callback'],
+        false,
         'user-1'
       )
       return result!.state
@@ -990,6 +1098,125 @@ describe('oauth', () => {
       expect(body.get('grant_type')).toBe('authorization_code')
       expect(body.get('code')).toBe('auth-code-xyz')
       expect(body.get('redirect_uri')).toBe('http://localhost/callback')
+    })
+
+    it('reports electron + custom-scheme delivery flags so the callback can hand back to the app', async () => {
+      // Electron flow whose DCR accepts the custom app scheme on the first try.
+      mockFetch.mockResolvedValueOnce(
+        new Response(null, {
+          status: 401,
+          headers: {
+            'WWW-Authenticate':
+              'Bearer resource_metadata="https://mcp.example.com/.well-known/res"',
+          },
+        })
+      )
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            resource: 'https://mcp.example.com',
+            authorization_servers: ['https://auth.example.com'],
+          }),
+          { status: 200 }
+        )
+      )
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            registration_endpoint: 'https://auth.example.com/register',
+          }),
+          { status: 200 }
+        )
+      )
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ client_id: 'dyn-scheme' }), { status: 201 })
+      )
+
+      const initiated = await initiateNewServerOAuth(
+        'https://mcp.example.com/mcp',
+        'Scheme Electron',
+        ['superagent://mcp-oauth-callback', 'http://localhost:47891/api/remote-mcps/oauth-callback'],
+        true,
+        'user-1'
+      )
+      expect(initiated).not.toBeNull()
+
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ access_token: 'access-tok', token_type: 'Bearer' }),
+          { status: 200 }
+        )
+      )
+      mockInsertValues.mockResolvedValue(undefined)
+
+      const result = await completeOAuthFlow(initiated!.state, 'auth-code')
+
+      expect(result.success).toBe(true)
+      expect(result.electron).toBe(true)
+      // The custom app scheme won registration, so the callback route keeps the
+      // main-process-parsed HTML rather than the external-browser hand-off.
+      expect(result.redirectWasScheme).toBe(true)
+    })
+
+    it('reports a non-scheme (loopback) redirect so the callback hands back via the external browser', async () => {
+      // Electron flow whose DCR rejects the scheme and falls back to loopback.
+      mockFetch.mockResolvedValueOnce(
+        new Response(null, {
+          status: 401,
+          headers: {
+            'WWW-Authenticate':
+              'Bearer resource_metadata="https://mcp.example.com/.well-known/res"',
+          },
+        })
+      )
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            resource: 'https://mcp.example.com',
+            authorization_servers: ['https://auth.example.com'],
+          }),
+          { status: 200 }
+        )
+      )
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            registration_endpoint: 'https://auth.example.com/register',
+          }),
+          { status: 200 }
+        )
+      )
+      mockFetch.mockResolvedValueOnce(new Response('{}', { status: 400 }))
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ client_id: 'dyn-loopback' }), { status: 201 })
+      )
+
+      const initiated = await initiateNewServerOAuth(
+        'https://mcp.example.com/mcp',
+        'Loopback Electron',
+        ['superagent://mcp-oauth-callback', 'http://localhost:47891/api/remote-mcps/oauth-callback'],
+        true,
+        'user-1'
+      )
+      expect(initiated).not.toBeNull()
+
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ access_token: 'access-tok', token_type: 'Bearer' }),
+          { status: 200 }
+        )
+      )
+      mockInsertValues.mockResolvedValue(undefined)
+
+      const result = await completeOAuthFlow(initiated!.state, 'auth-code')
+
+      expect(result.success).toBe(true)
+      expect(result.electron).toBe(true)
+      expect(result.redirectWasScheme).toBe(false)
     })
 
     it('stores issuer metadata and accepts a matching iss when advertised as supported', async () => {

--- a/src/shared/lib/mcp/oauth.ts
+++ b/src/shared/lib/mcp/oauth.ts
@@ -205,6 +205,30 @@ export async function registerDynamicClient(
   }
 }
 
+/**
+ * Register a dynamic client, trying each candidate redirect URI in order until
+ * one is accepted. Returns the winning redirect URI alongside the credentials.
+ *
+ * Strict authorization servers (e.g. cal.com) reject any non-http(s) redirect
+ * during registration ("only http and https are allowed"), so the caller passes
+ * the custom app scheme first and an http loopback URL as the fallback. Whatever
+ * the AS accepts is what we must then use on the authorization and token
+ * requests — so it is returned here rather than assumed by the caller.
+ */
+async function registerDynamicClientWithFallback(
+  registrationEndpoint: string,
+  redirectCandidates: string[],
+  clientName: string,
+): Promise<{ clientId: string; clientSecret?: string; scope?: string; redirectUri: string } | null> {
+  for (const redirectUri of redirectCandidates) {
+    const registration = await registerDynamicClient(registrationEndpoint, redirectUri, clientName)
+    if (registration) {
+      return { ...registration, redirectUri }
+    }
+  }
+  return null
+}
+
 type PendingOAuthFlow = {
   codeVerifier: string
   redirectUri: string
@@ -217,6 +241,10 @@ type PendingOAuthFlow = {
   mcpId?: string
   newServer?: { name: string; url: string }
   userId?: string
+  // True when the flow was initiated by the Electron app. Combined with whether
+  // the winning redirect is the custom app scheme, this tells the callback route
+  // how to hand the result back (see completeOAuthFlow's return).
+  electron?: boolean
 }
 
 type OAuthIssuerValidationResult =
@@ -225,6 +253,23 @@ type OAuthIssuerValidationResult =
 
 // In-memory store for pending OAuth flows
 const pendingOAuthFlows = new Map<string, PendingOAuthFlow>()
+
+/**
+ * How the callback route should deliver the result to the client, derived from
+ * the pending flow. `redirectWasScheme` is true for the custom app scheme (any
+ * non-http(s) redirect) — that path is fetched+parsed by the Electron main
+ * process — and false for an http loopback redirect loaded in the external
+ * browser, which must be handed back to the app.
+ */
+function flowDeliveryFlags(flow: PendingOAuthFlow): {
+  electron: boolean
+  redirectWasScheme: boolean
+} {
+  return {
+    electron: flow.electron === true,
+    redirectWasScheme: !/^https?:/i.test(flow.redirectUri),
+  }
+}
 
 function validateAuthorizationResponseIssuer(
   flow: PendingOAuthFlow,
@@ -263,7 +308,7 @@ function validateAuthorizationResponseIssuer(
 export function validateAndConsumeOAuthErrorResponse(
   state: string | null | undefined,
   iss: string | null | undefined,
-): OAuthIssuerValidationResult {
+): OAuthIssuerValidationResult & { electron?: boolean; redirectWasScheme?: boolean } {
   if (!state) {
     return {
       valid: false,
@@ -279,14 +324,16 @@ export function validateAndConsumeOAuthErrorResponse(
     }
   }
 
+  const delivery = flowDeliveryFlags(flow)
+
   const validation = validateAuthorizationResponseIssuer(flow, iss)
   if (!validation.valid) {
     console.error('[mcp/oauth] Authorization error issuer validation failed:', validation.error)
-    return validation
+    return { ...validation, ...delivery }
   }
 
   pendingOAuthFlows.delete(state)
-  return { valid: true }
+  return { valid: true, ...delivery }
 }
 
 /**
@@ -296,7 +343,8 @@ export function validateAndConsumeOAuthErrorResponse(
 export async function initiateOAuthFlow(
   mcpId: string,
   mcpUrl: string,
-  redirectUri: string,
+  redirectCandidates: string[],
+  electron = false,
   clientNameOverride?: string,
   clientIdOverride?: string,
   clientSecretOverride?: string,
@@ -317,10 +365,14 @@ export async function initiateOAuthFlow(
     return null
   }
 
-  // Resolve client credentials: explicit override > stored > dynamic registration.
+  // Resolve client credentials: explicit override > dynamic registration > stored.
   let clientId: string | undefined
   let clientSecret: string | undefined
   let registeredScope: string | undefined
+  // Redirect actually used on the authorization + token requests. Defaults to the
+  // preferred candidate; dynamic registration may switch it to a fallback the AS
+  // accepts (e.g. an http loopback URL when the custom app scheme is rejected).
+  let redirectUri = redirectCandidates[0]
 
   // Check if we already have client credentials stored
   const [existing] = await db
@@ -332,20 +384,29 @@ export async function initiateOAuthFlow(
   if (clientIdOverride) {
     clientId = clientIdOverride
     clientSecret = clientSecretOverride || undefined
-  } else if (existing?.oauthClientId) {
-    clientId = existing.oauthClientId
-    clientSecret = existing.oauthClientSecret || undefined
   } else if (metadata.registration_endpoint) {
-    const registration = await registerDynamicClient(
+    // Prefer a fresh dynamic registration over a stored client_id on re-auth: it
+    // self-heals which redirect the AS accepts (custom scheme vs http loopback)
+    // and re-binds to the current loopback port, so a client first registered
+    // against a rejected scheme or a stale port doesn't break reconnection.
+    const registration = await registerDynamicClientWithFallback(
       metadata.registration_endpoint,
-      redirectUri,
+      redirectCandidates,
       clientNameOverride && clientNameOverride.length > 0 ? clientNameOverride : 'Superagent',
     )
     if (registration) {
       clientId = registration.clientId
       clientSecret = registration.clientSecret
       registeredScope = registration.scope
+      redirectUri = registration.redirectUri
+    } else if (existing?.oauthClientId) {
+      // Registration failed unexpectedly — fall back to the stored client.
+      clientId = existing.oauthClientId
+      clientSecret = existing.oauthClientSecret || undefined
     }
+  } else if (existing?.oauthClientId) {
+    clientId = existing.oauthClientId
+    clientSecret = existing.oauthClientSecret || undefined
   }
 
   if (!clientId) {
@@ -381,6 +442,7 @@ export async function initiateOAuthFlow(
     clientId,
     clientSecret,
     mcpId,
+    electron,
   })
 
   // Build authorization URL
@@ -426,7 +488,8 @@ export async function initiateOAuthFlow(
 export async function initiateNewServerOAuth(
   mcpUrl: string,
   name: string,
-  redirectUri: string,
+  redirectCandidates: string[],
+  electron = false,
   userId?: string,
   clientNameOverride?: string,
   clientIdOverride?: string,
@@ -449,20 +512,25 @@ export async function initiateNewServerOAuth(
   let clientId: string | undefined
   let clientSecret: string | undefined
   let registeredScope: string | undefined
+  // Redirect actually used on the authorization + token requests. Defaults to the
+  // preferred candidate; dynamic registration may switch it to a fallback the AS
+  // accepts (e.g. an http loopback URL when the custom app scheme is rejected).
+  let redirectUri = redirectCandidates[0]
 
   if (clientIdOverride) {
     clientId = clientIdOverride
     clientSecret = clientSecretOverride || undefined
   } else if (metadata.registration_endpoint) {
-    const registration = await registerDynamicClient(
+    const registration = await registerDynamicClientWithFallback(
       metadata.registration_endpoint,
-      redirectUri,
+      redirectCandidates,
       clientNameOverride && clientNameOverride.length > 0 ? clientNameOverride : 'Superagent',
     )
     if (registration) {
       clientId = registration.clientId
       clientSecret = registration.clientSecret
       registeredScope = registration.scope
+      redirectUri = registration.redirectUri
     }
   }
 
@@ -486,6 +554,7 @@ export async function initiateNewServerOAuth(
     clientSecret,
     newServer: { name, url: mcpUrl },
     userId,
+    electron,
   })
 
   let authUrl: URL
@@ -528,17 +597,23 @@ export async function completeOAuthFlow(
   state: string,
   code: string,
   iss?: string | null,
-): Promise<{ success: boolean; mcpId?: string }> {
+): Promise<{ success: boolean; mcpId?: string; electron?: boolean; redirectWasScheme?: boolean }> {
   const flow = pendingOAuthFlows.get(state)
   if (!flow) {
     console.error('[mcp/oauth] No pending flow for state:', state)
     return { success: false }
   }
 
+  // How the callback route should hand the result back: the custom app scheme
+  // path is fetched+parsed by the Electron main process (parseable HTML), while
+  // the http loopback path is loaded in the external browser (needs a hand-off
+  // back to the app).
+  const { electron, redirectWasScheme } = flowDeliveryFlags(flow)
+
   const issuerValidation = validateAuthorizationResponseIssuer(flow, iss)
   if (!issuerValidation.valid) {
     console.error('[mcp/oauth] Authorization response issuer validation failed:', issuerValidation.error)
-    return { success: false }
+    return { success: false, electron, redirectWasScheme }
   }
 
   pendingOAuthFlows.delete(state)
@@ -565,7 +640,7 @@ export async function completeOAuthFlow(
     if (!res.ok) {
       const errorBody = await res.text()
       console.error('[mcp/oauth] Token exchange failed:', res.status, errorBody)
-      return { success: false }
+      return { success: false, electron, redirectWasScheme }
     }
 
     const tokens: OAuthTokenResponse = await res.json()
@@ -594,7 +669,7 @@ export async function completeOAuthFlow(
         createdAt: now,
         updatedAt: now,
       })
-      return { success: true, mcpId: id }
+      return { success: true, mcpId: id, electron, redirectWasScheme }
     } else if (flow.mcpId) {
       // Existing server: UPDATE with tokens
       await db
@@ -608,13 +683,13 @@ export async function completeOAuthFlow(
           updatedAt: now,
         })
         .where(eq(remoteMcpServers.id, flow.mcpId))
-      return { success: true, mcpId: flow.mcpId }
+      return { success: true, mcpId: flow.mcpId, electron, redirectWasScheme }
     }
 
-    return { success: false }
+    return { success: false, electron, redirectWasScheme }
   } catch (error) {
     console.error('[mcp/oauth] Token exchange error:', error)
-    return { success: false }
+    return { success: false, electron, redirectWasScheme }
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes **SUP-350** — adding an OAuth remote MCP server in the **Electron** app failed with **"Failed to initiate OAuth flow"** for spec-strict authorization servers (repro: Cal.com, `https://mcp.cal.com/mcp`).

**Root cause:** In Electron we built the OAuth `redirect_uri` as the custom app scheme `superagent://mcp-oauth-callback`. Servers that follow RFC 7591 dynamic client registration strictly reject any non-`http(s)` redirect at registration (Cal.com: `400 … "only http and https are allowed"`), so `registerDynamicClient` → `null` → `initiateNewServerOAuth` → `null` → the route returned `500 "Failed to initiate OAuth flow"`. The web app was unaffected (it already uses an `https` callback).

Verified live: DCR with `superagent://…` → `400`; with `http://localhost:47891/api/remote-mcps/oauth-callback` → `201`.

## Approach — adaptive redirect with loopback fallback (no migration)

Detect the need for a loopback redirect **at registration time** and fall back automatically, per flow. The custom scheme stays the Electron default; the http loopback is used **only** when DCR with the scheme is rejected. Self-detecting, so there's no persisted "mode" column.

- **`src/api/routes/remote-mcps.ts`** — `POST /initiate-oauth` now passes **ordered redirect candidates**: Electron = `[superagent://mcp-oauth-callback, http-loopback]`, web = `[https-callback]`. The loopback base comes from `new URL(c.req.url).origin` (**not** `getAppBaseUrlFromRequest`) because the packaged renderer is served from `file://`, so its API fetches carry `Origin: null`.
- **`src/shared/lib/mcp/oauth.ts`** — `initiateOAuthFlow` / `initiateNewServerOAuth` accept `redirectCandidates: string[]`; a new `registerDynamicClientWithFallback` tries each candidate in order and returns the winning `redirect_uri`, which is then used for the authorization request, the token exchange, and the stored pending flow. `completeOAuthFlow` / `validateAndConsumeOAuthErrorResponse` return `{ electron, redirectWasScheme }` so the callback route can pick the right response.
  - **Re-auth self-heal:** on reconnect, DCR-capable servers re-run the candidate fallback instead of blindly reusing a stored `client_id`, so a client first registered against a rejected scheme (or a stale port) doesn't wedge reconnection. Non-DCR servers keep the stored client.
- **`src/api/routes/remote-mcps.ts`** (callback) — for the Electron **loopback** path the callback loads in the **external browser**, so the route renders a small hand-off page that bounces the result back into the app via `superagent://mcp-oauth-callback?success=…&mcpId=…`. Web and the Electron **custom-scheme** path keep the existing postMessage/BroadcastChannel/localStorage bridge.
- **`src/main/index.ts`** — the deep-link handler keys on `params.has('success')`: the hand-off page always sets it → notify the renderer directly (no second exchange); the custom-scheme `code`/`state` path is unchanged (still re-fetches to complete the exchange).

## Validation

- **Unit/route tests:** `oauth.test.ts` (49) + `remote-mcps.test.ts` (55) → **104 passing**, incl. new cases for scheme-rejected→loopback fallback, scheme-accepted (no fallback), the delivery flags, redirect-candidate construction, and the external-browser hand-off.
- **Typecheck + lint:** `tsc --noEmit` clean; eslint clean on changed files.
- **Live repro:** Cal.com DCR rejects `superagent://` (400), accepts loopback (201); post-fix `initiate` returns a valid auth URL and reaches the Cal.com consent screen.
- **Catalog-wide probe of the 27 loopback-only servers:** all **27/27** pass the real production initiate path → the authorization URL uses the loopback redirect → the authorization endpoint accepts our registered client (PKCE S256 + RFC 8707 `resource`) through to a live login/consent page. The 88 already-working (scheme-ok) servers are unchanged (scheme tried first, wins).

## Not in scope

- Persisting a redirect-mode column / migration (avoided via self-detection).
- The 9 "neither" servers (reject the scheme *and* have no usable DCR) and the no-DCR servers — a separate, unrelated class.

## Manual test

`npm run dev:electron` → add a custom MCP server (Name = Cal.com, Auth = OAuth, URL = `https://mcp.cal.com/mcp`) → Connect → external browser opens the Cal.com consent screen (no more "Failed to initiate OAuth flow") → approve → the app is notified and the server appears connected with its tools.
