### PR TITLE
fix(microvm): mint a per-VM hook token into runHookPayload

### DIFF
--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -303,6 +303,21 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(tokens[0]).not.toBe(tokens[1])
   })
 
+  it('mints a fresh hookToken per start and never leaks it into the agent env', async () => {
+    await new LambdaMicroVmRuntimeClient({ agentId: 'a', envVars: { FOO: 'bar' } }).start()
+    resetMicrovmRuntimeForTests()
+    Object.assign(process.env, FULL_ENV)
+    await new LambdaMicroVmRuntimeClient({ agentId: 'a', envVars: { FOO: 'bar' } }).start()
+    const tokens = sendMock.mock.calls
+      .filter((c) => c[0].type === 'Run')
+      .map((c) => JSON.parse(c[0].input.runHookPayload).hookToken)
+    expect(tokens).toHaveLength(2)
+    expect(tokens[0]).toBeTruthy()
+    expect(tokens[0]).not.toBe(tokens[1])
+    // The token rides only the run payload, never the agent's fetched env.
+    expect(readBootstrapEnv('a')).not.toHaveProperty('hookToken')
+  })
+
   it('includes the workspace mount in runHookPayload when fs/ap/mtip are configured', async () => {
     Object.assign(process.env, {
       MICROVM_FS_ID: 'fs-1',

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -494,8 +494,13 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
           token: env.PROXY_TOKEN ?? '',
         }
       : undefined
-    const payloadObj = { ...(bootstrap ? { bootstrap } : {}), ...(mount ? { mount } : {}) }
-    const runHookPayload = bootstrap || mount ? JSON.stringify(payloadObj) : undefined
+    // Per-VM secret the supervisor pins on its first (trusted) run hook and then
+    // requires on every later /run, so the untrusted in-VM agent can't forge a
+    // /run to re-mount /workspace with attacker-chosen S3 Files params. Delivered
+    // only in runHookPayload (never in the agent env), so the agent never sees it.
+    const hookToken = randomUUID()
+    const payloadObj = { ...(bootstrap ? { bootstrap } : {}), ...(mount ? { mount } : {}), hookToken }
+    const runHookPayload = JSON.stringify(payloadObj)
     const payloadBytes = runHookPayload ? Buffer.byteLength(runHookPayload, 'utf8') : 0
     if (payloadBytes > RUN_HOOK_PAYLOAD_MAX_BYTES) {
       throw new Error(


### PR DESCRIPTION
## What this is

Host-app side of the gamut-agent supervisor hardening (gamut-infra#36).

The in-VM agent shares the MicroVM with a root hook server on `:9000`. The supervisor now requires a token on every `/run` after the first, so a forged in-VM `/run` (which could otherwise re-mount `/workspace` with attacker-chosen S3 Files params) is rejected. This PR makes the host-app mint that token.

## What changed

`lambda-microvm-runtime.ts` `start()`:
- Mint a fresh `hookToken` (`randomUUID`) per VM and include it in `runHookPayload`. It is delivered only in the run payload, never in the agent's fetched env, so the agent can't read or forge it.
- `runHookPayload` is now always sent (previously omitted when there was neither bootstrap nor mount); the ~50-byte token stays well under the 4096-byte cap.

## Deploy note

Ship alongside the rebuilt gamut-agent image (gamut-infra#36). New host-app + old image is safe (old supervisor ignores the token); the token only enforces once both ship.

## Test plan

- [x] `npx vitest run lambda-microvm-runtime.test.ts` — 41/41 pass, incl. a new test asserting the token is fresh per start and never lands in the fetched agent env.
- [x] No new `tsc`/lint errors in the changed files.

Made with [Cursor](https://cursor.com)