### PR TITLE
test: cover mid-session 401 auto-signout + fix trailing-401 stash leak

### DIFF
--- a/e2e/auth/specs/auth-flow.spec.ts
+++ b/e2e/auth/specs/auth-flow.spec.ts
@@ -517,4 +517,97 @@ test.describe('Auth Flow', () => {
     const afterLogin = await user2Page.evaluate(() => sessionStorage.getItem('superagent.redirect'))
     expect(afterLogin).toBeNull()
   })
+
+  // ── Live 401 (session expiry mid-use) ───────────────────
+
+  test('mid-session 401 signs out in place and re-login restores the exact URL', async ({ user2Page }) => {
+    // The other half of the redirect-stash machinery: the session dies while
+    // the app is OPEN. The next apiFetch 401s, the handler stashes the current
+    // URL FIRST, then auto-signs-out — via the auth client directly, NOT the
+    // user-context signOut, so the stash survives for the in-place re-login.
+    expect(agentSlug).toBeTruthy()
+
+    const authPage = new AuthPage(user2Page)
+    const appPage = new AppPage(user2Page)
+
+    // Entering state: user2 signed in on the agent page (previous test).
+    await user2Page.goto(`/agents/${agentSlug}`)
+    await expect(user2Page.locator('[data-testid="agent-breadcrumb"]')).toBeVisible({ timeout: 15000 })
+
+    // Expire the session out from under the open app. The app's background
+    // polling fires the next apiFetch within seconds — don't drive the UI
+    // here: any element clicked can detach mid-action when the gate swaps in.
+    await user2Page.context().clearCookies()
+
+    // Auth gate renders IN PLACE: the address bar stays on the agent URL and
+    // the URL is stashed for restore.
+    await expect(user2Page.locator('[data-testid="auth-page"]')).toBeVisible({ timeout: 20000 })
+    await expect(user2Page).toHaveURL(new RegExp(`/agents/${agentSlug}$`))
+    const stashed = await user2Page.evaluate(() => sessionStorage.getItem('superagent.redirect'))
+    expect(stashed).toBe(`/agents/${agentSlug}`)
+
+    // Re-login restores the EXACT URL and consumes the stash.
+    await authPage.signIn(user2.email, user2.password)
+    await appPage.waitForAppLoaded()
+    await appPage.dismissWizardIfVisible()
+    await expect(user2Page).toHaveURL(new RegExp(`/agents/${agentSlug}$`))
+    await expect(user2Page.locator('[data-testid="agent-breadcrumb"]')).toBeVisible({ timeout: 15000 })
+    expect(await user2Page.evaluate(() => sessionStorage.getItem('superagent.redirect'))).toBeNull()
+  })
+
+  test('a 403 response never triggers the auto-signout', async ({ user2Page }) => {
+    // 403 means forbidden, not expired — the 401 handler must leave the
+    // session alone or a permission error would boot the user out.
+    await expect(user2Page.locator('[data-testid="agent-breadcrumb"]')).toBeVisible({ timeout: 15000 })
+
+    let saw403 = false
+    await user2Page.route('**/api/agents/**', async (route) => {
+      if (route.request().method() !== 'POST') return route.fallback()
+      saw403 = true
+      await route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Forbidden' }),
+      })
+    })
+
+    try {
+      await user2Page.locator('[data-testid="home-message-input"]').fill('this send gets a 403')
+      await user2Page.locator('[data-testid="home-send-button"]').click()
+      await expect.poll(() => saw403, { timeout: 10000 }).toBe(true)
+    } finally {
+      await user2Page.unroute('**/api/agents/**')
+    }
+
+    // Durable proof the session survived: a reload comes back signed in.
+    // (If the 403 had triggered authSignOut, the server session would be
+    // revoked and this reload would land on the auth gate.)
+    await user2Page.reload()
+    await expect(user2Page.locator('[data-testid="agent-breadcrumb"]')).toBeVisible({ timeout: 15000 })
+    await expect(user2Page.locator('[data-testid="auth-page"]')).not.toBeVisible()
+    expect(await user2Page.evaluate(() => sessionStorage.getItem('superagent.redirect'))).toBeNull()
+  })
+
+  test('manual sign-out clears a residual stash so it cannot leak into the next login', async ({ user2Page }) => {
+    // A residual stash can exist (the OAuth login path peeks without
+    // clearing). Manual sign-out must drop it so the next user on a shared
+    // tab is not pushed into the previous user's URL.
+    const authPage = new AuthPage(user2Page)
+    const appPage = new AppPage(user2Page)
+    const userBar = new UserBarPage(user2Page)
+
+    await user2Page.evaluate(() =>
+      sessionStorage.setItem('superagent.redirect', '/agents/leaked-path'),
+    )
+
+    await userBar.signOut()
+    await authPage.expectVisible()
+    expect(await user2Page.evaluate(() => sessionStorage.getItem('superagent.redirect'))).toBeNull()
+
+    // Sign back in: nothing to restore, so no push to the leaked path.
+    await authPage.signIn(user2.email, user2.password)
+    await appPage.waitForAppLoaded()
+    await appPage.dismissWizardIfVisible()
+    await expect(user2Page).not.toHaveURL(/leaked-path/)
+  })
 })

