### PR TITLE
test: de-flake stop-session chained-turn tests

### DIFF
--- a/e2e/specs/stop-session.spec.ts
+++ b/e2e/specs/stop-session.spec.ts
@@ -30,6 +30,12 @@ test.describe('Stop button interrupts the working agent', () => {
   let sessionPage: SessionPage
 
   test.beforeEach(async ({ page }, testInfo) => {
+    // These tests chain an interrupted turn plus three scripted mock turns
+    // (~15s of scheduled delays before any UI overhead), which doesn't fit the
+    // default test timeout on a loaded CI runner — both tests have timed out
+    // there with a fully correct end state in the failure snapshot.
+    test.slow()
+
     appPage = new AppPage(page)
     agentPage = new AgentPage(page)
     sessionPage = new SessionPage(page)
@@ -77,6 +83,12 @@ test.describe('Stop button interrupts the working agent', () => {
 
     // The new turn's stream replaced the interrupted partial text
     await expect(page.getByText('Working on the slow task...')).not.toBeVisible({ timeout: 10000 })
+
+    // Gate the next send on the composer leaving the working state: the mock
+    // emits the response text a few ms before its result/idle, so a send fired
+    // the instant the text renders can still hit the mid-turn steering path
+    // (which answers "Adjusting based on: ..." instead of running a fresh turn).
+    await expect(sessionPage.getStopButton()).not.toBeVisible({ timeout: 10000 })
     await sessionPage.sendMessage('slow response please, second check')
     await expect(delayedResponses).toHaveCount(2, { timeout: 15000 })
 
@@ -128,9 +140,14 @@ test.describe('Stop button interrupts the working agent', () => {
 
     // Chain two more 3s turns: with the resend gated on the 1.5s rescue grace,
     // finishing three chained turns is provably past both cancelled timers
-    // (the turn's 5s tail and the queued message's 8s steering pickup).
+    // (the turn's 5s tail and the queued message's 8s steering pickup). Each
+    // send is gated on the composer leaving the working state — the mock emits
+    // the response text a few ms before its result/idle, and a send in that
+    // window would take the mid-turn steering path instead of a fresh turn.
+    await expect(sessionPage.getStopButton()).not.toBeVisible({ timeout: 10000 })
     await sessionPage.sendMessage('slow response please, first check')
     await expect(delayedResponses).toHaveCount(2, { timeout: 15000 })
+    await expect(sessionPage.getStopButton()).not.toBeVisible({ timeout: 10000 })
     await sessionPage.sendMessage('slow response please, second check')
     await expect(delayedResponses).toHaveCount(3, { timeout: 15000 })
 


### PR DESCRIPTION
## What

CI marked `stop-session.spec.ts › stopping with a queued message rescues its text into the composer for resend` flaky (both attempts timed out at 30s, third passed). I pulled the CI artifacts (`e2e-playwright-artifacts` from run 28806779067) and inspected the failure snapshots for **both** attempts before changing anything.

## Diagnosis (evidence-backed)

Both snapshots show a **fully correct end state captured moments after the timeout**: all four user messages, all three delayed responses, empty composer, idle status, no steering ack, no duplicates. The app did everything right — the test ran out of clock. Its scripted minimum is ~15s of mock delays (interrupted turn + 1.5s rescue grace + three 3s turns), it shares its budget with a UI agent-creation `beforeEach`, and CI runs 4 workers on a shared runner. 30s has no headroom.

## Fix

1. **`test.slow()`** in the describe's `beforeEach` (3× → 90s) for both tests — they're long chained-turn tests by design.
2. **Close a latent race** the artifacts ruled out this time but the mock's timeline makes real: `SimpleTextResponseScenario` emits the response text ~40–90ms before the `result` event clears `busySessions`, so a follow-up send gated only on the rendered text can fire while the session is still busy and take the **steering path** ("Adjusting based on: …", no fresh turn — which would produce exactly this count-stuck-at-N failure with a different signature). Each chained send is now gated on the stop button being gone, i.e. the client has processed `session_idle`. These gates pass instantly in the common case and cost nothing.

## Validation

- tsc + eslint clean
- `stop-session` + `message-queueing` (adjacent steering machinery): 3 consecutive runs, 7/7 each
- Full suite at 6 workers: **210 passed, 0 failed**

## Note

This test flaked once locally during the #387 validation (1/4 full runs, different symptom in the rescue section). The budget fix covers that mode too; if it recurs it'll now have 90s of slack to prove it's a real logic issue rather than starvation.