### PR TITLE
test: cover admin invite + password-reset through the ForcePasswordChange gate

### DIFF
--- a/e2e/auth/specs/user-onboarding.spec.ts
+++ b/e2e/auth/specs/user-onboarding.spec.ts
@@ -1,0 +1,206 @@
+/**
+ * Admin user onboarding and recovery — invitation with a temporary password
+ * and admin password-reset, both forcing the change-password gate.
+ *
+ * Invitation is the only way to onboard users in closed/invitation_only
+ * signup mode, and admin reset IS password recovery (no email delivery
+ * exists). Both ride the hand-rolled /api/admin/users endpoints and the
+ * ForcePasswordChange AuthGate branch, which no test had ever rendered.
+ *
+ * Serial narrative on a dedicated server (auth-users project): user1 is the
+ * admin, user2 is the invitee. Identities are generated inside the tests so
+ * a serial-group retry (same live server) mints fresh users instead of
+ * colliding with the previous attempt's.
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '../fixtures/multi-user.fixture'
+import { AuthPage } from '../pages/auth.page'
+import { SettingsPage } from '../pages/settings.page'
+import { UserBarPage } from '../pages/user-bar.page'
+import { AppPage } from '../../pages/app.page'
+
+test.describe.configure({ mode: 'serial' })
+
+const admin = { name: 'Ivy Admin', email: 'ivy@test.com', password: 'password123' }
+const invitedName = 'Nina Newcomer'
+const firstPassword = 'first-real-pass-1'
+const secondPassword = 'second-real-pass-2'
+
+let invitedEmail = ''
+let inviteTempPassword = ''
+let resetTempPassword = ''
+
+function userRow(page: Page, email: string) {
+  return page.locator(`[data-testid="user-row-${email}"]`)
+}
+
+/** The amber "must change password on next login" indicator inside a user row. */
+function mustChangeDot(page: Page, email: string) {
+  return userRow(page, email).locator('span.rounded-full.bg-amber-500')
+}
+
+function changePasswordGate(page: Page) {
+  return page.getByText('Change Your Password')
+}
+
+/** Read the generated temp password out of the invite/reset result dialog. */
+async function readTempPassword(page: Page): Promise<string> {
+  const input = page.getByRole('dialog').locator('input.font-mono')
+  await expect(input).toBeVisible()
+  const value = await input.inputValue()
+  expect(value).toBeTruthy()
+  return value
+}
+
+async function openUsersTab(page: Page) {
+  const settingsPage = new SettingsPage(page)
+  await settingsPage.open()
+  await settingsPage.navigateToTab('users')
+}
+
+async function closeSettings(page: Page) {
+  await new SettingsPage(page).close()
+}
+
+async function submitPasswordChange(page: Page, current: string, next: string) {
+  await page.locator('#current-password').fill(current)
+  await page.locator('#new-password').fill(next)
+  await page.locator('#confirm-password').fill(next)
+  await page.getByRole('button', { name: 'Change Password' }).click()
+}
+
+/**
+ * Complete a forced change and end up inside the app. better-auth rotates the
+ * session on changePassword, so the ForcePasswordChange reload can come back
+ * signed out — in which case the user re-signs-in with the new password. Handle
+ * both the direct-in and re-login outcomes so the flow is deterministic.
+ */
+async function completeChangeAndEnter(page: Page, current: string, next: string, email: string) {
+  const appPage = new AppPage(page)
+  const authPage = new AuthPage(page)
+
+  await submitPasswordChange(page, current, next)
+
+  const settled = page.locator('[data-testid="app-sidebar"], [data-testid="auth-page"]').first()
+  await expect(settled).toBeVisible({ timeout: 15000 })
+
+  if (await page.locator('[data-testid="auth-page"]').isVisible().catch(() => false)) {
+    await authPage.signIn(email, next)
+  }
+
+  await appPage.waitForAppLoaded()
+  await appPage.dismissWizardIfVisible()
+  await expect(changePasswordGate(page)).not.toBeVisible()
+}
+
+test.describe('User Onboarding & Recovery', () => {
+  test('admin signs up', async ({ user1Page }) => {
+    const authPage = new AuthPage(user1Page)
+    const appPage = new AppPage(user1Page)
+
+    await authPage.resetToAuthPage()
+    await authPage.signUpOrSignIn(admin.name, admin.email, admin.password)
+    await appPage.waitForAppLoaded()
+    await appPage.dismissWizardIfVisible()
+  })
+
+  test('admin invites a user and receives a temporary password', async ({ user1Page }) => {
+    invitedEmail = `nina-${Date.now()}@test.com`
+
+    await openUsersTab(user1Page)
+    await user1Page.getByRole('button', { name: 'Invite' }).click()
+
+    const dialog = user1Page.getByRole('dialog')
+    await dialog.locator('#invite-name').fill(invitedName)
+    await dialog.locator('#invite-email').fill(invitedEmail)
+    // Role select stays on the default "User".
+    await dialog.getByRole('button', { name: 'Invite' }).click()
+
+    // The dialog flips to the temp-password view; capture the password.
+    await expect(dialog.getByText('User Invited')).toBeVisible()
+    inviteTempPassword = await readTempPassword(user1Page)
+    await dialog.getByRole('button', { name: 'Done' }).click()
+
+    // The new user appears in the list, flagged as must-change-password.
+    await expect(userRow(user1Page, invitedEmail)).toBeVisible()
+    await expect(mustChangeDot(user1Page, invitedEmail)).toBeVisible()
+    await closeSettings(user1Page)
+  })
+
+  test('invited user is blocked by the change-password gate on first sign-in', async ({ user2Page }) => {
+    const authPage = new AuthPage(user2Page)
+
+    await authPage.signIn(invitedEmail, inviteTempPassword)
+
+    // The gate replaces the whole app — no sidebar until the password changes.
+    await expect(changePasswordGate(user2Page)).toBeVisible({ timeout: 15000 })
+    await expect(user2Page.locator('[data-testid="app-sidebar"]')).not.toBeVisible()
+  })
+
+  test('wrong temporary password errors and keeps the gate up', async ({ user2Page }) => {
+    await submitPasswordChange(user2Page, 'not-the-temp-password', firstPassword)
+
+    await expect(user2Page.getByRole('alert')).toBeVisible({ timeout: 10000 })
+    await expect(changePasswordGate(user2Page)).toBeVisible()
+    await expect(user2Page.locator('[data-testid="app-sidebar"]')).not.toBeVisible()
+  })
+
+  test('valid change enters the app and clears the must-change flag', async ({ user1Page, user2Page }) => {
+    await completeChangeAndEnter(user2Page, inviteTempPassword, firstPassword, invitedEmail)
+
+    // Admin's Users tab no longer shows the must-change dot. The invitee cleared
+    // the flag in its own context, so reload the admin page to force a fresh
+    // users fetch rather than reading its cached (stale) list.
+    await user1Page.reload()
+    await openUsersTab(user1Page)
+    await expect(userRow(user1Page, invitedEmail)).toBeVisible()
+    await expect(mustChangeDot(user1Page, invitedEmail)).toHaveCount(0)
+    await closeSettings(user1Page)
+  })
+
+  test('admin password-reset re-arms the gate and invalidates the old password', async ({ user1Page, user2Page }) => {
+    const authPage = new AuthPage(user2Page)
+    const userBar = new UserBarPage(user2Page)
+
+    // The invitee signs out before the reset so the next sign-in is clean.
+    await userBar.signOut()
+    await new AuthPage(user2Page).expectVisible()
+
+    // Admin resets from the user row.
+    await openUsersTab(user1Page)
+    await userRow(user1Page, invitedEmail).getByRole('button', { name: 'Reset password' }).click()
+    const dialog = user1Page.getByRole('dialog')
+    await dialog.getByRole('button', { name: 'Reset Password' }).click()
+    await expect(dialog.getByText('Password Reset')).toBeVisible()
+    resetTempPassword = await readTempPassword(user1Page)
+    expect(resetTempPassword).not.toBe(inviteTempPassword)
+    await dialog.getByRole('button', { name: 'Done' }).click()
+
+    // The must-change dot is back.
+    await expect(mustChangeDot(user1Page, invitedEmail)).toBeVisible()
+    await closeSettings(user1Page)
+
+    // The password the user chose no longer works — the reset replaced it.
+    await authPage.signIn(invitedEmail, firstPassword)
+    await expect(user2Page.locator('[data-testid="signin-error"]')).toBeVisible()
+
+    // The new temp password signs in — straight into the gate again.
+    await authPage.signIn(invitedEmail, resetTempPassword)
+    await expect(changePasswordGate(user2Page)).toBeVisible({ timeout: 15000 })
+
+    // Completing the change enters the app.
+    await completeChangeAndEnter(user2Page, resetTempPassword, secondPassword, invitedEmail)
+  })
+
+  test('audit log records the invite and the reset', async ({ user1Page }) => {
+    const settingsPage = new SettingsPage(user1Page)
+    await settingsPage.open()
+    await settingsPage.navigateToTab('audit-log')
+
+    // Raw action values render in the Action column; `.first()` tolerates
+    // rows accumulated by serial-group retries on the same server.
+    await expect(user1Page.getByRole('cell', { name: 'invited', exact: true }).first()).toBeVisible()
+    await expect(user1Page.getByRole('cell', { name: 'reset_password', exact: true }).first()).toBeVisible()
+    await settingsPage.close()
+  })
+})

