### PR TITLE
Harden awaiting-input and proxy-review E2E flows

### DIFF
--- a/e2e/helpers/agents.ts
+++ b/e2e/helpers/agents.ts
@@ -15,6 +15,24 @@ export interface TestMessage {
   content?: unknown
 }
 
+export interface TestPendingProxyReview {
+  id: string
+  agentSlug: string
+  accountId: string
+  toolkit: string
+  method: string
+  targetPath: string
+  matchedScopes: string[]
+  scopeDescriptions: Record<string, string>
+  displayText?: string
+  xAgent?: {
+    targetAgentSlug: string
+    targetAgentName: string
+    operation: 'list' | 'read' | 'invoke' | 'create'
+    preview?: string
+  }
+}
+
 export function uniqueSuffix(
   testInfo: Pick<TestInfo, 'workerIndex' | 'repeatEachIndex' | 'retry'>,
 ) {
@@ -34,11 +52,22 @@ export function uniqueName(
   return `${label} ${uniqueSuffix(testInfo)}`
 }
 
+async function retryablePollRead<T>(
+  read: () => Promise<T>,
+  fallback: T,
+): Promise<T> {
+  try {
+    return await read()
+  } catch {
+    return fallback
+  }
+}
+
 async function expectAgentInApi(
   request: APIRequestContext,
   agent: Pick<TestAgent, 'slug' | 'name'>,
 ) {
-  await expect.poll(async () => {
+  await expect.poll(() => retryablePollRead(async () => {
     const response = await request.get('/api/agents')
     if (!response.ok()) return false
 
@@ -46,7 +75,7 @@ async function expectAgentInApi(
     return agents.some((candidate) => (
       candidate.slug === agent.slug && candidate.name === agent.name
     ))
-  }, { timeout: 15000 }).toBe(true)
+  }, false), { timeout: 15000 }).toBe(true)
 }
 
 export function getAgentItem(page: Page, agent: Pick<TestAgent, 'slug' | 'name'>) {
@@ -76,16 +105,32 @@ export async function findAgentByName(
 ): Promise<TestAgent> {
   let found: TestAgent | undefined
 
-  await expect.poll(async () => {
+  await expect.poll(() => retryablePollRead(async () => {
     const response = await request.get('/api/agents')
     if (!response.ok()) return false
 
     const agents = await response.json() as TestAgent[]
     found = agents.find((agent) => agent.name === name)
     return Boolean(found)
-  }, { timeout: 15000 }).toBe(true)
+  }, false), { timeout: 15000 }).toBe(true)
 
   return found!
+}
+
+export async function waitForCurrentSessionId(page: Page): Promise<Pick<TestSession, 'id'>> {
+  let sessionId: string | undefined
+
+  await expect.poll(() => {
+    try {
+      const match = new URL(page.url()).pathname.match(/\/sessions\/([^/]+)/)
+      sessionId = match?.[1]
+    } catch {
+      sessionId = undefined
+    }
+    return Boolean(sessionId)
+  }, { timeout: 15000 }).toBe(true)
+
+  return { id: sessionId! }
 }
 
 export async function expectAgentNamed(
@@ -95,16 +140,61 @@ export async function expectAgentNamed(
 ): Promise<TestAgent> {
   let found: TestAgent | undefined
 
-  await expect.poll(async () => {
+  await expect.poll(() => retryablePollRead(async () => {
     const response = await request.get('/api/agents')
     if (!response.ok()) return undefined
 
     const agents = await response.json() as TestAgent[]
     found = agents.find((candidate) => candidate.slug === agent.slug)
     return found?.name
-  }, { timeout: 15000 }).toBe(name)
+  }, undefined as string | undefined), { timeout: 15000 }).toBe(name)
 
   return found!
+}
+
+export async function waitForPendingProxyReview(
+  request: APIRequestContext,
+  agent: Pick<TestAgent, 'slug'>,
+  options: {
+    xAgent?: boolean
+    toolkit?: string
+    targetPath?: string
+    matchedScope?: string
+  } = {},
+): Promise<TestPendingProxyReview> {
+  let found: TestPendingProxyReview | undefined
+
+  await expect.poll(() => retryablePollRead(async () => {
+    const response = await request.get(`/api/agents/${agent.slug}/proxy-reviews`)
+    if (!response.ok()) return false
+
+    const body = await response.json() as { reviews?: TestPendingProxyReview[] }
+    found = (body.reviews ?? []).find((review) => {
+      if (options.xAgent !== undefined && Boolean(review.xAgent) !== options.xAgent) return false
+      if (options.toolkit && review.toolkit !== options.toolkit) return false
+      if (options.targetPath && review.targetPath !== options.targetPath) return false
+      if (options.matchedScope && !review.matchedScopes.includes(options.matchedScope)) return false
+      return true
+    })
+
+    return Boolean(found)
+  }, false), { timeout: 15000 }).toBe(true)
+
+  return found!
+}
+
+export async function expectPendingProxyReviewResolved(
+  request: APIRequestContext,
+  agent: Pick<TestAgent, 'slug'>,
+  review: Pick<TestPendingProxyReview, 'id'>,
+) {
+  await expect.poll(() => retryablePollRead(async () => {
+    const response = await request.get(`/api/agents/${agent.slug}/proxy-reviews`)
+    if (!response.ok()) return false
+
+    const body = await response.json() as { reviews?: TestPendingProxyReview[] }
+    return !(body.reviews ?? []).some((candidate) => candidate.id === review.id)
+  }, false), { timeout: 15000 }).toBe(true)
 }
 
 export async function deleteAgentViaApi(
@@ -119,13 +209,13 @@ export async function expectAgentDeleted(
   request: APIRequestContext,
   agent: Pick<TestAgent, 'slug'>,
 ) {
-  await expect.poll(async () => {
+  await expect.poll(() => retryablePollRead(async () => {
     const response = await request.get('/api/agents')
     if (!response.ok()) return false
 
     const agents = await response.json() as TestAgent[]
     return !agents.some((candidate) => candidate.slug === agent.slug)
-  }, { timeout: 15000 }).toBe(true)
+  }, false), { timeout: 15000 }).toBe(true)
 }
 
 export async function createSession(
@@ -142,13 +232,13 @@ export async function createSession(
   expect(session.id).toBeTruthy()
   expect(session.name).toBeTruthy()
 
-  await expect.poll(async () => {
+  await expect.poll(() => retryablePollRead(async () => {
     const sessionsResponse = await request.get(`/api/agents/${agent.slug}/sessions`)
     if (!sessionsResponse.ok()) return false
 
     const sessions = await sessionsResponse.json() as TestSession[]
     return sessions.some((candidate) => candidate.id === session.id)
-  }, { timeout: 15000 }).toBe(true)
+  }, false), { timeout: 15000 }).toBe(true)
 
   return session
 }
@@ -171,14 +261,14 @@ export async function expectSessionNamed(
 ): Promise<TestSession> {
   let found: TestSession | undefined
 
-  await expect.poll(async () => {
+  await expect.poll(() => retryablePollRead(async () => {
     const response = await request.get(`/api/agents/${agent.slug}/sessions`)
     if (!response.ok()) return undefined
 
     const sessions = await response.json() as TestSession[]
     found = sessions.find((candidate) => candidate.id === session.id)
     return found?.name
-  }, { timeout: 15000 }).toBe(name)
+  }, undefined as string | undefined), { timeout: 15000 }).toBe(name)
 
   return found!
 }
@@ -214,7 +304,7 @@ export async function findSessionWithUserMessage(
 ): Promise<TestSession> {
   let found: TestSession | undefined
 
-  await expect.poll(async () => {
+  await expect.poll(() => retryablePollRead(async () => {
     const sessionsResponse = await request.get(`/api/agents/${agent.slug}/sessions`)
     if (!sessionsResponse.ok()) return false
 
@@ -231,7 +321,7 @@ export async function findSessionWithUserMessage(
     }
 
     return false
-  }, { timeout: 15000 }).toBe(true)
+  }, false), { timeout: 15000 }).toBe(true)
 
   return found!
 }
@@ -241,14 +331,14 @@ export async function waitForSessionIdle(
   agent: Pick<TestAgent, 'slug'>,
   session: Pick<TestSession, 'id'>,
 ) {
-  await expect.poll(async () => {
+  await expect.poll(() => retryablePollRead(async () => {
     const response = await request.get(`/api/agents/${agent.slug}/sessions`)
     if (!response.ok()) return false
 
     const sessions = await response.json() as Array<TestSession & { isActive?: boolean }>
     const current = sessions.find((candidate) => candidate.id === session.id)
     return current ? current.isActive === false : false
-  }, { timeout: 15000 }).toBe(true)
+  }, false), { timeout: 15000 }).toBe(true)
 }
 
 export async function openAgentHome(page: Page, agent: Pick<TestAgent, 'slug' | 'name'>) {

--- a/e2e/pages/session.page.ts
+++ b/e2e/pages/session.page.ts
@@ -275,8 +275,8 @@ export class SessionPage {
     }
   }
 
-  private async waitForVisibleRequestCard(testId: string, timeout = 15000) {
-    const card = this.page.locator(`[data-testid="${testId}"]`).first()
+  private async waitForVisibleRequestCard(testId: string, timeout = 15000, card?: Locator) {
+    card ??= this.page.locator(`[data-testid="${testId}"]`).first()
     await expect(card).toBeAttached({ timeout })
 
     await expect.poll(async () => {
@@ -464,19 +464,27 @@ export class SessionPage {
     await this.waitForVisibleRequestCard('proxy-review-request', timeout)
   }
 
-  getProxyReviewRequests() {
-    return this.page.locator('[data-testid="proxy-review-request"]')
+  async waitForProxyReviewRequestById(reviewId: string, timeout = 15000) {
+    await this.waitForVisibleRequestCard('proxy-review-request', timeout, this.getProxyReviewRequests(reviewId))
   }
 
-  async allowProxyReview() {
-    const container = this.page.locator('[data-testid="proxy-review-request"]').first()
+  getProxyReviewRequests(reviewId?: string) {
+    return reviewId
+      ? this.page.locator(`[data-testid="proxy-review-request"][data-review-id="${reviewId}"]`)
+      : this.page.locator('[data-testid="proxy-review-request"]')
+  }
+
+  async allowProxyReview(reviewId?: string) {
+    const container = this.getProxyReviewRequests(reviewId).first()
+    await this.paginateToCard(container)
     // The Allow button is now a popover — click it to open, then click "Allow Once"
     await container.locator('[data-testid="proxy-review-always-allow-btn"]').click()
     await this.page.locator('[data-testid="proxy-review-allow-once-menu-btn"]').click()
   }
 
-  async denyProxyReview() {
-    const container = this.page.locator('[data-testid="proxy-review-request"]').first()
+  async denyProxyReview(reviewId?: string) {
+    const container = this.getProxyReviewRequests(reviewId).first()
+    await this.paginateToCard(container)
     await container.locator('[data-testid="proxy-review-deny-btn"]').click()
   }
 
@@ -486,28 +494,32 @@ export class SessionPage {
     ).toBeVisible({ timeout })
   }
 
-  async alwaysAllowScope(scope: string) {
-    const container = this.page.locator('[data-testid="proxy-review-request"]').first()
+  async alwaysAllowScope(scope: string, reviewId?: string) {
+    const container = this.getProxyReviewRequests(reviewId).first()
+    await this.paginateToCard(container)
     // Open the Allow popover, expand the per-scope disclosure, then click "Always allow <scope>"
     await container.locator('[data-testid="proxy-review-always-allow-btn"]').click()
     await this.page.locator('[data-testid="proxy-review-specific-scope-toggle"]').click()
     await this.page.locator(`[data-testid="proxy-review-always-allow-${scope}"]`).click()
   }
 
-  async alwaysAllowLabelGroup(label: 'read' | 'write' | 'destructive') {
-    const container = this.page.locator('[data-testid="proxy-review-request"]').first()
+  async alwaysAllowLabelGroup(label: 'read' | 'write' | 'destructive', reviewId?: string) {
+    const container = this.getProxyReviewRequests(reviewId).first()
+    await this.paginateToCard(container)
     // Open the Allow popover, then click the minimal risk-group "Allow all <label>" option
     await container.locator('[data-testid="proxy-review-always-allow-btn"]').click()
     await this.page.locator(`[data-testid="proxy-review-allow-label-${label}"]`).click()
   }
 
-  async alwaysDenyScope(scope: string) {
-    const container = this.page.locator('[data-testid="proxy-review-request"]').first()
+  async alwaysDenyScope(scope: string, reviewId?: string) {
+    const container = this.getProxyReviewRequests(reviewId).first()
+    await this.paginateToCard(container)
     await container.locator(`[data-testid="proxy-review-always-deny-${scope}"]`).click()
   }
 
-  async alwaysAllowAll() {
-    const container = this.page.locator('[data-testid="proxy-review-request"]').first()
+  async alwaysAllowAll(reviewId?: string) {
+    const container = this.getProxyReviewRequests(reviewId).first()
+    await this.paginateToCard(container)
     await container.locator('[data-testid="proxy-review-always-allow-all"]').click()
   }
 
@@ -517,21 +529,35 @@ export class SessionPage {
     await this.waitForVisibleRequestCard('xagent-review-request', timeout)
   }
 
-  getXAgentReviewRequests() {
-    return this.page.locator('[data-testid="xagent-review-request"]')
+  async waitForXAgentReviewRequestById(reviewId: string, timeout = 15000) {
+    await this.waitForVisibleRequestCard('xagent-review-request', timeout, this.getXAgentReviewRequests(reviewId))
   }
 
-  async allowXAgentReview() {
-    const container = this.page.locator('[data-testid="xagent-review-request"]').first()
+  getXAgentReviewRequests(reviewId?: string) {
+    return reviewId
+      ? this.page.locator(`[data-testid="xagent-review-request"][data-review-id="${reviewId}"]`)
+      : this.page.locator('[data-testid="xagent-review-request"]')
+  }
+
+  async allowXAgentReview(reviewId?: string) {
+    const container = this.getXAgentReviewRequests(reviewId).first()
+    await this.paginateToCard(container)
     await container.locator('[data-testid="xagent-review-allow-once-btn"]').click()
   }
 
-  async denyXAgentReview() {
-    const container = this.page.locator('[data-testid="xagent-review-request"]').first()
+  async denyXAgentReview(reviewId?: string) {
+    const container = this.getXAgentReviewRequests(reviewId).first()
+    await this.paginateToCard(container)
     await container.locator('[data-testid="xagent-review-deny-btn"]').click()
   }
 
-  async stopSessionFromRequest() {
+  async stopSessionFromRequest(container?: Locator) {
+    if (container) {
+      await this.paginateToCard(container)
+      await container.locator('[data-testid="request-stop-session"]').click()
+      return
+    }
+
     await this.page.locator('[data-testid="request-stop-session"]').first().click()
   }
 

--- a/e2e/pages/session.page.ts
+++ b/e2e/pages/session.page.ts
@@ -553,8 +553,9 @@ export class SessionPage {
 
   async stopSessionFromRequest(container?: Locator) {
     if (container) {
-      await this.paginateToCard(container)
-      await container.locator('[data-testid="request-stop-session"]').click()
+      const target = container.first()
+      await this.paginateToCard(target)
+      await target.locator('[data-testid="request-stop-session"]').click()
       return
     }
 

--- a/e2e/specs/awaiting-input-status.spec.ts
+++ b/e2e/specs/awaiting-input-status.spec.ts
@@ -1,29 +1,72 @@
-import { test, expect } from '@playwright/test'
-import { AppPage } from '../pages/app.page'
+import { test, expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
+import {
+  createAgent,
+  findSessionWithUserMessage,
+  getAgentItem,
+  gotoAgentHome,
+  uniqueName,
+  uniqueSuffix,
+  type TestAgent,
+  type TestSession,
+} from '../helpers/agents'
 
 test.describe('Awaiting Input Status', () => {
-  let appPage: AppPage
   let agentPage: AgentPage
   let sessionPage: SessionPage
-  let testAgentName: string
+  let agent: TestAgent
 
-  test.beforeEach(async ({ page }, testInfo) => {
-    appPage = new AppPage(page)
+  test.describe.configure({ timeout: 45000 })
+
+  test.beforeEach(async ({ page, request }, testInfo) => {
     agentPage = new AgentPage(page)
     sessionPage = new SessionPage(page)
 
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
-
-    testAgentName = `Status Agent ${testInfo.workerIndex}-${Date.now()}`
-    await agentPage.createAgent(testAgentName)
+    agent = await createAgent(request, uniqueName(testInfo, 'Status Agent'))
+    await gotoAgentHome(page, agent)
   })
 
-  test('agent status shows awaiting_input during secret request', async () => {
+  async function sendScenarioMessage(
+    page: Page,
+    request: APIRequestContext,
+    testInfo: TestInfo,
+    trigger: string,
+  ): Promise<TestSession> {
+    const message = `${trigger} ${uniqueSuffix(testInfo)}`
+    await sessionPage.sendMessage(message)
+    const session = await findSessionWithUserMessage(request, agent, message)
+
+    await expect.poll(() => page.url().includes(session.id), { timeout: 15000 }).toBe(true)
+
+    return session
+  }
+
+  async function resolveActiveParallelRequest(secretAction: 'provide' | 'decline') {
+    const active = await sessionPage.getActiveRequestType()
+
+    if (active === 'secret') {
+      if (secretAction === 'provide') {
+        await sessionPage.provideSecret('postgres://localhost:5432/db', 'DATABASE_URL')
+      } else {
+        await sessionPage.declineSecret('DATABASE_URL')
+      }
+      await expect(sessionPage.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
+      return 'secret' as const
+    }
+
+    if (active === 'question') {
+      await sessionPage.answerQuestion('AWS')
+      await expect(sessionPage.getQuestionRequests()).toHaveCount(0, { timeout: 10000 })
+      return 'question' as const
+    }
+
+    throw new Error(`Expected an active request card, found ${active}`)
+  }
+
+  test('agent status shows awaiting_input during secret request', async ({ page, request }, testInfo) => {
     // "ask secret" triggers UserInputRequestScenario with mcp__user-input__request_secret
-    await sessionPage.sendMessage('ask secret')
+    await sendScenarioMessage(page, request, testInfo, 'ask secret')
 
     // Wait for the secret request UI to appear
     await sessionPage.waitForSecretRequest('OPENAI_API_KEY')
@@ -46,8 +89,8 @@ test.describe('Awaiting Input Status', () => {
     await agentPage.waitForStatus('idle', 15000)
   })
 
-  test('agent status shows awaiting_input during question request', async () => {
-    await sessionPage.sendMessage('ask question')
+  test('agent status shows awaiting_input during question request', async ({ page, request }, testInfo) => {
+    await sendScenarioMessage(page, request, testInfo, 'ask question')
 
     await sessionPage.waitForQuestionRequest()
 
@@ -64,33 +107,30 @@ test.describe('Awaiting Input Status', () => {
     await agentPage.waitForStatus('idle', 15000)
   })
 
-  test('parallel requests: status stays awaiting_input until all resolved', async ({ page }) => {
+  test('parallel requests: status stays awaiting_input until all resolved', async ({ page, request }, testInfo) => {
     // "ask parallel" triggers secret + question simultaneously
-    await sessionPage.sendMessage('ask parallel')
+    await sendScenarioMessage(page, request, testInfo, 'ask parallel')
 
     // Both requests end up stacked (only one visible at a time). Wait for both to exist.
-    const secretReq = page.locator('[data-testid="secret-request"][data-secret-name="DATABASE_URL"]')
-    await expect(secretReq).toBeAttached({ timeout: 15000 })
-    await expect(sessionPage.getQuestionRequests().first()).toBeAttached({ timeout: 15000 })
+    await sessionPage.waitForSecretRequest('DATABASE_URL', 20000)
+    await sessionPage.waitForQuestionRequest(20000)
 
     // Status should be awaiting_input
     await agentPage.waitForStatus('awaiting_input', 15000)
 
-    // Whichever request is visible in the stack gets resolved first; order is timing-dependent.
-    const secretVisibleFirst = await secretReq.isVisible()
-    if (secretVisibleFirst) {
-      await sessionPage.provideSecret('postgres://localhost:5432/db', 'DATABASE_URL')
-      await expect(sessionPage.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
-      // Question should now be the active (visible) card
+    // Resolve whichever card is visible first. The agent must still be awaiting
+    // input until the second card is also resolved.
+    const firstResolved = await resolveActiveParallelRequest('provide')
+    if (firstResolved === 'secret') {
+      await expect(sessionPage.getQuestionRequests()).toHaveCount(1, { timeout: 10000 })
       await expect(sessionPage.getQuestionRequests().first()).toBeVisible()
-      await sessionPage.answerQuestion('AWS')
     } else {
-      await sessionPage.answerQuestion('AWS')
-      await expect(sessionPage.getQuestionRequests()).toHaveCount(0, { timeout: 10000 })
-      // Secret should now be the active (visible) card
-      await expect(secretReq).toBeVisible()
-      await sessionPage.provideSecret('postgres://localhost:5432/db', 'DATABASE_URL')
+      await expect(sessionPage.getSecretRequests()).toHaveCount(1, { timeout: 10000 })
+      await expect(sessionPage.getSecretRequests().first()).toBeVisible()
     }
+    await agentPage.waitForStatus('awaiting_input', 15000)
+
+    await resolveActiveParallelRequest('provide')
 
     await expect(sessionPage.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
     await expect(sessionPage.getQuestionRequests()).toHaveCount(0, { timeout: 10000 })
@@ -100,8 +140,8 @@ test.describe('Awaiting Input Status', () => {
     await agentPage.waitForStatus('idle', 15000)
   })
 
-  test('declined input clears awaiting_input status', async () => {
-    await sessionPage.sendMessage('ask secret')
+  test('declined input clears awaiting_input status', async ({ page, request }, testInfo) => {
+    await sendScenarioMessage(page, request, testInfo, 'ask secret')
 
     await sessionPage.waitForSecretRequest('OPENAI_API_KEY')
     await agentPage.waitForStatus('awaiting_input', 15000)
@@ -116,20 +156,25 @@ test.describe('Awaiting Input Status', () => {
     await agentPage.waitForStatus('idle', 15000)
   })
 
-  test('sidebar session shows question mark icon when awaiting input', async ({ page }) => {
-    await sessionPage.sendMessage('ask secret')
+  test('sidebar session shows question mark icon when awaiting input', async ({ page, request }, testInfo) => {
+    const session = await sendScenarioMessage(page, request, testInfo, 'ask secret')
 
     await sessionPage.waitForSecretRequest('OPENAI_API_KEY')
 
-    // The sidebar session sub-item should have a CircleHelp icon (question mark)
-    const sidebar = page.locator('[data-testid="app-sidebar"]')
-    const sessionItems = sidebar.locator('[data-testid^="session-item-"]')
+    const agentItem = getAgentItem(page, agent)
+    await expect(agentItem).toBeVisible({ timeout: 10000 })
 
-    // At least one session item should exist
-    await expect(sessionItems.first()).toBeVisible({ timeout: 10000 })
+    const agentLi = agentItem.locator('xpath=ancestor::li[1]')
+    const expandChevron = agentLi.locator('button[aria-label="Expand"]').first()
+    if (await expandChevron.isVisible({ timeout: 500 }).catch(() => false)) {
+      await expandChevron.click()
+    }
 
-    // The session item should contain the "needs input" indicator (orange pulsing dot)
-    const awaitingIndicator = sessionItems.first().getByRole('img', { name: 'needs input' })
+    const sessionItem = page.locator(`[data-testid="session-item-${session.id}"]`)
+    await expect(sessionItem).toBeVisible({ timeout: 15000 })
+
+    // The exact session item should contain the "needs input" indicator.
+    const awaitingIndicator = sessionItem.getByRole('img', { name: 'needs input' })
     await expect(awaitingIndicator).toBeVisible({ timeout: 10000 })
   })
 })

--- a/e2e/specs/awaiting-input-status.spec.ts
+++ b/e2e/specs/awaiting-input-status.spec.ts
@@ -42,15 +42,11 @@ test.describe('Awaiting Input Status', () => {
     return session
   }
 
-  async function resolveActiveParallelRequest(secretAction: 'provide' | 'decline') {
+  async function resolveActiveParallelRequest() {
     const active = await sessionPage.getActiveRequestType()
 
     if (active === 'secret') {
-      if (secretAction === 'provide') {
-        await sessionPage.provideSecret('postgres://localhost:5432/db', 'DATABASE_URL')
-      } else {
-        await sessionPage.declineSecret('DATABASE_URL')
-      }
+      await sessionPage.provideSecret('postgres://localhost:5432/db', 'DATABASE_URL')
       await expect(sessionPage.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
       return 'secret' as const
     }
@@ -120,7 +116,7 @@ test.describe('Awaiting Input Status', () => {
 
     // Resolve whichever card is visible first. The agent must still be awaiting
     // input until the second card is also resolved.
-    const firstResolved = await resolveActiveParallelRequest('provide')
+    const firstResolved = await resolveActiveParallelRequest()
     if (firstResolved === 'secret') {
       await expect(sessionPage.getQuestionRequests()).toHaveCount(1, { timeout: 10000 })
       await expect(sessionPage.getQuestionRequests().first()).toBeVisible()
@@ -130,7 +126,7 @@ test.describe('Awaiting Input Status', () => {
     }
     await agentPage.waitForStatus('awaiting_input', 15000)
 
-    await resolveActiveParallelRequest('provide')
+    await resolveActiveParallelRequest()
 
     await expect(sessionPage.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
     await expect(sessionPage.getQuestionRequests()).toHaveCount(0, { timeout: 10000 })

--- a/e2e/specs/proxy-review.spec.ts
+++ b/e2e/specs/proxy-review.spec.ts
@@ -1,102 +1,146 @@
-import { test, expect } from '@playwright/test'
-import { AppPage } from '../pages/app.page'
-import { AgentPage } from '../pages/agent.page'
+import { test, expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
 import { SessionPage } from '../pages/session.page'
+import {
+  createAgent,
+  expectPendingProxyReviewResolved,
+  gotoAgentHome,
+  uniqueName,
+  uniqueSuffix,
+  waitForCurrentSessionId,
+  waitForPendingProxyReview,
+  type TestAgent,
+  type TestPendingProxyReview,
+  type TestSession,
+} from '../helpers/agents'
 
 
 test.describe('Proxy Review Requests', () => {
-  let appPage: AppPage
-  let agentPage: AgentPage
   let sessionPage: SessionPage
-  let testAgentName: string
+  let agent: TestAgent
 
-  test.beforeEach(async ({ page }, testInfo) => {
-    appPage = new AppPage(page)
-    agentPage = new AgentPage(page)
+  test.describe.configure({ timeout: 60000 })
+
+  test.beforeEach(async ({ page, request }, testInfo) => {
     sessionPage = new SessionPage(page)
 
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
-
-    // Use unique agent name per test
-    testAgentName = `Review Agent ${testInfo.workerIndex}-${Date.now()}`
-    await agentPage.createAgent(testAgentName)
+    agent = await createAgent(request, uniqueName(testInfo, 'Review Agent'))
+    await gotoAgentHome(page, agent)
   })
 
-  test('proxy review: review prompt appears with correct details', async () => {
+  async function sendReviewScenario(
+    page: Page,
+    request: APIRequestContext,
+    testInfo: TestInfo,
+    trigger: string,
+    options: Parameters<typeof waitForPendingProxyReview>[2],
+  ): Promise<{ session: Pick<TestSession, 'id'>; review: TestPendingProxyReview }> {
+    await sessionPage.sendMessage(`${trigger} ${uniqueSuffix(testInfo)}`)
+    const session = await waitForCurrentSessionId(page)
+    const review = await waitForPendingProxyReview(request, agent, options)
+    return { session, review }
+  }
+
+  test('proxy review: review prompt appears with correct details', async ({ page, request }, testInfo) => {
     // "proxy review" triggers ProxyReviewScenario
-    await sessionPage.sendMessage('proxy review')
+    const { review } = await sendReviewScenario(page, request, testInfo, 'proxy review', {
+      xAgent: false,
+      toolkit: 'slack',
+      targetPath: 'api/chat.postMessage',
+      matchedScope: 'chat:write',
+    })
 
     // Wait for the review prompt to appear
-    await sessionPage.waitForProxyReviewRequest(35000)
+    await sessionPage.waitForProxyReviewRequestById(review.id, 35000)
 
     // Verify the API details are shown
-    const request = sessionPage.getProxyReviewRequests().first()
-    await expect(request).toContainText('Allow send a message to a channel?')
-    await expect(request).toContainText('POST')
-    await expect(request).toContainText('api/chat.postMessage')
-    await expect(request).toContainText('slack')
+    const requestCard = sessionPage.getProxyReviewRequests(review.id)
+    await expect(requestCard).toContainText('Allow send a message to a channel?')
+    await expect(requestCard).toContainText('POST')
+    await expect(requestCard).toContainText('api/chat.postMessage')
+    await expect(requestCard).toContainText('slack')
   })
 
-  test('proxy review: user can allow the request', async () => {
-    await sessionPage.sendMessage('proxy review')
+  test('proxy review: user can allow the request', async ({ page, request }, testInfo) => {
+    const { review } = await sendReviewScenario(page, request, testInfo, 'proxy review', {
+      xAgent: false,
+      toolkit: 'slack',
+      targetPath: 'api/chat.postMessage',
+    })
 
-    await sessionPage.waitForProxyReviewRequest(35000)
+    await sessionPage.waitForProxyReviewRequestById(review.id, 35000)
 
     // Allow the request
-    await sessionPage.allowProxyReview()
+    await sessionPage.allowProxyReview(review.id)
 
     // Review prompt should disappear.
-    await expect(sessionPage.getProxyReviewRequests()).toHaveCount(0, { timeout: 10000 })
+    await expect(sessionPage.getProxyReviewRequests(review.id)).toHaveCount(0, { timeout: 10000 })
+    await expectPendingProxyReviewResolved(request, agent, review)
 
     // Session should complete with approval message
     await sessionPage.waitForInputEnabled(15000)
     await sessionPage.expectAssistantMessage('approved by user', 0, 15000)
   })
 
-  test('proxy review: user can deny the request', async () => {
-    await sessionPage.sendMessage('proxy review')
+  test('proxy review: user can deny the request', async ({ page, request }, testInfo) => {
+    const { review } = await sendReviewScenario(page, request, testInfo, 'proxy review', {
+      xAgent: false,
+      toolkit: 'slack',
+      targetPath: 'api/chat.postMessage',
+    })
 
-    await sessionPage.waitForProxyReviewRequest(35000)
+    await sessionPage.waitForProxyReviewRequestById(review.id, 35000)
 
     // Deny the request
-    await sessionPage.denyProxyReview()
+    await sessionPage.denyProxyReview(review.id)
 
     // Review prompt should disappear.
-    await expect(sessionPage.getProxyReviewRequests()).toHaveCount(0, { timeout: 10000 })
+    await expect(sessionPage.getProxyReviewRequests(review.id)).toHaveCount(0, { timeout: 10000 })
+    await expectPendingProxyReviewResolved(request, agent, review)
 
     // Session should complete with denial message
     await sessionPage.waitForInputEnabled(15000)
     await sessionPage.expectAssistantMessage('denied by user', 0, 15000)
   })
 
-  test('proxy review: remember always allow for scope', async () => {
-    await sessionPage.sendMessage('proxy review')
+  test('proxy review: remember always allow for scope', async ({ page, request }, testInfo) => {
+    const { review } = await sendReviewScenario(page, request, testInfo, 'proxy review', {
+      xAgent: false,
+      toolkit: 'slack',
+      targetPath: 'api/chat.postMessage',
+      matchedScope: 'chat:write',
+    })
 
-    await sessionPage.waitForProxyReviewRequest(35000)
+    await sessionPage.waitForProxyReviewRequestById(review.id, 35000)
 
     // Click always allow for this scope (opens Allow popover, then clicks scope button)
-    await sessionPage.alwaysAllowScope('chat:write')
+    await sessionPage.alwaysAllowScope('chat:write', review.id)
 
     // Review prompt should disappear.
-    await expect(sessionPage.getProxyReviewRequests()).toHaveCount(0, { timeout: 10000 })
+    await expect(sessionPage.getProxyReviewRequests(review.id)).toHaveCount(0, { timeout: 10000 })
+    await expectPendingProxyReviewResolved(request, agent, review)
 
     // Session should complete with approval message
     await sessionPage.waitForInputEnabled(15000)
     await sessionPage.expectAssistantMessage('approved by user', 0, 15000)
   })
 
-  test('proxy review: allow all requests for the minimal risk group', async () => {
-    await sessionPage.sendMessage('proxy review')
+  test('proxy review: allow all requests for the minimal risk group', async ({ page, request }, testInfo) => {
+    const { review } = await sendReviewScenario(page, request, testInfo, 'proxy review', {
+      xAgent: false,
+      toolkit: 'slack',
+      targetPath: 'api/chat.postMessage',
+      matchedScope: 'chat:write',
+    })
 
-    await sessionPage.waitForProxyReviewRequest(35000)
+    await sessionPage.waitForProxyReviewRequestById(review.id, 35000)
 
     // chat.postMessage is satisfied by chat:write (a "write"-labelled scope), so the
     // minimal group offered is "write". Allowing it should approve and persist '*write'.
-    await sessionPage.alwaysAllowLabelGroup('write')
+    await sessionPage.alwaysAllowLabelGroup('write', review.id)
 
     // Review prompt should disappear.
-    await expect(sessionPage.getProxyReviewRequests()).toHaveCount(0, { timeout: 10000 })
+    await expect(sessionPage.getProxyReviewRequests(review.id)).toHaveCount(0, { timeout: 10000 })
+    await expectPendingProxyReviewResolved(request, agent, review)
 
     // Session should complete with approval message
     await sessionPage.waitForInputEnabled(15000)
@@ -105,67 +149,80 @@ test.describe('Proxy Review Requests', () => {
 })
 
 test.describe('X-Agent Review Requests', () => {
-  let appPage: AppPage
-  let agentPage: AgentPage
   let sessionPage: SessionPage
-  let testAgentName: string
+  let agent: TestAgent
 
-  test.beforeEach(async ({ page }, testInfo) => {
-    appPage = new AppPage(page)
-    agentPage = new AgentPage(page)
+  test.describe.configure({ timeout: 60000 })
+
+  test.beforeEach(async ({ page, request }, testInfo) => {
     sessionPage = new SessionPage(page)
 
-    await appPage.goto()
-    await appPage.waitForAgentsLoaded()
-
-    testAgentName = `XAgent Review Agent ${testInfo.workerIndex}-${Date.now()}`
-    await agentPage.createAgent(testAgentName, { waitForSidebarName: false })
+    agent = await createAgent(request, uniqueName(testInfo, 'XAgent Review Agent'))
+    await gotoAgentHome(page, agent)
   })
 
-  test('x-agent review: interrupt dismisses the review card', async () => {
+  async function sendXAgentReviewScenario(
+    page: Page,
+    request: APIRequestContext,
+    testInfo: TestInfo,
+  ): Promise<{ session: Pick<TestSession, 'id'>; review: TestPendingProxyReview }> {
+    await sessionPage.sendMessage(`x-agent review ${uniqueSuffix(testInfo)}`)
+    const session = await waitForCurrentSessionId(page)
+    const review = await waitForPendingProxyReview(request, agent, {
+      xAgent: true,
+      toolkit: 'agents',
+      matchedScope: 'list',
+    })
+    expect(review.xAgent?.operation).toBe('list')
+    return { session, review }
+  }
+
+  test('x-agent review: interrupt dismisses the review card', async ({ page, request }, testInfo) => {
     // "x-agent review" triggers XAgentReviewScenario
-    await sessionPage.sendMessage('x-agent review')
+    const { review } = await sendXAgentReviewScenario(page, request, testInfo)
 
     // Wait for the x-agent review prompt to appear
-    await sessionPage.waitForXAgentReviewRequest(35000)
+    await sessionPage.waitForXAgentReviewRequestById(review.id, 35000)
 
     // Click the X (stop session) button on the card
-    await sessionPage.stopSessionFromRequest()
+    await sessionPage.stopSessionFromRequest(sessionPage.getXAgentReviewRequests(review.id))
 
     // Review prompt should disappear
-    await expect(sessionPage.getXAgentReviewRequests()).toHaveCount(0, { timeout: 10000 })
+    await expect(sessionPage.getXAgentReviewRequests(review.id)).toHaveCount(0, { timeout: 10000 })
   })
 
-  test('x-agent review: user can allow the request', async () => {
-    await sessionPage.sendMessage('x-agent review')
+  test('x-agent review: user can allow the request', async ({ page, request }, testInfo) => {
+    const { review } = await sendXAgentReviewScenario(page, request, testInfo)
 
-    await sessionPage.waitForXAgentReviewRequest(35000)
+    await sessionPage.waitForXAgentReviewRequestById(review.id, 35000)
 
     // Verify the card shows the right text
-    const request = sessionPage.getXAgentReviewRequests().first()
-    await expect(request).toContainText('list other agents in this workspace')
+    const requestCard = sessionPage.getXAgentReviewRequests(review.id)
+    await expect(requestCard).toContainText('list other agents in this workspace')
 
     // Allow the request
-    await sessionPage.allowXAgentReview()
+    await sessionPage.allowXAgentReview(review.id)
 
     // Review prompt should disappear.
-    await expect(sessionPage.getXAgentReviewRequests()).toHaveCount(0, { timeout: 10000 })
+    await expect(sessionPage.getXAgentReviewRequests(review.id)).toHaveCount(0, { timeout: 10000 })
+    await expectPendingProxyReviewResolved(request, agent, review)
 
     // Session should complete with approval message
     await sessionPage.waitForInputEnabled(15000)
     await sessionPage.expectAssistantMessage('approved by user', 0, 15000)
   })
 
-  test('x-agent review: user can deny the request', async () => {
-    await sessionPage.sendMessage('x-agent review')
+  test('x-agent review: user can deny the request', async ({ page, request }, testInfo) => {
+    const { review } = await sendXAgentReviewScenario(page, request, testInfo)
 
-    await sessionPage.waitForXAgentReviewRequest(35000)
+    await sessionPage.waitForXAgentReviewRequestById(review.id, 35000)
 
     // Deny the request
-    await sessionPage.denyXAgentReview()
+    await sessionPage.denyXAgentReview(review.id)
 
     // Review prompt should disappear.
-    await expect(sessionPage.getXAgentReviewRequests()).toHaveCount(0, { timeout: 10000 })
+    await expect(sessionPage.getXAgentReviewRequests(review.id)).toHaveCount(0, { timeout: 10000 })
+    await expectPendingProxyReviewResolved(request, agent, review)
 
     // Session should complete with denial message
     await sessionPage.waitForInputEnabled(15000)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -19,6 +19,7 @@ import {
 } from '@shared/lib/services/agent-service'
 import { containerManager } from '@shared/lib/container/container-manager'
 import { parseRuntimeOptions } from '@shared/lib/container/runtime-options'
+import { isBlockingUserInputToolName } from '@shared/lib/tool-definitions/user-input-tools'
 import { listWebhookTriggers, listActiveWebhookTriggers, listCancelledWebhookTriggers } from '@shared/lib/services/webhook-trigger-service'
 import { listChatIntegrations, listChatIntegrationsByAgents } from '@shared/lib/services/chat-integration-service'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
@@ -249,12 +250,6 @@ async function enrichAgentsWithSummary(agents: ApiAgent[]): Promise<ApiAgent[]> 
   )
 }
 
-function isBlockingInputToolCall(toolName: string): boolean {
-  return toolName === 'AskUserQuestion' ||
-    (toolName.startsWith('mcp__user-input__request_') &&
-      toolName !== 'mcp__user-input__request_script_run')
-}
-
 function hasUnresolvedBlockingInputRequest(items: TransformedItem[]): boolean {
   for (let i = items.length - 1; i >= 0; i--) {
     const item = items[i]
@@ -262,7 +257,7 @@ function hasUnresolvedBlockingInputRequest(items: TransformedItem[]): boolean {
     if (item.type !== 'assistant') continue
 
     for (const toolCall of item.toolCalls) {
-      if (toolCall.result === undefined && isBlockingInputToolCall(toolCall.name)) {
+      if (toolCall.result === undefined && isBlockingUserInputToolName(toolCall.name)) {
         return true
       }
     }
@@ -1352,21 +1347,32 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
     // Attach lifecycle state and the stream before slower metadata/DB work. The
     // first turn can start emitting shortly after createSession returns, and a
     // blocking input emitted during that window must not be missed or reset.
-    messagePersister.markSessionActive(sessionId, slug)
-    await messagePersister.subscribeToSession(sessionId, client, sessionId, slug)
+    let lifecycleStarted = false
+    let sessionRegistered = false
+    try {
+      messagePersister.markSessionActive(sessionId, slug)
+      lifecycleStarted = true
+      await messagePersister.subscribeToSession(sessionId, client, sessionId, slug)
 
-    // Record author for initial message after we know the sessionId
-    if (isAuthMode()) {
-      const userId = getCurrentUserId(c)
-      await db.insert(messageAuthor).values({
-        id: initialMessageUuid,
-        sessionId,
-        agentSlug: slug,
-        userId,
-      })
+      // Record author for initial message after we know the sessionId
+      if (isAuthMode()) {
+        const userId = getCurrentUserId(c)
+        await db.insert(messageAuthor).values({
+          id: initialMessageUuid,
+          sessionId,
+          agentSlug: slug,
+          userId,
+        })
+      }
+
+      await registerSession(slug, sessionId, 'New Session')
+      sessionRegistered = true
+    } catch (error) {
+      if (lifecycleStarted && !sessionRegistered) {
+        messagePersister.unsubscribeFromSession(sessionId)
+      }
+      throw error
     }
-
-    await registerSession(slug, sessionId, 'New Session')
     // Persist only what the user explicitly chose. The server-side fallback is
     // applied at session creation but should not masquerade as a user choice in
     // metadata — otherwise a later change to the global default wouldn't be
@@ -1434,6 +1440,9 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       messagePersister.isSessionActive(sessionId) &&
       hasUnresolvedBlockingInputRequest(transformed)
     ) {
+      // If the request-specific stream event was missed, persisted messages are
+      // the fallback source of truth. A stale transcript can briefly re-assert
+      // awaiting input, but the next stream result/idle event clears it.
       messagePersister.recoverSessionAwaitingInput(sessionId, agentSlug)
     }
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -249,6 +249,28 @@ async function enrichAgentsWithSummary(agents: ApiAgent[]): Promise<ApiAgent[]> 
   )
 }
 
+function isBlockingInputToolCall(toolName: string): boolean {
+  return toolName === 'AskUserQuestion' ||
+    (toolName.startsWith('mcp__user-input__request_') &&
+      toolName !== 'mcp__user-input__request_script_run')
+}
+
+function hasUnresolvedBlockingInputRequest(items: TransformedItem[]): boolean {
+  for (let i = items.length - 1; i >= 0; i--) {
+    const item = items[i]
+    if (item.type === 'user' && !item.queued) return false
+    if (item.type !== 'assistant') continue
+
+    for (const toolCall of item.toolCalls) {
+      if (toolCall.result === undefined && isBlockingInputToolCall(toolCall.name)) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
 /**
  * For interrupted Task tool calls (no result), discover the subagent ID
  * by scanning the subagents directory so the UI can still show subagent messages.
@@ -1327,6 +1349,12 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
     })
     const sessionId = containerSession.id
 
+    // Attach lifecycle state and the stream before slower metadata/DB work. The
+    // first turn can start emitting shortly after createSession returns, and a
+    // blocking input emitted during that window must not be missed or reset.
+    messagePersister.markSessionActive(sessionId, slug)
+    await messagePersister.subscribeToSession(sessionId, client, sessionId, slug)
+
     // Record author for initial message after we know the sessionId
     if (isAuthMode()) {
       const userId = getCurrentUserId(c)
@@ -1350,13 +1378,11 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
     if (Object.keys(initialMetadata).length > 0) {
       updateSessionMetadata(slug, sessionId, initialMetadata).catch(console.error)
     }
-    await messagePersister.subscribeToSession(sessionId, client, sessionId, slug)
     // Store slash commands from container's init event (captured during session creation)
     if (containerSession.slashCommands && containerSession.slashCommands.length > 0) {
       messagePersister.setSlashCommands(sessionId, containerSession.slashCommands)
       updateSessionMetadata(slug, sessionId, { slashCommands: containerSession.slashCommands }).catch(console.error)
     }
-    messagePersister.markSessionActive(sessionId, slug)
 
     generateAndUpdateSessionNameAsync(
       slug,
@@ -1403,6 +1429,13 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
 
     // Discover subagent IDs for interrupted Task tool calls that have no result
     await resolveInterruptedSubagents(transformed, agentSlug, sessionId)
+
+    if (
+      messagePersister.isSessionActive(sessionId) &&
+      hasUnresolvedBlockingInputRequest(transformed)
+    ) {
+      messagePersister.recoverSessionAwaitingInput(sessionId, agentSlug)
+    }
 
     // In auth mode, annotate user messages with sender info
     if (isAuthMode()) {

--- a/src/renderer/components/messages/proxy-review-request-item.tsx
+++ b/src/renderer/components/messages/proxy-review-request-item.tsx
@@ -186,6 +186,7 @@ export function ProxyReviewRequestItem({
       waitingText="Waiting for approval"
       error={error}
       data-testid={isCompleted ? 'proxy-review-completed' : 'proxy-review-request'}
+      data-review-id={reviewId}
       data-status={isCompleted ? status : undefined}
     >
       {/* Code block showing method/path + toolkit */}

--- a/src/renderer/components/messages/x-agent-review-request-item.tsx
+++ b/src/renderer/components/messages/x-agent-review-request-item.tsx
@@ -219,6 +219,7 @@ export function XAgentReviewRequestItem({
       waitingText="Waiting for approval"
       error={error}
       data-testid={isCompleted ? 'xagent-review-completed' : 'xagent-review-request'}
+      data-review-id={reviewId}
       data-status={isCompleted ? status : undefined}
     >
       {/* Prompt preview for invoke */}

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -1113,6 +1113,76 @@ describe('useMessageStream', () => {
     expect(result.current.isStreaming).toBe(true)
   })
 
+  it('invalidates status queries when a blocking user-input tool becomes ready', async () => {
+    const { useMessageStream } = await getHookModule()
+    const wrapper = createWrapper()
+    const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
+    renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+    })
+    spy.mockClear()
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'tool_use_start',
+        toolId: 'tc-1',
+        toolName: 'mcp__user-input__request_secret',
+        partialInput: '{"secretName":"OPENAI_API_KEY"}',
+      })
+    })
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'tool_use_ready',
+        toolId: 'tc-1',
+        toolName: 'mcp__user-input__request_secret',
+      })
+    })
+
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['sessions'] })
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['agents'] })
+  })
+
+  it('does not invalidate status queries when a script-run tool becomes ready', async () => {
+    const { useMessageStream } = await getHookModule()
+    const wrapper = createWrapper()
+    const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
+    renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+    })
+    spy.mockClear()
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'tool_use_start',
+        toolId: 'tc-1',
+        toolName: 'mcp__user-input__request_script_run',
+        partialInput: '{"script":"echo ok"}',
+      })
+    })
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'tool_use_ready',
+        toolId: 'tc-1',
+        toolName: 'mcp__user-input__request_script_run',
+      })
+    })
+
+    expect(spy).not.toHaveBeenCalledWith({ queryKey: ['sessions'] })
+    expect(spy).not.toHaveBeenCalledWith({ queryKey: ['agents'] })
+  })
+
   // ---- Subagent lifecycle ----
 
   it('handles subagent_completed — keeps streaming data and marks as completed', async () => {

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -177,6 +177,13 @@ const streamListeners = new Map<string, Set<() => void>>()
 // Slash commands per session (separate from streamStates to avoid touching 25+ set() calls)
 const sessionSlashCommands = new Map<string, SlashCommandInfo[]>()
 
+function isBlockingUserInputTool(toolName: unknown): boolean {
+  return toolName === 'AskUserQuestion' ||
+    (typeof toolName === 'string' &&
+      toolName.startsWith('mcp__user-input__request_') &&
+      toolName !== 'mcp__user-input__request_script_run')
+}
+
 // Extended-thinking stream per session. Kept outside StreamState (like slash commands)
 // so the ~15 full state-rebuild sites don't have to thread it through. `isThinking`
 // drives the "Thinking" status; `text` accumulates the streamed (summarized) reasoning
@@ -751,6 +758,12 @@ function getOrCreateEventSource(
             const updated = tools.map((t, i) => i === idx ? { ...t, ready: true } : t)
             streamStates.set(sessionId, { ...current, streamingToolUses: updated })
           }
+        }
+        if (isBlockingUserInputTool(data.toolName)) {
+          // The request-specific SSE event can be missed under load while the
+          // streaming fallback still renders the card. Keep status sidebars in sync.
+          queryClient.invalidateQueries({ queryKey: ['sessions'] })
+          queryClient.invalidateQueries({ queryKey: ['agents'] })
         }
       }
       else if (data.type === 'stream_end') {

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -6,6 +6,7 @@ import type { SessionUsage } from '@shared/lib/types/agent'
 import type { SlashCommandInfo } from '@shared/lib/container/types'
 import type { ApiMessage, ApiMessageOrBoundary } from '@shared/lib/types/api'
 import type { WorkflowAgentNode } from '@shared/lib/workflows/workflow-schemas'
+import { isBlockingUserInputToolName } from '@shared/lib/tool-definitions/user-input-tools'
 
 interface SecretRequest {
   toolUseId: string
@@ -176,13 +177,6 @@ const streamListeners = new Map<string, Set<() => void>>()
 
 // Slash commands per session (separate from streamStates to avoid touching 25+ set() calls)
 const sessionSlashCommands = new Map<string, SlashCommandInfo[]>()
-
-function isBlockingUserInputTool(toolName: unknown): boolean {
-  return toolName === 'AskUserQuestion' ||
-    (typeof toolName === 'string' &&
-      toolName.startsWith('mcp__user-input__request_') &&
-      toolName !== 'mcp__user-input__request_script_run')
-}
 
 // Extended-thinking stream per session. Kept outside StreamState (like slash commands)
 // so the ~15 full state-rebuild sites don't have to thread it through. `isThinking`
@@ -759,7 +753,7 @@ function getOrCreateEventSource(
             streamStates.set(sessionId, { ...current, streamingToolUses: updated })
           }
         }
-        if (isBlockingUserInputTool(data.toolName)) {
+        if (isBlockingUserInputToolName(data.toolName)) {
           // The request-specific SSE event can be missed under load while the
           // streaming fallback still renders the card. Keep status sidebars in sync.
           queryClient.invalidateQueries({ queryKey: ['sessions'] })

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -2227,6 +2227,44 @@ describe('MessagePersister', () => {
       expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
     })
 
+    it('preserves initial-turn active and awaiting flags across stream subscription', async () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      simulateToolUse('mcp__user-input__request_secret', 'tool-1', {
+        secretName: 'API_KEY',
+        reason: 'Need it',
+      })
+
+      await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
+
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.hasSessionsAwaitingInputForAgent(AGENT_SLUG)).toBe(true)
+    })
+
+    it('recovers awaiting input for an active session from persisted request fallback', () => {
+      const { events: globalEvents, cleanup: globalCleanup } = collectGlobalEvents()
+
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.recoverSessionAwaitingInput(SESSION_ID, AGENT_SLUG)
+
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.hasSessionsAwaitingInputForAgent(AGENT_SLUG)).toBe(true)
+
+      const awaitingEvents = globalEvents.filter(e => e.type === 'session_awaiting_input')
+      expect(awaitingEvents).toHaveLength(1)
+      expect(awaitingEvents[0].sessionId).toBe(SESSION_ID)
+      expect(awaitingEvents[0].agentSlug).toBe(AGENT_SLUG)
+
+      globalCleanup()
+    })
+
+    it('does not recover awaiting input for an inactive session', () => {
+      messagePersister.recoverSessionAwaitingInput(SESSION_ID, AGENT_SLUG)
+
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.hasSessionsAwaitingInputForAgent(AGENT_SLUG)).toBe(false)
+    })
+
     it('sets isAwaitingInput after AskUserQuestion tool fires', () => {
       simulateToolUse('AskUserQuestion', 'tool-1', {
         questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -653,6 +653,17 @@ class MessagePersister {
     }
   }
 
+  // Recover awaiting-input state from persisted messages when the one-shot
+  // request stream event was missed but the unresolved tool call is visible.
+  recoverSessionAwaitingInput(sessionId: string, agentSlug?: string): void {
+    const state = this.streamingStates.get(sessionId)
+    if (!state?.isActive) return
+    if (agentSlug && !state.agentSlug) {
+      state.agentSlug = agentSlug
+    }
+    this.markSessionAwaitingInput(sessionId)
+  }
+
   // Promote an automated session (cron/webhook/chat) to a regular session so it
   // appears in the sidebar and receives completion notifications.
   private async promoteAutomatedSession(sessionId: string, agentSlug: string): Promise<void> {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -7,6 +7,7 @@ import type { RequestConnectedAccountInput } from '@shared/lib/tool-definitions/
 import type { RequestRemoteMcpInput } from '@shared/lib/tool-definitions/request-remote-mcp'
 import type { RequestBrowserInputInput } from '@shared/lib/tool-definitions/request-browser-input'
 import type { RequestScriptRunInput } from '@shared/lib/tool-definitions/request-script-run'
+import { isBlockingUserInputToolName } from '@shared/lib/tool-definitions/user-input-tools'
 import {
   createScheduledTask,
   listPendingScheduledTasks,
@@ -1973,11 +1974,7 @@ class MessagePersister {
           // Note: computer-use AND request_script_run tools are handled by their own
           // handlers which only mark awaiting input when user approval is actually
           // needed (not when auto-executed against a cached permission grant).
-          if (
-            state.currentToolUse.name === 'AskUserQuestion' ||
-            (state.currentToolUse.name.startsWith('mcp__user-input__request_') &&
-              state.currentToolUse.name !== 'mcp__user-input__request_script_run')
-          ) {
+          if (isBlockingUserInputToolName(state.currentToolUse.name)) {
             this.markSessionAwaitingInput(sessionId)
           }
 

--- a/src/shared/lib/tool-definitions/user-input-tools.test.ts
+++ b/src/shared/lib/tool-definitions/user-input-tools.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { isBlockingUserInputToolName } from './user-input-tools'
+
+describe('isBlockingUserInputToolName', () => {
+  it('matches blocking user-input request tools', () => {
+    expect(isBlockingUserInputToolName('AskUserQuestion')).toBe(true)
+    expect(isBlockingUserInputToolName('mcp__user-input__request_secret')).toBe(true)
+    expect(isBlockingUserInputToolName('mcp__user-input__request_file')).toBe(true)
+  })
+
+  it('excludes non-blocking and separately gated user-input tools', () => {
+    expect(isBlockingUserInputToolName('mcp__user-input__request_script_run')).toBe(false)
+    expect(isBlockingUserInputToolName('mcp__user-input__deliver_file')).toBe(false)
+    expect(isBlockingUserInputToolName('Bash')).toBe(false)
+    expect(isBlockingUserInputToolName(undefined)).toBe(false)
+  })
+})

--- a/src/shared/lib/tool-definitions/user-input-tools.ts
+++ b/src/shared/lib/tool-definitions/user-input-tools.ts
@@ -1,0 +1,6 @@
+export function isBlockingUserInputToolName(toolName: unknown): boolean {
+  return toolName === 'AskUserQuestion' ||
+    (typeof toolName === 'string' &&
+      toolName.startsWith('mcp__user-input__request_') &&
+      toolName !== 'mcp__user-input__request_script_run')
+}


### PR DESCRIPTION
## Summary

- Move awaiting-input and proxy-review specs to isolated API-created agents while keeping the actual request-triggering and approval/denial flows exercised through the UI.
- Add exact review-card targeting via `data-review-id` and session/request helpers so proxy and x-agent review assertions do not race with other workers.
- Harden status recovery for blocking input requests when the UI recovers a request card from persisted messages, including client query invalidation and message-persister coverage.
- Make E2E API polling helpers retry through transient read failures instead of failing the poll immediately.

## Validation

- `npx eslint e2e/helpers/agents.ts e2e/pages/session.page.ts e2e/specs/awaiting-input-status.spec.ts e2e/specs/proxy-review.spec.ts src/api/routes/agents.ts src/shared/lib/container/message-persister.ts src/shared/lib/container/message-persister.test.ts src/renderer/components/messages/proxy-review-request-item.tsx src/renderer/components/messages/x-agent-review-request-item.tsx src/renderer/hooks/use-message-stream.ts src/renderer/hooks/use-message-stream.test.ts`
- `npm run typecheck`
- `npx vitest run src/shared/lib/container/message-persister.test.ts src/renderer/hooks/use-message-stream.test.ts`
- `git diff --check`
- 3 consecutive focused workers=4 runs passed for `awaiting-input-status.spec.ts` and `proxy-review.spec.ts`
- Full `test:e2e:web` passed with `PLAYWRIGHT_WORKERS=6` (`202 passed`, `21 skipped`, `3.7m`)