### PR TITLE
chore(deps): upgrade better-auth 1.4.20 → 1.6.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@types/react-file-icon": "^1.0.4",
         "analytics": "^0.8.19",
         "archiver": "^7.0.1",
-        "better-auth": "^1.4.19",
+        "better-auth": "^1.6.23",
         "better-sqlite3": "^12.8.0",
         "ccusage": "^15.2.0",
         "chrono-node": "^2.9.0",
@@ -2460,44 +2460,137 @@
       }
     },
     "node_modules/@better-auth/core": {
-      "version": "1.4.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.20.tgz",
-      "integrity": "sha512-Qf29DOL4LricVJWsPOwg2Ymm+qfYQ14EkyTlnMOp8qKSPzbfMSgRvr6oiwZqmUFxystJ3ft8TzDwTvOSAuNbfA==",
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.23.tgz",
+      "integrity": "sha512-beEhOs0uVeOxYOZKUfIEBd/nQV2Bd4/6wyLxZ0OFkn6CMTK2Vi+hXuZLnyPBeB6RdHpebEoJWiHqwHxBIxgPDQ==",
+      "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "zod": "^4.3.5"
+        "@opentelemetry/semantic-conventions": "^1.39.0",
+        "@standard-schema/spec": "^1.1.0",
+        "zod": "^4.3.6"
       },
       "peerDependencies": {
-        "@better-auth/utils": "0.3.0",
-        "@better-fetch/fetch": "1.1.21",
-        "better-call": "1.1.8",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1",
+        "@cloudflare/workers-types": ">=4",
+        "@opentelemetry/api": "^1.9.0",
+        "better-call": "1.3.7",
         "jose": "^6.1.0",
-        "kysely": "^0.28.5",
+        "kysely": "^0.28.5 || ^0.29.0",
         "nanostores": "^1.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/drizzle-adapter": {
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.23.tgz",
+      "integrity": "sha512-2+/PTVfIP9E7iz6af8TB3lhnowHUj9ljC66kECmHaFEdUqPgzHoWux9epotKwO7XDg2ui4ttWQ8CMeNFLvQeKQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "drizzle-orm": "^0.45.2"
+      },
+      "peerDependenciesMeta": {
+        "drizzle-orm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/kysely-adapter": {
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.23.tgz",
+      "integrity": "sha512-zbNJsMbG09exfkGyvFqBLLqWoMPAUWjxCuUnEK5AsjbYoZeIjj/QGZgdf4CapVWryKxjA9Q6Jlr6fbiPpC3VAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "kysely": "^0.28.17 || ^0.29.0"
+      },
+      "peerDependenciesMeta": {
+        "kysely": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/memory-adapter": {
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.23.tgz",
+      "integrity": "sha512-krIiR0pIVkaKlAzm690n5bcMW4NGbqeMg0HQSD9fz/KcQF/eWLqcq9gG/BhHTj2i/y96qH+W5JWPmaSOS5iTgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2"
+      }
+    },
+    "node_modules/@better-auth/mongo-adapter": {
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.23.tgz",
+      "integrity": "sha512-7+QdevitGlKBbP6JbiSk5SBnzPsKV/mDrQBGBn8hwByQLeJwqpqbuBPw7ZI8vzUlFfAAnyFiqwP3Eb8mxnp7pA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "mongodb": "^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mongodb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/prisma-adapter": {
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.23.tgz",
+      "integrity": "sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
       }
     },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.4.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.4.20.tgz",
-      "integrity": "sha512-ItRo5WswZl6gU8MPRrcn94d7mXk7vbN2zi6gSX8y2QcILRv7aXr6WhxTNKNeh5pnBUfIPdFYZcOnGf1uwgNKxg==",
-      "dependencies": {
-        "@better-auth/utils": "0.3.0",
-        "@better-fetch/fetch": "1.1.21"
-      },
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.23.tgz",
+      "integrity": "sha512-/R2Kb+z2BpDOOWwVHqOk+c0VNpuwfCv4Hp5Yr9003WIZPax/zyNraGLB9CFE8qF2gZW8Dsz419k4I8CPrGzpDA==",
+      "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.4.20"
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1"
       }
     },
     "node_modules/@better-auth/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
