### PR TITLE
fix: eliminate permanently stuck chat working indicators

### DIFF
--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { serve } from '@hono/node-server';
 import { SessionManager } from './session-manager';
+import { parseStreamCursor } from './stream-replay';
 import { CreateSessionRequest, SendMessageRequest } from './types';
 import type { UUID } from 'crypto';
 import * as http from 'http';
@@ -1648,11 +1649,7 @@ server.on('upgrade', (request: http.IncomingMessage, socket: any, head: Buffer) 
     const sessionId = sessionMatch[1];
     // Optional resume cursor: the host's last-processed position. Replay picks
     // up exactly after it (same epoch) so no message is lost across reconnects.
-    const cursorEpoch = url.searchParams.get('epoch');
-    const sinceSeqRaw = url.searchParams.get('since_seq');
-    const sinceSeq = sinceSeqRaw !== null && Number.isInteger(Number(sinceSeqRaw))
-      ? Number(sinceSeqRaw)
-      : null;
+    const { epoch: cursorEpoch, sinceSeq } = parseStreamCursor(url.searchParams);
 
     wss.handleUpgrade(request, socket, head, (ws: WebSocket) => {
       handleWebSocketConnection(ws, sessionId, cursorEpoch, sinceSeq);

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -1646,9 +1646,16 @@ server.on('upgrade', (request: http.IncomingMessage, socket: any, head: Buffer) 
   const sessionMatch = pathname.match(/^\/sessions\/([^/]+)\/stream$/);
   if (sessionMatch) {
     const sessionId = sessionMatch[1];
+    // Optional resume cursor: the host's last-processed position. Replay picks
+    // up exactly after it (same epoch) so no message is lost across reconnects.
+    const cursorEpoch = url.searchParams.get('epoch');
+    const sinceSeqRaw = url.searchParams.get('since_seq');
+    const sinceSeq = sinceSeqRaw !== null && Number.isInteger(Number(sinceSeqRaw))
+      ? Number(sinceSeqRaw)
+      : null;
 
     wss.handleUpgrade(request, socket, head, (ws: WebSocket) => {
-      handleWebSocketConnection(ws, sessionId);
+      handleWebSocketConnection(ws, sessionId, cursorEpoch, sinceSeq);
     });
     return;
   }
@@ -1669,7 +1676,12 @@ server.on('upgrade', (request: http.IncomingMessage, socket: any, head: Buffer) 
   socket.destroy();
 });
 
-async function handleWebSocketConnection(ws: WebSocket, sessionId: string) {
+async function handleWebSocketConnection(
+  ws: WebSocket,
+  sessionId: string,
+  cursorEpoch: string | null = null,
+  sinceSeq: number | null = null
+) {
   console.log(`WebSocket connection established for session ${sessionId}`);
 
   const session = await sessionManager.getSession(sessionId);
@@ -1679,26 +1691,43 @@ async function handleWebSocketConnection(ws: WebSocket, sessionId: string) {
     return;
   }
 
-  // Announce the stream contract before relaying any SDK message (WS is FIFO,
-  // and this is sent before the subscription below, so it always precedes the
-  // first relayed message). session_state_events: this build runs the CLI with
-  // CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS, so the host can treat
-  // session_state_changed:'idle' as the idle authority from the first turn —
-  // a 'result' alone must not end the session while queued messages keep the
-  // runtime going.
-  ws.send(JSON.stringify({
-    type: 'system',
-    subtype: 'capabilities',
-    session_state_events: true,
-    timestamp: new Date(),
-  }));
-
-  // Subscribe to session events (SDK messages)
-  const unsubscribe = sessionManager.subscribe(sessionId, (message) => {
+  // Snapshot the replay set and subscribe in one synchronous operation, so no
+  // message can fall between them and wire order is strict: hello < replay <
+  // live (ws.send buffers FIFO; nothing can interleave inside this sync block).
+  const attach = sessionManager.attachStream(sessionId, cursorEpoch, sinceSeq, (message) => {
     if (ws.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify(message));
     }
   });
+  if (!attach) {
+    ws.send(JSON.stringify({ type: 'error', message: 'Session not found' }));
+    ws.close();
+    return;
+  }
+
+  // Announce the stream contract before relaying any SDK message.
+  // session_state_events: this build runs the CLI with
+  // CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS, so the host can treat
+  // session_state_changed:'idle' as the idle authority from the first turn —
+  // a 'result' alone must not end the session while queued messages keep the
+  // runtime going. epoch/max_seq: this incarnation's identity and current
+  // position, so the host can baseline (first attach), resume (same epoch),
+  // or reconcile a session whose previous incarnation died (epoch mismatch).
+  ws.send(JSON.stringify({
+    type: 'system',
+    subtype: 'capabilities',
+    session_state_events: true,
+    epoch: attach.epoch,
+    max_seq: attach.maxSeq,
+    timestamp: new Date(),
+  }));
+
+  // Lossless resume: everything after the host's cursor, before live relay.
+  for (const message of attach.replay) {
+    ws.send(JSON.stringify(message));
+  }
+
+  const unsubscribe = attach.unsubscribe;
 
   // Handle incoming messages
   ws.on('message', async (data: Buffer) => {

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -7,12 +7,17 @@ import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import { releaseBrowserLock } from './browser-state';
 import { claudeSettingsSchema, SESSION_RETENTION_DAYS } from './claude-settings-schema';
+import { computeReplay } from './stream-replay';
 
 interface SessionData {
   session: Session;
   process: ClaudeCodeProcess;
   messages: SDKMessage[];
   subscribers: Set<(message: SDKMessage) => void>;
+  // Identity of this in-memory incarnation (fresh on create AND on resume).
+  // Message seq numbers are per-epoch (the messages[] index); a host cursor
+  // from another epoch is meaningless and gets a full replay instead.
+  epoch: string;
 }
 
 export class SessionManager extends EventEmitter {
@@ -174,6 +179,7 @@ export class SessionManager extends EventEmitter {
       process,
       messages: [],
       subscribers: new Set(),
+      epoch: uuidv4(),
     };
 
     // Set up event listeners
@@ -262,6 +268,7 @@ export class SessionManager extends EventEmitter {
         process,
         messages: [],
         subscribers: new Set(),
+        epoch: uuidv4(),
       };
 
       // Set up event listeners (same as createSession)
@@ -404,6 +411,32 @@ export class SessionManager extends EventEmitter {
     };
   }
 
+  // Attach a stream consumer with a lossless handoff: snapshot the replay set
+  // and subscribe in ONE synchronous operation, so no message can fall between
+  // them and wire order is strict (attach header < replay < live). The replay
+  // honors the consumer's (epoch, sinceSeq) cursor — see computeReplay.
+  attachStream(
+    sessionId: string,
+    cursorEpoch: string | null,
+    sinceSeq: number | null,
+    callback: (message: SDKMessage) => void
+  ): { epoch: string; maxSeq: number; replay: SDKMessage[]; unsubscribe: () => void } | null {
+    const sessionData = this.sessions.get(sessionId);
+    if (!sessionData) return null;
+
+    const replay = computeReplay(sessionData.messages, sessionData.epoch, cursorEpoch, sinceSeq);
+    sessionData.subscribers.add(callback);
+
+    return {
+      epoch: sessionData.epoch,
+      maxSeq: sessionData.messages.length - 1,
+      replay,
+      unsubscribe: () => {
+        sessionData.subscribers.delete(callback);
+      },
+    };
+  }
+
   // Broadcast an arbitrary message to all subscribers of a session
   broadcast(sessionId: string, message: unknown): void {
     const sessionData = this.sessions.get(sessionId);
@@ -421,6 +454,12 @@ export class SessionManager extends EventEmitter {
   private handleMessage(sessionId: string, message: SDKMessage): void {
     const sessionData = this.sessions.get(sessionId);
     if (!sessionData) return;
+
+    // Stamp the per-epoch sequence number (the messages[] index) before
+    // storing, so the stored copy and every relayed copy carry it. A
+    // reconnecting host resumes from its last-processed (epoch, seq) cursor
+    // via attachStream's replay. broadcast() frames are seq-less by design.
+    (message as SDKMessage & { seq?: number }).seq = sessionData.messages.length;
 
     // Store the message
     sessionData.messages.push(message);

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -397,20 +397,6 @@ export class SessionManager extends EventEmitter {
     return [...sessionData.messages];
   }
 
-  subscribe(sessionId: string, callback: (message: SDKMessage) => void): () => void {
-    const sessionData = this.sessions.get(sessionId);
-    if (!sessionData) {
-      throw new Error(`Session ${sessionId} not found`);
-    }
-
-    sessionData.subscribers.add(callback);
-
-    // Return unsubscribe function
-    return () => {
-      sessionData.subscribers.delete(callback);
-    };
-  }
-
   // Attach a stream consumer with a lossless handoff: snapshot the replay set
   // and subscribe in ONE synchronous operation, so no message can fall between
   // them and wire order is strict (attach header < replay < live). The replay

--- a/agent-container/src/stream-replay.test.ts
+++ b/agent-container/src/stream-replay.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { computeReplay } from './stream-replay';
+import type { SDKMessage } from './types';
+
+// Replay selection for a (re)attaching stream consumer. The contract:
+// - no cursor            → live-only (empty replay). A fresh host attaching to
+//                          an old session must NOT replay history (it would
+//                          re-register long-dead background tasks).
+// - same-epoch cursor    → exactly the messages after it (lossless resume).
+// - different epoch      → everything this incarnation has: the numbering
+//                          restarted with the new process, and the new
+//                          epoch's history is small by construction.
+
+const msg = (i: number) => ({ type: 'assistant', seq: i }) as unknown as SDKMessage;
+const MESSAGES = [msg(0), msg(1), msg(2), msg(3)];
+const EPOCH = 'epoch-a';
+
+describe('computeReplay', () => {
+  it('returns nothing without a cursor (live-only attach)', () => {
+    expect(computeReplay(MESSAGES, EPOCH, null, null)).toEqual([]);
+  });
+
+  it('returns exactly the messages after a same-epoch cursor', () => {
+    expect(computeReplay(MESSAGES, EPOCH, EPOCH, 1)).toEqual([msg(2), msg(3)]);
+  });
+
+  it('returns everything after a same-epoch cursor of -1 (attach from the very start)', () => {
+    expect(computeReplay(MESSAGES, EPOCH, EPOCH, -1)).toEqual(MESSAGES);
+  });
+
+  it('returns nothing when the same-epoch cursor is already caught up', () => {
+    expect(computeReplay(MESSAGES, EPOCH, EPOCH, 3)).toEqual([]);
+  });
+
+  it('returns the full new-epoch history on an epoch mismatch (renumbered stream)', () => {
+    expect(computeReplay(MESSAGES, EPOCH, 'epoch-old', 999)).toEqual(MESSAGES);
+  });
+
+  it('returns a copy, never the live array', () => {
+    const out = computeReplay(MESSAGES, EPOCH, 'epoch-old', 0);
+    expect(out).not.toBe(MESSAGES);
+  });
+});

--- a/agent-container/src/stream-replay.test.ts
+++ b/agent-container/src/stream-replay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeReplay } from './stream-replay';
+import { computeReplay, parseStreamCursor } from './stream-replay';
 import type { SDKMessage } from './types';
 
 // Replay selection for a (re)attaching stream consumer. The contract:
@@ -39,5 +39,51 @@ describe('computeReplay', () => {
   it('returns a copy, never the live array', () => {
     const out = computeReplay(MESSAGES, EPOCH, 'epoch-old', 0);
     expect(out).not.toBe(MESSAGES);
+  });
+
+  it('handles an empty history for every cursor kind', () => {
+    expect(computeReplay([], EPOCH, null, null)).toEqual([]);
+    expect(computeReplay([], EPOCH, EPOCH, -1)).toEqual([]);
+    expect(computeReplay([], EPOCH, 'epoch-old', 5)).toEqual([]);
+  });
+
+  it('returns nothing when the cursor claims to be ahead of the history', () => {
+    expect(computeReplay(MESSAGES, EPOCH, EPOCH, 999)).toEqual([]);
+  });
+
+  it('clamps a below-range cursor to a full replay instead of slicing the tail', () => {
+    expect(computeReplay(MESSAGES, EPOCH, EPOCH, -5)).toEqual(MESSAGES);
+  });
+
+  it('replays from the start when asked without an epoch (fresh-session first attach)', () => {
+    // A host subscribing to a session it JUST created has no epoch yet but
+    // must not miss the first turn's events emitted before it attached.
+    expect(computeReplay(MESSAGES, EPOCH, null, -1)).toEqual(MESSAGES);
+  });
+
+  it('stays live-only for an epochless cursor at any other position', () => {
+    expect(computeReplay(MESSAGES, EPOCH, null, 1)).toEqual([]);
+  });
+});
+
+describe('parseStreamCursor', () => {
+  const parse = (qs: string) => parseStreamCursor(new URLSearchParams(qs));
+
+  it('returns nulls when the params are absent', () => {
+    expect(parse('')).toEqual({ epoch: null, sinceSeq: null });
+  });
+
+  it('parses a well-formed cursor', () => {
+    expect(parse('epoch=e1&since_seq=5')).toEqual({ epoch: 'e1', sinceSeq: 5 });
+    expect(parse('epoch=e1&since_seq=-1')).toEqual({ epoch: 'e1', sinceSeq: -1 });
+  });
+
+  it('treats an empty since_seq as no cursor (Number("") is 0, not a position)', () => {
+    expect(parse('epoch=e1&since_seq=')).toEqual({ epoch: 'e1', sinceSeq: null });
+  });
+
+  it('rejects non-integer since_seq values', () => {
+    expect(parse('since_seq=abc')).toEqual({ epoch: null, sinceSeq: null });
+    expect(parse('since_seq=1.5')).toEqual({ epoch: null, sinceSeq: null });
   });
 });

--- a/agent-container/src/stream-replay.ts
+++ b/agent-container/src/stream-replay.ts
@@ -1,0 +1,23 @@
+import type { SDKMessage } from './types';
+
+// Replay selection for a (re)attaching stream consumer.
+// - No cursor: live-only. A fresh host attaching to an old session must not
+//   replay history — it would re-process the whole transcript and re-register
+//   long-dead background tasks.
+// - Same-epoch cursor: exactly the messages after it (lossless resume across
+//   a reconnect gap; seq is the messages[] index, stamped at store time).
+// - Different epoch: the numbering restarted with this process incarnation,
+//   so the cursor is meaningless — send everything this incarnation has
+//   (small by construction: the epoch just started).
+export function computeReplay(
+  messages: SDKMessage[],
+  currentEpoch: string,
+  cursorEpoch: string | null,
+  sinceSeq: number | null
+): SDKMessage[] {
+  if (cursorEpoch === null) return [];
+  if (cursorEpoch === currentEpoch) {
+    return sinceSeq === null ? [] : messages.slice(sinceSeq + 1);
+  }
+  return [...messages];
+}

--- a/agent-container/src/stream-replay.ts
+++ b/agent-container/src/stream-replay.ts
@@ -15,9 +15,31 @@ export function computeReplay(
   cursorEpoch: string | null,
   sinceSeq: number | null
 ): SDKMessage[] {
-  if (cursorEpoch === null) return [];
+  if (cursorEpoch === null) {
+    // An explicit epochless `since_seq=-1` is the from-start request a host
+    // makes when attaching to a session it JUST created (it has no epoch yet,
+    // but must not miss first-turn events emitted before the attach). Any
+    // other epochless attach stays live-only.
+    return sinceSeq === -1 ? [...messages] : [];
+  }
   if (cursorEpoch === currentEpoch) {
-    return sinceSeq === null ? [] : messages.slice(sinceSeq + 1);
+    if (sinceSeq === null) return [];
+    // Clamp below -1: a raw-dial negative like -5 would slice(-4) and replay
+    // the TAIL — out of contract. Anything under -1 means "from the start".
+    return messages.slice(Math.max(sinceSeq + 1, 0));
   }
   return [...messages];
+}
+
+// Parse the resume cursor off the /stream upgrade URL. Missing, empty, or
+// non-integer values mean "no cursor" — `Number('')` is 0, so an explicit
+// empty-string guard keeps `?since_seq=` from silently reading as position 0.
+export function parseStreamCursor(params: URLSearchParams): {
+  epoch: string | null;
+  sinceSeq: number | null;
+} {
+  const epoch = params.get('epoch');
+  const raw = params.get('since_seq');
+  const n = raw === null || raw.trim() === '' ? NaN : Number(raw);
+  return { epoch, sinceSeq: Number.isInteger(n) ? n : null };
 }

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -105,6 +105,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
     subscribeToSession: vi.fn(),
     unsubscribeFromSession: vi.fn(),
     markSessionActive: vi.fn(),
+    markSessionInterrupted: vi.fn(),
     cancelAwaitingInput: vi.fn(),
     broadcastSessionEvent: vi.fn(),
   },
@@ -2189,6 +2190,43 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
     const body = await res.json()
     expect(body.queued).toBe(true)
     expect(mockSendMessage).toHaveBeenCalledWith('sess-1', 'hello', expect.any(String), {})
+  })
+})
+
+describe('failed send does not strand the working indicator — POST /:id/sessions/:sessionId/messages', () => {
+  let app: ReturnType<typeof createApp>
+  const URL = '/api/agents/test-agent/sessions/sess-1/messages'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    vi.mocked(getAgent).mockResolvedValue({ slug: 'test-agent', name: 'Test Agent' } as any)
+    mockIsAuthMode.mockReturnValue(false)
+  })
+
+  it('clears the freshly-activated session when the container send throws', async () => {
+    // Fresh turn (not queued): the handler marks the session active, then the send fails.
+    vi.mocked(messagePersister.isSessionActive).mockReturnValueOnce(false)
+    mockSendMessage.mockRejectedValueOnce(new Error('container unreachable'))
+
+    const res = await postJson(app, URL, { content: 'hello' })
+
+    expect(res.status).toBe(500)
+    // No turn will run to emit the settling idle, so the working indicator (and the
+    // desktop sidebar) would stay stuck forever unless we clear the session here.
+    expect(messagePersister.markSessionInterrupted).toHaveBeenCalledWith('sess-1')
+  })
+
+  it('does NOT clear the session when a queued send throws (an in-flight turn is still running)', async () => {
+    // wasQueued: the session was already active, so a real turn is mid-flight.
+    vi.mocked(messagePersister.isSessionActive).mockReturnValueOnce(true)
+    mockSendMessage.mockRejectedValueOnce(new Error('boom'))
+
+    const res = await postJson(app, URL, { content: 'hello' })
+
+    expect(res.status).toBe(500)
+    // The original turn will still emit its own idle — clearing here would wrongly settle it.
+    expect(messagePersister.markSessionInterrupted).not.toHaveBeenCalled()
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1573,6 +1573,10 @@ agents.get('/:id/sessions/:sessionId/raw-log', AgentRead(), async (c) => {
 
 // POST /api/agents/:id/sessions/:sessionId/messages - Send a message
 agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
+  // Set once we mark a fresh turn active. Hoisted so the catch can settle it: if the
+  // send (or the pre-send DB/broadcast work) throws, no turn runs to emit the idle that
+  // would clear the "Working…" indicator, so we must clear it ourselves.
+  let freshTurnSessionId: string | null = null
   try {
     const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
@@ -1616,6 +1620,9 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
     const wasQueued = messagePersister.isSessionActive(sessionId)
 
     messagePersister.markSessionActive(sessionId, agentSlug)
+    // Only a fresh turn: a queued send rides an already-active turn, whose own idle
+    // settles the indicator — clearing it on our send failure would wrongly cut it short.
+    if (!wasQueued) freshTurnSessionId = sessionId
 
     // A mid-turn send must not carry model/effort: the container treats a
     // parameter change as interrupt/restart of the in-flight query. The
@@ -1668,6 +1675,12 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
     return c.json({ success: true, uuid: messageUuid, queued: wasQueued }, 201)
   } catch (error) {
     console.error('Failed to send message:', error)
+    // A fresh turn we marked active never dispatched — clear it so the indicator
+    // doesn't hang (markSessionInterrupted only touches host state; nothing is
+    // running in the container to interrupt).
+    if (freshTurnSessionId) {
+      await messagePersister.markSessionInterrupted(freshTurnSessionId)
+    }
     return c.json({ error: 'Failed to send message' }, 500)
   }
 })

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1353,7 +1353,9 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
     try {
       messagePersister.markSessionActive(sessionId, slug)
       lifecycleStarted = true
-      await messagePersister.subscribeToSession(sessionId, client, sessionId, slug)
+      // fromStart: the first turn began at createSession, before this attach —
+      // replay from the start so a fast turn's terminal events aren't missed.
+      await messagePersister.subscribeToSession(sessionId, client, sessionId, slug, { fromStart: true })
 
       // Record author for initial message after we know the sessionId
       if (isAuthMode()) {

--- a/src/api/routes/scheduled-tasks.test.ts
+++ b/src/api/routes/scheduled-tasks.test.ts
@@ -231,6 +231,13 @@ describe('scheduled-tasks route', () => {
       { fromStart: true },
     )
     expect(mockMessagePersister.markSessionActive).toHaveBeenCalledWith('container-session-1', 'agent-one')
+    // Ordering matters: markSessionActive must run BEFORE subscribeToSession so
+    // the from-start replay's terminal events land with isActive already true.
+    // Marking after would let a fast turn's replayed result/idle be skipped,
+    // then clear the grace bits — pinning "working" forever.
+    expect(mockMessagePersister.markSessionActive.mock.invocationCallOrder[0]).toBeLessThan(
+      mockMessagePersister.subscribeToSession.mock.invocationCallOrder[0],
+    )
     expect(mockRecordManualExecution).toHaveBeenCalledWith('task-1', 'container-session-1')
     expect(mockMarkTaskExecuted).not.toHaveBeenCalled()
   })

--- a/src/api/routes/scheduled-tasks.test.ts
+++ b/src/api/routes/scheduled-tasks.test.ts
@@ -228,6 +228,7 @@ describe('scheduled-tasks route', () => {
       { createSession: mockCreateSession },
       'container-session-1',
       'agent-one',
+      { fromStart: true },
     )
     expect(mockMessagePersister.markSessionActive).toHaveBeenCalledWith('container-session-1', 'agent-one')
     expect(mockRecordManualExecution).toHaveBeenCalledWith('task-1', 'container-session-1')

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -293,12 +293,15 @@ scheduledTasksRouter.post('/:taskId/run-now', TaskAgentRole('user'), async (c) =
       scheduledTaskName: task.name || undefined,
     })
 
-    // fromStart: the task prompt is already running in the container —
-    // replay from the start so a fast first turn's terminal events aren't missed.
+    // Mark active BEFORE subscribing (matches agents.ts / x-agent.ts): the task
+    // turn is already running and subscribeToSession replays it from the start,
+    // so a fast turn's replayed result/idle must land with isActive already true.
+    // Marking after would let the idle be skipped, then clear the grace bits —
+    // pinning "working" forever.
+    messagePersister.markSessionActive(sessionId, task.agentSlug)
     await messagePersister.subscribeToSession(sessionId, client, sessionId, task.agentSlug, {
       fromStart: true,
     })
-    messagePersister.markSessionActive(sessionId, task.agentSlug)
 
     if (task.isRecurring) {
       // Recurring: keep schedule, just record the manual execution

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -293,7 +293,11 @@ scheduledTasksRouter.post('/:taskId/run-now', TaskAgentRole('user'), async (c) =
       scheduledTaskName: task.name || undefined,
     })
 
-    await messagePersister.subscribeToSession(sessionId, client, sessionId, task.agentSlug)
+    // fromStart: the task prompt is already running in the container —
+    // replay from the start so a fast first turn's terminal events aren't missed.
+    await messagePersister.subscribeToSession(sessionId, client, sessionId, task.agentSlug, {
+      fromStart: true,
+    })
     messagePersister.markSessionActive(sessionId, task.agentSlug)
 
     if (task.isRecurring) {

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -104,6 +104,7 @@ vi.mock('@shared/lib/container/container-manager', () => ({
 const mockIsSessionActive = vi.fn((_sessionId?: string): boolean => false)
 const mockIsSessionAwaitingInput = vi.fn((_sessionId?: string): boolean => false)
 const mockWaitForIdle = vi.fn(async (..._args: unknown[]) => {})
+const mockMarkSessionInterrupted = vi.fn(async (..._args: unknown[]) => {})
 vi.mock('@shared/lib/container/message-persister', () => ({
   messagePersister: {
     isSessionActive: (sessionId?: string) => mockIsSessionActive(sessionId),
@@ -113,6 +114,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
     subscribeToSession: vi.fn(),
     unsubscribeFromSession: vi.fn(),
     markSessionActive: vi.fn(),
+    markSessionInterrupted: (...args: unknown[]) => mockMarkSessionInterrupted(...args),
     setSlashCommands: vi.fn(),
   },
 }))
@@ -426,6 +428,24 @@ describe('/invoke', () => {
     mockGetAgent.mockResolvedValue(null)
     const res = await authedFetch('/x-agent/invoke', { slug: 'ghost', prompt: 'hi' })
     expect(res.status).toBe(404)
+  })
+
+  it('clears an existing session when the container send throws (no turn to emit the settling idle)', async () => {
+    reviewDecisions.push('allow')
+    // Existing-session invoke: isSessionActive=false (default) passes the 409 guard, so
+    // the handler marks the session active and dispatches. Make the container send fail.
+    mockSendMessage.mockRejectedValueOnce(new Error('container unreachable'))
+
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'hi',
+      sessionId: 'existing-sess-1',
+    })
+
+    // The send never reached the container, so nothing will emit the idle that settles
+    // the target's "Working…" (desktop sidebar + any mapped chat). Clear it, then fail.
+    expect(mockMarkSessionInterrupted).toHaveBeenCalledWith('existing-sess-1')
+    expect(res.status).toBe(500)
   })
 
   it('blocks invoke when policy is block', async () => {

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -615,7 +615,9 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
     console.warn('[x-agent] updateSessionMetadata failed (session usable, provenance not recorded)', metaErr)
   }
 
-  await messagePersister.subscribeToSession(newSessionId, client, newSessionId, targetSlug)
+  // fromStart: the initial message is already running in the container —
+  // replay from the start so a fast first turn's terminal events aren't missed.
+  await messagePersister.subscribeToSession(newSessionId, client, newSessionId, targetSlug, { fromStart: true })
   if (containerSession.slashCommands && containerSession.slashCommands.length > 0) {
     messagePersister.setSlashCommands(newSessionId, containerSession.slashCommands)
   }

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -532,7 +532,15 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
       await messagePersister.subscribeToSession(existingSessionId, client, existingSessionId, targetSlug)
     }
     messagePersister.markSessionActive(existingSessionId, targetSlug)
-    await client.sendMessage(existingSessionId, prompt)
+    try {
+      await client.sendMessage(existingSessionId, prompt)
+    } catch (error) {
+      // The send never reached the container, so no turn will run to emit the idle that
+      // settles the indicator. The 409 guard above guarantees we started this turn fresh,
+      // so clear the active state we just set (host-only — nothing is running to interrupt).
+      await messagePersister.markSessionInterrupted(existingSessionId)
+      throw error
+    }
 
     if (sync) {
       try {

--- a/src/shared/lib/chat-integrations/base-connector.ts
+++ b/src/shared/lib/chat-integrations/base-connector.ts
@@ -80,8 +80,14 @@ export abstract class ChatClientConnector {
    * Stop the working indicator as the response takes over. Idempotent — safe to
    * call repeatedly. Default no-op for connectors whose indicator is ephemeral
    * and self-expires.
+   *
+   * `yieldingToStream` marks the clear that fires on the first reply token: a
+   * connector whose indicator SHARES the reply surface (Telegram streams the reply
+   * into the same draft the placeholder used) must leave that surface for the
+   * stream rather than tear it down. Connectors with an independent surface (a
+   * Slack reaction, an iMessage typing bubble) ignore the flag and always clear.
    */
-  async stopWorking(_chatId: string): Promise<void> {}
+  async stopWorking(_chatId: string, _opts?: { yieldingToStream?: boolean }): Promise<void> {}
 
   /**
    * Send a file to the chat. Returns the external message ID.

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -1541,11 +1541,16 @@ export function reconcileIndicator(managed: ManagedConnector, activity: SessionA
  * so repeated clears (idle ticks, several clear events in a row) make ZERO connector
  * calls. Clearing is always EXPLICIT — stopping the tick never clears a persistent
  * draft, so the four immediate clears and the non-busy tick all route through here.
+ *
+ * `yieldingToStream` is set only by the first-reply-token clear: the streamed reply
+ * takes over the reply surface, so a connector whose indicator shares that surface
+ * (Telegram's draft) must not tear it down. Every other clear (card, idle, error,
+ * the tick, teardown) tears the surface down authoritatively.
  */
-export function clearIndicator(managed: ManagedConnector): void {
+export function clearIndicator(managed: ManagedConnector, yieldingToStream = false): void {
   if (!managed.indicatorShown) return
   managed.indicatorShown = false
-  managed.connector.stopWorking(managed.chatId).catch(() => {})
+  managed.connector.stopWorking(managed.chatId, { yieldingToStream }).catch(() => {})
 }
 
 /** Pull cadence for the indicator tick. At/under Telegram's draft expiry so drafts stay alive. */
@@ -1669,8 +1674,10 @@ export async function processSSEEvent(
       const text = data.text as string
       if (!text) break
       // First reply token → 'streaming' (non-busy): the streamed text owns the
-      // reply surface, so settle the indicator now. Idempotent; the tick backstops.
-      clearIndicator(managed)
+      // reply surface, so settle the indicator now. Yield the surface — on Telegram
+      // this streamed reply reuses the placeholder's draft, so a hard teardown would
+      // wipe it. Idempotent; the tick backstops.
+      clearIndicator(managed, true)
       managed.streamingState.accumulatedText += text
 
       const now = Date.now()

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -955,7 +955,11 @@ class ChatIntegrationManager {
       displayName,
     })
 
-    await messagePersister.subscribeToSession(sessionId, client, sessionId, integration.agentSlug)
+    // fromStart: the initial message is already running in the container —
+    // replay from the start so a fast first turn's terminal events aren't missed.
+    await messagePersister.subscribeToSession(sessionId, client, sessionId, integration.agentSlug, {
+      fromStart: true,
+    })
     messagePersister.markSessionActive(sessionId, integration.agentSlug)
     this.subscribeChatSession(integration.id, chatId, sessionId)
   }

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -955,12 +955,15 @@ class ChatIntegrationManager {
       displayName,
     })
 
-    // fromStart: the initial message is already running in the container —
-    // replay from the start so a fast first turn's terminal events aren't missed.
+    // Mark active BEFORE subscribing (matches agents.ts / x-agent.ts): the first
+    // turn is already running and subscribeToSession replays it from the start,
+    // so a fast turn's replayed result/idle must land with isActive already true.
+    // Marking after would let the idle be skipped, then clear the grace bits —
+    // pinning "working" forever.
+    messagePersister.markSessionActive(sessionId, integration.agentSlug)
     await messagePersister.subscribeToSession(sessionId, client, sessionId, integration.agentSlug, {
       fromStart: true,
     })
-    messagePersister.markSessionActive(sessionId, integration.agentSlug)
     this.subscribeChatSession(integration.id, chatId, sessionId)
   }
 

--- a/src/shared/lib/chat-integrations/finalize-streaming.test.ts
+++ b/src/shared/lib/chat-integrations/finalize-streaming.test.ts
@@ -440,9 +440,15 @@ describe('TelegramConnector.startWorking / stopWorking', () => {
       const second = (sendRichMessageDraft.mock.calls[1][0] as any).draft_id
       expect(second).toBe(first) // stable draft id, so the streaming response replaces it in place
 
+      // stopWorking is authoritative: with no stream to overwrite the placeholder it
+      // tears it down with a single blank draft on the SAME id (cleared in place). Still
+      // no self-heartbeat — advancing time re-sends nothing.
       await connector.stopWorking('999')
+      expect(sendRichMessageDraft).toHaveBeenCalledTimes(3) // one teardown send
+      expect((sendRichMessageDraft.mock.calls[2][0] as any).draft_id).toBe(first)
+      expect((sendRichMessageDraft.mock.calls[2][0] as any).rich_message).toEqual({ html: '' })
       await vi.advanceTimersByTimeAsync(5000)
-      expect(sendRichMessageDraft).toHaveBeenCalledTimes(2) // stop yields the draft; no further sends
+      expect(sendRichMessageDraft).toHaveBeenCalledTimes(3) // no self-heartbeat after teardown
     } finally {
       vi.useRealTimers()
     }

--- a/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
+++ b/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
@@ -116,6 +116,24 @@ describe('reconcileIndicator (idempotent paint/clear)', () => {
     clearIndicator(managed)
     expect(connector.stoppedWorking).toEqual([])
   })
+
+  // Both immediate clears route through stopWorking, but only the first-reply-token
+  // clear yields the shared surface (Telegram's draft becomes the streamed reply);
+  // terminal clears must tear the surface down authoritatively.
+  it('first-token clear yields the surface; terminal clears tear it down', async () => {
+    const connector = new MockChatClientConnector()
+    const managed = makeManaged(connector, 'chat-w')
+    const stop = vi.spyOn(connector, 'stopWorking')
+
+    managed.indicatorShown = true
+    await processSSEEvent(managed, { type: 'stream_delta', text: 'answer' })
+    expect(stop).toHaveBeenCalledWith('chat-w', { yieldingToStream: true })
+
+    stop.mockClear()
+    managed.indicatorShown = true
+    await processSSEEvent(managed, { type: 'session_idle' })
+    expect(stop).toHaveBeenCalledWith('chat-w', { yieldingToStream: false })
+  })
 })
 
 // ── The per-session tick (pull) ────────────────────────────────────────────────
@@ -496,6 +514,23 @@ describe('Telegram: stopWorking tears down a stranded "Working…" draft', () =>
     const { connector, sendRichMessageDraft } = makeRealDmConnector()
     await connector.startWorking(DM_CHAT, 'working')
     await connector.stopWorking(DM_CHAT)
+    sendRichMessageDraft.mockClear()
+    await connector.stopWorking(DM_CHAT)
+    expect(sendRichMessageDraft).not.toHaveBeenCalled()
+  })
+
+  it('a failed teardown send is swallowed and not retried', async () => {
+    const { connector, sendRichMessageDraft } = makeRealDmConnector()
+    await connector.startWorking(DM_CHAT, 'working')
+    sendRichMessageDraft.mockClear()
+    sendRichMessageDraft.mockRejectedValueOnce(new Error('telegram unreachable'))
+
+    // The blank-draft send fails: non-critical (the draft self-expires), so the
+    // failure is swallowed rather than surfaced to the clear path.
+    await expect(connector.stopWorking(DM_CHAT)).resolves.toBeUndefined()
+    expect(sendRichMessageDraft).toHaveBeenCalledTimes(1)
+
+    // Tracking was dropped before the attempt, so a later stop does not retry.
     sendRichMessageDraft.mockClear()
     await connector.stopWorking(DM_CHAT)
     expect(sendRichMessageDraft).not.toHaveBeenCalled()

--- a/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
+++ b/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
@@ -467,3 +467,49 @@ describe('Telegram: the native draft is labeled by activity', () => {
     await connector.stopWorking(DM_CHAT)
   })
 })
+
+// ── Root C: authoritative surface teardown ─────────────────────────────────────
+// The manager settles the indicator correctly, but the connector's VISIBLE surface can
+// outlive that settle: a Telegram "Working…" draft on a no-stream terminal turn (an
+// errored / card-only / file-only turn) lingers until the ~30s draft expiry because
+// stopWorking was a no-op. stopWorking must be authoritative at the surface — while
+// still YIELDING the shared draft to a streamed reply, which reuses the same draft_id
+// and would be wiped by a blank.
+
+describe('Telegram: stopWorking tears down a stranded "Working…" draft', () => {
+  it('replaces the stale draft in place on a no-stream terminal turn (not a ~30s leak)', async () => {
+    const { connector, sendRichMessageDraft } = makeRealDmConnector()
+    await connector.startWorking(DM_CHAT, 'working')
+    const workingDraftId = sendRichMessageDraft.mock.calls[0][0].draft_id
+    sendRichMessageDraft.mockClear()
+
+    // No streamed reply overwrote the draft, so stop must clear it in place rather
+    // than wait out Telegram's ephemeral-draft expiry.
+    await connector.stopWorking(DM_CHAT)
+
+    expect(sendRichMessageDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ draft_id: workingDraftId, rich_message: { html: '' } }),
+    )
+  })
+
+  it('is idempotent: a second stop makes no further draft call (no blank-draft spam)', async () => {
+    const { connector, sendRichMessageDraft } = makeRealDmConnector()
+    await connector.startWorking(DM_CHAT, 'working')
+    await connector.stopWorking(DM_CHAT)
+    sendRichMessageDraft.mockClear()
+    await connector.stopWorking(DM_CHAT)
+    expect(sendRichMessageDraft).not.toHaveBeenCalled()
+  })
+
+  it('yields the draft to an incoming stream: does NOT blank it (the reply reuses the draft_id)', async () => {
+    const { connector, sendRichMessageDraft } = makeRealDmConnector()
+    await connector.startWorking(DM_CHAT, 'working')
+    sendRichMessageDraft.mockClear()
+
+    // The first reply token settles the indicator, but the streamed reply reuses this
+    // draft — blanking here would wipe/renumber the live reply, so stop is a no-op.
+    await connector.stopWorking(DM_CHAT, { yieldingToStream: true })
+
+    expect(sendRichMessageDraft).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/lib/chat-integrations/slack-connector.reactions.test.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.reactions.test.ts
@@ -59,6 +59,30 @@ describe('SlackConnector thinking-reaction teardown', () => {
     )
   })
 
+  it('a sweep over two tracked reactions drops only the confirmed-gone one and retries the other', async () => {
+    const { connector, remove } = makeConnector()
+    // A second message landed mid-turn, so TWO reactions are tracked. The sweep
+    // visits them in insertion order: the first removes cleanly, the second
+    // fails transiently and must stay tracked.
+    remove
+      .mockResolvedValueOnce({ ok: true }) // '100.1' → settled, untracked
+      .mockRejectedValueOnce({ data: { error: 'ratelimited' } }) // '200.2' → kept
+    seedUserMessage(connector, 'C1', '100.1')
+    await connector.startWorking('C1', 'working')
+    seedUserMessage(connector, 'C1', '200.2')
+    await connector.startWorking('C1', 'working')
+
+    await connector.stopWorking('C1') // sweep attempts both
+    expect(remove).toHaveBeenCalledTimes(2)
+    expect(remove).toHaveBeenCalledWith(expect.objectContaining({ timestamp: '100.1' }))
+    expect(remove).toHaveBeenCalledWith(expect.objectContaining({ timestamp: '200.2' }))
+
+    remove.mockClear()
+    await connector.stopWorking('C1') // retry sweep: only the kept key
+    expect(remove).toHaveBeenCalledTimes(1)
+    expect(remove).toHaveBeenCalledWith(expect.objectContaining({ timestamp: '200.2' }))
+  })
+
   it('serializes a paint then clear so the reaction ends up removed even if add resolves late', async () => {
     const { connector, add, remove } = makeConnector()
     let releaseAdd!: () => void

--- a/src/shared/lib/chat-integrations/slack-connector.reactions.test.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.reactions.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest'
+import { SlackConnector } from './slack-connector'
+
+// The thinking-reaction surface is a live Slack reaction that never expires, so a
+// teardown that loses track of a reaction strands "Working…" forever. These tests drive
+// the real startWorking/stopWorking against a mock Slack web client.
+
+function makeConnector() {
+  const add = vi.fn(async () => ({ ok: true }))
+  const remove = vi.fn(async () => ({ ok: true }))
+  const connector = new SlackConnector({ botToken: 'xoxb-test', appToken: 'xapp-test' })
+  // app is private and only built on connect(); inject a mock exposing what reactions use.
+  ;(connector as unknown as { app: unknown }).app = { client: { reactions: { add, remove } } }
+  return { connector, add, remove }
+}
+
+function seedUserMessage(connector: SlackConnector, chatId: string, ts: string) {
+  ;(connector as unknown as { lastUserMessageTs: Map<string, string> }).lastUserMessageTs.set(chatId, ts)
+}
+
+describe('SlackConnector thinking-reaction teardown', () => {
+  it('keeps the reaction tracked when reactions.remove fails transiently, so a later clear retries', async () => {
+    const { connector, remove } = makeConnector()
+    remove
+      .mockRejectedValueOnce({ data: { error: 'ratelimited' } }) // first clear: transient failure
+      .mockResolvedValueOnce({ ok: true }) // second clear: succeeds
+    seedUserMessage(connector, 'C1', '100.1')
+
+    await connector.startWorking('C1', 'working') // add + track
+    await connector.stopWorking('C1') // remove fails transiently → key must stay tracked
+    await connector.stopWorking('C1') // retry → remove attempted again
+
+    expect(remove).toHaveBeenCalledTimes(2)
+  })
+
+  it('drops tracking when the reaction is already gone (no endless retry)', async () => {
+    const { connector, remove } = makeConnector()
+    remove.mockRejectedValue({ data: { error: 'no_reaction' } })
+    seedUserMessage(connector, 'C1', '100.1')
+
+    await connector.startWorking('C1', 'working')
+    await connector.stopWorking('C1') // "no_reaction" means gone → untrack
+    await connector.stopWorking('C1') // nothing tracked → no further remove attempt
+
+    expect(remove).toHaveBeenCalledTimes(1)
+  })
+
+  it('tracks the reaction even when reactions.add throws, so teardown can still remove it', async () => {
+    const { connector, add, remove } = makeConnector()
+    // The add lands on Slack but the client sees an error (lost response after commit).
+    add.mockRejectedValueOnce({ data: { error: 'ratelimited' } })
+    seedUserMessage(connector, 'C1', '100.1')
+
+    await connector.startWorking('C1', 'working') // add "fails" client-side but may be live
+    await connector.stopWorking('C1') // must still attempt to remove it
+
+    expect(remove).toHaveBeenCalledWith(
+      expect.objectContaining({ timestamp: '100.1', name: 'thinking_face' }),
+    )
+  })
+
+  it('serializes a paint then clear so the reaction ends up removed even if add resolves late', async () => {
+    const { connector, add, remove } = makeConnector()
+    let releaseAdd!: () => void
+    const addGate = new Promise<void>((r) => { releaseAdd = r })
+    add.mockImplementationOnce(async () => { await addGate; return { ok: true } }) // slow add
+    seedUserMessage(connector, 'C1', '100.1')
+
+    const painting = connector.startWorking('C1', 'working') // enqueues a slow add
+    const clearing = connector.stopWorking('C1') // enqueues the remove behind it
+    releaseAdd()
+    await Promise.all([painting, clearing])
+
+    // The remove must run AFTER the add completes, so the final state is "removed".
+    expect(add).toHaveBeenCalledTimes(1)
+    expect(remove).toHaveBeenCalledTimes(1)
+    const addOrder = add.mock.invocationCallOrder[0]
+    const removeOrder = remove.mock.invocationCallOrder[0]
+    expect(removeOrder).toBeGreaterThan(addOrder)
+  })
+})

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -250,6 +250,45 @@ export function reactionsForChat(activeReactions: Set<string>, chatId: string): 
     .map((k) => ({ key: k, ts: k.slice(prefix.length) }))
 }
 
+// Slack error codes meaning the reaction (or its message/channel) is already gone,
+// so there is nothing left to remove — safe to stop tracking it.
+const REACTION_GONE_CODES = new Set(['no_reaction', 'message_not_found', 'channel_not_found'])
+
+/**
+ * After attempting reactions.remove, decide whether the thinking reaction is settled
+ * (gone) and can be untracked, or whether the removal failed transiently and the key
+ * must stay tracked for a later retry. A Slack reaction never expires, so untracking a
+ * still-live reaction strands it forever — default to "not settled" on any unknown error.
+ */
+export function reactionRemovalSettled(err: unknown): boolean {
+  if (err == null) return true // removed successfully
+  const code = (err as { data?: { error?: string } })?.data?.error
+  return code !== undefined && REACTION_GONE_CODES.has(code)
+}
+
+/**
+ * Serialize async operations per key: each op chains off the prior op on the same key,
+ * so fire-and-forget calls that would otherwise race at the network (e.g. a reaction add
+ * from one indicator tick and a remove from the next) apply in call order. Mirrors the
+ * per-chat promise-tail idiom used for the message queue in ChatIntegrationManager.
+ */
+export function createPerKeySerializer(): <T>(key: string, op: () => Promise<T>) => Promise<T> {
+  const tails = new Map<string, Promise<unknown>>()
+  return function run<T>(key: string, op: () => Promise<T>): Promise<T> {
+    const prev = tails.get(key) ?? Promise.resolve()
+    // Run op regardless of whether the prior op resolved or rejected, so one failed op
+    // doesn't stall the rest of the queue.
+    const result = prev.then(op, op)
+    const tail = result.catch(() => {}) // swallow so the chain itself never rejects
+    tails.set(key, tail)
+    // Evict once settled, but only if a newer op hasn't already replaced this tail.
+    void tail.finally(() => {
+      if (tails.get(key) === tail) tails.delete(key)
+    })
+    return result
+  }
+}
+
 // ── Connector ───────────────────────────────────────────────────────────
 
 export class SlackConnector extends ChatClientConnector {
@@ -275,6 +314,10 @@ export class SlackConnector extends ChatClientConnector {
 
   // Track whether we have a thinking reaction active
   private activeReactions: Set<string> = new Set() // effectiveChatId:ts
+
+  // Serialize reaction add/remove per chat so a paint (add) from one indicator tick and
+  // a clear (remove) from the next don't race at the network and re-strand the reaction.
+  private runReaction = createPerKeySerializer()
 
   // Thread context: maps effective chatId → real channel + thread anchor ts (for answerInThread)
   private threadContextMap: Map<string, { channel: string; threadTs: string }> = new Map()
@@ -616,16 +659,23 @@ export class SlackConnector extends ChatClientConnector {
     if (this.activeReactions.has(key)) return // Already reacting
 
     const { channel } = this.resolveChannel(chatId)
-    try {
-      await this.app.client.reactions.add({
-        channel,
-        timestamp: lastTs,
-        name: 'thinking_face',
-      })
-      this.activeReactions.add(key)
-    } catch {
-      // Already reacted or message deleted — non-critical
-    }
+    // Track BEFORE the network call: an add that lands on Slack but whose response is
+    // lost (timeout after commit) would otherwise leave a live reaction that no teardown
+    // sweep knows about, so it never clears. Tracking first means the sweep always sees
+    // it; a spurious remove of one that never landed is a harmless no-op.
+    this.activeReactions.add(key)
+    await this.runReaction(chatId, async () => {
+      try {
+        await this.app?.client.reactions.add({
+          channel,
+          timestamp: lastTs,
+          name: 'thinking_face',
+        })
+      } catch {
+        // Already reacted or message deleted — non-critical. The key stays tracked so the
+        // teardown sweep will attempt (and harmlessly no-op) a remove.
+      }
+    })
   }
 
   async stopWorking(chatId: string): Promise<void> {
@@ -808,22 +858,30 @@ export class SlackConnector extends ChatClientConnector {
     if (entries.length === 0) return
 
     const { channel } = this.resolveChannel(chatId)
-    for (const { key, ts } of entries) {
-      await this.removeThinkingReaction(channel, ts)
-      this.activeReactions.delete(key)
-    }
+    await this.runReaction(chatId, async () => {
+      for (const { key, ts } of entries) {
+        const settled = await this.removeThinkingReaction(channel, ts)
+        // Only stop tracking once the reaction is confirmed gone. A transient failure
+        // keeps the key so the next clear retries — a Slack reaction never self-expires,
+        // so dropping tracking on a failed remove would strand it forever.
+        if (settled) this.activeReactions.delete(key)
+      }
+    })
   }
 
-  private async removeThinkingReaction(channel: string, ts: string): Promise<void> {
-    if (!this.app) return
+  // Returns whether the reaction is settled (gone) and can be untracked; false on a
+  // transient failure that leaves it possibly-live, so the caller keeps it for retry.
+  private async removeThinkingReaction(channel: string, ts: string): Promise<boolean> {
+    if (!this.app) return false
     try {
       await this.app.client.reactions.remove({
         channel,
         timestamp: ts,
         name: 'thinking_face',
       })
-    } catch {
-      // Reaction already removed or message deleted — non-critical
+      return true
+    } catch (err) {
+      return reactionRemovalSettled(err)
     }
   }
 

--- a/src/shared/lib/chat-integrations/slack-reactions.test.ts
+++ b/src/shared/lib/chat-integrations/slack-reactions.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { reactionRemovalSettled, createPerKeySerializer } from './slack-connector'
+
+// ── reactionRemovalSettled ──────────────────────────────────────────────
+// Decides whether we can stop tracking a thinking reaction after attempting to
+// remove it. "Settled" (true) = the reaction is gone (removed, or never there),
+// so drop the tracking key. Not settled (false) = a transient failure left the
+// reaction live on Slack, so KEEP the key and retry on the next sweep. A Slack
+// reaction never expires, so dropping tracking on a failed remove strands it forever.
+
+describe('reactionRemovalSettled', () => {
+  it('treats a successful removal as settled (drop the key)', () => {
+    expect(reactionRemovalSettled(undefined)).toBe(true)
+    expect(reactionRemovalSettled(null)).toBe(true)
+  })
+
+  it('treats "reaction/message/channel already gone" as settled — nothing left to retry', () => {
+    expect(reactionRemovalSettled({ data: { error: 'no_reaction' } })).toBe(true)
+    expect(reactionRemovalSettled({ data: { error: 'message_not_found' } })).toBe(true)
+    expect(reactionRemovalSettled({ data: { error: 'channel_not_found' } })).toBe(true)
+  })
+
+  it('treats transient failures as NOT settled — keep the key and retry', () => {
+    expect(reactionRemovalSettled({ data: { error: 'ratelimited' } })).toBe(false)
+    expect(reactionRemovalSettled({ data: { error: 'internal_error' } })).toBe(false)
+    // A plain network error has no Slack error code — assume the reaction may still be live.
+    expect(reactionRemovalSettled(new Error('socket hang up'))).toBe(false)
+  })
+})
+
+// ── createPerKeySerializer ──────────────────────────────────────────────
+// Serializes async ops per key so fire-and-forget calls (reaction add from one
+// tick, remove from the next) apply in call order instead of racing at the network.
+
+describe('createPerKeySerializer', () => {
+  it('runs same-key ops in call order even when the first settles later', async () => {
+    const run = createPerKeySerializer()
+    const order: string[] = []
+    let releaseA!: () => void
+    const gateA = new Promise<void>((r) => { releaseA = r })
+
+    const p1 = run('k', async () => { await gateA; order.push('A') }) // slow op enqueued first
+    const p2 = run('k', async () => { order.push('B') })              // must wait behind A
+    releaseA()
+    await Promise.all([p1, p2])
+
+    expect(order).toEqual(['A', 'B'])
+  })
+
+  it('does not serialize across different keys', async () => {
+    const run = createPerKeySerializer()
+    const order: string[] = []
+    let releaseA!: () => void
+    const gateA = new Promise<void>((r) => { releaseA = r })
+
+    const p1 = run('k1', async () => { await gateA; order.push('A') })
+    const p2 = run('k2', async () => { order.push('B') }) // different key runs immediately
+    await p2
+    expect(order).toEqual(['B'])
+
+    releaseA()
+    await p1
+    expect(order).toEqual(['B', 'A'])
+  })
+
+  it('a rejected op does not stall the next op on the same key', async () => {
+    const run = createPerKeySerializer()
+    const order: string[] = []
+
+    const p1 = run('k', async () => { order.push('A'); throw new Error('boom') })
+    const p2 = run('k', async () => { order.push('B') })
+
+    await expect(p1).rejects.toThrow('boom')
+    await p2
+    expect(order).toEqual(['A', 'B'])
+  })
+})

--- a/src/shared/lib/chat-integrations/slack-reactions.test.ts
+++ b/src/shared/lib/chat-integrations/slack-reactions.test.ts
@@ -74,4 +74,11 @@ describe('createPerKeySerializer', () => {
     await p2
     expect(order).toEqual(['A', 'B'])
   })
+
+  it('run resolves with the operation value even after a prior rejection on the same key', async () => {
+    const run = createPerKeySerializer()
+
+    await expect(run('k', async () => { throw new Error('x') })).rejects.toThrow()
+    await expect(run('k', async () => 42)).resolves.toBe(42)
+  })
 })

--- a/src/shared/lib/chat-integrations/telegram-connector.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.ts
@@ -458,10 +458,28 @@ export class TelegramConnector extends ChatClientConnector {
     await this.sendWorkingIndicator(chatId)
   }
 
-  async stopWorking(chatId: string): Promise<void> {
+  async stopWorking(chatId: string, opts?: { yieldingToStream?: boolean }): Promise<void> {
     this.workingActivity.delete(chatId)
-    // The streaming response shares the draft_id and replaces the draft in place,
-    // so the clear yields the surface — there is nothing else to tear down.
+    // The streamed reply reuses this chat's draft_id (the "Working…" placeholder
+    // morphs into the reply text), so when we are yielding to that stream there is
+    // nothing to tear down — blanking here would wipe the live reply.
+    if (opts?.yieldingToStream) return
+    // Otherwise the turn ended with no streamed reply to overwrite the draft (an
+    // errored, card-only, or file-only turn). Telegram has no delete-draft API, so
+    // replace the stale placeholder in place with a blank draft (same draft_id →
+    // animated) — else it lingers showing "Working…" until the ~30s draft expiry.
+    const draftId = this.activeDrafts.get(chatId)
+    if (draftId === undefined || !this.bot) return
+    this.activeDrafts.delete(chatId)
+    try {
+      await this.bot.api.raw.sendRichMessageDraft({
+        chat_id: Number(chatId),
+        draft_id: draftId,
+        rich_message: { html: '' },
+      })
+    } catch {
+      // Non-critical: the stale draft self-expires within ~30s if this send fails.
+    }
   }
 
   /** The native-draft label for a busy activity (`<tg-thinking>` inner HTML). */

--- a/src/shared/lib/container/base-container-client.stream.test.ts
+++ b/src/shared/lib/container/base-container-client.stream.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { BaseContainerClient } from './base-container-client'
+import type { ContainerConfig, ContainerInfo, StreamMessage } from './types'
+
+// ============================================================================
+// subscribeToStream — resume cursors, socket identity guards, Zod envelope
+// ============================================================================
+
+/**
+ * Controllable stand-in for the `ws` module. Hand-rolled listener registry
+ * (vi.hoisted runs before module imports, so extending Node's EventEmitter is
+ * not an option here). close()/terminate() are deliberate no-ops: a real
+ * socket's 'close' arrives asynchronously, so tests emit it by hand to model
+ * the replaced-socket race.
+ */
+const { FakeWebSocket } = vi.hoisted(() => {
+  class FakeWebSocket {
+    static OPEN = 1
+    static instances: FakeWebSocket[] = []
+    readonly url: string
+    readyState = 1
+    private listeners = new Map<string, Array<(...args: unknown[]) => void>>()
+
+    constructor(url: string) {
+      this.url = url
+      FakeWebSocket.instances.push(this)
+    }
+
+    ping(): void {}
+
+    on(event: string, listener: (...args: unknown[]) => void): this {
+      const existing = this.listeners.get(event) ?? []
+      existing.push(listener)
+      this.listeners.set(event, existing)
+      return this
+    }
+
+    emit(event: string, ...args: unknown[]): void {
+      for (const listener of this.listeners.get(event) ?? []) {
+        listener(...args)
+      }
+    }
+
+    removeAllListeners(): this {
+      this.listeners.clear()
+      return this
+    }
+
+    close(): void {}
+    terminate(): void {}
+  }
+  return { FakeWebSocket }
+})
+
+vi.mock('ws', () => ({ default: FakeWebSocket }))
+
+/** Minimal concrete client whose container reports as running, so
+ * subscribeToStream's getPortOrThrow resolves and a socket is created. */
+class RunningTestClient extends BaseContainerClient {
+  protected getRunnerCommand(): string {
+    return 'docker'
+  }
+  async getInfoFromRuntime(): Promise<ContainerInfo> {
+    return { status: 'running', port: 12345 }
+  }
+}
+
+function makeClient(): RunningTestClient {
+  return new RunningTestClient({ agentId: 'test-agent' } as ContainerConfig)
+}
+
+/** Socket creation happens after an awaited getPortOrThrow, so tests wait for
+ * the fake constructor to have run before emitting events on it. */
+async function socketAt(index: number): Promise<InstanceType<typeof FakeWebSocket>> {
+  await vi.waitFor(() => {
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(index)
+  })
+  return FakeWebSocket.instances[index]
+}
+
+beforeEach(() => {
+  FakeWebSocket.instances.length = 0
+})
+
+describe('subscribeToStream connection lifecycle', () => {
+  it('delivers exactly one connection_closed when the tracked socket closes', async () => {
+    const client = makeClient()
+    const received: StreamMessage[] = []
+    const { ready } = client.subscribeToStream('sess-a', (m) => received.push(m))
+
+    const ws = await socketAt(0)
+    ws.emit('open')
+    await ready
+
+    ws.emit('close')
+    // A second close from the same (now untracked) socket must stay silent.
+    ws.emit('close')
+
+    expect(received).toHaveLength(1)
+    expect(received[0].type).toBe('connection_closed')
+    expect(received[0].sessionId).toBe('sess-a')
+  })
+
+  it('a replaced socket closes silently; only the tracked socket reports connection_closed', async () => {
+    const client = makeClient()
+    const cb1 = vi.fn<(m: StreamMessage) => void>()
+    const cb2 = vi.fn<(m: StreamMessage) => void>()
+
+    const sub1 = client.subscribeToStream('sess-b', cb1)
+    sub1.ready.catch(() => {})
+    const ws1 = await socketAt(0)
+    ws1.emit('open')
+    await sub1.ready
+
+    // Re-subscribe for the same session: ws2 replaces ws1 in the map.
+    const sub2 = client.subscribeToStream('sess-b', cb2)
+    sub2.ready.catch(() => {})
+    const ws2 = await socketAt(1)
+    ws2.emit('open')
+    await sub2.ready
+
+    // The old socket's close arrives late (fake close() is a no-op, so this
+    // models the real async close). Identity guard: nobody hears it.
+    ws1.emit('close')
+    expect(cb1).not.toHaveBeenCalled()
+    expect(cb2).not.toHaveBeenCalled()
+
+    ws2.emit('close')
+    expect(cb1).not.toHaveBeenCalled()
+    expect(cb2).toHaveBeenCalledTimes(1)
+    expect(cb2.mock.calls[0][0].type).toBe('connection_closed')
+  })
+
+  it("ignores 'error' from a replaced socket but emits it for the tracked one", async () => {
+    const client = makeClient()
+    const errorSpy = vi.fn()
+    client.on('error', errorSpy)
+
+    const sub1 = client.subscribeToStream('sess-c', () => {})
+    sub1.ready.catch(() => {})
+    const ws1 = await socketAt(0)
+
+    const sub2 = client.subscribeToStream('sess-c', () => {})
+    sub2.ready.catch(() => {})
+    const ws2 = await socketAt(1)
+
+    ws1.emit('error', new Error('stale socket error'))
+    expect(errorSpy).not.toHaveBeenCalled()
+
+    ws2.emit('error', new Error('live socket error'))
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    expect((errorSpy.mock.calls[0][0] as Error).message).toBe('live socket error')
+  })
+})
+
+describe('subscribeToStream resume cursor', () => {
+  it('appends epoch and since_seq query params when a cursor is given', async () => {
+    const client = makeClient()
+    const sub = client.subscribeToStream('sess-d', () => {}, { epoch: 'e1', sinceSeq: 5 })
+    sub.ready.catch(() => {})
+
+    const ws = await socketAt(0)
+    expect(ws.url.endsWith('/sessions/sess-d/stream?epoch=e1&since_seq=5')).toBe(true)
+  })
+
+  it('omits query params when no cursor is given', async () => {
+    const client = makeClient()
+    const sub = client.subscribeToStream('sess-d2', () => {})
+    sub.ready.catch(() => {})
+
+    const ws = await socketAt(0)
+    expect(ws.url).not.toContain('?')
+    expect(ws.url.endsWith('/sessions/sess-d2/stream')).toBe(true)
+  })
+})
+
+describe('subscribeToStream liveness (ping/pong)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('terminates a half-open socket after a missed pong window and reports the loss', async () => {
+    const client = makeClient()
+    const received: StreamMessage[] = []
+    const sub = client.subscribeToStream('sess-f', (m) => received.push(m))
+    sub.ready.catch(() => {})
+    const ws = await socketAt(0)
+
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] })
+    const ping = vi.spyOn(ws, 'ping')
+    const terminate = vi.spyOn(ws, 'terminate')
+    ws.emit('open')
+    await sub.ready
+
+    // First window: ping goes out, nothing answers.
+    vi.advanceTimersByTime(30_000)
+    expect(ping).toHaveBeenCalledTimes(1)
+    expect(terminate).not.toHaveBeenCalled()
+
+    // Second window with no pong: the peer is gone — terminate.
+    vi.advanceTimersByTime(30_000)
+    expect(terminate).toHaveBeenCalledTimes(1)
+
+    // The real socket fires 'close' after terminate; that is the recovery path.
+    ws.emit('close')
+    expect(received).toHaveLength(1)
+    expect(received[0].type).toBe('connection_closed')
+
+    // The timer died with the socket: no pings after close.
+    vi.advanceTimersByTime(120_000)
+    expect(ping).toHaveBeenCalledTimes(1)
+  })
+
+  it('a responsive socket is never terminated', async () => {
+    const client = makeClient()
+    const sub = client.subscribeToStream('sess-g', () => {})
+    sub.ready.catch(() => {})
+    const ws = await socketAt(0)
+
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] })
+    const ping = vi.spyOn(ws, 'ping')
+    const terminate = vi.spyOn(ws, 'terminate')
+    ws.emit('open')
+    await sub.ready
+
+    for (let i = 1; i <= 3; i++) {
+      vi.advanceTimersByTime(30_000)
+      expect(ping).toHaveBeenCalledTimes(i)
+      ws.emit('pong')
+    }
+    expect(terminate).not.toHaveBeenCalled()
+  })
+})
+
+describe('subscribeToStream envelope validation', () => {
+  it('drops frames that fail the envelope schema and keeps the subscription alive', async () => {
+    const client = makeClient()
+    const received: StreamMessage[] = []
+    const sub = client.subscribeToStream('sess-e', (m) => received.push(m))
+    sub.ready.catch(() => {})
+
+    const ws = await socketAt(0)
+    ws.emit('open')
+    await sub.ready
+
+    // Not JSON at all.
+    ws.emit('message', 'not json')
+    expect(received).toHaveLength(0)
+
+    // Valid JSON but missing the required `type` field.
+    ws.emit('message', '{"foo":1}')
+    expect(received).toHaveLength(0)
+
+    // A valid frame still gets through — bad frames didn't kill the handler.
+    ws.emit('message', '{"type":"system","subtype":"capabilities"}')
+    expect(received).toHaveLength(1)
+    expect(received[0].type).toBe('system')
+    expect(received[0].content).toMatchObject({ type: 'system', subtype: 'capabilities' })
+    expect(received[0].sessionId).toBe('sess-e')
+  })
+})

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -218,6 +218,13 @@ export function isConnectionError(err: Error): boolean {
 
 export const AGENT_CONTAINER_PATH = './agent-container'
 export const CONTAINER_INTERNAL_PORT = 3000
+
+// Liveness probe for the session stream socket. The host never writes on it
+// (messages go over HTTP), so a half-open TCP connection would otherwise die
+// silently — no close event, no reconnect, and every event in the gap lost.
+// A missed pong terminates the socket, which fires the close handler and
+// routes into the normal reconnect + cursor-replay recovery.
+export const STREAM_PING_INTERVAL_MS = 30_000
 // Host port where findAvailablePort() starts scanning. Overridable via
 // SUPERAGENT_BASE_PORT so a second app instance (e.g. `dev:electron` alongside a
 // prod install) can publish containers in a non-overlapping range. Cross-runtime
@@ -1240,7 +1247,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   subscribeToStream(
     sessionId: string,
     callback: (message: StreamMessage) => void,
-    cursor?: { epoch: string; sinceSeq: number }
+    cursor?: { epoch?: string; sinceSeq: number }
   ): { unsubscribe: () => void; ready: Promise<void> } {
     let resolveReady: () => void
     let rejectReady: (error: Error) => void
@@ -1259,26 +1266,56 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
       // Resume cursor: the container replays exactly what was missed after the
       // host's last-processed (epoch, seq) position, so terminal events emitted
-      // during a reconnect gap are never lost.
-      const cursorParams = cursor
-        ? `?epoch=${encodeURIComponent(cursor.epoch)}&since_seq=${cursor.sinceSeq}`
-        : ''
+      // during a reconnect gap are never lost. Epochless -1 = from-start
+      // (first attach to a just-created session).
+      let cursorParams = ''
+      if (cursor) {
+        const params = new URLSearchParams()
+        if (cursor.epoch) params.set('epoch', cursor.epoch)
+        params.set('since_seq', String(cursor.sinceSeq))
+        cursorParams = `?${params}`
+      }
       const ws = new WebSocket(
         `${this.getWebSocketBaseUrl(port)}/sessions/${sessionId}/stream${cursorParams}`
       )
 
+      // Liveness: the host never writes on this socket, so a half-open TCP
+      // connection (NAT idle-timeout, VM pause) would die silently — no close
+      // event, no reconnect, every event in the gap lost. Ping each interval;
+      // a window with no pong means the peer is gone: terminate(), which
+      // fires the close handler and routes into reconnect + cursor replay.
+      let pongReceived = true
+      let pingTimer: ReturnType<typeof setInterval> | null = null
+
       ws.on('open', () => {
         console.log(`WebSocket connected for session ${sessionId}`)
+        pingTimer = setInterval(() => {
+          if (ws.readyState !== WebSocket.OPEN) return
+          if (!pongReceived) {
+            console.warn(`No pong on session ${sessionId} stream, terminating half-open socket`)
+            ws.terminate()
+            return
+          }
+          pongReceived = false
+          ws.ping()
+        }, STREAM_PING_INTERVAL_MS)
         resolveReady()
+      })
+
+      ws.on('pong', () => {
+        pongReceived = true
       })
 
       ws.on('message', (data) => {
         try {
           const message = streamEnvelopeSchema.parse(JSON.parse(data.toString()))
+          // Narrow the loose passthrough field at runtime rather than casting;
+          // a malformed timestamp degrades to "now" instead of dropping the frame.
+          const ts = message.timestamp
           const streamMessage: StreamMessage = {
             type: message.type,
             content: message,
-            timestamp: new Date((message.timestamp as string | number | undefined) || Date.now()),
+            timestamp: new Date(typeof ts === 'string' || typeof ts === 'number' ? ts : Date.now()),
             sessionId,
           }
           callback(streamMessage)
@@ -1299,6 +1336,12 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       })
 
       ws.on('close', () => {
+        // The ping timer belongs to THIS socket — clear it whether or not the
+        // socket is still the tracked one.
+        if (pingTimer) {
+          clearInterval(pingTimer)
+          pingTimer = null
+        }
         // Identity guard: a replaced or deliberately-unsubscribed socket's
         // close must be silent. Without it, the old socket's async close
         // deletes the NEW socket from the map and routes a spurious

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -19,6 +19,7 @@ import type {
   StreamMessage,
 } from './types'
 import type { RuntimeOptions } from './runtime-options'
+import { streamEnvelopeSchema } from './stream-schema'
 import { getAgentWorkspaceDir } from '@shared/lib/config/data-dir'
 import { getContainerHostUrl, getAppPort } from '@shared/lib/proxy/host-url'
 import { getSettings } from '@shared/lib/config/settings'
@@ -1238,7 +1239,8 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
   subscribeToStream(
     sessionId: string,
-    callback: (message: StreamMessage) => void
+    callback: (message: StreamMessage) => void,
+    cursor?: { epoch: string; sinceSeq: number }
   ): { unsubscribe: () => void; ready: Promise<void> } {
     let resolveReady: () => void
     let rejectReady: (error: Error) => void
@@ -1255,8 +1257,14 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
         existing.close()
       }
 
+      // Resume cursor: the container replays exactly what was missed after the
+      // host's last-processed (epoch, seq) position, so terminal events emitted
+      // during a reconnect gap are never lost.
+      const cursorParams = cursor
+        ? `?epoch=${encodeURIComponent(cursor.epoch)}&since_seq=${cursor.sinceSeq}`
+        : ''
       const ws = new WebSocket(
-        `${this.getWebSocketBaseUrl(port)}/sessions/${sessionId}/stream`
+        `${this.getWebSocketBaseUrl(port)}/sessions/${sessionId}/stream${cursorParams}`
       )
 
       ws.on('open', () => {
@@ -1266,11 +1274,11 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
       ws.on('message', (data) => {
         try {
-          const message = JSON.parse(data.toString())
+          const message = streamEnvelopeSchema.parse(JSON.parse(data.toString()))
           const streamMessage: StreamMessage = {
             type: message.type,
             content: message,
-            timestamp: new Date(message.timestamp || Date.now()),
+            timestamp: new Date((message.timestamp as string | number | undefined) || Date.now()),
             sessionId,
           }
           callback(streamMessage)
@@ -1281,8 +1289,9 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       })
 
       ws.on('error', (error) => {
-        // Only log and emit if this connection is still tracked (not cleaned up by stop())
-        if (this.wsConnections.has(sessionId)) {
+        // Only log and emit if this exact socket is still the tracked one
+        // (not cleaned up by stop(), not replaced by a re-subscribe)
+        if (this.wsConnections.get(sessionId) === ws) {
           console.error(`WebSocket error for session ${sessionId}:`, error)
           this.safeEmitError(error)
         }
@@ -1290,6 +1299,16 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       })
 
       ws.on('close', () => {
+        // Identity guard: a replaced or deliberately-unsubscribed socket's
+        // close must be silent. Without it, the old socket's async close
+        // deletes the NEW socket from the map and routes a spurious
+        // connection_closed — handleConnectionClosed then re-subscribes,
+        // closing a healthy socket or leaving one open and untracked
+        // (duplicate delivery), and with replay cursors that becomes
+        // double-processing.
+        if (this.wsConnections.get(sessionId) !== ws) {
+          return
+        }
         console.log(`WebSocket closed for session ${sessionId}`)
         this.wsConnections.delete(sessionId)
         // Notify the callback that the connection was lost

--- a/src/shared/lib/container/connection-recovery.test.ts
+++ b/src/shared/lib/container/connection-recovery.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import type { ContainerClient, StreamMessage } from './types'
+
+// Connection-loss recovery: when the container stream dies and cannot be
+// re-attached, the host must drop the dead subscription entry so
+// isSubscribed() tells the truth. A stale entry makes every send-message
+// route skip its re-subscribe (`if (!isSubscribed) subscribe`), so the next
+// turn runs with NO stream at all — no result is ever seen, the grace
+// backstop can never arm, and the session is pinned "working" forever.
+// Same for a connection_closed that arrives while the session is
+// interrupted: the interrupted gate must not swallow the one frame whose
+// handler exists to clean the connection state up.
+
+// ----- Mocks for external dependencies (mirrors grace-after-result) -----
+
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  createScheduledTask: vi.fn(),
+}))
+vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionMetadata: vi.fn(() => Promise.resolve(null)),
+  updateSessionMetadata: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerSessionComplete: vi.fn(() => Promise.resolve()),
+    triggerSessionWaitingInput: vi.fn(() => Promise.resolve()),
+  },
+}))
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({}),
+  VALID_SCRIPT_TYPES: { darwin: ['applescript', 'shell'], linux: ['shell'], win32: ['powershell'] },
+}))
+vi.mock('@shared/lib/computer-use/permission-manager', () => ({
+  computerUsePermissionManager: {
+    checkPermission: vi.fn(() => 'prompt_needed'),
+    getGrabbedApp: vi.fn(() => undefined),
+    setGrabbedApp: vi.fn(),
+    clearGrabbedApp: vi.fn(),
+    consumeOnceGrant: vi.fn(),
+  },
+}))
+vi.mock('@shared/lib/computer-use/types', () => ({
+  getRequiredPermissionLevel: vi.fn(() => 'use_application'),
+  resolveTargetApp: vi.fn(() => undefined),
+  READ_ONLY_METHODS: new Set(['apps', 'windows', 'status', 'displays', 'permissions']),
+  TIMED_GRANT_DURATION_MS: 15 * 60 * 1000,
+}))
+vi.mock('@shared/lib/computer-use/executor', () => ({
+  resolveAppFromWindowRef: vi.fn(() => undefined),
+}))
+vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
+  createWebhookTrigger: vi.fn(() => Promise.resolve('trigger_new_id')),
+  listActiveWebhookTriggers: vi.fn(() => Promise.resolve([])),
+  cancelWebhookTriggerWithCleanup: vi.fn(() => Promise.resolve(true)),
+}))
+vi.mock('@shared/lib/composio/triggers', () => ({
+  getAvailableTriggers: vi.fn(() => Promise.resolve([])),
+  enableComposioTrigger: vi.fn(() => Promise.resolve('composio_trigger_id')),
+  deleteComposioTrigger: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('@shared/lib/composio/client', () => ({
+  isPlatformComposioActive: vi.fn(() => true),
+}))
+vi.mock('@shared/lib/services/timezone-resolver', () => ({
+  resolveTimezoneForAgent: vi.fn(() => Promise.resolve('UTC')),
+}))
+vi.mock('@shared/lib/analytics/server-analytics', () => ({
+  trackServerEvent: vi.fn(),
+}))
+vi.mock('@shared/lib/db', () => ({ db: {} }))
+vi.mock('@shared/lib/db/schema', () => ({ connectedAccounts: {} }))
+vi.mock('drizzle-orm', () => ({ eq: vi.fn() }))
+vi.mock('@shared/lib/utils/file-storage', () => ({
+  getAgentSessionsDir: (_agentSlug: string) => '/nonexistent',
+}))
+
+// ----- Helpers -----
+
+const AGENT_SLUG = 'test-agent'
+
+let sessionCounter = 0
+let teardown: (() => void) | null = null
+
+function createRecoveryClient(sessionId: string) {
+  let callback: ((message: StreamMessage) => void) | null = null
+  const getSession = vi.fn(() => Promise.resolve<unknown>(null))
+  const client = {
+    subscribeToStream: vi.fn((_sid: string, cb: (message: StreamMessage) => void) => {
+      callback = cb
+      return { unsubscribe: vi.fn(), ready: Promise.resolve() }
+    }),
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopSync: vi.fn(),
+    getInfoFromRuntime: vi.fn(),
+    getInfo: vi.fn(),
+    fetch: vi.fn(),
+    waitForHealthy: vi.fn(),
+    isHealthy: vi.fn(),
+    getStats: vi.fn(),
+    createSession: vi.fn(),
+    getSession,
+    deleteSession: vi.fn(),
+    sendMessage: vi.fn(),
+    getMessages: vi.fn(),
+    interruptSession: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  } as unknown as ContainerClient
+  const send = async (content: Record<string, unknown>) => {
+    callback?.({
+      type: (content.type as string) ?? 'message',
+      content,
+      timestamp: new Date(),
+      sessionId,
+    } as StreamMessage)
+    // handleConnectionClosed resolves getSession asynchronously — drain a few ticks
+    for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r))
+  }
+  return { client, send, getSession }
+}
+
+async function setUp() {
+  vi.resetModules()
+  const { messagePersister } = await import('./message-persister')
+  const sessionId = `recovery-test-session-${++sessionCounter}`
+  const { client, send, getSession } = createRecoveryClient(sessionId)
+
+  teardown = () => {
+    messagePersister.unsubscribeFromSession(sessionId)
+  }
+
+  await messagePersister.subscribeToSession(sessionId, client, sessionId, AGENT_SLUG)
+  await send({ type: 'system', subtype: 'capabilities', session_state_events: true })
+  messagePersister.markSessionActive(sessionId, AGENT_SLUG)
+
+  return { messagePersister, sessionId, client, send, getSession }
+}
+
+// =====================================================================
+// Tests
+// =====================================================================
+
+describe('connection-loss recovery keeps isSubscribed honest', () => {
+  afterEach(() => {
+    teardown?.()
+    teardown = null
+    vi.clearAllMocks()
+  })
+
+  it('drops the subscription when the session is gone from the container', async () => {
+    const { messagePersister, sessionId, send, getSession } = await setUp()
+    getSession.mockResolvedValue(null)
+
+    await send({ type: 'connection_closed' })
+
+    expect(messagePersister.isSessionActive(sessionId)).toBe(false)
+    // The stale entry is the bug: with it, the next send skips re-subscribe
+    // and the turn runs invisibly — unfixably stuck.
+    expect(messagePersister.isSubscribed(sessionId)).toBe(false)
+  })
+
+  it('drops the subscription when the container is unreachable', async () => {
+    const { messagePersister, sessionId, send, getSession } = await setUp()
+    getSession.mockRejectedValue(new Error('connect ECONNREFUSED'))
+
+    await send({ type: 'connection_closed' })
+
+    expect(messagePersister.isSessionActive(sessionId)).toBe(false)
+    expect(messagePersister.isSubscribed(sessionId)).toBe(false)
+  })
+
+  it('drops the subscription when the container reports the session not running', async () => {
+    const { messagePersister, sessionId, send, getSession } = await setUp()
+    getSession.mockResolvedValue({ id: sessionId, isRunning: false })
+
+    await send({ type: 'connection_closed' })
+
+    expect(messagePersister.isSessionActive(sessionId)).toBe(false)
+    expect(messagePersister.isSubscribed(sessionId)).toBe(false)
+  })
+
+  it('keeps the subscription when it successfully re-subscribes to a running session', async () => {
+    const { messagePersister, sessionId, client, send, getSession } = await setUp()
+    getSession.mockResolvedValue({ id: sessionId, isRunning: true })
+
+    await send({ type: 'connection_closed' })
+
+    expect(messagePersister.isSubscribed(sessionId)).toBe(true)
+    // Re-subscribed on the same client (initial subscribe + reconnect).
+    expect(client.subscribeToStream).toHaveBeenCalledTimes(2)
+  })
+
+  it('an interrupted session still processes connection_closed (the gate must not swallow it)', async () => {
+    const { messagePersister, sessionId, send, getSession } = await setUp()
+    await messagePersister.markSessionInterrupted(sessionId)
+    getSession.mockResolvedValue(null)
+
+    await send({ type: 'connection_closed' })
+
+    expect(messagePersister.isSubscribed(sessionId)).toBe(false)
+  })
+})

--- a/src/shared/lib/container/connection-recovery.test.ts
+++ b/src/shared/lib/container/connection-recovery.test.ts
@@ -226,4 +226,64 @@ describe('connection-loss recovery keeps isSubscribed honest', () => {
     // Only the dead socket's entry may be dropped — the fresh one survives.
     expect(messagePersister.isSubscribed(sessionId)).toBe(true)
   })
+
+  it('a fromStart subscribe that never connects settles instead of pinning active', async () => {
+    // Regression guard for the mark-active-BEFORE-subscribe reorder: if the WS
+    // never opens, base-container-client synthesizes a connection_closed through
+    // the callback (asynchronously, AFTER doSubscribeToSession installs the
+    // subscription entry). With isActive already true and the container gone,
+    // that must SETTLE the session and drop the dead entry — not leave it pinned
+    // "working" with a stale subscription. This is why the reorder needs no
+    // try/catch cleanup: the self-heal already covers a failed attach.
+    vi.resetModules()
+    const { messagePersister } = await import('./message-persister')
+    const sessionId = `recovery-fail-session-${++sessionCounter}`
+
+    const getSession = vi.fn(() => Promise.resolve<unknown>(null)) // container gone
+    const client = {
+      subscribeToStream: vi.fn((_sid: string, cb: (message: StreamMessage) => void) => {
+        // Mirror setupWebSocket().catch: connection_closed lands async, after the
+        // subscription entry is installed and after `ready` rejects.
+        setImmediate(() =>
+          cb({
+            type: 'connection_closed',
+            content: { type: 'connection_closed' },
+            timestamp: new Date(),
+            sessionId,
+          } as StreamMessage),
+        )
+        return { unsubscribe: vi.fn(), ready: Promise.reject(new Error('WS connect failed')) }
+      }),
+      start: vi.fn(),
+      stop: vi.fn(),
+      stopSync: vi.fn(),
+      getInfoFromRuntime: vi.fn(),
+      getInfo: vi.fn(),
+      fetch: vi.fn(),
+      waitForHealthy: vi.fn(),
+      isHealthy: vi.fn(),
+      getStats: vi.fn(),
+      createSession: vi.fn(),
+      getSession,
+      deleteSession: vi.fn(),
+      sendMessage: vi.fn(),
+      getMessages: vi.fn(),
+      interruptSession: vi.fn(),
+      on: vi.fn(),
+      off: vi.fn(),
+    } as unknown as ContainerClient
+
+    teardown = () => messagePersister.unsubscribeFromSession(sessionId)
+
+    // Fixed call-site order: mark active BEFORE subscribing.
+    messagePersister.markSessionActive(sessionId, AGENT_SLUG)
+    await messagePersister
+      .subscribeToSession(sessionId, client, sessionId, AGENT_SLUG, { fromStart: true })
+      .catch(() => {}) // ready rejects → subscribeToSession throws; the heal is async
+    for (let i = 0; i < 6; i++) await new Promise((r) => setImmediate(r))
+
+    // Settled via the synthesized connection_closed, not pinned working.
+    expect(messagePersister.isSessionActive(sessionId)).toBe(false)
+    expect(messagePersister.isSubscribed(sessionId)).toBe(false)
+  })
 })

--- a/src/shared/lib/container/connection-recovery.test.ts
+++ b/src/shared/lib/container/connection-recovery.test.ts
@@ -200,4 +200,30 @@ describe('connection-loss recovery keeps isSubscribed honest', () => {
 
     expect(messagePersister.isSubscribed(sessionId)).toBe(false)
   })
+
+  it('does not drop a fresh subscription installed by a concurrent re-subscribe', async () => {
+    const { messagePersister, sessionId, client, send, getSession } = await setUp()
+
+    // handleConnectionClosed queries the container asynchronously; hold that
+    // check open so a concurrent send-route re-subscribe can install a fresh
+    // live socket under this sessionId while the check is in flight. Dropping
+    // the entry then would delete a LIVE subscription — isSubscribed() would
+    // lie false and the next turn would run with no stream.
+    let resolveGetSession: (v: unknown) => void = () => {}
+    getSession.mockReturnValue(new Promise((r) => { resolveGetSession = r }))
+
+    // Enter handleConnectionClosed; its getSession stays parked (unresolved).
+    await send({ type: 'connection_closed' })
+
+    // Concurrent re-subscribe replaces the entry with a fresh live unsubscribe.
+    await messagePersister.subscribeToSession(sessionId, client, sessionId, AGENT_SLUG)
+    expect(messagePersister.isSubscribed(sessionId)).toBe(true)
+
+    // Now the stale check resolves "session gone".
+    resolveGetSession(null)
+    for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r))
+
+    // Only the dead socket's entry may be dropped — the fresh one survives.
+    expect(messagePersister.isSubscribed(sessionId)).toBe(true)
+  })
 })

