### PR TITLE
Remove the container's unbounded per-session message buffer

### DIFF
--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -123,18 +123,6 @@ app.post('/sessions/:id/interrupt', async (c) => {
 });
 
 // Message endpoints
-app.get('/sessions/:id/messages', async (c) => {
-  const sessionId = c.req.param('id');
-  const session = await sessionManager.getSession(sessionId);
-
-  if (!session) {
-    return c.json({ error: 'Session not found' }, 404);
-  }
-
-  const messages = sessionManager.getMessages(sessionId);
-  return c.json(messages);
-});
-
 app.post('/sessions/:id/messages', async (c) => {
   const sessionId = c.req.param('id');
   const session = await sessionManager.getSession(sessionId);
@@ -2419,7 +2407,6 @@ console.log('  GET    /sessions/:id');
 console.log('  GET    /sessions');
 console.log('  DELETE /sessions/:id');
 console.log('  POST   /sessions/:id/interrupt');
-console.log('  GET    /sessions/:id/messages');
 console.log('  POST   /sessions/:id/messages');
 console.log('  WS     /sessions/:id/stream');
 console.log('  GET    /files/*');

--- a/agent-container/src/session-gc-durability.e2e.test.ts
+++ b/agent-container/src/session-gc-durability.e2e.test.ts
@@ -54,6 +54,21 @@ function assistantText(messages: AnyMessage[]): string {
     .join('\n');
 }
 
+// The manager keeps no message history (the old unbounded per-session buffer
+// backed an endpoint nothing called) — observe the stream the way production
+// consumers do: by subscription. Attach right after createSession/getSession
+// resolves; turn output only starts after the next sendMessage, so nothing
+// the assertions need can be missed. NOTE: a manager-restart resume builds a
+// fresh SessionData (fresh subscriber set) — re-collect after it.
+function collectMessages(
+  manager: { subscribe(id: string, cb: (m: unknown) => void): () => void },
+  id: string
+): AnyMessage[] {
+  const collected: AnyMessage[] = [];
+  manager.subscribe(id, (m) => collected.push(m as AnyMessage));
+  return collected;
+}
+
 function describeMessages(messages: AnyMessage[]): string {
   return messages
     .filter((m) => m.type !== 'stream_event')
@@ -146,15 +161,16 @@ describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => 
         model: MODEL,
       });
       const id = session.id;
+      const msgs = collectMessages(manager, id);
       dlog(`A2: created ${id}`);
 
-      await waitFor('A2 first result', () => resultCount(manager.getMessages(id)) >= 1, 120_000);
+      await waitFor('A2 first result', () => resultCount(msgs) >= 1, 120_000);
       await waitFor('A2 reaped once', () => !manager.isSessionRunning(id), 45_000);
       logDisk(configDir, 'A2 after evict#1', ['papaya-7']);
 
       await manager.sendMessage(id, 'Remember: codeword two is walnut-9. Reply with exactly: OK');
-      await waitFor('A2 second result', () => resultCount(manager.getMessages(id)) >= 2, 120_000);
-      dlog(`A2 turn-2 msgs: ${describeMessages(manager.getMessages(id))}`);
+      await waitFor('A2 second result', () => resultCount(msgs) >= 2, 120_000);
+      dlog(`A2 turn-2 msgs: ${describeMessages(msgs)}`);
       logDisk(configDir, 'A2 after turn 2 (pre-evict)', ['papaya-7', 'walnut-9']);
       await waitFor('A2 reaped twice', () => !manager.isSessionRunning(id), 45_000);
       // Give the CLI a beat, then check what survived the eviction kill.
@@ -169,13 +185,17 @@ describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => 
         evictionPollMs: 60_000,
       });
       managers.push(manager2);
+      // Resume first (bare getSession) so the fresh SessionData exists to
+      // subscribe to before the question's turn produces any frames.
+      await manager2.getSession(id);
+      const msgs2 = collectMessages(manager2, id);
       await manager2.sendMessage(
         id,
         'What are codeword one and codeword two? Reply with only the two codewords.'
       );
