### PR TITLE
Settlement-tracked idle session eviction (supersedes #419)

### DIFF
--- a/.claude/skills/update-claude-deps/SKILL.md
+++ b/.claude/skills/update-claude-deps/SKILL.md
@@ -50,6 +50,26 @@ Review the current versions of Claude-related packages and create an upgrade pla
   ```
   Then replace the template literal in `src/api/llm-sdk-bundle.ts` with the contents of `/tmp/sdk-bundle.js` (escape any backticks with `\``)
 
+## Validation after upgrading
+
+1. **Container unit suite**: `cd agent-container && npx vitest run` — includes the settlement-tracker fixture replays (19 real captured SDK streams), which catch most protocol-shape regressions.
+
+2. **Gated session-GC E2E suites** (MANDATORY on any `@anthropic-ai/claude-agent-sdk` / CLI bump — CI never runs these, and they guard CLI-behavior assumptions the idle-eviction reaper depends on):
+   ```bash
+   cd agent-container
+   RUN_SESSION_GC_E2E=1 ANTHROPIC_API_KEY=... npx vitest run src/session-gc.e2e.test.ts
+   RUN_SESSION_GC_E2E=1 ANTHROPIC_API_KEY=... npx vitest run src/session-gc-durability.e2e.test.ts
+   ```
+   - Run the two files **separately**, never in one vitest invocation: the pgrep zero-process assertions in each see the other worker's CLI subprocesses.
+   - Costs real API tokens (~$0.05, ~1.5 min total on haiku).
+   - What they hold in place, and what breaks silently if an SDK/CLI change violates it:
+     - the CLI does NOT emit `session_state_changed:idle` between a finished turn and a queued follow-up (violation → the reaper kills queued messages);
+     - an interrupt yields a `result` + `idle` so the session settles (violation → every user Stop pins a ~250MB parked subprocess forever);
+     - the CLI exits cleanly on stdin EOF, flushing its transcript (violation → eviction silently loses the latest turns / `shouldQuery:false` appends on the next `--resume`);
+     - `--resume` resumes in-place with the same session id, with prior context intact.
+
+3. If either E2E file fails, do not ship the bump — check the settlement tracker (`agent-container/src/session-settlement.ts`) and graceful-stop path (`claude-code.ts stop({graceful:true})`) against the new CLI's stream behavior.
+
 ## Important notes
 
 - The Claude Code CLI is installed as a native binary in Docker (not npm). Version is pinned via `curl -fsSL https://claude.ai/install.sh | bash -s <VERSION>`

--- a/agent-container/src/claude-code-stop-race.test.ts
+++ b/agent-container/src/claude-code-stop-race.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Regression test for the evict-then-resume teardown race.
+ *
+ * stop() used to sleep a fixed 100ms and return without awaiting the
+ * processMessages loop. When SDK teardown outlived that sleep, a restart
+ * (sendMessage after eviction) started query B while query A was still
+ * unwinding; A's finally then cleared the shared isReady/isProcessing flags,
+ * so the next message spawned query C without ever closing B — leaking B's
+ * subprocess and double-routing its messages. stop() now awaits the loop
+ * (bounded), and the finally is generation-guarded for the timeout path.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const queryCalls: unknown[] = []
+// How long after abort the mocked SDK query takes to actually unwind.
+let teardownDelayMs = 250
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => {
+  function makeQuery(args: { prompt: unknown; options: { abortController: AbortController } }) {
+    const signal = args.options.abortController.signal
+    const abortError = Object.assign(new Error('aborted'), { name: 'AbortError' })
+    const iter = {
+      [Symbol.asyncIterator]() {
+        return this
+      },
+      next() {
+        return new Promise<IteratorResult<never>>((_, reject) => {
+          const fail = () => setTimeout(() => reject(abortError), teardownDelayMs)
+          if (signal.aborted) fail()
+          else signal.addEventListener('abort', fail, { once: true })
+        })
+      },
+      return() {
+        return Promise.resolve({ value: undefined, done: true } as IteratorResult<never>)
+      },
+      throw(err?: unknown) {
+        return Promise.reject(err)
+      },
+      interrupt: () => Promise.resolve(),
+      setModel: () => Promise.resolve(),
+    }
+    return iter
+  }
+
+  return {
+    query: vi.fn((args: { prompt: unknown; options: { abortController: AbortController } }) => {
+      queryCalls.push(args)
+      return makeQuery(args)
+    }),
+  }
+})
+
+vi.mock('./mcp-server', () => ({
+  createUserInputMcpServer: () => ({}),
+  createBrowserMcpServer: () => ({}),
+  createComputerUseMcpServer: () => ({}),
+  createDashboardsMcpServer: () => ({}),
+  createAgentsMcpServer: () => ({}),
+  createChatMcpServer: () => ({}),
+}))
+vi.mock('./tools/browser', () => ({ createBrowserTools: () => [] }))
+vi.mock('./tools/computer-use', () => ({ computerUseTools: [] }))
+vi.mock('./file-hooks', () => ({ fileHooks: {}, resolveToolFilePath: () => '' }))
+vi.mock('./input-manager', () => ({ inputManager: {} }))
+
+import { ClaudeCodeProcess } from './claude-code'
+
+describe('ClaudeCodeProcess stop/restart teardown race', () => {
+  beforeEach(() => {
+    queryCalls.length = 0
+    teardownDelayMs = 250
+  })
+
+  it('stop() waits for the query loop to unwind before returning', async () => {
+    const proc = new ClaudeCodeProcess({ sessionId: 's1', workingDirectory: '/tmp' })
+    await proc.start()
+    expect(proc.isRunning()).toBe(true)
+
+    const before = Date.now()
+    await proc.stop()
+    // Must have outlasted the mocked 250ms teardown, not just a fixed sleep.
+    expect(Date.now() - before).toBeGreaterThanOrEqual(240)
+    expect(proc.isRunning()).toBe(false)
+  })
+
+  it('a restart during slow teardown cannot be marked stopped by the old loop', async () => {
+    const proc = new ClaudeCodeProcess({ sessionId: 's2', workingDirectory: '/tmp' })
+    await proc.start()
+    expect(queryCalls.length).toBe(1)
+
+    await proc.stop() // awaits teardown → old loop fully unwound
+    await proc.sendMessage('follow-up') // cold path → restart → query B
+    expect(queryCalls.length).toBe(2)
+    expect(proc.isRunning()).toBe(true)
+
+    // Give any straggler teardown from query A time to fire its finally.
+    await new Promise((r) => setTimeout(r, teardownDelayMs + 100))
+    expect(proc.isRunning()).toBe(true) // B is still the live query
+
+    // And the next message must NOT spawn a third query.
+    await proc.sendMessage('again')
+    expect(queryCalls.length).toBe(2)
+
+    await proc.stop()
+  })
+
+  it('interrupt() landing during a stop() teardown must not revive the query', async () => {
+    const proc = new ClaudeCodeProcess({ sessionId: 's4', workingDirectory: '/tmp' })
+    await proc.start()
+    expect(queryCalls.length).toBe(1)
+
+    // Eviction begins stopping; a user Stop (interruptSession) races in while
+    // the old loop is still unwinding.
+    const stopP = proc.stop()
+    const intP = proc.interrupt()
+    await Promise.all([stopP, intP])
+    // Let any deferred restart from interrupt() surface.
+    await new Promise((r) => setTimeout(r, teardownDelayMs + 200))
+
+    // The stop must win: no second query may have been spawned, and the
+    // process must read as cold so the reaper/manager stay consistent.
+    expect(queryCalls.length).toBe(1)
+    expect(proc.isRunning()).toBe(false)
+  })
+
+  it('a stop() landing while interrupt() is mid-flight also suppresses the restart', async () => {
+    const proc = new ClaudeCodeProcess({ sessionId: 's4b', workingDirectory: '/tmp' })
+    await proc.start()
+    expect(queryCalls.length).toBe(1)
+
+    // Reverse order: interrupt enters first (passes its entry guard, waits
+    // for the loop to unwind), then the eviction/delete stop races in.
+    const intP = proc.interrupt()
+    await new Promise((r) => setTimeout(r, 50))
+    const stopP = proc.stop()
+    await Promise.all([intP, stopP])
+    await new Promise((r) => setTimeout(r, teardownDelayMs + 200))
+
+    expect(queryCalls.length).toBe(1)
+    expect(proc.isRunning()).toBe(false)
+  })
+
+  it('a disposed process (deleteSession) cannot be revived by late sendMessage or interrupt', async () => {
+    const proc = new ClaudeCodeProcess({ sessionId: 's5', workingDirectory: '/tmp' })
+    await proc.start()
+    expect(queryCalls.length).toBe(1)
+
+    // deleteSession semantics: the session is gone for good — a straggler
+    // MCP-injection continuation (addRemoteMcpServer's setTimeout closure
+    // calls interrupt + sendMessage directly) must not resurrect a subprocess
+    // that no longer belongs to any tracked session.
+    await proc.dispose()
+    expect(proc.isRunning()).toBe(false)
+
+    const outcome = await proc.interrupt()
+    expect(outcome.interrupted).toBe(false)
+    await expect(proc.sendMessage('straggler')).rejects.toThrow()
+
+    await new Promise((r) => setTimeout(r, teardownDelayMs + 200))
+    expect(queryCalls.length).toBe(1)
+    expect(proc.isRunning()).toBe(false)
+  })
+
+  it('every sendMessage emits outbound-message (settlement visibility for bypass callers)', async () => {
+    const proc = new ClaudeCodeProcess({ sessionId: 's6', workingDirectory: '/tmp' })
+    await proc.start()
+
+    const outbound: Array<{ expectsResponse: boolean }> = []
+    proc.on('outbound-message', (info: { expectsResponse: boolean }) => outbound.push(info))
+
+    await proc.sendMessage('a real turn')
+    await proc.sendMessage('a transcript-only append', undefined, { shouldQuery: false })
+
+    expect(outbound).toEqual([{ expectsResponse: true }, { expectsResponse: false }])
+    await proc.stop()
+  })
+
+  it('graceful stop falls back to abort when the loop ignores the closed queue', async () => {
+    // The mocked query never ends on queue-close (like a wedged CLI): the
+    // graceful window must expire and the abort must still tear it down.
+    const proc = new ClaudeCodeProcess({ sessionId: 's7', workingDirectory: '/tmp' })
+    await proc.start()
+
+    const before = Date.now()
+    await proc.stop({ graceful: true, graceMs: 100 })
+    const elapsed = Date.now() - before
+    expect(elapsed).toBeGreaterThanOrEqual(100 + 240) // grace + mocked teardown
+    expect(proc.isRunning()).toBe(false)
+  })
+
+  it('generation guard: even a teardown that outlives the stop() bound cannot clobber the new query', async () => {
+    // Teardown slower than stop()'s 5s wait bound — stop() gives up waiting,
+    // sendMessage restarts, and A's finally fires AFTER B is live.
+    teardownDelayMs = 5600
+    const proc = new ClaudeCodeProcess({ sessionId: 's3', workingDirectory: '/tmp' })
+    await proc.start()
+
+    await proc.stop() // returns at the 5s bound, A still unwinding
+    teardownDelayMs = 250 // subsequent queries tear down promptly
+    await proc.sendMessage('follow-up') // query B
+    expect(queryCalls.length).toBe(2)
+    expect(proc.isRunning()).toBe(true)
+
+    // A's finally fires ~600ms from now — the generation guard must ignore it.
+    await new Promise((r) => setTimeout(r, 900))
+    expect(proc.isRunning()).toBe(true)
+    await proc.sendMessage('again')
+    expect(queryCalls.length).toBe(2)
+
+    await proc.stop()
+  }, 15_000)
+})

--- a/agent-container/src/claude-code-stop-race.test.ts
+++ b/agent-container/src/claude-code-stop-race.test.ts
@@ -175,6 +175,26 @@ describe('ClaudeCodeProcess stop/restart teardown race', () => {
     await proc.stop()
   })
 
