### PR TITLE
Prune abandoned InputManager requests

### DIFF
--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -648,7 +648,8 @@ export class ClaudeCodeProcess extends EventEmitter {
               const answers = await inputManager.createPendingWithType<Record<string, string>>(
                 requestId,
                 'question',
-                questions
+                questions,
+                this.sessionId
               );
 
               console.log('[canUseTool] Got answers:', JSON.stringify(answers));
@@ -676,7 +677,7 @@ export class ClaudeCodeProcess extends EventEmitter {
           // but if two user-input tools fire concurrently the first ID could
           // be overwritten before consumeCurrentToolUseId is called.
           if ((toolName.startsWith('mcp__user-input__') || toolName.startsWith('mcp__computer-use__')) && options.toolUseID) {
-            inputManager.setCurrentToolUseId(options.toolUseID);
+            inputManager.setCurrentToolUseId(options.toolUseID, this.sessionId);
           }
 
           // Auto-approve other tools (we're in bypassPermissions mode)
@@ -689,7 +690,7 @@ export class ClaudeCodeProcess extends EventEmitter {
               hooks: [
                 async (_input, toolUseId) => {
                   if (toolUseId) {
-                    inputManager.setCurrentToolUseId(toolUseId);
+                    inputManager.setCurrentToolUseId(toolUseId, this.sessionId);
                   }
                   return {};
                 },
@@ -700,7 +701,7 @@ export class ClaudeCodeProcess extends EventEmitter {
               hooks: [
                 async (_input, toolUseId) => {
                   if (toolUseId) {
-                    inputManager.setCurrentToolUseId(toolUseId);
+                    inputManager.setCurrentToolUseId(toolUseId, this.sessionId);
                   }
                   return {};
                 },

--- a/agent-container/src/input-manager.test.ts
+++ b/agent-container/src/input-manager.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, vi } from 'vitest'
-import { inputManager } from './input-manager'
+import { describe, it, expect } from 'vitest'
+import {
+  inputManager,
+  AUTOMATED_INPUT_TTL_MS,
+  HUMAN_INPUT_TTL_MS,
+  EARLY_RESULT_TTL_MS,
+} from './input-manager'
 
 describe('InputManager', () => {
   // Tests use the exported singleton but unique toolUseIds per test to avoid cross-contamination.
@@ -212,28 +217,20 @@ describe('InputManager', () => {
     })
   })
 
-  describe('cleanupStale', () => {
-    it('rejects pending entries older than maxAgeMs', async () => {
-      vi.useFakeTimers()
-      try {
-        const promise = inputManager.createPending('stale-1', 'OLD_KEY')
+  describe('cleanupStale (type-aware TTLs)', () => {
+    it('rejects a human-input entry past the human TTL', async () => {
+      const promise = inputManager.createPending('stale-1', 'OLD_KEY')
 
-        // Advance time past the maxAge threshold
-        vi.advanceTimersByTime(10_000)
-        inputManager.cleanupStale(5_000)
+      inputManager.cleanupStale(Date.now() + HUMAN_INPUT_TTL_MS + 1_000)
 
-        await expect(promise).rejects.toThrow('Input request timed out')
-        expect(inputManager.hasPending('stale-1')).toBe(false)
-      } finally {
-        vi.useRealTimers()
-      }
+      await expect(promise).rejects.toThrow('Input request timed out')
+      expect(inputManager.hasPending('stale-1')).toBe(false)
     })
 
-    it('does not reject entries younger than maxAgeMs', async () => {
+    it('keeps a human-input entry that is younger than the human TTL', async () => {
       const promise = inputManager.createPending('fresh-1', 'NEW_KEY')
 
-      // Cleanup with a very large maxAge — nothing should be removed
-      inputManager.cleanupStale(999_999_999)
+      inputManager.cleanupStale(Date.now() + HUMAN_INPUT_TTL_MS - 60_000)
       expect(inputManager.hasPending('fresh-1')).toBe(true)
 
       // Clean up
@@ -241,16 +238,147 @@ describe('InputManager', () => {
       await promise
     })
 
-    it('clears stale early results', () => {
+    it('rejects an automated entry on the short TTL while a same-age human entry survives', async () => {
+      const automated = inputManager.createPendingWithType<string>(
+        'stale-auto-1',
+        'list_scheduled_tasks'
+      )
+      const human = inputManager.createPendingWithType<string>(
+        'stale-human-1',
+        'script_run',
+        { script: 'ls' }
+      )
+
+      // Past the automated TTL but well inside the human TTL.
+      inputManager.cleanupStale(Date.now() + AUTOMATED_INPUT_TTL_MS + 1_000)
+
+      await expect(automated).rejects.toThrow('Input request timed out')
+      expect(inputManager.hasPending('stale-auto-1')).toBe(false)
+      expect(inputManager.hasPending('stale-human-1')).toBe(true)
+
+      // Clean up
+      inputManager.resolve('stale-human-1', 'x')
+      await human
+    })
+
+    it('an unknown input type gets the long (fail-safe) TTL', async () => {
+      const promise = inputManager.createPendingWithType<string>(
+        'stale-unknown-1',
+        'some_future_type'
+      )
+
+      inputManager.cleanupStale(Date.now() + AUTOMATED_INPUT_TTL_MS + 1_000)
+      expect(inputManager.hasPending('stale-unknown-1')).toBe(true)
+
+      // Clean up
+      inputManager.resolve('stale-unknown-1', 'x')
+      await promise
+    })
+
+    it('drops an early result past its TTL', () => {
       inputManager.resolve('stale-early-1', 'buffered')
-      inputManager.cleanupStale(0)
+      inputManager.cleanupStale(Date.now() + EARLY_RESULT_TTL_MS + 1_000)
 
       // The early result should be gone — createPending should now block normally
-      const promise = inputManager.createPending('stale-early-1', 'KEY')
+      inputManager.createPending('stale-early-1', 'KEY')
       expect(inputManager.hasPending('stale-early-1')).toBe(true)
 
       // Clean up
       inputManager.resolve('stale-early-1', 'x')
+    })
+
+    it('keeps a fresh early result across a sweep (the race-bridging must survive periodic sweeps)', async () => {
+      inputManager.resolve('fresh-early-1', 'buffered-value')
+
+      // A periodic sweep firing between the answer and createPending must
+      // NOT eat the buffered value (the old implementation cleared ALL
+      // early results on every call).
+      inputManager.cleanupStale()
+
+      const value = await inputManager.createPending('fresh-early-1', 'KEY')
+      expect(value).toBe('buffered-value')
+    })
+  })
+
+  describe('session attribution and rejectForSession', () => {
+    it('rejects only the deleted session\'s pending entries', async () => {
+      inputManager.setCurrentToolUseId('sess-tool-A', 'session-1')
+      expect(inputManager.consumeCurrentToolUseId()).toBe('sess-tool-A')
+      const promiseA = inputManager.createPendingWithType<string>('sess-tool-A', 'secret', {
+        secretName: 'KEY_A',
+      })
+
+      inputManager.setCurrentToolUseId('sess-tool-B', 'session-2')
+      expect(inputManager.consumeCurrentToolUseId()).toBe('sess-tool-B')
+      const promiseB = inputManager.createPendingWithType<string>('sess-tool-B', 'secret', {
+        secretName: 'KEY_B',
+      })
+
+      const rejected = inputManager.rejectForSession('session-1')
+      expect(rejected).toBe(1)
+
+      await expect(promiseA).rejects.toThrow('Input request abandoned')
+      expect(inputManager.hasPending('sess-tool-A')).toBe(false)
+      expect(inputManager.hasPending('sess-tool-B')).toBe(true)
+
+      // Clean up
+      inputManager.resolve('sess-tool-B', 'x')
+      await promiseB
+    })
+
+    it('an explicit sessionId parameter wins over the hook-recorded one', async () => {
+      inputManager.setCurrentToolUseId('sess-tool-C', 'hook-session')
+      const promise = inputManager.createPendingWithType<string>(
+        'sess-tool-C',
+        'question',
+        undefined,
+        'explicit-session'
+      )
+
+      expect(inputManager.rejectForSession('hook-session')).toBe(0)
+      expect(inputManager.hasPending('sess-tool-C')).toBe(true)
+
+      expect(inputManager.rejectForSession('explicit-session')).toBe(1)
+      await expect(promise).rejects.toThrow('Input request abandoned')
+    })
+
+    it('untagged entries are untouched by rejectForSession', async () => {
+      const promise = inputManager.createPending('untagged-1', 'KEY')
+
+      expect(inputManager.rejectForSession('any-session')).toBe(0)
+      expect(inputManager.hasPending('untagged-1')).toBe(true)
+
+      // Clean up
+      inputManager.resolve('untagged-1', 'x')
+      await promise
+    })
+
+    it('interleaved hook fires from two sessions cannot cross-tag (keyed by toolUseId, not a slot)', async () => {
+      // Both hooks fire before either handler registers its pending.
+      inputManager.setCurrentToolUseId('interleave-A', 'session-X')
+      inputManager.setCurrentToolUseId('interleave-B', 'session-Y')
+
+      const promiseA = inputManager.createPendingWithType<string>('interleave-A', 'secret')
+      const promiseB = inputManager.createPendingWithType<string>('interleave-B', 'secret')
+
+      expect(inputManager.rejectForSession('session-X')).toBe(1)
+      await expect(promiseA).rejects.toThrow('Input request abandoned')
+      expect(inputManager.hasPending('interleave-B')).toBe(true)
+
+      // Clean up
+      inputManager.resolve('interleave-B', 'x')
+      await promiseB
+    })
+
+    it('getAllPending exposes the owning sessionId', () => {
+      inputManager.setCurrentToolUseId('expose-1', 'session-Z')
+      inputManager.createPendingWithType<string>('expose-1', 'secret')
+
+      const entry = inputManager.getAllPending().find((p) => p.toolUseId === 'expose-1')
+      expect(entry?.sessionId).toBe('session-Z')
+
+      // Clean up
+      inputManager.resolve('expose-1', 'x')
     })
   })
 

--- a/agent-container/src/input-manager.ts
+++ b/agent-container/src/input-manager.ts
@@ -18,12 +18,47 @@ interface PendingInput<T extends InputValue = string> {
   inputType: string // 'secret' | 'question' | 'connected_account'
   metadata?: unknown // questions array, secretName, toolkit, etc.
   createdAt: Date
+  // Owning session, when known — lets deleteSession reject the session's
+  // abandoned requests instead of leaving them (and the tool-handler closures
+  // they retain) in the map forever.
+  sessionId?: string
 }
 
 // Buffered result for when resolve/reject arrives before createPending
 type EarlyResult =
-  | { type: 'resolve'; value: InputValue }
-  | { type: 'reject'; error: string }
+  | { type: 'resolve'; value: InputValue; createdAt: Date }
+  | { type: 'reject'; error: string; createdAt: Date }
+
+// Input types the HOST answers programmatically (message-persister handlers
+// hitting the DB/scheduler) — normally within milliseconds. An entry this old
+// means the host handler died mid-request; nobody is coming back for it.
+const AUTOMATED_INPUT_TYPES: ReadonlySet<string> = new Set([
+  'schedule_task',
+  'list_scheduled_tasks',
+  'cancel_scheduled_task',
+  'pause_scheduled_task',
+  'resume_scheduled_task',
+  'create_webhook_endpoint',
+  'update_webhook_endpoint',
+  'inspect_webhook_events',
+  'list_triggers',
+  'get_available_triggers',
+  'setup_trigger',
+  'cancel_trigger',
+])
+export const AUTOMATED_INPUT_TTL_MS = 10 * 60 * 1000
+
+// Everything else waits on a human decision (secrets, questions, script/file
+// approvals, browser takeover). Generous by design — an overnight answer must
+// still land — and the fail-safe default for unknown future types: worst case
+// is a 24h-bounded entry, never a prematurely rejected human prompt.
+export const HUMAN_INPUT_TTL_MS = 24 * 60 * 60 * 1000
+
+// Early results only bridge the answer-before-createPending race, which is
+// millisecond-scale (parallel tool calls). Anything older is an answer to a
+// request whose handler never registered (e.g. the query was interrupted) —
+// and since the buffer can hold secret values, it must not sit in memory.
+export const EARLY_RESULT_TTL_MS = 5 * 60 * 1000
 
 class InputManager {
   // Pending requests keyed by toolUseId
@@ -39,12 +74,37 @@ class InputManager {
   // The hook sets this before the tool handler runs
   private currentToolUseId: string | null = null
 
+  // Session attribution recorded at hook time, consumed when the matching
+  // createPending* runs. Keyed by toolUseId (not a single slot) so two
+  // sessions' interleaved tool calls can't cross-tag each other. Bounded
+  // FIFO: a hook can fire for a call whose handler never registers a pending
+  // (validation early-returns), so stragglers are possible but capped.
+  private sessionIdByToolUse: Map<string, string> = new Map()
+  private static readonly SESSION_TAG_CAP = 200
+
   /**
-   * Set the current tool use ID (called by PreToolUse hook)
+   * Set the current tool use ID (called by PreToolUse hook / canUseTool).
+   * Pass the owning sessionId when known so the eventual pending entry can be
+   * rejected if that session is deleted.
    */
-  setCurrentToolUseId(toolUseId: string): void {
+  setCurrentToolUseId(toolUseId: string, sessionId?: string): void {
     this.currentToolUseId = toolUseId
+    if (sessionId) {
+      this.sessionIdByToolUse.set(toolUseId, sessionId)
+      while (this.sessionIdByToolUse.size > InputManager.SESSION_TAG_CAP) {
+        const oldest = this.sessionIdByToolUse.keys().next().value
+        if (oldest === undefined) break
+        this.sessionIdByToolUse.delete(oldest)
+      }
+    }
     console.log(`[InputManager] Set current toolUseId: ${toolUseId}`)
+  }
+
+  /** Get and clear the session recorded for a toolUseId at hook time. */
+  private takeSessionIdFor(toolUseId: string): string | undefined {
+    const sessionId = this.sessionIdByToolUse.get(toolUseId)
+    this.sessionIdByToolUse.delete(toolUseId)
+    return sessionId
   }
 
   /**
@@ -68,35 +128,9 @@ class InputManager {
     secretName: string,
     reason?: string
   ): Promise<string> {
-    // Check if the user already responded before this pending was created
-    const early = this.earlyResults.get(toolUseId)
-    if (early) {
-      this.earlyResults.delete(toolUseId)
-      if (early.type === 'resolve') {
-        console.log(
-          `[InputManager] Immediately resolving ${toolUseId} for secret ${secretName} (early result)`
-        )
-        return Promise.resolve(early.value as string)
-      } else {
-        console.log(
-          `[InputManager] Immediately rejecting ${toolUseId} for secret ${secretName} (early result): ${early.error}`
-        )
-        return Promise.reject(new Error(early.error))
-      }
-    }
-
-    return new Promise((resolve, reject) => {
-      this.pending.set(toolUseId, {
-        resolve: resolve as (value: InputValue) => void,
-        reject,
-        inputType: 'secret',
-        metadata: { secretName, reason },
-        createdAt: new Date(),
-      })
-
-      console.log(
-        `[InputManager] Created pending request ${toolUseId} for secret ${secretName}`
-      )
+    return this.createPendingWithType<string>(toolUseId, 'secret', {
+      secretName,
+      reason,
     })
   }
 
@@ -110,8 +144,13 @@ class InputManager {
   createPendingWithType<T extends InputValue>(
     toolUseId: string,
     inputType: string,
-    metadata?: unknown
+    metadata?: unknown,
+    sessionId?: string
   ): Promise<T> {
+    // Session attribution: explicit param wins, else whatever the hook
+    // recorded for this toolUseId. Consume the tag either way.
+    const owner = sessionId ?? this.takeSessionIdFor(toolUseId)
+
     // Check if the user already responded before this pending was created
     const early = this.earlyResults.get(toolUseId)
     if (early) {
@@ -136,12 +175,34 @@ class InputManager {
         inputType,
         metadata,
         createdAt: new Date(),
+        sessionId: owner,
       })
 
       console.log(
-        `[InputManager] Created pending ${inputType} request ${toolUseId}`
+        `[InputManager] Created pending ${inputType} request ${toolUseId}${owner ? ` (session ${owner})` : ''}`
       )
     })
+  }
+
+  /**
+   * Reject and remove every pending request owned by a session. Called when
+   * the session is deleted — the host will never answer them, and each entry
+   * pins its tool-handler closure (and the dead query context) in memory. A
+   * still-live awaiter gets a clean error instead of a permanent hang.
+   * @returns number of requests rejected
+   */
+  rejectForSession(sessionId: string, reason = 'Input request abandoned: the session was deleted'): number {
+    let rejected = 0
+    for (const [toolUseId, pending] of this.pending) {
+      if (pending.sessionId !== sessionId) continue
+      console.log(
+        `[InputManager] Rejecting ${pending.inputType} request ${toolUseId} (session ${sessionId} deleted)`
+      )
+      this.pending.delete(toolUseId)
+      pending.reject(new Error(reason))
+      rejected++
+    }
+    return rejected
   }
 
   /**
@@ -161,7 +222,7 @@ class InputManager {
       console.log(
         `[InputManager] No pending request found for ${toolUseId}, buffering early resolve`
       )
-      this.earlyResults.set(toolUseId, { type: 'resolve', value })
+      this.earlyResults.set(toolUseId, { type: 'resolve', value, createdAt: new Date() })
       return true
     }
 
@@ -190,7 +251,7 @@ class InputManager {
       console.log(
         `[InputManager] No pending request found for ${toolUseId}, buffering early reject`
       )
-      this.earlyResults.set(toolUseId, { type: 'reject', error })
+      this.earlyResults.set(toolUseId, { type: 'reject', error, createdAt: new Date() })
       return true
     }
 
@@ -219,36 +280,40 @@ class InputManager {
     inputType: string
     metadata?: unknown
     createdAt: Date
+    sessionId?: string
   }> {
     return Array.from(this.pending.entries()).map(([toolUseId, pending]) => ({
       toolUseId,
       inputType: pending.inputType,
       metadata: pending.metadata,
       createdAt: pending.createdAt,
+      sessionId: pending.sessionId,
     }))
   }
 
   /**
-   * Cleanup stale pending requests (optional timeout mechanism).
-   * @param maxAgeMs - Maximum age in milliseconds before a request is considered stale
+   * Reject pending requests past their type's TTL and drop expired early
+   * results. Run periodically (the server wires a 60s sweep) — without it,
+   * entries the host never answers live forever.
    */
-  cleanupStale(maxAgeMs: number = 5 * 60 * 1000): void {
-    const now = new Date()
+  cleanupStale(nowMs: number = Date.now()): void {
     for (const [toolUseId, pending] of this.pending) {
-      if (now.getTime() - pending.createdAt.getTime() > maxAgeMs) {
+      const ttlMs = AUTOMATED_INPUT_TYPES.has(pending.inputType)
+        ? AUTOMATED_INPUT_TTL_MS
+        : HUMAN_INPUT_TTL_MS
+      if (nowMs - pending.createdAt.getTime() > ttlMs) {
         console.log(
           `[InputManager] Cleaning up stale ${pending.inputType} request ${toolUseId}`
         )
-        pending.reject(new Error('Input request timed out'))
         this.pending.delete(toolUseId)
+        pending.reject(new Error('Input request timed out'))
       }
     }
-    // Early results should be consumed almost immediately; clear any stragglers
-    if (this.earlyResults.size > 0) {
-      console.log(
-        `[InputManager] Cleaning up ${this.earlyResults.size} stale early results`
-      )
-      this.earlyResults.clear()
+    for (const [toolUseId, early] of this.earlyResults) {
+      if (nowMs - early.createdAt.getTime() > EARLY_RESULT_TTL_MS) {
+        console.log(`[InputManager] Dropping expired early result for ${toolUseId}`)
+        this.earlyResults.delete(toolUseId)
+      }
     }
   }
 }

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -96,6 +96,12 @@ app.delete('/sessions/:id', async (c) => {
   const sessionId = c.req.param('id');
   const deleted = await sessionManager.deleteSession(sessionId);
 
+  // The host never answers a deleted session's input requests — reject them
+  // so awaiting tool handlers unblock and the entries don't live forever.
+  // Unconditional: a not-found session may still own entries from a racing
+  // or repeated delete.
+  inputManager.rejectForSession(sessionId);
+
   if (!deleted) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -2399,6 +2405,12 @@ function handleBrowserStreamConnection(ws: WebSocket) {
 dashboardManager.scanAndStartAll().catch((error) => {
   console.error('[DashboardManager] Failed to scan and start dashboards:', error);
 });
+
+// Sweep abandoned input requests. Entries the host never answers (session
+// deleted mid-prompt, app closed, request card ignored) would otherwise live
+// forever — pinning dead tool-handler closures and, via the early-result
+// buffer, secret values. TTLs are type-aware inside cleanupStale.
+setInterval(() => inputManager.cleanupStale(), 60_000).unref();
 
 console.log(`Server running on http://localhost:${port}`);
 console.log('Available endpoints:');


### PR DESCRIPTION
Item 2 of the container lifecycle-audit series (follows #443).

## Problem

`InputManager.pending` and `.earlyResults` entries were removed **only** by an explicit host resolve/reject. Any request the host never answers — session deleted mid-prompt, app closed, pending-request card ignored — lived forever, pinning the dead query's tool-handler closure and its context. The early-result buffer was worse: when an answer arrives for a `toolUseId` whose `createPending` never runs (interrupted query, handler crash), the answered **value — including secret material — sat in memory indefinitely**. `cleanupStale()` existed but had zero production callers, and entries carried no session association, so per-session teardown wasn't even possible.

## Changes

**Session attribution without touching ~20 tool signatures.** Both `setCurrentToolUseId` sites live inside `ClaudeCodeProcess` where the session is known, so the hook now records a `toolUseId → sessionId` pairing (bounded FIFO map, cap 200) that `createPendingWithType` consumes. Keyed by `toolUseId` rather than a single slot, so interleaved tool calls from two sessions can't cross-tag each other. The `AskUserQuestion` path (which doesn't go through the hook) passes its session explicitly via a new optional parameter.

**Rejection on session delete.** `DELETE /sessions/:id` calls `inputManager.rejectForSession(sessionId)` — entries are removed and their awaiting tool promises rejected with a clean "request abandoned" error, so a still-live query gets a tool result instead of hanging forever. Called unconditionally (a 404'd repeat delete may still own entries).

**Type-aware TTL sweep.** A 60s `unref()`'d interval runs the rewritten `cleanupStale()`:
- **10 min** for host-automated types (schedule/webhook/trigger ops) — the host answers these in milliseconds; anything old means the handler died.
- **24 h** for human-input types (secrets, questions, script/file approvals, browser takeover) — an overnight answer must still land. This is also the fail-safe default for unknown future types: worst case is a bounded entry, never a prematurely rejected human prompt.
- **5 min** for early results — they only bridge a millisecond-scale race, and they can hold secrets.

Behavioral fix along the way: the old `cleanupStale` cleared **all** early results on every call, which under periodic invocation would break the answer-before-`createPending` bridge it exists for; it's now TTL-based, with a regression test.

`createPending` (the legacy secret-flavored variant) now delegates to `createPendingWithType` instead of duplicating the flow.

## Tests

New unit coverage: session-scoped rejection leaves other sessions' entries alone; explicit sessionId beats hook-recorded; interleaved two-session hook fires can't cross-tag; automated TTL rejects while same-age human entry survives; unknown type gets the long TTL; early-result expiry and fresh-survival across a sweep. Existing suite updated to the new `cleanupStale(now)` API.

## Validation

- agent-container unit suite: **611 passed** | 1 skipped (30/30 in `input-manager.test.ts`)
- `tsc --noEmit` clean
- Gated real-CLI GC E2E re-run live (the hook changes sit in the query-init path): lifecycle **2/2**, durability **5/5**
