### PR TITLE
feat(browser): browser_download tool — save page assets through the browser session

### DIFF
--- a/agent-container/src/browser-download.test.ts
+++ b/agent-container/src/browser-download.test.ts
@@ -1,0 +1,265 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  extensionForContentType,
+  filenameFromContentDisposition,
+  filenameFromUrl,
+  parseBrowserDownloadRequest,
+  parseDataUrl,
+  resolveDownloadFilename,
+  runBrowserDownload,
+  sanitizeFilename,
+  writeDownloadFile,
+} from './browser-download'
+
+describe('browser download request parsing', () => {
+  it('parses a minimal request', () => {
+    expect(parseBrowserDownloadRequest({
+      sessionId: 'session-1',
+      url: 'https://example.com/photo.jpg',
+    })).toEqual({
+      success: true,
+      data: { sessionId: 'session-1', url: 'https://example.com/photo.jpg' },
+    })
+  })
+
+  it('rejects requests missing a url', () => {
+    const parsed = parseBrowserDownloadRequest({ sessionId: 'session-1' })
+    expect(parsed.success).toBe(false)
+  })
+})
+
+describe('sanitizeFilename', () => {
+  it('strips directory traversal down to the basename', () => {
+    expect(sanitizeFilename('../../etc/passwd')).toBe('passwd')
+    expect(sanitizeFilename('..\\..\\windows\\system32\\cmd.exe')).toBe('cmd.exe')
+  })
+
+  it('removes unsafe characters and trims dots/spaces', () => {
+    expect(sanitizeFilename('  re<po>rt:v1?.pdf  ')).toBe('reportv1.pdf')
+    expect(sanitizeFilename('...hidden...')).toBe('hidden')
+  })
+
+  it('falls back to "download" when nothing usable remains', () => {
+    expect(sanitizeFilename('...')).toBe('download')
+    expect(sanitizeFilename('<>:"|?*')).toBe('download')
+  })
+
+  it('caps length while preserving the extension', () => {
+    const long = 'a'.repeat(200) + '.jpeg'
+    const result = sanitizeFilename(long)
+    expect(result.length).toBe(150)
+    expect(result.endsWith('.jpeg')).toBe(true)
+  })
+})
+
+describe('filenameFromContentDisposition', () => {
+  it('parses quoted filenames', () => {
+    expect(filenameFromContentDisposition('attachment; filename="report.pdf"')).toBe('report.pdf')
+  })
+
+  it('parses unquoted filenames', () => {
+    expect(filenameFromContentDisposition('attachment; filename=report.pdf')).toBe('report.pdf')
+  })
+
+  it('prefers the RFC 5987 extended form', () => {
+    expect(filenameFromContentDisposition(
+      'attachment; filename="fallback.pdf"; filename*=UTF-8\'\'r%C3%A9sum%C3%A9.pdf'
+    )).toBe('résumé.pdf')
+  })
+
+  it('returns null for missing headers', () => {
+    expect(filenameFromContentDisposition(null)).toBeNull()
+    expect(filenameFromContentDisposition('inline')).toBeNull()
+  })
+})
+
+describe('filenameFromUrl', () => {
+  it('takes the last path segment, ignoring the query string', () => {
+    // Shape of a real LinkedIn media URL — the trigger case for this tool
+    expect(filenameFromUrl(
+      'https://media.licdn.com/dms/image/v2/D5603AQGo26bYjMHGxw/profile-displayphoto-crop_800_800/0/1752140421383?e=1785369600&v=beta&t=OJ4'
+    )).toBe('1752140421383')
+    expect(filenameFromUrl('https://example.com/files/report%20final.pdf?dl=1')).toBe('report final.pdf')
+  })
+
+  it('returns null for root paths and invalid URLs', () => {
+    expect(filenameFromUrl('https://example.com/')).toBeNull()
+    expect(filenameFromUrl('not a url')).toBeNull()
+  })
+})
+
+describe('resolveDownloadFilename', () => {
+  it('prefers the explicit filename', () => {
+    expect(resolveDownloadFilename({
+      explicit: 'iddo.jpg',
+      url: 'https://media.licdn.com/dms/image/photo?e=1',
+      contentDisposition: 'attachment; filename="other.png"',
+      contentType: 'image/jpeg',
+    })).toBe('iddo.jpg')
+  })
+
+  it('appends an extension from the content type when the name has none', () => {
+    expect(resolveDownloadFilename({
+      url: 'https://media.licdn.com/dms/image/v2/abc/0/1752140421383?e=1',
+      contentDisposition: null,
+      contentType: 'image/jpeg',
+    })).toBe('1752140421383.jpg')
+  })
+
+  it('falls back to "download" plus extension for extensionless URLs', () => {
+    expect(resolveDownloadFilename({
+      url: 'https://example.com/',
+      contentDisposition: null,
+      contentType: 'application/pdf',
+    })).toBe('download.pdf')
+  })
+
+  it('sanitizes traversal in explicit filenames', () => {
+    expect(resolveDownloadFilename({
+      explicit: '../../.ssh/authorized_keys',
+      url: 'https://example.com/x',
+      contentDisposition: null,
+      contentType: null,
+    })).toBe('authorized_keys')
+  })
+})
+
+describe('extensionForContentType', () => {
+  it('maps common types case-insensitively', () => {
+    expect(extensionForContentType('image/PNG')).toBe('.png')
+    expect(extensionForContentType('application/pdf')).toBe('.pdf')
+    expect(extensionForContentType('application/x-unknown')).toBeNull()
+    expect(extensionForContentType(null)).toBeNull()
+  })
+})
+
+describe('parseDataUrl', () => {
+  it('decodes base64 data URLs with a content type', () => {
+    const parsed = parseDataUrl('data:image/png;base64,' + Buffer.from('png-bytes').toString('base64'))
+    expect(parsed).not.toBeNull()
+    expect(parsed!.buffer.toString('utf8')).toBe('png-bytes')
+    expect(parsed!.contentType).toBe('image/png')
+  })
+
+  it('decodes percent-encoded data URLs without a content type', () => {
+    const parsed = parseDataUrl('data:,hello%20world')
+    expect(parsed).not.toBeNull()
+    expect(parsed!.buffer.toString('utf8')).toBe('hello world')
+    expect(parsed!.contentType).toBeNull()
+  })
+
+  it('returns null for malformed data URLs', () => {
+    expect(parseDataUrl('data:no-comma')).toBeNull()
+  })
+})
+
+describe('writeDownloadFile', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'browser-download-test-'))
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(dir, { recursive: true, force: true })
+  })
+
+  it('writes into the directory, creating it if needed', async () => {
+    const nested = path.join(dir, 'downloads')
+    const saved = await writeDownloadFile(nested, 'photo.jpg', Buffer.from('abc'))
+    expect(saved).toBe(path.join(nested, 'photo.jpg'))
+    expect(await fs.promises.readFile(saved, 'utf8')).toBe('abc')
+  })
+
+  it('suffixes instead of clobbering existing files', async () => {
+    const first = await writeDownloadFile(dir, 'photo.jpg', Buffer.from('one'))
+    const second = await writeDownloadFile(dir, 'photo.jpg', Buffer.from('two'))
+    expect(second).toBe(path.join(dir, 'photo-1.jpg'))
+    expect(await fs.promises.readFile(first, 'utf8')).toBe('one')
+    expect(await fs.promises.readFile(second, 'utf8')).toBe('two')
+  })
+})
+
+describe('runBrowserDownload validation paths', () => {
+  const baseOptions = {
+    validateSession: () => null,
+    isBrowserActive: () => true,
+    getConnectionUrl: () => 'ws://never-connected',
+    getActiveTargetUrl: async () => null,
+    urlsMatch: () => false,
+  }
+
+  it('rejects invalid request bodies', async () => {
+    const result = await runBrowserDownload({ sessionId: 's1' }, baseOptions)
+    expect(result.success).toBe(false)
+    if (!result.success) expect(result.status).toBe(400)
+  })
+
+  it('rejects when another session owns the browser', async () => {
+    const result = await runBrowserDownload(
+      { sessionId: 's1', url: 'https://example.com/a.png' },
+      { ...baseOptions, validateSession: () => 'Browser is owned by session other' }
+    )
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.status).toBe(409)
+      expect(result.body.error).toContain('owned by session')
+    }
+  })
+
+  it('rejects when the browser is not active', async () => {
+    const result = await runBrowserDownload(
+      { sessionId: 's1', url: 'https://example.com/a.png' },
+      { ...baseOptions, isBrowserActive: () => false }
+    )
+    expect(result.success).toBe(false)
+    if (!result.success) expect(result.status).toBe(400)
+  })
+
+  it('rejects unsupported URL schemes', async () => {
+    const result = await runBrowserDownload(
+      { sessionId: 's1', url: 'file:///etc/passwd' },
+      baseOptions
+    )
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.status).toBe(400)
+      expect(result.body.error).toContain('Unsupported URL scheme')
+    }
+  })
+
+  it('saves data: URLs without a browser connection', async () => {
+    const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'browser-download-data-'))
+    try {
+      const result = await runBrowserDownload(
+        {
+          sessionId: 's1',
+          url: 'data:image/png;base64,' + Buffer.from('fake-png').toString('base64'),
+          filename: 'pixel.png',
+        },
+        { ...baseOptions, downloadsDir: dir }
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.body.file.name).toBe('pixel.png')
+        expect(result.body.file.size).toBe(8)
+        expect(result.body.file.contentType).toBe('image/png')
+        expect(await fs.promises.readFile(result.body.file.path, 'utf8')).toBe('fake-png')
+      }
+    } finally {
+      await fs.promises.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects empty data: URL payloads', async () => {
+    const result = await runBrowserDownload(
+      { sessionId: 's1', url: 'data:image/png;base64,' },
+      baseOptions
+    )
+    expect(result.success).toBe(false)
+    if (!result.success) expect(result.body.error).toContain('0 bytes')
+  })
+})

