### PR TITLE
fix(tray): clamp drawer to container width so header controls aren't clipped on small windows

### DIFF
--- a/e2e/specs/file-preview.spec.ts
+++ b/e2e/specs/file-preview.spec.ts
@@ -221,6 +221,44 @@ test.describe('File Preview', () => {
     await expect(page.getByText('At 0:00', { exact: false }).first()).toBeVisible({ timeout: 10000 })
   })
 
+  test.describe('narrow window', () => {
+    test.use({ viewport: { width: 800, height: 700 } })
+
+    test('header controls stay on-screen when the stored drawer width exceeds the window', async ({ page }) => {
+      // Persisted drawer width wider than the window used to push the drawer
+      // past the right viewport edge, clipping the download/close buttons.
+      await page.addInitScript(() => localStorage.setItem('tray_drawer_width', '800'))
+      await appPage.goto()
+      await appPage.waitForAgentsLoaded()
+
+      await agentPage.createAgent(`NarrowTray ${Date.now()}`)
+      const agentSlug = await getLatestAgentSlug(page)
+      seedWorkspaceFile(agentSlug, 'output/report.md', '# Report')
+
+      await sessionPage.sendMessage('deliver file')
+      await sessionPage.waitForResponse(15000)
+
+      const filePill = getFilePill(page, 'report.md').first()
+      await expect(filePill).toBeVisible({ timeout: 10000 })
+      await filePill.click()
+
+      const header = page.getByTestId('file-preview-header')
+      await expect(header).toBeVisible({ timeout: 5000 })
+
+      // Poll: the drawer animates open (300ms width transition), during which
+      // header controls are transiently clipped even in the fixed layout.
+      const viewportWidth = page.viewportSize()!.width
+      await expect(async () => {
+        for (const control of [header.getByTitle('Download file'), header.getByTitle('Hide files panel')]) {
+          await expect(control).toBeVisible()
+          const box = await control.boundingBox()
+          expect(box).not.toBeNull()
+          expect(box!.x + box!.width).toBeLessThanOrEqual(viewportWidth)
+        }
+      }).toPass({ timeout: 5000 })
+    })
+  })
+
   test('multiple file tabs, switching, and image rendering', async ({ page }) => {
     await agentPage.createAgent(`MultiFile ${Date.now()}`)
     const agentSlug = await getLatestAgentSlug(page)

--- a/src/renderer/components/tray/drawer-shell.tsx
+++ b/src/renderer/components/tray/drawer-shell.tsx
@@ -88,7 +88,7 @@ export const DrawerShell = forwardRef<DrawerShellHandle, DrawerShellProps>(funct
         !isResizing && 'transition-[width] duration-300 ease-in-out',
         className
       )}
-      style={{ width: isOpen ? drawerWidth : 0, contain: 'layout paint', willChange: 'transform' }}
+      style={{ width: isOpen ? drawerWidth : 0, maxWidth: '100%', contain: 'layout paint', willChange: 'transform' }}
       onTransitionEnd={onTransitionEnd}
     >
       {/* Resize handle on left edge */}


### PR DESCRIPTION
## Problem

On small windows, the side tray (Files / Browser / Workflow) clips its header buttons off the right edge of the screen — e.g. the Files tray's download and hide-panel buttons become unreachable.

**Root cause:** `DrawerShell` renders the tray at a fixed pixel width (persisted in localStorage, up to 800px via the expand button) with `shrink-0`. When the window is narrower than that stored width, the chat column collapses to zero and the drawer extends past the viewport's right edge.

## Fix

One line: add `maxWidth: '100%'` to the drawer's inline style so it can never outgrow its container. Pure CSS, so it also re-clamps live while resizing the window. The open/close width transition and the resize drag handle are unaffected (the stored width is preserved; only the rendered width is clamped).

## Testing

- New regression E2E in `file-preview.spec.ts`: seeds an 800px stored drawer width in an 800px viewport, opens a file, and asserts both header controls sit fully inside the viewport. The assertion polls via `expect().toPass()` because the drawer's 300ms open animation transiently clips the controls even in the fixed layout.
- Verified the test catches the bug: with the fix reverted it fails (button right edge at 1044px vs 800px viewport); with the fix the full file-preview suite is 8/8 green.
- `tsc --noEmit` + eslint green.