--- a/playwright.auth.config.ts
+++ b/playwright.auth.config.ts
@@ -26,6 +26,13 @@ const authProjects = [
     dataDir: path.join(e2eDataDir, 'settings'),
     viteCacheDir: path.join(e2eDataDir, '.vite', 'settings'),
   },
+  {
+    name: 'auth-users',
+    testMatch: '**/user-onboarding.spec.ts',
+    port: e2ePort + 2,
+    dataDir: path.join(e2eDataDir, 'users'),
+    viteCacheDir: path.join(e2eDataDir, '.vite', 'users'),
+  },
 ].map((project, index) => ({
   ...project,
   baseURL: index === 0 && process.env.E2E_BASE_URL


### PR DESCRIPTION
## What

E2E coverage-gap batch item #10: admin onboards and recovers users — invite with a temp password and admin password-reset, both forcing the change-password gate. Invitation is the **only** onboarding path in closed/invitation_only signup mode, and admin reset **is** password recovery (no email delivery exists). Both ride the hand-rolled `/api/admin/users/{invite,reset-password}` endpoints and the `ForcePasswordChange` AuthGate branch — which no test had ever rendered. Zero prior coverage.

New `e2e/auth/specs/user-onboarding.spec.ts` on a dedicated **auth-users** project (serial narrative, admin = user1, invitee = user2):

1. Admin invites a user (name/email, default User role) → temp-password result view → password captured; the new user appears in the Users tab flagged with the amber must-change dot.
2. Invitee signs in with the temp password → **ForcePasswordChange gate** blocks the whole app (no sidebar).
3. Wrong temporary password → inline error, gate stays up.
4. Valid change → enters the app, and the admin's Users tab no longer shows the must-change dot.
5. Admin **Reset Password** from the user row → new temp password (≠ the invite's); the dot returns; the user's own chosen password now fails (`signin-error`); the new temp password signs in straight into the gate again; completing the change re-enters the app.
6. Audit Log shows both the `invited` and `reset_password` action rows.

## Two behaviors worth calling out

- **The forced change rotates the session.** better-auth's `changePassword({revokeOtherSessions:true})` + the component's `window.location.reload()` can come back signed out, so completing the gate sometimes lands on the auth page and re-login with the new password is required. The flow handles both direct-in and re-login outcomes deterministically (waits for sidebar-or-auth-page, signs in if needed) — matching what a real user experiences.
- **Cross-context cache.** The invitee clears `mustChangePassword` in *its* browser context; the admin's cached users list doesn't auto-refetch, so the dot-cleared assertion reloads the admin page to force a fresh fetch (found via a `--repeat-each` flake, 3/4 → now 28/28).

## Config / CI

- `playwright.auth.config.ts`: new `auth-users` project on `port+2` with its own data dir (a saved-user/onboarding narrative mutates global server state — same isolation pattern as the existing auth-flow / auth-settings projects).
- **No workflow change:** the existing `e2e-auth-tests` job runs `npm run test:e2e:auth` with `PORT=3001`, so the config derives 3001/3002/3003 and just starts a third dev server on the fresh runner.

## Validation

- **auth-users**: 7/7, then `--repeat-each=4` → **28/28** with `--retries=0`.
- **Full auth suite (all 4 projects): 54/54** — proves the new project coexists with auth-flow / auth-settings / typing-indicator on their shared runner.
- `tsc --noEmit` + eslint clean.
- Test-only + config; no product code touched, and no main-suite files, so the mock main suite can't exercise this path (auth suite is the gate).

## Notes

Next batch candidate after this merges: tier-2 (ranks 11–22) from the tracker — I'll surface the top one when you're ready.