### PR TITLE
feat: per-agent default model and effort

### DIFF
--- a/agent-container/src/file-hooks/agent-preferences-hook.ts
+++ b/agent-container/src/file-hooks/agent-preferences-hook.ts
@@ -4,6 +4,8 @@ import { FileHook, type FileHookReadResult, type FileHookWriteResult } from './f
 // Keep in sync with src/shared/lib/types/agent-preferences.ts
 const agentPreferencesSchema = z.object({
   autoDeleteInactiveDays: z.number().int().positive().optional(),
+  defaultModel: z.string().trim().min(1).optional(),
+  defaultEffort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
 })
 
 const PREFERENCES_PATH = '/workspace/agent-preferences.json'
@@ -12,10 +14,14 @@ const READ_HINT = `This is the agent preferences file. It stores per-agent setti
 
 Format: a JSON object with optional fields:
 - "autoDeleteInactiveDays" (positive integer, optional): Automatically delete sessions inactive for this many days. Starred sessions are preserved.
+- "defaultModel" (string, optional): Default model for this agent's new sessions — a concrete model id or a bare family alias. Per-session and per-trigger picks still win.
+- "defaultEffort" (one of "low" | "medium" | "high" | "xhigh" | "max", optional): Default reasoning effort for this agent's new sessions.
 
 Example:
 {
-  "autoDeleteInactiveDays": 90
+  "autoDeleteInactiveDays": 90,
+  "defaultModel": "opus",
+  "defaultEffort": "high"
 }
 
 Omit a field or remove it to fall back to the app-wide default.`

--- a/e2e/specs/agent-default-model.spec.ts
+++ b/e2e/specs/agent-default-model.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+
+const E2E_DATA_DIR = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
+const RECORDER_FILE = path.join(E2E_DATA_DIR, '.e2e-mock-recorder.jsonl')
+
+interface MockRecord {
+  type: 'sendMessage' | 'createSession'
+  agentSlug: string
+  sessionId?: string
+  content?: string
+  initialMessage?: string
+  effort?: string
+  model?: string
+  timestamp: string
+}
+
+function readRecords(): MockRecord[] {
+  if (!fs.existsSync(RECORDER_FILE)) return []
+  const lines = fs.readFileSync(RECORDER_FILE, 'utf-8').trim().split('\n').filter(Boolean)
+  return lines.map((l) => JSON.parse(l) as MockRecord)
+}
+
+// The recorder file is shared across Playwright workers, so callers must
+// filter by a test-unique attribute (unique message content) — never truncate
+// the file or assume it's empty at start.
+async function waitForRecord(
+  predicate: (r: MockRecord) => boolean,
+  timeoutMs = 10000
+): Promise<MockRecord> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    const found = readRecords().find(predicate)
+    if (found) return found
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  throw new Error(`Timed out waiting for matching record. Records seen: ${JSON.stringify(readRecords(), null, 2)}`)
+}
+
+// Distinct from the global default (Opus) so adoption is observable.
+const HAIKU_PINNED = 'claude-haiku-4-5'
+
+test.describe('Per-agent default model', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+
+  test.beforeEach(async ({ page }) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+  })
+
+  test('setting a default on the homepage row flows to an untouched composer send', async ({ page }, testInfo) => {
+    const tag = `${testInfo.workerIndex}-${Date.now()}`
+    const initialMessage = `Agent default message ${tag}`
+
+    await agentPage.clickCreateAgent()
+    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
+
+    // Unset default: the card shows the app-wide fallback and no reset affordance.
+    const card = page.locator('[data-testid="home-default-model-card"]')
+    await expect(card).toBeVisible()
+    await expect(page.locator('[data-testid="home-default-model-reset"]')).not.toBeVisible()
+
+    // One click on the family header selects that family's latest (bare alias)
+    // and keeps the popover open...
+    await card.locator('[data-testid="settings-model-trigger"]').click()
+    await page.locator('[data-testid="model-family-haiku"]').click()
+    await expect(card.locator('[data-testid="settings-model-trigger"]')).toContainText('Haiku · latest')
+
+    // ...with the versions expanded, so pinning a concrete one is one tap away.
+    await page.locator(`[data-testid="model-pinned-${HAIKU_PINNED}"]`).click()
+    await expect(card.locator('[data-testid="settings-model-trigger"]')).toContainText('Haiku 4.5')
+
+    // Pick a default effort too.
+    await card.locator('[data-testid="settings-model-trigger"]').click()
+    await page.locator('[data-testid="effort-option-high"]').click()
+    await expect(card.locator('[data-testid="settings-model-trigger"]')).toContainText('High')
+
+    // A custom default surfaces the reset-to-global affordance.
+    await expect(page.locator('[data-testid="home-default-model-reset"]')).toBeVisible()
+
+    // The untouched composer adopts the agent default...
+    await expect(page.locator('[data-testid="composer-options-trigger"]')).toContainText('Haiku 4.5')
+    await expect(page.locator('[data-testid="composer-options-trigger"]')).toContainText('High')
+
+    // ...and the created session carries it on the wire.
+    await page.locator('[data-testid="home-message-input"]').fill(initialMessage)
+    await page.locator('[data-testid="home-send-button"]').click()
+    await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
+
+    const record = await waitForRecord(
+      (r) => r.type === 'createSession' && r.initialMessage === initialMessage
+    )
+    expect(record.model).toBe(HAIKU_PINNED)
+    expect(record.effort).toBe('high')
+
+    // Reset back to the global default: the card shows the Global hint again,
+    // the untouched composer follows it, and the next session is created with
+    // the app-wide default (bare 'opus' alias, resolved to the latest concrete
+    // id on the wire).
+    const resetMessage = `Reset to global message ${tag}`
+    await page.goBack()
+    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
+
+    await page.locator('[data-testid="home-default-model-reset"]').click()
+    await expect(page.locator('[data-testid="home-default-model-reset"]')).not.toBeVisible()
+    await expect(card).toContainText('Global')
+    await expect(page.locator('[data-testid="composer-options-trigger"]')).toContainText('Opus')
+
+    await page.locator('[data-testid="home-message-input"]').fill(resetMessage)
+    await page.locator('[data-testid="home-send-button"]').click()
+
+    const resetRecord = await waitForRecord(
+      (r) => r.type === 'createSession' && r.initialMessage === resetMessage
+    )
+    expect(resetRecord.model).toBe('claude-opus-4-8')
+  })
+})

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -348,9 +348,12 @@ vi.mock('@shared/lib/utils/message-transform', () => ({
   resolveInterruptedSubagents: vi.fn(),
 }))
 
