### PR TITLE
test: cover composer stop-button interrupt; make mock aborts deterministic

### DIFF
--- a/e2e/specs/stop-session.spec.ts
+++ b/e2e/specs/stop-session.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+
+/**
+ * Stopping the agent from the composer stop button.
+ *
+ * Uses the mock's SlowWorkScenario ("work slowly", ~5s turn) so there is a
+ * live streaming turn to interrupt. The composer stop button POSTs
+ * .../interrupt, which aborts the in-flight turn: streaming halts, the
+ * session settles, and the next send starts a fresh turn (not the mid-turn
+ * steering path). The mock mirrors the real CLI's abort semantics — the
+ * interrupted scenario's remaining scheduled output is dropped and queued
+ * steering messages are never picked up — so these tests also pin that the
+ * aborted turn's tail can never land later.
+ *
+ * To prove the tail stayed dead without clock-based waits, the tests chain
+ * "slow response" turns (3s each) after the stop: each completed turn is a
+ * user-visible event a known distance past the interrupt, so by the time the
+ * chain finishes, the aborted turn's 5s completion (and the queued message's
+ * 8s pickup) would already have landed if it were going to.
+ *
+ * This is a different code path from the request-card X button
+ * (request-stop-session), which pending-request-reconnect.spec covers.
+ */
+test.describe('Stop button interrupts the working agent', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+
+    const testAgentName = `Stop Agent ${testInfo.workerIndex}-${Date.now()}`
+    await agentPage.createAgent(testAgentName)
+  })
+
+  test('stop mid-stream halts the turn and the next send starts a fresh turn', async ({ page }) => {
+    // Warm-up turn: a fresh agent's first turn races the SSE join (the stream
+    // can start before the EventSource attaches, dropping early deltas), so
+    // establish the stream on a quick turn first — the slow turn below then
+    // streams over a connected socket and its partial text is reliably visible.
+    await sessionPage.sendMessage('hello before the stop test')
+    await expect(
+      sessionPage.getAssistantMessages().filter({ hasText: 'This is a mock response from the E2E test container.' })
+    ).toBeVisible({ timeout: 15000 })
+
+    await sessionPage.sendMessage('please work slowly for the stop test')
+
+    // The turn is live: stop button up, partial text streaming
+    await expect(sessionPage.getStopButton()).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Working on the slow task...')).toBeVisible({ timeout: 10000 })
+
+    await sessionPage.getStopButton().click()
+
+    // The session settles: the stop button leaves. The interrupted turn's
+    // partial stream text is deliberately KEPT on idle (use-message-stream
+    // preserves streamingMessage until persisted data or a new turn replaces
+    // it) — it must not vanish the moment the user stops the agent.
+    await expect(sessionPage.getStopButton()).not.toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Working on the slow task...')).toBeVisible()
+
+    // Follow-up sends start fresh turns. If the interrupt had left the mock
+    // session on the busy path, these would take the steering route and answer
+    // with "Adjusting based on: ..." instead of completing normally. Two
+    // chained 3s turns also put us provably past the aborted turn's 5s tail.
+    const delayedResponses = sessionPage.getAssistantMessages()
+      .filter({ hasText: 'This is a delayed mock response.' })
+    await sessionPage.sendMessage('slow response please, first check')
+    await expect(delayedResponses).toHaveCount(1, { timeout: 15000 })
+
+    // The new turn's stream replaced the interrupted partial text
+    await expect(page.getByText('Working on the slow task...')).not.toBeVisible({ timeout: 10000 })
+    await sessionPage.sendMessage('slow response please, second check')
+    await expect(delayedResponses).toHaveCount(2, { timeout: 15000 })
+
+    // The aborted turn's tail never landed: no completion text, no steering
+    // acknowledgements, no phantom reactivation, and the transcript holds
+    // exactly the warm-up turn and the two fresh follow-up turns.
+    await expect(sessionPage.getAssistantMessages().filter({ hasText: 'Finished the slow work.' })).toHaveCount(0)
+    await expect(sessionPage.getAssistantMessages().filter({ hasText: 'Adjusting based on:' })).toHaveCount(0)
+    await expect(sessionPage.getAssistantMessages()).toHaveCount(3)
+    await expect(sessionPage.getStopButton()).not.toBeVisible()
+    await sessionPage.waitForUserMessageCount(4)
+    await sessionPage.expectUserMessage('please work slowly for the stop test', 1)
+  })
+
+  test('stopping with a queued message rescues its text into the composer for resend', async ({ page }) => {
+    await sessionPage.sendMessage('please work slowly for the draft rescue test')
+    await expect(sessionPage.getStopButton()).toBeVisible({ timeout: 10000 })
+
+    // Queue a message mid-turn. The 'pickup after turn' keyword gives the
+    // mock's steering pickup an 8s delay, so the stop below deterministically
+    // lands while the message is still queued. The text also contains 'slow
+    // response' so that, once rescued and resent as a fresh message, it runs
+    // a 3s turn usable as a clock for the tail-stayed-dead proof.
+    const queuedText = 'slow response please pickup after turn'
+    await sessionPage.typeMessage(queuedText)
+    await sessionPage.getSendButton().click()
+
+    const ghost = page.locator('[data-testid="queued-user-message"]')
+    await expect(ghost).toBeVisible({ timeout: 5000 })
+    await expect(ghost).toContainText('Queued')
+
+    await sessionPage.getStopButton().click()
+    await expect(sessionPage.getStopButton()).not.toBeVisible({ timeout: 10000 })
+
+    // The queued message was never picked up — after the idle grace period its
+    // ghost is removed and its text is restored into the composer draft
+    await expect(ghost).not.toBeAttached({ timeout: 10000 })
+    await expect(sessionPage.getMessageInput()).toHaveValue(queuedText, { timeout: 10000 })
+
+    // Resend the rescued text — it goes out as a fresh turn and persists as a
+    // real user message
+    const delayedResponses = sessionPage.getAssistantMessages()
+      .filter({ hasText: 'This is a delayed mock response.' })
+    await sessionPage.getSendButton().click()
+    await expect(delayedResponses).toHaveCount(1, { timeout: 15000 })
+    await sessionPage.waitForUserMessageCount(2, 15000)
+    await sessionPage.expectUserMessage('please work slowly for the draft rescue test', 0)
+    await sessionPage.expectUserMessage(queuedText, 1)
+
+    // Chain two more 3s turns: with the resend gated on the 1.5s rescue grace,
+    // finishing three chained turns is provably past both cancelled timers
+    // (the turn's 5s tail and the queued message's 8s steering pickup).
+    await sessionPage.sendMessage('slow response please, first check')
+    await expect(delayedResponses).toHaveCount(2, { timeout: 15000 })
+    await sessionPage.sendMessage('slow response please, second check')
+    await expect(delayedResponses).toHaveCount(3, { timeout: 15000 })
+
+    // Neither cancelled timer fired: no steering acknowledgement, no
+    // completion text, no duplicate of the rescued message.
+    await expect(sessionPage.getAssistantMessages().filter({ hasText: 'Adjusting based on:' })).toHaveCount(0)
+    await expect(sessionPage.getAssistantMessages().filter({ hasText: 'Finished the slow work.' })).toHaveCount(0)
+    await expect(sessionPage.getUserMessages()).toHaveCount(4)
+    await expect(sessionPage.getStopButton()).not.toBeVisible()
+  })
+})

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1381,6 +1381,10 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
   // cancelled before pickup (mirrors the CLI's cancel_async_message).
   private queuedSteeringTimers = new Map<string, Map<string, ReturnType<typeof setTimeout>>>()
 
