### PR TITLE
fix(env): fail-closed .env reads + line-preserving merges — stop the secret-wiping race

### DIFF
--- a/agent-container/src/atomic-file.statscope.test.ts
+++ b/agent-container/src/atomic-file.statscope.test.ts
@@ -1,0 +1,89 @@
+/**
+ * existingMode stat scoping in the atomic writers: a non-ENOENT stat error
+ * (NFS ESTALE after a cross-client rename, EIO) means "state unknown", not
+ * "file absent" — the write must FAIL instead of proceeding as a create, which
+ * would silently reset the target's permissions to the caller's default mode
+ * (the 0o666 → 0o600 flip observed in the /workspace/.env wipe).
+ *
+ * Lives in its own file with a module-level fs mock: Node's builtin module
+ * properties are non-configurable, so vi.spyOn cannot patch fs.statSync.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as path from 'path';
+import * as os from 'os';
+
+const statFailure = vi.hoisted(() => ({ active: false }));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  const estale = () =>
+    Object.assign(new Error('ESTALE: stale file handle'), { code: 'ESTALE' });
+  return {
+    ...actual,
+    statSync: ((...args: Parameters<typeof actual.statSync>) => {
+      if (statFailure.active) throw estale();
+      return actual.statSync(...args);
+    }) as typeof actual.statSync,
+    promises: {
+      ...actual.promises,
+      stat: (async (...args: Parameters<typeof actual.promises.stat>) => {
+        if (statFailure.active) throw estale();
+        return actual.promises.stat(...args);
+      }) as typeof actual.promises.stat,
+    },
+  };
+});
+
+import * as fs from 'fs';
+import { writeFileAtomic, writeFileAtomicSync } from './atomic-file';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'atomic-statscope-')));
+});
+
+afterEach(() => {
+  statFailure.active = false;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function leftoverTmpFiles(dir: string): string[] {
+  return fs.readdirSync(dir).filter((f) => f.endsWith('.tmp'));
+}
+
+describe('existingMode stat is ENOENT-scoped (fail-closed)', () => {
+  it('async: a non-ENOENT stat error fails the write and leaves the target untouched', async () => {
+    const p = path.join(tmpDir, 'f.txt');
+    fs.writeFileSync(p, 'precious');
+
+    statFailure.active = true;
+    await expect(writeFileAtomic(p, 'replacement')).rejects.toMatchObject({ code: 'ESTALE' });
+    statFailure.active = false;
+
+    expect(fs.readFileSync(p, 'utf-8')).toBe('precious');
+    expect(leftoverTmpFiles(tmpDir)).toEqual([]);
+  });
+
+  it('sync: a non-ENOENT stat error fails the write and leaves the target untouched', () => {
+    const p = path.join(tmpDir, 'f-sync.txt');
+    fs.writeFileSync(p, 'precious');
+
+    statFailure.active = true;
+    expect(() => writeFileAtomicSync(p, 'replacement')).toThrow('ESTALE');
+    statFailure.active = false;
+
+    expect(fs.readFileSync(p, 'utf-8')).toBe('precious');
+    expect(leftoverTmpFiles(tmpDir)).toEqual([]);
+  });
+
+  it('a genuinely absent target still creates with the requested mode', async () => {
+    // ENOENT must keep meaning "create" — the scoping only rejects OTHER errors.
+    const p = path.join(tmpDir, 'new.txt');
+    await writeFileAtomic(p, 'fresh', 0o600);
+    expect(fs.readFileSync(p, 'utf-8')).toBe('fresh');
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(p).mode & 0o777).toBe(0o600);
+    }
+  });
+});

--- a/agent-container/src/atomic-file.ts
+++ b/agent-container/src/atomic-file.ts
@@ -79,8 +79,11 @@ export async function writeFileAtomic(filePath: string, content: string, mode = 
   let existingMode: number | undefined;
   try {
     existingMode = (await fs.promises.stat(filePath)).mode & 0o777;
-  } catch {
-    // target absent → create with `mode`
+  } catch (err) {
+    // Only a confirmed-absent target is a create. Anything else (ESTALE from a
+    // cross-client NFS rename, EIO) must fail the write — treating it as a
+    // create would silently reset the file's permissions to `mode`.
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err;
   }
   try {
     // 'wx' = O_EXCL: never reuse a stray temp file. Unique name makes this safe.
@@ -109,8 +112,9 @@ export function writeFileAtomicSync(filePath: string, content: string, mode = 0o
   let existingMode: number | undefined;
   try {
     existingMode = fs.statSync(filePath).mode & 0o777;
-  } catch {
-    // target absent → create with `mode`
+  } catch (err) {
+    // See writeFileAtomic: ENOENT-only, everything else fails the write.
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err;
   }
   try {
     const fd = fs.openSync(tmpPath, 'wx', mode);

--- a/agent-container/src/env-file-store.test.ts
+++ b/agent-container/src/env-file-store.test.ts
@@ -3,11 +3,17 @@
  * protocol-compatible with the host's withCrossProcessFileLock / writeFileAtomic
  * (same `<target>.lock` O_EXCL convention, same atomic temp+rename).
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { writeFileAtomic, withEnvFileLock } from './env-file-store';
+import {
+  writeFileAtomic,
+  withEnvFileLock,
+  readEnvFileOrNull,
+  upsertEnvContent,
+  updateEnvFileEntry,
+} from './env-file-store';
 
 let tmpDir: string;
 let envPath: string;
@@ -90,5 +96,202 @@ describe('withEnvFileLock', () => {
     });
     expect(ran).toBe(true);
     expect(fs.existsSync(lockPath)).toBe(false);
+  });
+});
+
+/** An NFS stale-file-handle error, as raised after another client rename-replaces
+ *  the file this client has a cached lookup for. */
+function estale(): NodeJS.ErrnoException {
+  return Object.assign(new Error('ESTALE: stale file handle'), { code: 'ESTALE' });
+}
+
+function enoent(p: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`ENOENT: no such file or directory, open '${p}'`), {
+    code: 'ENOENT',
+  });
+}
+
+/** Fail fs.promises.readFile for `target` the first `times` calls (-1 = always),
+ *  pass everything else (the lock release reads `<target>.lock`) through. */
+function failReadsOf(target: string, err: () => Error, times: number) {
+  const real = fs.promises.readFile.bind(fs.promises);
+  let remaining = times;
+  return vi.spyOn(fs.promises, 'readFile').mockImplementation((async (p: unknown, ...args: unknown[]) => {
+    if (p === target && (remaining === -1 || remaining-- > 0)) throw err();
+    return (real as any)(p, ...args);
+  }) as typeof fs.promises.readFile);
+}
+
+describe('readEnvFileOrNull', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the file content', async () => {
+    fs.writeFileSync(envPath, 'A=1\n');
+    expect(await readEnvFileOrNull(envPath)).toBe('A=1\n');
+  });
+
+  it('returns null when the file is genuinely absent', async () => {
+    expect(await readEnvFileOrNull(envPath)).toBeNull();
+  });
+
+  it('retries through a transient ESTALE and returns the content', async () => {
+    fs.writeFileSync(envPath, 'A=1\n');
+    failReadsOf(envPath, estale, 2);
+    expect(await readEnvFileOrNull(envPath)).toBe('A=1\n');
+  });
+
+  it('retries through a transient ENOENT (mid-rename lookup) and returns the content', async () => {
+    fs.writeFileSync(envPath, 'A=1\n');
+    failReadsOf(envPath, () => enoent(envPath), 1);
+    expect(await readEnvFileOrNull(envPath)).toBe('A=1\n');
+  });
+
+  it(
+    'THROWS on a persistent non-ENOENT error — never reports an existing file as absent',
+    { timeout: 10_000 },
+    async () => {
+      // Fail-closed is the load-bearing property: reporting an unreadable .env as
+      // "absent" made the caller merge into empty and atomically wipe every secret.
+      fs.writeFileSync(envPath, 'A=1\n');
+      failReadsOf(envPath, estale, -1);
+      await expect(readEnvFileOrNull(envPath)).rejects.toMatchObject({ code: 'ESTALE' });
+    }
+  );
+});
+
+describe('upsertEnvContent', () => {
+  const hostWritten = [
+    '# Superagent Secrets',
+    '# Format: ENV_VAR=value  # Display Name',
+    '',
+    'SUPABASE_URL=https://x.supabase.co',
+    'SUPABASE_SERVICE_ROLE_KEY=eyJhbGc  # Supabase Key',
+    'CLICKHOUSE_PASSWORD="p w"',
+    '',
+  ].join('\n');
+
+  it('appends a new key, preserving every existing line byte-for-byte', () => {
+    const result = upsertEnvContent(hostWritten, 'APOLLO_API_KEY', 'tok-123');
+    expect(result).toBe(hostWritten + 'APOLLO_API_KEY="tok-123"\n');
+  });
+
+  it('replaces an existing key in place, keeping its display-name comment', () => {
+    const result = upsertEnvContent(hostWritten, 'SUPABASE_SERVICE_ROLE_KEY', 'newkey');
+    expect(result).toContain('SUPABASE_SERVICE_ROLE_KEY="newkey"  # Supabase Key');
+    // Everything else untouched.
+    expect(result).toContain('# Superagent Secrets');
+    expect(result).toContain('SUPABASE_URL=https://x.supabase.co');
+    expect(result).toContain('CLICKHOUSE_PASSWORD="p w"');
+  });
+
+  it('does not treat a # inside a quoted value as a comment', () => {
+    const result = upsertEnvContent('K="a#b"\nOTHER=1\n', 'K', 'new');
+    expect(result).toBe('K="new"\nOTHER=1\n');
+  });
+
+  it('drops duplicate definitions of the updated key, keeps everything else', () => {
+    const result = upsertEnvContent('A=1\nB=2\nA=3\n', 'A', 'x');
+    expect(result).toBe('A="x"\nB=2\n');
+  });
+
+  it('handles empty content', () => {
+    expect(upsertEnvContent('', 'K', 'v')).toBe('K="v"\n');
+  });
+
+  it('adds a trailing newline when the source lacks one', () => {
+    expect(upsertEnvContent('A=1', 'B', 'v')).toBe('A=1\nB="v"\n');
+  });
+
+  it('escapes quotes and newlines so a value cannot break the line structure', () => {
+    const result = upsertEnvContent('', 'K', 'say "hi"\nline2');
+    expect(result).toBe('K="say \\"hi\\"\\nline2"\n');
+  });
+
+  it('escapes backslashes (matching the host serializer, so values round-trip)', () => {
+    const result = upsertEnvContent('', 'K', 'a\\b');
+    expect(result).toBe('K="a\\\\b"\n');
+  });
+
+  it('does not match keys of which the target is a prefix/suffix', () => {
+    const result = upsertEnvContent('MY_KEY=1\nKEY_2=2\n', 'KEY', 'v');
+    expect(result).toBe('MY_KEY=1\nKEY_2=2\nKEY="v"\n');
+  });
+});
+
+describe('updateEnvFileEntry', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('adding a key NEVER drops existing secrets (the .env wipe regression)', async () => {
+    // Reproduces the prod wipe: a host-format .env full of secrets, then the
+    // container upserts one new key via POST /env. Every prior secret must survive.
+    const before = [
+      '# Superagent Secrets',
+      '# Format: ENV_VAR=value  # Display Name',
+      '',
+      'SUPABASE_URL=https://x.supabase.co',
+      'SUPABASE_SERVICE_ROLE_KEY=eyJhbGc  # Supabase Key',
+      'STRIPE_SECRET_KEY=sk_live_123',
+      '',
+    ].join('\n');
+    fs.writeFileSync(envPath, before);
+
+    await updateEnvFileEntry(envPath, 'APOLLO_API_KEY', 'tok-123');
+
+    const after = fs.readFileSync(envPath, 'utf-8');
+    expect(after).toBe(before + 'APOLLO_API_KEY="tok-123"\n');
+  });
+
+  it(
+    'fails closed: a persistently unreadable .env aborts the update and leaves the file untouched',
+    { timeout: 10_000 },
+    async () => {
+      const before = 'SUPABASE_URL=https://x.supabase.co\n';
+      fs.writeFileSync(envPath, before);
+      failReadsOf(envPath, estale, -1);
+
+      await expect(
+        updateEnvFileEntry(envPath, 'APOLLO_API_KEY', 'tok')
+      ).rejects.toMatchObject({ code: 'ESTALE' });
+      vi.restoreAllMocks();
+
+      expect(fs.readFileSync(envPath, 'utf-8')).toBe(before);
+      // And the lock was released despite the failure.
+      expect(fs.existsSync(`${envPath}.lock`)).toBe(false);
+    }
+  );
+
+  it('creates a missing .env and works end-to-end', async () => {
+    await updateEnvFileEntry(envPath, 'K', 'v');
+    expect(fs.readFileSync(envPath, 'utf-8')).toBe('K="v"\n');
+  });
+
+  it.runIf(process.platform !== 'win32')(
+    'creates the file 0o666 (umask-applied) so the host — a different uid — can write it too',
+    async () => {
+      await updateEnvFileEntry(envPath, 'K', 'v');
+      const umask = process.umask();
+      expect(fs.statSync(envPath).mode & 0o777).toBe(0o666 & ~umask);
+    }
+  );
+
+  it.runIf(process.platform !== 'win32')('preserves an existing file mode', async () => {
+    fs.writeFileSync(envPath, 'A=1\n');
+    fs.chmodSync(envPath, 0o640);
+    await updateEnvFileEntry(envPath, 'K', 'v');
+    expect(fs.statSync(envPath).mode & 0o777).toBe(0o640);
+  });
+
+  it('concurrent upserts of distinct keys all survive', async () => {
+    fs.writeFileSync(envPath, 'SEED=1\n');
+    await Promise.all(
+      Array.from({ length: 10 }, (_, i) => updateEnvFileEntry(envPath, `KEY_${i}`, `v${i}`))
+    );
+    const content = fs.readFileSync(envPath, 'utf-8');
+    expect(content).toContain('SEED=1');
+    for (let i = 0; i < 10; i++) expect(content).toContain(`KEY_${i}="v${i}"`);
   });
 });

