### PR TITLE
Route MicroVM talk-back over private host IP

### DIFF
--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -968,7 +968,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     return `ws://127.0.0.1:${port}`
   }
 
-  public getHostApiBaseUrl(): string {
+  public getHostApiBaseUrl(): string | Promise<string> {
     return `http://${getContainerHostUrl()}:${getAppPort()}`
   }
 

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -516,7 +516,7 @@ class ContainerManager {
 
       // Set up proxy authentication
       const proxyToken = await getOrCreateProxyToken(agentId)
-      const hostApiBaseUrl = client.getHostApiBaseUrl()
+      const hostApiBaseUrl = await client.getHostApiBaseUrl()
       envVars['PROXY_BASE_URL'] = `${hostApiBaseUrl}/api/proxy/${agentId}`
       envVars['PROXY_TOKEN'] = proxyToken
 

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -71,7 +71,7 @@ const TOUCHED = [
   ...Object.keys(FULL_ENV),
   'AWS_REGION', 'AWS_DEFAULT_REGION', 'MICROVM_AGENT_IMAGE_VERSION', 'MICROVM_INGRESS_CONNECTOR_ARN',
   'MICROVM_AGENT_PORT', 'MICROVM_MAX_DURATION_SECONDS', 'MICROVM_SUSPENDED_SECONDS', 'MICROVM_LOG_GROUP',
-  'MICROVM_FS_ID', 'MICROVM_ACCESS_POINT', 'MICROVM_MOUNT_TARGET_IP',
+  'MICROVM_FS_ID', 'MICROVM_ACCESS_POINT', 'MICROVM_MOUNT_TARGET_IP', 'ECS_CONTAINER_METADATA_URI_V4', 'PORT',
 ]
 
 beforeEach(() => {
@@ -205,6 +205,34 @@ describe('LambdaMicroVmRuntimeClient eligibility', () => {
   })
 })
 
+describe('LambdaMicroVmRuntimeClient host API base URL', () => {
+  beforeEach(() => {
+    Object.assign(process.env, FULL_ENV)
+    resetMicrovmRuntimeForTests()
+  })
+
+  it('falls back to HOST_PUBLIC_URL when ECS metadata is unavailable', async () => {
+    process.env.HOST_PUBLIC_URL = 'https://host.example/'
+    await expect(new LambdaMicroVmRuntimeClient({ agentId: 'agent-url' }).getHostApiBaseUrl()).resolves.toBe('https://host.example')
+  })
+
+  it('uses the ECS task private IP and host-app port when metadata is available', async () => {
+    process.env.ECS_CONTAINER_METADATA_URI_V4 = 'http://metadata.local/v4/container'
+    process.env.PORT = '3456'
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      if (String(input) === 'http://metadata.local/v4/container') {
+        return {
+          ok: true,
+          json: async () => ({ Networks: [{ IPv4Addresses: ['10.0.12.34'] }] }),
+        } as Response
+      }
+      return { ok: true } as Response
+    })
+
+    await expect(new LambdaMicroVmRuntimeClient({ agentId: 'agent-url' }).getHostApiBaseUrl()).resolves.toBe('http://10.0.12.34:3456')
+  })
+})
+
 describe('LambdaMicroVmRuntimeClient lifecycle', () => {
   beforeEach(() => {
     Object.assign(process.env, FULL_ENV)
@@ -239,6 +267,23 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(payload.mount).toBeUndefined() // no mount configured here
     // The full env is stashed host-side for the VM to fetch at boot.
     expect(readBootstrapEnv('agent-xyz')).toMatchObject({ FOO: 'bar' })
+  })
+
+  it('puts the direct private host-app URL in the bootstrap payload when ECS metadata is available', async () => {
+    process.env.ECS_CONTAINER_METADATA_URI_V4 = 'http://metadata.local/v4/container'
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      if (String(input) === 'http://metadata.local/v4/container') {
+        return {
+          ok: true,
+          json: async () => ({ Networks: [{ IPv4Addresses: ['10.0.12.34'] }] }),
+        } as Response
+      }
+      return { ok: true } as Response
+    })
+
+    await newClient().start()
+    const input = sendMock.mock.calls.find((c) => c[0].type === 'Run')![0].input
+    expect(JSON.parse(input.runHookPayload).bootstrap.url).toBe('http://10.0.12.34:3000/api/agent-bootstrap/agent-xyz/env')
   })
 
   it('the bootstrap credential carries the agent PROXY_TOKEN for the boot fetch', async () => {

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -487,6 +487,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
         }
       : undefined
     const hostApiBaseUrl = await this.getHostApiBaseUrl()
+    console.info(`[LambdaMicroVmRuntimeClient] Using host API base URL for MicroVM talk-back: ${hostApiBaseUrl}`)
     const bootstrap = hasEnv
       ? {
           url: `${hostApiBaseUrl}/api/agent-bootstrap/${this.config.agentId}/env`,

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -12,6 +12,11 @@ import {
   TerminateMicrovmCommand,
   CreateMicrovmAuthTokenCommand,
 } from '@aws-sdk/client-lambda-microvms'
+import type {
+  CreateMicrovmAuthTokenCommandOutput,
+  GetMicrovmCommandOutput,
+  RunMicrovmCommandOutput,
+} from '@aws-sdk/client-lambda-microvms'
 import { BaseContainerClient, CONTAINER_INTERNAL_PORT } from './base-container-client'
 import type { ContainerConfig, ContainerInfo, ContainerStats, StartOptions, StopOptions, StopResult } from './types'
 import { getSettings } from '@shared/lib/config/settings'
@@ -33,6 +38,20 @@ const RESUME_RETRY_DELAY_MS = 400
 // which would otherwise wedge the resume-retry loop forever. Disabled once a WS
 // handshake completes (a live stream is idle by design).
 const UPSTREAM_IDLE_TIMEOUT_MS = 30_000
+const ECS_METADATA_TIMEOUT_MS = 2_000
+
+const ecsContainerMetadataSchema = z.object({
+  Networks: z.array(z.object({
+    IPv4Addresses: z.array(z.string().refine((ip) => net.isIP(ip) === 4)).optional().default([]),
+  })).optional().default([]),
+})
+
+const hostAppPortSchema = z.preprocess(
+  (value) => (value === undefined || value === '' ? CONTAINER_INTERNAL_PORT : value),
+  z.coerce.number().int().positive().max(65_535),
+)
+
+let memoizedHostPrivateIp: string | null | undefined
 
 // ---------------------------------------------------------------------------
 // Runtime config (env-driven, zod-validated, memoized)
@@ -116,6 +135,45 @@ export function getMicrovmRuntimeConfig(): MicrovmRuntimeConfig {
 
 export function isMicrovmRuntimeConfigured(): boolean {
   return resolveMicrovmRuntimeConfigOrNull() !== null
+}
+
+function getPublicHostApiBaseUrl(): string {
+  const publicUrl = process.env.HOST_PUBLIC_URL?.replace(/\/+$/, '')
+  if (!publicUrl) {
+    throw new Error('HOST_PUBLIC_URL is required for the MicroVM runtime')
+  }
+  return publicUrl
+}
+
+async function resolveHostPrivateIpFromEcsMetadata(): Promise<string | null> {
+  if (memoizedHostPrivateIp !== undefined) return memoizedHostPrivateIp
+
+  const metadataUrl = process.env.ECS_CONTAINER_METADATA_URI_V4?.trim()
+  if (!metadataUrl) {
+    memoizedHostPrivateIp = null
+    return memoizedHostPrivateIp
+  }
+
+  try {
+    const response = await fetch(metadataUrl, { signal: AbortSignal.timeout(ECS_METADATA_TIMEOUT_MS) })
+    if (!response.ok) throw new Error(`ECS metadata returned HTTP ${response.status}`)
+    const metadata = ecsContainerMetadataSchema.parse(await response.json())
+    memoizedHostPrivateIp = metadata.Networks.flatMap((network) => network.IPv4Addresses)[0] ?? null
+    return memoizedHostPrivateIp
+  } catch (error) {
+    console.warn('[LambdaMicroVmRuntimeClient] Failed to resolve ECS task private IP; falling back to HOST_PUBLIC_URL', error)
+    captureException(error, { tags: { area: 'container', op: 'microvm.resolveHostPrivateIp' } })
+    memoizedHostPrivateIp = null
+    return memoizedHostPrivateIp
+  }
+}
+
+async function resolveHostApiBaseUrlForMicrovm(): Promise<string> {
+  const privateIp = await resolveHostPrivateIpFromEcsMetadata()
+  if (!privateIp) return getPublicHostApiBaseUrl()
+
+  const port = hostAppPortSchema.parse(process.env.PORT)
+  return `http://${privateIp}:${port}`
 }
 
 // Idle→suspend window: app settings are the single source of truth.
@@ -428,9 +486,10 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
           subPath: `${process.env.K8S_WORKSPACES_SUBPATH_PREFIX || 'agents'}/${this.config.agentId}/workspace`,
         }
       : undefined
+    const hostApiBaseUrl = await this.getHostApiBaseUrl()
     const bootstrap = hasEnv
       ? {
-          url: `${this.getHostApiBaseUrl()}/api/agent-bootstrap/${this.config.agentId}/env`,
+          url: `${hostApiBaseUrl}/api/agent-bootstrap/${this.config.agentId}/env`,
           token: env.PROXY_TOKEN ?? '',
         }
       : undefined
@@ -465,7 +524,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
         // RunMicrovm return InternalFailure on the idempotency conflict).
         clientToken: randomUUID(),
       }),