--- a/src/shared/lib/container/grace-after-result.test.ts
+++ b/src/shared/lib/container/grace-after-result.test.ts
@@ -13,7 +13,8 @@ import type { ContainerClient, StreamMessage } from './types'
 // it arms only when the SDK's last word was "work done" (a result, with no
 // background tasks left and nothing opened since) and disarms the moment any
 // turn activity appears. It can therefore never fire during a genuinely
-// running turn (the #339 trap), including the queued-continuation turn that
+// running turn (the deleted-watchdog trap: a legit 20-minute silent tool also
+// emits no events), including the queued-continuation turn that
 // starts 73ms after the previous result (real capture, session d6ca7b70).
 
 // ----- Mocks for external dependencies (mirrors queued-message-idle-replay) -----
@@ -82,7 +83,7 @@ vi.mock('@shared/lib/utils/file-storage', () => ({
 // ----- Helpers -----
 
 // Must match RESULT_IDLE_GRACE_MS in message-persister.ts.
-const GRACE_MS = 10_000
+const GRACE_MS = 30_000
 
 const SESSION_ID = 'grace-test-session'
 const AGENT_SLUG = 'test-agent'
@@ -127,6 +128,7 @@ function streamMsg(content: Record<string, unknown>): StreamMessage {
 // Container message shapes (mirroring real captures)
 const CAPABILITIES = { type: 'system', subtype: 'capabilities', session_state_events: true }
 const RESULT_SUCCESS = { type: 'result', subtype: 'success' }
+const RESULT_ERROR_MAX_TURNS = { type: 'result', subtype: 'error_max_turns' }
 const STATE_IDLE = { type: 'system', subtype: 'session_state_changed', state: 'idle' }
 const ASSISTANT_MSG = { type: 'assistant', message: { content: [{ type: 'text', text: 'hi' }] } }
 const BROWSER_INACTIVE = { type: 'browser_active', active: false }
@@ -384,6 +386,45 @@ describe('grace-after-result backstop', () => {
     await vi.advanceTimersByTimeAsync(GRACE_MS * 3)
     expect(countIdle(sseEvents)).toBe(1)
     expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+
+    cleanup()
+    messagePersister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  it('settles a non-success result via grace without a completion notification', async () => {
+    const { messagePersister, notificationManager, sseEvents, cleanup, send } = await setUp()
+
+    await send(ASSISTANT_MSG)
+    await send(RESULT_ERROR_MAX_TURNS)
+
+    // error_max_turns is not a hard error (isActive stays true) and no idle
+    // follows — only the grace backstop settles it, and silently: a turn that
+    // did not succeed must not fabricate a "done" notification.
+    await vi.advanceTimersByTimeAsync(GRACE_MS + 1000)
+
+    expect(countIdle(sseEvents)).toBe(1)
+    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+    expect(notificationManager.triggerSessionComplete).not.toHaveBeenCalled()
+
+    cleanup()
+    messagePersister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  it('a user interrupt inside the grace window settles once and the backstop adds nothing', async () => {
+    const { messagePersister, notificationManager, sseEvents, cleanup, send } = await setUp()
+
+    await send(ASSISTANT_MSG)
+    await send(RESULT_SUCCESS)
+
+    // The user interrupts while the grace timer is armed: the interrupt emits
+    // its own session_idle, and the backstop firing later must add nothing.
+    await messagePersister.markSessionInterrupted(SESSION_ID)
+    const idleCountAtInterrupt = countIdle(sseEvents)
+
+    await vi.advanceTimersByTimeAsync(GRACE_MS * 3)
+
+    expect(countIdle(sseEvents)).toBe(idleCountAtInterrupt)
+    expect(notificationManager.triggerSessionComplete).not.toHaveBeenCalled()
 
     cleanup()
     messagePersister.unsubscribeFromSession(SESSION_ID)

--- a/src/shared/lib/container/grace-after-result.test.ts
+++ b/src/shared/lib/container/grace-after-result.test.ts
@@ -1,0 +1,406 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as path from 'path'
+import { promises as fs } from 'fs'
+import type { ContainerClient, StreamMessage } from './types'
+
+// Grace-after-result backstop: when a turn's `result` has been seen but the
+// authoritative session_state_changed:'idle' never arrives (the SDK hangs in
+// the post-result wind-down, or in the post-background-drain wind-down), the
+// host settles itself after a short grace window instead of pinning the
+// session "working" forever.
+//
+// The backstop is a DERIVED gate re-evaluated after every processed message —
+// it arms only when the SDK's last word was "work done" (a result, with no
+// background tasks left and nothing opened since) and disarms the moment any
+// turn activity appears. It can therefore never fire during a genuinely
+// running turn (the #339 trap), including the queued-continuation turn that
+// starts 73ms after the previous result (real capture, session d6ca7b70).
+
+// ----- Mocks for external dependencies (mirrors queued-message-idle-replay) -----
+
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  createScheduledTask: vi.fn(),
+}))
+vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionMetadata: vi.fn(() => Promise.resolve(null)),
+  updateSessionMetadata: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerSessionComplete: vi.fn(() => Promise.resolve()),
+    triggerSessionWaitingInput: vi.fn(() => Promise.resolve()),
+  },
+}))
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({}),
+  VALID_SCRIPT_TYPES: { darwin: ['applescript', 'shell'], linux: ['shell'], win32: ['powershell'] },
+}))
+vi.mock('@shared/lib/computer-use/permission-manager', () => ({
+  computerUsePermissionManager: {
+    checkPermission: vi.fn(() => 'prompt_needed'),
+    getGrabbedApp: vi.fn(() => undefined),
+    setGrabbedApp: vi.fn(),
+    clearGrabbedApp: vi.fn(),
+    consumeOnceGrant: vi.fn(),
+  },
+}))
+vi.mock('@shared/lib/computer-use/types', () => ({
+  getRequiredPermissionLevel: vi.fn(() => 'use_application'),
+  resolveTargetApp: vi.fn(() => undefined),
+  READ_ONLY_METHODS: new Set(['apps', 'windows', 'status', 'displays', 'permissions']),
+  TIMED_GRANT_DURATION_MS: 15 * 60 * 1000,
+}))
+vi.mock('@shared/lib/computer-use/executor', () => ({
+  resolveAppFromWindowRef: vi.fn(() => undefined),
+}))
+vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
+  createWebhookTrigger: vi.fn(() => Promise.resolve('trigger_new_id')),
+  listActiveWebhookTriggers: vi.fn(() => Promise.resolve([])),
+  cancelWebhookTriggerWithCleanup: vi.fn(() => Promise.resolve(true)),
+}))
+vi.mock('@shared/lib/composio/triggers', () => ({
+  getAvailableTriggers: vi.fn(() => Promise.resolve([])),
+  enableComposioTrigger: vi.fn(() => Promise.resolve('composio_trigger_id')),
+  deleteComposioTrigger: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('@shared/lib/composio/client', () => ({
+  isPlatformComposioActive: vi.fn(() => true),
+}))
+vi.mock('@shared/lib/services/timezone-resolver', () => ({
+  resolveTimezoneForAgent: vi.fn(() => Promise.resolve('UTC')),
+}))
+vi.mock('@shared/lib/analytics/server-analytics', () => ({
+  trackServerEvent: vi.fn(),
+}))
+vi.mock('@shared/lib/db', () => ({ db: {} }))
+vi.mock('@shared/lib/db/schema', () => ({ connectedAccounts: {} }))
+vi.mock('drizzle-orm', () => ({ eq: vi.fn() }))
+vi.mock('@shared/lib/utils/file-storage', () => ({
+  getAgentSessionsDir: (_agentSlug: string) => '/nonexistent',
+}))
+
+// ----- Helpers -----
+
+// Must match RESULT_IDLE_GRACE_MS in message-persister.ts.
+const GRACE_MS = 10_000
+
+const SESSION_ID = 'grace-test-session'
+const AGENT_SLUG = 'test-agent'
+
+function createReplayClient(): { client: ContainerClient; send: (message: StreamMessage) => void } {
+  let callback: ((message: StreamMessage) => void) | null = null
+  const client = {
+    subscribeToStream: vi.fn((_sid: string, cb: (message: StreamMessage) => void) => {
+      callback = cb
+      return { unsubscribe: vi.fn(), ready: Promise.resolve() }
+    }),
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopSync: vi.fn(),
+    getInfoFromRuntime: vi.fn(),
+    getInfo: vi.fn(),
+    fetch: vi.fn(),
+    waitForHealthy: vi.fn(),
+    isHealthy: vi.fn(),
+    getStats: vi.fn(),
+    createSession: vi.fn(),
+    getSession: vi.fn(() => Promise.resolve(null)),
+    deleteSession: vi.fn(),
+    sendMessage: vi.fn(),
+    getMessages: vi.fn(),
+    interruptSession: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  } as unknown as ContainerClient
+  return { client, send: (m) => callback?.(m) }
+}
+
+function streamMsg(content: Record<string, unknown>): StreamMessage {
+  return {
+    type: (content.type as string) ?? 'message',
+    content,
+    timestamp: new Date(),
+    sessionId: SESSION_ID,
+  } as StreamMessage
+}
+
+// Container message shapes (mirroring real captures)
+const CAPABILITIES = { type: 'system', subtype: 'capabilities', session_state_events: true }
+const RESULT_SUCCESS = { type: 'result', subtype: 'success' }
+const STATE_IDLE = { type: 'system', subtype: 'session_state_changed', state: 'idle' }
+const ASSISTANT_MSG = { type: 'assistant', message: { content: [{ type: 'text', text: 'hi' }] } }
+const BROWSER_INACTIVE = { type: 'browser_active', active: false }
+// A user message whose tool_use_result registers a backgrounded Bash task
+const BG_TASK_LAUNCH = {
+  type: 'user',
+  message: { content: [] },
+  tool_use_result: { backgroundTaskId: 'bg-1' },
+}
+// The idle/wake-path terminal notification that drains the task
+const BG_TASK_DRAIN = { type: 'system', subtype: 'task_notification', task_id: 'bg-1', status: 'completed' }
+
+async function setUp() {
+  vi.resetModules()
+  const { messagePersister } = await import('./message-persister')
+  const { notificationManager } = await import('@shared/lib/notifications/notification-manager')
+  const { client, send: rawSend } = createReplayClient()
+
+  const sseEvents: Array<Record<string, unknown>> = []
+  const cleanup = messagePersister.addSSEClient(SESSION_ID, (data) => {
+    sseEvents.push(data as Record<string, unknown>)
+  })
+
+  await messagePersister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
+
+  const send = async (content: Record<string, unknown>) => {
+    rawSend(streamMsg(content))
+    await new Promise((r) => setImmediate(r))
+  }
+
+  // The container announces state-event support on connect; the route marks
+  // the session active when the user's message is sent.
+  await send(CAPABILITIES)
+  messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+
+  return { messagePersister, notificationManager, client, sseEvents, cleanup, send }
+}
+
+const countIdle = (events: Array<Record<string, unknown>>) =>
+  events.filter((e) => e['type'] === 'session_idle').length
+
+// ----- Fixture loading (real queued-message capture, session d6ca7b70) -----
+
+interface FixtureEntry {
+  t: number
+  message: StreamMessage
+}
+
+async function loadQueuedFixture(): Promise<{
+  sessionId: string
+  agentSlug: string
+  entries: FixtureEntry[]
+}> {
+  const fixtureDir = path.join(__dirname, '__fixtures__', 'queued-message-final-response')
+  const meta = JSON.parse(await fs.readFile(path.join(fixtureDir, 'metadata.json'), 'utf8'))
+  const raw = await fs.readFile(path.join(fixtureDir, 'stream-input.jsonl'), 'utf8')
+  const entries = raw
+    .split('\n')
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l))
+  return { sessionId: meta.sessionId, agentSlug: meta.agentSlug, entries }
+}
+
+// =====================================================================
+// Tests
+// =====================================================================
+
+describe('grace-after-result backstop', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('settles a session whose idle never arrives after result (the post-result hang)', async () => {
+    const { messagePersister, notificationManager, sseEvents, cleanup, send } = await setUp()
+
+    await send(ASSISTANT_MSG)
+    await send(RESULT_SUCCESS)
+
+    // With state-event authority, result alone must not settle (that part is
+    // existing behavior) — the session waits for idle...
+    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+    expect(countIdle(sseEvents)).toBe(0)
+
+    // ...but when idle never comes, the grace backstop settles it.
+    await vi.advanceTimersByTimeAsync(GRACE_MS + 1000)
+
+    expect(countIdle(sseEvents)).toBe(1)
+    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+    // A merely-lost idle must not cost the user the completion notification.
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+
+    cleanup()
+    messagePersister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  it('never fires mid-turn: the queued continuation (real capture) cancels the pending grace', async () => {
+    // Fixture timeline: turn-1 result → (+73ms) continuation system init →
+    // turn 2 → turn-2 result → the ONLY session_state_changed:'idle'.
+    const { entries } = await loadQueuedFixture()
+    vi.resetModules()
+    const { messagePersister } = await import('./message-persister')
+    const { notificationManager } = await import('@shared/lib/notifications/notification-manager')
+    const { client, send: rawSend } = createReplayClient()
+
+    const meta = await loadQueuedFixture()
+    const sessionId = meta.sessionId
+    const sseEvents: Array<Record<string, unknown>> = []
+    const cleanup = messagePersister.addSSEClient(sessionId, (data) => {
+      sseEvents.push(data as Record<string, unknown>)
+    })
+    await messagePersister.subscribeToSession(sessionId, client, sessionId, meta.agentSlug)
+    messagePersister.markSessionActive(sessionId, meta.agentSlug)
+
+    const sendRange = async (from: number, to: number) => {
+      for (const entry of entries.slice(from, to)) {
+        rawSend(entry.message)
+        await new Promise((r) => setImmediate(r))
+      }
+    }
+    const firstResultIdx = entries.findIndex((e) => e.message.content?.type === 'result')
+    const secondResultIdx = entries.findIndex(
+      (e, i) => i > firstResultIdx && e.message.content?.type === 'result'
+    )
+
+    // Turn 1 through its result: grace arms here.
+    await sendRange(0, firstResultIdx + 1)
+    const idleCountAtTurn1Result = countIdle(sseEvents)
+
+    // The queued continuation's messages arrive (init + turn-2 activity), but
+    // turn 2 then goes SILENT (a long tool). Advance far past the grace
+    // window: the armed timer must have been cancelled by the turn-2 start —
+    // firing here would flip idle mid-turn (the exact bug stateEventsAuthority
+    // was built to kill).
+    await sendRange(firstResultIdx + 1, secondResultIdx)
+    await vi.advanceTimersByTimeAsync(GRACE_MS * 3)
+
+    expect(countIdle(sseEvents)).toBe(idleCountAtTurn1Result)
+    expect(messagePersister.isSessionActive(sessionId)).toBe(true)
+
+    // Finish the capture (turn-2 result + authoritative idle): exactly one
+    // idle, one notification — the grace path added nothing.
+    await sendRange(secondResultIdx, entries.length)
+    expect(countIdle(sseEvents)).toBe(1)
+    expect(messagePersister.isSessionActive(sessionId)).toBe(false)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+
+    cleanup()
+    messagePersister.unsubscribeFromSession(sessionId)
+  })
+
+  it('settles the second-idle hang: background task drains, then idle never arrives', async () => {
+    const { messagePersister, notificationManager, sseEvents, cleanup, send } = await setUp()
+
+    // A turn launches a backgrounded Bash task, finishes (result), and the SDK
+    // fires the turn-end idle while the task still runs — the host correctly
+    // refuses to settle (waiting on background).
+    await send(ASSISTANT_MSG)
+    await send(BG_TASK_LAUNCH)
+    await send(RESULT_SUCCESS)
+    await send(STATE_IDLE)
+    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+    expect(sseEvents.some((e) => e['type'] === 'session_waiting_background')).toBe(true)
+
+    // Hours later the task's terminal notification drains it… and the SDK
+    // hangs before the truly-settled second idle. No future result exists —
+    // only the grace backstop can settle this.
+    await send(BG_TASK_DRAIN)
+    expect(countIdle(sseEvents)).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(GRACE_MS + 1000)
+
+    expect(countIdle(sseEvents)).toBe(1)
+    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+
+    cleanup()
+    messagePersister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  it('is not disarmed by non-turn frames (browser_active) inside the grace window', async () => {
+    const { messagePersister, sseEvents, cleanup, send } = await setUp()
+
+    await send(ASSISTANT_MSG)
+    await send(RESULT_SUCCESS)
+
+    // The container's browser auto-stop broadcast rides the same stream and
+    // says nothing about turn progress — it must not switch the backstop off.
+    await vi.advanceTimersByTimeAsync(GRACE_MS / 2)
+    await send(BROWSER_INACTIVE)
+    await vi.advanceTimersByTimeAsync(GRACE_MS)
+
+    expect(countIdle(sseEvents)).toBe(1)
+    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+
+    cleanup()
+    messagePersister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  it('does not fire while the session is awaiting user input', async () => {
+    const { messagePersister, sseEvents, cleanup, send } = await setUp()
+
+    await send(ASSISTANT_MSG)
+    await send(RESULT_SUCCESS)
+
+    // An input request lands between arm and fire — settling would mask it
+    // (computeActivity only reports 'awaiting' while isActive is true).
+    messagePersister.recoverSessionAwaitingInput(SESSION_ID, AGENT_SLUG)
+    await vi.advanceTimersByTimeAsync(GRACE_MS * 3)
+
+    expect(countIdle(sseEvents)).toBe(0)
+    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+    expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+    cleanup()
+    messagePersister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  it('survives a re-subscribe inside the result→idle window (state carried, timer re-armed)', async () => {
+    const { messagePersister, notificationManager, client, sseEvents, cleanup, send } = await setUp()
+
+    await send(ASSISTANT_MSG)
+    await send(RESULT_SUCCESS)
+
+    // A reconnect re-subscribes mid-window. The fresh streaming state must
+    // carry the turn's "result seen" memory, and the grace must re-arm —
+    // otherwise a hang after a reconnect sticks forever.
+    await messagePersister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
+    await vi.advanceTimersByTimeAsync(GRACE_MS + 1000)
+
+    expect(countIdle(sseEvents)).toBe(1)
+    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+
+    cleanup()
+    messagePersister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  it('stays inert when the authoritative idle arrives normally (no double settle)', async () => {
+    const { messagePersister, notificationManager, sseEvents, cleanup, send } = await setUp()
+
+    await send(ASSISTANT_MSG)
+    await send(RESULT_SUCCESS)
+    await send(STATE_IDLE)
+
+    expect(countIdle(sseEvents)).toBe(1)
+    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+
+    // The grace window elapsing afterwards must add nothing.
+    await vi.advanceTimersByTimeAsync(GRACE_MS * 3)
+    expect(countIdle(sseEvents)).toBe(1)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+
+    cleanup()
+    messagePersister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  it('never arms mid-turn (no result seen yet)', async () => {
+    const { messagePersister, sseEvents, cleanup, send } = await setUp()
+
+    // A turn is running — a long silent tool produces no messages for far
+    // longer than the grace window. Nothing may settle.
+    await send(ASSISTANT_MSG)
+    await vi.advanceTimersByTimeAsync(GRACE_MS * 20)
+
+    expect(countIdle(sseEvents)).toBe(0)
+    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+
+    cleanup()
+    messagePersister.unsubscribeFromSession(SESSION_ID)
+  })
+})

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -4357,6 +4357,32 @@ describe('MessagePersister', () => {
       expect(sseEvents.filter(e => e.type === 'session_waiting_background')).toHaveLength(0)
     })
 
+    it('does not fire the legacy completion notification for a user-interrupted turn', async () => {
+      // Legacy container (no session-state events): the result handler fires the
+      // completion notification directly. A turn the user *interrupted* must not
+      // produce a "done" ping — isInterrupted gates it out. On state-events
+      // images the notification is already gated (idle/grace both require
+      // isActive), so this closes the legacy-only path.
+      const { notificationManager } = await import('@shared/lib/notifications/notification-manager')
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      await messagePersister.markSessionInterrupted(SESSION_ID)
+
+      mockClient._sendMessage({ type: 'result', subtype: 'success' })
+
+      expect(notificationManager.triggerSessionComplete).not.toHaveBeenCalled()
+    })
+
+    it('still fires the legacy completion notification for a normally-finished turn', async () => {
+      // Discriminator for the guard above: a normal (uninterrupted) legacy turn
+      // must still notify, so the isInterrupted check isn't suppressing everything.
+      const { notificationManager } = await import('@shared/lib/notifications/notification-manager')
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+
+      mockClient._sendMessage({ type: 'result', subtype: 'success' })
+
+      expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+    })
+
     it('ignores task_updated for non-terminal status or untracked task', () => {
       messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
       mockClient._sendMessage({

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -136,9 +136,11 @@ async function getContainerManager() {
 // Grace window between a turn's `result` and the authoritative idle. The
 // post-result wind-down is normally milliseconds; when the runtime hangs in
 // it, the session would otherwise stay "working" forever (state events are
-// the idle authority and no further result will come). Long enough for a slow
-// machine's wind-down, short enough that a stuck light heals promptly.
-const RESULT_IDLE_GRACE_MS = 10_000
+// the idle authority and no further result will come). Sized to tolerate the
+// slowest legitimate silences in that window — a queued continuation the
+// runtime is slow to dequeue, or a background-drain wake waiting on model
+// latency — while still healing a stuck light promptly.
+const RESULT_IDLE_GRACE_MS = 30_000
 
 // TODO this file is too big, this class is HUGE. Needs breaking up
 class MessagePersister {
@@ -154,6 +156,11 @@ class MessagePersister {
   // swallowed. Held outside streamingStates and NOT cleared on unsubscribe —
   // surviving the re-subscribe is its entire purpose.
   private streamCursors: Map<string, { epoch: string; seq: number }> = new Map()
+  // Sessions whose in-flight attach requested a from-start replay (just
+  // created, no cursor yet). Consumed by the attach hello: the cursor must
+  // baseline to -1 there, not to the hello's max_seq, or the dedup would
+  // skip the very replay the attach asked for.
+  private fromStartAttaches: Set<string> = new Set()
   private sseClients: Map<string, Set<(data: unknown) => void>> = new Map()
   // Per-run journal tailers driving the live workflow drawer, keyed `${sessionId}::${runId}`
   private workflowTailers: Map<string, WorkflowJournalTailer> = new Map()
@@ -180,11 +187,12 @@ class MessagePersister {
     sessionId: string,
     client: ContainerClient,
     containerSessionId: string,
-    agentSlug?: string
+    agentSlug?: string,
+    opts?: { fromStart?: boolean }
   ): Promise<void> {
     const inFlight = this.subscribingNow.get(sessionId)
     if (inFlight) return inFlight
-    const promise = this.doSubscribeToSession(sessionId, client, containerSessionId, agentSlug)
+    const promise = this.doSubscribeToSession(sessionId, client, containerSessionId, agentSlug, opts)
       .finally(() => {
         this.subscribingNow.delete(sessionId)
       })
@@ -196,7 +204,8 @@ class MessagePersister {
     sessionId: string,
     client: ContainerClient,
     containerSessionId: string,
-    agentSlug?: string
+    agentSlug?: string,
+    opts?: { fromStart?: boolean }
   ): Promise<void> {
     // Preserve session-lifecycle flags across (re-)subscribe so callers that
     // markSessionActive *before* subscribing (e.g. x-agent sync invoke) and
@@ -245,12 +254,21 @@ class MessagePersister {
     this.containerClients.set(sessionId, client)
 
     // Subscribe to the container's message stream, resuming from the last
-    // processed position so nothing emitted during a gap is lost.
+    // processed position so nothing emitted during a gap is lost. A caller
+    // that JUST created the session asks for a from-start replay instead
+    // (epochless sinceSeq -1): createSession dispatches the first turn before
+    // any subscriber exists, so a fast first turn's terminal events would
+    // otherwise be missed entirely — with no result ever seen, not even the
+    // grace backstop could settle it. Safe by construction: a just-created
+    // session's history is tiny. A stored cursor always wins over fromStart.
     const cursor = this.streamCursors.get(sessionId)
+    const fromStart = opts?.fromStart === true && !cursor
+    if (fromStart) this.fromStartAttaches.add(sessionId)
+    else this.fromStartAttaches.delete(sessionId)
     const { unsubscribe, ready } = client.subscribeToStream(
       containerSessionId,
       (message) => this.handleMessage(sessionId, message),
-      cursor ? { epoch: cursor.epoch, sinceSeq: cursor.seq } : undefined
+      cursor ? { epoch: cursor.epoch, sinceSeq: cursor.seq } : fromStart ? { sinceSeq: -1 } : undefined
     )
 
     this.subscriptions.set(sessionId, unsubscribe)
@@ -308,6 +326,18 @@ class MessagePersister {
   // continuation's first message re-opens the turn within ms of the previous
   // result) — only in the dead post-result / post-background-drain wind-down,
   // where the sole legitimate next event is the settling idle.
+  // One completion-notification idiom for all three settle paths — the
+  // authoritative idle, the grace backstop, and the epoch reconcile. Parity
+  // between them is load-bearing: a settle path that forgot the subtype gate
+  // would fire phantom "done" pings for error/resume exits.
+  private notifyCompletionIfSuccess(sessionId: string, state: StreamingState): void {
+    if (state.lastResultSubtype === 'success' && state.agentSlug) {
+      notificationManager.triggerSessionComplete(sessionId, state.agentSlug).catch((err) => {
+        console.error('[MessagePersister] Failed to trigger session complete notification:', err)
+      })
+    }
+  }
+
   private graceGateHolds(state: StreamingState): boolean {
     return (
       state.stateEventsAuthority &&
@@ -347,16 +377,23 @@ class MessagePersister {
     state: StreamingState,
     content: { epoch?: unknown; max_seq?: unknown }
   ): void {
+    // A cursor-capable hello carries BOTH fields; anything less is treated as
+    // legacy (no cursor, no reconcile). Baselining a missing max_seq to -1
+    // would make the next re-subscribe request a full-history replay of an
+    // old session — re-registering long-dead background tasks.
     const helloEpoch = typeof content.epoch === 'string' ? content.epoch : null
-    if (!helloEpoch) return
+    const maxSeq = typeof content.max_seq === 'number' ? content.max_seq : null
+    if (!helloEpoch || maxSeq === null) return
 
     const prev = this.streamCursors.get(sessionId)
     if (!prev) {
       // First attach with a cursor-capable container: baseline live-only.
       // Replaying an old session's history here would re-register long-dead
       // background tasks; live events settle everything from this point on.
-      const maxSeq = typeof content.max_seq === 'number' ? content.max_seq : -1
-      this.streamCursors.set(sessionId, { epoch: helloEpoch, seq: maxSeq })
+      // Exception: a from-start attach (just-created session) baselines to -1
+      // so the requested replay is processed rather than dedup-skipped.
+      const fromStart = this.fromStartAttaches.delete(sessionId)
+      this.streamCursors.set(sessionId, { epoch: helloEpoch, seq: fromStart ? -1 : maxSeq })
       return
     }
     if (prev.epoch === helloEpoch) return
@@ -366,9 +403,8 @@ class MessagePersister {
     )
     // A completed reply (result seen, idle lost with the process) still gets
     // its "done" notification; a mid-turn death must not fabricate one.
-    const completedAgentSlug =
-      state.isActive && state.lastResultSubtype === 'success' ? state.agentSlug : undefined
-    if (state.isActive) {
+    const wasActive = state.isActive
+    if (wasActive) {
       // Settles isActive and clears everything that died with the old
       // process: background tasks, subagents, workflow tailers. Deliberately
       // NOT markSessionInterrupted — its isInterrupted flag would gate the
@@ -378,10 +414,8 @@ class MessagePersister {
       state.activeBackgroundTasks.clear()
       this.stopAllWorkflowTailers(sessionId)
     }
-    if (completedAgentSlug) {
-      notificationManager.triggerSessionComplete(sessionId, completedAgentSlug).catch((err) => {
-        console.error('[MessagePersister] Failed to trigger session complete notification:', err)
-      })
+    if (wasActive) {
+      this.notifyCompletionIfSuccess(sessionId, state)
     }
     // The new epoch's numbering starts at 0; the full replay that follows the
     // hello is small by construction (the incarnation just started).
@@ -401,11 +435,7 @@ class MessagePersister {
       `[MessagePersister] No idle within ${RESULT_IDLE_GRACE_MS}ms of result for session ${sessionId}, settling via grace backstop`
     )
     this.finalizeIdle(sessionId, state)
-    if (state.lastResultSubtype === 'success' && state.agentSlug) {
-      notificationManager.triggerSessionComplete(sessionId, state.agentSlug).catch((err) => {
-        console.error('[MessagePersister] Failed to trigger session complete notification:', err)
-      })
-    }
+    this.notifyCompletionIfSuccess(sessionId, state)
   }
 
   // Check if a session is currently active (processing user request)
@@ -683,6 +713,14 @@ class MessagePersister {
           this.subscriptions.delete(sessionId)
         }
         this.containerClients.delete(sessionId)
+        // Symmetric with unsubscribeFromSession: an armed grace timer's fire
+        // would no-op (the gate re-check sees isActive false), but don't leave
+        // it ticking against a stopped container.
+        const graceTimer = this.graceTimers.get(sessionId)
+        if (graceTimer) {
+          clearTimeout(graceTimer)
+          this.graceTimers.delete(sessionId)
+        }
       }
     }
   }
@@ -952,9 +990,13 @@ class MessagePersister {
     // Advanced at delivery, not after handling — a message the handlers below
     // choose to drop (interrupted gate, sidechain filter) counts as consumed;
     // redelivering it after a reconnect would make the same choice with stale
-    // context. Seq-less frames (broadcasts, the synthesized connection_closed)
-    // pass through untouched. The hello re-baselines the cursor on epoch change
-    // before any of the new epoch's seqs arrive (WS is FIFO).
+    // context, and redelivering a partially-handled frame is NOT idempotent
+    // (double SSE broadcasts). Accepted residual: a swallowed handler throw on
+    // a terminal frame forfeits its replay — ultra-rare, and the grace
+    // backstop covers the result-shaped cases. Seq-less frames (broadcasts,
+    // the synthesized connection_closed) pass through untouched. The hello
+    // re-baselines the cursor on epoch change before any of the new epoch's
+    // seqs arrive (WS is FIFO).
     const seq = typeof message.content?.seq === 'number' ? (message.content.seq as number) : null
     if (seq !== null) {
       const cursor = this.streamCursors.get(sessionId)
@@ -965,8 +1007,17 @@ class MessagePersister {
     }
 
     // Skip processing if session was interrupted (prevents race conditions)
-    // Allow 'result' through as it indicates the container actually stopped
-    if (state.isInterrupted && message.content?.type !== 'result') {
+    // Allow 'result' through as it indicates the container actually stopped.
+    // Allow 'connection_closed' through too: its handler only does connection
+    // hygiene (settle or re-subscribe, and drop the dead subscription entry) —
+    // swallowing it here would strand a dead entry that makes isSubscribed()
+    // lie, so every later send skips its re-subscribe and the turn runs with
+    // no stream at all: no result, no grace, pinned "working" forever.
+    if (
+      state.isInterrupted &&
+      message.content?.type !== 'result' &&
+      message.content?.type !== 'connection_closed'
+    ) {
       return
     }
 
@@ -1411,11 +1462,7 @@ class MessagePersister {
                 this.finalizeIdle(sessionId, state)
                 // Completion notification at the real end of the work. Skip
                 // resume-exits: the session is pausing for a resume, not done.
-                if (state.lastResultSubtype === 'success' && state.agentSlug) {
-                  notificationManager.triggerSessionComplete(sessionId, state.agentSlug).catch((err) => {
-                    console.error('[MessagePersister] Failed to trigger session complete notification:', err)
-                  })
-                }
+                this.notifyCompletionIfSuccess(sessionId, state)
               }
             }
           } else if (content.state === 'running' && !state.isActive) {
@@ -1567,10 +1614,21 @@ class MessagePersister {
   }
 
   // Handle connection closed - check container and mark inactive if session is done
+  // On every path that does NOT re-subscribe, the dead subscription entry must
+  // be dropped: isSubscribed() feeds the send routes' `if (!isSubscribed)
+  // subscribe` guard, and a stale true makes the next turn run with no stream
+  // attached — no result ever seen, the grace backstop can never arm, pinned
+  // "working" forever. Dropping it means the next send re-attaches, WITH the
+  // surviving cursor, so replay heals whatever the gap swallowed.
+  private dropDeadSubscription(sessionId: string): void {
+    this.subscriptions.delete(sessionId)
+  }
+
   private handleConnectionClosed(sessionId: string, state: StreamingState): void {
     const client = this.containerClients.get(sessionId)
     if (!client) {
       // No client reference, assume session is done
+      this.dropDeadSubscription(sessionId)
       this.markSessionInactive(sessionId, state)
       return
     }
@@ -1581,6 +1639,7 @@ class MessagePersister {
         if (!containerSession) {
           // Session doesn't exist in container anymore
           console.log(`[MessagePersister] Session ${sessionId} not found in container, marking inactive`)
+          this.dropDeadSubscription(sessionId)
           this.markSessionInactive(sessionId, state)
           return
         }
@@ -1610,12 +1669,14 @@ class MessagePersister {
         } else {
           // Session finished
           console.log(`[MessagePersister] Session ${sessionId} not running in container, marking inactive`)
+          this.dropDeadSubscription(sessionId)
           this.markSessionInactive(sessionId, state)
         }
       })
       .catch((error) => {
         // Can't reach container, assume session is done
         console.error(`[MessagePersister] Failed to check container for session ${sessionId}:`, error)
+        this.dropDeadSubscription(sessionId)
         this.markSessionInactive(sessionId, state)
       })
   }

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -148,6 +148,12 @@ class MessagePersister {
   // streamingStates so a mid-window re-subscribe (which replaces the state
   // object) can't strand an armed timer or leak one across state resets.
   private graceTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
+  // Last-processed (epoch, seq) position on each session's container stream,
+  // set from the attach hello and advanced per relayed message. Passed back on
+  // every (re)subscribe so the container replays exactly what a reconnect gap
+  // swallowed. Held outside streamingStates and NOT cleared on unsubscribe —
+  // surviving the re-subscribe is its entire purpose.
+  private streamCursors: Map<string, { epoch: string; seq: number }> = new Map()
   private sseClients: Map<string, Set<(data: unknown) => void>> = new Map()
   // Per-run journal tailers driving the live workflow drawer, keyed `${sessionId}::${runId}`
   private workflowTailers: Map<string, WorkflowJournalTailer> = new Map()
@@ -238,10 +244,13 @@ class MessagePersister {
     // Store container client for reconnection checks
     this.containerClients.set(sessionId, client)
 
-    // Subscribe to the container's message stream
+    // Subscribe to the container's message stream, resuming from the last
+    // processed position so nothing emitted during a gap is lost.
+    const cursor = this.streamCursors.get(sessionId)
     const { unsubscribe, ready } = client.subscribeToStream(
       containerSessionId,
-      (message) => this.handleMessage(sessionId, message)
+      (message) => this.handleMessage(sessionId, message),
+      cursor ? { epoch: cursor.epoch, sinceSeq: cursor.seq } : undefined
     )
 
     this.subscriptions.set(sessionId, unsubscribe)
@@ -324,6 +333,59 @@ class MessagePersister {
       clearTimeout(armed)
       this.graceTimers.delete(sessionId)
     }
+  }
+
+  // Reconcile the host's view against the attach hello's epoch. Same epoch:
+  // nothing to do — the replay that follows carries any missed events, and
+  // they settle things naturally. Epoch mismatch: the previous container
+  // incarnation (and the turn + background tasks running in it) died, so the
+  // terminal signals the host is waiting for can never arrive — settle NOW.
+  // A hello without an epoch is an older container image: no cursor, no
+  // reconcile, exactly the pre-cursor behavior.
+  private reconcileStreamEpoch(
+    sessionId: string,
+    state: StreamingState,
+    content: { epoch?: unknown; max_seq?: unknown }
+  ): void {
+    const helloEpoch = typeof content.epoch === 'string' ? content.epoch : null
+    if (!helloEpoch) return
+
+    const prev = this.streamCursors.get(sessionId)
+    if (!prev) {
+      // First attach with a cursor-capable container: baseline live-only.
+      // Replaying an old session's history here would re-register long-dead
+      // background tasks; live events settle everything from this point on.
+      const maxSeq = typeof content.max_seq === 'number' ? content.max_seq : -1
+      this.streamCursors.set(sessionId, { epoch: helloEpoch, seq: maxSeq })
+      return
+    }
+    if (prev.epoch === helloEpoch) return
+
+    console.log(
+      `[MessagePersister] Container epoch changed for session ${sessionId} (${prev.epoch} → ${helloEpoch}), reconciling`
+    )
+    // A completed reply (result seen, idle lost with the process) still gets
+    // its "done" notification; a mid-turn death must not fabricate one.
+    const completedAgentSlug =
+      state.isActive && state.lastResultSubtype === 'success' ? state.agentSlug : undefined
+    if (state.isActive) {
+      // Settles isActive and clears everything that died with the old
+      // process: background tasks, subagents, workflow tailers. Deliberately
+      // NOT markSessionInterrupted — its isInterrupted flag would gate the
+      // new epoch's messages out of handleMessage.
+      this.markSessionInactive(sessionId, state)
+    } else {
+      state.activeBackgroundTasks.clear()
+      this.stopAllWorkflowTailers(sessionId)
+    }
+    if (completedAgentSlug) {
+      notificationManager.triggerSessionComplete(sessionId, completedAgentSlug).catch((err) => {
+        console.error('[MessagePersister] Failed to trigger session complete notification:', err)
+      })
+    }
+    // The new epoch's numbering starts at 0; the full replay that follows the
+    // hello is small by construction (the incarnation just started).
+    this.streamCursors.set(sessionId, { epoch: helloEpoch, seq: -1 })
   }
 
   // The idle never came. Re-check the full gate against CURRENT state (the
@@ -885,6 +947,23 @@ class MessagePersister {
     const state = this.streamingStates.get(sessionId)
     if (!state) return
 
+    // (epoch, seq) cursor over the relayed stream: skip anything already seen
+    // (overlapping replay, duplicate socket), advance for anything new.
+    // Advanced at delivery, not after handling — a message the handlers below
+    // choose to drop (interrupted gate, sidechain filter) counts as consumed;
+    // redelivering it after a reconnect would make the same choice with stale
+    // context. Seq-less frames (broadcasts, the synthesized connection_closed)
+    // pass through untouched. The hello re-baselines the cursor on epoch change
+    // before any of the new epoch's seqs arrive (WS is FIFO).
+    const seq = typeof message.content?.seq === 'number' ? (message.content.seq as number) : null
+    if (seq !== null) {
+      const cursor = this.streamCursors.get(sessionId)
+      if (cursor) {
+        if (seq <= cursor.seq) return
+        cursor.seq = seq
+      }
+    }
+
     // Skip processing if session was interrupted (prevents race conditions)
     // Allow 'result' through as it indicates the container actually stopped
     if (state.isInterrupted && message.content?.type !== 'result') {
@@ -1293,6 +1372,7 @@ class MessagePersister {
           if (content.session_state_events === true) {
             state.stateEventsAuthority = true
           }
+          this.reconcileStreamEpoch(sessionId, state, content)
         } else if (content.subtype === 'session_state_changed') {
           // The runtime's own session state — `idle` is the SDK's authoritative
           // "fully settled" signal: it fires only after heldBackResult flushes
@@ -1509,11 +1589,15 @@ class MessagePersister {
         // The container's getSession returns isRunning in the response
         const isRunning = (containerSession as any).isRunning
         if (isRunning) {
-          // Session still running, try to re-subscribe
+          // Session still running, try to re-subscribe — with the cursor, so
+          // the container replays anything emitted during the gap (a lost
+          // idle / task terminal would otherwise pin the session forever).
           console.log(`[MessagePersister] Session ${sessionId} still running, re-subscribing`)
+          const cursor = this.streamCursors.get(sessionId)
           const { unsubscribe, ready } = client.subscribeToStream(
             sessionId,
-            (message) => this.handleMessage(sessionId, message)
+            (message) => this.handleMessage(sessionId, message),
+            cursor ? { epoch: cursor.epoch, sinceSeq: cursor.seq } : undefined
           )
           this.subscriptions.set(sessionId, unsubscribe)
           // Defense-in-depth: we don't await the re-subscribe here, so attach a

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -108,6 +108,10 @@ interface StreamingState {
   // Subtype of the most recent result — gates the completion notification when
   // idle arrives via session_state_changed (resume-exits pause, not finish).
   lastResultSubtype: string | null
+  // Turn-phase bit for the grace-after-result backstop: true when the runtime's
+  // last word was "work done" (a result), false the moment any turn activity
+  // (assistant/user/stream/init message, or a host send) re-opens the turn.
+  turnClosed: boolean
   isRetrying: boolean // True while an API retry is in progress, cleared when the next message starts
 }
 
@@ -129,10 +133,21 @@ async function getContainerManager() {
   return _containerManagerModule.containerManager
 }
 
+// Grace window between a turn's `result` and the authoritative idle. The
+// post-result wind-down is normally milliseconds; when the runtime hangs in
+// it, the session would otherwise stay "working" forever (state events are
+// the idle authority and no further result will come). Long enough for a slow
+// machine's wind-down, short enough that a stuck light heals promptly.
+const RESULT_IDLE_GRACE_MS = 10_000
+
 // TODO this file is too big, this class is HUGE. Needs breaking up
 class MessagePersister {
   private streamingStates: Map<string, StreamingState> = new Map()
   private subscriptions: Map<string, () => void> = new Map()
+  // Grace-after-result backstop timers, keyed by sessionId. Held outside
+  // streamingStates so a mid-window re-subscribe (which replaces the state
+  // object) can't strand an armed timer or leak one across state resets.
+  private graceTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
   private sseClients: Map<string, Set<(data: unknown) => void>> = new Map()
   // Per-run journal tailers driving the live workflow drawer, keyed `${sessionId}::${runId}`
   private workflowTailers: Map<string, WorkflowJournalTailer> = new Map()
@@ -212,7 +227,11 @@ class MessagePersister {
       activeBackgroundTasks: priorBackgroundTasks,
       pendingDeliverFiles: new Map(),
       stateEventsAuthority: prior?.stateEventsAuthority ?? false,
-      lastResultSubtype: null,
+      // Carried like the other prior-flags: a re-subscribe landing inside the
+      // result→idle window must not wipe the turn's "result seen" memory, or
+      // the authoritative idle (and the grace backstop) would no-op → stuck.
+      lastResultSubtype: prior?.lastResultSubtype ?? null,
+      turnClosed: prior?.turnClosed ?? false,
       isRetrying: false,
     })
 
@@ -235,6 +254,10 @@ class MessagePersister {
 
     // Wait for the WebSocket connection to be established
     await ready
+
+    // A re-subscribe may have landed inside the result→idle window (its
+    // unsubscribe cancelled any armed grace) — re-arm from the carried state.
+    this.evaluateGrace(sessionId)
   }
 
   // Unsubscribe from a session
@@ -243,6 +266,11 @@ class MessagePersister {
     if (unsubscribe) {
       unsubscribe()
       this.subscriptions.delete(sessionId)
+    }
+    const graceTimer = this.graceTimers.get(sessionId)
+    if (graceTimer) {
+      clearTimeout(graceTimer)
+      this.graceTimers.delete(sessionId)
     }
     this.streamingStates.delete(sessionId)
     this.containerClients.delete(sessionId)
@@ -260,6 +288,62 @@ class MessagePersister {
       agentSlug: state.agentSlug,
       isActive: false,
     })
+  }
+
+  // Grace-after-result backstop — the derived arm/disarm evaluation, run after
+  // every processed message and after (re)subscribe. The gate holds only when
+  // the runtime's last word was "work done": a result was seen, nothing
+  // re-opened the turn since (turnClosed), no background task is pending and
+  // no input request is open. It therefore can't run during a genuinely
+  // working turn (a silent 20-minute tool has no result yet, and a queued
+  // continuation's first message re-opens the turn within ms of the previous
+  // result) — only in the dead post-result / post-background-drain wind-down,
+  // where the sole legitimate next event is the settling idle.
+  private graceGateHolds(state: StreamingState): boolean {
+    return (
+      state.stateEventsAuthority &&
+      state.isActive &&
+      state.lastResultSubtype !== null &&
+      state.turnClosed &&
+      state.activeBackgroundTasks.size === 0 &&
+      !state.isAwaitingInput
+    )
+  }
+
+  private evaluateGrace(sessionId: string): void {
+    const state = this.streamingStates.get(sessionId)
+    const armed = this.graceTimers.get(sessionId)
+    const gate = state !== undefined && this.graceGateHolds(state)
+    if (gate && !armed) {
+      const timer = setTimeout(() => {
+        this.graceTimers.delete(sessionId)
+        this.fireGrace(sessionId)
+      }, RESULT_IDLE_GRACE_MS)
+      this.graceTimers.set(sessionId, timer)
+    } else if (!gate && armed) {
+      clearTimeout(armed)
+      this.graceTimers.delete(sessionId)
+    }
+  }
+
+  // The idle never came. Re-check the full gate against CURRENT state (the
+  // state object may have been replaced since arming), then settle exactly
+  // like the authoritative-idle path — including the completion notification:
+  // a merely-lost idle must not cost the user the "done" signal.
+  private fireGrace(sessionId: string): void {
+    const state = this.streamingStates.get(sessionId)
+    if (!state || !this.graceGateHolds(state)) {
+      return
+    }
+    console.log(
+      `[MessagePersister] No idle within ${RESULT_IDLE_GRACE_MS}ms of result for session ${sessionId}, settling via grace backstop`
+    )
+    this.finalizeIdle(sessionId, state)
+    if (state.lastResultSubtype === 'success' && state.agentSlug) {
+      notificationManager.triggerSessionComplete(sessionId, state.agentSlug).catch((err) => {
+        console.error('[MessagePersister] Failed to trigger session complete notification:', err)
+      })
+    }
   }
 
   // Check if a session is currently active (processing user request)
@@ -654,6 +738,7 @@ class MessagePersister {
         pendingDeliverFiles: new Map(),
         stateEventsAuthority: false,
         lastResultSubtype: null,
+        turnClosed: false,
         isRetrying: false,
       }
       this.streamingStates.set(sessionId, state)
@@ -677,6 +762,7 @@ class MessagePersister {
     // already-finished (or interrupted) run can't fire a stale "success"
     // completion notification against the turn this message is starting.
     state.lastResultSubtype = null
+    state.turnClosed = false // The send opens a turn — disarm the grace backstop
     if (agentSlug) {
       state.agentSlug = agentSlug
     }
@@ -830,6 +916,21 @@ class MessagePersister {
     if (content.parent_tool_use_id != null) {
       this.handleSidechainMessage(sessionId, content, state)
       return
+    }
+
+    // Turn-phase tracking for the grace backstop: these messages evidence a
+    // running turn (a queued continuation's `init` arrives ~ms after the
+    // previous result). Everything else — state events, task terminals,
+    // browser/capabilities frames — says nothing about turn progress and must
+    // not touch the bit, or a stray frame could disarm the backstop for good.
+    if (
+      content.type === 'assistant' ||
+      content.type === 'user' ||
+      content.type === 'stream_event' ||
+      content.event != null ||
+      (content.type === 'system' && content.subtype === 'init')
+    ) {
+      state.turnClosed = false
     }
 
     switch (content.type) {
@@ -1271,6 +1372,7 @@ class MessagePersister {
         if (isError) state.isActive = false
         state.currentText = ''
         state.lastResultSubtype = typeof content.subtype === 'string' ? content.subtype : null
+        state.turnClosed = true // The runtime's last word is "work done" until something re-opens the turn
 
         // Extract and persist context usage from result event
         this.handleResultUsage(sessionId, state, content)
@@ -1376,6 +1478,12 @@ class MessagePersister {
           this.handleStreamEvent(sessionId, content.event, state)
         }
     }
+
+    // Every message can move the grace gate — a result (or the terminal task
+    // event that drains the last background task) arms it, turn activity
+    // disarms it, and the authoritative idle settles first and leaves it
+    // nothing to do.
+    this.evaluateGrace(sessionId)
   }
 
   // Handle connection closed - check container and mark inactive if session is done

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -299,6 +299,10 @@ class MessagePersister {
       clearTimeout(graceTimer)
       this.graceTimers.delete(sessionId)
     }
+    // A from-start marker is normally consumed by the attach hello; if that
+    // hello was legacy (no epoch) or never arrived, the entry would linger.
+    // Clear it on teardown so the Set can't accumulate across sessions.
+    this.fromStartAttaches.delete(sessionId)
     this.streamingStates.delete(sessionId)
     this.containerClients.delete(sessionId)
   }
@@ -1568,8 +1572,10 @@ class MessagePersister {
         // notification (vs just creating the DB record) is the renderer's
         // call — it knows about window focus, per-user viewing, and the
         // `notifyWhenUnfocused` toggle. Skip for 'resume' exits — the
-        // session is pausing for a resume, not truly finished.
-        if (content.subtype !== 'resume' && state.agentSlug) {
+        // session is pausing for a resume, not truly finished. Skip when the
+        // user interrupted — a turn they stopped must not ping "done" (the
+        // state-events path gates this via isActive; legacy has no such gate).
+        if (content.subtype !== 'resume' && !state.isInterrupted && state.agentSlug) {
           notificationManager.triggerSessionComplete(sessionId, state.agentSlug).catch((err) => {
             console.error('[MessagePersister] Failed to trigger session complete notification:', err)
           })
@@ -1620,15 +1626,24 @@ class MessagePersister {
   // attached — no result ever seen, the grace backstop can never arm, pinned
   // "working" forever. Dropping it means the next send re-attaches, WITH the
   // surviving cursor, so replay heals whatever the gap swallowed.
-  private dropDeadSubscription(sessionId: string): void {
-    this.subscriptions.delete(sessionId)
+  private dropDeadSubscription(sessionId: string, deadUnsub: (() => void) | undefined): void {
+    // Only drop the entry if it is STILL the dead socket's. The container check
+    // below is async, and during that window a send-route re-subscribe can
+    // install a fresh live unsubscribe under this sessionId; deleting THAT would
+    // make isSubscribed() lie false about a live socket and strand the next turn.
+    if (this.subscriptions.get(sessionId) === deadUnsub) {
+      this.subscriptions.delete(sessionId)
+    }
   }
 
   private handleConnectionClosed(sessionId: string, state: StreamingState): void {
+    // Capture the dying socket's entry now; every drop path below only fires if
+    // this is still the installed subscription when the async check resolves.
+    const deadUnsub = this.subscriptions.get(sessionId)
     const client = this.containerClients.get(sessionId)
     if (!client) {
       // No client reference, assume session is done
-      this.dropDeadSubscription(sessionId)
+      this.dropDeadSubscription(sessionId, deadUnsub)
       this.markSessionInactive(sessionId, state)
       return
     }
@@ -1639,7 +1654,7 @@ class MessagePersister {
         if (!containerSession) {
           // Session doesn't exist in container anymore
           console.log(`[MessagePersister] Session ${sessionId} not found in container, marking inactive`)
-          this.dropDeadSubscription(sessionId)
+          this.dropDeadSubscription(sessionId, deadUnsub)
           this.markSessionInactive(sessionId, state)
           return
         }
@@ -1669,14 +1684,14 @@ class MessagePersister {
         } else {
           // Session finished
           console.log(`[MessagePersister] Session ${sessionId} not running in container, marking inactive`)
-          this.dropDeadSubscription(sessionId)
+          this.dropDeadSubscription(sessionId, deadUnsub)
           this.markSessionInactive(sessionId, state)
         }
       })
       .catch((error) => {
         // Can't reach container, assume session is done
         console.error(`[MessagePersister] Failed to check container for session ${sessionId}:`, error)
-        this.dropDeadSubscription(sessionId)
+        this.dropDeadSubscription(sessionId, deadUnsub)
         this.markSessionInactive(sessionId, state)
       })
   }

--- a/src/shared/lib/container/stream-cursor-reconcile.test.ts
+++ b/src/shared/lib/container/stream-cursor-reconcile.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import type { ContainerClient, StreamMessage } from './types'
+
+// Lossless container→host stream: the host tracks a per-session
+// (epoch, seq) cursor over the relayed messages and passes it on every
+// (re)subscribe, so the container can replay exactly what was missed during a
+// reconnect gap. The attach hello carries the container incarnation's epoch:
+// a mismatch means the previous process (and the turn + background tasks
+// running in it) died — the host reconciles instead of waiting forever for
+// terminal signals that can no longer arrive.
+
+// ----- Mocks for external dependencies (mirrors grace-after-result) -----
+
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  createScheduledTask: vi.fn(),
+}))
+vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionMetadata: vi.fn(() => Promise.resolve(null)),
+  updateSessionMetadata: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerSessionComplete: vi.fn(() => Promise.resolve()),
+    triggerSessionWaitingInput: vi.fn(() => Promise.resolve()),
+  },
+}))
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({}),
+  VALID_SCRIPT_TYPES: { darwin: ['applescript', 'shell'], linux: ['shell'], win32: ['powershell'] },
+}))
+vi.mock('@shared/lib/computer-use/permission-manager', () => ({
+  computerUsePermissionManager: {
+    checkPermission: vi.fn(() => 'prompt_needed'),
+    getGrabbedApp: vi.fn(() => undefined),
+    setGrabbedApp: vi.fn(),
+    clearGrabbedApp: vi.fn(),
+    consumeOnceGrant: vi.fn(),
+  },
+}))
+vi.mock('@shared/lib/computer-use/types', () => ({
+  getRequiredPermissionLevel: vi.fn(() => 'use_application'),
+  resolveTargetApp: vi.fn(() => undefined),
+  READ_ONLY_METHODS: new Set(['apps', 'windows', 'status', 'displays', 'permissions']),
+  TIMED_GRANT_DURATION_MS: 15 * 60 * 1000,
+}))
+vi.mock('@shared/lib/computer-use/executor', () => ({
+  resolveAppFromWindowRef: vi.fn(() => undefined),
+}))
+vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
+  createWebhookTrigger: vi.fn(() => Promise.resolve('trigger_new_id')),
+  listActiveWebhookTriggers: vi.fn(() => Promise.resolve([])),
+  cancelWebhookTriggerWithCleanup: vi.fn(() => Promise.resolve(true)),
+}))
+vi.mock('@shared/lib/composio/triggers', () => ({
+  getAvailableTriggers: vi.fn(() => Promise.resolve([])),
+  enableComposioTrigger: vi.fn(() => Promise.resolve('composio_trigger_id')),
+  deleteComposioTrigger: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('@shared/lib/composio/client', () => ({
+  isPlatformComposioActive: vi.fn(() => true),
+}))
+vi.mock('@shared/lib/services/timezone-resolver', () => ({
+  resolveTimezoneForAgent: vi.fn(() => Promise.resolve('UTC')),
+}))
+vi.mock('@shared/lib/analytics/server-analytics', () => ({
+  trackServerEvent: vi.fn(),
+}))
+vi.mock('@shared/lib/db', () => ({ db: {} }))
+vi.mock('@shared/lib/db/schema', () => ({ connectedAccounts: {} }))
+vi.mock('drizzle-orm', () => ({ eq: vi.fn() }))
+vi.mock('@shared/lib/utils/file-storage', () => ({
+  getAgentSessionsDir: (_agentSlug: string) => '/nonexistent',
+}))
+
+// ----- Helpers -----
+
+const AGENT_SLUG = 'test-agent'
+
+// Unique session id per test: a failing assertion skips the trailing
+// unsubscribe, and subscribeToSession deliberately carries prior flags (incl.
+// activeBackgroundTasks) for a same-session re-subscribe — so a reused id
+// would leak one test's state into the next.
+let sessionCounter = 0
+
+// Unconditional teardown (assertion failures skip a test's trailing cleanup).
+let teardown: (() => void) | null = null
+
+type Cursor = { epoch: string; sinceSeq: number } | undefined
+
+function createCursorClient(sessionId: string): {
+  client: ContainerClient
+  send: (content: Record<string, unknown>) => Promise<void>
+  cursors: Cursor[]
+} {
+  let callback: ((message: StreamMessage) => void) | null = null
+  const cursors: Cursor[] = []
+  const client = {
+    subscribeToStream: vi.fn(
+      (_sid: string, cb: (message: StreamMessage) => void, cursor?: Cursor) => {
+        callback = cb
+        cursors.push(cursor)
+        return { unsubscribe: vi.fn(), ready: Promise.resolve() }
+      }
+    ),
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopSync: vi.fn(),
+    getInfoFromRuntime: vi.fn(),
+    getInfo: vi.fn(),
+    fetch: vi.fn(),
+    waitForHealthy: vi.fn(),
+    isHealthy: vi.fn(),
+    getStats: vi.fn(),
+    createSession: vi.fn(),
+    getSession: vi.fn(() => Promise.resolve(null)),
+    deleteSession: vi.fn(),
+    sendMessage: vi.fn(),
+    getMessages: vi.fn(),
+    interruptSession: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  } as unknown as ContainerClient
+  const send = async (content: Record<string, unknown>) => {
+    callback?.({
+      type: (content.type as string) ?? 'message',
+      content,
+      timestamp: new Date(),
+      sessionId,
+    } as StreamMessage)
+    await new Promise((r) => setImmediate(r))
+  }
+  return { client, send, cursors }
+}
+
+const hello = (epoch: string, maxSeq: number) => ({
+  type: 'system',
+  subtype: 'capabilities',
+  session_state_events: true,
+  epoch,
+  max_seq: maxSeq,
+})
+const LEGACY_HELLO = { type: 'system', subtype: 'capabilities', session_state_events: true }
+const assistant = (seq: number) => ({
+  type: 'assistant',
+  seq,
+  message: { content: [{ type: 'text', text: 'hi' }] },
+})
+const result = (seq: number) => ({ type: 'result', subtype: 'success', seq })
+const idle = (seq: number) => ({
+  type: 'system',
+  subtype: 'session_state_changed',
+  state: 'idle',
+  seq,
+})
+const bgLaunch = (seq: number) => ({
+  type: 'user',
+  seq,
+  message: { content: [] },
+  tool_use_result: { backgroundTaskId: 'bg-1' },
+})
+
+async function setUp() {
+  vi.resetModules()
+  const { messagePersister } = await import('./message-persister')
+  const { notificationManager } = await import('@shared/lib/notifications/notification-manager')
+  const sessionId = `cursor-test-session-${++sessionCounter}`
+  const { client, send, cursors } = createCursorClient(sessionId)
+
+  const sseEvents: Array<Record<string, unknown>> = []
+  const removeSSE = messagePersister.addSSEClient(sessionId, (data) => {
+    sseEvents.push(data as Record<string, unknown>)
+  })
+  teardown = () => {
+    removeSSE()
+    messagePersister.unsubscribeFromSession(sessionId)
+  }
+
+  await messagePersister.subscribeToSession(sessionId, client, sessionId, AGENT_SLUG)
+
+  const resubscribe = () =>
+    messagePersister.subscribeToSession(sessionId, client, sessionId, AGENT_SLUG)
+
+  return { messagePersister, notificationManager, sessionId, sseEvents, send, cursors, resubscribe }
+}
+
+const countIdle = (events: Array<Record<string, unknown>>) =>
+  events.filter((e) => e['type'] === 'session_idle').length
+const countMessagesUpdated = (events: Array<Record<string, unknown>>) =>
+  events.filter((e) => e['type'] === 'messages_updated').length
+
+// =====================================================================
+// Tests
+// =====================================================================
+
+describe('stream cursor + epoch reconcile', () => {
+  afterEach(() => {
+    teardown?.()
+    teardown = null
+    vi.clearAllMocks()
+  })
+
+  it('tracks the (epoch, seq) cursor and passes it on re-subscribe', async () => {
+    const { messagePersister, sessionId, send, cursors, resubscribe } = await setUp()
+
+    // First attach carries no cursor (live-only).
+    expect(cursors[0]).toBeUndefined()
+
+    await send(hello('epoch-1', 4))
+    messagePersister.markSessionActive(sessionId, AGENT_SLUG)
+    await send(assistant(5))
+    await send(assistant(6))
+
+    await resubscribe()
+    expect(cursors[1]).toEqual({ epoch: 'epoch-1', sinceSeq: 6 })
+  })
+
+  it('settles from replayed terminal events after a reconnect gap', async () => {
+    const { messagePersister, notificationManager, sessionId, sseEvents, send, cursors, resubscribe } =
+      await setUp()
+
+    await send(hello('epoch-1', -1))
+    messagePersister.markSessionActive(sessionId, AGENT_SLUG)
+    await send(assistant(0))
+    // ...the turn's result + idle are emitted during a WS gap and never seen live.
+
+    await resubscribe()
+    expect(cursors[1]).toEqual({ epoch: 'epoch-1', sinceSeq: 0 })
+
+    // The container replays exactly what was missed (same epoch).
+    await send(hello('epoch-1', 2))
+    await send(result(1))
+    await send(idle(2))
+
+    expect(countIdle(sseEvents)).toBe(1)
+    expect(messagePersister.isSessionActive(sessionId)).toBe(false)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('epoch mismatch mid-turn settles as interrupted: no completion notification, tasks dropped', async () => {
+    const { messagePersister, notificationManager, sessionId, sseEvents, send, resubscribe } =
+      await setUp()
+
+    await send(hello('epoch-1', -1))
+    messagePersister.markSessionActive(sessionId, AGENT_SLUG)
+    await send(assistant(0))
+    await send(bgLaunch(1))
+    expect(messagePersister.isSessionActive(sessionId)).toBe(true)
+
+    // Container restarted during the gap: new incarnation, fresh numbering.
+    // The turn and its background task died with the old process.
+    await resubscribe()
+    await send(hello('epoch-2', -1))
+
+    expect(messagePersister.isSessionActive(sessionId)).toBe(false)
+    expect(countIdle(sseEvents)).toBe(1)
+    expect(notificationManager.triggerSessionComplete).not.toHaveBeenCalled()
+
+    // The dead task must not wedge future settles: a fresh turn on the new
+    // epoch settles normally on its idle.
+    messagePersister.markSessionActive(sessionId, AGENT_SLUG)
+    await send(assistant(0))
+    await send(result(1))
+    await send(idle(2))
+    expect(messagePersister.isSessionActive(sessionId)).toBe(false)
+    expect(countIdle(sseEvents)).toBe(2)
+  })
+
+  it('epoch mismatch after a seen result settles WITH the completion notification', async () => {
+    const { messagePersister, notificationManager, sessionId, sseEvents, send, resubscribe } =
+      await setUp()
+
+    await send(hello('epoch-1', -1))
+    messagePersister.markSessionActive(sessionId, AGENT_SLUG)
+    await send(assistant(0))
+    await send(result(1))
+    // The reply is done; only the settling idle was pending when the
+    // container died. The user still deserves the "done" signal.
+
+    await resubscribe()
+    await send(hello('epoch-2', -1))
+
+    expect(messagePersister.isSessionActive(sessionId)).toBe(false)
+    expect(countIdle(sseEvents)).toBe(1)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips already-processed seqs (duplicate delivery is idempotent)', async () => {
+    const { messagePersister, sessionId, sseEvents, send } = await setUp()
+
+    await send(hello('epoch-1', -1))
+    messagePersister.markSessionActive(sessionId, AGENT_SLUG)
+    await send(assistant(0))
+    const updatedAfterFirst = countMessagesUpdated(sseEvents)
+
+    // The same message delivered again (overlapping replay / duplicate socket).
+    await send(assistant(0))
+    expect(countMessagesUpdated(sseEvents)).toBe(updatedAfterFirst)
+  })
+
+  it('seq-less frames are processed but never advance the cursor', async () => {
+    const { messagePersister, sessionId, sseEvents, send, cursors, resubscribe } = await setUp()
+
+    await send(hello('epoch-1', -1))
+    messagePersister.markSessionActive(sessionId, AGENT_SLUG)
+    await send(assistant(0))
+    await send({ type: 'browser_active', active: false })
+
+    expect(sseEvents.some((e) => e['type'] === 'browser_active')).toBe(true)
+    await resubscribe()
+    expect(cursors[1]).toEqual({ epoch: 'epoch-1', sinceSeq: 0 })
+  })
+
+  it('legacy hello without epoch keeps today\'s behavior: no cursor on re-subscribe', async () => {
+    const { messagePersister, notificationManager, sessionId, send, cursors, resubscribe } =
+      await setUp()
+
+    await send(LEGACY_HELLO)
+    messagePersister.markSessionActive(sessionId, AGENT_SLUG)
+    await send({ type: 'assistant', message: { content: [{ type: 'text', text: 'hi' }] } })
+    await send({ type: 'result', subtype: 'success' })
+    await send({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+
+    expect(messagePersister.isSessionActive(sessionId)).toBe(false)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+
+    await resubscribe()
+    expect(cursors[1]).toBeUndefined()
+  })
+})

--- a/src/shared/lib/container/stream-cursor-reconcile.test.ts
+++ b/src/shared/lib/container/stream-cursor-reconcile.test.ts
@@ -159,7 +159,7 @@ const bgLaunch = (seq: number) => ({
   tool_use_result: { backgroundTaskId: 'bg-1' },
 })
 
-async function setUp() {
+async function setUp(subscribeOpts?: { fromStart?: boolean }) {
   vi.resetModules()
   const { messagePersister } = await import('./message-persister')
   const { notificationManager } = await import('@shared/lib/notifications/notification-manager')
@@ -175,7 +175,7 @@ async function setUp() {
     messagePersister.unsubscribeFromSession(sessionId)
   }
 
-  await messagePersister.subscribeToSession(sessionId, client, sessionId, AGENT_SLUG)
+  await messagePersister.subscribeToSession(sessionId, client, sessionId, AGENT_SLUG, subscribeOpts)
 
   const resubscribe = () =>
     messagePersister.subscribeToSession(sessionId, client, sessionId, AGENT_SLUG)
@@ -284,6 +284,53 @@ describe('stream cursor + epoch reconcile', () => {
     expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
   })
 
+  it('an epoch mismatch while the grace timer is armed settles exactly once', async () => {
+    // The grace backstop arms a setTimeout after the result; fake timers for
+    // this one test so its window can be driven past deterministically.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      const { messagePersister, notificationManager, sessionId, sseEvents, send, resubscribe } =
+        await setUp()
+
+      await send(hello('epoch-1', -1))
+      messagePersister.markSessionActive(sessionId, AGENT_SLUG)
+      await send(assistant(0))
+      await send(result(1)) // result seen, idle pending → grace arms
+
+      // The container died inside the grace window; the re-attach hello
+      // carries a new epoch and the reconcile settles (with the notification).
+      await resubscribe()
+      await send(hello('epoch-2', -1))
+
+      expect(countIdle(sseEvents)).toBe(1)
+      expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+
+      // The armed grace window elapsing afterwards must not settle again.
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(countIdle(sseEvents)).toBe(1)
+      expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('a same-epoch hello on re-attach reconciles nothing: a mid-turn session stays active', async () => {
+    const { messagePersister, notificationManager, sessionId, sseEvents, send, resubscribe } =
+      await setUp()
+
+    await send(hello('epoch-1', -1))
+    messagePersister.markSessionActive(sessionId, AGENT_SLUG)
+    await send(assistant(0))
+
+    // Same incarnation across the reconnect gap: the turn is still running.
+    await resubscribe()
+    await send(hello('epoch-1', 0))
+
+    expect(messagePersister.isSessionActive(sessionId)).toBe(true)
+    expect(countIdle(sseEvents)).toBe(0)
+    expect(notificationManager.triggerSessionComplete).not.toHaveBeenCalled()
+  })
+
   it('skips already-processed seqs (duplicate delivery is idempotent)', async () => {
     const { messagePersister, sessionId, sseEvents, send } = await setUp()
 
@@ -325,5 +372,44 @@ describe('stream cursor + epoch reconcile', () => {
 
     await resubscribe()
     expect(cursors[1]).toBeUndefined()
+  })
+
+  it('a hello with an epoch but no max_seq is treated as legacy (no cursor)', async () => {
+    const { messagePersister, sessionId, send, cursors, resubscribe } = await setUp()
+
+    await send({ type: 'system', subtype: 'capabilities', session_state_events: true, epoch: 'epoch-1' })
+    messagePersister.markSessionActive(sessionId, AGENT_SLUG)
+    await send(assistant(0))
+
+    // Baselining a missing max_seq would make this re-subscribe request a
+    // full-history replay of an old session — the dead-background-task wedge.
+    await resubscribe()
+    expect(cursors[1]).toBeUndefined()
+    expect(messagePersister.isSessionActive(sessionId)).toBe(true)
+  })
+
+  it('a from-start subscribe replays the just-created session it would otherwise have missed', async () => {
+    // The stuck-case this kills: createSession dispatches the first turn
+    // BEFORE the host subscribes. A fast first turn's result+idle land before
+    // the attach — live-only, they are gone, and the session pins "working"
+    // forever (no result seen means the grace backstop can never arm).
+    const { messagePersister, notificationManager, sessionId, sseEvents, send, cursors } =
+      await setUp({ fromStart: true })
+
+    // The first attach must request everything from the very start.
+    expect(cursors[0]).toEqual({ sinceSeq: -1 })
+
+    messagePersister.markSessionActive(sessionId, AGENT_SLUG)
+
+    // Container replays the whole young history after the hello: the first
+    // turn already ran to completion inside the attach gap.
+    await send(hello('epoch-1', 2))
+    await send(assistant(0))
+    await send(result(1))
+    await send(idle(2))
+
+    expect(messagePersister.isSessionActive(sessionId)).toBe(false)
+    expect(countIdle(sseEvents)).toBe(1)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/shared/lib/container/stream-schema.ts
+++ b/src/shared/lib/container/stream-schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+// Envelope contract for frames arriving on the container→host session stream.
+// Validates only the fields the host's stream machinery consumes — `type` for
+// routing, and the cursor fields introduced by the lossless-replay protocol:
+// `seq` (per-epoch position, stamped by the container at store time; absent on
+// broadcast frames) and the attach hello's `epoch`/`max_seq`. The SDK message
+// payload itself is passed through untouched (loose): its shape is the SDK's
+// contract, consumed field-by-field downstream.
+export const streamEnvelopeSchema = z.looseObject({
+  type: z.string(),
+  seq: z.int().nonnegative().optional(),
+  epoch: z.string().optional(),
+  max_seq: z.int().gte(-1).optional(),
+})
+
+export type StreamEnvelope = z.infer<typeof streamEnvelopeSchema>

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -166,10 +166,14 @@ export interface ContainerClient {
   getMessages(sessionId: string): Promise<any[]>
   interruptSession(sessionId: string): Promise<boolean>
 
-  // Streaming - returns unsubscribe function and a ready promise
+  // Streaming - returns unsubscribe function and a ready promise. The optional
+  // cursor is the host's last-processed (epoch, seq) position: the container
+  // replays exactly what was missed after it (same epoch), so terminal events
+  // emitted during a reconnect gap are never lost.
   subscribeToStream(
     sessionId: string,
-    callback: (message: StreamMessage) => void
+    callback: (message: StreamMessage) => void,
+    cursor?: { epoch: string; sinceSeq: number }
   ): { unsubscribe: () => void; ready: Promise<void> }
 
   // Events

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -169,11 +169,12 @@ export interface ContainerClient {
   // Streaming - returns unsubscribe function and a ready promise. The optional
   // cursor is the host's last-processed (epoch, seq) position: the container
   // replays exactly what was missed after it (same epoch), so terminal events
-  // emitted during a reconnect gap are never lost.
+  // emitted during a reconnect gap are never lost. An epochless sinceSeq of -1
+  // requests a from-start replay (first attach to a just-created session).
   subscribeToStream(
     sessionId: string,
     callback: (message: StreamMessage) => void,
-    cursor?: { epoch: string; sinceSeq: number }
+    cursor?: { epoch?: string; sinceSeq: number }
   ): { unsubscribe: () => void; ready: Promise<void> }
 
   // Events

--- a/src/shared/lib/scheduler/task-scheduler.ts
+++ b/src/shared/lib/scheduler/task-scheduler.ts
@@ -220,12 +220,15 @@ class TaskScheduler {
       scheduledExecutionAt: task.nextExecutionAt.toISOString(),
     })
 
-    // Subscribe to the session for SSE updates
+    // Subscribe to the session for SSE updates. fromStart: the task prompt is
+    // already running in the container — replay from the start so a fast
+    // first turn's terminal events aren't missed.
     await messagePersister.subscribeToSession(
       sessionId,
       client,
       sessionId,
-      task.agentSlug
+      task.agentSlug,
+      { fromStart: true }
     )
     messagePersister.markSessionActive(sessionId, task.agentSlug)
 

--- a/src/shared/lib/scheduler/task-scheduler.ts
+++ b/src/shared/lib/scheduler/task-scheduler.ts
@@ -220,9 +220,12 @@ class TaskScheduler {
       scheduledExecutionAt: task.nextExecutionAt.toISOString(),
     })
 
-    // Subscribe to the session for SSE updates. fromStart: the task prompt is
-    // already running in the container — replay from the start so a fast
-    // first turn's terminal events aren't missed.
+    // Mark active BEFORE subscribing (matches agents.ts / x-agent.ts): the task
+    // turn is already running and subscribeToSession replays it from the start,
+    // so a fast turn's replayed result/idle must land with isActive already true.
+    // Marking after would let the idle be skipped, then clear the grace bits —
+    // pinning "working" forever.
+    messagePersister.markSessionActive(sessionId, task.agentSlug)
     await messagePersister.subscribeToSession(
       sessionId,
       client,
@@ -230,7 +233,6 @@ class TaskScheduler {
       task.agentSlug,
       { fromStart: true }
     )
-    messagePersister.markSessionActive(sessionId, task.agentSlug)
 
     console.log(
       `[TaskScheduler] Task ${task.id} started, session: ${sessionId}`

--- a/src/shared/lib/scheduler/trigger-manager.ts
+++ b/src/shared/lib/scheduler/trigger-manager.ts
@@ -319,11 +319,14 @@ class TriggerManager {
       webhookTriggerName: trigger.name || undefined,
     })
 
+    // fromStart: the trigger prompt is already running in the container —
+    // replay from the start so a fast first turn's terminal events aren't missed.
     await messagePersister.subscribeToSession(
       sessionId,
       client,
       sessionId,
-      trigger.agentSlug
+      trigger.agentSlug,
+      { fromStart: true }
     )
     messagePersister.markSessionActive(sessionId, trigger.agentSlug)
 

--- a/src/shared/lib/scheduler/trigger-manager.ts
+++ b/src/shared/lib/scheduler/trigger-manager.ts
@@ -319,8 +319,12 @@ class TriggerManager {
       webhookTriggerName: trigger.name || undefined,
     })
 
-    // fromStart: the trigger prompt is already running in the container —
-    // replay from the start so a fast first turn's terminal events aren't missed.
+    // Mark active BEFORE subscribing (matches agents.ts / x-agent.ts): the
+    // trigger turn is already running and subscribeToSession replays it from the
+    // start, so a fast turn's replayed result/idle must land with isActive
+    // already true. Marking after would let the idle be skipped, then clear the
+    // grace bits — pinning "working" forever.
+    messagePersister.markSessionActive(sessionId, trigger.agentSlug)
     await messagePersister.subscribeToSession(
       sessionId,
       client,
@@ -328,7 +332,6 @@ class TriggerManager {
       trigger.agentSlug,
       { fromStart: true }
     )
-    messagePersister.markSessionActive(sessionId, trigger.agentSlug)
 
     // Update trigger tracking
     await markTriggerFired(trigger.id, sessionId)


### PR DESCRIPTION
## What

Kills every cause of a permanently stuck "Working…" chat indicator except the two known-open ones (subagent input requests and proxy review, which have their own PRs). Since the indicator became a faithful pull-based projection of session state, any state-tracking bug shows up as a light that never turns off - across Telegram, Slack, iMessage, and the desktop sidebar. This branch closes that class at the state layer instead of patching surfaces.

## How

Seven commits, layered:

1. **Telegram surface teardown** - a no-stream terminal turn now blanks the un-committed draft in place; the first streamed token hands the draft to the stream instead (`yieldingToStream`).
2. **Turn-start route ordering** - `isActive` can no longer outlive a failed send: the existing-session send routes clear host state when the send never reached the container.
3. **Slack reaction teardown** - reaction tracking is dropped only on confirmed removal (Slack reactions never expire on their own), added optimistically on ambiguous failures, and per-chat writes are serialized.
4. **Grace-after-result backstop** - when a turn's `result` was seen but the settling `idle` never arrives (runtime hang in the wind-down), the host settles itself after 30s, completion notification included. The gate is derived and re-evaluated on every message: it arms only when the runtime's last word was "work done" and disarms on any turn activity, so it cannot fire during a genuinely running turn - verified against a real queued-continuation capture where the next turn starts 73ms after the previous result.
5. **Lossless container-to-host stream** - every relayed message carries a per-epoch sequence number; the host keeps an (epoch, seq) cursor and passes it on every re-subscribe, so a reconnect replays exactly what the gap swallowed (a lost `idle` or background-task terminal used to pin the session forever). An epoch mismatch means the old container process died: the host settles immediately, drops the dead background tasks, and fires the completion notification only if the reply's result was actually seen. Socket close/error handlers got identity guards (a replaced socket's late close used to be able to orphan the new socket and double-deliver).
6. **Audited residuals** - a whole-branch adversarial audit (two independent model sweeps plus coverage and conformance passes) surfaced and this branch fixes: two pre-existing paths where a dead subscription entry made `isSubscribed()` lie forever (the next send then ran with no stream attached - unfixably stuck); new sessions missing a fast first turn's terminal events because `createSession` starts the turn before the host subscribes (all six new-session paths now attach with a from-start replay); half-open sockets dying silently (the host never writes on the stream socket, so it now pings and terminates on a missed pong, routing into the normal reconnect-plus-replay recovery); and a set of boundary hardenings (cursor clamps, URL-parse edge, envelope narrowing).
7. **Coverage pins** for the regression directions none of the existing tests could see.

## Compatibility / rollout

- The stream protocol changes are version-skew safe in both directions: an old container image sends no epoch and the host behaves exactly as before; an old host ignores the new fields and attaches live-only. The E2E mock deliberately speaks the legacy protocol, pinning that path.
- `agent-container/` changed, so the fix only reaches live agents after an image rebuild + container recreate.

## Verification

- 6355 unit/integration tests green, typecheck and lint clean, rebased onto current main.
- New suites: grace state machine (10, fake-timer, incl. a real-capture replay), cursor/reconcile (11), connection recovery (5), client socket lifecycle + liveness (8), container replay/parse (15), plus route, Slack, and Telegram pins.
- Live smoke on a rebuilt image (normal round trip + sleep-the-laptop-mid-background-task) tracked separately before marking ready.
