### PR TITLE
fix(settings): lock Agent Image for runners with deployment-managed images

### DIFF
--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -80,6 +80,9 @@ vi.mock('@shared/lib/container/client-factory', () => ({
   checkAllRunnersAvailability: (...args: unknown[]) => mockCheckAllRunnersAvailability(...args),
   refreshRunnerAvailability: (...args: unknown[]) => mockRefreshRunnerAvailability(...args),
   startRunner: (...args: unknown[]) => mockStartRunner(...args),
+  getContainerClientClass: (runner: string) => ({
+    supportsCustomAgentImage: runner !== 'lambda-microvm',
+  }),
   SUPPORTED_RUNNERS: ['docker', 'podman'],
 }))
 
@@ -302,6 +305,68 @@ describe('settings route', () => {
       expect(res.status).toBe(200)
       const saved = mockUpdateSettings.mock.calls[0][0]
       expect(saved.container.resourceLimits).toEqual({ cpu: 8, memory: '16g' })
+    })
+  })
+
+  // =========================================================================
+  // Agent image locked for deployment-managed runners
+  // =========================================================================
+  describe('agentImage guard for runners without custom image support', () => {
+    it('returns 400 when changing agentImage while lambda-microvm is the configured runner', async () => {
+      mockGetSettings.mockReturnValue({
+        ...defaultSettings(),
+        container: {
+          containerRunner: 'lambda-microvm',
+          agentImage: 'superagent:latest',
+          resourceLimits: { cpu: 2, memory: '4g' },
+        },
+      })
+
+      const res = await putSettings({
+        container: { agentImage: 'ghcr.io/custom/image:v9' },
+      })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toContain('managed by the deployment')
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 when switching to lambda-microvm and changing agentImage in one request', async () => {
+      const res = await putSettings({
+        container: { containerRunner: 'lambda-microvm', agentImage: 'ghcr.io/custom/image:v9' },
+      })
+
+      expect(res.status).toBe(400)
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it('accepts an unchanged agentImage for lambda-microvm', async () => {
+      mockGetSettings.mockReturnValue({
+        ...defaultSettings(),
+        container: {
+          containerRunner: 'lambda-microvm',
+          agentImage: 'superagent:latest',
+          resourceLimits: { cpu: 2, memory: '4g' },
+        },
+      })
+
+      const res = await putSettings({
+        container: { agentImage: 'superagent:latest' },
+      })
+
+      expect(res.status).toBe(200)
+      expect(mockUpdateSettings).toHaveBeenCalledOnce()
+    })
+
+    it('still allows agentImage changes for runners that support it', async () => {
+      const res = await putSettings({
+        container: { agentImage: 'ghcr.io/custom/image:v9' },
+      })
+
+      expect(res.status).toBe(200)
+      const saved = mockUpdateSettings.mock.calls[0][0]
+      expect(saved.container.agentImage).toBe('ghcr.io/custom/image:v9')
     })
   })
 

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -36,7 +36,7 @@ import { getTenantId } from '@shared/lib/analytics/tenant-id'
 import { getSttProvider } from '@shared/lib/stt'
 import { findWebSearchProvider, getWebSearchProvider } from '@shared/lib/web-provider'
 import { containerManager } from '@shared/lib/container/container-manager'
-import { checkAllRunnersAvailability, refreshRunnerAvailability, startRunner, restartRunner, SUPPORTED_RUNNERS, type ContainerRunner } from '@shared/lib/container/client-factory'
+import { checkAllRunnersAvailability, refreshRunnerAvailability, startRunner, restartRunner, getContainerClientClass, SUPPORTED_RUNNERS, type ContainerRunner } from '@shared/lib/container/client-factory'
 import { VALID_LIMA_VM_MEMORY_OPTIONS, EFFORT_LEVELS } from '@shared/lib/container/types'
 import { customEnvVarsSchema } from '@shared/lib/container/reserved-env-vars'
 import { detectAllProviders } from '../../main/host-browser'
@@ -369,6 +369,23 @@ settings.put('/', async (c) => {
             runningAgents: await containerManager.getRunningAgentIds(),
           },
           409
+        )
+      }
+    }
+
+    // Reject agentImage changes for runners whose image is fixed by the
+    // deployment (e.g. lambda-microvm reads only MICROVM_AGENT_IMAGE_ARN).
+    if (body.container?.agentImage !== undefined) {
+      const newContainer = body.container as Partial<ContainerSettings>
+      const effectiveRunner = (newContainer.containerRunner ??
+        currentSettings.container.containerRunner) as ContainerRunner
+      if (
+        newContainer.agentImage !== currentSettings.container.agentImage &&
+        !getContainerClientClass(effectiveRunner).supportsCustomAgentImage
+      ) {
+        return c.json(
+          { error: `Agent image is managed by the deployment for the ${effectiveRunner} runner and cannot be changed here.` },
+          400
         )
       }
     }