-    )
+    ) as RunMicrovmCommandOutput
     if (!run.microvmId || !run.endpoint) {
       throw new Error('RunMicrovm returned no microvmId/endpoint')
     }
@@ -519,7 +578,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     try {
       const mvm = await getMicrovmClient(config.region).send(
         new GetMicrovmCommand({ microvmIdentifier: state.microvmId }),
-      )
+      ) as GetMicrovmCommandOutput
       // SUSPENDED is "running on demand": idlePolicy.autoResumeEnabled wakes it
       // on the next request through the proxy.
       if (mvm.state === 'RUNNING' || mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
@@ -550,12 +609,8 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     return ''
   }
 
-  public getHostApiBaseUrl(): string {
-    const publicUrl = process.env.HOST_PUBLIC_URL?.replace(/\/+$/, '')
-    if (!publicUrl) {
-      throw new Error('HOST_PUBLIC_URL is required for the MicroVM runtime')
-    }
-    return publicUrl
+  public getHostApiBaseUrl(): Promise<string> {
+    return resolveHostApiBaseUrlForMicrovm()
   }
 
   private async mintToken(microvmId: string): Promise<MicrovmAuthToken> {
@@ -566,7 +621,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
         expirationInMinutes: AUTH_TOKEN_EXPIRATION_MINUTES,
         allowedPorts: [{ port: config.agentPort }],
       }),
