### PR TITLE
feat: show thinking traces as tool-call-style cards in the transcript

### DIFF
--- a/e2e/specs/thinking-display.spec.ts
+++ b/e2e/specs/thinking-display.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { SessionPage } from '../pages/session.page'
+import { createAgent, createSession, openAgentSession, waitForSessionIdle } from '../helpers/agents'
+
+async function setupThinkingTest(
+  page: Page,
+  request: APIRequestContext,
+  testInfo: TestInfo,
+  label: string,
+) {
+  const appPage = new AppPage(page)
+  const sessionPage = new SessionPage(page)
+  const agentName = `Thinking Agent ${label} ${testInfo.workerIndex}-${testInfo.repeatEachIndex}-${Date.now()}`
+  const agent = await createAgent(request, agentName)
+  const setupSession = await createSession(
+    request,
+    agent,
+    `setup thinking display ${label} ${testInfo.workerIndex}-${testInfo.repeatEachIndex}`,
+  )
+  await waitForSessionIdle(request, agent, setupSession)
+
+  await appPage.goto()
+  await appPage.waitForAgentsLoaded()
+  await openAgentSession(page, agent, setupSession)
+  await sessionPage.waitForInputEnabled(15000)
+
+  return { sessionPage }
+}
+
+test.describe('Thinking Display', () => {
+  test('thinking streams into an expanded transcript card, then collapses', async ({ page, request }, testInfo) => {
+    const { sessionPage } = await setupThinkingTest(page, request, testInfo, 'Card')
+
+    // Triggers the "think out loud" mock scenario: ~5s of thinking_delta
+    // chunks, then a text response.
+    await sessionPage.sendMessage('please think out loud about this')
+
+    // While thinking: the card is in the transcript, expanded, and shows the
+    // streamed reasoning text in its scrollable body.
+    const card = page.getByTestId('thinking-block').last()
+    const toggle = card.getByTestId('thinking-block-toggle')
+    const body = card.getByTestId('thinking-block-body')
+    await expect(card).toBeVisible({ timeout: 10000 })
+    await expect(toggle).toContainText('Thinking')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    await expect(body).toBeVisible()
+    await expect(body).toContainText('Let me reason about this', { timeout: 10000 })
+
+    // After the thinking block stops, the card auto-collapses to a summary header.
+    await expect(toggle).toContainText('Thought for', { timeout: 20000 })
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(body).not.toBeVisible()
+
+    // The trace stays readable for the rest of the turn: expanding shows the full text.
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    await expect(body).toBeVisible()
+    await expect(body).toContainText('stream a few sentences of summarized reasoning')
+
+    // And the text response still arrives as normal.
+    await sessionPage.waitForInputEnabled(20000)
+    await expect(page.getByText('Done thinking — here is the answer.')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('collapsing the card mid-stream sticks', async ({ page, request }, testInfo) => {
+    const { sessionPage } = await setupThinkingTest(page, request, testInfo, 'Collapse')
+
+    await sessionPage.sendMessage('please think out loud about this')
+
+    const card = page.getByTestId('thinking-block').last()
+    const toggle = card.getByTestId('thinking-block-toggle')
+    const body = card.getByTestId('thinking-block-body')
+    await expect(card).toBeVisible({ timeout: 10000 })
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+
+    // User collapses while the trace is still streaming — the card must stay
+    // collapsed (their choice wins over the streaming default).
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(body).not.toBeVisible()
+    // Wait for the header to change (token count/elapsed grow as deltas keep
+    // arriving) and confirm the card is still collapsed.
+    const headerBefore = (await toggle.textContent()) ?? ''
+    await expect(toggle).not.toHaveText(headerBefore, { timeout: 10000 })
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    await sessionPage.waitForInputEnabled(30000)
+  })
+})

--- a/e2e/specs/thinking-display.spec.ts
+++ b/e2e/specs/thinking-display.spec.ts
@@ -52,7 +52,7 @@ test.describe('Thinking Display', () => {
     await sessionPage.waitForInputEnabled(30000)
     await expect(page.getByText('Done thinking — here is the answer.')).toBeVisible({ timeout: 10000 })
     await expect(page.getByTestId('thinking-block')).toHaveCount(1, { timeout: 15000 })
-    await expect(toggle).toContainText('Thought', { timeout: 10000 })
+    await expect(toggle).toContainText('Thought for', { timeout: 10000 })
     await expect(toggle).toHaveAttribute('aria-expanded', 'false')
     await expect(body).not.toBeVisible()
 
@@ -111,7 +111,8 @@ test.describe('Thinking Display', () => {
     const toggle = card.getByTestId('thinking-block-toggle')
     const body = card.getByTestId('thinking-block-body')
     await expect(card).toBeVisible({ timeout: 15000 })
-    await expect(toggle).toContainText('Thought')
+    // Duration comes from transcript timestamps, so it survives the reopen
+    await expect(toggle).toContainText('Thought for')
     await expect(toggle).toHaveAttribute('aria-expanded', 'false')
 
     await toggle.click()

--- a/e2e/specs/thinking-display.spec.ts
+++ b/e2e/specs/thinking-display.spec.ts
@@ -25,7 +25,7 @@ async function setupThinkingTest(
   await openAgentSession(page, agent, setupSession)
   await sessionPage.waitForInputEnabled(15000)
 
-  return { sessionPage }
+  return { appPage, sessionPage, agent, setupSession }
 }
 
 test.describe('Thinking Display', () => {
@@ -33,7 +33,7 @@ test.describe('Thinking Display', () => {
     const { sessionPage } = await setupThinkingTest(page, request, testInfo, 'Card')
 
     // Triggers the "think out loud" mock scenario: ~5s of thinking_delta
-    // chunks, then a text response.
+    // chunks, then a text response (thinking persisted in the JSONL).
     await sessionPage.sendMessage('please think out loud about this')
 
     // While thinking: the card is in the transcript, expanded, and shows the
@@ -47,20 +47,25 @@ test.describe('Thinking Display', () => {
     await expect(body).toBeVisible()
     await expect(body).toContainText('Let me reason about this', { timeout: 10000 })
 
-    // After the thinking block stops, the card auto-collapses to a summary header.
-    await expect(toggle).toContainText('Thought for', { timeout: 20000 })
+    // Turn finishes: the live card hands off to the persisted one (carried on
+    // the refetched message) with no duplication, collapsed to a summary header.
+    await sessionPage.waitForInputEnabled(30000)
+    await expect(page.getByText('Done thinking — here is the answer.')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByTestId('thinking-block')).toHaveCount(1, { timeout: 15000 })
+    await expect(toggle).toContainText('Thought', { timeout: 10000 })
     await expect(toggle).toHaveAttribute('aria-expanded', 'false')
     await expect(body).not.toBeVisible()
 
-    // The trace stays readable for the rest of the turn: expanding shows the full text.
-    await toggle.click()
-    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
-    await expect(body).toBeVisible()
+    // The trace stays readable: expanding shows the full text. The card can
+    // remount on a post-turn refetch (resetting local expansion state), so
+    // re-drive the toggle until the body agrees — mirrors tool-rendering.spec.
+    await expect(async () => {
+      if (await toggle.getAttribute('aria-expanded') !== 'true') {
+        await toggle.click()
+      }
+      await expect(body).toBeVisible({ timeout: 1000 })
+    }).toPass({ timeout: 20000 })
     await expect(body).toContainText('stream a few sentences of summarized reasoning')
-
-    // And the text response still arrives as normal.
-    await sessionPage.waitForInputEnabled(20000)
-    await expect(page.getByText('Done thinking — here is the answer.')).toBeVisible({ timeout: 10000 })
   })
 
   test('collapsing the card mid-stream sticks', async ({ page, request }, testInfo) => {
@@ -86,5 +91,32 @@ test.describe('Thinking Display', () => {
     await expect(toggle).toHaveAttribute('aria-expanded', 'false')
 
     await sessionPage.waitForInputEnabled(30000)
+  })
+
+  test('thinking persists in the transcript across a reopen', async ({ page, request }, testInfo) => {
+    const { appPage, sessionPage, agent, setupSession } = await setupThinkingTest(page, request, testInfo, 'Persist')
+
+    await sessionPage.sendMessage('please think out loud about this')
+    await sessionPage.waitForInputEnabled(30000)
+    await expect(page.getByText('Done thinking — here is the answer.')).toBeVisible({ timeout: 10000 })
+
+    // Re-open the session from scratch — the card now comes purely from the
+    // persisted transcript (stream state is gone).
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+    await openAgentSession(page, agent, setupSession)
+    await sessionPage.waitForInputEnabled(15000)
+
+    const card = page.getByTestId('thinking-block').last()
+    const toggle = card.getByTestId('thinking-block-toggle')
+    const body = card.getByTestId('thinking-block-body')
+    await expect(card).toBeVisible({ timeout: 15000 })
+    await expect(toggle).toContainText('Thought')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    await expect(body).toContainText('Let me reason about this')
+    await expect(page.getByTestId('thinking-block')).toHaveCount(1)
   })
 })

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -28,7 +28,7 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
     pendingSecretRequests, pendingConnectedAccountRequests, pendingQuestionRequests,
     pendingFileRequests, pendingRemoteMcpRequests, pendingBrowserInputRequests,
     apiRetry, computerUseApp, computerUseAppIcon, backgroundTasks,
-    isThinking, thinkingText,
+    isThinking,
   } = useMessageStream(sessionId, agentSlug)
 
   const [revoking, setRevoking] = useState(false)
@@ -38,8 +38,6 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
   // Non-null only for a platform billing 402 the workspace can act on (see hook).
   const billingUrl = usePlatformBillingUrl(error ?? '')
 
-  // Rough token estimate for the streamed reasoning (~4 chars/token). UI-only.
-  const thinkingTokens = thinkingText ? Math.ceil(thinkingText.length / 4) : 0
   const handleRevokeComputerUse = useCallback(async () => {
     setRevoking(true)
     setRevokeError(false)
@@ -240,9 +238,6 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
             )}></span>
           </span>
           <span className="text-sm font-medium">{statusText}</span>
-          {isThinking && thinkingTokens > 0 && (
-            <span className="text-xs text-muted-foreground tabular-nums">~{thinkingTokens.toLocaleString()} tokens</span>
-          )}
           {computerUseApp && (
             <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300">
               {computerUseAppIcon ? (
@@ -269,16 +264,8 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
           )}
         </div>
 
-        {/* Streamed (summarized) reasoning — shown only while actively thinking, removed
-            once the agent flips back to "Working". Clipped to ~4 lines and bottom-aligned
-            (justify-end + overflow-hidden) so the latest streamed text stays visible. */}
-        {isThinking && thinkingText && (
-          <div className="mt-2 flex max-h-20 flex-col justify-end overflow-hidden rounded bg-muted p-2 overflow-y-scroll">
-            <pre className="whitespace-pre-wrap text-xs text-muted-foreground select-text">
-              {thinkingText}
-            </pre>
-          </div>
-        )}
+        {/* Streamed reasoning renders as a thinking card in the transcript
+            (see ThinkingBlockItem) — only the "Thinking..." status shows here. */}
 
         {/* Active subagents */}
         {subagentItems.length > 0 && (

--- a/src/renderer/components/messages/message-error-boundary.tsx
+++ b/src/renderer/components/messages/message-error-boundary.tsx
@@ -4,7 +4,7 @@ import { cn } from '@shared/lib/utils/cn'
 import { captureRendererException } from '@renderer/lib/error-reporting'
 
 /** What kind of item failed to render — drives the copy and the Sentry tags. */
-type RenderItemKind = 'message' | 'tool call'
+type RenderItemKind = 'message' | 'tool call' | 'thinking block'
 
 interface MessageErrorBoundaryProps {
   children: ReactNode

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -4,6 +4,7 @@ import { Check, Copy, Link2 } from 'lucide-react'
 import { ProviderErrorCard } from '@renderer/components/ui/provider-error-card'
 import { InsufficientBalanceCard, usePlatformBillingUrl } from './insufficient-balance-card'
 import { ToolCallItem } from './tool-call-item'
+import { ThinkingBlockItem } from './thinking-block-item'
 import { SubAgentBlock } from './subagent-block'
 import { WorkflowBlock } from './workflow-block'
 import { WorkflowResultCard } from './workflow-result-card'
@@ -232,6 +233,11 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
   const text = textAfterNotifs
   const hasText = text && text.length > 0
   const toolCalls = message.toolCalls || []
+  // Persisted extended-thinking text. Defensive shape check — this field
+  // crosses the wire, and empty strings are real data in older transcripts.
+  const thinking = isAssistant && Array.isArray(message.thinking)
+    ? message.thinking.filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
+    : []
 
   const isSlashCommand = isUser && hasText && text.startsWith('/')
 
@@ -245,10 +251,10 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
   const billingUrl = usePlatformBillingUrl(rawText ?? '')
   const showBillingCard = isAssistant && !!message.apiError && !!billingUrl
 
-  // Don't render assistant messages that have no text and no tool calls
-  // (and aren't streaming). These are transient empty entries from partially-
-  // persisted JSONL that will be filled in on the next refetch.
-  if (isAssistant && !hasText && toolCalls.length === 0 && !isStreaming) {
+  // Don't render assistant messages that have no text, no tool calls, and no
+  // thinking (and aren't streaming). These are transient empty entries from
+  // partially-persisted JSONL that will be filled in on the next refetch.
+  if (isAssistant && !hasText && toolCalls.length === 0 && thinking.length === 0 && !isStreaming) {
     return null
   }
 
@@ -277,6 +283,19 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
         {/* Sender name for shared agent sessions */}
         {isUser && message.sender?.name && (
           <span className="text-xs text-muted-foreground">{message.sender.name}</span>
+        )}
+
+        {/* Persisted thinking — collapsed cards above the message text, one per
+            episode. Same card the live stream uses, minus timing (the transcript
+            doesn't carry it). */}
+        {thinking.length > 0 && (
+          <div className="w-full space-y-2">
+            {thinking.map((t, i) => (
+              <MessageErrorBoundary key={i} kind="thinking block" raw={t} itemId={`${message.id}-thinking-${i}`}>
+                <ThinkingBlockItem text={t} active={false} />
+              </MessageErrorBoundary>
+            ))}
+          </div>
         )}
 
         {/* Message bubble - only show if there's text content */}

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -233,10 +233,13 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
   const text = textAfterNotifs
   const hasText = text && text.length > 0
   const toolCalls = message.toolCalls || []
-  // Persisted extended-thinking text. Defensive shape check — this field
+  // Persisted extended-thinking blocks. Defensive shape check — this field
   // crosses the wire, and empty strings are real data in older transcripts.
   const thinking = isAssistant && Array.isArray(message.thinking)
-    ? message.thinking.filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
+    ? message.thinking.filter(
+        (t): t is { text: string; durationMs?: number } =>
+          typeof t?.text === 'string' && t.text.trim().length > 0
+      )
     : []
 
   const isSlashCommand = isUser && hasText && text.startsWith('/')
@@ -292,7 +295,7 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
           <div className="w-full space-y-2">
             {thinking.map((t, i) => (
               <MessageErrorBoundary key={i} kind="thinking block" raw={t} itemId={`${message.id}-thinking-${i}`}>
-                <ThinkingBlockItem text={t} active={false} />
+                <ThinkingBlockItem text={t.text} durationMs={t.durationMs} active={false} />
               </MessageErrorBoundary>
             ))}
           </div>

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -148,6 +148,7 @@ describe('MessageList', () => {
       completedSubagents: null,
       typingUser: null,
       peerUserMessages: [],
+      thinkingBlocks: [],
     })
   })
 
@@ -1685,6 +1686,86 @@ describe('MessageList', () => {
       // Pinned to bottom: the slice slides so the DOM stays bounded — m5 drops off.
       expect(screen.queryByText('m5')).not.toBeInTheDocument()
       expect(screen.getByText('m305')).toBeInTheDocument()
+    })
+  })
+
+  describe('thinking block dedup (live vs persisted)', () => {
+    const liveBlock = (text: string, endedAt: number | null = null) =>
+      ({ id: 1, text, startedAt: Date.now() - 5000, endedAt })
+
+    it('renders a live thinking card while the turn streams', () => {
+      mockMessagesData.data = [createUserMessage({ content: { text: 'Question' } })]
+      mockStreamState.isActive = true
+      mockStreamState.thinkingBlocks = [liveBlock('Reasoning about the question')]
+
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.getAllByTestId('thinking-block')).toHaveLength(1)
+      expect(screen.getByText('Reasoning about the question')).toBeInTheDocument()
+    })
+
+    it('hands off to the persisted card when the current turn carries the same text', () => {
+      mockMessagesData.data = [
+        createUserMessage({ content: { text: 'Question' } }),
+        createAssistantMessage({ content: { text: '' }, thinking: [{ text: 'Reasoning about the question in detail' }] }),
+      ]
+      mockStreamState.isActive = true
+      // Live stream trails the transcript — prefix in one direction
+      mockStreamState.thinkingBlocks = [liveBlock('Reasoning about the question')]
+
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      // Only the persisted card (from MessageItem) — no double render. It's
+      // collapsed, so identify it by its "Thought" header (a live card reads "Thinking").
+      expect(screen.getAllByTestId('thinking-block')).toHaveLength(1)
+      expect(screen.getByTestId('thinking-block-toggle')).toHaveTextContent('Thought')
+    })
+
+    it('does not suppress the live card when only an older turn has matching thinking', () => {
+      // Regression: models reuse stock openers ("Let me..."). A live block whose
+      // early streamed prefix matches a PREVIOUS turn's persisted thinking must
+      // still render — only the current turn participates in dedup.
+      mockMessagesData.data = [
+        createUserMessage({ content: { text: 'First question' } }),
+        createAssistantMessage({ content: { text: 'Answer one' }, thinking: [{ text: 'Let me check the config and think it through' }] }),
+        createUserMessage({ content: { text: 'Second question' } }),
+      ]
+      mockStreamState.isActive = true
+      mockStreamState.thinkingBlocks = [liveBlock('Let me check')]
+
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      // Old turn's persisted card + the new turn's live card
+      expect(screen.getAllByTestId('thinking-block')).toHaveLength(2)
+    })
+
+    it('removes leftover live cards at idle once the turn persisted its thinking, even when text diverged', () => {
+      // An SSE reconnect can drop deltas so the streamed text never prefix-matches
+      // the transcript — at idle the persisted cards own the display outright.
+      mockMessagesData.data = [
+        createUserMessage({ content: { text: 'Question' } }),
+        createAssistantMessage({ content: { text: 'Answer' }, thinking: [{ text: 'the full persisted reasoning' }] }),
+      ]
+      mockStreamState.isActive = false
+      mockStreamState.thinkingBlocks = [liveBlock('divergent streamed fragment', Date.now())]
+
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.getAllByTestId('thinking-block')).toHaveLength(1)
+      expect(screen.queryByText('divergent streamed fragment')).not.toBeInTheDocument()
+    })
+
+    it('keeps an empty-text live block while active but drops it at idle', () => {
+      mockMessagesData.data = [
+        createUserMessage({ content: { text: 'Question' } }),
+        createAssistantMessage({ content: { text: 'Answer with no persisted thinking' } }),
+      ]
+      mockStreamState.thinkingBlocks = [liveBlock('')]
+
+      mockStreamState.isActive = true
+      const { unmount } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.getAllByTestId('thinking-block')).toHaveLength(1)
+      unmount()
+
+      mockStreamState.isActive = false
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.queryByTestId('thinking-block')).not.toBeInTheDocument()
     })
   })
 })

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -51,6 +51,7 @@ const mockStreamState = {
   completedSubagents: null as Set<string> | null,
   typingUser: null as { id: string; name?: string } | null,
   peerUserMessages: [] as Array<{ uuid: string; receivedAt: number; content: string; sender: { id: string; name?: string; email?: string }; queued?: boolean }>,
+  thinkingBlocks: [] as Array<{ id: number; text: string; startedAt: number; endedAt: number | null }>,
 }
 
 const mockClearCompacting = vi.fn()

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -386,11 +386,22 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   const unpersistedThinkingBlocks = useMemo(() => {
     if (!thinkingBlocks.length || !messages?.length) return thinkingBlocks
     const persisted: string[] = []
-    for (const m of messages) {
+    let currentTurnHasPersistedThinking = false
+    let inCurrentTurn = true
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i]
+      if (inCurrentTurn && isTurnStartingUserMessage(m)) inCurrentTurn = false
       if (m.type === 'assistant' && Array.isArray((m as ApiMessage).thinking)) {
         persisted.push(...(m as ApiMessage).thinking!)
+        if (inCurrentTurn) currentTurnHasPersistedThinking = true
       }
     }
+    // Once the turn is over and its thinking made it into the transcript, the
+    // persisted cards own the display outright. This catches blocks whose
+    // streamed text diverged from the transcript (e.g. an SSE reconnect
+    // dropped deltas) — text matching would miss them and the leftover card
+    // would strand below the persisted message, appearing to "jump" there.
+    if (!isActive && currentTurnHasPersistedThinking) return []
     if (!persisted.length) return thinkingBlocks
     return thinkingBlocks.filter(b => {
       const t = b.text.trim()
@@ -399,7 +410,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       if (!t) return true
       return !persisted.some(p => p.startsWith(t) || t.startsWith(p.trim()))
     })
-  }, [messages, thinkingBlocks])
+  }, [messages, thinkingBlocks, isActive])
 
   // Filter streaming tool uses to only those NOT yet in persisted messages
   const unpersistedStreamingToolUses = useMemo(() => {

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -378,6 +378,29 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     return persistedText.startsWith(streamingText) || streamingText.startsWith(persistedText)
   }, [messages, streamingMessage])
 
+  // Filter live thinking blocks to only those NOT yet carried by a persisted
+  // message (mirrors unpersistedStreamingToolUses). Once the refetched assistant
+  // message arrives with its `thinking` array, the persisted card in MessageItem
+  // takes over and the ephemeral one must not double-render. Matched by text
+  // prefix in either direction since the stream can trail the transcript.
+  const unpersistedThinkingBlocks = useMemo(() => {
+    if (!thinkingBlocks.length || !messages?.length) return thinkingBlocks
+    const persisted: string[] = []
+    for (const m of messages) {
+      if (m.type === 'assistant' && Array.isArray((m as ApiMessage).thinking)) {
+        persisted.push(...(m as ApiMessage).thinking!)
+      }
+    }
+    if (!persisted.length) return thinkingBlocks
+    return thinkingBlocks.filter(b => {
+      const t = b.text.trim()
+      // Blocks with no streamed text (display option off) have no persisted
+      // counterpart to collide with — keep them.
+      if (!t) return true
+      return !persisted.some(p => p.startsWith(t) || t.startsWith(p.trim()))
+    })
+  }, [messages, thinkingBlocks])
+
   // Filter streaming tool uses to only those NOT yet in persisted messages
   const unpersistedStreamingToolUses = useMemo(() => {
     if (!streamingToolUses.length || !messages?.length) return streamingToolUses
@@ -749,13 +772,16 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
 
         {/* Thinking episodes for the current turn — tool-call-style cards, expanded
             and scrollable while streaming, collapsed to a "Thought for Ns" header
-            once done. Ephemeral: cleared when the next turn starts. */}
-        {thinkingBlocks.map((block, i) => (
+            once done. Kept until the refetched persisted message carries the same
+            text (see unpersistedThinkingBlocks), then MessageItem's card takes over. */}
+        {unpersistedThinkingBlocks.map(block => (
           <MessageErrorBoundary key={block.id} kind="thinking block" raw={block} itemId={`thinking-${block.id}`}>
             <div className="max-w-[80%]">
               <ThinkingBlockItem
-                block={block}
-                active={isActive && isThinking && i === thinkingBlocks.length - 1}
+                text={block.text}
+                startedAt={block.startedAt}
+                endedAt={block.endedAt}
+                active={isActive && isThinking && block.id === thinkingBlocks[thinkingBlocks.length - 1]?.id}
               />
             </div>
           </MessageErrorBoundary>

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -133,7 +133,6 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     typingUser,
     peerUserMessages,
     workflows,
-    isThinking,
     thinkingBlocks,
   } = useMessageStream(sessionId, agentSlug)
   const isOnline = useIsOnline()
@@ -383,19 +382,19 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   // message arrives with its `thinking` array, the persisted card in MessageItem
   // takes over and the ephemeral one must not double-render. Matched by text
   // prefix in either direction since the stream can trail the transcript.
+  // Only the current turn's persisted thinking is compared — live blocks are
+  // reset on session_active, so a match against an older turn can only be a
+  // false positive (the model reusing a stock opener suppresses the live card).
   const unpersistedThinkingBlocks = useMemo(() => {
     if (!thinkingBlocks.length || !messages?.length) return thinkingBlocks
     const persisted: string[] = []
-    let currentTurnHasPersistedThinking = false
-    let inCurrentTurn = true
     for (let i = messages.length - 1; i >= 0; i--) {
       const m = messages[i]
-      if (inCurrentTurn && isTurnStartingUserMessage(m)) inCurrentTurn = false
+      if (isTurnStartingUserMessage(m)) break
       if (m.type === 'assistant' && Array.isArray((m as ApiMessage).thinking)) {
         for (const t of (m as ApiMessage).thinking!) {
-          if (typeof t?.text === 'string') persisted.push(t.text)
+          if (typeof t?.text === 'string' && t.text.trim()) persisted.push(t.text.trim())
         }
-        if (inCurrentTurn) currentTurnHasPersistedThinking = true
       }
     }
     // Once the turn is over and its thinking made it into the transcript, the
@@ -403,14 +402,14 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     // streamed text diverged from the transcript (e.g. an SSE reconnect
     // dropped deltas) — text matching would miss them and the leftover card
     // would strand below the persisted message, appearing to "jump" there.
-    if (!isActive && currentTurnHasPersistedThinking) return []
-    if (!persisted.length) return thinkingBlocks
+    if (!isActive && persisted.length) return []
     return thinkingBlocks.filter(b => {
       const t = b.text.trim()
       // Blocks with no streamed text (display option off) have no persisted
-      // counterpart to collide with — keep them.
-      if (!t) return true
-      return !persisted.some(p => p.startsWith(t) || t.startsWith(p.trim()))
+      // counterpart to collide with — keep them while the turn runs, but don't
+      // let them strand in an idle transcript.
+      if (!t) return isActive
+      return !persisted.some(p => p.startsWith(t) || t.startsWith(p))
     })
   }, [messages, thinkingBlocks, isActive])
 
@@ -794,7 +793,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
                 text={block.text}
                 startedAt={block.startedAt}
                 endedAt={block.endedAt}
-                active={isActive && isThinking && block.id === thinkingBlocks[thinkingBlocks.length - 1]?.id}
+                active={isActive && block.endedAt === null}
               />
             </div>
           </MessageErrorBoundary>

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -12,6 +12,7 @@ import {
 import { isTurnStartingUserMessage, type PendingMessage } from './pending-message'
 import { MessageItem } from './message-item'
 import { ToolCallItem, StreamingToolCallItem } from './tool-call-item'
+import { ThinkingBlockItem } from './thinking-block-item'
 import { SubAgentBlock } from './subagent-block'
 import { WorkflowBlock } from './workflow-block'
 import { CompactBoundaryItem } from './compact-boundary-item'
@@ -132,6 +133,8 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     typingUser,
     peerUserMessages,
     workflows,
+    isThinking,
+    thinkingBlocks,
   } = useMessageStream(sessionId, agentSlug)
   const isOnline = useIsOnline()
 
@@ -522,7 +525,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     if (scrollRef.current && isScrolledToBottomRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight
     }
-  }, [messages, pendingUserMessages, streamingMessage, streamingToolUses, isCompacting, pendingRequestCount, activeSubagents])
+  }, [messages, pendingUserMessages, streamingMessage, streamingToolUses, thinkingBlocks, isCompacting, pendingRequestCount, activeSubagents])
 
   // Peer messages still worth showing optimistically: not our own, and the
   // persisted copy (by uuid, or — for queued/steering messages whose uuid the
@@ -743,6 +746,20 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
             </div>
           </div>
         )}
+
+        {/* Thinking episodes for the current turn — tool-call-style cards, expanded
+            and scrollable while streaming, collapsed to a "Thought for Ns" header
+            once done. Ephemeral: cleared when the next turn starts. */}
+        {thinkingBlocks.map((block, i) => (
+          <MessageErrorBoundary key={block.id} kind="thinking block" raw={block} itemId={`thinking-${block.id}`}>
+            <div className="max-w-[80%]">
+              <ThinkingBlockItem
+                block={block}
+                active={isActive && isThinking && i === thinkingBlocks.length - 1}
+              />
+            </div>
+          </MessageErrorBoundary>
+        ))}
 
         {/* Streaming text message - keep visible until persisted data arrives */}
         {streamingMessage && !isStreamingMessagePersisted && (

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -392,7 +392,9 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       const m = messages[i]
       if (inCurrentTurn && isTurnStartingUserMessage(m)) inCurrentTurn = false
       if (m.type === 'assistant' && Array.isArray((m as ApiMessage).thinking)) {
-        persisted.push(...(m as ApiMessage).thinking!)
+        for (const t of (m as ApiMessage).thinking!) {
+          if (typeof t?.text === 'string') persisted.push(t.text)
+        }
         if (inCurrentTurn) currentTurnHasPersistedThinking = true
       }
     }

--- a/src/renderer/components/messages/thinking-block-item.tsx
+++ b/src/renderer/components/messages/thinking-block-item.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@shared/lib/utils/cn'
-import { Brain, ChevronDown, ChevronRight } from 'lucide-react'
+import { Waypoints, ChevronDown, ChevronRight } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useElapsedTimer, formatElapsed } from '@renderer/hooks/use-elapsed-timer'
 import { StatusIndicator } from './tool-call-item'
@@ -78,7 +78,7 @@ export function ThinkingBlockItem({ text, active, startedAt, endedAt, durationMs
         onClick={() => setUserExpanded(!expanded)}
         className={cn('flex w-full items-center gap-2 pl-2 pr-2 py-1.5 group hover:bg-muted/50 transition-colors', expanded && 'bg-muted/50')}
       >
-        <Brain className={cn(
+        <Waypoints className={cn(
           'h-3.5 w-3.5 shrink-0 transition-colors',
           active ? 'text-foreground' : 'text-foreground/45 group-hover:text-foreground'
         )} />

--- a/src/renderer/components/messages/thinking-block-item.tsx
+++ b/src/renderer/components/messages/thinking-block-item.tsx
@@ -1,0 +1,123 @@
+import { cn } from '@shared/lib/utils/cn'
+import { Brain, ChevronDown, ChevronRight } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
+import { StatusIndicator } from './tool-call-item'
+import type { ThinkingBlock } from '@renderer/hooks/use-message-stream'
+
+interface ThinkingBlockItemProps {
+  block: ThinkingBlock
+  /** True while this block is the one currently streaming reasoning text. */
+  active: boolean
+}
+
+// How close (px) to the bottom counts as "pinned" — matches the tolerance the
+// message list uses for its own stick-to-bottom behavior.
+const PIN_THRESHOLD_PX = 32
+
+/**
+ * A thinking episode rendered as a tool-call-style card in the transcript.
+ *
+ * While the block streams it is expanded with a scrollable, bottom-pinned body so
+ * the trace can be read as it happens; when the block ends it collapses to a
+ * "Thought for Ns" header (unless the user toggled it themselves, which wins).
+ * Blocks are ephemeral — they live in stream state for the current turn only and
+ * are not persisted to the transcript.
+ */
+export function ThinkingBlockItem({ block, active }: ThinkingBlockItemProps) {
+  // null = follow the default (expanded while active); a user click overrides it
+  const [userExpanded, setUserExpanded] = useState<boolean | null>(null)
+  const expanded = userExpanded ?? active
+
+  // Memoized so the timer effect doesn't reset its interval on every delta re-render.
+  // Live while streaming (endDate null), static "Thought for" duration once done.
+  // A block that never got its stop event (interrupted turn) freezes rather than
+  // ticking forever on an idle session.
+  const startDate = useMemo(() => new Date(block.startedAt), [block.startedAt])
+  const endDate = useMemo(() => {
+    if (block.endedAt !== null) return new Date(block.endedAt)
+    return active ? null : new Date(block.startedAt)
+  }, [block.endedAt, active, block.startedAt])
+  const elapsed = useElapsedTimer(startDate, endDate)
+
+  // Rough token estimate for the streamed reasoning (~4 chars/token). UI-only.
+  const tokens = block.text ? Math.ceil(block.text.length / 4) : 0
+
+  // Stick-to-bottom: follow the streaming text unless the user scrolls up to read.
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const pinnedRef = useRef(true)
+  useEffect(() => {
+    const el = scrollRef.current
+    if (active && expanded && el && pinnedRef.current) {
+      el.scrollTop = el.scrollHeight
+    }
+  }, [block.text, active, expanded])
+
+  const handleScroll = () => {
+    const el = scrollRef.current
+    if (!el) return
+    pinnedRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < PIN_THRESHOLD_PX
+  }
+
+  return (
+    <div className="text-sm border border-border/70 rounded-md overflow-hidden" data-testid="thinking-block">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-label={`${expanded ? 'Collapse' : 'Expand'} thinking`}
+        data-testid="thinking-block-toggle"
+        onClick={() => setUserExpanded(!expanded)}
+        className={cn('flex w-full items-center gap-2 pl-2 pr-2 py-1.5 group hover:bg-muted/50 transition-colors', expanded && 'bg-muted/50')}
+      >
+        <Brain className={cn(
+          'h-3.5 w-3.5 shrink-0 transition-colors',
+          active ? 'text-foreground' : 'text-foreground/45 group-hover:text-foreground'
+        )} />
+        <span className={cn(
+          'font-sans font-normal shrink-0 text-sm leading-none transition-colors',
+          active ? 'text-foreground' : 'text-foreground/65 group-hover:text-foreground'
+        )}>
+          {active ? 'Thinking' : `Thought for ${elapsed}`}
+        </span>
+        {tokens > 0 && (
+          <span className="shrink-0 text-xs leading-none text-muted-foreground/70 group-hover:text-muted-foreground tabular-nums transition-colors">
+            ~{tokens.toLocaleString()} tokens
+          </span>
+        )}
+        {active && elapsed && (
+          <span className="shrink-0 text-2xs text-muted-foreground/70 tabular-nums ml-auto">
+            {elapsed}
+          </span>
+        )}
+        {active ? (
+          <span className={cn('relative shrink-0 flex h-4 w-4 items-center justify-center', !elapsed && 'ml-auto')}>
+            <span className="transition-opacity group-hover:opacity-0">
+              <StatusIndicator status="running" />
+            </span>
+            <span className="absolute inset-0 flex items-center justify-center text-muted-foreground/60 opacity-0 transition-opacity group-hover:text-muted-foreground group-hover:opacity-100">
+              {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+            </span>
+          </span>
+        ) : (
+          <span className="shrink-0 flex h-4 w-4 items-center justify-center ml-auto text-muted-foreground/60 group-hover:text-muted-foreground transition-colors">
+            {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+          </span>
+        )}
+      </button>
+
+      {expanded && (
+        <div
+          ref={scrollRef}
+          onScroll={handleScroll}
+          className="border-t border-border/70 bg-muted/50 px-3 py-2 max-h-64 overflow-y-auto"
+          data-testid="thinking-block-body"
+        >
+          <pre className="whitespace-pre-wrap break-words text-xs text-muted-foreground select-text font-sans">
+            {block.text || <span className="italic">Thinking…</span>}
+            {active && <span className="animate-pulse">|</span>}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/messages/thinking-block-item.tsx
+++ b/src/renderer/components/messages/thinking-block-item.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@shared/lib/utils/cn'
-import { Route, ChevronDown, ChevronRight } from 'lucide-react'
+import { ListTree, ChevronDown, ChevronRight } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useElapsedTimer, formatElapsed } from '@renderer/hooks/use-elapsed-timer'
 import { StatusIndicator } from './tool-call-item'
@@ -78,7 +78,7 @@ export function ThinkingBlockItem({ text, active, startedAt, endedAt, durationMs
         onClick={() => setUserExpanded(!expanded)}
         className={cn('flex w-full items-center gap-2 pl-2 pr-2 py-1.5 group hover:bg-muted/50 transition-colors', expanded && 'bg-muted/50')}
       >
-        <Route className={cn(
+        <ListTree className={cn(
           'h-3.5 w-3.5 shrink-0 transition-colors',
           active ? 'text-foreground' : 'text-foreground/45 group-hover:text-foreground'
         )} />

--- a/src/renderer/components/messages/thinking-block-item.tsx
+++ b/src/renderer/components/messages/thinking-block-item.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@shared/lib/utils/cn'
 import { Brain, ChevronDown, ChevronRight } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
+import { useElapsedTimer, formatElapsed } from '@renderer/hooks/use-elapsed-timer'
 import { StatusIndicator } from './tool-call-item'
 
 interface ThinkingBlockItemProps {
@@ -11,11 +11,13 @@ interface ThinkingBlockItemProps {
   /**
    * Live-stream timing (ms epoch). Present for stream-state blocks so the
    * header can show a live timer / "Thought for Ns"; absent for blocks read
-   * back from the persisted transcript, which carries no timing.
+   * back from the persisted transcript.
    */
   startedAt?: number
   /** null while the live block is still streaming */
   endedAt?: number | null
+  /** Transcript-derived duration for persisted blocks (no live timing). */
+  durationMs?: number
 }
 
 // How close (px) to the bottom counts as "pinned" — matches the tolerance the
@@ -30,7 +32,7 @@ const PIN_THRESHOLD_PX = 32
  * "Thought for Ns" header (unless the user toggled it themselves, which wins).
  * Persisted transcript blocks render the same card, collapsed, headed "Thought".
  */
-export function ThinkingBlockItem({ text, active, startedAt, endedAt }: ThinkingBlockItemProps) {
+export function ThinkingBlockItem({ text, active, startedAt, endedAt, durationMs }: ThinkingBlockItemProps) {
   // null = follow the default (expanded while active); a user click overrides it
   const [userExpanded, setUserExpanded] = useState<boolean | null>(null)
   const expanded = userExpanded ?? active
@@ -46,9 +48,9 @@ export function ThinkingBlockItem({ text, active, startedAt, endedAt }: Thinking
     return active ? null : new Date(startedAt)
   }, [endedAt, active, startedAt])
   const elapsed = useElapsedTimer(startDate, endDate)
-
-  // Rough token estimate for the streamed reasoning (~4 chars/token). UI-only.
-  const tokens = text ? Math.ceil(text.length / 4) : 0
+  // Live timing wins (exact); persisted blocks fall back to the
+  // transcript-derived duration; header degrades to plain "Thought" without either.
+  const doneDuration = elapsed ?? (durationMs !== undefined ? formatElapsed(durationMs) : null)
 
   // Stick-to-bottom: follow the streaming text unless the user scrolls up to read.
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -84,13 +86,8 @@ export function ThinkingBlockItem({ text, active, startedAt, endedAt }: Thinking
           'font-sans font-normal shrink-0 text-sm leading-none transition-colors',
           active ? 'text-foreground' : 'text-foreground/65 group-hover:text-foreground'
         )}>
-          {active ? 'Thinking' : elapsed ? `Thought for ${elapsed}` : 'Thought'}
+          {active ? 'Thinking' : doneDuration ? `Thought for ${doneDuration}` : 'Thought'}
         </span>
-        {tokens > 0 && (
-          <span className="shrink-0 text-xs leading-none text-muted-foreground/70 group-hover:text-muted-foreground tabular-nums transition-colors">
-            ~{tokens.toLocaleString()} tokens
-          </span>
-        )}
         {active && elapsed && (
           <span className="shrink-0 text-2xs text-muted-foreground/70 tabular-nums ml-auto">
             {elapsed}

--- a/src/renderer/components/messages/thinking-block-item.tsx
+++ b/src/renderer/components/messages/thinking-block-item.tsx
@@ -3,12 +3,19 @@ import { Brain, ChevronDown, ChevronRight } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
 import { StatusIndicator } from './tool-call-item'
-import type { ThinkingBlock } from '@renderer/hooks/use-message-stream'
 
 interface ThinkingBlockItemProps {
-  block: ThinkingBlock
+  text: string
   /** True while this block is the one currently streaming reasoning text. */
   active: boolean
+  /**
+   * Live-stream timing (ms epoch). Present for stream-state blocks so the
+   * header can show a live timer / "Thought for Ns"; absent for blocks read
+   * back from the persisted transcript, which carries no timing.
+   */
+  startedAt?: number
+  /** null while the live block is still streaming */
+  endedAt?: number | null
 }
 
 // How close (px) to the bottom counts as "pinned" — matches the tolerance the
@@ -16,15 +23,14 @@ interface ThinkingBlockItemProps {
 const PIN_THRESHOLD_PX = 32
 
 /**
- * A thinking episode rendered as a tool-call-style card in the transcript.
+ * A thinking episode rendered as a tool-call-style card.
  *
  * While the block streams it is expanded with a scrollable, bottom-pinned body so
  * the trace can be read as it happens; when the block ends it collapses to a
  * "Thought for Ns" header (unless the user toggled it themselves, which wins).
- * Blocks are ephemeral — they live in stream state for the current turn only and
- * are not persisted to the transcript.
+ * Persisted transcript blocks render the same card, collapsed, headed "Thought".
  */
-export function ThinkingBlockItem({ block, active }: ThinkingBlockItemProps) {
+export function ThinkingBlockItem({ text, active, startedAt, endedAt }: ThinkingBlockItemProps) {
   // null = follow the default (expanded while active); a user click overrides it
   const [userExpanded, setUserExpanded] = useState<boolean | null>(null)
   const expanded = userExpanded ?? active
@@ -33,15 +39,16 @@ export function ThinkingBlockItem({ block, active }: ThinkingBlockItemProps) {
   // Live while streaming (endDate null), static "Thought for" duration once done.
   // A block that never got its stop event (interrupted turn) freezes rather than
   // ticking forever on an idle session.
-  const startDate = useMemo(() => new Date(block.startedAt), [block.startedAt])
+  const startDate = useMemo(() => (startedAt !== undefined ? new Date(startedAt) : null), [startedAt])
   const endDate = useMemo(() => {
-    if (block.endedAt !== null) return new Date(block.endedAt)
-    return active ? null : new Date(block.startedAt)
-  }, [block.endedAt, active, block.startedAt])
+    if (startedAt === undefined) return null
+    if (endedAt !== null && endedAt !== undefined) return new Date(endedAt)
+    return active ? null : new Date(startedAt)
+  }, [endedAt, active, startedAt])
   const elapsed = useElapsedTimer(startDate, endDate)
 
   // Rough token estimate for the streamed reasoning (~4 chars/token). UI-only.
-  const tokens = block.text ? Math.ceil(block.text.length / 4) : 0
+  const tokens = text ? Math.ceil(text.length / 4) : 0
 
   // Stick-to-bottom: follow the streaming text unless the user scrolls up to read.
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -51,7 +58,7 @@ export function ThinkingBlockItem({ block, active }: ThinkingBlockItemProps) {
     if (active && expanded && el && pinnedRef.current) {
       el.scrollTop = el.scrollHeight
     }
-  }, [block.text, active, expanded])
+  }, [text, active, expanded])
 
   const handleScroll = () => {
     const el = scrollRef.current
@@ -77,7 +84,7 @@ export function ThinkingBlockItem({ block, active }: ThinkingBlockItemProps) {
           'font-sans font-normal shrink-0 text-sm leading-none transition-colors',
           active ? 'text-foreground' : 'text-foreground/65 group-hover:text-foreground'
         )}>
-          {active ? 'Thinking' : `Thought for ${elapsed}`}
+          {active ? 'Thinking' : elapsed ? `Thought for ${elapsed}` : 'Thought'}
         </span>
         {tokens > 0 && (
           <span className="shrink-0 text-xs leading-none text-muted-foreground/70 group-hover:text-muted-foreground tabular-nums transition-colors">
@@ -113,7 +120,7 @@ export function ThinkingBlockItem({ block, active }: ThinkingBlockItemProps) {
           data-testid="thinking-block-body"
         >
           <pre className="whitespace-pre-wrap break-words text-xs text-muted-foreground select-text font-sans">
-            {block.text || <span className="italic">Thinking…</span>}
+            {text || <span className="italic">Thinking…</span>}
             {active && <span className="animate-pulse">|</span>}
           </pre>
         </div>

--- a/src/renderer/components/messages/thinking-block-item.tsx
+++ b/src/renderer/components/messages/thinking-block-item.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@shared/lib/utils/cn'
-import { Waypoints, ChevronDown, ChevronRight } from 'lucide-react'
+import { Route, ChevronDown, ChevronRight } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useElapsedTimer, formatElapsed } from '@renderer/hooks/use-elapsed-timer'
 import { StatusIndicator } from './tool-call-item'
@@ -78,7 +78,7 @@ export function ThinkingBlockItem({ text, active, startedAt, endedAt, durationMs
         onClick={() => setUserExpanded(!expanded)}
         className={cn('flex w-full items-center gap-2 pl-2 pr-2 py-1.5 group hover:bg-muted/50 transition-colors', expanded && 'bg-muted/50')}
       >
-        <Waypoints className={cn(
+        <Route className={cn(
           'h-3.5 w-3.5 shrink-0 transition-colors',
           active ? 'text-foreground' : 'text-foreground/45 group-hover:text-foreground'
         )} />

--- a/src/renderer/components/messages/thinking-block-item.tsx
+++ b/src/renderer/components/messages/thinking-block-item.tsx
@@ -20,8 +20,8 @@ interface ThinkingBlockItemProps {
   durationMs?: number
 }
 
-// How close (px) to the bottom counts as "pinned" — matches the tolerance the
-// message list uses for its own stick-to-bottom behavior.
+// How close (px) to the bottom counts as "pinned" — tighter than the message
+// list's 80px tolerance since the card body is a small (max-h-64) scroller.
 const PIN_THRESHOLD_PX = 32
 
 /**
@@ -39,13 +39,15 @@ export function ThinkingBlockItem({ text, active, startedAt, endedAt, durationMs
 
   // Memoized so the timer effect doesn't reset its interval on every delta re-render.
   // Live while streaming (endDate null), static "Thought for" duration once done.
-  // A block that never got its stop event (interrupted turn) freezes rather than
-  // ticking forever on an idle session.
+  // A block that never got its stop event (interrupted turn, missed idle event)
+  // freezes at the elapsed time when `active` flips off, rather than ticking
+  // forever or snapping back to 0s. Normally dead code: the stream handlers
+  // close open blocks on thinking_start/stop and session_idle.
   const startDate = useMemo(() => (startedAt !== undefined ? new Date(startedAt) : null), [startedAt])
   const endDate = useMemo(() => {
     if (startedAt === undefined) return null
     if (endedAt !== null && endedAt !== undefined) return new Date(endedAt)
-    return active ? null : new Date(startedAt)
+    return active ? null : new Date()
   }, [endedAt, active, startedAt])
   const elapsed = useElapsedTimer(startDate, endDate)
   // Live timing wins (exact); persisted blocks fall back to the

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -2968,3 +2968,109 @@ describe('useMessageStream — workflow drawer reducers', () => {
     expect(typeof result.current.workflows[0].completedAt).toBe('number')
   })
 })
+
+describe('useMessageStream — extended thinking blocks', () => {
+  async function setup() {
+    const { useMessageStream } = await getHookModule()
+    const rendered = renderHook(() => useMessageStream('session-1', 'agent-1'), { wrapper: createWrapper() })
+    const es = () => MockEventSource.instances[MockEventSource.instances.length - 1]
+    return { ...rendered, es }
+  }
+
+  it('opens a block on thinking_start and accumulates deltas onto it', async () => {
+    const { result, es } = await setup()
+
+    act(() => { es().simulateMessage({ type: 'thinking_start' }) })
+    expect(result.current.isThinking).toBe(true)
+    expect(result.current.thinkingBlocks).toHaveLength(1)
+    expect(result.current.thinkingBlocks[0]).toMatchObject({ text: '', endedAt: null })
+
+    act(() => { es().simulateMessage({ type: 'thinking_delta', text: 'Let me ' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_delta', text: 'reason.' }) })
+    expect(result.current.thinkingBlocks).toHaveLength(1)
+    expect(result.current.thinkingBlocks[0].text).toBe('Let me reason.')
+    expect(result.current.thinkingBlocks[0].endedAt).toBeNull()
+  })
+
+  it('thinking_stop closes the block but keeps it readable for the rest of the turn', async () => {
+    const { result, es } = await setup()
+
+    act(() => { es().simulateMessage({ type: 'thinking_start' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_delta', text: 'Deep thought.' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_stop' }) })
+
+    expect(result.current.isThinking).toBe(false)
+    expect(result.current.thinkingBlocks).toHaveLength(1)
+    expect(result.current.thinkingBlocks[0].text).toBe('Deep thought.')
+    expect(typeof result.current.thinkingBlocks[0].endedAt).toBe('number')
+  })
+
+  it('a bare thinking_delta opens a block (missed start after reconnect)', async () => {
+    const { result, es } = await setup()
+
+    act(() => { es().simulateMessage({ type: 'thinking_delta', text: 'resumed mid-block' }) })
+
+    expect(result.current.isThinking).toBe(true)
+    expect(result.current.thinkingBlocks).toHaveLength(1)
+    expect(result.current.thinkingBlocks[0]).toMatchObject({ text: 'resumed mid-block', endedAt: null })
+  })
+
+  it('a new thinking_start closes the previous block so at most one is live', async () => {
+    const { result, es } = await setup()
+
+    act(() => { es().simulateMessage({ type: 'thinking_start' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_delta', text: 'first episode' }) })
+    // No thinking_stop — the stop event was dropped
+    act(() => { es().simulateMessage({ type: 'thinking_start' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_delta', text: 'second episode' }) })
+
+    expect(result.current.thinkingBlocks).toHaveLength(2)
+    expect(result.current.thinkingBlocks[0].text).toBe('first episode')
+    expect(typeof result.current.thinkingBlocks[0].endedAt).toBe('number')
+    expect(result.current.thinkingBlocks[1]).toMatchObject({ text: 'second episode', endedAt: null })
+  })
+
+  it('session_idle closes an open block (interrupt without thinking_stop)', async () => {
+    const { result, es } = await setup()
+
+    act(() => { es().simulateMessage({ type: 'connected', isActive: true }) })
+    act(() => { es().simulateMessage({ type: 'thinking_start' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_delta', text: 'interrupted mid-thought' }) })
+    act(() => { es().simulateMessage({ type: 'session_idle' }) })
+
+    // The card must freeze at the real elapsed time, not tick forever or read 0s
+    expect(result.current.isThinking).toBe(false)
+    expect(result.current.thinkingBlocks).toHaveLength(1)
+    expect(result.current.thinkingBlocks[0].text).toBe('interrupted mid-thought')
+    expect(typeof result.current.thinkingBlocks[0].endedAt).toBe('number')
+  })
+
+  it('session_active resets blocks for the new turn', async () => {
+    const { result, es } = await setup()
+
+    act(() => { es().simulateMessage({ type: 'thinking_start' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_delta', text: 'old turn' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_stop' }) })
+    expect(result.current.thinkingBlocks).toHaveLength(1)
+
+    act(() => { es().simulateMessage({ type: 'session_active' }) })
+
+    expect(result.current.thinkingBlocks).toEqual([])
+    expect(result.current.isThinking).toBe(false)
+  })
+
+  it('keeps the blocks array reference stable across unrelated events', async () => {
+    const { result, es } = await setup()
+
+    act(() => { es().simulateMessage({ type: 'thinking_start' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_delta', text: 'stable' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_stop' }) })
+    const before = result.current.thinkingBlocks
+
+    act(() => { es().simulateMessage({ type: 'stream_start' }) })
+    act(() => { es().simulateMessage({ type: 'stream_delta', text: 'unrelated text' }) })
+
+    // No thinking event fired — consumers must not re-derive from a fresh array
+    expect(result.current.thinkingBlocks).toBe(before)
+  })
+})

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -180,12 +180,24 @@ const sessionSlashCommands = new Map<string, SlashCommandInfo[]>()
 
 // Extended-thinking stream per session. Kept outside StreamState (like slash commands)
 // so the ~15 full state-rebuild sites don't have to thread it through. `isThinking`
-// drives the "Thinking" status; `text` accumulates the streamed (summarized) reasoning
-// for the "View thinking" panel. Text only arrives when the agent requests
+// drives the "Thinking" status; `blocks` accumulates one entry per thinking episode
+// (a turn can think several times, between tool calls) so each renders as its own
+// card in the transcript. Text only arrives when the agent requests
 // `display: 'summarized'` (see agent-container/src/claude-code.ts).
-interface ThinkingState { text: string; isThinking: boolean }
-const EMPTY_THINKING: ThinkingState = { text: '', isThinking: false }
+// Blocks are ephemeral — never persisted — and reset when the next turn starts.
+// State is updated immutably (fresh state object + blocks array per event) so the
+// hook mirror can bail out of re-renders with a reference check.
+export interface ThinkingBlock {
+  id: number
+  text: string
+  startedAt: number
+  /** null while this block is still streaming */
+  endedAt: number | null
+}
+interface ThinkingState { blocks: ThinkingBlock[]; isThinking: boolean }
+const EMPTY_THINKING: ThinkingState = { blocks: [], isThinking: false }
 const sessionThinking = new Map<string, ThinkingState>()
+let nextThinkingBlockId = 1
 
 // Live state for dynamic-workflow (`Workflow` tool) runs in this session. Kept
 // outside StreamState (like thinking/slash commands) so the ~15 full state-rebuild
@@ -862,18 +874,34 @@ function getOrCreateEventSource(
         }
       }
       else if (data.type === 'thinking_start') {
-        // New thinking episode — reset text so the panel shows only the current block
-        sessionThinking.set(sessionId, { text: '', isThinking: true })
+        // New thinking episode — open a fresh block. If a previous block never got
+        // its stop (dropped event), close it now so at most one block is live.
+        const t = sessionThinking.get(sessionId) ?? EMPTY_THINKING
+        const blocks = t.blocks.map(b => b.endedAt === null ? { ...b, endedAt: Date.now() } : b)
+        blocks.push({ id: nextThinkingBlockId++, text: '', startedAt: Date.now(), endedAt: null })
+        sessionThinking.set(sessionId, { blocks, isThinking: true })
       }
       else if (data.type === 'thinking_delta') {
-        // Accumulate streamed (summarized) reasoning text for the "View thinking" panel
+        // Accumulate streamed (summarized) reasoning text on the live block.
+        // A delta with no open block (missed start after reconnect) opens one.
         const t = sessionThinking.get(sessionId) ?? EMPTY_THINKING
-        sessionThinking.set(sessionId, { text: t.text + (data.text ?? ''), isThinking: true })
+        const blocks = [...t.blocks]
+        const last = blocks[blocks.length - 1]
+        if (last && last.endedAt === null) {
+          blocks[blocks.length - 1] = { ...last, text: last.text + (data.text ?? '') }
+        } else {
+          blocks.push({ id: nextThinkingBlockId++, text: data.text ?? '', startedAt: Date.now(), endedAt: null })
+        }
+        sessionThinking.set(sessionId, { blocks, isThinking: true })
       }
       else if (data.type === 'thinking_stop') {
-        // Thinking block ended — flip back to "Working", keep accumulated text
+        // Thinking block ended — flip back to "Working", keep the block (its card
+        // collapses but stays readable for the rest of the turn)
         const t = sessionThinking.get(sessionId)
-        if (t) sessionThinking.set(sessionId, { text: t.text, isThinking: false })
+        if (t) {
+          const blocks = t.blocks.map(b => b.endedAt === null ? { ...b, endedAt: Date.now() } : b)
+          sessionThinking.set(sessionId, { blocks, isThinking: false })
+        }
       }
       else if (data.type === 'secret_request') {
         // Agent is requesting a secret from the user
@@ -1502,13 +1530,14 @@ export function useMessageStream(sessionId: string | null, agentSlug: string | n
         setState(globalState)
       }
       setSlashCommands(sessionSlashCommands.get(sessionId) ?? [])
-      // Mirror the thinking side-map into React state, preserving referential
-      // stability when nothing changed so consumers don't re-render needlessly.
+      // Mirror the thinking side-map into React state. The map's value is replaced
+      // wholesale on every thinking event, so a reference check is enough to
+      // preserve referential stability when nothing changed.
       const t = sessionThinking.get(sessionId)
       setThinking((prev) => {
         if (!t) return prev === EMPTY_THINKING ? prev : EMPTY_THINKING
-        if (prev.text === t.text && prev.isThinking === t.isThinking) return prev
-        return { text: t.text, isThinking: t.isThinking }
+        if (prev.blocks === t.blocks && prev.isThinking === t.isThinking) return prev
+        return t
       })
       const approved = sessionAutoApprovedScriptRunIds.get(sessionId)
       // Hand back a fresh snapshot when the contents changed so React re-renders consumers.
@@ -1585,5 +1614,5 @@ export function useMessageStream(sessionId: string | null, agentSlug: string | n
     }
   }, [sessionId, agentSlug, updateState, queryClient])
 
-  return { ...state, slashCommands, autoApprovedScriptRunIds, autoApprovedComputerUseIds, workflows, isThinking: thinking.isThinking, thinkingText: thinking.text }
+  return { ...state, slashCommands, autoApprovedScriptRunIds, autoApprovedComputerUseIds, workflows, isThinking: thinking.isThinking, thinkingBlocks: thinking.blocks }
 }

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -199,6 +199,14 @@ const EMPTY_THINKING: ThinkingState = { blocks: [], isThinking: false }
 const sessionThinking = new Map<string, ThinkingState>()
 let nextThinkingBlockId = 1
 
+// Stamp endedAt on any still-open block. Used when a new block starts (at most
+// one may be live), when a block stops, and at turn end — a turn that ends
+// without thinking_stop (interrupt, error) must freeze its timer at the actual
+// elapsed time, not tick forever or read "0s".
+function closeOpenThinkingBlocks(blocks: ThinkingBlock[]): ThinkingBlock[] {
+  return blocks.map(b => b.endedAt === null ? { ...b, endedAt: Date.now() } : b)
+}
+
 // Live state for dynamic-workflow (`Workflow` tool) runs in this session. Kept
 // outside StreamState (like thinking/slash commands) so the ~15 full state-rebuild
 // sites don't thread it through. A workflow's per-agent tree lives on disk (fetched
@@ -461,6 +469,13 @@ function getOrCreateEventSource(
         // Clear streamingToolUses - if tools were persisted, ToolCallItem renders them;
         // if they weren't (interrupted mid-stream), they should disappear.
         if (data.sessionId && data.sessionId !== sessionId) return
+        // A turn interrupted mid-thinking never gets thinking_stop: close open
+        // blocks so their cards freeze at the real elapsed time instead of "0s",
+        // and drop the "Thinking" status.
+        const thinkingAtIdle = sessionThinking.get(sessionId)
+        if (thinkingAtIdle && (thinkingAtIdle.isThinking || thinkingAtIdle.blocks.some(b => b.endedAt === null))) {
+          sessionThinking.set(sessionId, { blocks: closeOpenThinkingBlocks(thinkingAtIdle.blocks), isThinking: false })
+        }
         streamStates.set(sessionId, {
           isActive: false,
           isStreaming: false,
@@ -877,7 +892,7 @@ function getOrCreateEventSource(
         // New thinking episode — open a fresh block. If a previous block never got
         // its stop (dropped event), close it now so at most one block is live.
         const t = sessionThinking.get(sessionId) ?? EMPTY_THINKING
-        const blocks = t.blocks.map(b => b.endedAt === null ? { ...b, endedAt: Date.now() } : b)
+        const blocks = closeOpenThinkingBlocks(t.blocks)
         blocks.push({ id: nextThinkingBlockId++, text: '', startedAt: Date.now(), endedAt: null })
         sessionThinking.set(sessionId, { blocks, isThinking: true })
       }
@@ -899,8 +914,7 @@ function getOrCreateEventSource(
         // collapses but stays readable for the rest of the turn)
         const t = sessionThinking.get(sessionId)
         if (t) {
-          const blocks = t.blocks.map(b => b.endedAt === null ? { ...b, endedAt: Date.now() } : b)
-          sessionThinking.set(sessionId, { blocks, isThinking: false })
+          sessionThinking.set(sessionId, { blocks: closeOpenThinkingBlocks(t.blocks), isThinking: false })
         }
       }
       else if (data.type === 'secret_request') {

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -135,6 +135,86 @@ export class SimpleTextResponseScenario implements MockScenario {
 }
 
 /**
+ * Extended-thinking scenario — streams a thinking block (content_block_start
+ * type:'thinking' + thinking_delta chunks) before the text response, so E2E
+ * tests can exercise the thinking card in the transcript: expanded while
+ * streaming, collapsed to a "Thought for Ns" header once the block stops.
+ */
+export class ThinkingResponseScenario implements MockScenario {
+  constructor(
+    private thinkingText: string,
+    private responseText: string,
+    /** Delay between thinking chunks — sets how long the card stays live. */
+    private chunkDelayMs = 200
+  ) {}
+
+  execute(sessionId: string, client: MockContainerClient, userMessage: string): void {
+    const chunks = this.thinkingText.split(' ')
+
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'message_start' } },
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'thinking' } } },
+      })
+    }, 10)
+
+    chunks.forEach((word, i) => {
+      setTimeout(() => {
+        client.emitStreamMessage(sessionId, {
+          type: 'stream_event',
+          content: { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: (i > 0 ? ' ' : '') + word } } },
+        })
+      }, 20 + i * this.chunkDelayMs)
+    })
+
+    const thinkingDone = 30 + chunks.length * this.chunkDelayMs
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_stop' } },
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'text' } } },
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: this.responseText } } },
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_stop' } },
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'message_stop' } },
+      })
+    }, thinkingDone)
+
+    setTimeout(() => {
+      client.writeJsonlEntry(sessionId, {
+        type: 'user',
+        message: { content: userMessage },
+        timestamp: new Date().toISOString(),
+      })
+      client.writeJsonlEntry(sessionId, {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: this.responseText }] },
+        timestamp: new Date().toISOString(),
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'result',
+        content: { type: 'result', subtype: 'success' },
+      })
+    }, thinkingDone + 50)
+  }
+}
+
+/**
  * Slow scenario for message-queueing E2E tests: holds the session in the
  * working state long enough for the test to send mid-turn messages, which the
  * mock records as queued_command attachments (mirroring the real CLI's
@@ -1035,6 +1115,12 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
   static scenarios = new Map<string, MockScenario>([
     // Slow response window for message-queueing tests (send mid-turn → queued)
     ['work slowly', new SlowWorkScenario()],
+    // Extended-thinking card in the transcript (expanded while streaming, then collapsed)
+    ['think out loud', new ThinkingResponseScenario(
+      'Let me reason about this. The user wants a demonstration of extended thinking, ' +
+      'so I will stream a few sentences of summarized reasoning before replying.',
+      'Done thinking — here is the answer.'
+    )],
     // Register the "list files" scenario for tool use tests
     ['list files', new ToolUseScenario(
       'Bash',

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -201,9 +201,16 @@ export class ThinkingResponseScenario implements MockScenario {
         message: { content: userMessage },
         timestamp: new Date().toISOString(),
       })
+      // The real CLI persists the thinking block in the transcript (CLI 2.1.181+),
+      // which the messages read-path extracts into ApiMessage.thinking.
       client.writeJsonlEntry(sessionId, {
         type: 'assistant',
-        message: { content: [{ type: 'text', text: this.responseText }] },
+        message: {
+          content: [
+            { type: 'thinking', thinking: this.thinkingText, signature: 'mock-signature' },
+            { type: 'text', text: this.responseText },
+          ],
+        },
         timestamp: new Date().toISOString(),
       })
       client.emitStreamMessage(sessionId, {

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -152,6 +152,13 @@ export class ThinkingResponseScenario implements MockScenario {
     const chunks = this.thinkingText.split(' ')
 
     setTimeout(() => {
+      // Written up front (like the real CLI) so the read-path can derive the
+      // thinking duration from the user→assistant entry timestamp gap.
+      client.writeJsonlEntry(sessionId, {
+        type: 'user',
+        message: { content: userMessage },
+        timestamp: new Date().toISOString(),
+      })
       client.emitStreamMessage(sessionId, {
         type: 'stream_event',
         content: { type: 'stream_event', event: { type: 'message_start' } },
@@ -196,11 +203,6 @@ export class ThinkingResponseScenario implements MockScenario {
     }, thinkingDone)
 
     setTimeout(() => {
-      client.writeJsonlEntry(sessionId, {
-        type: 'user',
-        message: { content: userMessage },
-        timestamp: new Date().toISOString(),
-      })
       // The real CLI persists the thinking block in the transcript (CLI 2.1.181+),
       // which the messages read-path extracts into ApiMessage.thinking.
       client.writeJsonlEntry(sessionId, {

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -161,11 +161,12 @@ export interface ApiMessage {
    */
   queued?: boolean
   /**
-   * Summarized extended-thinking text persisted in the session transcript,
-   * one entry per thinking block, in order. Absent when the turn had no
-   * thinking or the transcript predates thinking-text persistence.
+   * Summarized extended-thinking blocks persisted in the session transcript,
+   * in order. Absent when the turn had no thinking or the transcript predates
+   * thinking-text persistence. `durationMs` is derived from transcript entry
+   * timestamps and absent when underivable.
    */
