### PR TITLE
fix: don't restore an in-flight send into the composer as undelivered

### DIFF
--- a/e2e/specs/composer-failure-recovery.spec.ts
+++ b/e2e/specs/composer-failure-recovery.spec.ts
@@ -131,4 +131,39 @@ test.describe('Composer failure recovery', () => {
     await expect(page.getByTestId('file-pill').filter({ hasText: 'guarded.txt' }).first()).toBeVisible({ timeout: 5000 })
     await expect(sessionPage.getMessageInput()).toHaveValue('')
   })
+
+  test('a slow successful send is not yanked back into the composer', async ({ page }) => {
+    // Regression for the restored-successful-send bug: sending into a session
+    // whose container is waking means the server spends seconds before it
+    // accepts the message and broadcasts session_active. The 1.5s undelivered-
+    // ghost grace used to fire in that window and restore the text into the
+    // composer even though the send was on its way — the message then landed
+    // in the transcript with its text ALSO sitting in the input, baiting a
+    // duplicate resend. Holding the POST for 2.5s reproduces that shape
+    // deterministically (session_active is only broadcast once the server
+    // processes the POST).
+    const text = 'slow send that must stay sent'
+    await page.route('**/sessions/*/messages', async (route) => {
+      if (route.request().method() !== 'POST') return route.continue()
+      await new Promise((r) => setTimeout(r, 2500))
+      return route.continue()
+    })
+
+    await sessionPage.typeMessage(text)
+    await sessionPage.getSendButton().click()
+
+    // The held send completes and materializes as a real message with a
+    // normal response — exactly one copy
+    await sessionPage.waitForUserMessageCount(2, 20000)
+    await sessionPage.expectUserMessage(text, 1)
+    await expect(
+      sessionPage.getAssistantMessages().filter({ hasText: 'This is a mock response from the E2E test container.' })
+    ).toHaveCount(2, { timeout: 15000 })
+    await expect(sessionPage.getUserMessages()).toHaveCount(2)
+
+    // ...and the composer stayed empty throughout — the mid-flight message
+    // was never treated as undelivered (pre-fix, its text reappeared here at
+    // ~1.5s and was still present at this point)
+    await expect(sessionPage.getMessageInput()).toHaveValue('')
+  })
 })

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -731,6 +731,85 @@ describe('MessageList', () => {
     }
   })
 