-      await waitFor('A2 post-restart result', () => resultCount(manager2.getMessages(id)) >= 1, 120_000);
-      const reply = assistantText(manager2.getMessages(id));
-      dlog(`A2 post-restart msgs: ${describeMessages(manager2.getMessages(id))}`);
+      await waitFor('A2 post-restart result', () => resultCount(msgs2) >= 1, 120_000);
+      const reply = assistantText(msgs2);
+      dlog(`A2 post-restart msgs: ${describeMessages(msgs2)}`);
       dlog(`A2: post-restart reply=${JSON.stringify(reply)}`);
 
       expect(reply).toContain('papaya-7');
@@ -200,7 +220,8 @@ describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => 
         model: MODEL,
       });
       const id = session.id;
-      await waitFor('D2 first result', () => resultCount(manager.getMessages(id)) >= 1, 120_000);
+      const msgs = collectMessages(manager, id);
+      await waitFor('D2 first result', () => resultCount(msgs) >= 1, 120_000);
       await waitFor('D2 reaped', () => !manager.isSessionRunning(id), 45_000);
       logDisk(configDir, 'D2 after evict#1', ['ready']);
       dlog('D2: appending notification with shouldQuery:false into cold session');
@@ -213,21 +234,21 @@ describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => 
       );
       await waitFor('D2 re-reaped after append', () => !manager.isSessionRunning(id), 45_000);
       await new Promise((r) => setTimeout(r, 2_000));
-      dlog(`D2 post-append msgs: ${describeMessages(manager.getMessages(id))}`);
+      dlog(`D2 post-append msgs: ${describeMessages(msgs)}`);
       logDisk(configDir, 'D2 after append+evict', ['q3-report-xyzzy']);
 
-      const baseline = resultCount(manager.getMessages(id));
+      const baseline = resultCount(msgs);
       await manager.sendMessage(
         id,
         'What file path did the notification from finance-bot mention? Reply with only the path.'
       );
       await waitFor(
         'D2 question result',
-        () => resultCount(manager.getMessages(id)) > baseline,
+        () => resultCount(msgs) > baseline,
         120_000
       );
-      const reply = assistantText(manager.getMessages(id));
-      dlog(`D2 all msgs: ${describeMessages(manager.getMessages(id))}`);
+      const reply = assistantText(msgs);
+      dlog(`D2 all msgs: ${describeMessages(msgs)}`);
       dlog(`D2: reply=${JSON.stringify(reply)}`);
 
       // Invariant: the transcript-only append must not be silently lost.
@@ -257,11 +278,12 @@ describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => 
         model: MODEL,
       });
       const id = session.id;
+      const msgs = collectMessages(manager, id);
       // Queue a second message while turn 1 is (very likely) still running.
       await manager.sendMessage(id, 'Reply with exactly: beta-two');
 
-      await waitFor('both chained results', () => resultCount(manager.getMessages(id)) >= 2, 120_000);
-      const text = assistantText(manager.getMessages(id));
+      await waitFor('both chained results', () => resultCount(msgs) >= 2, 120_000);
+      const text = assistantText(msgs);
       dlog(`chained-turns text=${JSON.stringify(text)}`);
       expect(text).toContain('alpha-one');
       expect(text).toContain('beta-two');
@@ -293,12 +315,13 @@ describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => 
         model: MODEL,
       });
       const id = session.id;
+      const msgs = collectMessages(manager, id);
 
-      await waitFor('bg-task first result', () => resultCount(manager.getMessages(id)) >= 1, 120_000);
+      await waitFor('bg-task first result', () => resultCount(msgs) >= 1, 120_000);
 
       // The test is only valid if a background task was actually registered.
       const sawBgTask = () =>
