### PR TITLE
fix: disable flaky github-whoami Agent E2E test

### DIFF
--- a/.qagent/stories/happy_path/github-whoami.yaml.disabled
+++ b/.qagent/stories/happy_path/github-whoami.yaml.disabled
@@ -1,3 +1,10 @@
+# TODO(SUP): re-enable in Agent E2E Test (happy-path).
+# Disabled because the `ensureOAuth` setup hook consistently fails with
+# `Composio API error: 401 Invalid API key: ak_**71Tq` in CI, failing every
+# PR's Agent E2E Test run regardless of the change under test. Root cause
+# looks like the COMPOSIO_API_KEY GitHub secret being invalid/expired.
+# Fix: rotate/validate the COMPOSIO_API_KEY repo secret, then rename this
+# file back to `github-whoami.yaml`.
 id: github-whoami
 name: "Agent requests GitHub account, perform who-am-i"
 mode: happy-path


### PR DESCRIPTION
## Summary

- The `Agent E2E Test` (happy-path) workflow has been failing consistently on unrelated PRs. Root cause: the `github-whoami` story's `ensureOAuth` setup hook fails with `Composio API error: 401 Invalid API key: ak_**71Tq` — confirmed across multiple independent CI runs (e.g. #28609050399, #28607787345, #28557042862, #28552552894), always at the same `ensureOAuth` step, never in the code under test.
- Disabled the `github-whoami` story (renamed `.qagent/stories/happy_path/github-whoami.yaml` → `github-whoami.yaml.disabled`) so it's skipped by qagent's story loader (only picks up `*.yaml`/`*.yml`), unblocking Agent E2E Test for other PRs.
- Left a `TODO` comment in the story file with the root cause and the re-enable instructions.

## Root cause (not fixed here)

The `COMPOSIO_API_KEY` GitHub secret used in CI appears invalid/expired. Fixing that (rotating/validating the secret) is out of scope for this PR — filed as the TODO in the story file.

## Test plan

- [ ] Confirm `Agent E2E Test` (happy-path) job no longer runs/fails on the `github-whoami` story on this PR's CI run.
- [ ] Follow-up: rotate `COMPOSIO_API_KEY` secret, rename `github-whoami.yaml.disabled` back to `github-whoami.yaml`, verify it passes in CI.

Made with [Cursor](https://cursor.com)