### PR TITLE
feat(SUP-343): platform notifications — realtime OS notifications, merged inbox, detail route

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -11,6 +11,7 @@ import scheduledTasks from './routes/scheduled-tasks'
 import webhookTriggers from './routes/webhook-triggers'
 import chatIntegrationsRouter from './routes/chat-integrations'
 import notifications from './routes/notifications'
+import platformNotifications from './routes/platform-notifications'
 import proxy from './routes/proxy'
 import mcpProxy from './routes/mcp-proxy'
 import browser from './routes/browser'
@@ -177,6 +178,7 @@ app.route('/api/scheduled-tasks', scheduledTasks)
 app.route('/api/webhook-triggers', webhookTriggers)
 app.route('/api/chat-integrations', chatIntegrationsRouter)
 app.route('/api/notifications', notifications)
+app.route('/api/platform-notifications', platformNotifications)
 app.route('/api/proxy', proxy)
 app.route('/api/agent-bootstrap', agentBootstrap)
 app.route('/api/mcp-proxy', mcpProxy)

--- a/src/api/routes/platform-notifications.test.ts
+++ b/src/api/routes/platform-notifications.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+// ---------------------------------------------------------------------------
+// Mock dependencies
+// ---------------------------------------------------------------------------
+
+let mockProxyUrl: string | null = 'https://proxy.test.example'
+vi.mock('@shared/lib/platform-auth/config', () => ({
+  getPlatformProxyBaseUrl: () => mockProxyUrl,
+}))
+
+let mockToken: string | null = 'pk_test'
+vi.mock('@shared/lib/services/platform-auth-service', () => ({
+  getPlatformAccessToken: () => mockToken,
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({ platformAuth: { memberId: 'sub_member_1' } }),
+}))
+
+const mockListNotifications = vi.fn()
+const mockMarkRead = vi.fn()
+vi.mock('@shared/lib/services/platform-notifications-client', () => ({
+  listPlatformNotifications: (...args: unknown[]) => mockListNotifications(...args),
+  markPlatformNotificationsRead: (...args: unknown[]) => mockMarkRead(...args),
+}))
+
+// Auth middleware: no-op in tests
+vi.mock('../middleware/auth', () => ({
+  Authenticated: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}))
+
+import platformNotificationsRouter from './platform-notifications'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const NTF_1 = 'ntf_00000001-1111-1111-1111-111111111111'
+const NTF_2 = 'ntf_00000002-2222-2222-2222-222222222222'
+
+const LIST_RESPONSE = {
+  notifications: [
+    {
+      id: NTF_1,
+      org_id: null,
+      title: 'Hello',
+      body: 'World',
+      action_url: null,
+      kind: 'broadcast',
+      read_at: null,
+      expires_at: null,
+      created_at: '2026-07-08T00:00:00+00:00',
+    },
+  ],
+  total: 1,
+  unread_count: 1,
+}
+
+const DISCONNECTED_LIST = { notifications: [], total: 0, unread_count: 0, connected: false }
+
+function makeApp() {
+  const app = new Hono()
+  app.route('/api/platform-notifications', platformNotificationsRouter)
+  return app
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockProxyUrl = 'https://proxy.test.example'
+  mockToken = 'pk_test'
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /api/platform-notifications', () => {
+  it('relays the platform list with connected: true', async () => {
+    mockListNotifications.mockResolvedValue(LIST_RESPONSE)
+    const res = await makeApp().request('/api/platform-notifications?status=unread&limit=20&offset=15')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ...LIST_RESPONSE, connected: true })
+    expect(mockListNotifications).toHaveBeenCalledWith(
+      { status: 'unread', limit: 20, offset: 15 },
+      'sub_member_1',
+    )
+  })
+
+  it('returns the disconnected shape without touching the client when not connected', async () => {
+    mockToken = null
+    const res = await makeApp().request('/api/platform-notifications')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual(DISCONNECTED_LIST)
+    expect(mockListNotifications).not.toHaveBeenCalled()
+  })
+
+  it('degrades an upstream failure to the disconnected shape, not a 502', async () => {
+    // The everyday laptop-offline case: platform auth configured, proxy
+    // unreachable. A 5xx here would spin the renderer's polling queries
+    // through retry cycles and Sentry captures forever.
+    mockListNotifications.mockRejectedValue(new Error('fetch failed'))
+    const res = await makeApp().request('/api/platform-notifications')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual(DISCONNECTED_LIST)
+  })
+
+  it('drops non-numeric pagination params and clamps out-of-range ones', async () => {
+    mockListNotifications.mockResolvedValue(LIST_RESPONSE)
+    const app = makeApp()
+
+    await app.request('/api/platform-notifications?limit=abc&offset=xyz')
+    expect(mockListNotifications).toHaveBeenLastCalledWith(
+      { status: undefined, limit: undefined, offset: undefined },
+      'sub_member_1',
+    )
+
+    await app.request('/api/platform-notifications?limit=500&offset=-3')
+    expect(mockListNotifications).toHaveBeenLastCalledWith(
+      { status: undefined, limit: 100, offset: 0 },
+      'sub_member_1',
+    )
+  })
+})
+
+describe('GET /api/platform-notifications/unread-count', () => {
+  it('returns the unread count', async () => {
+    mockListNotifications.mockResolvedValue({ ...LIST_RESPONSE, unread_count: 7 })
+    const res = await makeApp().request('/api/platform-notifications/unread-count')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ count: 7 })
+    expect(mockListNotifications).toHaveBeenCalledWith(
+      { status: 'unread', limit: 1 },
+      'sub_member_1',
+    )
+  })
+
+  it('degrades an upstream failure to a zero badge, not a 502', async () => {
+    mockListNotifications.mockRejectedValue(new Error('fetch failed'))
+    const res = await makeApp().request('/api/platform-notifications/unread-count')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ count: 0 })
+  })
+})
+
+describe('POST /api/platform-notifications/read', () => {
+  function postRead(body: unknown) {
+    return makeApp().request('/api/platform-notifications/read', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  it('acks the given ids and reports the updated count', async () => {
+    mockMarkRead.mockResolvedValue(2)
+    const res = await postRead({ ids: [NTF_1, NTF_2] })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, updated: 2 })
+    expect(mockMarkRead).toHaveBeenCalledWith([NTF_1, NTF_2], 'sub_member_1')
+  })
+
+  it('rejects missing, empty, or non-array ids with 400', async () => {
+    for (const body of [{}, { ids: [] }, { ids: 'ntf_x' }, { ids: 5 }, { ids: [1, 2] }]) {
+      const res = await postRead(body)
+      expect(res.status).toBe(400)
+    }
+    expect(mockMarkRead).not.toHaveBeenCalled()
+  })
+
+  it('returns 409 when the platform is not connected', async () => {
+    mockToken = null
+    const res = await postRead({ ids: [NTF_1] })
+    expect(res.status).toBe(409)
+    expect(mockMarkRead).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an upstream failure as 502 (user-initiated, unlike the polled reads)', async () => {
+    mockMarkRead.mockRejectedValue(new Error('fetch failed'))
+    const res = await postRead({ ids: [NTF_1] })
+    expect(res.status).toBe(502)
+  })
+})
+
+describe('POST /api/platform-notifications/read-all', () => {
+  function postReadAll() {
+    return makeApp().request('/api/platform-notifications/read-all', { method: 'POST' })
+  }
+
+  it('resolves the unread page and acks those ids', async () => {
+    mockListNotifications.mockResolvedValue({
+      notifications: [{ ...LIST_RESPONSE.notifications[0] }, { ...LIST_RESPONSE.notifications[0], id: NTF_2 }],
+      total: 2,
+      unread_count: 2,
+    })
+    mockMarkRead.mockResolvedValue(2)
+
+    const res = await postReadAll()
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, updated: 2 })
+    expect(mockListNotifications).toHaveBeenCalledWith(
+      { status: 'unread', limit: 100 },
+      'sub_member_1',
+    )
+    expect(mockMarkRead).toHaveBeenCalledWith([NTF_1, NTF_2], 'sub_member_1')
+  })
+
+  it('skips the ack call when nothing is unread', async () => {
+    mockListNotifications.mockResolvedValue({ notifications: [], total: 0, unread_count: 0 })
+    const res = await postReadAll()
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, updated: 0 })
+    expect(mockMarkRead).not.toHaveBeenCalled()
+  })
+
+  it('no-ops with success when the platform is not connected', async () => {
+    mockToken = null
+    const res = await postReadAll()
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, updated: 0 })
+  })
+})

--- a/src/api/routes/platform-notifications.ts
+++ b/src/api/routes/platform-notifications.ts
@@ -1,0 +1,126 @@
+/**
+ * Platform Notifications API Routes
+ *
+ * Proxy-live reads: thin forwards to the platform proxy's /v1/notifications
+ * endpoints, identical in both auth modes (no local mirror). When the
+ * platform isn't connected the list degrades to empty — the Notifications
+ * page still renders local agent notifications.
+ */
+
+import { Hono } from 'hono'
+import { getSettings } from '@shared/lib/config/settings'
+import { getPlatformProxyBaseUrl } from '@shared/lib/platform-auth/config'
+import { getPlatformAccessToken } from '@shared/lib/services/platform-auth-service'
+import {
+  listPlatformNotifications,
+  markPlatformNotificationsRead,
+} from '@shared/lib/services/platform-notifications-client'
+import { Authenticated } from '../middleware/auth'
+
+const platformNotificationsRouter = new Hono()
+
+platformNotificationsRouter.use('*', Authenticated())
+
+function isPlatformConnected(): boolean {
+  return Boolean(getPlatformProxyBaseUrl() && getPlatformAccessToken())
+}
+
+// Org JWTs need an acting member appended to the bearer (in auth mode the
+// request-scoped fetch interceptor re-attributes it to the acting user);
+// opaque personal keys ignore the suffix.
+function getMemberId(): string {
+  return getSettings().platformAuth?.memberId ?? 'local'
+}
+
+const EMPTY_LIST = { notifications: [], total: 0, unread_count: 0, connected: false }
+
+// The proxy rejects non-numeric/out-of-range values; drop them here so a bad
+// param degrades to the default instead of an upstream 400.
+function parseBoundedInt(value: string | undefined, min: number, max: number): number | undefined {
+  if (!value) return undefined
+  const parsed = parseInt(value, 10)
+  if (!Number.isFinite(parsed)) return undefined
+  return Math.min(Math.max(parsed, min), max)
+}
+
+// GET /api/platform-notifications?status=&limit=&offset= - live list from the platform
+platformNotificationsRouter.get('/', async (c) => {
+  if (!isPlatformConnected()) {
+    return c.json(EMPTY_LIST)
+  }
+  try {
+    const status = c.req.query('status') === 'unread' ? ('unread' as const) : undefined
+    const list = await listPlatformNotifications(
+      {
+        status,
+        limit: parseBoundedInt(c.req.query('limit'), 1, 100),
+        offset: parseBoundedInt(c.req.query('offset'), 0, Number.MAX_SAFE_INTEGER),
+      },
+      getMemberId(),
+    )
+    return c.json({ ...list, connected: true })
+  } catch (error) {
+    // An unreachable proxy is the everyday offline case, not an app error:
+    // degrade to the disconnected shape (a 200) so the renderer's polling
+    // queries don't spin through retry cycles and Sentry captures forever.
+    console.error('Failed to fetch platform notifications:', error)
+    return c.json(EMPTY_LIST)
+  }
+})
+
+// GET /api/platform-notifications/unread-count - unread count for the badge
+platformNotificationsRouter.get('/unread-count', async (c) => {
+  if (!isPlatformConnected()) {
+    return c.json({ count: 0 })
+  }
+  try {
+    const list = await listPlatformNotifications({ status: 'unread', limit: 1 }, getMemberId())
+    return c.json({ count: list.unread_count })
+  } catch (error) {
+    // Same offline degradation as the list route: a zero badge, not a 502.
+    console.error('Failed to fetch platform unread count:', error)
+    return c.json({ count: 0 })
+  }
+})
+
+// POST /api/platform-notifications/read { ids } - write-through mark-read
+platformNotificationsRouter.post('/read', async (c) => {
+  if (!isPlatformConnected()) {
+    return c.json({ error: 'Platform not connected' }, 409)
+  }
+  try {
+    const body = (await c.req.json().catch(() => null)) as { ids?: unknown } | null
+    const ids = Array.isArray(body?.ids)
+      ? body.ids.filter((id): id is string => typeof id === 'string' && id.length > 0)
+      : []
+    if (ids.length === 0) {
+      return c.json({ error: 'Missing ids array' }, 400)
+    }
+    const updated = await markPlatformNotificationsRead(ids, getMemberId())
+    return c.json({ success: true, updated })
+  } catch (error) {
+    console.error('Failed to mark platform notifications read:', error)
+    return c.json({ error: 'Failed to mark platform notifications read' }, 502)
+  }
+})
+
+// POST /api/platform-notifications/read-all - mark every unread row read
+platformNotificationsRouter.post('/read-all', async (c) => {
+  if (!isPlatformConnected()) {
+    return c.json({ success: true, updated: 0 })
+  }
+  try {
+    const memberId = getMemberId()
+    // The platform has no bulk endpoint; resolve the unread page (100 covers
+    // realistic announcement volume) and ack those ids.
+    const unread = await listPlatformNotifications({ status: 'unread', limit: 100 }, memberId)
+    const ids = unread.notifications.map((n) => n.id)
+    const updated = ids.length > 0 ? await markPlatformNotificationsRead(ids, memberId) : 0
+    return c.json({ success: true, updated })
+  } catch (error) {
+    console.error('Failed to mark all platform notifications read:', error)
+    return c.json({ error: 'Failed to mark all platform notifications read' }, 502)
+  }
+})
+
+export default platformNotificationsRouter

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -218,6 +218,8 @@ function isNotificationTypeAllowedLocally(notificationType: string | undefined):
         return n.sessionWaiting !== false
       case 'session_scheduled':
         return n.sessionScheduled !== false
+      case 'platform_notification':
+        return n.platformNotification !== false
       default:
         return true
     }

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -63,6 +63,7 @@ import { useIsMobile } from '@renderer/hooks/use-mobile'
 import { useUser } from '@renderer/context/user-context'
 import { useUpdateStatus } from '@renderer/context/update-status-context'
 import { useUnreadNotificationCount } from '@renderer/hooks/use-notifications'