-        manager.getMessages(id).some(
+        msgs.some(
           (m) =>
             m.type === 'system' &&
             (m.subtype === 'task_started' || m.subtype === 'background_tasks_changed')
@@ -314,13 +337,13 @@ describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => 
       // Completion wake delivers the task output to the model...
       await waitFor(
         'wake turn observed',
-        () => assistantText(manager.getMessages(id)).includes('SLEEP-DONE') ||
-              resultCount(manager.getMessages(id)) >= 2,
+        () => assistantText(msgs).includes('SLEEP-DONE') ||
+              resultCount(msgs) >= 2,
         60_000
       );
       // ...and only after the wake settles does the reaper take the process.
       await waitFor('reaped after wake settled', () => !manager.isSessionRunning(id), 60_000);
-      dlog(`bg-task msgs: ${describeMessages(manager.getMessages(id))}`);
+      dlog(`bg-task msgs: ${describeMessages(msgs)}`);
     },
     360_000
   );

--- a/agent-container/src/session-gc.e2e.test.ts
+++ b/agent-container/src/session-gc.e2e.test.ts
@@ -80,6 +80,21 @@ function assistantText(messages: AnyMessage[]): string {
     .join('\n');
 }
 
+// The manager keeps no message history (the old unbounded per-session buffer
+// backed an endpoint nothing called) — observe the stream the way production
+// consumers do: by subscription. Attach right after createSession/getSession
+// resolves; turn output only starts after the next sendMessage, so nothing
+// the assertions need can be missed. NOTE: a manager-restart resume builds a
+// fresh SessionData (fresh subscriber set) — re-collect after it.
+function collectMessages(
+  manager: { subscribe(id: string, cb: (m: unknown) => void): () => void },
+  id: string
+): AnyMessage[] {
+  const collected: AnyMessage[] = [];
+  manager.subscribe(id, (m) => collected.push(m as AnyMessage));
+  return collected;
+}
+
 describe.skipIf(!ENABLED)('session GC end-to-end (real CLI subprocesses)', () => {
   let workDir: string;
   // Loaded dynamically AFTER the env below is in place.
@@ -126,11 +141,12 @@ describe.skipIf(!ENABLED)('session GC end-to-end (real CLI subprocesses)', () =>
         model: MODEL,
       });
       const id = session.id;
+      const msgs = collectMessages(manager, id);
 
       // Turn completes → a real `claude` subprocess exists and is parked.
       await waitFor(
         'first result',
-        () => resultCount(manager.getMessages(id)) >= 1,
+        () => resultCount(msgs) >= 1,
         120_000
       );
       expect(countClaudeSubprocesses()).toBeGreaterThanOrEqual(1);
@@ -149,10 +165,10 @@ describe.skipIf(!ENABLED)('session GC end-to-end (real CLI subprocesses)', () =>
       );
       await waitFor(
         'resume result',
-        () => resultCount(manager.getMessages(id)) >= 2,
+        () => resultCount(msgs) >= 2,
         120_000
       );
-      expect(assistantText(manager.getMessages(id))).toContain('kumquat-42');
+      expect(assistantText(msgs)).toContain('kumquat-42');
 
       // And the resumed (now interactive-class, via promotion) turn gets
       // reaped again once its 5s idle threshold elapses.
@@ -178,9 +194,10 @@ describe.skipIf(!ENABLED)('session GC end-to-end (real CLI subprocesses)', () =>
         model: MODEL,
       });
       const id = session.id;
+      const msgs = collectMessages(manager, id);
       await waitFor(
         'first result',
-        () => resultCount(manager.getMessages(id)) >= 1,
+        () => resultCount(msgs) >= 1,
         120_000
       );
       const settledAt = Date.now();