+  // Interrupt epoch per session — bumped by interruptSession() to supersede
+  // the in-flight scenario (see scenarioView).
+  private interruptEpochs = new Map<string, number>()
+
   getAgentId(): string {
     return this.config.agentId
   }
@@ -1764,7 +1768,7 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
         // masking a regression of the capabilities handshake that the host
         // actually relies on (the exact failure that already shipped once).
         this.busySessions.add(sessionId)
-        scenario.execute(sessionId, this, options.initialMessage!)
+        scenario.execute(sessionId, this.scenarioView(sessionId), options.initialMessage!)
       }, 100)  // Brief delay to ensure subscription is set up
     }
 
@@ -1787,6 +1791,7 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
       for (const timer of timers.values()) clearTimeout(timer)
       this.queuedSteeringTimers.delete(sessionId)
     }
+    this.interruptEpochs.delete(sessionId)
     console.log(`[MockContainerClient] Deleted session ${sessionId}`)
     return existed
   }
@@ -1928,7 +1933,7 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     // publish — so emitting 'running' here mirrors the runtime.
     this.busySessions.add(sessionId)
     this.emitSessionState(sessionId, 'running')
-    scenario.execute(sessionId, this, content)
+    scenario.execute(sessionId, this.scenarioView(sessionId), content)
   }
 
   async getMessages(sessionId: string): Promise<unknown[]> {
@@ -1945,17 +1950,52 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     return true
   }
 
