### PR TITLE
feat: quick-dispatch global launcher

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -53,6 +53,14 @@ export default defineConfig({
     root: './src/renderer',
     build: {
       outDir: path.resolve(__dirname, 'dist/renderer'),
+      rollupOptions: {
+        // Two entry HTMLs: the main app and the standalone quick-dispatch
+        // launcher window (a separate BrowserWindow / renderer process).
+        input: {
+          index: path.resolve(__dirname, 'src/renderer/index.html'),
+          quickDispatch: path.resolve(__dirname, 'src/renderer/quick-dispatch.html'),
+        },
+      },
     },
     resolve: {
       alias: {

--- a/package.json
+++ b/package.json
@@ -219,7 +219,20 @@
       "icon": "build/icon.icon",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
-      "notarize": true
+      "notarize": true,
+      "extendInfo": {
+        "CFBundleDocumentTypes": [
+          {
+            "CFBundleTypeName": "Any File",
+            "CFBundleTypeRole": "Viewer",
+            "LSHandlerRank": "Alternate",
+            "LSItemContentTypes": [
+              "public.item",
+              "public.content"
+            ]
+          }
+        ]
+      }
     },
     "win": {
       "target": [
@@ -239,6 +252,20 @@
         }
       ],
       "icon": "build/icon.png",
+      "fileAssociations": [
+        { "ext": "png", "name": "PNG Image" },
+        { "ext": "jpg", "name": "JPEG Image" },
+        { "ext": "jpeg", "name": "JPEG Image" },
+        { "ext": "gif", "name": "GIF Image" },
+        { "ext": "webp", "name": "WebP Image" },
+        { "ext": "pdf", "name": "PDF Document" },
+        { "ext": "txt", "name": "Text Document" },
+        { "ext": "md", "name": "Markdown Document" },
+        { "ext": "csv", "name": "CSV File" },
+        { "ext": "json", "name": "JSON File" },
+        { "ext": "docx", "name": "Word Document" },
+        { "ext": "xlsx", "name": "Excel Spreadsheet" }
+      ],
       "signExts": [
         ".exe",
         ".dll",

--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -768,6 +768,43 @@ describe('settings route', () => {
   })
 
   // =========================================================================
+  // Quick-dispatch global shortcut validation
+  // =========================================================================
+  describe('app.globalDispatchShortcut validation', () => {
+    it('accepts a valid accelerator (200)', async () => {
+      const res = await putSettings({ app: { globalDispatchShortcut: 'CommandOrControl+Shift+K' } })
+
+      expect(res.status).toBe(200)
+      const saved = mockUpdateSettings.mock.calls[0][0]
+      expect(saved.app.globalDispatchShortcut).toBe('CommandOrControl+Shift+K')
+    })
+
+    it('accepts an empty string as "disabled" (200)', async () => {
+      const res = await putSettings({ app: { globalDispatchShortcut: '' } })
+
+      expect(res.status).toBe(200)
+      const saved = mockUpdateSettings.mock.calls[0][0]
+      expect(saved.app.globalDispatchShortcut).toBe('')
+    })
+
+    it('rejects a garbage accelerator (400) and does not persist', async () => {
+      const res = await putSettings({ app: { globalDispatchShortcut: 'not a shortcut' } })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toContain('globalDispatchShortcut')
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it('rejects a non-string accelerator (400)', async () => {
+      const res = await putSettings({ app: { globalDispatchShortcut: 123 } })
+
+      expect(res.status).toBe(400)
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+  })
+
+  // =========================================================================
   // STT key validation
   // =========================================================================
   describe('POST /validate-stt-key', () => {

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -31,6 +31,7 @@ import {
   type GlobalSettingsResponse,
 } from '@shared/lib/config/settings'
 import { validateFaviconDataUrl } from '@shared/lib/config/favicon'
+import { isValidAccelerator } from '@shared/lib/config/shortcuts'
 import { getTenantId } from '@shared/lib/analytics/tenant-id'
 import { getSttProvider } from '@shared/lib/stt'
 import { containerManager } from '@shared/lib/container/container-manager'
@@ -376,6 +377,19 @@ settings.put('/', async (c) => {
     // Validate agentEffort if provided
     if (body.models?.agentEffort !== undefined && !EFFORT_LEVELS.includes(body.models.agentEffort)) {
       return c.json({ error: `agentEffort must be one of: ${EFFORT_LEVELS.join(', ')}` }, 400)
+    }
+
+    // Validate the quick-dispatch global shortcut accelerator. Empty string is
+    // allowed and means "disabled"; any other value must be a plausible
+    // accelerator (main's globalShortcut.register is the authoritative gate).
+    if (body.app?.globalDispatchShortcut !== undefined) {
+      const acc = body.app.globalDispatchShortcut
+      if (typeof acc !== 'string' || (acc !== '' && !isValidAccelerator(acc))) {
+        return c.json(
+          { error: 'globalDispatchShortcut must be an accelerator like "CommandOrControl+Shift+Space" (or "" to disable)' },
+          400,
+        )
+      }
     }
 
     // Validate runtimeSettings if provided

--- a/src/main/global-dispatch-shortcut.test.ts
+++ b/src/main/global-dispatch-shortcut.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock electron's globalShortcut so we can assert register/unregister calls
+// without a live main process. `vi.hoisted` keeps the spies reachable from the
+// hoisted mock factory.
+const { register, unregister, unregisterAll } = vi.hoisted(() => ({
+  register: vi.fn(),
+  unregister: vi.fn(),
+  unregisterAll: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  globalShortcut: { register, unregister, unregisterAll },
+}))
+
+import {
+  registerGlobalDispatchShortcut,
+  unregisterGlobalDispatchShortcut,
+} from './global-dispatch-shortcut'
+
+describe('registerGlobalDispatchShortcut', () => {
+  const onTrigger = vi.fn()
+
+  beforeEach(() => {
+    // Reset the module's remembered binding, then clear spy history so each test
+    // starts from a clean slate.
+    unregisterGlobalDispatchShortcut()
+    vi.clearAllMocks()
+    register.mockReturnValue(true) // register() succeeds by default
+  })
+
+  it('registers a valid accelerator with the trigger callback', () => {
+    const result = registerGlobalDispatchShortcut('CommandOrControl+Shift+Space', onTrigger)
+
+    expect(result).toEqual({ success: true })
+    expect(register).toHaveBeenCalledWith('CommandOrControl+Shift+Space', onTrigger)
+  })
+
+  it('treats an empty string as "disabled" — no registration', () => {
+    const result = registerGlobalDispatchShortcut('', onTrigger)
+
+    expect(result).toEqual({ success: true })
+    expect(register).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the default when the accelerator is undefined', () => {
+    const result = registerGlobalDispatchShortcut(undefined, onTrigger)
+
+    expect(result.success).toBe(true)
+    expect(register).toHaveBeenCalledWith('CommandOrControl+Shift+Space', onTrigger)
+  })
+
+  it('rejects a garbage accelerator without registering', () => {
+    const result = registerGlobalDispatchShortcut('not a shortcut', onTrigger)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/valid/i)
+    expect(register).not.toHaveBeenCalled()
+  })
+
+  it('reports a conflict when register() returns false', () => {
+    register.mockReturnValue(false)
+
+    const result = registerGlobalDispatchShortcut('Control+Alt+K', onTrigger)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/already in use/i)
+  })
+
+  it('catches a thrown registration error and surfaces its message', () => {
+    register.mockImplementation(() => {
+      throw new Error('boom')
+    })
+
+    const result = registerGlobalDispatchShortcut('Control+Alt+K', onTrigger)
+
+    expect(result).toEqual({ success: false, error: 'boom' })
+  })
+
+  it('unregisters the previous binding before registering a new one', () => {
+    registerGlobalDispatchShortcut('Control+Alt+K', onTrigger)
+    expect(unregister).not.toHaveBeenCalled() // nothing bound before
+
+    registerGlobalDispatchShortcut('Control+Alt+J', onTrigger)
+
+    expect(unregister).toHaveBeenCalledWith('Control+Alt+K') // old one released
+    expect(register).toHaveBeenLastCalledWith('Control+Alt+J', onTrigger)
+  })
+
+  it('does not re-unregister after being disabled (state cleared)', () => {
+    registerGlobalDispatchShortcut('Control+Alt+K', onTrigger)
+    registerGlobalDispatchShortcut('', onTrigger) // disable → releases the old one
+    expect(unregister).toHaveBeenCalledTimes(1)
+
+    registerGlobalDispatchShortcut('Control+Alt+J', onTrigger) // nothing to release now
+    expect(unregister).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('unregisterGlobalDispatchShortcut', () => {
+  beforeEach(() => {
+    unregisterGlobalDispatchShortcut()
+    vi.clearAllMocks()
+    register.mockReturnValue(true)
+  })
+
+  it('releases the current binding', () => {
+    registerGlobalDispatchShortcut('Control+Alt+K', vi.fn())
+    unregisterGlobalDispatchShortcut()
+
+    expect(unregister).toHaveBeenCalledWith('Control+Alt+K')
+  })
+
+  it('is a no-op when nothing is bound', () => {
+    unregisterGlobalDispatchShortcut()
+    expect(unregister).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/global-dispatch-shortcut.ts
+++ b/src/main/global-dispatch-shortcut.ts
@@ -1,0 +1,58 @@
+import { globalShortcut } from 'electron'
+import { DEFAULT_GLOBAL_DISPATCH_SHORTCUT, isValidAccelerator } from '@shared/lib/config/shortcuts'
+
+// Owns the single OS-global accelerator that opens the quick-dispatch launcher.
+// Extracted from index.ts so the register/unregister/validate branching can be
+// unit-tested without booting the whole main process. The trigger callback is
+// injected (rather than imported) to keep this module free of window deps.
+
+export interface ShortcutRegistrationResult {
+  success: boolean
+  error?: string
+}
+
+// The currently-registered accelerator, so a change can unregister the old
+// binding before registering the new one (otherwise old shortcuts leak).
+let currentDispatchShortcut: string | null = null
+
+/** Unregister the current quick-dispatch accelerator (if any) and clear state. */
+export function unregisterGlobalDispatchShortcut(): void {
+  if (currentDispatchShortcut) {
+    globalShortcut.unregister(currentDispatchShortcut)
+    currentDispatchShortcut = null
+  }
+}
+
+/**
+ * Register (or re-register) the OS-global quick-dispatch accelerator, calling
+ * `onTrigger` when it fires. `undefined` falls back to the default; `''` leaves
+ * the launcher disabled. Returns a result so the settings UI can surface a
+ * "shortcut already in use" conflict instead of silently failing.
+ */
+export function registerGlobalDispatchShortcut(
+  accelerator: string | undefined,
+  onTrigger: () => void,
+): ShortcutRegistrationResult {
+  // Always release the previous binding first.
+  unregisterGlobalDispatchShortcut()
+
+  const accel = accelerator ?? DEFAULT_GLOBAL_DISPATCH_SHORTCUT
+  if (accel === '') return { success: true } // disabled
+  if (!isValidAccelerator(accel)) {
+    return { success: false, error: "That shortcut isn't a valid key combination." }
+  }
+
+  try {
+    const ok = globalShortcut.register(accel, onTrigger)
+    if (!ok) {
+      return { success: false, error: 'That shortcut is already in use by another app.' }
+    }
+    currentDispatchShortcut = accel
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to register the shortcut.',
+    }
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,6 +38,21 @@ import { detectAllProviders } from './host-browser'
 import { registerUpdateHandlers, initAutoUpdater, updateAutoUpdaterWindow } from './auto-updater'
 import { enableKeepAwake, disableKeepAwake, cleanupKeepAwake, restoreKeepAwakeOnStartup } from './keep-awake'
 import { openDashboardWindow, installPopupHandler, closeAllDashboardWindows } from './dashboard-window'
+import {
+  prewarmQuickDispatchWindow,
+  toggleQuickDispatchWindow,
+  hideQuickDispatchWindow,
+  closeQuickDispatchWindow,
+  setQuickDispatchModal,
+  setQuickDispatchContentHeight,
+  startQuickDispatchDrag,
+  moveQuickDispatchDrag,
+  endQuickDispatchDrag,
+  openQuickDispatchWithFile,
+  drainQuickDispatchAttachPaths,
+} from './quick-dispatch-window'
+import { registerGlobalDispatchShortcut, unregisterGlobalDispatchShortcut } from './global-dispatch-shortcut'
+import { filesFromCommandLine } from './opened-files'
 import { safeOpenExternalFromApp } from './safe-open-external'
 
 // In dev mode, use a separate data directory to avoid mixing with production data.
@@ -572,6 +587,61 @@ ipcMain.handle('flush-pending-menu-commands', () => {
   return flushPendingMenuCommands()
 })
 
+// --- Quick-dispatch launcher IPC ---
+
+// Dispatched an agent from the launcher: hide the panel and raise the main
+// window on the brand-new session so the user can watch it work.
+ipcMain.on('quick-dispatch:dispatched', (_event, payload: { agentSlug: string; sessionId: string }) => {
+  hideQuickDispatchWindow()
+  focusMainWindowOnSession(payload.agentSlug, payload.sessionId)
+})
+
+// Esc / explicit dismiss from the launcher.
+ipcMain.on('quick-dispatch:close', () => {
+  hideQuickDispatchWindow()
+})
+
+// The launcher reports its measured content height so the frameless panel can
+// hug its contents (and grow when a dropdown opens).
+ipcMain.on('quick-dispatch:resize', (_event, height: number) => {
+  if (typeof height === 'number' && Number.isFinite(height)) {
+    setQuickDispatchContentHeight(height)
+  }
+})
+
+// Suppress the blur-to-hide while a native picker (file/folder dialog) is open.
+ipcMain.on('quick-dispatch:set-modal', (_event, open: boolean) => {
+  setQuickDispatchModal(!!open)
+})
+
+// JS window drag (the frameless panel can't use a CSS drag region — that's inert
+// to file drops). The renderer streams cursor deltas; we reposition the window.
+ipcMain.on('quick-dispatch:drag-start', () => {
+  startQuickDispatchDrag()
+})
+ipcMain.on('quick-dispatch:drag-move', (_event, delta: { dx: number; dy: number }) => {
+  if (delta && Number.isFinite(delta.dx) && Number.isFinite(delta.dy)) {
+    moveQuickDispatchDrag(delta.dx, delta.dy)
+  }
+})
+ipcMain.on('quick-dispatch:drag-end', () => {
+  endQuickDispatchDrag()
+})
+
+// "Set up voice input" from the launcher's mic button → open the main window's
+// settings (the launcher itself has no settings surface).
+ipcMain.on('quick-dispatch:open-settings', () => {
+  hideQuickDispatchWindow()
+  showOrCreateMainWindow()
+  sendToMainWindowWhenReady((win) => win.webContents.send('open-settings'))
+})
+
+// Live re-bind the global shortcut after the user changes it in Settings.
+// Returns the registration result so the UI can surface a conflict.
+ipcMain.handle('set-global-dispatch-shortcut', (_event, accelerator: string) => {
+  return registerGlobalDispatchShortcut(accelerator, toggleQuickDispatchWindow)
+})
+
 // IPC handler for setting dock badge count (macOS)
 ipcMain.handle('set-badge-count', (_event, count: number) => {
   if (process.platform === 'darwin') {
@@ -626,6 +696,10 @@ const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp'])
 
 // Track paths returned by get-recent-files so read-local-file can validate (#1 security)
 const allowedRecentPaths = new Set<string>()
+// Paths the user explicitly opened via the OS (dock drop / "Open With"). Kept
+// separate because get-recent-files clears allowedRecentPaths on every call —
+// that must not evict a just-opened file before the launcher reads it.
+const explicitlyOpenedPaths = new Set<string>()
 
 function sanitizeLimit(raw: unknown): number {
   const n = Math.floor(Number(raw) || 5)
@@ -736,8 +810,9 @@ function getRecentFilesMac(limit: number): Promise<{ name: string; path: string 
 
 // IPC handler for reading a local file as a buffer (used by recent files picker)
 ipcMain.handle('read-local-file', async (_event, filePath: string): Promise<{ buffer: ArrayBuffer; name: string; type: string } | null> => {
-  // Security: only allow reading files that were returned by get-recent-files (#1)
-  if (!allowedRecentPaths.has(filePath)) {
+  // Security: only allow reading files the user surfaced to us — either via
+  // get-recent-files (#1) or by explicitly opening them with the app.
+  if (!allowedRecentPaths.has(filePath) && !explicitlyOpenedPaths.has(filePath)) {
     console.warn('read-local-file: path not in allowed recent files:', filePath)
     return null
   }
@@ -1314,6 +1389,22 @@ async function startApp() {
   restoreKeepAwakeOnStartup(userSettings.keepAwakeEnabled).catch((error) => {
     console.error('Failed to restore keep-awake state:', error)
   })
+
+  // Quick-dispatch launcher: pre-create the hidden panel and bind its global
+  // shortcut so the first invocation appears instantly.
+  prewarmQuickDispatchWindow()
+  const dispatchResult = registerGlobalDispatchShortcut(settings.app?.globalDispatchShortcut, toggleQuickDispatchWindow)
+  if (!dispatchResult.success) {
+    console.warn(`Quick-dispatch shortcut not registered: ${dispatchResult.error}`)
+  }
+  // Windows/Linux "Open With" / drag-onto-exe / CLI file args come in on THIS
+  // launch's command line (macOS uses open-file). Queue them before the flush.
+  for (const filePath of openedFilesFrom(process.argv)) {
+    handleOpenedFile(filePath)
+  }
+  // The launcher window now exists, so any files opened before startup finished
+  // (dock drop on macOS, argv above) can be delivered to it.
+  flushPendingOpenedFiles()
 }
 
 // App lifecycle - handle activate separately
@@ -1338,6 +1429,30 @@ function showOrCreateMainWindow() {
   mainWindow.focus()
 }
 
+// Run `fn` against the main window once its renderer is ready to receive IPC.
+// If the window was just (re)created its listeners aren't mounted yet, so the
+// send would be lost — wait for the load and give React a beat to subscribe.
+function sendToMainWindowWhenReady(fn: (win: BrowserWindow) => void): void {
+  const win = mainWindow
+  if (!win || win.isDestroyed()) return
+  if (win.webContents.isLoading()) {
+    win.webContents.once('did-finish-load', () => setTimeout(() => {
+      if (mainWindow && !mainWindow.isDestroyed()) fn(mainWindow)
+    }, 300))
+  } else {
+    fn(win)
+  }
+}
+
+// Raise the main window and route it to a specific session. Reuses the same
+// 'navigate-to-agent' channel the tray/notifications use (MenuCommandHandler).
+function focusMainWindowOnSession(agentSlug: string, sessionId: string): void {
+  showOrCreateMainWindow()
+  sendToMainWindowWhenReady((win) =>
+    win.webContents.send('navigate-to-agent', agentSlug, sessionId),
+  )
+}
+
 app.whenReady().then(() => {
 
   app.on('activate', () => {
@@ -1354,6 +1469,63 @@ app.on('window-all-closed', () => {
   }
 })
 
+// Files opened with the app arrive differently per OS: macOS fires `open-file`
+// (dock drop / "Open With"), while Windows/Linux pass the paths as argv (on a
+// cold launch AND, for an already-running instance, via `second-instance`). Both
+// funnel into handleOpenedFile, which opens the launcher with the file attached.
+// open-file can fire before `ready` (cold launch by dropping a file), so paths
+// queue until the launcher window has been pre-warmed. Registered at module
+// scope so it's live before `ready`, per Electron's guidance.
+const pendingOpenedFiles: string[] = []
+let quickDispatchReadyForFiles = false
+
+// Resolve real file paths from a process command line (the Windows/Linux path),
+// wiring the pure helper to Electron/fs. No-op on macOS and in dev builds.
+function openedFilesFrom(commandLine: string[], workingDirectory?: string): string[] {
+  return filesFromCommandLine(commandLine, {
+    platform: process.platform,
+    isPackaged: app.isPackaged,
+    protocolScheme: PROTOCOL_SCHEME,
+    workingDirectory: workingDirectory || process.cwd(),
+    fileExists: (p) => {
+      try {
+        return fs.statSync(p).isFile()
+      } catch {
+        return false
+      }
+    },
+  })
+}
+
+function handleOpenedFile(filePath: string): void {
+  // Authorize this exact path for `read-local-file`: the user explicitly opened
+  // it with the app (dock drop / "Open With"), so the launcher renderer is
+  // allowed to read it. Kept in a dedicated set that get-recent-files never
+  // clears, so opening the Attach menu can't evict it before the drain reads it.
+  explicitlyOpenedPaths.add(filePath)
+  if (!quickDispatchReadyForFiles) {
+    pendingOpenedFiles.push(filePath)
+    return
+  }
+  openQuickDispatchWithFile(filePath)
+}
+
+// Renderer drains queued dock-drop / "Open With" files (pull, race-free).
+ipcMain.handle('quick-dispatch:drain-attach', () => drainQuickDispatchAttachPaths())
+
+function flushPendingOpenedFiles(): void {
+  quickDispatchReadyForFiles = true
+  while (pendingOpenedFiles.length > 0) {
+    const filePath = pendingOpenedFiles.shift()
+    if (filePath) openQuickDispatchWithFile(filePath)
+  }
+}
+
+app.on('open-file', (event, filePath) => {
+  event.preventDefault()
+  handleOpenedFile(filePath)
+})
+
 // Single-instance handling (must run BEFORE startApp). When the app is already
 // running in the tray and the user re-launches it (e.g. from the Start menu), a
 // second process spawns. It MUST bail out immediately — if it falls through to
@@ -1367,7 +1539,7 @@ if (!gotTheLock) {
   // up and nothing should ever become visible.
   app.exit(0)
 } else {
-  app.on('second-instance', (_event, commandLine) => {
+  app.on('second-instance', (_event, commandLine, workingDirectory) => {
     // The re-launch landed here on the original instance. Surface its window —
     // recreating it if it was closed to the tray — otherwise a plain re-launch
     // does nothing visible.
@@ -1377,6 +1549,12 @@ if (!gotTheLock) {
     const url = commandLine.find((arg) => arg.startsWith(`${PROTOCOL_SCHEME}://`))
     if (url) {
       handleDeepLinkUrl(url)
+    }
+
+    // Files "Open With"-ed / dropped on the exe while already running arrive as
+    // the re-launch's argv → open the launcher with them attached (Windows/Linux).
+    for (const filePath of openedFilesFrom(commandLine, workingDirectory)) {
+      handleOpenedFile(filePath)
     }
   })
 
@@ -1401,6 +1579,10 @@ async function gracefulShutdown() {
 
   // Close all dashboard windows
   closeAllDashboardWindows()
+
+  // Tear down the quick-dispatch launcher and release its global shortcut.
+  unregisterGlobalDispatchShortcut()
+  closeQuickDispatchWindow()
 
   // Destroy tray and app menu
   destroyTray()

--- a/src/main/opened-files.test.ts
+++ b/src/main/opened-files.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { filesFromCommandLine, type CommandLineFileOpts } from './opened-files'
+
+// Extraction logic is identical for every non-macOS platform, so the portable
+// cases use platform 'linux' + POSIX paths (path.resolve is host-relative). The
+// darwin / unpackaged gates are covered explicitly.
+function opts(over: Partial<CommandLineFileOpts> = {}): CommandLineFileOpts {
+  return {
+    platform: 'linux',
+    isPackaged: true,
+    protocolScheme: 'superagent',
+    workingDirectory: '/work',
+    fileExists: () => true,
+    ...over,
+  }
+}
+
+/** An existence oracle that only recognizes the given absolute paths. */
+function existsFor(...paths: string[]) {
+  const set = new Set(paths)
+  return (p: string) => set.has(p)
+}
+
+describe('filesFromCommandLine', () => {
+  it('returns [] on macOS (open-file handles it there)', () => {
+    expect(
+      filesFromCommandLine(['exe', '/work/a.txt'], opts({ platform: 'darwin' })),
+    ).toEqual([])
+  })
+
+  it('returns [] in unpackaged/dev builds', () => {
+    expect(
+      filesFromCommandLine(['electron', '/work/a.txt'], opts({ isPackaged: false })),
+    ).toEqual([])
+  })
+
+  it('extracts existing files and drops argv[0] (the executable)', () => {
+    const result = filesFromCommandLine(
+      ['/work/Gamut', '/work/a.txt', '/work/b.png'],
+      opts({ fileExists: existsFor('/work/Gamut', '/work/a.txt', '/work/b.png') }),
+    )
+    // argv[0] is sliced off even though it "exists".
+    expect(result).toEqual(['/work/a.txt', '/work/b.png'])
+  })
+
+  it('skips flags / Electron switches', () => {
+    const result = filesFromCommandLine(
+      ['exe', '--enable-foo', '/work/a.txt', '-x'],
+      opts({ fileExists: existsFor('/work/a.txt') }),
+    )
+    expect(result).toEqual(['/work/a.txt'])
+  })
+
+  it('skips deep-link protocol URLs', () => {
+    const result = filesFromCommandLine(
+      ['exe', 'superagent://open/thing', '/work/a.txt'],
+      opts({ fileExists: existsFor('/work/a.txt') }),
+    )
+    expect(result).toEqual(['/work/a.txt'])
+  })
+
+  it('resolves relative args against the working directory', () => {
+    const result = filesFromCommandLine(
+      ['exe', 'doc.txt'],
+      opts({ workingDirectory: '/work', fileExists: existsFor('/work/doc.txt') }),
+    )
+    expect(result).toEqual(['/work/doc.txt'])
+  })
+
+  it('filters out args that are not real files', () => {
+    const result = filesFromCommandLine(
+      ['exe', '/work/missing.txt'],
+      opts({ fileExists: existsFor() }),
+    )
+    expect(result).toEqual([])
+  })
+})

--- a/src/main/opened-files.ts
+++ b/src/main/opened-files.ts
@@ -1,0 +1,32 @@
+import path from 'path'
+
+export interface CommandLineFileOpts {
+  platform: NodeJS.Platform
+  isPackaged: boolean
+  protocolScheme: string
+  workingDirectory: string
+  /** True if the resolved absolute path exists and is a regular file. */
+  fileExists: (absPath: string) => boolean
+}
+
+/**
+ * Extract real file paths from a process command line — the Windows/Linux
+ * counterpart to macOS's `open-file` event. "Open With", dragging a file onto
+ * the executable / a shortcut, and CLI file args all arrive as argv there.
+ *
+ * Returns [] on macOS (which uses `open-file` instead) and in unpackaged/dev
+ * builds, where argv carries the Electron entry script and Chromium switches
+ * that would masquerade as file paths.
+ */
+export function filesFromCommandLine(commandLine: string[], opts: CommandLineFileOpts): string[] {
+  if (opts.platform === 'darwin' || !opts.isPackaged) return []
+  const files: string[] = []
+  // slice(1): argv[0] is the executable itself, never a document to attach.
+  for (const arg of commandLine.slice(1)) {
+    if (!arg || arg.startsWith('-')) continue // Electron/Chromium switches
+    if (arg.startsWith(`${opts.protocolScheme}://`)) continue // deep-link URL (handled elsewhere)
+    const resolved = path.isAbsolute(arg) ? arg : path.resolve(opts.workingDirectory, arg)
+    if (opts.fileExists(resolved)) files.push(resolved)
+  }
+  return files
+}

--- a/src/main/quick-dispatch-window.ts
+++ b/src/main/quick-dispatch-window.ts
@@ -235,19 +235,32 @@ export function setQuickDispatchContentHeight(height: number): void {
 // --- JS window drag (frameless move without a CSS drag region, which would be
 // inert to file drops). The renderer tracks the cursor and reports deltas; we
 // move the window relative to its position at drag-start.
-let dragOrigin: { x: number; y: number } | null = null
+//
+// We snapshot the SIZE at drag-start and re-assert it on every move via
+// setBounds (not setPosition). On Windows with fractional display scaling
+// (125%/150%), setPosition round-trips content-size ⇄ window-size ⇄ DIP ⇄
+// physical px and re-rounds each call, so a stream of setPosition calls during a
+// drag makes the window creep larger (vertically or horizontally) until release
+// (Electron #10862). Pinning width+height every move cancels that drift.
+let dragOrigin: { x: number; y: number; width: number; height: number } | null = null
 
-/** Begin a window drag: remember where the window was when the drag started. */
+/** Begin a window drag: remember where/how big the window was at drag start. */
 export function startQuickDispatchDrag(): void {
   if (!quickWindow || quickWindow.isDestroyed()) return
   const [x, y] = quickWindow.getPosition()
-  dragOrigin = { x, y }
+  const [width, height] = quickWindow.getSize()
+  dragOrigin = { x, y, width, height }
 }
 
 /** Move the window to its drag-start position offset by the cursor delta. */
 export function moveQuickDispatchDrag(dx: number, dy: number): void {
   if (!quickWindow || quickWindow.isDestroyed() || !dragOrigin) return
-  quickWindow.setPosition(Math.round(dragOrigin.x + dx), Math.round(dragOrigin.y + dy))
+  quickWindow.setBounds({
+    x: Math.round(dragOrigin.x + dx),
+    y: Math.round(dragOrigin.y + dy),
+    width: dragOrigin.width,
+    height: dragOrigin.height,
+  })
 }
 
 /** End the current window drag. */

--- a/src/main/quick-dispatch-window.ts
+++ b/src/main/quick-dispatch-window.ts
@@ -1,0 +1,289 @@
+import { app, BrowserWindow, screen } from 'electron'
+import path from 'path'
+import { installPopupHandler } from './dashboard-window'
+
+// The quick-dispatch launcher: a frameless, translucent, always-on-top panel
+// (Spotlight/Raycast style) that floats over whatever the user is doing. It is
+// created ONCE (hidden) and then shown/hidden by the global shortcut, so it
+// appears instantly. Kept in its own module + handle so it never collides with
+// the main window's `mainWindow`-null-on-close recreation logic (index.ts).
+
+const QUICK_WIDTH = 720
+// Initial size before the renderer reports its real height; kept close to the
+// real content so there's no first-paint jump.
+const INITIAL_HEIGHT = 100
+// Floor for the content-driven resize. Must be SMALL — the real panel is only
+// ~106px, so a large floor (the old 132) leaves an empty "chin" below it.
+const MIN_HEIGHT = 48
+
+let quickWindow: BrowserWindow | null = null
+
+// When a native picker (file/folder dialog) is open, the BrowserWindow blurs
+// even though the user hasn't left the launcher — suppress the blur-to-hide so
+// the panel doesn't vanish mid-pick. The renderer toggles this around opening
+// pickers and clears it when focus returns.
+let suppressBlurHide = false
+
+// Dev ergonomics: clicking the terminal/devtools blurs (and would hide) the
+// panel, making it impossible to inspect. Set QUICK_DISPATCH_NO_BLUR_HIDE=1 to
+// keep it visible on blur while testing.
+const blurHideDisabled = process.env.QUICK_DISPATCH_NO_BLUR_HIDE === '1'
+
+function buildQuickDispatchWindow(): BrowserWindow {
+  const win = new BrowserWindow({
+    width: QUICK_WIDTH,
+    height: INITIAL_HEIGHT,
+    frame: false,
+    // Native vibrancy (macOS) / acrylic (Windows) = real whole-window frost.
+    // The window grows to fit FULL-WIDTH dropdowns (Raycast-style), so the
+    // frosted area is always filled by the menu — never an empty frosted gap.
+    // (CSS backdrop-blur can't frost the desktop here, so native is the only
+    // real-frost option; whole-window is fine because menus fill the growth.)
+    transparent: process.platform === 'linux',
+    ...(process.platform === 'linux' && { backgroundColor: '#00000000' }),
+    resizable: false,
+    movable: true,
+    minimizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    skipTaskbar: true,
+    show: false,
+    hasShadow: true,
+    roundedCorners: true,
+    alwaysOnTop: true,
+    useContentSize: true,
+    webPreferences: {
+      preload: path.join(__dirname, '../preload/index.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      spellcheck: true,
+    },
+    ...(process.platform === 'darwin' && {
+      // Translucent behind-window frost (Raycast look). The file-drop bug was the
+      // window LEVEL, not the material — with 'floating' (see setAlwaysOnTop
+      // below) drops work. If 'under-window' (behind-window blend → more
+      // transparent backing) ever regresses drops, fall back to a within-window
+      // material ('hud' / 'menu' / 'popover' / 'sidebar').
+      vibrancy: 'under-window' as const,
+      visualEffectState: 'active' as const,
+    }),
+    ...(process.platform === 'win32' && {
+      backgroundMaterial: 'acrylic' as const,
+    }),
+  })
+
+  // Float above normal windows on every Space (macOS), like a launcher.
+  // The level MUST stay low-ish: macOS does not deliver file drag-and-drop to
+  // windows at very high levels. The original 'screen-saver' level made the
+  // launcher a non-drop-target, so Finder drags fell straight through to the
+  // window behind. 'floating' still floats above normal windows AND accepts drops.
+  win.setAlwaysOnTop(true, 'floating')
+  // `skipTransformProcessType: true` keeps the regular (foreground) process type
+  // (setVisibleOnAllWorkspaces otherwise flips to accessory/UIElement, hiding the
+  // dock icon).
+  win.setVisibleOnAllWorkspaces(true, {
+    visibleOnFullScreen: true,
+    skipTransformProcessType: true,
+  })
+
+  // Belt-and-suspenders: re-assert the dock icon in case any other panel trait
+  // still nudges the app toward accessory policy at pre-warm (before first show).
+  if (process.platform === 'darwin') {
+    void app.dock?.show()
+  }
+
+  // Trusted first-party content, but deny window.open and route any external
+  // links through the same scheme-validated opener as the rest of the app.
+  installPopupHandler(win.webContents)
+
+  if (process.env.ELECTRON_RENDERER_URL) {
+    void win.loadURL(`${process.env.ELECTRON_RENDERER_URL}/quick-dispatch.html`)
+  } else {
+    void win.loadFile(path.join(__dirname, '../renderer/quick-dispatch.html'))
+  }
+
+  // Debug aid: the launcher is frameless with no menu, so devtools is otherwise
+  // unreachable. When blur-to-hide is disabled for inspection, pop it detached.
+  if (blurHideDisabled) {
+    win.webContents.once('did-finish-load', () => {
+      if (!win.isDestroyed()) win.webContents.openDevTools({ mode: 'detach' })
+    })
+  }
+
+  win.on('blur', () => {
+    if (blurHideDisabled || suppressBlurHide) return
+    // Defer one tick so a focus that bounces straight back (e.g. a native
+    // dialog dismissed) cancels the hide.
+    setTimeout(() => {
+      if (
+        !suppressBlurHide &&
+        quickWindow &&
+        !quickWindow.isDestroyed() &&
+        !quickWindow.isFocused()
+      ) {
+        quickWindow.hide()
+      }
+    }, 80)
+  })
+
+  // The panel is hidden (not destroyed) between uses, so its composer state
+  // survives. Tell the renderer to reset when it hides so the next open is
+  // fresh — fires for every dismiss path (Esc, blur, post-dispatch).
+  win.on('hide', () => {
+    if (!win.isDestroyed()) win.webContents.send('quick-dispatch:reset')
+  })
+
+  win.on('closed', () => {
+    quickWindow = null
+  })
+
+  return win
+}
+
+/** Lazily create the (hidden) launcher window and return it. */
+export function getQuickDispatchWindow(): BrowserWindow {
+  if (!quickWindow || quickWindow.isDestroyed()) {
+    quickWindow = buildQuickDispatchWindow()
+  }
+  return quickWindow
+}
+
+/** Pre-create the hidden window at startup so the first open is instant. */
+export function prewarmQuickDispatchWindow(): void {
+  getQuickDispatchWindow()
+}
+
+function positionQuickWindow(win: BrowserWindow): void {
+  const cursor = screen.getCursorScreenPoint()
+  const display = screen.getDisplayNearestPoint(cursor)
+  const { x, y, width, height } = display.workArea
+  const [winW] = win.getSize()
+  const winX = Math.round(x + (width - winW) / 2)
+  // Anchor in the upper third — classic launcher placement.
+  const winY = Math.round(y + height * 0.22)
+  win.setPosition(winX, winY)
+}
+
+export function showQuickDispatchWindow(): void {
+  const win = getQuickDispatchWindow()
+  suppressBlurHide = false
+  positionQuickWindow(win)
+  win.show()
+  win.focus()
+  // Re-assert the dock icon in case showing the all-workspaces panel re-flipped
+  // the activation policy (see buildQuickDispatchWindow).
+  if (process.platform === 'darwin') {
+    void app.dock?.show()
+  }
+  // Tell the renderer to focus the input and re-measure its height.
+  win.webContents.send('quick-dispatch:shown')
+}
+
+export function hideQuickDispatchWindow(): void {
+  if (quickWindow && !quickWindow.isDestroyed() && quickWindow.isVisible()) {
+    quickWindow.hide()
+  }
+}
+
+export function toggleQuickDispatchWindow(): void {
+  const win = getQuickDispatchWindow()
+  if (win.isVisible() && win.isFocused()) {
+    // Already open: a second shortcut press toggles dictation rather than hiding
+    // the panel (Esc / click-away still dismiss it). The renderer decides
+    // start-vs-stop from the current voice state.
+    win.webContents.send('quick-dispatch:toggle-dictation')
+  } else {
+    showQuickDispatchWindow()
+  }
+}
+
+export function closeQuickDispatchWindow(): void {
+  if (quickWindow && !quickWindow.isDestroyed()) {
+    quickWindow.destroy()
+  }
+  quickWindow = null
+}
+
+/** Suppress (or restore) the blur-to-hide while a native picker is open. */
+export function setQuickDispatchModal(open: boolean): void {
+  suppressBlurHide = open
+}
+
+/** Resize the panel's content height to hug its contents (renderer-driven). */
+export function setQuickDispatchContentHeight(height: number): void {
+  if (!quickWindow || quickWindow.isDestroyed()) return
+  const clamped = Math.max(MIN_HEIGHT, Math.min(Math.round(height), 900))
+  const [, currentH] = quickWindow.getContentSize()
+  if (currentH === clamped) return
+
+  // Capture the top edge BEFORE resizing. On macOS, setContentSize anchors the
+  // window's bottom-left (Cocoa's origin is bottom-left), so growing the content
+  // pushes the TOP upward — which shoves the text input off the top of the
+  // screen when a menu opens. Re-pin the top afterward so the panel always grows
+  // DOWNWARD from a fixed anchor (Raycast-style), respecting any user drag.
+  const { x, y: topBefore } = quickWindow.getBounds()
+  quickWindow.setContentSize(QUICK_WIDTH, clamped)
+
+  // Hold the original top, but clamp so the (possibly taller) window stays fully
+  // within the display's work area.
+  const { workArea } = screen.getDisplayNearestPoint({ x, y: topBefore })
+  const maxTop = workArea.y + workArea.height - clamped - 8
+  const top = Math.max(workArea.y + 8, Math.min(topBefore, maxTop))
+  quickWindow.setPosition(x, Math.round(top))
+}
+
+// --- JS window drag (frameless move without a CSS drag region, which would be
+// inert to file drops). The renderer tracks the cursor and reports deltas; we
+// move the window relative to its position at drag-start.
+let dragOrigin: { x: number; y: number } | null = null
+
+/** Begin a window drag: remember where the window was when the drag started. */
+export function startQuickDispatchDrag(): void {
+  if (!quickWindow || quickWindow.isDestroyed()) return
+  const [x, y] = quickWindow.getPosition()
+  dragOrigin = { x, y }
+}
+
+/** Move the window to its drag-start position offset by the cursor delta. */
+export function moveQuickDispatchDrag(dx: number, dy: number): void {
+  if (!quickWindow || quickWindow.isDestroyed() || !dragOrigin) return
+  quickWindow.setPosition(Math.round(dragOrigin.x + dx), Math.round(dragOrigin.y + dy))
+}
+
+/** End the current window drag. */
+export function endQuickDispatchDrag(): void {
+  dragOrigin = null
+}
+
+// Files awaiting attachment, delivered PULL-style: the renderer drains this on
+// mount AND on the `attach-pending` ping. Pull (not push) so a file queued
+// before the renderer registered its listener is never lost to a timing race —
+// the mount-time drain always catches it. See openQuickDispatchWithFile.
+const pendingAttachPaths: string[] = []
+
+/** Return and clear the queued attach paths (renderer calls this to drain). */
+export function drainQuickDispatchAttachPaths(): string[] {
+  const paths = pendingAttachPaths.slice()
+  pendingAttachPaths.length = 0
+  return paths
+}
+
+/**
+ * Show the launcher and queue a file (dropped on the dock icon / "Open With")
+ * for the renderer to attach. Queue first, then nudge the renderer with a ping;
+ * even if the ping is missed on a cold launch, the renderer's mount-time drain
+ * picks up the already-queued path.
+ */
+export function openQuickDispatchWithFile(filePath: string): void {
+  const win = getQuickDispatchWindow()
+  pendingAttachPaths.push(filePath)
+  const deliver = () => {
+    showQuickDispatchWindow()
+    win.webContents.send('quick-dispatch:attach-pending')
+  }
+  if (win.webContents.isLoading()) {
+    win.webContents.once('did-finish-load', deliver)
+  } else {
+    deliver()
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -334,6 +334,81 @@ contextBridge.exposeInMainWorld('electronAPI', {
   removeUpdateStatus: () => {
     ipcRenderer.removeAllListeners('update-status')
   },
+
+  // --- Quick-dispatch launcher ---
+
+  // Fired by the launcher renderer after an agent is dispatched: hide the panel
+  // and raise the main window on the new session.
+  quickDispatchDispatched: (payload: { agentSlug: string; sessionId: string }) => {
+    ipcRenderer.send('quick-dispatch:dispatched', payload)
+  },
+  // Dismiss the launcher (Esc / blur from the renderer).
+  quickDispatchClose: () => {
+    ipcRenderer.send('quick-dispatch:close')
+  },
+  // Report measured content height so the frameless panel hugs its contents.
+  quickDispatchResize: (height: number) => {
+    ipcRenderer.send('quick-dispatch:resize', height)
+  },
+  // Suppress blur-to-hide while a native picker is open (true), then restore (false).
+  quickDispatchSetModal: (open: boolean) => {
+    ipcRenderer.send('quick-dispatch:set-modal', open)
+  },
+  // "Set up voice input" → open the main window's settings.
+  quickDispatchOpenSettings: () => {
+    ipcRenderer.send('quick-dispatch:open-settings')
+  },
+  // JS window-drag: the panel can't use a CSS drag region (inert to file drops),
+  // so the renderer drives the move — start, then stream cursor deltas, then end.
+  quickDispatchDragStart: () => {
+    ipcRenderer.send('quick-dispatch:drag-start')
+  },
+  quickDispatchDragMove: (delta: { dx: number; dy: number }) => {
+    ipcRenderer.send('quick-dispatch:drag-move', delta)
+  },
+  quickDispatchDragEnd: () => {
+    ipcRenderer.send('quick-dispatch:drag-end')
+  },
+  // Main → launcher: the panel was just shown (focus input, re-measure).
+  onQuickDispatchShown: (callback: () => void): (() => void) => {
+    const handler = () => callback()
+    ipcRenderer.on('quick-dispatch:shown', handler)
+    return () => {
+      ipcRenderer.removeListener('quick-dispatch:shown', handler)
+    }
+  },
+  // Main → launcher: a second shortcut press while open → toggle dictation.
+  onQuickDispatchToggleDictation: (callback: () => void): (() => void) => {
+    const handler = () => callback()
+    ipcRenderer.on('quick-dispatch:toggle-dictation', handler)
+    return () => {
+      ipcRenderer.removeListener('quick-dispatch:toggle-dictation', handler)
+    }
+  },
+  // Pull the queued dock-drop / "Open With" file paths (race-free: the renderer
+  // drains on mount and on the `attach-pending` ping below).
+  quickDispatchDrainAttach: (): Promise<string[]> => ipcRenderer.invoke('quick-dispatch:drain-attach'),
+  // Main → launcher: files are queued for attach — drain them now.
+  onQuickDispatchAttachPending: (callback: () => void): (() => void) => {
+    const handler = () => callback()
+    ipcRenderer.on('quick-dispatch:attach-pending', handler)
+    return () => {
+      ipcRenderer.removeListener('quick-dispatch:attach-pending', handler)
+    }
+  },
+  // Main → launcher: the panel was hidden — reset transient state (attachments).
+  onQuickDispatchReset: (callback: () => void): (() => void) => {
+    const handler = () => callback()
+    ipcRenderer.on('quick-dispatch:reset', handler)
+    return () => {
+      ipcRenderer.removeListener('quick-dispatch:reset', handler)
+    }
+  },
+  // Re-bind the global launcher shortcut (from Settings). Resolves to the
+  // registration result so the UI can surface conflicts.
+  setGlobalDispatchShortcut: (accelerator: string): Promise<{ success: boolean; error?: string }> => {
+    return ipcRenderer.invoke('set-global-dispatch-shortcut', accelerator)
+  },
 })
 
 // OAuth callback params from main process
@@ -417,6 +492,20 @@ declare global {
       getUpdateStatus: () => Promise<any>
       onUpdateStatus: (callback: (status: any) => void) => () => void
       removeUpdateStatus: () => void
+      quickDispatchDispatched: (payload: { agentSlug: string; sessionId: string }) => void
+      quickDispatchClose: () => void
+      quickDispatchResize: (height: number) => void
+      quickDispatchSetModal: (open: boolean) => void
+      quickDispatchOpenSettings: () => void
+      quickDispatchDragStart: () => void
+      quickDispatchDragMove: (delta: { dx: number; dy: number }) => void
+      quickDispatchDragEnd: () => void
+      onQuickDispatchShown: (callback: () => void) => () => void
+      onQuickDispatchToggleDictation: (callback: () => void) => () => void
+      quickDispatchDrainAttach: () => Promise<string[]>
+      onQuickDispatchAttachPending: (callback: () => void) => () => void
+      onQuickDispatchReset: (callback: () => void) => () => void
+      setGlobalDispatchShortcut: (accelerator: string) => Promise<{ success: boolean; error?: string }>
     }
   }
 }

--- a/src/renderer/components/quick-dispatch/quick-dispatch-app.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch-app.tsx
@@ -1,0 +1,107 @@
+import { useEffect, type ReactNode } from 'react'
+import { QueryProvider } from '@renderer/providers/query-provider'
+import { UserProvider } from '@renderer/context/user-context'
+import { AnalyticsProvider } from '@renderer/context/analytics-context'
+import { ConnectivityProvider } from '@renderer/context/connectivity-context'
+import { DraftsProvider } from '@renderer/context/drafts-context'
+import { DialogContext, type DialogContextType } from '@renderer/context/dialog-context'
+import { useTheme } from '@renderer/hooks/use-theme'
+import { Toaster } from '@renderer/components/ui/sonner'
+import { QuickDispatch } from './quick-dispatch'
+
+/**
+ * The launcher window's root. A deliberately slim subset of the main app's
+ * provider stack — NO router, NO app shell, NO background SSE — just what the
+ * reused composer pieces need:
+ *   - QueryProvider     → all the data hooks (agents, settings, create-session)
+ *   - UserProvider      → useUser() (no-op/network-free outside auth mode)
+ *   - AnalyticsProvider → useAnalyticsTracking() in create-session / voice
+ *   - ConnectivityProvider, DraftsProvider → composer state
+ *   - DialogContext     → a router-free stub so VoiceInputButton's
+ *                         openSettings('voice') routes to the MAIN window
+ */
+
+// The real DialogProvider needs the router (it navigates to /settings). Here we
+// supply a value that hands the intent to the main process instead.
+const launcherDialogValue: DialogContextType = {
+  openSettings: () => window.electronAPI?.quickDispatchOpenSettings?.(),
+  closeSettings: () => {},
+  openWizard: () => {},
+}
+
+/** Apply the user's theme (dark/light/system) — same effect the main app uses. */
+function ThemeSync({ children }: { children: ReactNode }) {
+  useTheme()
+  return <>{children}</>
+}
+
+/**
+ * Keep the frameless panel sized to its contents. Measures the rendered card
+ * (plus any open Radix dropdown, which portals to <body> outside #root) and
+ * tells the main process to set the window's content height. rAF-throttled.
+ */
+function AutoResizeWindow() {
+  useEffect(() => {
+    let raf = 0
+    const measure = () => {
+      raf = 0
+      // Never measure from a scrolled state: a stray focus-into-view can scroll
+      // the panel up, which would make getBoundingClientRect under-report the
+      // card height and freeze the window too short. Snap back to the top first.
+      const se = document.scrollingElement
+      if (se && se.scrollTop !== 0) se.scrollTop = 0
+      // Measure the launcher card itself — NOT #root, which globals.css stretches
+      // to full height (would make the frameless window measure full-screen-tall).
+      const card = document.querySelector('[data-testid="quick-dispatch"]')
+      let bottom = card ? card.getBoundingClientRect().bottom : 0
+      // The inline menus grow the card itself, but a few reused bits still portal
+      // a Radix popper to <body> outside the card (e.g. the mic button's tooltip).
+      // Include any such popper so the window grows to fit it instead of clipping.
+      let popperOpen = false
+      document.querySelectorAll('[data-radix-popper-content-wrapper]').forEach((el) => {
+        popperOpen = true
+        bottom = Math.max(bottom, (el as HTMLElement).getBoundingClientRect().bottom)
+      })
+      // Resting: hug tight (+2, no "chin"). With a dropdown open: a little more so
+      // its shadow isn't clipped at the window edge.
+      window.electronAPI?.quickDispatchResize?.(Math.ceil(bottom) + (popperOpen ? 10 : 2))
+    }
+    const schedule = () => {
+      if (!raf) raf = requestAnimationFrame(measure)
+    }
+    const ro = new ResizeObserver(schedule)
+    ro.observe(document.body)
+    // Dropdowns/dialogs add & remove portaled nodes under <body>.
+    const mo = new MutationObserver(schedule)
+    mo.observe(document.body, { childList: true, subtree: true })
+    schedule()
+    return () => {
+      ro.disconnect()
+      mo.disconnect()
+      if (raf) cancelAnimationFrame(raf)
+    }
+  }, [])
+  return null
+}
+
+export function QuickDispatchApp() {
+  return (
+    <QueryProvider>
+      <UserProvider>
+        <AnalyticsProvider>
+          <ConnectivityProvider>
+            <DraftsProvider>
+              <DialogContext.Provider value={launcherDialogValue}>
+                <ThemeSync>
+                  <AutoResizeWindow />
+                  <QuickDispatch />
+                  <Toaster />
+                </ThemeSync>
+              </DialogContext.Provider>
+            </DraftsProvider>
+          </ConnectivityProvider>
+        </AnalyticsProvider>
+      </UserProvider>
+    </QueryProvider>
+  )
+}

--- a/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
@@ -1,0 +1,239 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { AtSign, Check, FileIcon, FolderOpen, Loader2, Search } from 'lucide-react'
+import { cn } from '@shared/lib/utils'
+import { ModelFamilyList } from '@renderer/components/messages/model-family-list'
+import { findCatalogModel, type ComposerOptionsState } from '@renderer/components/messages/composer-options'
+import { EFFORT_LEVELS, type EffortLevel } from '@shared/lib/container/types'
+import { FileTypeIcon } from '@renderer/components/ui/file-type-icon'
+import type { ApiAgent } from '@renderer/hooks/use-agents'
+
+// Inline, full-width menus for the quick-dispatch launcher. Unlike the main
+// app's floating popovers, these render INSIDE the panel's flex column so the
+// frameless window grows to fit them (Raycast-style) — the whole frosted area
+// is filled by the menu, never an empty frosted surround.
+
+export const EFFORT_LABELS: Record<EffortLevel, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  xhigh: 'Extra High',
+  max: 'Max',
+}
+
+function SectionHeader({ children }: { children: ReactNode }) {
+  return (
+    <div className="px-2 pt-1 pb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+      {children}
+    </div>
+  )
+}
+
+function activityTime(a: ApiAgent): number {
+  return a.lastActivityAt ? new Date(a.lastActivityAt).getTime() : 0
+}
+
+export function AgentMenu({
+  agents,
+  selectedSlug,
+  onSelect,
+  maxHeight,
+}: {
+  agents: ApiAgent[]
+  selectedSlug: string | undefined
+  onSelect: (slug: string) => void
+  /** Caps the scrollable list height (inline style — guaranteed, no Tailwind purge risk). */
+  maxHeight: number
+}) {
+  const [query, setQuery] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    // `preventScroll` is LOAD-BEARING: the search box sits below the fold while
+    // the window is still growing to fit the menu, so a normal focus would
+    // scroll the whole panel up to reveal it — shoving the text input off the
+    // top of the window (and freezing the auto-resize at the wrong height).
+    requestAnimationFrame(() => inputRef.current?.focus({ preventScroll: true }))
+  }, [])
+
+  const ordered = useMemo(() => [...agents].sort((a, b) => activityTime(b) - activityTime(a)), [agents])
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return q ? ordered.filter((a) => a.name.toLowerCase().includes(q)) : ordered
+  }, [ordered, query])
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 px-3 py-2">
+        <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search agents…"
+          className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          data-testid="quick-dispatch-agent-search"
+        />
+      </div>
+      <div className="overflow-y-auto p-1" style={{ maxHeight }}>
+        {filtered.length === 0 ? (
+          <div className="px-3 py-6 text-center text-sm text-muted-foreground">No agents</div>
+        ) : (
+          filtered.map((agent) => (
+            <button
+              key={agent.slug}
+              type="button"
+              onClick={() => onSelect(agent.slug)}
+              data-testid="quick-dispatch-agent-option"
+              className={cn(
+                'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent',
+                agent.slug === selectedSlug && 'bg-accent',
+              )}
+            >
+              <AtSign className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="truncate">{agent.name}</span>
+              {agent.slug === selectedSlug && <Check className="ml-auto h-3.5 w-3.5 shrink-0" />}
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function ModelEffortMenu({ state, maxHeight }: { state: ComposerOptionsState; maxHeight: number }) {
+  const { effort, setEffort, model, setModel, catalog } = state
+  const selected =
+    findCatalogModel(model, catalog) ?? catalog.find((m) => m.family === 'sonnet' && m.isLatest) ?? catalog[0]
+  const efforts = EFFORT_LEVELS.filter((l) => (selected ? selected.supportedEfforts.includes(l) : true))
+
+  return (
+    // Only the model list scrolls; the effort row is pinned to the bottom so
+    // it's always reachable however long the catalog is. `maxHeight` (not a
+    // fixed height) keeps the menu content-sized when short — no dead gap above
+    // the pinned effort row; `min-h-0` lets the list actually shrink to scroll.
+    <div className="flex flex-col" style={{ maxHeight }}>
+      <div className="min-h-0 flex-1 overflow-y-auto px-1 pt-2">
+        <SectionHeader>Model</SectionHeader>
+        <ModelFamilyList catalog={catalog} value={model} onPick={setModel} onSelectFamilyLatest={setModel} />
+      </div>
+      <div className="shrink-0 px-1 pb-1 pt-2">
+        <SectionHeader>Effort</SectionHeader>
+        <div className="flex flex-wrap gap-1 px-2">
+          {efforts.map((l) => (
+            <button
+              key={l}
+              type="button"
+              onClick={() => setEffort(l)}
+              data-testid={`effort-option-${l}`}
+              className={cn(
+                'rounded-md px-2.5 py-1 text-xs hover:bg-accent',
+                effort === l ? 'bg-accent font-medium' : 'text-muted-foreground',
+              )}
+            >
+              {EFFORT_LABELS[l]}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface RecentFile {
+  name: string
+  path: string
+  thumbnail?: string
+}
+
+export function AttachMenu({
+  onFileSelect,
+  onFolderSelect,
+  onRecentFileAttach,
+}: {
+  onFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onFolderSelect: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onRecentFileAttach: (file: File) => void
+}) {
+  const fileRef = useRef<HTMLInputElement>(null)
+  const folderRef = useRef<HTMLInputElement>(null)
+  const [recent, setRecent] = useState<RecentFile[]>([])
+  const [loadingPath, setLoadingPath] = useState<string | null>(null)
+  const isElectron = !!window.electronAPI?.getRecentFiles
+
+  useEffect(() => {
+    if (!isElectron) return
+    let cancelled = false
+    window.electronAPI!.getRecentFiles(5)
+      .then((files) => {
+        if (!cancelled) setRecent(files)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [isElectron])
+
+  const handleRecent = useCallback(
+    async (filePath: string) => {
+      const api = window.electronAPI
+      if (!api?.readLocalFile) return
+      setLoadingPath(filePath)
+      try {
+        const result = await api.readLocalFile(filePath)
+        if (result) onRecentFileAttach(new File([result.buffer], result.name, { type: result.type }))
+      } finally {
+        setLoadingPath(null)
+      }
+    },
+    [onRecentFileAttach],
+  )
+
+  return (
+    <div className="p-1">
+      <input ref={fileRef} type="file" multiple className="hidden" onChange={onFileSelect} />
+      <input
+        ref={folderRef}
+        type="file"
+        className="hidden"
+        onChange={onFolderSelect}
+        {...({ webkitdirectory: '', directory: '' } as React.InputHTMLAttributes<HTMLInputElement>)}
+      />
+      {recent.length > 0 && (
+        <>
+          <SectionHeader>Recent</SectionHeader>
+          {recent.map((f) => (
+            <button
+              key={f.path}
+              type="button"
+              disabled={loadingPath !== null}
+              onClick={() => handleRecent(f.path)}
+              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left hover:bg-accent disabled:opacity-50"
+            >
+              {loadingPath === f.path ? (
+                <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
+              ) : f.thumbnail ? (
+                <img src={f.thumbnail} alt="" className="h-5 w-5 shrink-0 rounded-sm object-cover" />
+              ) : (
+                <FileTypeIcon filename={f.name} size={14} />
+              )}
+              <span className="truncate text-xs">{f.name}</span>
+            </button>
+          ))}
+        </>
+      )}
+      <button
+        type="button"
+        onClick={() => fileRef.current?.click()}
+        className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent"
+      >
+        <FileIcon className="h-4 w-4" /> Files
+      </button>
+      <button
+        type="button"
+        onClick={() => folderRef.current?.click()}
+        className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent"
+      >
+        <FolderOpen className="h-4 w-4" /> Folder
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/components/quick-dispatch/quick-dispatch.test.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.test.tsx
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// QuickDispatch wires the reused composer to the launcher's window IPC. These
+// tests exercise its OWN logic — default-agent selection, the Enter handler, and
+// the dock-drop / reset effects — by mocking the composer + data hooks so we can
+// spy on the calls it makes.
+
+// --- controllable mock state (hoisted so the vi.mock factories can read it) ---
+const state = vi.hoisted(() => ({
+  agents: [] as { slug: string; name: string; lastActivityAt?: string }[],
+}))
+
+const composerMock = vi.hoisted(() => ({
+  message: '',
+  attachments: [] as unknown[],
+  isUploading: false,
+  canSubmit: true,
+  uploadError: null as string | null,
+  setMessage: vi.fn(),
+  addFiles: vi.fn(),
+  clearAttachments: vi.fn(),
+  removeAttachment: vi.fn(),
+  handleSubmit: vi.fn((e?: { preventDefault?: () => void }) => e?.preventDefault?.()),
+  handlePaste: vi.fn(),
+  handleFileSelect: vi.fn(),
+  handleFolderSelect: vi.fn(),
+  clearUploadError: vi.fn(),
+  voiceInput: {
+    isRecording: false,
+    isConnecting: false,
+    isFinalizing: false,
+    error: null,
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+    clearError: vi.fn(),
+  },
+  mountDialog: { open: false, onChoice: vi.fn(), folderName: undefined },
+  dragHandlers: { onDrop: vi.fn() },
+}))
+
+const createSessionMock = vi.hoisted(() => ({
+  mutateAsync: vi.fn().mockResolvedValue({ id: 'sess-1' }),
+  isPending: false,
+}))
+
+vi.mock('@renderer/hooks/use-agents', () => ({ useAgents: () => ({ data: state.agents }) }))
+vi.mock('@renderer/hooks/use-sessions', () => ({ useCreateSession: () => createSessionMock }))
+vi.mock('@renderer/hooks/use-message-composer', () => ({ useMessageComposer: () => composerMock }))
+vi.mock('@renderer/hooks/use-voice-input', () => ({
+  useIsVoiceConfigured: () => true,
+  useVoiceInput: () => ({}),
+}))
+vi.mock('@renderer/components/messages/composer-options', () => ({
+  useComposerOptions: () => ({
+    model: 'sonnet',
+    effort: 'high',
+    catalog: [{ family: 'sonnet', isLatest: true, label: 'Sonnet', icon: 'sonnet', supportedEfforts: ['low', 'high'] }],
+    setModel: vi.fn(),
+    setEffort: vi.fn(),
+    toRuntimeOptions: () => ({}),
+  }),
+  findCatalogModel: () => ({ label: 'Sonnet', icon: 'sonnet' }),
+}))
+
+// The inline menus + heavy children pull in their own deps; stub them since these
+// tests never open a menu. EFFORT_LABELS must stay a real map (read in the footer).
+vi.mock('./quick-dispatch-menus', () => ({
+  AgentMenu: () => null,
+  AttachMenu: () => null,
+  ModelEffortMenu: () => null,
+  EFFORT_LABELS: { low: 'Low', medium: 'Medium', high: 'High', xhigh: 'Extra High', max: 'Max' },
+}))
+vi.mock('@renderer/components/messages/attachment-preview', () => ({ AttachmentPreview: () => null }))
+vi.mock('@renderer/components/ui/voice-input-button', () => ({ VoiceInputButton: () => null, VoiceInputError: () => null }))
+vi.mock('@renderer/components/ui/upload-error', () => ({ UploadError: () => null }))
+vi.mock('@renderer/components/ui/mount-choice-dialog', () => ({ MountChoiceDialog: () => null }))
+vi.mock('@renderer/components/ui/model-icon', () => ({ ModelIcon: () => null }))
+vi.mock('@renderer/lib/api', () => ({ apiFetch: vi.fn() }))
+vi.mock('@renderer/lib/upload', () => ({ uploadFileChunked: vi.fn() }))
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+import { QuickDispatch } from './quick-dispatch'
+
+/** Install a window.electronAPI stub; returns captured main→renderer callbacks. */
+function installElectronAPI(overrides: Record<string, unknown> = {}) {
+  const listeners: Record<string, () => void> = {}
+  const capture = (key: string) =>
+    vi.fn((cb: () => void) => {
+      listeners[key] = cb
+      return vi.fn()
+    })
+  window.electronAPI = {
+    onQuickDispatchShown: capture('shown'),
+    onQuickDispatchToggleDictation: capture('toggleDictation'),
+    onQuickDispatchAttachPending: capture('attachPending'),
+    onQuickDispatchReset: capture('reset'),
+    quickDispatchDrainAttach: vi.fn().mockResolvedValue([]),
+    readLocalFile: vi.fn(),
+    quickDispatchDispatched: vi.fn(),
+    quickDispatchClose: vi.fn(),
+    quickDispatchResize: vi.fn(),
+    quickDispatchSetModal: vi.fn(),
+    quickDispatchOpenSettings: vi.fn(),
+    quickDispatchDragStart: vi.fn(),
+    quickDispatchDragMove: vi.fn(),
+    quickDispatchDragEnd: vi.fn(),
+    getRecentFiles: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  } as unknown as typeof window.electronAPI
+  return listeners
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Reset controllable state to defaults.
+  state.agents = [{ slug: 'a1', name: 'Agent One', lastActivityAt: '2024-01-01T00:00:00Z' }]
+  composerMock.message = ''
+  composerMock.attachments = []
+  composerMock.isUploading = false
+  composerMock.canSubmit = true
+  composerMock.uploadError = null
+})
+
+afterEach(() => {
+  cleanup()
+  delete (window as { electronAPI?: unknown }).electronAPI
+})
+
+describe('QuickDispatch', () => {
+  it('defaults to the most-recently-active agent', async () => {
+    state.agents = [
+      { slug: 'old', name: 'Older', lastActivityAt: '2024-01-01T00:00:00Z' },
+      { slug: 'new', name: 'Newest', lastActivityAt: '2024-03-01T00:00:00Z' },
+      { slug: 'mid', name: 'Middle', lastActivityAt: '2024-02-01T00:00:00Z' },
+    ]
+    installElectronAPI()
+    render(<QuickDispatch />)
+
+    // The default-agent effect runs after mount; the footer trigger reflects it.
+    await waitFor(() =>
+      expect(screen.getByTestId('quick-dispatch-agent-trigger')).toHaveTextContent('Newest'),
+    )
+    expect(screen.getByTestId('quick-dispatch-input')).toHaveAttribute('placeholder', 'Dispatch Newest…')
+  })
+
+  it('dispatches on Enter but inserts a newline on Shift+Enter', async () => {
+    installElectronAPI()
+    render(<QuickDispatch />)
+    await waitFor(() =>
+      expect(screen.getByTestId('quick-dispatch-agent-trigger')).toHaveTextContent('Agent One'),
+    )
+    const input = screen.getByTestId('quick-dispatch-input')
+
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true })
+    expect(composerMock.handleSubmit).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(composerMock.handleSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears attachments when the window is hidden (reset)', async () => {
+    const listeners = installElectronAPI()
+    render(<QuickDispatch />)
+    await waitFor(() => expect(listeners.reset).toBeTypeOf('function'))
+
+    act(() => listeners.reset())
+
+    expect(composerMock.clearAttachments).toHaveBeenCalledTimes(1)
+  })
+
+  it('drains and attaches a dock-dropped file on mount', async () => {
+    installElectronAPI({
+      quickDispatchDrainAttach: vi.fn().mockResolvedValue(['/tmp/dropped.txt']),
+      readLocalFile: vi.fn().mockResolvedValue({
+        buffer: new ArrayBuffer(3),
+        name: 'dropped.txt',
+        type: 'text/plain',
+      }),
+    })
+    render(<QuickDispatch />)
+
+    await waitFor(() => expect(composerMock.addFiles).toHaveBeenCalledTimes(1))
+    const attached = composerMock.addFiles.mock.calls[0][0] as { file: File }[]
+    expect(attached[0].file.name).toBe('dropped.txt')
+  })
+
+  it('also drains when the attach-pending ping fires (already-open case)', async () => {
+    const drain = vi.fn().mockResolvedValue([])
+    const listeners = installElectronAPI({ quickDispatchDrainAttach: drain })
+    render(<QuickDispatch />)
+    await waitFor(() => expect(drain).toHaveBeenCalledTimes(1)) // mount drain
+
+    await act(async () => {
+      listeners.attachPending()
+    })
+    expect(drain).toHaveBeenCalledTimes(2) // ping drain
+  })
+})

--- a/src/renderer/components/quick-dispatch/quick-dispatch.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.tsx
@@ -1,0 +1,455 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { ArrowUp, AtSign, ChevronDown, Loader2, Paperclip } from 'lucide-react'
+import { cn } from '@shared/lib/utils'
+import { Button } from '@renderer/components/ui/button'
+import { ModelIcon } from '@renderer/components/ui/model-icon'
+import { apiFetch } from '@renderer/lib/api'
+import { uploadFileChunked } from '@renderer/lib/upload'
+import { useAgents, type ApiAgent } from '@renderer/hooks/use-agents'
+import { useCreateSession } from '@renderer/hooks/use-sessions'
+import { useMessageComposer } from '@renderer/hooks/use-message-composer'
+import { AttachmentPreview } from '@renderer/components/messages/attachment-preview'
+import { findCatalogModel, useComposerOptions } from '@renderer/components/messages/composer-options'
+import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
+import { useIsVoiceConfigured } from '@renderer/hooks/use-voice-input'
+import { UploadError } from '@renderer/components/ui/upload-error'
+import { MountChoiceDialog } from '@renderer/components/ui/mount-choice-dialog'
+import { toast } from 'sonner'
+import { AgentMenu, AttachMenu, ModelEffortMenu, EFFORT_LABELS } from './quick-dispatch-menus'
+
+type OpenMenu = 'agent' | 'model' | 'attach' | null
+
+// Hard cap on a menu's scrollable height so the window never grows off-screen.
+// Window ≈ input + footer + this ≈ 450px, which fits below the launcher's
+// top anchor on any common display.
+const MENU_MAX_HEIGHT = 300
+
+function activityTime(a: ApiAgent): number {
+  return a.lastActivityAt ? new Date(a.lastActivityAt).getTime() : 0
+}
+
+/** A borderless, floaty footer trigger that toggles an inline menu. */
+function TriggerButton({
+  active,
+  onClick,
+  children,
+  testId,
+}: {
+  active: boolean
+  onClick: () => void
+  children: ReactNode
+  testId?: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={testId}
+      className={cn(
+        'inline-flex h-[34px] max-w-[200px] items-center gap-1.5 rounded-md px-2 text-xs font-medium hover:bg-accent',
+        active && 'bg-accent',
+      )}
+    >
+      {children}
+    </button>
+  )
+}
+
+/**
+ * The quick-dispatch launcher composer. Reuses the main app's composer logic —
+ * useMessageComposer (uploads, voice, paste, mount dialog) + useComposerOptions
+ * — but renders its agent / model·effort / attachment pickers as INLINE,
+ * full-width menus that grow the frameless window (Raycast-style) rather than
+ * floating popovers, so the frosted panel is always filled. On submit it
+ * creates a session via POST /api/agents/:slug/sessions and asks the main
+ * process to raise the main window on the new session.
+ */
+export function QuickDispatch() {
+  const { data: agents } = useAgents()
+  const agentList = useMemo(() => (Array.isArray(agents) ? agents : []), [agents])
+  const [selectedSlug, setSelectedSlug] = useState<string | undefined>(undefined)
+  const [openMenu, setOpenMenu] = useState<OpenMenu>(null)
+  // Whether a file is being dragged over the window (drives the drop overlay).
+  const [dropActive, setDropActive] = useState(false)
+
+  // Default to the most-recently-active agent once the list loads.
+  useEffect(() => {
+    if (selectedSlug || agentList.length === 0) return
+    const mostRecent = [...agentList].sort((a, b) => activityTime(b) - activityTime(a))[0]
+    setSelectedSlug(mostRecent?.slug)
+  }, [agentList, selectedSlug])
+
+  const selectedAgent = agentList.find((a) => a.slug === selectedSlug)
+  const agentSlug = selectedSlug ?? ''
+  const composerOptions = useComposerOptions()
+  const createSession = useCreateSession()
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const selectedModel =
+    findCatalogModel(composerOptions.model, composerOptions.catalog) ??
+    composerOptions.catalog.find((m) => m.family === 'sonnet' && m.isLatest) ??
+    composerOptions.catalog[0]
+
+  const composer = useMessageComposer({
+    agentSlug,
+    uploadFile: useCallback(
+      ({ file }: { file: File }) =>
+        uploadFileChunked<{ path: string }>({ url: `/api/agents/${agentSlug}/upload-file`, file }),
+      [agentSlug],
+    ),
+    uploadFolder: useCallback(
+      async ({ sourcePath }: { sourcePath: string }) => {
+        const res = await apiFetch(`/api/agents/${agentSlug}/upload-folder`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sourcePath }),
+        })
+        if (!res.ok) throw new Error('Failed to upload folder')
+        return res.json() as Promise<{ path: string }>
+      },
+      [agentSlug],
+    ),
+    onSubmit: useCallback(
+      async (content: string) => {
+        if (!selectedSlug) return
+        try {
+          const session = await createSession.mutateAsync({
+            agentSlug: selectedSlug,
+            message: content,
+            ...composerOptions.toRuntimeOptions(),
+          })
+          // Hand off to the main process: hide the launcher and raise the main
+          // window on the brand-new session.
+          window.electronAPI?.quickDispatchDispatched?.({
+            agentSlug: selectedSlug,
+            sessionId: session.id,
+          })
+        } catch (error) {
+          toast.error('Failed to dispatch', {
+            description: error instanceof Error ? error.message : 'Please try again.',
+          })
+          throw error // let useMessageComposer restore the message
+        }
+      },
+      [selectedSlug, createSession, composerOptions],
+    ),
+    submitDisabled: createSession.isPending || !selectedSlug,
+    draftKey: 'quick-dispatch',
+  })
+
+  // Refocus + select the input each time the launcher is re-shown (autoFocus
+  // only fires on the first mount; the window is hidden, not destroyed).
+  useEffect(() => {
+    const unsub = window.electronAPI?.onQuickDispatchShown?.(() => {
+      setOpenMenu(null)
+      const el = textareaRef.current
+      if (el) {
+        el.focus()
+        el.select()
+      }
+    })
+    return () => unsub?.()
+  }, [])
+
+  // Second global-shortcut press while the launcher is already open toggles
+  // dictation (main sends `toggle-dictation` instead of hiding). Refs keep the
+  // one-time listener reading the latest voice state + message.
+  const voiceConfigured = useIsVoiceConfigured()
+  const voiceRef = useRef(composer.voiceInput)
+  voiceRef.current = composer.voiceInput
+  const messageRef = useRef(composer.message)
+  messageRef.current = composer.message
+  const voiceConfiguredRef = useRef(voiceConfigured)
+  voiceConfiguredRef.current = voiceConfigured
+  useEffect(() => {
+    const unsub = window.electronAPI?.onQuickDispatchToggleDictation?.(() => {
+      const vi = voiceRef.current
+      if (vi.isRecording || vi.isConnecting) {
+        vi.stopRecording()
+      } else if (voiceConfiguredRef.current && !vi.isFinalizing) {
+        void vi.startRecording(messageRef.current)
+      }
+    })
+    return () => unsub?.()
+  }, [])
+
+  // Files dropped on the app's dock icon (macOS `open-file`) open the launcher
+  // with that file attached. Main QUEUES the path; the renderer PULLS it — both
+  // on mount (catches files queued before this listener existed, i.e. cold
+  // launch) and on the `attach-pending` ping (already-open case). Read each path
+  // into a File via the same route the recent-files menu uses. Ref keeps the
+  // handlers on the latest `addFiles`.
+  const addFilesRef = useRef(composer.addFiles)
+  addFilesRef.current = composer.addFiles
+  useEffect(() => {
+    const api = window.electronAPI
+    if (!api) return
+    const attachPath = async (filePath: string) => {
+      if (!api.readLocalFile) return
+      const result = await api.readLocalFile(filePath)
+      if (result) {
+        addFilesRef.current([{ file: new File([result.buffer], result.name, { type: result.type }) }])
+      }
+    }
+    const drain = async () => {
+      const paths = (await api.quickDispatchDrainAttach?.()) ?? []
+      for (const p of paths) await attachPath(p)
+    }
+    void drain() // cold launch: catch anything queued before mount
+    const unsub = api.onQuickDispatchAttachPending?.(() => void drain()) // warm: ping
+    return () => unsub?.()
+  }, [])
+
+  // The panel is hidden (not destroyed) between uses, so attachments would
+  // otherwise linger into the next open. Clear them when main reports the hide.
+  const clearAttachmentsRef = useRef(composer.clearAttachments)
+  clearAttachmentsRef.current = composer.clearAttachments
+  useEffect(() => {
+    const unsub = window.electronAPI?.onQuickDispatchReset?.(() => clearAttachmentsRef.current())
+    return () => unsub?.()
+  }, [])
+
+  // Esc closes an open menu first, otherwise dismisses the launcher. Let an open
+  // Radix dialog/popover (e.g. the mount-choice dialog) consume Esc itself.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      if (document.querySelector('[data-radix-popper-content-wrapper], [role="dialog"], [role="alertdialog"]')) return
+      if (openMenu) setOpenMenu(null)
+      else window.electronAPI?.quickDispatchClose?.()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [openMenu])
+
+  // File drop is handled by root-level React handlers on the panel (see the
+  // return below). The panel is NO LONGER a `-webkit-app-region: drag` region:
+  // macOS treats drag regions as window chrome and passes file drags THROUGH to
+  // the window behind, so a drag region and file-drop are mutually exclusive.
+  // (Window dragging is reintroduced separately, via JS, not CSS drag regions.)
+  const handlePanelDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setDropActive(true)
+  }, [])
+  const handlePanelDragLeave = useCallback((e: React.DragEvent) => {
+    // Ignore dragleave fired while crossing between inner elements — only clear
+    // when the pointer actually leaves the panel.
+    if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setDropActive(false)
+  }, [])
+  const handlePanelDrop = useCallback(
+    (e: React.DragEvent) => {
+      setDropActive(false)
+      composer.dragHandlers.onDrop(e)
+    },
+    [composer],
+  )
+
+  // Drag-to-move the frameless window from any non-interactive part of the panel.
+  // Done in JS (mousedown → IPC setPosition) rather than a `-webkit-app-region:
+  // drag` region, because a CSS drag region is inert to file drops — the two are
+  // mutually exclusive, and drops win. rAF-throttled so we don't flood IPC.
+  const handleWindowDragStart = useCallback((e: React.MouseEvent) => {
+    if (e.button !== 0) return
+    // Never start a window-drag from controls, text fields, or the menus.
+    if ((e.target as HTMLElement).closest('button, input, textarea, a, [data-no-window-drag]')) return
+    const startX = e.screenX
+    const startY = e.screenY
+    window.electronAPI?.quickDispatchDragStart?.()
+    let raf = 0
+    let pending: { dx: number; dy: number } | null = null
+    const flush = () => {
+      raf = 0
+      if (pending) window.electronAPI?.quickDispatchDragMove?.(pending)
+    }
+    const onMove = (ev: MouseEvent) => {
+      pending = { dx: ev.screenX - startX, dy: ev.screenY - startY }
+      if (!raf) raf = requestAnimationFrame(flush)
+    }
+    const onUp = () => {
+      if (raf) cancelAnimationFrame(raf)
+      window.electronAPI?.quickDispatchDragEnd?.()
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+  }, [])
+
+  // Suppress the main-process blur-to-hide while a native file picker is open
+  // (clicking a hidden <input type=file> blurs the window). Cleared when focus
+  // returns to the launcher.
+  useEffect(() => {
+    const onPickerClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null
+      if (target instanceof HTMLInputElement && target.type === 'file') {
+        window.electronAPI?.quickDispatchSetModal?.(true)
+      }
+    }
+    const onFocus = () => window.electronAPI?.quickDispatchSetModal?.(false)
+    document.addEventListener('click', onPickerClick, true)
+    window.addEventListener('focus', onFocus)
+    return () => {
+      document.removeEventListener('click', onPickerClick, true)
+      window.removeEventListener('focus', onFocus)
+    }
+  }, [])
+
+  const toggleMenu = (menu: Exclude<OpenMenu, null>) =>
+    setOpenMenu((prev) => (prev === menu ? null : menu))
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Enter (and ⌘/Ctrl+Enter) dispatches; Shift+Enter inserts a newline.
+    // Matches the main app's composer (submit on `Enter && !shiftKey`).
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      composer.handleSubmit(e)
+    }
+  }
+
+  const isDisabled = createSession.isPending || composer.isUploading || !selectedSlug
+
+  return (
+    // The window IS the panel (Raycast-style): one frosted, edge-to-edge rounded
+    // surface. bg-transparent lets the native window vibrancy show through. The
+    // panel is a real drop target (root-level drag handlers) — NOT a CSS drag
+    // region, which would pass file drags through to the window behind.
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions -- onMouseDown here is a pointer-only window-drag gesture (frameless move); it has no meaningful keyboard equivalent and exposes no interactive control.
+    <div
+      data-testid="quick-dispatch"
+      className="relative flex flex-col overflow-hidden rounded-[12px] bg-transparent ring-1 ring-foreground/10"
+      onMouseDown={handleWindowDragStart}
+      onDragOver={handlePanelDragOver}
+      onDragLeave={handlePanelDragLeave}
+      onDrop={handlePanelDrop}
+    >
+      <MountChoiceDialog
+        open={composer.mountDialog.open}
+        onChoice={composer.mountDialog.onChoice}
+        folderName={composer.mountDialog.folderName}
+      />
+      <form onSubmit={composer.handleSubmit}>
+        {/* Input row — large, borderless, full-width like Raycast's search
+            field. File drops are handled at the panel root (any file dragged
+            anywhere over the window attaches here). */}
+        <div className="px-4 pt-3.5 pb-2.5">
+          {composer.attachments.length > 0 && (
+            <div className="mb-2">
+              <AttachmentPreview attachments={composer.attachments} onRemove={composer.removeAttachment} />
+            </div>
+          )}
+          <textarea
+            ref={textareaRef}
+            dir="auto"
+            value={composer.message}
+            onChange={(e) => composer.setMessage(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onPaste={composer.handlePaste}
+            onFocus={() => setOpenMenu(null)}
+            placeholder={selectedAgent ? `Dispatch ${selectedAgent.name}…` : 'Dispatch an agent…'}
+            disabled={isDisabled}
+            rows={1}
+            autoFocus
+            data-testid="quick-dispatch-input"
+            className="max-h-[200px] w-full resize-none bg-transparent text-[15px] leading-relaxed outline-none [field-sizing:content] placeholder:text-muted-foreground/70 disabled:opacity-60"
+          />
+        </div>
+
+        {/* Footer toolbar. The pickers are inline menus (below) rather than
+            popovers, so the window grows to fit them. */}
+        <div className="flex items-center gap-1 px-3 py-2">
+          <TriggerButton active={openMenu === 'agent'} onClick={() => toggleMenu('agent')} testId="quick-dispatch-agent-trigger">
+            <AtSign className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate">{selectedAgent?.name ?? 'Select agent'}</span>
+            <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+          </TriggerButton>
+          <TriggerButton active={openMenu === 'attach'} onClick={() => toggleMenu('attach')} testId="quick-dispatch-attach-trigger">
+            <Paperclip className="h-3.5 w-3.5 shrink-0" />
+          </TriggerButton>
+          <TriggerButton active={openMenu === 'model'} onClick={() => toggleMenu('model')} testId="composer-options-trigger">
+            {selectedModel && <ModelIcon icon={selectedModel.icon} className="h-3.5 w-3.5 shrink-0" />}
+            <span className="truncate">
+              {selectedModel?.label}
+              <span className="text-muted-foreground">
+                {selectedModel?.label ? ' · ' : ''}{EFFORT_LABELS[composerOptions.effort]}
+              </span>
+            </span>
+            <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+          </TriggerButton>
+          <div className="ml-auto flex items-center gap-2">
+            <span className="inline-flex">
+              <VoiceInputButton voiceInput={composer.voiceInput} message={composer.message} disabled={isDisabled} />
+            </span>
+            <Button
+              type="submit"
+              size="icon"
+              className="h-[34px] w-[34px]"
+              disabled={!composer.canSubmit}
+              data-testid="quick-dispatch-send"
+              aria-label="Dispatch agent"
+            >
+              {isDisabled ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowUp className="h-4 w-4" />}
+            </Button>
+          </div>
+        </div>
+
+        {/* Inline, full-width menu — grows the window so the frosted area is
+            filled by the menu (never an empty frosted gap). pb keeps the list
+            off the window's rounded bottom edge. */}
+        {openMenu && (
+          <div className="pb-3" data-no-window-drag>
+            {openMenu === 'agent' && (
+              <AgentMenu
+                agents={agentList}
+                selectedSlug={selectedSlug}
+                maxHeight={MENU_MAX_HEIGHT}
+                onSelect={(slug) => {
+                  setSelectedSlug(slug)
+                  setOpenMenu(null)
+                }}
+              />
+            )}
+            {openMenu === 'model' && <ModelEffortMenu state={composerOptions} maxHeight={MENU_MAX_HEIGHT} />}
+            {openMenu === 'attach' && (
+              <AttachMenu
+                onFileSelect={(e) => {
+                  composer.handleFileSelect(e)
+                  setOpenMenu(null)
+                }}
+                onFolderSelect={(e) => {
+                  composer.handleFolderSelect(e)
+                  setOpenMenu(null)
+                }}
+                onRecentFileAttach={(file) => {
+                  composer.addFiles([{ file }])
+                  setOpenMenu(null)
+                }}
+              />
+            )}
+          </div>
+        )}
+
+        {(composer.voiceInput.error || composer.uploadError) && (
+          <div className="px-4 pb-2">
+            <VoiceInputError error={composer.voiceInput.error} onDismiss={composer.voiceInput.clearError} />
+            <UploadError error={composer.uploadError} onDismiss={composer.clearUploadError} />
+          </div>
+        )}
+      </form>
+
+      {/* Drag-over affordance — a pure visual. The actual drop is caught by the
+          panel root's handlers, so this stays `pointer-events-none` and never
+          intercepts events. Mounted only while a file is being dragged over. */}
+      {dropActive && (
+        <div
+          className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center rounded-[12px] border-2 border-dashed border-primary/60 bg-background/80"
+          data-testid="quick-dispatch-dropzone"
+        >
+          <div className="flex items-center gap-2 text-sm font-medium text-primary">
+            <Paperclip className="h-4 w-4" />
+            Drop files to attach
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/settings/general-tab.tsx
+++ b/src/renderer/components/settings/general-tab.tsx
@@ -14,6 +14,7 @@ import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
 import { useUser } from '@renderer/context/user-context'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { useUpdateStatus } from '@renderer/context/update-status-context'
+import { ShortcutsSection } from './shortcuts-section'
 import { applyWebFavicon, getWebFaviconHref } from '@renderer/lib/favicon'
 import {
   Wand2,
@@ -308,6 +309,8 @@ export function GeneralTab({ onOpenWizard }: GeneralTabProps) {
           )}
         </div>
       </div>
+
+      {isElectronApp && <ShortcutsSection />}
 
       {showWebFaviconSettings && (
         <div className="space-y-2">

--- a/src/renderer/components/settings/shortcuts-section.tsx
+++ b/src/renderer/components/settings/shortcuts-section.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Button } from '@renderer/components/ui/button'
+import { Switch } from '@renderer/components/ui/switch'
+import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
+import { getPlatform } from '@renderer/lib/env'
+import {
+  DEFAULT_GLOBAL_DISPATCH_SHORTCUT,
+  eventToAccelerator,
+  formatAccelerator,
+} from '@shared/lib/config/shortcuts'
+import { toast } from 'sonner'
+
+// Shared with the General tab's other sections so this box looks native there.
+const CARD_CLASS = 'rounded-xl border bg-background divide-y divide-border/50 overflow-hidden'
+const SECTION_HEADING = 'text-xs font-medium text-muted-foreground px-1'
+
+/**
+ * The "Shortcuts" section of General settings (Electron-only). Currently just
+ * the quick-dispatch launcher's global accelerator: an enable/disable toggle
+ * plus a key-recorder. Empty accelerator = disabled.
+ */
+export function ShortcutsSection() {
+  const { data: settings } = useSettings()
+  const updateSettings = useUpdateSettings()
+  const platform = getPlatform() ?? ''
+
+  const current = settings?.app?.globalDispatchShortcut ?? DEFAULT_GLOBAL_DISPATCH_SHORTCUT
+  const enabled = current !== ''
+  const [recording, setRecording] = useState(false)
+
+  // Remember the last enabled accelerator so flipping the toggle back on
+  // restores it (the empty-string "disabled" state can't carry it). Falls back
+  // to the default when the launcher starts out disabled.
+  const lastEnabledRef = useRef(enabled ? current : DEFAULT_GLOBAL_DISPATCH_SHORTCUT)
+  if (enabled) lastEnabledRef.current = current
+
+  // Register the accelerator with the main process FIRST (the authoritative
+  // gate — it rejects conflicts), then persist it only if registration stuck,
+  // so the saved value always matches what's actually bound.
+  const applyShortcut = useCallback(
+    async (accel: string) => {
+      const result = await window.electronAPI?.setGlobalDispatchShortcut?.(accel)
+      if (result && !result.success) {
+        toast.error('Could not set shortcut', { description: result.error })
+        return
+      }
+      try {
+        await updateSettings.mutateAsync({ app: { globalDispatchShortcut: accel } })
+        toast.success(accel === '' ? 'Launcher disabled' : 'Shortcut updated')
+      } catch {
+        toast.error('Failed to save shortcut')
+      }
+    },
+    [updateSettings],
+  )
+
+  const handleToggle = useCallback(
+    (next: boolean) => {
+      if (recording) setRecording(false)
+      void applyShortcut(next ? lastEnabledRef.current || DEFAULT_GLOBAL_DISPATCH_SHORTCUT : '')
+    },
+    [applyShortcut, recording],
+  )
+
+  // While recording, capture the next valid combo (Esc cancels).
+  useEffect(() => {
+    if (!recording) return
+    const onKey = (e: KeyboardEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (e.key === 'Escape') {
+        setRecording(false)
+        return
+      }
+      if (['Control', 'Shift', 'Alt', 'Meta'].includes(e.key)) return // wait for a real key
+      const accel = eventToAccelerator(e, platform)
+      if (!accel) return
+      setRecording(false)
+      void applyShortcut(accel)
+    }
+    window.addEventListener('keydown', onKey, true)
+    return () => window.removeEventListener('keydown', onKey, true)
+  }, [recording, platform, applyShortcut])
+
+  return (
+    <div className="space-y-2">
+      <h3 className={SECTION_HEADING}>Shortcuts</h3>
+      <div className={CARD_CLASS}>
+        <div className="py-3 px-4">
+          <div className="flex items-center gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="text-xs font-medium truncate block">Quick Dispatch Launcher</div>
+              <div className="text-[11px] text-muted-foreground mt-0.5">
+                Pop up a floating box from anywhere to dispatch an agent
+              </div>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              {enabled && (
+                <>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="min-w-[120px] font-mono text-xs"
+                    onClick={() => setRecording((v) => !v)}
+                    data-testid="dispatch-shortcut-record"
+                  >
+                    {recording ? 'Press keys…' : formatAccelerator(current, platform)}
+                  </Button>
+                  {current !== DEFAULT_GLOBAL_DISPATCH_SHORTCUT && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => void applyShortcut(DEFAULT_GLOBAL_DISPATCH_SHORTCUT)}
+                    >
+                      Reset
+                    </Button>
+                  )}
+                </>
+              )}
+              <Switch
+                checked={enabled}
+                onCheckedChange={handleToggle}
+                aria-label="Enable Quick Dispatch launcher"
+                data-testid="dispatch-shortcut-toggle"
+              />
+            </div>
+          </div>
+          {recording && (
+            <div className="text-[11px] text-muted-foreground mt-2">
+              Hold a modifier (⌘/Ctrl/⌥/⇧) and press a key. Esc to cancel.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/context/dialog-context.tsx
+++ b/src/renderer/context/dialog-context.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useCallback } from 'react'
 import { useRouter } from '@tanstack/react-router'
 import { settingsSearchSchema } from '@renderer/router/search-schemas'
 
-interface DialogContextType {
+export interface DialogContextType {
   /** Open global settings (optionally to a tab); captures the current location as `?from=`. */
   openSettings: (tab?: string) => void
   /** Close settings → push back to the captured `?from=` origin (or home on a cold deep-link). */
@@ -10,7 +10,10 @@ interface DialogContextType {
   openWizard: () => void
 }
 
-const DialogContext = createContext<DialogContextType | null>(null)
+// Exported so router-free surfaces (e.g. the standalone quick-dispatch window)
+// can supply their own value — VoiceInputButton reads useDialogs().openSettings,
+// but the real DialogProvider needs the router, which those surfaces don't mount.
+export const DialogContext = createContext<DialogContextType | null>(null)
 
 /**
  * Global settings lives at a URL (`/settings`, `/settings/$tab`); DialogContext is

--- a/src/renderer/hooks/use-message-composer.ts
+++ b/src/renderer/hooks/use-message-composer.ts
@@ -209,6 +209,7 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     isDragOver,
     addFiles,
     removeAttachment,
+    clearAttachments,
     handleFileSelect,
     handleFolderSelect,
     dragHandlers,

--- a/src/renderer/quick-dispatch-main.tsx
+++ b/src/renderer/quick-dispatch-main.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import './globals.css'
+import { QuickDispatchApp } from './components/quick-dispatch/quick-dispatch-app'
+import { initApiBaseUrl, isElectron, getPlatform } from './lib/env'
+import { initRendererErrorReporting } from './lib/error-reporting'
+
+// Standalone entry for the quick-dispatch launcher window — a separate
+// BrowserWindow / renderer process, so it boots its own (slim) provider tree
+// with NO router and none of the main app shell. Mirrors main.tsx's startup
+// order: error reporting → vibrancy class → API base URL → render.
+
+initRendererErrorReporting()
+
+if (isElectron() && (getPlatform() === 'darwin' || getPlatform() === 'win32')) {
+  document.documentElement.classList.add('electron-vibrancy')
+  if (getPlatform() === 'win32') {
+    document.documentElement.classList.add('electron-vibrancy-win')
+  }
+}
+
+// Resolve the Electron API base URL before the first apiFetch, then render.
+initApiBaseUrl()
+  .catch((error) => {
+    console.error('Failed to initialize quick-dispatch:', error)
+  })
+  .finally(() => {
+    ReactDOM.createRoot(document.getElementById('root')!).render(
+      <React.StrictMode>
+        <QuickDispatchApp />
+      </React.StrictMode>,
+    )
+  })

--- a/src/renderer/quick-dispatch.html
+++ b/src/renderer/quick-dispatch.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Quick Dispatch</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    /* Frameless + transparent window: the visible UI is the rounded card the
+       React app renders; everything else stays see-through so the OS vibrancy /
+       desktop shows in the corners. overflow:hidden avoids transient scrollbars
+       while the window auto-resizes to content. height:auto is LOAD-BEARING —
+       globals.css stretches #root to 100% for the main app, which would make the
+       window measure full-screen-tall; here the panel must hug its contents. */
+    html { overflow: hidden; }
+    html, body, #root {
+      margin: 0;
+      background: transparent !important;
+      height: auto !important;
+      min-height: 0 !important;
+    }
+    body { -webkit-user-select: none; user-select: none; }
+    /* The window is moved via a JS drag (mousedown → IPC setPosition), NOT a
+       CSS `-webkit-app-region: drag` region — a drag region is inert to file
+       drops, and the panel must accept dropped files. So no drag-region CSS. */
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="./quick-dispatch-main.tsx"></script>
+</body>
+</html>

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -10,6 +10,7 @@ import {
 } from '@shared/lib/utils/file-storage'
 import { captureException } from '@shared/lib/error-reporting'
 import { persistedSettingsSchema } from './settings-schema'
+import { DEFAULT_GLOBAL_DISPATCH_SHORTCUT } from './shortcuts'
 import type { SkillsetConfig } from '@shared/lib/types/skillset'
 import { DEFAULT_PUBLIC_SKILLSET } from '@shared/lib/skillset-provider/default-public-skillset'
 import type { ComputerUseSettings } from '@shared/lib/computer-use/types'
@@ -98,6 +99,12 @@ export interface AppPreferences {
   chromeHeadless?: boolean
   allowPrereleaseUpdates?: boolean
   theme?: 'system' | 'light' | 'dark'
+  /**
+   * OS-global accelerator that opens the quick-dispatch launcher (e.g.
+   * "CommandOrControl+Shift+Space"). Read by the main process at startup and
+   * re-registered live on change. Empty string disables the launcher.
+   */
+  globalDispatchShortcut?: string
   maxBrowserTabs?: number
   faviconDataUrl?: string
   faviconUpdatedAt?: string
@@ -309,6 +316,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   app: {
     showMenuBarIcon: true,
     autoSleepTimeoutMinutes: 30,
+    globalDispatchShortcut: DEFAULT_GLOBAL_DISPATCH_SHORTCUT,
     notifications: {
       enabled: true,
       sessionComplete: true,

--- a/src/shared/lib/config/shortcuts.test.ts
+++ b/src/shared/lib/config/shortcuts.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_GLOBAL_DISPATCH_SHORTCUT,
+  isValidAccelerator,
+  codeToKey,
+  eventToAccelerator,
+  formatAccelerator,
+  type KeyComboEvent,
+} from './shortcuts'
+
+describe('isValidAccelerator', () => {
+  it('accepts the default and other real accelerators', () => {
+    expect(isValidAccelerator(DEFAULT_GLOBAL_DISPATCH_SHORTCUT)).toBe(true)
+    expect(isValidAccelerator('CommandOrControl+Shift+Space')).toBe(true)
+    expect(isValidAccelerator('Control+Alt+K')).toBe(true)
+    expect(isValidAccelerator('Command+F5')).toBe(true)
+  })
+
+  it('rejects empty, single-token, and garbage values', () => {
+    expect(isValidAccelerator('')).toBe(false) // empty = "disabled", not a valid accelerator
+    expect(isValidAccelerator('Space')).toBe(false) // needs modifier + key
+    expect(isValidAccelerator('Command+')).toBe(false)
+    expect(isValidAccelerator('+Space')).toBe(false)
+    expect(isValidAccelerator('Command Shift Space')).toBe(false)
+    expect(isValidAccelerator('Command+Sh!ft+Space')).toBe(false)
+  })
+
+  it('rejects absurdly long values', () => {
+    expect(isValidAccelerator('A+' + 'B'.repeat(100))).toBe(false)
+  })
+})
+
+describe('codeToKey', () => {
+  it('maps letters, digits, and function keys', () => {
+    expect(codeToKey('KeyA')).toBe('A')
+    expect(codeToKey('Digit7')).toBe('7')
+    expect(codeToKey('F5')).toBe('F5')
+    expect(codeToKey('F24')).toBe('F24')
+  })
+
+  it('maps named keys', () => {
+    expect(codeToKey('Space')).toBe('Space')
+    expect(codeToKey('ArrowUp')).toBe('Up')
+    expect(codeToKey('ArrowDown')).toBe('Down')
+    expect(codeToKey('Enter')).toBe('Return')
+  })
+
+  it('returns null for unsupported codes', () => {
+    expect(codeToKey('Comma')).toBeNull()
+    expect(codeToKey('F25')).toBeNull()
+    expect(codeToKey('ShiftLeft')).toBeNull()
+  })
+})
+
+describe('eventToAccelerator', () => {
+  const ev = (over: Partial<KeyComboEvent>): KeyComboEvent => ({
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    code: 'KeyA',
+    ...over,
+  })
+
+  it('builds a mac accelerator with Command for the meta key', () => {
+    expect(eventToAccelerator(ev({ metaKey: true, shiftKey: true, code: 'Space' }), 'darwin')).toBe(
+      'Command+Shift+Space',
+    )
+  })
+
+  it('uses Super for the meta key off mac', () => {
+    expect(eventToAccelerator(ev({ metaKey: true, code: 'KeyK' }), 'win32')).toBe('Super+K')
+  })
+
+  it('orders modifiers Control, Meta, Alt, Shift', () => {
+    expect(
+      eventToAccelerator(ev({ ctrlKey: true, altKey: true, shiftKey: true, code: 'KeyJ' }), 'darwin'),
+    ).toBe('Control+Alt+Shift+J')
+  })
+
+  it('returns null without a modifier or without a mappable key', () => {
+    expect(eventToAccelerator(ev({ code: 'KeyA' }), 'darwin')).toBeNull() // no modifier
+    expect(eventToAccelerator(ev({ metaKey: true, code: 'Comma' }), 'darwin')).toBeNull() // no key
+  })
+})
+
+describe('formatAccelerator', () => {
+  it('renders symbol chips on mac', () => {
+    expect(formatAccelerator('CommandOrControl+Shift+Space', 'darwin')).toBe('⌘ ⇧ Space')
+    expect(formatAccelerator('Control+Alt+K', 'darwin')).toBe('⌃ ⌥ K')
+  })
+
+  it('renders +-joined tokens off mac', () => {
+    expect(formatAccelerator('CommandOrControl+Shift+Space', 'win32')).toBe('Ctrl+Shift+Space')
+    expect(formatAccelerator('Super+K', 'win32')).toBe('Win+K')
+  })
+
+  it('renders empty as Disabled', () => {
+    expect(formatAccelerator('', 'darwin')).toBe('Disabled')
+    expect(formatAccelerator('', 'win32')).toBe('Disabled')
+  })
+})

--- a/src/shared/lib/config/shortcuts.ts
+++ b/src/shared/lib/config/shortcuts.ts
@@ -1,0 +1,95 @@
+/**
+ * Global keyboard-shortcut config shared by the Electron main process (which
+ * registers the OS-level accelerator), the settings write boundary (which
+ * validates it), and the renderer settings UI (which records it).
+ *
+ * This module is intentionally dependency-free (no `fs`/`electron`) so the
+ * renderer can import it without pulling node-only modules into its bundle —
+ * unlike settings.ts, which is type-only-safe for the renderer.
+ */
+
+/** Out-of-box default for the quick-dispatch launcher. ⌘⇧Space / Ctrl+Shift+Space. */
+export const DEFAULT_GLOBAL_DISPATCH_SHORTCUT = 'CommandOrControl+Shift+Space'
+
+// A loose Electron-accelerator validator: 2+ tokens (modifier(s) + key) joined
+// by '+', each token alphanumeric (covers letters, digits, Space, F1-F24, Up,
+// Plus-named keys). This only rejects obvious garbage at the settings boundary
+// and in the UI — the authoritative gate is globalShortcut.register() in main,
+// which is wrapped in try/catch and reports failure back to the renderer.
+const ACCELERATOR_RE = /^[A-Za-z0-9]+(\+[A-Za-z0-9]+)+$/
+
+/** True if `value` is plausibly a registerable accelerator (e.g. "CommandOrControl+Shift+Space"). */
+export function isValidAccelerator(value: string): boolean {
+  return value.length > 0 && value.length <= 64 && ACCELERATOR_RE.test(value)
+}
+
+// --- Accelerator <-> keyboard-event helpers (shared by the settings recorder) ---
+//
+// Kept here (not in the .tsx) so they stay dependency-free and unit-testable.
+// The event shape is structural (a subset of the DOM KeyboardEvent) so this
+// module never pulls in `lib.dom` for the main process that also imports it.
+
+/** The subset of a keydown we need to derive an accelerator. */
+export interface KeyComboEvent {
+  ctrlKey: boolean
+  metaKey: boolean
+  altKey: boolean
+  shiftKey: boolean
+  /** `KeyboardEvent.code`, e.g. "KeyA", "Digit1", "Space", "ArrowUp". */
+  code: string
+}
+
+/** Map a `KeyboardEvent.code` to the key token Electron accelerators use, or null if unsupported. */
+export function codeToKey(code: string): string | null {
+  if (/^Key[A-Z]$/.test(code)) return code.slice(3)
+  if (/^Digit[0-9]$/.test(code)) return code.slice(5)
+  if (/^F([1-9]|1[0-9]|2[0-4])$/.test(code)) return code
+  if (code === 'Space') return 'Space'
+  if (code === 'ArrowUp') return 'Up'
+  if (code === 'ArrowDown') return 'Down'
+  if (code === 'ArrowLeft') return 'Left'
+  if (code === 'ArrowRight') return 'Right'
+  if (code === 'Enter') return 'Return'
+  return null
+}
+
+/**
+ * Convert a keydown into an Electron accelerator, or null if it isn't a usable
+ * combo. Requires at least one modifier plus a mappable key (a bare key would
+ * be a global grab of a normal keystroke).
+ */
+export function eventToAccelerator(e: KeyComboEvent, platform: string): string | null {
+  const mods: string[] = []
+  if (e.ctrlKey) mods.push('Control')
+  if (e.metaKey) mods.push(platform === 'darwin' ? 'Command' : 'Super')
+  if (e.altKey) mods.push('Alt')
+  if (e.shiftKey) mods.push('Shift')
+  const key = codeToKey(e.code)
+  if (!key || mods.length === 0) return null
+  return [...mods, key].join('+')
+}
+
+const MAC_SYMBOLS: Record<string, string> = {
+  CommandOrControl: '⌘',
+  Command: '⌘',
+  Control: '⌃',
+  Alt: '⌥',
+  Option: '⌥',
+  Shift: '⇧',
+  Super: '⌘',
+}
+
+/** Render an accelerator as friendly chips (⌘⇧Space on mac, Ctrl+Shift+Space elsewhere; "" → "Disabled"). */
+export function formatAccelerator(accel: string, platform: string): string {
+  if (!accel) return 'Disabled'
+  const isMac = platform === 'darwin'
+  const tokens = accel.split('+').map((tok) => {
+    if (isMac && MAC_SYMBOLS[tok]) return MAC_SYMBOLS[tok]
+    if (!isMac) {
+      if (tok === 'CommandOrControl' || tok === 'Control') return 'Ctrl'
+      if (tok === 'Super') return 'Win'
+    }
+    return tok
+  })
+  return tokens.join(isMac ? ' ' : '+')
+}


### PR DESCRIPTION
## Summary

A frameless, translucent, always-on-top Spotlight/Raycast-style composer bound to a configurable OS-global shortcut (default **⌘⇧Space** / **Ctrl+Shift+Space**) to dispatch an agent from anywhere. On dispatch it creates a session and raises the main window on the new session.

## What's included

- **Dedicated launcher window** — a second renderer entry (`quick-dispatch.html`) with a slim, router-free provider tree and no background SSE; pre-warmed hidden at startup so the first open is instant.
- **Reuses the main composer** (agent picker, model/effort, mic, attach) rendered as inline, full-width menus that grow the frameless window (Raycast-style) instead of floating popovers.
- **File attach**
  - Drag a file onto the window.
  - Open a file _with_ the app → launcher opens with it attached: macOS dock-drop / "Open With" (`open-file`), and Windows/Linux via argv (cold launch **and** `second-instance`). Both funnel into one race-free queue.
- **Settings → General → Shortcuts** (Electron-only) — enable/disable toggle + key-recorder. The accelerator is validated at the write boundary and registered live in the main process.
- **Interaction niceties** — ⌘/Ctrl+Enter to send, a second shortcut-press toggles dictation, JS drag-to-move (frameless), attachments reset on close, borderless translucent styling.

## Tests

- `shortcuts.test.ts` — accelerator validate / record / format helpers
- `global-dispatch-shortcut.test.ts` — the OS-shortcut registrar (register / disable / conflict / throw / unregister-old-before-new)
- `opened-files.test.ts` — the Windows/Linux argv → file-path parser
- `settings.test.ts` — PUT validation for the shortcut setting
- `quick-dispatch.test.tsx` — launcher behavior (default agent, Enter vs Shift+Enter, reset-on-hide, dock-drop drain)

Full unit suite green (6008 passing); `tsc` + ESLint clean.

## Notes / deliberate scope

- **macOS** registers `CFBundleDocumentTypes` (public.item/public.content) → Gamut appears in Finder "Open With" for _any_ file (intended, but user-visible). **Windows** uses a curated `fileAssociations` list (Windows can't express "any file"), but the argv path attaches any explicitly-opened file regardless of association.
- **Acrylic frost is Windows 11-only** (`backgroundMaterial`); Windows 10 falls back to an opaque panel (functional, not frosted).
- A startup shortcut-registration conflict is only logged (`console.warn`); Settings still shows the accelerator as bound.
- **Launcher E2E is out of scope** (separate BrowserWindow + OS-global shortcut). The web build never renders the launcher or its settings section (`isElectron`-gated), so web E2E is unaffected.

## Test plan

- [ ] `⌘⇧Space` opens the launcher; dispatch focuses the new session in the main window
- [ ] Settings → General → Shortcuts: re-record, Reset, and the enable/disable toggle
- [ ] Drag a file onto the window → attaches
- [ ] macOS: drop a file on the dock icon / "Open With" → launcher opens with it attached
- [ ] Windows: "Open With → Gamut" (and while already running) → launcher opens with it attached