-  thinking?: string[]
+  thinking?: Array<{ text: string; durationMs?: number }>
 }
 
 /**

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -160,6 +160,12 @@ export interface ApiMessage {
    * detection) must skip it.
    */
   queued?: boolean
+  /**
+   * Summarized extended-thinking text persisted in the session transcript,
+   * one entry per thinking block, in order. Absent when the turn had no
+   * thinking or the transcript predates thinking-text persistence.
+   */
+  thinking?: string[]
 }
 
 /**

--- a/src/shared/lib/utils/message-transform.test.ts
+++ b/src/shared/lib/utils/message-transform.test.ts
@@ -682,7 +682,7 @@ describe('transformMessages', () => {
       expect(asMessage(result[0]).content.text).toBe('Hello')
     })
 
-    it('ignores thinking blocks in content', () => {
+    it('extracts thinking blocks into the thinking field', () => {
       const entries: JsonlMessageEntry[] = [
         createAssistantMessage('uuid-1', 'msg-1', [
           { type: 'thinking', thinking: 'Let me think about this...' } as ContentBlock,
@@ -692,9 +692,41 @@ describe('transformMessages', () => {
 
       const result = transformMessages(entries)
 
-      // Thinking block should be ignored, only text extracted
+      // Thinking text is extracted alongside the message text
       expect(asMessage(result[0]).content.text).toBe('Here is my answer.')
+      expect(asMessage(result[0]).thinking).toEqual(['Let me think about this...'])
       expect(asMessage(result[0]).toolCalls).toHaveLength(0)
+    })
+
+    it('extracts multiple thinking blocks in order, skipping empty ones', () => {
+      const entries: JsonlMessageEntry[] = [
+        createAssistantMessage('uuid-1', 'msg-1', [
+          { type: 'thinking', thinking: 'First episode.' } as ContentBlock,
+          { type: 'tool_use', id: 'tool-1', name: 'Bash', input: {} },
+          // Old transcripts (pre CLI 2.1.181) persist empty thinking text — skipped
+          { type: 'thinking', thinking: '' } as ContentBlock,
+          { type: 'thinking', thinking: '   ' } as ContentBlock,
+          { type: 'thinking', thinking: 'Second episode.' } as ContentBlock,
+          { type: 'text', text: 'Answer.' },
+        ]),
+      ]
+
+      const result = transformMessages(entries)
+
+      expect(asMessage(result[0]).thinking).toEqual(['First episode.', 'Second episode.'])
+      expect(asMessage(result[0]).toolCalls).toHaveLength(1)
+    })
+
+    it('omits the thinking field when there are no thinking blocks', () => {
+      const entries: JsonlMessageEntry[] = [
+        createAssistantMessage('uuid-1', 'msg-1', [
+          { type: 'text', text: 'No thinking here.' },
+        ]),
+      ]
+
+      const result = transformMessages(entries)
+
+      expect(asMessage(result[0]).thinking).toBeUndefined()
     })
 
     it('handles tool result for non-existent tool (orphaned result)', () => {
@@ -780,9 +812,10 @@ describe('transformMessages', () => {
 
       const result = transformMessages(entries)
 
-      // Should produce a message with empty text
+      // Should produce a message with empty text but the thinking preserved
       expect(result).toHaveLength(1)
       expect(asMessage(result[0]).content.text).toBe('')
+      expect(asMessage(result[0]).thinking).toEqual(['Deep thoughts...'])
       expect(asMessage(result[0]).toolCalls).toHaveLength(0)
     })
 

--- a/src/shared/lib/utils/message-transform.test.ts
+++ b/src/shared/lib/utils/message-transform.test.ts
@@ -684,18 +684,21 @@ describe('transformMessages', () => {
 
     it('extracts thinking blocks into the thinking field', () => {
       const entries: JsonlMessageEntry[] = [
+        createUserMessage('uuid-0', 'Question?', '2026-01-24T10:00:00.000Z'),
         createAssistantMessage('uuid-1', 'msg-1', [
           { type: 'thinking', thinking: 'Let me think about this...' } as ContentBlock,
           { type: 'text', text: 'Here is my answer.' },
-        ]),
+        ], '2026-01-24T10:00:05.000Z'),
       ]
 
       const result = transformMessages(entries)
 
-      // Thinking text is extracted alongside the message text
-      expect(asMessage(result[0]).content.text).toBe('Here is my answer.')
-      expect(asMessage(result[0]).thinking).toEqual(['Let me think about this...'])
-      expect(asMessage(result[0]).toolCalls).toHaveLength(0)
+      // Thinking is extracted alongside the message text, with a duration
+      // derived from the gap to the previous entry's timestamp
+      const message = asMessage(result[1])
+      expect(message.content.text).toBe('Here is my answer.')
+      expect(message.thinking).toEqual([{ text: 'Let me think about this...', durationMs: 5000 }])
+      expect(message.toolCalls).toHaveLength(0)
     })
 
     it('extracts multiple thinking blocks in order, skipping empty ones', () => {
@@ -713,8 +716,34 @@ describe('transformMessages', () => {
 
       const result = transformMessages(entries)
 
-      expect(asMessage(result[0]).thinking).toEqual(['First episode.', 'Second episode.'])
+      // No preceding entry — durations are underivable and omitted
+      expect(asMessage(result[0]).thinking).toEqual([{ text: 'First episode.' }, { text: 'Second episode.' }])
       expect(asMessage(result[0]).toolCalls).toHaveLength(1)
+    })
+
+    it('derives per-episode durations across merged entries', () => {
+      const entries: JsonlMessageEntry[] = [
+        createUserMessage('uuid-0', 'Question?', '2026-01-24T10:00:00.000Z'),
+        createAssistantMessage('uuid-1', 'msg-1', [
+          { type: 'thinking', thinking: 'First episode.' } as ContentBlock,
+        ], '2026-01-24T10:00:03.000Z'),
+        createAssistantMessage('uuid-2', 'msg-1', [
+          { type: 'tool_use', id: 'tool-1', name: 'Bash', input: {} },
+        ], '2026-01-24T10:00:04.000Z'),
+        createUserMessage('uuid-3', [
+          { type: 'tool_result', tool_use_id: 'tool-1', content: 'result' },
+        ], '2026-01-24T10:00:05.000Z'),
+        createAssistantMessage('uuid-4', 'msg-2', [
+          { type: 'thinking', thinking: 'Second episode.' } as ContentBlock,
+          { type: 'text', text: 'Answer.' },
+        ], '2026-01-24T10:00:09.000Z'),
+      ]
+
+      const result = transformMessages(entries)
+
+      // Message 1: thinking took user→entry gap; message 2: tool_result→entry gap
+      expect(asMessage(result[1]).thinking).toEqual([{ text: 'First episode.', durationMs: 3000 }])
+      expect(asMessage(result[2]).thinking).toEqual([{ text: 'Second episode.', durationMs: 4000 }])
     })
 
     it('omits the thinking field when there are no thinking blocks', () => {
@@ -813,9 +842,10 @@ describe('transformMessages', () => {
       const result = transformMessages(entries)
 
       // Should produce a message with empty text but the thinking preserved
+      // (no preceding entry, so no derivable duration)
       expect(result).toHaveLength(1)
       expect(asMessage(result[0]).content.text).toBe('')
-      expect(asMessage(result[0]).thinking).toEqual(['Deep thoughts...'])
+      expect(asMessage(result[0]).thinking).toEqual([{ text: 'Deep thoughts...' }])
       expect(asMessage(result[0]).toolCalls).toHaveLength(0)
     })
 

--- a/src/shared/lib/utils/message-transform.test.ts
+++ b/src/shared/lib/utils/message-transform.test.ts
@@ -758,6 +758,24 @@ describe('transformMessages', () => {
       expect(asMessage(result[0]).thinking).toBeUndefined()
     })
 
+    it('skips thinking blocks whose value is not a string instead of throwing', () => {
+      // A corrupt or hand-edited transcript entry must not take down the whole
+      // messages read path (the route 500s the entire session on a throw here)
+      const entries: JsonlMessageEntry[] = [
+        createAssistantMessage('uuid-1', 'msg-1', [
+          { type: 'thinking', thinking: 123 } as unknown as ContentBlock,
+          { type: 'thinking', thinking: { nested: true } } as unknown as ContentBlock,
+          { type: 'thinking', thinking: 'Valid episode.' } as ContentBlock,
+          { type: 'text', text: 'Answer.' },
+        ]),
+      ]
+
+      const result = transformMessages(entries)
+
+      expect(asMessage(result[0]).content.text).toBe('Answer.')
+      expect(asMessage(result[0]).thinking).toEqual([{ text: 'Valid episode.' }])
+    })
+
     it('handles tool result for non-existent tool (orphaned result)', () => {
       const entries: JsonlMessageEntry[] = [
         createAssistantMessage('uuid-1', 'msg-1', [

--- a/src/shared/lib/utils/message-transform.test.ts
+++ b/src/shared/lib/utils/message-transform.test.ts
@@ -746,6 +746,29 @@ describe('transformMessages', () => {
       expect(asMessage(result[2]).thinking).toEqual([{ text: 'Second episode.', durationMs: 4000 }])
     })
 
+    it('omits durationMs when the previous entry belongs to the same message', () => {
+      // Some provider paths (e.g. OpenRouter reasoning) flush all of a message's
+      // block entries in one burst at completion, with thinking AFTER its sibling
+      // text entry. The ms-scale gap to the sibling is write jitter, not thinking
+      // time — deriving it produced "Thought for 0s" cards.
+      const entries: JsonlMessageEntry[] = [
+        createUserMessage('uuid-0', 'Question?', '2026-01-24T10:00:00.000Z'),
+        createAssistantMessage('uuid-1', 'msg-1', [
+          { type: 'text', text: 'I will search the web.' },
+        ], '2026-01-24T10:00:06.327Z'),
+        createAssistantMessage('uuid-2', 'msg-1', [
+          { type: 'thinking', thinking: 'Reasoning that arrived after the text entry.' } as ContentBlock,
+        ], '2026-01-24T10:00:06.332Z'),
+      ]
+
+      const result = transformMessages(entries)
+
+      // No duration — the 5ms sibling gap must not be reported as thinking time
+      expect(asMessage(result[1]).thinking).toEqual([
+        { text: 'Reasoning that arrived after the text entry.' },
+      ])
+    })
+
     it('omits the thinking field when there are no thinking blocks', () => {
       const entries: JsonlMessageEntry[] = [
         createAssistantMessage('uuid-1', 'msg-1', [

--- a/src/shared/lib/utils/message-transform.ts
+++ b/src/shared/lib/utils/message-transform.ts
@@ -36,11 +36,12 @@ export interface TransformedMessage {
   /** User message delivered mid-turn (queued/steering input) — does not end the turn it appears in */
   queued?: boolean
   /**
-   * Summarized extended-thinking text, one entry per thinking block, in order.
-   * Only present when the transcript carries non-empty text (CLI 2.1.181+ —
-   * older transcripts persist the block with an empty string, which is skipped).
+   * Summarized extended-thinking blocks, in order. Only present when the
+   * transcript carries non-empty text (CLI 2.1.181+ — older transcripts persist
+   * the block with an empty string, which is skipped). `durationMs` is derived
+   * from entry timestamps (see thinkingByEntry) and absent when underivable.
    */
