### PR TITLE
test: cover session deletion end-to-end (sidebar menu + agent-home kebab)

### DIFF
--- a/e2e/helpers/agents.ts
+++ b/e2e/helpers/agents.ts
@@ -253,6 +253,18 @@ export async function listSessions(
   return await response.json() as TestSession[]
 }
 
+export async function renameSessionViaApi(
+  request: APIRequestContext,
+  agent: Pick<TestAgent, 'slug'>,
+  session: Pick<TestSession, 'id'>,
+  name: string,
+) {
+  const response = await request.patch(`/api/agents/${agent.slug}/sessions/${session.id}`, {
+    data: { name },
+  })
+  expect(response.ok()).toBeTruthy()
+}
+
 export async function expectSessionNamed(
   request: APIRequestContext,
   agent: Pick<TestAgent, 'slug'>,

--- a/e2e/pages/session.page.ts
+++ b/e2e/pages/session.page.ts
@@ -175,22 +175,25 @@ export class SessionPage {
   }
 
   /**
-   * Delete a session via context menu
+   * Delete a session via the sidebar right-click context menu, confirming the
+   * dialog. Targets the row by session id (names appear in the breadcrumb and
+   * agent-home list too, so a text match would be ambiguous). Pass expectedName
+   * to also assert the confirm dialog names the right session.
    */
-  async deleteSessionViaContextMenu(sessionName: string) {
-    // Right-click on the session in the sidebar
-    const sessionItem = this.page.getByText(sessionName)
+  async deleteSessionViaContextMenu(sessionId: string, expectedName?: string) {
+    const sessionItem = this.page.locator(`[data-testid="session-item-${sessionId}"]`)
+    await expect(sessionItem).toBeVisible({ timeout: 15000 })
     await sessionItem.click({ button: 'right' })
 
-    // Click delete
     await this.page.locator('[data-testid="delete-session-item"]').click()
 
-    // Confirm deletion
-    await expect(this.page.locator('[data-testid="confirm-dialog"]')).toBeVisible()
+    const dialog = this.page.locator('[data-testid="confirm-dialog"]')
+    await expect(dialog).toBeVisible()
+    if (expectedName) {
+      await expect(dialog).toContainText(expectedName)
+    }
     await this.page.locator('[data-testid="confirm-button"]').click()
-
-    // Wait for dialog to close
-    await expect(this.page.locator('[data-testid="confirm-dialog"]')).not.toBeVisible()
+    await expect(dialog).not.toBeVisible()
   }
 
   /**

--- a/e2e/specs/session-delete.spec.ts
+++ b/e2e/specs/session-delete.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { SessionPage } from '../pages/session.page'
+import {
+  createAgent,
+  createSession,
+  expectSessionNamed,
+  listSessions,
+  openAgentSession,
+  gotoAgentHome,
+  renameSessionViaApi,
+  uniqueName,
+  waitForSessionIdle,
+  type TestAgent,
+  type TestSession,
+} from '../helpers/agents'
+
+/**
+ * Session deletion — the only destructive session operation — must remove the
+ * session everywhere, durably, and navigate correctly:
+ *
+ * - deleting the session you are currently VIEWING up-navigates to the agent
+ *   home (the `strict:false` params.sessionId guard in session-context-menu);
+ * - deleting a session you are NOT viewing must NOT navigate;
+ * - the deletion is durable: gone from the sessions API after reload, and a
+ *   deep-link to the dead id renders the SessionNotFound leaf (after TanStack
+ *   Query's default 404 retries, so those assertions get generous timeouts);
+ * - the agent-home list exposes the same delete via its kebab menu, guarded by
+ *   the same confirm dialog, and Cancel leaves the session untouched.
+ *
+ * Each test owns its agent and sessions (created via API), so the spec is
+ * fully parallel-safe.
+ */
+test.describe('Session deletion', () => {
+  async function createTwoSessionFixture(
+    page: Page,
+    request: APIRequestContext,
+    testInfo: TestInfo,
+    label: string,
+  ): Promise<{ agent: TestAgent; sessionA: TestSession; sessionB: TestSession }> {
+    const agent = await createAgent(request, uniqueName(testInfo, label))
+    const createdA = await createSession(request, agent, `First ${uniqueName(testInfo, 'delete-target')}`)
+    const createdB = await createSession(request, agent, `Second ${uniqueName(testInfo, 'delete-target')}`)
+    // Let both mock turns finish so deletion never races an in-flight
+    // transcript write
+    await waitForSessionIdle(request, agent, createdA)
+    await waitForSessionIdle(request, agent, createdB)
+
+    // Fresh sessions all display the default "New Session" name, which makes
+    // every name-based assertion (confirm-dialog copy, kebab aria-labels)
+    // ambiguous — give each session a unique name before the UI loads
+    const nameA = uniqueName(testInfo, 'Alpha Session')
+    const nameB = uniqueName(testInfo, 'Beta Session')
+    await renameSessionViaApi(request, agent, createdA, nameA)
+    await renameSessionViaApi(request, agent, createdB, nameB)
+    const sessionA = await expectSessionNamed(request, agent, createdA, nameA)
+    const sessionB = await expectSessionNamed(request, agent, createdB, nameB)
+
+    const appPage = new AppPage(page)
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+
+    return { agent, sessionA, sessionB }
+  }
+
+  test('sidebar delete: no nav when deleting another session, up-nav to home when deleting the viewed one, durably gone', async ({ page, request }, testInfo) => {
+    const { agent, sessionA, sessionB } = await createTwoSessionFixture(
+      page, request, testInfo, 'Session Delete Sidebar',
+    )
+    const sessionPage = new SessionPage(page)
+
+    await openAgentSession(page, agent, sessionA)
+
+    // Delete session B while viewing session A: the confirm dialog names B,
+    // and after deletion we must still be on session A (no up-nav — the guard
+    // only fires for the session being viewed)
+    await sessionPage.deleteSessionViaContextMenu(sessionB.id, sessionB.name)
+    await expect(page).toHaveURL(new RegExp(`/agents/${agent.slug}/sessions/${sessionA.id}$`))
+    await expect(page.locator('[data-testid="message-list"]')).toBeVisible()
+    await expect(page.locator(`[data-testid="session-item-${sessionB.id}"]`)).toHaveCount(0)
+
+    let remaining = await listSessions(request, agent)
+    expect(remaining.map((s) => s.id)).toEqual([sessionA.id])
+
+    // Now delete session A — the one being viewed — and land on agent home
+    await sessionPage.deleteSessionViaContextMenu(sessionA.id, sessionA.name)
+    await expect(page).toHaveURL(new RegExp(`/agents/${agent.slug}/?$`))
+    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
+    await expect(page.locator(`[data-testid="session-item-${sessionA.id}"]`)).toHaveCount(0)
+
+    // Durable: still gone from the sessions API after a reload
+    await page.reload()
+    const appPage = new AppPage(page)
+    await appPage.waitForAgentsLoaded()
+    remaining = await listSessions(request, agent)
+    expect(remaining).toEqual([])
+
+    // Deep-linking the deleted id renders the not-found leaf (after the
+    // session query exhausts its default retries), not a stuck loader or a
+    // resurrected session
+    await page.goto(`/agents/${agent.slug}/sessions/${sessionA.id}`)
+    const notFound = page.locator('[data-testid="session-not-found"]')
+    await expect(notFound).toBeVisible({ timeout: 20000 })
+    await expect(notFound).toContainText('Session not available')
+
+    // ...and its escape hatch leads back to the agent home
+    await notFound.getByRole('link', { name: 'Back to agent' }).click()
+    await expect(page).toHaveURL(new RegExp(`/agents/${agent.slug}/?$`))
+    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
+  })
+
+  test('agent-home kebab delete: cancel keeps the session, confirm removes only that session without navigating', async ({ page, request }, testInfo) => {
+    const { agent, sessionA, sessionB } = await createTwoSessionFixture(
+      page, request, testInfo, 'Session Delete Home',
+    )
+
+    await gotoAgentHome(page, agent)
+
+    // exact:true — role-name matching is substring by default, and the row
+    // button's accessible name embeds the kebab's label, so a substring match
+    // resolves to both the row and its kebab
+    const kebabFor = (session: TestSession) =>
+      page.getByRole('button', { name: `Actions for ${session.name}`, exact: true })
+    const deleteDialog = page.getByRole('alertdialog')
+
+    // Cancel path: open the kebab, choose Delete Session, then back out — the
+    // session must survive
+    await kebabFor(sessionB).click()
+    await page.getByRole('button', { name: 'Delete Session', exact: true }).click()
+    await expect(deleteDialog).toBeVisible()
+    await deleteDialog.getByRole('button', { name: 'Cancel' }).click()
+    await expect(deleteDialog).not.toBeVisible()
+    await expect(kebabFor(sessionB)).toBeVisible()
+    expect((await listSessions(request, agent)).map((s) => s.id).sort())
+      .toEqual([sessionA.id, sessionB.id].sort())
+
+    // Confirm path: the dialog names the session, and confirming deletes it
+    // without navigating away from the agent home
+    await kebabFor(sessionB).click()
+    await page.getByRole('button', { name: 'Delete Session', exact: true }).click()
+    await expect(deleteDialog).toBeVisible()
+    await expect(deleteDialog).toContainText(sessionB.name)
+    await deleteDialog.getByRole('button', { name: 'Delete', exact: true }).click()
+    await expect(deleteDialog).not.toBeVisible()
+
+    await expect(page).toHaveURL(new RegExp(`/agents/${agent.slug}/?$`))
+    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
+
+    // Only session B is gone — from the agent-home list and from the API
+    await expect(kebabFor(sessionB)).toHaveCount(0)
+    await expect(kebabFor(sessionA)).toBeVisible()
+    expect((await listSessions(request, agent)).map((s) => s.id)).toEqual([sessionA.id])
+
+    // And it stays gone across a reload
+    await page.reload()
+    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible({ timeout: 15000 })
+    await expect(kebabFor(sessionA)).toBeVisible({ timeout: 15000 })
+    await expect(kebabFor(sessionB)).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## What

Batch #3 of the E2E coverage-gap series (gap rank #3: session deletion — the only destructive session operation had zero coverage; the page object even shipped an unused `deleteSessionViaContextMenu` helper).

Two new tests in `e2e/specs/session-delete.spec.ts`:

1. **Sidebar right-click delete** — both polarities of the up-nav guard (`params.sessionId` match with `strict:false` in `session-context-menu.tsx`):
   - deleting a session you are **not** viewing → no navigation, you stay on the open session
   - deleting the session you **are** viewing → up-navigates to agent home
   - the confirm dialog names the session being deleted
   - durability: gone from the sessions API after reload; a deep-link to the dead id renders the `SessionNotFound` leaf (after TanStack Query's default 404 retries) and its "Back to agent" link works
2. **Agent-home kebab delete** (`related-sessions.tsx`, a separate code path with its own confirm dialog):
   - Cancel leaves the session untouched
   - Confirm removes only that session, without navigating off agent home
   - stays gone across a reload

## Supporting changes

- `e2e/pages/session.page.ts`: rewrote the never-used `deleteSessionViaContextMenu` to target rows by session id (`session-item-<id>`) instead of a bare text match — the session name also appears in the breadcrumb and agent-home list, so text targeting is ambiguous. Optional `expectedName` asserts the confirm dialog names the right session.
- `e2e/helpers/agents.ts`: new `renameSessionViaApi` (PATCH `/api/agents/:slug/sessions/:id`). In E2E mock mode the LLM auto-namer can't run, so **every** fresh session displays "New Session"; the fixture renames its two sessions to unique names so name-based assertions (kebab aria-labels, dialog copy) actually discriminate.

Spec-writing gotcha worth recording: `getByRole` name matching is **substring** by default, and the agent-home row button's accessible name embeds its kebab's `Actions for <name>` label — so a non-exact locator resolves to row + kebab both. The kebab locator uses `exact: true`.

## Validation

- `tsc --noEmit` and eslint clean
- `session-delete` + `session-rename` (shares the helpers file): 3 consecutive runs, 4/4 each
- Full suite at 6 workers: **210 passed, 2 failed** — `dashboard-and-tasks.spec.ts:74` and `global-connections.spec.ts:43`, both in areas this diff doesn't touch, and both pass standalone immediately after (7/7). This matches the documented ~1-2 random load-induced failures per full local run. `browser-stream.spec.ts` passed — the local environmental failure from 2026-07-02 has cleared.

Tests are fully parallel-safe: each test creates its own agent + sessions via API.