### PR TITLE
feat: add GPT-5.6 family to Platform catalog and local pricing

### DIFF
--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -248,6 +248,49 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
   {
     id: 'gpt-5.5',
     label: 'GPT-5.5',
+    blurb: 'OpenAI, served via Platform',
+    family: 'gpt',
+    icon: 'openai',
+    supportedEfforts: NON_CLAUDE_EFFORTS,
+    supportsWebSearch: true,
+    pricing: { inputPerMtok: 5, outputPerMtok: 30 },
+    // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.5).
+    contextWindow: 1_050_000,
+    longContextPriceCliff: GPT_LONG_CONTEXT_CLIFF,
+    promptHints: GPT_TOOL_USE_PROMPT_HINTS,
+  },
+  {
+    id: 'gpt-5.6-luna',
+    label: 'GPT-5.6 Luna',
+    blurb: 'OpenAI fastest tier, served via Platform',
+    family: 'gpt',
+    icon: 'openai',
+    supportedEfforts: NON_CLAUDE_EFFORTS,
+    supportsWebSearch: true,
+    pricing: { inputPerMtok: 1, outputPerMtok: 6 },
+    // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.6-luna).
+    contextWindow: 1_050_000,
+    longContextPriceCliff: GPT_LONG_CONTEXT_CLIFF,
+    promptHints: GPT_TOOL_USE_PROMPT_HINTS,
+  },
+  {
+    id: 'gpt-5.6-terra',
+    label: 'GPT-5.6 Terra',
+    blurb: 'OpenAI balanced tier, served via Platform',
+    family: 'gpt',
+    icon: 'openai',
+    supportedEfforts: NON_CLAUDE_EFFORTS,
+    supportsWebSearch: true,
+    pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
+    // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.6-terra).
+    contextWindow: 1_050_000,
+    longContextPriceCliff: GPT_LONG_CONTEXT_CLIFF,
+    promptHints: GPT_TOOL_USE_PROMPT_HINTS,
+  },
+  {
+    // OpenAI's `gpt-5.6` alias routes here; the bare `gpt` family alias follows suit.
+    id: 'gpt-5.6-sol',
+    label: 'GPT-5.6 Sol',
     blurb: 'OpenAI flagship, served via Platform',
     family: 'gpt',
     isLatest: true,
@@ -255,7 +298,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     supportedEfforts: NON_CLAUDE_EFFORTS,
     supportsWebSearch: true,
     pricing: { inputPerMtok: 5, outputPerMtok: 30 },
-    // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.5).
+    // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.6-sol).
     contextWindow: 1_050_000,
     longContextPriceCliff: GPT_LONG_CONTEXT_CLIFF,
     promptHints: GPT_TOOL_USE_PROMPT_HINTS,

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -92,11 +92,30 @@ describe('getProviderCatalog', () => {
     // gpt rides the OpenAI Responses wire, which maps native web_search.
     expect(gpt).toMatchObject({
       family: 'gpt',
-      isLatest: true,
       icon: 'openai',
       supportsWebSearch: true,
       pricing: { inputPerMtok: 5, outputPerMtok: 30 },
     })
+    expect(gpt.isLatest).toBeFalsy()
+    // The 5.6 tiers: Sol is the flagship the bare `gpt` alias tracks.
+    expect(catalog.find((m) => m.id === 'gpt-5.6-luna')).toMatchObject({
+      family: 'gpt',
+      supportsWebSearch: true,
+      pricing: { inputPerMtok: 1, outputPerMtok: 6 },
+    })
+    expect(catalog.find((m) => m.id === 'gpt-5.6-terra')).toMatchObject({
+      family: 'gpt',
+      supportsWebSearch: true,
+      pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
+    })
+    expect(catalog.find((m) => m.id === 'gpt-5.6-sol')).toMatchObject({
+      family: 'gpt',
+      isLatest: true,
+      supportsWebSearch: true,
+      pricing: { inputPerMtok: 5, outputPerMtok: 30 },
+    })
+    const gptLatest = catalog.filter((m) => m.family === 'gpt' && m.isLatest)
+    expect(gptLatest.map((m) => m.id)).toEqual(['gpt-5.6-sol'])
     // Platform keys off bare ids, never the OpenRouter vendor-prefixed slugs.
     expect(catalog.some((m) => m.id === 'openai/gpt-5.5')).toBe(false)
     expect(catalog.some((m) => m.id === 'z-ai/glm-5.2')).toBe(false)
@@ -290,6 +309,7 @@ describe('getModelContextWindow', () => {
   it('returns the catalog window for Platform GPT models', () => {
     expect(getModelContextWindow('gpt-5.5', 'platform')).toBe(1_050_000)
     expect(getModelContextWindow('gpt-5.4', 'platform')).toBe(1_050_000)
+    expect(getModelContextWindow('gpt-5.6-sol', 'platform')).toBe(1_050_000)
   })
 
   it('returns the catalog window for OpenRouter GPT models', () => {
@@ -372,8 +392,9 @@ describe('resolveModelForProvider', () => {
   })
 
   it('resolves Platform GPT models to bare ids and falls back for unsupported glm', () => {
-    expect(resolveModelForProvider('gpt', 'platform', 'agent')).toBe('gpt-5.5')
+    expect(resolveModelForProvider('gpt', 'platform', 'agent')).toBe('gpt-5.6-sol')
     expect(resolveModelForProvider('gpt-5.4', 'platform', 'agent')).toBe('gpt-5.4')
+    expect(resolveModelForProvider('gpt-5.6-luna', 'platform', 'agent')).toBe('gpt-5.6-luna')
     expect(resolveModelForProvider('glm', 'platform', 'agent')).toBe('claude-opus-4-8')
   })
 

--- a/src/shared/lib/services/model-pricing.json
+++ b/src/shared/lib/services/model-pricing.json
@@ -163,6 +163,45 @@
       "cacheRead": 1
     }
   },
+  "gpt-5.6-luna": {
+    "input": 1,
+    "output": 6,
+    "cacheCreation": 1,
+    "cacheRead": 0.1,
+    "longContext": {
+      "thresholdTokens": 272000,
+      "input": 2,
+      "output": 9,
+      "cacheCreation": 2,
+      "cacheRead": 0.2
+    }
+  },
+  "gpt-5.6-sol": {
+    "input": 5,
+    "output": 30,
+    "cacheCreation": 5,
+    "cacheRead": 0.5,
+    "longContext": {
+      "thresholdTokens": 272000,
+      "input": 10,
+      "output": 45,
+      "cacheCreation": 10,
+      "cacheRead": 1
+    }
+  },
+  "gpt-5.6-terra": {
+    "input": 2.5,
+    "output": 15,
+    "cacheCreation": 2.5,
+    "cacheRead": 0.25,
+    "longContext": {
+      "thresholdTokens": 272000,
+      "input": 5,
+      "output": 22.5,
+      "cacheCreation": 5,
+      "cacheRead": 0.5
+    }
+  },
   "openai/gpt-5.4": {
     "input": 2.5,
     "output": 15,


### PR DESCRIPTION
OpenAI released API access to the GPT-5.6 family. This adds the three tiers to the **Platform provider** catalog and to local pricing for usage/cost display.

## Models (verified against OpenAI's model pages)

| Model | Input | Cached | Output |
|---|---|---|---|
| `gpt-5.6-sol` (flagship) | $5.00 | $0.50 | $30.00 |
| `gpt-5.6-terra` | $2.50 | $0.25 | $15.00 |
| `gpt-5.6-luna` | $1.00 | $0.10 | $6.00 |

All tiers: 1,050,000 context window, 128K max output, and the same >272K long-context cliff as 5.4/5.5 (2x input / 1.5x output on the whole request).

## Changes

- `PLATFORM_EXTRA_MODELS` in `builtin-catalogs.ts`: three new entries (ordered Luna → Terra → Sol), `supportsWebSearch: true` (Responses wire maps native web_search), shared 272K cliff, GPT prompt hints.
- **`isLatest` moved from `gpt-5.5` to `gpt-5.6-sol`** — the bare `gpt` family alias now resolves to Sol on Platform, mirroring OpenAI's own `gpt-5.6` → sol aliasing. Note: agents stored with the bare `gpt` alias silently upgrade to 5.6 Sol (same price as 5.5).
- `model-pricing.json`: bare ids with per-tier `longContext` blocks for local cost accounting.
- OpenRouter catalog deliberately unchanged (scope = Platform provider).

Companion proxy PR: SkillfulAgents/platform#161

## Testing

- Full unit suite: 6,509 passed
- `tsc --noEmit` + eslint clean