-  thinking?: string[]
+  thinking?: Array<{ text: string; durationMs?: number }>
 }
 
 export interface TransformedCompactBoundary {
@@ -201,8 +202,18 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
   const mergedEntries: JsonlMessageEntry[] = []
   const assistantMessageIds = new Map<string, number>() // message.id -> index in mergedEntries
 
+  // Extended-thinking blocks per merged entry. Extracted here — before the merge
+  // collapses per-block entries — because the duration is derived from entry
+  // timestamps: the CLI writes an assistant entry when its content block
+  // completes, so (thinking entry ts − previous entry ts) ≈ how long the agent
+  // thought. Old transcripts (pre CLI 2.1.181) persist the block with an empty
+  // string (signature only) — those are skipped, they carry nothing to show.
+  const thinkingByEntry = new Map<JsonlMessageEntry, Array<{ text: string; durationMs?: number }>>()
+  let prevEntryTs: number | null = null
+
   for (const entry of messageEntries) {
     const messageId = entry.message.id
+    let target = entry
     if (entry.type === 'assistant' && messageId) {
       const existingIndex = assistantMessageIds.get(messageId)
       if (existingIndex !== undefined) {
@@ -216,6 +227,7 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
           ;(existing.message.content as ContentBlock[]).push(...(newContent as ContentBlock[]))
         }
         // Keep the original entry's uuid and timestamp for correct ordering
+        target = existing
       } else {
         // First time seeing this message.id - clone to avoid mutating original
         const clonedEntry = {
@@ -229,11 +241,31 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
         }
         assistantMessageIds.set(messageId, mergedEntries.length)
         mergedEntries.push(clonedEntry)
+        target = clonedEntry
       }
     } else {
       // User messages or messages without id - keep as-is
       mergedEntries.push(entry)
     }
+
+    const entryTs = new Date(entry.timestamp).getTime()
+    if (entry.type === 'assistant' && Array.isArray(entry.message.content)) {
+      const texts = (entry.message.content as ContentBlock[])
+        .filter((b) => b.type === 'thinking' && b.thinking?.trim())
+        .map((b) => (b as { thinking: string }).thinking)
+      if (texts.length > 0) {
+        const durationMs =
+          prevEntryTs !== null && Number.isFinite(entryTs) && entryTs > prevEntryTs
+            ? entryTs - prevEntryTs
+            : undefined
+        const list = thinkingByEntry.get(target) ?? []
+        // The duration covers the whole entry — if one entry carries several
+        // thinking blocks (rare), attach it to the first
+        texts.forEach((text, i) => list.push(i === 0 && durationMs !== undefined ? { text, durationMs } : { text }))
+        thinkingByEntry.set(target, list)
+      }
+    }
+    if (Number.isFinite(entryTs)) prevEntryTs = entryTs
   }
 
   // First pass: build a map of tool_use_id -> result
