### PR TITLE
feat: CEL delivery filters for custom webhook endpoints

### DIFF
--- a/agent-container/src/mcp-server.ts
+++ b/agent-container/src/mcp-server.ts
@@ -26,6 +26,7 @@ import {
   cancelTriggerTool,
   createWebhookEndpointTool,
   updateWebhookEndpointTool,
+  inspectWebhookEventsTool,
 } from './tools/webhook-triggers'
 import { deliverFileTool } from './tools/deliver-file'
 import { deliverSessionTool } from './tools/deliver-session'
@@ -82,7 +83,9 @@ export function createUserInputMcpServer() {
       ...(includeComposioTriggers || includeWebhookEndpoints
         ? [listTriggersTool, cancelTriggerTool]
         : []),
-      ...(includeWebhookEndpoints ? [createWebhookEndpointTool, updateWebhookEndpointTool] : []),
+      ...(includeWebhookEndpoints
+        ? [createWebhookEndpointTool, updateWebhookEndpointTool, inspectWebhookEventsTool]
+        : []),
     ],
   })
 }

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -533,7 +533,8 @@ name: "Email Monitor"
 For services with no Composio trigger (Vercel, Sentry, internal systems, anything), you can mint a dedicated public webhook URL:
 
 - `mcp__user-input__create_webhook_endpoint` — Mint a public URL. Provide a name and a prompt describing what to do when a webhook arrives. Returns the URL.
-- `mcp__user-input__update_webhook_endpoint` — Attach or change HMAC signature verification, or rename the endpoint.
+- `mcp__user-input__update_webhook_endpoint` — Attach or change HMAC signature verification, set or change the delivery filter, or rename the endpoint.
+- `mcp__user-input__inspect_webhook_events` — View recent deliveries (including filtered-out ones) and dry-run candidate filter expressions against them.
 - `list_triggers` / `cancel_trigger` also cover custom endpoints.
 
 **The full loop:**
@@ -546,6 +547,12 @@ For services with no Composio trigger (Vercel, Sentry, internal systems, anythin
    - Registration handshakes (Slack `url_verification`, Dropbox/Meta GET challenges, MS Graph `validationToken`) are answered automatically; you do not need to handle them. Zoom's crypto-challenge and AWS SNS confirmation are NOT supported.
 3. If the service gives you a signing secret (often only after registration), attach it with `update_webhook_endpoint`. Supported schemes: HMAC-SHA256/SHA1 over a template like `{body}`, `{timestamp}.{body}` (Stripe), `v0:{timestamp}:{body}` (Slack/Zoom), `{webhook_id}.{timestamp}.{body}` (Standard Webhooks — set `secret_encoding: "base64"` for `whsec_` secrets), `{url}{body}` (Square), `{method}{url}{body}{timestamp}` (HubSpot v3).
 4. Each delivery starts a new session with your prompt plus the request (method, headers, query, body).
+
+**Delivery filters — use them.** Most services can't scope their webhooks as narrowly as the trigger you actually want (Linear sends ALL Issue events; you probably care about "assigned to me changed"). Without a filter, every irrelevant event starts a session that exists only to conclude "not relevant". Set `filter_exp` — a CEL expression evaluated at the edge against `body` (parsed JSON), `headers`, `query`, `method`, `verified`:
+- Only `true` delivers. Filtered events are logged, never lost — `inspect_webhook_events` shows them with their verdicts.
+- Guard optional fields with `has()` and optional headers with `in`: dereferencing a missing key is an error, and errors FAIL OPEN (delivered, error recorded).
+- Example (Linear "assignee changed"): `headers["linear-event"] == "Issue" && body.action == "update" && has(body.updatedFrom.assigneeId)`
+- Iterate safely: once real traffic has arrived, dry-run candidates with `inspect_webhook_events` (`test_filter_exp`) — it evaluates against the actual stored deliveries with the same evaluator — then apply the winner with `update_webhook_endpoint`.
 
 **Security — take this seriously:**
 - The URL is a secret (a capability URL). Don't echo it into logs or public places; anyone who has it can trigger you.

--- a/agent-container/src/tools/webhook-triggers.ts
+++ b/agent-container/src/tools/webhook-triggers.ts
@@ -59,7 +59,7 @@ const FILTER_EXP_DESCRIPTION = `Optional CEL filter expression evaluated against
 
 Context variables: body (parsed JSON body; null when the body is not JSON), headers (lowercased header map), query (query-string map), method, verified (HMAC verification result), content_type.
 
-Rules: the expression must evaluate to a boolean. Guard fields that are not always present with has() — has(body.data.assignee) && body.data.assignee.email == "x" — and headers with in — "x-github-event" in headers && ... — because dereferencing a missing key is an ERROR, and errors FAIL OPEN (the event is delivered with the error recorded). matches() uses JavaScript regex syntax (no (?i) inline flags).
+Rules: the expression must evaluate to a boolean. Guard fields that are not always present with has() — has(body.data.assignee) && body.data.assignee.email == "x" — and headers with in — "x-github-event" in headers && ... — because dereferencing a missing key is an ERROR, and errors FAIL OPEN (the event is delivered with the error recorded). matches()/regex is NOT supported (rejected at validation) — use contains(), startsWith(), or endsWith() instead.
 
 Examples: Linear assignee changed: headers["linear-event"] == "Issue" && body.action == "update" && has(body.updatedFrom.assigneeId) · GitHub issues opened: headers["x-github-event"] == "issues" && body.action == "opened" · Stripe: body.type == "invoice.payment_failed" · Slack mention: body.event.type == "app_mention" · Shopify: headers["x-shopify-topic"] == "orders/create".
 

--- a/agent-container/src/tools/webhook-triggers.ts
+++ b/agent-container/src/tools/webhook-triggers.ts
@@ -51,6 +51,20 @@ const verificationProfileSchema = z.object({
     .describe('Set "base64" for Standard-Webhooks/svix secrets (whsec_...); default utf8'),
 })
 
+/**
+ * CEL filter expression — evaluated platform-side per delivery. The teaching
+ * text lives in one place so create/update stay in sync.
+ */
+const FILTER_EXP_DESCRIPTION = `Optional CEL filter expression evaluated against every delivery at the edge; only events where it returns true start a session. Use it whenever the service's webhook subscription is coarser than the actual trigger condition (e.g. Linear sends ALL Issue events — filter to "assigned to me changed") so irrelevant events never wake you. Filtered events are still logged (see inspect_webhook_events), never lost silently.
+
+Context variables: body (parsed JSON body; null when the body is not JSON), headers (lowercased header map), query (query-string map), method, verified (HMAC verification result), content_type.
+
+Rules: the expression must evaluate to a boolean. Guard fields that are not always present with has() — has(body.data.assignee) && body.data.assignee.email == "x" — and headers with in — "x-github-event" in headers && ... — because dereferencing a missing key is an ERROR, and errors FAIL OPEN (the event is delivered with the error recorded). matches() uses JavaScript regex syntax (no (?i) inline flags).
+
+Examples: Linear assignee changed: headers["linear-event"] == "Issue" && body.action == "update" && has(body.updatedFrom.assigneeId) · GitHub issues opened: headers["x-github-event"] == "issues" && body.action == "opened" · Stripe: body.type == "invoice.payment_failed" · Slack mention: body.event.type == "app_mention" · Shopify: headers["x-shopify-topic"] == "orders/create".
+
+Before setting or changing a filter on an endpoint that has already received traffic, dry-run the candidate with inspect_webhook_events (test_filter_exp) against real deliveries.`
+
 export const getAvailableTriggersTool = tool(
   'get_available_triggers',
   `List available webhook triggers for a connected account. Returns trigger types that can fire webhooks (e.g., "new email received", "new GitHub push").
@@ -220,6 +234,7 @@ If the service reveals a signing secret only AFTER registration, attach it after
     verification: verificationProfileSchema
       .optional()
       .describe('Optional HMAC signature verification profile, if you already know the signing secret'),
+    filter_exp: z.string().optional().describe(FILTER_EXP_DESCRIPTION),
     model: z
       .enum(['opus', 'sonnet', 'haiku'])
       .optional()
@@ -255,6 +270,7 @@ If the service reveals a signing secret only AFTER registration, attach it after
           name: args.name,
           prompt: args.prompt,
           verification: args.verification,
+          filter_exp: args.filter_exp,
           model: args.model,
           effort: args.effort,
         },
