### PR TITLE
ci(release): dispatch gamut-infra release-ingest after container images publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,24 @@ jobs:
           cache-from: type=gha,scope=app-${{ matrix.auth_mode }}
           cache-to: type=gha,mode=max,scope=app-${{ matrix.auth_mode }}
 
+  # Kick gamut-infra's release-ingest: crane copy the -auth image to ECR,
+  # build the MicroVM agent image, register the release_registry row. Needs
+  # both container images published first.
+  dispatch-release-ingest:
+    runs-on: ubuntu-latest
+    needs: [prepare, build-agent-container, build-app-container]
+    steps:
+      - name: Dispatch superagent-release to gamut-infra
+        env:
+          # Fine-grained PAT (or GitHub App token) with contents:write on
+          # SkillfulAgents/gamut-infra — repository_dispatch requires it.
+          GH_TOKEN: ${{ secrets.GAMUT_INFRA_DISPATCH_TOKEN }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          gh api repos/SkillfulAgents/gamut-infra/dispatches \
+            -f event_type=superagent-release \
+            -f "client_payload[version]=$VERSION"
+
   # Build macOS Electron app (signed + notarized)
   build-mac:
     runs-on: macos-26


### PR DESCRIPTION
## What

Adds a `dispatch-release-ingest` job to `release.yml`: after both container image jobs succeed, fire `repository_dispatch` (`superagent-release`, payload `{version}`) at SkillfulAgents/gamut-infra.

The receiving workflow (gamut-infra#50) crane-copies the `-auth` app image to in-region ECR, builds the MicroVM agent image from the matching agent-container base, and registers the `release_registry` row that gamut-controller resolves at startup (gamut-infra#49) — removing the last manual step from the cloud release flow.

## Setup required before merge

Create the `GAMUT_INFRA_DISPATCH_TOKEN` repo secret: a fine-grained PAT (or GitHub App token) with `contents: write` on SkillfulAgents/gamut-infra — that's the permission `repository_dispatch` requires.

## Notes

- The job only gates on the two container jobs, not the desktop builds — the cloud artifacts don't depend on the Electron apps.
- A failed dispatch fails this job visibly but doesn't block other release jobs; gamut-infra's workflow also has a manual `workflow_dispatch` fallback for re-ingest.

Made with [Cursor](https://cursor.com)