### PR TITLE
fix(test): disable analytics in E2E mock mode

### DIFF
--- a/e2e/setup-e2e-data.js
+++ b/e2e/setup-e2e-data.js
@@ -148,6 +148,8 @@ const settings = {
     resourceLimits: { cpu: 1, memory: '512m' },
   },
   app: { setupCompleted: true },
+  // E2E runs must never emit real analytics events.
+  shareAnalytics: false,
   skillsets: [
     {
       id: SKILLSET_ID,

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
     define: {
       __APP_VERSION__: JSON.stringify(pkg.version),
       __AUTH_MODE__: JSON.stringify(false),
+      __E2E_MOCK__: JSON.stringify(process.env.E2E_MOCK === 'true'),
       __WEB__: JSON.stringify(false), // all Electron (dev http + prod file://) → hash history
       __AMPLITUDE_API_KEY__: JSON.stringify(process.env.AMPLITUDE_API_KEY || analyticsConfig.defaultAmplitudeKey),
       __RENDER_TRACKING__: JSON.stringify(process.env.RENDER_TRACKING === 'true'),

--- a/src/renderer/lib/analytics.test.ts
+++ b/src/renderer/lib/analytics.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('hasActivePlugins', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it('disables analytics plugins in E2E mock mode', async () => {
+    vi.stubGlobal('__E2E_MOCK__', true)
+    vi.stubGlobal('__AMPLITUDE_API_KEY__', 'test-amplitude-key')
+
+    const { hasActivePlugins } = await import('./analytics')
+
+    expect(hasActivePlugins(true, [
+      { type: 'amplitude', enabled: true, config: { apiKey: 'custom-key' } },
+    ])).toBe(false)
+  })
+
+  it('keeps normal analytics behavior outside E2E mock mode', async () => {
+    vi.stubGlobal('__E2E_MOCK__', false)
+    vi.stubGlobal('__AMPLITUDE_API_KEY__', 'test-amplitude-key')
+
+    const { hasActivePlugins } = await import('./analytics')
+
+    expect(hasActivePlugins(true)).toBe(true)
+  })
+})

--- a/src/renderer/lib/analytics.ts
+++ b/src/renderer/lib/analytics.ts
@@ -6,6 +6,8 @@ import type { AnalyticsTarget } from '@shared/lib/config/settings'
 import { isElectron } from './env'
 
 function buildPlugins(shareAnalytics: boolean, targets?: AnalyticsTarget[]) {
+  if (__E2E_MOCK__) return []
+
   const plugins: ReturnType<typeof amplitudePlugin>[] = []
 
   // Datawizz sharing via hardcoded Amplitude key
@@ -74,6 +76,7 @@ export function createAnalyticsInstance(
 }
 
 export function hasActivePlugins(shareAnalytics: boolean, targets?: AnalyticsTarget[]): boolean {
+  if (__E2E_MOCK__) return false
   if (shareAnalytics && __AMPLITUDE_API_KEY__) return true
   if (targets?.some(t => t.enabled)) return true
   return false

--- a/src/renderer/vite-env.d.ts
+++ b/src/renderer/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 declare const __APP_VERSION__: string
 declare const __AUTH_MODE__: boolean
+declare const __E2E_MOCK__: boolean
 declare const __AMPLITUDE_API_KEY__: string
 declare const __RENDER_TRACKING__: boolean
 declare const __WEB__: boolean

--- a/src/shared/lib/analytics/server-analytics.test.ts
+++ b/src/shared/lib/analytics/server-analytics.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getSettingsMock = vi.fn()
+const getTenantIdMock = vi.fn(() => 'tenant-test')
+
+vi.mock('../config/settings', () => ({
+  getSettings: getSettingsMock,
+}))
+
+vi.mock('./tenant-id', () => ({
+  getTenantId: getTenantIdMock,
+}))
+
+vi.mock('./constants', () => ({
+  DEFAULT_AMPLITUDE_KEY: 'default-amplitude-key',
+}))
+
+import { trackServerEvent } from './server-analytics'
+
+describe('trackServerEvent', () => {
+  beforeEach(() => {
+    getSettingsMock.mockReturnValue({
+      shareAnalytics: true,
+      analyticsTargets: [
+        { type: 'amplitude', enabled: true, config: { apiKey: 'custom-amplitude-key' } },
+      ],
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('does not send analytics while E2E mock mode is enabled', async () => {
+    vi.stubEnv('E2E_MOCK', 'true')
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    trackServerEvent('agent_created', { source: 'new' })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns before reading settings in E2E mock mode', async () => {
+    vi.stubEnv('E2E_MOCK', 'true')
+    trackServerEvent('agent_created', { source: 'new' })
+
+    expect(getSettingsMock).not.toHaveBeenCalled()
+    expect(getTenantIdMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/lib/analytics/server-analytics.ts
+++ b/src/shared/lib/analytics/server-analytics.ts
@@ -125,6 +125,8 @@ export function trackServerEvent(
   properties: Record<string, unknown> = {},
   userId?: string,
 ) {
+  if (process.env.E2E_MOCK === 'true') return
+
   const settings = getSettings()
   const targets = settings.analyticsTargets ?? []
   const effectiveUserId = userId ?? getTenantId()

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
     __AUTH_MODE__: JSON.stringify(process.env.AUTH_MODE === 'true'),
+    __E2E_MOCK__: JSON.stringify(process.env.E2E_MOCK === 'true'),
     __WEB__: JSON.stringify(true), // web bundle → browser/path history (Hono SPA fallback)
     __AMPLITUDE_API_KEY__: JSON.stringify(process.env.AMPLITUDE_API_KEY || analyticsConfig.defaultAmplitudeKey),
     __RENDER_TRACKING__: JSON.stringify(process.env.RENDER_TRACKING === 'true'),


### PR DESCRIPTION
## Summary
- stop seeded E2E environments from inheriting production analytics by writing `shareAnalytics: false` into the generated test settings
- disable both renderer and server analytics whenever `E2E_MOCK` is enabled so future default flips cannot leak events to Amplitude again
- add focused regression tests for the renderer plugin gate and the server-side early return

## Test plan
- [x] `npx vitest run src/renderer/lib/analytics.test.ts src/shared/lib/analytics/server-analytics.test.ts`
- [x] `npx eslint e2e/setup-e2e-data.js vite.config.ts electron.vite.config.ts src/renderer/vite-env.d.ts src/renderer/lib/analytics.ts src/renderer/lib/analytics.test.ts src/shared/lib/analytics/server-analytics.ts src/shared/lib/analytics/server-analytics.test.ts`
- [ ] `npm run typecheck` *(currently fails on pre-existing repo issues unrelated to this PR, including `react-hook-form` exports, missing `e2b` / `@daytonaio/sdk`, and `vitest/config` types)*

Made with [Cursor](https://cursor.com)