+const mockGetEffectiveModels = vi.fn(
+  (): Record<string, string | undefined> => ({ summarizerModel: 'claude-3-haiku' })
+)
 vi.mock('@shared/lib/config/settings', () => ({
   getEffectiveAnthropicApiKey: () => 'test-key',
-  getEffectiveModels: () => ({ summarizerModel: 'claude-3-haiku' }),
+  getEffectiveModels: () => mockGetEffectiveModels(),
   getEffectiveAgentLimits: () => ({}),
   getCustomEnvVars: () => ({}),
   getSettings: () => ({ container: {}, skillsets: [] }),
@@ -412,7 +415,9 @@ import { listPendingScheduledTasks, listPendingScheduledTasksByAgents } from '@s
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds } from '@shared/lib/services/notification-service'
 import { messagePersister } from '@shared/lib/container/message-persister'
-import { listUserSecrets, setSecret, getSecret, keyToEnvVar } from '@shared/lib/services/secrets-service'
+import { containerManager } from '@shared/lib/container/container-manager'
+import { listUserSecrets, setSecret, getSecret, keyToEnvVar, getSecretEnvVars } from '@shared/lib/services/secrets-service'
+import { readJsonFileStrict, writeJsonFileAtomic } from '@shared/lib/utils/file-storage'
 
 // ============================================================================
 // Test Helpers
@@ -3366,5 +3371,206 @@ describe('Secrets routes — reserved-env-var enforcement (SUP-239)', () => {
       expect(body.error).toContain('REMOTE_MCPS')
       expect(setSecret).not.toHaveBeenCalled()
     })
+  })
+})
+
+// ============================================================================
+// Agent preferences — PUT /:id/preferences
+// ============================================================================
+
+describe('agent preferences — PUT /:id/preferences', () => {
+  let app: ReturnType<typeof createApp>
+
+  const PREFS_URL = '/api/agents/test-agent/preferences'
+  const PREFS_PATH = '/mock/workspace/test-agent/agent-preferences.json'
+
+  async function putJson(url: string, body: unknown): Promise<Response> {
+    return app.request(`http://localhost${url}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    // The real agent-preferences-service runs against the file-storage mocks:
+    // readJsonFileStrict supplies the stored prefs (default: no file yet) and
+    // writeJsonFileAtomic captures what gets persisted.
+    vi.mocked(readJsonFileStrict).mockResolvedValue({} as never)
+  })
+
+  it('sets defaultModel and defaultEffort and persists them', async () => {
+    const res = await putJson(PREFS_URL, { defaultModel: 'claude-opus-4', defaultEffort: 'high' })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ defaultModel: 'claude-opus-4', defaultEffort: 'high' })
+    expect(writeJsonFileAtomic).toHaveBeenCalledWith(PREFS_PATH, {
+      defaultModel: 'claude-opus-4',
+      defaultEffort: 'high',
+    })
+  })
+
+  it('rejects an unknown defaultEffort with 400 and never writes', async () => {
+    const res = await putJson(PREFS_URL, { defaultEffort: 'turbo' })
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toContain('defaultEffort')
+    expect(writeJsonFileAtomic).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty defaultModel with 400', async () => {
+    const res = await putJson(PREFS_URL, { defaultModel: '' })
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toContain('defaultModel')
+    expect(writeJsonFileAtomic).not.toHaveBeenCalled()
+  })
+
+  it('rejects a whitespace-only defaultModel with 400', async () => {
+    const res = await putJson(PREFS_URL, { defaultModel: '   ' })
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toContain('defaultModel')
+    expect(writeJsonFileAtomic).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 (not 500) for a null body', async () => {
+    const res = await putJson(PREFS_URL, null)
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toContain('Invalid preferences')
+    expect(writeJsonFileAtomic).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 (not 500) for a string body', async () => {
+    const res = await putJson(PREFS_URL, 'just a string')
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toContain('Invalid preferences')
+    expect(writeJsonFileAtomic).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 (not 500) for an array body', async () => {
+    const res = await putJson(PREFS_URL, [{ defaultModel: 'opus' }])
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toContain('Invalid preferences')
+    expect(writeJsonFileAtomic).not.toHaveBeenCalled()
+  })
+
+  it('null clears a previously-set field back to the app-wide default', async () => {
+    vi.mocked(readJsonFileStrict).mockResolvedValue({
+      defaultModel: 'claude-sonnet-4',
+      defaultEffort: 'high',
+    } as never)
+
+    const res = await putJson(PREFS_URL, { defaultModel: null })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ defaultEffort: 'high' })
+    expect(writeJsonFileAtomic).toHaveBeenCalledWith(PREFS_PATH, { defaultEffort: 'high' })
+  })
+
+  it('trims surrounding whitespace before storing defaultModel', async () => {
+    const res = await putJson(PREFS_URL, { defaultModel: ' opus ' })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.defaultModel).toBe('opus')
+    expect(writeJsonFileAtomic).toHaveBeenCalledWith(PREFS_PATH, { defaultModel: 'opus' })
+  })
+
+  it('strips unknown keys from the stored prefs and the response', async () => {
+    const res = await putJson(PREFS_URL, { defaultModel: 'opus', favoriteColor: 'blue' })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ defaultModel: 'opus' })
+    expect(writeJsonFileAtomic).toHaveBeenCalledWith(PREFS_PATH, { defaultModel: 'opus' })
+  })
+})
+
+// ============================================================================
+// Session model/effort resolution — POST /:id/sessions
+// ============================================================================
+
+describe('session model/effort resolution — POST /:id/sessions', () => {
+  let app: ReturnType<typeof createApp>
+
+  const SESSIONS_URL = '/api/agents/test-agent/sessions'
+  const mockCreateSession = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    // Agent prefs come from the real service reading through the file-storage
+    // mock; default = no prefs file.
+    vi.mocked(readJsonFileStrict).mockResolvedValue({} as never)
+    vi.mocked(getAgent).mockResolvedValue({
+      slug: 'test-agent',
+      frontmatter: { name: 'Test Agent' },
+    } as never)
+    vi.mocked(getSecretEnvVars).mockResolvedValue([])
+    mockCreateSession.mockResolvedValue({ id: 'session-123' })
+    vi.mocked(containerManager.ensureRunning).mockResolvedValue({
+      createSession: mockCreateSession,
+    } as never)
+    mockGetEffectiveModels.mockReturnValue({
+      summarizerModel: 'claude-3-haiku',
+      agentModel: 'global-agent-model',
+      browserModel: 'browser-model',
+      dashboardBuilderModel: 'dashboard-model',
+    })
+  })
+
+  it('falls back to agent preference defaults when the request has no model/effort', async () => {
+    vi.mocked(readJsonFileStrict).mockResolvedValue({
+      defaultModel: 'haiku',
+      defaultEffort: 'high',
+    } as never)
+
+    const res = await postJson(app, SESSIONS_URL, { message: 'hello' })
+
+    expect(res.status).toBe(201)
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    const args = mockCreateSession.mock.calls[0][0]
+    expect(args.model).toBe('haiku')
+    expect(args.effort).toBe('high')
+  })
+
+  it('explicit per-session model/effort win over agent preference defaults', async () => {
+    vi.mocked(readJsonFileStrict).mockResolvedValue({
+      defaultModel: 'haiku',
+      defaultEffort: 'high',
+    } as never)
+
+    const res = await postJson(app, SESSIONS_URL, {
+      message: 'hello',
+      model: 'claude-opus-4',
+      effort: 'low',
+    })
+
+    expect(res.status).toBe(201)
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    const args = mockCreateSession.mock.calls[0][0]
+    expect(args.model).toBe('claude-opus-4')
+    expect(args.effort).toBe('low')
+  })
+
+  it('uses the global default model when the agent has no preferences', async () => {
+    const res = await postJson(app, SESSIONS_URL, { message: 'hello' })
+
+    expect(res.status).toBe(201)
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    const args = mockCreateSession.mock.calls[0][0]
+    expect(args.model).toBe('global-agent-model')
+    expect(args.effort).toBeUndefined()
   })
 })

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -128,6 +128,7 @@ import { getAgentWorkspaceDir } from '@shared/lib/utils/file-storage'
 import { isPathWithinDir, sanitizeUploadFilename } from '@shared/lib/utils/path-safety'
 import { AGENT_PACKAGE_EXTENSION, SKILL_PACKAGE_EXTENSION } from '@shared/lib/utils/package-extensions'
 import { readAgentPreferences, updateAgentPreferences } from '@shared/lib/services/agent-preferences-service'
+import { agentPreferencesUpdateSchema } from '@shared/lib/types/agent-preferences'
 import { cleanupAgentData } from '@shared/lib/services/agent-cleanup-service'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
 import { captureException } from '@shared/lib/error-reporting'
@@ -895,21 +896,14 @@ agents.put('/:id/preferences', AgentAdmin(), async (c) => {
       return c.json({ error: 'Agent not found' }, 404)
     }
 
-    const body = await c.req.json()
-
-    if ('autoDeleteInactiveDays' in body) {
-      const val = body.autoDeleteInactiveDays
-      if (val !== null && val !== undefined) {
-        if (typeof val !== 'number' || !Number.isInteger(val) || val <= 0) {
-          return c.json(
-            { error: 'autoDeleteInactiveDays must be a positive integer or null' },
-            400
-          )
-        }
-      }
+    const parsed = agentPreferencesUpdateSchema.safeParse(await c.req.json())
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0]
+      const field = issue?.path.join('.') || 'body'
+      return c.json({ error: `Invalid preferences: ${field}: ${issue?.message ?? 'invalid value'}` }, 400)
     }
 
-    const merged = await updateAgentPreferences(slug, body)
+    const merged = await updateAgentPreferences(slug, parsed.data)
     return c.json(merged)
   } catch (error) {
     console.error('Failed to update agent preferences:', error)
@@ -1327,7 +1321,9 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
     // the client can materialize its optimistic copy by exact id match.
     const initialMessageUuid = randomUUID()
 
-    const sessionModel = runtimeOptions.model ?? getEffectiveModels().agentModel
+    // Model/effort preference order: explicit per-session pick > agent default > global default.
+    const agentPrefs = await readAgentPreferences(slug)
+    const sessionModel = runtimeOptions.model ?? agentPrefs.defaultModel ?? getEffectiveModels().agentModel
 
     const containerSession = await client.createSession({
       availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
@@ -1342,7 +1338,7 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
       maxBudgetUsd: agentLimits.maxBudgetUsd,
       customEnvVars: Object.keys(customEnvVars).length > 0 ? customEnvVars : undefined,
       maxBrowserTabs: getSettings().app?.maxBrowserTabs,
-      effort: runtimeOptions.effort,
+      effort: runtimeOptions.effort ?? agentPrefs.defaultEffort,
     })
     const sessionId = containerSession.id
 

--- a/src/api/routes/scheduled-tasks.test.ts
+++ b/src/api/routes/scheduled-tasks.test.ts
@@ -74,6 +74,12 @@ vi.mock('@shared/lib/config/settings', () => ({
   getModelCatalogSettings: () => ({}),
 }))
 
+const mockReadAgentPreferences = vi.fn()
+
+vi.mock('@shared/lib/services/agent-preferences-service', () => ({
+  readAgentPreferences: (...args: unknown[]) => mockReadAgentPreferences(...args),
+}))
+
 const mockValidateCronExpression = vi.fn()
 const mockGetFrequencyWarning = vi.fn()
 
@@ -178,6 +184,7 @@ describe('scheduled-tasks route', () => {
       browserModel: 'claude-browser',
       summarizerModel: 'claude-haiku-4-5',
     })
+    mockReadAgentPreferences.mockResolvedValue({})
     mockValidateCronExpression.mockReturnValue({ valid: true })
     mockGetFrequencyWarning.mockReturnValue(null)
     mockMessagesCreate.mockResolvedValue({ content: [{ type: 'text', text: 'Every weekday at 9:00 AM' }] })
@@ -249,6 +256,40 @@ describe('scheduled-tasks route', () => {
     expect(mockRegisterSession).toHaveBeenCalledWith('agent-one', 'container-session-1', 'Scheduled Task (Run Now)')
     expect(mockMarkTaskExecuted).toHaveBeenCalledWith('task-1', 'container-session-1')
     expect(mockRecordManualExecution).not.toHaveBeenCalled()
+  })
+
+  describe('run-now model and effort resolution', () => {
+    // Preference order: task override > agent default > global default.
+    async function runNow(overrides: Record<string, unknown> = {}) {
+      task = createTask(overrides)
+      const res = await app.request('http://localhost/api/scheduled-tasks/task-1/run-now', {
+        method: 'POST',
+      })
+      expect(res.status).toBe(201)
+      expect(mockCreateSession).toHaveBeenCalledTimes(1)
+      return mockCreateSession.mock.calls[0][0]
+    }
+
+    it('uses the global default when neither task nor agent set one', async () => {
+      const args = await runNow()
+      expect(args.model).toBe('claude-agent')
+      expect(args.effort).toBeUndefined()
+    })
+
+    it('falls back to the agent default over the global default', async () => {
+      mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
+      const args = await runNow()
+      expect(mockReadAgentPreferences).toHaveBeenCalledWith('agent-one')
+      expect(args.model).toBe('opus')
+      expect(args.effort).toBe('high')
+    })
+
+    it('prefers the task override over the agent default', async () => {
+      mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
+      const args = await runNow({ model: 'claude-haiku-4-5-20251001', effort: 'low' })
+      expect(args.model).toBe('claude-haiku-4-5-20251001')
+      expect(args.effort).toBe('low')
+    })
   })
 
   it('does not start a container for non-runnable task statuses', async () => {

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -32,6 +32,7 @@ import { getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { containerManager } from '@shared/lib/container/container-manager'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { getEffectiveModels } from '@shared/lib/config/settings'
+import { readAgentPreferences } from '@shared/lib/services/agent-preferences-service'
 import { validateCronExpression, getFrequencyWarning } from '@shared/lib/services/schedule-parser'
 import { RuntimeOptionsSchema } from '@shared/lib/container/runtime-options'
 import type { EffortLevel } from '@shared/lib/container/types'
@@ -272,15 +273,18 @@ scheduledTasksRouter.post('/:taskId/run-now', TaskAgentRole('user'), async (c) =
 
     const client = await containerManager.ensureRunning(task.agentSlug)
     const availableEnvVars = await getSecretEnvVars(task.agentSlug)
+    // Model/effort preference order: task override > agent default > global default.
     const models = getEffectiveModels()
+    const agentPrefs = await readAgentPreferences(task.agentSlug)
+    const effort = task.effort ?? agentPrefs.defaultEffort
 
     const containerSession = await client.createSession({
       availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
       initialMessage: task.prompt,
-      model: task.model || models.agentModel,
+      model: task.model || agentPrefs.defaultModel || models.agentModel,
       browserModel: models.browserModel,
       dashboardBuilderModel: models.dashboardBuilderModel,
-      ...(task.effort ? { effort: task.effort as EffortLevel } : {}),
+      ...(effort ? { effort: effort as EffortLevel } : {}),
     })
 
     const sessionId = containerSession.id

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -128,6 +128,12 @@ vi.mock('@shared/lib/services/secrets-service', () => ({
   getSecretEnvVars: vi.fn(async () => []),
 }))
 
+// Agent preferences (file-based) — per-agent default model/effort
+const mockReadAgentPreferences = vi.fn(async (..._args: unknown[]): Promise<Record<string, unknown>> => ({}))
+vi.mock('@shared/lib/services/agent-preferences-service', () => ({
+  readAgentPreferences: (...args: unknown[]) => mockReadAgentPreferences(...args),
+}))
+
 // Review manager (direct decision injection)
 let reviewDecisions: Array<'allow' | 'deny'> = []
 vi.mock('@shared/lib/proxy/review-manager', () => ({
@@ -210,6 +216,7 @@ beforeEach(async () => {
   mockIsSessionActive.mockReturnValue(false)
   mockIsSessionAwaitingInput.mockReturnValue(false)
   mockWaitForIdle.mockResolvedValue(undefined)
+  mockReadAgentPreferences.mockResolvedValue({})
   mockEnsureRunning.mockClear()
   mockEnsureRunning.mockResolvedValue({
     createSession: mockCreateSession,
@@ -628,6 +635,43 @@ describe('/invoke', () => {
     })
     const res = await authedFetch('/x-agent/invoke', { slug: TARGET_SLUG, prompt: 'hi' })
     expect(res.status).toBe(200)
+  })
+})
+
+// ============================================================================
+// /invoke model and effort resolution
+// ============================================================================
+
+describe('/invoke model and effort resolution', () => {
+  // /invoke has no per-call model/effort override, so the order is just:
+  // target agent default (agent preferences) > global default.
+  beforeEach(() => {
+    mockGetAgent.mockResolvedValue({
+      slug: TARGET_SLUG,
+      frontmatter: { name: 'Target', createdAt: '2024-01-01' },
+      instructions: '',
+    })
+    mockCreateSession.mockResolvedValue({ id: 'new-sess-id' })
+    reviewDecisions.push('allow')
+  })
+
+  it('uses the target agent default over the global default', async () => {
+    mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
+    const res = await authedFetch('/x-agent/invoke', { slug: TARGET_SLUG, prompt: 'hello' })
+    expect(res.status).toBe(200)
+    expect(mockReadAgentPreferences).toHaveBeenCalledWith(TARGET_SLUG)
+    const args = mockCreateSession.mock.calls[0][0] as Record<string, unknown>
+    expect(args.model).toBe('opus')
+    expect(args.effort).toBe('high')
+  })
+
+  it('falls back to the global default and omits effort when the agent sets none', async () => {
+    const res = await authedFetch('/x-agent/invoke', { slug: TARGET_SLUG, prompt: 'hello' })
+    expect(res.status).toBe(200)
+    const args = mockCreateSession.mock.calls[0][0] as Record<string, unknown>
+    expect(args.model).toBe('sonnet') // the mocked getEffectiveModels().agentModel
+    // Effort must be omitted entirely, not sent as undefined.
+    expect('effort' in args).toBe(false)
   })
 })
 

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -43,6 +43,7 @@ import {
 } from '@shared/lib/services/x-agent-policy-service'
 import { getEffectiveModels, getEffectiveAgentLimits, getCustomEnvVars, getSettings } from '@shared/lib/config/settings'
 import { getSecretEnvVars } from '@shared/lib/services/secrets-service'
+import { readAgentPreferences } from '@shared/lib/services/agent-preferences-service'
 import type { JsonlMessageEntry, JsonlSystemEntry } from '@shared/lib/types/agent'
 
 // Typed context variables for the x-agent router. Using Hono's generic instead
@@ -560,12 +561,16 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
   const agentLimits = getEffectiveAgentLimits()
   const customEnvVars = getCustomEnvVars()
 
+  // Model/effort preference order: target agent's default > global default.
+  const targetPrefs = await readAgentPreferences(targetSlug)
+
   const containerSession = await client.createSession({
     availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
     initialMessage: prompt,
-    model: getEffectiveModels().agentModel,
+    model: targetPrefs.defaultModel ?? getEffectiveModels().agentModel,
     browserModel: getEffectiveModels().browserModel,
     dashboardBuilderModel: getEffectiveModels().dashboardBuilderModel,
+    ...(targetPrefs.defaultEffort ? { effort: targetPrefs.defaultEffort } : {}),
     maxOutputTokens: agentLimits.maxOutputTokens,
     maxThinkingTokens: agentLimits.maxThinkingTokens,
     maxTurns: agentLimits.maxTurns,

--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -515,9 +515,12 @@ describe('AgentHome', () => {
       expect.objectContaining({
         agentSlug: 'test-agent',
         message: 'Hello agent',
-        effort: 'medium',
       })
     )
+    // Untouched composer: model/effort omitted so the server resolves
+    // agent-default > global instead of receiving the display echo as a pick.
+    expect(mockCreateSession.mutateAsync.mock.calls[0][0]).not.toHaveProperty('effort')
+    expect(mockCreateSession.mutateAsync.mock.calls[0][0]).not.toHaveProperty('model')
     // The uuid is server-assigned: never sent in the request, and the one
     // from the response is forwarded to onSessionCreated.
     expect(mockCreateSession.mutateAsync.mock.calls[0][0]).not.toHaveProperty('messageUuid')

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -28,6 +28,7 @@ import { ComposerOptions, useComposerOptions } from '@renderer/components/messag
 import { InlineEditableTitle } from '@renderer/components/ui/inline-editable-title'
 import { HomeTriggers } from './home-triggers'
 import { HomeSkills } from './home-skills'
+import { HomeDefaultModel } from './home-default-model'
 import { HomeExtras } from './home-extras'
 import { HomeConnections } from './home-connections'
 import { HomeChatIntegrations } from './home-chat-integrations'
@@ -35,6 +36,7 @@ import { HomeVolumes } from './home-volumes'
 import { HomeBookmarks } from './home-bookmarks'
 import { DashboardCard } from '@renderer/components/home/dashboard-card'
 import { useUpdateAgent, useDeleteAgent, type ApiAgent } from '@renderer/hooks/use-agents'
+import { useAgentPreferences } from '@renderer/hooks/use-agent-preferences'
 import { AgentCreationAids, type ImportResult } from '@renderer/components/agents/agent-creation-aids'
 import { useStartOnboardingSession } from '@renderer/hooks/use-start-onboarding-session'
 import {
@@ -86,7 +88,15 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   const [sessionSearch, setSessionSearch] = useState('')
   const [sessionSort, setSessionSort] = useState<SortOrder>('newest')
   const { data: sessionsData } = useSessions(agent.slug)
-  const composerOptions = useComposerOptions()
+  const { data: agentPrefs } = useAgentPreferences(agent.slug)
+  const composerOptions = useComposerOptions({
+    agentDefaultModel: agentPrefs?.defaultModel,
+    agentDefaultEffort: agentPrefs?.defaultEffort,
+    agentKey: agent.slug,
+    // The default-model card sits next to this composer; an untouched selection
+    // must visibly track it, including a reset back to the global default.
+    followDefaults: true,
+  })
   const sessionSearchRef = useRef<HTMLInputElement>(null)
   const composerTextareaRef = useRef<HTMLTextAreaElement>(null)
   const isMobile = useIsMobile()
@@ -512,6 +522,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
             }} />
             <HomeChatIntegrations className="intro-step intro-step-7" agentSlug={agent.slug} />
             <HomeVolumes className="intro-step intro-step-8" agentSlug={agent.slug} />
+            <HomeDefaultModel className="intro-step intro-step-9" agentSlug={agent.slug} />
             <HomeExtras className="intro-step intro-step-9" agentSlug={agent.slug} onOpenSettings={handleOpenSettings} />
           </div>
         )}

--- a/src/renderer/components/agents/agent-home/home-default-model.tsx
+++ b/src/renderer/components/agents/agent-home/home-default-model.tsx
@@ -1,0 +1,62 @@
+import { RotateCcw } from 'lucide-react'
+import { cn } from '@shared/lib/utils/cn'
+import { Button } from '@renderer/components/ui/button'
+import { useSettings } from '@renderer/hooks/use-settings'
+import { useAgentPreferences, useUpdateAgentPreferences } from '@renderer/hooks/use-agent-preferences'
+import { SettingsModelSelect } from '@renderer/components/settings/settings-model-select'
+import type { EffortLevel } from '@shared/lib/container/types'
+
+interface HomeDefaultModelProps {
+  agentSlug: string
+  className?: string
+}
+
+/**
+ * Slim card with the agent's default model + effort, stored in agent
+ * preferences. Optional — when unset the picker displays the app-wide default,
+ * and new sessions, crons, webhooks and chat integrations fall back to it. A
+ * per-trigger or per-session pick still wins over both.
+ */
+export function HomeDefaultModel({ agentSlug, className }: HomeDefaultModelProps) {
+  const { data: settings } = useSettings()
+  const { data: prefs } = useAgentPreferences(agentSlug)
+  const updatePreferences = useUpdateAgentPreferences(agentSlug)
+
+  const hasCustom = Boolean(prefs?.defaultModel || prefs?.defaultEffort)
+  const displayModel = prefs?.defaultModel ?? settings?.models?.agentModel
+  const displayEffort = prefs?.defaultEffort ?? settings?.models?.agentEffort ?? 'medium'
+
+  return (
+    <div
+      className={cn('flex items-center justify-between gap-2 rounded-xl border bg-background py-2 px-4', className)}
+      data-testid="home-default-model-card"
+    >
+      <span className="text-sm font-medium text-muted-foreground">Default Model</span>
+      <div className="flex min-w-0 items-center gap-1">
+        {hasCustom ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0 text-muted-foreground"
+            aria-label="Reset to global default"
+            title="Reset to global default"
+            data-testid="home-default-model-reset"
+            onClick={() => updatePreferences.mutate({ defaultModel: null, defaultEffort: null })}
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+          </Button>
+        ) : (
+          <span className="shrink-0 text-xs text-muted-foreground/70">Global</span>
+        )}
+        <SettingsModelSelect
+          model={displayModel}
+          onModelChange={(m) => updatePreferences.mutate({ defaultModel: m })}
+          includeEffort
+          effort={displayEffort as EffortLevel}
+          onEffortChange={(e) => updatePreferences.mutate({ defaultEffort: e })}
+          disabled={updatePreferences.isPending}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/messages/composer-options.test.tsx
+++ b/src/renderer/components/messages/composer-options.test.tsx
@@ -123,6 +123,40 @@ describe('useComposerOptions default adoption', () => {
     expect(result.current.effort).toBe('low')
   })
 
+  it('omits untouched knobs from runtime options so the server resolves the defaults', () => {
+    const { result } = render({
+      agentKey: 'a',
+      agentDefaultModel: 'haiku',
+      agentDefaultEffort: 'high',
+      agentDefaultsReady: true,
+    })
+    // Adopted for display, but nothing was explicitly chosen — the wire bag
+    // stays empty so a still-loading or later-edited default can't be beaten
+    // by its own stale echo.
+    expect(result.current.model).toBe('haiku')
+    expect(result.current.toRuntimeOptions()).toEqual({})
+  })
+
+  it('serializes explicitly picked and session-seeded values', () => {
+    const { result } = render({ agentKey: 'a', agentDefaultsReady: true })
+    act(() => {
+      result.current.setModel('claude-opus-4-7')
+    })
+    // Model picked, effort untouched: only the pick goes on the wire.
+    expect(result.current.toRuntimeOptions()).toEqual({ model: 'claude-opus-4-7' })
+
+    const seeded = render({
+      initialModel: 'claude-opus-4-6',
+      initialEffort: 'xhigh',
+      agentKey: 'a',
+      agentDefaultsReady: true,
+    })
+    expect(seeded.result.current.toRuntimeOptions()).toEqual({
+      model: 'claude-opus-4-6',
+      effort: 'xhigh',
+    })
+  })
+
   it('session-seeded initial values win over defaults', () => {
     const { result } = render({
       initialModel: 'claude-opus-4-6',

--- a/src/renderer/components/messages/composer-options.test.tsx
+++ b/src/renderer/components/messages/composer-options.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useComposerOptions, type UseComposerOptionsArgs } from './composer-options'
+
+// Mutable settings the mocked useSettings reads at call time, so tests can
+// simulate the query resolving (undefined → loaded) and later refetches.
+const state = vi.hoisted(() => ({ settings: undefined as unknown }))
+
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useSettings: () => ({ data: state.settings }),
+}))
+
+const LOADED_SETTINGS = {
+  llmProvider: 'anthropic',
+  models: { agentModel: 'opus' },
+  llmProviderStatus: [
+    { id: 'anthropic', catalog: [], defaultModels: { agent: 'sonnet' } },
+  ],
+}
+
+function render(initialProps: UseComposerOptionsArgs) {
+  return renderHook((props: UseComposerOptionsArgs) => useComposerOptions(props), {
+    initialProps,
+  })
+}
+
+describe('useComposerOptions default adoption', () => {
+  beforeEach(() => {
+    state.settings = LOADED_SETTINGS
+  })
+
+  it('adopts the agent default over the global default as sources stream in', () => {
+    state.settings = undefined
+    const { result, rerender } = render({ agentKey: 'a', agentDefaultsReady: false })
+    expect(result.current.model).toBeUndefined()
+
+    // Settings resolve first: adopt the global default.
+    state.settings = LOADED_SETTINGS
+    rerender({ agentKey: 'a', agentDefaultsReady: false })
+    expect(result.current.model).toBe('opus')
+    expect(result.current.effort).toBe('medium')
+
+    // Agent preferences resolve later: the agent default wins.
+    rerender({
+      agentKey: 'a',
+      agentDefaultModel: 'haiku',
+      agentDefaultEffort: 'high',
+      agentDefaultsReady: true,
+    })
+    expect(result.current.model).toBe('haiku')
+    expect(result.current.effort).toBe('high')
+  })
+
+  it('locks once both sources answered: a background default change cannot swap an untouched selection', () => {
+    const { result, rerender } = render({
+      agentKey: 'a',
+      agentDefaultModel: 'haiku',
+      agentDefaultEffort: 'high',
+      agentDefaultsReady: true,
+    })
+    expect(result.current.model).toBe('haiku')
+
+    // Another window edits the default and the query refetches mid-compose.
+    rerender({
+      agentKey: 'a',
+      agentDefaultModel: 'sonnet',
+      agentDefaultEffort: 'low',
+      agentDefaultsReady: true,
+    })
+    expect(result.current.model).toBe('haiku')
+    expect(result.current.effort).toBe('high')
+  })
+
+  it('followDefaults keeps tracking after load, including a reset back to the global default', () => {
+    const { result, rerender } = render({
+      agentKey: 'a',
+      followDefaults: true,
+      agentDefaultModel: 'haiku',
+      agentDefaultsReady: true,
+    })
+    expect(result.current.model).toBe('haiku')
+
+    rerender({ agentKey: 'a', followDefaults: true, agentDefaultModel: 'sonnet', agentDefaultsReady: true })
+    expect(result.current.model).toBe('sonnet')
+
+    // Reset-to-global on the agent-home card: defaults cleared → global default.
+    rerender({ agentKey: 'a', followDefaults: true, agentDefaultsReady: true })
+    expect(result.current.model).toBe('opus')
+  })
+
+  it('an agentKey change unlocks and re-adopts, dropping to medium effort when the new agent has no defaults', () => {
+    const { result, rerender } = render({
+      agentKey: 'a',
+      agentDefaultModel: 'haiku',
+      agentDefaultEffort: 'max',
+      agentDefaultsReady: true,
+    })
+    expect(result.current.model).toBe('haiku')
+    expect(result.current.effort).toBe('max')
+
+    // Quick-dispatch switches to an agent with no defaults (and no global
+    // agentEffort configured): both knobs must follow.
+    rerender({ agentKey: 'b', agentDefaultsReady: true })
+    expect(result.current.model).toBe('opus')
+    expect(result.current.effort).toBe('medium')
+  })
+
+  it('an explicit user pick survives default changes and agent switches', () => {
+    const { result, rerender } = render({ agentKey: 'a', agentDefaultsReady: true })
+    act(() => {
+      result.current.setModel('claude-opus-4-7')
+      result.current.setEffort('low')
+    })
+
+    rerender({
+      agentKey: 'b',
+      agentDefaultModel: 'haiku',
+      agentDefaultEffort: 'max',
+      agentDefaultsReady: true,
+    })
+    expect(result.current.model).toBe('claude-opus-4-7')
+    expect(result.current.effort).toBe('low')
+  })
+
+  it('session-seeded initial values win over defaults', () => {
+    const { result } = render({
+      initialModel: 'claude-opus-4-6',
+      initialEffort: 'xhigh',
+      agentKey: 'a',
+      agentDefaultModel: 'haiku',
+      agentDefaultEffort: 'low',
+      agentDefaultsReady: true,
+    })
+    expect(result.current.model).toBe('claude-opus-4-6')
+    expect(result.current.effort).toBe('xhigh')
+  })
+})

--- a/src/renderer/components/messages/composer-options.tsx
+++ b/src/renderer/components/messages/composer-options.tsx
@@ -31,8 +31,15 @@ export interface ComposerOptionsState {
   /** Active host web-provider id (settings-derived), so the model picker's web-tools availability
    *  warning knows a configured vendor makes those tools work on any model. Undefined = native. */
   webProvider?: string
-  /** Pluck the runtime-options bag for an API payload. Drops `model` when undefined. */
-  toRuntimeOptions(): { effort: EffortLevel; model?: string }
+  /**
+   * Pluck the runtime-options bag for an API payload. UNTOUCHED knobs (no
+   * explicit user pick, no session-seeded value) are OMITTED, not serialized:
+   * an adopted default sent as an explicit value would beat the server's own
+   * agent-default > global resolution — wrong whenever the display is racing
+   * a still-loading preferences query — and would override the actual model of
+   * a session that carries none in its metadata (e.g. trigger-created).
+   */
+  toRuntimeOptions(): { effort?: EffortLevel; model?: string }
 }
 
 /**
@@ -194,8 +201,13 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
     followDefaults,
   ])
 
+  // Seeded refs are read at submit time: only a user pick or a session-seeded
+  // value counts as an explicit choice worth putting on the wire.
   const toRuntimeOptions = useCallback(
-    () => ({ effort, ...(model ? { model } : {}) }),
+    () => ({
+      ...(effortSeededRef.current ? { effort } : {}),
+      ...(modelSeededRef.current && model ? { model } : {}),
+    }),
     [effort, model],
   )
 

--- a/src/renderer/components/messages/composer-options.tsx
+++ b/src/renderer/components/messages/composer-options.tsx
@@ -56,10 +56,43 @@ export interface UseComposerOptionsArgs {
   initialEffort?: EffortLevel
   /** Model last used on this session, seeds the selector once if provided. */
   initialModel?: string
+  /** The agent's own default model, if set. Slots between a session's initial model and the app-wide default. */
+  agentDefaultModel?: string
+  /** The agent's own default effort, if set. Slots between a session's initial effort and the app-wide default. */
+  agentDefaultEffort?: EffortLevel
+  /**
+   * Identity of the agent the defaults belong to. When it changes (quick-dispatch
+   * switching agents) a locked, untouched selection unlocks and re-adopts the new
+   * agent's effective defaults.
+   */
+  agentKey?: string
+  /**
+   * Whether the agent-defaults source has answered (its query settled). Until
+   * settings AND this are true, an untouched selection keeps adopting the
+   * effective default as the sources stream in; after both, adoption locks so a
+   * background change (another window editing a default, a focus refetch) can't
+   * swap a selection out from under a mid-compose user. Defaults to true for
+   * callers with no agent-defaults source.
+   */
+  agentDefaultsReady?: boolean
+  /**
+   * Never lock: an untouched selection live-follows the effective default. For
+   * surfaces that edit the default right next to the composer (agent home),
+   * where the two must visibly stay in sync.
+   */
+  followDefaults?: boolean
 }
 
 export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerOptionsState {
-  const { initialEffort, initialModel } = args
+  const {
+    initialEffort,
+    initialModel,
+    agentDefaultModel,
+    agentDefaultEffort,
+    agentKey,
+    agentDefaultsReady = true,
+    followDefaults = false,
+  } = args
 
   const { data: settings } = useSettings()
 
@@ -72,15 +105,6 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
       effortSeededRef.current = true
     }
   }, [initialEffort])
-  // For brand-new sessions (no `initialEffort`), adopt the user's configured
-  // default effort once settings load. Doesn't flip the seeded ref, so a
-  // late-arriving session effort can still win, and stops once the user picks.
-  const defaultEffort = settings?.models?.agentEffort
-  useEffect(() => {
-    if (!effortSeededRef.current && initialEffort === undefined && defaultEffort) {
-      setEffortState(defaultEffort)
-    }
-  }, [defaultEffort, initialEffort])
   // Wrap the setter so an explicit user pick locks out the late-arriving
   // initial-seed effect — otherwise a slow `useSession` resolution can clobber
   // the user's choice if they pick before session data lands.
@@ -96,17 +120,18 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
     [settings, activeProvider],
   )
   const catalog = useMemo(() => providerInfo?.catalog ?? [], [providerInfo])
-  // Fallback hierarchy: user's "Default Model" → provider's agent default → the
-  // catalog's latest Sonnet → first catalog entry. The first non-empty wins.
-  // Aliases and concrete ids are both valid wire values, so any of these is a
-  // usable selection string.
+  // Fallback hierarchy: the agent's own default → user's "Default Model" →
+  // provider's agent default → the catalog's latest Sonnet → first catalog
+  // entry. The first non-empty wins. Aliases and concrete ids are both valid
+  // wire values, so any of these is a usable selection string.
   const fallbackModel = useMemo(
     () =>
+      agentDefaultModel ??
       settings?.models?.agentModel ??
       providerInfo?.defaultModels?.agent ??
       catalog.find((m) => m.family === 'sonnet' && m.isLatest)?.id ??
       catalog[0]?.id,
-    [settings, providerInfo, catalog],
+    [agentDefaultModel, settings, providerInfo, catalog],
   )
 
   // ---- Model ----
@@ -119,16 +144,55 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
       modelSeededRef.current = true
     }
   }, [initialModel])
-  // Adopt provider default if the selector is still empty by the time settings load.
-  useEffect(() => {
-    if (!modelSeededRef.current && model === undefined && fallbackModel) {
-      setModelState(fallbackModel)
-    }
-  }, [model, fallbackModel])
   const setModel = useCallback((m: string) => {
     modelSeededRef.current = true
     setModelState(m)
   }, [])
+
+  // ---- Default adoption ----
+  // An untouched knob follows the effective default (agent default → user
+  // setting → built-in) while the sources stream in: settings and agent
+  // preferences resolve at different times, and quick-dispatch switches agents.
+  // Once both sources have answered, adoption LOCKS (unless `followDefaults`),
+  // so a later background change — another window editing a default, a focus
+  // refetch — can't swap a selection out from under a mid-compose user. An
+  // `agentKey` change unlocks and re-adopts for the new agent. Session-seeded
+  // values and explicit user picks always win via the seeded refs.
+  const adoptionLockedRef = useRef(false)
+  const adoptionKeyRef = useRef(agentKey)
+  const fallbackEffort =
+    agentDefaultEffort ?? settings?.models?.agentEffort ?? (settings ? DEFAULT_EFFORT : undefined)
+  useEffect(() => {
+    if (adoptionKeyRef.current !== agentKey) {
+      adoptionKeyRef.current = agentKey
+      adoptionLockedRef.current = false
+    }
+    if (adoptionLockedRef.current) return
+    if (!modelSeededRef.current && fallbackModel && model !== fallbackModel) {
+      setModelState(fallbackModel)
+    }
+    if (
+      !effortSeededRef.current &&
+      initialEffort === undefined &&
+      fallbackEffort &&
+      effort !== fallbackEffort
+    ) {
+      setEffortState(fallbackEffort)
+    }
+    if (!followDefaults && settings && agentDefaultsReady) {
+      adoptionLockedRef.current = true
+    }
+  }, [
+    agentKey,
+    model,
+    fallbackModel,
+    effort,
+    fallbackEffort,
+    initialEffort,
+    settings,
+    agentDefaultsReady,
+    followDefaults,
+  ])
 
   const toRuntimeOptions = useCallback(
     () => ({ effort, ...(model ? { model } : {}) }),

--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -211,10 +211,14 @@ describe('MessageInput', () => {
           sessionId: 's-1',
           agentSlug: 'agent-1',
           content: 'Hello world',
-          effort: 'medium',
         })
       )
     })
+    // Untouched composer: model/effort are omitted so the server resolves
+    // agent-default > global instead of receiving the display echo as a pick.
+    const call = mockSendMessage.mutateAsync.mock.calls[0][0]
+    expect(call).not.toHaveProperty('effort')
+    expect(call).not.toHaveProperty('model')
   })
 
   it('does not submit on Shift+Enter', async () => {
@@ -273,7 +277,6 @@ describe('MessageInput', () => {
           sessionId: 's-1',
           agentSlug: 'agent-1',
           content: 'Hello by button',
-          effort: 'medium',
         })
       )
     })
@@ -653,7 +656,6 @@ describe('MessageInput', () => {
           sessionId: 's-1',
           agentSlug: 'agent-1',
           content: 'Hello',
-          effort: 'medium',
         })
       )
     })

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -16,6 +16,7 @@ import { useMessageComposer } from '@renderer/hooks/use-message-composer'
 import { useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
 import { ChatComposerBox } from './chat-composer-box'
 import { ComposerOptions, useComposerOptions } from './composer-options'
+import { useAgentPreferences } from '@renderer/hooks/use-agent-preferences'
 import { useRenderTracker } from '@renderer/lib/perf'
 import type { EffortLevel } from '@shared/lib/container/types'
 
@@ -41,7 +42,15 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
   const lastTypingNotification = useRef(0)
   const [slashMenuOpen, setSlashMenuOpen] = useState(false)
   const [slashMenuIndex, setSlashMenuIndex] = useState(0)
-  const composerOptions = useComposerOptions({ initialEffort, initialModel })
+  const { data: agentPrefs, isFetched: agentPrefsFetched } = useAgentPreferences(agentSlug)
+  const composerOptions = useComposerOptions({
+    initialEffort,
+    initialModel,
+    agentDefaultModel: agentPrefs?.defaultModel,
+    agentDefaultEffort: agentPrefs?.defaultEffort,
+    agentKey: agentSlug,
+    agentDefaultsReady: agentPrefsFetched,
+  })
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const sendMessage = useSendMessage()
   const uploadFile = useUploadFile()

--- a/src/renderer/components/messages/model-family-list.test.tsx
+++ b/src/renderer/components/messages/model-family-list.test.tsx
@@ -122,8 +122,9 @@ describe('ModelFamilyList', () => {
     )
     expect(screen.queryByTestId('model-pinned-claude-opus-4-8')).not.toBeInTheDocument()
     await user.click(screen.getByTestId('model-family-opus'))
-    // selects the family's latest concrete id, and does NOT take the close path
-    expect(onSelectFamilyLatest).toHaveBeenCalledWith('claude-opus-4-8')
+    // selects the family's latest concrete id (family alias alongside, for
+    // callers that store "latest" as the bare alias), and does NOT take the close path
+    expect(onSelectFamilyLatest).toHaveBeenCalledWith('claude-opus-4-8', 'opus')
     expect(onPick).not.toHaveBeenCalled()
     // and expands so the rest are one tap away
     expect(await screen.findByTestId('model-pinned-claude-opus-4-7')).toBeInTheDocument()

--- a/src/renderer/components/messages/model-family-list.tsx
+++ b/src/renderer/components/messages/model-family-list.tsx
@@ -85,12 +85,13 @@ interface ModelFamilyListProps {
    */
   offerLatest?: boolean
   /**
-   * When set, clicking a family header also selects that family's latest concrete
-   * version (without closing) and expands it — one click gets the latest, the rest
-   * stay visible for refinement. Used by the composer (the common "just give me the
-   * latest" case); omitted by the settings picker, where the family is just a toggle.
+   * When set, clicking a family header also selects that family's latest (without
+   * closing) and expands it — one click gets the latest, the rest stay visible for
+   * refinement. Called with the latest concrete version id and the bare family
+   * alias: the composer stores the concrete id (per-message picks are concrete);
+   * the settings picker stores the alias (a saved "latest" rides upgrades).
    */
-  onSelectFamilyLatest?: (value: string) => void
+  onSelectFamilyLatest?: (latestId: string, family: string) => void
   /**
    * Active host web-provider id from global settings. Native web search/fetch depend on the model
    * (the `supportsWebSearch` flag; Claude and GPT-over-Platform have them); a configured vendor
@@ -226,7 +227,7 @@ export function ModelFamilyList({
                   // One-click latest: expand and select the family's newest
                   // version without closing, so refinement stays one tap away.
                   setExpanded(group.family)
-                  onSelectFamilyLatest(latestVersion.id)
+                  onSelectFamilyLatest(latestVersion.id, group.family)
                 } else {
                   setExpanded(isOpen ? null : group.family)
                 }

--- a/src/renderer/components/quick-dispatch/quick-dispatch.test.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.test.tsx
@@ -50,6 +50,9 @@ const composerOptionsSpy = vi.hoisted(() => ({ value: null as Record<string, unk
 
 vi.mock('@renderer/hooks/use-agents', () => ({ useAgents: () => ({ data: state.agents }) }))
 vi.mock('@renderer/hooks/use-sessions', () => ({ useCreateSession: () => createSessionMock }))
+vi.mock('@renderer/hooks/use-agent-preferences', () => ({
+  useAgentPreferences: () => ({ data: undefined, isFetched: true }),
+}))
 vi.mock('@renderer/hooks/use-message-composer', () => ({
   useMessageComposer: (options: Record<string, unknown>) => {
     composerOptionsSpy.value = options

--- a/src/renderer/components/quick-dispatch/quick-dispatch.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.tsx
@@ -8,6 +8,7 @@ import { uploadFileChunked } from '@renderer/lib/upload'
 import { readLocalFileAsFile } from '@renderer/lib/read-local-file'
 import { useAgents, type ApiAgent } from '@renderer/hooks/use-agents'
 import { useCreateSession } from '@renderer/hooks/use-sessions'
+import { useAgentPreferences } from '@renderer/hooks/use-agent-preferences'
 import { useMessageComposer } from '@renderer/hooks/use-message-composer'
 import { AttachmentPreview } from '@renderer/components/messages/attachment-preview'
 import { findCatalogModel, useComposerOptions } from '@renderer/components/messages/composer-options'
@@ -82,7 +83,16 @@ export function QuickDispatch() {
 
   const selectedAgent = agentList.find((a) => a.slug === selectedSlug)
   const agentSlug = selectedSlug ?? ''
-  const composerOptions = useComposerOptions()
+  // An untouched model/effort selection follows the selected agent's defaults:
+  // agentKey re-adopts on switch, then adoption locks so background preference
+  // edits can't swap the selection while the user types.
+  const { data: agentPrefs, isFetched: agentPrefsFetched } = useAgentPreferences(agentSlug)
+  const composerOptions = useComposerOptions({
+    agentDefaultModel: agentPrefs?.defaultModel,
+    agentDefaultEffort: agentPrefs?.defaultEffort,
+    agentKey: agentSlug,
+    agentDefaultsReady: agentPrefsFetched,
+  })
   const createSession = useCreateSession()
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 

--- a/src/renderer/components/settings/settings-model-select.tsx
+++ b/src/renderer/components/settings/settings-model-select.tsx
@@ -137,6 +137,9 @@ function SettingsModelSelectImpl({
           value={model}
           onPick={pick}
           offerLatest
+          // Family click = that family's latest, stored as the bare alias (same
+          // as the "· latest" row). Stays open so a pinned version is one tap away.
+          onSelectFamilyLatest={(_latestId, family) => onModelChange(family)}
           webProvider={settings?.webProvider}
         />
         {includeEffort && (

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -920,17 +920,21 @@ class ChatIntegrationManager {
     const { getEffectiveModels } = await import('@shared/lib/config/settings')
     const { getSecretEnvVars } = await import('@shared/lib/services/secrets-service')
     const { registerSession, updateSessionMetadata } = await import('@shared/lib/services/session-service')
+    const { readAgentPreferences } = await import('@shared/lib/services/agent-preferences-service')
 
     const availableEnvVars = await getSecretEnvVars(integration.agentSlug)
+    // Model/effort preference order: integration override > agent default > global default.
     const models = getEffectiveModels()
+    const agentPrefs = await readAgentPreferences(integration.agentSlug)
+    const effort = integration.effort ?? agentPrefs.defaultEffort
 
     const containerSession = await client.createSession({
       availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
       initialMessage: messageText,
-      model: integration.model || models.agentModel,
+      model: integration.model || agentPrefs.defaultModel || models.agentModel,
       browserModel: models.browserModel,
       dashboardBuilderModel: models.dashboardBuilderModel,
-      ...(integration.effort ? { effort: integration.effort as EffortLevel } : {}),
+      ...(effort ? { effort: effort as EffortLevel } : {}),
       ...(integration.provider === 'imessage' ? { systemPrompt: IMESSAGE_SYSTEM_PROMPT } : {}),
     })
 

--- a/src/shared/lib/chat-integrations/chat-integration-model-resolution.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-model-resolution.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Chat integration model/effort resolution tests.
+ *
+ * Preference order when a chat message spawns a new agent session:
+ * integration override > agent default (agent preferences) > global default.
+ * Reuses the e2e harness wiring (MockChatClientConnector →
+ * ChatIntegrationManager → MockContainerClient); createSession options are
+ * captured via an instance spy because the mock client normalizes the model
+ * before recording it in its static call log.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import * as schema from '../db/schema'
+import { MockChatClientConnector } from './mock-connector'
+
+// ── Test state ─────────────────────────────────────────────────────────
+
+let testDir: string
+let testDb: ReturnType<typeof drizzle>
+let testSqlite: InstanceType<typeof Database>
+let mockConnector: MockChatClientConnector
+let mockContainerClient: InstanceType<typeof MockContainerClient>
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('../db', () => ({
+  get db() { return testDb },
+  get sqlite() { return testSqlite },
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+  addErrorBreadcrumb: vi.fn(),
+}))
+
+vi.mock('@shared/lib/platform-attribution', () => ({
+  runWithOptionalUser: (_userId: string | undefined, fn: () => unknown) => fn(),
+}))
+
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: {
+    ensureRunning: vi.fn(),
+  },
+}))
+
+vi.mock('@shared/lib/services/agent-service', () => ({
+  agentExists: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('@shared/lib/services/session-service', () => ({
+  registerSession: vi.fn().mockResolvedValue(undefined),
+  updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
+  getSessionMetadata: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getEffectiveModels: () => ({
+    agentModel: 'claude-sonnet-4-20250514',
+    browserModel: 'claude-sonnet-4-20250514',
+  }),
+  getSettings: () => ({}),
+}))
+
+vi.mock('@shared/lib/services/secrets-service', () => ({
+  getSecretEnvVars: vi.fn().mockResolvedValue([]),
+}))
+
+// The manager loads this via a dynamic import at session-spawn time; vi.mock
+// intercepts that path too.
+const mockReadAgentPreferences = vi.fn()
+vi.mock('@shared/lib/services/agent-preferences-service', () => ({
+  readAgentPreferences: (...args: unknown[]) => mockReadAgentPreferences(...args),
+}))
+
+// Mock telegram connector to return our MockChatClientConnector
+vi.mock('./telegram-connector', () => ({
+  TelegramConnector: class {
+    constructor() {
+      return mockConnector
+    }
+  },
+}))
+
+// ── Imports (after mocks) ──────────────────────────────────────────────
+
+import { chatIntegrationManager } from './chat-integration-manager'
+import { createChatIntegration } from '@shared/lib/services/chat-integration-service'
+import { containerManager } from '@shared/lib/container/container-manager'
+import { MockContainerClient } from '@shared/lib/container/mock-container-client'
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function waitForCondition(
+  check: () => boolean,
+  timeoutMs = 2000,
+  intervalMs = 10,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs
+    const poll = () => {
+      if (check()) return resolve()
+      if (Date.now() > deadline) return reject(new Error('Timed out waiting for condition'))
+      setTimeout(poll, intervalMs)
+    }
+    poll()
+  })
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe('chat integration model and effort resolution', () => {
+  let createSessionSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(async () => {
+    testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'chat-model-res-test-'))
+    process.env.SUPERAGENT_DATA_DIR = testDir
+
+    testSqlite = new Database(':memory:')
+    testDb = drizzle(testSqlite, { schema })
+    migrate(testDb, { migrationsFolder: path.join(process.cwd(), 'src/shared/lib/db/migrations') })
+
+    mockConnector = new MockChatClientConnector()
+
+    mockContainerClient = new MockContainerClient({ agentId: 'test-agent' })
+    await mockContainerClient.start()
+    MockContainerClient.resetCallRecords()
+    // Capture the raw options the manager passes, before the mock client
+    // resolves the model alias for its static call records.
+    createSessionSpy = vi.spyOn(mockContainerClient, 'createSession') as ReturnType<typeof vi.spyOn>;
+
+    (containerManager.ensureRunning as ReturnType<typeof vi.fn>).mockResolvedValue(mockContainerClient)
+
+    mockReadAgentPreferences.mockReset()
+    mockReadAgentPreferences.mockResolvedValue({})
+  })
+
+  afterEach(async () => {
+    chatIntegrationManager.stop()
+    // Let pending async handlers drain before closing the DB
+    await new Promise(r => setTimeout(r, 50))
+    testSqlite?.close()
+    await fs.promises.rm(testDir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  // Preference order: integration override > agent default > global default.
+  async function startSession(integrationOverrides: Record<string, unknown> = {}) {
+    const integrationId = createChatIntegration({
+      agentSlug: 'test-agent',
+      provider: 'telegram',
+      config: { botToken: 'test-token-123' },
+      name: 'Test Bot',
+      ...integrationOverrides,
+    })
+    // These tests exercise session-spawn defaults, not access control, so
+    // disable the owner-approval gate telegram integrations get by default.
+    testSqlite.prepare('UPDATE chat_integrations SET require_approval = 0 WHERE id = ?').run(integrationId)
+    await chatIntegrationManager.addIntegration(integrationId)
+
+    mockConnector.simulateIncomingMessage('Hello agent!', 'chat-1', 'user-1')
+    await waitForCondition(() => createSessionSpy.mock.calls.length > 0)
+    return createSessionSpy.mock.calls[0][0] as Record<string, unknown>
+  }
+
+  it('uses the global default when neither integration nor agent set one', async () => {
+    const args = await startSession()
+    expect(args.model).toBe('claude-sonnet-4-20250514')
+    // Effort must be omitted entirely, not sent as undefined.
+    expect('effort' in args).toBe(false)
+  })
+
+  it('falls back to the agent default over the global default', async () => {
+    mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
+    const args = await startSession()
+    expect(mockReadAgentPreferences).toHaveBeenCalledWith('test-agent')
+    expect(args.model).toBe('opus')
+    expect(args.effort).toBe('high')
+  })
+
+  it('prefers the integration override over the agent default', async () => {
+    mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
+    const args = await startSession({ model: 'claude-haiku-4-5-20251001', effort: 'low' })
+    expect(args.model).toBe('claude-haiku-4-5-20251001')
+    expect(args.effort).toBe('low')
+  })
+})

--- a/src/shared/lib/scheduler/task-scheduler.model-resolution.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.model-resolution.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { ScheduledTask } from '@shared/lib/services/scheduled-task-service'
+
+const mockGetDueTasks = vi.fn()
+const mockMarkTaskExecuted = vi.fn()
+const mockMarkTaskFailed = vi.fn()
+const mockUpdateNextExecution = vi.fn()
+
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  getDueTasks: (...args: unknown[]) => mockGetDueTasks(...args),
+  markTaskExecuted: (...args: unknown[]) => mockMarkTaskExecuted(...args),
+  markTaskFailed: (...args: unknown[]) => mockMarkTaskFailed(...args),
+  updateNextExecution: (...args: unknown[]) => mockUpdateNextExecution(...args),
+}))
+
+const mockCreateSession = vi.fn()
+const mockEnsureRunning = vi.fn()
+
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: {
+    ensureRunning: (...args: unknown[]) => mockEnsureRunning(...args),
+  },
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getEffectiveModels: () => ({
+    agentModel: 'claude-sonnet-4-20250514',
+    browserModel: 'claude-browser',
+    dashboardBuilderModel: 'claude-dashboard',
+  }),
+}))
+
+const mockReadAgentPreferences = vi.fn()
+
+vi.mock('@shared/lib/services/agent-preferences-service', () => ({
+  readAgentPreferences: (...args: unknown[]) => mockReadAgentPreferences(...args),
+}))
+
+const mockSubscribeToSession = vi.fn()
+const mockMarkSessionActive = vi.fn()
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    subscribeToSession: (...args: unknown[]) => mockSubscribeToSession(...args),
+    markSessionActive: (...args: unknown[]) => mockMarkSessionActive(...args),
+  },
+}))
+
+const mockTriggerScheduledSessionStarted = vi.fn()
+
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerScheduledSessionStarted: (...args: unknown[]) =>
+      mockTriggerScheduledSessionStarted(...args),
+  },
+}))
+
+const mockGetSessionForScheduledExecution = vi.fn()
+const mockRegisterSession = vi.fn()
+
+vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionForScheduledExecution: (...args: unknown[]) =>
+    mockGetSessionForScheduledExecution(...args),
+  registerSession: (...args: unknown[]) => mockRegisterSession(...args),
+}))
+
+const mockGetSecretEnvVars = vi.fn()
+
+vi.mock('@shared/lib/services/secrets-service', () => ({
+  getSecretEnvVars: (...args: unknown[]) => mockGetSecretEnvVars(...args),
+}))
+
+const mockAgentExists = vi.fn()
+
+vi.mock('@shared/lib/services/agent-service', () => ({
+  agentExists: (...args: unknown[]) => mockAgentExists(...args),
+}))
+
+const mockGetNextCronTime = vi.fn()
+
+vi.mock('@shared/lib/services/schedule-parser', () => ({
+  getNextCronTime: (...args: unknown[]) => mockGetNextCronTime(...args),
+}))
+
+vi.mock('@shared/lib/platform-attribution', () => ({
+  runWithOptionalUser: (_userId: string | null | undefined, fn: () => unknown) => fn(),
+}))
+
+const mockCaptureException = vi.fn()
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}))
+
+import { taskScheduler } from './task-scheduler'
+
+function createTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
+  return {
+    id: 'task-1',
+    agentSlug: 'agent-one',
+    scheduleType: 'at',
+    scheduleExpression: 'at 2026-06-26 10:00',
+    prompt: 'Run the scheduled report',
+    name: 'Daily report',
+    status: 'pending',
+    nextExecutionAt: new Date('2026-06-26T17:00:00.000Z'),
+    lastExecutedAt: null,
+    isRecurring: false,
+    executionCount: 0,
+    lastSessionId: null,
+    createdBySessionId: null,
+    createdByUserId: 'user-1',
+    timezone: 'America/Los_Angeles',
+    model: null,
+    effort: null,
+    createdAt: new Date('2026-06-26T16:00:00.000Z'),
+    cancelledAt: null,
+    pausedAt: null,
+    ...overrides,
+  }
+}
+
+describe('TaskScheduler model and effort resolution', () => {
+  beforeEach(() => {
+    taskScheduler.stop()
+    vi.clearAllMocks()
+
+    mockEnsureRunning.mockResolvedValue({ createSession: mockCreateSession })
+    mockCreateSession.mockResolvedValue({ id: 'container-session-1' })
+    mockSubscribeToSession.mockResolvedValue(undefined)
+    mockTriggerScheduledSessionStarted.mockResolvedValue(undefined)
+    mockRegisterSession.mockResolvedValue(undefined)
+    mockGetSecretEnvVars.mockResolvedValue([])
+    mockAgentExists.mockResolvedValue(true)
+    mockGetSessionForScheduledExecution.mockResolvedValue(null)
+    mockMarkTaskExecuted.mockResolvedValue(undefined)
+    mockMarkTaskFailed.mockResolvedValue(undefined)
+    mockUpdateNextExecution.mockResolvedValue(undefined)
+    mockReadAgentPreferences.mockResolvedValue({})
+  })
+
+  afterEach(() => {
+    taskScheduler.stop()
+  })
+
+  // Preference order: task override > agent default > global default.
+  async function executeTask(overrides: Partial<ScheduledTask> = {}) {
+    mockGetDueTasks.mockResolvedValue([createTask(overrides)])
+    await taskScheduler.triggerExecution()
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    return mockCreateSession.mock.calls[0][0]
+  }
+
+  it('uses the global default when neither task nor agent set one', async () => {
+    const args = await executeTask()
+    expect(args.model).toBe('claude-sonnet-4-20250514')
+    expect(args.effort).toBeUndefined()
+  })
+
+  it('falls back to the agent default over the global default', async () => {
+    mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
+    const args = await executeTask()
+    expect(mockReadAgentPreferences).toHaveBeenCalledWith('agent-one')
+    expect(args.model).toBe('opus')
+    expect(args.effort).toBe('high')
+  })
+
+  it('prefers the task override over the agent default', async () => {
+    mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
+    const args = await executeTask({ model: 'claude-haiku-4-5-20251001', effort: 'low' })
+    expect(args.model).toBe('claude-haiku-4-5-20251001')
+    expect(args.effort).toBe('low')
+  })
+})

--- a/src/shared/lib/scheduler/task-scheduler.ts
+++ b/src/shared/lib/scheduler/task-scheduler.ts
@@ -7,6 +7,7 @@
 
 import { containerManager } from '@shared/lib/container/container-manager'
 import { getEffectiveModels } from '@shared/lib/config/settings'
+import { readAgentPreferences } from '@shared/lib/services/agent-preferences-service'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
 import { runWithOptionalUser } from '@shared/lib/platform-attribution'
@@ -197,17 +198,20 @@ class TaskScheduler {
     // Get available env vars for the agent
     const availableEnvVars = await getSecretEnvVars(task.agentSlug)
 
-    // Create a new session with the scheduled prompt
+    // Create a new session with the scheduled prompt.
+    // Model/effort preference order: task override > agent default > global default.
     const models = getEffectiveModels()
+    const agentPrefs = await readAgentPreferences(task.agentSlug)
+    const effort = task.effort ?? agentPrefs.defaultEffort
     const containerSession = await client.createSession({
       availableEnvVars:
         availableEnvVars.length > 0 ? availableEnvVars : undefined,
       initialMessage: task.prompt,
-      model: task.model || models.agentModel,
+      model: task.model || agentPrefs.defaultModel || models.agentModel,
       browserModel: models.browserModel,
       dashboardBuilderModel: models.dashboardBuilderModel,
       metadata: { isAutomated: true },
-      ...(task.effort ? { effort: task.effort as EffortLevel } : {}),
+      ...(effort ? { effort: effort as EffortLevel } : {}),
     })
 
     const sessionId = containerSession.id

--- a/src/shared/lib/scheduler/trigger-manager.test.ts
+++ b/src/shared/lib/scheduler/trigger-manager.test.ts
@@ -68,6 +68,11 @@ vi.mock('@shared/lib/services/secrets-service', () => ({
   getSecretEnvVars: vi.fn().mockResolvedValue([]),
 }))
 
+const mockReadAgentPreferences = vi.fn().mockResolvedValue({})
+vi.mock('@shared/lib/services/agent-preferences-service', () => ({
+  readAgentPreferences: (...args: unknown[]) => mockReadAgentPreferences(...args),
+}))
+
 const mockAgentExists = vi.fn().mockResolvedValue(true)
 vi.mock('@shared/lib/services/agent-service', () => ({
   agentExists: (...args: unknown[]) => mockAgentExists(...args),
@@ -133,6 +138,7 @@ describe('TriggerManager', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockCreateSession.mockResolvedValue({ id: 'session_123' })
+    mockReadAgentPreferences.mockResolvedValue({})
     mockGetDistinctMemberIds.mockReturnValue(['sub_test_member'])
     mockGetPlatformAccessToken.mockReturnValue('opaque_test_token')
     mockDecodeOrgIdFromToken.mockReturnValue(null)
@@ -322,6 +328,54 @@ describe('TriggerManager', () => {
       expect(mockCreateSession).toHaveBeenCalledTimes(1)
 
       triggerManager.stop()
+    })
+  })
+
+  describe('model and effort resolution', () => {
+    // Preference order: trigger override > agent default > global default.
+    async function fireTrigger(overrides: Record<string, unknown> = {}) {
+      mockPollAndClaimEvents.mockResolvedValue({
+        events: [
+          { id: 'whe_1', composio_trigger_id: 'ti_abc', trigger_type: 'GMAIL', payload: {}, created_at: '' },
+        ],
+        realtime: null,
+      })
+      mockGetWebhookTriggersByComposioId.mockResolvedValue([{
+        id: 'trigger_1',
+        agentSlug: 'test-agent',
+        composioTriggerId: 'ti_abc',
+        prompt: 'Handle it',
+        status: 'active',
+        fireCount: 0,
+        model: null,
+        effort: null,
+        ...overrides,
+      }])
+      await triggerManager.start()
+      triggerManager.stop()
+      expect(mockCreateSession).toHaveBeenCalledTimes(1)
+      return mockCreateSession.mock.calls[0][0]
+    }
+
+    it('uses the global default when neither trigger nor agent set one', async () => {
+      const args = await fireTrigger()
+      expect(args.model).toBe('claude-sonnet-4-20250514')
+      expect(args.effort).toBeUndefined()
+    })
+
+    it('falls back to the agent default over the global default', async () => {
+      mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
+      const args = await fireTrigger()
+      expect(mockReadAgentPreferences).toHaveBeenCalledWith('test-agent')
+      expect(args.model).toBe('opus')
+      expect(args.effort).toBe('high')
+    })
+
+    it('prefers the trigger override over the agent default', async () => {
+      mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
+      const args = await fireTrigger({ model: 'claude-haiku-4-5-20251001', effort: 'low' })
+      expect(args.model).toBe('claude-haiku-4-5-20251001')
+      expect(args.effort).toBe('low')
     })
   })
 

--- a/src/shared/lib/scheduler/trigger-manager.ts
+++ b/src/shared/lib/scheduler/trigger-manager.ts
@@ -11,6 +11,7 @@ import { captureException } from '@shared/lib/error-reporting'
 import { getPlatformProxyBaseUrl } from '@shared/lib/platform-auth/config'
 import { containerManager } from '@shared/lib/container/container-manager'
 import { getEffectiveModels } from '@shared/lib/config/settings'
+import { readAgentPreferences } from '@shared/lib/services/agent-preferences-service'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
 import { runWithOptionalUser, attribution } from '@shared/lib/platform-attribution'
@@ -358,15 +359,18 @@ class TriggerManager {
     const client = await containerManager.ensureRunning(trigger.agentSlug)
     const availableEnvVars = await getSecretEnvVars(trigger.agentSlug)
 
+    // Model/effort preference order: trigger override > agent default > global default.
     const models = getEffectiveModels()
+    const agentPrefs = await readAgentPreferences(trigger.agentSlug)
+    const effort = trigger.effort ?? agentPrefs.defaultEffort
     const containerSession = await client.createSession({
       availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
       initialMessage: prompt,
-      model: trigger.model || models.agentModel,
+      model: trigger.model || agentPrefs.defaultModel || models.agentModel,
       browserModel: models.browserModel,
       dashboardBuilderModel: models.dashboardBuilderModel,
       metadata: { isAutomated: true },
-      ...(trigger.effort ? { effort: trigger.effort as EffortLevel } : {}),
+      ...(effort ? { effort: effort as EffortLevel } : {}),
     })
 
     const sessionId = containerSession.id

--- a/src/shared/lib/services/agent-preferences-service.test.ts
+++ b/src/shared/lib/services/agent-preferences-service.test.ts
@@ -110,6 +110,34 @@ describe('agent-preferences-service', () => {
       expect(result).toEqual({ autoDeleteInactiveDays: 30 })
       expect('unknownKey' in result).toBe(false)
     })
+
+    it('accepts valid defaultModel and defaultEffort', () => {
+      expect(
+        agentPreferencesSchema.parse({ defaultModel: 'opus', defaultEffort: 'high' })
+      ).toEqual({ defaultModel: 'opus', defaultEffort: 'high' })
+    })
+
+    it('rejects an empty defaultModel', () => {
+      expect(() => agentPreferencesSchema.parse({ defaultModel: '' })).toThrow()
+    })
+
+    // The container file hook shares this schema shape; a whitespace-only model
+    // that passed validation would ride the ?? chains onto the wire and break
+    // every spawn for the agent.
+    it('rejects a whitespace-only defaultModel and trims a padded one', () => {
+      expect(() => agentPreferencesSchema.parse({ defaultModel: '   ' })).toThrow()
+      expect(agentPreferencesSchema.parse({ defaultModel: ' opus ' })).toEqual({
+        defaultModel: 'opus',
+      })
+    })
+
+    it('rejects a non-string defaultModel', () => {
+      expect(() => agentPreferencesSchema.parse({ defaultModel: 42 })).toThrow()
+    })
+
+    it('rejects an unknown defaultEffort level', () => {
+      expect(() => agentPreferencesSchema.parse({ defaultEffort: 'turbo' })).toThrow()
+    })
   })
 
   // ==========================================================================
@@ -158,6 +186,26 @@ describe('agent-preferences-service', () => {
       )
       const result = await readAgentPreferences('test-agent')
       expect(result).toEqual({})
+    })
+
+    // Fail-open: preferences only supply defaults, and every session-spawn
+    // site reads them — a non-corrupt read failure (EACCES, EISDIR, transient
+    // FS errors) must degrade to {} rather than take down session creation.
+    it('returns empty object when the file is unreadable (not just corrupt)', async () => {
+      const workspaceDir = await createWorkspaceDir('test-agent')
+      // A directory at the prefs path makes reads fail with EISDIR — a
+      // non-corrupt I/O error, unlike the garbled-JSON cases above.
+      await fs.promises.mkdir(path.join(workspaceDir, 'agent-preferences.json'))
+      const result = await readAgentPreferences('test-agent')
+      expect(result).toEqual({})
+    })
+
+    it('an unreadable file still aborts the read-modify-write update path', async () => {
+      const workspaceDir = await createWorkspaceDir('test-agent')
+      await fs.promises.mkdir(path.join(workspaceDir, 'agent-preferences.json'))
+      await expect(
+        updateAgentPreferences('test-agent', { autoDeleteInactiveDays: 30 })
+      ).rejects.toThrow()
     })
   })
 

--- a/src/shared/lib/services/agent-preferences-service.ts
+++ b/src/shared/lib/services/agent-preferences-service.ts
@@ -21,9 +21,13 @@ async function readAgentPreferencesStrict(agentSlug: string): Promise<AgentPrefe
 }
 
 /**
- * Read prefs for READ-ONLY consumers. Tolerant: a corrupt file degrades to `{}`
- * (logged + captured) rather than crashing, but this never writes — only the
- * serialized {@link updateAgentPreferences} writes, and it re-throws on corruption.
+ * Read prefs for READ-ONLY consumers. Fail-open: ANY read failure — corrupt
+ * file, EACCES after a container-side ownership flip, transient FS errors —
+ * degrades to `{}` (logged + captured) rather than throwing. Preferences only
+ * supply defaults, and every session-spawn site reads them, so a throw here
+ * would take down session creation for the agent. This never writes — only the
+ * serialized {@link updateAgentPreferences} writes, and its strict read still
+ * aborts on any failure so a broken file is never overwritten.
  */
 export async function readAgentPreferences(
   agentSlug: string
@@ -31,12 +35,10 @@ export async function readAgentPreferences(
   try {
     return await readAgentPreferencesStrict(agentSlug)
   } catch (error) {
-    if (error instanceof CorruptFileError) {
-      console.error(`Corrupt agent preferences for ${agentSlug}; using empty (NOT overwriting)`, error)
-      captureException(error, { tags: { area: 'agent-preferences', op: 'read' }, extra: { agentSlug } })
-      return {}
-    }
-    throw error
+    const kind = error instanceof CorruptFileError ? 'Corrupt' : 'Unreadable'
+    console.error(`${kind} agent preferences for ${agentSlug}; using empty (NOT overwriting)`, error)
+    captureException(error, { tags: { area: 'agent-preferences', op: 'read' }, extra: { agentSlug } })
+    return {}
   }
 }
 

--- a/src/shared/lib/types/agent-preferences.ts
+++ b/src/shared/lib/types/agent-preferences.ts
@@ -1,8 +1,25 @@
 import { z } from 'zod'
+import { EFFORT_LEVELS } from '@shared/lib/container/types'
 
 // Keep in sync with agent-container/src/file-hooks/agent-preferences-hook.ts
 export const agentPreferencesSchema = z.object({
   autoDeleteInactiveDays: z.number().int().positive().optional(),
+  /** Default model for new sessions — a concrete id (pinned) or a bare family alias (latest). Overrides the global default; per-session/trigger picks still win. */
+  defaultModel: z.string().trim().min(1).optional(),
+  /** Default effort for new sessions. Overrides the global default; per-session/trigger picks still win. */
+  defaultEffort: z.enum(EFFORT_LEVELS).optional(),
 })
 
 export type AgentPreferences = z.infer<typeof agentPreferencesSchema>
+
+/**
+ * PUT /api/agents/:id/preferences body: each field optional, `null` clears it
+ * back to the app-wide default. Unknown keys are stripped.
+ */
+export const agentPreferencesUpdateSchema = z.object({
+  autoDeleteInactiveDays: z.number().int().positive().nullish(),
+  defaultModel: z.string().trim().min(1).nullish(),
+  defaultEffort: z.enum(EFFORT_LEVELS).nullish(),
+})
+
+export type AgentPreferencesUpdate = z.infer<typeof agentPreferencesUpdateSchema>


### PR DESCRIPTION
## Summary

Lets users set an optional **default model + effort per agent**, stored in the agent's `agent-preferences.json` (schema mirrored in the container file hook). When unset, everything falls back to the global default.

**Resolution order everywhere a session spawns** — explicit/trigger pick > agent default > global default — applied at all six sites: `POST /:id/sessions`, task-scheduler, scheduled-task run-now, webhook trigger-manager, chat-integration-manager, and x-agent invoke (no per-call override there, so agent default > global).

### UI

- New slim **Default Model card** on the agent homepage (right column), using the standard `SettingsModelSelect` with effort. Shows a muted "Global" hint when unset; reset button clears back to the global default.
- The composer (agent home, in-session, quick-dispatch) adopts the agent default for untouched selections via a new fallback chain in `useComposerOptions`; explicit picks always win.
- `SettingsModelSelect` family-header click now one-click-selects that family's **latest** (stored as the bare alias so it rides upgrades), matching the composer's behavior; the popover stays open for pinning a concrete version.

### Hardening (from multi-agent review)

- `readAgentPreferences` is **fail-open on any read error** (not just corrupt JSON) — an unreadable prefs file can no longer take down session spawning. The write path stays fail-closed.
- Composer adoption semantics made explicit: untouched knobs follow the effective default while settings/prefs load, then **lock** so background refetches can't swap a mid-compose selection; an agent switch (quick-dispatch) unlocks and re-adopts; agent home passes `followDefaults` so the card and composer visibly stay in sync (incl. reset).
- PUT `/:id/preferences` validation **zodified** (`agentPreferencesUpdateSchema`): non-object bodies now 400 instead of 500, `defaultModel` trimmed on write, whitespace-only rejected in both synced schemas.

### Tests

- Resolution-order unit tests at **all six spawn sites** + route-level tests for the `POST /sessions` server-side fallback and all PUT validation branches (13 new route tests).
- `useComposerOptions` hook tests (adoption, locking, unlock-on-agent-switch, user-pick precedence, session seeding).
- New E2E `agent-default-model.spec.ts`: set Haiku+High on the card → untouched composer adopts → session created with it on the wire → reset → next session goes out on the global default.

## Test plan

- [x] `npx tsc --noEmit` (main + agent-container) clean
- [x] `npx eslint 'src/**/*.{ts,tsx}'` — 0 errors
- [x] 338 unit tests across all 13 touched test files
- [x] E2E: agent-default-model + model-selection + settings — 35 passed / 3 pre-existing env-gated skips