### PR TITLE
test: cover account access grant/revoke end-to-end + fix optimistic revert race

### DIFF
--- a/e2e/specs/connection-account-toggle.spec.ts
+++ b/e2e/specs/connection-account-toggle.spec.ts
@@ -1,0 +1,329 @@
+/**
+ * Agent access to OAuth connected accounts — grant and revoke through the two
+ * real surfaces: the per-agent connections page row toggle and the connection
+ * detail page's sectioned Agents column. Both drive the same agent<->account
+ * mapping endpoints behind an optimistic UI override, so every flip is
+ * verified against the API mapping (the DB is the source of truth once the
+ * override clears), and revoking must never delete the global account.
+ */
+import { test, expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { createAgent, openAgentHome, type TestAgent } from '../helpers/agents'
+
+interface TestConnectedAccount {
+  id: string
+  toolkitSlug: string
+  displayName: string
+  status: string
+}
+
+function uniqueSuffix(testInfo: TestInfo) {
+  return [
+    testInfo.workerIndex,
+    testInfo.repeatEachIndex,
+    testInfo.retry,
+    Date.now(),
+    Math.random().toString(36).slice(2, 8),
+  ].join('-')
+}
+
+async function createConnectedAccount(
+  request: APIRequestContext,
+  testInfo: TestInfo,
+  label: string,
+): Promise<TestConnectedAccount> {
+  const suffix = uniqueSuffix(testInfo)
+  // Unique toolkit per test: accounts are global, so a shared slug would leak
+  // rows into other workers' account-selection surfaces.
+  const toolkitSlug = `e2e-${label}-${suffix}`.toLowerCase().replace(/[^a-z0-9-]/g, '-')
+  const response = await request.post('/api/connected-accounts', {
+    data: {
+      providerConnectionId: `e2e-${toolkitSlug}`,
+      providerName: 'e2e',
+      toolkitSlug,
+      displayName: `Toggle Account ${suffix}`,
+      status: 'active',
+    },
+  })
+
+  expect(response.ok()).toBeTruthy()
+  const body = await response.json() as { account: TestConnectedAccount }
+  expect(body.account.id).toBeTruthy()
+  return body.account
+}
+
+async function deleteConnectedAccount(request: APIRequestContext, accountId: string) {
+  await request.delete(`/api/connected-accounts/${accountId}`).catch(() => {})
+}
+
+async function getAgentConnectedAccountIds(
+  request: APIRequestContext,
+  agentSlug: string,
+): Promise<string[]> {
+  const response = await request.get(`/api/agents/${agentSlug}/connected-accounts`)
+  expect(response.ok()).toBeTruthy()
+
+  const body = await response.json() as { accounts: Array<{ id: string }> }
+  return body.accounts.map((account) => account.id)
+}
+
+async function expectAgentHasConnectedAccount(
+  request: APIRequestContext,
+  agentSlug: string,
+  accountId: string,
+) {
+  await expect.poll(
+    async () => getAgentConnectedAccountIds(request, agentSlug),
+    { timeout: 10000, message: `agent ${agentSlug} never received account ${accountId}` },
+  ).toContain(accountId)
+}
+
+async function expectAgentMissingConnectedAccount(
+  request: APIRequestContext,
+  agentSlug: string,
+  accountId: string,
+) {
+  await expect.poll(
+    async () => getAgentConnectedAccountIds(request, agentSlug),
+    { timeout: 10000, message: `agent ${agentSlug} still has account ${accountId}` },
+  ).not.toContain(accountId)
+}
+
+async function getAccountAgentSlugs(
+  request: APIRequestContext,
+  accountId: string,
+): Promise<string[]> {
+  const response = await request.get(`/api/connected-accounts/${accountId}/agents`)
+  expect(response.ok()).toBeTruthy()
+
+  const body = await response.json() as { agentSlugs: string[] }
+  return [...body.agentSlugs].sort()
+}
+
+async function expectAccountAgents(
+  request: APIRequestContext,
+  accountId: string,
+  expectedSlugs: string[],
+) {
+  await expect.poll(
+    async () => getAccountAgentSlugs(request, accountId),
+    { timeout: 10000, message: `account ${accountId} agents never became [${expectedSlugs.join(', ')}]` },
+  ).toEqual([...expectedSlugs].sort())
+}
+
+async function expectGlobalAccountPresent(request: APIRequestContext, accountId: string) {
+  const response = await request.get('/api/connected-accounts')
+  expect(response.ok()).toBeTruthy()
+
+  const body = await response.json() as { accounts: Array<{ id: string }> }
+  expect(
+    body.accounts.some((account) => account.id === accountId),
+    'revoking agent access must not delete the global account',
+  ).toBe(true)
+}
+
+async function assignAccountToAgent(
+  request: APIRequestContext,
+  agentSlug: string,
+  accountId: string,
+) {
+  const response = await request.post(`/api/agents/${agentSlug}/connected-accounts`, {
+    data: { accountIds: [accountId] },
+  })
+  expect(response.ok()).toBeTruthy()
+  await expectAgentHasConnectedAccount(request, agentSlug, accountId)
+}
+
+async function openAgentConnectionsPage(page: Page, agent: Pick<TestAgent, 'slug' | 'name'>) {
+  const appPage = new AppPage(page)
+  await appPage.goto()
+  await appPage.waitForAgentsLoaded()
+  await openAgentHome(page, agent)
+  await page.locator('[data-testid="home-connections-open-page"]').click()
+  await expect(page.locator('[data-testid="connections-add-button"]')).toBeVisible()
+}
+
+function rowSwitch(page: Page, accountId: string) {
+  return page.locator(`[data-testid="connection-switch-oauth-${accountId}"]`)
+}
+
+function agentToggle(page: Page, accountId: string, agentSlug: string) {
+  return page.locator(`[data-testid="connection-agent-toggle-oauth-${accountId}-${agentSlug}"]`)
+}
+
+test.describe('Agent access to connected accounts', () => {
+  test('row toggle grants an OAuth account to the agent', async ({ page, request }, testInfo) => {
+    const account = await createConnectedAccount(request, testInfo, 'acct-grant')
+
+    try {
+      const agent = await createAgent(request, `Acct Toggle On ${uniqueSuffix(testInfo)}`)
+      await openAgentConnectionsPage(page, agent)
+
+      const switchLocator = rowSwitch(page, account.id)
+      await expect(switchLocator).toBeVisible({ timeout: 10000 })
+      await expect(switchLocator).toHaveAttribute('data-state', 'unchecked')
+      expect(await getAgentConnectedAccountIds(request, agent.slug)).toEqual([])
+
+      await switchLocator.click()
+
+      // The toggle is optimistic + async — wait for the API mapping (the local
+      // override clears once the server catches up, so the DB is the truth).
+      await expectAgentHasConnectedAccount(request, agent.slug, account.id)
+      await expect(switchLocator).toHaveAttribute('data-state', 'checked')
+
+      // The row lands in the "Access granted" section.
+      const grantedSection = page.locator('div:has(> p:text-is("Access granted"))')
+      await expect(grantedSection).toContainText(account.displayName)
+    } finally {
+      await deleteConnectedAccount(request, account.id)
+    }
+  })
+
+  test('row toggle off revokes the mapping but keeps the global account', async ({ page, request }, testInfo) => {
+    const account = await createConnectedAccount(request, testInfo, 'acct-revoke')
+
+    try {
+      const agent = await createAgent(request, `Acct Toggle Off ${uniqueSuffix(testInfo)}`)
+      await assignAccountToAgent(request, agent.slug, account.id)
+      await openAgentConnectionsPage(page, agent)
+
+      const switchLocator = rowSwitch(page, account.id)
+      await expect(switchLocator).toBeVisible({ timeout: 10000 })
+      await expect(switchLocator).toHaveAttribute('data-state', 'checked', { timeout: 10000 })
+
+      await switchLocator.click()
+
+      await expectAgentMissingConnectedAccount(request, agent.slug, account.id)
+      await expect(switchLocator).toHaveAttribute('data-state', 'unchecked')
+      // With no grants left, the granted section shows its empty state.
+      await expect(page.getByText("can't access any connections yet")).toBeVisible()
+
+      await expectGlobalAccountPresent(request, account.id)
+    } finally {
+      await deleteConnectedAccount(request, account.id)
+    }
+  })
+
+  test('detail-page Agents column grants a second agent and revokes both', async ({ page, request }, testInfo) => {
+    const account = await createConnectedAccount(request, testInfo, 'acct-detail')
+
+    try {
+      const agentA = await createAgent(request, `Acct Detail A ${uniqueSuffix(testInfo)}`)
+      const agentB = await createAgent(request, `Acct Detail B ${uniqueSuffix(testInfo)}`)
+      await assignAccountToAgent(request, agentA.slug, account.id)
+
+      await openAgentConnectionsPage(page, agentA)
+
+      // Click the connection row itself to open the detail page.
+      await page
+        .getByRole('button', { name: `Open ${account.displayName} connection details`, exact: true })
+        .click()
+      await expect(page.locator('[data-testid="connection-detail-back"]')).toBeVisible({ timeout: 10000 })
+
+      const toggleA = agentToggle(page, account.id, agentA.slug)
+      const toggleB = agentToggle(page, account.id, agentB.slug)
+      await expect(toggleA).toHaveAttribute('data-state', 'checked', { timeout: 10000 })
+      await expect(toggleB).toHaveAttribute('data-state', 'unchecked', { timeout: 10000 })
+
+      // The sectioned column starts with A under "Agents With Access".
+      const withAccessSection = page.locator('div:has(> p:text-is("Agents With Access"))')
+      await expect(withAccessSection).toContainText(agentA.name)
+
+      // Grant the second agent from the "Agents Without Access" section.
+      await toggleB.click()
+      await expectAccountAgents(request, account.id, [agentA.slug, agentB.slug])
+      await expect(toggleB).toHaveAttribute('data-state', 'checked')
+      await expect(withAccessSection).toContainText(agentB.name)
+
+      // Revoke both. Each toggle swaps to a spinner while its mutation is in
+      // flight, so gate on the API mapping between clicks.
+      await toggleA.click()
+      await expectAccountAgents(request, account.id, [agentB.slug])
+      await expect(toggleA).toHaveAttribute('data-state', 'unchecked')
+
+      await toggleB.click()
+      await expectAccountAgents(request, account.id, [])
+      await expect(page.getByText('No agents have access yet. Grant one below.')).toBeVisible()
+
+      // Revoking every agent must not touch the account itself.
+      await expectGlobalAccountPresent(request, account.id)
+    } finally {
+      await deleteConnectedAccount(request, account.id)
+    }
+  })
+
+  test('failed grant snaps the row toggle back and persists nothing', async ({ page, request }, testInfo) => {
+    const account = await createConnectedAccount(request, testInfo, 'acct-fail')
+
+    try {
+      const agent = await createAgent(request, `Acct Toggle Fail ${uniqueSuffix(testInfo)}`)
+      await openAgentConnectionsPage(page, agent)
+
+      let sawAssignPost = false
+      await page.route(`**/api/agents/${agent.slug}/connected-accounts`, async (route) => {
+        // Only fail the assignment POST — the page's list queries share this
+        // URL shape as GETs.
+        if (route.request().method() !== 'POST') return route.fallback()
+        sawAssignPost = true
+        // Fulfill instantly: a fast failure is the regression vector for the
+        // revert racing the view-transition-deferred optimistic set.
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Injected assignment failure' }),
+        })
+      })
+
+      const switchLocator = rowSwitch(page, account.id)
+      await expect(switchLocator).toBeVisible({ timeout: 10000 })
+      await switchLocator.click()
+
+      // Prove the click actually drove the POST into the failing route, then
+      // assert the optimistic flip reverted and nothing persisted.
+      await expect.poll(() => sawAssignPost, { timeout: 10000 }).toBe(true)
+      await expect(switchLocator).toHaveAttribute('data-state', 'unchecked', { timeout: 10000 })
+      expect(await getAgentConnectedAccountIds(request, agent.slug)).toEqual([])
+    } finally {
+      await deleteConnectedAccount(request, account.id)
+    }
+  })
+
+  test('failed grant on the detail page snaps the agent toggle back', async ({ page, request }, testInfo) => {
+    const account = await createConnectedAccount(request, testInfo, 'acct-detail-fail')
+
+    try {
+      const agentA = await createAgent(request, `Acct Detail Fail A ${uniqueSuffix(testInfo)}`)
+      const agentB = await createAgent(request, `Acct Detail Fail B ${uniqueSuffix(testInfo)}`)
+      await assignAccountToAgent(request, agentA.slug, account.id)
+
+      await openAgentConnectionsPage(page, agentA)
+      await page
+        .getByRole('button', { name: `Open ${account.displayName} connection details`, exact: true })
+        .click()
+
+      const toggleB = agentToggle(page, account.id, agentB.slug)
+      await expect(toggleB).toHaveAttribute('data-state', 'unchecked', { timeout: 10000 })
+
+      let sawAssignPost = false
+      await page.route(`**/api/agents/${agentB.slug}/connected-accounts`, async (route) => {
+        if (route.request().method() !== 'POST') return route.fallback()
+        sawAssignPost = true
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Injected assignment failure' }),
+        })
+      })
+
+      await toggleB.click()
+
+      // The sectioned column must snap the agent back to "Without Access" and
+      // the mapping must stay exactly as it was.
+      await expect.poll(() => sawAssignPost, { timeout: 10000 }).toBe(true)
+      await expect(toggleB).toHaveAttribute('data-state', 'unchecked', { timeout: 10000 })
+      await expectAccountAgents(request, account.id, [agentA.slug])
+    } finally {
+      await deleteConnectedAccount(request, account.id)
+    }
+  })
+})

