### PR TITLE
test: de-flake table-breakout spec against the finalization re-mount

### DIFF
--- a/e2e/specs/table-expand.spec.ts
+++ b/e2e/specs/table-expand.spec.ts
@@ -12,6 +12,8 @@ import { AppPage } from '../pages/app.page'
 import { SessionPage } from '../pages/session.page'
 import { createAgent, createSession, openAgentSession, waitForSessionIdle } from '../helpers/agents'
 
+type Box = { x: number; y: number; width: number; height: number }
+
 async function setupSessionView(page: Page, request: APIRequestContext, testInfo: TestInfo) {
   const appPage = new AppPage(page)
   const sessionPage = new SessionPage(page)
@@ -39,34 +41,54 @@ test.describe('Agent response table breakout (SUP-319)', () => {
     await sessionPage.sendMessage('wide table')
     await sessionPage.waitForInputEnabled(20000)
 
-    const lastAssistant = sessionPage.getAssistantMessages().last()
-    const table = lastAssistant.getByTestId('markdown-table')
-    await expect(table).toBeVisible({ timeout: 20000 })
+    // The wide-table response is the only assistant message containing a table,
+    // so anchor directly on the table (and the unique intro text) rather than
+    // getAssistantMessages().last(): during a finalization re-mount ".last()" can
+    // transiently resolve to an empty trailing bubble, which flaked the header
+    // count to 0. The intro paragraph stays inside the constrained reading column
+    // and is our reference for "the narrow column".
+    const table = page.getByTestId('markdown-table')
+    const intro = page.getByText('Here is the quarterly breakdown:')
+    const contentArea = page.locator('[data-message-content-area]')
+
     // All 10 header cells render — confirms the wide table is fully present.
-    await expect(lastAssistant.locator('th')).toHaveCount(10)
+    // (A web-first assertion, so it auto-retries through the finalization re-mount.)
+    await expect(table.locator('th')).toHaveCount(10, { timeout: 20000 })
 
-    // The intro paragraph stays inside the constrained reading column; it is our
-    // reference for "the narrow column".
-    const intro = lastAssistant.getByText('Here is the quarterly breakdown:')
-    await expect(intro).toBeVisible()
-
-    const tableBox = await table.boundingBox()
-    const introBox = await intro.boundingBox()
-    expect(tableBox).not.toBeNull()
-    expect(introBox).not.toBeNull()
+    // Read all three boxes atomically once the DOM has settled. After the turn
+    // goes idle, a finalization reconcile (the persisted-messages refetch racing
+    // the JSONL write) can re-mount the assistant message node — so a bare
+    // boundingBox()/toBeVisible() here intermittently sees a detached node (it
+    // returns null, or throws strict-mode when the old and new nodes briefly
+    // co-exist). Poll the whole locate-and-measure so a mid-swap detach just
+    // retries, capturing all three boxes in the same tick before asserting.
+    let tableBox!: Box
+    let introBox!: Box
+    let areaBox!: Box
+    await expect.poll(async () => {
+      const [t, i, a] = await Promise.all([
+        table.boundingBox().catch(() => null),
+        intro.boundingBox().catch(() => null),
+        contentArea.boundingBox().catch(() => null),
+      ])
+      if (t && i && a) {
+        tableBox = t
+        introBox = i
+        areaBox = a
+        return true
+      }
+      return false
+    }, { timeout: 25000 }).toBe(true)
 
     // The table is wider than the readable column...
-    expect(tableBox!.width).toBeGreaterThan(introBox!.width + 40)
+    expect(tableBox.width).toBeGreaterThan(introBox.width + 40)
     // ...and breaks out past the column's left edge (it didn't just scroll in place).
-    expect(tableBox!.x).toBeLessThan(introBox!.x - 8)
+    expect(tableBox.x).toBeLessThan(introBox.x - 8)
     // ...and extends past the column's right edge too.
-    expect(tableBox!.x + tableBox!.width).toBeGreaterThan(introBox!.x + introBox!.width + 8)
+    expect(tableBox.x + tableBox.width).toBeGreaterThan(introBox.x + introBox.width + 8)
 
     // The breakout stays inside the chat content area (no full-page horizontal scroll).
-    const contentArea = page.locator('[data-message-content-area]')
-    const areaBox = await contentArea.boundingBox()
-    expect(areaBox).not.toBeNull()
-    expect(tableBox!.x).toBeGreaterThanOrEqual(areaBox!.x - 1)
-    expect(tableBox!.x + tableBox!.width).toBeLessThanOrEqual(areaBox!.x + areaBox!.width + 1)
+    expect(tableBox.x).toBeGreaterThanOrEqual(areaBox.x - 1)
+    expect(tableBox.x + tableBox.width).toBeLessThanOrEqual(areaBox.x + areaBox.width + 1)
   })
 })


### PR DESCRIPTION
## What

De-flakes `table-expand.spec.ts:36` (SUP-319 wide-table breakout). It intermittently failed in CI at `expect(tableBox).not.toBeNull()` — the table passed `toBeVisible()` a moment earlier, then measured **null**. It normally recovered on retry (it passed as `retry #1` on the recent **green** #390 and #392 runs), but on PR #393's run it exhausted all three attempts and reddened the `e2e-tests` job. This is unrelated to #393's diff — it surfaced there by bad luck.

## Root cause

After the turn goes idle, the **turn-finalization reconcile** — the persisted-messages refetch that races the JSONL write — re-mounts the assistant message node. A bare `boundingBox()` taken just after the visibility check lands in that mid-swap window on a detached node and returns null. (`getAssistantMessages().last()` has the same fragility: during a re-mount it can transiently resolve to an empty trailing bubble, which flaked the header-count assertion to `0` under heavier load.)

## Fix (test-only, no product code)

- **Anchor on the table itself** (`page.getByTestId('markdown-table')`) and the unique intro text instead of `getAssistantMessages().last()`.
- **Read all three boxes atomically inside `expect.poll`**, each guarded with `.catch(() => null)`, so a mid-swap detach (null) or a transient strict-mode double-match (old+new node briefly co-existing) just **retries** instead of failing. The geometry is asserted on the captured, settled values.

The breakout geometry assertions themselves are unchanged.

## Validation

- `tsc --noEmit` + eslint clean
- **Full-suite runs ×2: `table-expand` passes first-try** (5.1s / 4.6s, no retry)
- Under a pathological `--repeat-each=12` (twelve identical big-table SSE streams on one dev server — far harsher than CI's mixed suite): **11/12 vs the original 8/12**, and it **no longer fails at the CI boundingBox-null pattern** at all. The lone remaining loss is a genuine render-timeout under that synthetic overload, which CI does not reproduce.
- Other failures seen in the full runs (`dashboard-and-tasks`, `user-input-requests`) are pre-existing load-flakes in untouched specs — both pass standalone (6/6, 15/15).