### PR TITLE
fix(env): force 0o666 on the agent .env — atomic renames flip ownership and can lock the other writer out

### DIFF
--- a/agent-container/src/atomic-file.test.ts
+++ b/agent-container/src/atomic-file.test.ts
@@ -93,4 +93,21 @@ describe('writeFileAtomic (async)', () => {
     expect(fs.statSync(target).isDirectory()).toBe(true);
     expect(leftoverTmpFiles(tmpDir)).toEqual([]);
   });
+
+  // forceMode: for two-uid files (the agent .env) the mode must be applied on
+  // EVERY write — the rename transfers ownership, so preserving a stray
+  // restrictive mode locks the other writer out permanently.
+  it.runIf(process.platform !== 'win32')('forceMode overrides an existing restrictive mode', async () => {
+    const p = path.join(tmpDir, 'shared.env');
+    fs.writeFileSync(p, 'A=1\n');
+    fs.chmodSync(p, 0o600);
+    await writeFileAtomic(p, 'A=2\n', 0o666, { forceMode: true });
+    expect(fs.statSync(p).mode & 0o777).toBe(0o666);
+  });
+
+  it.runIf(process.platform !== 'win32')('forceMode applies the exact mode on create (not umask-reduced)', async () => {
+    const p = path.join(tmpDir, 'fresh.env');
+    await writeFileAtomic(p, 'A=1\n', 0o666, { forceMode: true });
+    expect(fs.statSync(p).mode & 0o777).toBe(0o666);
+  });
 });

--- a/agent-container/src/atomic-file.test.ts
+++ b/agent-container/src/atomic-file.test.ts
@@ -110,4 +110,33 @@ describe('writeFileAtomic (async)', () => {
     await writeFileAtomic(p, 'A=1\n', 0o666, { forceMode: true });
     expect(fs.statSync(p).mode & 0o777).toBe(0o666);
   });
+
+  // Ownership preservation: the rename replaces the inode, which would hand
+  // the file to this process's uid:gid. Group is the one dimension testable
+  // without root — a process may chgrp a file it owns to any of its
+  // supplementary groups.
+  it.runIf(process.platform !== 'win32')('restores the file group across an atomic overwrite (async)', async () => {
+    const altGroup = process.getgroups?.().find((g) => g !== process.getgid?.());
+    if (altGroup === undefined) return; // single-group environment — nothing to assert
+    const p = path.join(tmpDir, 'grp.txt');
+    fs.writeFileSync(p, 'v1');
+    fs.chownSync(p, process.getuid!(), altGroup);
+
+    await writeFileAtomic(p, 'v2');
+
+    expect(fs.readFileSync(p, 'utf-8')).toBe('v2');
+    expect(fs.statSync(p).gid).toBe(altGroup);
+  });
+
+  it.runIf(process.platform !== 'win32')('restores the file group across an atomic overwrite (sync)', () => {
+    const altGroup = process.getgroups?.().find((g) => g !== process.getgid?.());
+    if (altGroup === undefined) return;
+    const p = path.join(tmpDir, 'grp-sync.txt');
+    fs.writeFileSync(p, 'v1');
+    fs.chownSync(p, process.getuid!(), altGroup);
+
+    writeFileAtomicSync(p, 'v2');
+
+    expect(fs.statSync(p).gid).toBe(altGroup);
+  });
 });

--- a/agent-container/src/atomic-file.ts
+++ b/agent-container/src/atomic-file.ts
@@ -10,10 +10,11 @@
  * data-loss bug-class for the container's own /workspace state files.
  *
  * `mode` (matching fs.writeFile) applies only when CREATING the target; an
