### PR TITLE
fix: sync pending user-input requests across tabs viewing the same session (SUP-336)

### DIFF
--- a/e2e/specs/concurrent-tabs-request-sync.spec.ts
+++ b/e2e/specs/concurrent-tabs-request-sync.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+
+/**
+ * Two tabs viewing the same session must stay in sync on pending user-input
+ * requests. Each tab holds its request cards in EventSource-fed local state:
+ * the tab that resolves a request removes its card via a local optimistic
+ * update, and every OTHER tab must drop the card when the server broadcasts
+ * that request's tool_result.
+ *
+ * Regression: the non-resolving tab kept showing the already-resolved card
+ * until the whole turn ended (session_idle), because the renderer's
+ * tool_result handler never removed entries from the pending-request lists.
+ *
+ * The `ask parallel` scenario (secret + question) is used deliberately:
+ * resolving only one of the two requests keeps the session active, so the
+ * session_idle turn boundary cannot mask a missing per-request sync.
+ */
+test.describe('Concurrent tabs: pending request sync', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+    await agentPage.createAgent(`Two Tab Agent ${testInfo.workerIndex}-${Date.now()}`)
+  })
+
+  /** Open the current session in a second tab of the same browser context. */
+  async function openSecondTab(page: import('@playwright/test').Page) {
+    await expect(page).toHaveURL(/\/agents\/[^/]+\/sessions\/[^/?#]+/)
+    const pageB = await page.context().newPage()
+    await pageB.goto(page.url())
+    return pageB
+  }
+
+  test('providing a secret in one tab clears it in the other while the question stays pending', async ({ page }) => {
+    await sessionPage.sendMessage('ask parallel')
+    await sessionPage.waitForSecretRequest('DATABASE_URL')
+    await sessionPage.waitForQuestionRequest()
+
+    const pageB = await openSecondTab(page)
+    const sessionB = new SessionPage(pageB)
+    // The second tab joined after the one-shot request broadcasts; the server
+    // replays pending requests on stream connect.
+    await sessionB.waitForSecretRequest('DATABASE_URL')
+    await sessionB.waitForQuestionRequest()
+
+    // Resolve the secret in tab A — its card disappears locally.
+    await sessionPage.provideSecret('postgres://localhost:5432/db', 'DATABASE_URL')
+    await expect(sessionPage.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
+
+    // Tab B must drop the resolved secret card too, while the still-pending
+    // question card stays. The session is still active here, so only a
+    // per-request sync (not the turn boundary) can clear it.
+    await expect(sessionB.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
+    await expect(sessionB.getQuestionRequests()).toHaveCount(1)
+    await expect(sessionPage.getQuestionRequests()).toHaveCount(1)
+
+    // Reverse direction: answer the question from tab B, tab A follows.
+    await sessionB.answerQuestion('AWS')
+    await expect(sessionB.getQuestionRequests()).toHaveCount(0, { timeout: 10000 })
+    await expect(sessionPage.getQuestionRequests()).toHaveCount(0, { timeout: 10000 })
+
+    // Both inputs resolved — the session completes in both tabs.
+    await sessionPage.waitForInputEnabled(15000)
+    await sessionB.waitForInputEnabled(15000)
+    await pageB.close()
+  })
+
+  test('answering the question in one tab keeps the secret request pending in both tabs', async ({ page }) => {
+    await sessionPage.sendMessage('ask parallel')
+    await sessionPage.waitForSecretRequest('DATABASE_URL')
+    await sessionPage.waitForQuestionRequest()
+
+    const pageB = await openSecondTab(page)
+    const sessionB = new SessionPage(pageB)
+    await sessionB.waitForSecretRequest('DATABASE_URL')
+    await sessionB.waitForQuestionRequest()
+
+    // Resolve the question in tab A this time (reverse order of the tests
+    // above) — only the question card may disappear, in both tabs.
+    await sessionPage.answerQuestion('AWS')
+    await expect(sessionPage.getQuestionRequests()).toHaveCount(0, { timeout: 10000 })
+    await expect(sessionB.getQuestionRequests()).toHaveCount(0, { timeout: 10000 })
+
+    // The unresolved secret request must survive in BOTH tabs.
+    await expect(sessionPage.getSecretRequests()).toHaveCount(1)
+    await expect(sessionB.getSecretRequests()).toHaveCount(1)
+
+    // And it must still be functional cross-tab: provide it from tab B and
+    // watch tab A clear and the session complete everywhere.
+    await sessionB.provideSecret('postgres://localhost:5432/db', 'DATABASE_URL')
+    await expect(sessionB.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
+    await expect(sessionPage.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
+    await sessionPage.waitForInputEnabled(15000)
+    await sessionB.waitForInputEnabled(15000)
+    await pageB.close()
+  })
+
+  test('declining a secret in one tab clears it in the other', async ({ page }) => {
+    await sessionPage.sendMessage('ask parallel')
+    await sessionPage.waitForSecretRequest('DATABASE_URL')
+    await sessionPage.waitForQuestionRequest()
+
+    const pageB = await openSecondTab(page)
+    const sessionB = new SessionPage(pageB)
+    await sessionB.waitForSecretRequest('DATABASE_URL')
+    await sessionB.waitForQuestionRequest()
+
+    // Decline (reject path) in tab A.
+    await sessionPage.declineSecret('DATABASE_URL')
+    await expect(sessionPage.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
+
+    // Tab B drops the declined card; the question remains pending in both.
+    await expect(sessionB.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
+    await expect(sessionB.getQuestionRequests()).toHaveCount(1)
+    await expect(sessionPage.getQuestionRequests()).toHaveCount(1)
+
+    // Finish the turn so the session settles cleanly.
+    await sessionB.answerQuestion('GCP')
+    await expect(sessionPage.getQuestionRequests()).toHaveCount(0, { timeout: 10000 })
+    await sessionPage.waitForInputEnabled(15000)
+    await pageB.close()
+  })
+})

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -871,6 +871,13 @@ function getOrCreateEventSource(
             isStreaming: false,
           })
         }
+        // A tool_result for a pending user-input request means it was resolved —
+        // possibly by another tab/window viewing the same session. The resolving
+        // tab removes its card optimistically; every other tab relies on this
+        // broadcast to drop the stale card instead of waiting for session_idle.
+        if (data.type === 'tool_result' && typeof data.toolUseId === 'string') {
+          removePendingRequestsByToolUseId(sessionId, data.toolUseId)
+        }
         queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
       }
       else if (data.type === 'context_usage') {
@@ -1367,6 +1374,40 @@ function releaseEventSource(sessionId: string): void {
       eventSources.delete(key)
     }
     refCounts.delete(key)
+  }
+}
+
+// Drop any pending user-input request matching a resolved tool call. Driven by
+// the server's `tool_result` broadcast, which fires for every tool — for ids
+// that never had a request card this is a no-op (no state write, no re-render).
+function removePendingRequestsByToolUseId(sessionId: string, toolUseId: string): void {
+  const current = streamStates.get(sessionId)
+  if (!current) return
+  const strip = <T extends { toolUseId: string }>(list: T[]): T[] =>
+    list.some((r) => r.toolUseId === toolUseId) ? list.filter((r) => r.toolUseId !== toolUseId) : list
+  const next: StreamState = {
+    ...current,
+    pendingSecretRequests: strip(current.pendingSecretRequests),
+    pendingConnectedAccountRequests: strip(current.pendingConnectedAccountRequests),
+    pendingQuestionRequests: strip(current.pendingQuestionRequests),
+    pendingFileRequests: strip(current.pendingFileRequests),
+    pendingRemoteMcpRequests: strip(current.pendingRemoteMcpRequests),
+    pendingBrowserInputRequests: strip(current.pendingBrowserInputRequests),
+    pendingScriptRunRequests: strip(current.pendingScriptRunRequests),
+    pendingComputerUseRequests: strip(current.pendingComputerUseRequests),
+  }
+  const changed =
+    next.pendingSecretRequests !== current.pendingSecretRequests ||
+    next.pendingConnectedAccountRequests !== current.pendingConnectedAccountRequests ||
+    next.pendingQuestionRequests !== current.pendingQuestionRequests ||
+    next.pendingFileRequests !== current.pendingFileRequests ||
+    next.pendingRemoteMcpRequests !== current.pendingRemoteMcpRequests ||
+    next.pendingBrowserInputRequests !== current.pendingBrowserInputRequests ||
+    next.pendingScriptRunRequests !== current.pendingScriptRunRequests ||
+    next.pendingComputerUseRequests !== current.pendingComputerUseRequests
+  if (changed) {
+    streamStates.set(sessionId, next)
+    streamListeners.get(sessionId)?.forEach((listener) => listener())
   }
 }
 

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1720,15 +1720,39 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     }
 
     // Handle input resolve/reject — decrement pending count and complete session when all done
-    const resolveMatch = fetchPath.match(/^\/inputs\/[^/]+\/(resolve|reject)$/)
+    const resolveMatch = fetchPath.match(/^\/inputs\/([^/]+)\/(resolve|reject)$/)
     if (resolveMatch) {
-      console.log(`[MockContainerClient] Input ${resolveMatch[1]}: ${fetchPath}`)
+      let toolUseId = resolveMatch[1]
+      try {
+        toolUseId = decodeURIComponent(toolUseId)
+      } catch {
+        // Malformed escape — keep the raw path segment (mock tool ids are alphanumeric anyway)
+      }
+      console.log(`[MockContainerClient] Input ${resolveMatch[2]}: ${fetchPath}`)
       // Find the session with pending inputs (we only have one active at a time in tests)
       for (const [sessionId, count] of this.pendingInputCounts) {
         if (count > 0) {
           const remaining = count - 1
           this.pendingInputCounts.set(sessionId, remaining)
           console.log(`[MockContainerClient] Session ${sessionId}: ${remaining} pending inputs remaining`)
+          // The real SDK surfaces each resolved/rejected input as a 'user' message
+          // carrying the tool_result block — persisted to the transcript and
+          // streamed so MessagePersister broadcasts `tool_result` to every SSE
+          // client (this is what lets other tabs drop the resolved card).
+          const toolResultBlocks = [{
+            type: 'tool_result',
+            tool_use_id: toolUseId,
+            content: resolveMatch[2] === 'resolve' ? 'User provided input' : 'User declined the request',
+          }]
+          this.writeJsonlEntry(sessionId, {
+            type: 'user',
+            message: { content: toolResultBlocks },
+            timestamp: new Date().toISOString(),
+          })
+          this.emitStreamMessage(sessionId, {
+            type: 'user',
+            content: { type: 'user', message: { content: toolResultBlocks } },
+          })
           if (remaining === 0) {
             this.pendingInputCounts.delete(sessionId)
             // Complete the session after a short delay


### PR DESCRIPTION
## Problem

Open the same session in two tabs, have the agent ask for a question / key / account, resolve it in one tab — the other tab keeps showing the pending request card until the whole turn ends ([SUP-336](https://linear.app/datawizz/issue/SUP-336)).

## Root cause

Each tab holds pending-request cards in its own EventSource-fed local state. The resolving tab removes its card via a local optimistic update. The server already broadcasts a `tool_result` SSE event (with the request's `toolUseId`) to every connected client when an input resolves — but the renderer's `tool_result` handler only invalidated the messages query and never removed entries from the `pending*Requests` lists. So non-resolving tabs kept the card until `session_idle`.

## Fix

- **`use-message-stream.ts`** — on `tool_result`, strip any pending request (secret / question / account / file / remote-MCP / browser-input / script-run / computer-use) matching the broadcast `toolUseId`. No-op (no state write, no re-render) for tool results that never had a request card.
- **`mock-container-client.ts`** — on `/inputs/:id/resolve|reject`, emit the per-input `tool_result` user message (persisted to JSONL + streamed), matching the real SDK. Previously the mock only emitted a final `result` once *all* inputs resolved, so the E2E harness couldn't exercise the broadcast path.

## Tests (TDD — spec written first, failed on main, passes with the fix)

New `e2e/specs/concurrent-tabs-request-sync.spec.ts`: two tabs of the same browser context on one session, using the `ask parallel` scenario (secret + question) so resolving one request keeps the session active — the turn boundary can't mask a missing per-request sync.

1. Provide secret in tab A → tab B drops it, question stays in both tabs; answer question from tab B → tab A syncs; both composers return.
2. Answer question in tab A first (reverse order) → secret survives in both tabs and is still functional from tab B.
3. Decline secret in tab A → tab B drops it, question stays in both tabs.

## Verification

- New spec: fails on main (tab-B card stuck at count 1), passes with the fix, stable across repeats
- Regression E2E: `user-input-requests`, `pending-request-reconnect`, `awaiting-input-status`, `connected-accounts` — 33 passed
- Unit: `use-message-stream`, `message-persister`, `chat-integration-e2e` — 342 passed
- `tsc --noEmit` + eslint clean