### PR TITLE
feat(analytics): fire first_agent_created once per user for ad-conversion dedup

### DIFF
--- a/src/renderer/components/agents/agent-template-browse-dialog.tsx
+++ b/src/renderer/components/agents/agent-template-browse-dialog.tsx
@@ -26,7 +26,7 @@ export function AgentTemplateBrowseDialog({
 }: AgentTemplateBrowseDialogProps) {
   const { data: discoverableAgents } = useDiscoverableAgents()
   const navigate = useNavigate()
-  const { track } = useAnalyticsTracking()
+  const { trackAgentCreated } = useAnalyticsTracking()
   const startOnboardingSession = useStartOnboardingSession()
   const queryClient = useQueryClient()
   const [templateToInstall, setTemplateToInstall] = useState<ApiDiscoverableAgent | null>(null)
@@ -37,7 +37,7 @@ export function AgentTemplateBrowseDialog({
 
   const handleInstalled = useCallback(
     async (agent: ApiAgent, meta: { hasOnboarding?: boolean }) => {
-      track('agent_created', { source: 'skillset', num_skills_added_at_creation: 0 })
+      trackAgentCreated({ source: 'skillset', num_skills_added_at_creation: 0 })
       await queryClient.refetchQueries({ queryKey: ['agents'] })
       void navigate({ to: '/agents/$slug', params: { slug: agent.slug } })
       if (meta.hasOnboarding) {
@@ -45,7 +45,7 @@ export function AgentTemplateBrowseDialog({
       }
       onOpenChange(false)
     },
-    [track, queryClient, navigate, startOnboardingSession, onOpenChange],
+    [trackAgentCreated, queryClient, navigate, startOnboardingSession, onOpenChange],
   )
 
   const hasTemplates = discoverableAgents && discoverableAgents.length > 0

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -52,19 +52,19 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
   const createAgent = useCreateAgent()
   const createSession = useCreateSession()
   const navigate = useNavigate()
-  const { track } = useAnalyticsTracking()
+  const { trackAgentCreated } = useAnalyticsTracking()
   const startOnboardingSession = useStartOnboardingSession()
 
   const finishCreatedAgent = useCallback(
     async (agent: ApiAgent, source: 'new' | 'import' | 'skillset', hasOnboarding?: boolean) => {
-      track('agent_created', { source, num_skills_added_at_creation: 0 })
+      trackAgentCreated({ source, num_skills_added_at_creation: 0 })
       void navigate({ to: '/agents/$slug', params: { slug: agent.displaySlug } })
       if (hasOnboarding) {
         await startOnboardingSession(agent.slug)
       }
       await onAgentCreated?.()
     },
-    [track, navigate, startOnboardingSession, onAgentCreated],
+    [trackAgentCreated, navigate, startOnboardingSession, onAgentCreated],
   )
 
   const composer = useMessageComposer({
@@ -86,7 +86,7 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
           // family alias to the active provider's specific model.
           model: 'opus',
         })
-        track('agent_created', { source: 'new', num_skills_added_at_creation: 0 })
+        trackAgentCreated({ source: 'new', num_skills_added_at_creation: 0 })
         void navigate({ to: '/agents/$slug/sessions/$sessionId', params: { slug: newAgent.displaySlug, sessionId: session.id } })
         await onAgentCreated?.()
       } catch (error) {
@@ -95,7 +95,7 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
           description: error instanceof Error ? error.message : 'Please try again.',
         })
       }
-    }, [createAgent, createSession, navigate, track, onAgentCreated]),
+    }, [createAgent, createSession, navigate, trackAgentCreated, onAgentCreated]),
   })
 
   useEffect(() => {

--- a/src/renderer/context/analytics-context.tsx
+++ b/src/renderer/context/analytics-context.tsx
@@ -4,9 +4,12 @@ import { useSettings } from '@renderer/hooks/use-settings'
 import { useUser } from '@renderer/context/user-context'
 import { usePlatformAuthStatus } from '@renderer/hooks/use-platform-auth'
 import { createAnalyticsInstance, getAnalyticsMetadata, hasActivePlugins } from '@renderer/lib/analytics'
+import { claimFirstAgentCreated } from '@renderer/lib/first-agent-created'
 
 interface AnalyticsContextValue {
   track: (event: string, properties?: Record<string, unknown>) => void
+  /** Tracks agent_created, plus a once-per-user first_agent_created (ad-conversion dedup). */
+  trackAgentCreated: (properties?: Record<string, unknown>) => void
   identify: () => void
 }
 
@@ -91,6 +94,15 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
     })
   }, [instance, tenantId])
 
