### PR TITLE
fix(SUP-366): align Done button height with Decline on browser-input card

### DIFF
--- a/src/renderer/components/messages/browser-input-request-item.test.tsx
+++ b/src/renderer/components/messages/browser-input-request-item.test.tsx
@@ -74,6 +74,20 @@ describe('BrowserInputRequestItem', () => {
     expect(screen.getByTestId('browser-input-complete-btn')).toBeInTheDocument()
   })
 
+  // Regression for SUP-366: the Done button carried an `h-8` override while the
+  // Decline button uses the shared `xs` size (`h-7`), so the two ends of the
+  // action row were different heights. Every other request card (connected
+  // account, secret, file, etc.) renders both buttons at the `xs` height with
+  // no override; the browser-input card must match that.
+  it('renders Done and Decline at the same height (xs / h-7, no h-8 override)', () => {
+    render(<BrowserInputRequestItem {...defaultProps} />)
+    const done = screen.getByTestId('browser-input-complete-btn')
+    const decline = screen.getByTestId('browser-input-decline-btn')
+    expect(done.className).toContain('h-7')
+    expect(done.className).not.toContain('h-8')
+    expect(decline.className).toContain('h-7')
+  })
+
   it('decline with no reason → posts only the decline, shows Declined, touches no draft or error', async () => {
     const user = userEvent.setup()
     mockApiFetch.mockResolvedValueOnce(ok())

--- a/src/renderer/components/messages/browser-input-request-item.tsx
+++ b/src/renderer/components/messages/browser-input-request-item.tsx
@@ -101,7 +101,7 @@ export function BrowserInputRequestItem({
           loading={submittingAction === 'completing'}
           disabled={status === 'submitting'}
           size="xs"
-          className="h-8 min-w-24 bg-blue-600 text-white hover:bg-blue-700"
+          className="min-w-24 bg-blue-600 text-white hover:bg-blue-700"
           data-testid="browser-input-complete-btn"
         >
           Done


### PR DESCRIPTION
## Summary

The **Browser Input Request Card** rendered its **Done** and **Decline** buttons at different heights: the `Done` button carried an explicit `h-8` (32px) override while `DeclineButton` uses the shared `xs` size (`h-7`, 28px).

Every other request card (connected account, secret, file, question, etc.) renders both its primary action and the decline button at the `xs` height with no height override. This change drops the `h-8` override so the browser-input card matches that standard and the two ends of the action row line up.

## Change

- `browser-input-request-item.tsx`: removed `h-8` from the Done button's className (keeps `min-w-24` + colors), so `size="xs"` (`h-7`) applies — identical to the Decline button.

## Testing

- Added a regression test asserting Done and Decline both render at `h-7` with no `h-8` override.
- `npm run test:run` (full suite), `npm run typecheck`, `npm run lint` all pass.

Linear: https://linear.app/datawizz/issue/SUP-366/browser-input-request-card-in-session-view-mismatch-between-done-and

Closes SUP-366