@@ -275,7 +291,7 @@ If the service reveals a signing secret only AFTER registration, attach it after
 
 export const updateWebhookEndpointTool = tool(
   'update_webhook_endpoint',
-  `Update a custom webhook endpoint: attach or change its HMAC signature verification (many services only reveal the signing secret after you register the URL), or rename it. Pass the trigger ID from list_triggers or create_webhook_endpoint.
+  `Update a custom webhook endpoint: attach or change its HMAC signature verification (many services only reveal the signing secret after you register the URL), set or change its delivery filter expression, or rename it. Pass the trigger ID from list_triggers or create_webhook_endpoint.
 
 Once verification is attached, incoming requests with bad signatures are rejected at the edge and valid events are marked verified.`,
   {
@@ -285,6 +301,11 @@ Once verification is attached, incoming requests with bad signatures are rejecte
       .nullable()
       .optional()
       .describe('HMAC verification profile to attach; pass null to remove verification'),
+    filter_exp: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(`Pass null to remove the filter (deliver everything). ${FILTER_EXP_DESCRIPTION}`),
   },
   async (args) => {
     console.log(`[update_webhook_endpoint] Updating endpoint for trigger ${args.trigger_id}`)
@@ -305,6 +326,7 @@ Once verification is attached, incoming requests with bad signatures are rejecte
           trigger_id: args.trigger_id,
           name: args.name,
           verification: args.verification,
+          filter_exp: args.filter_exp,
         },
       )
 
@@ -315,6 +337,60 @@ Once verification is attached, incoming requests with bad signatures are rejecte
       const msg = error instanceof Error ? error.message : 'Unknown error'
       return {
         content: [{ type: 'text' as const, text: `Failed to update webhook endpoint: ${msg}` }],
+        isError: true,
+      }
+    }
+  },
+)
+
+export const inspectWebhookEventsTool = tool(
+  'inspect_webhook_events',
+  `Inspect recent deliveries to a custom webhook endpoint — INCLUDING events the filter expression withheld — and optionally dry-run a candidate filter expression against them.
+
+Use it to answer "why didn't my trigger fire?" (check the stored filter verdicts and any eval errors) and to iterate on a filter safely: pass test_filter_exp to see which of the recent real deliveries a candidate expression would pass/filter/error on, using the exact evaluator that runs at delivery time. The dry run never changes the endpoint; apply the winning expression with update_webhook_endpoint.`,
+  {
+    trigger_id: z.string().describe('The trigger ID of the custom webhook endpoint (from list_triggers)'),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .optional()
+      .describe('How many recent deliveries to inspect (default 20, max 50)'),
+    test_filter_exp: z
+      .string()
+      .optional()
+      .describe('Candidate CEL filter expression to dry-run against the recent deliveries'),
+  },
+  async (args) => {
+    console.log(`[inspect_webhook_events] Inspecting trigger ${args.trigger_id}`)
+
+    const toolUseId = inputManager.consumeCurrentToolUseId()
+    if (!toolUseId) {
+      return {
+        content: [{ type: 'text' as const, text: 'Unable to process request — no tool use ID available.' }],
+        isError: true,
+      }
+    }
+
+    try {
+      const result = await inputManager.createPendingWithType<string>(
+        toolUseId,
+        'inspect_webhook_events',
+        {
+          trigger_id: args.trigger_id,
+          limit: args.limit,
+          test_filter_exp: args.test_filter_exp,
+        },
+      )
+
+      return {
+        content: [{ type: 'text' as const, text: result }],
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'Unknown error'
+      return {
+        content: [{ type: 'text' as const, text: `Failed to inspect webhook events: ${msg}` }],
         isError: true,
       }
     }

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -101,10 +101,14 @@ vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
 const mockCreatePlatformWebhookEndpoint = vi.fn<MockFn>()
 const mockUpdatePlatformWebhookEndpoint = vi.fn<MockFn>(() => Promise.resolve({}))
 const mockDisablePlatformWebhookEndpoint = vi.fn<MockFn>(() => Promise.resolve())
+const mockListPlatformWebhookEvents = vi.fn<MockFn>(() => Promise.resolve({ filterExp: null, events: [] }))
+const mockTestPlatformWebhookFilter = vi.fn<MockFn>()
 vi.mock('@shared/lib/services/webhook-endpoints-client', () => ({
   createPlatformWebhookEndpoint: (...args: unknown[]) => mockCreatePlatformWebhookEndpoint(...args),
   updatePlatformWebhookEndpoint: (...args: unknown[]) => mockUpdatePlatformWebhookEndpoint(...args),
   disablePlatformWebhookEndpoint: (...args: unknown[]) => mockDisablePlatformWebhookEndpoint(...args),
+  listPlatformWebhookEvents: (...args: unknown[]) => mockListPlatformWebhookEvents(...args),
+  testPlatformWebhookFilter: (...args: unknown[]) => mockTestPlatformWebhookFilter(...args),
 }))
 
 // Platform-authed by default: the create/update endpoint handlers gate on the
@@ -3669,6 +3673,52 @@ describe('MessagePersister', () => {
         await flushHandlers('/inputs/tool-mint-6/resolve')
         expect(mockCreatePlatformWebhookEndpoint).toHaveBeenCalled()
       })
+
+      it('passes filter_exp through to the platform and confirms it in the result', async () => {
+        simulateToolUse('mcp__user-input__create_webhook_endpoint', 'tool-mint-7', {
+          name: 'Filtered hook',
+          prompt: 'Handle assigned issues',
+          filter_exp: 'headers["linear-event"] == "Issue" && has(body.updatedFrom.assigneeId)',
+        })
+
+        const resolveCall = await flushHandlers('/inputs/tool-mint-7/resolve')
+        expect(mockCreatePlatformWebhookEndpoint.mock.calls[0][1].filter_exp).toBe(
+          'headers["linear-event"] == "Issue" && has(body.updatedFrom.assigneeId)',
+        )
+        const body = JSON.parse(resolveCall[1].body)
+        expect(body.value).toContain('Delivery filter active')
+        expect(body.value).toContain('inspect_webhook_events')
+      })
+
+      it('teaches the filter loop when minting WITHOUT a filter', async () => {
+        simulateToolUse('mcp__user-input__create_webhook_endpoint', 'tool-mint-8', {
+          name: 'Unfiltered hook',
+          prompt: 'Handle it',
+        })
+
+        const resolveCall = await flushHandlers('/inputs/tool-mint-8/resolve')
+        expect(mockCreatePlatformWebhookEndpoint.mock.calls[0][1].filter_exp).toBeUndefined()
+        const body = JSON.parse(resolveCall[1].body)
+        // No filter → the result must make filtering an explicit decision
+        // (compare subscription breadth vs the prompt) and point at
+        // filter_exp + the dry-run tool.
+        expect(body.value).toContain('decide whether you need one')
+        expect(body.value).toContain('filter_exp')
+        expect(body.value).toContain('update_webhook_endpoint')
+        expect(body.value).toContain('test_filter_exp')
+      })
+
+      it('rejects an over-length filter_exp before any platform call', async () => {
+        simulateToolUse('mcp__user-input__create_webhook_endpoint', 'tool-mint-9', {
+          name: 'Too long',
+          prompt: 'Handle it',
+          filter_exp: `body.a == "${'x'.repeat(2100)}"`,
+        })
+
+        const rejectCall = await flushHandlers('/inputs/tool-mint-9/reject')
+        expect(JSON.parse(rejectCall[1].body).reason).toContain('filter_exp')
+        expect(mockCreatePlatformWebhookEndpoint).not.toHaveBeenCalled()
+      })
     })
 
     describe('update_webhook_endpoint', () => {
@@ -3731,6 +3781,189 @@ describe('MessagePersister', () => {
 
         await flushHandlers('/inputs/tool-upd-3/reject')
         expect(mockUpdatePlatformWebhookEndpoint).not.toHaveBeenCalled()
+      })
+
+      it('sets a filter_exp and explains the filtered-events semantics', async () => {
+        simulateToolUse('mcp__user-input__update_webhook_endpoint', 'tool-upd-4', {
+          trigger_id: 'trigger_custom_1',
+          filter_exp: 'body.action == "update"',
+        })
+
+        const resolveCall = await flushHandlers('/inputs/tool-upd-4/resolve')
+        expect(mockUpdatePlatformWebhookEndpoint).toHaveBeenCalledWith(
+          expect.any(String),
+          customTrigger.composioTriggerId,
+          { filter_exp: 'body.action == "update"' },
+        )
+        const value = JSON.parse(resolveCall[1].body).value
+        expect(value).toContain('filter set')
+        expect(value).toContain('fail open')
+      })
+
+      it('clears the filter with filter_exp: null', async () => {
+        simulateToolUse('mcp__user-input__update_webhook_endpoint', 'tool-upd-5', {
+          trigger_id: 'trigger_custom_1',
+          filter_exp: null,
+        })
+
+        const resolveCall = await flushHandlers('/inputs/tool-upd-5/resolve')
+        expect(mockUpdatePlatformWebhookEndpoint).toHaveBeenCalledWith(
+          expect.any(String),
+          customTrigger.composioTriggerId,
+          { filter_exp: null },
+        )
+        const value = JSON.parse(resolveCall[1].body).value
+        expect(value).toContain('filter removed')
+      })
+    })
+
+    describe('inspect_webhook_events', () => {
+      const customTrigger = {
+        id: 'trigger_custom_1',
+        agentSlug: 'test-agent',
+        kind: 'custom',
+        composioTriggerId: 'whep_11111111-2222-4333-8444-555555555555',
+        status: 'active',
+      }
+
+      beforeEach(() => {
+        mockListPlatformWebhookEvents.mockClear()
+        mockTestPlatformWebhookFilter.mockClear()
+        mockGetWebhookTrigger.mockResolvedValue(customTrigger)
+        mockListPlatformWebhookEvents.mockResolvedValue({ filterExp: null, events: [] })
+      })
+
+      it('lists recent deliveries with filter verdicts and body previews', async () => {
+        mockListPlatformWebhookEvents.mockResolvedValue({
+          filterExp: 'body.action == "update"',
+          events: [
+            {
+              id: 'whe_1',
+              created_at: '2026-07-07T20:45:19Z',
+              status: 'consumed',
+              kind: 'event',
+              verified: true,
+              filter: { outcome: 'passed' },
+              method: 'POST',
+              content_type: 'application/json',
+              body: '{"action":"update"}',
+            },
+            {
+              id: 'whe_2',
+              created_at: '2026-07-07T20:44:00Z',
+              status: 'filtered',
+              kind: 'event',
+              verified: true,
+              filter: { outcome: 'filtered' },
+              method: 'POST',
+              content_type: 'application/json',
+              body: `{"action":"create","pad":"${'x'.repeat(500)}"}`,
+            },
+            {
+              id: 'whe_3',
+              created_at: '2026-07-07T20:43:00Z',
+              status: 'pending',
+              kind: 'event',
+              verified: false,
+              filter: { outcome: 'error', error: 'No such key: parent' },
+              method: 'POST',
+              content_type: 'application/json',
+              body: '{"other":1}',
+            },
+          ],
+        })
+
+        simulateToolUse('mcp__user-input__inspect_webhook_events', 'tool-insp-1', {
+          trigger_id: 'trigger_custom_1',
+        })
+
+        const resolveCall = await flushHandlers('/inputs/tool-insp-1/resolve')
+        expect(mockListPlatformWebhookEvents).toHaveBeenCalledWith(
+          expect.any(String),
+          customTrigger.composioTriggerId,
+          undefined,
+        )
+        const value = JSON.parse(resolveCall[1].body).value as string
+        expect(value).toContain('body.action == "update"')
+        expect(value).toContain('whe_1')
+        expect(value).toContain('filter: passed')
+        expect(value).toContain('filter: filtered')
+        expect(value).toContain('No such key: parent')
+        // Body previews are capped so 50 events can't crowd the context.
+        expect(value.length).toBeLessThan(2000)
+      })
+
+      it('reports when no deliveries exist yet', async () => {
+        simulateToolUse('mcp__user-input__inspect_webhook_events', 'tool-insp-2', {
+          trigger_id: 'trigger_custom_1',
+        })
+
+        const resolveCall = await flushHandlers('/inputs/tool-insp-2/resolve')
+        const value = JSON.parse(resolveCall[1].body).value as string
+        expect(value).toContain('No deliveries recorded yet')
+      })
+
+      it('dry-runs a candidate filter and summarizes the verdicts', async () => {
+        mockTestPlatformWebhookFilter.mockResolvedValue({
+          filter_exp: 'body.action == "update"',
+          evaluated: 3,
+          summary: { passed: 1, filtered: 1, error: 1, skipped: 0 },
+          results: [
+            { event_id: 'whe_1', created_at: '2026-07-07T20:45:19Z', stored_status: 'consumed', outcome: 'passed' },
+            { event_id: 'whe_2', created_at: '2026-07-07T20:44:00Z', stored_status: 'filtered', outcome: 'filtered' },
+            { event_id: 'whe_3', created_at: '2026-07-07T20:43:00Z', stored_status: 'pending', outcome: 'error', error: 'No such key: action' },
+          ],
+        })
+
+        simulateToolUse('mcp__user-input__inspect_webhook_events', 'tool-insp-3', {
+          trigger_id: 'trigger_custom_1',
+          test_filter_exp: 'body.action == "update"',
+          limit: 10,
+        })
+
+        const resolveCall = await flushHandlers('/inputs/tool-insp-3/resolve')
+        expect(mockTestPlatformWebhookFilter).toHaveBeenCalledWith(
+          expect.any(String),
+          customTrigger.composioTriggerId,
+          'body.action == "update"',
+          10,
+        )
+        expect(mockListPlatformWebhookEvents).not.toHaveBeenCalled()
+        const value = JSON.parse(resolveCall[1].body).value as string
+        expect(value).toContain('1 would pass')
+        expect(value).toContain('No such key: action')
+        expect(value).toContain('Nothing was changed')
+        expect(value).toContain('update_webhook_endpoint')
+      })
+
+      it('surfaces the platform 400 (CEL parser message) for an invalid candidate', async () => {
+        mockTestPlatformWebhookFilter.mockRejectedValue(
+          new Error('Webhook endpoints API error 400: Invalid filter expression: invalid CEL expression: Unexpected token: EOF'),
+        )
+
+        simulateToolUse('mcp__user-input__inspect_webhook_events', 'tool-insp-4', {
+          trigger_id: 'trigger_custom_1',
+          test_filter_exp: 'has(body.x) &&',
+        })
+
+        const rejectCall = await flushHandlers('/inputs/tool-insp-4/reject')
+        expect(JSON.parse(rejectCall[1].body).reason).toContain('Unexpected token')
+      })
+
+      it('rejects non-custom triggers and missing platform auth', async () => {
+        mockGetWebhookTrigger.mockResolvedValue({ ...customTrigger, kind: 'composio' })
+        simulateToolUse('mcp__user-input__inspect_webhook_events', 'tool-insp-5', {
+          trigger_id: 'trigger_custom_1',
+        })
+        await flushHandlers('/inputs/tool-insp-5/reject')
+        expect(mockListPlatformWebhookEvents).not.toHaveBeenCalled()
+
+        mockGetPlatformAccessToken.mockReturnValue(null)
+        simulateToolUse('mcp__user-input__inspect_webhook_events', 'tool-insp-6', {
+          trigger_id: 'trigger_custom_1',
+        })
+        const rejectCall = await flushHandlers('/inputs/tool-insp-6/reject')
+        expect(JSON.parse(rejectCall[1].body).reason).toContain('platform')
       })
     })
 
@@ -3809,6 +4042,9 @@ describe('MessagePersister', () => {
         // Dead end must redirect to the custom-endpoint path.
         expect(body.value).toContain('create_webhook_endpoint')
         expect(body.value).toContain('update_webhook_endpoint')
+        // ...including the filter step for over-broad vendor webhooks.
+        expect(body.value).toContain('filter_exp')
+        expect(body.value).toContain('inspect_webhook_events')
       })
     })
   })

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -30,12 +30,16 @@ import {
   createPlatformWebhookEndpoint,
   updatePlatformWebhookEndpoint,
   disablePlatformWebhookEndpoint,
+  listPlatformWebhookEvents,
+  testPlatformWebhookFilter,
 } from '@shared/lib/services/webhook-endpoints-client'
 import {
   createWebhookEndpointInputSchema,
   updateWebhookEndpointInputSchema,
+  inspectWebhookEventsInputSchema,
   extractEndpointUrl,
   CUSTOM_WEBHOOK_TRIGGER_TYPE,
+  type WebhookEndpointEvent,
 } from '@shared/lib/services/webhook-endpoint-schema'
 import { getPlatformAccessToken, getStoredPlatformMemberId } from '@shared/lib/services/platform-auth-service'
 import {
@@ -155,6 +159,24 @@ const SECRET_BEARING_TOOL_NAMES = new Set([
   'create_webhook_endpoint',
   'update_webhook_endpoint',
 ])
+
+// One inspection line per stored delivery. Bodies are already previews
+// (proxy caps at 2KB); cap harder here — this text lands in the agent's
+// context and 50 events × 2KB would crowd out the actual work.
+const INSPECT_BODY_PREVIEW_CHARS = 200
+
+export function formatWebhookEventLine(event: WebhookEndpointEvent): string {
+  const filterNote = event.filter
+    ? ` · filter: ${event.filter.outcome}${event.filter.outcome === 'error' && event.filter.error ? ` (${event.filter.error})` : ''}`
+    : ''
+  const kindNote = event.kind === 'handshake' ? ' · handshake' : ''
+  const verifiedNote = event.kind === 'event' ? (event.verified ? ' · verified' : ' · unverified') : ''
+  const body = typeof event.body === 'string' && event.body
+    ? event.body.slice(0, INSPECT_BODY_PREVIEW_CHARS) +
+      (event.body.length > INSPECT_BODY_PREVIEW_CHARS || event.body_truncated ? '…' : '')
+    : '(empty body)'
+  return `- ${event.id} · ${event.created_at} · ${event.status}${kindNote}${verifiedNote}${filterNote}\n  ${event.method ?? 'POST'} ${event.content_type ?? ''} — ${body}`
+}
 
 /**
  * Mask the value of a `secret` field in (possibly still-streaming) tool-input
@@ -2066,6 +2088,11 @@ class MessagePersister {
               sessionId, state.currentToolUse.id, state.currentToolInput, state.agentSlug
             )
           }
+          if (state.currentToolUse.name === 'mcp__user-input__inspect_webhook_events') {
+            this.handleInspectWebhookEventsTool(
+              sessionId, state.currentToolUse.id, state.currentToolInput, state.agentSlug
+            )
+          }
 
           // Check if this is an AskUserQuestion tool
           if (state.currentToolUse.name === 'AskUserQuestion') {
@@ -2744,7 +2771,8 @@ ${continuation}`
             'You can still react to events from this service with a custom webhook endpoint:\n' +
             '1. Call create_webhook_endpoint to mint a public URL (with a prompt describing what to do per event).\n' +
             `2. Register that URL with the service — most expose webhook registration via their API (use the connected ${account.toolkitSlug} account) or a settings page.\n` +
-            '3. If the service provides a signing secret, attach it with update_webhook_endpoint so deliveries are verified.'
+            '3. If the service provides a signing secret, attach it with update_webhook_endpoint so deliveries are verified.\n' +
+            '4. If the service\'s webhook events are broader than what you need (most are), add a CEL filter_exp so only matching events start a session — dry-run candidates against real deliveries with inspect_webhook_events first.'
           : `Available triggers for ${account.toolkitSlug}:\n\n${triggers.map((t) =>
               `- **${t.slug}** (${t.name}): ${t.description}${t.type === 'poll' ? ' [poll-based]' : ''}`
             ).join('\n')}\n\nUse setup_trigger with the trigger slug to subscribe. ` +
@@ -2940,6 +2968,7 @@ ${continuation}`
         }
         const input = parsedInput.data
         const verification = input.verification ?? undefined
+        const filterExp = input.filter_exp ?? undefined
 
         const memberId = await this.resolvePlatformMemberForSession(agentSlug, sessionId)
 
@@ -2947,6 +2976,7 @@ ${continuation}`
         const endpoint = await createPlatformWebhookEndpoint(memberId, {
           name: input.name.trim(),
           ...(verification ? { verification } : {}),
+          ...(filterExp ? { filter_exp: filterExp } : {}),
         })
 
         // 2. Save the local trigger row (rollback the mint on failure)
@@ -3014,6 +3044,9 @@ ${continuation}`
           `${verification
             ? 'Signature verification is configured — events with bad signatures are rejected at the edge.'
             : 'No signature verification is configured yet — events will be marked UNVERIFIED. If the service provides a signing secret (many reveal it only after registration), attach it with update_webhook_endpoint.'}\n\n` +
+          `${filterExp
+            ? `Delivery filter active: only events matching \`${filterExp}\` start a session (filtered events are logged — inspect_webhook_events shows them). After real traffic arrives, verify the filter behaves with inspect_webhook_events.`
+            : 'No delivery filter is set — EVERY event this URL receives will start a session. After registering, decide whether you need one: compare the events the service will actually send against what your prompt handles. If the subscription is broader (it usually is — most services can\'t filter by assignee/status/type at registration), add a CEL filter_exp via update_webhook_endpoint so irrelevant events are dropped at the edge instead of waking you. Once real deliveries exist, dry-run candidates with inspect_webhook_events (test_filter_exp) before applying.'}\n\n` +
           `Every delivery to this URL starts a session with your prompt plus the request details.`)
 
         console.log(`[MessagePersister] Custom webhook endpoint ${endpoint.id} created (trigger: ${triggerId})`)
@@ -3084,11 +3117,16 @@ ${continuation}`
           return
         }
 