+  // Best-effort once-per-user conversion signal: the Amplitude → Meta sync
+  // subscribes to first_agent_created only, so Meta counts one conversion per user.
+  const trackAgentCreated = useCallback((properties?: Record<string, unknown>) => {
+    track('agent_created', properties)
+    if (userId && claimFirstAgentCreated(userId)) {
+      track('first_agent_created', properties)
+    }
+  }, [track, userId])
+
   const identify = useCallback(() => {
     if (!instance || !userId) return
     const metadata = getAnalyticsMetadata()
@@ -100,7 +112,10 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
     })
   }, [instance, userId, tenantId])
 
-  const value = useMemo<AnalyticsContextValue>(() => ({ track, identify }), [track, identify])
+  const value = useMemo<AnalyticsContextValue>(
+    () => ({ track, trackAgentCreated, identify }),
+    [track, trackAgentCreated, identify],
+  )
 
   return <AnalyticsContext.Provider value={value}>{children}</AnalyticsContext.Provider>
 }

--- a/src/renderer/hooks/use-agent-templates.ts
+++ b/src/renderer/hooks/use-agent-templates.ts
@@ -98,7 +98,7 @@ export type ImportProgress = UploadProgress
 
 export function useImportAgentTemplate() {
   const queryClient = useQueryClient()
-  const { track } = useAnalyticsTracking()
+  const { trackAgentCreated } = useAnalyticsTracking()
 
   return useMutation<
     ApiAgent & { hasOnboarding?: boolean },
@@ -115,7 +115,7 @@ export function useImportAgentTemplate() {
       })
     },
     onSuccess: () => {
-      track('agent_created', { source: 'file_import' })
+      trackAgentCreated({ source: 'file_import' })
       queryClient.invalidateQueries({ queryKey: ['agents'] })
       queryClient.invalidateQueries({ queryKey: ['my-agent-roles'] })
     },
@@ -124,7 +124,7 @@ export function useImportAgentTemplate() {
 
 export function useInstallAgentFromSkillset() {
   const queryClient = useQueryClient()
-  const { track } = useAnalyticsTracking()
+  const { trackAgentCreated } = useAnalyticsTracking()
 
   return useMutation<
     ApiAgent & { hasOnboarding?: boolean },
@@ -150,7 +150,7 @@ export function useInstallAgentFromSkillset() {
       return res.json()
     },
     onSuccess: () => {
-      track('agent_created', { source: 'skillset' })
+      trackAgentCreated({ source: 'skillset' })
       queryClient.invalidateQueries({ queryKey: ['agents'] })
       queryClient.invalidateQueries({ queryKey: ['discoverable-agents'] })
       queryClient.invalidateQueries({ queryKey: ['my-agent-roles'] })

--- a/src/renderer/hooks/use-create-untitled-agent.ts
+++ b/src/renderer/hooks/use-create-untitled-agent.ts
@@ -14,12 +14,12 @@ export function useCreateUntitledAgent() {
   // AgentHome's first-mount initializer reads it and plays the intro once.
   const { setJustCreatedSlug } = useNavTransient()
   const navigate = useNavigate()
-  const { track } = useAnalyticsTracking()
+  const { trackAgentCreated } = useAnalyticsTracking()
 
   const createUntitledAgent = useCallback(async () => {
     try {
       const agent = await createAgent.mutateAsync({ name: UNTITLED_AGENT_NAME })
-      track('agent_created', { source: 'new', num_skills_added_at_creation: 0 })
+      trackAgentCreated({ source: 'new', num_skills_added_at_creation: 0 })
 
       // Morph tag keys on the canonical id (AgentHome compares against agent.slug);
       // navigate with the pretty display slug so the URL reflects the name.
@@ -40,7 +40,7 @@ export function useCreateUntitledAgent() {
       })
       return null
     }
-  }, [createAgent, setJustCreatedSlug, navigate, track])
+  }, [createAgent, setJustCreatedSlug, navigate, trackAgentCreated])
 
   return {
     createUntitledAgent,

--- a/src/renderer/lib/first-agent-created.test.ts
+++ b/src/renderer/lib/first-agent-created.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { claimFirstAgentCreated, resetFirstAgentCreatedMemoryForTest } from './first-agent-created'
+
+vi.mock('@renderer/lib/error-reporting', () => ({
+  captureRendererException: vi.fn(),
+}))
+
+describe('claimFirstAgentCreated', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    resetFirstAgentCreatedMemoryForTest()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns true on the first claim and false afterwards', () => {
+    expect(claimFirstAgentCreated('user-a')).toBe(true)
+    expect(claimFirstAgentCreated('user-a')).toBe(false)
+  })
+
+  it('tracks users independently', () => {
+    expect(claimFirstAgentCreated('user-a')).toBe(true)
+    expect(claimFirstAgentCreated('user-b')).toBe(true)
+  })
+
+  it('persists the claim across the in-memory cache reset (localStorage)', () => {
+    expect(claimFirstAgentCreated('user-a')).toBe(true)
+    resetFirstAgentCreatedMemoryForTest()
+    expect(claimFirstAgentCreated('user-a')).toBe(false)
+  })
+
+  it('falls back to session-scoped dedup when localStorage throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => { throw new Error('denied') })
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('denied') })
+
+    expect(claimFirstAgentCreated('user-a')).toBe(true)
+    expect(claimFirstAgentCreated('user-a')).toBe(false)
+  })
+})

