### PR TITLE
fix(llm): generic-provider hardening + thinking-tolerant summarizer calls (SUP-277 follow-up)

### DIFF
--- a/src/api/routes/agents-owner-acl-rollback.sup207.test.ts
+++ b/src/api/routes/agents-owner-acl-rollback.sup207.test.ts
@@ -225,6 +225,7 @@ vi.mock('@shared/lib/utils/retry', () => ({ withRetry: vi.fn((fn: () => unknown)
 vi.mock('@shared/lib/llm-provider/helpers', () => ({
   getConfiguredLlmClient: () => ({ messages: { create: vi.fn() } }),
   extractTextFromLlmResponse: () => null,
+  createSummarizerText: async () => null,
 }))
 vi.mock('@shared/lib/utils/message-transform', () => ({ transformMessages: vi.fn(), resolveInterruptedSubagents: vi.fn() }))
 vi.mock('@shared/lib/proxy/token-store', () => ({ revokeProxyToken: vi.fn(), validateProxyToken: vi.fn() }))

--- a/src/api/routes/agents.delete-ordering.sup208.test.ts
+++ b/src/api/routes/agents.delete-ordering.sup208.test.ts
@@ -226,6 +226,7 @@ vi.mock('@shared/lib/utils/retry', () => ({ withRetry: vi.fn((fn: () => unknown)
 vi.mock('@shared/lib/llm-provider/helpers', () => ({
   getConfiguredLlmClient: () => ({ messages: { create: vi.fn() } }),
   extractTextFromLlmResponse: () => null,
+  createSummarizerText: async () => null,
 }))
 
 vi.mock('@shared/lib/utils/message-transform', () => ({

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -340,6 +340,10 @@ vi.mock('@shared/lib/llm-provider/helpers', () => ({
   }),
   extractTextFromLlmResponse: (response: unknown) =>
     (response as { content?: Array<{ text?: string }> })?.content?.[0]?.text ?? null,
+  createSummarizerText: async (_client: unknown, request: unknown) => {
+    const response = await mockLlmMessagesCreate(request)
+    return (response as { content?: Array<{ text?: string }> })?.content?.[0]?.text ?? null
+  },
 }))
 
 const mockTransformMessages = vi.fn()

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -114,14 +114,13 @@ import {
 } from '@shared/lib/services/agent-template-service'
 import { getSkillsetProvider } from '@shared/lib/skillset-provider'
 import type { SkillsetConfig } from '@shared/lib/types/skillset'
-import { withRetry } from '@shared/lib/utils/retry'
 import { transformMessages, type TransformedMessage, type TransformedItem } from '@shared/lib/utils/message-transform'
 import { workflowRoutes } from './workflows'
 import { getEffectiveModels, getEffectiveAgentLimits, getCustomEnvVars, getSettings, VALID_SCRIPT_TYPES } from '@shared/lib/config/settings'
 import { computerUsePermissionManager } from '@shared/lib/computer-use/permission-manager'
 import { executeComputerUseCommand, checkACPermissions, ungrabAC } from '@shared/lib/computer-use/executor'
 import { resolveTargetApp } from '@shared/lib/computer-use/types'
-import { getConfiguredLlmClient, extractTextFromLlmResponse } from '@shared/lib/llm-provider/helpers'
+import { getConfiguredLlmClient, createSummarizerText } from '@shared/lib/llm-provider/helpers'
 import { resolveActiveProviderModel } from '@shared/lib/llm-provider'
 import { revokeProxyToken } from '@shared/lib/proxy/token-store'
 import { getAgentWorkspaceDir } from '@shared/lib/utils/file-storage'
@@ -563,16 +562,22 @@ const generateNameBodySchema = z.object({
   prompt: z.string().min(1, 'Prompt is required'),
 })
 
+// The prompts ask for a short name, but a chatty model can answer with prose
+// anyway (the old max_tokens: 50 doubled as a truncator); clamp to one line
+// and a sidebar-sized length before using it.
+function clampGeneratedName(raw: string): string {
+  return raw.split('\n')[0].trim().substring(0, 80)
+}
+
 agents.post('/generate-name', zValidator('json', generateNameBodySchema), async (c) => {
   try {
     const { prompt } = c.req.valid('json')
     const truncatedPrompt = prompt.trim().substring(0, 10_000)
 
     const anthropic = getLlmClient()
-    const response = await withRetry(() =>
-      anthropic.messages.create({
+    const rawName = (
+      await createSummarizerText(anthropic, {
         model: getSummarizerModel(),
-        max_tokens: 50,
         messages: [
           {
             role: 'user',
@@ -584,9 +589,8 @@ Respond with ONLY the agent name, nothing else. No quotes, no explanation.`,
           },
         ],
       })
-    )
-
-    const name = extractTextFromLlmResponse(response)?.trim()
+    )?.trim()
+    const name = rawName ? clampGeneratedName(rawName) : undefined
     if (!name) {
       return c.json({ error: 'Failed to generate name' }, 500)
     }
@@ -672,32 +676,42 @@ async function generateAndUpdateSessionNameAsync(
   message: string,
   agentName: string
 ): Promise<void> {
+  let sessionName: string | null = null
   try {
     const anthropic = getLlmClient()
-    const response = await withRetry(() =>
-      anthropic.messages.create({
-        model: getSummarizerModel(),
-        max_tokens: 50,
-        messages: [
-          {
-            role: 'user',
-            content: `Generate a short, descriptive session name (3-6 words max) for a conversation with an AI agent named "${agentName}". The first message in the conversation is:
+    sessionName = await createSummarizerText(anthropic, {
+      model: getSummarizerModel(),
+      messages: [
+        {
+          role: 'user',
+          content: `Generate a short, descriptive session name (3-6 words max) for a conversation with an AI agent named "${agentName}". The first message in the conversation is:
 
 "${message}"
 
 Respond with ONLY the session name, nothing else. No quotes, no explanation.`,
-          },
-        ],
-      })
-    )
-
-    const sessionName = extractTextFromLlmResponse(response)
-    if (sessionName) {
-      await updateSessionName(agentSlug, sessionId, sessionName)
+        },
+      ],
+    })
+  } catch (error) {
+    console.error('Failed to generate session name after retries:', error)
+  }
+  try {
+    // Naming can fail outright (misconfigured summarizer model) or return no
+    // text (thinking-first ruminators like small qwen burn the whole budget);
+    // fall back to the truncated first message so the session is still
+    // identifiable in the sidebar instead of staying "New Session".
+    if (!sessionName) {
+      console.warn(`Session name generation returned no text; falling back to truncated message for session ${sessionId}`)
+    }
+    const finalName = sessionName
+      ? clampGeneratedName(sessionName)
+      : message.trim().split(/\s+/).slice(0, 6).join(' ').substring(0, 60)
+    if (finalName) {
+      await updateSessionName(agentSlug, sessionId, finalName)
       messagePersister.broadcastSessionUpdate(sessionId)
     }
   } catch (error) {
-    console.error('Failed to generate session name after retries:', error)
+    console.error('Failed to update session name:', error)
   }
 }
 

--- a/src/api/routes/scheduled-tasks.test.ts
+++ b/src/api/routes/scheduled-tasks.test.ts
@@ -98,6 +98,8 @@ vi.mock('@shared/lib/llm-provider/helpers', () => ({
     },
   }),
   extractTextFromLlmResponse: (...args: unknown[]) => mockExtractTextFromLlmResponse(...args),
+  createSummarizerText: async (_client: unknown, request: unknown) =>
+    mockExtractTextFromLlmResponse(await mockMessagesCreate(request)),
 }))
 
 const mockWithRetry = vi.fn(async (fn: () => Promise<unknown>) => fn())
@@ -414,7 +416,6 @@ describe('scheduled-tasks route', () => {
     })
     expect(mockMessagesCreate).toHaveBeenCalledWith(expect.objectContaining({
       model: 'claude-haiku-4-5',
-      max_tokens: 50,
     }))
   })
 

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -6,7 +6,7 @@
  */
 
 import { Hono } from 'hono'
-import { getConfiguredLlmClient, extractTextFromLlmResponse } from '@shared/lib/llm-provider/helpers'
+import { getConfiguredLlmClient, createSummarizerText } from '@shared/lib/llm-provider/helpers'
 import { resolveActiveProviderModel } from '@shared/lib/llm-provider'
 import {
   getScheduledTask,
@@ -36,7 +36,6 @@ import { readAgentPreferences } from '@shared/lib/services/agent-preferences-ser
 import { validateCronExpression, getFrequencyWarning } from '@shared/lib/services/schedule-parser'
 import { RuntimeOptionsSchema } from '@shared/lib/container/runtime-options'
 import type { EffortLevel } from '@shared/lib/container/types'
-import { withRetry } from '@shared/lib/utils/retry'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
 import { Authenticated, EntityAgentRole } from '../middleware/auth'
@@ -329,14 +328,12 @@ scheduledTasksRouter.post('/:taskId/describe-schedule', TaskAgentRole('viewer'),
     }
 
     const client = getConfiguredLlmClient()
-    const response = await withRetry(() =>
-      client.messages.create({
-        model: resolveActiveProviderModel(getEffectiveModels().summarizerModel, 'summarizer'),
-        max_tokens: 100,
-        messages: [
-          {
-            role: 'user',
-            content: `Translate the following crontab expression to a concise human-readable English description. Respond with ONLY the description, nothing else. No quotes, no explanation.
+    const description = await createSummarizerText(client, {
+      model: resolveActiveProviderModel(getEffectiveModels().summarizerModel, 'summarizer'),
+      messages: [
+        {
+          role: 'user',
+          content: `Translate the following crontab expression to a concise human-readable English description. Respond with ONLY the description, nothing else. No quotes, no explanation.
 
 Cron expression: ${task.scheduleExpression}
 
@@ -344,12 +341,9 @@ Examples:
 "0 9 * * 1-5" → "Every weekday at 9:00 AM"
 "*/15 * * * *" → "Every 15 minutes"
 "0 0 1 * *" → "First day of every month at midnight"`,
-          },
-        ],
-      })
-    )
-
-    const description = extractTextFromLlmResponse(response)
+        },
+      ],
+    })
     if (!description) {
       return c.json({ error: 'Failed to generate description' }, 500)
     }
@@ -376,14 +370,12 @@ scheduledTasksRouter.post('/:taskId/parse-schedule', TaskAgentRole('user'), asyn
     }
 
     const client = getConfiguredLlmClient()
-    const response = await withRetry(() =>
-      client.messages.create({
-        model: resolveActiveProviderModel(getEffectiveModels().summarizerModel, 'summarizer'),
-        max_tokens: 50,
-        messages: [
-          {
-            role: 'user',
-            content: `Convert the following English schedule description to a standard 5-field crontab expression (minute hour day-of-month month day-of-week). Respond with ONLY the cron expression, nothing else. No quotes, no explanation.
+    const expression = await createSummarizerText(client, {
+      model: resolveActiveProviderModel(getEffectiveModels().summarizerModel, 'summarizer'),
+      messages: [
+        {
+          role: 'user',
+          content: `Convert the following English schedule description to a standard 5-field crontab expression (minute hour day-of-month month day-of-week). Respond with ONLY the cron expression, nothing else. No quotes, no explanation.
 
 Description: ${body.description.trim()}
 
@@ -391,12 +383,9 @@ Examples:
 "Every weekday at 9:00 AM" → 0 9 * * 1-5
 "Every 15 minutes" → */15 * * * *
 "First day of every month at midnight" → 0 0 1 * *`,
-          },
-        ],
-      })
-    )
-
-    const expression = extractTextFromLlmResponse(response)
+        },
+      ],
+    })
     if (!expression) {
       return c.json({ error: 'Failed to generate cron expression' }, 500)
     }

--- a/src/api/routes/security-repro.test.ts
+++ b/src/api/routes/security-repro.test.ts
@@ -303,6 +303,7 @@ vi.mock('@shared/lib/utils/retry', () => ({ withRetry: vi.fn((fn: () => unknown)
 vi.mock('@shared/lib/llm-provider/helpers', () => ({
   getConfiguredLlmClient: () => ({ messages: { create: vi.fn() } }),
   extractTextFromLlmResponse: () => null,
+  createSummarizerText: async () => null,
 }))
 
 vi.mock('@shared/lib/utils/message-transform', () => ({

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { randomUUID } from 'crypto'
 import { Hono, type Context } from 'hono'
-import { getLlmProvider, getAllProviderInfo, modelCatalogSettingsSchema } from '@shared/lib/llm-provider'
+import { getLlmProvider, getAllProviderInfo, modelCatalogSettingsSchema, GenericLlmProvider } from '@shared/lib/llm-provider'
 import type { LlmProviderId } from '@shared/lib/llm-provider'
 import type { BedrockLlmProvider } from '@shared/lib/llm-provider/bedrock-provider'
 import { getDataDir, getAgentsDataDir } from '@shared/lib/config/data-dir'
@@ -281,6 +281,12 @@ type AppPreferencesPatch = Partial<AppPreferences> & {
   hostBrowserProvider?: unknown
 }
 
+/** The generic provider's saved endpoint — displayed (not secret) in Settings. */
+function getGenericBaseUrl(): string | undefined {
+  const provider = getLlmProvider('generic')
+  return provider instanceof GenericLlmProvider ? provider.getEffectiveBaseUrl() : undefined
+}
+
 /** Build the GlobalSettingsResponse shared by GET and PUT handlers. */
 function buildSettingsResponse(
   appSettings: AppSettings,
@@ -314,6 +320,7 @@ function buildSettingsResponse(
     agentLimits: getEffectiveAgentLimits(),
     customEnvVars: getCustomEnvVars(),
     composioUserId: getComposioUserId(),
+    genericBaseUrl: getGenericBaseUrl(),
     accountProviderUserId: getAccountProviderUserId(),
     setupCompleted: !!appSettings.app?.setupCompleted,
     hostBrowserStatus: { providers: detectAllProviders() },

--- a/src/renderer/components/settings/generic-credentials-input.tsx
+++ b/src/renderer/components/settings/generic-credentials-input.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Input } from '@renderer/components/ui/input'
 import { Label } from '@renderer/components/ui/label'
 import { Button } from '@renderer/components/ui/button'
@@ -23,10 +23,19 @@ export function GenericCredentialsInput({ disabled = false }: GenericCredentials
   const updateSettings = useUpdateSettings()
 
   const [baseUrl, setBaseUrl] = useState('')
+  const [baseUrlEdited, setBaseUrlEdited] = useState(false)
   const [apiKeyInput, setApiKeyInput] = useState('')
   const [isValidating, setIsValidating] = useState(false)
   const [isRemoving, setIsRemoving] = useState(false)
   const [validationResult, setValidationResult] = useState<{ valid: boolean; error?: string } | null>(null)
+
+  // The endpoint is not a secret: show the saved value so the user can see
+  // (and correct) what the provider actually points at. Stop syncing once
+  // they start typing.
+  const savedBaseUrl = settings?.genericBaseUrl ?? ''
+  useEffect(() => {
+    if (!baseUrlEdited) setBaseUrl(savedBaseUrl)
+  }, [savedBaseUrl, baseUrlEdited])
 
   const apiKeyStatus: ApiKeyStatus | undefined = settings?.apiKeyStatus?.generic
   const isBusy = isValidating || isRemoving
@@ -46,10 +55,16 @@ export function GenericCredentialsInput({ disabled = false }: GenericCredentials
       const result = await res.json()
       setValidationResult(result)
       if (result.valid) {
-        await updateSettings.mutateAsync({
-          apiKeys: { genericBaseUrl: trimmedUrl, genericApiKey: trimmedKey },
-        })
-        setApiKeyInput('')
+        try {
+          await updateSettings.mutateAsync({
+            apiKeys: { genericBaseUrl: trimmedUrl, genericApiKey: trimmedKey },
+          })
+          setApiKeyInput('')
+        } catch {
+          // The credentials ARE valid — don't report a save failure as a
+          // validation failure or the user will retry a working key.
+          setValidationResult({ valid: false, error: 'Credentials are valid, but saving them failed — try again.' })
+        }
       }
     } catch {
       setValidationResult({ valid: false, error: 'Failed to validate' })
@@ -65,6 +80,7 @@ export function GenericCredentialsInput({ disabled = false }: GenericCredentials
         apiKeys: { genericBaseUrl: '', genericApiKey: '' },
       })
       setBaseUrl('')
+      setBaseUrlEdited(false)
       setApiKeyInput('')
       setValidationResult(null)
     } catch (error) {
@@ -102,7 +118,7 @@ export function GenericCredentialsInput({ disabled = false }: GenericCredentials
         <Input
           id="generic-base-url"
           value={baseUrl}
-          onChange={(e) => { setBaseUrl(e.target.value); setValidationResult(null) }}
+          onChange={(e) => { setBaseUrl(e.target.value); setBaseUrlEdited(true); setValidationResult(null) }}
           placeholder="http://localhost:4000"
           disabled={disabled || isBusy}
           className="bg-background"

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -298,6 +298,8 @@ export interface GlobalSettingsResponse {
     exa: ApiKeyStatus
   }
   composioUserId?: string
+  /** Saved generic-provider endpoint. Not a secret — echoed so the Settings UI can display/edit it. */
+  genericBaseUrl?: string
   accountProviderUserId?: string
   voice?: VoiceSettings
   models: ModelSettings

--- a/src/shared/lib/llm-provider/container-url.ts
+++ b/src/shared/lib/llm-provider/container-url.ts
@@ -1,0 +1,30 @@
+/**
+ * Loopback hostnames that resolve to the machine itself. Inside an agent
+ * container these point at the container, not the host, so a host-reachable
+ * URL using them is unreachable from the container.
+ */
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1'])
+
+/**
+ * Rewrite a loopback URL to the container-reachable host gateway
+ * (host.docker.internal — forwarded by Docker Desktop/Lima, and added via
+ * --add-host on Linux). Matches on the parsed hostname, so loopback IPs are
+ * covered and hostnames that merely start with "localhost"
+ * (e.g. localhost.mycorp.dev) are left alone. Non-URL input passes through
+ * unchanged.
+ */
+export function rewriteLoopbackForContainer(url: string | undefined): string | undefined {
+  if (!url) return url
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return url
+  }
+  if (!LOOPBACK_HOSTNAMES.has(parsed.hostname)) return url
+  parsed.hostname = 'host.docker.internal'
+  const rewritten = parsed.toString()
+  // URL.toString() appends a trailing slash to a bare origin; don't introduce
+  // one the caller didn't have.
+  return url.endsWith('/') ? rewritten : rewritten.replace(/\/$/, '')
+}

--- a/src/shared/lib/llm-provider/generic-provider.test.ts
+++ b/src/shared/lib/llm-provider/generic-provider.test.ts
@@ -110,6 +110,31 @@ describe('GenericLlmProvider.getContainerEnvVars', () => {
   it('leaves a non-localhost baseURL untouched', () => {
     expect(provider.getContainerEnvVars().ANTHROPIC_BASE_URL).toBe('https://proxy.example')
   })
+
+  it('rewrites loopback IPs, not just the localhost hostname', () => {
+    settingsMock.mockReturnValue({
+      apiKeys: { genericApiKey: 'k', genericBaseUrl: 'http://127.0.0.1:11434' },
+    })
+    expect(provider.getContainerEnvVars().ANTHROPIC_BASE_URL).toBe('http://host.docker.internal:11434')
+  })
+
+  it('does not mangle hostnames that merely start with localhost', () => {
+    settingsMock.mockReturnValue({
+      apiKeys: { genericApiKey: 'k', genericBaseUrl: 'http://localhost.mycorp.dev:4000' },
+    })
+    expect(provider.getContainerEnvVars().ANTHROPIC_BASE_URL).toBe('http://localhost.mycorp.dev:4000')
+  })
+})
+
+describe('GenericLlmProvider.getApiKeyStatus', () => {
+  it('reports not-configured when a key is set without a base URL', () => {
+    settingsMock.mockReturnValue({ apiKeys: { genericApiKey: 'k' } })
+    expect(provider.getApiKeyStatus()).toEqual({ isConfigured: false, source: 'none' })
+  })
+
+  it('reports configured when both key and base URL are set', () => {
+    expect(provider.getApiKeyStatus()).toEqual({ isConfigured: true, source: 'settings' })
+  })
 })
 
 describe('GenericLlmProvider.createClient', () => {
@@ -285,6 +310,24 @@ describe('GenericLlmProvider.validateKey', () => {
   it('treats a 404 as reachable-but-not-listable (soft-passes so the user can proceed)', async () => {
     stubFetch({ ok: false, status: 404 })
     expect(await provider.validateKey('key')).toEqual({ valid: true })
+  })
+
+  it('rejects a /v1-suffixed base URL with guidance when the stripped base serves the listing', async () => {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => ({
+      ok: !url.includes('/v1/v1/'),
+      status: url.includes('/v1/v1/') ? 404 : 200,
+      json: async () => ({}),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    const result = await provider.validateKey('key', { baseUrl: 'http://localhost:4000/v1' })
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('use http://localhost:4000')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('still soft-passes a /v1-suffixed base URL when the stripped base 404s too', async () => {
+    stubFetch({ ok: false, status: 404 })
+    expect(await provider.validateKey('key', { baseUrl: 'http://localhost:4000/v1' })).toEqual({ valid: true })
   })
 
   it('reports the status code on other non-OK responses', async () => {

--- a/src/shared/lib/llm-provider/generic-provider.ts
+++ b/src/shared/lib/llm-provider/generic-provider.ts
@@ -2,7 +2,8 @@ import Anthropic from '@anthropic-ai/sdk'
 import { BaseLlmProvider, type ModelPurpose } from './base-llm-provider'
 import type { ModelDefinition, ModelSearchResult } from './model-catalog-schema'
 import type { EffortLevel } from '../container/types'
-import { getSettings, getModelCatalogSettings } from '../config/settings'
+import { getSettings, getModelCatalogSettings, type ApiKeyStatus } from '../config/settings'
+import { rewriteLoopbackForContainer } from './container-url'
 
 const BASE_URL_ENV = 'GENERIC_BASE_URL'
 const DEFAULT_MODEL_ENV = 'GENERIC_DEFAULT_MODEL'
@@ -84,6 +85,17 @@ export class GenericLlmProvider extends BaseLlmProvider {
   protected readonly settingsKeyField = 'genericApiKey' as const
   protected readonly envVarName = 'GENERIC_API_KEY'
 
+  /**
+   * A key without an endpoint is not a usable configuration: createClient and
+   * searchModels both require the base URL, so reporting configured on the key
+   * alone lets getConfiguredLlmClient's guard pass and then throw downstream.
+   */
+  override getApiKeyStatus(): ApiKeyStatus {
+    const status = super.getApiKeyStatus()
+    if (!status.isConfigured || this.getEffectiveBaseUrl()) return status
+    return { isConfigured: false, source: 'none' }
+  }
+
   /** User-supplied endpoint, from settings (preferred) or GENERIC_BASE_URL env. */
   getEffectiveBaseUrl(): string | undefined {
     const fromSettings = getSettings().apiKeys?.genericBaseUrl?.trim()
@@ -117,10 +129,10 @@ export class GenericLlmProvider extends BaseLlmProvider {
   }
 
   getContainerEnvVars(): Record<string, string | undefined> {
-    // A 'localhost' endpoint (e.g. ollama on the host) isn't reachable as
+    // A loopback endpoint (e.g. ollama on the host) isn't reachable as
     // localhost from inside the agent container; rewrite to the host gateway
     // (same translation the platform provider applies).
-    const containerUrl = this.getEffectiveBaseUrl()?.replace('://localhost', '://host.docker.internal')
+    const containerUrl = rewriteLoopbackForContainer(this.getEffectiveBaseUrl())
     return {
       ANTHROPIC_API_KEY: '',
       ANTHROPIC_BASE_URL: containerUrl,
@@ -157,6 +169,22 @@ export class GenericLlmProvider extends BaseLlmProvider {
       return { valid: false, error: `Auth rejected (${response.status}) — check the API key.` }
     }
     if (response.status === 404) {
+      // The SDK appends /v1/* itself, so a base URL that already ends in /v1
+      // (the OpenAI-docs convention) probes /v1/v1/models and 404s. If the
+      // stripped base serves the listing, tell the user exactly what to fix
+      // instead of soft-passing a config that can never serve a request.
+      const trimmed = baseURL.replace(/\/+$/, '')
+      const stripped = trimmed.replace(/\/v1$/i, '')
+      if (stripped !== trimmed) {
+        try {
+          const retry = await fetchModelsList(stripped, apiKey)
+          if (retry.ok) {
+            return { valid: false, error: `Base URL should not include the /v1 suffix — use ${stripped}` }
+          }
+        } catch {
+          // Stripped probe unreachable; fall through to the soft-pass below.
+        }
+      }
       // Reachable but no /v1/models — key not verifiable this way. Allow save so
       // the user can proceed to add models manually.
       return { valid: true }

--- a/src/shared/lib/llm-provider/helpers.test.ts
+++ b/src/shared/lib/llm-provider/helpers.test.ts
@@ -10,7 +10,13 @@ vi.mock('./index', () => ({
   }),
 }))
 
-import { getConfiguredLlmClient, extractTextFromLlmResponse } from './helpers'
+// createSummarizerText wraps its calls in withRetry; run it as a passthrough
+// so failure-path tests don't sit through backoff delays.
+vi.mock('../utils/retry', () => ({
+  withRetry: (fn: () => Promise<unknown>) => fn(),
+}))
+
+import { getConfiguredLlmClient, extractTextFromLlmResponse, createSummarizerText, SUMMARIZER_MAX_TOKENS } from './helpers'
 import type Anthropic from '@anthropic-ai/sdk'
 
 describe('getConfiguredLlmClient', () => {
@@ -79,5 +85,72 @@ describe('extractTextFromLlmResponse', () => {
   it('returns null for whitespace-only text', () => {
     const response = makeResponse([textBlock('   ')])
     expect(extractTextFromLlmResponse(response)).toBeNull()
+  })
+})
+
+describe('createSummarizerText', () => {
+  function textResponse(text: string, stopReason = 'end_turn') {
+    return { content: [{ type: 'text', text }], stop_reason: stopReason }
+  }
+
+  const thinkingOnlyResponse = {
+    content: [{ type: 'thinking', thinking: 'ruminating…' }],
+    stop_reason: 'max_tokens',
+  }
+
+  function clientWith(create: ReturnType<typeof vi.fn>): Anthropic {
+    return { messages: { create } } as unknown as Anthropic
+  }
+
+  const REQUEST = { model: 'some-model', messages: [{ role: 'user' as const, content: 'name this' }] }
+
+  let create: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    create = vi.fn()
+  })
+
+  it('applies the summarizer token budget to the request', async () => {
+    create.mockResolvedValue(textResponse('A Name'))
+    const result = await createSummarizerText(clientWith(create), REQUEST)
+    expect(result).toBe('A Name')
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'some-model',
+      max_tokens: SUMMARIZER_MAX_TOKENS,
+    }))
+  })
+
+  it('retries with a thinking cap when the response carries no text', async () => {
+    create
+      .mockResolvedValueOnce(thinkingOnlyResponse)
+      .mockResolvedValueOnce(textResponse('After Retry'))
+    const result = await createSummarizerText(clientWith(create), REQUEST)
+    expect(result).toBe('After Retry')
+    expect(create).toHaveBeenCalledTimes(2)
+    expect(create).toHaveBeenLastCalledWith(expect.objectContaining({
+      max_tokens: SUMMARIZER_MAX_TOKENS,
+      thinking: expect.objectContaining({ type: 'enabled' }),
+    }))
+  })
+
+  it('retries even when a text-less response reports a non-max_tokens stop reason', async () => {
+    create
+      .mockResolvedValueOnce({ content: [{ type: 'thinking', thinking: 'x' }], stop_reason: 'end_turn' })
+      .mockResolvedValueOnce(textResponse('Recovered'))
+    expect(await createSummarizerText(clientWith(create), REQUEST)).toBe('Recovered')
+  })
+
+  it('returns null when the retry also yields no text', async () => {
+    create.mockResolvedValue(thinkingOnlyResponse)
+    expect(await createSummarizerText(clientWith(create), REQUEST)).toBeNull()
+    expect(create).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns null instead of throwing when the endpoint rejects the thinking param', async () => {
+    create
+      .mockResolvedValueOnce(thinkingOnlyResponse)
+      .mockRejectedValueOnce(new Error('thinking is not supported with this model'))
+    expect(await createSummarizerText(clientWith(create), REQUEST)).toBeNull()
   })
 })

--- a/src/shared/lib/llm-provider/helpers.ts
+++ b/src/shared/lib/llm-provider/helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { getActiveLlmProvider } from './index'
+import { withRetry } from '../utils/retry'
 import type Anthropic from '@anthropic-ai/sdk'
 
 /**
@@ -21,6 +22,22 @@ export function getConfiguredLlmClient(): Anthropic {
 }
 
 /**
+ * Token budget for host-direct summarizer calls (session/agent naming, PR
+ * metadata). Thinking-first models (qwen, Spark, other reasoners reached via
+ * the generic provider) emit several hundred thinking tokens before any text;
+ * a budget sized to the expected text alone gets fully consumed by thinking
+ * and the response carries no text block at all.
+ */
+export const SUMMARIZER_MAX_TOKENS = 2000
+
+/**
+ * Thinking cap for the retry path in createSummarizerText. Some thinking-first
+ * models (qwen via ollama) ruminate indefinitely when uncapped; an explicit
+ * budget forces them to stop thinking and emit text.
+ */
+const SUMMARIZER_THINKING_BUDGET = 1024
+
+/**
  * Extract the text content from an Anthropic message response.
  * Returns the trimmed text from the first text block, or null if none found.
  */
@@ -30,4 +47,52 @@ export function extractTextFromLlmResponse(
   const textBlock = response.content.find((block) => block.type === 'text')
   if (!textBlock || textBlock.type !== 'text') return null
   return textBlock.text.trim() || null
+}
+
+/**
+ * Run a summarizer-purpose completion (naming, PR metadata) and return its
+ * text, tolerating thinking-first models. Such models spend output tokens on
+ * thinking before any text, so a response can consume the whole budget and
+ * carry no text block at all. When that happens (text-less + max_tokens), the
+ * call is retried once with an explicit thinking cap so text can follow.
+ * Models that would reject the thinking param never reach the retry — they
+ * return text on the first attempt.
+ */
+export async function createSummarizerText(
+  client: Anthropic,
+  request: Omit<Anthropic.MessageCreateParamsNonStreaming, 'max_tokens'>,
+): Promise<string | null> {
+  const response = await withRetry(() =>
+    client.messages.create({ ...request, max_tokens: SUMMARIZER_MAX_TOKENS }),
+  )
+  const text = extractTextFromLlmResponse(response)
+  // Retry on ANY text-less response, not just stop_reason 'max_tokens' — some
+  // Anthropic-compat endpoints return thinking-only output with 'end_turn' or
+  // a nonstandard stop_reason. One wasted call in the rare non-thinking case
+  // beats silently returning null.
+  if (text) return text
+
+  try {
+    const retried = await withRetry(() =>
+      client.messages.create({
+        ...request,
+        max_tokens: SUMMARIZER_MAX_TOKENS,
+        thinking: { type: 'enabled', budget_tokens: SUMMARIZER_THINKING_BUDGET },
+      }),
+    )
+    const retriedText = extractTextFromLlmResponse(retried)
+    if (!retriedText) {
+      console.warn(
+        `Summarizer call returned no text even after thinking-capped retry (model: ${request.model}, stop_reason: ${retried.stop_reason})`,
+      )
+    }
+    return retriedText
+  } catch (error) {
+    // Endpoints that don't accept the thinking param reject the retry; the
+    // first attempt already failed, so report that rather than throwing.
+    console.warn(
+      `Summarizer thinking-capped retry failed (model: ${request.model}): ${error instanceof Error ? error.message : String(error)}`,
+    )
+    return null
+  }
 }

--- a/src/shared/lib/llm-provider/platform-provider.ts
+++ b/src/shared/lib/llm-provider/platform-provider.ts
@@ -1,5 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { BaseLlmProvider, type ModelPurpose } from './base-llm-provider'
+import { rewriteLoopbackForContainer } from './container-url'
 import type { ModelDefinition } from './model-catalog-schema'
 import { PLATFORM_CATALOG } from './builtin-catalogs'
 import { attribution } from '@shared/lib/platform-attribution'
@@ -55,7 +56,7 @@ export class PlatformLlmProvider extends BaseLlmProvider {
 
   getContainerEnvVars(): Record<string, string | undefined> {
     const proxyUrl = getPlatformProxyBaseUrl()
-    const containerUrl = proxyUrl.replace('://localhost', '://host.docker.internal')
+    const containerUrl = rewriteLoopbackForContainer(proxyUrl)
 
     const auth = attribution.current()
     const authToken = auth?.bearerToken() ?? this.getEffectiveApiKey()

--- a/src/shared/lib/services/agent-template-service.ts
+++ b/src/shared/lib/services/agent-template-service.ts
@@ -25,9 +25,8 @@ import {
   serializeMarkdownWithFrontmatter,
 } from '@shared/lib/utils/file-storage'
 import { getEffectiveModels } from '@shared/lib/config/settings'
-import { getConfiguredLlmClient, extractTextFromLlmResponse } from '@shared/lib/llm-provider/helpers'
+import { getConfiguredLlmClient, createSummarizerText } from '@shared/lib/llm-provider/helpers'
 import { resolveActiveProviderModel } from '@shared/lib/llm-provider'
-import { withRetry } from '@shared/lib/utils/retry'
 import { isPathWithinDir } from '@shared/lib/utils/path-safety'
 import {
   readIndexJson,
@@ -1023,14 +1022,12 @@ async function generateAgentPRSuggestions(
   try {
     const model = resolveActiveProviderModel(getEffectiveModels().summarizerModel, 'summarizer')
 
-    const response = await withRetry(() =>
-      client.messages.create({
-        model,
-        max_tokens: 500,
-        messages: [
-          {
-            role: 'user',
-            content: `You are analyzing changes to an agent template. The agent is named "${meta.agentName}" and has been locally modified. Generate a PR title, description, and new SemVer version.
+    const text = await createSummarizerText(client, {
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: `You are analyzing changes to an agent template. The agent is named "${meta.agentName}" and has been locally modified. Generate a PR title, description, and new SemVer version.
 
 Current version: ${meta.installedVersion}
 
@@ -1043,27 +1040,24 @@ Rules for the version bump:
 - PATCH (x.y.Z): bug fixes, typo corrections, minor wording tweaks
 - MINOR (x.Y.0): new features, added capabilities, significant improvements
 - MAJOR (X.0.0): breaking changes, fundamental restructuring`,
-          },
-        ],
-        output_config: {
-          format: {
-            type: 'json_schema' as const,
-            schema: {
-              type: 'object',
-              properties: {
-                title: { type: 'string', description: 'Concise imperative PR title' },
-                body: { type: 'string', description: 'Markdown description of what changed' },
-                version: { type: 'string', description: 'New SemVer version' },
-              },
-              required: ['title', 'body', 'version'],
-              additionalProperties: false,
+        },
+      ],
+      output_config: {
+        format: {
+          type: 'json_schema' as const,
+          schema: {
+            type: 'object',
+            properties: {
+              title: { type: 'string', description: 'Concise imperative PR title' },
+              body: { type: 'string', description: 'Markdown description of what changed' },
+              version: { type: 'string', description: 'New SemVer version' },
             },
+            required: ['title', 'body', 'version'],
+            additionalProperties: false,
           },
         },
-      })
-    )
-
-    const text = extractTextFromLlmResponse(response)
+      },
+    })
     if (!text) return fallback
 
     const parsed = JSON.parse(text)
@@ -1097,14 +1091,12 @@ async function generateAgentPublishSuggestions(
   try {
     const model = resolveActiveProviderModel(getEffectiveModels().summarizerModel, 'summarizer')
 
-    const response = await withRetry(() =>
-      client.messages.create({
-        model,
-        max_tokens: 500,
-        messages: [
-          {
-            role: 'user',
-            content: `You are reviewing a new agent template (CLAUDE.md) being submitted to a shared skillset repository. Generate a PR title, description, and version.
+    const text = await createSummarizerText(client, {
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: `You are reviewing a new agent template (CLAUDE.md) being submitted to a shared skillset repository. Generate a PR title, description, and version.
 
 Agent name: ${agentName}
 
@@ -1117,27 +1109,24 @@ Generate:
 - A concise, imperative PR title (e.g. "Add research assistant agent")
 - A markdown description explaining what the agent does and its key capabilities
 - The version to use (default "1.0.0" for new agents)`,
-          },
-        ],
-        output_config: {
-          format: {
-            type: 'json_schema' as const,
-            schema: {
-              type: 'object',
-              properties: {
-                title: { type: 'string', description: 'Concise imperative PR title' },
-                body: { type: 'string', description: 'Markdown description of the agent' },
-                version: { type: 'string', description: 'SemVer version' },
-              },
-              required: ['title', 'body', 'version'],
-              additionalProperties: false,
+        },
+      ],
+      output_config: {
+        format: {
+          type: 'json_schema' as const,
+          schema: {
+            type: 'object',
+            properties: {
+              title: { type: 'string', description: 'Concise imperative PR title' },
+              body: { type: 'string', description: 'Markdown description of the agent' },
+              version: { type: 'string', description: 'SemVer version' },
             },
+            required: ['title', 'body', 'version'],
+            additionalProperties: false,
           },
         },
-      })
-    )
-
-    const text = extractTextFromLlmResponse(response)
+      },
+    })
     if (!text) return fallback
 
     const parsed = JSON.parse(text)

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -14,9 +14,8 @@ import fs from 'fs'
 import yaml from 'js-yaml'
 import { getDataDir } from '@shared/lib/config/data-dir'
 import { getEffectiveModels } from '@shared/lib/config/settings'
-import { getConfiguredLlmClient, extractTextFromLlmResponse } from '@shared/lib/llm-provider/helpers'
+import { getConfiguredLlmClient, createSummarizerText } from '@shared/lib/llm-provider/helpers'
 import { resolveActiveProviderModel } from '@shared/lib/llm-provider'
-import { withRetry } from '@shared/lib/utils/retry'
 import { isPathWithinDir } from '@shared/lib/utils/path-safety'
 import {
   getAgentWorkspaceDir,
@@ -1289,14 +1288,12 @@ async function generatePRSuggestions(
   try {
     const model = resolveActiveProviderModel(getEffectiveModels().summarizerModel, 'summarizer')
 
-    const response = await withRetry(() =>
-      client.messages.create({
-        model,
-        max_tokens: 500,
-        messages: [
-          {
-            role: 'user',
-            content: `You are analyzing changes to a skill definition file (SKILL.md). Compare the original and modified versions and generate a PR title, description, and new SemVer version.
+    const text = await createSummarizerText(client, {
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: `You are analyzing changes to a skill definition file (SKILL.md). Compare the original and modified versions and generate a PR title, description, and new SemVer version.
 
 Current version: ${meta.installedVersion}
 
@@ -1322,27 +1319,24 @@ Rules for the version bump:
 - PATCH (x.y.Z): bug fixes, typo corrections, minor wording tweaks
 - MINOR (x.Y.0): new features, added capabilities, significant improvements
 - MAJOR (X.0.0): breaking changes, fundamental restructuring`,
-          },
-        ],
-        output_config: {
-          format: {
-            type: 'json_schema' as const,
-            schema: {
-              type: 'object',
-              properties: {
-                title: { type: 'string', description: 'Concise imperative PR title' },
-                body: { type: 'string', description: 'Markdown description of what changed' },
-                version: { type: 'string', description: 'New SemVer version' },
-              },
-              required: ['title', 'body', 'version'],
-              additionalProperties: false,
+        },
+      ],
+      output_config: {
+        format: {
+          type: 'json_schema' as const,
+          schema: {
+            type: 'object',
+            properties: {
+              title: { type: 'string', description: 'Concise imperative PR title' },
+              body: { type: 'string', description: 'Markdown description of what changed' },
+              version: { type: 'string', description: 'New SemVer version' },
             },
+            required: ['title', 'body', 'version'],
+            additionalProperties: false,
           },
         },
-      })
-    )
-
-    const text = extractTextFromLlmResponse(response)
+      },
+    })
     if (!text) return fallback
 
     const parsed = JSON.parse(text)
@@ -1521,14 +1515,12 @@ async function generatePublishSuggestions(
   try {
     const model = resolveActiveProviderModel(getEffectiveModels().summarizerModel, 'summarizer')
 
-    const response = await withRetry(() =>
-      client.messages.create({
-        model,
-        max_tokens: 500,
-        messages: [
-          {
-            role: 'user',
-            content: `You are reviewing a new skill definition file (SKILL.md) that is being submitted to a shared skillset repository. Generate a PR title, description, and confirm the version.
+    const text = await createSummarizerText(client, {
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: `You are reviewing a new skill definition file (SKILL.md) that is being submitted to a shared skillset repository. Generate a PR title, description, and confirm the version.
 
 Skill name: ${skillName}
 
@@ -1541,27 +1533,24 @@ Generate:
 - A concise, imperative PR title (e.g. "Add NDA review skill")
 - A markdown description explaining what the skill does and its key capabilities
 - The version to use (use the version from the skill's metadata if present, otherwise "1.0.0")`,
-          },
-        ],
-        output_config: {
-          format: {
-            type: 'json_schema' as const,
-            schema: {
-              type: 'object',
-              properties: {
-                title: { type: 'string', description: 'Concise imperative PR title' },
-                body: { type: 'string', description: 'Markdown description of the skill' },
-                version: { type: 'string', description: 'SemVer version for the skill' },
-              },
-              required: ['title', 'body', 'version'],
-              additionalProperties: false,
+        },
+      ],
+      output_config: {
+        format: {
+          type: 'json_schema' as const,
+          schema: {
+            type: 'object',
+            properties: {
+              title: { type: 'string', description: 'Concise imperative PR title' },
+              body: { type: 'string', description: 'Markdown description of the skill' },
+              version: { type: 'string', description: 'SemVer version for the skill' },
             },
+            required: ['title', 'body', 'version'],
+            additionalProperties: false,
           },
         },
-      })
-    )
-
-    const text = extractTextFromLlmResponse(response)
+      },
+    })
     if (!text) return fallback
 
     const parsed = JSON.parse(text)


### PR DESCRIPTION
## Follow-up to #415 — live-testing + review findings

Hardening from live-testing the generic provider against a real ollama box (Tailscale host, `qwen3:4b`) and Meta's Muse Spark 1.1 (`https://api.meta.ai`), plus the adversarially-verified findings from a multi-agent review of #415.

Linear: https://linear.app/datawizz/issue/SUP-277

### Thinking-tolerant summarizer calls
Session/agent naming used `max_tokens: 50` (cron describe/parse 100/50, PR metadata 500). Thinking-first models — qwen via ollama, Spark, anything reasoning-first behind a generic endpoint — spend the whole budget on thinking, return **zero text**, and the naming path silently skipped the rename: sessions stayed "New Session" forever.

- New `createSummarizerText()` in `llm-provider/helpers.ts` used by all 8 summarizer call sites: 2000-token budget, one retry with `thinking: {enabled, budget_tokens: 1024}` on **any** text-less response (Spark honors the cap; retry errors are caught, since some endpoints 400 on the thinking param).
- Results clamped to one line / 80 chars — the old tiny `max_tokens` doubled as a truncator, so a chatty model could otherwise persist a paragraph as a sidebar name.
- Session naming falls back to the truncated first message when the model yields nothing (ollama ignores `budget_tokens`, and small qwen ruminates 2–8K tokens on a naming prompt — heavy-tailed, not fixable by budget alone).
- Unit tests for the helper restore the token-bound regression coverage.

### Generic-provider validation + container reachability
- **Loopback rewrite by parsed hostname** (`container-url.ts`, shared with the platform provider): `127.0.0.1`/`0.0.0.0`/`::1` now rewrite to `host.docker.internal` (previously only the literal `://localhost`, so a loopback-IP config validated on the host then failed every agent turn), and `localhost.mycorp.dev`-style hostnames are no longer mangled.
- **`/v1`-suffix guidance in `validateKey`**: a base URL ending in `/v1` (the OpenAI-docs convention) used to soft-pass validation via the 404 branch and then 404 on every real request at `/v1/v1/messages`. Now the stripped base is probed and the user gets `Base URL should not include the /v1 suffix — use <stripped>`. Verified live against `https://api.meta.ai/v1`.
- **`getApiKeyStatus` requires the base URL**: key-without-endpoint no longer reports configured (it would pass `getConfiguredLlmClient`'s guard and throw downstream as 500s).

### Settings UX
- Settings response echoes `genericBaseUrl` (not a secret) and the LLM tab seeds the Base URL field from it — a bad saved endpoint is now visible instead of hiding behind a placeholder. Playwright-verified.
- A failed settings save is no longer reported as "Failed to validate".

### Testing
- `npm run` typecheck clean, lint clean.
- 746 tests across the affected suites (llm-provider, agents, scheduled-tasks, settings, template/skillset services) all pass; new cases for the loopback rewrite, /v1 guidance, key-without-URL status, and `createSummarizerText`.
- Live end-to-end (real containerized agent turns): ollama `qwen3:4b` session named via fallback; Spark session named by the model ("Design Team Welcome Email Draft"); `validateKey` guidance confirmed against the real Meta endpoint.

### Known gaps deliberately left out (follow-ups)
- Keyless endpoints still require a dummy API key in the UI.
- Model search still requires a ≥2-char query (generic's list-all is unreachable from the UI).
- The model-search route echoes raw provider error messages (useful for generic, leaky for Bedrock/OpenRouter).
- Changing the generic base URL does not reset model selections, so a stale model id 404s against the new endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)