-        const patch: { name?: string; verification?: import('@shared/lib/services/webhook-endpoint-schema').VerificationProfile | null } = {}
+        const patch: {
+          name?: string
+          verification?: import('@shared/lib/services/webhook-endpoint-schema').VerificationProfile | null
+          filter_exp?: string | null
+        } = {}
         if (input.name) patch.name = input.name
         if (input.verification !== undefined) patch.verification = input.verification
+        if (input.filter_exp !== undefined) patch.filter_exp = input.filter_exp
         if (Object.keys(patch).length === 0) {
-          await this.rejectContainerInput(agentSlug, toolUseId, 'Nothing to update: pass name and/or verification')
+          await this.rejectContainerInput(agentSlug, toolUseId, 'Nothing to update: pass name, verification, and/or filter_exp')
           return
         }
 
@@ -3107,11 +3145,16 @@ ${continuation}`
         const changed = [
           patch.name ? 'name' : null,
           patch.verification === null ? 'verification removed' : patch.verification ? 'verification attached' : null,
+          patch.filter_exp === null ? 'filter removed' : patch.filter_exp ? 'filter set' : null,
         ].filter(Boolean).join(', ')
         await this.resolveContainerInput(agentSlug, toolUseId,
           `Webhook endpoint updated (${changed}).${patch.verification
             ? ' Incoming requests are now signature-verified at the edge; events with bad signatures are rejected.'
-            : ''}`)
+            : ''}${patch.filter_exp
+            ? ` Only deliveries matching \`${patch.filter_exp}\` will start a session; non-matching ones are logged as filtered (inspect_webhook_events shows them, including any filter eval errors — errors fail open and still deliver).`
+            : patch.filter_exp === null
+              ? ' The delivery filter was removed — every event starts a session again.'
+              : ''}`)
 
         console.log(`[MessagePersister] Custom webhook endpoint ${trigger.composioTriggerId} updated (${changed})`)
       } catch (error) {
@@ -3124,6 +3167,95 @@ ${continuation}`
         if (agentSlug) {
           const msg = error instanceof Error ? error.message : String(error)
           await this.rejectContainerInput(agentSlug, toolUseId, `Failed to update webhook endpoint: ${msg}`).catch(console.error)
+        }
+      }
+    })()
+  }
+
+  // Handle inspect_webhook_events - blocking: read recent stored deliveries
+  // (including filter-withheld rows) from the platform, or dry-run a candidate
+  // filter expression against them. Read-only on both sides.
+  private handleInspectWebhookEventsTool(
+    sessionId: string,
+    toolUseId: string,
+    toolInput: string,
+    agentSlug?: string
+  ): void {
+    ;(async () => {
+      try {
+        if (!agentSlug) {
+          console.error('[MessagePersister] inspect_webhook_events missing agentSlug')
+          return
+        }
+
+        if (!getPlatformAccessToken()) {
+          await this.rejectContainerInput(agentSlug, toolUseId, 'Custom webhook endpoints are only available when connected to the platform')
+          return
+        }
+
+        let rawInput: unknown
+        try {
+          rawInput = JSON.parse(toolInput)
+        } catch {
+          await this.rejectContainerInput(agentSlug, toolUseId, 'Invalid tool input')
+          return
+        }
+
+        const parsedInput = inspectWebhookEventsInputSchema.safeParse(rawInput)
+        if (!parsedInput.success) {
+          await this.rejectContainerInput(agentSlug, toolUseId,
+            `Invalid tool input: ${parsedInput.error.issues.map((i) => `${i.path.join('.') || 'input'}: ${i.message}`).join('; ')}`)
+          return
+        }
+        const input = parsedInput.data
+
+        // Cancelled triggers stay inspectable on purpose: the stored events
+        // outlive the endpoint and post-mortems are a legitimate use.
+        const trigger = await getWebhookTrigger(input.trigger_id)
+        if (!trigger || trigger.agentSlug !== agentSlug || trigger.kind !== 'custom' || !trigger.composioTriggerId) {
+          await this.rejectContainerInput(agentSlug, toolUseId, `No custom webhook endpoint found for trigger ${input.trigger_id}`)
+          return
+        }
+
+        // Creator-first member resolution, same as update/teardown.
+        const memberId =
+          resolvePlatformMemberForCandidates([trigger.createdByUserId])?.memberId ??
+          (await this.resolvePlatformMemberForSession(agentSlug, sessionId))
+
+        if (input.test_filter_exp) {
+          const result = await testPlatformWebhookFilter(
+            memberId, trigger.composioTriggerId, input.test_filter_exp, input.limit)
+          const lines = result.results.map((r) => {
+            const stored = r.stored_status ? ` (stored: ${r.stored_status})` : ''
+            const detail = r.outcome === 'error' && r.error ? ` — ${r.error}` : ''
+            return `- ${r.event_id} · ${r.created_at}${stored}: ${r.outcome.toUpperCase()}${detail}`
+          })
+          await this.resolveContainerInput(agentSlug, toolUseId,
+            `Dry-run of \`${result.filter_exp}\` against the ${result.evaluated} most recent deliveries — ` +
+            `${result.summary.passed} would pass, ${result.summary.filtered} filtered out, ` +
+            `${result.summary.error} errored (errors fail open = delivered), ${result.summary.skipped} skipped (handshakes/scrubbed).\n\n` +
+            `${lines.length ? lines.join('\n') : 'No stored deliveries to evaluate yet — send a test event first.'}\n\n` +
+            `Nothing was changed. When the verdicts look right, apply it with update_webhook_endpoint (filter_exp).`)
+        } else {
+          const { filterExp, events } = await listPlatformWebhookEvents(
+            memberId, trigger.composioTriggerId, input.limit)
+          await this.resolveContainerInput(agentSlug, toolUseId,
+            `Active filter: ${filterExp ? `\`${filterExp}\`` : 'none (every event delivers)'}\n\n` +
+            `${events.length
+              ? `Recent deliveries (newest first):\n${events.map(formatWebhookEventLine).join('\n')}`
+              : 'No deliveries recorded yet for this endpoint.'}`)
+        }
+
+        console.log(`[MessagePersister] Inspected webhook events for ${trigger.composioTriggerId}`)
+      } catch (error) {
+        console.error('[MessagePersister] Error handling inspect_webhook_events:', error)
+        captureException(error, {
+          tags: { area: 'webhook-endpoints', op: 'inspect' },
+          extra: { agentSlug, sessionId, toolUseId },
+        })
+        if (agentSlug) {
+          const msg = error instanceof Error ? error.message : String(error)
+          await this.rejectContainerInput(agentSlug, toolUseId, `Failed to inspect webhook events: ${msg}`).catch(console.error)
         }
       }
     })()

--- a/src/shared/lib/services/webhook-endpoint-schema.ts
+++ b/src/shared/lib/services/webhook-endpoint-schema.ts
@@ -52,6 +52,14 @@ export const verificationProfileSchema = z
 export type VerificationProfile = z.infer<typeof verificationProfileSchema>
 
 /**
+ * CEL filter expression evaluated by the proxy against each delivery. Only
+ * shape-checked here (string, length cap mirroring the platform column
+ * constraint) — the platform compiles it at the write boundary and its parser
+ * error message is what the agent needs to see, so don't pre-empt it.
+ */
+export const filterExpressionSchema = z.string().trim().min(1).max(2048)
+
+/**
  * Container tool inputs, validated host-side before anything is minted or
  * stored (the container is not a trusted boundary). Unknown keys are dropped;
  * model/effort reuse the shared runtime-options shape.
@@ -60,6 +68,7 @@ export const createWebhookEndpointInputSchema = z.object({
   name: z.string().trim().min(1),
   prompt: z.string().trim().min(1),
   verification: verificationProfileSchema.nullish(),
+  filter_exp: filterExpressionSchema.nullish(),
   model: RuntimeOptionsSchema.shape.model,
   effort: RuntimeOptionsSchema.shape.effort,
 })
@@ -69,6 +78,16 @@ export const updateWebhookEndpointInputSchema = z.object({
   name: z.string().trim().min(1).optional(),
   // null explicitly clears the profile; absent leaves it untouched.
   verification: verificationProfileSchema.nullable().optional(),
+  // null explicitly clears the filter; absent leaves it untouched.
+  filter_exp: filterExpressionSchema.nullable().optional(),
+})
+
+export const inspectWebhookEventsInputSchema = z.object({
+  trigger_id: z.string().trim().min(1),
+  limit: z.number().int().min(1).max(50).optional(),
+  // When set, dry-run this candidate expression against the recent
+  // deliveries instead of just listing them.
+  test_filter_exp: filterExpressionSchema.optional(),
 })
 
 /**
@@ -83,6 +102,7 @@ export const webhookEndpointSchema = z
     name: z.string(),
     status: z.string(),
     verification: z.object({ has_secret: z.boolean().optional() }).loose().nullable().optional(),
+    filter_exp: z.string().nullable().optional(),
     receive_count: z.number().optional(),
     rejected_count: z.number().optional(),
     last_received_at: z.string().nullable().optional(),
@@ -106,6 +126,9 @@ export const webhookEnvelopeSchema = z
     kind: z.string(), // 'event' | 'handshake'
     handshake_type: z.string().optional(),
     verified: z.boolean(),
+    // Filter verdict stamped by ingest when the endpoint has a filter_exp
+    // ('passed' | 'filtered' | 'error'; filtered rows never reach dispatch).
+    filter: z.object({ outcome: z.string(), error: z.string().optional() }).loose().optional(),
     method: z.string().optional(),
     url: z.string().optional(),
     query: z.record(z.string(), z.string()).optional(),
@@ -118,6 +141,66 @@ export const webhookEnvelopeSchema = z
   .loose()
 
 export type WebhookEnvelope = z.infer<typeof webhookEnvelopeSchema>
+
+/**
+ * One stored delivery as the proxy's inspection route returns it
+ * (GET /v1/webhook-endpoints/{id}/events). Bodies are previews (capped
+ * proxy-side); lenient so proxy evolution never breaks inspection.
+ */
+export const webhookEndpointEventSchema = z
+  .object({
+    id: z.string(),
+    created_at: z.string(),
+    status: z.string(),
+    kind: z.string().nullable().optional(),
+    verified: z.boolean().optional(),
+    filter: z.object({ outcome: z.string(), error: z.string().optional() }).loose().nullable().optional(),
+    method: z.string().nullable().optional(),
+    content_type: z.string().nullable().optional(),
+    headers: z.record(z.string(), z.string()).nullable().optional(),
+    query: z.record(z.string(), z.string()).nullable().optional(),
+    body: z.string().nullable().optional(),
+    body_truncated: z.boolean().optional(),
+    body_encoding: z.string().nullable().optional(),
+  })
+  .loose()
+
+export type WebhookEndpointEvent = z.infer<typeof webhookEndpointEventSchema>
+
+export const webhookEndpointEventsSchema = z
+  .object({
+    endpoint_id: z.string().optional(),
+    filter_exp: z.string().nullable().optional(),
+    events: z.array(webhookEndpointEventSchema),
+  })
+  .loose()
+
+/** Dry-run result from POST /v1/webhook-endpoints/{id}/test-filter. */
+export const webhookFilterTestResultSchema = z
+  .object({
+    filter_exp: z.string(),
+    evaluated: z.number(),
+    summary: z.object({
+      passed: z.number(),
+      filtered: z.number(),
+      error: z.number(),
+      skipped: z.number(),
+    }),
+    results: z.array(
+      z
+        .object({
+          event_id: z.string(),
+          created_at: z.string(),
+          stored_status: z.string().optional(),
+          outcome: z.string(),
+          error: z.string().optional(),
+        })
+        .loose()
+    ),
+  })
+  .loose()
+
+export type WebhookFilterTestResult = z.infer<typeof webhookFilterTestResultSchema>
 
 /**
  * Local mirror of the endpoint's public URL stored in

--- a/src/shared/lib/services/webhook-endpoints-client.test.ts
+++ b/src/shared/lib/services/webhook-endpoints-client.test.ts
@@ -22,6 +22,8 @@ import {
   updatePlatformWebhookEndpoint,
   disablePlatformWebhookEndpoint,
   listPlatformWebhookEndpoints,
+  listPlatformWebhookEvents,
+  testPlatformWebhookFilter,
 } from './webhook-endpoints-client'
 
 const ENDPOINT = {
@@ -107,6 +109,96 @@ describe('webhook-endpoints-client', () => {
     const endpoints = await listPlatformWebhookEndpoints('sub_member_1')
     expect(endpoints).toHaveLength(1)
     expect(endpoints[0].id).toBe(ENDPOINT.id)
+  })
+
+  it('sends filter_exp on mint and PATCH (null clears)', async () => {
+    await createPlatformWebhookEndpoint('sub_member_1', {
+      name: 'n',
+      filter_exp: 'body.action == "update"',
+    })
+    expect(JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string).filter_exp).toBe(
+      'body.action == "update"',
+    )
+
+    mockFetch.mockResolvedValue(new Response(JSON.stringify(ENDPOINT), { status: 200 }))
+    await updatePlatformWebhookEndpoint('sub_member_1', ENDPOINT.id, { filter_exp: null })
+    expect(
+      JSON.parse((mockFetch.mock.calls[1][1] as RequestInit).body as string),
+    ).toEqual({ filter_exp: null })
+  })
+
+  it('lists recent events (filtered included) and surfaces the active filter', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          endpoint_id: ENDPOINT.id,
+          filter_exp: 'verified',
+          events: [
+            {
+              id: 'whe_1',
+              created_at: '2026-07-07T20:45:19Z',
+              status: 'filtered',
+              kind: 'event',
+              verified: true,
+              filter: { outcome: 'filtered' },
+              method: 'POST',
+              content_type: 'application/json',
+              headers: { 'linear-event': 'Issue' },
+              query: {},
+              body: '{"action":"create"}',
+              body_truncated: false,
+              body_encoding: 'utf8',
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    )
+    const { filterExp, events } = await listPlatformWebhookEvents('sub_member_1', ENDPOINT.id, 5)
+    expect(filterExp).toBe('verified')
+    expect(events).toHaveLength(1)
+    expect(events[0].filter?.outcome).toBe('filtered')
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(String(url)).toBe(`https://proxy.test/v1/webhook-endpoints/${ENDPOINT.id}/events?limit=5`)
+    expect((init as RequestInit).method).toBe('GET')
+  })
+
+  it('dry-runs a candidate filter via test-filter', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          endpoint_id: ENDPOINT.id,
+          filter_exp: 'body.action == "update"',
+          evaluated: 2,
+          summary: { passed: 1, filtered: 1, error: 0, skipped: 0 },
+          results: [
+            { event_id: 'whe_1', created_at: '2026-07-07T20:45:19Z', stored_status: 'consumed', outcome: 'passed' },
+            { event_id: 'whe_2', created_at: '2026-07-07T20:44:00Z', stored_status: 'filtered', outcome: 'filtered' },
+          ],
+        }),
+        { status: 200 },
+      ),
+    )
+    const result = await testPlatformWebhookFilter('sub_member_1', ENDPOINT.id, 'body.action == "update"')
+    expect(result.summary.passed).toBe(1)
+    expect(result.results[1].outcome).toBe('filtered')
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(String(url)).toBe(`https://proxy.test/v1/webhook-endpoints/${ENDPOINT.id}/test-filter`)
+    expect((init as RequestInit).method).toBe('POST')
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      filter_exp: 'body.action == "update"',
+    })
+  })
+
+  it('propagates the proxy 400 (with the CEL parser message) on an invalid dry-run expression', async () => {
+    mockFetch.mockResolvedValue(
+      new Response('{"message":"Invalid filter expression: invalid CEL expression: Unexpected token: EOF"}', {
+        status: 400,
+      }),
+    )
+    await expect(
+      testPlatformWebhookFilter('sub_member_1', ENDPOINT.id, 'body.action =='),
+    ).rejects.toThrow(/400.*Unexpected token/)
   })
 
   it('throws on non-OK responses with the status and body', async () => {

--- a/src/shared/lib/services/webhook-endpoints-client.ts
+++ b/src/shared/lib/services/webhook-endpoints-client.ts
@@ -13,8 +13,12 @@ import { getPlatformAccessToken } from '@shared/lib/services/platform-auth-servi
 import {
   webhookEndpointSchema,
   webhookEndpointListSchema,
+  webhookEndpointEventsSchema,
+  webhookFilterTestResultSchema,
   type VerificationProfile,
   type WebhookEndpoint,
+  type WebhookEndpointEvent,
+  type WebhookFilterTestResult,
 } from './webhook-endpoint-schema'
 
 // Org JWTs encode the acting member as `<token>::<memberId>`; opaque keys ignore it.
@@ -62,7 +66,7 @@ async function endpointsFetch(
 /** Mint a new public webhook endpoint; returns it including the public URL. */
 export async function createPlatformWebhookEndpoint(
   memberId: string,
-  params: { name: string; verification?: VerificationProfile },
+  params: { name: string; verification?: VerificationProfile; filter_exp?: string },
 ): Promise<WebhookEndpoint> {
   const data = await endpointsFetch('', memberId, {
     method: 'POST',
@@ -116,13 +120,55 @@ export async function getPlatformWebhookEndpoint(
 export async function updatePlatformWebhookEndpoint(
   memberId: string,
   endpointId: string,
-  params: { name?: string; verification?: VerificationProfile | null },
+  params: { name?: string; verification?: VerificationProfile | null; filter_exp?: string | null },
 ): Promise<WebhookEndpoint> {
   const data = await endpointsFetch(`/${encodeURIComponent(endpointId)}`, memberId, {
     method: 'PATCH',
     body: JSON.stringify(params),
   })
   return webhookEndpointSchema.parse(data)
+}
+
+/**
+ * Recent stored deliveries for an endpoint, newest first — INCLUDING rows the
+ * filter withheld (status 'filtered'). The filter-debugging surface: "why
+ * didn't my trigger fire?" is answered here.
+ */
+export async function listPlatformWebhookEvents(
+  memberId: string,
+  endpointId: string,
+  limit?: number,
+): Promise<{ filterExp: string | null; events: WebhookEndpointEvent[] }> {
+  const search = limit !== undefined ? `?limit=${encodeURIComponent(limit)}` : ''
+  const data = await endpointsFetch(
+    `/${encodeURIComponent(endpointId)}/events${search}`,
+    memberId,
+    { method: 'GET' },
+  )
+  const parsed = webhookEndpointEventsSchema.parse(data)
+  return { filterExp: parsed.filter_exp ?? null, events: parsed.events }
+}
+
+/**
+ * Dry-run a candidate filter expression against the endpoint's recent stored
+ * deliveries using the platform's live evaluator (never touches the stored
+ * filter). 400s with the parser message on an invalid expression.
+ */
+export async function testPlatformWebhookFilter(
+  memberId: string,
+  endpointId: string,
+  filterExp: string,
+  limit?: number,
+): Promise<WebhookFilterTestResult> {
+  const data = await endpointsFetch(
+    `/${encodeURIComponent(endpointId)}/test-filter`,
+    memberId,
+    {
+      method: 'POST',
+      body: JSON.stringify({ filter_exp: filterExp, ...(limit !== undefined ? { limit } : {}) }),
+    },
+  )
+  return webhookFilterTestResultSchema.parse(data)
 }
 
 /** Disable (soft-delete): ingest starts returning 404 for the URL. */

--- a/src/shared/lib/startup.ts
+++ b/src/shared/lib/startup.ts
@@ -6,7 +6,6 @@ import { taskScheduler } from './scheduler/task-scheduler'
 import { triggerManager } from './scheduler/trigger-manager'
 import { chatIntegrationManager } from './chat-integrations/chat-integration-manager'
 import { captureException } from './error-reporting'
-import { isPlatformComposioActive } from './composio/client'
 import { registerAllAccountProviders } from './account-providers/register'
 import { autoSleepMonitor } from './scheduler/auto-sleep-monitor'
 import { sessionAutoDeleteMonitor } from './scheduler/session-auto-delete-monitor'
@@ -117,8 +116,12 @@ export async function initializeServices() {
     console.error('Failed to start task scheduler:', error)
   })
 
-  // Start trigger manager (only when platform Composio is connected)
-  if (isPlatformComposioActive()) {
+  // Start trigger manager whenever platform auth exists: webhook events
+  // (Composio-brokered AND custom endpoints) are claimed from the platform
+  // with the platform token, so a personal Composio key must not disable
+  // delivery — same trap as the endpoint tool/teardown gating. The manager
+  // itself no-ops per-poll when the token is missing.
+  if (getPlatformAccessToken()) {
     triggerManager.start().catch((error) => {
       console.error('Failed to start trigger manager:', error)
     })


### PR DESCRIPTION
## Why

Follow-up to #407. Most services can't scope their webhook subscriptions as narrowly as the trigger an agent actually wants (Linear sends **all** Issue events; the trigger is "assigned to me changed"), so every irrelevant delivery spawns a session that exists only to conclude "not relevant". Endpoints now carry a CEL filter evaluated platform-side — irrelevant events are dropped at the edge, logged, and never wake the agent.

Platform counterpart (evaluation engine, storage, inspection routes): SkillfulAgents/platform#147.

## What

**Agent tools**
- `create_webhook_endpoint` / `update_webhook_endpoint` gain `filter_exp` (null clears), with a shared teaching block: context shape (`body` parsed JSON / `headers` / `query` / `method` / `verified`), `has()`/`in` guard rules (missing keys error → fail open), no `(?i)` regex flags, vendor examples (Linear assignee-change, GitHub header-based, Stripe, Slack, Shopify)
- **new `inspect_webhook_events` tool** — recent deliveries *including* filter-withheld ones with their verdicts and eval errors, plus `test_filter_exp` to dry-run a candidate expression against real stored deliveries with the platform's live evaluator before applying it
- result-message guidance closes the loop: minting without a filter prompts an explicit decision ("compare what the service will send vs what your prompt handles"); with a filter, verify against real traffic; `get_available_triggers` empty-catalog runbook gains the filter step
- system prompt: "Delivery filters — use them" section

**Client**: `filter_exp` on create/update, `listPlatformWebhookEvents` + `testPlatformWebhookFilter` with Zod boundaries; envelope schema learns the `filter` verdict field.

**Fix (separate commit, caught by live E2E)**: `triggerManager.start()` was gated on `isPlatformComposioActive()` — with a personal Composio key + platform auth, custom endpoints could be *minted* but their events were **never delivered** (third instance of the gating bug class fixed for tool exposure + teardown in #407 review). Now gates on `getPlatformAccessToken()`; the manager already token-guards each poll.

## Validation

- Persister suite 215/215 (filter pass-through, guidance assertions, inspect tool: list/dry-run/error-surfacing/authz gating); client tests incl. dry-run 400 propagation; typecheck + lint clean
- **Full live-stack E2E** (local supabase reset + wrangler + `dev:web`, curl as vendor, signed Linear-shaped deliveries): matching event → real agent session replied correctly; title-only edit → `filtered`, never claimed, no session; missing-`updatedFrom` → fail-open, error recorded, delivered; handshake bypassed; then the complete self-heal loop live — inspect showed the eval error, dry-run of the `has()`-guarded fix scored 0 errors, PATCH applied it, re-fired event silently filtered. The trigger-manager gate fix was verified in the same run.