### PR TITLE
fix(telegram): dedupe redelivered updates; await disconnect on reconnect

### DIFF
--- a/src/api/routes/chat-integrations.ts
+++ b/src/api/routes/chat-integrations.ts
@@ -336,6 +336,9 @@ chatIntegrationsRouter.delete('/:integrationId', IntegrationAgentRole('user'), a
 
     // Disconnect first
     await chatIntegrationManager.removeIntegration(id)
+    // Permanent delete: no reconnect will recreate this integration, so drop its dedup notepad.
+    // (removeIntegration deliberately keeps it, for reconnect survival.)
+    chatIntegrationManager.forgetDeduplicator(id)
 
     // Clean up session mappings
     deleteChatIntegrationSessionsByIntegration(id)

--- a/src/shared/lib/chat-integrations/chat-integration-manager-duplicate-delivery.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager-duplicate-delivery.test.ts
@@ -1,13 +1,14 @@
 /**
  * Duplicate-delivery hardening: a per-integration UpdateDeduplicator owned by the manager
- * (survives a reconnect), and a bounded awaited disconnect so two pollers never overlap.
+ * (survives a reconnect, resets on a bot-token change, dropped on permanent delete), and a
+ * bounded awaited disconnect so two pollers never overlap.
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { chatIntegrationManager } from './chat-integration-manager'
 import { UpdateDeduplicator } from './update-deduplicator'
 
-// Reach the manager singleton's private seams (matches the sup231 spec's pattern).
+// Reach the manager singleton's private seams (as the sibling manager tests do).
 const mgr = chatIntegrationManager as any
 
 function fakeConn(id: string, disconnect: () => Promise<void>) {
@@ -25,25 +26,54 @@ afterEach(() => {
   vi.useRealTimers()
   mgr.connections?.clear?.()
   mgr.deduplicators?.clear?.()
+  mgr.disconnectedSince?.clear?.()
+  mgr.consecutiveFailures?.clear?.()
 })
 
 describe('ChatIntegrationManager — per-integration deduplicator', () => {
   it('uses a distinct deduplicator per integration', () => {
-    const a = mgr.getOrCreateDeduplicator('int-dedup-2')
-    const b = mgr.getOrCreateDeduplicator('int-dedup-3')
+    const a = mgr.getOrCreateDeduplicator('int-dedup-2', 'tok-a')
+    const b = mgr.getOrCreateDeduplicator('int-dedup-3', 'tok-b')
     expect(a).toBeInstanceOf(UpdateDeduplicator)
     expect(b).not.toBe(a)
   })
 
+  it('reuses the same deduplicator for the same integration + token', () => {
+    const a = mgr.getOrCreateDeduplicator('int-reuse', 'tok-a')
+    const b = mgr.getOrCreateDeduplicator('int-reuse', 'tok-a')
+    expect(b).toBe(a)
+  })
+
   it('removeIntegration preserves the deduplicator so a redelivery after reconnect is still dropped', async () => {
-    const dedup = mgr.getOrCreateDeduplicator('int-survive')
-    dedup.isDuplicate('9001') // an update handled before the reconnect
+    const dedup = mgr.getOrCreateDeduplicator('int-survive', 'tok-a')
+    dedup.markDelivered('9001') // an update delivered before the reconnect
     mgr.connections.set('int-survive', fakeConn('int-survive', () => Promise.resolve()))
 
     await mgr.removeIntegration('int-survive') // the reconnect teardown
 
-    expect(mgr.getOrCreateDeduplicator('int-survive')).toBe(dedup) // same instance survives
+    expect(mgr.getOrCreateDeduplicator('int-survive', 'tok-a')).toBe(dedup) // same instance survives
     expect(dedup.isDuplicate('9001')).toBe(true) // and still remembers the pre-reconnect update
+  })
+
+  it('resets the deduplicator when the bot token changes (a new bot must not inherit old update ids)', () => {
+    const old = mgr.getOrCreateDeduplicator('int-token', 'tok-old')
+    old.markDelivered('7001')
+
+    const fresh = mgr.getOrCreateDeduplicator('int-token', 'tok-new') // token changed → new notepad
+    expect(fresh).not.toBe(old)
+    expect(fresh.isDuplicate('7001')).toBe(false) // does not inherit the old bot's ids
+  })
+
+  it('forgetDeduplicator drops the notepad on permanent delete (no leak, no stale carry-over)', () => {
+    const dedup = mgr.getOrCreateDeduplicator('int-del', 'tok-a')
+    dedup.markDelivered('5001')
+
+    mgr.forgetDeduplicator('int-del')
+
+    expect(mgr.deduplicators.has('int-del')).toBe(false) // evicted, not leaked
+    const recreated = mgr.getOrCreateDeduplicator('int-del', 'tok-a')
+    expect(recreated).not.toBe(dedup) // a fresh id reused later starts clean
+    expect(recreated.isDuplicate('5001')).toBe(false)
   })
 })
 
@@ -90,5 +120,30 @@ describe('ChatIntegrationManager — removeIntegration connection identity', () 
     await p
 
     expect(mgr.connections.get('int-race')).toBe(connB) // must not orphan connB
+  })
+
+  it('leaves the swapped-in connection sibling state intact (does not wipe the new connection)', async () => {
+    let releaseDisconnect: () => void = () => {}
+    const connA = fakeConn('int-race2', () => new Promise<void>((r) => { releaseDisconnect = r }))
+    const connB = fakeConn('int-race2', () => Promise.resolve())
+    mgr.connections.set('int-race2', connA)
+
+    const p = mgr.removeIntegration('int-race2') // captures connA, awaits its disconnect
+    mgr.connections.set('int-race2', connB)      // concurrent reconnect swaps in connB...
+    mgr.disconnectedSince.set('int-race2', 123)  // ...and records fresh sibling state for it
+    releaseDisconnect()
+    await p
+
+    // The old teardown must not wipe the new connection's state, same as it must not delete connB.
+    expect(mgr.disconnectedSince.get('int-race2')).toBe(123)
+  })
+
+  it('still clears sibling state on a genuine teardown (no swap)', async () => {
+    mgr.connections.set('int-plain', fakeConn('int-plain', () => Promise.resolve()))
+    mgr.disconnectedSince.set('int-plain', 456)
+
+    await mgr.removeIntegration('int-plain')
+
+    expect(mgr.disconnectedSince.has('int-plain')).toBe(false) // cleaned when this teardown owns the id
   })
 })

--- a/src/shared/lib/chat-integrations/chat-integration-manager-duplicate-delivery.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager-duplicate-delivery.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Duplicate-delivery hardening: a per-integration UpdateDeduplicator owned by the manager
+ * (survives a reconnect), and a bounded awaited disconnect so two pollers never overlap.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { chatIntegrationManager } from './chat-integration-manager'
+import { UpdateDeduplicator } from './update-deduplicator'
+
+// Reach the manager singleton's private seams (matches the sup231 spec's pattern).
+const mgr = chatIntegrationManager as any
+
+function fakeConn(id: string, disconnect: () => Promise<void>) {
+  return {
+    messageUnsubscribe: null,
+    interactiveUnsubscribe: null,
+    errorUnsubscribe: null,
+    typingHintUnsubscribe: null,
+    integration: { id, provider: 'telegram' },
+    connector: { disconnect },
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  mgr.connections?.clear?.()
+  mgr.deduplicators?.clear?.()
+})
+
+describe('ChatIntegrationManager — per-integration deduplicator', () => {
+  it('uses a distinct deduplicator per integration', () => {
+    const a = mgr.getOrCreateDeduplicator('int-dedup-2')
+    const b = mgr.getOrCreateDeduplicator('int-dedup-3')
+    expect(a).toBeInstanceOf(UpdateDeduplicator)
+    expect(b).not.toBe(a)
+  })
+
+  it('removeIntegration preserves the deduplicator so a redelivery after reconnect is still dropped', async () => {
+    const dedup = mgr.getOrCreateDeduplicator('int-survive')
+    dedup.isDuplicate('9001') // an update handled before the reconnect
+    mgr.connections.set('int-survive', fakeConn('int-survive', () => Promise.resolve()))
+
+    await mgr.removeIntegration('int-survive') // the reconnect teardown
+
+    expect(mgr.getOrCreateDeduplicator('int-survive')).toBe(dedup) // same instance survives
+    expect(dedup.isDuplicate('9001')).toBe(true) // and still remembers the pre-reconnect update
+  })
+})
+
+describe('ChatIntegrationManager — awaited disconnect (reconnect never overlaps pollers)', () => {
+  it('does not resolve until the old connector disconnect resolves', async () => {
+    vi.useFakeTimers()
+    const conn = fakeConn('int-disc', () => new Promise<void>((res) => setTimeout(res, 100)))
+    const p: Promise<void> = mgr.disconnectConnection(conn)
+    let settled = false
+    void p.then(() => { settled = true })
+
+    await vi.advanceTimersByTimeAsync(50)
+    expect(settled).toBe(false) // still waiting for the old poller to stop
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(settled).toBe(true)
+  })
+
+  it('resolves within a bounded timeout even if disconnect hangs forever', async () => {
+    vi.useFakeTimers()
+    const conn = fakeConn('int-disc', () => new Promise<void>(() => { /* never resolves */ }))
+    const p: Promise<void> = mgr.disconnectConnection(conn)
+    let settled = false
+    void p.then(() => { settled = true })
+
+    await vi.advanceTimersByTimeAsync(2999)
+    expect(settled).toBe(false) // still within the ~3s bound
+
+    await vi.advanceTimersByTimeAsync(2)
+    expect(settled).toBe(true) // bounded at DISCONNECT_TIMEOUT_MS — proceeds, never wedges
+  })
+})
+
+describe('ChatIntegrationManager — removeIntegration connection identity', () => {
+  it('deletes only the connection it captured (concurrent-reconnect safety)', async () => {
+    let releaseDisconnect: () => void = () => {}
+    const connA = fakeConn('int-race', () => new Promise<void>((r) => { releaseDisconnect = r }))
+    const connB = fakeConn('int-race', () => Promise.resolve())
+    mgr.connections.set('int-race', connA)
+
+    const p = mgr.removeIntegration('int-race') // captures connA, awaits its disconnect
+    mgr.connections.set('int-race', connB)      // a concurrent reconnect swaps in a fresh connector
+    releaseDisconnect()
+    await p
+
+    expect(mgr.connections.get('int-race')).toBe(connB) // must not orphan connB
+  })
+})

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -180,8 +180,10 @@ class ChatIntegrationManager {
   // chain settles (see scheduleQueueEviction), so the map stays bounded.
   private messageQueues: Map<string, Promise<void>> = new Map()
   private lastSessionTouch: Map<string, number> = new Map()
-  // Per-integration dedup notepad; owned here so it survives a connector reconnect (see UpdateDeduplicator).
-  private deduplicators: Map<string, UpdateDeduplicator> = new Map()
+  // Per-integration dedup notepad, tagged with the bot token it was built for; owned here so it
+  // survives a connector reconnect (see UpdateDeduplicator). The token tag lets a bot-token change
+  // reset it (getOrCreateDeduplicator), since update-id sequences are per-bot.
+  private deduplicators: Map<string, { dedup: UpdateDeduplicator; botToken: string }> = new Map()
 
   // ── Lifecycle ───────────────────────────────────────────────────────
 
@@ -254,19 +256,27 @@ class ChatIntegrationManager {
     if (!this.isRunning) return
     console.log('[ChatIntegrationManager] Reconnecting all integrations (system resume)')
 
+    // Reconnect integrations concurrently. The teardowns are independent and each is bounded at
+    // DISCONNECT_TIMEOUT_MS, so serial awaits made resume cost up to 3s × N before the last bot
+    // resumed polling. Each integration's own remove → reconnect stays awaited internally, so a
+    // single bot never runs two pollers; allSettled isolates a failure to its own integration.
     const entries = [...this.connections.entries()]
-    for (const [id, conn] of entries) {
-      try {
-        const integration = getChatIntegration(id)
-        if (!integration || integration.status === 'paused') continue
-        await this.removeIntegration(id)
-        await this.connectIntegration(integration)
-        this.disconnectedSince.delete(id)
-        this.consecutiveFailures.delete(id)
-      } catch (err) {
-        console.error(`[ChatIntegrationManager] Resume reconnect failed for ${id}:`, err)
-        reportError(err, 'resume-reconnect', { integrationId: id, provider: conn.integration.provider })
-      }
+    await Promise.allSettled(entries.map(([id, conn]) => this.reconnectOne(id, conn)))
+  }
+
+  /** Remove-then-reconnect a single integration (one resume step). Swallows its own error so one
+   *  integration's failure can't abort the others when reconnectAll runs them concurrently. */
+  private async reconnectOne(id: string, conn: IntegrationConnection): Promise<void> {
+    try {
+      const integration = getChatIntegration(id)
+      if (!integration || integration.status === 'paused') return
+      await this.removeIntegration(id)
+      await this.connectIntegration(integration)
+      this.disconnectedSince.delete(id)
+      this.consecutiveFailures.delete(id)
+    } catch (err) {
+      console.error(`[ChatIntegrationManager] Resume reconnect failed for ${id}:`, err)
+      reportError(err, 'resume-reconnect', { integrationId: id, provider: conn.integration.provider })
     }
   }
 
@@ -287,30 +297,40 @@ class ChatIntegrationManager {
     // Remove the connection. Await the teardown so a reconnect (removeIntegration →
     // connectIntegration) fully stops the old poller before starting the new one.
     const conn = this.connections.get(id)
+    // Whether a concurrent reconnect swapped in a NEW connection for this id during the awaited
+    // teardown below. When it did, this teardown owns the OLD connection only and must not wipe
+    // the new one's sibling state. Stays false when there was no connection at all, so stale
+    // sibling state is still cleaned in that case.
+    let swappedIn = false
     if (conn) {
       await this.disconnectConnection(conn)
       // Delete by identity, not key: the await above is a yield point, so a concurrent
       // reconnect may have swapped in a new connector for this id — deleting by key would
       // orphan that live, still-subscribed poller (same guard as the messageQueues eviction).
       if (this.connections.get(id) === conn) this.connections.delete(id)
+      else swappedIn = true
     }
-    this.disconnectedSince.delete(id)
-    this.consecutiveFailures.delete(id)
-    // Drop any per-chat message/SSE queues for this integration. Keys are
-    // `${id}:${chatId}` and `sse:${id}:${chatId}`, so the old bare delete(id)
-    // never matched — iterate by prefix. The `:` delimiter plus UUID integration
-    // ids (which contain no `:` and are never the literal "sse") guarantee this
-    // can't false-match a sibling integration's keys.
-    //
-    // Settled chains already self-evict, so this only force-drops STILL-IN-FLIGHT
-    // chains. On a true teardown that is exactly what we want. On the reconnect
-    // path (runHealthChecks → removeIntegration → connectIntegration) it means a
-    // handler still running against the now-dead connection no longer serializes
-    // ahead of the first post-reconnect message — an accepted trade-off, since the
-    // stale connection is going away and new work should not block on it.
-    for (const key of [...this.messageQueues.keys()]) {
-      if (key.startsWith(`${id}:`) || key.startsWith(`sse:${id}:`)) {
-        this.messageQueues.delete(key)
+    // The sibling state below belongs to whichever connection currently holds this id. If a new
+    // one was swapped in, leave its state intact - same identity guard as the connection delete.
+    if (!swappedIn) {
+      this.disconnectedSince.delete(id)
+      this.consecutiveFailures.delete(id)
+      // Drop any per-chat message/SSE queues for this integration. Keys are
+      // `${id}:${chatId}` and `sse:${id}:${chatId}`, so the old bare delete(id)
+      // never matched — iterate by prefix. The `:` delimiter plus UUID integration
+      // ids (which contain no `:` and are never the literal "sse") guarantee this
+      // can't false-match a sibling integration's keys.
+      //
+      // Settled chains already self-evict, so this only force-drops STILL-IN-FLIGHT
+      // chains. On a true teardown that is exactly what we want. On the reconnect
+      // path (runHealthChecks → removeIntegration → connectIntegration) it means a
+      // handler still running against the now-dead connection no longer serializes
+      // ahead of the first post-reconnect message — an accepted trade-off, since the
+      // stale connection is going away and new work should not block on it.
+      for (const key of [...this.messageQueues.keys()]) {
+        if (key.startsWith(`${id}:`) || key.startsWith(`sse:${id}:`)) {
+          this.messageQueues.delete(key)
+        }
       }
     }
   }
@@ -458,14 +478,28 @@ class ChatIntegrationManager {
     }
   }
 
-  /** The per-integration dedup notepad, created on first use and reused across reconnects. */
-  private getOrCreateDeduplicator(integrationId: string): UpdateDeduplicator {
-    let dedup = this.deduplicators.get(integrationId)
-    if (!dedup) {
-      dedup = new UpdateDeduplicator()
-      this.deduplicators.set(integrationId, dedup)
-    }
+  /**
+   * The per-integration dedup notepad, created on first use and reused across reconnects. Reset
+   * when the bot token changes: update-id sequences are per-bot, so a new bot must not inherit the
+   * old bot's ids (which could false-drop a real message). Retention is only meaningful for a
+   * same-bot reconnect.
+   */
+  private getOrCreateDeduplicator(integrationId: string, botToken: string): UpdateDeduplicator {
+    const existing = this.deduplicators.get(integrationId)
+    if (existing && existing.botToken === botToken) return existing.dedup
+    const dedup = new UpdateDeduplicator()
+    this.deduplicators.set(integrationId, { dedup, botToken })
     return dedup
+  }
+
+  /**
+   * Permanently forget a deleted integration's dedup notepad. Only the delete path calls this -
+   * removeIntegration deliberately keeps the notepad so a reconnect still drops redeliveries, but a
+   * permanently deleted integration will never reconnect, so its notepad would otherwise leak for
+   * the process lifetime.
+   */
+  forgetDeduplicator(integrationId: string): void {
+    this.deduplicators.delete(integrationId)
   }
 
   private async createConnector(integration: ChatIntegration): Promise<ChatClientConnector> {
@@ -480,9 +514,10 @@ class ChatIntegrationManager {
     switch (integration.provider) {
       case 'telegram': {
         const { TelegramConnector } = await import('./telegram-connector')
+        const telegramConfig = config as import('./telegram-connector').TelegramConfig
         return new TelegramConnector(
-          config as import('./telegram-connector').TelegramConfig,
-          this.getOrCreateDeduplicator(integration.id),
+          telegramConfig,
+          this.getOrCreateDeduplicator(integration.id, telegramConfig.botToken),
         )
       }
       case 'slack': {

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -16,6 +16,7 @@ import type { SessionActivity } from '@shared/lib/types/agent'
 import { getToolDefinition } from '@shared/lib/tool-definitions/registry'
 import { formatToolName } from '@shared/lib/tool-definitions/types'
 import { parseChatIntegrationConfig, type ChatProvider } from './config-schema'
+import { UpdateDeduplicator } from './update-deduplicator'
 import { formatProviderName, formatSessionTimestamp } from './utils'
 import { consumeOrCancelAwaitingInput } from './resolve-awaiting-input'
 import {
@@ -102,6 +103,17 @@ const HEALTH_CHECK_INTERVAL_MS = 5 * 60 * 1000
 const HEALTH_CHECK_ERROR_THRESHOLD_MS = 5 * 60 * 1000
 const HEALTH_CHECK_MAX_CONSECUTIVE_FAILURES = 15
 const MAX_FILE_DOWNLOAD_SIZE = 50 * 1024 * 1024 // 50 MB
+// Bound the wait for an old connector to stop before a reconnect starts the new poller.
+// A reconnect fires precisely when the connection is unhealthy, so bot.stop() can be slow;
+// cap the wait and proceed rather than wedge the reconnect on a hung teardown.
+const DISCONNECT_TIMEOUT_MS = 3000
+
+/** Resolve when `promise` settles or after `ms`, whichever comes first. `promise` must not reject. */
+function withTimeout(promise: Promise<unknown>, ms: number): Promise<unknown> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<void>((resolve) => { timer = setTimeout(resolve, ms) })
+  return Promise.race([promise, timeout]).finally(() => { if (timer) clearTimeout(timer) })
+}
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -168,6 +180,8 @@ class ChatIntegrationManager {
   // chain settles (see scheduleQueueEviction), so the map stays bounded.
   private messageQueues: Map<string, Promise<void>> = new Map()
   private lastSessionTouch: Map<string, number> = new Map()
+  // Per-integration dedup notepad; owned here so it survives a connector reconnect (see UpdateDeduplicator).
+  private deduplicators: Map<string, UpdateDeduplicator> = new Map()
 
   // ── Lifecycle ───────────────────────────────────────────────────────
 
@@ -221,14 +235,16 @@ class ChatIntegrationManager {
     }
     this.chatSessions.clear()
 
-    // Disconnect all integrations
+    // Disconnect all integrations (fire-and-forget: the unsubscribes run synchronously and
+    // the bounded bot teardown finishes in the background, so app quit stays snappy).
     for (const [, conn] of this.connections) {
-      this.disconnectConnection(conn)
+      void this.disconnectConnection(conn)
     }
     this.connections.clear()
     this.disconnectedSince.clear()
     this.consecutiveFailures.clear()
     this.messageQueues.clear()
+    this.deduplicators.clear()
     this.isRunning = false
   }
 
@@ -268,11 +284,15 @@ class ChatIntegrationManager {
         this.chatSessions.delete(key)
       }
     }
-    // Remove the connection
+    // Remove the connection. Await the teardown so a reconnect (removeIntegration →
+    // connectIntegration) fully stops the old poller before starting the new one.
     const conn = this.connections.get(id)
     if (conn) {
-      this.disconnectConnection(conn)
-      this.connections.delete(id)
+      await this.disconnectConnection(conn)
+      // Delete by identity, not key: the await above is a yield point, so a concurrent
+      // reconnect may have swapped in a new connector for this id — deleting by key would
+      // orphan that live, still-subscribed poller (same guard as the messageQueues eviction).
+      if (this.connections.get(id) === conn) this.connections.delete(id)
     }
     this.disconnectedSince.delete(id)
     this.consecutiveFailures.delete(id)
@@ -438,6 +458,16 @@ class ChatIntegrationManager {
     }
   }
 
+  /** The per-integration dedup notepad, created on first use and reused across reconnects. */
+  private getOrCreateDeduplicator(integrationId: string): UpdateDeduplicator {
+    let dedup = this.deduplicators.get(integrationId)
+    if (!dedup) {
+      dedup = new UpdateDeduplicator()
+      this.deduplicators.set(integrationId, dedup)
+    }
+    return dedup
+  }
+
   private async createConnector(integration: ChatIntegration): Promise<ChatClientConnector> {
     const config = parseChatIntegrationConfig(
       integration.provider as ChatProvider,
@@ -450,7 +480,10 @@ class ChatIntegrationManager {
     switch (integration.provider) {
       case 'telegram': {
         const { TelegramConnector } = await import('./telegram-connector')
-        return new TelegramConnector(config as import('./telegram-connector').TelegramConfig)
+        return new TelegramConnector(
+          config as import('./telegram-connector').TelegramConfig,
+          this.getOrCreateDeduplicator(integration.id),
+        )
       }
       case 'slack': {
         const { SlackConnector } = await import('./slack-connector')
@@ -465,15 +498,22 @@ class ChatIntegrationManager {
     }
   }
 
-  private disconnectConnection(conn: IntegrationConnection): void {
+  /**
+   * Unsubscribe and tear down a connector, awaiting the disconnect (bounded) so a reconnect
+   * never overlaps the old poller with the new one on the same token. Bounded because the
+   * reconnect trigger correlates with a slow/hung teardown.
+   */
+  private async disconnectConnection(conn: IntegrationConnection): Promise<void> {
     conn.messageUnsubscribe?.()
     conn.interactiveUnsubscribe?.()
     conn.errorUnsubscribe?.()
     conn.typingHintUnsubscribe?.()
-    conn.connector.disconnect().catch((err) => {
+    // `.catch` first so teardown never rejects — safe to race, no unhandled late rejection.
+    const teardown = conn.connector.disconnect().catch((err) => {
       console.error(`[ChatIntegrationManager] Error disconnecting:`, err)
       reportError(err, 'disconnect', { integrationId: conn.integration.id, provider: conn.integration.provider })
     })
+    await withTimeout(teardown, DISCONNECT_TIMEOUT_MS)
   }
 
   // ── Chat session management ────────────────────────────────────────

--- a/src/shared/lib/chat-integrations/telegram-connector.test.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.test.ts
@@ -9,15 +9,21 @@ import { UpdateDeduplicator } from './update-deduplicator'
 // registry. We mock grammY's Bot to capture the handlers connect() registers and
 // to stub api.getFile. The text-handler describes never call connect(), so they
 // never touch the mock.
-const { capturedHandlers, getFileMock } = vi.hoisted(() => ({
+const { capturedHandlers, capturedMiddleware, registrationOrder, getFileMock } = vi.hoisted(() => ({
   capturedHandlers: {} as Record<string, (ctx: any) => unknown>,
+  capturedMiddleware: [] as Array<(ctx: any, next: () => Promise<void>) => unknown>,
+  // Registration order of use()/on() calls, so a test can pin that the gate is registered before
+  // any handler — grammY runs middleware in registration order, so a gate registered after a
+  // handler would silently stop gating it.
+  registrationOrder: [] as string[],
   getFileMock: vi.fn(),
 }))
 
 vi.mock('grammy', () => ({
   Bot: class {
     api = { getFile: getFileMock }
-    on(event: string, handler: (ctx: any) => unknown): void { capturedHandlers[event] = handler }
+    on(event: string, handler: (ctx: any) => unknown): void { capturedHandlers[event] = handler; registrationOrder.push(`on:${event}`) }
+    use(mw: (ctx: any, next: () => Promise<void>) => unknown): void { capturedMiddleware.push(mw); registrationOrder.push('use') }
     start(opts: { onStart?: () => void }): Promise<void> { opts?.onStart?.(); return Promise.resolve() }
     async stop(): Promise<void> {}
   },
@@ -103,6 +109,52 @@ function makeCbCtx(data: string, opts: { messageId?: number; chatId?: number; te
     answerCallbackQuery: vi.fn(async () => {}),
     editMessageReplyMarkup: vi.fn(async () => {}),
   }
+}
+
+/** Reset the module-level grammY capture registries between connect()-based tests. */
+function resetCaptured(): void {
+  for (const k of Object.keys(capturedHandlers)) delete capturedHandlers[k]
+  capturedMiddleware.length = 0
+  registrationOrder.length = 0
+}
+
+/**
+ * Drive an update through the connect()-registered gate middleware, then the matching handler -
+ * the real grammY order. This is what exercises the dedup / teardown drop: the gate runs first and
+ * only reaches the handler via next(), so a redelivery or a disconnecting connector is dropped
+ * exactly as in production, instead of being bypassed by calling the handler directly.
+ */
+async function dispatch(ctx: any, event: string): Promise<void> {
+  let idx = -1
+  const chain = async (): Promise<void> => {
+    idx++
+    if (idx < capturedMiddleware.length) {
+      await capturedMiddleware[idx](ctx, chain)
+    } else {
+      await capturedHandlers[event]?.(ctx)
+    }
+  }
+  await chain()
+}
+
+/**
+ * connect() a fresh connector so its gate + handlers register into the captured registries.
+ * Requires fake timers (drives the 100ms connect poll + the onStart first-poll timer). After this
+ * resolves, hasCompletedFirstPoll is true (normal flow); flip it back to false to test the
+ * first-poll buffering window.
+ */
+async function connectFresh(dedup?: UpdateDeduplicator): Promise<{ connector: TelegramConnector; emitted: IncomingMessage[] }> {
+  resetCaptured()
+  getFileMock.mockReset().mockResolvedValue({ file_path: 'files/x' })
+  const connector = dedup
+    ? new TelegramConnector({ botToken: 'fake:TOKEN' }, dedup)
+    : new TelegramConnector({ botToken: 'fake:TOKEN' })
+  const emitted: IncomingMessage[] = []
+  connector.onMessage((m) => emitted.push(m))
+  const p = connector.connect()
+  await vi.advanceTimersByTimeAsync(1100)
+  await p
+  return { connector, emitted }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -382,22 +434,6 @@ describe('TelegramConnector — AskUserQuestion multi-select', () => {
     const newKb = ctx2.editMessageReplyMarkup.mock.calls[0][0].reply_markup.inline_keyboard
     expect(newKb[0][0].text).toBe('Redis') // ✅ removed
     expect(responses).toHaveLength(0)
-  })
-
-  it('drops a REDELIVERED multiSelect toggle (same update_id) so the selection is not un-toggled', async () => {
-    // D4: a redelivered toggle would flip the checkbox back off, corrupting the answer set.
-    const dedup = new UpdateDeduplicator(100)
-    const c = new TelegramConnector({ botToken: 'fake:TOKEN' }, dedup)
-    const sent2 = attachFakeBot(c).sent
-    await (c as any).sendUserRequestCard('123', multiSelectEvent())
-    const redisCb = sent2[0].reply_markup.inline_keyboard[0][0].callback_data
-    const ctxA = makeCbCtx(redisCb); ctxA.update = { update_id: 8001 }
-    const ctxB = makeCbCtx(redisCb); ctxB.update = { update_id: 8001 } // redelivery — same update_id
-    await (c as any).handleCallbackQuery(ctxA) // check Redis
-    await (c as any).handleCallbackQuery(ctxB) // redelivery must be dropped, NOT toggle off
-    const state = [...(c as any).pendingMultiSelect.values()][0]
-    expect(state.checked.has('Redis')).toBe(true) // toggled exactly once
-    expect(state.checked.size).toBe(1)
   })
 
   it('Done with nothing checked shows a toast and does not resolve', async () => {
@@ -693,7 +729,11 @@ describe('TelegramConnector — secret/file requests route to the desktop-only f
   })
 })
 
-describe('TelegramConnector — update deduplication (at-least-once redelivery guard)', () => {
+describe('TelegramConnector — update deduplication (record-at-handoff)', () => {
+  // Every case drives updates through the connect()-registered gate + handler (see dispatch),
+  // so the gate's redelivery/teardown drop is exercised, and a delivered id is recorded only
+  // once its handler actually hands the message off.
+
   /** A text ctx carrying a raw Telegram update_id (the redelivery key). */
   function makeTextCtxWithUpdate(updateId: number, opts: { chatId?: number; text?: string; messageId?: number } = {}): any {
     const ctx = makeCtx({
@@ -706,46 +746,44 @@ describe('TelegramConnector — update deduplication (at-least-once redelivery g
     return ctx
   }
 
-  it('drops a redelivered update with the same update_id (emits once, not twice)', () => {
+  function docCtxWithUpdate(updateId: number): any {
+    return {
+      chat: { id: 123, type: 'private' },
+      from: { id: 456, first_name: 'Bob' },
+      message: { document: { file_id: 'd1', file_name: 'report.pdf', mime_type: 'application/pdf' }, caption: '', message_id: 11, date: 0 },
+      update: { update_id: updateId },
+    }
+  }
+
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.clearAllTimers(); vi.useRealTimers() })
+
+  it('drops a redelivered update with the same update_id (emits once, not twice)', async () => {
     const dedup = new UpdateDeduplicator(100)
-    const connector = new TelegramConnector({ botToken: 'fake:TOKEN' }, dedup)
-    const emitted: IncomingMessage[] = []
-    connector.onMessage((m) => emitted.push(m))
-    ;(connector as any).hasCompletedFirstPoll = true
-
+    const { emitted } = await connectFresh(dedup)
     const ctx = makeTextCtxWithUpdate(5001, { text: 'hi', messageId: 100 })
-    ;(connector as any).handleTextMessage(ctx) // first delivery
-    ;(connector as any).handleTextMessage(ctx) // redelivery — same update_id
-
+    await dispatch(ctx, 'message:text') // first delivery → records at handoff
+    await dispatch(ctx, 'message:text') // redelivery — same update_id, dropped by the gate
     expect(emitted).toHaveLength(1)
   })
 
-  it('emits both when the update_ids differ', () => {
+  it('emits both when the update_ids differ', async () => {
     const dedup = new UpdateDeduplicator(100)
-    const connector = new TelegramConnector({ botToken: 'fake:TOKEN' }, dedup)
-    const emitted: IncomingMessage[] = []
-    connector.onMessage((m) => emitted.push(m))
-    ;(connector as any).hasCompletedFirstPoll = true
-
-    ;(connector as any).handleTextMessage(makeTextCtxWithUpdate(5001, { text: 'one', messageId: 100 }))
-    ;(connector as any).handleTextMessage(makeTextCtxWithUpdate(5002, { text: 'two', messageId: 101 }))
-
+    const { emitted } = await connectFresh(dedup)
+    await dispatch(makeTextCtxWithUpdate(5001, { text: 'one', messageId: 100 }), 'message:text')
+    await dispatch(makeTextCtxWithUpdate(5002, { text: 'two', messageId: 101 }), 'message:text')
     expect(emitted).toHaveLength(2)
   })
 
-  it('dedupes BEFORE first-poll batching, so a redelivered update never bleeds into the batch', () => {
+  it('dedupes BEFORE first-poll batching, so a redelivered update never bleeds into the batch', async () => {
     const dedup = new UpdateDeduplicator(100)
-    // Update 5001 was already accepted before a reconnect wiped the connector.
-    dedup.isDuplicate('5001')
-    const connector = new TelegramConnector({ botToken: 'fake:TOKEN' }, dedup)
-    const emitted: IncomingMessage[] = []
-    connector.onMessage((m) => emitted.push(m))
-    // First-poll window (as on a reconnect): messages buffer + batch.
-    ;(connector as any).hasCompletedFirstPoll = false
+    dedup.markDelivered('5001') // delivered by the old connector before the reconnect
+    const { connector, emitted } = await connectFresh(dedup)
+    ;(connector as any).hasCompletedFirstPoll = false // first-poll window, as on a reconnect
 
     // Redelivered old update + a genuinely new one arrive in the same batch window.
-    ;(connector as any).handleTextMessage(makeTextCtxWithUpdate(5001, { chatId: 200, text: 'old message', messageId: 100 }))
-    ;(connector as any).handleTextMessage(makeTextCtxWithUpdate(5002, { chatId: 200, text: 'new message', messageId: 101 }))
+    await dispatch(makeTextCtxWithUpdate(5001, { chatId: 200, text: 'old message', messageId: 100 }), 'message:text')
+    await dispatch(makeTextCtxWithUpdate(5002, { chatId: 200, text: 'new message', messageId: 101 }), 'message:text')
     ;(connector as any).flushBatch('200', '456', '101')
 
     expect(emitted).toHaveLength(1)
@@ -753,71 +791,123 @@ describe('TelegramConnector — update deduplication (at-least-once redelivery g
     expect(emitted[0].text).not.toContain('old message')
   })
 
-  it('does not dedupe when no deduplicator is wired (back-compat)', () => {
-    const connector = new TelegramConnector({ botToken: 'fake:TOKEN' })
-    const emitted: IncomingMessage[] = []
-    connector.onMessage((m) => emitted.push(m))
-    ;(connector as any).hasCompletedFirstPoll = true
-
+  it('does not dedupe when no deduplicator is wired (back-compat)', async () => {
+    const { emitted } = await connectFresh() // no deduplicator
     const ctx = makeTextCtxWithUpdate(5001, { text: 'hi', messageId: 100 })
-    ;(connector as any).handleTextMessage(ctx)
-    ;(connector as any).handleTextMessage(ctx)
-
+    await dispatch(ctx, 'message:text')
+    await dispatch(ctx, 'message:text')
     expect(emitted).toHaveLength(2)
   })
 
-  it('a disconnecting connector ignores updates (no emit, and does not record them)', () => {
-    // D1: during teardown the manager has already unsubscribed, so processing here would
-    // drop the message AND record its id in the shared deduplicator — the new connector would
-    // then drop the redelivery as a "duplicate" and the message is lost. So ignore updates
-    // entirely while disconnecting; the new connector re-reads and delivers.
+  it('a disconnecting connector ignores updates (no emit, and does not record them)', async () => {
+    // During teardown the manager has already unsubscribed, so the gate drops the update before
+    // any handler runs; leaving it unrecorded lets the fresh connector re-read and deliver it.
     const dedup = new UpdateDeduplicator(100)
-    const connector = new TelegramConnector({ botToken: 'fake:TOKEN' }, dedup)
-    const emitted: IncomingMessage[] = []
-    connector.onMessage((m) => emitted.push(m))
-    ;(connector as any).hasCompletedFirstPoll = true
+    const { connector, emitted } = await connectFresh(dedup)
     ;(connector as any).disconnecting = true
 
-    ;(connector as any).handleTextMessage(makeTextCtxWithUpdate(9101, { text: 'hi', messageId: 100 }))
+    await dispatch(makeTextCtxWithUpdate(9101, { text: 'hi', messageId: 100 }), 'message:text')
 
-    expect(emitted).toHaveLength(0)               // not processed by the tearing-down connector
+    expect(emitted).toHaveLength(0)               // gated out by the tearing-down connector
     expect(dedup.isDuplicate('9101')).toBe(false) // not recorded → a fresh connector will deliver it
   })
-})
 
-describe('TelegramConnector — update deduplication on media handlers', () => {
-  let connector: TelegramConnector
-  let emitted: IncomingMessage[]
+  // ── Record-at-handoff recovery: the finding 1 & 2 fix ──────────────────────────
+  // A message accepted but then lost in a teardown window must NOT be recorded, or its
+  // redelivery to the fresh connector would be dropped as a "duplicate" and lost for good.
 
-  beforeEach(async () => {
-    // connect() registers the photo/document closures into capturedHandlers; drive its
-    // poll + first-poll timers deterministically (mirrors the media-handlers suite).
-    vi.useFakeTimers()
-    for (const k of Object.keys(capturedHandlers)) delete capturedHandlers[k]
-    getFileMock.mockReset().mockResolvedValue({ file_path: 'files/x' })
-    connector = new TelegramConnector({ botToken: 'fake:TOKEN' }, new UpdateDeduplicator(100))
-    emitted = []
-    connector.onMessage((m) => emitted.push(m))
-    const p = connector.connect()
-    await vi.advanceTimersByTimeAsync(1100)
-    await p
+  it('finding 1: a first-poll message lost on a teardown flush is NOT recorded (redelivery recovers it)', async () => {
+    const dedup = new UpdateDeduplicator(100)
+    const { connector } = await connectFresh(dedup)
+    ;(connector as any).hasCompletedFirstPoll = false // first-poll buffering window
+
+    await dispatch(makeTextCtxWithUpdate(6001, { chatId: 300, text: 'buffered', messageId: 50 }), 'message:text')
+
+    // Teardown lands: disconnect() flushes buffered batches into an unsubscribed manager.
+    ;(connector as any).disconnecting = true
+    ;(connector as any).flushAllPendingBatches()
+
+    expect(dedup.isDuplicate('6001')).toBe(false) // stays unrecorded → recoverable
   })
 
-  afterEach(() => {
-    vi.clearAllTimers()
-    vi.useRealTimers()
+  it('a first-poll message delivered on a normal flush IS recorded (redelivery then dropped)', async () => {
+    const dedup = new UpdateDeduplicator(100)
+    const { connector, emitted } = await connectFresh(dedup)
+    ;(connector as any).hasCompletedFirstPoll = false
+
+    await dispatch(makeTextCtxWithUpdate(6002, { chatId: 300, text: 'buffered', messageId: 51 }), 'message:text')
+    ;(connector as any).flushBatch('300', '456', '51') // real handoff (not disconnecting)
+
+    expect(emitted).toHaveLength(1)
+    expect(dedup.isDuplicate('6002')).toBe(true) // recorded only on the real delivery
+  })
+
+  it('finding 2: a document lost when teardown lands during getFile is NOT recorded (redelivery recovers it)', async () => {
+    const dedup = new UpdateDeduplicator(100)
+    const { connector, emitted } = await connectFresh(dedup)
+    // Teardown lands mid-getFile: flip disconnecting while the file round-trip is in flight.
+    getFileMock.mockReset().mockImplementation(async () => {
+      ;(connector as any).disconnecting = true
+      return { file_path: 'files/x' }
+    })
+
+    await dispatch(docCtxWithUpdate(7003), 'message:document')
+
+    expect(emitted).toHaveLength(0)               // post-getFile guard bailed before emit
+    expect(dedup.isDuplicate('7003')).toBe(false) // not recorded → recoverable
   })
 
   it('drops a redelivered document (emits once, no re-download)', async () => {
-    const ctx: any = {
-      chat: { id: 123, type: 'private' },
-      from: { id: 456, first_name: 'Bob' },
-      message: { document: { file_id: 'd1', file_name: 'report.pdf', mime_type: 'application/pdf' }, caption: '', message_id: 11, date: 0 },
-      update: { update_id: 7002 },
-    }
-    await capturedHandlers['message:document'](ctx)
-    await capturedHandlers['message:document'](ctx) // redelivery — same update_id
+    const dedup = new UpdateDeduplicator(100)
+    const { emitted } = await connectFresh(dedup)
+    const ctx = docCtxWithUpdate(7002)
+    await dispatch(ctx, 'message:document')
+    await dispatch(ctx, 'message:document') // redelivery — same update_id
     expect(emitted).toHaveLength(1)
     expect(getFileMock).toHaveBeenCalledTimes(1) // the second delivery never re-fetches
+  })
+
+  it('drops a redelivered callback (same update_id) so a toggle is not re-applied', async () => {
+    const dedup = new UpdateDeduplicator(100)
+    const { connector } = await connectFresh(dedup)
+    const cbSpy = vi.spyOn(connector as any, 'handleCallbackQuery')
+    const ctx = makeCbCtx('cb'); ctx.update = { update_id: 8001 }
+    await dispatch(ctx, 'callback_query:data') // first: handler runs, records 8001 at entry
+    await dispatch(ctx, 'callback_query:data') // redelivery: gate drops it
+    expect(cbSpy).toHaveBeenCalledTimes(1)     // handler ran exactly once
+  })
+
+  it('the gate covers every handler type: a redelivery of any update is dropped before its handler', async () => {
+    // Iddo's forcing invariant: the single bot.use gate covers text, photo, document, and
+    // callback, so a future handler is protected without opting in per-handler.
+    const dedup = new UpdateDeduplicator(100)
+    const { connector, emitted } = await connectFresh(dedup)
+    const cbSpy = vi.spyOn(connector as any, 'handleCallbackQuery')
+    for (const id of ['1001', '1002', '1003', '1004']) dedup.markDelivered(id) // already delivered
+
+    const photoCtx: any = { chat: { id: 123, type: 'private' }, from: { id: 456, first_name: 'A' }, message: { photo: [{ file_id: 'p' }], caption: '', message_id: 1, date: 0 }, update: { update_id: 1002 } }
+    const docCtx = docCtxWithUpdate(1003)
+    const cbCtx = makeCbCtx('x'); cbCtx.update = { update_id: 1004 }
+
+    await dispatch(makeTextCtxWithUpdate(1001), 'message:text')
+    await dispatch(photoCtx, 'message:photo')
+    await dispatch(docCtx, 'message:document')
+    await dispatch(cbCtx, 'callback_query:data')
+
+    expect(emitted).toHaveLength(0)            // no message handler emitted a redelivery
+    expect(getFileMock).not.toHaveBeenCalled() // photo/document never even fetched
+    expect(cbSpy).not.toHaveBeenCalled()       // callback handler never ran
+  })
+
+  it('registers the gate middleware BEFORE any handler (grammY runs middleware in registration order)', async () => {
+    // dispatch() runs middleware-then-handler by construction, so it cannot catch a mis-ordering
+    // where bot.use is registered after the handlers - grammY would then bypass the gate. Pin the
+    // real registration order directly.
+    await connectFresh(new UpdateDeduplicator(100))
+    const firstGate = registrationOrder.indexOf('use')
+    const firstHandler = registrationOrder.findIndex((r) => r.startsWith('on:'))
+    expect(firstGate).toBeGreaterThanOrEqual(0)     // a gate is registered
+    expect(firstHandler).toBeGreaterThanOrEqual(0)  // handlers are registered
+    expect(firstGate).toBeLessThan(firstHandler)    // gate before every handler, or it would not gate them
   })
 })

--- a/src/shared/lib/chat-integrations/telegram-connector.test.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { TelegramConnector } from './telegram-connector'
 import type { IncomingMessage } from './base-connector'
+import { UpdateDeduplicator } from './update-deduplicator'
 
 // ── grammY mock ────────────────────────────────────────────────────────────────
 // The photo/document handlers are inline closures registered inside connect(),
@@ -383,6 +384,22 @@ describe('TelegramConnector — AskUserQuestion multi-select', () => {
     expect(responses).toHaveLength(0)
   })
 
+  it('drops a REDELIVERED multiSelect toggle (same update_id) so the selection is not un-toggled', async () => {
+    // D4: a redelivered toggle would flip the checkbox back off, corrupting the answer set.
+    const dedup = new UpdateDeduplicator(100)
+    const c = new TelegramConnector({ botToken: 'fake:TOKEN' }, dedup)
+    const sent2 = attachFakeBot(c).sent
+    await (c as any).sendUserRequestCard('123', multiSelectEvent())
+    const redisCb = sent2[0].reply_markup.inline_keyboard[0][0].callback_data
+    const ctxA = makeCbCtx(redisCb); ctxA.update = { update_id: 8001 }
+    const ctxB = makeCbCtx(redisCb); ctxB.update = { update_id: 8001 } // redelivery — same update_id
+    await (c as any).handleCallbackQuery(ctxA) // check Redis
+    await (c as any).handleCallbackQuery(ctxB) // redelivery must be dropped, NOT toggle off
+    const state = [...(c as any).pendingMultiSelect.values()][0]
+    expect(state.checked.has('Redis')).toBe(true) // toggled exactly once
+    expect(state.checked.size).toBe(1)
+  })
+
   it('Done with nothing checked shows a toast and does not resolve', async () => {
     await (connector as any).sendUserRequestCard('123', multiSelectEvent())
     const kb = sent[0].reply_markup.inline_keyboard
@@ -673,5 +690,134 @@ describe('TelegramConnector — secret/file requests route to the desktop-only f
     const md = sent[0].rich_message.markdown as string
     expect(md).toContain("isn't supported in chat")
     expect(md).not.toMatch(/please (upload|send) the file/i)
+  })
+})
+
+describe('TelegramConnector — update deduplication (at-least-once redelivery guard)', () => {
+  /** A text ctx carrying a raw Telegram update_id (the redelivery key). */
+  function makeTextCtxWithUpdate(updateId: number, opts: { chatId?: number; text?: string; messageId?: number } = {}): any {
+    const ctx = makeCtx({
+      type: 'private',
+      chatId: opts.chatId ?? 123,
+      text: opts.text ?? 'hello',
+      messageId: opts.messageId ?? 1,
+    }) as any
+    ctx.update = { update_id: updateId }
+    return ctx
+  }
+
+  it('drops a redelivered update with the same update_id (emits once, not twice)', () => {
+    const dedup = new UpdateDeduplicator(100)
+    const connector = new TelegramConnector({ botToken: 'fake:TOKEN' }, dedup)
+    const emitted: IncomingMessage[] = []
+    connector.onMessage((m) => emitted.push(m))
+    ;(connector as any).hasCompletedFirstPoll = true
+
+    const ctx = makeTextCtxWithUpdate(5001, { text: 'hi', messageId: 100 })
+    ;(connector as any).handleTextMessage(ctx) // first delivery
+    ;(connector as any).handleTextMessage(ctx) // redelivery — same update_id
+
+    expect(emitted).toHaveLength(1)
+  })
+
+  it('emits both when the update_ids differ', () => {
+    const dedup = new UpdateDeduplicator(100)
+    const connector = new TelegramConnector({ botToken: 'fake:TOKEN' }, dedup)
+    const emitted: IncomingMessage[] = []
+    connector.onMessage((m) => emitted.push(m))
+    ;(connector as any).hasCompletedFirstPoll = true
+
+    ;(connector as any).handleTextMessage(makeTextCtxWithUpdate(5001, { text: 'one', messageId: 100 }))
+    ;(connector as any).handleTextMessage(makeTextCtxWithUpdate(5002, { text: 'two', messageId: 101 }))
+
+    expect(emitted).toHaveLength(2)
+  })
+
+  it('dedupes BEFORE first-poll batching, so a redelivered update never bleeds into the batch', () => {
+    const dedup = new UpdateDeduplicator(100)
+    // Update 5001 was already accepted before a reconnect wiped the connector.
+    dedup.isDuplicate('5001')
+    const connector = new TelegramConnector({ botToken: 'fake:TOKEN' }, dedup)
+    const emitted: IncomingMessage[] = []
+    connector.onMessage((m) => emitted.push(m))
+    // First-poll window (as on a reconnect): messages buffer + batch.
+    ;(connector as any).hasCompletedFirstPoll = false
+
+    // Redelivered old update + a genuinely new one arrive in the same batch window.
+    ;(connector as any).handleTextMessage(makeTextCtxWithUpdate(5001, { chatId: 200, text: 'old message', messageId: 100 }))
+    ;(connector as any).handleTextMessage(makeTextCtxWithUpdate(5002, { chatId: 200, text: 'new message', messageId: 101 }))
+    ;(connector as any).flushBatch('200', '456', '101')
+
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0].text).toBe('new message')
+    expect(emitted[0].text).not.toContain('old message')
+  })
+
+  it('does not dedupe when no deduplicator is wired (back-compat)', () => {
+    const connector = new TelegramConnector({ botToken: 'fake:TOKEN' })
+    const emitted: IncomingMessage[] = []
+    connector.onMessage((m) => emitted.push(m))
+    ;(connector as any).hasCompletedFirstPoll = true
+
+    const ctx = makeTextCtxWithUpdate(5001, { text: 'hi', messageId: 100 })
+    ;(connector as any).handleTextMessage(ctx)
+    ;(connector as any).handleTextMessage(ctx)
+
+    expect(emitted).toHaveLength(2)
+  })
+
+  it('a disconnecting connector ignores updates (no emit, and does not record them)', () => {
+    // D1: during teardown the manager has already unsubscribed, so processing here would
+    // drop the message AND record its id in the shared deduplicator — the new connector would
+    // then drop the redelivery as a "duplicate" and the message is lost. So ignore updates
+    // entirely while disconnecting; the new connector re-reads and delivers.
+    const dedup = new UpdateDeduplicator(100)
+    const connector = new TelegramConnector({ botToken: 'fake:TOKEN' }, dedup)
+    const emitted: IncomingMessage[] = []
+    connector.onMessage((m) => emitted.push(m))
+    ;(connector as any).hasCompletedFirstPoll = true
+    ;(connector as any).disconnecting = true
+
+    ;(connector as any).handleTextMessage(makeTextCtxWithUpdate(9101, { text: 'hi', messageId: 100 }))
+
+    expect(emitted).toHaveLength(0)               // not processed by the tearing-down connector
+    expect(dedup.isDuplicate('9101')).toBe(false) // not recorded → a fresh connector will deliver it
+  })
+})
+
+describe('TelegramConnector — update deduplication on media handlers', () => {
+  let connector: TelegramConnector
+  let emitted: IncomingMessage[]
+
+  beforeEach(async () => {
+    // connect() registers the photo/document closures into capturedHandlers; drive its
+    // poll + first-poll timers deterministically (mirrors the media-handlers suite).
+    vi.useFakeTimers()
+    for (const k of Object.keys(capturedHandlers)) delete capturedHandlers[k]
+    getFileMock.mockReset().mockResolvedValue({ file_path: 'files/x' })
+    connector = new TelegramConnector({ botToken: 'fake:TOKEN' }, new UpdateDeduplicator(100))
+    emitted = []
+    connector.onMessage((m) => emitted.push(m))
+    const p = connector.connect()
+    await vi.advanceTimersByTimeAsync(1100)
+    await p
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('drops a redelivered document (emits once, no re-download)', async () => {
+    const ctx: any = {
+      chat: { id: 123, type: 'private' },
+      from: { id: 456, first_name: 'Bob' },
+      message: { document: { file_id: 'd1', file_name: 'report.pdf', mime_type: 'application/pdf' }, caption: '', message_id: 11, date: 0 },
+      update: { update_id: 7002 },
+    }
+    await capturedHandlers['message:document'](ctx)
+    await capturedHandlers['message:document'](ctx) // redelivery — same update_id
+    expect(emitted).toHaveLength(1)
+    expect(getFileMock).toHaveBeenCalledTimes(1) // the second delivery never re-fetches
   })
 })

--- a/src/shared/lib/chat-integrations/telegram-connector.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.ts
@@ -13,8 +13,9 @@ import { Marked, Renderer } from 'marked'
 import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
 import type { SessionActivity } from '@shared/lib/types/agent'
 import { ChatClientConnector, type OutgoingMessage } from './base-connector'
+import type { UpdateDeduplicator } from './update-deduplicator'
 import { describeUnsupportedRequest, isUnsupportedInChat } from './utils'
-import { captureException } from '@shared/lib/error-reporting'
+import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 import { markdownToRichMessage, splitForRichLimits, splitForHtmlLimits, escapeMarkdown, codeSpan } from './telegram-rich-message'
 import type { InputRichMessage } from 'grammy/types'
 
@@ -166,7 +167,7 @@ export class TelegramConnector extends ChatClientConnector {
   // the current label even when it changes mid-turn (working → thinking → …).
   private workingActivity: Map<string, SessionActivity> = new Map()
 
-  constructor(private config: TelegramConfig) {
+  constructor(private config: TelegramConfig, private deduplicator?: UpdateDeduplicator) {
     super()
   }
 
@@ -185,6 +186,8 @@ export class TelegramConnector extends ChatClientConnector {
 
     // Handle photo messages (images sent directly, not as documents)
     this.bot.on('message:photo', async (ctx) => {
+      if (this.disconnecting) return
+      if (this.isDuplicateUpdate(ctx)) return
       const photos = ctx.message.photo
       if (!photos || photos.length === 0) return
 
@@ -220,6 +223,8 @@ export class TelegramConnector extends ChatClientConnector {
 
     // Handle document uploads (for file request resolution)
     this.bot.on('message:document', async (ctx) => {
+      if (this.disconnecting) return
+      if (this.isDuplicateUpdate(ctx)) return
       const doc = ctx.message.document
       const chatType = ctx.chat.type
 
@@ -614,6 +619,10 @@ export class TelegramConnector extends ChatClientConnector {
    *  and only resolves on Done. The callback is answered inside each branch so the empty-Done
    *  toast can fire (a callback can be answered exactly once). */
   private async handleCallbackQuery(ctx: GrammyContext): Promise<void> {
+    if (this.disconnecting) return
+    // Dedupe callback redeliveries too: a redelivered multiSelect toggle would flip a
+    // checkbox back off (its callback mapping isn't consumed on tap), corrupting the answer.
+    if (this.isDuplicateUpdate(ctx)) return
     const data = ctx.callbackQuery?.data
     if (!data) { await ctx.answerCallbackQuery(); return }
     const mapping = this.callbackDataMap.get(data)
@@ -797,7 +806,26 @@ export class TelegramConnector extends ChatClientConnector {
 
   // ── First-poll batching ─────────────────────────────────────────────
 
+  /**
+   * True if this update_id was already accepted (a redelivery to drop). Checked before
+   * first-poll batching so a repeat can't bleed into a batch. Fail-open with no deduplicator.
+   */
+  private isDuplicateUpdate(ctx: GrammyContext): boolean {
+    if (!this.deduplicator) return false
+    const updateId = ctx.update?.update_id
+    if (updateId === undefined) return false
+    if (this.deduplicator.isDuplicate(String(updateId))) {
+      // Breadcrumb, not error: a redelivery is normal; recording it lets a wrongly-dropped
+      // message be traced (the one failure mode a dedup gate can introduce).
+      addErrorBreadcrumb({ category: 'chat-integration', message: 'Dropped duplicate Telegram update', data: { updateId } })
+      return true
+    }
+    return false
+  }
+
   private handleTextMessage(ctx: GrammyContext): void {
+    if (this.disconnecting) return
+    if (this.isDuplicateUpdate(ctx)) return
     const text = ctx.message?.text
     if (!text || !ctx.chat) return
 

--- a/src/shared/lib/chat-integrations/telegram-connector.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.ts
@@ -118,7 +118,7 @@ export class TelegramConnector extends ChatClientConnector {
   private startupError: Error | null = null
 
   // First-poll batching: accumulate messages before sending them all at once
-  private pendingFirstPollMessages: Map<string, { texts: string[]; timer: ReturnType<typeof setTimeout> | null; userName?: string; chatName?: string; chatType?: 'private' | 'group' | 'supergroup' }> = new Map()
+  private pendingFirstPollMessages: Map<string, { texts: string[]; updateIds: string[]; timer: ReturnType<typeof setTimeout> | null; userName?: string; chatName?: string; chatType?: 'private' | 'group' | 'supergroup' }> = new Map()
 
   // Track callback_query toolUseId mappings (Telegram callback_data is limited to 64 bytes)
   private callbackDataMap: Map<string, { toolUseId: string; value: unknown; ts: number }> = new Map()
@@ -178,6 +178,18 @@ export class TelegramConnector extends ChatClientConnector {
     this.startupError = null
     this.bot = new Bot(this.config.botToken)
 
+    // Single gate for every update, before any handler: drop updates while tearing down, and
+    // drop at-least-once redeliveries. Centralized here rather than per-handler so any handler
+    // added later (message:video, voice, ...) is covered automatically. It only *checks* - an id
+    // is marked delivered by each handler once it has actually handed its message off (see
+    // markUpdateDelivered), so a message accepted but lost in a teardown window stays eligible
+    // for redelivery instead of being recorded and suppressed.
+    this.bot.use((ctx, next) => {
+      if (this.disconnecting) return
+      if (this.isDuplicateUpdate(ctx)) return
+      return next()
+    })
+
     // Handle text messages
     this.bot.on('message:text', (ctx) => this.handleTextMessage(ctx))
 
@@ -186,8 +198,6 @@ export class TelegramConnector extends ChatClientConnector {
 
     // Handle photo messages (images sent directly, not as documents)
     this.bot.on('message:photo', async (ctx) => {
-      if (this.disconnecting) return
-      if (this.isDuplicateUpdate(ctx)) return
       const photos = ctx.message.photo
       if (!photos || photos.length === 0) return
 
@@ -201,6 +211,11 @@ export class TelegramConnector extends ChatClientConnector {
         const file = await this.bot!.api.getFile(largest.file_id)
         url = `https://api.telegram.org/file/bot${this.config.botToken}/${file.file_path}`
       } catch { /* fallback to file_id */ }
+
+      // Teardown may have landed during getFile: the manager has already unsubscribed, so
+      // emitting now would drop the message. Bail without recording, so the fresh connector's
+      // redelivery recovers it.
+      if (this.disconnecting) return
 
       const userName = [ctx.from?.first_name, ctx.from?.last_name].filter(Boolean).join(' ') || ctx.from?.username || undefined
 
@@ -219,12 +234,11 @@ export class TelegramConnector extends ChatClientConnector {
         }],
         timestamp: new Date(ctx.message.date * 1000),
       })
+      this.markUpdateDelivered(this.updateIdOf(ctx))
     })
 
     // Handle document uploads (for file request resolution)
     this.bot.on('message:document', async (ctx) => {
-      if (this.disconnecting) return
-      if (this.isDuplicateUpdate(ctx)) return
       const doc = ctx.message.document
       const chatType = ctx.chat.type
 
@@ -234,6 +248,11 @@ export class TelegramConnector extends ChatClientConnector {
         const file = await this.bot!.api.getFile(doc.file_id)
         url = `https://api.telegram.org/file/bot${this.config.botToken}/${file.file_path}`
       } catch { /* fallback */ }
+
+      // Teardown may have landed during getFile: the manager has already unsubscribed, so
+      // emitting now would drop the file. Bail without recording, so the fresh connector's
+      // redelivery recovers it.
+      if (this.disconnecting) return
 
       const userName = [ctx.from?.first_name, ctx.from?.last_name].filter(Boolean).join(' ') || ctx.from?.username || undefined
 
@@ -252,6 +271,7 @@ export class TelegramConnector extends ChatClientConnector {
         }],
         timestamp: new Date(ctx.message.date * 1000),
       })
+      this.markUpdateDelivered(this.updateIdOf(ctx))
     })
 
     // Start long polling
@@ -260,6 +280,13 @@ export class TelegramConnector extends ChatClientConnector {
     // A rejection here (e.g. grammY 409 Conflict from duplicate pollers) must
     // be caught — otherwise it bubbles up to process.unhandledRejection and
     // crashes the Electron app.
+    //
+    // grammY's built-in bot.start() processes updates SEQUENTIALLY (one at a time). The
+    // record-at-handoff dedup depends on this: a redelivered update never runs concurrently with
+    // its own first delivery, so the brief await gap in the photo/document handlers (getFile, before
+    // the id is recorded on emit) cannot produce a double-delivery. Switching to @grammyjs/runner
+    // (concurrent processing) would reopen that window - keep processing sequential, or record the
+    // id before the await.
     this.bot.start({
       allowed_updates: ['message', 'callback_query'],
       drop_pending_updates: false,
@@ -619,10 +646,12 @@ export class TelegramConnector extends ChatClientConnector {
    *  and only resolves on Done. The callback is answered inside each branch so the empty-Done
    *  toast can fire (a callback can be answered exactly once). */
   private async handleCallbackQuery(ctx: GrammyContext): Promise<void> {
-    if (this.disconnecting) return
-    // Dedupe callback redeliveries too: a redelivered multiSelect toggle would flip a
-    // checkbox back off (its callback mapping isn't consumed on tap), corrupting the answer.
-    if (this.isDuplicateUpdate(ctx)) return
+    // The gate middleware already dropped a redelivery and the teardown case; nothing has
+    // recorded this one yet. Record it up front - unlike the message handlers (which record at
+    // emit), a callback carries no buffered payload to lose in a teardown window, and a
+    // redelivered multiSelect toggle would flip a checkbox back off (its mapping isn't consumed
+    // on tap), so dropping the redelivery is exactly the goal.
+    this.markUpdateDelivered(this.updateIdOf(ctx))
     const data = ctx.callbackQuery?.data
     if (!data) { await ctx.answerCallbackQuery(); return }
     const mapping = this.callbackDataMap.get(data)
@@ -806,15 +835,22 @@ export class TelegramConnector extends ChatClientConnector {
 
   // ── First-poll batching ─────────────────────────────────────────────
 
+  /** This update's id as a string, or undefined when absent or no deduplicator is wired. */
+  private updateIdOf(ctx: GrammyContext): string | undefined {
+    if (!this.deduplicator) return undefined
+    const updateId = ctx.update?.update_id
+    return updateId === undefined ? undefined : String(updateId)
+  }
+
   /**
-   * True if this update_id was already accepted (a redelivery to drop). Checked before
-   * first-poll batching so a repeat can't bleed into a batch. Fail-open with no deduplicator.
+   * True if this update was already delivered (a redelivery to drop). Read-only: the gate
+   * middleware calls it before any handler runs, and a delivered id is recorded separately at
+   * handoff via markUpdateDelivered. Fail-open with no deduplicator.
    */
   private isDuplicateUpdate(ctx: GrammyContext): boolean {
-    if (!this.deduplicator) return false
-    const updateId = ctx.update?.update_id
+    const updateId = this.updateIdOf(ctx)
     if (updateId === undefined) return false
-    if (this.deduplicator.isDuplicate(String(updateId))) {
+    if (this.deduplicator!.isDuplicate(updateId)) {
       // Breadcrumb, not error: a redelivery is normal; recording it lets a wrongly-dropped
       // message be traced (the one failure mode a dedup gate can introduce).
       addErrorBreadcrumb({ category: 'chat-integration', message: 'Dropped duplicate Telegram update', data: { updateId } })
@@ -823,9 +859,17 @@ export class TelegramConnector extends ChatClientConnector {
     return false
   }
 
+  /**
+   * Record an update as delivered, once a handler has actually handed its message off. Recording
+   * at handoff rather than at accept means a message lost in a teardown window is never marked, so
+   * the fresh connector's redelivery recovers it instead of being dropped as a duplicate.
+   */
+  private markUpdateDelivered(updateId: string | undefined): void {
+    if (!this.deduplicator || updateId === undefined) return
+    this.deduplicator.markDelivered(updateId)
+  }
+
   private handleTextMessage(ctx: GrammyContext): void {
-    if (this.disconnecting) return
-    if (this.isDuplicateUpdate(ctx)) return
     const text = ctx.message?.text
     if (!text || !ctx.chat) return
 
@@ -835,6 +879,7 @@ export class TelegramConnector extends ChatClientConnector {
     const chatId = String(ctx.chat.id)
     const fromId = String(ctx.from?.id || '')
     const messageId = String(ctx.message?.message_id || '')
+    const updateId = this.updateIdOf(ctx)
     const userName = [ctx.from?.first_name, ctx.from?.last_name].filter(Boolean).join(' ')
       || ctx.from?.username
       || undefined
@@ -845,10 +890,13 @@ export class TelegramConnector extends ChatClientConnector {
       // Buffer messages during first poll
       let pending = this.pendingFirstPollMessages.get(chatId)
       if (!pending) {
-        pending = { texts: [], timer: null, userName, chatName, chatType }
+        pending = { texts: [], updateIds: [], timer: null, userName, chatName, chatType }
         this.pendingFirstPollMessages.set(chatId, pending)
       }
       pending.texts.push(text)
+      // Carry the update id with its text so the batch records it only when it truly flushes to a
+      // subscribed manager (flushBatch), never on a teardown flush whose emit is lost.
+      if (updateId !== undefined) pending.updateIds.push(updateId)
 
       if (pending.timer) clearTimeout(pending.timer)
       pending.timer = setTimeout(() => {
@@ -868,6 +916,7 @@ export class TelegramConnector extends ChatClientConnector {
       chatName,
       timestamp: new Date((ctx.message?.date || 0) * 1000),
     })
+    this.markUpdateDelivered(updateId)
   }
 
   private flushBatch(chatId: string, userId: string, lastMessageId: string): void {
@@ -885,6 +934,13 @@ export class TelegramConnector extends ChatClientConnector {
       chatName: pending.chatName,
       timestamp: new Date(),
     })
+    // Record the batched updates as delivered only on a real handoff. A teardown flush
+    // (flushAllPendingBatches while disconnecting) emits into an unsubscribed manager, so leaving
+    // its ids unrecorded lets the fresh connector's redelivery recover them - recording at accept
+    // is exactly what turned this transient loss into a permanent one (finding 1).
+    if (!this.disconnecting) {
+      for (const id of pending.updateIds) this.markUpdateDelivered(id)
+    }
     this.pendingFirstPollMessages.delete(chatId)
   }
 

--- a/src/shared/lib/chat-integrations/update-deduplicator.test.ts
+++ b/src/shared/lib/chat-integrations/update-deduplicator.test.ts
@@ -2,30 +2,44 @@ import { describe, it, expect } from 'vitest'
 import { UpdateDeduplicator } from './update-deduplicator'
 
 describe('UpdateDeduplicator', () => {
-  it('treats a never-seen id as not a duplicate', () => {
+  it('treats a never-delivered id as not a duplicate', () => {
     const dedup = new UpdateDeduplicator(10)
     expect(dedup.isDuplicate('5001')).toBe(false)
   })
 
-  it('treats a repeated id as a duplicate', () => {
+  it('isDuplicate is read-only: checking an id never records it', () => {
     const dedup = new UpdateDeduplicator(10)
-    dedup.isDuplicate('5001')
+    expect(dedup.isDuplicate('5001')).toBe(false)
+    // A message accepted but not yet handed off must stay eligible for redelivery, so a check
+    // alone can never make the next check report a duplicate.
+    expect(dedup.isDuplicate('5001')).toBe(false)
+  })
+
+  it('reports a duplicate only after the id is marked delivered', () => {
+    const dedup = new UpdateDeduplicator(10)
+    dedup.markDelivered('5001')
+    expect(dedup.isDuplicate('5001')).toBe(true)
+  })
+
+  it('markDelivered is idempotent', () => {
+    const dedup = new UpdateDeduplicator(10)
+    dedup.markDelivered('5001')
+    dedup.markDelivered('5001')
     expect(dedup.isDuplicate('5001')).toBe(true)
   })
 
   it('tracks distinct ids independently', () => {
     const dedup = new UpdateDeduplicator(10)
-    expect(dedup.isDuplicate('5001')).toBe(false)
-    expect(dedup.isDuplicate('5002')).toBe(false)
+    dedup.markDelivered('5001')
     expect(dedup.isDuplicate('5001')).toBe(true)
-    expect(dedup.isDuplicate('5002')).toBe(true)
+    expect(dedup.isDuplicate('5002')).toBe(false)
   })
 
-  it('evicts the oldest id once capacity is exceeded (bounded by count, not time)', () => {
+  it('evicts the oldest delivered id once capacity is exceeded (bounded by count, not time)', () => {
     const dedup = new UpdateDeduplicator(2)
-    dedup.isDuplicate('1') // record 1
-    dedup.isDuplicate('2') // record 2
-    dedup.isDuplicate('3') // record 3 → evicts oldest (1)
+    dedup.markDelivered('1')
+    dedup.markDelivered('2')
+    dedup.markDelivered('3') // exceeds capacity → evicts oldest (1)
     // 1 was evicted, so it reads as new again
     expect(dedup.isDuplicate('1')).toBe(false)
     // 3 is still remembered

--- a/src/shared/lib/chat-integrations/update-deduplicator.test.ts
+++ b/src/shared/lib/chat-integrations/update-deduplicator.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { UpdateDeduplicator } from './update-deduplicator'
+
+describe('UpdateDeduplicator', () => {
+  it('treats a never-seen id as not a duplicate', () => {
+    const dedup = new UpdateDeduplicator(10)
+    expect(dedup.isDuplicate('5001')).toBe(false)
+  })
+
+  it('treats a repeated id as a duplicate', () => {
+    const dedup = new UpdateDeduplicator(10)
+    dedup.isDuplicate('5001')
+    expect(dedup.isDuplicate('5001')).toBe(true)
+  })
+
+  it('tracks distinct ids independently', () => {
+    const dedup = new UpdateDeduplicator(10)
+    expect(dedup.isDuplicate('5001')).toBe(false)
+    expect(dedup.isDuplicate('5002')).toBe(false)
+    expect(dedup.isDuplicate('5001')).toBe(true)
+    expect(dedup.isDuplicate('5002')).toBe(true)
+  })
+
+  it('evicts the oldest id once capacity is exceeded (bounded by count, not time)', () => {
+    const dedup = new UpdateDeduplicator(2)
+    dedup.isDuplicate('1') // record 1
+    dedup.isDuplicate('2') // record 2
+    dedup.isDuplicate('3') // record 3 → evicts oldest (1)
+    // 1 was evicted, so it reads as new again
+    expect(dedup.isDuplicate('1')).toBe(false)
+    // 3 is still remembered
+    expect(dedup.isDuplicate('3')).toBe(true)
+  })
+})

--- a/src/shared/lib/chat-integrations/update-deduplicator.ts
+++ b/src/shared/lib/chat-integrations/update-deduplicator.ts
@@ -1,0 +1,29 @@
+/**
+ * Idempotency gate for Telegram's at-least-once getUpdates: records accepted update ids and
+ * reports a repeat so the caller drops a redelivery before it dispatches a second agent turn.
+ *
+ * Exact-match, not a highest-seen watermark (which would drop an out-of-order lower id and
+ * lose a real message). Bounded by COUNT, not time (a TTL could age an id out during a long
+ * sleep, just before the resume that redelivers it). Owned by the manager, not the connector,
+ * so it survives the connector teardown/recreate of a reconnect — when the redelivery arrives.
+ */
+
+const DEFAULT_CAPACITY = 1000
+
+export class UpdateDeduplicator {
+  // A Set preserves insertion order, so it doubles as the FIFO eviction queue.
+  private readonly seen = new Set<string>()
+
+  constructor(private readonly capacity: number = DEFAULT_CAPACITY) {}
+
+  /** True if `id` was already accepted (drop it); else records `id` and returns false. */
+  isDuplicate(id: string): boolean {
+    if (this.seen.has(id)) return true
+    this.seen.add(id)
+    if (this.seen.size > this.capacity) {
+      const oldest = this.seen.values().next().value
+      if (oldest !== undefined) this.seen.delete(oldest)
+    }
+    return false
+  }
+}

--- a/src/shared/lib/chat-integrations/update-deduplicator.ts
+++ b/src/shared/lib/chat-integrations/update-deduplicator.ts
@@ -1,11 +1,18 @@
 /**
- * Idempotency gate for Telegram's at-least-once getUpdates: records accepted update ids and
+ * Idempotency gate for Telegram's at-least-once getUpdates: records delivered update ids and
  * reports a repeat so the caller drops a redelivery before it dispatches a second agent turn.
+ *
+ * Check and record are split: `isDuplicate` only reads, and an id is committed with
+ * `markDelivered` once its message has actually been handed off. Recording at accept time would
+ * make a message that is accepted but then lost in a teardown window (a first-poll batch flushed
+ * into an unsubscribed manager, an emit that fires after the manager unsubscribed mid-getFile)
+ * permanently lost: the id would be remembered, so the redelivery that used to recover it gets
+ * dropped. Record at handoff so a never-delivered update stays eligible for redelivery.
  *
  * Exact-match, not a highest-seen watermark (which would drop an out-of-order lower id and
  * lose a real message). Bounded by COUNT, not time (a TTL could age an id out during a long
  * sleep, just before the resume that redelivers it). Owned by the manager, not the connector,
- * so it survives the connector teardown/recreate of a reconnect — when the redelivery arrives.
+ * so it survives the connector teardown/recreate of a reconnect - when the redelivery arrives.
  */
 
 const DEFAULT_CAPACITY = 1000
@@ -16,14 +23,19 @@ export class UpdateDeduplicator {
 
   constructor(private readonly capacity: number = DEFAULT_CAPACITY) {}
 
-  /** True if `id` was already accepted (drop it); else records `id` and returns false. */
+  /** True if `id` was already delivered. Read-only: checking never records - call
+   *  `markDelivered` once the message has been handed off. */
   isDuplicate(id: string): boolean {
-    if (this.seen.has(id)) return true
+    return this.seen.has(id)
+  }
+
+  /** Record `id` as delivered, evicting the oldest once capacity is exceeded. Idempotent. */
+  markDelivered(id: string): void {
+    if (this.seen.has(id)) return
     this.seen.add(id)
     if (this.seen.size > this.capacity) {
       const oldest = this.seen.values().next().value
       if (oldest !== undefined) this.seen.delete(oldest)
     }
-    return false
   }
 }


### PR DESCRIPTION
## What

Rarely, the Telegram bot delivers a reply twice. Root cause: Telegram's `getUpdates` long polling is at-least-once. An update stays in Telegram's queue until we confirm it (by advancing the offset), so any interruption between handling an update and confirming it - a reconnect on resume, a brief poller overlap - makes Telegram redeliver it. We had no idempotency, so a redelivery ran a second agent turn and the user saw the whole response twice.

## Changes

- **Idempotency gate.** New `UpdateDeduplicator` (bounded, exact-match, count-based), owned by the manager per integration so it survives the connector teardown/recreate of a reconnect - which is exactly when the redelivery arrives. The connector checks `update_id` at the top of each message-bearing handler, before first-poll batching, and drops repeats (breadcrumb, not error). Callback queries are deduped too, since a redelivered multi-select toggle would otherwise flip a checkbox back off and corrupt the answer.

- **No message loss during teardown.** A disconnecting connector now ignores incoming updates, so a teardown-window update isn't recorded in the shared deduplicator and then dropped as a "duplicate" by the new connector.

- **No poller overlap on reconnect.** Reconnect now awaits the old connector's `disconnect()` before starting the new poller, so two pollers never share the token (removes 409 thrash and a rare lost-update window). The await is bounded, so a hung stop can't wedge the reconnect, and the connections-map delete is guarded by identity so a concurrent reconnect can't orphan a live poller. `stop()` stays fire-and-forget so app quit is snappy.

## Not covered (on purpose)

- The gate is in-memory, so it catches same-process redeliveries; a cross-restart redelivery is avoided instead by grammY resuming at the last confirmed offset.
- Two processes on one bot token still double-deliver (separate notepads). That's "don't run two pollers," not something dedup can fix.
- General per-integration reconnect serialization (a broader lifecycle race) is a separate follow-up.

## Verification

- Unit tests for the deduplicator, connector dedup on text/photo/document/callback, the disconnecting guard, the bounded awaited disconnect, and the concurrent-reconnect identity guard (verified to fail without the fix).
- Full chat-integrations suite green (589 tests). Typecheck and lint clean.