-      "license": "MIT"
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.2.tgz",
+      "integrity": "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
     },
     "node_modules/@better-fetch/fetch": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.3.1.tgz",
+      "integrity": "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==",
+      "license": "MIT"
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -10979,23 +11072,28 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.4.20",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.4.20.tgz",
-      "integrity": "sha512-cUQaUhZ/EZwb7xgoL9wHl78yWp0eaxC/L++B/r8RJxk23L766Tk7fLjWG6bQK8eAHDDpfQNwXsJowiei8tJWJw==",
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.23.tgz",
+      "integrity": "sha512-4vOaRd9UiKGKm9R+ej0jjU1es3MiJIiNc9Qq3VCnYqOZ4/nb5272QqTxWYoDxyUXl5x6A2x2we5KZKQO9teTQQ==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.4.20",
-        "@better-auth/telemetry": "1.4.20",
-        "@better-auth/utils": "0.3.0",
-        "@better-fetch/fetch": "1.1.21",
-        "@noble/ciphers": "^2.0.0",
-        "@noble/hashes": "^2.0.0",
-        "better-call": "1.1.8",
+        "@better-auth/core": "1.6.23",
+        "@better-auth/drizzle-adapter": "1.6.23",
+        "@better-auth/kysely-adapter": "1.6.23",
+        "@better-auth/memory-adapter": "1.6.23",
+        "@better-auth/mongo-adapter": "1.6.23",
+        "@better-auth/prisma-adapter": "1.6.23",
+        "@better-auth/telemetry": "1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1",
+        "@noble/ciphers": "^2.1.1",
+        "@noble/hashes": "^2.0.1",
+        "better-call": "1.3.7",
         "defu": "^6.1.4",
-        "jose": "^6.1.0",
-        "kysely": "^0.28.5",
-        "nanostores": "^1.0.1",
-        "zod": "^4.3.5"
+        "jose": "^6.1.3",
+        "kysely": "^0.28.17 || ^0.29.0",
+        "nanostores": "^1.1.1",
+        "zod": "^4.3.6"
       },
       "peerDependencies": {
         "@lynx-js/react": "*",
@@ -11005,7 +11103,7 @@
         "@tanstack/solid-start": "^1.0.0",
         "better-sqlite3": "^12.0.0",
         "drizzle-kit": ">=0.31.4",
-        "drizzle-orm": ">=0.41.0",
+        "drizzle-orm": "^0.45.2",
         "mongodb": "^6.0.0 || ^7.0.0",
         "mysql2": "^3.0.0",
         "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -11079,15 +11177,15 @@
       }
     },
     "node_modules/better-call": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.8.tgz",
-      "integrity": "sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.7.tgz",
+      "integrity": "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/utils": "^0.3.0",
-        "@better-fetch/fetch": "^1.1.4",
-        "rou3": "^0.7.10",
-        "set-cookie-parser": "^2.7.1"
+        "@better-auth/utils": "^0.4.0",
+        "@better-fetch/fetch": "^1.1.21",
+        "rou3": "^0.7.12",
+        "set-cookie-parser": "^3.0.1"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
@@ -20873,9 +20971,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.1.tgz",
+      "integrity": "sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==",
       "license": "MIT"
     },
     "node_modules/set-function-length": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@types/react-file-icon": "^1.0.4",
     "analytics": "^0.8.19",
     "archiver": "^7.0.1",
-    "better-auth": "^1.4.19",
+    "better-auth": "^1.6.23",
     "better-sqlite3": "^12.8.0",
     "ccusage": "^15.2.0",
     "chrono-node": "^2.9.0",

--- a/src/shared/lib/auth/index.ts
+++ b/src/shared/lib/auth/index.ts
@@ -14,8 +14,10 @@ import { getGenericOAuthProviderConfigs } from './provider-config'
 // so consumers that only need the check don't pull in ESM deps.
 export { isAuthMode } from './mode'
 