- * existing file's permissions are preserved so the rename doesn't reset perms
- * the host relies on for cross-process access (e.g. the world-writable
- * /workspace/.env). The whole workspace dir is bind-mounted, so a temp file +
- * rename within it is on the same filesystem and propagates to the host.
+ * existing file's owner, group, and permissions are restored after the rename
+ * (ownership best-effort — only root can give a file away), so replacing a
+ * file doesn't silently re-own it to this process with fresh perms. The whole
+ * workspace dir is bind-mounted, so a temp file + rename within it is on the
+ * same filesystem and propagates to the host.
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -81,14 +82,19 @@ export async function writeFileAtomic(
 ): Promise<void> {
   const dir = path.dirname(filePath);
   const tmpPath = tempPathFor(filePath);
-  // `forceMode` skips the preserve-existing-perms behavior for files that must
-  // hold `mode` no matter what: the rename below also transfers OWNERSHIP to
-  // this process, so preserving a stray restrictive mode on a two-uid file
-  // (the agent .env) would lock the other writer out permanently.
-  let existingMode: number | undefined;
+  // The rename below replaces the inode, handing the file to this process's
+  // uid with the temp file's perms — so an existing target's owner, group, and
+  // mode are restored (ownership best-effort: only root can give a file away).
+  //
+  // `forceMode` skips preservation for files that must hold `mode` no matter
+  // what: the agent .env is a two-uid file and the non-root writer can never
+  // chown it back, so a preserved stray restrictive mode would lock the other
+  // writer out permanently — only a forced world-RW mode is uid-independent.
+  let existing: { mode: number; uid: number; gid: number } | undefined;
   if (!opts.forceMode) {
     try {
-      existingMode = (await fs.promises.stat(filePath)).mode & 0o777;
+      const st = await fs.promises.stat(filePath);
+      existing = { mode: st.mode & 0o777, uid: st.uid, gid: st.gid };
     } catch (err) {
       // Only a confirmed-absent target is a create. Anything else (ESTALE from a
       // cross-client NFS rename, EIO) must fail the write — treating it as a
@@ -102,9 +108,14 @@ export async function writeFileAtomic(
     try {
       await handle.writeFile(content, 'utf-8');
       // Best-effort: a perms-less mount (e.g. an S3 FUSE driver) may reject
-      // chmod — never let a permission tweak fail the data write.
-      const chmodTo = opts.forceMode ? mode : existingMode;
-      if (chmodTo !== undefined) await handle.chmod(chmodTo).catch(() => {});
+      // chown/chmod — never let a metadata tweak fail the data write.
+      // chown before chmod: chown can clear mode bits on some platforms.
+      if (opts.forceMode) {
+        await handle.chmod(mode).catch(() => {});
+      } else if (existing) {
+        await handle.chown(existing.uid, existing.gid).catch(() => {});
+        await handle.chmod(existing.mode).catch(() => {});
+      }
       await handle.sync();
     } finally {
       await handle.close();
@@ -121,9 +132,10 @@ export async function writeFileAtomic(
 export function writeFileAtomicSync(filePath: string, content: string, mode = 0o666): void {
   const dir = path.dirname(filePath);
   const tmpPath = tempPathFor(filePath);
-  let existingMode: number | undefined;
+  let existing: { mode: number; uid: number; gid: number } | undefined;
   try {
-    existingMode = fs.statSync(filePath).mode & 0o777;
+    const st = fs.statSync(filePath);
+    existing = { mode: st.mode & 0o777, uid: st.uid, gid: st.gid };
   } catch (err) {
     // See writeFileAtomic: ENOENT-only, everything else fails the write.
     if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err;
@@ -132,11 +144,16 @@ export function writeFileAtomicSync(filePath: string, content: string, mode = 0o
     const fd = fs.openSync(tmpPath, 'wx', mode);
     try {
       fs.writeFileSync(fd, content, 'utf-8');
-      // Best-effort (see writeFileAtomic): a perms-less mount's chmod rejection
-      // must not fail the data write.
-      if (existingMode !== undefined) {
+      // Best-effort (see writeFileAtomic): a perms-less mount's chown/chmod
+      // rejection must not fail the data write. chown before chmod.
+      if (existing) {
         try {
-          fs.fchmodSync(fd, existingMode);
+          fs.fchownSync(fd, existing.uid, existing.gid);
+        } catch {
+          // ignore — only root can give a file away
+        }
+        try {
+          fs.fchmodSync(fd, existing.mode);
         } catch {
           // ignore — perms are advisory on object-storage mounts
         }

--- a/agent-container/src/atomic-file.ts
+++ b/agent-container/src/atomic-file.ts
@@ -73,17 +73,28 @@ function fsyncDirSync(dir: string): void {
  * dir). On ANY error the temp file is removed and the existing target is left
  * exactly as it was. The parent directory must already exist.
  */
-export async function writeFileAtomic(filePath: string, content: string, mode = 0o666): Promise<void> {
+export async function writeFileAtomic(
+  filePath: string,
+  content: string,
+  mode = 0o666,
+  opts: { forceMode?: boolean } = {}
+): Promise<void> {
   const dir = path.dirname(filePath);
   const tmpPath = tempPathFor(filePath);
+  // `forceMode` skips the preserve-existing-perms behavior for files that must
+  // hold `mode` no matter what: the rename below also transfers OWNERSHIP to
+  // this process, so preserving a stray restrictive mode on a two-uid file
+  // (the agent .env) would lock the other writer out permanently.
   let existingMode: number | undefined;
-  try {
-    existingMode = (await fs.promises.stat(filePath)).mode & 0o777;
-  } catch (err) {
-    // Only a confirmed-absent target is a create. Anything else (ESTALE from a
-    // cross-client NFS rename, EIO) must fail the write — treating it as a
-    // create would silently reset the file's permissions to `mode`.
-    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err;
+  if (!opts.forceMode) {
+    try {
+      existingMode = (await fs.promises.stat(filePath)).mode & 0o777;
+    } catch (err) {
+      // Only a confirmed-absent target is a create. Anything else (ESTALE from a
+      // cross-client NFS rename, EIO) must fail the write — treating it as a
+      // create would silently reset the file's permissions to `mode`.
+      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err;
+    }
   }
   try {
     // 'wx' = O_EXCL: never reuse a stray temp file. Unique name makes this safe.
@@ -92,7 +103,8 @@ export async function writeFileAtomic(filePath: string, content: string, mode = 
       await handle.writeFile(content, 'utf-8');
       // Best-effort: a perms-less mount (e.g. an S3 FUSE driver) may reject
       // chmod — never let a permission tweak fail the data write.
-      if (existingMode !== undefined) await handle.chmod(existingMode).catch(() => {});
+      const chmodTo = opts.forceMode ? mode : existingMode;
+      if (chmodTo !== undefined) await handle.chmod(chmodTo).catch(() => {});
       await handle.sync();
     } finally {
       await handle.close();

--- a/agent-container/src/env-file-store.test.ts
+++ b/agent-container/src/env-file-store.test.ts
@@ -270,19 +270,20 @@ describe('updateEnvFileEntry', () => {
   });
 
   it.runIf(process.platform !== 'win32')(
-    'creates the file 0o666 (umask-applied) so the host — a different uid — can write it too',
+    'creates the file world-writable (exact 0o666) so the host — a different uid — can write it too',
     async () => {
       await updateEnvFileEntry(envPath, 'K', 'v');
-      const umask = process.umask();
-      expect(fs.statSync(envPath).mode & 0o777).toBe(0o666 & ~umask);
+      expect(fs.statSync(envPath).mode & 0o777).toBe(0o666);
     }
   );
 
-  it.runIf(process.platform !== 'win32')('preserves an existing file mode', async () => {
+  it.runIf(process.platform !== 'win32')('heals a stuck restrictive mode back to 0o666', async () => {
+    // The atomic rename transfers ownership; preserving a stray 0o600 on this
+    // two-uid file would lock the host writer out of its own next update.
     fs.writeFileSync(envPath, 'A=1\n');
-    fs.chmodSync(envPath, 0o640);
+    fs.chmodSync(envPath, 0o600);
     await updateEnvFileEntry(envPath, 'K', 'v');
-    expect(fs.statSync(envPath).mode & 0o777).toBe(0o640);
+    expect(fs.statSync(envPath).mode & 0o777).toBe(0o666);
   });
 
   it('concurrent upserts of distinct keys all survive', async () => {

--- a/agent-container/src/env-file-store.ts
+++ b/agent-container/src/env-file-store.ts
@@ -174,13 +174,16 @@ export function upsertEnvContent(content: string, key: string, value: string): s
  * Cross-process-safe upsert of a single `key=value` into the env file:
  * lock → fail-closed read → line-preserving merge → atomic write.
  *
- * Created with mode 0o666 (matching the host's setSecret) so whichever side
- * creates the file first, the other side — a different uid — can still write it.
+ * Mode 0o666 is FORCED (not umask'd, not preserved-from-existing): the file is
+ * written by two different uids (this container and the host app), and the
+ * atomic rename transfers ownership to whoever wrote last — carrying over a
+ * stray 0o600 would leave a file only the last writer can even read, locking
+ * the other side out on its next update.
  */
 export async function updateEnvFileEntry(filePath: string, key: string, value: string): Promise<void> {
   await withEnvFileLock(filePath, async () => {
     const existing = await readEnvFileOrNull(filePath);
     const next = upsertEnvContent(existing ?? '', key, value);
-    await writeFileAtomic(filePath, next, 0o666);
+    await writeFileAtomic(filePath, next, 0o666, { forceMode: true });
   });
 }

--- a/src/shared/lib/services/secrets-service.atomic.test.ts
+++ b/src/shared/lib/services/secrets-service.atomic.test.ts
@@ -73,13 +73,24 @@ describe('atomic .env writes', () => {
     expect(secrets[0]).toMatchObject({ envVar: 'API_KEY', value: 'sk-123' })
   })
 
-  it.runIf(process.platform !== 'win32')('creates the .env with the agent-container 0o666 mode (umask-applied), matching prior behavior', async () => {
+  it.runIf(process.platform !== 'win32')('creates the .env world-writable (exact 0o666) so the container — a different uid — can write it', async () => {
     const { setSecret } = await importService()
     await setSecret('agent', { envVar: 'X', key: 'X', value: '1' })
-    // Atomic write preserves the same creation perms the old fs.writeFile used:
-    // 0o666 reduced by the process umask (e.g. 0o644). NOT forced world-writable.
-    const umask = process.umask()
-    expect(fs.statSync(envPath('agent')).mode & 0o777).toBe(0o666 & ~umask)
+    expect(fs.statSync(envPath('agent')).mode & 0o777).toBe(0o666)
+  })
+
+  it.runIf(process.platform !== 'win32')('heals a .env stuck at 0o600 back to 0o666 on the next write', async () => {
+    // The atomic rename transfers ownership to this process; if it also
+    // preserved a stray 0o600 (left by the old container create-mode), the
+    // container could no longer even READ the file — its next POST /env would
+    // fail with EACCES (or, before the fail-closed fix, wipe the file).
+    const { setSecret } = await importService()
+    await setSecret('agent', { envVar: 'A', key: 'A', value: '1' })
+    fs.chmodSync(envPath('agent'), 0o600)
+
+    await setSecret('agent', { envVar: 'B', key: 'B', value: '2' })
+
+    expect(fs.statSync(envPath('agent')).mode & 0o777).toBe(0o666)
   })
 
   it('deleteSecret returns false and writes nothing for an unknown key', async () => {

--- a/src/shared/lib/services/secrets-service.test.ts
+++ b/src/shared/lib/services/secrets-service.test.ts
@@ -453,10 +453,11 @@ describe('secrets service integration', () => {
       )
       const stats = await fs.promises.stat(envPath)
 
-      // Mode 0o666 is requested so non-root agent containers can read secrets.
-      // Effective permissions depend on process umask.
-      const umask = process.umask()
-      expect(stats.mode & 0o777).toBe(0o666 & ~umask)
+      // Exact 0o666 is FORCED (not umask-reduced, not preserved-from-existing):
+      // the atomic rename transfers ownership to this process, and the
+      // container — a different uid — must still be able to read AND write the
+      // file. A carried-over restrictive mode locks it out (EACCES on POST /env).
+      expect(stats.mode & 0o777).toBe(0o666)
     })
   })
 

--- a/src/shared/lib/services/secrets-service.ts
+++ b/src/shared/lib/services/secrets-service.ts
@@ -206,7 +206,9 @@ export async function setSecret(agentSlug: string, secret: AgentSecret): Promise
   // lock the container honors too, re-read FRESH under the lock, and write
   // atomically so an interleaved/interrupted write can't drop other
   // secrets or truncate the file (which doubles as the container runtime env).
-  // mode 0o666 is preserved so the container (different uid) can still write it.
+  // mode 0o666 is FORCED: the atomic rename transfers ownership to this
+  // process, so preserving a stray restrictive mode would leave a file the
+  // container (different uid) can no longer read or write.
   await withCrossProcessFileLock(envPath, async () => {
     const secrets = await listSecrets(agentSlug)
 
@@ -217,7 +219,7 @@ export async function setSecret(agentSlug: string, secret: AgentSecret): Promise
       secrets.push(secret)
     }
 
-    await writeFileAtomic(envPath, serializeEnvFile(secrets), { mode: 0o666 })
+    await writeFileAtomic(envPath, serializeEnvFile(secrets), { mode: 0o666, forceMode: true })
   })
 }
 
@@ -243,9 +245,9 @@ export async function deleteSecret(agentSlug: string, envVar: string): Promise<b
 
     if (filtered.length === 0) {
       // No secrets left — leave an empty (but valid) header file.
-      await writeFileAtomic(envPath, '# Superagent Secrets\n', { mode: 0o666 })
+      await writeFileAtomic(envPath, '# Superagent Secrets\n', { mode: 0o666, forceMode: true })
     } else {
-      await writeFileAtomic(envPath, serializeEnvFile(filtered), { mode: 0o666 })
+      await writeFileAtomic(envPath, serializeEnvFile(filtered), { mode: 0o666, forceMode: true })
     }
 
     return true

--- a/src/shared/lib/utils/file-storage.atomic.test.ts
+++ b/src/shared/lib/utils/file-storage.atomic.test.ts
@@ -140,6 +140,35 @@ describe('writeFileAtomic / writeFileAtomicSync', () => {
     await writeFileAtomic(p, 'A=1\n', { mode: 0o666, forceMode: true })
     expect(fs.statSync(p).mode & 0o777).toBe(0o666)
   })
+
+  // Ownership preservation: the rename replaces the inode, which would hand
+  // the file to this process's uid:gid. Group is the one dimension testable
+  // without root — a process may chgrp a file it owns to any of its
+  // supplementary groups.
+  it.runIf(process.platform !== 'win32')('restores the file group across an atomic overwrite (async)', async () => {
+    const altGroup = process.getgroups?.().find((g) => g !== process.getgid?.())
+    if (altGroup === undefined) return // single-group environment — nothing to assert
+    const p = path.join(tmpDir, 'grp.txt')
+    fs.writeFileSync(p, 'v1')
+    fs.chownSync(p, process.getuid!(), altGroup)
+
+    await writeFileAtomic(p, 'v2')
+
+    expect(fs.readFileSync(p, 'utf-8')).toBe('v2')
+    expect(fs.statSync(p).gid).toBe(altGroup)
+  })
+
+  it.runIf(process.platform !== 'win32')('restores the file group across an atomic overwrite (sync)', () => {
+    const altGroup = process.getgroups?.().find((g) => g !== process.getgid?.())
+    if (altGroup === undefined) return
+    const p = path.join(tmpDir, 'grp-sync.txt')
+    fs.writeFileSync(p, 'v1')
+    fs.chownSync(p, process.getuid!(), altGroup)
+
+    writeFileAtomicSync(p, 'v2')
+
+    expect(fs.statSync(p).gid).toBe(altGroup)
+  })
 })
 
 describe('writeJsonFileAtomic / writeJsonFile (delegates to atomic)', () => {

--- a/src/shared/lib/utils/file-storage.atomic.test.ts
+++ b/src/shared/lib/utils/file-storage.atomic.test.ts
@@ -114,6 +114,32 @@ describe('writeFileAtomic / writeFileAtomicSync', () => {
     await writeFileAtomic(p, JSON.stringify({ keep: true, more: 1 }))
     expect(JSON.parse(fs.readFileSync(p, 'utf-8'))).toEqual({ keep: true, more: 1 })
   })
+
+  // forceMode: for two-uid files (the agent .env) the mode must be applied on
+  // EVERY write, not preserved — the rename transfers ownership, so carrying
+  // over a stray restrictive mode locks the other writer out permanently.
+  it.runIf(process.platform !== 'win32')('forceMode overrides an existing restrictive mode (async)', async () => {
+    const p = path.join(tmpDir, 'shared.env')
+    fs.writeFileSync(p, 'A=1\n')
+    fs.chmodSync(p, 0o600)
+    await writeFileAtomic(p, 'A=2\n', { mode: 0o666, forceMode: true })
+    expect(fs.statSync(p).mode & 0o777).toBe(0o666)
+    expect(fs.readFileSync(p, 'utf-8')).toBe('A=2\n')
+  })
+
+  it.runIf(process.platform !== 'win32')('forceMode overrides an existing restrictive mode (sync)', () => {
+    const p = path.join(tmpDir, 'shared-sync.env')
+    fs.writeFileSync(p, 'A=1\n')
+    fs.chmodSync(p, 0o600)
+    writeFileAtomicSync(p, 'A=2\n', { mode: 0o666, forceMode: true })
+    expect(fs.statSync(p).mode & 0o777).toBe(0o666)
+  })
+
+  it.runIf(process.platform !== 'win32')('forceMode applies the exact mode on create (not umask-reduced)', async () => {
+    const p = path.join(tmpDir, 'fresh.env')
+    await writeFileAtomic(p, 'A=1\n', { mode: 0o666, forceMode: true })
+    expect(fs.statSync(p).mode & 0o777).toBe(0o666)
+  })
 })
 
 describe('writeJsonFileAtomic / writeJsonFile (delegates to atomic)', () => {

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -679,7 +679,7 @@ function renameWithRetrySync(from: string, to: string, attempts = 10): void {
 export async function writeFileAtomic(
   filePath: string,
   content: string,
-  options?: { mode?: number }
+  options?: { mode?: number; forceMode?: boolean }
 ): Promise<void> {
   const dir = path.dirname(filePath)
   const tmpPath = tempPathFor(filePath)
@@ -687,14 +687,21 @@ export async function writeFileAtomic(
   // target. If it already exists, preserve its current permissions — an atomic
   // rename would otherwise reset perms to the temp file's (which could, e.g.,
   // make a world-writable .env or relax a 0o600 secrets file).
+  //
+  // `forceMode` inverts this for files that MUST hold a specific mode no matter
+  // what (the agent .env is written by two different uids; because the rename
+  // also transfers ownership, preserving a stray 0o600 permanently locks the
+  // other writer out).
   let existingMode: number | undefined
-  try {
-    existingMode = (await fs.promises.stat(filePath)).mode & 0o777
-  } catch (err) {
-    // Only a confirmed-absent target is a create. Anything else (ESTALE from a
-    // cross-client NFS rename, EIO) must fail the write — treating it as a
-    // create would silently reset the file's permissions to options.mode.
-    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err
+  if (!options?.forceMode) {
+    try {
+      existingMode = (await fs.promises.stat(filePath)).mode & 0o777
+    } catch (err) {
+      // Only a confirmed-absent target is a create. Anything else (ESTALE from a
+      // cross-client NFS rename, EIO) must fail the write — treating it as a
+      // create would silently reset the file's permissions to options.mode.
+      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err
+    }
   }
   try {
     // 'wx' = O_EXCL: never reuse a stray temp file. Unique name makes this safe.
@@ -703,7 +710,8 @@ export async function writeFileAtomic(
       await handle.writeFile(content, 'utf-8')
       // Best-effort: object-storage / perms-less mounts (e.g. an S3 FUSE driver)
       // may reject chmod — a permission tweak must never fail the data write.
-      if (existingMode !== undefined) await handle.chmod(existingMode).catch(() => {})
+      const chmodTo = options?.forceMode ? (options.mode ?? 0o666) : existingMode
+      if (chmodTo !== undefined) await handle.chmod(chmodTo).catch(() => {})
       await handle.sync()
     } finally {
       await handle.close()
@@ -720,16 +728,18 @@ export async function writeFileAtomic(
 export function writeFileAtomicSync(
   filePath: string,
   content: string,
-  options?: { mode?: number }
+  options?: { mode?: number; forceMode?: boolean }
 ): void {
   const dir = path.dirname(filePath)
   const tmpPath = tempPathFor(filePath)
   let existingMode: number | undefined
-  try {
-    existingMode = (fs.statSync(filePath).mode & 0o777)
-  } catch (err) {
-    // See writeFileAtomic: ENOENT-only, everything else fails the write.
-    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err
+  if (!options?.forceMode) {
+    try {
+      existingMode = (fs.statSync(filePath).mode & 0o777)
+    } catch (err) {
+      // See writeFileAtomic: ENOENT-only, everything else fails the write.
+      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err
+    }
   }
   try {
     const fd = fs.openSync(tmpPath, 'wx', options?.mode ?? 0o666)
@@ -737,9 +747,10 @@ export function writeFileAtomicSync(
       fs.writeFileSync(fd, content, 'utf-8')
       // Best-effort (see writeFileAtomic): never let a perms-less mount's chmod
       // rejection fail the data write.
-      if (existingMode !== undefined) {
+      const chmodTo = options?.forceMode ? (options.mode ?? 0o666) : existingMode
+      if (chmodTo !== undefined) {
         try {
-          fs.fchmodSync(fd, existingMode)
+          fs.fchmodSync(fd, chmodTo)
         } catch {
           // ignore — perms are advisory on object-storage mounts
         }

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -684,18 +684,22 @@ export async function writeFileAtomic(
   const dir = path.dirname(filePath)
   const tmpPath = tempPathFor(filePath)
   // Match fs.writeFile(mode) semantics: `mode` applies only when CREATING the
-  // target. If it already exists, preserve its current permissions — an atomic
-  // rename would otherwise reset perms to the temp file's (which could, e.g.,
-  // make a world-writable .env or relax a 0o600 secrets file).
+  // target. If it already exists, preserve its current owner, group, and
+  // permissions — the rename below replaces the inode, which would otherwise
+  // hand the file to this process's uid with the temp file's perms. Ownership
+  // preservation is best-effort (only root can give a file away; EPERM is
+  // ignored), matching npm write-file-atomic.
   //
-  // `forceMode` inverts this for files that MUST hold a specific mode no matter
-  // what (the agent .env is written by two different uids; because the rename
-  // also transfers ownership, preserving a stray 0o600 permanently locks the
-  // other writer out).
-  let existingMode: number | undefined
+  // `forceMode` inverts the mode handling for files that MUST hold a specific
+  // mode no matter what (the agent .env is written by two different uids, and
+  // the non-root writer can never chown it back — so a preserved stray 0o600
+  // would permanently lock the other writer out; only a forced world-RW mode
+  // makes ownership irrelevant).
+  let existing: { mode: number; uid: number; gid: number } | undefined
   if (!options?.forceMode) {
     try {
-      existingMode = (await fs.promises.stat(filePath)).mode & 0o777
+      const st = await fs.promises.stat(filePath)
+      existing = { mode: st.mode & 0o777, uid: st.uid, gid: st.gid }
     } catch (err) {
       // Only a confirmed-absent target is a create. Anything else (ESTALE from a
       // cross-client NFS rename, EIO) must fail the write — treating it as a
@@ -709,9 +713,14 @@ export async function writeFileAtomic(
     try {
       await handle.writeFile(content, 'utf-8')
       // Best-effort: object-storage / perms-less mounts (e.g. an S3 FUSE driver)
-      // may reject chmod — a permission tweak must never fail the data write.
-      const chmodTo = options?.forceMode ? (options.mode ?? 0o666) : existingMode
-      if (chmodTo !== undefined) await handle.chmod(chmodTo).catch(() => {})
+      // may reject chown/chmod — a metadata tweak must never fail the data write.
+      // chown before chmod: chown can clear mode bits on some platforms.
+      if (options?.forceMode) {
+        await handle.chmod(options.mode ?? 0o666).catch(() => {})
+      } else if (existing) {
+        await handle.chown(existing.uid, existing.gid).catch(() => {})
+        await handle.chmod(existing.mode).catch(() => {})
+      }
       await handle.sync()
     } finally {
       await handle.close()
@@ -732,10 +741,11 @@ export function writeFileAtomicSync(
 ): void {
   const dir = path.dirname(filePath)
   const tmpPath = tempPathFor(filePath)
-  let existingMode: number | undefined
+  let existing: { mode: number; uid: number; gid: number } | undefined
   if (!options?.forceMode) {
     try {
-      existingMode = (fs.statSync(filePath).mode & 0o777)
+      const st = fs.statSync(filePath)
+      existing = { mode: st.mode & 0o777, uid: st.uid, gid: st.gid }
     } catch (err) {
       // See writeFileAtomic: ENOENT-only, everything else fails the write.
       if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err
@@ -745,15 +755,21 @@ export function writeFileAtomicSync(
     const fd = fs.openSync(tmpPath, 'wx', options?.mode ?? 0o666)
     try {
       fs.writeFileSync(fd, content, 'utf-8')
-      // Best-effort (see writeFileAtomic): never let a perms-less mount's chmod
-      // rejection fail the data write.
-      const chmodTo = options?.forceMode ? (options.mode ?? 0o666) : existingMode
-      if (chmodTo !== undefined) {
-        try {
-          fs.fchmodSync(fd, chmodTo)
-        } catch {
-          // ignore — perms are advisory on object-storage mounts
+      // Best-effort (see writeFileAtomic): never let a perms-less mount's
+      // chown/chmod rejection fail the data write. chown before chmod.
+      try {
+        if (options?.forceMode) {
+          fs.fchmodSync(fd, options.mode ?? 0o666)
+        } else if (existing) {
+          try {
+            fs.fchownSync(fd, existing.uid, existing.gid)
+          } catch {
+            // ignore — only root can give a file away
+          }
+          fs.fchmodSync(fd, existing.mode)
         }
+      } catch {
+        // ignore — perms are advisory on object-storage mounts
       }
       fs.fsyncSync(fd)
     } finally {


### PR DESCRIPTION
Follow-up to #398, which turned the silent secret wipe into a loud failure — this closes the failure itself, and revises the root cause based on a deterministic local repro.

## The repro (Linux DooD, observed after #398)

Providing a secret from the request card fails:

```
[provide-secret] Failed to set env var: {"error":"EACCES: permission denied, open '/workspace/.env'"}
```

while adding the same secret from the Secrets UI works. The workspace shows `-rw------- 1 root root .env`.

## Revised root cause (simpler than NFS staleness)

The rename-based atomic write (#320) **transfers file ownership to whichever process wrote last**, while its "preserve existing mode" carries a stray `0o600` forward:

1. `.env` starts `0o600` owned by the **container** user (the old container create-mode).
2. The host's first rename-write makes it `0o600` owned by the **host** uid.
3. The container can now no longer even *read* the file. Before #398's fail-closed read, that EACCES became "file doesn't exist, start fresh" → **the wipe**. After #398, `POST /env` correctly errors — which is exactly what surfaced.

No NFS involvement required — this reproduces on plain Linux DooD. (The ESTALE retry from #398 remains useful as a transient-error belt on the File Gateway.)

## Fix

The agent `.env` is deliberately a **two-uid file**, so its mode is a contract, not a preference. New `forceMode` option on `writeFileAtomic` (host `file-storage.ts` + container `atomic-file.ts`, async + sync): re-assert the exact requested mode via fchmod on the temp fd — not umask-reduced, not preserved-from-existing. The three `.env` writers (`setSecret`, `deleteSecret`, `updateEnvFileEntry`) pass `{ mode: 0o666, forceMode: true }`.

This also **self-heals** an already-stuck 0600 file on the next successful write from either side (one secret edit from the UI is enough). Every other `writeFileAtomic` caller keeps the existing preserve-mode behavior.

## Tests

- Stuck-0600 heal regressions: host `setSecret` and container `updateEnvFileEntry` restore 0o666 over a poisoned file.
- `forceMode` override + exact-mode-on-create tests for all four atomic writers.
- Updated the one assertion that encoded the old umask-reduced expectation to the forced-exact-0666 contract.
- Full suites green on this base: host 6320 / container 422, tsc + lint clean.