### PR TITLE
test: cover proxy-review policy persistence end-to-end

### DIFF
--- a/e2e/pages/session.page.ts
+++ b/e2e/pages/session.page.ts
@@ -517,13 +517,27 @@ export class SessionPage {
   async alwaysDenyScope(scope: string, reviewId?: string) {
     const container = this.getProxyReviewRequests(reviewId).first()
     await this.paginateToCard(container)
-    await container.locator(`[data-testid="proxy-review-always-deny-${scope}"]`).click()
+    // The "Always deny <scope>" options live inside the Deny chevron popover —
+    // open it first, otherwise the portaled content isn't mounted yet.
+    await container.locator('[data-testid="proxy-review-deny-btn-chevron"]').click()
+    await this.page.locator(`[data-testid="proxy-review-always-deny-${scope}"]`).click()
+  }
+
+  async denyWithReason(reason: string, reviewId?: string) {
+    const container = this.getProxyReviewRequests(reviewId).first()
+    await this.paginateToCard(container)
+    // The reason textarea + submit arrow live inside the Deny chevron popover.
+    await container.locator('[data-testid="proxy-review-deny-btn-chevron"]').click()
+    await this.page.locator('[data-testid="proxy-review-deny-reason-input"]').fill(reason)
+    await this.page.locator('[data-testid="proxy-review-deny-reason-submit"]').click()
   }
 
   async alwaysAllowAll(reviewId?: string) {
     const container = this.getProxyReviewRequests(reviewId).first()
     await this.paginateToCard(container)
-    await container.locator('[data-testid="proxy-review-always-allow-all"]').click()
+    // "Always allow all <toolkit> requests" lives inside the Allow popover — open it first.
+    await container.locator('[data-testid="proxy-review-always-allow-btn"]').click()
+    await this.page.locator('[data-testid="proxy-review-always-allow-all"]').click()
   }
 
   // --- X-Agent Review Request Helpers ---

--- a/e2e/specs/proxy-review-persistence.spec.ts
+++ b/e2e/specs/proxy-review-persistence.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
+import { SessionPage } from '../pages/session.page'
+import {
+  createAgent,
+  expectPendingProxyReviewResolved,
+  gotoAgentHome,
+  uniqueName,
+  uniqueSuffix,
+  waitForCurrentSessionId,
+  waitForPendingProxyReview,
+  type TestAgent,
+  type TestPendingProxyReview,
+} from '../helpers/agents'
+
+/**
+ * Proxy-review policy PERSISTENCE — the security contract behind every "always"
+ * choice on a review card. proxy-review.spec already clicks Allow / Deny /
+ * always-allow-scope / always-allow-label, but never checks whether any "always"
+ * decision actually wrote a policy. An always-deny that silently fails to persist
+ * means dangerous requests keep flowing with no visible sign anything is wrong,
+ * so these tests drive each card affordance and then assert the row that landed
+ * (or, for the one-time paths, that nothing landed) in /api/policies/scope.
+ *
+ * The three previously-undriven affordances are covered here: always-deny-scope
+ * (Deny chevron menu), always-allow-all (account-wide '*'), and deny-with-reason
+ * (the free-text one-time deny).
+ *
+ * Each test drives its review against its OWN connected account via the
+ * `account_id=<id>` scenario token (a harness addition in this batch):
+ * apiScopePolicies is keyed by (accountId, scope), so without a per-test account
+ * the persisted rows would collide across the 6 parallel workers.
+ */
+
+interface ScopePolicy {
+  scope: string
+  decision: string
+  accountId: string
+}
+
+test.describe('Proxy review policy persistence', () => {
+  let sessionPage: SessionPage
+  let agent: TestAgent
+
+  test.describe.configure({ timeout: 60000 })
+
+  test.beforeEach(async ({ page, request }, testInfo) => {
+    sessionPage = new SessionPage(page)
+    agent = await createAgent(request, uniqueName(testInfo, 'Policy Persist Agent'))
+    await gotoAgentHome(page, agent)
+  })
+
+  // Fire a proxy review bound to a fresh, test-owned account and wait for its card.
+  async function triggerReview(
+    page: Page,
+    request: APIRequestContext,
+    testInfo: TestInfo,
+  ): Promise<{ accountId: string; review: TestPendingProxyReview }> {
+    const accountId = `acct-${uniqueSuffix(testInfo)}`
+    await sessionPage.sendMessage(`proxy review account_id=${accountId} ${uniqueSuffix(testInfo)}`)
+    await waitForCurrentSessionId(page)
+    const review = await waitForPendingProxyReview(request, agent, {
+      xAgent: false,
+      toolkit: 'slack',
+      targetPath: 'api/chat.postMessage',
+      matchedScope: 'chat:write',
+    })
+    // The parameterized account id flowed all the way through to the review.
+    expect(review.accountId).toBe(accountId)
+    await sessionPage.waitForProxyReviewRequestById(review.id, 35000)
+    return { accountId, review }
+  }
+
+  async function getScopePolicies(request: APIRequestContext, accountId: string): Promise<ScopePolicy[]> {
+    const res = await request.get(`/api/policies/scope/${accountId}`)
+    expect(res.ok(), `get scope policies ${res.status()}`).toBeTruthy()
+    const body = await res.json() as { policies: ScopePolicy[] }
+    return body.policies
+  }
+
+  async function expectPersistedPolicy(
+    request: APIRequestContext,
+    accountId: string,
+    scope: string,
+    decision: string,
+  ) {
+    await expect.poll(async () => {
+      const policies = await getScopePolicies(request, accountId)
+      return policies.some((p) => p.scope === scope && p.decision === decision)
+    }, { timeout: 10000 }).toBe(true)
+  }
+
+  test('always-allow for a scope persists an allow policy for that scope', async ({ page, request }, testInfo) => {
+    const { accountId, review } = await triggerReview(page, request, testInfo)
+
+    await sessionPage.alwaysAllowScope('chat:write', review.id)
+
+    await expect(sessionPage.getProxyReviewRequests(review.id)).toHaveCount(0, { timeout: 10000 })
+    await expectPendingProxyReviewResolved(request, agent, review)
+    // The contract: the choice actually wrote the scope policy, not just resolved the card.
+    await expectPersistedPolicy(request, accountId, 'chat:write', 'allow')
+
+    await sessionPage.waitForInputEnabled(15000)
+    await sessionPage.expectAssistantMessage('approved by user', 0, 15000)
+  })
+
+  test('always-deny for a scope persists a block policy for that scope', async ({ page, request }, testInfo) => {
+    const { accountId, review } = await triggerReview(page, request, testInfo)
+
+    // Deny chevron menu > "Always deny chat:write" — previously undriven.
+    await sessionPage.alwaysDenyScope('chat:write', review.id)
+
+    await expect(sessionPage.getProxyReviewRequests(review.id)).toHaveCount(0, { timeout: 10000 })
+    await expectPendingProxyReviewResolved(request, agent, review)
+    // A denied "always" decision persists as the 'block' decision.
+    await expectPersistedPolicy(request, accountId, 'chat:write', 'block')
+
+    await sessionPage.waitForInputEnabled(15000)
+    await sessionPage.expectAssistantMessage('denied by user', 0, 15000)
+  })
+
+  test('always-allow-all persists an account-wide allow default', async ({ page, request }, testInfo) => {
+    const { accountId, review } = await triggerReview(page, request, testInfo)
+
+    // "Always allow all Slack requests" > the account-wide '*' sentinel — previously undriven.
+    await sessionPage.alwaysAllowAll(review.id)
+
+    await expect(sessionPage.getProxyReviewRequests(review.id)).toHaveCount(0, { timeout: 10000 })
+    await expectPendingProxyReviewResolved(request, agent, review)
+    await expectPersistedPolicy(request, accountId, '*', 'allow')
+
+    await sessionPage.waitForInputEnabled(15000)
+    await sessionPage.expectAssistantMessage('approved by user', 0, 15000)
+  })
+
+  test('always-allow the minimal risk group persists the label-default sentinel', async ({ page, request }, testInfo) => {
+    const { accountId, review } = await triggerReview(page, request, testInfo)
+
+    // chat:write is a "write"-labelled scope, so the minimal risk group offered is "write".
+    await sessionPage.alwaysAllowLabelGroup('write', review.id)
+
+    await expect(sessionPage.getProxyReviewRequests(review.id)).toHaveCount(0, { timeout: 10000 })
+    await expectPendingProxyReviewResolved(request, agent, review)
+    // Persisted as the '*write' label sentinel, not the raw scope.
+    await expectPersistedPolicy(request, accountId, '*write', 'allow')
+
+    await sessionPage.waitForInputEnabled(15000)
+    await sessionPage.expectAssistantMessage('approved by user', 0, 15000)
+  })
+
+  test('deny-with-reason denies once without persisting any policy', async ({ page, request }, testInfo) => {
+    const { accountId, review } = await triggerReview(page, request, testInfo)
+
+    // Deny chevron menu > free-text reason > submit — previously undriven.
+    await sessionPage.denyWithReason('Not permitted during this test', review.id)
+
+    await expect(sessionPage.getProxyReviewRequests(review.id)).toHaveCount(0, { timeout: 10000 })
+    await expectPendingProxyReviewResolved(request, agent, review)
+    await sessionPage.waitForInputEnabled(15000)
+    await sessionPage.expectAssistantMessage('denied by user', 0, 15000)
+
+    // A one-time deny is NOT an "always" decision: unlike always-deny above, it
+    // writes nothing to the scope-policy table.
+    const policies = await getScopePolicies(request, accountId)
+    expect(policies).toEqual([])
+  })
+})

--- a/src/renderer/components/messages/proxy-review-request-item.tsx
+++ b/src/renderer/components/messages/proxy-review-request-item.tsx
@@ -297,6 +297,7 @@ export function ProxyReviewRequestItem({
                   <div className="mx-3 mt-2 flex min-h-10 gap-2 rounded-md border border-border bg-background pl-3 pr-0 pb-1">
                     <textarea
                       ref={denyReasonInputRef}
+                      data-testid="proxy-review-deny-reason-input"
                       placeholder="Reason for denying..."
                       value={denyReason}
                       rows={1}
@@ -317,6 +318,7 @@ export function ProxyReviewRequestItem({
                     <Button
                       type="button"
                       size="icon"
+                      data-testid="proxy-review-deny-reason-submit"
                       disabled={!denyReason.trim() || status === 'submitting'}
                       onClick={() => {
                         setDenyMenuOpen(false)

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -26,13 +26,19 @@ export const MOCK_ACCOUNT_ID = 'mock-account-id'
 // /proxy-review/.../always endpoint persists an apiScopePolicies row whose
 // account_id has a FK on connected_accounts; without this seed the insert
 // fails and the route returns 500, breaking the "always allow" test.
-let mockAccountSeeded = false
-async function seedMockConnectedAccount(): Promise<void> {
-  if (mockAccountSeeded) return
+//
+// The account id is parameterizable so a spec can pass a per-test id
+// (`proxy review account_id=<uuid>`). apiScopePolicies is keyed by
+// (accountId, scope), so tests that persist "always" decisions must each own a
+// distinct account or they race on the shared MOCK_ACCOUNT_ID rows across the
+// 6 workers. The toolkit stays 'slack' so 'chat:write' remains a valid scope.
+const seededMockAccounts = new Set<string>()
+async function seedMockConnectedAccount(accountId: string = MOCK_ACCOUNT_ID): Promise<void> {
+  if (seededMockAccounts.has(accountId)) return
   const now = new Date()
   await db.insert(connectedAccounts).values({
-    id: MOCK_ACCOUNT_ID,
-    providerConnectionId: MOCK_ACCOUNT_ID,
+    id: accountId,
+    providerConnectionId: accountId,
     providerName: 'composio',
     toolkitSlug: 'slack',
     displayName: 'Mock Account',
@@ -41,7 +47,7 @@ async function seedMockConnectedAccount(): Promise<void> {
     createdAt: now,
     updatedAt: now,
   }).onConflictDoNothing()
-  mockAccountSeeded = true
+  seededMockAccounts.add(accountId)
 }
 
 /**
@@ -751,14 +757,18 @@ export class ProxyReviewScenario implements MockScenario {
     }, delay)
     delay += 20
 
-    // Now trigger the proxy review via ReviewManager
+    // Now trigger the proxy review via ReviewManager. The account id is
+    // parameterizable (`account_id=<uuid>`) so specs that persist "always"
+    // policies each own a distinct account and don't race on the shared
+    // MOCK_ACCOUNT_ID scope-policy rows across workers.
+    const accountId = getMessageParam(userMessage, 'account_id') ?? MOCK_ACCOUNT_ID
     const capturedDelay = delay
     setTimeout(async () => {
-      await seedMockConnectedAccount()
+      await seedMockConnectedAccount(accountId)
       // Fire-and-forget — the promise resolves when the user decides
       reviewManager.requestReview({
         agentSlug,
-        accountId: MOCK_ACCOUNT_ID,
+        accountId,
         toolkit: this.toolkit,
         method: this.method,
         targetPath: this.targetPath,


### PR DESCRIPTION
## What

Gap rank #5 from the E2E coverage audit — proxy-review **policy persistence**. The card's "always" choices are a security contract, but `proxy-review.spec` only ever checked that the card *resolved*; no spec asserted whether any "always" decision actually **wrote a policy**. A silent regression in the persist path means an always-deny stops blocking (or an always-allow stops allowing) with no visible sign anything is wrong. Three card affordances were also entirely undriven.

## Tests (`e2e/specs/proxy-review-persistence.spec.ts`, 5)

Each drives the **real** card affordance, then asserts the exact row in `GET /api/policies/scope/:accountId`:

| Affordance | Persisted row |
|---|---|
| Always allow `chat:write` | `{ scope: 'chat:write', decision: 'allow' }` |
| **Always deny** `chat:write` (Deny chevron menu) | `{ scope: 'chat:write', decision: 'block' }` |
| **Always allow all** Slack requests | `{ scope: '*', decision: 'allow' }` |
| Always allow the "write" risk group | `{ scope: '*write', decision: 'allow' }` (label sentinel) |
| **Deny with reason** (free-text one-time) | *nothing* — proves it's transient, unlike always-deny |

The **bold** three (always-deny-scope, always-allow-all, deny-with-reason) had never been driven by any spec.

## Harness

- **`ProxyReviewScenario` account id is now parameterizable** via an `account_id=` message token. `apiScopePolicies` is keyed by `(accountId, scope)`, so every test must own a distinct account or the persisted rows race across the 6 parallel workers (all previously shared `mock-account-id`). The seed keeps `toolkitSlug: 'slack'` so `chat:write` stays a valid scope and the FK holds.
- **Two latent bugs fixed** in previously-unused page-object helpers: `alwaysDenyScope` and `alwaysAllowAll` clicked portaled popover items *without opening the popover first* (the new spec caught `alwaysAllowAll` on first run). Added a `denyWithReason` helper and two test hooks (`data-testid`) on the reason textarea + submit button, consistent with the component's existing testid pattern.

## Validation

- `tsc --noEmit` + eslint clean
- New spec **5/5**
- Coupled `proxy-review.spec` + `proxy-review-persistence.spec` **×3 repeats = 39/39** (deterministic; verifies the shared scenario/component/page-object changes don't regress the existing suite)
- Full suite **223 passed, 0 failed, 21 skipped** (standard project-gated skips)