### PR TITLE
test: cover MCP tool-policy enforcement end-to-end

### DIFF
--- a/e2e/helpers/mock-mcp-server.ts
+++ b/e2e/helpers/mock-mcp-server.ts
@@ -7,10 +7,17 @@ import * as http from 'http'
 export interface MockMcpServer {
   url: string
   port: number
+  /**
+   * Every tools/call the server received, in arrival order. Lets specs prove
+   * a policy-blocked call never reached the upstream server, not just that
+   * the proxy returned 403.
+   */
+  toolCalls: Array<{ name: string; arguments?: Record<string, unknown> }>
   close: () => Promise<void>
 }
 
 export async function startMockMcpServer(port = 9876): Promise<MockMcpServer> {
+  const toolCalls: MockMcpServer['toolCalls'] = []
   return new Promise((resolve, reject) => {
     const server = http.createServer((req, res) => {
       if (req.method !== 'POST') {
@@ -71,6 +78,16 @@ export async function startMockMcpServer(port = 9876): Promise<MockMcpServer> {
                 ],
               },
             }))
+          } else if (rpc.method === 'tools/call') {
+            toolCalls.push({ name: rpc.params?.name, arguments: rpc.params?.arguments })
+            res.writeHead(200)
+            res.end(JSON.stringify({
+              jsonrpc: '2.0',
+              id: rpc.id,
+              result: {
+                content: [{ type: 'text', text: `mock tool result for ${rpc.params?.name}` }],
+              },
+            }))
           } else {
             res.writeHead(200)
             res.end(JSON.stringify({
@@ -92,6 +109,7 @@ export async function startMockMcpServer(port = 9876): Promise<MockMcpServer> {
       resolve({
         url: `http://127.0.0.1:${actualPort}/mcp`,
         port: actualPort,
+        toolCalls,
         close: () => new Promise<void>((res) => server.close(() => res())),
       })
     })

--- a/e2e/specs/mcp-policy-enforcement.spec.ts
+++ b/e2e/specs/mcp-policy-enforcement.spec.ts
@@ -1,0 +1,242 @@
+import { test, expect, type APIRequestContext, type TestInfo } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+import { AppPage } from '../pages/app.page'
+import { SessionPage } from '../pages/session.page'
+import {
+  createAgent,
+  createSession,
+  openAgentSession,
+  uniqueName,
+  waitForPendingProxyReview,
+  expectPendingProxyReviewResolved,
+  type TestAgent,
+  type TestSession,
+} from '../helpers/agents'
+import { createRemoteMcp, assignRemoteMcpToAgent, type TestRemoteMcp } from '../helpers/connections'
+import { startMockMcpServer, type MockMcpServer } from '../helpers/mock-mcp-server'
+
+/**
+ * MCP tool-policy enforcement — the product's main MCP safety mechanism, which
+ * had zero E2E coverage at every layer. These tests drive the real proxy
+ * (src/api/routes/mcp-proxy.ts) the way an agent container does: a JSON-RPC
+ * tools/call with the agent's Bearer proxy token, against a real (mock) remote
+ * MCP server whose received calls are recorded so we can prove a blocked call
+ * never reaches upstream — not merely that the proxy returned 403.
+ *
+ * Two harness unlocks make this reachable (both in this batch):
+ * - MockContainerClient.start now writes the agent's PROXY_TOKEN to the E2E
+ *   recorder (there is deliberately no HTTP endpoint that returns it), so a
+ *   spec can authenticate to the proxy as the container would;
+ * - the mock MCP server now answers tools/call and records what it received.
+ *
+ * The proxy path is an ordinary API route (no auth-mode / real-container gate),
+ * so each test owns its agent, session, mock MCP server, and policies, keeping
+ * the whole file parallel-safe.
+ */
+
+const E2E_DATA_DIR = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
+const RECORDER_FILE = path.join(E2E_DATA_DIR, '.e2e-mock-recorder.jsonl')
+
+interface MockRecord {
+  type: string
+  agentSlug: string
+  proxyToken?: string
+  timestamp: string
+}
+
+function readRecords(): MockRecord[] {
+  if (!fs.existsSync(RECORDER_FILE)) return []
+  return fs
+    .readFileSync(RECORDER_FILE, 'utf-8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as MockRecord)
+}
+
+// The recorder file is shared across workers, so the predicate MUST filter by
+// a test-unique attribute (the agent slug) — never assume it starts empty.
+async function waitForRecord(predicate: (r: MockRecord) => boolean, timeoutMs = 12000): Promise<MockRecord> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    const found = readRecords().find(predicate)
+    if (found) return found
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  throw new Error('Timed out waiting for container_start recorder record')
+}
+
+type PolicyDecision = 'allow' | 'review' | 'block'
+
+interface McpAuditEntry {
+  matchedTool?: string
+  policyDecision?: string
+  requestPath?: string
+  statusCode?: number
+  remoteMcpName?: string
+}
+
+test.describe('MCP tool-policy enforcement', () => {
+  const openServers: MockMcpServer[] = []
+
+  test.afterEach(async () => {
+    for (const server of openServers.splice(0)) {
+      await server.close()
+    }
+  })
+
+  async function setupMcpAgent(
+    request: APIRequestContext,
+    testInfo: TestInfo,
+    label: string,
+  ): Promise<{ agent: TestAgent; session: TestSession; mcp: TestRemoteMcp; mockMcp: MockMcpServer; proxyToken: string }> {
+    const agent = await createAgent(request, uniqueName(testInfo, label))
+
+    // Creating a session wakes the (mock) container, which writes its
+    // PROXY_TOKEN to the recorder — the credential the proxy expects.
+    const session = await createSession(request, agent, `wake ${uniqueName(testInfo, 'mcp')}`)
+    const record = await waitForRecord((r) => r.type === 'container_start' && r.agentSlug === agent.slug)
+    const proxyToken = record.proxyToken
+    expect(proxyToken, 'proxy token exposed to the container').toBeTruthy()
+
+    const mockMcp = await startMockMcpServer(0)
+    openServers.push(mockMcp)
+
+    // Connecting verifies the server + discovers its tools (initialize +
+    // tools/list) before saving; then map it onto the agent.
+    const mcp = await createRemoteMcp(request, { name: uniqueName(testInfo, 'Mock MCP'), url: mockMcp.url, authType: 'none' })
+    await assignRemoteMcpToAgent(request, agent.slug, mcp.id)
+
+    return { agent, session, mcp, mockMcp, proxyToken: proxyToken! }
+  }
+
+  async function setPolicies(
+    request: APIRequestContext,
+    mcpId: string,
+    policies: Array<{ toolName: string; decision: PolicyDecision }>,
+  ) {
+    const res = await request.put(`/api/policies/tool/${mcpId}`, { data: { policies } })
+    expect(res.ok(), `set policies ${res.status()}`).toBeTruthy()
+  }
+
+  function callTool(
+    request: APIRequestContext,
+    agentSlug: string,
+    mcpId: string,
+    proxyToken: string,
+    toolName: string,
+    args: Record<string, unknown> = {},
+  ) {
+    return request.post(`/api/mcp-proxy/${agentSlug}/${mcpId}`, {
+      headers: { Authorization: `Bearer ${proxyToken}`, 'Content-Type': 'application/json' },
+      data: { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: toolName, arguments: args } },
+      timeout: 30000,
+      failOnStatusCode: false,
+    })
+  }
+
+  async function getMcpAuditLog(request: APIRequestContext, agentSlug: string): Promise<McpAuditEntry[]> {
+    const res = await request.get(`/api/agents/${agentSlug}/mcp-audit-log?limit=100`)
+    expect(res.ok()).toBeTruthy()
+    const body = await res.json() as { entries: McpAuditEntry[] }
+    return body.entries
+  }
+
+  test('a blocked tool returns 403 and never reaches upstream, while an allowed tool forwards', async ({ request }, testInfo) => {
+    const { agent, mcp, mockMcp, proxyToken } = await setupMcpAgent(request, testInfo, 'MCP Block Allow')
+
+    // hello_world is explicitly blocked; everything else (the '*' default) is
+    // allowed. Enforcement must happen at the proxy, before the upstream call.
+    await setPolicies(request, mcp.id, [
+      { toolName: 'hello_world', decision: 'block' },
+      { toolName: '*', decision: 'allow' },
+    ])
+
+    const blocked = await callTool(request, agent.slug, mcp.id, proxyToken, 'hello_world', { name: 'e2e' })
+    expect(blocked.status()).toBe(403)
+    expect((await blocked.json()).error).toBe('blocked_by_policy')
+    // The upstream server never saw it — the security contract, not just the status
+    expect(mockMcp.toolCalls.map((c) => c.name)).not.toContain('hello_world')
+
+    const allowed = await callTool(request, agent.slug, mcp.id, proxyToken, 'get_weather', { city: 'Denver' })
+    expect(allowed.status()).toBe(200)
+    // This one forwarded, with its arguments intact
+    await expect.poll(() => mockMcp.toolCalls.map((c) => c.name)).toContain('get_weather')
+    expect(mockMcp.toolCalls.find((c) => c.name === 'get_weather')?.arguments).toEqual({ city: 'Denver' })
+
+    // Both decisions are audited with their tool + outcome
+    await expect.poll(async () => {
+      const entries = await getMcpAuditLog(request, agent.slug)
+      return entries.some((e) => e.matchedTool === 'hello_world' && e.policyDecision === 'block')
+        && entries.some((e) => e.matchedTool === 'get_weather' && e.policyDecision === 'allow')
+    }, { timeout: 10000 }).toBe(true)
+  })
+
+  test('a review-default tool raises the review card: approve forwards, deny returns denied_by_user', async ({ page, request }, testInfo) => {
+    const { agent, session, mcp, mockMcp, proxyToken } = await setupMcpAgent(request, testInfo, 'MCP Review')
+    await setPolicies(request, mcp.id, [{ toolName: '*', decision: 'review' }])
+
+    const appPage = new AppPage(page)
+    const sessionPage = new SessionPage(page)
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+    await openAgentSession(page, agent, session)
+
+    // APPROVE — fire the call (held open server-side awaiting the decision),
+    // let the review surface, click Allow on the real card; the held request
+    // then forwards upstream and returns 200. We assert the durable outcome
+    // (held response + review resolved) rather than the completed-card visual,
+    // which is a local 2s state that races the list's resolve-driven refetch.
+    const approvePromise = callTool(request, agent.slug, mcp.id, proxyToken, 'hello_world', { name: 'e2e' })
+    const review = await waitForPendingProxyReview(request, agent, {
+      toolkit: mcp.name,
+      targetPath: 'tools/call: hello_world',
+    })
+    await sessionPage.waitForProxyReviewRequestById(review.id)
+    await sessionPage.allowProxyReview(review.id)
+
+    const approved = await approvePromise
+    expect(approved.status()).toBe(200)
+    expect(mockMcp.toolCalls.map((c) => c.name)).toContain('hello_world')
+    await expectPendingProxyReviewResolved(request, agent, review)
+
+    // DENY — a second call, held the same way, denied via the card, returns
+    // 403 denied_by_user and never forwards.
+    const denyPromise = callTool(request, agent.slug, mcp.id, proxyToken, 'get_weather', { city: 'Denver' })
+    const review2 = await waitForPendingProxyReview(request, agent, {
+      toolkit: mcp.name,
+      targetPath: 'tools/call: get_weather',
+    })
+    await sessionPage.waitForProxyReviewRequestById(review2.id)
+    await sessionPage.denyProxyReview(review2.id)
+
+    const denied = await denyPromise
+    expect(denied.status()).toBe(403)
+    expect((await denied.json()).error).toBe('denied_by_user')
+    expect(mockMcp.toolCalls.map((c) => c.name)).not.toContain('get_weather')
+    await expectPendingProxyReviewResolved(request, agent, review2)
+  })
+
+  test('the API Logs page shows MCP-sourced rows with their policy decisions', async ({ page, request }, testInfo) => {
+    const { agent, mcp, proxyToken } = await setupMcpAgent(request, testInfo, 'MCP Logs')
+    await setPolicies(request, mcp.id, [
+      { toolName: 'hello_world', decision: 'block' },
+      { toolName: '*', decision: 'allow' },
+    ])
+
+    // Generate one auto-blocked and one auto-allowed MCP audit row
+    await callTool(request, agent.slug, mcp.id, proxyToken, 'hello_world', { name: 'e2e' })
+    await callTool(request, agent.slug, mcp.id, proxyToken, 'get_weather', { city: 'Denver' })
+    await expect.poll(async () => (await getMcpAuditLog(request, agent.slug)).length, { timeout: 10000 })
+      .toBeGreaterThanOrEqual(2)
+
+    await page.goto(`/agents/${agent.slug}/api-logs`)
+
+    // MCP rows are badged distinctly from HTTP-proxy rows and carry a
+    // human-readable policy-decision label
+    await expect(page.getByText('MCP', { exact: true }).first()).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText('auto-blocked', { exact: true }).first()).toBeVisible()
+    await expect(page.getByText('auto-allowed', { exact: true }).first()).toBeVisible()
+  })
+})

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1623,8 +1623,20 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
 
   // Lifecycle management
 
-  async start(_options?: StartOptions): Promise<void> {
+  async start(options?: StartOptions): Promise<void> {
     this.running = true
+    // Surface the container env that carries the proxy credentials so E2E
+    // specs can call the API/MCP proxies the way a real container would
+    // (there is deliberately no HTTP endpoint that returns the proxy token).
+    if (options?.envVars?.['PROXY_TOKEN']) {
+      this.writeMockRecord({
+        type: 'container_start',
+        agentSlug: this.config.agentId,
+        proxyToken: options.envVars['PROXY_TOKEN'],
+        remoteMcps: options.envVars['REMOTE_MCPS'] ?? null,
+        timestamp: new Date().toISOString(),
+      })
+    }
     console.log(`[MockContainerClient] Started mock container for agent ${this.config.agentId}`)
   }
 


### PR DESCRIPTION
## What

Batch #4 of the E2E coverage-gap series (gap rank #4). MCP tool-policy enforcement — the product's main MCP safety mechanism — had **zero** coverage at every layer: no spec hit `src/api/routes/mcp-proxy.ts`, none ever *saved* a tool policy (existing specs only press Cancel in the editor), the review card's `mcp` branch had never rendered, and `mcpAuditLog` was never written. A silent regression there stops enforcing user-configured blocks — and it's invisible in the UI.

New `e2e/specs/mcp-policy-enforcement.spec.ts` drives the **real proxy** the way an agent container does — a JSON-RPC `tools/call` carrying the agent's Bearer proxy token, against a real (mock) remote MCP server:

1. **Enforcement matrix (no UI):** `hello_world`=block, `*`=allow. Blocked call → `403 blocked_by_policy` **and the upstream server never receives it** — proven via the mock's recorded calls, not just the status code. Allowed call → forwards upstream with arguments intact. Both decisions land in the MCP audit log.
2. **Review card (UI):** `*`=review. The `tools/call` is held open server-side and raises the `ProxyReviewRequestItem` card in the session. Clicking **Allow** forwards (200); a second call clicking **Deny** returns `403 denied_by_user` and never forwards.
3. **API Logs page (UI):** the audit rows surface at `/agents/$slug/api-logs` with their distinct **MCP** source badge and policy-decision labels (`auto-blocked`, `auto-allowed`).

## Harness unlocks (both minimal, E2E-gated)

These are two of the five unlocks the audit flagged as gating multiple future flows:

- **`MockContainerClient.start`** now writes the container's `PROXY_TOKEN` to `.e2e-mock-recorder.jsonl` (a `container_start` record). There is deliberately no HTTP endpoint that returns the proxy token, so this is how a spec authenticates to the proxy as the container would. Guarded on `E2E_MOCK` + presence of `envVars.PROXY_TOKEN`, so it's a no-op for the unit test that calls `start()` with no args and for real runs.
- **`mock-mcp-server.ts`** now answers `tools/call` and exposes a `toolCalls[]` witness array, so a policy-blocked call can be proven to never reach upstream.

## Design notes

- The review assertions pin the **durable outcome** (the held response's status + the review resolved via `GET /proxy-reviews`) rather than the transient `proxy-review-completed` card, which is local 2s component state that races the pending-list's resolve-driven refetch — asserting it flaked on the deny branch, so I dropped it in favor of the deterministic contract while still clicking the real Allow/Deny buttons.
- Each test owns its agent, session, mock MCP server, and policies → fully parallel-safe. Mock MCP servers are closed in `afterEach`.

## Validation

- tsc clean; eslint clean (one pre-existing-pattern `JSON.parse` warning, identical to the other recorder-reading specs `agent-secrets`/`model-selection`)
- New spec: 3 consecutive runs, 3/3 each
- Coupled specs sharing the harness (`global-connections`, `connections-management`, `proxy-review`, `mcp-policy-enforcement`): 14/14
- Full suite at 6 workers: **217 passed, 1 failed** — the failure is `settings.spec.ts:730` (a `?from=` refresh test this diff doesn't touch), which passes standalone; the documented ~1 random load-flake per full local run.