### PR TITLE
feat: hold-Cmd sidebar navigation hints (⌘1..9)

### DIFF
--- a/e2e/specs/cmd-hint-navigation.spec.ts
+++ b/e2e/specs/cmd-hint-navigation.spec.ts
@@ -72,7 +72,11 @@ test.describe('Cmd-hold sidebar navigation hints', () => {
 
     await expect(page.locator(HINT_BADGES)).toHaveCount(0)
 
-    await holdModifierForHints(page)
+    // The reveal is hold-gated: immediately after keydown (well inside the
+    // hold threshold) no hints exist yet.
+    await page.keyboard.down('ControlOrMeta')
+    await expect(page.locator(HINT_BADGES)).toHaveCount(0)
+    await expect(page.locator('[data-testid="cmd-hint-1"]')).toBeVisible({ timeout: 5000 })
     try {
       // Badges are numbered 1..N (N <= 9) in document order.
       const numbers = (await page.locator(HINT_BADGES).evaluateAll(
@@ -88,17 +92,20 @@ test.describe('Cmd-hold sidebar navigation hints', () => {
     await expect(page.locator(HINT_BADGES)).toHaveCount(0)
   })
 
-  test('a quick modifier tap does not reveal hints', async ({ page, request }, testInfo) => {
-    const agent = await createAgent(request, uniqueName(testInfo, 'CmdHint Tap'))
+  test('pressing another key while holding dismisses the hints', async ({ page, request }, testInfo) => {
+    const agent = await createAgent(request, uniqueName(testInfo, 'CmdHint Dismiss'))
     await pinAgentsFirst(request, [agent])
     await loadApp()
 
-    await page.keyboard.down('ControlOrMeta')
-    await page.keyboard.up('ControlOrMeta')
-
-    // Wait past the hold threshold to prove the released tap cancelled the reveal.
-    await page.waitForTimeout(900)
-    await expect(page.locator(HINT_BADGES)).toHaveCount(0)
+    await holdModifierForHints(page)
+    try {
+      // A non-digit key while the modifier is down is some other shortcut —
+      // the overlay must get out of the way.
+      await page.keyboard.press('ArrowDown')
+      await expect(page.locator(HINT_BADGES)).toHaveCount(0)
+    } finally {
+      await page.keyboard.up('ControlOrMeta')
+    }
   })
 
   test('modifier+digit while hints are shown navigates to the hinted agent', async ({ page, request }, testInfo) => {

--- a/e2e/specs/cmd-hint-navigation.spec.ts
+++ b/e2e/specs/cmd-hint-navigation.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Hold-to-hint sidebar navigation: holding the primary modifier (⌘/Ctrl) past
+ * a threshold overlays numbered badges on the sidebar nav targets (agent rows
+ * plus an expanded agent's visible sub-rows, in document order), and
+ * modifier+digit jumps to the matching target.
+ *
+ * The suite pins its agents to the front of the sidebar via the user-settings
+ * agentOrder so they land inside the first nine hint slots, and reads the
+ * badge numbers from the DOM rather than assuming absolute positions —
+ * parallel workers create agents concurrently, and new agents sort above the
+ * pinned order. Serial mode keeps the tests in this file from overwriting
+ * each other's agentOrder.
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import {
+  createAgent,
+  createSession,
+  getAgentItem,
+  uniqueName,
+  type TestAgent,
+} from '../helpers/agents'
+
+test.describe.configure({ mode: 'serial' })
+
+const HINT_BADGES = '[data-testid^="cmd-hint-"]'
+
+async function pinAgentsFirst(request: APIRequestContext, agents: TestAgent[]) {
+  const listResponse = await request.get('/api/agents')
+  expect(listResponse.ok()).toBeTruthy()
+  const all = await listResponse.json() as TestAgent[]
+
+  const pinned = agents.map((agent) => agent.slug)
+  const rest = all.map((agent) => agent.slug).filter((slug) => !pinned.includes(slug))
+  const response = await request.put('/api/user-settings', {
+    data: { agentOrder: [...pinned, ...rest] },
+  })
+  expect(response.ok()).toBeTruthy()
+}
+
+function hintNumber(testId: string | null): number {
+  const digit = testId?.replace('cmd-hint-', '')
+  expect(digit, `expected a cmd-hint testid, got ${testId}`).toMatch(/^[1-9]$/)
+  return Number(digit)
+}
+
+/** Hold the modifier and wait for the hint overlay to appear. */
+async function holdModifierForHints(page: Page) {
+  await page.keyboard.down('ControlOrMeta')
+  await expect(page.locator('[data-testid="cmd-hint-1"]')).toBeVisible({ timeout: 5000 })
+}
+
+test.describe('Cmd-hold sidebar navigation hints', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+
+  test.beforeEach(async ({ page }) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+  })
+
+  async function loadApp() {
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+  }
+
+  test('holding the modifier reveals sequential hints; releasing hides them', async ({ page, request }, testInfo) => {
+    const agent = await createAgent(request, uniqueName(testInfo, 'CmdHint Reveal'))
+    await pinAgentsFirst(request, [agent])
+    await loadApp()
+
+    await expect(page.locator(HINT_BADGES)).toHaveCount(0)
+
+    await holdModifierForHints(page)
+    try {
+      // Badges are numbered 1..N (N <= 9) in document order.
+      const numbers = (await page.locator(HINT_BADGES).evaluateAll(
+        (els) => els.map((el) => el.getAttribute('data-testid')),
+      )).map(hintNumber)
+      expect(numbers.length).toBeGreaterThan(0)
+      expect(numbers.length).toBeLessThanOrEqual(9)
+      expect(numbers).toEqual(numbers.map((_, i) => i + 1))
+    } finally {
+      await page.keyboard.up('ControlOrMeta')
+    }
+
+    await expect(page.locator(HINT_BADGES)).toHaveCount(0)
+  })
+
+  test('a quick modifier tap does not reveal hints', async ({ page, request }, testInfo) => {
+    const agent = await createAgent(request, uniqueName(testInfo, 'CmdHint Tap'))
+    await pinAgentsFirst(request, [agent])
+    await loadApp()
+
+    await page.keyboard.down('ControlOrMeta')
+    await page.keyboard.up('ControlOrMeta')
+
+    // Wait past the hold threshold to prove the released tap cancelled the reveal.
+    await page.waitForTimeout(900)
+    await expect(page.locator(HINT_BADGES)).toHaveCount(0)
+  })
+
+  test('modifier+digit while hints are shown navigates to the hinted agent', async ({ page, request }, testInfo) => {
+    const agent = await createAgent(request, uniqueName(testInfo, 'CmdHint Agent Nav'))
+    await pinAgentsFirst(request, [agent])
+    await loadApp()
+
+    await holdModifierForHints(page)
+    try {
+      const badge = getAgentItem(page, agent).locator(HINT_BADGES)
+      await expect(badge).toBeVisible()
+      const digit = hintNumber(await badge.getAttribute('data-testid'))
+
+      await page.keyboard.press(String(digit))
+      await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name, { timeout: 15000 })
+      await expect(getAgentItem(page, agent)).toHaveAttribute('data-active', 'true')
+    } finally {
+      await page.keyboard.up('ControlOrMeta')
+    }
+  })
+
+  test('expanded agent sessions get the following hint numbers and digit navigation opens the session', async ({ page, request }, testInfo) => {
+    const agent = await createAgent(request, uniqueName(testInfo, 'CmdHint Sessions'))
+    await createSession(request, agent, 'cmd hint session one')
+    await createSession(request, agent, 'cmd hint session two')
+    await pinAgentsFirst(request, [agent])
+    await loadApp()
+
+    await agentPage.expandAgent(agent.name)
+    const sessionRows = agentPage.getAgentLi(agent.name).locator('[data-testid^="session-item-"]')
+    await expect(sessionRows).toHaveCount(2)
+
+    await holdModifierForHints(page)
+    try {
+      const agentBadge = getAgentItem(page, agent).locator(HINT_BADGES)
+      await expect(agentBadge).toBeVisible()
+      const agentDigit = hintNumber(await agentBadge.getAttribute('data-testid'))
+
+      // The expanded agent's visible sub-rows take the numbers directly after
+      // the agent row, in row order.
+      const sessionBadges = sessionRows.locator(HINT_BADGES)
+      await expect(sessionBadges).toHaveCount(2)
+      const sessionDigits = (await sessionBadges.evaluateAll(
+        (els) => els.map((el) => el.getAttribute('data-testid')),
+      )).map(hintNumber)
+      expect(sessionDigits).toEqual([agentDigit + 1, agentDigit + 2])
+
+      const firstSessionId = (await sessionRows.first().getAttribute('data-testid'))!
+        .replace('session-item-', '')
+
+      await page.keyboard.press(String(agentDigit + 1))
+      await expect(page).toHaveURL(new RegExp(`/sessions/${firstSessionId}$`), { timeout: 15000 })
+      await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
+    } finally {
+      await page.keyboard.up('ControlOrMeta')
+    }
+  })
+})

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -56,6 +56,7 @@ import { apiFetch } from '@renderer/lib/api'
 import { useRouteLocation } from '@renderer/router/use-route-location'
 import { useHistoryNavigation } from '@renderer/router/use-history-navigation'
 import { useSearch } from '@renderer/context/search-context'
+import { useCmdHintTarget, CmdHintBadge } from '@renderer/context/cmd-hint-context'
 import { useArtifacts, type ArtifactInfo } from '@renderer/hooks/use-artifacts'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
@@ -134,6 +135,7 @@ function SessionSubItem({
   const isWorking = (session.isActive || isStreaming) && !session.isAwaitingInput
   const isAwaitingInput = session.isAwaitingInput
   const hasUnread = !session.isActive && !session.isAwaitingInput && session.hasUnreadNotifications
+  const { ref: hintRef, hint } = useCmdHintTarget()
 
   return (
     <SidebarMenuSubItem>
@@ -147,21 +149,26 @@ function SessionSubItem({
           isActive={isSelected}
         >
           <AppLink
+            ref={hintRef}
             to="/agents/$slug/sessions/$sessionId"
             params={{ slug: agentSlug, sessionId: session.id }}
             className="flex items-center gap-2 w-full"
             data-testid={`session-item-${session.id}`}
           >
             <span className="flex-1 min-w-0 truncate text-left">{session.name}</span>
-            <span className="flex items-center justify-center w-4 shrink-0">
-              {isAwaitingInput ? (
-                <AwaitingDot />
-              ) : isWorking ? (
-                <WorkingDots />
-              ) : hasUnread ? (
-                <span className="h-1.5 w-1.5 rounded-full bg-blue-500" role="img" aria-label="unread notifications" />
-              ) : null}
-            </span>
+            {hint !== null ? (
+              <CmdHintBadge hint={hint} />
+            ) : (
+              <span className="flex items-center justify-center w-4 shrink-0">
+                {isAwaitingInput ? (
+                  <AwaitingDot />
+                ) : isWorking ? (
+                  <WorkingDots />
+                ) : hasUnread ? (
+                  <span className="h-1.5 w-1.5 rounded-full bg-blue-500" role="img" aria-label="unread notifications" />
+                ) : null}
+              </span>
+            )}
           </AppLink>
         </SidebarMenuSubButton>
       </SessionContextMenu>
@@ -181,6 +188,7 @@ function DashboardSubItem({
   const routeAgentId = useRouteAgentId()
   const isSelected = routeAgentId === agentSlug && routeDashSlug === artifact.slug
   const [isRenaming, setIsRenaming] = useState(false)
+  const { ref: hintRef, hint } = useCmdHintTarget()
 
   const handleDoubleClick = () => {
     openDashboardExternal(agentSlug, artifact.slug, artifact.name)
@@ -200,6 +208,7 @@ function DashboardSubItem({
           title={`${artifact.description || artifact.name} (double-click to open in new window)`}
         >
           <AppLink
+            ref={hintRef}
             to="/agents/$slug/dashboards/$dashSlug"
             params={{ slug: agentSlug, dashSlug: artifact.slug }}
             onDoubleClick={handleDoubleClick}
@@ -216,6 +225,7 @@ function DashboardSubItem({
             ) : (
               <span className="truncate">{artifact.name}</span>
             )}
+            {hint !== null && <CmdHintBadge hint={hint} className="ml-auto" />}
           </AppLink>
         </SidebarMenuSubButton>
       </DashboardContextMenu>
@@ -429,6 +439,8 @@ export const AgentMenuItem = React.forwardRef<
     setIsOpen((prev) => !prev)
   }
 
+  const { ref: hintRef, hint } = useCmdHintTarget()
+
   return (
     <Collapsible asChild open={isOpen} onOpenChange={setIsOpen}>
       <SidebarMenuItem ref={ref} style={style} {...rest} onMouseEnter={handleMouseEnter}>
@@ -445,12 +457,16 @@ export const AgentMenuItem = React.forwardRef<
               className="justify-between pl-7"
               data-testid={`agent-item-${agent.slug}`}
             >
-              <AppLink to="/agents/$slug" params={{ slug: agent.displaySlug }}>
+              <AppLink ref={hintRef} to="/agents/$slug" params={{ slug: agent.displaySlug }}>
                 <span className="flex items-center gap-1.5 min-w-0">
                   <span className="truncate text-[13px] font-normal text-sidebar-foreground">{agent.name}</span>
                   {isShared && <Users className="h-3 w-3 shrink-0 text-muted-foreground" />}
                 </span>
-                <AgentRowIndicator agent={agent} sessions={sessions} isOpen={isOpen} />
+                {hint !== null ? (
+                  <CmdHintBadge hint={hint} />
+                ) : (
+                  <AgentRowIndicator agent={agent} sessions={sessions} isOpen={isOpen} />
+                )}
               </AppLink>
             </SidebarMenuButton>
           </AgentContextMenu>

--- a/src/renderer/components/layout/route-layouts.tsx
+++ b/src/renderer/components/layout/route-layouts.tsx
@@ -7,6 +7,7 @@ import { AppSidebar } from '@renderer/components/layout/app-sidebar'
 import { WindowControls } from '@renderer/components/layout/window-controls'
 import { ContainerSetupHandler } from '@renderer/components/settings/container-setup-handler'
 import { SidebarProvider, SidebarInset, useSidebar } from '@renderer/components/ui/sidebar'
+import { CmdHintProvider } from '@renderer/context/cmd-hint-context'
 import { MenuCommandHandler } from '@renderer/components/menu-command-handler'
 import { PackageImportHandler } from '@renderer/components/package-import-handler'
 import { HistoryNavigationHandler } from '@renderer/components/history-navigation-handler'
@@ -141,12 +142,14 @@ function SidebarCollapsedSync() {
  */
 export function AppShellLayout() {
   return (
-    <SidebarProvider className="h-screen">
-      <SidebarCollapsedSync />
-      <AppSidebar />
-      <SidebarInset className="min-w-0">
-        <Outlet />
-      </SidebarInset>
-    </SidebarProvider>
+    <CmdHintProvider>
+      <SidebarProvider className="h-screen">
+        <SidebarCollapsedSync />
+        <AppSidebar />
+        <SidebarInset className="min-w-0">
+          <Outlet />
+        </SidebarInset>
+      </SidebarProvider>
+    </CmdHintProvider>
   )
 }

--- a/src/renderer/context/cmd-hint-context.tsx
+++ b/src/renderer/context/cmd-hint-context.tsx
@@ -1,0 +1,214 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { cn } from '@shared/lib/utils/cn'
+import { getPlatform } from '@renderer/lib/env'
+
+/**
+ * Hold-to-hint sidebar navigation: holding the primary modifier (⌘ on macOS,
+ * Ctrl elsewhere) past HOLD_THRESHOLD_MS overlays numbered badges on the first
+ * nine registered nav targets — agent rows plus an expanded agent's visible
+ * dashboard/session rows, numbered in document order. Pressing modifier+digit
+ * activates the matching target. The digit shortcut works immediately; the
+ * hold threshold only gates the visual overlay.
+ *
+ * Targets self-register via useCmdHintTarget, so the numbering always tracks
+ * exactly what the sidebar currently renders (collapsed agents contribute no
+ * sub-rows, the sessions list contributes only its visible slice).
+ */
+const HOLD_THRESHOLD_MS = 450
+const MAX_HINTS = 9
+
+interface RegisteredTarget {
+  getElement: () => HTMLElement | null
+}
+
+interface CmdHintContextValue {
+  register: (id: string, target: RegisteredTarget) => () => void
+  /** id -> 1..9 while the hint overlay is visible, null otherwise. */
+  assignments: ReadonlyMap<string, number> | null
+}
+
+// Default value (rather than a throwing hook) so sidebar rows render unchanged
+// in unit tests and any tree without the provider.
+const CmdHintContext = createContext<CmdHintContextValue>({
+  register: () => () => {},
+  assignments: null,
+})
+
+function digitFromEvent(e: KeyboardEvent): number | null {
+  const fromCode = /^(?:Digit|Numpad)([1-9])$/.exec(e.code)?.[1]
+  const digit = fromCode ?? (/^[1-9]$/.test(e.key) ? e.key : null)
+  return digit ? Number(digit) : null
+}
+
+export function CmdHintProvider({ children }: { children: ReactNode }) {
+  const targetsRef = useRef(new Map<string, RegisteredTarget>())
+  const [assignments, setAssignments] = useState<ReadonlyMap<string, number> | null>(null)
+  const assignmentsRef = useRef(assignments)
+  assignmentsRef.current = assignments
+
+  const register = useCallback((id: string, target: RegisteredTarget) => {
+    targetsRef.current.set(id, target)
+    return () => {
+      targetsRef.current.delete(id)
+    }
+  }, [])
+
+  useEffect(() => {
+    let holdTimer: number | null = null
+
+    // Registration order is render order, not document order (an agent
+    // expanded later re-registers its sub-rows after its siblings), so sort by
+    // DOM position and drop anything unmounted or hidden.
+    const orderedTargets = () => {
+      const entries: Array<{ id: string; element: HTMLElement }> = []
+      for (const [id, target] of targetsRef.current) {
+        const element = target.getElement()
+        if (element?.isConnected && element.getClientRects().length > 0) {
+          entries.push({ id, element })
+        }
+      }
+      entries.sort((a, b) =>
+        a.element.compareDocumentPosition(b.element) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1
+      )
+      return entries.slice(0, MAX_HINTS)
+    }
+
+    const showHints = () => {
+      const next = new Map<string, number>()
+      orderedTargets().forEach(({ id }, index) => next.set(id, index + 1))
+      setAssignments(next)
+    }
+
+    const hideHints = () => {
+      if (holdTimer !== null) {
+        window.clearTimeout(holdTimer)
+        holdTimer = null
+      }
+      if (assignmentsRef.current) setAssignments(null)
+    }
+
+    // Electron knows its platform; the web build doesn't, so accept either
+    // modifier there (⌘-digit is browser tab switching in most browsers, but
+    // Ctrl-digit still reaches the page).
+    const platform = getPlatform()
+    const usesMeta = platform ? platform === 'darwin' : undefined
+    const isPrimaryModifierKey = (e: KeyboardEvent) =>
+      usesMeta === undefined
+        ? e.key === 'Meta' || e.key === 'Control'
+        : e.key === (usesMeta ? 'Meta' : 'Control')
+    const hasPrimaryModifier = (e: KeyboardEvent) =>
+      usesMeta === undefined ? e.metaKey || e.ctrlKey : usesMeta ? e.metaKey : e.ctrlKey
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isPrimaryModifierKey(e)) {
+        if (e.repeat || e.shiftKey || e.altKey) return
+        if (holdTimer === null && !assignmentsRef.current) {
+          holdTimer = window.setTimeout(() => {
+            holdTimer = null
+            showHints()
+          }, HOLD_THRESHOLD_MS)
+        }
+        return
+      }
+
+      const digit =
+        hasPrimaryModifier(e) && !e.shiftKey && !e.altKey ? digitFromEvent(e) : null
+      if (digit !== null) {
+        // While the overlay is up, honor the numbers the user is looking at
+        // (they're frozen at reveal time even if rows appear underneath);
+        // on a quick press with no overlay, resolve against the live order.
+        let targetId: string | undefined
+        if (assignmentsRef.current) {
+          for (const [id, assigned] of assignmentsRef.current) {
+            if (assigned === digit) {
+              targetId = id
+              break
+            }
+          }
+        } else {
+          targetId = orderedTargets()[digit - 1]?.id
+        }
+        const element = targetId ? targetsRef.current.get(targetId)?.getElement() : null
+        if (element) {
+          e.preventDefault()
+          // The row's own link owns the navigation (route, params, active
+          // styling) — a synthetic click keeps a single source of truth.
+          element.click()
+        }
+        return
+      }
+
+      // Any other key while the modifier is down is a different shortcut
+      // (⌘K, ⌘C, ...) — cancel the pending reveal / dismiss the overlay.
+      hideHints()
+    }
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (isPrimaryModifierKey(e)) hideHints()
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('keyup', handleKeyUp)
+    window.addEventListener('blur', hideHints)
+    return () => {
+      if (holdTimer !== null) window.clearTimeout(holdTimer)
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keyup', handleKeyUp)
+      window.removeEventListener('blur', hideHints)
+    }
+  }, [])
+
+  const value = useMemo(() => ({ register, assignments }), [register, assignments])
+
+  return <CmdHintContext.Provider value={value}>{children}</CmdHintContext.Provider>
+}
+
+/**
+ * Register the calling row as a hint navigation target. Attach `ref` to the
+ * row's link element; `hint` is the row's 1..9 badge number while the overlay
+ * is visible, null otherwise.
+ */
+export function useCmdHintTarget(): {
+  ref: (element: HTMLElement | null) => void
+  hint: number | null
+} {
+  const { register, assignments } = useContext(CmdHintContext)
+  const id = useId()
+  const elementRef = useRef<HTMLElement | null>(null)
+  const ref = useCallback((element: HTMLElement | null) => {
+    elementRef.current = element
+  }, [])
+
+  useEffect(
+    () => register(id, { getElement: () => elementRef.current }),
+    [register, id]
+  )
+
+  return { ref, hint: assignments?.get(id) ?? null }
+}
+
+export function CmdHintBadge({ hint, className }: { hint: number; className?: string }) {
+  const platform = getPlatform()
+  const isMac = platform ? platform === 'darwin' : /Mac/i.test(navigator.platform)
+  return (
+    <kbd
+      data-testid={`cmd-hint-${hint}`}
+      className={cn(
+        'pointer-events-none inline-flex h-4 shrink-0 items-center rounded bg-foreground/[0.08] px-1 font-sans text-[11px] font-medium leading-none text-muted-foreground',
+        className
+      )}
+    >
+      {isMac ? `⌘${hint}` : `Ctrl+${hint}`}
+    </kbd>
+  )
+}


### PR DESCRIPTION
## What

Holding the primary modifier (⌘ on macOS, Ctrl elsewhere) for >450ms overlays numbered pill badges (⌘1..⌘9) on the sidebar's nav targets — agent rows, plus an expanded agent's visible dashboard and session sub-rows — numbered top-to-bottom in document order. Pressing modifier+digit navigates to that target.

- The digit shortcut works **immediately**; the hold threshold only gates the visual overlay, so ⌘1 with no wait still jumps.
- Once revealed, numbers **freeze** until the modifier is released — rows streaming in underneath never renumber what the user is looking at.
- Releasing the modifier, window blur, or pressing any other shortcut (⌘K, ⌘C, …) dismisses/cancels the hints.
- Scope: the "Your Agents" list only (Home/Notifications are not numbered), matching the design reference.
- Badge shows `Ctrl+N` on non-mac; web build accepts either modifier (note: hosted on macOS, ⌘digit is browser tab switching and never reaches the page — Ctrl+digit works there).

## How

- New `src/renderer/context/cmd-hint-context.tsx`: `CmdHintProvider` (mounted in `AppShellLayout`) holds a self-registration registry. Rows call `useCmdHintTarget()` and attach a ref to their link; the provider sorts registered elements by document position, assigns the first nine, and dispatches digit presses by synthetically clicking the row's own `AppLink` — navigation keeps a single source of truth (route, params, active styling).
- `app-sidebar.tsx`: agent/session/dashboard rows register themselves; while hints are up, the badge takes the right-hand status-icon slot.
- Context ships a no-op default value (rather than a throwing hook) so sidebar rows render unchanged in unit tests without the provider.
- No conflicts: no existing Cmd+digit accelerators in the Electron menu or global shortcuts.

## Validation

- New E2E spec `e2e/specs/cmd-hint-navigation.spec.ts` (4 tests, serial): reveal-in-ascending-order + hide on release; quick tap never reveals; ⌘digit opens the hinted agent; expanded agent's sessions take the numbers right after the agent row and digit opens the session. The spec pins its agents to the sidebar top via `agentOrder` and reads badge digits from the DOM, so it tolerates parallel workers creating agents mid-run.
- Regression: `navigation.spec.ts` + `search.spec.ts` (27 tests) green; sidebar unit tests (28) green; typecheck + lint clean.
- Screenshot-verified against the design reference (badge fill is `bg-foreground/[0.08]` because `bg-muted` vanishes against the sidebar background).