+  it('does not restore a non-queued pending whose POST is still in flight', async () => {
+    // A send into a waking container: the session still reads inactive and the
+    // POST has not returned a uuid yet. The message is usually mid-delivery —
+    // yanking it back into the composer makes it land in the transcript AND
+    // the input (the restored-successful-send bug). Failure of the POST has
+    // its own restore path (the composer's catch), so idle-restore must leave
+    // these pending.
+    vi.useFakeTimers()
+    try {
+      const onAppeared = vi.fn()
+      mockMessagesData.data = []
+      mockStreamState.isActive = false
+
+      const DraftProbe = () => {
+        const [draft] = useDraft<string>('session:s-1')
+        return <div data-testid="draft-probe">{draft ?? ''}</div>
+      }
+
+      renderWithProviders(
+        <>
+          <MessageList
+            sessionId="s-1"
+            agentSlug="agent-1"
+            pendingUserMessages={[{ localId: 'l1', text: 'mid-delivery message', sentAt: Date.now() }]}
+            onPendingMessageAppeared={onAppeared}
+          />
+          <DraftProbe />
+        </>
+      )
+
+      await act(async () => {
+        vi.advanceTimersByTime(1500)
+      })
+
+      expect(onAppeared).not.toHaveBeenCalled()
+      expect(screen.getByTestId('draft-probe')).toHaveTextContent('')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('still restores a non-queued pending that was accepted (uuid) but never materialized', async () => {
+    // The POST succeeded but the message never showed up in the transcript by
+    // idle (e.g. an interrupt raced the CLI before it persisted the entry) —
+    // this is genuinely lost work, so the restore must still fire.
+    vi.useFakeTimers()
+    try {
+      const onAppeared = vi.fn()
+      mockMessagesData.data = []
+      mockStreamState.isActive = false
+
+      const DraftProbe = () => {
+        const [draft] = useDraft<string>('session:s-1')
+        return <div data-testid="draft-probe">{draft ?? ''}</div>
+      }
+
+      renderWithProviders(
+        <>
+          <MessageList
+            sessionId="s-1"
+            agentSlug="agent-1"
+            pendingUserMessages={[{ localId: 'l1', uuid: 'server-uuid', text: 'accepted then dropped', sentAt: Date.now() }]}
+            onPendingMessageAppeared={onAppeared}
+          />
+          <DraftProbe />
+        </>
+      )
+
+      await act(async () => {
+        vi.advanceTimersByTime(1500)
+      })
+
+      expect(onAppeared).toHaveBeenCalledWith('l1')
+      expect(screen.getByTestId('draft-probe')).toHaveTextContent('accepted then dropped')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   // ---- Cancelling queued messages ----
 
   it('shows Cancel on queued ghosts only once the server uuid is known', () => {

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -213,20 +213,28 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     }
   }, [messages, pendingUserMessages, peerUserMessages, onPendingMessageAppeared, sessionId, user?.id])
 
-  // Once the session goes idle, any of our messages still showing as pending
-  // were never persisted to the transcript — the agent was interrupted before
-  // picking them up, or the turn ended without consuming them. Restore their
-  // text to the composer so the user can edit/resend, and remove the ghosts;
-  // drop peer ghosts (we can't restore another user's text into our composer —
-  // their own client restores it for them). Messages that WERE delivered clear
-  // via the materialize effect above, which prunes them from this list as the
-  // post-idle refetch lands. The short grace below gives that refetch a beat to
-  // settle so a just-answered message isn't yanked back into the composer; it's
-  // a single refetch window, not a delivery guess (restoring is non-destructive
-  // either way). While the agent is active, queued ghosts may wait minutes.
+  // Once the session goes idle, our messages still showing as pending are
+  // treated as undelivered — the agent was interrupted before picking them
+  // up, or the turn ended without consuming them. Restore their text to the
+  // composer so the user can edit/resend, and remove the ghosts; drop peer
+  // ghosts (we can't restore another user's text into our composer — their
+  // own client restores it for them). Messages that WERE delivered clear via
+  // the materialize effect above, which prunes them from this list as the
+  // post-idle refetch lands. The short grace below gives that refetch a beat
+  // to settle so a just-answered message isn't yanked back into the composer.
+  // While the agent is active, queued ghosts may wait minutes.
+  //
+  // EXCEPT: a non-queued pending without a uuid has its POST still in flight
+  // — commonly a send into a session whose container is waking, where the
+  // server can spend seconds before it accepts the message and broadcasts
+  // session_active. Its outcome already has owners (a failed POST restores
+  // the text via the composer's catch; a successful one assigns the uuid and
+  // materializes above), so restoring it here would yank back a message that
+  // is actually mid-delivery — it then lands in the transcript AND sits in
+  // the composer, baiting a duplicate resend. Leave those pending.
   useEffect(() => {
     if (isActive || ((pendingUserMessages?.length ?? 0) === 0 && peerUserMessages.length === 0)) return
-    const undelivered = pendingUserMessages ?? []
+    const undelivered = (pendingUserMessages ?? []).filter((p) => p.queued || p.uuid)
     const timerId = setTimeout(() => {
       if (undelivered.length > 0) {
         const draftKey = `session:${sessionId}`


### PR DESCRIPTION
Fixes the intermittent "message sends fine but bounces back into the input box" bug (batch #3 of the E2E series).

## Root cause

Sending into a session whose container is asleep leaves the session looking inactive for seconds: the messages POST handler runs `ensureRunning` + awaits the stream subscription **before** `markSessionActive` broadcasts `session_active`, and the POST response (which assigns the message uuid) returns later still. Meanwhile the idle-grace restore in `MessageList` arms a 1.5s timer whenever the session is inactive with pending ghosts — and it never consulted delivery state. The timer fired mid-wake: text yanked back into the composer as if the send failed, then the message landed in the transcript anyway — its text ALSO sitting in the input, baiting a duplicate resend. Explains the "resuming longer/older sessions" correlation (those are the sessions with sleeping containers). Reproduced deterministically before fixing: hold the POST 2.5s via route interception (the active broadcast only happens once the server processes the POST) — 3/3 repro of the full symptom.

## Fix

The idle restore now skips **non-queued pendings that have no uuid yet** — their POST is still in flight, and its outcome already has owners: a failed POST restores the text via the composer's catch (`use-message-composer.ts`), a successful one assigns the uuid and materializes from the transcript refetch. Unchanged: queued ghosts (the stop/interrupt rescue path from #380) and accepted-but-never-materialized sends (uuid assigned, absent from the transcript at idle — genuinely lost work) restore exactly as before.

Deliberately NOT in this PR: reordering `markSessionActive` ahead of the container wake server-side (would make the session show "working" immediately on cold sends — a UX improvement, but it touches the wake path's error handling and deserves its own review). The client guard alone fully kills the data-loss/duplicate symptom under both trigger windows (cold wake, and the rarer missed-`session_active` SSE join).

## Tests

- Unit (`message-list.test.tsx`): two new — in-flight non-queued pending is NOT restored at idle; accepted-but-unmaterialized (uuid) pending still IS. The pre-existing queued-restore test passes unchanged.
- E2E: third test in `composer-failure-recovery.spec.ts` — the held-POST repro inverted: slow successful send materializes exactly once and the composer stays empty (red before this fix, green after).

## Validation

- `tsc` + eslint clean; `message-list.test.tsx` 73/73; full messages+hooks unit blast radius 738/738
- New/coupled specs (`composer-failure-recovery`, `stop-session`, `message-queueing`) ×2: 20/20
- Full suite: **207 passed**, sole failure = `browser-stream` — environmental on this machine, not this diff: it passed 4/4 full runs earlier today, then began failing consistently at ~18:10 **including on pure main** and **with #385 locally reverted** (both verified by revert-and-rerun); server-side scenario logs are byte-identical between passing and failing runs. CI's GHA run will adjudicate independently.