### PR TITLE
fix(quick-dispatch): keep typed text on send + stop dictation on close

### DIFF
--- a/src/renderer/components/quick-dispatch/quick-dispatch.test.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.test.tsx
@@ -45,9 +45,17 @@ const createSessionMock = vi.hoisted(() => ({
   isPending: false,
 }))
 
+// Captures the options QuickDispatch passes to useMessageComposer.
+const composerOptionsSpy = vi.hoisted(() => ({ value: null as Record<string, unknown> | null }))
+
 vi.mock('@renderer/hooks/use-agents', () => ({ useAgents: () => ({ data: state.agents }) }))
 vi.mock('@renderer/hooks/use-sessions', () => ({ useCreateSession: () => createSessionMock }))
-vi.mock('@renderer/hooks/use-message-composer', () => ({ useMessageComposer: () => composerMock }))
+vi.mock('@renderer/hooks/use-message-composer', () => ({
+  useMessageComposer: (options: Record<string, unknown>) => {
+    composerOptionsSpy.value = options
+    return composerMock
+  },
+}))
 vi.mock('@renderer/hooks/use-voice-input', () => ({
   useIsVoiceConfigured: () => true,
   useVoiceInput: () => ({}),
@@ -158,6 +166,14 @@ describe('QuickDispatch', () => {
 
     fireEvent.keyDown(input, { key: 'Enter' })
     expect(composerMock.handleSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the typed message in the input until the dispatch completes', () => {
+    installElectronAPI()
+    render(<QuickDispatch />)
+    // Without this the composer clears the text up front, so it vanishes while
+    // the send spinner is showing.
+    expect(composerOptionsSpy.value?.keepMessageUntilComplete).toBe(true)
   })
 
   it('clears attachments when the window is hidden (reset)', async () => {

--- a/src/renderer/components/quick-dispatch/quick-dispatch.test.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.test.tsx
@@ -129,6 +129,9 @@ beforeEach(() => {
   composerMock.isUploading = false
   composerMock.canSubmit = true
   composerMock.uploadError = null
+  composerMock.voiceInput.isRecording = false
+  composerMock.voiceInput.isConnecting = false
+  composerMock.voiceInput.isFinalizing = false
 })
 
 afterEach(() => {
@@ -184,6 +187,29 @@ describe('QuickDispatch', () => {
     act(() => listeners.reset())
 
     expect(composerMock.clearAttachments).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops in-flight dictation and clears its error on reset', async () => {
+    composerMock.voiceInput.isRecording = true
+    const listeners = installElectronAPI()
+    render(<QuickDispatch />)
+    await waitFor(() => expect(listeners.reset).toBeTypeOf('function'))
+
+    act(() => listeners.reset())
+
+    expect(composerMock.voiceInput.stopRecording).toHaveBeenCalledTimes(1)
+    expect(composerMock.voiceInput.clearError).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call stopRecording on reset when not dictating', async () => {
+    const listeners = installElectronAPI()
+    render(<QuickDispatch />)
+    await waitFor(() => expect(listeners.reset).toBeTypeOf('function'))
+
+    act(() => listeners.reset())
+
+    expect(composerMock.voiceInput.stopRecording).not.toHaveBeenCalled()
+    expect(composerMock.voiceInput.clearError).toHaveBeenCalledTimes(1)
   })
 
   it('drains and attaches a dock-dropped file on mount', async () => {

--- a/src/renderer/components/quick-dispatch/quick-dispatch.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.tsx
@@ -204,12 +204,19 @@ export function QuickDispatch() {
     return () => unsub?.()
   }, [])
 
-  // The panel is hidden (not destroyed) between uses, so attachments would
-  // otherwise linger into the next open. Clear them when main reports the hide.
+  // The panel is hidden (not destroyed) between uses, so transient state would
+  // otherwise linger into the next open. When main reports the hide (Esc, blur,
+  // post-dispatch), clear attachments AND stop any in-flight dictation — an
+  // active mic mustn't keep recording after the window is dismissed.
   const clearAttachmentsRef = useRef(composer.clearAttachments)
   clearAttachmentsRef.current = composer.clearAttachments
   useEffect(() => {
-    const unsub = window.electronAPI?.onQuickDispatchReset?.(() => clearAttachmentsRef.current())
+    const unsub = window.electronAPI?.onQuickDispatchReset?.(() => {
+      clearAttachmentsRef.current()
+      const vi = voiceRef.current
+      if (vi.isRecording || vi.isConnecting) void vi.stopRecording()
+      vi.clearError()
+    })
     return () => unsub?.()
   }, [])
 

--- a/src/renderer/components/quick-dispatch/quick-dispatch.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.tsx
@@ -134,6 +134,10 @@ export function QuickDispatch() {
       [selectedSlug, createSession, composerOptions],
     ),
     submitDisabled: createSession.isPending || !selectedSlug,
+    // Keep the typed message in the (disabled) input while the dispatch is in
+    // flight, instead of clearing it up front — seeing your text vanish mid-send
+    // is unnerving. It clears once the session is created, or stays on failure.
+    keepMessageUntilComplete: true,
     draftKey: 'quick-dispatch',
   })
 


### PR DESCRIPTION
## Summary

Two small quick-dispatch launcher fixes.

### 1. Keep the typed message while dispatching
Hitting Enter/Send cleared the input **before** awaiting the dispatch — so the text you just typed vanished under the send spinner. Now passes `keepMessageUntilComplete: true`, so the message stays in the (disabled) input until the session is created, and stays put on failure.

### 2. Stop dictation when the launcher closes
Dictation kept recording after the mini-window was dismissed (Esc / blur / post-dispatch) — the mic status lingered into the next open. The reset-on-hide hook now also stops any in-flight recording and clears voice error state.

## Tests

`quick-dispatch.test.tsx` — asserts the composer keeps the message until complete, stops dictation on reset when recording, and does **not** call `stopRecording` when idle. TSC + lint clean.

## Test plan

- [ ] Type a message, hit Enter → text stays (dimmed/disabled) with the spinner, then hands off to the new session; on a failed dispatch it remains
- [ ] Start dictation, press Esc / click away → recording stops and the mic resets; reopen → clean