-// Lazy singleton for the Better Auth instance
-let _auth: ReturnType<typeof betterAuth> | null = null
+// Lazy singleton for the Better Auth instance.
+// Typed via createAuthInstance so the concrete plugin/option inference is
+// preserved (betterAuth's generic default is not assignable since 1.6).
+let _auth: ReturnType<typeof createAuthInstance> | null = null
 
 /**
  * Reset the Better Auth singleton so the next getAuth() call
@@ -31,140 +33,155 @@ export function resetAuth() {
  */
 export function getAuth() {
   if (!_auth) {
-    const trustedOrigins = getTrustedOrigins()
-    const settings = getSettings()
-    const authSettings = { ...DEFAULT_AUTH_SETTINGS, ...settings.auth }
-    const oauthProviders = getGenericOAuthProviderConfigs()
-    const oauthPlugin = oauthProviders.length > 0
-      ? genericOAuth({
-          config: oauthProviders,
-        })
-      : null
+    _auth = createAuthInstance()
+  }
+  return _auth
+}
 
-    _auth = betterAuth({
-      database: drizzleAdapter(db, {
-        provider: 'sqlite',
-        schema: {
-          user: schema.user,
-          session: schema.authSession,
-          account: schema.authAccount,
-          verification: schema.verification,
+function createAuthInstance() {
+  const trustedOrigins = getTrustedOrigins()
+  const settings = getSettings()
+  const authSettings = { ...DEFAULT_AUTH_SETTINGS, ...settings.auth }
+  const oauthProviders = getGenericOAuthProviderConfigs()
+  const oauthPlugin = oauthProviders.length > 0
+    ? genericOAuth({
+        config: oauthProviders,
+      })
+    : null
+
+  return betterAuth({
+    database: drizzleAdapter(db, {
+      provider: 'sqlite',
+      schema: {
+        user: schema.user,
+        session: schema.authSession,
+        account: schema.authAccount,
+        verification: schema.verification,
+      },
+    }),
+    emailAndPassword: {
+      enabled: true,
+      minPasswordLength: authSettings.passwordMinLength,
+      maxPasswordLength: authSettings.passwordMaxLength,
+    },
+    account: {
+      accountLinking: {
+        // Keep pre-1.6.11 behavior: OAuth sign-in with a matching email
+        // auto-links to the local account even if its email is unverified.
+        // This app does not require email verification, so the hardened
+        // default would stop OAuth/password accounts from merging.
+        // The option is deprecated upstream and the secure gate becomes
+        // unconditional in the next minor — revisit before moving past 1.6.
+        requireLocalEmailVerified: false,
+      },
+    },
+    session: {
+      expiresIn: (authSettings.sessionMaxLifetimeHrs ?? 24) * 3600,
+      updateAge: (authSettings.sessionIdleTimeoutMin ?? 60) * 60,
+    },
+    user: {
+      additionalFields: {
+        mustChangePassword: {
+          type: 'boolean',
+          required: false,
+          defaultValue: false,
+          input: false, // users cannot set this on self-registration
         },
+      },
+    },
+    plugins: [
+      admin({
+        defaultRole: authSettings.defaultUserRole === 'admin' ? 'admin' : 'user',
       }),
-      emailAndPassword: {
-        enabled: true,
-        minPasswordLength: authSettings.passwordMinLength,
-        maxPasswordLength: authSettings.passwordMaxLength,
-      },
-      session: {
-        expiresIn: (authSettings.sessionMaxLifetimeHrs ?? 24) * 3600,
-        updateAge: (authSettings.sessionIdleTimeoutMin ?? 60) * 60,
-      },
+      ...(oauthPlugin ? [oauthPlugin] : []),
+    ],
+    secret: getOrCreateAuthSecret(),
+    baseURL: getAppBaseUrl(),
+    // When trustedOrigins is explicitly configured, use that list.
+    // Otherwise allow all origins (matches spec: "Default: allow all origins").
+    trustedOrigins: trustedOrigins.length > 0
+      ? trustedOrigins
+      : (request) => {
+          const origin = request?.headers.get('origin')
+          return origin ? [origin] : []
+        },
+    databaseHooks: {
       user: {
-        additionalFields: {
-          mustChangePassword: {
-            type: 'boolean',
-            required: false,
-            defaultValue: false,
-            input: false, // users cannot set this on self-registration
+        create: {
+          after: async (createdUser) => {
+            try {
+              // Atomic: only promote if this is the sole user in the table
+              const result = db
+                .update(schema.user)
+                .set({ role: 'admin' })
+                .where(
+                  and(
+                    eq(schema.user.id, createdUser.id),
+                    sql`(SELECT count(*) FROM user) = 1`
+                  )
+                )
+                .run()
+              if (result.changes > 0) {
+                console.log(`First user ${createdUser.email} promoted to admin`)
+              }
+
+              // If admin approval is required and this is NOT the first user,
+              // auto-ban them pending admin review.
+              // Read fresh settings so runtime changes are picked up without
+              // needing to recreate the Better Auth singleton.
+              const currentSettings = getSettings()
+              const currentAuth = { ...DEFAULT_AUTH_SETTINGS, ...currentSettings.auth }
+              if (result.changes === 0 && currentAuth.requireAdminApproval) {
+                db.update(schema.user)
+                  .set({ banned: true, banReason: 'Pending admin approval' })
+                  .where(eq(schema.user.id, createdUser.id))
+                  .run()
+                console.log(`User ${createdUser.email} requires admin approval`)
+              }
+            } catch (err) {
+              console.error('Failed to check/set admin role:', err)
+            }
           },
         },
       },
-      plugins: [
-        admin({
-          defaultRole: authSettings.defaultUserRole === 'admin' ? 'admin' : 'user',
-        }),
-        ...(oauthPlugin ? [oauthPlugin] : []),
-      ],
-      secret: getOrCreateAuthSecret(),
-      baseURL: getAppBaseUrl(),
-      // When trustedOrigins is explicitly configured, use that list.
-      // Otherwise allow all origins (matches spec: "Default: allow all origins").
-      trustedOrigins: trustedOrigins.length > 0
-        ? trustedOrigins
-        : (request) => {
-            const origin = request?.headers.get('origin')
-            return origin ? [origin] : []
-          },
-      databaseHooks: {
-        user: {
-          create: {
-            after: async (createdUser) => {
-              try {
-                // Atomic: only promote if this is the sole user in the table
-                const result = db
-                  .update(schema.user)
-                  .set({ role: 'admin' })
+      account: {
+        update: {
+          after: async (account) => {
+            // Auto-clear mustChangePassword when a user changes their password.
+            // The changePassword endpoint calls updateAccount() which returns the
+            // full row via .returning(), so we have userId and providerId here.
+            // Admin setUserPassword uses updateMany (returns count, not row) — no-op.
+            try {
+              if (account && account.providerId === 'credential' && account.userId) {
+                db.update(schema.user)
+                  .set({ mustChangePassword: false })
                   .where(
                     and(
-                      eq(schema.user.id, createdUser.id),
-                      sql`(SELECT count(*) FROM user) = 1`
+                      eq(schema.user.id, account.userId as string),
+                      eq(schema.user.mustChangePassword, true)
                     )
                   )
                   .run()
-                if (result.changes > 0) {
-                  console.log(`First user ${createdUser.email} promoted to admin`)
-                }
-
-                // If admin approval is required and this is NOT the first user,
-                // auto-ban them pending admin review.
-                // Read fresh settings so runtime changes are picked up without
-                // needing to recreate the Better Auth singleton.
-                const currentSettings = getSettings()
-                const currentAuth = { ...DEFAULT_AUTH_SETTINGS, ...currentSettings.auth }
-                if (result.changes === 0 && currentAuth.requireAdminApproval) {
-                  db.update(schema.user)
-                    .set({ banned: true, banReason: 'Pending admin approval' })
-                    .where(eq(schema.user.id, createdUser.id))
-                    .run()
-                  console.log(`User ${createdUser.email} requires admin approval`)
-                }
-              } catch (err) {
-                console.error('Failed to check/set admin role:', err)
               }
-            },
-          },
-        },
-        account: {
-          update: {
-            after: async (account) => {
-              // Auto-clear mustChangePassword when a user changes their password.
-              // The changePassword endpoint calls updateAccount() which returns the
-              // full row via .returning(), so we have userId and providerId here.
-              // Admin setUserPassword uses updateMany (returns count, not row) — no-op.
-              try {
-                if (account && account.providerId === 'credential' && account.userId) {
-                  db.update(schema.user)
-                    .set({ mustChangePassword: false })
-                    .where(
-                      and(
-                        eq(schema.user.id, account.userId as string),
-                        eq(schema.user.mustChangePassword, true)
-                      )
-                    )
-                    .run()
-                }
-              } catch (err) {
-                console.error('Failed to clear mustChangePassword:', err)
-              }
-            },
-          },
-        },
-        session: {
-          create: {
-            after: async (session) => {
-              try {
-                const sessSettings = getSettings()
-                const sessAuth = { ...DEFAULT_AUTH_SETTINGS, ...sessSettings.auth }
-                enforceMaxConcurrentSessions(session.userId, sessAuth.maxConcurrentSessions ?? 5)
-              } catch (err) {
-                console.error('Failed to enforce max concurrent sessions:', err)
-              }
-            },
+            } catch (err) {
+              console.error('Failed to clear mustChangePassword:', err)
+            }
           },
         },
       },
-    })
-  }
-  return _auth
+      session: {
+        create: {
+          after: async (session) => {
+            try {
+              const sessSettings = getSettings()
+              const sessAuth = { ...DEFAULT_AUTH_SETTINGS, ...sessSettings.auth }
+              enforceMaxConcurrentSessions(session.userId, sessAuth.maxConcurrentSessions ?? 5)
+            } catch (err) {
+              console.error('Failed to enforce max concurrent sessions:', err)
+            }
+          },
+        },
+      },
+    },
+  })
 }


### PR DESCRIPTION
## Why
Clears the last **critical** npm-audit item on main. The critical advisory itself (refresh-token replay) lives in the `oidcProvider`/`mcp-server` plugins we don't use, but three advisories DO hit our surface (admin + genericOAuth):
- OAuth state-mismatch without PKCE (fixed 1.6.2)
- Account takeover via OAuth auto-link to an unverified local email (fixed 1.6.11)
- Stale sessions surviving admin user-deletion (fixed 1.6.13)

1.6.23 published 2026-06-29 — clears the 7-day cooldown.

## Changes
- `better-auth` `^1.4.19` → `^1.6.23`
- **`account.accountLinking.requireLocalEmailVerified: false`** — keeps the pre-1.6.11 linking UX (OAuth sign-in with a matching email still auto-merges into the local account even when its email is unverified; we don't require email verification, so the hardened default would have blocked merging). ⚠️ Upstream deprecates this option and makes the secure gate unconditional in the next minor — must revisit before 1.7 (which also removes `signIn.oauth2`, used in auth-page.tsx).
- Auth singleton re-typed via `createAuthInstance()` — in 1.6 `betterAuth(...)`'s concrete return type no longer assigns to `Auth<BetterAuthOptions>`, which silently broke null-narrowing for every `getAuth()` caller.

## No DB migration
Regenerated the Better Auth schema with `@better-auth/cli generate` (1.6.23, same plugin set) and diffed against `schema.ts`: all four auth tables identical column-for-column.

## Behavioral notes (1.4 → 1.6)
- `databaseHooks` after-hooks now run **post-commit** (1.5.0) — first-user admin promotion, admin-approval auto-ban, mustChangePassword clearing, and session-cap enforcement all covered by the auth E2E suite.
- No API-surface changes for the plugins in use (admin, genericOAuth, drizzleAdapter, better-auth/crypto).

## Verification
- typecheck + lint clean
- unit: 6400 passed
- **auth E2E: 54/54** (sign-in/up, first-user promotion, ForcePasswordChange, session limits, 401-stash flows)
- Runtime check: `getAuth().options.account.accountLinking` resolves to `{"requireLocalEmailVerified":false}` in AUTH_MODE