### PR TITLE
fix(dialog): let dialog grid children shrink below their min-content width (SUP-378)

### DIFF
--- a/e2e/specs/agent-secrets.spec.ts
+++ b/e2e/specs/agent-secrets.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Locator } from '@playwright/test'
 import * as fs from 'fs'
 import * as path from 'path'
 import { AppPage } from '../pages/app.page'
@@ -138,5 +138,64 @@ test.describe('Agent Secrets (reach the container & persist)', () => {
       (r) => r.type === 'createSession' && r.initialMessage === sessionMessage
     )
     expect(record.availableEnvVars ?? []).not.toContain(expectedEnvVar)
+  })
+
+  /**
+   * DialogContent and AlertDialogContent are `display: grid`. A direct child of a grid
+   * container has `min-width: auto`, so its automatic minimum size is its min-content
+   * width. One long unbreakable token drives that to thousands of pixels: the child
+   * overflows the capped dialog and the dialog's own controls are laid out outside it,
+   * unreachable. Both primitives neutralize it with `[&>*]:min-w-0`.
+   *
+   * Assert geometry, never the class name, so any other way of reintroducing the
+   * overflow fails this too.
+   */
+  test('an unbreakable token must not strand dialog controls', async ({ page }) => {
+    const longToken = 'a'.repeat(240)
+
+    const expectContainedIn = async (control: Locator, container: Locator) => {
+      await expect(control).toBeVisible({ timeout: 10000 })
+      const containerBox = await container.boundingBox()
+      const controlBox = await control.boundingBox()
+      expect(containerBox).not.toBeNull()
+      expect(controlBox).not.toBeNull()
+      expect(controlBox!.x + controlBox!.width).toBeLessThanOrEqual(containerBox!.x + containerBox!.width)
+    }
+
+    await agentPage.openSettings()
+
+    await test.step('DialogContent: an overlong secret key leaves Delete reachable', async () => {
+      await page.locator('[data-testid="agent-settings-nav-secrets"]').click()
+      await page.locator('#secret-key').fill(longToken)
+      await page.locator('#secret-value').fill('overlong-key-value')
+      await page.getByRole('button', { name: 'Add Secret' }).click()
+
+      const deleteButton = page.locator(`[data-testid="delete-secret-${longToken.toUpperCase()}"]`)
+      await expectContainedIn(deleteButton, page.locator('[data-testid="agent-settings-dialog"]'))
+      // The click is the other half of the guard: a stranded button is not hittable.
+      await deleteButton.click()
+    })
+
+    await test.step('AlertDialogContent: an overlong agent name leaves Confirm reachable and wraps', async () => {
+      await page.locator('[data-testid="agent-settings-nav-general"]').click()
+      // The confirmation quotes the live value of this field, so the dialog inflates
+      // without the rename ever being saved.
+      await page.locator('#agent-name').fill(longToken)
+      await page.locator('[data-testid="delete-agent-button"]').click()
+
+      const alertDialog = page.getByRole('alertdialog')
+      const confirmButton = page.locator('[data-testid="confirm-button"]')
+      await expectContainedIn(confirmButton, alertDialog)
+
+      // Reachable controls are not enough: the name itself must wrap rather than paint
+      // out through the alert's edge, which `overflow: visible` on the dialog allows.
+      const descOverflow = await alertDialog
+        .locator('p')
+        .first()
+        .evaluate((el) => el.scrollWidth - el.clientWidth)
+      expect(descOverflow).toBeLessThanOrEqual(0)
+
+      await confirmButton.click()
+    })
   })
 })

--- a/src/renderer/components/agents/settings/secrets-tab.tsx
+++ b/src/renderer/components/agents/settings/secrets-tab.tsx
@@ -55,7 +55,7 @@ function SecretRow({ secret, agentSlug, onDelete }: SecretRowProps) {
     <div className="flex items-center gap-3 p-3 border rounded-lg">
       <div className="flex-1 min-w-0">
         <div className="font-medium truncate">{secret.key}</div>
-        <div className="text-xs text-muted-foreground font-mono">{secret.envVar}</div>
+        <div className="text-xs text-muted-foreground font-mono truncate">{secret.envVar}</div>
       </div>
       <div className="flex items-center gap-2 shrink-0">
         {isEditing ? (

--- a/src/renderer/components/ui/alert-dialog.tsx
+++ b/src/renderer/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid [&>*]:min-w-0 w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}
@@ -89,7 +89,7 @@ const AlertDialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-sm text-muted-foreground break-words", className)}
     {...props}
   />
 ))

--- a/src/renderer/components/ui/dialog.tsx
+++ b/src/renderer/components/ui/dialog.tsx
@@ -33,7 +33,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[90vh] overflow-y-scroll translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid [&>*]:min-w-0 w-full max-w-lg max-h-[90vh] overflow-y-scroll translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className
       )}
       onKeyDown={(e) => {
@@ -101,7 +101,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
+    className={cn('text-sm text-muted-foreground break-words', className)}
     {...props}
   />
 ))


### PR DESCRIPTION
A secret whose key is a long unbreakable token made the Update and Delete controls
in the agent Secrets tab unreachable - the row was still there, the buttons just
weren't clickable, because they were laid out past the edge of the dialog.

### Cause

`DialogContent` and `AlertDialogContent` are `display: grid`. A direct child of a
grid container has `min-width: auto`, so its automatic minimum size is its
**min-content width**. One 240-char token drives that to thousands of pixels.

Measured with such a key: the dialog held at its 800px `max-width`, while the grid
item grew to 2621px and the row's buttons landed at x=2833, outside the clip box.
The dialog never inflated - a correctly-sized dialog was overflowed by its own child.

The same input strands the Delete button in the **delete-agent confirmation**, which
nobody had reported.

### Fix

Neutralize it once per primitive with `[&>*]:min-w-0`, mirroring `ui/alert.tsx`, which
already ships `[&>:not(svg)]:min-w-0` on its grid for exactly this reason. A box escapes
the automatic minimum via *either* `min-width: 0` *or* a non-visible `overflow`, so the
wrapper chain below needs no further change. This subsumes the ~7 call sites that would
otherwise each need patching.

Reachable controls turned out not to be sufficient. An unbreakable token still *painted*
out through the alert's edge while the buttons sat correctly inside it, so both
`Description` primitives now `break-words`. The secret row's env-var line truncates like
the key line directly above it.

### Verification

The guard lives in `agent-secrets.spec.ts`, whose `beforeEach` already builds the agent it
needs. It asserts geometry rather than class names, so any other way of reintroducing the
overflow fails it too. Each pinned line was observed failing on its own before the fix and
passing after:

| line | overflow when removed |
|---|---|
| `dialog.tsx` `[&>*]:min-w-0` | button at x=2833 |
| `alert-dialog.tsx` `[&>*]:min-w-0` | button at x=2103 |
| `alert-dialog.tsx` `break-words` | 1309px of text overflow |

`break-words` on `DialogDescription` is the one changed line no test pins - reaching a
visible `DialogDescription` needs a fixture path through reset-password or add-to-dock.
It is verified by measurement instead: without it, a real `DialogDescription` reports
`scrollWidth` 1752 against `clientWidth` 798. Its twin on `AlertDialogDescription` is
pinned, and the mechanism is identical.

### Note for review

PR #135 replaces `secrets-tab.tsx` with a standalone Agent Secrets page, and its
replacement already carries `truncate` on the same env-var line. The one-line change here
is correct against `main` today and disappears cleanly whenever #135 lands - no conflict
either way. The two primitive fixes are unaffected and still needed.