--- a/src/renderer/lib/first-agent-created.ts
+++ b/src/renderer/lib/first-agent-created.ts
@@ -1,0 +1,26 @@
+import { captureRendererException } from '@renderer/lib/error-reporting'
+
+const STORAGE_KEY_PREFIX = 'analytics.firstAgentCreated:'
+// Fallback when localStorage is unavailable — dedupes within the app session.
+const claimedInMemory = new Set<string>()
+
+/**
+ * Claims the once-per-user first_agent_created slot. Returns true exactly once
+ * per userId (best-effort: persisted in localStorage, in-memory fallback).
+ */
+export function claimFirstAgentCreated(userId: string): boolean {
+  if (claimedInMemory.has(userId)) return false
+  claimedInMemory.add(userId)
+  try {
+    if (localStorage.getItem(STORAGE_KEY_PREFIX + userId) !== null) return false
+    localStorage.setItem(STORAGE_KEY_PREFIX + userId, new Date().toISOString())
+  } catch (err) {
+    captureRendererException(err, { tags: { area: 'analytics', op: 'first-agent-created-claim' } })
+  }
+  return true
+}
+
+/** Test-only: clears the in-memory claim cache. */
+export function resetFirstAgentCreatedMemoryForTest(): void {
+  claimedInMemory.clear()
+}


### PR DESCRIPTION
## What's broken

The Amplitude → Meta Pixel event-streaming sync forwards every `agent_created` event, so a user who creates 5 agents is counted as 5 ad conversions on Meta. Marketing wants exactly one conversion per user.

The Meta Pixel destination can only filter by event name and existing properties — it has no "first event per user" capability (Historical Count is chart-only, and transformed events aren't supported by the destination). So the filter has to be a real event that only fires once.

## What changed

- New `first_agent_created` event: fired alongside the first `agent_created` for a given analytics user, never again. The Meta sync should subscribe to `first_agent_created` only; `agent_created` keeps firing on every creation for product analytics.
- `claimFirstAgentCreated(userId)` (`src/renderer/lib/first-agent-created.ts`): persists the claim in `localStorage` keyed by the resolved analytics userId (platform user id when connected, else tenantId), with an in-memory fallback when storage is unavailable. Storage failures are reported to Sentry.
- `trackAgentCreated(properties)` added to `AnalyticsContext`; all 5 `track('agent_created', …)` call sites switched to it (`use-create-untitled-agent`, `create-agent-form` ×2, `agent-template-browse-dialog`, `use-agent-templates` ×2).
- E2E stays clean: analytics are already no-op under `E2E_MOCK` (#410), so neither event escapes CI.

## Known limits (by design)

Once-per-user is **best-effort**: a reinstall, new device, or cleared storage can re-fire the event once, and a user identified pre/post platform-connect counts as two identities. Exact dedup would need server-side tracking, which isn't warranted for ad-conversion noise tolerance.

## Repro / verify

1. Fresh profile → create an agent → both `agent_created` and `first_agent_created` are tracked.
2. Create a second agent → only `agent_created`.
3. Reload the app → create another agent → still only `agent_created` (claim persisted).
4. `npx vitest run src/renderer/lib/first-agent-created.test.ts` — 4 tests cover first/subsequent claim, per-user independence, persistence across memory reset, and the storage-throw fallback.

## Follow-up (not in this PR)

Amplitude-side config: point the Meta Pixel sync at `first_agent_created` instead of `agent_created`, then verify via the sync's Live Log.

Made with [Cursor](https://cursor.com)