### PR TITLE
fix(env): auto-heal poisoned .env permissions on agent start

### DIFF
--- a/agent-container/src/env-file-store.test.ts
+++ b/agent-container/src/env-file-store.test.ts
@@ -13,6 +13,7 @@ import {
   readEnvFileOrNull,
   upsertEnvContent,
   updateEnvFileEntry,
+  healEnvFilePermissions,
 } from './env-file-store';
 
 let tmpDir: string;
@@ -294,5 +295,28 @@ describe('updateEnvFileEntry', () => {
     const content = fs.readFileSync(envPath, 'utf-8');
     expect(content).toContain('SEED=1');
     for (let i = 0; i < 10; i++) expect(content).toContain(`KEY_${i}="v${i}"`);
+  });
+});
+
+describe('healEnvFilePermissions (startup self-heal)', () => {
+  it.runIf(process.platform !== 'win32')('fixes a poisoned 0o600 file back to 0o666 without touching content', async () => {
+    fs.writeFileSync(envPath, 'SUPABASE_URL=https://x\n');
+    fs.chmodSync(envPath, 0o600);
+
+    expect(await healEnvFilePermissions(envPath)).toBe(true);
+
+    expect(fs.statSync(envPath).mode & 0o777).toBe(0o666);
+    expect(fs.readFileSync(envPath, 'utf-8')).toBe('SUPABASE_URL=https://x\n');
+  });
+
+  it.runIf(process.platform !== 'win32')('is a no-op on an already-correct file', async () => {
+    fs.writeFileSync(envPath, 'A=1\n');
+    fs.chmodSync(envPath, 0o666);
+    expect(await healEnvFilePermissions(envPath)).toBe(false);
+    expect(fs.statSync(envPath).mode & 0o777).toBe(0o666);
+  });
+
+  it('is a no-op (never throws) when the file is absent', async () => {
+    expect(await healEnvFilePermissions(envPath)).toBe(false);
   });
 });