--- a/src/renderer/components/settings/runtime-tab.test.tsx
+++ b/src/renderer/components/settings/runtime-tab.test.tsx
@@ -29,6 +29,7 @@ const mockSettings = {
         running: true,
         available: true,
         canStart: false,
+        supportsCustomAgentImage: true,
       },
     ],
     runtimeReadiness: { status: 'READY', message: 'Ready' },
@@ -80,8 +81,19 @@ vi.mock('@renderer/hooks/use-settings', () => ({
 describe('RuntimeTab', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockSettings.data.container.containerRunner = 'docker'
     mockSettings.data.container.agentImage = 'ghcr.io/skillfulagents/superagent-agent-container-base:latest'
     mockSettings.data.customEnvVars = {}
+    mockSettings.data.runnerAvailability = [
+      {
+        runner: 'docker',
+        installed: true,
+        running: true,
+        available: true,
+        canStart: false,
+        supportsCustomAgentImage: true,
+      },
+    ]
     mockUpdateSettings.isPending = false
     mockUpdateSettings.error = null
   })
@@ -126,6 +138,40 @@ describe('RuntimeTab', () => {
     await user.click(screen.getByRole('button', { name: 'Use default' }))
 
     expect(screen.getByLabelText('Agent Image')).toHaveValue(getDefaultAgentImage())
+  })
+
+  describe('runner without custom agent image support (e.g. lambda-microvm)', () => {
+    beforeEach(() => {
+      mockSettings.data.container.containerRunner = 'lambda-microvm'
+      mockSettings.data.runnerAvailability = [
+        {
+          runner: 'lambda-microvm',
+          installed: true,
+          running: true,
+          available: true,
+          canStart: false,
+          supportsCustomAgentImage: false,
+        },
+      ]
+    })
+
+    it('disables the Agent Image input and hides Use default', () => {
+      renderWithProviders(<RuntimeTab />)
+
+      expect(screen.getByLabelText('Agent Image')).toBeDisabled()
+      expect(screen.queryByRole('button', { name: 'Use default' })).not.toBeInTheDocument()
+      expect(
+        screen.getByText('Agent image is managed by the deployment for this runner and cannot be changed here.')
+      ).toBeInTheDocument()
+    })
+
+    it('does not treat a blank persisted agent image as a validation error', () => {
+      mockSettings.data.container.agentImage = ''
+
+      renderWithProviders(<RuntimeTab />)
+
+      expect(screen.queryByText('Agent image is required.')).not.toBeInTheDocument()
+    })
   })
 
   it('adds a custom environment variable through the dialog', async () => {

--- a/src/renderer/components/settings/runtime-tab.tsx
+++ b/src/renderer/components/settings/runtime-tab.tsx
@@ -132,17 +132,23 @@ export function RuntimeTab() {
 
   // Compute runner availability map with detailed status
   const runnerAvailabilityMap = useMemo(() => {
-    const map = new Map<string, { installed: boolean; running: boolean; available: boolean; canStart: boolean }>()
+    const map = new Map<string, { installed: boolean; running: boolean; available: boolean; canStart: boolean; supportsCustomAgentImage: boolean }>()
     settings?.runnerAvailability?.forEach((r) => {
       map.set(r.runner, {
         installed: r.installed,
         running: r.running,
         available: r.available,
         canStart: r.canStart,
+        supportsCustomAgentImage: r.supportsCustomAgentImage ?? true,
       })
     })
     return map
   }, [settings?.runnerAvailability])
+
+  // Runners whose image is fixed by the deployment (e.g. lambda-microvm) ignore
+  // settings.container.agentImage — lock the field so edits aren't misleading.
+  const agentImageLocked =
+    runnerAvailabilityMap.get(containerRunner)?.supportsCustomAgentImage === false
 
   const noRunnersAvailable = useMemo(() => {
     if (!settings?.runnerAvailability) return false
@@ -207,16 +213,16 @@ export function RuntimeTab() {
 
     const changed =
       containerRunner !== settings.container.containerRunner ||
-      agentImage !== settings.container.agentImage ||
+      (!agentImageLocked && agentImage !== settings.container.agentImage) ||
       cpuLimit !== settings.container.resourceLimits.cpu.toString() ||
       memoryLimit !== settings.container.resourceLimits.memory
 
     setHasChanges(changed)
-  }, [containerRunner, agentImage, cpuLimit, memoryLimit, settings])
+  }, [containerRunner, agentImage, cpuLimit, memoryLimit, settings, agentImageLocked])
 
   const latestAgentImage = getDefaultAgentImage()
   const trimmedAgentImage = agentImage.trim()
-  const agentImageMissing = trimmedAgentImage.length === 0
+  const agentImageMissing = !agentImageLocked && trimmedAgentImage.length === 0
   const isLatestAgentImage = trimmedAgentImage === latestAgentImage
 
   const handleSave = async () => {
@@ -225,7 +231,10 @@ export function RuntimeTab() {
       await updateSettings.mutateAsync({
         container: {
           containerRunner,
-          agentImage: trimmedAgentImage,
+          // A locked field never submits edits — keep whatever is persisted.
+          agentImage: agentImageLocked
+            ? (settings?.container.agentImage ?? trimmedAgentImage)
+            : trimmedAgentImage,
           resourceLimits: {
             cpu: parseInt(cpuLimit, 10) || 1,
             memory: memoryLimit,
@@ -608,21 +617,26 @@ export function RuntimeTab() {
           value={agentImage}
           onChange={(e) => setAgentImage(e.target.value)}
           placeholder="ghcr.io/skillfulagents/superagent-agent-container-base:latest"
-          disabled={isLoading}
+          disabled={isLoading || agentImageLocked}
+          className={agentImageLocked ? 'bg-muted' : ''}
         />
         <p className="text-xs text-muted-foreground">
-          Docker image to use for agent containers.
+          {agentImageLocked
+            ? 'Agent image is managed by the deployment for this runner and cannot be changed here.'
+            : 'Docker image to use for agent containers.'}
         </p>
-        <Button
-          type="button"
-          variant="link"
-          size="sm"
-          className="h-auto px-0 text-xs"
-          onClick={() => setAgentImage(latestAgentImage)}
-          disabled={isLoading || isLatestAgentImage}
-        >
-          Use default
-        </Button>
+        {!agentImageLocked && (
+          <Button
+            type="button"
+            variant="link"
+            size="sm"
+            className="h-auto px-0 text-xs"
+            onClick={() => setAgentImage(latestAgentImage)}
+            disabled={isLoading || isLatestAgentImage}
+          >
+            Use default
+          </Button>
+        )}
         {agentImageMissing && (
           <p className="text-xs text-destructive">Agent image is required.</p>
         )}

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -276,6 +276,9 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
   static readonly requiresLocalImage: boolean = true
 
+  /** Whether settings.container.agentImage is honored by this runtime. */
+  static readonly supportsCustomAgentImage: boolean = true
+
   /** Whether the CLI is installed. Subclasses must override. */
   static async isAvailable(): Promise<boolean> {
     throw new Error('Subclass must implement static isAvailable()')

--- a/src/shared/lib/container/client-factory.ts
+++ b/src/shared/lib/container/client-factory.ts
@@ -26,6 +26,8 @@ export interface RunnerAvailability {
   available: boolean
   /** If installed but not running, can we attempt to start it? */
   canStart: boolean
+  /** Whether settings.container.agentImage is honored by this runner. */
+  supportsCustomAgentImage: boolean
 }
 
 export interface StartRunnerResult {
@@ -277,9 +279,10 @@ export async function restartRunner(runner: ContainerRunner): Promise<StartRunne
  * Check detailed availability of a specific runner.
  */
 async function checkRunnerDetailedAvailability(runner: ContainerRunner): Promise<RunnerAvailability> {
+  const supportsCustomAgentImage = getContainerClientClass(runner).supportsCustomAgentImage
   const entry = ALL_RUNNERS.find((r) => r.name === runner)
   if (!entry) {
-    return { runner, installed: false, running: false, available: false, canStart: false }
+    return { runner, installed: false, running: false, available: false, canStart: false, supportsCustomAgentImage }
   }
 
   const installed = await entry.isAvailable()
@@ -291,6 +294,7 @@ async function checkRunnerDetailedAvailability(runner: ContainerRunner): Promise
       running: false,
       available: false,
       canStart: false,
+      supportsCustomAgentImage,
     }
   }
 
@@ -302,6 +306,7 @@ async function checkRunnerDetailedAvailability(runner: ContainerRunner): Promise
     running,
     available: running,
     canStart: !running && canAttemptStart(runner),
+    supportsCustomAgentImage,
   }
 }
 
@@ -312,7 +317,7 @@ async function checkRunnerDetailedAvailability(runner: ContainerRunner): Promise
 export async function checkAllRunnersAvailability(): Promise<RunnerAvailability[]> {
   // In E2E mock mode, skip real runtime checks
   if (process.env.E2E_MOCK === 'true') {
-    return [{ runner: 'docker', installed: true, running: true, available: true, canStart: false }]
+    return [{ runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true }]
   }
 
   const now = Date.now()

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -662,7 +662,7 @@ describe('containerManager.ensureImageReady — state machine', () => {
 
   it('transitions to READY when runner is available and image exists', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
-      { runner: 'docker', installed: true, running: true, available: true, canStart: false },
+      { runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },
     ])
     vi.mocked(checkImageExists).mockResolvedValue(true)
 
@@ -675,7 +675,7 @@ describe('containerManager.ensureImageReady — state machine', () => {
 
   it('transitions to RUNTIME_UNAVAILABLE when configured runner is not available', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
-      { runner: 'docker', installed: false, running: false, available: false, canStart: false },
+      { runner: 'docker', installed: false, running: false, available: false, canStart: false, supportsCustomAgentImage: true },
     ])
 
     await containerManager.ensureImageReady()
@@ -687,7 +687,7 @@ describe('containerManager.ensureImageReady — state machine', () => {
 
   it('pulls image when runner available but image does not exist', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
-      { runner: 'docker', installed: true, running: true, available: true, canStart: false },
+      { runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },
     ])
     vi.mocked(checkImageExists).mockResolvedValue(false)
     vi.mocked(canBuildImage).mockReturnValue(false)
@@ -704,7 +704,7 @@ describe('containerManager.ensureImageReady — state machine', () => {
 
   it('builds image when canBuildImage is true and image does not exist', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
-      { runner: 'docker', installed: true, running: true, available: true, canStart: false },
+      { runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },
     ])
     vi.mocked(checkImageExists).mockResolvedValue(false)
     vi.mocked(canBuildImage).mockReturnValue(true)
@@ -722,7 +722,7 @@ describe('containerManager.ensureImageReady — state machine', () => {
 
   it('transitions to ERROR when pull fails', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
-      { runner: 'docker', installed: true, running: true, available: true, canStart: false },
+      { runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },
     ])
     vi.mocked(checkImageExists).mockResolvedValue(false)
     vi.mocked(canBuildImage).mockReturnValue(false)
@@ -737,7 +737,7 @@ describe('containerManager.ensureImageReady — state machine', () => {
 
   it('transitions to ERROR when build fails', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
-      { runner: 'docker', installed: true, running: true, available: true, canStart: false },
+      { runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },
     ])
     vi.mocked(checkImageExists).mockResolvedValue(false)
     vi.mocked(canBuildImage).mockReturnValue(true)
@@ -752,7 +752,7 @@ describe('containerManager.ensureImageReady — state machine', () => {
 
   it('broadcasts readiness changes via SSE', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
-      { runner: 'docker', installed: true, running: true, available: true, canStart: false },
+      { runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },
     ])
     vi.mocked(checkImageExists).mockResolvedValue(true)
 
@@ -770,8 +770,8 @@ describe('containerManager.ensureImageReady — state machine', () => {
 
   it('auto-switches runner when configured runner unavailable but alternative exists', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
-      { runner: 'docker', installed: false, running: false, available: false, canStart: false },
-      { runner: 'podman', installed: true, running: true, available: true, canStart: false },
+      { runner: 'docker', installed: false, running: false, available: false, canStart: false, supportsCustomAgentImage: true },
+      { runner: 'podman', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },
     ])
     vi.mocked(checkImageExists).mockResolvedValue(true)
 
@@ -786,7 +786,7 @@ describe('containerManager.ensureImageReady — state machine', () => {
 
   it('reports RUNTIME_UNAVAILABLE when runner installed but not running and no alternative', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
-      { runner: 'docker', installed: true, running: false, available: false, canStart: false },
+      { runner: 'docker', installed: true, running: false, available: false, canStart: false, supportsCustomAgentImage: true },
     ])
 
     await containerManager.ensureImageReady()
@@ -798,7 +798,7 @@ describe('containerManager.ensureImageReady — state machine', () => {
 
   it('invokes progress callback during pull', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
-      { runner: 'docker', installed: true, running: true, available: true, canStart: false },
+      { runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },
     ])
     vi.mocked(checkImageExists).mockResolvedValue(false)
     vi.mocked(canBuildImage).mockReturnValue(false)
@@ -823,7 +823,7 @@ describe('containerManager.ensureImageReady — state machine', () => {
 
   it('transitions to ERROR when disk space is insufficient', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
-      { runner: 'docker', installed: true, running: true, available: true, canStart: false },
+      { runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },
     ])
     vi.mocked(checkImageExists).mockResolvedValue(false)
     // 1 GB free (below 5 GB threshold)
@@ -841,7 +841,7 @@ describe('containerManager.ensureImageReady — state machine', () => {
 
   it('sends info-level Sentry event when disk space is insufficient', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
-      { runner: 'docker', installed: true, running: true, available: true, canStart: false },
+      { runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },
     ])
     vi.mocked(checkImageExists).mockResolvedValue(false)
     mockStatfs.mockResolvedValue({ bavail: 2 * 1024 * 1024 * 1024 / 4096, bsize: 4096 })
@@ -860,7 +860,7 @@ describe('containerManager.ensureImageReady — state machine', () => {
 
   it('proceeds with pull when disk space is sufficient', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
-      { runner: 'docker', installed: true, running: true, available: true, canStart: false },
+      { runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },
     ])
     vi.mocked(checkImageExists).mockResolvedValue(false)
     vi.mocked(canBuildImage).mockReturnValue(false)
@@ -876,7 +876,7 @@ describe('containerManager.ensureImageReady — state machine', () => {
 
   it('proceeds with pull when statfs fails', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
-      { runner: 'docker', installed: true, running: true, available: true, canStart: false },
+      { runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },
     ])
     vi.mocked(checkImageExists).mockResolvedValue(false)
     vi.mocked(canBuildImage).mockReturnValue(false)
@@ -891,7 +891,7 @@ describe('containerManager.ensureImageReady — state machine', () => {
 
   it('skips disk space check when image already exists', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
-      { runner: 'docker', installed: true, running: true, available: true, canStart: false },
+      { runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },
     ])
     vi.mocked(checkImageExists).mockResolvedValue(true)
 

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -446,6 +446,8 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   static readonly runnerName = 'lambda-microvm'
   // Image is built once via create-microvm-image and run by AWS; nothing local.
   static readonly requiresLocalImage = false
+  // Image comes solely from MICROVM_AGENT_IMAGE_ARN/_VERSION; settings.container.agentImage is ignored.
+  static readonly supportsCustomAgentImage = false
 
   constructor(config: ContainerConfig) {
     super(config)


### PR DESCRIPTION
## What was broken

On the Runtime settings tab, the **Agent Image** field is editable when the container runner is `lambda-microvm` — but that runtime never reads `settings.container.agentImage`. Its image comes exclusively from `MICROVM_AGENT_IMAGE_ARN` / `MICROVM_AGENT_IMAGE_VERSION` env vars passed to `RunMicrovmCommand`. Editing the field persists a value that silently does nothing, misleading users into thinking they changed the running image.

## Repro

1. Deploy with `containerRunner: lambda-microvm`.
2. Open Settings → Runtime.
3. Agent Image shows an editable `ghcr.io/...` value; change it and save — nothing changes in the actual microVM image.

## What changed

- New static `supportsCustomAgentImage` flag on container client classes (default `true`; `false` for `LambdaMicroVmRuntimeClient`), following the existing `requiresLocalImage` pattern — no runner-type branching in the UI.
- Flag is surfaced through `RunnerAvailability` so the renderer reuses the existing settings payload.
- UI: Agent Image input is disabled (with explanatory helper text) and "Use default" is hidden when the selected runner doesn't honor the setting; the field is excluded from change detection/save payload.
- Server: `PUT /api/settings` returns 400 if a request tries to change `agentImage` while the effective runner doesn't support it (covers runner-switch-in-same-request).

## Test plan

- [x] `settings.test.ts`: 400 on agentImage change for lambda-microvm (current runner and switch-in-same-request), 200 for unchanged value, 200 for docker.
- [x] `runtime-tab.test.tsx`: field disabled + Use default hidden for unsupported runner; blank persisted image not flagged as validation error.
- [x] All 5 affected suites green (255 tests), typecheck/lint introduce no new issues.

Made with [Cursor](https://cursor.com)