-    )
+    ) as CreateMicrovmAuthTokenCommandOutput
     if (!out.authToken) throw new Error('CreateMicrovmAuthToken returned no token')
     return out.authToken
   }
@@ -574,7 +629,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   private async waitForRunning(client: LambdaMicrovmsClient, microvmId: string, timeoutMs: number): Promise<void> {
     const startedAt = Date.now()
     while (Date.now() - startedAt < timeoutMs) {
-      const mvm = await client.send(new GetMicrovmCommand({ microvmIdentifier: microvmId }))
+      const mvm = await client.send(new GetMicrovmCommand({ microvmIdentifier: microvmId })) as GetMicrovmCommandOutput
       if (mvm.state === 'RUNNING') return
       if (mvm.state === 'TERMINATED' || mvm.state === 'TERMINATING') {
         throw new Error(`MicroVM ${microvmId} entered ${mvm.state} before becoming ready`)
@@ -592,7 +647,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     try {
       const mvm = await getMicrovmClient(config.region).send(
         new GetMicrovmCommand({ microvmIdentifier: state.microvmId }),
-      )
+      ) as GetMicrovmCommandOutput
       if (mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') return
       if (mvm.state === 'TERMINATED' || mvm.state === 'TERMINATING') {
         this.cleanupLocal()
@@ -636,5 +691,6 @@ export function resetMicrovmRuntimeForTests(): void {
   agentStates.clear()
   memoizedClient = null
   memoizedConfig = null
+  memoizedHostPrivateIp = undefined
   configComputed = false
 }

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -144,7 +144,7 @@ export interface ContainerClient {
   fetch(path: string, init?: RequestInit): Promise<Response>
 
   getWebSocketBaseUrl(port: number): string
-  getHostApiBaseUrl(): string
+  getHostApiBaseUrl(): string | Promise<string>
 
   // Health checks
   waitForHealthy(timeoutMs?: number, knownPort?: number): Promise<boolean>


### PR DESCRIPTION
## Summary
- Resolve the host-app task private IPv4 from ECS container metadata for Lambda MicroVM runtime talk-back.
- Use `http://<private-ip>:<PORT>` for MicroVM bootstrap/proxy host URLs, with `HOST_PUBLIC_URL` preserved as the non-ECS fallback.
- Allow `getHostApiBaseUrl()` to resolve asynchronously and cover the direct/private URL path in MicroVM tests.

## Test plan
- `npm test -- src/shared/lib/container/lambda-microvm-runtime.test.ts --run`
- `npx eslint src/shared/lib/container/lambda-microvm-runtime.ts src/shared/lib/container/lambda-microvm-runtime.test.ts src/shared/lib/container/container-manager.ts src/shared/lib/container/base-container-client.ts src/shared/lib/container/types.ts`
- `npm run typecheck` (fails on existing repo-wide issues: `react-hook-form` exports, missing `e2b`/`@daytonaio/sdk` types, `vitest/config` export, and existing implicit-any tool/slack errors)


Made with [Cursor](https://cursor.com)