@@ -348,7 +380,8 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
     let text = ''
     let messageType: 'user' | 'assistant' = entry.type
     const toolCalls: TransformedMessage['toolCalls'] = []
-    const thinking: string[] = []
+    // Extracted during the merge pass (needs per-entry timestamps for durations)
+    const thinking = thinkingByEntry.get(entry)
 
     if (typeof content === 'string') {
       text = content
@@ -356,12 +389,6 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
       for (const block of content as ContentBlock[]) {
         if (block.type === 'text') {
           text += block.text
-        } else if (block.type === 'thinking') {
-          // Old transcripts (pre CLI 2.1.181) persist the block with an empty
-          // string (signature only) — skip those, they carry nothing to show.
-          if (block.thinking?.trim()) {
-            thinking.push(block.thinking)
-          }
         } else if (block.type === 'tool_use') {
           const toolResult = toolResults.get(block.id)
           // Use toolUseResult.stdout if available, otherwise use content
@@ -413,7 +440,7 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
       createdAt: new Date(entry.timestamp),
       ...(entry.error && { apiError: entry.error }),
       ...(entry.isQueuedCommand && { queued: true }),
-      ...(thinking.length > 0 && { thinking }),
+      ...(thinking && thinking.length > 0 && { thinking }),
     })
   }
 