@@ -197,7 +214,7 @@ describe.skipIf(!ENABLED)('session GC end-to-end (real CLI subprocesses)', () =>
       await manager.sendMessage(id, 'Reply with exactly: hello again');
       await waitFor(
         'resume result',
-        () => resultCount(manager.getMessages(id)) >= 2,
+        () => resultCount(msgs) >= 2,
         120_000
       );
       expect(manager.isSessionRunning(id)).toBe(true);

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -12,7 +12,6 @@ import { SessionSettlementTracker } from './session-settlement';
 interface SessionData {
   session: Session;
   process: ClaudeCodeProcess;
-  messages: SDKMessage[];
   subscribers: Set<(message: SDKMessage) => void>;
   // Whether the session is settled (turn over, no background work, not in a
   // completion-wake window) — the only state a subprocess may be stopped in.
@@ -255,7 +254,6 @@ export class SessionManager extends EventEmitter {
     const sessionData: SessionData = {
       session,
       process,
-      messages: [],
       subscribers: new Set(),
       // Authority: this container always runs the CLI with
       // CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=1, so idle comes from state
@@ -391,7 +389,6 @@ export class SessionManager extends EventEmitter {
       const data: SessionData = {
         session,
         process,
-        messages: [],
         subscribers: new Set(),
         // Born-idle: a bare getSession() resume gets no turn (no result, never
         // idle), so born-busy would park the process beyond the reaper forever.
@@ -558,12 +555,6 @@ export class SessionManager extends EventEmitter {
     return sessionData.process.cancelQueuedMessage(uuid);
   }
 
-  getMessages(sessionId: string): SDKMessage[] {
-    const sessionData = this.sessions.get(sessionId);
-    if (!sessionData) return [];
-    return [...sessionData.messages];
-  }
-
   subscribe(sessionId: string, callback: (message: SDKMessage) => void): () => void {
     const sessionData = this.sessions.get(sessionId);
     if (!sessionData) {
@@ -595,9 +586,6 @@ export class SessionManager extends EventEmitter {
   private handleMessage(sessionId: string, message: SDKMessage): void {
     const sessionData = this.sessions.get(sessionId);
     if (!sessionData) return;
-
-    // Store the message
-    sessionData.messages.push(message);
 
     sessionData.settlement.handleMessage(message);
 

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -1230,20 +1230,6 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     return response.ok
   }
 
-  async getMessages(sessionId: string): Promise<any[]> {
-    const port = await this.getPortOrThrow()
-
-    const response = await fetch(
-      `${this.getBaseUrl(port)}/sessions/${sessionId}/messages`
-    )
-
-    if (!response.ok) {
-      throw new Error(`Failed to get messages: ${response.statusText}`)
-    }
-
-    return response.json()
-  }
-
   subscribeToStream(
     sessionId: string,
     callback: (message: StreamMessage) => void

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -223,7 +223,6 @@ function createMockClient(): ContainerClient & {
     getSession: vi.fn(() => Promise.resolve(null)),
     deleteSession: vi.fn(),
     sendMessage: vi.fn(),
-    getMessages: vi.fn(),
     interruptSession: vi.fn(),
     subscribeToStream: vi.fn((sessionId: string, callback: (message: StreamMessage) => void) => {
       messageCallback = callback
@@ -5314,7 +5313,6 @@ describe('MessagePersister.handleConnectionClosed re-subscribe', () => {
       getSession: vi.fn(() => Promise.resolve({ isRunning: true } as any)),
       deleteSession: vi.fn(),
       sendMessage: vi.fn(),
-      getMessages: vi.fn(),
       interruptSession: vi.fn(),
       subscribeToStream: vi.fn((_sessionId: string, cb: (message: StreamMessage) => void) => {
         callback = cb

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1458,7 +1458,6 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
   private running: boolean = false
   private activeBrowserSessionId: string | null = null
   private sessions: Map<string, ContainerSession> = new Map()
-  private sessionMessages: Map<string, unknown[]> = new Map()
   private streamCallbacks: Map<string, Set<(message: StreamMessage) => void>> = new Map()
   // Map from containerSessionId to our internal sessionId (which is the same as the API sessionId)
   private sessionToApiSession: Map<string, string> = new Map()
@@ -1657,7 +1656,6 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     }
     this.running = false
     this.sessions.clear()
-    this.sessionMessages.clear()
     this.streamCallbacks.clear()
     console.log(`[MockContainerClient] Stopped mock container for agent ${this.config.agentId}`)
     return { forceStopUsed: false, stopped: true }
@@ -1670,7 +1668,6 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     }
     this.running = false
     this.sessions.clear()
-    this.sessionMessages.clear()
     this.streamCallbacks.clear()
     console.log(`[MockContainerClient] Stopped mock container (sync) for agent ${this.config.agentId}`)
   }
@@ -1863,7 +1860,6 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     }
 
     this.sessions.set(sessionId, session)
-    this.sessionMessages.set(sessionId, [])
     this.streamCallbacks.set(sessionId, new Set())
 
     console.log(`[MockContainerClient] Created session ${sessionId}`)
@@ -1876,14 +1872,6 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
           { uuid: options.initialMessageUuid, content: options.initialMessage },
         ])
       }
-      // Store user message
-      const userMessage = {
-        role: 'user',
-        content: options.initialMessage,
-        timestamp: new Date().toISOString(),
-      }
-      this.sessionMessages.get(sessionId)?.push(userMessage)
-
       // Delay message emission to give time for subscription
       // The API subscribes after createSession returns, so we need to wait
       setTimeout(() => {
@@ -1923,7 +1911,6 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
   async deleteSession(sessionId: string): Promise<boolean> {
     const existed = this.sessions.has(sessionId)
     this.sessions.delete(sessionId)
-    this.sessionMessages.delete(sessionId)
     this.streamCallbacks.delete(sessionId)
     this.pendingUserMessageUuids.delete(sessionId)
     this.busySessions.delete(sessionId)
@@ -1974,12 +1961,6 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
 
     // shouldQuery: false — append to transcript without triggering a response
     if (options?.shouldQuery === false) {
-      this.sessionMessages.get(sessionId)?.push({
-        role: 'user',
-        content,
-        timestamp: new Date().toISOString(),
-        shouldQuery: false,
-      })
       return
     }
 
@@ -2038,14 +2019,6 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
       return
     }
 
-    // Store user message
-    const userMessage = {
-      role: 'user',
-      content,
-      timestamp: new Date().toISOString(),
-    }
-    this.sessionMessages.get(sessionId)?.push(userMessage)
-
     // Remember the uuid so the scenario's JSONL echo of this message gets it
     if (uuid) {
       const queue = this.pendingUserMessageUuids.get(sessionId) ?? []
@@ -2075,10 +2048,6 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     this.busySessions.add(sessionId)
     this.emitSessionState(sessionId, 'running')
     scenario.execute(sessionId, this.scenarioView(sessionId), content)
-  }
-
-  async getMessages(sessionId: string): Promise<unknown[]> {
-    return this.sessionMessages.get(sessionId) || []
   }
 
   async cancelQueuedMessage(sessionId: string, uuid: string): Promise<boolean> {

--- a/src/shared/lib/container/queued-message-idle-replay.test.ts
+++ b/src/shared/lib/container/queued-message-idle-replay.test.ts
@@ -123,7 +123,6 @@ function createReplayClient(): { client: ContainerClient; send: (message: Stream
     getSession: vi.fn(() => Promise.resolve(null)),
     deleteSession: vi.fn(),
     sendMessage: vi.fn(),
-    getMessages: vi.fn(),
     interruptSession: vi.fn(),
     on: vi.fn(),
     off: vi.fn(),

--- a/src/shared/lib/container/sdk206-fixtures-replay.test.ts
+++ b/src/shared/lib/container/sdk206-fixtures-replay.test.ts
@@ -140,7 +140,6 @@ function createReplayClient(): {
     getSession: vi.fn(() => Promise.resolve(null)),
     deleteSession: vi.fn(),
     sendMessage: vi.fn(),
-    getMessages: vi.fn(),
     interruptSession: vi.fn(),
     on: vi.fn(),
     off: vi.fn(),

--- a/src/shared/lib/container/subagent-routing-replay.test.ts
+++ b/src/shared/lib/container/subagent-routing-replay.test.ts
@@ -135,7 +135,6 @@ function createReplayClient(): {
     getSession: vi.fn(() => Promise.resolve(null)),
     deleteSession: vi.fn(),
     sendMessage: vi.fn(),
-    getMessages: vi.fn(),
     interruptSession: vi.fn(),
     on: vi.fn(),
     off: vi.fn(),

--- a/src/shared/lib/container/subagent-task-events-replay.test.ts
+++ b/src/shared/lib/container/subagent-task-events-replay.test.ts
@@ -157,7 +157,6 @@ function createReplayClient(): {
     getSession: vi.fn(() => Promise.resolve(null)),
     deleteSession: vi.fn(),
     sendMessage: vi.fn(),
-    getMessages: vi.fn(),
     interruptSession: vi.fn(),
     on: vi.fn(),
     off: vi.fn(),

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -163,7 +163,6 @@ export interface ContainerClient {
   // Cancel a queued (not yet picked up) message by the uuid it was sent with.
   // false = too late (already picked up) or session not live — never throws for that.
   cancelQueuedMessage(sessionId: string, uuid: string): Promise<boolean>
-  getMessages(sessionId: string): Promise<any[]>
   interruptSession(sessionId: string): Promise<boolean>
 
   // Streaming - returns unsubscribe function and a ready promise


### PR DESCRIPTION
## Problem

The container's `SessionManager` pushed **every** SDK frame of every session into an in-memory `messages` array — and because the query runs with `includePartialMessages: true`, that includes one `stream_event` object per streamed delta, i.e. O(streamed tokens) objects per turn. The buffer survived idle eviction (which only stops the subprocess) and was freed only by explicit session deletion, which for most sessions never happens. On a container that runs for weeks this quietly erodes the session-GC win from #440: the ~250MB CLI subprocess is reclaimed while the manager itself accumulates full transcripts at delta granularity.

## Why deletion (not capping) is safe

The buffer's only consumer was `GET /sessions/:id/messages`. An adversarial audit of the host app found it **unused**: zero callers across `src/`, `e2e/`, `scripts/`, and all container-client implementations (Docker/Podman/Lima/Apple/WSL2/Lambda/K8s/Mock); the artifact proxy is prefix-locked and can't reach it; and `git log -S` shows a host-side caller has *never existed* — host history flows over the WS stream into the message-persister's JSONL. Removing the route also removes one bare-GET path that could resurrect a cold session's subprocess as a side effect.

## Changes

- **agent-container**: drop `SessionData.messages`, the `handleMessage` push, `getMessages()`, and the `GET /sessions/:id/messages` route.
- **host**: drop `ContainerClient.getMessages` (interface + base client), the mock's implementation and its now-reader-less `sessionMessages` mirror map, and the dead `getMessages: vi.fn()` stubs in five test files.
- **gated GC E2E**: the tests used `manager.getMessages()` as their assertion oracle; they now collect frames via `manager.subscribe()` — the same way production consumers observe sessions. Subscription attaches right after `createSession`/`getSession` resolves, before any turn output can exist; the manager-restart test resumes explicitly (`getSession`) before re-subscribing since resume rebuilds the subscriber set.

## Validation

- agent-container unit suite: **603 passed** | 1 skipped
- host container-lib suite: **694 passed** | 3 skipped
- `tsc --noEmit` clean in both roots; eslint clean on changed host files
- Gated real-CLI E2E re-run live (run separately, per their headers): `session-gc.e2e.test.ts` **2/2**, `session-gc-durability.e2e.test.ts` **5/5**

First PR of the agent-container lifecycle-audit series (session leftovers / memory leaks).