--- a/agent-container/src/browser-download.ts
+++ b/agent-container/src/browser-download.ts
@@ -1,0 +1,379 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { chromium } from 'playwright-core'
+import { z } from 'zod'
+import { getActivePage } from './browser-upload'
+
+const BrowserDownloadRequestSchema = z.object({
+  sessionId: z.string().min(1),
+  url: z.string().min(1),
+  filename: z.string().min(1).optional(),
+})
+
+export type BrowserDownloadRequest = z.infer<typeof BrowserDownloadRequestSchema>
+
+/** Result of an in-page blob fetch, validated at the CDP boundary */
+const BlobFetchResultSchema = z.object({
+  base64: z.string(),
+  contentType: z.string().nullable(),
+})
+
+export const DOWNLOADS_DIR = '/workspace/downloads'
+
+/** Hard cap — the whole file is buffered in memory while crossing the CDP wire */
+export const MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
+
+interface RunBrowserDownloadOptions {
+  validateSession: (sessionId: string) => string | null
+  isBrowserActive: () => boolean
+  getConnectionUrl: () => string
+  getActiveTargetUrl: () => Promise<string | null>
+  urlsMatch: (left: string, right: string) => boolean
+  /** Override for tests — defaults to /workspace/downloads */
+  downloadsDir?: string
+}
+
+export interface DownloadedFileInfo {
+  name: string
+  path: string
+  size: number
+  contentType: string | null
+}
+
+type BrowserDownloadResponse =
+  | { success: true; body: { success: true; file: DownloadedFileInfo } }
+  | { success: false; status: 400 | 409 | 500; body: { error: string } }
+
+export function parseBrowserDownloadRequest(rawBody: unknown):
+  | { success: true; data: BrowserDownloadRequest }
+  | { success: false; error: string } {
+  const parsed = BrowserDownloadRequestSchema.safeParse(rawBody)
+  if (parsed.success) {
+    return { success: true, data: parsed.data }
+  }
+  return {
+    success: false,
+    error: parsed.error.issues.map(issue => issue.message).join(', '),
+  }
+}
+
+/** Content types we can map to an extension when the filename has none */
+const EXTENSION_BY_CONTENT_TYPE: Record<string, string> = {
+  'application/json': '.json',
+  'application/pdf': '.pdf',
+  'application/zip': '.zip',
+  'audio/mpeg': '.mp3',
+  'image/avif': '.avif',
+  'image/gif': '.gif',
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/svg+xml': '.svg',
+  'image/webp': '.webp',
+  'text/csv': '.csv',
+  'text/html': '.html',
+  'text/plain': '.txt',
+  'video/mp4': '.mp4',
+}
+
+export function extensionForContentType(contentType: string | null): string | null {
+  if (!contentType) return null
+  return EXTENSION_BY_CONTENT_TYPE[contentType.toLowerCase()] || null
+}
+
+/**
+ * Reduce any candidate filename to a safe basename: strips directories (so a
+ * traversal like `../../etc/passwd` becomes `passwd`), removes characters that
+ * are unsafe on common filesystems, and caps the length while preserving the
+ * extension. Falls back to "download" when nothing usable remains.
+ */
+export function sanitizeFilename(name: string): string {
+  // Normalize both separators before basename so `..\\..\\x` can't slip through
+  const base = path.basename(name.replace(/\\/g, '/'))
+  // eslint-disable-next-line no-control-regex
+  const cleaned = base.replace(/[\x00-\x1f<>:"|?*]/g, '').replace(/^[.\s]+|[.\s]+$/g, '')
+  if (!cleaned) return 'download'
+  if (cleaned.length <= 150) return cleaned
+  const ext = path.extname(cleaned)
+  return cleaned.slice(0, 150 - ext.length) + ext
+}
+
+/** Extract a filename from a Content-Disposition header (RFC 5987 or plain) */
+export function filenameFromContentDisposition(header: string | null | undefined): string | null {
+  if (!header) return null
+  // RFC 5987: filename*=UTF-8''percent%20encoded.pdf
+  const extended = /filename\*\s*=\s*(?:UTF-8|utf-8)''([^;]+)/.exec(header)
+  if (extended) {
+    try {
+      return decodeURIComponent(extended[1].trim())
+    } catch {
+      // fall through to the plain form
+    }
+  }
+  const plain = /filename\s*=\s*"([^"]+)"|filename\s*=\s*([^;]+)/.exec(header)
+  const value = plain ? (plain[1] ?? plain[2])?.trim() : null
+  return value || null
+}
+
+/** Derive a filename from a URL's pathname (null for empty/root paths) */
+export function filenameFromUrl(url: string): string | null {
+  try {
+    const pathname = new URL(url).pathname
+    const base = path.posix.basename(pathname)
+    if (!base) return null
+    try {
+      return decodeURIComponent(base)
+    } catch {
+      return base
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Pick the final filename: explicit request > Content-Disposition > URL path,
+ * then append an extension inferred from the content type when there is none.
+ */
+export function resolveDownloadFilename(input: {
+  explicit?: string
+  url: string
+  contentDisposition: string | null
+  contentType: string | null
+}): string {
+  const candidate = input.explicit
+    || filenameFromContentDisposition(input.contentDisposition)
+    || filenameFromUrl(input.url)
+    || 'download'
+  const sanitized = sanitizeFilename(candidate)
+  if (!path.extname(sanitized)) {
+    const ext = extensionForContentType(input.contentType)
+    if (ext) return sanitized + ext
+  }
+  return sanitized
+}
+
+/** Parse a data: URL into bytes without touching the browser */
+export function parseDataUrl(url: string): { buffer: Buffer; contentType: string | null } | null {
+  const match = /^data:([^,]*),(.*)$/s.exec(url)
+  if (!match) return null
+  const meta = match[1]
+  const isBase64 = /;base64$/i.test(meta)
+  const contentType = meta.replace(/;base64$/i, '') || null
+  try {
+    const buffer = isBase64
+      ? Buffer.from(match[2], 'base64')
+      : Buffer.from(decodeURIComponent(match[2]), 'utf8')
+    return { buffer, contentType }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Write the buffer into the downloads dir without clobbering existing files:
+ * `wx` creation with a `-1`, `-2`, ... suffix on collision.
+ */
+export async function writeDownloadFile(dir: string, filename: string, buffer: Buffer): Promise<string> {
+  await fs.promises.mkdir(dir, { recursive: true })
+  const ext = path.extname(filename)
+  const stem = filename.slice(0, filename.length - ext.length)
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const candidate = path.join(dir, attempt === 0 ? filename : `${stem}-${attempt}${ext}`)
+    try {
+      await fs.promises.writeFile(candidate, buffer, { flag: 'wx' })
+      return candidate
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException)?.code !== 'EEXIST') throw error
+    }
+  }
+  throw new Error(`Could not find a free filename for ${filename} in ${dir}`)
+}
+
+interface FetchedResource {
+  buffer: Buffer
+  contentType: string | null
+  contentDisposition: string | null
+}
+
+function primaryContentType(headerValue: string | null | undefined): string | null {
+  if (!headerValue) return null
+  return headerValue.split(';')[0].trim().toLowerCase() || null
+}
+
+/**
+ * Fetch a URL's bytes THROUGH the browser so cookies/login state apply and the
+ * bytes travel over the CDP wire — the browser may be running on the host or a
+ * remote provider (Browserbase) whose filesystem the container cannot see.
+ *
+ * - http(s): open a throwaway tab in the browser's own context and read the
+ *   navigation response body (immune to CORS, uses the browser's network
+ *   stack/proxy/fingerprint). URLs that force an attachment download abort the
+ *   navigation — those fall back to the context's request API, which shares
+ *   the browser's cookies but issues the request from the container.
+ * - blob: evaluated in the ACTIVE page — blob URLs only exist in the document
+ *   that created them.
+ * - data: decoded directly, no browser round-trip.
+ */
+export async function fetchResourceViaBrowser(
+  url: string,
+  options: Pick<RunBrowserDownloadOptions, 'getConnectionUrl' | 'getActiveTargetUrl' | 'urlsMatch'>
+): Promise<FetchedResource> {
+  const scheme = url.split(':')[0]?.toLowerCase()
+
+  if (scheme === 'data') {
+    const parsed = parseDataUrl(url)
+    if (!parsed) throw new Error('Malformed data: URL')
+    return { buffer: parsed.buffer, contentType: parsed.contentType, contentDisposition: null }
+  }
+
+  const browser = await chromium.connectOverCDP(options.getConnectionUrl())
+  try {
+    if (scheme === 'blob') {
+      const page = getActivePage(browser, await options.getActiveTargetUrl(), options.urlsMatch)
+      const raw = await page.evaluate(async (blobUrl: string) => {
+        const response = await fetch(blobUrl)
+        const blob = await response.blob()
+        const bytes = new Uint8Array(await blob.arrayBuffer())
+        let binary = ''
+        const chunk = 0x8000
+        for (let i = 0; i < bytes.length; i += chunk) {
+          binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+        }
+        return { base64: btoa(binary), contentType: blob.type || null }
+      }, url)
+      const result = BlobFetchResultSchema.parse(raw)
+      return {
+        buffer: Buffer.from(result.base64, 'base64'),
+        contentType: primaryContentType(result.contentType),
+        contentDisposition: null,
+      }
+    }
+
+    if (scheme !== 'http' && scheme !== 'https') {
+      throw new Error(`Unsupported URL scheme: ${scheme || '(none)'} — use http(s), blob: or data: URLs`)
+    }
+
+    const context = browser.contexts()[0]
+    if (!context) throw new Error('No browser context available')
+
+    const page = await context.newPage()
+    try {
+      const response = await page.goto(url, { waitUntil: 'commit', timeout: 30000 })
+      if (!response) throw new Error('Navigation returned no response')
+      if (response.status() >= 400) {
+        throw new Error(`HTTP ${response.status()} when fetching ${url}`)
+      }
+      const headers = response.headers()
+      return {
+        buffer: await response.body(),
+        contentType: primaryContentType(headers['content-type']),
+        contentDisposition: headers['content-disposition'] ?? null,
+      }
+    } catch (error: unknown) {
+      // A Content-Disposition: attachment response aborts the navigation with
+      // "Download is starting" / ERR_ABORTED. Re-fetch via the context's
+      // request API — same cookie jar, plain HTTP semantics, no download.
+      const message = error instanceof Error ? error.message : String(error)
+      if (!/Download is starting|ERR_ABORTED/i.test(message)) throw error
+
+      const apiResponse = await context.request.get(url, { timeout: 30000 })
+      if (!apiResponse.ok()) {
+        throw new Error(`HTTP ${apiResponse.status()} when fetching ${url}`)
+      }
+      const apiHeaders = apiResponse.headers()
+      return {
+        buffer: await apiResponse.body(),
+        contentType: primaryContentType(apiHeaders['content-type']),
+        contentDisposition: apiHeaders['content-disposition'] ?? null,
+      }
+    } finally {
+      await page.close().catch(() => { /* page may already be gone */ })
+    }
+  } finally {
+    await browser.close({ reason: 'browser_download complete' }).catch((error) => {
+      console.warn('[Browser] Failed to close Playwright CDP connection:', error)
+    })
+  }
+}
+
+export async function runBrowserDownload(
+  rawBody: unknown,
+  options: RunBrowserDownloadOptions
+): Promise<BrowserDownloadResponse> {
+  const parsed = parseBrowserDownloadRequest(rawBody)
+  if (!parsed.success) {
+    return { success: false, status: 400, body: { error: parsed.error } }
+  }
+
+  const body = parsed.data
+  const validationError = options.validateSession(body.sessionId)
+  if (validationError) {
+    return { success: false, status: 409, body: { error: validationError } }
+  }
+
+  if (!options.isBrowserActive()) {
+    return { success: false, status: 400, body: { error: 'Browser is not active — open it with browser_open first' } }
+  }
+
+  const scheme = body.url.split(':')[0]?.toLowerCase()
+  if (!['http', 'https', 'blob', 'data'].includes(scheme || '')) {
+    return {
+      success: false,
+      status: 400,
+      body: { error: `Unsupported URL scheme: ${scheme || '(none)'} — use http(s), blob: or data: URLs` },
+    }
+  }
+
+  let resource: FetchedResource
+  try {
+    resource = await fetchResourceViaBrowser(body.url, options)
+  } catch (error: unknown) {
+    return {
+      success: false,
+      status: 500,
+      body: { error: error instanceof Error ? error.message : String(error) },
+    }
+  }
+
+  if (resource.buffer.length === 0) {
+    return { success: false, status: 500, body: { error: 'Downloaded 0 bytes — the URL may require different credentials or headers' } }
+  }
+  if (resource.buffer.length > MAX_DOWNLOAD_BYTES) {
+    return {
+      success: false,
+      status: 400,
+      body: { error: `File is ${resource.buffer.length} bytes — exceeds the ${MAX_DOWNLOAD_BYTES} byte browser_download limit` },
+    }
+  }
+
+  const filename = resolveDownloadFilename({
+    explicit: body.filename,
+    url: body.url,
+    contentDisposition: resource.contentDisposition,
+    contentType: resource.contentType,
+  })
+
+  let savedPath: string
+  try {
+    savedPath = await writeDownloadFile(options.downloadsDir || DOWNLOADS_DIR, filename, resource.buffer)
+  } catch (error: unknown) {
+    return {
+      success: false,
+      status: 500,
+      body: { error: error instanceof Error ? error.message : String(error) },
+    }
+  }
+
+  return {
+    success: true,
+    body: {
+      success: true,
+      file: {
+        name: path.basename(savedPath),
+        path: savedPath,
+        size: resource.buffer.length,
+        contentType: resource.contentType,
+      },
+    },
+  }
+}

--- a/agent-container/src/browser-upload.ts
+++ b/agent-container/src/browser-upload.ts
@@ -267,14 +267,15 @@ export async function uploadToFileInput({
   }
 }
 
-function getActivePage(
+/** Find the Playwright page matching the daemon's active tab (shared with browser-download) */
+export function getActivePage(
   browser: Browser,
   activeTargetUrl: string | null,
   urlsMatch: (left: string, right: string) => boolean
 ): Page {
   const pages = browser.contexts().flatMap(context => context.pages())
   if (pages.length === 0) {
-    throw new Error('No browser pages available for upload')
+    throw new Error('No browser pages available')
   }
 
   const activePage = activeTargetUrl

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -15,6 +15,7 @@ import { inputManager } from './input-manager';
 import { dashboardManager } from './dashboard-manager';
 import { tabManager } from './tab-manager';
 import { runBrowserUpload } from './browser-upload';
+import { runBrowserDownload } from './browser-download';
 import { updateEnvFileEntry, healEnvFilePermissions } from './env-file-store';
 
 import { getEditingCommands } from './cdp-editing-commands';
@@ -828,6 +829,21 @@ async function setDownloadBehaviorViaCDP(cdpUrl: string, downloadPath: string): 
   });
 }
 
+// The CDP download path applied for the current browser (host path in host
+// mode, /workspace/downloads locally). Playwright connections made mid-session
+// (browser_upload/browser_download) can clobber Browser.setDownloadBehavior,
+// so we remember what we applied and re-apply it after those calls.
+let appliedCdpDownloadPath: string | null = null;
+
+async function reapplyDownloadBehavior(): Promise<void> {
+  if (!browserState.cdpUrl || !appliedCdpDownloadPath) return;
+  try {
+    await setDownloadBehaviorViaCDP(browserState.cdpUrl, appliedCdpDownloadPath);
+  } catch (err) {
+    console.error('[Browser] Failed to re-apply download behavior via CDP:', err);
+  }
+}
+
 // Tell the host to stop the Chrome process for this agent.
 async function stopHostBrowserIfNeeded(): Promise<void> {
   if (!process.env.AGENT_BROWSER_USE_HOST) return;
@@ -928,9 +944,11 @@ app.post('/browser/open', async (c) => {
     // For host browser: use the host-filesystem path (volume-mounted as /workspace).
     // For container browser: use /workspace/downloads directly.
     const downloadPath = hostBrowser?.hostDownloadDir || WORKSPACE_DOWNLOADS_DIR;
+    appliedCdpDownloadPath = null;
     if (cdpUrl) {
       try {
         await setDownloadBehaviorViaCDP(cdpUrl, downloadPath);
+        appliedCdpDownloadPath = downloadPath;
       } catch (err) {
         console.error('[Browser] Failed to set download behavior via CDP:', err);
       }
@@ -1421,6 +1439,10 @@ app.post('/browser/upload', async (c) => {
       urlsMatch: (left, right) => tabManager.urlsMatch(left, right),
     });
 
+    // Playwright's CDP attach can reset Browser.setDownloadBehavior — re-apply
+    // ours so click-triggered downloads keep landing in the workspace.
+    await reapplyDownloadBehavior();
+
     if (!result.success) {
       return c.json(result.body, result.status);
     }
@@ -1430,6 +1452,36 @@ app.post('/browser/upload', async (c) => {
   } catch (error: any) {
     console.error('[Browser] Error uploading file:', error);
     return c.json({ error: error.message || 'Failed to upload file' }, 500);
+  }
+});
+
+// POST /browser/download - Download a URL's bytes through the browser session
+// into /workspace/downloads. The bytes travel over the CDP wire, so this works
+// even when the browser's own filesystem is unreachable (host Chrome, Browserbase).
+app.post('/browser/download', async (c) => {
+  try {
+    const rawBody = await c.req.json().catch(() => ({}));
+    const result = await runBrowserDownload(rawBody, {
+      validateSession: validateBrowserSessionWithRecovery,
+      isBrowserActive: () => browserState.active,
+      getConnectionUrl: () => browserState.cdpUrl || getCdpHttpEndpoint(),
+      getActiveTargetUrl: async () => (await findActivePageTarget())?.url ?? null,
+      urlsMatch: (left, right) => tabManager.urlsMatch(left, right),
+    });
+
+    // Playwright's CDP attach can reset Browser.setDownloadBehavior — re-apply
+    // ours so click-triggered downloads keep landing in the workspace.
+    await reapplyDownloadBehavior();
+
+    if (!result.success) {
+      return c.json(result.body, result.status);
+    }
+
+    notifyBrowserAction();
+    return c.json(result.body);
+  } catch (error: any) {
+    console.error('[Browser] Error downloading file:', error);
+    return c.json({ error: error.message || 'Failed to download file' }, 500);
   }
 });
 

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -463,6 +463,39 @@ The selector must target the actual file input element, such as input[type="file
   }
 )
 
+const browserDownloadTool = tool(
+  'browser_download',
+  `Download a file or page asset (image, PDF, CSV, ...) into the workspace THROUGH the browser — the browser's cookies and login state apply, so this works for assets behind a login that curl/fetch outside the browser cannot reach. The bytes travel over the browser connection, so it also works when the browser runs outside the container (host Chrome, remote providers).
+
+Files are saved under /workspace/downloads/ and the saved path is returned.
+
+- Get the asset URL from the page first: browser_snapshot with includeUrls, browser_run("get attr @eN src"), or browser_eval (e.g. document.querySelector('img.profile-photo').src).
+- Supports http(s) URLs, blob: URLs (files the page generated — fetched from the current page), and data: URLs.
+- Links/buttons that trigger a browser download can also just be clicked — those files land in /workspace/downloads/ too.`,
+  {
+    url: z.string().describe('URL of the file to download — an <img> src, <a> href, blob: or data: URL'),
+    filename: z
+      .string()
+      .optional()
+      .describe('Optional filename to save as (basename only). Derived from the URL/response headers when omitted.'),
+  },
+  async (args) => {
+    const result = await browserFetch('download', { url: args.url, filename: args.filename })
+    if (!result.success) return errorResult(result.error!)
+    const data = result.data as { file?: { name: string; path: string; size: number; contentType: string | null } }
+    const file = data.file
+    if (!file) return errorResult('Download did not return file info')
+
+    let text = `Downloaded to ${file.path} (${file.size} bytes${file.contentType ? `, ${file.contentType}` : ''}).`
+    if (file.contentType === 'text/html') {
+      text += '\nWARNING: the response is an HTML page, not a file asset — this is usually a login or error page. Check the URL or your session.'
+    }
+    return {
+      content: [{ type: 'text' as const, text }],
+    }
+  }
+)
+
 const browserTypeTool = tool(
   'browser_type',
   `Type text with REAL keystrokes into the currently focused element — or pass a ref to focus that element first.
@@ -646,6 +679,7 @@ const browserGetStateTool = tool(
     browserSelectTool,
     browserHoverTool,
     browserUploadTool,
+    browserDownloadTool,
     browserTypeTool,
     browserEvalTool,
     browserRunTool,

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -15,6 +15,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 - `browser_hover(ref)` — Hover over an element (triggers dropdown menus, tooltips)
 - `browser_select(ref, value)` — Select an option in a NATIVE `<select>` (by value or visible label; commit is verified). Custom dropdowns (role=combobox/listbox divs): click the trigger, re-snapshot, type into the filter input, click the option's FRESH ref — refs renumber after each committed selection, so re-snapshot between selections
 - `browser_upload(filePath, selector?)` — Upload a local file into an `<input type="file">`. Use this for Dropbox, Box, Dropzone, and any file picker flow.
+- `browser_download(url, filename?)` — Download a file/image/asset through the browser (cookies + login state apply) into `/workspace/downloads/`. To save an image: get its URL first (`browser_run("get attr @e5 src")` or `browser_eval`), then download it. Report the returned path to the parent agent.
 - `browser_wait(for)` — Wait for a CSS selector to appear on the page. Do NOT use for load states — `browser_open` already waits for the page to load.
 - `browser_screenshot(full?)` — Take a screenshot (returns file path; use Read to see the image)
 
@@ -70,6 +71,7 @@ Tabs have **stable string ids** like `t1`, `t2` (run `browser_run("tab")` to lis
 - Use `browser_screenshot()` when you need to visually verify something the accessibility tree cannot tell you.
 - For file uploads, target the actual `<input type="file">` with `browser_upload(filePath, selector)`. Do not click "Upload" buttons to trigger a file picker.
 - If you need to upload a file but don't have one available locally (e.g. the user mentioned an upload but didn't attach anything), call `request_file` first, then pass the returned `/workspace/...` path to `browser_upload`.
+- **To save an image or file from a page, use `browser_download`** — never substitute a screenshot for the real asset. Files land in `/workspace/downloads/`; include the returned path in your final response.
 - If a page has not fully rendered dynamic content, re-snapshot after a moment.
 - The browser preserves cookies/sessions — the user logs in once and you can reuse the session.
 

--- a/src/renderer/components/messages/tool-renderers/browser-tools.ts
+++ b/src/renderer/components/messages/tool-renderers/browser-tools.ts
@@ -1,6 +1,7 @@
 
 import {
   Braces,
+  Download,
   Globe,
   MousePointerClick,
   TextCursorInput,
@@ -17,7 +18,7 @@ import {
   browserOpenDef, browserCloseDef, browserSnapshotDef,
   browserClickDef, browserFillDef, browserScrollDef,
   browserWaitDef, browserPressDef, browserTypeDef, browserScreenshotDef,
-  browserSelectDef, browserHoverDef, browserEvalDef, browserRunDef,
+  browserSelectDef, browserHoverDef, browserDownloadDef, browserEvalDef, browserRunDef,
 } from '@shared/lib/tool-definitions/browser-tools'
 
 export const browserOpenRenderer: ToolRenderer = { displayName: browserOpenDef.displayName, icon: Globe, getSummary: browserOpenDef.getSummary }
@@ -32,5 +33,6 @@ export const browserTypeRenderer: ToolRenderer = { displayName: browserTypeDef.d
 export const browserScreenshotRenderer: ToolRenderer = { displayName: browserScreenshotDef.displayName, icon: Camera, getSummary: browserScreenshotDef.getSummary, ExpandedView: () => null }
 export const browserSelectRenderer: ToolRenderer = { displayName: browserSelectDef.displayName, icon: CircleDot, getSummary: browserSelectDef.getSummary }
 export const browserHoverRenderer: ToolRenderer = { displayName: browserHoverDef.displayName, icon: MousePointer2, getSummary: browserHoverDef.getSummary }
+export const browserDownloadRenderer: ToolRenderer = { displayName: browserDownloadDef.displayName, icon: Download, getSummary: browserDownloadDef.getSummary }
 export const browserEvalRenderer: ToolRenderer = { displayName: browserEvalDef.displayName, icon: Braces, getSummary: browserEvalDef.getSummary }
 export const browserRunRenderer: ToolRenderer = { displayName: browserRunDef.displayName, icon: Terminal, getSummary: browserRunDef.getSummary }

--- a/src/renderer/components/messages/tool-renderers/index.ts
+++ b/src/renderer/components/messages/tool-renderers/index.ts
@@ -31,6 +31,7 @@ import {
   browserScreenshotRenderer,
   browserSelectRenderer,
   browserHoverRenderer,
+  browserDownloadRenderer,
   browserEvalRenderer,
   browserRunRenderer,
 } from './browser-tools'
@@ -118,6 +119,7 @@ const toolRenderers: Record<string, ToolRenderer> = {
   'mcp__browser__browser_screenshot': browserScreenshotRenderer,
   'mcp__browser__browser_select': browserSelectRenderer,
   'mcp__browser__browser_hover': browserHoverRenderer,
+  'mcp__browser__browser_download': browserDownloadRenderer,
   'mcp__browser__browser_eval': browserEvalRenderer,
   'mcp__browser__browser_run': browserRunRenderer,
 

--- a/src/shared/lib/tool-definitions/browser-tools.ts
+++ b/src/shared/lib/tool-definitions/browser-tools.ts
@@ -78,6 +78,16 @@ export const browserHoverDef: ToolDefinition = {
   getSummary: (input) => (input as { ref?: string }).ref ?? null,
 }
 
+export const browserDownloadDef: ToolDefinition = {
+  displayName: 'Download File',
+  getSummary: (input) => {
+    const { url, filename } = input as { url?: string; filename?: string }
+    if (filename) return filename
+    if (!url) return null
+    return url.length > 60 ? `${url.slice(0, 57)}...` : url
+  },
+}
+
 export const browserEvalDef: ToolDefinition = {
   displayName: 'Run JavaScript',
   getSummary: (input) => {

--- a/src/shared/lib/tool-definitions/registry.ts
+++ b/src/shared/lib/tool-definitions/registry.ts
@@ -38,6 +38,7 @@ import {
   browserScreenshotDef,
   browserSelectDef,
   browserHoverDef,
+  browserDownloadDef,
   browserEvalDef,
   browserRunDef,
 } from './browser-tools'
@@ -119,6 +120,7 @@ const definitions: Record<string, ToolDefinition> = {
   'mcp__browser__browser_screenshot': browserScreenshotDef,
   'mcp__browser__browser_select': browserSelectDef,
   'mcp__browser__browser_hover': browserHoverDef,
+  'mcp__browser__browser_download': browserDownloadDef,
   'mcp__browser__browser_eval': browserEvalDef,
   'mcp__browser__browser_run': browserRunDef,
 


### PR DESCRIPTION
## Problem

Agents had no way to save a page asset (image, PDF, generated file) from the browser to the workspace. Observed live: the web-browser subagent (browser tools only, no Bash/Write) spent turns trying to save LinkedIn profile photos and structurally couldn't — browser JS has no fs access, and in host-CDP / Browserbase mode the browser's filesystem isn't the container's `/workspace` at all. The workaround (extract signed URLs, curl from the main agent) only works for publicly fetchable URLs, never auth-gated ones.

## Fix: `browser_download(url, filename?)`

Bytes travel **over the CDP wire** and are written by the container server to `/workspace/downloads` — the browser machine's filesystem is never involved, so behavior is identical for container Chrome, host-CDP Chrome, and Browserbase.

- **http(s)**: throwaway tab in the browser's own context, `page.goto(waitUntil: 'commit')` + `response.body()` — CORS-immune, uses the browser's cookies/network stack/proxy/fingerprint. Attachment responses (`Content-Disposition`) abort navigation → fallback to `context.request.get`, which shares the browser's cookie jar.
- **blob:** fetched inside the active page (blob URLs only exist in their creating document); **data:** decoded directly.
- Filename: explicit param → Content-Disposition (incl. RFC 5987) → URL path, extension inferred from content type; sanitized (traversal-safe basename), collision-suffixed, 100MB cap. `text/html` responses get a login-/error-page warning in the tool result.
- Same per-call `connectOverCDP` pattern as `browser_upload`; new `/browser/download` endpoint mirrors the upload endpoint.

Also fixes a latent bug found on the way: Playwright's CDP attach can reset `Browser.setDownloadBehavior`, silently breaking click-triggered download routing after any `browser_upload`. The server now remembers the applied download path and re-applies it after every upload/download call.

Wiring: tool registered in the browser tool set (main agent + web-browser subagent get it automatically), subagent prompt updated (use `browser_download`, never substitute a screenshot for the real asset), tool-definition added so the UI renders "Download File".

## Testing

- 25 new unit tests (`browser-download.test.ts`): filename derivation/sanitization, data: URL parsing, collision-safe writes, request validation paths.
- Live verification against a real Chromium over CDP (external launch + `connectOverCDP`, matching container setup): cookie-gated image via navigation, cookie-gated attachment via the request fallback (proves the fallback shares the cookie jar), blob: URL, 404 surfacing, end-to-end `runBrowserDownload` with URL- and Content-Disposition-derived filenames, no stray tabs left. 11/11 checks.
- Confirmed end-to-end in a rebuilt container against real sites (auth-gated LinkedIn profile photo).
- `tsc` + `eslint` clean in repo root and agent-container.

## Known gap (follow-up)

On Browserbase, **click-triggered** downloads still land in Browserbase's cloud storage (empty `downloadDir` → `setDownloadBehavior` no-op); retrieving those needs their session-downloads API wired into the host. `browser_download` itself works on Browserbase since it never relies on the browser's disk.