--- a/src/shared/lib/utils/message-transform.ts
+++ b/src/shared/lib/utils/message-transform.ts
@@ -35,6 +35,12 @@ export interface TransformedMessage {
   apiError?: string
   /** User message delivered mid-turn (queued/steering input) — does not end the turn it appears in */
   queued?: boolean
+  /**
+   * Summarized extended-thinking text, one entry per thinking block, in order.
+   * Only present when the transcript carries non-empty text (CLI 2.1.181+ —
+   * older transcripts persist the block with an empty string, which is skipped).
+   */
+  thinking?: string[]
 }
 
 export interface TransformedCompactBoundary {
@@ -342,6 +348,7 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
     let text = ''
     let messageType: 'user' | 'assistant' = entry.type
     const toolCalls: TransformedMessage['toolCalls'] = []
+    const thinking: string[] = []
 
     if (typeof content === 'string') {
       text = content
@@ -349,6 +356,12 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
       for (const block of content as ContentBlock[]) {
         if (block.type === 'text') {
           text += block.text
+        } else if (block.type === 'thinking') {
+          // Old transcripts (pre CLI 2.1.181) persist the block with an empty
+          // string (signature only) — skip those, they carry nothing to show.
+          if (block.thinking?.trim()) {
+            thinking.push(block.thinking)
+          }
         } else if (block.type === 'tool_use') {
           const toolResult = toolResults.get(block.id)
           // Use toolUseResult.stdout if available, otherwise use content
@@ -400,6 +413,7 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
       createdAt: new Date(entry.timestamp),
       ...(entry.error && { apiError: entry.error }),
       ...(entry.isQueuedCommand && { queued: true }),
+      ...(thinking.length > 0 && { thinking }),
     })
   }
 

--- a/src/shared/lib/utils/message-transform.ts
+++ b/src/shared/lib/utils/message-transform.ts
@@ -210,6 +210,12 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
   // string (signature only) — those are skipped, they carry nothing to show.
   const thinkingByEntry = new Map<JsonlMessageEntry, Array<{ text: string; durationMs?: number }>>()
   let prevEntryTs: number | null = null
+  // message.id of the entry prevEntryTs came from (null for user entries).
+  // Some provider paths flush ALL of a message's block entries in one burst at
+  // response completion, with thinking ordered after its sibling text block —
+  // a gap measured against a sibling of the same message is milliseconds of
+  // write jitter, not thinking time, and must not become a "Thought for 0s".
+  let prevEntryMessageId: string | null = null
 
   for (const entry of messageEntries) {
     const messageId = entry.message.id
@@ -256,8 +262,12 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
         .filter((b) => b.type === 'thinking' && typeof b.thinking === 'string' && b.thinking.trim())
         .map((b) => (b as { thinking: string }).thinking)
       if (texts.length > 0) {
+        // Only derivable when the previous entry is a different message (user
+        // entry or another assistant response) — an intra-message gap is write
+        // jitter. Underivable durations are omitted (header reads "Thought").
+        const prevIsSameMessage = messageId !== undefined && prevEntryMessageId === messageId
         const durationMs =
-          prevEntryTs !== null && Number.isFinite(entryTs) && entryTs > prevEntryTs
+          prevEntryTs !== null && !prevIsSameMessage && Number.isFinite(entryTs) && entryTs > prevEntryTs
             ? entryTs - prevEntryTs
             : undefined
         const list = thinkingByEntry.get(target) ?? []
@@ -267,7 +277,10 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
         thinkingByEntry.set(target, list)
       }
     }
-    if (Number.isFinite(entryTs)) prevEntryTs = entryTs
+    if (Number.isFinite(entryTs)) {
+      prevEntryTs = entryTs
+      prevEntryMessageId = entry.type === 'assistant' ? (messageId ?? null) : null
+    }
   }
 
   // First pass: build a map of tool_use_id -> result

