### PR TITLE
[codex] Harden tool rendering at higher E2E concurrency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
         env:
           PORT: '3000'
           SUPERAGENT_DATA_DIR: .e2e-data/web
-          PLAYWRIGHT_WORKERS: '4'
+          PLAYWRIGHT_WORKERS: '6'
           PLAYWRIGHT_OUTPUT_DIR: test-results/web
           PLAYWRIGHT_HTML_REPORT: playwright-report/web
         run: npm run test:e2e

--- a/e2e/specs/tool-rendering.spec.ts
+++ b/e2e/specs/tool-rendering.spec.ts
@@ -38,7 +38,27 @@ async function setToolCallExpanded(toolCall: Locator, toolName: string, expanded
   if (await toggle.getAttribute('aria-expanded') !== String(expanded)) {
     await toggle.click()
   }
-  await expect(toggle).toHaveAttribute('aria-expanded', String(expanded))
+  await expect(toggle).toHaveAttribute('aria-expanded', String(expanded), { timeout: 1000 })
+}
+
+async function expectToolCallExpanded(
+  toolCall: Locator,
+  toolName: string,
+  expanded: boolean,
+  expandedContent?: Locator,
+) {
+  // Tool calls can remount after a post-turn message refetch, resetting local
+  // expansion state. Re-drive the UI transition until the content agrees.
+  await expect(async () => {
+    await setToolCallExpanded(toolCall, toolName, expanded)
+    if (expandedContent) {
+      if (expanded) {
+        await expect(expandedContent).toBeVisible({ timeout: 1000 })
+      } else {
+        await expect(expandedContent).not.toBeVisible({ timeout: 1000 })
+      }
+    }
+  }).toPass({ timeout: 20000 })
 }
 
 test.describe('Tool Call Rendering', () => {
@@ -54,11 +74,11 @@ test.describe('Tool Call Rendering', () => {
     const toolCall = renderedToolCall(sessionPage, 'Bash')
     await expect(toolCall).toBeVisible()
 
-    // Click to expand
-    await setToolCallExpanded(toolCall, 'Bash', true)
+    const terminal = toolCall.getByTestId('bash-terminal')
+    await expectToolCallExpanded(toolCall, 'Bash', true, terminal)
 
-    // Verify terminal-style display (black background)
-    await expect(toolCall.getByTestId('bash-terminal')).toBeVisible()
+    // Verify terminal-style display
+    await expect(terminal).toHaveCSS('background-color', 'rgb(0, 0, 0)')
   })
 
   test('renders Read tool call with file path summary', async ({ page, request }, testInfo) => {
@@ -137,22 +157,10 @@ test.describe('Tool Call Rendering', () => {
     const toolCall = renderedToolCall(sessionPage, 'Bash')
     await expect(toolCall).toBeVisible({ timeout: 20000 })
 
-    // The row's expanded state is local; a post-turn message refetch can remount
-    // it and reset the toggle. Re-drive each transition until the rendered
-    // terminal matches, so the assertions don't race that remount.
-    await expect(async () => {
-      await setToolCallExpanded(toolCall, 'Bash', false)
-      await expect(toolCall.getByTestId('bash-terminal')).not.toBeVisible({ timeout: 1000 })
-    }).toPass({ timeout: 20000 })
+    const terminal = toolCall.getByTestId('bash-terminal')
 
-    await expect(async () => {
-      await setToolCallExpanded(toolCall, 'Bash', true)
-      await expect(toolCall.getByTestId('bash-terminal')).toBeVisible({ timeout: 1000 })
-    }).toPass({ timeout: 20000 })
-
-    await expect(async () => {
-      await setToolCallExpanded(toolCall, 'Bash', false)
-      await expect(toolCall.getByTestId('bash-terminal')).not.toBeVisible({ timeout: 1000 })
-    }).toPass({ timeout: 20000 })
+    await expectToolCallExpanded(toolCall, 'Bash', false, terminal)
+    await expectToolCallExpanded(toolCall, 'Bash', true, terminal)
+    await expectToolCallExpanded(toolCall, 'Bash', false, terminal)
   })
 })


### PR DESCRIPTION
## Summary

- Harden tool-call expansion/collapse assertions against post-turn remounts.
- Keep assertion depth by verifying the Bash terminal content and terminal styling after expansion.
- Raise the main web E2E CI worker setting from 4 to 6.

## Validation

- PLAYWRIGHT_WORKERS=6 npm run test:e2e:web -- e2e/specs/tool-rendering.spec.ts --repeat-each=5 -> 35 passed
- PLAYWRIGHT_WORKERS=6 npm run test:e2e:web -> 202 passed, 21 skipped
- PLAYWRIGHT_WORKERS=8 npm run test:e2e:web exploratory probe -> 200 passed, 21 skipped, 2 failed in new-agent-intro.spec.ts and persistence.spec.ts
- npm run lint:e2e -> 0 errors, existing warnings only

After the successful 6x validations, this local sandbox began rejecting all localhost binds with listen EPERM, so I could not complete additional consecutive local full-suite runs here.