--- a/agent-container/src/env-file-store.ts
+++ b/agent-container/src/env-file-store.ts
@@ -18,8 +18,9 @@
  * (server.ts) keep importing it from this module.
  */
 import * as fs from 'fs';
+import { writeFileAtomic } from './atomic-file';
 
-export { writeFileAtomic } from './atomic-file';
+export { writeFileAtomic };
 
 const TIMEOUT_MS = 5000;
 const RETRY_INTERVAL_MS = 50;
@@ -86,4 +87,100 @@ export async function withEnvFileLock<T>(targetPath: string, fn: () => Promise<T
       await fs.promises.rm(lockPath, { force: true }).catch(() => {});
     }
   }
+}
+
+// Read-retry budget. On the shared S3 File Gateway NFS, the host app's atomic
+// rename-replace of .env swaps the inode; this client's cached lookup can then
+// fail with ESTALE (or transiently ENOENT) for up to the attribute-cache window
+// (~3s) even though the file exists. Retry across that window before concluding
+// anything.
+const READ_RETRY_BASE_MS = 150;
+const READ_ATTEMPTS_ENOENT = 3; // genuinely-absent is common (first secret) — give up fast
+const READ_ATTEMPTS_OTHER = 6; // ESTALE/EIO: ~2.3s total, spans the NFS attr-cache window
+
+/**
+ * Read the env file, retrying transient errors. Returns null ONLY for a
+ * persistent ENOENT (file genuinely absent). Any other persistent error THROWS.
+ *
+ * Fail-closed is load-bearing: treating an unreadable .env as empty and then
+ * writing the merge result back atomically wiped every secret in the file
+ * (observed in prod when a host-side rename raced this client's NFS cache).
+ */
+export async function readEnvFileOrNull(filePath: string): Promise<string | null> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fs.promises.readFile(filePath, 'utf-8');
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      const maxAttempts = code === 'ENOENT' ? READ_ATTEMPTS_ENOENT : READ_ATTEMPTS_OTHER;
+      if (attempt >= maxAttempts) {
+        if (code === 'ENOENT') return null;
+        throw err;
+      }
+      await sleep(READ_RETRY_BASE_MS * attempt);
+    }
+  }
+}
+
+/** Quote a value for the env file: always double-quoted, with backslashes,
+ *  embedded quotes and newlines escaped so one value can never break the file's
+ *  line structure. Mirrors the host's serializeEnvFile escaping (the inverse of
+ *  its parseEnvFile unescape) so values round-trip across both writers. */
+function encodeEnvValue(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\r?\n/g, '\\n')}"`;
+}
+
+/**
+ * Upsert `key=value` into env-file `content`, preserving every other line
+ * byte-for-byte — the host app owns this file's header and writes display-name
+ * comments (`KEY=v  # Name`) that a parse-and-reserialize would destroy.
+ * Replaces the first line defining `key` (keeping its inline comment), drops any
+ * duplicate definitions, appends at the end when the key is new.
+ */
+export function upsertEnvContent(content: string, key: string, value: string): string {
+  const encoded = encodeEnvValue(value);
+  const lines = content.split('\n');
+  const out: string[] = [];
+  let replaced = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed && !trimmed.startsWith('#')) {
+      const eqIndex = line.indexOf('=');
+      if (eqIndex > 0 && line.slice(0, eqIndex).trim() === key) {
+        if (replaced) continue; // drop duplicate definitions of the same key
+        replaced = true;
+        const rest = line.slice(eqIndex + 1);
+        // Keep a trailing comment (host display name). Quote-aware: a '#'
+        // inside a quoted value is part of the value, not a comment.
+        const m = rest.match(/^(".*?"|'.*?'|[^#]*?)(\s+#\s*.*)$/);
+        out.push(line.slice(0, eqIndex + 1) + encoded + (m ? m[2] : ''));
+        continue;
+      }
+    }
+    out.push(line);
+  }
+
+  if (!replaced) {
+    // Append after the last non-empty line so the file keeps a single trailing
+    // newline instead of accumulating blank lines across upserts.
+    while (out.length > 0 && out[out.length - 1] === '') out.pop();
+    out.push(`${key}=${encoded}`);
+  }
+  return out.join('\n') + (out[out.length - 1] === '' ? '' : '\n');
+}
+
+/**
+ * Cross-process-safe upsert of a single `key=value` into the env file:
+ * lock → fail-closed read → line-preserving merge → atomic write.
+ *
+ * Created with mode 0o666 (matching the host's setSecret) so whichever side
+ * creates the file first, the other side — a different uid — can still write it.
+ */
+export async function updateEnvFileEntry(filePath: string, key: string, value: string): Promise<void> {
+  await withEnvFileLock(filePath, async () => {
+    const existing = await readEnvFileOrNull(filePath);
+    const next = upsertEnvContent(existing ?? '', key, value);
+    await writeFileAtomic(filePath, next, 0o666);
+  });
 }

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -15,7 +15,7 @@ import { inputManager } from './input-manager';
 import { dashboardManager } from './dashboard-manager';
 import { tabManager } from './tab-manager';
 import { runBrowserUpload } from './browser-upload';
-import { withEnvFileLock, writeFileAtomic } from './env-file-store';
+import { updateEnvFileEntry } from './env-file-store';
 
 import { getEditingCommands } from './cdp-editing-commands';
 
@@ -345,44 +345,12 @@ async function updateEnvFile(key: string, value: string): Promise<void> {
   const envFilePath = '/workspace/.env';
 
   try {
-    // The host app also writes this file (user secrets). Serialize via the shared
-    // on-disk lock and write atomically so neither side drops the
-    // other's keys or sees a torn file. Read-modify-write happens INSIDE the lock.
-    await withEnvFileLock(envFilePath, async () => {
-      // Read existing .env file or start fresh
-      let envContent = '';
-      try {
-        envContent = await fs.promises.readFile(envFilePath, 'utf-8');
-      } catch {
-        // File doesn't exist yet, start fresh
-      }
-
-      // Parse existing entries
-      const lines = envContent.split('\n');
-      const entries = new Map<string, string>();
-
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (trimmed && !trimmed.startsWith('#')) {
-          const eqIndex = trimmed.indexOf('=');
-          if (eqIndex > 0) {
-            const k = trimmed.substring(0, eqIndex);
-            const v = trimmed.substring(eqIndex + 1);
-            entries.set(k, v);
-          }
-        }
-      }
-
-      // Update or add the new entry (quote the value to handle special chars)
-      entries.set(key, `"${value.replace(/"/g, '\\"')}"`);
-
-      // Write back atomically
-      const newContent = Array.from(entries.entries())
-        .map(([k, v]) => `${k}=${v}`)
-        .join('\n') + '\n';
-
-      await writeFileAtomic(envFilePath, newContent, 0o600);
-    });
+    // The host app also writes this file (user secrets). updateEnvFileEntry
+    // serializes via the shared on-disk lock, reads fail-closed (an unreadable
+    // file THROWS instead of being treated as empty — merging into "empty" and
+    // writing back once wiped every secret), merges line-preservingly (the
+    // host's header and display-name comments survive), and writes atomically.
+    await updateEnvFileEntry(envFilePath, key, value);
     console.log(`[ENV] Updated .env file with ${key}`);
   } catch (error) {
     console.error(`[ENV] Failed to update .env file:`, error);

--- a/src/shared/lib/config/settings.test.ts
+++ b/src/shared/lib/config/settings.test.ts
@@ -84,6 +84,12 @@ const originalEnv = { ...process.env }
 beforeEach(() => {
   vi.clearAllMocks()
   clearSettingsCache()
+  // The auto-mocked fs.statSync returns undefined, which writeFileAtomicSync's
+  // ENOENT-scoped existingMode probe would rethrow as a TypeError. Simulate the
+  // "target absent → create with mode" path the save tests assume.
+  mockedFs.statSync.mockImplementation(() => {
+    throw Object.assign(new Error('ENOENT: no such file'), { code: 'ENOENT' })
+  })
   // Reset env vars that could interfere
   delete process.env.ANTHROPIC_API_KEY
   delete process.env.COMPOSIO_API_KEY

--- a/src/shared/lib/services/secrets-service.atomic.test.ts
+++ b/src/shared/lib/services/secrets-service.atomic.test.ts
@@ -3,7 +3,7 @@
  * writes so an interleaved or interrupted read-modify-write can't drop other
  * secrets or truncate the file (which doubles as the container runtime env).
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
@@ -88,6 +88,37 @@ describe('atomic .env writes', () => {
     const before = fs.readFileSync(envPath('agent'), 'utf-8')
 
     expect(await deleteSecret('agent', 'NOPE')).toBe(false)
+    expect(fs.readFileSync(envPath('agent'), 'utf-8')).toBe(before)
+  })
+
+  it('setSecret fails closed when the .env is unreadable — never rewrites from an empty view', async () => {
+    // If the under-lock re-read errors (NFS ESTALE, EIO — anything but a true
+    // ENOENT), setSecret must abort, NOT treat the file as empty: merging into
+    // "empty" and writing back atomically wipes every other secret.
+    const { setSecret } = await importService()
+    await setSecret('agent', { envVar: 'SUPABASE_URL', key: 'SUPABASE_URL', value: 'https://x' })
+    await setSecret('agent', { envVar: 'STRIPE_KEY', key: 'STRIPE_KEY', value: 'sk-1' })
+    const before = fs.readFileSync(envPath('agent'), 'utf-8')
+
+    const realReadFile = fs.promises.readFile.bind(fs.promises)
+    const spy = vi.spyOn(fs.promises, 'readFile').mockImplementation((async (
+      p: unknown,
+      ...args: unknown[]
+    ) => {
+      if (typeof p === 'string' && p.endsWith(path.join('workspace', '.env'))) {
+        throw Object.assign(new Error('ESTALE: stale file handle'), { code: 'ESTALE' })
+      }
+      return (realReadFile as any)(p, ...args)
+    }) as typeof fs.promises.readFile)
+
+    try {
+      await expect(
+        setSecret('agent', { envVar: 'NEW', key: 'NEW', value: 'v' })
+      ).rejects.toMatchObject({ code: 'ESTALE' })
+    } finally {
+      spy.mockRestore()
+    }
+
     expect(fs.readFileSync(envPath('agent'), 'utf-8')).toBe(before)
   })
 

--- a/src/shared/lib/services/secrets-service.crossprocess.test.ts
+++ b/src/shared/lib/services/secrets-service.crossprocess.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Cross-implementation interop for the agent .env: the host's setSecret
+ * (withCrossProcessFileLock + writeFileAtomic) and the agent-container's
+ * updateEnvFileEntry (withEnvFileLock + its own writeFileAtomic) write the SAME
+ * bind-mounted file from different processes. The two lock implementations are
+ * intentionally protocol-compatible (`<target>.lock`, O_EXCL, stale-steal) —
+ * this suite is the only place that runs them against each other, modeling the
+ * exact prod collision that wiped /workspace/.env: the provide-secret route
+ * calls host setSecret and container POST /env back-to-back.
+ *
+ * Deliberately imports container code into a host test (the dependency rule
+ * only forbids agent-container importing @shared, not the reverse).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import { updateEnvFileEntry } from '../../../../agent-container/src/env-file-store'
+
+let tmpDir: string
+
+function envPath(slug: string): string {
+  return path.join(tmpDir, 'agents', slug, 'workspace', '.env')
+}
+
+beforeEach(() => {
+  tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'secrets-xproc-')))
+  process.env.SUPERAGENT_DATA_DIR = tmpDir
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+  delete process.env.SUPERAGENT_DATA_DIR
+})
+
+async function importService() {
+  return import('./secrets-service')
+}
+
+describe('host setSecret ↔ container updateEnvFileEntry interop', () => {
+  it('the provide-secret sequence (host write, then container write) keeps every secret', async () => {
+    // The exact prod sequence that wiped the file: host merges the new secret
+    // into .env, then the container's POST /env upserts the same key again.
+    const { setSecret, listSecrets } = await importService()
+    await setSecret('agent', { envVar: 'SUPABASE_URL', key: 'SUPABASE_URL', value: 'https://x' })
+    await setSecret('agent', { envVar: 'STRIPE_KEY', key: 'Stripe Key', value: 'sk-1' })
+
+    await setSecret('agent', { envVar: 'APOLLO_API_KEY', key: 'APOLLO_API_KEY', value: 'tok' })
+    await updateEnvFileEntry(envPath('agent'), 'APOLLO_API_KEY', 'tok')
+
+    const secrets = await listSecrets('agent')
+    const byVar = new Map(secrets.map((s) => [s.envVar, s]))
+    expect(byVar.get('SUPABASE_URL')?.value).toBe('https://x')
+    expect(byVar.get('STRIPE_KEY')?.value).toBe('sk-1')
+    expect(byVar.get('APOLLO_API_KEY')?.value).toBe('tok')
+    // The container's rewrite preserved the host's display-name comment.
+    expect(byVar.get('STRIPE_KEY')?.key).toBe('Stripe Key')
+    // And the host header survived the container write.
+    expect(fs.readFileSync(envPath('agent'), 'utf-8')).toMatch(/^# Superagent Secrets/)
+  })
+
+  it('interleaved host and container writers never lose a key', { timeout: 30_000 }, async () => {
+    const { setSecret, listSecrets } = await importService()
+    // Seed so the workspace dir + file exist before the storm.
+    await setSecret('agent', { envVar: 'SEED', key: 'Seed Secret', value: 'seed' })
+
+    const hostWrites = Array.from({ length: 10 }, (_, i) =>
+      setSecret('agent', { envVar: `HOST_${i}`, key: `HOST_${i}`, value: `h${i}` })
+    )
+    const containerWrites = Array.from({ length: 10 }, (_, i) =>
+      updateEnvFileEntry(envPath('agent'), `CONTAINER_${i}`, `c${i}`)
+    )
+    await Promise.all([...hostWrites, ...containerWrites])
+
+    const secrets = await listSecrets('agent')
+    const byVar = new Map(secrets.map((s) => [s.envVar, s.value]))
+    expect(byVar.get('SEED')).toBe('seed')
+    for (let i = 0; i < 10; i++) {
+      expect(byVar.get(`HOST_${i}`)).toBe(`h${i}`)
+      expect(byVar.get(`CONTAINER_${i}`)).toBe(`c${i}`)
+    }
+    expect(secrets).toHaveLength(21)
+    // No stray lock or temp files once the dust settles.
+    const dir = path.dirname(envPath('agent'))
+    const stray = fs.readdirSync(dir).filter((f) => f.endsWith('.tmp') || f.endsWith('.lock'))
+    expect(stray).toEqual([])
+  })
+
+  it('a container write between two host writes round-trips values with special characters', async () => {
+    const { setSecret, listSecrets } = await importService()
+    await setSecret('agent', { envVar: 'JSONISH', key: 'JSONISH', value: '{"a": "b c", "n": 1}' })
+
+    await updateEnvFileEntry(envPath('agent'), 'CONNECTED_ACCOUNTS', '{"github": [{"name": "x"}]}')
+    await setSecret('agent', { envVar: 'AFTER', key: 'AFTER', value: 'v' })
+
+    const byVar = new Map((await listSecrets('agent')).map((s) => [s.envVar, s.value]))
+    expect(byVar.get('JSONISH')).toBe('{"a": "b c", "n": 1}')
+    expect(byVar.get('CONNECTED_ACCOUNTS')).toBe('{"github": [{"name": "x"}]}')
+    expect(byVar.get('AFTER')).toBe('v')
+  })
+})

--- a/src/shared/lib/services/secrets-service.test.ts
+++ b/src/shared/lib/services/secrets-service.test.ts
@@ -119,6 +119,43 @@ BAZ=qux`
 
     expect(result.size).toBe(2)
   })
+
+  it('unescapes quotes, backslashes and newlines in double-quoted values', () => {
+    const content = 'JSON="{\\"a\\": \\"b c\\"}"\nMULTI="line1\\nline2"\nSLASH="a\\\\b"'
+    const result = parseEnvFile(content)
+
+    expect(result.get('JSON')?.value).toBe('{"a": "b c"}')
+    expect(result.get('MULTI')?.value).toBe('line1\nline2')
+    expect(result.get('SLASH')?.value).toBe('a\\b')
+  })
+
+  it('leaves single-quoted values literal (no unescaping)', () => {
+    const result = parseEnvFile("RAW='a\\nb'")
+    expect(result.get('RAW')?.value).toBe('a\\nb')
+  })
+})
+
+describe('serialize → parse round trip', () => {
+  it('values with quotes/JSON/backslashes/newlines survive repeated cycles unchanged', () => {
+    // Regression: parseEnvFile used to strip quotes WITHOUT unescaping, so a
+    // value containing `"` gained an escape level on every read-modify-write —
+    // progressive corruption of e.g. JSON-valued secrets.
+    const values = [
+      '{"github": [{"name": "x y"}]}',
+      'has "quotes" and \\backslash\\',
+      'line1\nline2',
+      'plain',
+      'tricky \\" pre-escaped-looking',
+    ]
+    let secrets = values.map((value, i) => ({ key: `K_${i}`, envVar: `K_${i}`, value }))
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      const parsed = parseEnvFile(serializeEnvFile(secrets))
+      secrets = secrets.map((s) => ({ ...s, value: parsed.get(s.envVar)!.value }))
+    }
+
+    expect(secrets.map((s) => s.value)).toEqual(values)
+  })
 })
 
 describe('serializeEnvFile', () => {

--- a/src/shared/lib/services/secrets-service.ts
+++ b/src/shared/lib/services/secrets-service.ts
@@ -65,11 +65,15 @@ export function parseEnvFile(content: string): Map<string, { value: string; comm
       value = rest.trim()
     }
 
-    // Remove surrounding quotes
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
+    // Remove surrounding quotes. Double-quoted values also unescape the
+    // sequences serializeEnvFile writes (\\ , \" , \n) — without this, a value
+    // containing quotes gained an escape level on EVERY read-modify-write
+    // cycle, progressively corrupting it. Single-quoted values stay literal.
+    if (value.startsWith('"') && value.endsWith('"')) {
+      value = value
+        .slice(1, -1)
+        .replace(/\\(["\\n])/g, (_, c: string) => (c === 'n' ? '\n' : c))
+    } else if (value.startsWith("'") && value.endsWith("'")) {
       value = value.slice(1, -1)
     }
 
@@ -100,8 +104,10 @@ export function serializeEnvFile(secrets: AgentSecret[]): string {
       value.includes('#') ||
       value.includes('\n')
     ) {
-      // Escape double quotes and wrap in double quotes
-      value = `"${value.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`
+      // Escape backslashes first, then quotes and newlines, and wrap in double
+      // quotes — the exact inverse of parseEnvFile's unescape, so values
+      // round-trip byte-for-byte through repeated read-modify-write cycles.
+      value = `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`
     }
 
     // Add inline comment with display name if different from env var

--- a/src/shared/lib/utils/file-storage.statscope.test.ts
+++ b/src/shared/lib/utils/file-storage.statscope.test.ts
@@ -1,0 +1,89 @@
+/**
+ * existingMode stat scoping in the atomic writers: a non-ENOENT stat error
+ * (NFS ESTALE after a cross-client rename, EIO) means "state unknown", not
+ * "file absent" — the write must FAIL instead of proceeding as a create, which
+ * would silently reset the target's permissions to options.mode (the
+ * 0o666 → 0o600 flip observed in the agent .env wipe).
+ *
+ * Lives in its own file with a module-level fs mock: Node's builtin module
+ * properties are non-configurable, so vi.spyOn cannot patch fs.statSync.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as path from 'path'
+import * as os from 'os'
+
+const statFailure = vi.hoisted(() => ({ active: false }))
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  const estale = () =>
+    Object.assign(new Error('ESTALE: stale file handle'), { code: 'ESTALE' })
+  return {
+    ...actual,
+    statSync: ((...args: Parameters<typeof actual.statSync>) => {
+      if (statFailure.active) throw estale()
+      return actual.statSync(...args)
+    }) as typeof actual.statSync,
+    promises: {
+      ...actual.promises,
+      stat: (async (...args: Parameters<typeof actual.promises.stat>) => {
+        if (statFailure.active) throw estale()
+        return actual.promises.stat(...args)
+      }) as typeof actual.promises.stat,
+    },
+  }
+})
+
+import * as fs from 'fs'
+import { writeFileAtomic, writeFileAtomicSync } from './file-storage'
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'fs-statscope-')))
+})
+
+afterEach(() => {
+  statFailure.active = false
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function leftoverTmpFiles(dir: string): string[] {
+  return fs.readdirSync(dir).filter((f) => f.endsWith('.tmp'))
+}
+
+describe('existingMode stat is ENOENT-scoped (fail-closed)', () => {
+  it('async: a non-ENOENT stat error fails the write and leaves the target untouched', async () => {
+    const p = path.join(tmpDir, 'f.txt')
+    fs.writeFileSync(p, 'precious')
+
+    statFailure.active = true
+    await expect(writeFileAtomic(p, 'replacement')).rejects.toMatchObject({ code: 'ESTALE' })
+    statFailure.active = false
+
+    expect(fs.readFileSync(p, 'utf-8')).toBe('precious')
+    expect(leftoverTmpFiles(tmpDir)).toEqual([])
+  })
+
+  it('sync: a non-ENOENT stat error fails the write and leaves the target untouched', () => {
+    const p = path.join(tmpDir, 'f-sync.txt')
+    fs.writeFileSync(p, 'precious')
+
+    statFailure.active = true
+    expect(() => writeFileAtomicSync(p, 'replacement')).toThrow('ESTALE')
+    statFailure.active = false
+
+    expect(fs.readFileSync(p, 'utf-8')).toBe('precious')
+    expect(leftoverTmpFiles(tmpDir)).toEqual([])
+  })
+
+  it('a genuinely absent target still creates with the requested mode', async () => {
+    // ENOENT must keep meaning "create" — the scoping only rejects OTHER errors.
+    const p = path.join(tmpDir, 'new.txt')
+    await writeFileAtomic(p, 'fresh', { mode: 0o600 })
+    expect(fs.readFileSync(p, 'utf-8')).toBe('fresh')
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(p).mode & 0o777).toBe(0o600)
+    }
+  })
+})

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -690,8 +690,11 @@ export async function writeFileAtomic(
   let existingMode: number | undefined
   try {
     existingMode = (await fs.promises.stat(filePath)).mode & 0o777
-  } catch {
-    // target absent (or unstattable) → this is a create; apply options.mode
+  } catch (err) {
+    // Only a confirmed-absent target is a create. Anything else (ESTALE from a
+    // cross-client NFS rename, EIO) must fail the write — treating it as a
+    // create would silently reset the file's permissions to options.mode.
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err
   }
   try {
     // 'wx' = O_EXCL: never reuse a stray temp file. Unique name makes this safe.
@@ -724,8 +727,9 @@ export function writeFileAtomicSync(
   let existingMode: number | undefined
   try {
     existingMode = (fs.statSync(filePath).mode & 0o777)
-  } catch {
-    // target absent → create with options.mode
+  } catch (err) {
+    // See writeFileAtomic: ENOENT-only, everything else fails the write.
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err
   }
   try {
     const fd = fs.openSync(tmpPath, 'wx', options?.mode ?? 0o666)


### PR DESCRIPTION
## The bug (observed in prod, authmode)

Providing a secret via `request_secret` wiped `/workspace/.env` down to just the new key — every other secret (SUPABASE_URL, service keys, …) gone.

**Root cause chain:**
1. The provide-secret route double-writes: host `setSecret()` (lock → merge → atomic rename), then container `POST /env` milliseconds later.
2. Since the atomic-write work (#320), every host write is a temp-file **rename** — a new inode each time. On the shared S3 File Gateway NFS, the container pod's cached lookup then hits **ESTALE** instead of seeing the new file.
3. The container's `updateEnvFile` had a bare `catch {}` around its read: *any* error meant "file doesn't exist yet, start fresh." It merged the one new key into an empty view and durably, atomically wrote the wipe.

The wiped file's fingerprint confirms this path: no host header, container-style quoted value, and mode `0600` — which `writeFileAtomic` only applies when its `stat` of the target *also* failed.

## Fixes

- **Fail-closed reads** (`agent-container/src/env-file-store.ts`): `readEnvFileOrNull` retries transient errors across the NFS attribute-cache window (~2.3s) and **throws** on anything persistent that isn't ENOENT. `POST /env` now 500s loudly instead of wiping; only a confirmed-absent file means "create".
- **ENOENT-scoped `existingMode` stat** in all four atomic writers (host `file-storage.ts` + container `atomic-file.ts`, async + sync): an unstattable target fails the write instead of silently resetting perms.
- **Line-preserving container merge**: `upsertEnvContent` edits only the target key's line — the host's header, display-name comments, and every other line survive byte-for-byte. File creation is 0o666 (umask-applied) matching the host, so cross-uid writes keep working.
- **Escape/unescape symmetry** (found by the new cross-implementation stress test): host `serializeEnvFile` escaped `"` but `parseEnvFile` never unescaped, so quoted/JSON secrets gained an escape level on **every** read-modify-write cycle. Both serializers and the parser now do symmetric `\\` / `\"` / `\n` handling, backward-compatible with existing files.

## Tests

- Wipe regression: host-format `.env` + container upsert → all prior bytes survive; persistent ESTALE → update rejects, file untouched, lock released.
- `secrets-service.crossprocess.test.ts`: host `setSecret` and container `updateEnvFileEntry` (the two real prod writers) interleaved 20-deep on one file — no key lost, no stray locks/temps, display names and header survive both writers.
- `*.statscope.test.ts` (host + container): non-ENOENT stat errors fail the write and leave the target untouched; ENOENT still creates with the requested mode.
- Round-trip suite: values with quotes/JSON/backslashes/newlines survive repeated serialize→parse cycles unchanged.
- Full runs green: host 6294 unit / container 420 unit / tsc both / lint 0 errors / secrets E2E specs 17 passed.

## Not changed (deliberately)

`POST /env` keeps writing the file: the CONNECTED_ACCOUNTS and REMOTE_MCPS callers have no host-side write, and non-shared-FS runtimes need it. The residual double-write in provide-secret is now harmless (fail-closed + line-preserving).