--- a/src/renderer/context/user-context.tsx
+++ b/src/renderer/context/user-context.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useSession, signOut as authSignOut } from '@renderer/lib/auth-client'
-import { apiFetch, clearRedirectStash } from '@renderer/lib/api'
+import { apiFetch, clearRedirectStash, markDeliberateSignOut, clearDeliberateSignOut } from '@renderer/lib/api'
 import { useAgents, resolveRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
 import type { AgentRole } from '@shared/lib/types/agent'
 
@@ -110,6 +110,10 @@ export function UserProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (isAuthenticated) {
       wasAuthenticatedRef.current = true
+      // Re-arm the apiFetch 401 auto-sign-out once a session is live again —
+      // signOut() below latches it off so trailing 401s from a deliberate
+      // sign-out can't re-stash the signed-out user's URL.
+      clearDeliberateSignOut()
     } else if (wasAuthenticatedRef.current) {
       wasAuthenticatedRef.current = false
       queryClient.clear()
@@ -178,6 +182,11 @@ export function UserProvider({ children }: { children: ReactNode }) {
   )
 
   const signOut = useCallback(async () => {
+    // Gate the apiFetch 401 handler FIRST: revoking the session 401s every
+    // trailing background request, and each would otherwise re-stash this
+    // user's URL right after we drop it below (defeating the shared-tab
+    // guard) and re-fire the auto sign-out.
+    markDeliberateSignOut()
     // Drop any stashed redirect target so this user's last path can't be restored
     // into the next user's session on a shared tab (e.g. a residual stash left by
     // their own OAuth login, which peeks but never clears it).

--- a/src/renderer/lib/api.test.ts
+++ b/src/renderer/lib/api.test.ts
@@ -18,6 +18,8 @@ import {
   peekRedirectStash,
   consumeRedirectStash,
   clearRedirectStash,
+  markDeliberateSignOut,
+  clearDeliberateSignOut,
 } from './api'
 
 const KEY = 'superagent.redirect'
@@ -174,5 +176,22 @@ describe('apiFetch 401 auto-stash (warm, router-mounted)', () => {
     await apiFetch('/api/agents/foo')
     expect(sessionStorage.getItem(KEY)).toBeNull()
     expect(signOutMock).not.toHaveBeenCalled()
+  })
+
+  it('is latched off during a deliberate sign-out and re-arms after sign-in', async () => {
+    window.history.replaceState(null, '', '/agents/foo')
+
+    // Trailing background 401s after the user clicked Sign out must not
+    // re-stash the signed-out user's URL (shared-tab leak) nor re-fire signOut.
+    markDeliberateSignOut()
+    await apiFetch('/api/agents/foo')
+    expect(sessionStorage.getItem(KEY)).toBeNull()
+    expect(signOutMock).not.toHaveBeenCalled()
+
+    // Once a session authenticates again the handler is re-armed.
+    clearDeliberateSignOut()
+    await apiFetch('/api/agents/foo')
+    expect(sessionStorage.getItem(KEY)).toBe('/agents/foo')
+    expect(signOutMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/lib/api.ts
+++ b/src/renderer/lib/api.ts
@@ -16,9 +16,13 @@ export async function apiFetch(
 
   // Auto-sign-out on 401 in auth mode (skip auth endpoints to avoid loops).
   // Stash the current URL FIRST so any successful in-place re-sign-in restores it.
-  // Only on 401 (expired) — never 403 (forbidden). AUTH_MODE is web-only,
-  // so pathname+search is the route; the hash is included for completeness.
-  if (__AUTH_MODE__ && response.status === 401 && !path.startsWith('/api/auth/')) {
+  // Only on 401 (expired) — never 403 (forbidden), and never while a deliberate
+  // sign-out is in effect: revoking the session 401s every trailing background
+  // request, and without the gate those would re-stash the signed-out user's
+  // URL right after clearRedirectStash() dropped it (shared-tab leak).
+  // AUTH_MODE is web-only, so pathname+search is the route; the hash is
+  // included for completeness.
+  if (__AUTH_MODE__ && response.status === 401 && !deliberateSignOut && !path.startsWith('/api/auth/')) {
     const here = window.location.pathname + window.location.search + window.location.hash
     if (here !== '/') sessionStorage.setItem(REDIRECT_KEY, here)
     const { signOut } = await import('./auth-client')
@@ -29,6 +33,21 @@ export async function apiFetch(
 }
 
 const REDIRECT_KEY = 'superagent.redirect'
+
+// Latched while a deliberate sign-out is in effect, gating the 401 branch
+// above. Module state, so a full page load naturally resets it; the warm
+// reset happens when the next session authenticates.
+let deliberateSignOut = false
+
+/** Called by the user-context sign-out before revoking the session. */
+export function markDeliberateSignOut(): void {
+  deliberateSignOut = true
+}
+
+/** Called once a session is authenticated again, re-arming the 401 handler. */
+export function clearDeliberateSignOut(): void {
+  deliberateSignOut = false
+}
 
 /**
  * A safe internal path. Must start with a single `/` and reject anything the


### PR DESCRIPTION
## What

E2E coverage-gap batch item #9: the live half of the redirect-stash machinery. Only the cold deep-link path was covered; the mid-session 401 handler (stash-first, in-place sign-out, never-on-403) had no E2E coverage. Three tests appended to the `auth-flow` serial narrative (no new config — they extend the existing project):

1. **Mid-session 401 restores the exact URL** — `clearCookies()` expires the session under the open app; the next background `apiFetch` 401s, the auth gate renders **in place** (address bar stays on the agent URL), the URL is stashed, and re-login restores the exact URL and consumes the stash. (Learned the hard way: don't drive the UI to trigger the 401 — background polling fires it within milliseconds and detaches whatever you were clicking.)
2. **403 never signs out** — an injected 403 on a send, then the durable proof: a reload comes back signed in. If the handler had treated 403 like 401, the server session would be revoked and the reload would land on the auth gate.
3. **Manual sign-out clears a residual stash** — seeded stash (the OAuth login path peeks without clearing), sign out via the user bar, stash must be gone and the next login must not be pushed into it.

## The bug test 3 caught

Manual sign-out calls `clearRedirectStash()` then revokes the session — but revoking 401s **every trailing background request**, and each one re-ran the 401 auto-stash, writing the signed-out user's URL right back after it was cleared. Observed live: the stash contained the previous user's `/agents/<slug>` after sign-out, so the next user on a shared tab would be pushed into it. This is precisely the leak the audit flagged, defeated by any in-flight poll — deterministic in practice (failed 2/2 calibration runs).

**Fix:** latch the `apiFetch` 401 handler off while a deliberate sign-out is in effect — `markDeliberateSignOut()` in the user-context `signOut` (before the stash clear), re-armed by `clearDeliberateSignOut()` when a session authenticates again (and naturally by any full page load, since it's module state). Expired-session behavior (test 1) is untouched: the latch is only ever set by the explicit sign-out action. Unit case added to the existing `apiFetch 401 auto-stash` suite covering both the latched and re-armed states.

## Validation

- Auth suite: **47/47** with the fix; red-without-fix calibration **2/2 failures** at the same assertion (fix committed first, sources reverted to origin/main for the runs, then restored); auth-flow re-run with `--retries=0` after restore: 32/32.
- Unit: `api.test.ts` + user-context suites, 43/43.
- Main mock suite: **230 passed / 0 failed / 21 skipped** (the 401 branch is `__AUTH_MODE__` compile-time dead code there; one earlier run had 3 load-timeouts in untouched specs — all 12/12 standalone with no retries, and the re-run was fully green).
- `tsc --noEmit` + eslint clean (one pre-existing warning in auth-flow.spec.ts untouched).

## Notes

Next batch candidate after this merges: gap #10 (admin invite + password-reset through the ForcePasswordChange gate — the chunkier auth item) or your pick from the tracker.