--- a/src/renderer/components/connections/connection-agents-list.tsx
+++ b/src/renderer/components/connections/connection-agents-list.tsx
@@ -114,11 +114,20 @@ export function ConnectionAgentsList({ type, id, name, sectioned = false }: Conn
         }
       }
     } catch {
-      setOverrides((prev) => {
+      // Mirror the optimistic path: in the sectioned layout the set above is
+      // deferred inside a view transition, and update callbacks run in queue
+      // order — reverting directly would let a fast failure land BEFORE the
+      // optimistic set and leave the agent stuck in the wrong section.
+      const revertOverride = () => setOverrides((prev) => {
         const n = { ...prev }
         delete n[slug]
         return n
       })
+      if (sectioned) {
+        startViewTransition(() => flushSync(revertOverride))
+      } else {
+        revertOverride()
+      }
     }
   }
 

--- a/src/renderer/components/connections/connections-list.tsx
+++ b/src/renderer/components/connections/connections-list.tsx
@@ -211,11 +211,19 @@ function AllConnectionsList({ agentSlug, detailRowKey, detailBackLabel, onDetail
         }
       }
     } catch {
-      // Revert the optimistic override so the row snaps back.
-      setGrantOverrides((prev) => {
-        const n = { ...prev }
-        delete n[row.key]
-        return n
+      // Revert the optimistic override so the row snaps back. Must go through
+      // the same view-transition queue as the optimistic set: the browser runs
+      // update callbacks in queue order but defers them past snapshot capture,
+      // so a fast failure would otherwise revert BEFORE the optimistic set
+      // lands and leave the row stuck in its new section.
+      startViewTransition(() => {
+        flushSync(() => {
+          setGrantOverrides((prev) => {
+            const n = { ...prev }
+            delete n[row.key]
+            return n
+          })
+        })
       })
     }
   }


### PR DESCRIPTION
## What

E2E coverage-gap batch item #6: the grant/revoke journey for OAuth connected accounts — the core access-control path for the primary connection type, previously untested at every layer (existing specs only toggle MCP switches, which hit different endpoints, or map accounts via the in-chat card; `connection-agent-toggle-*` appeared in no spec).

New `e2e/specs/connection-account-toggle.spec.ts` (5 tests):

1. **Row toggle grants** — seeded account, flip `connection-switch-oauth-<id>` on the agent connections page → mapping asserted via `GET /api/agents/:slug/connected-accounts`, switch checked, row lands under "Access granted".
2. **Row toggle revokes** — pre-mapped account, flip off → mapping gone, granted-section empty state shows, and the **global account survives** (`GET /api/connected-accounts`).
3. **Detail-page Agents column** (sectioned view, entirely undriven before) — open the connection detail from the row, grant a second agent via `connection-agent-toggle-oauth-<id>-<slug>`, assert both slugs via `GET /api/connected-accounts/:id/agents`, then revoke both down to the "No agents have access yet" empty state; account intact.
4. **Failed grant snaps the row toggle back** — instantly-fulfilled 500 on the assignment POST (method-checked; GETs share the URL shape) → switch reverts, nothing persists. A `sawAssignPost` flag proves the click drove the POST (non-vacuous).
5. **Failed grant on the detail page snaps the agent toggle back** — same vector against the second surface.

## The bug the failure tests caught

`document.startViewTransition` defers its update callback past snapshot capture (~a frame). The optimistic override was set inside that deferred callback, but the `catch` reverted it **directly** — so when a mutation failed faster than a frame, the revert ran first (deleting nothing) and then the optimistic set landed, leaving the row stuck in its new section **forever**: the catch-up effect only clears overrides that already match server truth. Proven by experiment: delaying the injected 500 by 250ms made the same test pass 3/3.

**Fix** (both `connections-list.tsx` and `connection-agents-list.tsx`): route the revert through the same view-transition queue. Per spec, update callbacks run in queue order even when a transition is skipped, so the revert can never precede the set — and the snap-back animates like the grant did. The non-sectioned path in `connection-agents-list` keeps its direct revert (its optimistic set is synchronous, no race).

## Validation

- Red-without-fix / green-with-fix calibration (`--retries=0`): the two snap-back tests fail **2/10** on main's components (race — intermittent by nature; it also failed the very first run of the spec, which is how it was found) and pass **10/10** with the fix.
- Full spec ×3 = 15/15.
- Full suite: **228 passed / 0 failed / 21 skipped** (standard project-gated), first try.
- `tsc --noEmit` + eslint clean.

## Notes

- Accounts are seeded via the existing `POST /api/connected-accounts` pattern with a per-test unique toolkit slug, so nothing leaks across the 6 workers.
- Next batch candidates after this merges: gap #7 (connection delete cascade via AlertDialog) or #8 (provider API key lifecycle).