### PR TITLE
feat(llm): generic provider for custom baseURL + API key (SUP-277)

### DIFF
--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -191,6 +191,8 @@ settings.use('*', Authenticated(), IsAdmin())
 const API_KEY_FIELDS: (keyof ApiKeySettings)[] = [
   'anthropicApiKey',
   'openrouterApiKey',
+  'genericApiKey',
+  'genericBaseUrl',
   'bedrockApiKey',
   'bedrockAccessKeyId',
   'bedrockSecretAccessKey',
@@ -299,6 +301,7 @@ function buildSettingsResponse(
       openrouter: getLlmProvider('openrouter').getApiKeyStatus(),
       bedrock: getLlmProvider('bedrock').getApiKeyStatus(),
       platform: getLlmProvider('platform').getApiKeyStatus(),
+      generic: getLlmProvider('generic').getApiKeyStatus(),
       browserbase: getBrowserbaseApiKeyStatus(),
       composio: getComposioApiKeyStatus(),
       nango: getNangoApiKeyStatus(),
@@ -687,19 +690,27 @@ settings.post('/validate-anthropic-key', async (c) => {
 // POST /api/settings/validate-llm-key - Validate an API key for any LLM provider
 settings.post('/validate-llm-key', async (c) => {
   try {
-    const { provider, apiKey } = await c.req.json()
+    const { provider, apiKey, baseUrl } = await c.req.json()
     if (!apiKey || typeof apiKey !== 'string') {
       return c.json({ valid: false, error: 'API key is required' }, 400)
     }
     if (!provider || typeof provider !== 'string') {
       return c.json({ valid: false, error: 'Provider is required' }, 400)
     }
-    if (provider !== 'anthropic' && provider !== 'openrouter' && provider !== 'bedrock') {
+    if (
+      provider !== 'anthropic' &&
+      provider !== 'openrouter' &&
+      provider !== 'bedrock' &&
+      provider !== 'generic'
+    ) {
       return c.json({ valid: false, error: `Unknown provider: ${provider}` }, 400)
     }
 
     const llmProvider = getLlmProvider(provider)
-    const result = await llmProvider.validateKey(apiKey)
+    const result = await llmProvider.validateKey(
+      apiKey,
+      typeof baseUrl === 'string' ? { baseUrl } : undefined,
+    )
     return c.json(result)
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'Invalid API key'

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -232,7 +232,8 @@ settings.get('/llm-providers/:providerId/models/search', async (c) => {
       return c.json({ error: error.message }, 400)
     }
     console.error('Failed to search provider models:', error)
-    return c.json({ error: 'Failed to search provider models' }, 500)
+    const message = error instanceof Error ? error.message : 'Failed to search provider models'
+    return c.json({ error: message }, 500)
   }
 })
 

--- a/src/renderer/components/settings/generic-credentials-input.tsx
+++ b/src/renderer/components/settings/generic-credentials-input.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react'
+import { Input } from '@renderer/components/ui/input'
+import { Label } from '@renderer/components/ui/label'
+import { Button } from '@renderer/components/ui/button'
+import { PasswordInput } from '@renderer/components/ui/password-input'
+import { RequestError } from '@renderer/components/messages/request-error'
+import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
+import { apiFetch } from '@renderer/lib/api'
+import { Check, Loader2 } from 'lucide-react'
+import type { ApiKeyStatus } from '@shared/lib/config/settings'
+
+interface GenericCredentialsInputProps {
+  disabled?: boolean
+}
+
+/**
+ * Credentials for the generic provider: a user-supplied Anthropic-wire endpoint
+ * (baseURL) plus an API key. Both are validated together via the shared
+ * validate-llm-key endpoint before being saved.
+ */
+export function GenericCredentialsInput({ disabled = false }: GenericCredentialsInputProps) {
+  const { data: settings } = useSettings()
+  const updateSettings = useUpdateSettings()
+
+  const [baseUrl, setBaseUrl] = useState('')
+  const [apiKeyInput, setApiKeyInput] = useState('')
+  const [isValidating, setIsValidating] = useState(false)
+  const [isRemoving, setIsRemoving] = useState(false)
+  const [validationResult, setValidationResult] = useState<{ valid: boolean; error?: string } | null>(null)
+
+  const apiKeyStatus: ApiKeyStatus | undefined = settings?.apiKeyStatus?.generic
+  const isBusy = isValidating || isRemoving
+
+  const handleValidateAndSave = async () => {
+    const trimmedUrl = baseUrl.trim()
+    const trimmedKey = apiKeyInput.trim()
+    if (!trimmedUrl || !trimmedKey) return
+    setIsValidating(true)
+    setValidationResult(null)
+    try {
+      const res = await apiFetch('/api/settings/validate-llm-key', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider: 'generic', apiKey: trimmedKey, baseUrl: trimmedUrl }),
+      })
+      const result = await res.json()
+      setValidationResult(result)
+      if (result.valid) {
+        await updateSettings.mutateAsync({
+          apiKeys: { genericBaseUrl: trimmedUrl, genericApiKey: trimmedKey },
+        })
+        setApiKeyInput('')
+      }
+    } catch {
+      setValidationResult({ valid: false, error: 'Failed to validate' })
+    } finally {
+      setIsValidating(false)
+    }
+  }
+
+  const handleRemove = async () => {
+    setIsRemoving(true)
+    try {
+      await updateSettings.mutateAsync({
+        apiKeys: { genericBaseUrl: '', genericApiKey: '' },
+      })
+      setBaseUrl('')
+      setApiKeyInput('')
+      setValidationResult(null)
+    } catch (error) {
+      console.error('Failed to remove credentials:', error)
+    } finally {
+      setIsRemoving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Label>Custom endpoint</Label>
+        {apiKeyStatus?.isConfigured && (
+          <span
+            className={`text-xs px-2 py-0.5 rounded-full ${
+              apiKeyStatus.source === 'settings'
+                ? 'bg-green-500/10 text-green-700 dark:text-green-400'
+                : 'bg-blue-500/10 text-blue-700 dark:text-blue-400'
+            }`}
+          >
+            {apiKeyStatus.source === 'settings' ? 'Using saved setting' : 'Using environment variable'}
+          </span>
+        )}
+      </div>
+
+      <p className="text-[11px] text-muted-foreground">
+        Point at any Anthropic-compatible endpoint (a self-hosted gateway or a LiteLLM/proxy in
+        Anthropic mode). Add your models below in the catalog editor. ollama&apos;s native API is
+        OpenAI-compatible, so front it with an Anthropic-compatible proxy.
+      </p>
+
+      <div className="space-y-1">
+        <Label htmlFor="generic-base-url" className="font-normal text-muted-foreground">Base URL</Label>
+        <Input
+          id="generic-base-url"
+          value={baseUrl}
+          onChange={(e) => { setBaseUrl(e.target.value); setValidationResult(null) }}
+          placeholder="http://localhost:4000"
+          disabled={disabled || isBusy}
+          className="bg-background"
+        />
+      </div>
+
+      <div className="space-y-1">
+        <Label htmlFor="generic-api-key" className="font-normal text-muted-foreground">API Key</Label>
+        <PasswordInput
+          id="generic-api-key"
+          value={apiKeyInput}
+          onChange={(e) => { setApiKeyInput(e.target.value); setValidationResult(null) }}
+          placeholder={apiKeyStatus?.isConfigured ? '••••••••••••••••' : 'Enter API key...'}
+          disabled={disabled || isBusy}
+          className="bg-background"
+        />
+      </div>
+
+      <div className="flex gap-2">
+        {baseUrl.trim() && apiKeyInput.trim() && (
+          <Button size="sm" onClick={handleValidateAndSave} disabled={isBusy}>
+            {isValidating ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Validating...</> : 'Validate & Save'}
+          </Button>
+        )}
+        {apiKeyStatus?.source === 'settings' && (
+          <Button size="sm" variant="outline" onClick={handleRemove} disabled={isBusy}>
+            {isRemoving ? 'Removing...' : 'Remove Saved Credentials'}
+          </Button>
+        )}
+      </div>
+
+      {validationResult && !validationResult.valid && (
+        <RequestError message={validationResult.error || 'Invalid credentials'} variant="compact" />
+      )}
+      {validationResult?.valid && (
+        <p className="text-xs text-green-600 dark:text-green-400 flex items-center gap-1">
+          <Check className="h-3 w-3" />
+          Credentials are valid and have been saved.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/settings/llm-tab.tsx
+++ b/src/renderer/components/settings/llm-tab.tsx
@@ -5,6 +5,7 @@ import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
 import { usePlatformAuthStatus } from '@renderer/hooks/use-platform-auth'
 import { ProviderApiKeyInput } from './provider-api-key-input'
 import { BedrockCredentialsInput } from './bedrock-credentials-input'
+import { GenericCredentialsInput } from './generic-credentials-input'
 import { SettingsModelSelect } from './settings-model-select'
 import { CatalogEditor } from './model-catalog/catalog-editor'
 import type { LlmProviderId } from '@shared/lib/config/settings'
@@ -35,6 +36,7 @@ const PROVIDER_DESCRIPTIONS: Partial<Record<LlmProviderId, string>> = {
   openrouter: 'Multi-model access through a single API key.',
   bedrock: 'AWS-managed Claude inference with IAM or API key credentials.',
   platform: 'Use credentials provided by your Gamut account.',
+  generic: 'Point at any Anthropic-compatible endpoint — localhost ollama, a self-hosted gateway, or a proxy.',
 }
 
 const CARD_CLASS = 'rounded-xl border bg-background divide-y divide-border/50 overflow-hidden'
@@ -234,6 +236,8 @@ export function LlmTab() {
                   disabled={isLoading}
                   showNotConfiguredAlert={false}
                 />
+              ) : provider.id === 'generic' ? (
+                <GenericCredentialsInput key="generic" disabled={isLoading} />
               ) : keyConfig ? (
                 <ProviderApiKeyInput
                   key={provider.id}

--- a/src/renderer/hooks/use-settings.ts
+++ b/src/renderer/hooks/use-settings.ts
@@ -61,6 +61,8 @@ export interface UpdateSettingsParams {
   apiKeys?: {
     anthropicApiKey?: string
     openrouterApiKey?: string
+    genericApiKey?: string
+    genericBaseUrl?: string
     bedrockApiKey?: string
     bedrockAccessKeyId?: string
     bedrockSecretAccessKey?: string

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -37,6 +37,10 @@ export interface ContainerSettings {
 export interface ApiKeySettings {
   anthropicApiKey?: string
   openrouterApiKey?: string
+  /** Generic (custom baseURL) provider key, sent as ANTHROPIC_AUTH_TOKEN. */
+  genericApiKey?: string
+  /** Generic provider endpoint (Anthropic-wire-compatible), e.g. a LiteLLM proxy. */
+  genericBaseUrl?: string
   bedrockApiKey?: string
   bedrockAccessKeyId?: string
   bedrockSecretAccessKey?: string
@@ -274,6 +278,7 @@ export interface GlobalSettingsResponse {
     openrouter: ApiKeyStatus
     bedrock: ApiKeyStatus
     platform: ApiKeyStatus
+    generic: ApiKeyStatus
     composio: ApiKeyStatus
     nango: ApiKeyStatus
     browserbase: ApiKeyStatus

--- a/src/shared/lib/llm-provider/base-llm-provider.ts
+++ b/src/shared/lib/llm-provider/base-llm-provider.ts
@@ -2,7 +2,7 @@ import Anthropic from '@anthropic-ai/sdk'
 import { getSettings, type ApiKeySettings, type ApiKeyStatus } from '../config/settings'
 import type { ModelDefinition, ModelSearchResult } from './model-catalog-schema'
 
-export type LlmProviderId = 'anthropic' | 'openrouter' | 'bedrock' | 'platform'
+export type LlmProviderId = 'anthropic' | 'openrouter' | 'bedrock' | 'platform' | 'generic'
 
 export type ModelPurpose = 'agent' | 'summarizer' | 'browser' | 'dashboard'
 
@@ -80,8 +80,14 @@ export abstract class BaseLlmProvider {
   /** Get env vars to inject into agent containers. */
   abstract getContainerEnvVars(): Record<string, string | undefined>
 
-  /** Validate an API key. */
-  abstract validateKey(apiKey: string): Promise<{ valid: boolean; error?: string }>
+  /**
+   * Validate an API key. `opts.baseUrl` is only meaningful for providers whose
+   * endpoint is user-supplied (the generic provider); others ignore it.
+   */
+  abstract validateKey(
+    apiKey: string,
+    opts?: { baseUrl?: string },
+  ): Promise<{ valid: boolean; error?: string }>
 
   /**
    * Search provider-native model catalogs and return normalized local-catalog

--- a/src/shared/lib/llm-provider/generic-provider.test.ts
+++ b/src/shared/lib/llm-provider/generic-provider.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The provider reads settings for its key/baseURL and the model catalog for its
+// (empty) built-in list; stub both so tests are deterministic.
+const settingsMock = vi.fn()
+const catalogMock = vi.fn()
+vi.mock('../config/settings', () => ({
+  getSettings: () => settingsMock(),
+  getModelCatalogSettings: () => catalogMock(),
+}))
+
+// Capture SDK construction + intercept messages.create for validateKey.
+const messagesCreate = vi.fn()
+const anthropicCtor = vi.fn()
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class {
+    messages = { create: (...args: unknown[]) => messagesCreate(...args) }
+    constructor(opts: unknown) {
+      anthropicCtor(opts)
+    }
+  },
+}))
+
+import { GenericLlmProvider, GENERIC_FALLBACK_MODEL } from './generic-provider'
+
+const provider = new GenericLlmProvider()
+
+const ENV_KEYS = ['GENERIC_API_KEY', 'GENERIC_BASE_URL', 'GENERIC_DEFAULT_MODEL'] as const
+const savedEnv: Record<string, string | undefined> = {}
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+  settingsMock.mockReturnValue({ apiKeys: { genericApiKey: 'test-key', genericBaseUrl: 'https://proxy.example' } })
+  catalogMock.mockReturnValue({})
+})
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key]
+    else process.env[key] = savedEnv[key]
+  }
+  vi.clearAllMocks()
+})
+
+describe('GenericLlmProvider — catalog and capabilities', () => {
+  it('ships an empty built-in catalog and no model search', () => {
+    expect(provider.getBuiltinCatalog()).toEqual([])
+    expect(provider.supportsModelSearch).toBe(false)
+  })
+})
+
+describe('GenericLlmProvider.getEffectiveBaseUrl', () => {
+  it('prefers the settings baseURL over the env var', () => {
+    process.env.GENERIC_BASE_URL = 'https://env.example'
+    expect(provider.getEffectiveBaseUrl()).toBe('https://proxy.example')
+  })
+
+  it('falls back to GENERIC_BASE_URL when settings has none', () => {
+    settingsMock.mockReturnValue({ apiKeys: {} })
+    process.env.GENERIC_BASE_URL = 'https://env.example'
+    expect(provider.getEffectiveBaseUrl()).toBe('https://env.example')
+  })
+
+  it('is undefined when neither is configured', () => {
+    settingsMock.mockReturnValue({ apiKeys: {} })
+    expect(provider.getEffectiveBaseUrl()).toBeUndefined()
+  })
+})
+
+describe('GenericLlmProvider.getDefaultModel', () => {
+  it('returns the first non-disabled user-added model', () => {
+    catalogMock.mockReturnValue({
+      generic: { overrides: [{ id: 'llama3.1' }, { id: 'mistral' }] },
+    })
+    expect(provider.getDefaultModel('agent')).toBe('llama3.1')
+  })
+
+  it('skips disabled user models', () => {
+    catalogMock.mockReturnValue({
+      generic: { overrides: [{ id: 'llama3.1', disabled: true }, { id: 'mistral' }] },
+    })
+    expect(provider.getDefaultModel('agent')).toBe('mistral')
+  })
+
+  it('honors GENERIC_DEFAULT_MODEL when no user models are configured', () => {
+    process.env.GENERIC_DEFAULT_MODEL = 'my-default'
+    expect(provider.getDefaultModel('agent')).toBe('my-default')
+  })
+
+  it('falls back to the placeholder when nothing is configured', () => {
+    expect(provider.getDefaultModel('agent')).toBe(GENERIC_FALLBACK_MODEL)
+  })
+})
+
+describe('GenericLlmProvider.getContainerEnvVars', () => {
+  it('sets the Anthropic-wire env, rewriting localhost to the container host gateway', () => {
+    settingsMock.mockReturnValue({
+      apiKeys: { genericApiKey: 'k', genericBaseUrl: 'http://localhost:11434' },
+    })
+    expect(provider.getContainerEnvVars()).toEqual({
+      ANTHROPIC_API_KEY: '',
+      ANTHROPIC_BASE_URL: 'http://host.docker.internal:11434',
+      ANTHROPIC_AUTH_TOKEN: 'k',
+    })
+  })
+
+  it('leaves a non-localhost baseURL untouched', () => {
+    expect(provider.getContainerEnvVars().ANTHROPIC_BASE_URL).toBe('https://proxy.example')
+  })
+})
+
+describe('GenericLlmProvider.createClient', () => {
+  it('builds an Anthropic client with the baseURL and Bearer auth token', () => {
+    provider.createClient()
+    expect(anthropicCtor).toHaveBeenCalledWith({
+      apiKey: '',
+      baseURL: 'https://proxy.example',
+      authToken: 'test-key',
+    })
+  })
+
+  it('throws when the base URL is missing', () => {
+    settingsMock.mockReturnValue({ apiKeys: { genericApiKey: 'k' } })
+    expect(() => provider.createClient()).toThrow('base URL not configured')
+  })
+
+  it('throws when the API key is missing', () => {
+    settingsMock.mockReturnValue({ apiKeys: { genericBaseUrl: 'https://proxy.example' } })
+    expect(() => provider.createClient()).toThrow('API key not configured')
+  })
+})
+
+describe('GenericLlmProvider.validateKey', () => {
+  it('requires a base URL', async () => {
+    settingsMock.mockReturnValue({ apiKeys: {} })
+    expect(await provider.validateKey('key')).toEqual({ valid: false, error: 'Base URL is required' })
+  })
+
+  it('validates against the inline baseURL and reports success', async () => {
+    settingsMock.mockReturnValue({ apiKeys: {} })
+    messagesCreate.mockResolvedValue({})
+    const result = await provider.validateKey('key', { baseUrl: 'https://inline.example' })
+    expect(result).toEqual({ valid: true })
+    expect(anthropicCtor).toHaveBeenCalledWith({
+      apiKey: '',
+      baseURL: 'https://inline.example',
+      authToken: 'key',
+    })
+  })
+
+  it('reports the error message on failure', async () => {
+    messagesCreate.mockRejectedValue(new Error('401 unauthorized'))
+    expect(await provider.validateKey('bad')).toEqual({ valid: false, error: '401 unauthorized' })
+  })
+})

--- a/src/shared/lib/llm-provider/generic-provider.test.ts
+++ b/src/shared/lib/llm-provider/generic-provider.test.ts
@@ -224,6 +224,12 @@ describe('GenericLlmProvider.searchModels', () => {
     await expect(provider.searchModels('')).rejects.toThrow('failed (500)')
   })
 
+  it('surfaces a timeout message when the request aborts', async () => {
+    const abort = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' })
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abort))
+    await expect(provider.searchModels('')).rejects.toThrow(/timed out after 15s/)
+  })
+
   it('throws when the base URL is missing', async () => {
     settingsMock.mockReturnValue({ apiKeys: { genericApiKey: 'k' } })
     await expect(provider.searchModels('')).rejects.toThrow('base URL not configured')
@@ -236,25 +242,68 @@ describe('GenericLlmProvider.searchModels', () => {
 })
 
 describe('GenericLlmProvider.validateKey', () => {
+  function stubFetch(init: { ok?: boolean; status?: number } = {}) {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: init.ok ?? true,
+      status: init.status ?? 200,
+      json: async () => ({}),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+
+  afterEach(() => vi.unstubAllGlobals())
+
   it('requires a base URL', async () => {
     settingsMock.mockReturnValue({ apiKeys: {} })
     expect(await provider.validateKey('key')).toEqual({ valid: false, error: 'Base URL is required' })
   })
 
-  it('validates against the inline baseURL and reports success', async () => {
+  it('probes /v1/models on the inline baseURL and reports success without needing a real model id', async () => {
     settingsMock.mockReturnValue({ apiKeys: {} })
-    messagesCreate.mockResolvedValue({})
-    const result = await provider.validateKey('key', { baseUrl: 'https://inline.example' })
+    const fetchMock = stubFetch({ ok: true, status: 200 })
+    const result = await provider.validateKey('key', { baseUrl: 'http://localhost:11434' })
     expect(result).toEqual({ valid: true })
-    expect(anthropicCtor).toHaveBeenCalledWith({
-      apiKey: '',
-      baseURL: 'https://inline.example',
-      authToken: 'key',
-    })
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('http://localhost:11434/v1/models')
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer key' })
   })
 
-  it('reports the error message on failure', async () => {
-    messagesCreate.mockRejectedValue(new Error('401 unauthorized'))
-    expect(await provider.validateKey('bad')).toEqual({ valid: false, error: '401 unauthorized' })
+  it('reports an auth-specific error on 401', async () => {
+    stubFetch({ ok: false, status: 401 })
+    const result = await provider.validateKey('bad')
+    expect(result.valid).toBe(false)
+    expect(result.error).toMatch(/Auth rejected.*401/)
+  })
+
+  it('reports an auth-specific error on 403', async () => {
+    stubFetch({ ok: false, status: 403 })
+    const result = await provider.validateKey('bad')
+    expect(result.error).toMatch(/Auth rejected.*403/)
+  })
+
+  it('treats a 404 as reachable-but-not-listable (soft-passes so the user can proceed)', async () => {
+    stubFetch({ ok: false, status: 404 })
+    expect(await provider.validateKey('key')).toEqual({ valid: true })
+  })
+
+  it('reports the status code on other non-OK responses', async () => {
+    stubFetch({ ok: false, status: 502 })
+    expect(await provider.validateKey('key')).toEqual({ valid: false, error: 'Endpoint returned 502' })
+  })
+
+  it('surfaces a friendly message when the fetch fails outright', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')))
+    const result = await provider.validateKey('key')
+    expect(result.valid).toBe(false)
+    expect(result.error).toMatch(/Could not reach https:\/\/proxy\.example/)
+  })
+
+  it('surfaces a timeout message when the request aborts', async () => {
+    const abort = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' })
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abort))
+    const result = await provider.validateKey('key')
+    expect(result.valid).toBe(false)
+    expect(result.error).toMatch(/Timed out/)
   })
 })

--- a/src/shared/lib/llm-provider/generic-provider.test.ts
+++ b/src/shared/lib/llm-provider/generic-provider.test.ts
@@ -46,9 +46,9 @@ afterEach(() => {
 })
 
 describe('GenericLlmProvider — catalog and capabilities', () => {
-  it('ships an empty built-in catalog and no model search', () => {
+  it('ships an empty built-in catalog and opts into model search', () => {
     expect(provider.getBuiltinCatalog()).toEqual([])
-    expect(provider.supportsModelSearch).toBe(false)
+    expect(provider.supportsModelSearch).toBe(true)
   })
 })
 
@@ -130,6 +130,108 @@ describe('GenericLlmProvider.createClient', () => {
   it('throws when the API key is missing', () => {
     settingsMock.mockReturnValue({ apiKeys: { genericBaseUrl: 'https://proxy.example' } })
     expect(() => provider.createClient()).toThrow('API key not configured')
+  })
+})
+
+describe('GenericLlmProvider.searchModels', () => {
+  function stubFetch(body: unknown, init?: { ok?: boolean; status?: number }) {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: init?.ok ?? true,
+      status: init?.status ?? 200,
+      json: async () => body,
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('lists ollama-shape entries and passes the Bearer key', async () => {
+    const fetchMock = stubFetch({
+      object: 'list',
+      data: [
+        { id: 'qwen3.6:27b-mlx', object: 'model' },
+        { id: 'gemma3:270m', object: 'model' },
+      ],
+    })
+
+    const results = await provider.searchModels('')
+
+    expect(results).toEqual([
+      { id: 'qwen3.6:27b-mlx', label: 'qwen3.6:27b-mlx', supportedEfforts: ['low', 'medium', 'high'], supportsWebSearch: false },
+      { id: 'gemma3:270m', label: 'gemma3:270m', supportedEfforts: ['low', 'medium', 'high'], supportsWebSearch: false },
+    ])
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://proxy.example/v1/models')
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer test-key' })
+  })
+
+  it('uses display_name as the label when present (Anthropic /v1/models shape)', async () => {
+    stubFetch({
+      data: [{ id: 'claude-opus-4-8', display_name: 'Claude Opus 4.8' }],
+    })
+
+    const [model] = await provider.searchModels('')
+    expect(model).toMatchObject({ id: 'claude-opus-4-8', label: 'Claude Opus 4.8' })
+  })
+
+  it('filters by substring against both id and label, case-insensitive', async () => {
+    stubFetch({
+      data: [
+        { id: 'qwen3.6:27b-mlx' },
+        { id: 'gemma3:270m' },
+        { id: 'llama3.1', display_name: 'Meta Llama 3.1' },
+      ],
+    })
+
+    const qwen = await provider.searchModels('QWEN')
+    expect(qwen.map((m) => m.id)).toEqual(['qwen3.6:27b-mlx'])
+
+    const meta = await provider.searchModels('meta')
+    expect(meta.map((m) => m.id)).toEqual(['llama3.1'])
+  })
+
+  it('drops entries without an id and caps the result at 50', async () => {
+    const data = [
+      { object: 'model' },
+      ...Array.from({ length: 60 }, (_, i) => ({ id: `model-${i}` })),
+    ]
+    stubFetch({ data })
+
+    const results = await provider.searchModels('')
+    expect(results).toHaveLength(50)
+    expect(results.every((m) => m.id.startsWith('model-'))).toBe(true)
+  })
+
+  it('strips a trailing slash on the base URL before appending /v1/models', async () => {
+    settingsMock.mockReturnValue({
+      apiKeys: { genericApiKey: 'k', genericBaseUrl: 'https://proxy.example///' },
+    })
+    const fetchMock = stubFetch({ data: [] })
+
+    await provider.searchModels('')
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe('https://proxy.example/v1/models')
+  })
+
+  it('throws a friendly message when the endpoint has no /v1/models (404)', async () => {
+    stubFetch({}, { ok: false, status: 404 })
+    await expect(provider.searchModels('')).rejects.toThrow('does not support model listing')
+  })
+
+  it('throws with the status code on other non-OK responses', async () => {
+    stubFetch({}, { ok: false, status: 500 })
+    await expect(provider.searchModels('')).rejects.toThrow('failed (500)')
+  })
+
+  it('throws when the base URL is missing', async () => {
+    settingsMock.mockReturnValue({ apiKeys: { genericApiKey: 'k' } })
+    await expect(provider.searchModels('')).rejects.toThrow('base URL not configured')
+  })
+
+  it('throws when the API key is missing', async () => {
+    settingsMock.mockReturnValue({ apiKeys: { genericBaseUrl: 'https://proxy.example' } })
+    await expect(provider.searchModels('')).rejects.toThrow('API key not configured')
   })
 })
 

--- a/src/shared/lib/llm-provider/generic-provider.ts
+++ b/src/shared/lib/llm-provider/generic-provider.ts
@@ -1,6 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { BaseLlmProvider, type ModelPurpose } from './base-llm-provider'
-import type { ModelDefinition } from './model-catalog-schema'
+import type { ModelDefinition, ModelSearchResult } from './model-catalog-schema'
+import type { EffortLevel } from '../container/types'
 import { getSettings, getModelCatalogSettings } from '../config/settings'
 
 const BASE_URL_ENV = 'GENERIC_BASE_URL'
@@ -23,9 +24,43 @@ export const GENERIC_FALLBACK_MODEL = 'default'
  * ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN). ollama's native OpenAI-compatible
  * API is NOT spoken directly; point at an Anthropic-compatible proxy.
  */
+const DISCOVERED_MODEL_LIMIT = 50
+const DISCOVERED_MODEL_EFFORTS: EffortLevel[] = ['low', 'medium', 'high']
+
+interface RemoteModelListing {
+  id?: unknown
+  /** OpenAI/ollama: undefined. Anthropic /v1/models: human display name. */
+  display_name?: unknown
+  /** OpenAI/ollama shape: 'model' | 'list'. Anthropic: often absent. */
+  object?: unknown
+}
+
+interface RemoteModelsResponse {
+  data?: unknown
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined
+}
+
+function mapRemoteModel(model: RemoteModelListing): ModelSearchResult | null {
+  const id = stringValue(model.id)
+  if (!id) return null
+  const label = stringValue(model.display_name) ?? id
+  return {
+    id,
+    label,
+    supportedEfforts: DISCOVERED_MODEL_EFFORTS,
+    // Non-Claude endpoints don't route Anthropic's native web-search tool;
+    // omit rather than promise a capability we can't verify.
+    supportsWebSearch: false,
+  }
+}
+
 export class GenericLlmProvider extends BaseLlmProvider {
   readonly id = 'generic' as const
   readonly name = 'Generic'
+  override readonly supportsModelSearch = true
   protected readonly settingsKeyField = 'genericApiKey' as const
   protected readonly envVarName = 'GENERIC_API_KEY'
 
@@ -91,5 +126,49 @@ export class GenericLlmProvider extends BaseLlmProvider {
     } catch (error) {
       return { valid: false, error: error instanceof Error ? error.message : 'Validation failed' }
     }
+  }
+
+  /**
+   * List models by hitting `<baseURL>/v1/models` (Bearer auth). Both
+   * Anthropic's `/v1/models` and OpenAI-compatible endpoints (ollama, LiteLLM)
+   * return `{data: [{id, ...}]}`, so one permissive mapper covers both. The
+   * query filters the returned ids/labels client-side — neither endpoint
+   * accepts a search parameter the way OpenRouter does.
+   */
+  override async searchModels(query: string): Promise<ModelSearchResult[]> {
+    const baseURL = this.getEffectiveBaseUrl()
+    if (!baseURL) throw new Error('Generic provider base URL not configured')
+    const apiKey = this.getEffectiveApiKey()
+    if (!apiKey) throw new Error('Generic provider API key not configured')
+
+    const url = `${baseURL.replace(/\/+$/, '')}/v1/models`
+    let response: Response
+    try {
+      response = await fetch(url, { headers: { Authorization: `Bearer ${apiKey}` } })
+    } catch (error) {
+      throw new Error(
+        `Generic provider model listing failed: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new Error(
+          `Generic provider endpoint does not support model listing (${response.status} at ${url})`,
+        )
+      }
+      throw new Error(`Generic provider model listing failed (${response.status})`)
+    }
+
+    const body = (await response.json()) as RemoteModelsResponse
+    const data = Array.isArray(body.data) ? body.data : []
+    const mapped = data
+      .map((entry) => mapRemoteModel(entry as RemoteModelListing))
+      .filter((entry): entry is ModelSearchResult => entry !== null)
+
+    const q = query.trim().toLowerCase()
+    const filtered = q
+      ? mapped.filter((m) => m.id.toLowerCase().includes(q) || m.label.toLowerCase().includes(q))
+      : mapped
+    return filtered.slice(0, DISCOVERED_MODEL_LIMIT)
   }
 }

--- a/src/shared/lib/llm-provider/generic-provider.ts
+++ b/src/shared/lib/llm-provider/generic-provider.ts
@@ -197,7 +197,14 @@ export class GenericLlmProvider extends BaseLlmProvider {
       throw new Error(`Generic provider model listing failed (${response.status})`)
     }
 
-    const body = (await response.json()) as RemoteModelsResponse
+    let body: RemoteModelsResponse
+    try {
+      body = (await response.json()) as RemoteModelsResponse
+    } catch (error) {
+      throw new Error(
+        `Generic provider returned a non-JSON response: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
     const data = Array.isArray(body.data) ? body.data : []
     const mapped = data
       .map((entry) => mapRemoteModel(entry as RemoteModelListing))

--- a/src/shared/lib/llm-provider/generic-provider.ts
+++ b/src/shared/lib/llm-provider/generic-provider.ts
@@ -26,6 +26,26 @@ export const GENERIC_FALLBACK_MODEL = 'default'
  */
 const DISCOVERED_MODEL_LIMIT = 50
 const DISCOVERED_MODEL_EFFORTS: EffortLevel[] = ['low', 'medium', 'high']
+const REQUEST_TIMEOUT_MS = 15_000
+
+/**
+ * Fetch `<baseURL>/v1/models` with Bearer auth and a hard timeout. Returns
+ * the raw Response for the caller to interpret. Both Anthropic's `/v1/models`
+ * and OpenAI-compat endpoints (ollama, LiteLLM) speak this shape.
+ */
+async function fetchModelsList(baseURL: string, apiKey: string): Promise<Response> {
+  const url = `${baseURL.replace(/\/+$/, '')}/v1/models`
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  try {
+    return await fetch(url, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: controller.signal,
+    })
+  } finally {
+    clearTimeout(timer)
+  }
+}
 
 interface RemoteModelListing {
   id?: unknown
@@ -108,6 +128,14 @@ export class GenericLlmProvider extends BaseLlmProvider {
     }
   }
 
+  /**
+   * Validate credentials by probing `<baseURL>/v1/models` — the same endpoint
+   * search uses, so if validation passes, search works too. This avoids the
+   * chicken-and-egg problem of needing a real model id before any have been
+   * added: 200 means auth + connectivity both work, 401/403 pinpoints an auth
+   * failure, and a 404 is treated as a soft-warn (endpoint reachable but
+   * doesn't expose /v1/models — the user can still add models manually).
+   */
   async validateKey(
     apiKey: string,
     opts?: { baseUrl?: string },
@@ -115,17 +143,25 @@ export class GenericLlmProvider extends BaseLlmProvider {
     // baseURL may not be saved yet during first-time setup, so accept it inline.
     const baseURL = opts?.baseUrl?.trim() || this.getEffectiveBaseUrl()
     if (!baseURL) return { valid: false, error: 'Base URL is required' }
+    let response: Response
     try {
-      const client = new Anthropic({ apiKey: '', baseURL, authToken: apiKey })
-      await client.messages.create({
-        model: this.getDefaultModel('summarizer'),
-        max_tokens: 1,
-        messages: [{ role: 'user', content: 'Hi' }],
-      })
-      return { valid: true }
+      response = await fetchModelsList(baseURL, apiKey)
     } catch (error) {
-      return { valid: false, error: error instanceof Error ? error.message : 'Validation failed' }
+      const message = error instanceof Error && error.name === 'AbortError'
+        ? `Timed out after ${REQUEST_TIMEOUT_MS / 1000}s — check the base URL is reachable.`
+        : `Could not reach ${baseURL}: ${error instanceof Error ? error.message : String(error)}`
+      return { valid: false, error: message }
     }
+    if (response.ok) return { valid: true }
+    if (response.status === 401 || response.status === 403) {
+      return { valid: false, error: `Auth rejected (${response.status}) — check the API key.` }
+    }
+    if (response.status === 404) {
+      // Reachable but no /v1/models — key not verifiable this way. Allow save so
+      // the user can proceed to add models manually.
+      return { valid: true }
+    }
+    return { valid: false, error: `Endpoint returned ${response.status}` }
   }
 
   /**
@@ -141,11 +177,13 @@ export class GenericLlmProvider extends BaseLlmProvider {
     const apiKey = this.getEffectiveApiKey()
     if (!apiKey) throw new Error('Generic provider API key not configured')
 
-    const url = `${baseURL.replace(/\/+$/, '')}/v1/models`
     let response: Response
     try {
-      response = await fetch(url, { headers: { Authorization: `Bearer ${apiKey}` } })
+      response = await fetchModelsList(baseURL, apiKey)
     } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error(`Generic provider model listing timed out after ${REQUEST_TIMEOUT_MS / 1000}s`)
+      }
       throw new Error(
         `Generic provider model listing failed: ${error instanceof Error ? error.message : String(error)}`,
       )
@@ -153,7 +191,7 @@ export class GenericLlmProvider extends BaseLlmProvider {
     if (!response.ok) {
       if (response.status === 404) {
         throw new Error(
-          `Generic provider endpoint does not support model listing (${response.status} at ${url})`,
+          `Generic provider endpoint does not support model listing (404 at ${baseURL.replace(/\/+$/, '')}/v1/models)`,
         )
       }
       throw new Error(`Generic provider model listing failed (${response.status})`)

--- a/src/shared/lib/llm-provider/generic-provider.ts
+++ b/src/shared/lib/llm-provider/generic-provider.ts
@@ -1,0 +1,95 @@
+import Anthropic from '@anthropic-ai/sdk'
+import { BaseLlmProvider, type ModelPurpose } from './base-llm-provider'
+import type { ModelDefinition } from './model-catalog-schema'
+import { getSettings, getModelCatalogSettings } from '../config/settings'
+
+const BASE_URL_ENV = 'GENERIC_BASE_URL'
+const DEFAULT_MODEL_ENV = 'GENERIC_DEFAULT_MODEL'
+
+/**
+ * Ultimate fallback model id when the user has added no models and set no
+ * GENERIC_DEFAULT_MODEL. A placeholder — the generic provider is only usable
+ * once the user adds at least one model via the catalog editor (SUP-276).
+ */
+export const GENERIC_FALLBACK_MODEL = 'default'
+
+/**
+ * A user-pointed provider for any Anthropic-wire-compatible endpoint: a
+ * self-hosted gateway, a LiteLLM/proxy in Anthropic mode, or a localhost ollama
+ * fronted by such a proxy. Ships an EMPTY built-in catalog — users add their
+ * own models (SUP-276) — and takes a user-supplied baseURL + key.
+ *
+ * Wire format: Anthropic (same env shape as OpenRouter/Platform —
+ * ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN). ollama's native OpenAI-compatible
+ * API is NOT spoken directly; point at an Anthropic-compatible proxy.
+ */
+export class GenericLlmProvider extends BaseLlmProvider {
+  readonly id = 'generic' as const
+  readonly name = 'Generic'
+  protected readonly settingsKeyField = 'genericApiKey' as const
+  protected readonly envVarName = 'GENERIC_API_KEY'
+
+  /** User-supplied endpoint, from settings (preferred) or GENERIC_BASE_URL env. */
+  getEffectiveBaseUrl(): string | undefined {
+    const fromSettings = getSettings().apiKeys?.genericBaseUrl?.trim()
+    if (fromSettings) return fromSettings
+    const fromEnv = process.env[BASE_URL_ENV]?.trim()
+    return fromEnv || undefined
+  }
+
+  createClient(): Anthropic {
+    const baseURL = this.getEffectiveBaseUrl()
+    if (!baseURL) throw new Error('Generic provider base URL not configured')
+    const apiKey = this.getEffectiveApiKey()
+    if (!apiKey) throw new Error('Generic provider API key not configured')
+    // Anthropic-wire endpoint with Bearer auth (same shape as OpenRouter/Platform):
+    // apiKey '' suppresses the x-api-key header; authToken sends Authorization: Bearer.
+    return new Anthropic({ apiKey: '', baseURL, authToken: apiKey })
+  }
+
+  getBuiltinCatalog(): ModelDefinition[] {
+    // Empty by design — users add their models via the catalog editor (SUP-276).
+    return []
+  }
+
+  getDefaultModel(_purpose: ModelPurpose): string {
+    // No built-in catalog: default to the first user-added model, then an
+    // env-configurable default, then a placeholder the user overrides.
+    const firstUserModel = (getModelCatalogSettings()[this.id]?.overrides ?? [])
+      .find((entry) => entry.disabled !== true)?.id
+    if (firstUserModel) return firstUserModel
+    return process.env[DEFAULT_MODEL_ENV]?.trim() || GENERIC_FALLBACK_MODEL
+  }
+
+  getContainerEnvVars(): Record<string, string | undefined> {
+    // A 'localhost' endpoint (e.g. ollama on the host) isn't reachable as
+    // localhost from inside the agent container; rewrite to the host gateway
+    // (same translation the platform provider applies).
+    const containerUrl = this.getEffectiveBaseUrl()?.replace('://localhost', '://host.docker.internal')
+    return {
+      ANTHROPIC_API_KEY: '',
+      ANTHROPIC_BASE_URL: containerUrl,
+      ANTHROPIC_AUTH_TOKEN: this.getEffectiveApiKey(),
+    }
+  }
+
+  async validateKey(
+    apiKey: string,
+    opts?: { baseUrl?: string },
+  ): Promise<{ valid: boolean; error?: string }> {
+    // baseURL may not be saved yet during first-time setup, so accept it inline.
+    const baseURL = opts?.baseUrl?.trim() || this.getEffectiveBaseUrl()
+    if (!baseURL) return { valid: false, error: 'Base URL is required' }
+    try {
+      const client = new Anthropic({ apiKey: '', baseURL, authToken: apiKey })
+      await client.messages.create({
+        model: this.getDefaultModel('summarizer'),
+        max_tokens: 1,
+        messages: [{ role: 'user', content: 'Hi' }],
+      })
+      return { valid: true }
+    } catch (error) {
+      return { valid: false, error: error instanceof Error ? error.message : 'Validation failed' }
+    }
+  }
+}

--- a/src/shared/lib/llm-provider/index.ts
+++ b/src/shared/lib/llm-provider/index.ts
@@ -4,6 +4,7 @@ export { AnthropicLlmProvider } from './anthropic-provider'
 export { OpenRouterLlmProvider } from './openrouter-provider'
 export { BedrockLlmProvider } from './bedrock-provider'
 export { PlatformLlmProvider } from './platform-provider'
+export { GenericLlmProvider } from './generic-provider'
 export {
   modelDefinitionSchema,
   modelCatalogSchema,
@@ -37,6 +38,7 @@ import { AnthropicLlmProvider } from './anthropic-provider'
 import { OpenRouterLlmProvider } from './openrouter-provider'
 import { BedrockLlmProvider } from './bedrock-provider'
 import { PlatformLlmProvider } from './platform-provider'
+import { GenericLlmProvider } from './generic-provider'
 import { getSettings } from '../config/settings'
 
 const providers: Record<LlmProviderId, BaseLlmProvider> = {
@@ -44,6 +46,7 @@ const providers: Record<LlmProviderId, BaseLlmProvider> = {
   openrouter: new OpenRouterLlmProvider(),
   bedrock: new BedrockLlmProvider(),
   platform: new PlatformLlmProvider(),
+  generic: new GenericLlmProvider(),
 }
 
 /** Get a specific provider by ID. */

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -411,6 +411,35 @@ describe('resolveModelForProvider', () => {
     expect(resolveModelForProvider('opus', 'anthropic', 'agent')).toBe('claude-opus-4-9-custom')
   })
 
+  it('handles the generic provider empty built-in catalog: resolves user-added ids, passes versioned pins, else falls back to the default', () => {
+    settingsMock.mockReturnValue({
+      llmProvider: 'generic',
+      modelCatalog: {
+        generic: {
+          overrides: [
+            {
+              id: 'llama3.1',
+              label: 'Llama 3.1',
+              supportedEfforts: ['low', 'medium', 'high'],
+            },
+          ],
+        },
+      },
+    })
+
+    // 1. A user-added id resolves exactly (it lives in the effective catalog).
+    expect(resolveModelForProvider('llama3.1', 'generic', 'agent')).toBe('llama3.1')
+    // 2. An unknown but versioned selection passes straight through to the SDK.
+    expect(resolveModelForProvider('mixtral-8x7b', 'generic', 'agent')).toBe('mixtral-8x7b')
+    // 3. An unknown alias falls back to the default — the first user-added model.
+    expect(resolveModelForProvider('mystery', 'generic', 'agent')).toBe('llama3.1')
+  })
+
+  it('falls back to the generic placeholder default when no user models are configured', () => {
+    settingsMock.mockReturnValue({ llmProvider: 'generic' })
+    expect(resolveModelForProvider('mystery', 'generic', 'agent')).toBe('default')
+  })
+
   it('falls back cleanly when the only latest member of a family is disabled', () => {
     settingsMock.mockReturnValue({
       llmProvider: 'anthropic',


### PR DESCRIPTION
## Generic LLM provider (custom baseURL + API key) — SUP-277

Adds a new `generic` provider that lets users point SuperAgent at any custom
endpoint — a localhost ollama instance (via a proxy), a self-hosted gateway, or
any Anthropic-compatible proxy — so non-hosted / local models run without us
shipping anything.

Linear: https://linear.app/datawizz/issue/SUP-277/generic-llm-provider-custom-baseurl-api-key-for-ollamalocalhost

### Open question — wire format (resolved)
The ticket flagged that ollama natively exposes an **OpenAI-compatible** API, not
the Anthropic wire format, and asked whether `generic` should assume an
Anthropic-compatible endpoint or ship an OpenAI adapter.

**Decision: Anthropic-wire-compatible**, matching the ticket's explicit
`getContainerEnvVars()` spec (`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`, same
shape as OpenRouter/Platform). This works with proxies / LiteLLM in Anthropic
mode and any Anthropic-compatible gateway. Raw ollama (OpenAI-native) is reached
by fronting it with such a proxy; a full OpenAI adapter would be a much larger,
separate effort and is out of scope here. The Settings UI states this explicitly.

### What's included
- **`GenericLlmProvider`** (`src/shared/lib/llm-provider/generic-provider.ts`):
  - User-supplied **baseURL** + **API key** stored in `settings.apiKeys`
    (`genericBaseUrl`, `genericApiKey`); env fallbacks `GENERIC_BASE_URL` /
    `GENERIC_API_KEY`.
  - `getBuiltinCatalog()` → `[]` (users add models via the SUP-276 catalog editor).
  - `getContainerEnvVars()` sets `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`,
    rewriting `://localhost` → `://host.docker.internal` so a host ollama is
    reachable from the agent container (same translation the platform provider uses).
  - `getDefaultModel()` → first user-added model, else `GENERIC_DEFAULT_MODEL`,
    else a placeholder.
  - `validateKey(apiKey, { baseUrl })` — accepts an inline baseURL for first-time
    setup before anything is saved.
- Registered in the provider map; `generic` added to `LlmProviderId`.
- **Settings UI**: new `GenericCredentialsInput` (baseURL + key + Validate & Save),
  wired into the LLM settings tab. The catalog editor already renders for `generic`.
- **API**: `validate-llm-key` accepts an optional `baseUrl` and allows `generic`;
  `apiKeyStatus.generic` surfaced in the settings response.
- **Resolver**: confirmed `resolveModelForProvider` behaves for an empty built-in
  catalog — resolves user-added ids, passes versioned pins straight through, and
  falls back to the default. Added tests.

### Testing
- New `generic-provider.test.ts` (16 tests) + new resolver cases in
  `model-catalog.test.ts`.
- `npm run typecheck` — clean.
- `npm run lint` — 0 errors.
- Targeted suites for the touched areas (llm-provider, settings/llm routes) —
  207 passing. (The repo's broader renderer component tests currently fail in this
  environment due to a pre-existing React-render issue unrelated to this change,
  reproduced on a clean tree.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