--- a/agent-container/src/env-file-store.ts
+++ b/agent-container/src/env-file-store.ts
@@ -171,6 +171,25 @@ export function upsertEnvContent(content: string, key: string, value: string): s
 }
 
 /**
+ * Best-effort startup heal for a .env left with broken permissions by older
+ * builds: an atomic rename-replace flipped the file's owner while preserving a
+ * stray 0o600, locking the OTHER writer out entirely (it can't even read the
+ * file, let alone chmod it). chmod succeeds only for the file's owner — which
+ * is exactly the poisoned state this side can and must fix; everything else
+ * (absent file, not ours) is ignored. Returns true when a fix was applied.
+ */
+export async function healEnvFilePermissions(filePath: string): Promise<boolean> {
+  try {
+    const st = await fs.promises.stat(filePath);
+    if ((st.mode & 0o777) === 0o666) return false;
+    await fs.promises.chmod(filePath, 0o666);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Cross-process-safe upsert of a single `key=value` into the env file:
  * lock → fail-closed read → line-preserving merge → atomic write.
  *

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -15,7 +15,7 @@ import { inputManager } from './input-manager';
 import { dashboardManager } from './dashboard-manager';
 import { tabManager } from './tab-manager';
 import { runBrowserUpload } from './browser-upload';
-import { updateEnvFileEntry } from './env-file-store';
+import { updateEnvFileEntry, healEnvFilePermissions } from './env-file-store';
 
 import { getEditingCommands } from './cdp-editing-commands';
 
@@ -1623,6 +1623,13 @@ async function buildFileTree(
     return null;
   }
 }
+
+// Startup self-heal: older builds could leave /workspace/.env 0o600 and
+// owner-flipped, locking one writer out permanently. If WE own the poisoned
+// file, only we can fix it — do so before any session starts.
+void healEnvFilePermissions('/workspace/.env').then((healed) => {
+  if (healed) console.log('[ENV] Healed /workspace/.env permissions back to 0666');
+});
 
 // Start the server
 const port = parseInt(process.env.PORT || '3000');

--- a/src/shared/lib/services/secrets-service.atomic.test.ts
+++ b/src/shared/lib/services/secrets-service.atomic.test.ts
@@ -133,6 +133,50 @@ describe('atomic .env writes', () => {
     expect(fs.readFileSync(envPath('agent'), 'utf-8')).toBe(before)
   })
 
+  it.runIf(process.platform !== 'win32')('getSecretEnvVars heals a poisoned 0o600 .env on session start', async () => {
+    const { setSecret, getSecretEnvVars } = await importService()
+    await setSecret('agent', { envVar: 'SUPABASE_URL', key: 'SUPABASE_URL', value: 'https://x' })
+    fs.chmodSync(envPath('agent'), 0o600)
+
+    const names = await getSecretEnvVars('agent')
+
+    expect(names).toEqual(['SUPABASE_URL'])
+    expect(fs.statSync(envPath('agent')).mode & 0o777).toBe(0o666)
+  })
+
+  it('getSecretEnvVars degrades to [] (never wedges session start) when the .env is unreadable', async () => {
+    // Models the container-owned poisoned file: this process can neither chmod
+    // (owner-only) nor read it. Session creation must proceed with no secret
+    // names — the container heals the file it owns on boot — instead of 500ing
+    // forever (an unstartable session means the heal never runs: a hard wedge).
+    const { setSecret, getSecretEnvVars } = await importService()
+    await setSecret('agent', { envVar: 'SUPABASE_URL', key: 'SUPABASE_URL', value: 'https://x' })
+    const before = fs.readFileSync(envPath('agent'), 'utf-8')
+
+    const eacces = () =>
+      Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
+    const eperm = () => Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' })
+    const realReadFile = fs.promises.readFile.bind(fs.promises)
+    const readSpy = vi.spyOn(fs.promises, 'readFile').mockImplementation((async (
+      p: unknown,
+      ...args: unknown[]
+    ) => {
+      if (typeof p === 'string' && p.endsWith(path.join('workspace', '.env'))) throw eacces()
+      return (realReadFile as any)(p, ...args)
+    }) as typeof fs.promises.readFile)
+    const chmodSpy = vi.spyOn(fs.promises, 'chmod').mockRejectedValue(eperm())
+
+    try {
+      await expect(getSecretEnvVars('agent')).resolves.toEqual([])
+    } finally {
+      readSpy.mockRestore()
+      chmodSpy.mockRestore()
+    }
+
+    // Degradation is read-only: the file itself was never touched.
+    expect(fs.readFileSync(envPath('agent'), 'utf-8')).toBe(before)
+  })
+
   it('deleteSecret returns false (does NOT throw) when the workspace/.env is absent', async () => {
     // The agent's workspace dir doesn't exist, so opening the cross-process
     // lockfile would ENOENT. deleteSecret must short-circuit to false (→ route

--- a/src/shared/lib/services/secrets-service.ts
+++ b/src/shared/lib/services/secrets-service.ts
@@ -5,6 +5,7 @@
  * Secrets are stored in .env files in the agent workspace.
  */
 
+import * as fs from 'fs'
 import {
   getAgentEnvPath,
   getAgentWorkspaceDir,
@@ -268,9 +269,40 @@ export async function hasSecrets(agentSlug: string): Promise<boolean> {
 }
 
 /**
- * Get list of env var names (for passing to container session)
+ * Get list of env var names (for passing to container session).
+ *
+ * This runs on EVERY session start, which makes it the host's self-heal point
+ * for a .env poisoned by older builds (0o600 + owner flipped by an atomic
+ * rename): if this process owns the file, chmod it back to the 0o666 contract.
+ * If it can't even read the file (the container owns the poisoned copy),
+ * degrade to [] instead of failing session creation — this consumer only
+ * surfaces NAMES to the agent, and the booting container heals the file it
+ * owns on startup, so the next session recovers fully. Mutating paths
+ * (setSecret/deleteSecret) stay strictly fail-closed.
  */
 export async function getSecretEnvVars(agentSlug: string): Promise<string[]> {
-  const secrets = await listSecrets(agentSlug)
-  return secrets.map((s) => s.envVar)
+  const envPath = getAgentEnvPath(agentSlug)
+  try {
+    const st = await fs.promises.stat(envPath)
+    if ((st.mode & 0o777) !== 0o666) {
+      await fs.promises.chmod(envPath, 0o666)
+      console.warn(`[secrets] Healed ${envPath} permissions back to 0666`)
+    }
+  } catch {
+    // absent, or not ours to fix (chmod is owner-only) — the container heals its own
+  }
+  try {
+    const secrets = await listSecrets(agentSlug)
+    return secrets.map((s) => s.envVar)
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code
+    if (code === 'EACCES' || code === 'EPERM') {
+      console.warn(
+        `[secrets] ${envPath} unreadable (${code}) — starting session without secret names; ` +
+          'the agent container heals the file permissions on boot'
+      )
+      return []
+    }
+    throw err
+  }
 }


### PR DESCRIPTION
Follow-up to #398/#400. Those PRs stop *new* .env poisoning — this one rescues agents whose .env is **already** 0o600 + owner-flipped from when the buggy version was live. Without it, nothing auto-fixes them:

- **Host-owned 0600**: the container is locked out of its own env file until someone happens to edit a secret from the UI (that write force-restores 0666). Agent-side `source .env` fails silently in the meantime.
- **Container-owned 0600 + non-root host**: a **hard wedge**. `getSecretEnvVars` at session start (agents.ts) throws EACCES → session creation 500s → the container never boots → the only process that *can* chmod the file (its owner) never runs. The Secrets UI 500s too, and fail-closed `setSecret` refuses the write — no recovery path at all.

## Fix: both sides self-heal on agent start

Each side can always chmod a file **it** owns, and the two poisoned states are each owned by exactly one side — so dual best-effort heal covers everything:

1. **Container server boot**: `healEnvFilePermissions('/workspace/.env')` — chmod back to 0o666, owner-only by nature, logged when it fires.
2. **Host `getSecretEnvVars`** (runs on every session start, also used by scheduled tasks): chmod-heal when owner; if the file is *still* unreadable (EACCES/EPERM), start the session with **no secret names** instead of failing — a names-only, loudly-logged degradation. The booting container then heals the file it owns, and the next session recovers fully.

All mutating paths (`setSecret` / `deleteSecret` / `updateEnvFileEntry`) remain strictly fail-closed — the degradation applies only to the read-only names listing, so it can never re-introduce the wipe.

## Tests

- Container: heal fixes 0600→0666 without touching content; no-op on already-correct and absent files.
- Host: `getSecretEnvVars` heals a poisoned file on session start; unreadable file (mocked EACCES read + EPERM chmod, the non-owner case) degrades to `[]` without touching the file, instead of throwing.
- Full suites green on both packages on this base.