### PR TITLE
test: cover the provider API key lifecycle in the quarantined config

### DIFF
--- a/e2e/specs/provider-api-key.spec.ts
+++ b/e2e/specs/provider-api-key.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Provider API key lifecycle on the LLM settings tab — validate & save,
+ * invalid-key inline error, remove — cross-checked against the sidebar
+ * "No API key configured" warning and the settings API.
+ *
+ * Runs in the quarantined wizard config (single worker, own data dir): a
+ * saved key is global server state, and the fully-parallel main suite is
+ * deliberately keyless. Key validation is route-mocked — the real
+ * /api/settings/validate-llm-key fires an actual Anthropic API call.
+ *
+ * The sidebar (and its warning) only exists on the app shell: Settings is a
+ * top-level sibling route that replaces the whole shell, so the warning
+ * cross-checks happen on `/`.
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+
+test.describe.configure({ mode: 'serial' })
+
+const GOOD_KEY = 'sk-ant-e2e-valid-key'
+const BAD_KEY = 'sk-ant-e2e-invalid-key'
+
+interface KeyStatus {
+  isConfigured: boolean
+  source: string
+}
+
+async function getAnthropicKeyStatus(request: APIRequestContext): Promise<KeyStatus> {
+  const response = await request.get('/api/settings')
+  expect(response.ok()).toBeTruthy()
+  const body = await response.json() as { apiKeyStatus: { anthropic: KeyStatus } }
+  return body.apiKeyStatus.anthropic
+}
+
+/** The sidebar ApiKeyWarning — "Click to set up" only appears there. */
+function sidebarWarning(page: Page) {
+  return page.getByText('Click to set up')
+}
+
+function keyInput(page: Page) {
+  return page.locator('#anthropic-api-key')
+}
+
+/** Mock the validation endpoint (the real one calls Anthropic). */
+async function mockValidation(page: Page, result: { valid: boolean; error?: string }) {
+  await page.route('**/api/settings/validate-llm-key', async (route) => {
+    if (route.request().method() !== 'POST') return route.fallback()
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(result),
+    })
+  })
+}
+
+async function gotoLlmSettings(page: Page) {
+  await page.goto('/settings/llm')
+  await expect(keyInput(page)).toBeVisible({ timeout: 15000 })
+}
+
+test.describe('Provider API key lifecycle', () => {
+  test.beforeEach(async ({ request }) => {
+    // Keyless, onboarded baseline. The wizard spec shares this server and
+    // toggles onboarding state, so re-establish both defensively.
+    await request.put('/api/user-settings', { data: { setupCompleted: true } })
+    await request.put('/api/settings', {
+      data: { app: { setupCompleted: true }, apiKeys: { anthropicApiKey: '' } },
+    })
+  })
+
+  test.afterEach(async ({ request }) => {
+    await request.put('/api/settings', { data: { apiKeys: { anthropicApiKey: '' } } })
+  })
+
+  test('keyless sidebar warning deep-links to the LLM settings tab', async ({ page }) => {
+    const appPage = new AppPage(page)
+    await appPage.goto()
+    await appPage.waitForAppLoaded()
+
+    await expect(sidebarWarning(page)).toBeVisible({ timeout: 15000 })
+    await sidebarWarning(page).click()
+
+    await expect(page).toHaveURL(/\/settings\/llm/)
+    await expect(keyInput(page)).toBeVisible({ timeout: 15000 })
+  })
+
+  test('invalid key shows the inline error and saves nothing', async ({ page, request }) => {
+    await mockValidation(page, { valid: false, error: 'Invalid API key: 401 unauthorized' })
+    await gotoLlmSettings(page)
+
+    await keyInput(page).fill(BAD_KEY)
+    await page.getByRole('button', { name: 'Validate & Save' }).click()
+
+    await expect(page.getByText('Invalid API key: 401 unauthorized')).toBeVisible()
+    // The input keeps the rejected key for correction rather than clearing it.
+    await expect(keyInput(page)).toHaveValue(BAD_KEY)
+
+    expect(await getAnthropicKeyStatus(request)).toEqual({ isConfigured: false, source: 'none' })
+  })
+
+  test('valid key saves and clears the warning; removing restores it', async ({ page, request }) => {
+    await mockValidation(page, { valid: true })
+    await gotoLlmSettings(page)
+
+    await keyInput(page).fill(GOOD_KEY)
+    await page.getByRole('button', { name: 'Validate & Save' }).click()
+
+    // Saved state: success note, source pill, and the input resets.
+    await expect(page.getByText('API key is valid and has been saved.')).toBeVisible()
+    await expect(page.getByText('Using saved setting')).toBeVisible()
+    await expect(keyInput(page)).toHaveValue('')
+    await expect.poll(async () => getAnthropicKeyStatus(request)).toEqual({
+      isConfigured: true,
+      source: 'settings',
+    })
+
+    // Settings PUT contract: a payload without apiKeys must keep the key
+    // (only an explicit empty string deletes).
+    const putRes = await request.put('/api/settings', { data: { llmProvider: 'anthropic' } })
+    expect(putRes.ok()).toBeTruthy()
+    expect(await getAnthropicKeyStatus(request)).toEqual({ isConfigured: true, source: 'settings' })
+
+    // The sidebar warning is gone once a key is configured.
+    const appPage = new AppPage(page)
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+    await expect(sidebarWarning(page)).toHaveCount(0)
+
+    // Remove the saved key through the confirm dialog.
+    await gotoLlmSettings(page)
+    await page.getByRole('button', { name: 'Remove Saved Key' }).click()
+    const dialog = page.getByRole('alertdialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole('button', { name: 'Remove', exact: true }).click()
+
+    await expect(page.getByRole('button', { name: 'Remove Saved Key' })).toHaveCount(0)
+    await expect.poll(async () => getAnthropicKeyStatus(request)).toEqual({
+      isConfigured: false,
+      source: 'none',
+    })
+
+    // And the warning returns.
+    await appPage.goto()
+    await appPage.waitForAppLoaded()
+    await expect(sidebarWarning(page)).toBeVisible({ timeout: 15000 })
+  })
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,6 +19,8 @@ const configuredWorkers = process.env.PLAYWRIGHT_WORKERS
 const webTestIgnore = [
   '**/auth/**',
   '**/getting-started-wizard.spec.ts',
+  // Mutates the global provider API key — quarantined to the wizard config.
+  '**/provider-api-key.spec.ts',
 ]
 
 if (process.env.E2E_INCLUDE_A11Y !== 'true') {

--- a/playwright.wizard.config.ts
+++ b/playwright.wizard.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig, devices, chromium } from '@playwright/test'
 import path from 'path'
 
-// Wizard tests intentionally mutate onboarding state. Keep that state in a
-// server/data directory that is separate from the main web suite.
+// Quarantine config for specs that mutate GLOBAL server state (onboarding
+// flags, the provider API key): single worker, own server/data directory,
+// separate from the fully-parallel main web suite.
 const defaultE2eDataDir = path.join(__dirname, '.e2e-data', 'wizard')
 if (!process.env.SUPERAGENT_DATA_DIR) {
   process.env.SUPERAGENT_DATA_DIR = defaultE2eDataDir
@@ -27,6 +28,9 @@ function buildWebServerCommand() {
     E2E_MOCK: 'true',
     PORT: e2ePort,
     VITE_CACHE_DIR: path.join(e2eDataDir, '.vite'),
+    // A machine-level key would flip apiKeyStatus.source to 'env' and break
+    // the keyless baseline these specs assert. Empty string reads as unset.
+    ANTHROPIC_API_KEY: '',
   }
   if (chromiumPath) env.E2E_CHROMIUM_PATH = chromiumPath
 
@@ -41,7 +45,10 @@ function buildWebServerCommand() {
 
 export default defineConfig({
   testDir: './e2e',
-  testMatch: '**/getting-started-wizard.spec.ts',
+  testMatch: [
+    '**/getting-started-wizard.spec.ts',
+    '**/provider-api-key.spec.ts',
+  ],
   outputDir: playwrightOutputDir,
   fullyParallel: false,
   forbidOnly: !!process.env.CI,


### PR DESCRIPTION
## What

E2E coverage-gap batch item #8: the provider API key lifecycle — validate, save, remove — with the sidebar "No API key configured" warning cross-checked. This is the onboarding-critical path (no key = no agents) and it had zero coverage; the settings PUT's empty-deletes/absent-keeps/truthy-sets contract and the sidebar `ApiKeyWarning` were asserted nowhere.

New `e2e/specs/provider-api-key.spec.ts` (3 tests, serial):

1. **Keyless sidebar warning deep-links** — the warning renders on the app shell and clicking it lands on `/settings/llm` with the anthropic key input visible. (Settings is a top-level sibling of the shell, so all warning assertions happen on `/`.)
2. **Invalid key** — route-mocked `{valid:false, error}` → inline error renders, the input keeps the rejected key for correction, and the API confirms nothing saved (`{isConfigured:false, source:'none'}`).
3. **Valid key + remove** — route-mocked `{valid:true}` → success note, "Using saved setting" pill, input resets, API shows `source:'settings'`; then the **absent-keeps contract** (a settings PUT without `apiKeys` leaves the key intact); warning gone from the sidebar; Remove Saved Key → confirm dialog → key deleted (`empty-string-deletes`, driven through the real UI) and the warning returns.

Validation is route-mocked per the audit's harness note — the real `POST /api/settings/validate-llm-key` fires an actual Anthropic API call.

## Why the wizard config

A saved key is **global server state**, and the fully-parallel 6-worker main suite is deliberately keyless (a configured key could change concurrent specs' behavior — auto-namer, provider gating). So the spec joins the existing quarantine: `playwright.wizard.config.ts` (workers=1, own `.e2e-data/wizard` dir, already wired into CI via `npm run test:e2e:wizard` — **no workflow changes needed**). Config changes:

- `playwright.wizard.config.ts`: `testMatch` gains the new spec; header comment generalized; the server env now sets `ANTHROPIC_API_KEY: ''` so a machine-level env var can't flip `apiKeyStatus.source` to `'env'` and break the keyless baseline (the audit's explicit guard note — this also makes the existing wizard spec deterministic on dev machines).
- `playwright.config.ts`: the spec is added to `webTestIgnore` (verified: `--list` shows 0 matches in the main suite).

## Validation

- Full wizard-config suite (7 existing wizard tests + 3 new): **10/10** — also proves the two specs coexist on the shared serial server (each re-establishes the keyless/onboarded baseline).
- New spec ×3 repeats, `--retries=0`: **9/9**.
- Full main suite: **230 passed / 0 failed / 21 skipped**, first try.
- `tsc --noEmit` + eslint clean.

## Notes

Next batch candidates after this merges: gap #9 (mid-session 401 auto-signout + exact-URL restore, auth suite) or #10 onward from the tracker.