+import { usePlatformUnreadCount } from '@renderer/hooks/use-platform-notifications'
 import { useIsOnline } from '@renderer/context/connectivity-context'
 import {
   DndContext,
@@ -536,7 +537,8 @@ if (__RENDER_TRACKING__) {
 
 function NotificationsMenuButton() {
   const { data: countData } = useUnreadNotificationCount()
-  const unreadCount = countData?.count ?? 0
+  const { data: platformCountData } = usePlatformUnreadCount()
+  const unreadCount = (countData?.count ?? 0) + (platformCountData?.count ?? 0)
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const isActive = pathname === '/notifications'
 

--- a/src/renderer/components/layout/notification-detail-route.tsx
+++ b/src/renderer/components/layout/notification-detail-route.tsx
@@ -1,0 +1,28 @@
+import { useSidebar } from '@renderer/components/ui/sidebar'
+import { useFullScreen } from '@renderer/hooks/use-fullscreen'
+import { isElectron, getPlatform } from '@renderer/lib/env'
+import { ErrorBoundary } from '@renderer/components/ui/error-boundary'
+import { PlatformNotificationDetail } from '@renderer/components/notifications/platform-notification-detail'
+import { ContentShell } from './content-shell'
+
+/**
+ * The `/notifications/$id` route: markdown detail view for one platform
+ * notification, deep-linkable like the inbox itself.
+ */
+export function NotificationDetailRoute() {
+  const { state: sidebarState } = useSidebar()
+  const isFullScreen = useFullScreen()
+  const needsTrafficLightPadding =
+    isElectron() && getPlatform() === 'darwin' && sidebarState === 'collapsed' && !isFullScreen
+
+  return (
+    <ContentShell
+      needsTrafficLightPadding={needsTrafficLightPadding}
+      headerContent={<span className="truncate text-sm font-light text-foreground">Notifications</span>}
+    >
+      <ErrorBoundary>
+        <PlatformNotificationDetail />
+      </ErrorBoundary>
+    </ContentShell>
+  )
+}

--- a/src/renderer/components/notifications/global-notification-handler.test.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.test.tsx
@@ -51,6 +51,18 @@ vi.mock('@renderer/hooks/use-notifications', () => ({
   useUnreadNotificationCount: () => ({ data: { count: 0 } }),
 }))
 
+vi.mock('@renderer/hooks/use-platform-notifications', () => ({
+  usePlatformUnreadCount: () => ({ data: { count: 0 } }),
+}))
+
+// The global setup mocks useNavigate as an unobservable no-op; the platform
+// notification click path needs an assertable spy.
+const mockNavigate = vi.hoisted(() => vi.fn())
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
 vi.mock('@renderer/hooks/use-user-settings', () => ({
   useUserSettings: vi.fn(() => ({ data: undefined })),
 }))
@@ -430,5 +442,85 @@ describe('GlobalNotificationHandler — proxy review SSE pathway', () => {
     )
     expect(sessionCalls.length).toBe(1)
     expect((sessionCalls[0][0] as { queryKey: unknown[] }).queryKey).toEqual(['sessions', 'my-agent'])
+  })
+
+  it('platform_notifications_changed refreshes the proxy-live inbox queries', () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <GlobalNotificationHandler />
+      </QueryClientProvider>
+    )
+
+    simulateSSEMessage(getLatestEventSource(), { type: 'platform_notifications_changed' })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['platform-notifications'] })
+  })
+
+  it('platform_notification pops an OS notification whose click opens the detail route', async () => {
+    const { showOSNotification } = await import('@renderer/lib/os-notifications')
+    vi.mocked(showOSNotification).mockClear()
+    mockNavigate.mockClear()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <GlobalNotificationHandler />
+      </QueryClientProvider>
+    )
+
+    const platformNotificationId = 'ntf_00000001-1111-1111-1111-111111111111'
+    simulateSSEMessage(getLatestEventSource(), {
+      type: 'os_notification',
+      notificationType: 'platform_notification',
+      platformNotificationId,
+      title: 'Welcome',
+      body: 'markdown body',
+      actionContext: { kind: 'platform_notification', platformNotificationId },
+    })
+
+    // The proxy-live inbox/badge refresh fires alongside the popup.
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['platform-notifications'] })
+
+    expect(showOSNotification).toHaveBeenCalledTimes(1)
+    const [title, body, onClick] = vi.mocked(showOSNotification).mock.calls[0]
+    expect(title).toBe('Welcome')
+    expect(body).toBe('markdown body')
+
+    // Web Notifications wire the click straight to the detail route (the
+    // write-through mark-read happens there on open).
+    expect(onClick).toBeTypeOf('function')
+    onClick!()
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/notifications/$id',
+      params: { id: platformNotificationId },
+    })
+  })
+
+  it('platform_notification popup respects the settings toggle', async () => {
+    const { showOSNotification } = await import('@renderer/lib/os-notifications')
+    vi.mocked(showOSNotification).mockClear()
+
+    const { useUserSettings } = await import('@renderer/hooks/use-user-settings')
+    vi.mocked(useUserSettings).mockReturnValue({
+      data: { notifications: { enabled: true, platformNotification: false } },
+    } as unknown as ReturnType<typeof useUserSettings>)
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <GlobalNotificationHandler />
+      </QueryClientProvider>
+    )
+
+    simulateSSEMessage(getLatestEventSource(), {
+      type: 'os_notification',
+      notificationType: 'platform_notification',
+      platformNotificationId: 'ntf_00000001-1111-1111-1111-111111111111',
+      title: 'Welcome',
+      body: 'markdown body',
+    })
+
+    expect(showOSNotification).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -19,6 +19,7 @@ import { useRouteLocation } from '@renderer/router/use-route-location'
 import { useNavigate } from '@tanstack/react-router'
 import { useUser } from '@renderer/context/user-context'
 import { useUnreadNotificationCount } from '@renderer/hooks/use-notifications'
+import { usePlatformUnreadCount } from '@renderer/hooks/use-platform-notifications'
 import { useUserSettings } from '@renderer/hooks/use-user-settings'
 import { setMountWarning } from '@renderer/hooks/use-mount-warnings'
 import type { UserSettingsData } from '@shared/lib/services/user-settings-service'
@@ -40,6 +41,7 @@ function isNotificationTypeEnabled(
     case 'session_complete': return n.sessionComplete !== false
     case 'session_waiting': return n.sessionWaiting !== false
     case 'session_scheduled': return n.sessionScheduled !== false
+    case 'platform_notification': return n.platformNotification !== false
     default: return true
   }
 }
@@ -51,6 +53,7 @@ export function GlobalNotificationHandler() {
   const navigate = useNavigate()
   const selectedSessionId = view.kind === 'session' ? view.id : null
   const { data: unreadData } = useUnreadNotificationCount()
+  const { data: platformUnreadData } = usePlatformUnreadCount()
   const { data: userSettings } = useUserSettings()
   const { canAccessAgent } = useUser()
   // Use refs to avoid recreating EventSource when reactive values change
@@ -64,10 +67,10 @@ export function GlobalNotificationHandler() {
   // Sync dock badge count with unread notifications (macOS Electron only)
   useEffect(() => {
     if (isElectron() && window.electronAPI?.setBadgeCount) {
-      const count = unreadData?.count ?? 0
+      const count = (unreadData?.count ?? 0) + (platformUnreadData?.count ?? 0)
       window.electronAPI.setBadgeCount(count)
     }
-  }, [unreadData?.count])
+  }, [unreadData?.count, platformUnreadData?.count])
 
   // Dispatch a single notification interaction event. Shared between live
   // events (onNotificationEvent) and queued events flushed on mount.
@@ -95,6 +98,31 @@ export function GlobalNotificationHandler() {
         .catch(() => {
           // Best-effort: a stale notificationId is fine to silently ignore.
         })
+    }
+
+    // Platform notifications: clicking the OS notification opens the
+    // markdown detail route and write-through-marks the platform row read
+    // (it has no local DB record — the notificationId path above is a no-op).
+    const platformCtx = NotificationActionContextSchema.safeParse(event.context)
+    if (platformCtx.success && platformCtx.data.kind === 'platform_notification') {
+      const platformNotificationId = platformCtx.data.platformNotificationId
+      apiFetch('/api/platform-notifications/read', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: [platformNotificationId] }),
+      })
+        .then((res) => {
+          if (res.ok) {
+            queryClient.invalidateQueries({ queryKey: ['platform-notifications'] })
+          }
+        })
+        .catch(() => {
+          // Best-effort: the detail view marks read on open anyway.
+        })
+      if (event.type === 'click') {
+        void navigate({ to: '/notifications/$id', params: { id: platformNotificationId } })
+      }
+      return
     }
 
     // Action button interactions also dispatch a proxy-review decision.
@@ -125,7 +153,7 @@ export function GlobalNotificationHandler() {
       .catch((err) => {
         console.error('[notification-action] Error submitting proxy review decision:', err)
       })
-  }, [queryClient])
+  }, [queryClient, navigate])
 
   // Dispatch OS notification action button events (macOS only) back into the
   // app. For proxy reviews this means submitting Approve/Deny without the user
@@ -167,9 +195,19 @@ export function GlobalNotificationHandler() {
         const data = JSON.parse(event.data)
 
         switch (data.type) {
+          case 'platform_notifications_changed': {
+            // A platform notification INSERT arrived over Realtime — refresh
+            // the proxy-live inbox + badge (there is no local copy to update).
+            queryClient.invalidateQueries({ queryKey: ['platform-notifications'] })
+            break
+          }
+
           case 'os_notification': {
             // Refresh notification list (for badge/dropdown)
             queryClient.invalidateQueries({ queryKey: ['notifications'] })
+            if (data.notificationType === 'platform_notification') {
+              queryClient.invalidateQueries({ queryKey: ['platform-notifications'] })
+            }
             // Refresh sessions so unread indicators update in sidebar
             const notifAgentSlug = data.agentSlug as string | undefined
             if (notifAgentSlug) {
@@ -248,7 +286,22 @@ export function GlobalNotificationHandler() {
                 sessionId: notificationSessionId ?? baseContext.sessionId,
                 notificationId: data.notificationId ?? baseContext.notificationId,
               }
-              showOSNotification(title, body, undefined, { actions, context })
+              // Web Notifications have no context round-trip — wire the click
+              // straight to the platform detail route (Electron routes the
+              // click through dispatchNotificationEvent instead).
+              const platformNotificationId =
+                notificationType === 'platform_notification' &&
+                typeof data.platformNotificationId === 'string'
+                  ? data.platformNotificationId
+                  : null
+              const onClick = platformNotificationId
+                ? () =>
+                    void navigate({
+                      to: '/notifications/$id',
+                      params: { id: platformNotificationId },
+                    })
+                : undefined
+              showOSNotification(title, body, onClick, { actions, context })
             } else if (suppressedByActiveView && typeof data.notificationId === 'string') {
               // Popup suppressed because the user is actively viewing this
               // focused session — but the backend still created the DB record.
@@ -362,7 +415,7 @@ export function GlobalNotificationHandler() {
     return () => {
       es.close()
     }
-  }, [queryClient])
+  }, [queryClient, navigate])
 
   return null
 }

--- a/src/renderer/components/notifications/notifications-view.test.tsx
+++ b/src/renderer/components/notifications/notifications-view.test.tsx
@@ -423,6 +423,39 @@ describe('NotificationsView', () => {
     expect(screen.getByText('30 total')).toBeTruthy()
   })
 