+  it('a sendMessage racing a graceful stop waits it out instead of throwing the message away', async () => {
+    // The MCP-injection continuation (and any bypass caller) can hit
+    // sendMessage while a graceful stop has already closed the queue but not
+    // yet nulled it — pushing would throw "MessageQueue is closed" and the
+    // message would be silently lost. It must instead wait for the stop to
+    // finish and cold-restart, exactly like a send into an evicted session.
+    const proc = new ClaudeCodeProcess({ sessionId: 's8', workingDirectory: '/tmp' })
+    await proc.start()
+    expect(queryCalls.length).toBe(1)
+
+    const stopP = proc.stop({ graceful: true, graceMs: 400 })
+    await new Promise((r) => setTimeout(r, 50)) // inside the graceful window
+    await proc.sendMessage('rescue me') // must not throw
+    await stopP
+
+    expect(queryCalls.length).toBe(2) // restarted once, after the stop completed
+    expect(proc.isRunning()).toBe(true)
+    await proc.stop()
+  })
+
   it('graceful stop falls back to abort when the loop ignores the closed queue', async () => {
     // The mocked query never ends on queue-close (like a wedged CLI): the
     // graceful window must expire and the abort must still tear it down.

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -396,6 +396,11 @@ export class ClaudeCodeProcess extends EventEmitter {
   // tore down: the revived subprocess would belong to a session the manager
   // believes is cold (or gone), invisible to the idle reaper.
   private stopping = false;
+  // Completion of the most recent stop(). A sendMessage racing an in-flight
+  // stop (its queue already closed but not yet nulled) must wait this out and
+  // cold-restart — pushing into the closed queue would throw and silently
+  // lose the message (e.g. an MCP-injection continuation).
+  private currentStop: Promise<void> | null = null;
   // Terminal: the session was deleted. No path may revive this process.
   private disposed = false;
   private userMessageCount: number = 0;
@@ -804,6 +809,11 @@ export class ClaudeCodeProcess extends EventEmitter {
     this.messageQueue = new MessageQueue();
     this.queryInstance = this.createQuery();
     this.isReady = true;
+    // Background tasks are process-local and die with the old process; the
+    // SessionManager listens for this to reset its settlement bookkeeping —
+    // a task id carried across the replacement would pin the session
+    // unevictable forever (no terminal signal or snapshot ever comes).
+    this.emit('query-start');
   }
 
   async start(): Promise<void> {
@@ -966,9 +976,14 @@ export class ClaudeCodeProcess extends EventEmitter {
       this.model = model;
     }
 
-    if (!this.messageQueue || !this.isReady) {
-      // Cold session — first init will pick up the (possibly new) effort/model values.
+    if (this.stopping || !this.messageQueue || !this.isReady) {
+      // Cold session, or a stop in flight (queue closed but not yet nulled —
+      // pushing would throw and lose the message): wait the stop out, then
+      // restart. First init picks up the (possibly new) effort/model values.
       console.log(`[Session ${this.sessionId}] Session not running, restarting...`);
+      if (this.currentStop) {
+        await this.currentStop.catch(() => undefined);
+      }
       await this.restart();
     } else if (effortChanged) {
       // Effort can only be set at query creation time — the SDK has no setEffort
@@ -1092,6 +1107,12 @@ export class ClaudeCodeProcess extends EventEmitter {
    * anyway).
    */
   async stop(options?: { graceful?: boolean; graceMs?: number }): Promise<void> {
+    const stopRun = this.performStop(options);
+    this.currentStop = stopRun;
+    await stopRun;
+  }
+
+  private async performStop(options?: { graceful?: boolean; graceMs?: number }): Promise<void> {
     console.log(`[Session ${this.sessionId}] Stopping session${options?.graceful ? ' (graceful)' : ''}`);
     this.stopping = true;
 

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -383,6 +383,21 @@ export class ClaudeCodeProcess extends EventEmitter {
   private effort: EffortLevel | undefined;
   private isReady: boolean = false;
   private isProcessing: boolean = false;
+  // Monotonic id of the current query; bumped by initializeQuery. A previous
+  // query's processMessages loop checks it before clearing shared flags in
+  // its finally, so a slow teardown can't mark a fresh query stopped.
+  private queryGeneration = 0;
+  // Resolves when the current processMessages loop has fully unwound. stop()
+  // awaits it so an evict-then-resume can't start a second query while the
+  // first is still tearing down.
+  private processingDone: Promise<void> | null = null;
+  // Set by stop(), cleared by the sanctioned revival paths (start/restart).
+  // An interrupt() overlapping a stop() must not restart the query it just
+  // tore down: the revived subprocess would belong to a session the manager
+  // believes is cold (or gone), invisible to the idle reaper.
+  private stopping = false;
+  // Terminal: the session was deleted. No path may revive this process.
+  private disposed = false;
   private userMessageCount: number = 0;
   private isResumedSession: boolean;
   public slashCommands: { name: string; description: string; argumentHint: string }[] = [];
@@ -782,6 +797,9 @@ export class ClaudeCodeProcess extends EventEmitter {
    * Initializes the abort controller and message queue, then creates a new query.
    */
   private initializeQuery(): void {
+    // New query generation: a stale processMessages loop from a previous
+    // query must not clobber this one's state when it finally unwinds.
+    this.queryGeneration++;
     this.abortController = new AbortController();
     this.messageQueue = new MessageQueue();
     this.queryInstance = this.createQuery();
@@ -789,6 +807,10 @@ export class ClaudeCodeProcess extends EventEmitter {
   }
 
   async start(): Promise<void> {
+    if (this.disposed) {
+      throw new Error(`Session ${this.sessionId} process was disposed`);
+    }
+    this.stopping = false;
     const isResuming = !!this.claudeSessionId;
     console.log(`[Session ${this.sessionId}] Starting SDK-based session`);
     console.log(`[Session ${this.sessionId}] ANTHROPIC_API_KEY set:`, !!process.env.ANTHROPIC_API_KEY);
@@ -799,12 +821,13 @@ export class ClaudeCodeProcess extends EventEmitter {
     this.emit('ready');
 
     // Start processing messages in the background
-    this.processMessages();
+    this.processingDone = this.processMessages();
   }
 
   private async processMessages(): Promise<void> {
     if (!this.queryInstance) return;
 
+    const generation = this.queryGeneration;
     this.isProcessing = true;
     // Tracks whether the MOST RECENT result was an error. The catch below emits
     // a synthetic error result only when the SDK hasn't already reported this
@@ -911,8 +934,13 @@ export class ClaudeCodeProcess extends EventEmitter {
         }
       }
     } finally {
-      this.isProcessing = false;
-      this.isReady = false;
+      // A newer query may already be live (initializeQuery bumped the
+      // generation while this loop was still unwinding) — its flags are not
+      // ours to clear.
+      if (generation === this.queryGeneration) {
+        this.isProcessing = false;
+        this.isReady = false;
+      }
       this.emit('exit', 0);
     }
   }
@@ -989,6 +1017,12 @@ export class ClaudeCodeProcess extends EventEmitter {
     }
     console.log(`[Session ${this.sessionId}] Sending message (userMessageCount=${this.userMessageCount}):`, content.substring(0, 100));
     this.messageQueue!.push(message);
+    // Every send path must reach the session's settlement tracker — including
+    // internal ones that bypass SessionManager.sendMessage (the MCP-injection
+    // continuation in addRemoteMcpServer). Without this, a send landing while
+    // the tracker reads settled leaves the reaper free to kill the turn it
+    // just started.
+    this.emit('outbound-message', { expectsResponse: shouldQuery !== false });
   }
 
   /**
@@ -1026,17 +1060,55 @@ export class ClaudeCodeProcess extends EventEmitter {
 
   // Restart the session (used when session exits and user sends a new message)
   private async restart(): Promise<void> {
+    if (this.disposed) {
+      throw new Error(`Session ${this.sessionId} process was disposed`);
+    }
     console.log(`[Session ${this.sessionId}] Restarting session`);
+    this.stopping = false;
     this.initializeQuery();
-    this.processMessages();
+    this.processingDone = this.processMessages();
   }
 
-  async stop(): Promise<void> {
-    console.log(`[Session ${this.sessionId}] Stopping session`);
+  /**
+   * Terminal stop for deleteSession/shutdown: after this, no straggler
+   * (a deferred MCP-injection interrupt/continuation, a late caller holding
+   * the object) can revive the subprocess — the session it belonged to no
+   * longer exists anywhere the reaper can see.
+   */
+  async dispose(options?: { graceful?: boolean; graceMs?: number }): Promise<void> {
+    this.disposed = true;
+    await this.stop(options);
+  }
+
+  /**
+   * graceful: close the input stream and give the CLI a bounded window to
+   * exit on stdin EOF BEFORE aborting. An immediate abort hard-kills the CLI,
+   * racing its transcript flush — a reaper sweep landing right after idle (or
+   * during the boot of a shouldQuery:false append restart) then truncates the
+   * tail of the session JSONL, and the next --resume silently loses those
+   * turns. Proven live: identical evict-after-turn runs lost walnut-9/turn-2
+   * context on one run and kept it on the next. Eviction and shutdown must
+   * quiesce; deleteSession may keep the hard kill (the transcript is doomed
+   * anyway).
+   */
+  async stop(options?: { graceful?: boolean; graceMs?: number }): Promise<void> {
+    console.log(`[Session ${this.sessionId}] Stopping session${options?.graceful ? ' (graceful)' : ''}`);
+    this.stopping = true;
 
     // Close the message queue to signal end of input
     if (this.messageQueue) {
       this.messageQueue.close();
+    }
+
+    if (options?.graceful && this.processingDone) {
+      // Stdin EOF lets the CLI finish pending work (transcript writes, an
+      // in-flight append) and exit cleanly, ending the message stream. Bounded:
+      // a CLI that ignores EOF gets the abort below, same as a hard stop.
+      // (Live-measured: a settled CLI exits ~1s after EOF.)
+      await Promise.race([
+        this.processingDone.catch(() => undefined),
+        new Promise((resolve) => setTimeout(resolve, options.graceMs ?? 8000)),
+      ]);
     }
 
     // Abort the query if still running
@@ -1044,8 +1116,18 @@ export class ClaudeCodeProcess extends EventEmitter {
       this.abortController.abort();
     }
 
-    // Wait a moment for cleanup
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    // Wait for the processing loop to fully unwind — a fixed sleep is not
+    // enough: if SDK teardown outlives it, a restart (evict-then-resume) can
+    // start a second query while this one is still alive, whose finally then
+    // marks the new query stopped and the next message spawns a third,
+    // leaking the second's subprocess. Bounded so a hung teardown cannot
+    // wedge stop() forever; the generation guard covers the timeout path.
+    if (this.processingDone) {
+      await Promise.race([
+        this.processingDone.catch(() => undefined),
+        new Promise((resolve) => setTimeout(resolve, 5000)),
+      ]);
+    }
 
     this.isReady = false;
     this.queryInstance = null;
@@ -1060,7 +1142,7 @@ export class ClaudeCodeProcess extends EventEmitter {
   async interrupt(): Promise<InterruptOutcome> {
     console.log(`[Session ${this.sessionId}] Interrupting current query`);
 
-    if (!this.abortController || !this.isProcessing) {
+    if (this.stopping || !this.abortController || !this.isProcessing) {
       console.log(`[Session ${this.sessionId}] Nothing to interrupt`);
       return { interrupted: false, discardedUuids: [] };
     }
@@ -1131,10 +1213,19 @@ export class ClaudeCodeProcess extends EventEmitter {
       });
     }
 
+    // A stop()/dispose() may have raced in while we were waiting above — the
+    // teardown wins: restarting here would revive a subprocess for a session
+    // the manager already considers cold (or deleted), leaking it past the
+    // reaper. The abort already landed, so the turn is dead either way.
+    if (this.stopping) {
+      console.log(`[Session ${this.sessionId}] Stop raced the interrupt — not restarting query`);
+      return { interrupted: true, discardedUuids };
+    }
+
     // Restart the query with resume to continue the session
     console.log(`[Session ${this.sessionId}] Restarting query after interrupt`);
     this.initializeQuery();
-    this.processMessages();
+    this.processingDone = this.processMessages();
 
     return { interrupted: true, discardedUuids };
   }

--- a/agent-container/src/session-gc-durability.e2e.test.ts
+++ b/agent-container/src/session-gc-durability.e2e.test.ts
@@ -270,6 +270,62 @@ describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => 
   );
 
   it(
+    'a live background task holds off the reaper; the session is reaped only after the wake turn settles',
+    async () => {
+      // Live guard for the background-task hold: fixtures pin the tracker
+      // against captured frames, but only a real CLI proves the end-to-end
+      // signal chain (task_started/background_tasks_changed actually emitted
+      // for a live task, completion wake actually delivered). Background
+      // bash is the one task type triggerable deterministically; subagents
+      // and workflows ride the same type-agnostic task_id bookkeeping and
+      // are covered by the fixture replays.
+      const manager = new SessionManager(workDir, {
+        idleEvictionMs: 60 * 60_000,
+        automatedIdleEvictionMs: 0, // most aggressive class
+        evictionPollMs: 500,
+      });
+      managers.push(manager);
+
+      const session = await manager.createSession({
+        initialMessage:
+          'Use the Bash tool with run_in_background: true to run exactly: sleep 15 && echo SLEEP-DONE. Do not wait for it. After starting it, reply with exactly: started',
+        metadata: { isAutomated: true },
+        model: MODEL,
+      });
+      const id = session.id;
+
+      await waitFor('bg-task first result', () => resultCount(manager.getMessages(id)) >= 1, 120_000);
+
+      // The test is only valid if a background task was actually registered.
+      const sawBgTask = () =>
+        manager.getMessages(id).some(
+          (m) =>
+            m.type === 'system' &&
+            (m.subtype === 'task_started' || m.subtype === 'background_tasks_changed')
+        );
+      expect(sawBgTask()).toBe(true);
+
+      // ~16 threshold-0 sweeps fire while the task runs — none may evict.
+      for (let i = 0; i < 16; i++) {
+        await new Promise((r) => setTimeout(r, 500));
+        expect(manager.isSessionRunning(id)).toBe(true);
+      }
+
+      // Completion wake delivers the task output to the model...
+      await waitFor(
+        'wake turn observed',
+        () => assistantText(manager.getMessages(id)).includes('SLEEP-DONE') ||
+              resultCount(manager.getMessages(id)) >= 2,
+        60_000
+      );
+      // ...and only after the wake settles does the reaper take the process.
+      await waitFor('reaped after wake settled', () => !manager.isSessionRunning(id), 60_000);
+      dlog(`bg-task msgs: ${describeMessages(manager.getMessages(id))}`);
+    },
+    360_000
+  );
+
+  it(
     'an interrupted session settles and is reaped (no permanent busy-pin leak)',
     async () => {
       // Guards the other CLI-behavior assumption: an interrupt yields a

--- a/agent-container/src/session-gc-durability.e2e.test.ts
+++ b/agent-container/src/session-gc-durability.e2e.test.ts
@@ -236,4 +236,69 @@ describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => 
     },
     360_000
   );
+
+  it(
+    'a message queued mid-turn survives an aggressive reaper (no idle gap between chained turns)',
+    async () => {
+      // Guards a CLI-behavior assumption the reaper depends on: the CLI does
+      // NOT emit session_state_changed:idle between a finished turn and a
+      // queued follow-up. If a future CLI/SDK does, a threshold-0 sweep
+      // landing in that gap would evict and silently kill the queued message.
+      const manager = new SessionManager(workDir, {
+        idleEvictionMs: 0, // human promotion flips class → keep both classes at 0
+        automatedIdleEvictionMs: 0,
+        evictionPollMs: 250,
+      });
+      managers.push(manager);
+
+      const session = await manager.createSession({
+        initialMessage: 'Reply with exactly: alpha-one',
+        metadata: { isAutomated: true },
+        model: MODEL,
+      });
+      const id = session.id;
+      // Queue a second message while turn 1 is (very likely) still running.
+      await manager.sendMessage(id, 'Reply with exactly: beta-two');
+
+      await waitFor('both chained results', () => resultCount(manager.getMessages(id)) >= 2, 120_000);
+      const text = assistantText(manager.getMessages(id));
+      dlog(`chained-turns text=${JSON.stringify(text)}`);
+      expect(text).toContain('alpha-one');
+      expect(text).toContain('beta-two');
+    },
+    360_000
+  );
+
+  it(
+    'an interrupted session settles and is reaped (no permanent busy-pin leak)',
+    async () => {
+      // Guards the other CLI-behavior assumption: an interrupt yields a
+      // result (error_during_execution) + idle, so the tracker settles and
+      // the fresh parked query gets reaped. If an SDK change stops emitting
+      // those frames, every user Stop would pin a ~250MB subprocess forever.
+      const manager = new SessionManager(workDir, {
+        idleEvictionMs: 3_000,
+        automatedIdleEvictionMs: -1,
+        evictionPollMs: 500,
+      });
+      managers.push(manager);
+
+      const session = await manager.createSession({
+        initialMessage:
+          'Write a numbered list of 60 short sentences about the ocean, one per line. Do not stop early.',
+        model: MODEL,
+      });
+      const id = session.id;
+
+      // Interrupt mid-turn, then the restarted parked query must become
+      // settled and get reaped by the real sweep.
+      await new Promise((r) => setTimeout(r, 2_500));
+      const outcome = await manager.interruptSession(id);
+      dlog(`interrupt outcome=${JSON.stringify(outcome)}`);
+      expect(outcome.found).toBe(true);
+
+      await waitFor('reaped after interrupt', () => !manager.isSessionRunning(id), 45_000);
+    },
+    360_000
+  );
 });

--- a/agent-container/src/session-gc-durability.e2e.test.ts
+++ b/agent-container/src/session-gc-durability.e2e.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Live durability E2E for session GC: proves eviction cannot lose transcript
+ * data. Disk forensics (grepping the CLI's own JSONL transcripts between
+ * phases) separate "transcript never written" from "resume mechanics broken"
+ * from "model answered badly".
+ *
+ * Regression background: eviction originally stopped the CLI with an
+ * immediate abort, racing its transcript flush — identical runs lost the
+ * latest turn's context on some runs and kept it on others, and a
+ * shouldQuery:false append into a cold threshold-0 session could be killed
+ * mid-boot before the append ever reached disk. Eviction now stops the CLI
+ * gracefully (stdin EOF, bounded), which these tests hold in place.
+ *
+ * Opt-in only — costs real API tokens (~20s on haiku). Run separately from
+ * session-gc.e2e.test.ts: its pgrep-based zero-process assertions see this
+ * file's subprocesses when both run in parallel vitest workers.
+ *   RUN_SESSION_GC_E2E=1 ANTHROPIC_API_KEY=... npx vitest run src/session-gc-durability.e2e.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const ENABLED = process.env.RUN_SESSION_GC_E2E === '1' && !!process.env.ANTHROPIC_API_KEY;
+const MODEL = 'claude-haiku-4-5-20251001';
+const LOG = process.env.PROBE_LOG_FILE || '';
+const T0 = Date.now();
+
+function dlog(msg: string): void {
+  if (LOG) fs.appendFileSync(LOG, `[+${((Date.now() - T0) / 1000).toFixed(2)}s] ${msg}\n`);
+}
+
+type AnyMessage = {
+  type?: string;
+  subtype?: string;
+  state?: string;
+  is_error?: boolean;
+  error?: unknown;
+  result?: unknown;
+  session_id?: string;
+  message?: { content?: Array<{ type?: string; text?: string }> };
+};
+
+function resultCount(messages: AnyMessage[]): number {
+  return messages.filter((m) => m.type === 'result').length;
+}
+
+function assistantText(messages: AnyMessage[]): string {
+  return messages
+    .filter((m) => m.type === 'assistant')
+    .flatMap((m) => m.message?.content ?? [])
+    .filter((b) => b.type === 'text')
+    .map((b) => b.text)
+    .join('\n');
+}
+
+function describeMessages(messages: AnyMessage[]): string {
+  return messages
+    .filter((m) => m.type !== 'stream_event')
+    .map((m) => {
+      const bits = [m.type, m.subtype, m.state].filter(Boolean).join('/');
+      const err = m.is_error || m.error ? ` ERR=${JSON.stringify(m.error ?? m.result ?? true)}` : '';
+      const text =
+        m.type === 'assistant' || m.type === 'user'
+          ? ` "${(m.message?.content ?? []).map((b) => b.text ?? `[${b.type}]`).join('').slice(0, 80)}"`
+          : '';
+      return `${bits}${err}${text}`;
+    })
+    .join(' | ');
+}
+
+/** All CLI transcript JSONL files under the probe's CLAUDE_CONFIG_DIR-adjacent project dirs. */
+function transcriptFiles(configDir: string): Array<{ file: string; size: number }> {
+  const out: Array<{ file: string; size: number }> = [];
+  const walk = (dir: string) => {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (entry.name.endsWith('.jsonl')) out.push({ file: p, size: fs.statSync(p).size });
+    }
+  };
+  walk(path.join(configDir, 'projects'));
+  return out;
+}
+
+function grepTranscripts(configDir: string, needle: string): string[] {
+  return transcriptFiles(configDir)
+    .filter(({ file }) => fs.readFileSync(file, 'utf-8').includes(needle))
+    .map(({ file }) => path.basename(file));
+}
+
+function logDisk(configDir: string, label: string, needles: string[]): void {
+  const files = transcriptFiles(configDir)
+    .map((f) => `${path.basename(f.file)}:${f.size}B`)
+    .join(', ');
+  dlog(`${label}: transcripts=[${files}]`);
+  for (const needle of needles) {
+    dlog(`${label}: "${needle}" in ${JSON.stringify(grepTranscripts(configDir, needle))}`);
+  }
+}
+
+async function waitFor(label: string, cond: () => boolean, timeoutMs: number, intervalMs = 250): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (cond()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`Timed out waiting for: ${label}`);
+}
+
+describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => {
+  let workDir: string;
+  let configDir: string;
+  let SessionManager: typeof import('./session-manager').SessionManager;
+  const managers: Array<{ stopAll(): Promise<void> }> = [];
+
+  beforeAll(async () => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gc-durability-'));
+    configDir = path.join(workDir, '.claude');
+    process.env.SUPERAGENT_SESSIONS_FILE = path.join(workDir, 'sessions.json');
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    delete process.env.CLAUDECODE;
+    delete process.env.CLAUDE_CODE_ENTRYPOINT;
+    ({ SessionManager } = await import('./session-manager'));
+  });
+
+  afterAll(async () => {
+    for (const m of managers) await m.stopAll();
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it(
+    'turns from a resumed (post-eviction) query survive on disk and across a manager restart',
+    async () => {
+      const manager = new SessionManager(workDir, {
+        idleEvictionMs: 0,
+        automatedIdleEvictionMs: 0,
+        evictionPollMs: 500,
+      });
+      managers.push(manager);
+
+      const session = await manager.createSession({
+        initialMessage: 'Remember: codeword one is papaya-7. Reply with exactly: OK',
+        metadata: { isAutomated: true },
+        model: MODEL,
+      });
+      const id = session.id;
+      dlog(`A2: created ${id}`);
+
+      await waitFor('A2 first result', () => resultCount(manager.getMessages(id)) >= 1, 120_000);
+      await waitFor('A2 reaped once', () => !manager.isSessionRunning(id), 45_000);
+      logDisk(configDir, 'A2 after evict#1', ['papaya-7']);
+
+      await manager.sendMessage(id, 'Remember: codeword two is walnut-9. Reply with exactly: OK');
+      await waitFor('A2 second result', () => resultCount(manager.getMessages(id)) >= 2, 120_000);
+      dlog(`A2 turn-2 msgs: ${describeMessages(manager.getMessages(id))}`);
+      logDisk(configDir, 'A2 after turn 2 (pre-evict)', ['papaya-7', 'walnut-9']);
+      await waitFor('A2 reaped twice', () => !manager.isSessionRunning(id), 45_000);
+      // Give the CLI a beat, then check what survived the eviction kill.
+      await new Promise((r) => setTimeout(r, 1_500));
+      logDisk(configDir, 'A2 after evict#2', ['papaya-7', 'walnut-9']);
+
+      // Fresh manager = container restart.
+      await manager.stopAll();
+      const manager2 = new SessionManager(workDir, {
+        idleEvictionMs: 60 * 60_000,
+        automatedIdleEvictionMs: 60 * 60_000,
+        evictionPollMs: 60_000,
+      });
+      managers.push(manager2);
+      await manager2.sendMessage(
+        id,
+        'What are codeword one and codeword two? Reply with only the two codewords.'
+      );
+      await waitFor('A2 post-restart result', () => resultCount(manager2.getMessages(id)) >= 1, 120_000);
+      const reply = assistantText(manager2.getMessages(id));
+      dlog(`A2 post-restart msgs: ${describeMessages(manager2.getMessages(id))}`);
+      dlog(`A2: post-restart reply=${JSON.stringify(reply)}`);
+
+      expect(reply).toContain('papaya-7');
+      expect(reply).toContain('walnut-9');
+    },
+    360_000
+  );
+
+  it(
+    'a shouldQuery:false append into a cold automated session reaches disk despite instant eviction',
+    async () => {
+      const manager = new SessionManager(workDir, {
+        idleEvictionMs: 0,
+        automatedIdleEvictionMs: 0,
+        evictionPollMs: 250,
+      });
+      managers.push(manager);
+
+      const session = await manager.createSession({
+        initialMessage: 'Reply with exactly: ready',
+        metadata: { isAutomated: true },
+        model: MODEL,
+      });
+      const id = session.id;
+      await waitFor('D2 first result', () => resultCount(manager.getMessages(id)) >= 1, 120_000);
+      await waitFor('D2 reaped', () => !manager.isSessionRunning(id), 45_000);
+      logDisk(configDir, 'D2 after evict#1', ['ready']);
+      dlog('D2: appending notification with shouldQuery:false into cold session');
+
+      await manager.sendMessage(
+        id,
+        '[Notification from agent finance-bot]: The Q3 report is ready at /tmp/q3-report-xyzzy.pdf',
+        undefined,
+        { shouldQuery: false }
+      );
+      await waitFor('D2 re-reaped after append', () => !manager.isSessionRunning(id), 45_000);
+      await new Promise((r) => setTimeout(r, 2_000));
+      dlog(`D2 post-append msgs: ${describeMessages(manager.getMessages(id))}`);
+      logDisk(configDir, 'D2 after append+evict', ['q3-report-xyzzy']);
+
+      const baseline = resultCount(manager.getMessages(id));
+      await manager.sendMessage(
+        id,
+        'What file path did the notification from finance-bot mention? Reply with only the path.'
+      );
+      await waitFor(
+        'D2 question result',
+        () => resultCount(manager.getMessages(id)) > baseline,
+        120_000
+      );
+      const reply = assistantText(manager.getMessages(id));
+      dlog(`D2 all msgs: ${describeMessages(manager.getMessages(id))}`);
+      dlog(`D2: reply=${JSON.stringify(reply)}`);
+
+      // Invariant: the transcript-only append must not be silently lost.
+      expect(grepTranscripts(configDir, 'q3-report-xyzzy')).not.toEqual([]);
+      expect(reply).toContain('q3-report-xyzzy.pdf');
+    },
+    360_000
+  );
+});

--- a/agent-container/src/session-gc.e2e.test.ts
+++ b/agent-container/src/session-gc.e2e.test.ts
@@ -1,0 +1,207 @@
+/**
+ * End-to-end session GC validation against the REAL stack: SessionManager →
+ * ClaudeCodeProcess → Agent SDK → a real `claude` CLI subprocess talking to
+ * the Anthropic API. Nothing is mocked.
+ *
+ * Verifies, at the OS level (pgrep), that:
+ *  - an automated (threshold 0) session's subprocess is reaped by the real
+ *    sweep timer once the turn settles, RSS actually released;
+ *  - an interactive session with a real timeout survives until the threshold
+ *    elapses, then is reaped;
+ *  - a reaped session resumes transparently on the next sendMessage, with
+ *    conversation context intact (--resume, not a fresh session).
+ *
+ * Opt-in only — costs real API tokens and takes ~2-4 minutes. Run this file
+ * ALONE: the pgrep assertions count every CLI subprocess spawned from this
+ * package tree, so another E2E file running in a parallel vitest worker
+ * (e.g. session-gc-durability.e2e.test.ts) makes the zero-process checks lie.
+ *   RUN_SESSION_GC_E2E=1 ANTHROPIC_API_KEY=... npx vitest run src/session-gc.e2e.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const ENABLED = process.env.RUN_SESSION_GC_E2E === '1' && !!process.env.ANTHROPIC_API_KEY;
+
+const MODEL = 'claude-haiku-4-5-20251001'; // cheap + fast; the GC is model-agnostic
+
+// The SDK spawns its bundled per-platform binary from THIS package tree —
+// counting processes whose cmdline contains this path counts exactly the
+// subprocesses this test created (and not, say, a developer's own CLI).
+const SDK_BINARY_FRAGMENT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'node_modules',
+  '@anthropic-ai'
+);
+
+function countClaudeSubprocesses(): number {
+  try {
+    const out = execSync(`pgrep -fl "${SDK_BINARY_FRAGMENT}"`, { encoding: 'utf-8' });
+    return out.trim().split('\n').filter(Boolean).length;
+  } catch {
+    return 0; // pgrep exits 1 on no match
+  }
+}
+
+async function waitFor(
+  label: string,
+  cond: () => boolean,
+  timeoutMs: number,
+  intervalMs = 250
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (cond()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`Timed out waiting for: ${label}`);
+}
+
+type AnyMessage = {
+  type?: string;
+  subtype?: string;
+  message?: { content?: Array<{ type?: string; text?: string }> };
+};
+
+function resultCount(messages: AnyMessage[]): number {
+  return messages.filter((m) => m.type === 'result').length;
+}
+
+function assistantText(messages: AnyMessage[]): string {
+  return messages
+    .filter((m) => m.type === 'assistant')
+    .flatMap((m) => m.message?.content ?? [])
+    .filter((b) => b.type === 'text')
+    .map((b) => b.text)
+    .join('\n');
+}
+
+describe.skipIf(!ENABLED)('session GC end-to-end (real CLI subprocesses)', () => {
+  let workDir: string;
+  // Loaded dynamically AFTER the env below is in place.
+  let SessionManager: typeof import('./session-manager').SessionManager;
+  const managers: Array<{ stopAll(): Promise<void> }> = [];
+
+  beforeAll(async () => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-gc-e2e-'));
+    // Isolate from the developer machine: our own persistence file, our own
+    // CLAUDE_CONFIG_DIR (no personal ~/.claude settings/hooks), and no
+    // nested-Claude-Code env bleeding into the child CLI.
+    process.env.SUPERAGENT_SESSIONS_FILE = path.join(workDir, 'sessions.json');
+    process.env.CLAUDE_CONFIG_DIR = path.join(workDir, '.claude');
+    delete process.env.CLAUDECODE;
+    delete process.env.CLAUDE_CODE_ENTRYPOINT;
+    ({ SessionManager } = await import('./session-manager'));
+    expect(countClaudeSubprocesses()).toBe(0);
+  });
+
+  afterAll(async () => {
+    for (const m of managers) await m.stopAll();
+    await waitFor('all subprocesses gone after stopAll', () => countClaudeSubprocesses() === 0, 15_000);
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it(
+    'automated session: reaped by the real sweep once settled, resumes with context intact',
+    async () => {
+      // Interactive threshold is short but nonzero: the human-style resume
+      // message below PROMOTES the automated session to the interactive
+      // class, so the re-reap at the end exercises the promoted (interactive)
+      // path — the first reap exercises the automated (threshold 0) path.
+      const manager = new SessionManager(workDir, {
+        idleEvictionMs: 5_000,
+        automatedIdleEvictionMs: 0,
+        evictionPollMs: 1_000,
+      });
+      managers.push(manager);
+
+      const session = await manager.createSession({
+        initialMessage:
+          'Remember this codeword: kumquat-42. Reply with exactly: OK',
+        metadata: { isAutomated: true },
+        model: MODEL,
+      });
+      const id = session.id;
+
+      // Turn completes → a real `claude` subprocess exists and is parked.
+      await waitFor(
+        'first result',
+        () => resultCount(manager.getMessages(id)) >= 1,
+        120_000
+      );
+      expect(countClaudeSubprocesses()).toBeGreaterThanOrEqual(1);
+
+      // The REAL 1s sweep timer must reap it (threshold 0, settle-gated).
+      await waitFor('subprocess reaped', () => !manager.isSessionRunning(id), 45_000);
+      expect(manager.hasActiveSession(id)).toBe(true); // entry survives eviction
+      await waitFor('OS process actually exited', () => countClaudeSubprocesses() === 0, 15_000);
+
+      // Resume: next message must restart with --resume, transparently, and
+      // the model must still know the codeword — proving the SAME session
+      // continued, not a fresh one.
+      await manager.sendMessage(
+        id,
+        'What was the codeword I gave you earlier? Reply with only the codeword.'
+      );
+      await waitFor(
+        'resume result',
+        () => resultCount(manager.getMessages(id)) >= 2,
+        120_000
+      );
+      expect(assistantText(manager.getMessages(id))).toContain('kumquat-42');
+
+      // And the resumed (now interactive-class, via promotion) turn gets
+      // reaped again once its 5s idle threshold elapses.
+      await waitFor('re-reaped after resume', () => !manager.isSessionRunning(id), 45_000);
+      await waitFor('OS process gone again', () => countClaudeSubprocesses() === 0, 15_000);
+    },
+    360_000
+  );
+
+  it(
+    'interactive session: survives until the real timeout elapses, then is reaped and resumable',
+    async () => {
+      const IDLE_MS = 6_000;
+      const manager = new SessionManager(workDir, {
+        idleEvictionMs: IDLE_MS,
+        automatedIdleEvictionMs: 0,
+        evictionPollMs: 1_000,
+      });
+      managers.push(manager);
+
+      const session = await manager.createSession({
+        initialMessage: 'Reply with exactly: hello',
+        model: MODEL,
+      });
+      const id = session.id;
+      await waitFor(
+        'first result',
+        () => resultCount(manager.getMessages(id)) >= 1,
+        120_000
+      );
+      const settledAt = Date.now();
+
+      // Inside the idle window several sweeps fire — none may evict.
+      await new Promise((r) => setTimeout(r, 2_500));
+      expect(manager.isSessionRunning(id)).toBe(true);
+
+      // Past the threshold the sweep must take it.
+      await waitFor('reaped after timeout', () => !manager.isSessionRunning(id), 45_000);
+      expect(Date.now() - settledAt).toBeGreaterThanOrEqual(IDLE_MS - 1_500);
+
+      // Interactive resume path works the same way.
+      await manager.sendMessage(id, 'Reply with exactly: hello again');
+      await waitFor(
+        'resume result',
+        () => resultCount(manager.getMessages(id)) >= 2,
+        120_000
+      );
+      expect(manager.isSessionRunning(id)).toBe(true);
+    },
+    360_000
+  );
+});

--- a/agent-container/src/session-manager-idle-eviction.test.ts
+++ b/agent-container/src/session-manager-idle-eviction.test.ts
@@ -34,6 +34,7 @@ class MockClaudeProcess extends EventEmitter {
   stopCalls = 0
   disposeCalls = 0
   sendMessageCalls = 0
+  lastStopOptions: { graceful?: boolean } | undefined
   sessionId: string
 
   constructor(options: { sessionId: string }) {
@@ -67,14 +68,15 @@ class MockClaudeProcess extends EventEmitter {
     this.emit('init-complete')
   }
 
-  async stop(): Promise<void> {
+  async stop(options?: { graceful?: boolean }): Promise<void> {
     this.stopCalls++
+    this.lastStopOptions = options
     this.running = false
   }
 
-  async dispose(): Promise<void> {
+  async dispose(options?: { graceful?: boolean }): Promise<void> {
     this.disposeCalls++
-    await this.stop()
+    await this.stop(options)
   }
 
   isRunning(): boolean {
@@ -481,6 +483,32 @@ describe('SessionManager idle eviction', () => {
     } finally {
       await promoManager.stopAll()
     }
+  })
+
+  it('eviction stops the process GRACEFULLY (transcript-flush protection)', async () => {
+    // A hard abort races the CLI's transcript flush — the durability E2E
+    // proved probabilistic loss of the latest turns. This pins the graceful
+    // flag at unit level so a revert can't slip through the normal suite.
+    const { proc } = await createIdleSession({ metadata: { isAutomated: true } })
+    await manager.evictIdleSessions()
+    expect(proc.stopCalls).toBe(1)
+    expect(proc.lastStopOptions?.graceful).toBe(true)
+  })
+
+  it('stopAll disposes gracefully; deleteSession disposes hard', async () => {
+    // stopAll precedes a container restart that will resume these sessions —
+    // transcripts must flush. deleteSession's transcript is doomed anyway,
+    // so it may keep the fast hard kill. Both must DISPOSE (terminal), so a
+    // straggler interrupt/continuation can't revive an untracked subprocess.
+    const { id, proc } = await createIdleSession()
+    await manager.deleteSession(id)
+    expect(proc.disposeCalls).toBe(1)
+    expect(proc.lastStopOptions?.graceful).toBeFalsy()
+
+    const { proc: proc2 } = await createIdleSession()
+    await manager.stopAll()
+    expect(proc2.disposeCalls).toBe(1)
+    expect(proc2.lastStopOptions?.graceful).toBe(true)
   })
 
   it('a send that bypasses SessionManager.sendMessage still marks the session busy (outbound-message event)', async () => {

--- a/agent-container/src/session-manager-idle-eviction.test.ts
+++ b/agent-container/src/session-manager-idle-eviction.test.ts
@@ -34,6 +34,7 @@ class MockClaudeProcess extends EventEmitter {
   stopCalls = 0
   disposeCalls = 0
   sendMessageCalls = 0
+  sentContents: string[] = []
   lastStopOptions: { graceful?: boolean } | undefined
   sessionId: string
 
@@ -55,8 +56,9 @@ class MockClaudeProcess extends EventEmitter {
     this.running = true
   }
 
-  async sendMessage(): Promise<void> {
+  async sendMessage(content?: string): Promise<void> {
     this.sendMessageCalls++
+    this.sentContents.push(content ?? '')
     if (nextInitFailure) {
       const err = nextInitFailure
       nextInitFailure = null
@@ -238,16 +240,50 @@ describe('SessionManager idle eviction', () => {
     expect(proc.stopCalls).toBe(1)
   })
 
-  it('treats result as the idle signal when no state events were seen', async () => {
+  it('a bare result without an idle event does NOT settle (state events are authoritative)', async () => {
+    // This container always pins a CLI that emits session_state_changed, so a
+    // result arriving before any state event (the pre-init running event is
+    // dropped by listener-attach timing; queued-message streams contain
+    // intermediate results) must not read as idle — a queued turn may still
+    // be pending.
     const session = await manager.createSession({ initialMessage: 'hi' })
     const proc = spawnedProcesses[spawnedProcesses.length - 1]
     proc.emit('message', { type: 'result', subtype: 'success' })
     await pastThreshold()
 
     await manager.evictIdleSessions()
+    expect(proc.stopCalls).toBe(0)
 
+    emitIdle(proc) // the authoritative signal
+    await pastThreshold()
+    await manager.evictIdleSessions()
     expect(proc.stopCalls).toBe(1)
     expect(manager.hasActiveSession(session.id)).toBe(true)
+  })
+
+  it('an intermediate result with a message queued cannot evict the pending turn', async () => {
+    // Real capture (queued-message-final-response) shows four results before
+    // the single final idle. A threshold-0 sweep landing after result #1
+    // must not kill the queued turns.
+    const promoOff = new SessionManager(workDir, {
+      idleEvictionMs: 0,
+      automatedIdleEvictionMs: 0,
+    })
+    try {
+      const session = await promoOff.createSession({ initialMessage: 'first question' })
+      const proc = spawnedProcesses[spawnedProcesses.length - 1]
+      await promoOff.sendMessage(session.id, 'second question') // queued mid-turn
+
+      proc.emit('message', { type: 'result', subtype: 'success' }) // turn 1 done, turn 2 pending
+      await promoOff.evictIdleSessions()
+      expect(proc.stopCalls).toBe(0)
+
+      emitSettled(proc) // turn 2's result + the real final idle
+      await promoOff.evictIdleSessions()
+      expect(proc.stopCalls).toBe(1)
+    } finally {
+      await promoOff.stopAll()
+    }
   })
 
   it('sendMessage after eviction restarts the same process transparently', async () => {
@@ -313,16 +349,24 @@ describe('SessionManager idle eviction', () => {
     expect(proc.stopCalls).toBe(0)
   })
 
-  it('assistant traffic flips busy on a legacy stream without state events', async () => {
+  it('assistant traffic neither settles nor pins an authority tracker', async () => {
+    // Under state-event authority, stream traffic is not a settlement signal
+    // in either direction: a result + assistant frames stay busy until the
+    // idle event, and post-idle echoes don't re-pin.
     const session = await manager.createSession({ initialMessage: 'hi' })
     const proc = spawnedProcesses[spawnedProcesses.length - 1]
-    proc.emit('message', { type: 'result', subtype: 'success' }) // legacy settle
+    proc.emit('message', { type: 'result', subtype: 'success' })
     proc.emit('message', { type: 'assistant', message: { content: [] } })
     await pastThreshold()
 
     await manager.evictIdleSessions()
+    expect(proc.stopCalls).toBe(0) // no idle event yet — still busy
 
-    expect(proc.stopCalls).toBe(0)
+    emitIdle(proc)
+    proc.emit('message', { type: 'assistant', message: { content: [] } }) // late echo
+    await pastThreshold()
+    await manager.evictIdleSessions()
+    expect(proc.stopCalls).toBe(1)
     expect(manager.hasActiveSession(session.id)).toBe(true)
   })
 
@@ -589,6 +633,51 @@ describe('SessionManager idle eviction', () => {
     } finally {
       await restarted.stopAll()
     }
+  })
+
+  it('concurrent sends into a cold session are delivered in order', async () => {
+    // A half-initialized session must not be visible to concurrent senders:
+    // if the second caller can send while the first is still inside
+    // resumeSession, the model receives the messages in reverse order.
+    const { id } = await createIdleSession()
+    await manager.stopAll()
+
+    const restarted = new SessionManager(workDir, {
+      idleEvictionMs: IDLE_MS,
+      automatedIdleEvictionMs: 0,
+    })
+    try {
+      nextStartDelayMs = 50
+      await Promise.all([
+        restarted.sendMessage(id, 'first'),
+        restarted.sendMessage(id, 'second'),
+      ])
+      nextStartDelayMs = 0
+
+      const proc = spawnedProcesses[spawnedProcesses.length - 1]
+      expect(proc.sentContents).toEqual(['first', 'second'])
+    } finally {
+      await restarted.stopAll()
+    }
+  })
+
+  it('background-task bookkeeping resets when the process is replaced (tasks die with the CLI)', async () => {
+    // background_tasks_changed is process-local and a fresh process emits no
+    // initial snapshot: a task id carried across a process replacement
+    // (interrupt/crash mid-task) would pin the session unevictable forever.
+    const { proc } = await createIdleSession({ metadata: { isAutomated: true } })
+    proc.emit('message', { type: 'system', subtype: 'task_started', task_id: 'orphan-1' })
+
+    await manager.evictIdleSessions()
+    expect(proc.stopCalls).toBe(0) // held by the live task
+
+    // The CLI process is replaced (user interrupt / crash) — the task died
+    // with it, and no terminal signal or snapshot will ever arrive for it.
+    proc.emit('query-start')
+    emitSettled(proc)
+
+    await manager.evictIdleSessions()
+    expect(proc.stopCalls).toBe(1)
   })
 
   it('a shouldQuery:false append does NOT promote an automated session', async () => {

--- a/agent-container/src/session-manager-idle-eviction.test.ts
+++ b/agent-container/src/session-manager-idle-eviction.test.ts
@@ -1,0 +1,587 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+const mockReleaseBrowserLock = vi.fn(() => false)
+vi.mock('./browser-state', () => ({
+  releaseBrowserLock: (...args: unknown[]) => mockReleaseBrowserLock(...(args as [])),
+}))
+
+const persistedSessions = new Map<string, Record<string, unknown>>()
+vi.mock('./session-persistence', () => ({
+  SessionPersistence: class {
+    saveSession(meta: { sessionId: string } & Record<string, unknown>) {
+      persistedSessions.set(meta.sessionId, meta)
+    }
+    getSession(id: string) { return persistedSessions.get(id) ?? null }
+    deleteSession() {}
+    updateLastActivity() {}
+    updateEffort() {}
+    updateModel() {}
+    updateMetadata(id: string, metadata: Record<string, unknown> | undefined) {
+      const existing = persistedSessions.get(id)
+      if (existing) persistedSessions.set(id, { ...existing, metadata })
+    }
+  },
+}))
+
+// Minimal stand-in for ClaudeCodeProcess: an EventEmitter whose sendMessage
+// emits the init handshake createSession waits on.
+class MockClaudeProcess extends EventEmitter {
+  running = false
+  stopCalls = 0
+  disposeCalls = 0
+  sendMessageCalls = 0
+  sessionId: string
+
+  constructor(options: { sessionId: string }) {
+    super()
+    this.sessionId = options.sessionId
+  }
+
+  async start(): Promise<void> {
+    if (nextStartDelayMs > 0) {
+      const delay = nextStartDelayMs
+      await new Promise((r) => setTimeout(r, delay))
+    }
+    if (nextStartFailure) {
+      const err = nextStartFailure
+      nextStartFailure = null
+      throw err
+    }
+    this.running = true
+  }
+
+  async sendMessage(): Promise<void> {
+    this.sendMessageCalls++
+    if (nextInitFailure) {
+      const err = nextInitFailure
+      nextInitFailure = null
+      this.emit('error', err)
+      return
+    }
+    this.running = true
+    this.emit('claude-session-id', this.sessionId)
+    this.emit('init-complete')
+  }
+
+  async stop(): Promise<void> {
+    this.stopCalls++
+    this.running = false
+  }
+
+  async dispose(): Promise<void> {
+    this.disposeCalls++
+    await this.stop()
+  }
+
+  isRunning(): boolean {
+    return this.running
+  }
+
+  get slashCommands() {
+    return []
+  }
+}
+
+const spawnedProcesses: MockClaudeProcess[] = []
+// One-shot failure/latency injection for the next spawned process.
+let nextInitFailure: Error | null = null
+let nextStartFailure: Error | null = null
+let nextStartDelayMs = 0
+vi.mock('./claude-code', () => ({
+  ClaudeCodeProcess: class {
+    constructor(options: { sessionId: string }) {
+      const proc = new MockClaudeProcess(options)
+      spawnedProcesses.push(proc)
+      return proc
+    }
+  },
+}))
+
+import { SessionManager } from './session-manager'
+
+const IDLE_MS = 10
+
+function emitIdle(proc: MockClaudeProcess) {
+  proc.emit('message', { type: 'system', subtype: 'session_state_changed', state: 'idle' })
+}
+
+// Settled turn: result then idle (matches CLI order; bare idle is ignored).
+function emitSettled(proc: MockClaudeProcess) {
+  proc.emit('message', { type: 'result', subtype: 'success' })
+  emitIdle(proc)
+}
+
+async function pastThreshold() {
+  await new Promise((r) => setTimeout(r, IDLE_MS + 10))
+}
+
+describe('SessionManager idle eviction', () => {
+  let manager: SessionManager
+  let workDir: string
+
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-manager-test-'))
+    spawnedProcesses.length = 0
+    persistedSessions.clear()
+    mockReleaseBrowserLock.mockClear()
+    nextInitFailure = null
+    nextStartFailure = null
+    nextStartDelayMs = 0
+    // Interactive waits IDLE_MS; automated (cron/webhook) evicts immediately when idle.
+    manager = new SessionManager(workDir, {
+      idleEvictionMs: IDLE_MS,
+      automatedIdleEvictionMs: 0,
+    })
+  })
+
+  afterEach(async () => {
+    await manager.stopAll()
+    fs.rmSync(workDir, { recursive: true, force: true })
+  })
+
+  async function createIdleSession(options?: {
+    metadata?: Record<string, unknown>
+  }): Promise<{ id: string; proc: MockClaudeProcess }> {
+    const session = await manager.createSession({
+      initialMessage: 'hi',
+      metadata: options?.metadata,
+    })
+    const proc = spawnedProcesses[spawnedProcesses.length - 1]
+    emitSettled(proc)
+    return { id: session.id, proc }
+  }
+
+  it('stops the process of a session idle past the threshold and keeps the session entry', async () => {
+    const { id, proc } = await createIdleSession()
+    await pastThreshold()
+
+    await manager.evictIdleSessions()
+
+    expect(proc.stopCalls).toBe(1)
+    expect(proc.isRunning()).toBe(false)
+    // Entry survives: still resolvable without a resume-from-persistence.
+    expect(manager.hasActiveSession(id)).toBe(true)
+    expect(mockReleaseBrowserLock).toHaveBeenCalledWith(id)
+  })
+
+  it('does not evict a session that is still busy', async () => {
+    const { proc } = await createIdleSession()
+    proc.emit('message', { type: 'system', subtype: 'session_state_changed', state: 'running' })
+    await pastThreshold()
+
+    await manager.evictIdleSessions()
+
+    expect(proc.stopCalls).toBe(0)
+  })
+
+  it('does not evict an interactive session before the idle threshold elapses', async () => {
+    const { proc } = await createIdleSession()
+
+    await manager.evictIdleSessions()
+
+    expect(proc.stopCalls).toBe(0)
+  })
+
+  it('evicts an automated session as soon as it is idle (threshold 0)', async () => {
+    const { id, proc } = await createIdleSession({ metadata: { isAutomated: true } })
+
+    await manager.evictIdleSessions()
+
+    expect(proc.stopCalls).toBe(1)
+    expect(proc.isRunning()).toBe(false)
+    expect(manager.hasActiveSession(id)).toBe(true)
+  })
+
+  it('ignores idle without a result for this turn (stale idle race)', async () => {
+    const session = await manager.createSession({ initialMessage: 'hi' })
+    const proc = spawnedProcesses[spawnedProcesses.length - 1]
+    emitIdle(proc) // no preceding result
+    await pastThreshold()
+
+    await manager.evictIdleSessions()
+
+    expect(proc.stopCalls).toBe(0)
+    expect(manager.hasActiveSession(session.id)).toBe(true)
+  })
+
+  it('does not evict while a background task is running, evicts after it settles', async () => {
+    const { proc } = await createIdleSession()
+    proc.emit('message', { type: 'system', subtype: 'task_started', task_id: 'bg-1' })
+    emitSettled(proc) // SDK fires idle at turn-end while background work runs
+    await pastThreshold()
+
+    await manager.evictIdleSessions()
+    expect(proc.stopCalls).toBe(0)
+
+    proc.emit('message', { type: 'system', subtype: 'task_updated', task_id: 'bg-1', patch: { status: 'completed' } })
+    emitSettled(proc)
+    await pastThreshold()
+
+    await manager.evictIdleSessions()
+    expect(proc.stopCalls).toBe(1)
+  })
+
+  it('clears a background task via task_notification too', async () => {
+    const { proc } = await createIdleSession()
+    proc.emit('message', { type: 'system', subtype: 'task_started', task_id: 'bg-2' })
+    proc.emit('message', { type: 'system', subtype: 'task_notification', task_id: 'bg-2', status: 'completed' })
+    emitSettled(proc)
+    await pastThreshold()
+
+    await manager.evictIdleSessions()
+    expect(proc.stopCalls).toBe(1)
+  })
+
+  it('treats result as the idle signal when no state events were seen', async () => {
+    const session = await manager.createSession({ initialMessage: 'hi' })
+    const proc = spawnedProcesses[spawnedProcesses.length - 1]
+    proc.emit('message', { type: 'result', subtype: 'success' })
+    await pastThreshold()
+
+    await manager.evictIdleSessions()
+
+    expect(proc.stopCalls).toBe(1)
+    expect(manager.hasActiveSession(session.id)).toBe(true)
+  })
+
+  it('sendMessage after eviction restarts the same process transparently', async () => {
+    const { id, proc } = await createIdleSession()
+    await pastThreshold()
+    await manager.evictIdleSessions()
+    expect(proc.isRunning()).toBe(false)
+
+    await manager.sendMessage(id, 'follow-up')
+
+    expect(proc.sendMessageCalls).toBe(2) // initial + follow-up
+    expect(spawnedProcesses.length).toBe(1) // no new process object
+  })
+
+  it('evicts a session resumed via getSession that never receives a message', async () => {
+    persistedSessions.set('cold-1', {
+      sessionId: 'cold-1',
+      claudeSessionId: 'cold-1',
+      workingDirectory: workDir,
+      createdAt: new Date().toISOString(),
+      lastActivity: new Date().toISOString(),
+    })
+
+    const session = await manager.getSession('cold-1')
+    expect(session).not.toBeNull()
+    const proc = spawnedProcesses[spawnedProcesses.length - 1]
+    expect(proc.isRunning()).toBe(true)
+    await pastThreshold()
+
+    await manager.evictIdleSessions()
+
+    expect(proc.stopCalls).toBe(1)
+    expect(proc.isRunning()).toBe(false)
+    expect(manager.hasActiveSession('cold-1')).toBe(true)
+  })
+
+  it('a resumed session that receives a message goes busy and is not evicted', async () => {
+    persistedSessions.set('cold-2', {
+      sessionId: 'cold-2',
+      claudeSessionId: 'cold-2',
+      workingDirectory: workDir,
+      createdAt: new Date().toISOString(),
+      lastActivity: new Date().toISOString(),
+    })
+
+    await manager.sendMessage('cold-2', 'wake up')
+    const proc = spawnedProcesses[spawnedProcesses.length - 1]
+    await pastThreshold()
+
+    await manager.evictIdleSessions()
+
+    expect(proc.stopCalls).toBe(0)
+    expect(proc.isRunning()).toBe(true)
+  })
+
+  it('a running state event after idle prevents eviction', async () => {
+    const { proc } = await createIdleSession()
+    proc.emit('message', { type: 'system', subtype: 'session_state_changed', state: 'running' })
+    await pastThreshold()
+
+    await manager.evictIdleSessions()
+
+    expect(proc.stopCalls).toBe(0)
+  })
+
+  it('assistant traffic flips busy on a legacy stream without state events', async () => {
+    const session = await manager.createSession({ initialMessage: 'hi' })
+    const proc = spawnedProcesses[spawnedProcesses.length - 1]
+    proc.emit('message', { type: 'result', subtype: 'success' }) // legacy settle
+    proc.emit('message', { type: 'assistant', message: { content: [] } })
+    await pastThreshold()
+
+    await manager.evictIdleSessions()
+
+    expect(proc.stopCalls).toBe(0)
+    expect(manager.hasActiveSession(session.id)).toBe(true)
+  })
+
+  it('a shouldQuery:false append leaves the session evictable (no immortal busy)', async () => {
+    const { id, proc } = await createIdleSession()
+
+    // Transcript-only append (e.g. cross-agent chat notification): no turn
+    // runs, no result will ever come — must not pin the session busy.
+    await manager.sendMessage(id, 'fyi', undefined, { shouldQuery: false })
+    // The SDK may echo the appended user message into the stream.
+    proc.emit('message', { type: 'user', message: { role: 'user', content: [] } })
+    await pastThreshold()
+
+    await manager.evictIdleSessions()
+
+    expect(proc.stopCalls).toBe(1)
+    expect(manager.hasActiveSession(id)).toBe(true)
+  })
+
+  it("task_notification 'stopped' (TaskStop) clears the background hold", async () => {
+    const { proc } = await createIdleSession()
+    proc.emit('message', { type: 'system', subtype: 'task_started', task_id: 'bg-s' })
+    emitSettled(proc) // result clears any wake grace from the drain below
+    proc.emit('message', { type: 'system', subtype: 'task_notification', task_id: 'bg-s', status: 'stopped' })
+    emitSettled(proc)
+    await pastThreshold()
+
+    await manager.evictIdleSessions()
+    expect(proc.stopCalls).toBe(1)
+  })
+
+  it('a background_tasks_changed snapshot blocks and releases eviction', async () => {
+    const { proc } = await createIdleSession()
+    proc.emit('message', { type: 'system', subtype: 'background_tasks_changed', tasks: [{ task_id: 'snap-1' }] })
+    await pastThreshold()
+
+    await manager.evictIdleSessions()
+    expect(proc.stopCalls).toBe(0)
+
+    proc.emit('message', { type: 'system', subtype: 'background_tasks_changed', tasks: [] })
+    emitSettled(proc) // the wake turn after the drain
+    await pastThreshold()
+
+    await manager.evictIdleSessions()
+    expect(proc.stopCalls).toBe(1)
+  })
+
+  it('holds through the completion-wake gap and evicts only after the wake turn settles', async () => {
+    // Automated threshold 0 — the exact class exposed to the wake-gap race.
+    const gapManager = new SessionManager(workDir, {
+      idleEvictionMs: IDLE_MS,
+      automatedIdleEvictionMs: 0,
+      wakeGraceMs: 60_000,
+    })
+    try {
+      await gapManager.createSession({ initialMessage: 'hi', metadata: { isAutomated: true } })
+      const proc = spawnedProcesses[spawnedProcesses.length - 1]
+      proc.emit('message', { type: 'system', subtype: 'task_started', task_id: 'bg-w' })
+      emitSettled(proc) // premature idle: turn over, task still running
+
+      // The last task drains while the session is idle — the wake's `running`
+      // arrives 15-64ms later in real captures. A sweep in that gap must hold.
+      proc.emit('message', { type: 'system', subtype: 'task_updated', task_id: 'bg-w', patch: { status: 'completed' } })
+      await gapManager.evictIdleSessions()
+      expect(proc.stopCalls).toBe(0)
+
+      // Wake turn runs and settles — now the session is truly done.
+      proc.emit('message', { type: 'system', subtype: 'session_state_changed', state: 'running' })
+      emitSettled(proc)
+      await gapManager.evictIdleSessions()
+      expect(proc.stopCalls).toBe(1)
+    } finally {
+      await gapManager.stopAll()
+    }
+  })
+
+  it('settles after the wake grace expires when no wake ever comes', async () => {
+    const graceManager = new SessionManager(workDir, {
+      idleEvictionMs: IDLE_MS,
+      automatedIdleEvictionMs: 0,
+      wakeGraceMs: 5,
+    })
+    try {
+      await graceManager.createSession({ initialMessage: 'hi', metadata: { isAutomated: true } })
+      const proc = spawnedProcesses[spawnedProcesses.length - 1]
+      proc.emit('message', { type: 'system', subtype: 'task_started', task_id: 'bg-g' })
+      emitSettled(proc)
+      proc.emit('message', { type: 'system', subtype: 'task_updated', task_id: 'bg-g', patch: { status: 'completed' } })
+
+      await graceManager.evictIdleSessions()
+      expect(proc.stopCalls).toBe(0) // inside the grace
+
+      await new Promise((r) => setTimeout(r, 20))
+      await graceManager.evictIdleSessions()
+      expect(proc.stopCalls).toBe(1) // grace expired, no pin
+    } finally {
+      await graceManager.stopAll()
+    }
+  })
+
+  it('isAutomated survives persistence, so a bare-resumed automated session keeps its eviction class', async () => {
+    const session = await manager.createSession({
+      initialMessage: 'hi',
+      metadata: { isAutomated: true },
+    })
+    const firstProc = spawnedProcesses[spawnedProcesses.length - 1]
+    emitSettled(firstProc)
+    await manager.stopAll()
+
+    // Fresh manager = container restart. Interactive threshold is huge, so
+    // only the restored isAutomated flag (threshold 0) can allow eviction.
+    // Resume via a bare getSession — a human message would (correctly)
+    // promote the session to interactive instead.
+    const restarted = new SessionManager(workDir, {
+      idleEvictionMs: 60 * 60_000,
+      automatedIdleEvictionMs: 0,
+    })
+    try {
+      const resumed = await restarted.getSession(session.id)
+      expect(resumed?.metadata?.isAutomated).toBe(true)
+      const proc = spawnedProcesses[spawnedProcesses.length - 1]
+
+      await restarted.evictIdleSessions()
+      expect(proc.stopCalls).toBe(1)
+    } finally {
+      await restarted.stopAll()
+    }
+  })
+
+  it('a human message promotes an automated session to the interactive class', async () => {
+    const promoManager = new SessionManager(workDir, {
+      idleEvictionMs: 60 * 60_000, // interactive effectively off
+      automatedIdleEvictionMs: 0,
+    })
+    try {
+      const session = await promoManager.createSession({
+        initialMessage: 'hi',
+        metadata: { isAutomated: true },
+      })
+      const proc = spawnedProcesses[spawnedProcesses.length - 1]
+      emitSettled(proc)
+
+      await promoManager.evictIdleSessions()
+      expect(proc.stopCalls).toBe(1) // automated: reaped at threshold 0
+
+      // Human follow-up: resumes AND promotes — settled turns no longer
+      // evict at threshold 0.
+      await promoManager.sendMessage(session.id, 'hello, human here')
+      emitSettled(proc)
+      await promoManager.evictIdleSessions()
+      expect(proc.stopCalls).toBe(1) // interactive 1h threshold now applies
+
+      // Promotion is persisted: after a restart, a bare resume is still
+      // interactive-class.
+      expect(
+        (persistedSessions.get(session.id)?.metadata as { isAutomated?: boolean })?.isAutomated
+      ).toBe(false)
+    } finally {
+      await promoManager.stopAll()
+    }
+  })
+
+  it('a send that bypasses SessionManager.sendMessage still marks the session busy (outbound-message event)', async () => {
+    // The MCP-injection continuation calls ClaudeCodeProcess.sendMessage
+    // directly; the process emits outbound-message and the manager listener
+    // must flip the tracker busy, or a sweep landing before the CLI's
+    // 'running' event kills the turn it just started.
+    const { proc } = await createIdleSession({ metadata: { isAutomated: true } })
+
+    proc.emit('outbound-message', { expectsResponse: true })
+    await manager.evictIdleSessions()
+    expect(proc.stopCalls).toBe(0)
+
+    // The bypass turn then completes normally and the session settles again.
+    emitSettled(proc)
+    await manager.evictIdleSessions()
+    expect(proc.stopCalls).toBe(1)
+  })
+
+  it('a failed createSession init handshake does not leak the started process', async () => {
+    nextInitFailure = new Error('CLI crashed during boot')
+    await expect(
+      manager.createSession({ initialMessage: 'hi' })
+    ).rejects.toThrow('CLI crashed during boot')
+
+    // The process was started before the handshake failed; with no session
+    // entry it is invisible to the reaper, so createSession itself must
+    // stop it.
+    const proc = spawnedProcesses[spawnedProcesses.length - 1]
+    expect(proc.stopCalls).toBeGreaterThanOrEqual(1)
+    expect(proc.isRunning()).toBe(false)
+  })
+
+  it('a failed resume does not leave a zombie session entry in the map', async () => {
+    const { id } = await createIdleSession()
+    await manager.stopAll()
+
+    const restarted = new SessionManager(workDir, {
+      idleEvictionMs: IDLE_MS,
+      automatedIdleEvictionMs: 0,
+    })
+    try {
+      nextStartFailure = new Error('resume boot failure')
+      await expect(restarted.sendMessage(id, 'hello')).rejects.toThrow()
+      // The failed resume must not leave a half-built entry that later
+      // getSession/hasActiveSession calls report as a live session.
+      expect(restarted.hasActiveSession(id)).toBe(false)
+
+      // And the session is still resumable once the failure clears.
+      await restarted.sendMessage(id, 'hello again')
+      expect(restarted.hasActiveSession(id)).toBe(true)
+    } finally {
+      await restarted.stopAll()
+    }
+  })
+
+  it('concurrent resumes of the same cold session spawn exactly one process', async () => {
+    const { id } = await createIdleSession()
+    await manager.stopAll()
+
+    const restarted = new SessionManager(workDir, {
+      idleEvictionMs: IDLE_MS,
+      automatedIdleEvictionMs: 0,
+    })
+    try {
+      nextStartDelayMs = 50 // hold both callers inside resumeSession's start()
+      const before = spawnedProcesses.length
+      await Promise.all([
+        restarted.sendMessage(id, 'from the POST route'),
+        restarted.getSession(id),
+      ])
+      nextStartDelayMs = 0
+
+      // Without dedup, both callers miss the map and each spawns a process;
+      // the loser of the sessions.set race leaks a live subprocess that no
+      // map entry (and therefore no reaper sweep) can ever reach.
+      expect(spawnedProcesses.length - before).toBe(1)
+    } finally {
+      await restarted.stopAll()
+    }
+  })
+
+  it('a shouldQuery:false append does NOT promote an automated session', async () => {
+    const promoManager = new SessionManager(workDir, {
+      idleEvictionMs: 60 * 60_000,
+      automatedIdleEvictionMs: 0,
+    })
+    try {
+      const session = await promoManager.createSession({
+        initialMessage: 'hi',
+        metadata: { isAutomated: true },
+      })
+      const proc = spawnedProcesses[spawnedProcesses.length - 1]
+      emitSettled(proc)
+
+      // Cross-agent notification append: not a human, class unchanged.
+      await promoManager.sendMessage(session.id, 'fyi', undefined, { shouldQuery: false })
+      await promoManager.evictIdleSessions()
+      expect(proc.stopCalls).toBe(1) // still automated: reaped at threshold 0
+    } finally {
+      await promoManager.stopAll()
+    }
+  })
+})

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -52,6 +52,8 @@ function formatIdleThreshold(ms: number): string {
 
 export class SessionManager extends EventEmitter {
   private sessions: Map<string, SessionData> = new Map();
+  // In-flight resumes, keyed by session id — see resumeSession().
+  private resuming: Map<string, Promise<SessionData | undefined>> = new Map();
   private baseWorkingDirectory: string;
   private persistence: SessionPersistence;
   private readonly idleEvictionMs: number;
@@ -255,7 +257,15 @@ export class SessionManager extends EventEmitter {
       process,
       messages: [],
       subscribers: new Set(),
-      settlement: new SessionSettlementTracker({ wakeGraceMs: this.wakeGraceMs }),
+      // Authority: this container always runs the CLI with
+      // CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=1, so idle comes from state
+      // events only — a bare result (pre-init running event is dropped by
+      // listener-attach timing; queued streams carry intermediate results)
+      // must never read as settled.
+      settlement: new SessionSettlementTracker({
+        wakeGraceMs: this.wakeGraceMs,
+        stateEventsAuthority: true,
+      }),
       eviction: null,
     };
 
@@ -268,6 +278,12 @@ export class SessionManager extends EventEmitter {
     // continuation), so the tracker can never read settled mid-turn.
     process.on('outbound-message', (info: { expectsResponse: boolean }) => {
       sessionData.settlement.noteOutboundMessage(info);
+    });
+
+    // Background tasks die with the CLI process, and a fresh process emits no
+    // initial snapshot — carried-over ids would pin the session forever.
+    process.on('query-start', () => {
+      sessionData.settlement.resetBackgroundTasks();
     });
 
     process.on('stderr', (error: string) => {
@@ -308,7 +324,27 @@ export class SessionManager extends EventEmitter {
     return session;
   }
 
-  private async resumeSession(sessionId: string): Promise<SessionData | undefined> {
+  /**
+   * Dedup wrapper: concurrent callers of a cold session (a POST racing a GET,
+   * two rapid sends after a container restart) share ONE in-flight resume and
+   * only see the session once it has fully started. Publishing a
+   * half-initialized entry instead (the previous approach) let a second
+   * sender deliver its message before the first caller's — reversing
+   * conversation order at the model.
+   */
+  private resumeSession(sessionId: string): Promise<SessionData | undefined> {
+    const inFlight = this.resuming.get(sessionId);
+    if (inFlight) {
+      return inFlight;
+    }
+    const promise = this.doResumeSession(sessionId).finally(() => {
+      this.resuming.delete(sessionId);
+    });
+    this.resuming.set(sessionId, promise);
+    return promise;
+  }
+
+  private async doResumeSession(sessionId: string): Promise<SessionData | undefined> {
     // Check if we have persisted data for this session
     const persisted = this.persistence.getSession(sessionId);
     if (!persisted) {
@@ -317,7 +353,6 @@ export class SessionManager extends EventEmitter {
 
     console.log(`Attempting to resume session ${sessionId} with Claude session ID ${persisted.claudeSessionId}`);
 
-    let sessionData: SessionData | undefined;
     try {
       // Create a new Claude Code process with resume
       const process = new ClaudeCodeProcess({
@@ -364,10 +399,10 @@ export class SessionManager extends EventEmitter {
         settlement: new SessionSettlementTracker({
           bornIdle: true,
           wakeGraceMs: this.wakeGraceMs,
+          stateEventsAuthority: true,
         }),
         eviction: null,
       };
-      sessionData = data;
 
       // Set up event listeners (same as createSession)
       process.on('message', (message: SDKMessage) => {
@@ -378,6 +413,10 @@ export class SessionManager extends EventEmitter {
         data.settlement.noteOutboundMessage(info);
       });
 
+      process.on('query-start', () => {
+        data.settlement.resetBackgroundTasks();
+      });
+
       process.on('stderr', (error: string) => {
         console.error(`[Session ${sessionId}] stderr:`, error);
       });
@@ -386,23 +425,19 @@ export class SessionManager extends EventEmitter {
         console.log(`Resumed session ${sessionId} exited with code ${code}`);
       });
 
-      this.sessions.set(sessionId, data);
-
       // Start the process (which will resume the Claude session)
       // Note: slash commands are captured later when init event fires via WebSocket
       await process.start();
+
+      // Publish only once fully started — concurrent callers wait on the
+      // resuming promise, never on a half-initialized entry. A failed start
+      // therefore also can't leave a zombie in the map.
+      this.sessions.set(sessionId, data);
 
       console.log(`Successfully resumed session ${sessionId}`);
       return data;
     } catch (error) {
       console.error(`Failed to resume session ${sessionId}:`, error);
-      // The entry goes into the map BEFORE process.start() (which is also what
-      // dedupes concurrent resumes), so a failed start must remove OUR entry
-      // again — otherwise later calls find a zombie and report a dead session
-      // as live.
-      if (sessionData && this.sessions.get(sessionId) === sessionData) {
-        this.sessions.delete(sessionId);
-      }
       return undefined;
     }
   }

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -7,23 +7,95 @@ import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import { releaseBrowserLock } from './browser-state';
 import { claudeSettingsSchema, SESSION_RETENTION_DAYS } from './claude-settings-schema';
+import { SessionSettlementTracker } from './session-settlement';
 
 interface SessionData {
   session: Session;
   process: ClaudeCodeProcess;
   messages: SDKMessage[];
   subscribers: Set<(message: SDKMessage) => void>;
+  // Whether the session is settled (turn over, no background work, not in a
+  // completion-wake window) — the only state a subprocess may be stopped in.
+  settlement: SessionSettlementTracker;
+  eviction: Promise<void> | null;
+}
+
+const DEFAULT_INTERACTIVE_IDLE_EVICTION_MINUTES = 5;
+const DEFAULT_AUTOMATED_IDLE_EVICTION_MINUTES = 0;
+const IDLE_EVICTION_POLL_MS = 30_000;
+
+// Minutes → ms. < 0 disables that class; 0 = evict as soon as idle.
+// Parsed once at startup so misconfiguration is loud.
+function idleEvictionMsFromEnv(
+  envName: string,
+  defaultMinutes: number
+): number {
+  const raw = process.env[envName];
+  if (raw === undefined || raw.trim() === '') {
+    return defaultMinutes * 60_000;
+  }
+  const minutes = Number(raw);
+  if (!Number.isFinite(minutes)) {
+    console.error(
+      `Invalid ${envName} "${raw}" — using default ${defaultMinutes}`
+    );
+    return defaultMinutes * 60_000;
+  }
+  return minutes * 60_000;
+}
+
+function formatIdleThreshold(ms: number): string {
+  if (ms < 0) return 'disabled';
+  if (ms === 0) return 'immediate';
+  return `${Math.round(ms / 60_000)}m`;
 }
 
 export class SessionManager extends EventEmitter {
   private sessions: Map<string, SessionData> = new Map();
   private baseWorkingDirectory: string;
   private persistence: SessionPersistence;
+  private readonly idleEvictionMs: number;
+  private readonly automatedIdleEvictionMs: number;
+  private readonly wakeGraceMs: number | undefined;
+  private evictionTimer: ReturnType<typeof setInterval> | null = null;
 
-  constructor(baseWorkingDirectory: string = '/workspace') {
+  constructor(
+    baseWorkingDirectory: string = '/workspace',
+    options?: {
+      idleEvictionMs?: number;
+      automatedIdleEvictionMs?: number;
+      wakeGraceMs?: number;
+      evictionPollMs?: number;
+    }
+  ) {
     super();
     this.baseWorkingDirectory = baseWorkingDirectory;
     this.persistence = new SessionPersistence();
+    this.wakeGraceMs = options?.wakeGraceMs;
+    this.idleEvictionMs =
+      options?.idleEvictionMs ??
+      idleEvictionMsFromEnv(
+        'SESSION_IDLE_EVICTION_MINUTES',
+        DEFAULT_INTERACTIVE_IDLE_EVICTION_MINUTES
+      );
+    this.automatedIdleEvictionMs =
+      options?.automatedIdleEvictionMs ??
+      idleEvictionMsFromEnv(
+        'SESSION_AUTOMATED_IDLE_EVICTION_MINUTES',
+        DEFAULT_AUTOMATED_IDLE_EVICTION_MINUTES
+      );
+    if (this.idleEvictionMs >= 0 || this.automatedIdleEvictionMs >= 0) {
+      console.log(
+        `[SessionManager] Idle session eviction enabled: interactive=${formatIdleThreshold(this.idleEvictionMs)}, automated=${formatIdleThreshold(this.automatedIdleEvictionMs)}`
+      );
+      this.evictionTimer = setInterval(() => {
+        this.evictIdleSessions().catch((error) => {
+          console.error('[SessionManager] Idle eviction sweep failed:', error);
+        });
+      }, options?.evictionPollMs ?? IDLE_EVICTION_POLL_MS);
+      // Never keep the process alive just for the reaper.
+      this.evictionTimer.unref?.();
+    }
 
     // Ensure base directory exists
     if (!fs.existsSync(this.baseWorkingDirectory)) {
@@ -144,14 +216,22 @@ export class SessionManager extends EventEmitter {
       });
     });
 
-    // Start the Claude Code process
-    await process.start();
+    // Start the process and wait for the init handshake. On ANY failure the
+    // started process must be torn down here: it has no session entry yet, so
+    // nothing else — not the reaper, not a delete — could ever reach it.
+    let claudeSessionId: string;
+    try {
+      await process.start();
 
-    // Send the initial message - this triggers Claude to emit the session ID
-    await process.sendMessage(request.initialMessage, request.initialMessageUuid);
+      // Send the initial message - this triggers Claude to emit the session ID
+      await process.sendMessage(request.initialMessage, request.initialMessageUuid);
 
-    // Wait for init to complete (session ID + slash commands)
-    const claudeSessionId = await initCompletePromise;
+      // Wait for init to complete (session ID + slash commands)
+      claudeSessionId = await initCompletePromise;
+    } catch (error) {
+      await process.dispose().catch(() => undefined);
+      throw error;
+    }
     console.log(`Got Claude session ID: ${claudeSessionId}`);
 
     // Use Claude's session ID as the canonical session ID
@@ -175,11 +255,19 @@ export class SessionManager extends EventEmitter {
       process,
       messages: [],
       subscribers: new Set(),
+      settlement: new SessionSettlementTracker({ wakeGraceMs: this.wakeGraceMs }),
+      eviction: null,
     };
 
     // Set up event listeners
     process.on('message', (message: SDKMessage) => {
       this.handleMessage(sessionId, message);
+    });
+
+    // Covers send paths that bypass this.sendMessage (e.g. the MCP-injection
+    // continuation), so the tracker can never read settled mid-turn.
+    process.on('outbound-message', (info: { expectsResponse: boolean }) => {
+      sessionData.settlement.noteOutboundMessage(info);
     });
 
     process.on('stderr', (error: string) => {
@@ -211,6 +299,7 @@ export class SessionManager extends EventEmitter {
       maxBudgetUsd: request.maxBudgetUsd,
       customEnvVars: request.customEnvVars,
       effort: request.effort,
+      metadata: request.metadata,
     });
 
     this.sessions.set(sessionId, sessionData);
@@ -228,6 +317,7 @@ export class SessionManager extends EventEmitter {
 
     console.log(`Attempting to resume session ${sessionId} with Claude session ID ${persisted.claudeSessionId}`);
 
+    let sessionData: SessionData | undefined;
     try {
       // Create a new Claude Code process with resume
       const process = new ClaudeCodeProcess({
@@ -254,22 +344,38 @@ export class SessionManager extends EventEmitter {
         id: sessionId,
         createdAt: new Date(persisted.createdAt),
         lastActivity: new Date(),
+        // Restore metadata so a resumed automated session keeps its eviction
+        // class (and its release-browser-lock-on-result behavior).
+        metadata: persisted.metadata,
         workingDirectory: persisted.workingDirectory,
         systemPrompt: persisted.systemPrompt,
         modelPromptHints: persisted.modelPromptHints,
         availableEnvVars: persisted.availableEnvVars,
       };
 
-      const sessionData: SessionData = {
+      const data: SessionData = {
         session,
         process,
         messages: [],
         subscribers: new Set(),
+        // Born-idle: a bare getSession() resume gets no turn (no result, never
+        // idle), so born-busy would park the process beyond the reaper forever.
+        // sendMessage marks the tracker busy itself right after resuming.
+        settlement: new SessionSettlementTracker({
+          bornIdle: true,
+          wakeGraceMs: this.wakeGraceMs,
+        }),
+        eviction: null,
       };
+      sessionData = data;
 
       // Set up event listeners (same as createSession)
       process.on('message', (message: SDKMessage) => {
         this.handleMessage(sessionId, message);
+      });
+
+      process.on('outbound-message', (info: { expectsResponse: boolean }) => {
+        data.settlement.noteOutboundMessage(info);
       });
 
       process.on('stderr', (error: string) => {
@@ -280,16 +386,23 @@ export class SessionManager extends EventEmitter {
         console.log(`Resumed session ${sessionId} exited with code ${code}`);
       });
 
-      this.sessions.set(sessionId, sessionData);
+      this.sessions.set(sessionId, data);
 
       // Start the process (which will resume the Claude session)
       // Note: slash commands are captured later when init event fires via WebSocket
       await process.start();
 
       console.log(`Successfully resumed session ${sessionId}`);
-      return sessionData;
+      return data;
     } catch (error) {
       console.error(`Failed to resume session ${sessionId}:`, error);
+      // The entry goes into the map BEFORE process.start() (which is also what
+      // dedupes concurrent resumes), so a failed start must remove OUR entry
+      // again — otherwise later calls find a zombie and report a dead session
+      // as live.
+      if (sessionData && this.sessions.get(sessionId) === sessionData) {
+        this.sessions.delete(sessionId);
+      }
       return undefined;
     }
   }
@@ -328,8 +441,10 @@ export class SessionManager extends EventEmitter {
       console.log(`[Session ${sessionId}] Released browser lock (session deleted)`);
     }
 
-    // Stop the process
-    await sessionData.process.stop();
+    // Stop the process terminally — dispose (not stop) so a straggler
+    // interrupt/continuation can't revive a subprocess for a session that no
+    // longer exists in this map (the reaper would never see it).
+    await sessionData.process.dispose();
 
     // Clean up subscribers
     sessionData.subscribers.clear();
@@ -358,6 +473,27 @@ export class SessionManager extends EventEmitter {
       if (!sessionData) {
         throw new Error(`Session ${sessionId} not found`);
       }
+    }
+
+    // A racing idle eviction may be closing the message queue right now; wait it
+    // out, then process.sendMessage's cold-session path restarts with --resume.
+    if (sessionData.eviction) {
+      await sessionData.eviction;
+    }
+    // A shouldQuery:false append runs no turn — it must not mark the session
+    // busy, or it becomes unevictable until the next real turn.
+    const expectsResponse = options?.shouldQuery !== false;
+    sessionData.settlement.noteOutboundMessage({ expectsResponse });
+
+    // A real message into an automated session is human-originated (the
+    // scheduler and trigger-manager only ever CREATE sessions; cross-agent
+    // chat appends are shouldQuery:false) — promote it to the interactive
+    // eviction class so the conversation doesn't pay a cold restart after
+    // every turn.
+    if (expectsResponse && sessionData.session.metadata?.isAutomated) {
+      console.log(`[Session ${sessionId}] Promoting automated session to interactive (human message)`);
+      sessionData.session.metadata = { ...sessionData.session.metadata, isAutomated: false };
+      this.persistence.updateMetadata(sessionId, sessionData.session.metadata);
     }
 
     // Update last activity
@@ -428,6 +564,8 @@ export class SessionManager extends EventEmitter {
     // Store the message
     sessionData.messages.push(message);
 
+    sessionData.settlement.handleMessage(message);
+
     // Release browser lock when an automated session's turn completes.
     // The SDK query keeps the for-await loop alive waiting for the next user
     // message, so the 'exit' event never fires for idle sessions. Releasing
@@ -450,6 +588,51 @@ export class SessionManager extends EventEmitter {
 
     // Update last activity
     sessionData.session.lastActivity = new Date();
+  }
+
+  private idleThresholdMs(data: SessionData): number {
+    return data.session.metadata?.isAutomated
+      ? this.automatedIdleEvictionMs
+      : this.idleEvictionMs;
+  }
+
+  // Stop the claude subprocess of sessions idle past their class threshold.
+  // Interactive default 5m; automated (cron/webhook) default 0 = next sweep.
+  // Eviction only stops the process — SessionData + claudeSessionId survive so
+  // the next sendMessage restarts with --resume. Public for tests.
+  async evictIdleSessions(): Promise<void> {
+    const now = Date.now();
+    const evictions: Promise<void>[] = [];
+    for (const [sessionId, data] of this.sessions) {
+      if (data.eviction) continue; // already evicting
+      if (!data.settlement.isSettled(now)) continue;
+      if (!data.process.isRunning()) continue; // already cold
+      const thresholdMs = this.idleThresholdMs(data);
+      if (thresholdMs < 0) continue; // disabled for this class
+      if (now - data.session.lastActivity.getTime() < thresholdMs) continue;
+
+      data.eviction = (async () => {
+        try {
+          // An idle session has no business holding the shared browser.
+          if (releaseBrowserLock(sessionId)) {
+            console.log(`[Session ${sessionId}] Released browser lock (idle eviction)`);
+          }
+          // Graceful: let the CLI exit on stdin EOF and flush its transcript —
+          // a hard abort here races the flush and can truncate the session
+          // JSONL tail, silently losing the latest turns on the next resume.
+          await data.process.stop({ graceful: true });
+          console.log(
+            `[Session ${sessionId}] Evicted idle session process (idle ${Math.round((Date.now() - data.session.lastActivity.getTime()) / 60_000)}m)`
+          );
+        } catch (error) {
+          console.error(`[Session ${sessionId}] Idle eviction failed:`, error);
+        } finally {
+          data.eviction = null;
+        }
+      })();
+      evictions.push(data.eviction);
+    }
+    await Promise.all(evictions);
   }
 
   getAllSessions(): Session[] {
@@ -476,6 +659,10 @@ export class SessionManager extends EventEmitter {
    * Stop all active sessions. Used for graceful shutdown.
    */
   async stopAll(): Promise<void> {
+    if (this.evictionTimer) {
+      clearInterval(this.evictionTimer);
+      this.evictionTimer = null;
+    }
     const sessionIds = Array.from(this.sessions.keys());
     console.log(`Stopping ${sessionIds.length} active session(s)...`);
 
@@ -484,7 +671,9 @@ export class SessionManager extends EventEmitter {
         try {
           const sessionData = this.sessions.get(sessionId);
           if (sessionData) {
-            await sessionData.process.stop();
+            // Graceful shutdown: these sessions will be resumed after the
+            // container restarts, so their transcripts must be flushed.
+            await sessionData.process.dispose({ graceful: true });
             sessionData.subscribers.clear();
           }
         } catch (error) {

--- a/agent-container/src/session-persistence.ts
+++ b/agent-container/src/session-persistence.ts
@@ -22,9 +22,15 @@ interface SessionMetadata {
   maxBudgetUsd?: number;
   customEnvVars?: Record<string, string>;
   effort?: EffortLevel;
+  // Session classification (e.g. isAutomated) — must survive resume so the
+  // idle-eviction class and browser-lock-on-result behavior stay correct.
+  metadata?: Record<string, unknown>;
 }
 
-const SESSIONS_FILE = '/workspace/.superagent-sessions.json';
+// Overridable so the session-GC E2E harness (which runs this stack on a dev
+// machine, where /workspace does not exist) gets working persistence.
+const SESSIONS_FILE =
+  process.env.SUPERAGENT_SESSIONS_FILE || '/workspace/.superagent-sessions.json';
 
 export class SessionPersistence {
   private sessions: Map<string, SessionMetadata> = new Map();
@@ -106,6 +112,14 @@ export class SessionPersistence {
     const session = this.sessions.get(sessionId);
     if (session) {
       session.effort = effort;
+      this.save();
+    }
+  }
+
+  updateMetadata(sessionId: string, metadata: Record<string, unknown> | undefined): void {
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      session.metadata = metadata;
       this.save();
     }
   }

--- a/agent-container/src/session-settlement.test.ts
+++ b/agent-container/src/session-settlement.test.ts
@@ -405,6 +405,72 @@ function replay(frames: CapturedFrame[], tracker: SessionSettlementTracker): voi
   }
 }
 
+describe('SessionSettlementTracker — state-event authority', () => {
+  it('a result before any state event does not settle an authority tracker', () => {
+    const tracker = new SessionSettlementTracker({ stateEventsAuthority: true });
+    tracker.noteOutboundMessage();
+    tracker.handleMessage(result(), T0);
+    expect(tracker.isSettled(T0)).toBe(false); // idle needs the state event
+
+    tracker.handleMessage(state('idle'), T0);
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+
+  it('stream traffic does not flip an authority tracker busy', () => {
+    const tracker = new SessionSettlementTracker({ bornIdle: true, stateEventsAuthority: true });
+    tracker.handleMessage(userMsg(), T0);
+    tracker.handleMessage(assistantMsg(), T0);
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+
+  it('queued-message-final-response never settles before its final idle under authority', () => {
+    // The capture carries FOUR results before the single final idle — a
+    // legacy tracker reads idle at result #1 with three turns still pending;
+    // a threshold-0 sweep landing there would kill them.
+    const frames = loadFixture('queued-message-final-response');
+    const tracker = new SessionSettlementTracker({ stateEventsAuthority: true });
+    tracker.noteOutboundMessage();
+    const idleAt = frames.findIndex(
+      ({ frame }) => frame.subtype === 'session_state_changed' && frame.state === 'idle'
+    );
+    expect(idleAt).toBeGreaterThan(0);
+    frames.forEach(({ t, frame }, i) => {
+      tracker.handleMessage(frame, t);
+      if (i < idleAt) {
+        expect(tracker.isSettled(t)).toBe(false);
+      }
+    });
+    const endT = frames[frames.length - 1].t;
+    expect(tracker.isSettled(endT + DEFAULT_WAKE_GRACE_MS + 1)).toBe(true);
+  });
+});
+
+describe('SessionSettlementTracker — resetBackgroundTasks (process replacement)', () => {
+  it('clears edge tasks, snapshot tasks, and wake-grace state', () => {
+    const tracker = new SessionSettlementTracker({ stateEventsAuthority: true });
+    tracker.noteOutboundMessage();
+    tracker.handleMessage(taskStarted('edge-1'), T0);
+    tracker.handleMessage(snapshot(['edge-1', 'snap-only']), T0);
+    tracker.handleMessage(result(), T0);
+    tracker.handleMessage(state('idle'), T0);
+    expect(tracker.isSettled(T0)).toBe(false); // pinned by both sets
+
+    // The CLI process is replaced — its tasks died with it, and no terminal
+    // signal or startup snapshot will ever clear them.
+    tracker.resetBackgroundTasks();
+    expect(tracker.openBackgroundTaskCount).toBe(0);
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+
+  it('reset does not disturb turn state (busy stays busy)', () => {
+    const tracker = new SessionSettlementTracker({ stateEventsAuthority: true });
+    tracker.noteOutboundMessage();
+    tracker.handleMessage(taskStarted('t1'), T0);
+    tracker.resetBackgroundTasks();
+    expect(tracker.isSettled(T0)).toBe(false); // still mid-turn
+  });
+});
+
 describe('SessionSettlementTracker — real capture replay', () => {
   it('covers every capture fixture in the repo', () => {
     const onDisk = fs

--- a/agent-container/src/session-settlement.test.ts
+++ b/agent-container/src/session-settlement.test.ts
@@ -1,0 +1,508 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  SessionSettlementTracker,
+  parseBackgroundTasksChanged,
+  DEFAULT_WAKE_GRACE_MS,
+  TERMINAL_TASK_UPDATED_STATUSES,
+  TERMINAL_TASK_NOTIFICATION_STATUSES,
+} from './session-settlement';
+
+// ---------- frame factories ----------
+
+const result = (subtype = 'success') => ({ type: 'result', subtype });
+const state = (s: string) => ({ type: 'system', subtype: 'session_state_changed', state: s });
+const taskStarted = (id: string, taskType = 'local_bash') => ({
+  type: 'system',
+  subtype: 'task_started',
+  task_id: id,
+  task_type: taskType,
+});
+const taskUpdated = (id: string, status: string) => ({
+  type: 'system',
+  subtype: 'task_updated',
+  task_id: id,
+  patch: { status },
+});
+const taskNotification = (id: string, status: string) => ({
+  type: 'system',
+  subtype: 'task_notification',
+  task_id: id,
+  status,
+});
+const snapshot = (ids: string[]) => ({
+  type: 'system',
+  subtype: 'background_tasks_changed',
+  tasks: ids.map((task_id) => ({ task_id })),
+});
+const userMsg = () => ({ type: 'user', message: { role: 'user', content: [] } });
+const assistantMsg = () => ({ type: 'assistant', message: { content: [] } });
+
+const T0 = 1_000_000;
+
+/** Fresh tracker driven to a settled state via a completed turn. */
+function settledTracker(opts?: { wakeGraceMs?: number }): SessionSettlementTracker {
+  const tracker = new SessionSettlementTracker(opts);
+  tracker.handleMessage(state('running'), T0);
+  tracker.handleMessage(result(), T0);
+  tracker.handleMessage(state('idle'), T0);
+  expect(tracker.isSettled(T0)).toBe(true);
+  return tracker;
+}
+
+describe('SessionSettlementTracker — turn lifecycle', () => {
+  it('is born busy by default and settles on result + idle', () => {
+    const tracker = new SessionSettlementTracker();
+    expect(tracker.isSettled(T0)).toBe(false);
+    tracker.handleMessage(state('running'), T0);
+    tracker.handleMessage(result(), T0);
+    expect(tracker.isSettled(T0)).toBe(false); // idle is the authority once state events exist
+    tracker.handleMessage(state('idle'), T0);
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+
+  it('is born idle when constructed for a bare resume', () => {
+    const tracker = new SessionSettlementTracker({ bornIdle: true });
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+
+  it('treats result alone as settlement when no state events were ever seen (legacy stream)', () => {
+    const tracker = new SessionSettlementTracker();
+    tracker.handleMessage(result(), T0);
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+
+  it('ignores a stale idle with no result for this turn', () => {
+    const tracker = new SessionSettlementTracker();
+    tracker.handleMessage(state('idle'), T0); // no result yet — stale
+    expect(tracker.isSettled(T0)).toBe(false);
+  });
+
+  it('requires_action means busy — never evict a session awaiting permission input', () => {
+    const tracker = settledTracker();
+    tracker.noteOutboundMessage();
+    tracker.handleMessage(state('requires_action'), T0);
+    expect(tracker.isSettled(T0)).toBe(false);
+  });
+
+  it('a new outbound message clears the previous result gate', () => {
+    const tracker = settledTracker();
+    tracker.noteOutboundMessage();
+    expect(tracker.isSettled(T0)).toBe(false);
+    // Stale idle racing the new message must not settle: no result yet.
+    tracker.handleMessage(state('idle'), T0);
+    expect(tracker.isSettled(T0)).toBe(false);
+    tracker.handleMessage(result(), T0);
+    tracker.handleMessage(state('idle'), T0);
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+
+  it('an error result settles the turn like a success', () => {
+    const tracker = new SessionSettlementTracker();
+    tracker.handleMessage(state('running'), T0);
+    tracker.handleMessage(result('error_during_execution'), T0);
+    tracker.handleMessage(state('idle'), T0);
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+});
+
+describe('SessionSettlementTracker — outbound messages and stream echoes', () => {
+  it('a shouldQuery:false append does not mark the session busy', () => {
+    const tracker = settledTracker();
+    tracker.noteOutboundMessage({ expectsResponse: false });
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+
+  it('an echoed user message does not flip busy once state events are the authority', () => {
+    // This is what keeps a transcript-only append (whose user message the SDK
+    // may replay into the stream) from pinning the session busy forever.
+    const tracker = settledTracker();
+    tracker.handleMessage(userMsg(), T0);
+    tracker.handleMessage(assistantMsg(), T0);
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+
+  it('user/assistant traffic flips busy on legacy streams without state events', () => {
+    const tracker = new SessionSettlementTracker();
+    tracker.handleMessage(result(), T0); // settled via legacy fallback
+    expect(tracker.isSettled(T0)).toBe(true);
+    tracker.handleMessage(userMsg(), T0);
+    expect(tracker.isSettled(T0)).toBe(false);
+  });
+});
+
+describe('SessionSettlementTracker — background task edges', () => {
+  it.each([...TERMINAL_TASK_UPDATED_STATUSES])(
+    'task_updated status %s clears the task',
+    (status) => {
+      const tracker = settledTracker({ wakeGraceMs: 0 });
+      tracker.handleMessage(taskStarted('t1'), T0);
+      expect(tracker.isSettled(T0)).toBe(false);
+      tracker.handleMessage(taskUpdated('t1', status), T0);
+      expect(tracker.isSettled(T0)).toBe(true);
+    }
+  );
+
+  it.each([...TERMINAL_TASK_NOTIFICATION_STATUSES])(
+    'task_notification status %s clears the task',
+    (status) => {
+      const tracker = settledTracker({ wakeGraceMs: 0 });
+      tracker.handleMessage(taskStarted('t1'), T0);
+      tracker.handleMessage(taskNotification('t1', status), T0);
+      expect(tracker.isSettled(T0)).toBe(true);
+    }
+  );
+
+  it("task_notification 'stopped' (Query.stopTask / TaskStop) clears the task", () => {
+    // 'stopped' exists ONLY on task_notification (SDK type union) — a
+    // status list copied from task_updated would leak it and pin the session.
+    const tracker = settledTracker({ wakeGraceMs: 0 });
+    tracker.handleMessage(taskStarted('t1'), T0);
+    tracker.handleMessage(taskNotification('t1', 'stopped'), T0);
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+
+  it.each(['pending', 'running', 'paused'])(
+    'non-terminal task_updated status %s does NOT clear the task',
+    (status) => {
+      const tracker = settledTracker({ wakeGraceMs: 0 });
+      tracker.handleMessage(taskStarted('t1'), T0);
+      tracker.handleMessage(taskUpdated('t1', status), T0);
+      expect(tracker.isSettled(T0)).toBe(false);
+    }
+  );
+
+  it('an unknown future status does not clear the task (fail toward holding)', () => {
+    const tracker = settledTracker({ wakeGraceMs: 0 });
+    tracker.handleMessage(taskStarted('t1'), T0);
+    tracker.handleMessage(taskUpdated('t1', 'suspended'), T0);
+    tracker.handleMessage(taskNotification('t1', 'archived'), T0);
+    expect(tracker.isSettled(T0)).toBe(false);
+  });
+
+  it('holds while ANY of several tasks is open', () => {
+    const tracker = settledTracker({ wakeGraceMs: 0 });
+    tracker.handleMessage(taskStarted('t1'), T0);
+    tracker.handleMessage(taskStarted('t2'), T0);
+    tracker.handleMessage(taskUpdated('t1', 'completed'), T0);
+    expect(tracker.isSettled(T0)).toBe(false);
+    tracker.handleMessage(taskUpdated('t2', 'completed'), T0);
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+});
+
+describe('SessionSettlementTracker — background_tasks_changed snapshots', () => {
+  it('a snapshot-only task blocks settlement (snapshot leads task_started on the wire)', () => {
+    const tracker = settledTracker({ wakeGraceMs: 0 });
+    tracker.handleMessage(snapshot(['t1']), T0);
+    expect(tracker.isSettled(T0)).toBe(false);
+    tracker.handleMessage(snapshot([]), T0);
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+
+  it('self-heals: an edge-tracked task missing from the snapshot is cleared', () => {
+    // A missed terminal signal must not pin the session forever.
+    const tracker = settledTracker({ wakeGraceMs: 0 });
+    tracker.handleMessage(taskStarted('t1'), T0);
+    expect(tracker.isSettled(T0)).toBe(false);
+    tracker.handleMessage(snapshot([]), T0); // SDK says: nothing is running
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+
+  it('union semantics: an edge task missing from an OLDER snapshot still blocks until its terminal signal', () => {
+    const tracker = settledTracker({ wakeGraceMs: 0 });
+    tracker.handleMessage(snapshot(['t1']), T0);
+    tracker.handleMessage(taskStarted('t1'), T0);
+    // A second task starts edge-first (its announcing snapshot was dropped).
+    tracker.handleMessage(taskStarted('t2'), T0);
+    tracker.handleMessage(snapshot(['t1']), T0);
+    // t2 was self-healed away by the stale snapshot — deliberate: the SDK's
+    // full set is authoritative. t1 still blocks.
+    expect(tracker.isSettled(T0)).toBe(false);
+    tracker.handleMessage(taskNotification('t1', 'completed'), T0);
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+
+  it('a terminal edge clears a task the (stale) snapshot still lists', () => {
+    const tracker = settledTracker({ wakeGraceMs: 0 });
+    tracker.handleMessage(snapshot(['t1']), T0);
+    tracker.handleMessage(taskStarted('t1'), T0);
+    tracker.handleMessage(taskNotification('t1', 'completed'), T0); // no fresh snapshot seen
+    expect(tracker.isSettled(T0)).toBe(true);
+  });
+
+  it('ignores a malformed snapshot frame outright', () => {
+    const tracker = settledTracker({ wakeGraceMs: 0 });
+    tracker.handleMessage(taskStarted('t1'), T0);
+    tracker.handleMessage(
+      { type: 'system', subtype: 'background_tasks_changed', tasks: 'garbage' },
+      T0
+    );
+    // Acting on a partial parse could clear a running task — must hold.
+    expect(tracker.isSettled(T0)).toBe(false);
+  });
+});
+
+describe('SessionSettlementTracker — completion-wake grace', () => {
+  it('withholds settlement after the last task drains while idle (the wake window)', () => {
+    const tracker = settledTracker(); // default grace
+    tracker.handleMessage(taskStarted('t1'), T0);
+    tracker.handleMessage(taskUpdated('t1', 'completed'), T0 + 100);
+    // Real captures show session_state_changed:running 15-64ms after the
+    // drain; a sweep in that gap must not kill the wake.
+    expect(tracker.isSettled(T0 + 120)).toBe(false);
+    expect(tracker.isSettled(T0 + 100 + DEFAULT_WAKE_GRACE_MS - 1)).toBe(false);
+  });
+
+  it('the wake (running) clears the grace and the wake turn settles normally', () => {
+    const tracker = settledTracker();
+    tracker.handleMessage(taskStarted('t1'), T0);
+    tracker.handleMessage(taskNotification('t1', 'completed'), T0 + 100);
+    tracker.handleMessage(state('running'), T0 + 130);
+    expect(tracker.isSettled(T0 + 140)).toBe(false); // busy: wake turn running
+    tracker.handleMessage(result(), T0 + 500);
+    tracker.handleMessage(state('idle'), T0 + 501);
+    expect(tracker.isSettled(T0 + 502)).toBe(true);
+  });
+
+  it('settles after the grace expires when no wake ever comes (bounded, never a pin)', () => {
+    const tracker = settledTracker();
+    tracker.handleMessage(taskStarted('t1'), T0);
+    tracker.handleMessage(taskNotification('t1', 'stopped'), T0 + 100);
+    expect(tracker.isSettled(T0 + 200)).toBe(false);
+    expect(tracker.isSettled(T0 + 100 + DEFAULT_WAKE_GRACE_MS + 1)).toBe(true);
+  });
+
+  it('no grace when the drain happens mid-turn (busy-path completion)', () => {
+    const tracker = settledTracker();
+    tracker.noteOutboundMessage();
+    tracker.handleMessage(state('running'), T0);
+    tracker.handleMessage(taskStarted('t1'), T0);
+    tracker.handleMessage(taskUpdated('t1', 'completed'), T0 + 50); // turn still running
+    tracker.handleMessage(result(), T0 + 100);
+    tracker.handleMessage(state('idle'), T0 + 101);
+    // The running turn already absorbed the completion — no wake to wait for.
+    expect(tracker.isSettled(T0 + 102)).toBe(true);
+  });
+
+  it('only the LAST task draining while idle arms the grace', () => {
+    const tracker = settledTracker();
+    tracker.handleMessage(taskStarted('t1'), T0);
+    tracker.handleMessage(taskStarted('t2'), T0);
+    tracker.handleMessage(taskUpdated('t1', 'completed'), T0 + 100);
+    // Still one open task — blocked by the task itself, not the grace.
+    expect(tracker.getState().awaitingWakeSinceMs).toBeNull();
+    tracker.handleMessage(taskUpdated('t2', 'completed'), T0 + 200);
+    expect(tracker.getState().awaitingWakeSinceMs).toBe(T0 + 200);
+  });
+
+  it('a fresh outbound message clears a pending grace', () => {
+    const tracker = settledTracker();
+    tracker.handleMessage(taskStarted('t1'), T0);
+    tracker.handleMessage(taskUpdated('t1', 'completed'), T0 + 100);
+    tracker.noteOutboundMessage();
+    expect(tracker.getState().awaitingWakeSinceMs).toBeNull();
+    expect(tracker.isSettled(T0 + 200)).toBe(false); // busy: new turn pending
+  });
+});
+
+describe('parseBackgroundTasksChanged', () => {
+  it('parses a valid snapshot', () => {
+    const parsed = parseBackgroundTasksChanged({
+      tasks: [{ task_id: 'a', task_type: 'local_bash' }, { task_id: 'b' }],
+    });
+    expect(parsed).not.toBeNull();
+    expect([...parsed!.taskIds]).toEqual(['a', 'b']);
+  });
+
+  it('tolerates unexpected field types on optional fields', () => {
+    const parsed = parseBackgroundTasksChanged({
+      tasks: [{ task_id: 'a', task_type: 123, description: { nested: true } }],
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.tasks[0]).toEqual({ task_id: 'a' });
+  });
+
+  it('rejects frames without a valid tasks array', () => {
+    expect(parseBackgroundTasksChanged({})).toBeNull();
+    expect(parseBackgroundTasksChanged({ tasks: 'nope' })).toBeNull();
+    expect(parseBackgroundTasksChanged({ tasks: [{ no_id: true }] })).toBeNull();
+    expect(parseBackgroundTasksChanged(null)).toBeNull();
+  });
+});
+
+// ---------- real-capture replay ----------
+//
+// Every capture fixture is replayed through the tracker with its original
+// timestamps. `settledAtEnd` is ground truth read off each capture's tail:
+// captures that end with a post-result `idle` are settled; captures truncated
+// at the final `result` (older harness) or killed mid-flight (old-flow
+// interrupt: the stream just STOPS) are not.
+
+const FIXTURES_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../src/shared/lib/container/__fixtures__'
+);
+
+interface FixtureExpectation {
+  name: string;
+  settledAtEnd: boolean;
+}
+
+// The older captures are truncated at their final result, but by then every
+// task has closed and a post-result idle was already accepted — the stream's
+// last known state is settled, and the tracker says so.
+const FIXTURE_EXPECTATIONS: FixtureExpectation[] = [
+  { name: 'background-bash-busy-completion', settledAtEnd: true },
+  { name: 'background-bash-premature-idle', settledAtEnd: true },
+  { name: 'background-subagent-completion', settledAtEnd: true },
+  { name: 'background-subagent-premature-idle', settledAtEnd: true },
+  { name: 'parallel-subagents', settledAtEnd: true },
+  { name: 'queued-message-final-response', settledAtEnd: true },
+  { name: 'sdk206-bg-bash-busy-completion', settledAtEnd: true },
+  { name: 'sdk206-bg-bash-two-tasks-premature-idle', settledAtEnd: true },
+  { name: 'sdk206-bg-subagent-default', settledAtEnd: true },
+  { name: 'sdk206-bg-subagent-premature-idle', settledAtEnd: true },
+  { name: 'sdk206-error-turn-invalid-model', settledAtEnd: true },
+  { name: 'sdk206-parallel-subagents-sync', settledAtEnd: true },
+  { name: 'sdk206-queued-message-final-response', settledAtEnd: true },
+  { name: 'sdk206-queued-message-interrupt', settledAtEnd: false }, // stream stops post-abort
+  { name: 'sdk206-queued-message-interrupt-receipt', settledAtEnd: true },
+  { name: 'sdk206-sequential-different-types', settledAtEnd: true },
+  { name: 'sdk206-workflow-probe', settledAtEnd: true },
+  { name: 'sequential-different-types', settledAtEnd: true },
+  { name: 'single-subagent-progress', settledAtEnd: true },
+];
+
+interface CapturedFrame {
+  t: number;
+  frame: Record<string, unknown>;
+}
+
+function loadFixture(name: string): CapturedFrame[] {
+  const file = path.join(FIXTURES_DIR, name, 'stream-input.jsonl');
+  return fs
+    .readFileSync(file, 'utf-8')
+    .trim()
+    .split('\n')
+    .flatMap((line) => {
+      try {
+        const wrapper = JSON.parse(line) as { t: number; message?: { content?: unknown } };
+        const frame = wrapper.message?.content;
+        if (!frame || typeof frame !== 'object') return [];
+        return [{ t: wrapper.t, frame: frame as Record<string, unknown> }];
+      } catch {
+        return [];
+      }
+    });
+}
+
+function replay(frames: CapturedFrame[], tracker: SessionSettlementTracker): void {
+  for (const { t, frame } of frames) {
+    tracker.handleMessage(frame, t);
+  }
+}
+
+describe('SessionSettlementTracker — real capture replay', () => {
+  it('covers every capture fixture in the repo', () => {
+    const onDisk = fs
+      .readdirSync(FIXTURES_DIR)
+      .filter((d) => fs.existsSync(path.join(FIXTURES_DIR, d, 'stream-input.jsonl')))
+      .sort();
+    expect(onDisk).toEqual(FIXTURE_EXPECTATIONS.map((f) => f.name).sort());
+  });
+
+  it.each(FIXTURE_EXPECTATIONS)('$name replays to settledAtEnd=$settledAtEnd', (fixture) => {
+    const frames = loadFixture(fixture.name);
+    expect(frames.length).toBeGreaterThan(0);
+    const tracker = new SessionSettlementTracker();
+    tracker.noteOutboundMessage(); // the capture's driver sent the initial message
+    replay(frames, tracker);
+    const endT = frames[frames.length - 1].t;
+    // Past any wake grace — this asserts steady-state, not the gap.
+    expect(tracker.isSettled(endT + DEFAULT_WAKE_GRACE_MS + 1)).toBe(fixture.settledAtEnd);
+  });
+
+  it('is never settled while the capture has an open background task (frame-by-frame)', () => {
+    // Reference bookkeeping derived ONLY from per-task edges (task_started ..
+    // first terminal signal) — independent of the tracker's snapshot/union
+    // logic, so a tracker bug can't cancel out of both sides.
+    for (const { name } of FIXTURE_EXPECTATIONS) {
+      const frames = loadFixture(name);
+      const open = new Set<string>();
+      const tracker = new SessionSettlementTracker();
+      tracker.noteOutboundMessage();
+      for (const { t, frame } of frames) {
+        tracker.handleMessage(frame, t);
+        const f = frame as {
+          subtype?: string;
+          task_id?: string;
+          status?: string;
+          patch?: { status?: string };
+        };
+        if (f.subtype === 'task_started' && f.task_id) open.add(f.task_id);
+        const terminalUpdate =
+          f.subtype === 'task_updated' &&
+          f.patch?.status &&
+          TERMINAL_TASK_UPDATED_STATUSES.has(f.patch.status);
+        const terminalNotif =
+          f.subtype === 'task_notification' &&
+          f.status &&
+          TERMINAL_TASK_NOTIFICATION_STATUSES.has(f.status);
+        if ((terminalUpdate || terminalNotif) && f.task_id) open.delete(f.task_id);
+        if (open.size > 0) {
+          expect(tracker.isSettled(t), `${name}: settled with ${[...open]} open at t=${t}`).toBe(
+            false
+          );
+        }
+      }
+    }
+  });
+
+  it('holds through the measured wake gap in sdk206-bg-bash-two-tasks-premature-idle', () => {
+    // Ground truth from the capture: background_tasks_changed [] at t=230591
+    // (state still idle from t=210739), the wake's running at t=230624 — a
+    // 33ms window in which the PR-419 bookkeeping was evictable.
+    const frames = loadFixture('sdk206-bg-bash-two-tasks-premature-idle');
+    const tracker = new SessionSettlementTracker();
+    tracker.noteOutboundMessage();
+    for (const { t, frame } of frames) {
+      if (t >= 230624) break; // stop right before the wake's running frame
+      tracker.handleMessage(frame, t);
+    }
+    expect(tracker.openBackgroundTaskCount).toBe(0);
+    expect(tracker.getState().runtime).toBe('idle');
+    // A sweep landing inside the gap must hold.
+    expect(tracker.isSettled(230600)).toBe(false);
+    expect(tracker.isSettled(230623)).toBe(false);
+  });
+
+  it('holds through the measured wake gap in sdk206-bg-subagent-premature-idle', () => {
+    // Snapshot [] at t=274817, wake running at t=274832 — a 15ms window.
+    const frames = loadFixture('sdk206-bg-subagent-premature-idle');
+    const tracker = new SessionSettlementTracker();
+    tracker.noteOutboundMessage();
+    for (const { t, frame } of frames) {
+      if (t >= 274832) break;
+      tracker.handleMessage(frame, t);
+    }
+    expect(tracker.isSettled(274825)).toBe(false);
+  });
+
+  it("a subagent's inner bash edges never pin settlement past the subagent itself", () => {
+    // In sdk206-bg-subagent-premature-idle the subagent's inner Bash
+    // (task_started without a snapshot entry) flows through the lead stream.
+    // After the full replay + grace the session must settle — a tracker that
+    // required an explicit terminal signal for every edge would pin here if
+    // any inner edge went unmatched.
+    const frames = loadFixture('sdk206-bg-subagent-premature-idle');
+    const tracker = new SessionSettlementTracker();
+    tracker.noteOutboundMessage();
+    replay(frames, tracker);
+    const endT = frames[frames.length - 1].t;
+    expect(tracker.isSettled(endT + DEFAULT_WAKE_GRACE_MS + 1)).toBe(true);
+    expect(tracker.openBackgroundTaskCount).toBe(0);
+  });
+});

--- a/agent-container/src/session-settlement.ts
+++ b/agent-container/src/session-settlement.ts
@@ -83,6 +83,21 @@ export interface SettlementTrackerOptions {
    */
   bornIdle?: boolean;
   wakeGraceMs?: number;
+  /**
+   * The consumer KNOWS the process emits session_state_changed events
+   * (the container always sets CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=1 on a
+   * pinned CLI), so state events are authoritative from the first frame —
+   * before one has actually been observed. Without this, a result arriving
+   * before the first state event flips the tracker idle: the pre-init
+   * `running` event is dropped by listener-attach timing, and queued-message
+   * streams carry intermediate results (see the queued-message-final-response
+   * capture: four results before the single final idle) — a threshold-0
+   * sweep landing there would evict a session with turns still pending.
+   * Fail-safe direction: if the CLI ever stops emitting state events under
+   * this flag, sessions stop settling (a bounded leak), rather than settling
+   * early (killed queued work).
+   */
+  stateEventsAuthority?: boolean;
 }
 
 export interface SettlementState {
@@ -114,6 +129,24 @@ export class SessionSettlementTracker {
   constructor(options?: SettlementTrackerOptions) {
     this.runtime = options?.bornIdle ? 'idle' : 'busy';
     this.wakeGraceMs = options?.wakeGraceMs ?? DEFAULT_WAKE_GRACE_MS;
+    // Authority = behave as if a state event was already seen: results stop
+    // acting as idle signals and stream traffic stops acting as busy signals.
+    this.stateEventsSeen = options?.stateEventsAuthority ?? false;
+  }
+
+  /**
+   * Background tasks are process-local: they die with the CLI process, and a
+   * fresh process emits NO initial background_tasks_changed snapshot. Any
+   * edge/snapshot ids carried across a process replacement (interrupt or
+   * crash mid-task, cold restart) would therefore pin the session
+   * unevictable forever — no terminal signal or snapshot will ever arrive
+   * for them. Call whenever the underlying query/process is replaced; never
+   * for ordinary messages within the same process.
+   */
+  resetBackgroundTasks(): void {
+    this.edgeTaskIds.clear();
+    this.snapshotTaskIds = null;
+    this.awaitingWakeSince = null;
   }
 
   /**

--- a/agent-container/src/session-settlement.ts
+++ b/agent-container/src/session-settlement.ts
@@ -1,0 +1,269 @@
+import { z } from 'zod';
+
+// Session settlement tracking, shared between the container's SessionManager
+// (idle-eviction reaper) and the host's message-persister (which re-exports
+// the snapshot parsing from here — this file must stay dependency-free apart
+// from zod, and must not import anything host- or container-runtime-specific).
+//
+// "Settled" means: the turn is over (result-gated idle) AND no background
+// work (backgrounded Bash, background subagents, dynamic workflows) is live
+// AND we are not inside the completion-wake window (see below). Only a
+// settled session may have its subprocess stopped.
+
+// --- background_tasks_changed (claude-agent-sdk >= 0.3.203) ---
+// The SDK emits the FULL set of the session's live background tasks on every
+// membership change. Observed wire ordering (see the sdk206-* fixtures): each
+// snapshot LEADS its per-task signal — the frame announcing an addition
+// arrives just before task_started, the frame announcing a removal just
+// before the terminal task_notification/task_updated. The snapshot covers
+// only the lead session's own tasks (a subagent's inner tasks never appear).
+
+const backgroundTaskSchema = z.object({
+  task_id: z.string(),
+  task_type: z.string().optional().catch(undefined),
+  description: z.string().optional().catch(undefined),
+});
+
+const backgroundTasksChangedSchema = z.object({
+  tasks: z.array(backgroundTaskSchema),
+});
+
+export interface BackgroundTasksSnapshot {
+  taskIds: Set<string>;
+  tasks: Array<{ task_id: string; task_type?: string; description?: string }>;
+}
+
+/**
+ * Parse a background_tasks_changed payload. Returns null when the frame does
+ * not validate — the caller must then IGNORE the frame entirely (status quo
+ * bookkeeping), because acting on a partially-parsed snapshot could clear
+ * tasks that are still running. Fail-safe direction: a dropped frame costs
+ * nothing (the next membership change re-announces the full set); a wrong
+ * clear un-gates eviction/auto-sleep mid-job.
+ */
+export function parseBackgroundTasksChanged(content: unknown): BackgroundTasksSnapshot | null {
+  const parsed = backgroundTasksChangedSchema.safeParse(content);
+  if (!parsed.success) return null;
+  return {
+    taskIds: new Set(parsed.data.tasks.map((t) => t.task_id)),
+    tasks: parsed.data.tasks,
+  };
+}
+
+// Terminal statuses per frame kind, from the SDK 0.3.206 type unions — they
+// differ and must not be merged: SDKTaskUpdatedMessage.patch.status has
+// 'killed' (and non-terminal 'paused'), SDKTaskNotificationMessage.status has
+// 'stopped' (emitted by Query.stopTask / the TaskStop tool) instead.
+export const TERMINAL_TASK_UPDATED_STATUSES: ReadonlySet<string> = new Set([
+  'completed',
+  'failed',
+  'killed',
+]);
+export const TERMINAL_TASK_NOTIFICATION_STATUSES: ReadonlySet<string> = new Set([
+  'completed',
+  'failed',
+  'stopped',
+]);
+
+// After the LAST background task finishes while the session is idle-parked,
+// the SDK wakes the session to deliver the completion to the model: a
+// session_state_changed:running arrives 15-64ms later in real captures
+// (sdk206-bg-*-premature-idle fixtures), then a wake turn with its own
+// result + idle. Settlement is withheld for this grace window so a reaper
+// sweep landing in the gap cannot kill the wake. If the wake never comes
+// (e.g. the task was stopped with nothing to report), the grace expires and
+// the session settles — bounded delay, never a permanent pin.
+export const DEFAULT_WAKE_GRACE_MS = 30_000;
+
+export interface SettlementTrackerOptions {
+  /**
+   * A session resumed by a bare read (no message sent) never gets a turn —
+   * no result, no idle event — so it must be born settled or its process
+   * would sit beyond any reaper forever.
+   */
+  bornIdle?: boolean;
+  wakeGraceMs?: number;
+}
+
+export interface SettlementState {
+  runtime: 'idle' | 'busy';
+  stateEventsSeen: boolean;
+  lastResultSubtype: string | null;
+  openBackgroundTaskIds: string[];
+  awaitingWakeSinceMs: number | null;
+}
+
+export class SessionSettlementTracker {
+  private runtime: 'idle' | 'busy';
+  private stateEventsSeen = false;
+  // Cleared on outbound send; set on result. Mirrors message-persister: a
+  // bare session_state_changed:idle without a result for this turn is
+  // ignored (stale idle racing a fresh message).
+  private lastResultSubtype: string | null = null;
+  // Edge-tracked tasks (task_started .. terminal signal) unioned with the
+  // latest SDK snapshot. The snapshot leads the per-task signals on the wire,
+  // so around a membership change each side may briefly know a task the
+  // other doesn't; counting the union means a missed registration can't
+  // cause premature settlement and a missed terminal signal can't pin the
+  // session forever (the snapshot self-heal clears it).
+  private edgeTaskIds = new Set<string>();
+  private snapshotTaskIds: Set<string> | null = null;
+  private awaitingWakeSince: number | null = null;
+  private readonly wakeGraceMs: number;
+
+  constructor(options?: SettlementTrackerOptions) {
+    this.runtime = options?.bornIdle ? 'idle' : 'busy';
+    this.wakeGraceMs = options?.wakeGraceMs ?? DEFAULT_WAKE_GRACE_MS;
+  }
+
+  /**
+   * Record a message we are about to hand to the process. A transcript-only
+   * append (shouldQuery: false — e.g. cross-agent chat notifications) runs no
+   * turn and will produce no result/idle, so it must NOT mark the session
+   * busy: that would make it unevictable until the next real turn.
+   */
+  noteOutboundMessage(options?: { expectsResponse?: boolean }): void {
+    if (options?.expectsResponse === false) return;
+    this.runtime = 'busy';
+    this.lastResultSubtype = null;
+    this.awaitingWakeSince = null;
+  }
+
+  handleMessage(message: unknown, now: number = Date.now()): void {
+    const msg = message as {
+      type?: string;
+      subtype?: string;
+      state?: string;
+      task_id?: string;
+      status?: string;
+      patch?: { status?: string };
+    };
+
+    if (msg.type === 'result') {
+      this.lastResultSubtype = typeof msg.subtype === 'string' ? msg.subtype : 'unknown';
+      // A result after the drain IS the wake turn completing.
+      this.awaitingWakeSince = null;
+      if (!this.stateEventsSeen) {
+        this.runtime = 'idle';
+      }
+      return;
+    }
+
+    if (msg.type === 'system') {
+      switch (msg.subtype) {
+        case 'session_state_changed': {
+          this.stateEventsSeen = true;
+          if (msg.state === 'idle') {
+            // Ignore stale idle with no result for this turn.
+            if (this.lastResultSubtype !== null) {
+              this.runtime = 'idle';
+            }
+          } else {
+            // running / requires_action — including the completion wake.
+            this.runtime = 'busy';
+            this.awaitingWakeSince = null;
+          }
+          return;
+        }
+        case 'task_started': {
+          if (typeof msg.task_id === 'string') {
+            this.edgeTaskIds.add(msg.task_id);
+          }
+          return;
+        }
+        case 'task_updated': {
+          const status = msg.patch?.status;
+          if (
+            typeof msg.task_id === 'string' &&
+            typeof status === 'string' &&
+            TERMINAL_TASK_UPDATED_STATUSES.has(status)
+          ) {
+            this.removeTask(msg.task_id, now);
+          }
+          return;
+        }
+        case 'task_notification': {
+          if (
+            typeof msg.task_id === 'string' &&
+            typeof msg.status === 'string' &&
+            TERMINAL_TASK_NOTIFICATION_STATUSES.has(msg.status)
+          ) {
+            this.removeTask(msg.task_id, now);
+          }
+          return;
+        }
+        case 'background_tasks_changed': {
+          const snapshot = parseBackgroundTasksChanged(msg);
+          if (!snapshot) return;
+          const hadOpenWork = this.openBackgroundTaskCount > 0;
+          this.snapshotTaskIds = snapshot.taskIds;
+          // Self-heal: an edge-tracked task the SDK no longer lists has
+          // finished — its terminal signal normally follows within a frame
+          // and no-ops, but if that signal is missed the task would pin the
+          // session forever.
+          for (const id of [...this.edgeTaskIds]) {
+            if (!snapshot.taskIds.has(id)) {
+              this.edgeTaskIds.delete(id);
+            }
+          }
+          this.noteIfDrained(hadOpenWork, now);
+          return;
+        }
+      }
+      return;
+    }
+
+    if ((msg.type === 'user' || msg.type === 'assistant') && !this.stateEventsSeen) {
+      // Legacy streams without state events: any turn traffic means busy.
+      // With state events (always, on the pinned SDK) those are authoritative
+      // — deliberately NOT flipping busy here is what keeps a shouldQuery:
+      // false append's echoed user message from pinning the session busy.
+      this.runtime = 'busy';
+    }
+  }
+
+  private removeTask(taskId: string, now: number): void {
+    const hadOpenWork = this.openBackgroundTaskCount > 0;
+    this.edgeTaskIds.delete(taskId);
+    // A terminal per-task signal normally trails the snapshot that already
+    // dropped the task; if a snapshot was missed the union would pin, so the
+    // freshest information wins on both sides.
+    this.snapshotTaskIds?.delete(taskId);
+    this.noteIfDrained(hadOpenWork, now);
+  }
+
+  private noteIfDrained(hadOpenWork: boolean, now: number): void {
+    if (hadOpenWork && this.openBackgroundTaskCount === 0 && this.runtime === 'idle') {
+      this.awaitingWakeSince = now;
+    }
+  }
+
+  get openBackgroundTaskCount(): number {
+    if (!this.snapshotTaskIds) return this.edgeTaskIds.size;
+    const union = new Set(this.edgeTaskIds);
+    for (const id of this.snapshotTaskIds) union.add(id);
+    return union.size;
+  }
+
+  isSettled(now: number = Date.now()): boolean {
+    if (this.runtime !== 'idle') return false;
+    if (this.openBackgroundTaskCount > 0) return false;
+    if (this.awaitingWakeSince !== null && now - this.awaitingWakeSince < this.wakeGraceMs) {
+      return false;
+    }
+    return true;
+  }
+
+  /** Introspection for logging and tests. */
+  getState(): SettlementState {
+    return {
+      runtime: this.runtime,
+      stateEventsSeen: this.stateEventsSeen,
+      lastResultSubtype: this.lastResultSubtype,
+      openBackgroundTaskIds: [
+        ...new Set([...this.edgeTaskIds, ...(this.snapshotTaskIds ?? [])]),
+      ],
+      awaitingWakeSinceMs: this.awaitingWakeSince,
+    };
+  }
+}

--- a/src/shared/lib/container/background-tasks-changed.ts
+++ b/src/shared/lib/container/background-tasks-changed.ts
@@ -1,42 +1,10 @@
-import { z } from 'zod'
-
-// system/background_tasks_changed (claude-agent-sdk >= 0.3.203): the SDK emits
-// the FULL set of the session's live background tasks on every membership
-// change. Observed wire ordering (see the sdk206-* fixtures): each snapshot
-// LEADS its per-task signal — the frame announcing an addition arrives just
-// before task_started, the frame announcing a removal just before the
-// terminal task_notification/task_updated. The snapshot covers only the lead
-// session's own tasks (a subagent's inner tasks never appear), which matches
-// exactly what the persister tracks.
-
-const backgroundTaskSchema = z.object({
-  task_id: z.string(),
-  task_type: z.string().optional().catch(undefined),
-  description: z.string().optional().catch(undefined),
-})
-
-const backgroundTasksChangedSchema = z.object({
-  tasks: z.array(backgroundTaskSchema),
-})
-
-export interface BackgroundTasksSnapshot {
-  taskIds: Set<string>
-  tasks: Array<{ task_id: string; task_type?: string; description?: string }>
-}
-
-/**
- * Parse a background_tasks_changed payload. Returns null when the frame does
- * not validate — the caller must then IGNORE the frame entirely (status quo
- * bookkeeping), because acting on a partially-parsed snapshot could clear
- * tasks that are still running. Fail-safe direction: a dropped frame costs
- * nothing (the next membership change re-announces the full set); a wrong
- * clear un-gates auto-sleep mid-job.
- */
-export function parseBackgroundTasksChanged(content: unknown): BackgroundTasksSnapshot | null {
-  const parsed = backgroundTasksChangedSchema.safeParse(content)
-  if (!parsed.success) return null
-  return {
-    taskIds: new Set(parsed.data.tasks.map((t) => t.task_id)),
-    tasks: parsed.data.tasks,
-  }
-}
+// Single implementation lives in the agent-container tree (its Docker build
+// context cannot reach files outside agent-container/, so sharing must point
+// this way). The container's SessionManager consumes the full settlement
+// tracker; the persister consumes the snapshot parsing re-exported here.
+export {
+  parseBackgroundTasksChanged,
+  TERMINAL_TASK_UPDATED_STATUSES,
+  TERMINAL_TASK_NOTIFICATION_STATUSES,
+  type BackgroundTasksSnapshot,
+} from '../../../../agent-container/src/session-settlement'


### PR DESCRIPTION
Supersedes #419 — credit to @yiw190 for identifying the OOM accumulation problem (each idle session parks a ~250MB `claude` subprocess forever; Sentry ELECTRON-61 shows the SIGKILL fallout in the field) and for the core approach this keeps: a periodic reaper that stops only the subprocess, leaving session state intact so the next message resumes transparently with `--resume`.

## What this does

Idle sessions get their `claude` subprocess evicted once **settled** — turn over, no live background work, not inside a completion-wake window. Interactive sessions default to 5m idle (`SESSION_IDLE_EVICTION_MINUTES`), automated (cron/webhook) sessions to 0 = next sweep (`SESSION_AUTOMATED_IDLE_EVICTION_MINUTES`); `< 0` disables a class. Eviction stops only the process — `SessionData`, subscribers, and the CLI session id survive, and the next `sendMessage` cold-restarts with `--resume`. A human message into an automated session promotes it to the interactive class (persisted), so a conversation doesn't pay a cold restart per turn.

## Why a rewrite instead of iterating on #419

Review of #419 found the idleness detection re-derived busy/idle from raw stream traffic (the same whack-a-mole the message-persister already plays) and had three blocking races. This PR instead builds on the SDK ≥0.3.203 protocol and fixes what review + live probing surfaced:

- **`SessionSettlementTracker`** (`agent-container/src/session-settlement.ts`) — single-source settlement fold shared with the host (the host's `background-tasks-changed.ts` re-exports from it): result-gated `session_state_changed` idle authority, `background_tasks_changed` snapshots unioned with per-task edge signals (self-healing in both directions), per-frame terminal-status sets (`task_updated` has `killed`, `task_notification` has `stopped` — different unions), and a bounded wake-grace so a sweep can't kill the wake turn that delivers a background task's completion (measured 15–100ms gap).
- **stop()/teardown races** — `stop()` awaits the query loop unwinding (bounded), a generation guard keeps a slow teardown from clobbering a fresh query, a `stopping` flag keeps a racing `interrupt()` from reviving a query for an evicted session, and `deleteSession` uses a terminal `dispose()` so stragglers can't resurrect a deleted session's subprocess.
- **`shouldQuery:false` appends** don't mark the session busy (no immortal-busy), and every send path — including internal ones that bypass `SessionManager.sendMessage` — reaches the tracker via an `outbound-message` event.
- **Graceful eviction (`stop({graceful: true})`)** — the original immediate abort races the CLI's transcript flush: identical evict-after-turn runs lost the latest turn's context on some runs and kept it on others, and a transcript-only append into a cold threshold-0 session could be killed mid-boot before reaching disk. Eviction/shutdown now close stdin and let the CLI exit cleanly on EOF (live-measured ~1s), with a bounded abort fallback.
- **Failure-path leaks** — a failed `createSession` init handshake no longer leaks the started subprocess; a failed resume no longer leaves a zombie map entry.

## Testing

- `session-settlement.test.ts` — 60 tests: every tracker transition plus replay of 19 real captured SDK streams with real timestamps, including frame-by-frame never-settled-with-open-task invariants and the measured wake-gap hold points.
- `claude-code-stop-race.test.ts` — 8 tests: teardown races, both stop/interrupt interleavings, dispose semantics, graceful-stop abort fallback, outbound-message emission.
- `session-manager-idle-eviction.test.ts` — 25 tests: thresholds, stale-idle, background holds, wake grace, promotion, persistence restore, failure-path leaks, concurrent-resume dedup.
- **Real-CLI E2E** (opt-in, `RUN_SESSION_GC_E2E=1` + API key): `session-gc.e2e.test.ts` proves at the OS level (pgrep) that sessions are reaped by the real sweep, memory is released, and resume keeps conversation context; `session-gc-durability.e2e.test.ts` greps the CLI's own JSONL transcripts between evict phases to prove no turn or append is lost (3× soak clean). Run the two files separately — the pgrep zero-process assertions see each other's subprocesses in parallel workers.

Full container suite: 564 passed. `tsc` clean.

## Follow-ups (ticketed)

- SUP-384 — swap the message-persister's busy/idle accounting onto the shared tracker (shadow-first).
- SUP-385 — run-to-completion for automated sessions (close the input stream per message; first external message flips to interactive semantics).