--- a/src/shared/lib/utils/message-transform.ts
+++ b/src/shared/lib/utils/message-transform.ts
@@ -251,7 +251,9 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
     const entryTs = new Date(entry.timestamp).getTime()
     if (entry.type === 'assistant' && Array.isArray(entry.message.content)) {
       const texts = (entry.message.content as ContentBlock[])
-        .filter((b) => b.type === 'thinking' && b.thinking?.trim())
+        // typeof guard: this runs server-side on raw JSONL — a malformed
+        // non-string `thinking` must be skipped, not throw and 500 the route
+        .filter((b) => b.type === 'thinking' && typeof b.thinking === 'string' && b.thinking.trim())
         .map((b) => (b as { thinking: string }).thinking)
       if (texts.length > 0) {
         const durationMs =


### PR DESCRIPTION
## What

Thinking traces used to stream into a cramped, non-scrollable `max-h-20` box above the composer and vanish when the turn's messages refetched. They now render as tool-call-style cards in the transcript — live while streaming, and **permanently** from the persisted transcript afterwards:

- **While streaming**: the card is expanded with a scrollable body (max ~16rem) that pins to the bottom so the newest reasoning stays visible, and disengages when the user scrolls up to read. Header shows a live timer and a rough token estimate.
- **When the block ends**: the card auto-collapses to a `Thought for Ns · ~N tokens` header, re-expandable by click (same chevron/`aria-expanded` pattern as tool cards). A manual expand/collapse always wins over the streaming default.
- **After the turn / on reopen**: the summarized thinking text the CLI already persists in the session JSONL (2.1.181+) is extracted on the read path and rendered as collapsed cards above the message text — one per thinking episode. Older transcripts persist the block with an empty string; those are skipped.
- **Multiple episodes per turn** each get their own card — previously a second thinking block silently overwrote the first.
- The above-composer activity indicator keeps its "Thinking..." status but drops the inline reasoning panel and token estimate.

## How

- `message-transform.ts`: thinking blocks are extracted (previously silently dropped) into `thinking?: string[]`, mirrored on `ApiMessage`. Read-path + renderer only — the JSONL stays CLI-owned, no storage/persister/schema changes.
- New `ThinkingBlockItem` component modeled on `ToolCallItem`/`StreamingToolCallItem`; takes text + optional live timing (persisted blocks carry none, so their header reads "Thought").
- `use-message-stream.ts`: thinking side-map holds one immutable block per episode, with defensive handling for missed start/stop events after reconnects.
- `MessageList` renders live cards in the streaming area and dedupes them against refetched messages (mirrors `unpersistedStreamingToolUses`), so the card hands off into `MessageItem` without double-rendering.
- Thinking-only assistant messages are no longer suppressed by the empty-message guard.

## Testing

- `message-transform.test.ts`: drop-behavior tests flipped to assert extraction; new cases for multi-block ordering, empty-block skipping, and field omission (106 passing).
- New `think out loud` mock scenario (streams `thinking_delta` chunks, persists the block in its JSONL entry) + `e2e/specs/thinking-display.spec.ts`: expand-while-streaming, collapse-on-stop, sticky manual collapse, no-duplication handoff, and a session reopen reading purely from the transcript — all passing.
- `tool-rendering` (7/7) and `chat-flow` (6/6) still pass; typecheck + lint clean.
- Verified live in the dev Electron app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)