+  /**
+   * A view of this client handed to a scenario execution, pinned to the
+   * session's interrupt epoch at turn start. interruptSession() bumps the
+   * epoch, which turns the superseded scenario's remaining scheduled
+   * emissions (stream events and JSONL writes from its pending setTimeouts)
+   * into no-ops — observationally the same as cancelling the timers, without
+   * threading a cancellation handle through every scenario. Mirrors the real
+   * CLI: an aborted turn produces no further output.
+   */
+  private scenarioView(sessionId: string): MockContainerClient {
+    const epoch = this.interruptEpochs.get(sessionId) ?? 0
+    const live = () => (this.interruptEpochs.get(sessionId) ?? 0) === epoch
+    const view = Object.create(this) as MockContainerClient
+    view.emitStreamMessage = (sid: string, content: { type: string; content: unknown }): void => {
+      if (live()) this.emitStreamMessage(sid, content)
+    }
+    view.writeJsonlEntry = (sid: string, entry: Record<string, unknown>): void => {
+      if (live()) this.writeJsonlEntry(sid, entry)
+    }
+    return view
+  }
+
   async interruptSession(sessionId: string): Promise<boolean> {
     const session = this.sessions.get(sessionId)
-    if (session) {
-      // Emit interrupt event
-      this.emitStreamMessage(sessionId, {
-        type: 'session_idle',
-        content: { interrupted: true },
-      })
-      return true
+    if (!session) return false
+
+    // Supersede the in-flight scenario so its pending timers can't finish the
+    // turn after the abort (see scenarioView), and let the next send start a
+    // fresh turn instead of taking the mid-turn steering path.
+    this.interruptEpochs.set(sessionId, (this.interruptEpochs.get(sessionId) ?? 0) + 1)
+    this.busySessions.delete(sessionId)
+
+    // Queued steering messages die with the turn — the real CLI never picks
+    // them up after an abort; the renderer restores their text into the
+    // composer draft.
+    const timers = this.queuedSteeringTimers.get(sessionId)
+    if (timers) {
+      for (const timer of timers.values()) clearTimeout(timer)
+      timers.clear()
     }
-    return false
+
+    this.emitStreamMessage(sessionId, {
+      type: 'session_idle',
+      content: { interrupted: true },
+    })
+    return true
   }
 
   // Streaming


### PR DESCRIPTION
First batch from the E2E coverage-gap plan (rank #1: the Stop button was never clicked by any spec — existing interrupt tests go through the request-card X, a different code path).

## What's here

**`e2e/specs/stop-session.spec.ts`** — two tests:
1. **Stop mid-stream** — slow turn streaming → click stop → session settles (stop button leaves, the interrupted partial stream text is deliberately *kept* until the next turn replaces it, per `use-message-stream`'s idle contract) → follow-up sends complete as fresh turns, not the mid-turn steering route → the aborted turn's tail never lands.
2. **Stop with a queued message** — queue a message mid-turn → stop → the ghost is removed and its text is rescued into the composer draft (the 1.5s idle-grace restore in `message-list.tsx`) → resend persists it as a real user message → neither the turn's 5s tail nor the queued message's 8s steering pickup ever fires.

The `waitForTimeout` lint rule is respected: instead of clock waits, the tests chain the mock's 3s `slow response` turns as app-visible events to get provably past the cancelled timers before asserting the negatives.

**`mock-container-client.ts`** — `interruptSession` previously only emitted `session_idle`; the aborted scenario's pending timers still fired (finishing the turn seconds later), the session stayed on the busy path, and queued steering pickups still ran — making any stop test race the scenario's tail. It now mirrors the real CLI's abort semantics:
- an **interrupt epoch** per session supersedes the in-flight scenario — its remaining scheduled emissions (stream events + JSONL writes) become no-ops, observationally identical to cancelling its timers without threading a cancellation handle through every scenario;
- clears the busy path so the next send starts a fresh turn;
- cancels queued steering timers (the real CLI never picks up queued messages after an abort — the renderer's draft-restore depends on this).

Scenarios that legitimately emit after their turn's `result` (e.g. `BackgroundBashScenario`'s cross-turn completion) are unaffected: the epoch only advances on interrupt, never on send.

## Validation

- `tsc --noEmit` + eslint clean; unit tests touching the mock (chat-integration-e2e, client-factory): 46/46
- New spec: standalone ✓, `--repeat-each=3` under parallel workers ✓
- Full suite ×2: **204 passed / 0 failed** (202 before + 2 new), 21 skipped
- Blast-radius specs for the interrupt path (proxy-review, pending-request-reconnect, background-bash, message-queueing) all green — none depend on post-interrupt scenario emissions (verified before changing semantics)

One test-design note: the mid-stream assertion runs on the session's *second* turn behind a quick warm-up send, because a fresh agent's first turn races the SSE join and can drop early stream deltas under 6-worker load (caught in the first full-suite run).