+  it('clamps pagination to the platform fetch cap so every advertised page has content', async () => {
+    const user = userEvent.setup()
+    // 120 platform rows exist but only 100 are fetchable: the view must
+    // advertise 7 pages (100 rows), not 8, and the last page must render
+    // rows — not strand the user on an empty state with no pagination.
+    mockNotificationsData = { items: [], total: 0 }
+    mockPlatformData = {
+      notifications: Array.from({ length: 120 }, (_, i) =>
+        makePlatformNotification({ id: `ntf_${i + 1}` }),
+      ),
+      total: 120,
+      unread_count: 0,
+      connected: true,
+    }
+    renderWithProviders(<NotificationsView />)
+
+    expect(screen.getByText('1 / 7')).toBeTruthy()
+    expect(screen.getByText('100 total')).toBeTruthy()
+
+    const nextButton = screen.getAllByRole('button').find((b) =>
+      b.querySelector('.lucide-chevron-right'),
+    )
+    for (let i = 0; i < 6; i++) {
+      await user.click(nextButton!)
+    }
+
+    expect(screen.getByText('7 / 7')).toBeTruthy()
+    // Last page: the tail 10 of the 100 fetchable rows, and next is disabled.
+    expect(screen.getAllByTestId('platform-notification-row')).toHaveLength(10)
+    expect(nextButton!).toBeDisabled()
+    expect(screen.queryByText('No notifications yet.')).toBeNull()
+  })
+
   it('walks to page 2 of a mixed merged list without dropping or duplicating rows', async () => {
     const user = userEvent.setup()
     // 20 agent rows (newer, 10:00) + 10 platform rows (older, 09:00): page 1

--- a/src/renderer/components/notifications/notifications-view.test.tsx
+++ b/src/renderer/components/notifications/notifications-view.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderWithProviders, screen, userEvent } from '@renderer/test/test-utils'
 import type { ApiNotification } from '@shared/lib/types/api'
+import type { ApiPlatformNotification } from '@renderer/hooks/use-platform-notifications'
 
 // ---------------------------------------------------------------------------
 // Mock state — mutated by tests, reset in beforeEach
@@ -10,20 +11,34 @@ import type { ApiNotification } from '@shared/lib/types/api'
 const mockMarkReadMutate = vi.fn()
 const mockMarkAllReadMutate = vi.fn()
 const mockNavigate = vi.fn()
+const mockMarkPlatformReadMutate = vi.fn()
+const mockMarkAllPlatformReadMutate = vi.fn()
 
 let mockNotificationsData: { items: ApiNotification[]; total: number } | undefined
 let mockNotificationsLoading = false
 let mockUnreadCount = 0
 let mockAgents: { slug: string; name: string }[] = []
 let mockMarkAllPending = false
+let mockPlatformData: {
+  notifications: ApiPlatformNotification[]
+  total: number
+  unread_count: number
+  connected: boolean
+} = { notifications: [], total: 0, unread_count: 0, connected: false }
+let mockPlatformLoading = false
+let mockPlatformUnreadCount = 0
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
 vi.mock('@renderer/hooks/use-notifications', () => ({
-  useNotifications: () => ({
-    data: mockNotificationsData,
+  // The view fetches a growing window ((page+1)*PAGE_SIZE) and paginates
+  // client-side over the merged list — honor the limit like the server would.
+  useNotifications: (limit: number) => ({
+    data: mockNotificationsData
+      ? { ...mockNotificationsData, items: mockNotificationsData.items.slice(0, limit) }
+      : undefined,
     isLoading: mockNotificationsLoading,
   }),
   useUnreadNotificationCount: () => ({
@@ -35,6 +50,28 @@ vi.mock('@renderer/hooks/use-notifications', () => ({
   useMarkAllNotificationsRead: () => ({
     mutate: mockMarkAllReadMutate,
     isPending: mockMarkAllPending,
+  }),
+}))
+
+vi.mock('@renderer/hooks/use-platform-notifications', () => ({
+  // Honor the requested window like the platform would (same reasoning as the
+  // useNotifications mock above) so pagination tests exercise real slicing.
+  usePlatformNotifications: (limit?: number) => ({
+    data:
+      typeof limit === 'number'
+        ? { ...mockPlatformData, notifications: mockPlatformData.notifications.slice(0, limit) }
+        : mockPlatformData,
+    isLoading: mockPlatformLoading,
+  }),
+  usePlatformUnreadCount: () => ({
+    data: { count: mockPlatformUnreadCount },
+  }),
+  useMarkPlatformNotificationsRead: () => ({
+    mutate: mockMarkPlatformReadMutate,
+  }),
+  useMarkAllPlatformNotificationsRead: () => ({
+    mutate: mockMarkAllPlatformReadMutate,
+    isPending: false,
   }),
 }))
 
@@ -76,6 +113,22 @@ function makeNotification(overrides: Partial<ApiNotification> & { id: string }):
   }
 }
 
+function makePlatformNotification(
+  overrides: Partial<ApiPlatformNotification> & { id: string },
+): ApiPlatformNotification {
+  return {
+    org_id: null,
+    title: 'Platform announcement',
+    body: 'We shipped something',
+    action_url: null,
+    kind: 'broadcast',
+    read_at: null,
+    expires_at: null,
+    created_at: '2026-05-20T09:00:00Z',
+    ...overrides,
+  }
+}
+
 function makeNotifications(count: number): ApiNotification[] {
   return Array.from({ length: count }, (_, i) =>
     makeNotification({ id: `n${i + 1}` }),
@@ -94,6 +147,9 @@ describe('NotificationsView', () => {
     mockUnreadCount = 0
     mockAgents = []
     mockMarkAllPending = false
+    mockPlatformData = { notifications: [], total: 0, unread_count: 0, connected: false }
+    mockPlatformLoading = false
+    mockPlatformUnreadCount = 0
   })
 
   // -----------------------------------------------------------------------
@@ -267,7 +323,7 @@ describe('NotificationsView', () => {
 
   it('navigates to the next page when the next button is clicked', async () => {
     const user = userEvent.setup()
-    mockNotificationsData = { items: makeNotifications(15), total: 30 }
+    mockNotificationsData = { items: makeNotifications(30), total: 30 }
     renderWithProviders(<NotificationsView />)
     const nextButton = screen.getAllByRole('button').find((b) =>
       b.querySelector('.lucide-chevron-right'),
@@ -287,6 +343,118 @@ describe('NotificationsView', () => {
     renderWithProviders(<NotificationsView />)
     await user.click(screen.getByTestId('notifications-back-button'))
     expect(mockNavigate).toHaveBeenCalledWith({ to: '/' })
+  })
+
+  // -----------------------------------------------------------------------
+  // Platform notifications (merged rows)
+  // -----------------------------------------------------------------------
+
+  it('merges platform rows into the list sorted by date', () => {
+    mockNotificationsData = {
+      items: [makeNotification({ id: 'a1', createdAt: new Date('2026-05-20T10:00:00Z') })],
+      total: 1,
+    }
+    mockPlatformData = {
+      notifications: [
+        makePlatformNotification({ id: 'ntf_1', created_at: '2026-05-21T10:00:00Z' }),
+      ],
+      total: 1,
+      unread_count: 1,
+      connected: true,
+    }
+    renderWithProviders(<NotificationsView />)
+
+    const rows = screen.getAllByText(/Platform announcement|Notification a1/)
+    // Newer platform row sorts above the agent row
+    expect(rows[0].textContent).toContain('Platform announcement')
+    expect(screen.getByTestId('platform-notification-row')).toBeTruthy()
+  })
+
+  it('links a platform row to the notification detail route', () => {
+    mockPlatformData = {
+      notifications: [makePlatformNotification({ id: 'ntf_42' })],
+      total: 1,
+      unread_count: 1,
+      connected: true,
+    }
+    renderWithProviders(<NotificationsView />)
+    const link = screen.getByTestId('platform-notification-row')
+    expect(link).toHaveAttribute('data-to', '/notifications/$id')
+    expect(link).toHaveAttribute('data-params', JSON.stringify({ id: 'ntf_42' }))
+  })
+
+  it('shows the unread indicator for unread platform rows only', () => {
+    mockPlatformData = {
+      notifications: [
+        makePlatformNotification({ id: 'ntf_read', read_at: '2026-05-20T11:00:00Z' }),
+      ],
+      total: 1,
+      unread_count: 0,
+      connected: true,
+    }
+    renderWithProviders(<NotificationsView />)
+    expect(screen.queryByLabelText('Unread')).toBeNull()
+  })
+
+  it('marks platform notifications read too when mark-all is clicked', async () => {
+    const user = userEvent.setup()
+    mockPlatformUnreadCount = 2
+    mockPlatformData = {
+      notifications: [makePlatformNotification({ id: 'ntf_1' })],
+      total: 1,
+      unread_count: 2,
+      connected: true,
+    }
+    renderWithProviders(<NotificationsView />)
+    await user.click(screen.getByTestId('notifications-mark-all-read'))
+    expect(mockMarkAllReadMutate).toHaveBeenCalled()
+    expect(mockMarkAllPlatformReadMutate).toHaveBeenCalled()
+  })
+
+  it('counts platform totals into merged pagination', () => {
+    mockNotificationsData = { items: makeNotifications(15), total: 20 }
+    mockPlatformData = {
+      notifications: [makePlatformNotification({ id: 'ntf_1' })],
+      total: 10,
+      unread_count: 0,
+      connected: true,
+    }
+    renderWithProviders(<NotificationsView />)
+    expect(screen.getByText('30 total')).toBeTruthy()
+  })
+
+  it('walks to page 2 of a mixed merged list without dropping or duplicating rows', async () => {
+    const user = userEvent.setup()
+    // 20 agent rows (newer, 10:00) + 10 platform rows (older, 09:00): page 1
+    // must be all-agent, page 2 the remaining 5 agent rows + all 10 platform.
+    mockNotificationsData = { items: makeNotifications(20), total: 20 }
+    mockPlatformData = {
+      notifications: Array.from({ length: 10 }, (_, i) =>
+        makePlatformNotification({ id: `ntf_${i + 1}` }),
+      ),
+      total: 10,
+      unread_count: 0,
+      connected: true,
+    }
+    renderWithProviders(<NotificationsView />)
+
+    expect(screen.getByText('1 / 2')).toBeTruthy()
+    expect(screen.getByText('30 total')).toBeTruthy()
+    expect(screen.getByText('Notification n15')).toBeTruthy()
+    expect(screen.queryAllByTestId('platform-notification-row')).toHaveLength(0)
+
+    const nextButton = screen.getAllByRole('button').find((b) =>
+      b.querySelector('.lucide-chevron-right'),
+    )
+    await user.click(nextButton!)
+
+    expect(screen.getByText('2 / 2')).toBeTruthy()
+    // Nothing from page 1 repeats at the slice boundary...
+    expect(screen.queryByText('Notification n15')).toBeNull()
+    // ...and nothing is skipped: the agent tail and the full platform set.
+    expect(screen.getByText('Notification n16')).toBeTruthy()
+    expect(screen.getByText('Notification n20')).toBeTruthy()
+    expect(screen.getAllByTestId('platform-notification-row')).toHaveLength(10)
   })
 
   // -----------------------------------------------------------------------

--- a/src/renderer/components/notifications/notifications-view.tsx
+++ b/src/renderer/components/notifications/notifications-view.tsx
@@ -262,7 +262,10 @@ export function NotificationsView() {
     return [...agentItems, ...platformItems].sort((a, b) => b.sortKey - a.sortKey)
   }, [data?.items, platformData?.notifications])
 
-  const total = (data?.total ?? 0) + (platformData?.total ?? 0)
+  // Clamp the platform contribution to what the capped fetch can actually
+  // supply — otherwise >100 platform rows advertise pages whose slice of
+  // `merged` is empty, stranding the user past the last real page.
+  const total = (data?.total ?? 0) + Math.min(platformData?.total ?? 0, PLATFORM_FETCH_CAP)
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
   const currentPage = Math.min(page, totalPages - 1)
   const pageItems = merged.slice(currentPage * PAGE_SIZE, currentPage * PAGE_SIZE + PAGE_SIZE)

--- a/src/renderer/components/notifications/notifications-view.tsx
+++ b/src/renderer/components/notifications/notifications-view.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, Bell, CheckCheck, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react'
+import { ArrowRight, Bell, CheckCheck, ChevronLeft, ChevronRight, Loader2, Megaphone } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { format, isToday, isYesterday, isThisYear } from 'date-fns'
 import { Button } from '@renderer/components/ui/button'
@@ -9,6 +9,13 @@ import {
   useMarkAllNotificationsRead,
   type ApiNotification,
 } from '@renderer/hooks/use-notifications'
+import {
+  usePlatformNotifications,
+  usePlatformUnreadCount,
+  useMarkPlatformNotificationsRead,
+  useMarkAllPlatformNotificationsRead,
+  type ApiPlatformNotification,
+} from '@renderer/hooks/use-platform-notifications'
 import { useRouteLocation } from '@renderer/router/use-route-location'
 import { useNavigate } from '@tanstack/react-router'
 import { AppLink } from '@renderer/components/ui/app-link'
@@ -16,12 +23,58 @@ import { useAgents } from '@renderer/hooks/use-agents'
 import { PageTitle, SettingsPageContainer } from '@renderer/components/layout/settings-page'
 import { cn } from '@shared/lib/utils'
 import { useRenderTracker } from '@renderer/lib/perf'
+import { stripMarkdownPreview } from '@renderer/lib/markdown-preview'
 
 function formatNotificationDate(date: Date): string {
   if (isToday(date)) return format(date, 'h:mm a').toLowerCase()
   if (isYesterday(date)) return 'yesterday'
   if (isThisYear(date)) return format(date, 'MMM d').toLowerCase()
   return format(date, 'MMM d, yyyy').toLowerCase()
+}
+
+const ROW_CLASS_NAME = 'group relative block w-full text-left focus-visible:outline-none'
+
+function RowChrome({ isRead }: { isRead: boolean }) {
+  return (
+    <>
+      <span
+        aria-hidden
+        className="absolute inset-y-0 -left-6 -right-2 rounded-md group-hover:bg-accent/40 group-focus-visible:ring-2 group-focus-visible:ring-ring transition-colors"
+      />
+      {/* Unread dot — sits in the bled gutter, left of the aligned content */}
+      <span
+        role={!isRead ? 'status' : undefined}
+        className={cn(
+          'absolute -left-4 top-1/2 -translate-y-1/2 h-1.5 w-1.5 rounded-full',
+          !isRead ? 'bg-blue-500' : 'bg-transparent',
+        )}
+        aria-label={!isRead ? 'Unread' : undefined}
+      />
+    </>
+  )
+}
+
+function RowTrailing({ isRead, dateLabel }: { isRead: boolean; dateLabel: string }) {
+  return (
+    <span className="shrink-0 flex items-center">
+      <span
+        className={cn(
+          'w-24 text-right text-xs tabular-nums',
+          !isRead ? 'text-foreground/80 font-medium' : 'text-muted-foreground',
+        )}
+      >
+        {dateLabel}
+      </span>
+      {/* Inline chevron affordance — width animates from 0 on row hover,
+          nudging the timestamp left while it slides into view */}
+      <span
+        aria-hidden
+        className="flex justify-center overflow-hidden w-0 opacity-0 transition-all duration-200 ease-out group-hover:w-6 group-hover:opacity-100"
+      >
+        <ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      </span>
+    </span>
+  )
 }
 
 function NotificationRow({
@@ -48,23 +101,9 @@ function NotificationRow({
 
   const dateLabel = formatNotificationDate(new Date(notification.createdAt))
 
-  const rowClassName = 'group relative block w-full text-left focus-visible:outline-none'
-
   const content = (
     <>
-      <span
-        aria-hidden
-        className="absolute inset-y-0 -left-6 -right-2 rounded-md group-hover:bg-accent/40 group-focus-visible:ring-2 group-focus-visible:ring-ring transition-colors"
-      />
-      {/* Unread dot — sits in the bled gutter, left of the aligned content */}
-      <span
-        role={!notification.isRead ? 'status' : undefined}
-        className={cn(
-          'absolute -left-4 top-1/2 -translate-y-1/2 h-1.5 w-1.5 rounded-full',
-          !notification.isRead ? 'bg-blue-500' : 'bg-transparent',
-        )}
-        aria-label={!notification.isRead ? 'Unread' : undefined}
-      />
+      <RowChrome isRead={notification.isRead} />
       {/* Content — no negative margins, so left/right edges match the page
           title and pagination exactly */}
       <span className="relative flex items-center gap-4 py-3">
@@ -99,24 +138,7 @@ function NotificationRow({
             {notification.body}
           </span>
         </span>
-        <span className="shrink-0 flex items-center">
-          <span
-            className={cn(
-              'w-24 text-right text-xs tabular-nums',
-              !notification.isRead ? 'text-foreground/80 font-medium' : 'text-muted-foreground',
-            )}
-          >
-            {dateLabel}
-          </span>
-          {/* Inline chevron affordance — width animates from 0 on row hover,
-              nudging the timestamp left while it slides into view */}
-          <span
-            aria-hidden
-            className="flex justify-center overflow-hidden w-0 opacity-0 transition-all duration-200 ease-out group-hover:w-6 group-hover:opacity-100"
-          >
-            <ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          </span>
-        </span>
+        <RowTrailing isRead={notification.isRead} dateLabel={dateLabel} />
       </span>
     </>
   )
@@ -128,7 +150,7 @@ function NotificationRow({
       to="/agents/$slug/sessions/$sessionId"
       params={{ slug: notification.agentSlug, sessionId }}
       onClick={handleClick}
-      className={rowClassName}
+      className={ROW_CLASS_NAME}
     >
       {content}
     </AppLink>
@@ -137,36 +159,120 @@ function NotificationRow({
       to="/agents/$slug"
       params={{ slug: notification.agentSlug }}
       onClick={handleClick}
-      className={rowClassName}
+      className={ROW_CLASS_NAME}
     >
       {content}
     </AppLink>
   )
 }
 
+/**
+ * Platform announcement row: no agent column (a Platform tag instead) and the
+ * click opens the markdown detail view rather than navigating to a session.
+ * Mark-read happens on detail open, not here.
+ */
+function PlatformNotificationRow({ notification }: { notification: ApiPlatformNotification }) {
+  const isRead = Boolean(notification.read_at)
+  const dateLabel = formatNotificationDate(new Date(notification.created_at))
+
+  return (
+    <AppLink
+      to="/notifications/$id"
+      params={{ id: notification.id }}
+      className={ROW_CLASS_NAME}
+      data-testid="platform-notification-row"
+    >
+      <RowChrome isRead={isRead} />
+      <span className="relative flex items-center gap-4 py-3">
+        <span className="w-56 shrink min-w-0 truncate text-xs flex items-center gap-1.5">
+          <Megaphone className="h-3 w-3 shrink-0 text-muted-foreground" />
+          <span
+            className={cn(
+              'truncate',
+              !isRead ? 'font-medium text-foreground' : 'text-foreground/90',
+            )}
+          >
+            Platform
+          </span>
+        </span>
+        <span className="flex-1 min-w-0 flex items-baseline gap-2 truncate">
+          <span
+            className={cn(
+              'text-xs shrink-0 truncate max-w-[50%]',
+              !isRead ? 'font-medium text-foreground' : 'text-foreground/90',
+            )}
+          >
+            {notification.title}
+          </span>
+          <span className="text-xs text-muted-foreground truncate">
+            {stripMarkdownPreview(notification.body)}
+          </span>
+        </span>
+        <RowTrailing isRead={isRead} dateLabel={dateLabel} />
+      </span>
+    </AppLink>
+  )
+}
+
+type MergedNotification =
+  | { source: 'agent'; sortKey: number; agent: ApiNotification }
+  | { source: 'platform'; sortKey: number; platform: ApiPlatformNotification }
+
 const PAGE_SIZE = 15
+// The platform list endpoint caps at 100 rows per read; announcements past
+// that stop appearing in the merged history (they were read long ago anyway).
+const PLATFORM_FETCH_CAP = 100
 
 export function NotificationsView() {
   useRenderTracker('NotificationsView')
   const { selectedAgentSlug } = useRouteLocation()
   const navigate = useNavigate()
   const [page, setPage] = useState(0)
-  const offset = page * PAGE_SIZE
-  const { data, isLoading } = useNotifications(PAGE_SIZE, offset)
+  // Merged pagination over two sources: fetch the top (page+1)*PAGE_SIZE of
+  // EACH source, merge by date, then slice the requested window — correct as
+  // long as each source can supply its own top-k.
+  const fetchWindow = (page + 1) * PAGE_SIZE
+  const { data, isLoading } = useNotifications(fetchWindow, 0)
+  const { data: platformData, isLoading: isPlatformLoading } = usePlatformNotifications(
+    Math.min(fetchWindow, PLATFORM_FETCH_CAP),
+  )
   const { data: countData } = useUnreadNotificationCount()
+  const { data: platformCountData } = usePlatformUnreadCount()
   const { data: agents } = useAgents()
   const markAllRead = useMarkAllNotificationsRead()
-  const unreadCount = countData?.count ?? 0
+  const markAllPlatformRead = useMarkAllPlatformNotificationsRead()
+  const unreadCount = (countData?.count ?? 0) + (platformCountData?.count ?? 0)
 
   const agentNameBySlug = useMemo(
     () => new Map(agents?.map((a) => [a.slug, a.name]) ?? []),
     [agents],
   )
 
-  const items = data?.items ?? []
-  const total = data?.total ?? 0
+  const merged = useMemo<MergedNotification[]>(() => {
+    const agentItems: MergedNotification[] = (data?.items ?? []).map((n) => ({
+      source: 'agent',
+      sortKey: new Date(n.createdAt).getTime(),
+      agent: n,
+    }))
+    const platformItems: MergedNotification[] = (platformData?.notifications ?? []).map((n) => ({
+      source: 'platform',
+      sortKey: new Date(n.created_at).getTime(),
+      platform: n,
+    }))
+    return [...agentItems, ...platformItems].sort((a, b) => b.sortKey - a.sortKey)
+  }, [data?.items, platformData?.notifications])
+
+  const total = (data?.total ?? 0) + (platformData?.total ?? 0)
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
   const currentPage = Math.min(page, totalPages - 1)
+  const pageItems = merged.slice(currentPage * PAGE_SIZE, currentPage * PAGE_SIZE + PAGE_SIZE)
+
+  const handleMarkAllRead = () => {
+    markAllRead.mutate()
+    if ((platformCountData?.count ?? 0) > 0) {
+      markAllPlatformRead.mutate()
+    }
+  }
 
   return (
     <SettingsPageContainer fullScreen>
@@ -186,8 +292,8 @@ export function NotificationsView() {
           <Button
             variant="outline"
             size="sm"
-            onClick={() => markAllRead.mutate()}
-            disabled={markAllRead.isPending || unreadCount === 0}
+            onClick={handleMarkAllRead}
+            disabled={markAllRead.isPending || markAllPlatformRead.isPending || unreadCount === 0}
             data-testid="notifications-mark-all-read"
           >
             <CheckCheck className="h-3.5 w-3.5 mr-1.5" />
@@ -196,12 +302,12 @@ export function NotificationsView() {
         }
       />
 
-      {isLoading ? (
+      {isLoading || isPlatformLoading ? (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" />
           Loading notifications...
         </div>
-      ) : items.length === 0 ? (
+      ) : pageItems.length === 0 ? (
         <div className="rounded-xl border border-dashed p-12 text-center text-sm text-muted-foreground">
           <Bell className="h-8 w-8 mx-auto mb-3 opacity-20" />
           No notifications yet.
@@ -209,13 +315,20 @@ export function NotificationsView() {
       ) : (
         <>
           <div>
-            {items.map((notification) => (
-              <NotificationRow
-                key={notification.id}
-                notification={notification}
-                agentName={agentNameBySlug.get(notification.agentSlug) ?? null}
-              />
-            ))}
+            {pageItems.map((entry) =>
+              entry.source === 'agent' ? (
+                <NotificationRow
+                  key={`agent-${entry.agent.id}`}
+                  notification={entry.agent}
+                  agentName={agentNameBySlug.get(entry.agent.agentSlug) ?? null}
+                />
+              ) : (
+                <PlatformNotificationRow
+                  key={`platform-${entry.platform.id}`}
+                  notification={entry.platform}
+                />
+              ),
+            )}
           </div>
 
           {totalPages > 1 && (

--- a/src/renderer/components/notifications/platform-notification-detail.tsx
+++ b/src/renderer/components/notifications/platform-notification-detail.tsx
@@ -1,0 +1,102 @@
+import { ExternalLink, Loader2, Megaphone } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { format } from 'date-fns'
+import { useParams } from '@tanstack/react-router'
+import { useNavigate } from '@tanstack/react-router'
+import { buttonVariants } from '@renderer/components/ui/button'
+import { MarkdownBlock } from '@renderer/components/messages/message-item'
+import { markdownUrlTransform } from '@renderer/lib/markdown-url-transform'
+import {
+  usePlatformNotifications,
+  useMarkPlatformNotificationsRead,
+} from '@renderer/hooks/use-platform-notifications'
+import { PageTitle, SettingsPageContainer } from '@renderer/components/layout/settings-page'
+import { useRenderTracker } from '@renderer/lib/perf'
+
+/**
+ * Detail view for one platform notification (`/notifications/$id`): title +
+ * timestamp + markdown body, marked read on open. There is no by-id platform
+ * endpoint — the row comes from the same live list read the inbox uses.
+ */
+export function PlatformNotificationDetail() {
+  useRenderTracker('PlatformNotificationDetail')
+  const { id } = useParams({ strict: false }) as { id?: string }
+  const navigate = useNavigate()
+  const { data, isLoading } = usePlatformNotifications(100)
+  const markRead = useMarkPlatformNotificationsRead()
+
+  const notification = data?.notifications.find((n) => n.id === id)
+
+  // Mark read on open (write-through; once per mounted id)
+  const markedRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!notification || notification.read_at || markedRef.current === notification.id) return
+    markedRef.current = notification.id
+    markRead.mutate([notification.id])
+  }, [notification, markRead])
+
+  // action_url goes through the same URL-scheme allowlist as message links —
+  // a disallowed scheme transforms to '' and the button simply doesn't render.
+  // (The transform only reads url + key; the node param exists for the
+  // react-markdown call site.)
+  const transformHref = markdownUrlTransform as unknown as (
+    url: string,
+    key: string,
+  ) => string | null | undefined
+  const safeActionUrl = notification?.action_url
+    ? (transformHref(notification.action_url, 'href') ?? '')
+    : ''
+
+  return (
+    <SettingsPageContainer fullScreen>
+      <PageTitle
+        title={notification?.title ?? 'Notification'}
+        back={{
+          onClick: () => void navigate({ to: '/notifications' }),
+          testId: 'platform-notification-back-button',
+        }}
+      />
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading notification...
+        </div>
+      ) : !notification ? (
+        <div className="rounded-xl border border-dashed p-12 text-center text-sm text-muted-foreground">
+          <Megaphone className="h-8 w-8 mx-auto mb-3 opacity-20" />
+          Notification not found.
+        </div>
+      ) : (
+        <div className="max-w-2xl" data-testid="platform-notification-detail">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground mb-4">
+            <Megaphone className="h-3.5 w-3.5" />
+            <span>Platform</span>
+            <span aria-hidden>·</span>
+            <span className="tabular-nums">
+              {format(new Date(notification.created_at), 'MMM d, yyyy h:mm a')}
+            </span>
+          </div>
+          <div className="text-sm">
+            <MarkdownBlock text={notification.body} />
+          </div>
+          {safeActionUrl && (
+            <div className="mt-6">
+              {/* Styled directly (buttonVariants) rather than `<Button asChild>` —
+                  the Radix Slot trips React.Children.only (see route-fallbacks). */}
+              <a
+                href={safeActionUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={buttonVariants({ variant: 'outline', size: 'sm' })}
+              >
+                <ExternalLink className="h-3.5 w-3.5 mr-1.5" />
+                Open link
+              </a>
+            </div>
+          )}
+        </div>
+      )}
+    </SettingsPageContainer>
+  )
+}

--- a/src/renderer/components/settings/notifications-tab.tsx
+++ b/src/renderer/components/settings/notifications-tab.tsx
@@ -56,6 +56,7 @@ export function NotificationsTab() {
     sessionComplete: boolean
     sessionWaiting: boolean
     sessionScheduled: boolean
+    platformNotification: boolean
     notifyWhenUnfocused: boolean
   } | null>(null)
 
@@ -76,6 +77,7 @@ export function NotificationsTab() {
     sessionComplete: true,
     sessionWaiting: true,
     sessionScheduled: true,
+    platformNotification: true,
     notifyWhenUnfocused: false,
   }
 
@@ -167,6 +169,19 @@ export function NotificationsTab() {
               id="notify-session-scheduled"
               checked={notificationSettings.sessionScheduled}
               onCheckedChange={(checked) => updateNotificationSetting('sessionScheduled', checked)}
+              disabled={isLoading || !notificationSettings.enabled}
+            />
+          }
+        />
+        <SettingRow
+          htmlFor="notify-platform-notification"
+          name="Platform notifications"
+          subtitle="Product announcements and account updates from the platform"
+          right={
+            <Switch
+              id="notify-platform-notification"
+              checked={notificationSettings.platformNotification}
+              onCheckedChange={(checked) => updateNotificationSetting('platformNotification', checked)}
               disabled={isLoading || !notificationSettings.enabled}
             />
           }

--- a/src/renderer/hooks/use-platform-notifications.ts
+++ b/src/renderer/hooks/use-platform-notifications.ts
@@ -1,0 +1,97 @@
+import { apiFetch } from '@renderer/lib/api'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+/**
+ * Platform notification as served by /api/platform-notifications (the
+ * platform proxy's wire shape — snake_case, live read, no local mirror).
+ */
+export interface ApiPlatformNotification {
+  id: string
+  org_id?: string | null
+  title: string
+  body: string
+  action_url?: string | null
+  kind: string
+  read_at?: string | null
+  expires_at?: string | null
+  created_at: string
+}
+
+export interface PlatformNotificationsList {
+  notifications: ApiPlatformNotification[]
+  total: number
+  unread_count: number
+  connected: boolean
+}
+
+/**
+ * Fetch the newest `limit` platform notifications. Proxy-live: a short
+ * staleTime softens the fetch; realtime INSERTs invalidate via the
+ * `platform_notifications_changed` SSE signal.
+ */
+export function usePlatformNotifications(limit: number) {
+  return useQuery<PlatformNotificationsList>({
+    queryKey: ['platform-notifications', limit],
+    queryFn: async () => {
+      const res = await apiFetch(`/api/platform-notifications?limit=${limit}`)
+      if (!res.ok) throw new Error('Failed to fetch platform notifications')
+      return res.json()
+    },
+    staleTime: 15000,
+    refetchInterval: 60000,
+  })
+}
+
+/** Unread platform-notification count (combined into the sidebar badge). */
+export function usePlatformUnreadCount() {
+  return useQuery<{ count: number }>({
+    queryKey: ['platform-notifications', 'unread-count'],
+    queryFn: async () => {
+      const res = await apiFetch('/api/platform-notifications/unread-count')
+      if (!res.ok) throw new Error('Failed to fetch platform unread count')
+      return res.json()
+    },
+    staleTime: 15000,
+    refetchInterval: 30000,
+  })
+}
+
+/** Mark platform notifications read (write-through to the platform). */
+export function useMarkPlatformNotificationsRead() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    meta: { skipGlobalErrorToast: true },
+    mutationFn: async (ids: string[]) => {
+      const res = await apiFetch('/api/platform-notifications/read', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids }),
+      })
+      if (!res.ok) throw new Error('Failed to mark platform notifications read')
+      return res.json()
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['platform-notifications'] })
+    },
+  })
+}
+
+/** Mark every unread platform notification read. */
+export function useMarkAllPlatformNotificationsRead() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    meta: { skipGlobalErrorToast: true },
+    mutationFn: async () => {
+      const res = await apiFetch('/api/platform-notifications/read-all', {
+        method: 'POST',
+      })
+      if (!res.ok) throw new Error('Failed to mark all platform notifications read')
+      return res.json()
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['platform-notifications'] })
+    },
+  })
+}

--- a/src/renderer/lib/markdown-preview.test.ts
+++ b/src/renderer/lib/markdown-preview.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { stripMarkdownPreview } from './markdown-preview'
+
+describe('stripMarkdownPreview', () => {
+  it('strips emphasis, links, and list markers into one line', () => {
+    expect(
+      stripMarkdownPreview(
+        'This is a **markdown** body with a [link](https://gamutagents.com).\n\n- bullet one\n- bullet two',
+      ),
+    ).toBe('This is a markdown body with a link. bullet one bullet two')
+  })
+
+  it('keeps image alt text and inline code content', () => {
+    expect(stripMarkdownPreview('See ![diagram](https://x/img.png) and run `npm i`')).toBe(
+      'See diagram and run npm i',
+    )
+  })
+
+  it('drops headings, blockquotes, hrules, and code fences', () => {
+    expect(
+      stripMarkdownPreview('# Big news\n\n> quoted\n\n---\n\n```js\nconst x = 1\n```\nDone'),
+    ).toBe('Big news quoted Done')
+  })
+
+  it('handles bold-italic and strikethrough', () => {
+    expect(stripMarkdownPreview('***very*** important, ~~not~~ now')).toBe(
+      'very important, not now',
+    )
+  })
+
+  it('passes plain text through unchanged', () => {
+    expect(stripMarkdownPreview('Just a plain sentence.')).toBe('Just a plain sentence.')
+  })
+})

--- a/src/renderer/lib/markdown-preview.ts
+++ b/src/renderer/lib/markdown-preview.ts
@@ -1,0 +1,32 @@
+/**
+ * Flatten a markdown body into single-line plain text for truncated list
+ * previews (e.g. the notification inbox row). This is presentational-only —
+ * the full body is always rendered through ReactMarkdown with the URL-scheme
+ * allowlist; nothing security-relevant happens here.
+ */
+export function stripMarkdownPreview(markdown: string): string {
+  return (
+    markdown
+      // Code blocks first, so their content doesn't leak fence/language noise
+      .replace(/```[\s\S]*?```/g, ' ')
+      // Images: keep the alt text
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+      // Links: keep the label
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+      // Inline code
+      .replace(/`([^`]+)`/g, '$1')
+      // Bold / italic / strikethrough (longest markers first)
+      .replace(/(\*\*\*|___)(.+?)\1/g, '$2')
+      .replace(/(\*\*|__)(.+?)\1/g, '$2')
+      .replace(/(\*|_)(.+?)\1/g, '$2')
+      .replace(/~~(.+?)~~/g, '$1')
+      // Line-anchored syntax: headings, blockquotes, list markers, hrules
+      .replace(/^#{1,6}\s+/gm, '')
+      .replace(/^\s*>\s?/gm, '')
+      .replace(/^\s*(?:[-*+]|\d+[.)])\s+/gm, '')
+      .replace(/^\s*(?:[-*_]\s*){3,}$/gm, ' ')
+      // Collapse to one line
+      .replace(/\s+/g, ' ')
+      .trim()
+  )
+}

--- a/src/renderer/router/routes.ts
+++ b/src/renderer/router/routes.ts
@@ -10,6 +10,7 @@ import { chatSearchSchema, connectionsSearchSchema, rootSearchSchema, settingsSe
 import { HomePage } from '@renderer/components/home/home-page'
 import { RootLayout, AppShellLayout } from '@renderer/components/layout/route-layouts'
 import { NotificationsRoute } from '@renderer/components/layout/notifications-route'
+import { NotificationDetailRoute } from '@renderer/components/layout/notification-detail-route'
 import { AgentShell } from '@renderer/components/layout/agent-shell'
 import {
   AgentHomeRoute,
@@ -62,6 +63,13 @@ export const notificationsRoute = createRoute({
   getParentRoute: () => appShellRoute,
   path: 'notifications',
   component: NotificationsRoute,
+})
+
+export const notificationDetailRoute = createRoute({
+  getParentRoute: () => appShellRoute,
+  path: 'notifications/$id',
+  params: { parse: (raw) => ({ id: z.string().min(1).parse(raw.id) }) },
+  component: NotificationDetailRoute,
 })
 
 // ── AGENT LAYOUT: /agents/$slug — mount-survival anchor #2 (chat/SSE shell) ────
@@ -181,6 +189,7 @@ export const routeTree = rootRoute.addChildren([
   appShellRoute.addChildren([
     homeRoute,
     notificationsRoute,
+    notificationDetailRoute,
     agentLayoutRoute.addChildren([
       agentHomeRoute,
       sessionRoute,

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -63,6 +63,7 @@ export interface NotificationSettings {
   sessionComplete: boolean
   sessionWaiting: boolean
   sessionScheduled: boolean
+  platformNotification?: boolean
   notifyWhenUnfocused?: boolean
 }
 
@@ -224,8 +225,18 @@ export interface AppSettings {
   analyticsTargets?: AnalyticsTarget[]
   shareErrorReports?: boolean
   platformAuth?: PlatformAuthSettings
+  /**
+   * Desktop platform-notifications state: the OS-notification dedup watermark
+   * (newest created_at already OS-notified). Content is never mirrored locally
+   * — the inbox reads live from the platform.
+   */
+  platformNotifications?: PlatformNotificationsSettings
   /** Anthropic SDK tool search — defaults on; passed as `ENABLE_TOOL_SEARCH` to the container. */
   enableToolSearch?: boolean
+}
+
+export interface PlatformNotificationsSettings {
+  lastNotifiedAt?: string
 }
 
 // API key source types
@@ -462,6 +473,7 @@ function mergeLoadedSettings(loaded: Record<string, any>): AppSettings {
     analyticsTargets: loaded.analyticsTargets,
     shareErrorReports: loaded.shareErrorReports,
     platformAuth: loaded.platformAuth,
+    platformNotifications: loaded.platformNotifications,
     enableToolSearch: loaded.enableToolSearch ?? DEFAULT_SETTINGS.enableToolSearch,
   }
 }

--- a/src/shared/lib/notifications/notification-action-schema.ts
+++ b/src/shared/lib/notifications/notification-action-schema.ts
@@ -29,8 +29,16 @@ const ProxyReviewContextSchema = z.object({
   notificationId: z.string().min(1).optional(),
 })
 
+const PlatformNotificationContextSchema = z.object({
+  kind: z.literal('platform_notification'),
+  // Platform-side notification id (ntf_…) — clicking the OS notification
+  // opens /notifications/$id and write-through-marks the row read.
+  platformNotificationId: z.string().min(1),
+})
+
 export const NotificationActionContextSchema = z.discriminatedUnion('kind', [
   ProxyReviewContextSchema,
+  PlatformNotificationContextSchema,
 ])
 
 export type NotificationActionContext = z.infer<typeof NotificationActionContextSchema>

--- a/src/shared/lib/scheduler/platform-notifications-manager.test.ts
+++ b/src/shared/lib/scheduler/platform-notifications-manager.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+let mockIsAuthMode = false
+vi.mock('@shared/lib/auth/mode', () => ({
+  isAuthMode: () => mockIsAuthMode,
+}))
+
+let mockProxyUrl: string | null = 'https://proxy.test.example'
+vi.mock('@shared/lib/platform-auth/config', () => ({
+  getPlatformProxyBaseUrl: () => mockProxyUrl,
+}))
+
+let mockToken: string | null = 'pk_test'
+vi.mock('@shared/lib/services/platform-auth-service', () => ({
+  getPlatformAccessToken: () => mockToken,
+}))
+
+let mockSettings: Record<string, unknown> = {}
+const mockMutateSettings = vi.fn((mutator: (s: Record<string, unknown>) => void) => {
+  mutator(mockSettings)
+  return mockSettings
+})
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => mockSettings,
+  mutateSettings: (mutator: (s: Record<string, unknown>) => void) => mockMutateSettings(mutator),
+}))
+
+const mockBroadcastGlobal = vi.fn()
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    broadcastGlobal: (...args: unknown[]) => mockBroadcastGlobal(...args),
+  },
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+}))
+
+let mockUserNotificationSettings: Record<string, boolean> = { enabled: true }
+vi.mock('@shared/lib/services/user-settings-service', () => ({
+  getUserSettings: () => ({ notifications: mockUserNotificationSettings }),
+}))
+
+const mockGetRealtimeConfig = vi.fn()
+const mockListNotifications = vi.fn()
+vi.mock('@shared/lib/services/platform-notifications-client', () => ({
+  getNotificationsRealtimeConfig: (...args: unknown[]) => mockGetRealtimeConfig(...args),
+  listPlatformNotifications: (...args: unknown[]) => mockListNotifications(...args),
+}))
+
+// Fake realtime client capturing connect() so tests can inject INSERT records,
+// flip liveness, and fail the websocket handshake.
+type EventCallback = (record: unknown) => void
+const realtimeInstances: Array<{
+  config: unknown
+  onEvent: EventCallback | null
+  active: boolean
+  disconnect: ReturnType<typeof vi.fn>
+  updateToken: ReturnType<typeof vi.fn>
+}> = []
+let mockConnectError: Error | null = null
+vi.mock('@shared/lib/services/supabase-realtime-client', () => ({
+  SupabaseRealtimeClient: class {
+    config: unknown = null
+    onEvent: EventCallback | null = null
+    active = false
+    disconnect = vi.fn(() => {
+      this.active = false
+    })
+    updateToken = vi.fn()
+    isActive() {
+      return this.active
+    }
+    async connect(config: unknown, onEvent: EventCallback) {
+      this.config = config
+      this.onEvent = onEvent
+      realtimeInstances.push(this)
+      if (mockConnectError) {
+        const err = mockConnectError
+        mockConnectError = null
+        throw err
+      }
+      this.active = true
+    }
+  },
+}))
+
+import { platformNotificationsManager } from './platform-notifications-manager'
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const REALTIME_CONFIG = {
+  url: 'wss://x.supabase.co/realtime/v1',
+  apikey: 'anon',
+  jwt: 'jwt-1',
+  channel: 'realtime:public:notifications',
+  table: 'notifications',
+}
+
+function record(id: string, createdAt: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    title: `Title ${id}`,
+    body: 'markdown body',
+    created_at: createdAt,
+    ...overrides,
+  }
+}
+
+function osNotificationBroadcasts() {
+  return mockBroadcastGlobal.mock.calls.filter(
+    (call) => (call[0] as { type?: string }).type === 'os_notification',
+  )
+}
+
+function changedBroadcasts() {
+  return mockBroadcastGlobal.mock.calls.filter(
+    (call) => (call[0] as { type?: string }).type === 'platform_notifications_changed',
+  )
+}
+
+async function startWithDefaults(): Promise<EventCallback> {
+  mockGetRealtimeConfig.mockResolvedValue(REALTIME_CONFIG)
+  // Newest existing row — seeds the watermark on first start.
+  mockListNotifications.mockResolvedValue({
+    notifications: [record('ntf_seed', '2026-07-01T00:00:00Z')],
+    total: 1,
+    unread_count: 1,
+  })
+  await platformNotificationsManager.start()
+  const instance = realtimeInstances[realtimeInstances.length - 1]
+  expect(instance).toBeDefined()
+  return instance.onEvent!
+}
+
+const JWT_REFRESH_INTERVAL_MS = 50 * 60 * 1000
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useRealTimers()
+  realtimeInstances.length = 0
+  mockConnectError = null
+  mockIsAuthMode = false
+  mockProxyUrl = 'https://proxy.test.example'
+  mockToken = 'pk_test'
+  mockSettings = { platformAuth: { memberId: 'sub_member_1' } }
+  mockUserNotificationSettings = { enabled: true }
+  platformNotificationsManager.stop()
+})
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('PlatformNotificationsManager', () => {
+  it('does not start in auth mode', async () => {
+    mockIsAuthMode = true
+    await platformNotificationsManager.start()
+    expect(platformNotificationsManager.isActive()).toBe(false)
+    expect(mockGetRealtimeConfig).not.toHaveBeenCalled()
+  })
+
+  it('does not start without a platform connection', async () => {
+    mockToken = null
+    await platformNotificationsManager.start()
+    expect(platformNotificationsManager.isActive()).toBe(false)
+    expect(mockGetRealtimeConfig).not.toHaveBeenCalled()
+  })
+
+  it('subscribes with the platform-minted config and seeds the watermark', async () => {
+    const onEvent = await startWithDefaults()
+    expect(platformNotificationsManager.isActive()).toBe(true)
+    expect(realtimeInstances[0].config).toEqual(REALTIME_CONFIG)
+    expect(mockGetRealtimeConfig).toHaveBeenCalledWith('sub_member_1')
+
+    // The seed row (already existing before subscribe) must never OS-notify.
+    onEvent(record('ntf_seed', '2026-07-01T00:00:00Z'))
+    expect(osNotificationBroadcasts()).toHaveLength(0)
+  })
+
+  it('retries a null config on the refresh tick and subscribes once one is minted', async () => {
+    vi.useFakeTimers()
+    mockGetRealtimeConfig.mockResolvedValueOnce(null)
+    await platformNotificationsManager.start()
+    expect(platformNotificationsManager.isActive()).toBe(true)
+    expect(realtimeInstances).toHaveLength(0)
+
+    // e.g. an auth cache entry that predates the userId claim gets revalidated
+    mockGetRealtimeConfig.mockResolvedValue(REALTIME_CONFIG)
+    mockListNotifications.mockResolvedValue({ notifications: [], total: 0, unread_count: 0 })
+    await vi.advanceTimersByTimeAsync(JWT_REFRESH_INTERVAL_MS)
+
+    expect(realtimeInstances).toHaveLength(1)
+    expect(platformNotificationsManager.isRealtimeActive()).toBe(true)
+  })
+
+  it('refreshes the JWT on the 50-minute tick while the subscription is live', async () => {
+    vi.useFakeTimers()
+    await startWithDefaults()
+    const instance = realtimeInstances[0]
+
+    mockGetRealtimeConfig.mockResolvedValue({ ...REALTIME_CONFIG, jwt: 'jwt-2' })
+    await vi.advanceTimersByTimeAsync(JWT_REFRESH_INTERVAL_MS)
+
+    expect(instance.updateToken).toHaveBeenCalledWith('jwt-2')
+    // Still the same subscription — no churn while healthy.
+    expect(realtimeInstances).toHaveLength(1)
+  })
+
+  it('reconnects on the refresh tick when the subscription has died', async () => {
+    vi.useFakeTimers()
+    await startWithDefaults()
+    realtimeInstances[0].active = false // e.g. reconnect attempts exhausted
+
+    await vi.advanceTimersByTimeAsync(JWT_REFRESH_INTERVAL_MS)
+
+    expect(realtimeInstances).toHaveLength(2)
+    expect(platformNotificationsManager.isRealtimeActive()).toBe(true)
+  })
+
+  it('installs the retry cadence even when the initial websocket connect fails', async () => {
+    // A connection-refused at launch must not hang start() or strand the
+    // manager without its refresh interval (the realtime JWT only lasts 1h).
+    vi.useFakeTimers()
+    mockConnectError = new Error('WebSocket closed before connection established')
+    await startWithDefaults()
+    expect(platformNotificationsManager.isRealtimeActive()).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(JWT_REFRESH_INTERVAL_MS)
+
+    expect(realtimeInstances).toHaveLength(2)
+    expect(platformNotificationsManager.isRealtimeActive()).toBe(true)
+  })
+
+  it('a stale in-flight connect from before a stop/start cannot clobber the new subscription', async () => {
+    vi.useFakeTimers()
+    mockListNotifications.mockResolvedValue({ notifications: [], total: 0, unread_count: 0 })
+
+    // start #1 blocks on the realtime-config mint...
+    let resolveMint: (config: unknown) => void = () => {}
+    mockGetRealtimeConfig.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveMint = resolve)),
+    )
+    const firstStart = platformNotificationsManager.start()
+
+    // ...meanwhile the platform disconnects and reconnects (new identity).
+    platformNotificationsManager.stop()
+    mockGetRealtimeConfig.mockResolvedValue({ ...REALTIME_CONFIG, jwt: 'jwt-fresh' })
+    await platformNotificationsManager.start()
+    expect(realtimeInstances).toHaveLength(1)
+    const current = realtimeInstances[0]
+
+    // The stale mint resolving must not resubscribe with the old identity,
+    // disconnect the current client, or double-install the refresh interval.
+    resolveMint({ ...REALTIME_CONFIG, jwt: 'jwt-stale' })
+    await firstStart
+
+    expect(realtimeInstances).toHaveLength(1)
+    expect(current.disconnect).not.toHaveBeenCalled()
+    expect(platformNotificationsManager.isRealtimeActive()).toBe(true)
+
+    // Exactly one refresh interval: one tick mints exactly one config.
+    mockGetRealtimeConfig.mockClear()
+    await vi.advanceTimersByTimeAsync(JWT_REFRESH_INTERVAL_MS)
+    expect(mockGetRealtimeConfig).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not re-notify a reconnect replay of the newest row after a restart', async () => {
+    // Restart clears the in-session id-set; only the persisted watermark
+    // stands between a replayed INSERT (created_at equal to the watermark)
+    // and a duplicate OS notification.
+    const onEvent = await startWithDefaults()
+    onEvent(record('ntf_new', '2026-07-02T00:00:00Z'))
+    expect(osNotificationBroadcasts()).toHaveLength(1)
+
+    platformNotificationsManager.stop()
+    const onEventAfterRestart = await startWithDefaults()
+    onEventAfterRestart(record('ntf_new', '2026-07-02T00:00:00Z'))
+
+    expect(osNotificationBroadcasts()).toHaveLength(1)
+  })
+
+  it('fires one OS notification per INSERT and always signals the inbox', async () => {
+    const onEvent = await startWithDefaults()
+
+    onEvent(record('ntf_new', '2026-07-02T00:00:00Z'))
+
+    expect(changedBroadcasts()).toHaveLength(1)
+    const osNotifs = osNotificationBroadcasts()
+    expect(osNotifs).toHaveLength(1)
+    expect(osNotifs[0][0]).toMatchObject({
+      type: 'os_notification',
+      notificationType: 'platform_notification',
+      platformNotificationId: 'ntf_new',
+      title: 'Title ntf_new',
+      body: 'markdown body',
+      actionContext: {
+        kind: 'platform_notification',
+        platformNotificationId: 'ntf_new',
+      },
+    })
+  })
+
+  it('dedups reconnect replays by id and backdated inserts by watermark', async () => {
+    const onEvent = await startWithDefaults()
+
+    onEvent(record('ntf_new', '2026-07-02T00:00:00Z'))
+    onEvent(record('ntf_new', '2026-07-02T00:00:00Z')) // replay
+    onEvent(record('ntf_backdated', '2026-06-01T00:00:00Z')) // older than watermark
+
+    expect(osNotificationBroadcasts()).toHaveLength(1)
+    // The inbox signal still fires for every INSERT (live page update).
+    expect(changedBroadcasts()).toHaveLength(3)
+  })
+
+  it('persists the advanced watermark', async () => {
+    const onEvent = await startWithDefaults()
+    onEvent(record('ntf_new', '2026-07-02T00:00:00Z'))
+
+    expect(
+      (mockSettings.platformNotifications as { lastNotifiedAt?: string }).lastNotifiedAt,
+    ).toBe('2026-07-02T00:00:00Z')
+  })
+
+  it('prefers the persisted watermark over the list seed', async () => {
+    mockSettings.platformNotifications = { lastNotifiedAt: '2026-07-03T00:00:00Z' }
+    const onEvent = await startWithDefaults()
+    // No list seed needed — and an insert older than the persisted watermark
+    // stays silent.
+    onEvent(record('ntf_old', '2026-07-02T12:00:00Z'))
+    expect(osNotificationBroadcasts()).toHaveLength(0)
+
+    onEvent(record('ntf_newer', '2026-07-04T00:00:00Z'))
+    expect(osNotificationBroadcasts()).toHaveLength(1)
+  })
+
+  it('suppresses the OS notification when the settings toggle is off', async () => {
+    mockUserNotificationSettings = { enabled: true, platformNotification: false }
+    const onEvent = await startWithDefaults()
+
+    onEvent(record('ntf_new', '2026-07-02T00:00:00Z'))
+
+    expect(osNotificationBroadcasts()).toHaveLength(0)
+    expect(changedBroadcasts()).toHaveLength(1) // inbox still updates
+  })
+
+  it('drops records that fail schema validation', async () => {
+    const onEvent = await startWithDefaults()
+
+    onEvent({ id: 'ntf_bad' }) // missing title/body/created_at
+
+    expect(osNotificationBroadcasts()).toHaveLength(0)
+    expect(changedBroadcasts()).toHaveLength(0)
+  })
+
+  it('stop() disconnects the realtime client', async () => {
+    await startWithDefaults()
+    platformNotificationsManager.stop()
+    expect(realtimeInstances[0].disconnect).toHaveBeenCalled()
+    expect(platformNotificationsManager.isActive()).toBe(false)
+  })
+})

--- a/src/shared/lib/scheduler/platform-notifications-manager.ts
+++ b/src/shared/lib/scheduler/platform-notifications-manager.ts
@@ -1,0 +1,261 @@
+/**
+ * Platform Notifications Manager
+ *
+ * Desktop-only background subscription that turns platform notification
+ * INSERTs (Supabase Realtime, RLS-scoped to the connected user) into OS
+ * notifications and inbox-invalidation signals. Holds NO content store — the
+ * inbox always reads live from the platform proxy; this manager owns only the
+ * websocket and an OS-notification dedup watermark.
+ *
+ * Non-auth only: a multi-tenant auth_mode server has no business firing OS
+ * notifications; its web clients rely on the inbox query's refetch cadence.
+ */
+
+import { isAuthMode } from '@shared/lib/auth/mode'
+import { getSettings, mutateSettings } from '@shared/lib/config/settings'
+import { messagePersister } from '@shared/lib/container/message-persister'
+import { captureException } from '@shared/lib/error-reporting'
+import { getPlatformProxyBaseUrl } from '@shared/lib/platform-auth/config'
+import { getPlatformAccessToken } from '@shared/lib/services/platform-auth-service'
+import {
+  getNotificationsRealtimeConfig,
+  listPlatformNotifications,
+} from '@shared/lib/services/platform-notifications-client'
+import { platformNotificationRealtimeRecordSchema } from '@shared/lib/services/platform-notifications-schema'
+import { SupabaseRealtimeClient } from '@shared/lib/services/supabase-realtime-client'
+import { getUserSettings } from '@shared/lib/services/user-settings-service'
+
+// JWT lasts 1 hour; refresh with headroom. The same tick retries the
+// subscription when the proxy returned a null config earlier (e.g. an auth
+// cache entry that predates the userId claim).
+const JWT_REFRESH_INTERVAL_MS = 50 * 60 * 1000
+
+class PlatformNotificationsManager {
+  private isRunning = false
+  private realtimeClient: SupabaseRealtimeClient | null = null
+  private refreshInterval: NodeJS.Timeout | null = null
+  private notifiedIds = new Set<string>()
+  private lastNotifiedAt: string | null = null
+  // Bumped by every stop() and start(): an async connect that resumes after
+  // its generation passed must not touch the current one's client/interval
+  // (e.g. a quick platform disconnect→reconnect while the config mint is in
+  // flight would otherwise resubscribe with the stale identity's JWT).
+  private generation = 0
+
+  async start(): Promise<void> {
+    if (this.isRunning) return
+    if (isAuthMode()) return
+    if (!getPlatformProxyBaseUrl() || !getPlatformAccessToken()) {
+      console.log('[PlatformNotifications] Platform not connected, skipping')
+      return
+    }
+
+    this.isRunning = true
+    const generation = ++this.generation
+    console.log('[PlatformNotifications] Starting...')
+
+    try {
+      await this.connect(generation)
+    } catch (error) {
+      console.error('[PlatformNotifications] Initial connect failed:', error)
+    }
+
+    // The refresh interval retries a failed initial connect, so it installs
+    // even when connect() threw — but never for a superseded generation.
+    if (generation !== this.generation || !this.isRunning) return
+    this.refreshInterval = setInterval(() => {
+      void this.refreshOrReconnect()
+    }, JWT_REFRESH_INTERVAL_MS)
+  }
+
+  stop(): void {
+    if (!this.isRunning) return
+    this.isRunning = false
+    this.generation++
+
+    if (this.realtimeClient) {
+      this.realtimeClient.disconnect()
+      this.realtimeClient = null
+    }
+    if (this.refreshInterval) {
+      clearInterval(this.refreshInterval)
+      this.refreshInterval = null
+    }
+    this.notifiedIds.clear()
+    // The in-memory watermark re-seeds from settings on the next start; the
+    // persisted value survives disconnect/reconnect (and process restarts).
+    this.lastNotifiedAt = null
+    console.log('[PlatformNotifications] Stopped')
+  }
+
+  isActive(): boolean {
+    return this.isRunning
+  }
+
+  isRealtimeActive(): boolean {
+    return this.realtimeClient?.isActive() ?? false
+  }
+
+  // Org JWTs need the acting member appended to the bearer; opaque personal
+  // keys ignore it, so a placeholder is fine when no member is recorded.
+  private getMemberId(): string {
+    return getSettings().platformAuth?.memberId ?? 'local'
+  }
+
+  private async connect(generation: number): Promise<void> {
+    const memberId = this.getMemberId()
+    const config = await getNotificationsRealtimeConfig(memberId)
+    if (generation !== this.generation) return
+    if (!config) {
+      // No acting-user context on the proxy yet — the refresh tick retries.
+      console.log('[PlatformNotifications] Realtime config unavailable, will retry')
+      return
+    }
+
+    await this.seedWatermark(memberId)
+
+    if (generation !== this.generation || !this.isRunning) return
+    if (this.realtimeClient) {
+      this.realtimeClient.disconnect()
+    }
+    const client = new SupabaseRealtimeClient()
+    this.realtimeClient = client
+    await client.connect(config, (record) => {
+      this.handleRealtimeInsert(record)
+    })
+    if (generation !== this.generation) {
+      // Superseded while the socket opened: tear down our own client, but
+      // leave this.realtimeClient alone if a newer connect already replaced it.
+      client.disconnect()
+      return
+    }
+    console.log('[PlatformNotifications] Realtime subscription active')
+  }
+
+  /**
+   * The OS notification only ever fires from live INSERTs, so the watermark
+   * exists to suppress replays/backdated inserts — never to replay a backlog.
+   * Prefer the persisted value (survives restarts); seed a fresh install from
+   * the newest existing row so pre-existing notifications can't fire.
+   */
+  private async seedWatermark(memberId: string): Promise<void> {
+    if (this.lastNotifiedAt) return
+
+    const persisted = getSettings().platformNotifications?.lastNotifiedAt
+    if (persisted) {
+      this.lastNotifiedAt = persisted
+      return
+    }
+
+    try {
+      const list = await listPlatformNotifications({ limit: 1 }, memberId)
+      this.lastNotifiedAt = list.notifications[0]?.created_at ?? new Date(0).toISOString()
+    } catch (error) {
+      // Fail toward "notify nothing older than now" — an inbox read failure
+      // must not turn the next reconnect into a notification storm.
+      console.error('[PlatformNotifications] Watermark seed failed:', error)
+      this.lastNotifiedAt = new Date().toISOString()
+    }
+    this.persistWatermark()
+  }
+
+  private persistWatermark(): void {
+    const lastNotifiedAt = this.lastNotifiedAt
+    if (!lastNotifiedAt) return
+    try {
+      mutateSettings((settings) => {
+        settings.platformNotifications = { ...settings.platformNotifications, lastNotifiedAt }
+      })
+    } catch (error) {
+      captureException(error, {
+        tags: { area: 'platform-notifications', op: 'persist-watermark' },
+      })
+    }
+  }
+
+  private handleRealtimeInsert(rawRecord: unknown): void {
+    const parsed = platformNotificationRealtimeRecordSchema.safeParse(rawRecord)
+    if (!parsed.success) {
+      captureException(parsed.error, {
+        level: 'warning',
+        tags: { area: 'platform-notifications', op: 'record-parse' },
+      })
+      return
+    }
+    const record = parsed.data
+
+    // An open inbox page updates live regardless of OS-notification dedup.
+    messagePersister.broadcastGlobal({ type: 'platform_notifications_changed' })
+
+    // Dedup: the in-session id-set survives reconnect replays; the persisted
+    // watermark survives restarts and suppresses backdated inserts.
+    if (this.notifiedIds.has(record.id)) return
+    if (this.lastNotifiedAt && record.created_at <= this.lastNotifiedAt) return
+    this.notifiedIds.add(record.id)
+    this.lastNotifiedAt =
+      this.lastNotifiedAt && this.lastNotifiedAt > record.created_at
+        ? this.lastNotifiedAt
+        : record.created_at
+    this.persistWatermark()
+
+    if (!this.isPlatformNotificationEnabled()) return
+
+    // Fire straight from the record (notifications are plain data, not a
+    // claimable work queue — no re-poll). No agentSlug/sessionId: clicking
+    // opens the notification detail route instead of a session.
+    messagePersister.broadcastGlobal({
+      type: 'os_notification',
+      notificationType: 'platform_notification',
+      platformNotificationId: record.id,
+      title: record.title,
+      body: record.body,
+      actionContext: {
+        kind: 'platform_notification',
+        platformNotificationId: record.id,
+      },
+    })
+  }
+
+  // Manager runs non-auth only, so the single 'local' user's settings apply.
+  // The renderer re-checks its own settings before showing the popup; this
+  // gate just avoids broadcasting an event nobody may show.
+  private isPlatformNotificationEnabled(): boolean {
+    try {
+      const notifications = getUserSettings('local').notifications
+      if (!notifications.enabled) return false
+      return notifications.platformNotification !== false
+    } catch {
+      return true
+    }
+  }
+
+  /** 50-minute tick: refresh the Realtime JWT, or (re)connect if inactive. */
+  private async refreshOrReconnect(): Promise<void> {
+    if (!this.isRunning) return
+    const generation = this.generation
+    try {
+      if (!this.realtimeClient?.isActive()) {
+        await this.connect(generation)
+        return
+      }
+      const config = await getNotificationsRealtimeConfig(this.getMemberId())
+      if (config?.jwt && this.realtimeClient) {
+        await this.realtimeClient.updateToken(config.jwt)
+      }
+    } catch (error) {
+      console.error('[PlatformNotifications] JWT refresh failed:', error)
+    }
+  }
+}
+
+// Export singleton instance (persists across hot reloads)
+const globalForManager = globalThis as unknown as {
+  platformNotificationsManager: PlatformNotificationsManager | undefined
+}
+
+export const platformNotificationsManager =
+  globalForManager.platformNotificationsManager ?? new PlatformNotificationsManager()
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForManager.platformNotificationsManager = platformNotificationsManager
+}

--- a/src/shared/lib/services/platform-auth-service.ts
+++ b/src/shared/lib/services/platform-auth-service.ts
@@ -240,6 +240,17 @@ function notifyPlatformServiceAuthChanged(connected: boolean): void {
   void import('./platform-service')
     .then((mod) => mod.platformService.onAuthChanged(connected))
     .catch((error) => captureException(error, { tags: { area: 'platform-auth', op: 'notify-service' } }))
+  // The desktop notifications subscription follows platform connectivity:
+  // start on connect (self-gates on auth mode), tear down on disconnect.
+  void import('../scheduler/platform-notifications-manager')
+    .then((mod) =>
+      connected
+        ? mod.platformNotificationsManager.start()
+        : mod.platformNotificationsManager.stop(),
+    )
+    .catch((error) =>
+      captureException(error, { tags: { area: 'platform-auth', op: 'notify-notifications' } }),
+    )
 }
 
 function getEnvManagedStatus(): PlatformAuthStatus | null {

--- a/src/shared/lib/services/platform-notifications-client.test.ts
+++ b/src/shared/lib/services/platform-notifications-client.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+let mockToken: string | null = 'pk_test_opaque'
+vi.mock('@shared/lib/services/platform-auth-service', () => ({
+  getPlatformAccessToken: () => mockToken,
+}))
+
+let mockOrgId: string | null = null
+vi.mock('@shared/lib/platform-attribution', () => ({
+  decodeOrgIdFromToken: () => mockOrgId,
+}))
+
+vi.mock('@shared/lib/platform-auth/config', () => ({
+  getPlatformProxyBaseUrl: () => 'https://proxy.test.example',
+}))
+
+import {
+  listPlatformNotifications,
+  getNotificationsRealtimeConfig,
+  markPlatformNotificationsRead,
+} from './platform-notifications-client'
+
+const originalFetch = globalThis.fetch
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+const LIST_RESPONSE = {
+  notifications: [
+    {
+      id: 'ntf_11111111-1111-1111-1111-111111111111',
+      org_id: null,
+      title: 'Hello',
+      body: '**md**',
+      action_url: null,
+      kind: 'broadcast',
+      read_at: null,
+      expires_at: null,
+      created_at: '2026-07-01T00:00:00Z',
+    },
+  ],
+  total: 1,
+  unread_count: 1,
+}
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn()
+  mockToken = 'pk_test_opaque'
+  mockOrgId = null
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('platform-notifications-client', () => {
+  it('lists notifications with query params and parses the response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(jsonResponse(LIST_RESPONSE))
+
+    const result = await listPlatformNotifications(
+      { status: 'unread', limit: 10, offset: 5 },
+      'sub_member',
+    )
+    expect(result.notifications).toHaveLength(1)
+    expect(result.notifications[0].title).toBe('Hello')
+    expect(result.unread_count).toBe(1)
+
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0]
+    expect(String(url)).toBe(
+      'https://proxy.test.example/v1/notifications?status=unread&limit=10&offset=5',
+    )
+    expect(new Headers(init?.headers).get('Authorization')).toBe('Bearer pk_test_opaque')
+  })
+
+  it('appends ::memberId to the bearer for org JWTs only', async () => {
+    mockOrgId = 'org_1'
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(jsonResponse(LIST_RESPONSE))
+
+    await listPlatformNotifications({}, 'sub_member')
+
+    const init = vi.mocked(globalThis.fetch).mock.calls[0][1]
+    expect(new Headers(init?.headers).get('Authorization')).toBe(
+      'Bearer pk_test_opaque::sub_member',
+    )
+  })
+
+  it('rejects a malformed list response at the Zod boundary', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      jsonResponse({ notifications: [{ id: 42 }], total: 'x' }),
+    )
+
+    await expect(listPlatformNotifications({}, 'local')).rejects.toThrow()
+  })
+
+  it('throws a descriptive error on non-2xx responses', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response('nope', { status: 502 }))
+
+    await expect(listPlatformNotifications({}, 'local')).rejects.toThrow(
+      /Platform notifications API error 502/,
+    )
+  })
+
+  it('throws when no platform token is available', async () => {
+    mockToken = null
+    await expect(listPlatformNotifications({}, 'local')).rejects.toThrow(
+      /Platform access token not available/,
+    )
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled()
+  })
+
+  it('returns the parsed realtime config (including the table)', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      jsonResponse({
+        realtime: {
+          url: 'wss://x.supabase.co/realtime/v1',
+          apikey: 'anon',
+          jwt: 'jwt',
+          channel: 'realtime:public:notifications',
+          table: 'notifications',
+        },
+      }),
+    )
+
+    const config = await getNotificationsRealtimeConfig('local')
+    expect(config?.table).toBe('notifications')
+
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0]
+    expect(String(url)).toBe('https://proxy.test.example/v1/notifications/realtime')
+    expect(init?.method).toBe('POST')
+  })
+
+  it('returns null when the proxy has no acting-user context', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(jsonResponse({ realtime: null }))
+    await expect(getNotificationsRealtimeConfig('local')).resolves.toBeNull()
+  })
+
+  it('marks notifications read and returns the updated count', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(jsonResponse({ ok: true, updated: 2 }))
+
+    const updated = await markPlatformNotificationsRead(
+      ['ntf_11111111-1111-1111-1111-111111111111', 'ntf_22222222-2222-2222-2222-222222222222'],
+      'local',
+    )
+    expect(updated).toBe(2)
+
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0]
+    expect(String(url)).toBe('https://proxy.test.example/v1/notifications/read')
+    expect(JSON.parse(init?.body as string).ids).toHaveLength(2)
+  })
+
+  it('short-circuits mark-read for an empty ids array', async () => {
+    await expect(markPlatformNotificationsRead([], 'local')).resolves.toBe(0)
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/lib/services/platform-notifications-client.ts
+++ b/src/shared/lib/services/platform-notifications-client.ts
@@ -1,0 +1,91 @@
+/**
+ * Platform Notifications Client
+ *
+ * Calls the platform proxy's /v1/notifications endpoints: live inbox reads,
+ * Realtime credential minting, and mark-read write-through. Modeled on
+ * webhook-events-client; responses are Zod-parsed at this boundary.
+ */
+
+import { decodeOrgIdFromToken } from '@shared/lib/platform-attribution'
+import { getPlatformProxyBaseUrl } from '@shared/lib/platform-auth/config'
+import { getPlatformAccessToken } from '@shared/lib/services/platform-auth-service'
+import {
+  markReadResponseSchema,
+  notificationsRealtimeConfigSchema,
+  platformNotificationsListSchema,
+  type PlatformNotificationsList,
+} from '@shared/lib/services/platform-notifications-schema'
+import type { RealtimeConfig } from '@shared/lib/services/webhook-events-client'
+
+// Org JWTs encode the acting member as `<token>::<memberId>`; opaque keys ignore it.
+function buildBearer(memberId: string): string {
+  const token = getPlatformAccessToken()
+  if (!token) {
+    throw new Error('Platform access token not available')
+  }
+  return decodeOrgIdFromToken(token) ? `${token}::${memberId}` : token
+}
+
+async function notificationsFetch(
+  endpoint: string,
+  memberId: string,
+  options: RequestInit = {},
+): Promise<unknown> {
+  const baseUrl = getPlatformProxyBaseUrl()
+  const headers = new Headers(options.headers)
+  headers.set('Content-Type', 'application/json')
+  headers.set('Authorization', `Bearer ${buildBearer(memberId)}`)
+
+  const response = await fetch(`${baseUrl}/v1/notifications${endpoint}`, {
+    ...options,
+    headers,
+  })
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new Error(`Platform notifications API error ${response.status}: ${text}`)
+  }
+
+  return response.json()
+}
+
+export interface ListPlatformNotificationsOptions {
+  status?: 'all' | 'unread'
+  limit?: number
+  offset?: number
+}
+
+export async function listPlatformNotifications(
+  options: ListPlatformNotificationsOptions,
+  memberId: string,
+): Promise<PlatformNotificationsList> {
+  const params = new URLSearchParams()
+  if (options.status) params.set('status', options.status)
+  if (options.limit !== undefined) params.set('limit', String(options.limit))
+  if (options.offset !== undefined) params.set('offset', String(options.offset))
+  const query = params.size > 0 ? `?${params.toString()}` : ''
+
+  const raw = await notificationsFetch(query, memberId)
+  return platformNotificationsListSchema.parse(raw)
+}
+
+/** Mint user-scoped Realtime credentials; null when no acting user resolves. */
+export async function getNotificationsRealtimeConfig(
+  memberId: string,
+): Promise<RealtimeConfig | null> {
+  const raw = await notificationsFetch('/realtime', memberId, { method: 'POST' })
+  return notificationsRealtimeConfigSchema.parse(raw).realtime
+}
+
+/** Mark notifications read (scoped platform-side to the caller's user). */
+export async function markPlatformNotificationsRead(
+  ids: string[],
+  memberId: string,
+): Promise<number> {
+  if (ids.length === 0) return 0
+  const raw = await notificationsFetch('/read', memberId, {
+    method: 'POST',
+    body: JSON.stringify({ ids }),
+  })
+  return markReadResponseSchema.parse(raw).updated
+}

--- a/src/shared/lib/services/platform-notifications-schema.ts
+++ b/src/shared/lib/services/platform-notifications-schema.ts
@@ -1,0 +1,78 @@
+/**
+ * Platform Notifications Schemas
+ *
+ * Zod schemas for the platform proxy's /v1/notifications wire shapes and for
+ * the Supabase Realtime INSERT record. Parsed at every network boundary: the
+ * list/read responses, the realtime-config response, and each realtime record
+ * before it is used.
+ */
+
+import { z } from 'zod'
+
+/** One notification row as returned by GET /v1/notifications. */
+export const platformNotificationSchema = z.object({
+  id: z.string().min(1),
+  org_id: z.string().nullish(),
+  title: z.string(),
+  body: z.string(),
+  action_url: z.string().nullish(),
+  kind: z.string(),
+  read_at: z.string().nullish(),
+  expires_at: z.string().nullish(),
+  created_at: z.string(),
+})
+
+export type PlatformNotification = z.infer<typeof platformNotificationSchema>
+
+export const platformNotificationsListSchema = z.object({
+  notifications: z.array(platformNotificationSchema),
+  total: z.number().int().nonnegative(),
+  unread_count: z.number().int().nonnegative(),
+})
+
+export type PlatformNotificationsList = z.infer<typeof platformNotificationsListSchema>
+
+/**
+ * Realtime credentials from POST /v1/notifications/realtime. Same shape as the
+ * webhook-events config plus the table the client should subscribe to; null
+ * when the proxy has no acting-user context yet (the manager no-ops and
+ * retries on its refresh cadence).
+ */
+export const notificationsRealtimeConfigSchema = z.object({
+  realtime: z
+    .object({
+      url: z.string().min(1),
+      apikey: z.string().min(1),
+      jwt: z.string().min(1),
+      channel: z.string(),
+      table: z.string().optional(),
+    })
+    .nullable(),
+})
+
+export const markReadResponseSchema = z.object({
+  ok: z.boolean(),
+  updated: z.number().int().nonnegative(),
+})
+
+/**
+ * The Supabase Realtime INSERT record (the full new row — WALRUS broadcasts
+ * it after the RLS SELECT policy passes). The OS notification fires straight
+ * from this record with no re-fetch, so it must carry title/body.
+ */
+export const platformNotificationRealtimeRecordSchema = z
+  .object({
+    id: z.string().min(1),
+    title: z.string(),
+    body: z.string(),
+    action_url: z.string().nullish(),
+    kind: z.string().optional(),
+    status: z.string().optional(),
+    read_at: z.string().nullish(),
+    created_at: z.string(),
+  })
+  .passthrough()
+
+export type PlatformNotificationRealtimeRecord = z.infer<
+  typeof platformNotificationRealtimeRecordSchema
+>

--- a/src/shared/lib/services/supabase-realtime-client.table.test.ts
+++ b/src/shared/lib/services/supabase-realtime-client.table.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// ============================================================================
+// ws mock — captures constructed sockets + sent frames; fires onopen async
+// (mirrors the real handshake happening after the constructor returns).
+// ============================================================================
+
+type SentFrame = { topic: string; event: string; payload: Record<string, unknown> }
+
+interface FakeSocket {
+  url: string
+  sent: SentFrame[]
+  onopen: (() => void) | null
+  onmessage: ((event: { data: string }) => void) | null
+  onerror: ((err: unknown) => void) | null
+  onclose: (() => void) | null
+}
+
+// vi.mock factories are hoisted above imports, so the fake class + registry
+// must be hoisted with them.
+const { FakeWebSocket, sockets, socketBehavior } = vi.hoisted(() => {
+  const sockets: FakeSocket[] = []
+  const socketBehavior = { failNextConnection: false }
+
+  class FakeWebSocket implements FakeSocket {
+    static OPEN = 1
+    readyState = FakeWebSocket.OPEN
+    url: string
+    sent: SentFrame[] = []
+    onopen: (() => void) | null = null
+    onmessage: ((event: { data: string }) => void) | null = null
+    onerror: ((err: unknown) => void) | null = null
+    onclose: (() => void) | null = null
+
+    constructor(url: string) {
+      this.url = url
+      sockets.push(this)
+      if (socketBehavior.failNextConnection) {
+        socketBehavior.failNextConnection = false
+        // A refused/unreachable connection errors and closes without opening.
+        queueMicrotask(() => {
+          this.onerror?.(new Error('connect ECONNREFUSED'))
+          this.onclose?.()
+        })
+      } else {
+        queueMicrotask(() => this.onopen?.())
+      }
+    }
+
+    send(data: string): void {
+      this.sent.push(JSON.parse(data) as SentFrame)
+    }
+
+    close(): void {
+      this.onclose?.()
+    }
+  }
+
+  return { FakeWebSocket, sockets, socketBehavior }
+})
+
+vi.mock('ws', () => ({ default: FakeWebSocket }))
+
+import { SupabaseRealtimeClient } from './supabase-realtime-client'
+
+const BASE_CONFIG = {
+  url: 'wss://x.supabase.co/realtime/v1',
+  apikey: 'anon-key',
+  jwt: 'jwt-token',
+  channel: 'realtime:public:webhook_events',
+}
+
+function joinFrames(socket: FakeSocket): SentFrame[] {
+  return socket.sent.filter((frame) => frame.event === 'phx_join')
+}
+
+beforeEach(() => {
+  sockets.length = 0
+  socketBehavior.failNextConnection = false
+})
+
+describe('SupabaseRealtimeClient table parameterization', () => {
+  it('defaults to webhook_events when the config has no table (legacy poll response)', async () => {
+    const client = new SupabaseRealtimeClient()
+    await client.connect(BASE_CONFIG, () => {})
+
+    const [join] = joinFrames(sockets[0])
+    expect(join.topic).toBe('realtime:public:webhook_events')
+    const changes = (join.payload.config as {
+      postgres_changes: Array<{ event: string; schema: string; table: string }>
+    }).postgres_changes
+    expect(changes).toEqual([{ event: 'INSERT', schema: 'public', table: 'webhook_events' }])
+    expect(join.payload.access_token).toBe('jwt-token')
+
+    client.disconnect()
+  })
+
+  it('joins the configured table when the config carries one', async () => {
+    const client = new SupabaseRealtimeClient()
+    await client.connect(
+      { ...BASE_CONFIG, channel: 'realtime:public:notifications', table: 'notifications' },
+      () => {},
+    )
+
+    const [join] = joinFrames(sockets[0])
+    expect(join.topic).toBe('realtime:public:notifications')
+    const changes = (join.payload.config as {
+      postgres_changes: Array<{ table: string }>
+    }).postgres_changes
+    expect(changes[0].table).toBe('notifications')
+
+    client.disconnect()
+  })
+
+  it('sends the access_token refresh on the configured table topic', async () => {
+    const client = new SupabaseRealtimeClient()
+    await client.connect({ ...BASE_CONFIG, table: 'notifications' }, () => {})
+
+    await client.updateToken('fresh-jwt')
+
+    const refresh = sockets[0].sent.find((frame) => frame.event === 'access_token')
+    expect(refresh?.topic).toBe('realtime:public:notifications')
+    expect(refresh?.payload.access_token).toBe('fresh-jwt')
+
+    client.disconnect()
+  })
+
+  it('delivers INSERT records to the event callback', async () => {
+    const client = new SupabaseRealtimeClient()
+    const received: unknown[] = []
+    await client.connect({ ...BASE_CONFIG, table: 'notifications' }, (r) => received.push(r))
+
+    sockets[0].onmessage?.({
+      data: JSON.stringify({
+        topic: 'realtime:public:notifications',
+        event: 'postgres_changes',
+        payload: { data: { type: 'INSERT', record: { id: 'ntf_1', title: 'hi' } } },
+      }),
+    })
+
+    expect(received).toEqual([{ id: 'ntf_1', title: 'hi' }])
+    client.disconnect()
+  })
+})
+
+describe('SupabaseRealtimeClient connection failure', () => {
+  it('rejects connect() when the socket closes before it ever opens', async () => {
+    // The close event cancels the 10s timeout, so without an explicit
+    // rejection the promise would never settle and callers awaiting
+    // connect() (e.g. a manager installing its JWT-refresh interval after
+    // the await) would hang forever.
+    socketBehavior.failNextConnection = true
+    const client = new SupabaseRealtimeClient()
+
+    await expect(client.connect(BASE_CONFIG, () => {})).rejects.toThrow(
+      'WebSocket closed before connection established',
+    )
+
+    client.disconnect()
+  })
+})

--- a/src/shared/lib/services/supabase-realtime-client.ts
+++ b/src/shared/lib/services/supabase-realtime-client.ts
@@ -19,6 +19,10 @@ type RealtimeRecord = {
   status?: unknown
 }
 
+// Default preserved from before RealtimeConfig grew a `table` field, so the
+// webhook-events flow (whose poll response omits it) is untouched.
+const DEFAULT_TABLE = 'webhook_events'
+
 export class SupabaseRealtimeClient {
   private ws: WebSocket | null = null
   private heartbeatInterval: NodeJS.Timeout | null = null
@@ -54,6 +58,7 @@ export class SupabaseRealtimeClient {
     if (this.isStopped || !this.config) return
 
     const { url, apikey, jwt } = this.config
+    const table = this.config.table ?? DEFAULT_TABLE
 
     // apikey param = Supabase project anon key (for gateway auth)
     // jwt is sent later in the phx_join payload as access_token (for RLS)
@@ -73,18 +78,24 @@ export class SupabaseRealtimeClient {
         this.ws?.close()
       }, 10000)
 
+      // A socket that errors out fires close without ever opening; the
+      // promise must settle then (not wait out the 10s timeout, which close
+      // cancels) or callers awaiting connect() hang forever.
+      let opened = false
+
       this.ws.onopen = () => {
+        opened = true
         clearTimeout(timeout)
         this.isConnected = true
         this.reconnectAttempts = 0
         console.log('[SupabaseRealtime] Connected')
 
-        // Join the realtime channel for webhook_events with RLS
+        // Join the realtime channel for the configured table with RLS
         console.log(
-          `[SupabaseRealtime] Joining channel realtime:public:webhook_events jwt=${describeRealtimeJwt(jwt)}`,
+          `[SupabaseRealtime] Joining channel realtime:public:${table} jwt=${describeRealtimeJwt(jwt)}`,
         )
         this.sendMessage({
-          topic: `realtime:public:webhook_events`,
+          topic: `realtime:public:${table}`,
           event: 'phx_join',
           payload: {
             config: {
@@ -93,7 +104,7 @@ export class SupabaseRealtimeClient {
                 {
                   event: 'INSERT',
                   schema: 'public',
-                  table: 'webhook_events',
+                  table,
                 },
               ],
             },
@@ -156,6 +167,10 @@ export class SupabaseRealtimeClient {
         }
 
         this.onDisconnect?.()
+
+        if (!opened) {
+          reject(new Error('WebSocket closed before connection established'))
+        }
       }
     })
   }
@@ -226,7 +241,7 @@ export class SupabaseRealtimeClient {
     // Send access_token update if connected
     if (this.isConnected) {
       this.sendMessage({
-        topic: `realtime:public:webhook_events`,
+        topic: `realtime:public:${this.config.table ?? DEFAULT_TABLE}`,
         event: 'access_token',
         payload: { access_token: jwt },
         ref: this.nextRef(),

--- a/src/shared/lib/services/user-settings-service.ts
+++ b/src/shared/lib/services/user-settings-service.ts
@@ -11,6 +11,7 @@ const notificationSettingsSchema = z.object({
   sessionComplete: z.boolean().default(true),
   sessionWaiting: z.boolean().default(true),
   sessionScheduled: z.boolean().default(true),
+  platformNotification: z.boolean().default(true),
   notifyWhenUnfocused: z.boolean().default(false),
 })
 
@@ -21,6 +22,7 @@ export const userSettingsSchema = z.object({
     sessionComplete: true,
     sessionWaiting: true,
     sessionScheduled: true,
+    platformNotification: true,
     notifyWhenUnfocused: false,
   }),
   setupCompleted: z.boolean().default(false),
@@ -71,6 +73,7 @@ function seedFromAppSettings(): UserSettingsData {
           sessionComplete: appPrefs.notifications.sessionComplete ?? true,
           sessionWaiting: appPrefs.notifications.sessionWaiting ?? true,
           sessionScheduled: appPrefs.notifications.sessionScheduled ?? true,
+          platformNotification: appPrefs.notifications.platformNotification ?? true,
           notifyWhenUnfocused: appPrefs.notifications.notifyWhenUnfocused ?? false,
         }
       : undefined,

--- a/src/shared/lib/services/webhook-events-client.ts
+++ b/src/shared/lib/services/webhook-events-client.ts
@@ -27,6 +27,13 @@ export interface RealtimeConfig {
   apikey: string
   jwt: string
   channel: string
+  /**
+   * Postgres table to subscribe to. Optional for backwards compatibility with
+   * the webhook-events poll response, which predates the field — the realtime
+   * client defaults to `webhook_events`. Row scoping is enforced by RLS via
+   * the JWT's claims (whole-channel subscribe), so no filter param is needed.
+   */
+  table?: string
 }
 
 export interface PollResult {

--- a/src/shared/lib/startup.ts
+++ b/src/shared/lib/startup.ts
@@ -4,6 +4,7 @@ import { shutdownActiveRunner } from './container/client-factory'
 import { reviewManager } from './proxy/review-manager'
 import { taskScheduler } from './scheduler/task-scheduler'
 import { triggerManager } from './scheduler/trigger-manager'
+import { platformNotificationsManager } from './scheduler/platform-notifications-manager'
 import { chatIntegrationManager } from './chat-integrations/chat-integration-manager'
 import { captureException } from './error-reporting'
 import { registerAllAccountProviders } from './account-providers/register'
@@ -127,6 +128,14 @@ export async function initializeServices() {
     })
   }
 
+  // Desktop-only platform-notifications subscription (OS notifications from
+  // Supabase Realtime INSERTs). The manager self-gates on auth mode and
+  // platform connectivity; connect/disconnect after launch is handled by the
+  // platform auth-changed notifier.
+  platformNotificationsManager.start().catch((error) => {
+    console.error('Failed to start platform notifications manager:', error)
+  })
+
   // Start chat integration manager
   chatIntegrationManager.start().catch((error) => {
     console.error('Failed to start chat integration manager:', error)
@@ -179,6 +188,7 @@ export async function shutdownServices() {
   await stopAllProviders()
   taskScheduler.stop()
   triggerManager.stop()
+  platformNotificationsManager.stop()
   autoSleepMonitor.stop()
   sessionAutoDeleteMonitor.stop()
   accountSyncService.stop()


### PR DESCRIPTION
## Summary

App half of **SUP-341** (platform notifications), consuming the platform PR SkillfulAgents/platform#158 (SUP-342/344). Notifications are authored in Customer.io, land in the platform's `notifications` table one row per recipient, and reach the app two ways: **proxy-live reads** (inbox, badge — no local mirror, one code path for both auth modes) and a **direct Supabase Realtime subscription** (desktop OS notifications, instant inbox updates) using a proxy-minted user-scoped JWT where the RLS SELECT policy is the security boundary.

## What's in here

**Manager (`platform-notifications-manager.ts`, desktop/non-auth only)**
- Subscribes to Realtime INSERTs via the existing `SupabaseRealtimeClient`, which gains an optional `table` param (defaults to `webhook_events`; the trigger flow is byte-identical)
- Every INSERT broadcasts an SSE inbox invalidation; OS notifications additionally pass a dedup gate: persisted `lastNotifiedAt` watermark (survives restarts, suppresses reconnect replays/backdated inserts) + in-session id set. OS notifs only ever fire from live INSERTs, never from backlog
- 50-minute tick refreshes the 1h Realtime JWT or reconnects a dead subscription; a **generation token** bumped on stop/start keeps a stale in-flight connect from resubscribing with an old identity or leaking intervals
- `SupabaseRealtimeClient.connect()` now **rejects when the socket closes before ever opening** (previously the promise never settled — a connection-refused at launch would silently strand the manager without its refresh interval and kill realtime at the 1h token expiry)

**UI**
- Platform rows merged into the existing Notifications inbox (client-side merged pagination over both sources), markdown-stripped previews, Megaphone/Platform tag
- New `/notifications/$id` detail route: title as page title, `MarkdownBlock` body, `action_url` through the shared URL-scheme allowlist; opening write-through-marks the row read
- OS-notification click (Electron + web paths) navigates to the detail route; sidebar badge and dock badge combine local + platform unread counts
- Settings toggle ("Platform notifications", default on) gates the popup in renderer, main-process fallback, and manager

**API routes (`/api/platform-notifications`)**
- Thin relays for list/unread-count/read/read-all; polled GETs degrade upstream failures to the disconnected shape (200) so an **offline desktop doesn't error-loop the 30s/60s polling into Sentry captures**; pagination params sanitized/clamped

## Test plan

- ✅ 6,457 unit tests (340 files) — ~60 new across manager (fake-timer JWT refresh, dead-subscription reconnect, failed-initial-connect recovery, stop/start race, watermark equal-timestamp restart replay), realtime client (table threading in all three join spots, close-before-open rejection), API routes (degradation, validation, read-all fan-out), notification handler (platform SSE invalidation, click → detail route, settings toggle), merged inbox (page-2 walk with mixed sources, no dropped/duplicated rows)
- ✅ Playwright mock E2E: 230/231 passed; the 1 failure (`connection-account-toggle.spec.ts`, untouched by this diff) re-passed 10/10 on `--repeat-each=2` — flake
- ✅ `tsc --noEmit` + eslint clean
- ✅ Full loop proven live against local Supabase + wrangler dev: curl → cio receiver → Realtime INSERT → OS notification broadcast + open inbox updating in ~100ms without reload; mark-read write-through and cross-user isolation verified against real RLS

## Notes

- Requires the platform PR deployed for anything to light up; until then the inbox degrades to local agent notifications only (`connected: false`)
- Known v1 gaps (deliberate): no offline inbox (proxy-live reads), closed-window OS-notification clicks don't deep-link to the detail route, auth-mode web clients rely on the 60s refetch instead of realtime push