### PR TITLE
test: composer failure recovery never loses the user's work

### DIFF
--- a/e2e/specs/composer-failure-recovery.spec.ts
+++ b/e2e/specs/composer-failure-recovery.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+import * as path from 'path'
+import * as fs from 'fs'
+import * as os from 'os'
+
+function attachmentPreview(page: import('@playwright/test').Page, fileName: string) {
+  return page.getByTestId('attachment-preview').filter({ hasText: fileName })
+}
+
+/**
+ * Composer failure recovery: a failed send or a failed attachment upload must
+ * never lose the user's work.
+ *
+ * Two data-loss guards in use-message-composer are pinned here:
+ * - a failed message POST restores the typed text into the composer (the
+ *   optimistic ghost is dropped, nothing lands in the transcript), and the
+ *   restored text can be resent as-is once the server recovers;
+ * - a failed attachment upload short-circuits BEFORE the composer is cleared,
+ *   surfacing a dismissible error while both the text and the attachment
+ *   chips stay intact for a retry.
+ *
+ * Failures are injected per-page with route interception (POST-only — the
+ * transcript GETs on the same URL shape must keep flowing), so the tests are
+ * fully parallel-safe.
+ */
+test.describe('Composer failure recovery', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+  let tmpDir: string
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+
+    const testAgentName = `Recovery Agent ${testInfo.workerIndex}-${Date.now()}`
+    await agentPage.createAgent(testAgentName)
+
+    // Land on the session page (message-input.tsx) with one completed turn,
+    // so the tests exercise sends into an existing idle session
+    await sessionPage.sendMessage('hello')
+    await sessionPage.waitForResponse(15000)
+    await sessionPage.waitForInputEnabled()
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-recovery-'))
+  })
+
+  test.afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('a failed send restores the typed text for a successful resend', async ({ page }) => {
+    const text = 'this message must survive the failed send'
+
+    // Fail message POSTs; transcript GETs on the same URL shape pass through
+    await page.route('**/sessions/*/messages', (route) => {
+      if (route.request().method() !== 'POST') return route.continue()
+      return route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Injected send failure' }),
+      })
+    })
+
+    await sessionPage.typeMessage(text)
+    await sessionPage.getSendButton().click()
+
+    // The typed text is restored into the composer, the optimistic ghost is
+    // dropped, and nothing landed in the transcript
+    await expect(sessionPage.getMessageInput()).toHaveValue(text, { timeout: 10000 })
+    await expect(sessionPage.getUserMessages()).toHaveCount(1)
+
+    // Server recovers — the restored text resends as-is
+    await page.unroute('**/sessions/*/messages')
+    await sessionPage.getSendButton().click()
+
+    await sessionPage.waitForUserMessageCount(2, 15000)
+    await sessionPage.expectUserMessage(text, 1)
+    await expect(
+      sessionPage.getAssistantMessages().filter({ hasText: 'This is a mock response from the E2E test container.' })
+    ).toHaveCount(2, { timeout: 15000 })
+    await expect(sessionPage.getMessageInput()).toHaveValue('')
+  })
+
+  test('a failed upload preserves text and attachment for a retry', async ({ page }) => {
+    const filePath = path.join(tmpDir, 'guarded.txt')
+    fs.writeFileSync(filePath, 'file content that must not be lost')
+    const text = 'upload failure must keep my work'
+
+    const fileInput = page.locator('input[type="file"]:not([webkitdirectory])')
+    await fileInput.setInputFiles(filePath)
+    await expect(attachmentPreview(page, 'guarded.txt')).toBeVisible()
+    await sessionPage.typeMessage(text)
+
+    await page.route('**/upload-file*', (route) => route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'Injected upload failure' }),
+    }))
+
+    await sessionPage.getSendButton().click()
+
+    // The inline upload error surfaces in the composer (the same message also
+    // fires as a toast, so scope to the content area), and BOTH the text and
+    // the attachment chip survive — the send never happened
+    const inlineError = page.getByTestId('main-content').getByText('Injected upload failure')
+    await expect(inlineError).toBeVisible({ timeout: 10000 })
+    await expect(sessionPage.getMessageInput()).toHaveValue(text)
+    await expect(attachmentPreview(page, 'guarded.txt')).toBeVisible()
+    await expect(sessionPage.getUserMessages()).toHaveCount(1)
+
+    // The inline error is dismissible
+    await page.getByTestId('main-content').getByRole('button', { name: 'Dismiss' }).click()
+    await expect(inlineError).not.toBeVisible()
+
+    // Server recovers — the same composed message (text + file) sends through
+    await page.unroute('**/upload-file*')
+    await sessionPage.getSendButton().click()
+
+    await sessionPage.waitForUserMessageCount(2, 15000)
+    await sessionPage.expectUserMessage(text, 1)
+    await expect(page.getByTestId('file-pill').filter({ hasText: 'guarded.txt' }).first()).toBeVisible({ timeout: 5000 })
+    await expect(sessionPage.getMessageInput()).toHaveValue('')
+  })
+})


### PR DESCRIPTION
Batch #2 from the E2E coverage-gap plan (rank #2: no spec exercised any composer failure path — a regression here silently eats user messages).

## What's here

**`e2e/specs/composer-failure-recovery.spec.ts`** — two tests pinning the data-loss guards in `use-message-composer.ts`:

1. **Failed send restores the typed text** — 500 the message POST (route interception, POST-only so transcript GETs keep flowing) → the optimistic ghost is dropped, nothing lands in the transcript, and the typed text is restored into the composer → unroute → the restored text resends as-is and persists.
2. **Failed upload preserves text and attachments** — 500 the upload POST → the dismissible inline `UploadError` surfaces (scoped assertion: the same message also fires as a toast) while BOTH the text and the attachment chip survive → dismiss → unroute → the same composed message (text + file) sends through, file pill renders.

No harness changes needed — pure Playwright with per-page interception, parallel-safe.

## Validation

- eslint + `tsc --noEmit` clean
- New spec: `--repeat-each=3` ✓ (6/6)
- Full suite ×2 on this branch: both tests green in both runs; suite at **205 passed** (203 baseline + 2 new)

## Intermittents observed during validation (not from this diff)

Each full run showed one load-induced setup-phase timeout in an *unrelated* spec, a different one each run:
- `dashboard-and-tasks.spec.ts` P1-b failed once (generic `waitForResponse` timeout in setup before any deep-link logic), then passed 12/12 standalone stress and passed the next full run.
- `stop-session.spec.ts` rescue test (from #380, already on main) failed once in 4 full runs today: the queued ghost was removed but the composer stayed empty — same idle-grace restore machinery as the ghost-restore field bug just root-caused separately; I'll pick this up with that fix rather than paper over it here.