### PR TITLE
fix(sidebar): agent row keeps showing working/awaiting while expanded

### DIFF
--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -545,36 +545,14 @@ describe('AppSidebar — notifications', () => {
 // ============================================================================
 // AgentRowIndicator: priority + collapse-vs-expand behavior
 // ----------------------------------------------------------------------------
-// The right-side indicator on the agent row collapses session-derived states
-// (awaiting / working / unread) when the agent is expanded — those states
-// surface on the individual session sub-rows instead. When collapsed, priority
+// The right-side indicator on the agent row aggregates awaiting / working
+// across sessions with the same formula as the top-nav AgentStatus — the two
+// render on the same screen and must agree. Only the unread dot is collapsed
+// away when the agent is expanded (the session sub-rows surface it). Priority
 // is awaiting > working > unread > sleeping/idle. Sleeping/idle (which
 // describe the container itself) always render via <AgentStatus iconOnly>.
 // ============================================================================
 describe('AppSidebar — agent row indicator', () => {
-  it('uses fresh sessions data over stale agent flags when sessions are loaded', () => {
-    mockUseAgents.mockReturnValue({
-      data: [makeAgent({ hasSessionsAwaitingInput: false /* stale */, sessionCount: 1 })],
-      isLoading: false,
-      error: null,
-    })
-    mockUseSessions.mockImplementation((slug: string | null) => ({
-      data: slug === 'test-agent' ? [makeSession({ isAwaitingInput: true /* fresh */ })] : [],
-      isLoading: false,
-    }))
-    mockRouteParams = { slug: 'test-agent' }
-
-    renderWithProviders(<AppSidebar />)
-    // Agent is selected (expanded) so AgentRowIndicator suppresses
-    // session-derived flags on the AGENT row. But the session sub-row should
-    // still surface its awaiting indicator — which our mock shows via the
-    // `<AgentStatus>` `data-awaiting` attribute on session-derived flags.
-    // Since the agent is expanded, the agent-level status should NOT be
-    // marked awaiting (data-awaiting='false').
-    const status = screen.getByTestId('agent-status-running')
-    expect(status).toHaveAttribute('data-awaiting', 'false')
-  })
-
   it('falls back to agent-level flags when sessions data is not yet loaded', () => {
     mockUseAgents.mockReturnValue({
       data: [makeAgent({ hasSessionsAwaitingInput: true })],
@@ -602,6 +580,48 @@ describe('AppSidebar — agent row indicator', () => {
     // Sessions data has no unread, so no session-row dot either. Net: zero
     // accessible "unread notifications" labels.
     expect(screen.queryByLabelText('unread notifications')).not.toBeInTheDocument()
+  })
+
+  // Regression: the selected agent auto-expands, and the expanded agent row
+  // used to zero out its working/awaiting state — while the top-nav
+  // AgentStatus (agent-header) kept aggregating session activity. Same
+  // screen, two answers: header said "working", sidebar row said idle. The
+  // agent row must keep reporting working/awaiting when expanded.
+  it('shows working on the expanded agent row when a session is active (top-nav parity)', () => {
+    mockUseAgents.mockReturnValue({
+      data: [makeAgent({ hasActiveSessions: true })],
+      isLoading: false,
+      error: null,
+    })
+    mockUseSessions.mockImplementation((slug: string | null) => ({
+      data: slug === 'test-agent' ? [makeSession({ isActive: true })] : [],
+      isLoading: false,
+    }))
+    mockRouteParams = { slug: 'test-agent' }
+
+    renderWithProviders(<AppSidebar />)
+    // The agent is expanded — its session sub-row is visible and working…
+    expect(screen.getByTestId('session-item-session-1')).toBeInTheDocument()
+    // …and the agent row itself still reports working, like the top nav.
+    const status = screen.getByTestId('agent-status-running')
+    expect(status).toHaveAttribute('data-active', 'true')
+  })
+
+  it('shows awaiting on the expanded agent row when a session awaits input (top-nav parity)', () => {
+    mockUseAgents.mockReturnValue({
+      data: [makeAgent({ hasSessionsAwaitingInput: false /* stale */ })],
+      isLoading: false,
+      error: null,
+    })
+    mockUseSessions.mockImplementation((slug: string | null) => ({
+      data: slug === 'test-agent' ? [makeSession({ isAwaitingInput: true /* fresh */ })] : [],
+      isLoading: false,
+    }))
+    mockRouteParams = { slug: 'test-agent' }
+
+    renderWithProviders(<AppSidebar />)
+    const status = screen.getByTestId('agent-status-running')
+    expect(status).toHaveAttribute('data-awaiting', 'true')
   })
 
   it('prioritizes awaiting > working > unread when collapsed', () => {

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -462,10 +462,14 @@ function SessionsSkeleton() {
 }
 
 // Right-side indicator on the agent row.
-// When expanded, suppress session-derived states (awaiting / working / unread)
-// since the individual session rows already surface those. Keep agent-level
-// sleeping / idle states which describe the container itself.
-// Priority when collapsed: awaiting > working > unread > sleeping/idle.
+// Awaiting / working aggregate across sessions regardless of expansion, with
+// the same formula as the agent header's AgentStatus (fresh sessions data
+// when loaded, agent-level flags as fallback) — the sidebar and the top nav
+// render on the same screen and must never disagree about whether an agent
+// is working. The unread dot IS still suppressed when expanded: it's a
+// sidebar-only navigation aid with no header counterpart, and the session
+// rows already point at the unread session.
+// Priority: awaiting > working > unread > sleeping/idle.
 function AgentRowIndicator({
   agent,
   sessions,
@@ -475,8 +479,8 @@ function AgentRowIndicator({
   sessions: ApiSession[] | undefined
   isOpen: boolean
 }) {
-  const isAwaiting = !isOpen && (sessions?.some((s) => s.isAwaitingInput) || (agent.hasSessionsAwaitingInput ?? false))
-  const isWorking = !isOpen && !isAwaiting && (sessions?.some((s) => s.isActive) || (agent.hasActiveSessions ?? false))
+  const isAwaiting = sessions?.some((s) => s.isAwaitingInput) || (agent.hasSessionsAwaitingInput ?? false)
+  const isWorking = !isAwaiting && (sessions?.some((s) => s.isActive) || (agent.hasActiveSessions ?? false))
   const isUnread = !isOpen && !isAwaiting && !isWorking && (agent.hasUnreadNotifications ?? false)
   if (isUnread) {
     return (


### PR DESCRIPTION
## Problem

The sidebar's agent-row status and the top-nav status disagreed on the same screen: with a session actively working, the top nav said **Working** while the sidebar agent row showed the idle circle.

## Root cause

`AgentRowIndicator` (app-sidebar.tsx) zeroed out all session-derived state (`!isOpen && ...`) whenever the agent's submenu was expanded, falling back to the container-level idle indicator — while the agent header always aggregates `sessions?.some(s => s.isActive) || agent.hasActiveSessions`. Since the agent you're viewing is auto-expanded in the sidebar, the mismatch showed up exactly when the header is visible.

Introduced in 94aceacd (Apr 28, "sidebar polish") as a deliberate de-duplication ("session rows already surface those states") that traded away cross-surface consistency. Server-side data was never wrong.

## Fix

`AgentRowIndicator` now uses the header's exact aggregation formula for awaiting/working regardless of expansion. The **unread** blue dot stays suppressed when expanded — it's a sidebar-only navigation aid with no header counterpart, and the session rows already point at the unread session.

## Tests

Two regression tests (verified red before the fix): expanded agent row shows **working** when a session is active, and **awaiting** when a session awaits input. One obsolete test asserting the old suppression was superseded by the awaiting test; collapsed-fallback, unread-suppression, and priority-order tests pass unchanged. Sidebar suite 27/27; typecheck + lint clean.