### PR TITLE
fix: sweep stale agent-browser screenshots (pinned dir + 24h janitor)

### DIFF
--- a/agent-container/src/screenshot-janitor.test.ts
+++ b/agent-container/src/screenshot-janitor.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import {
+  pinScreenshotDir,
+  sweepStaleScreenshots,
+  SCREENSHOT_MAX_AGE_MS,
+} from './screenshot-janitor'
+
+describe('pinScreenshotDir', () => {
+  it('sets the default under HOME when unset', () => {
+    const env: NodeJS.ProcessEnv = { HOME: '/home/claude' }
+    const dir = pinScreenshotDir(env)
+    expect(dir).toBe('/home/claude/.agent-browser/tmp/screenshots')
+    expect(env.AGENT_BROWSER_SCREENSHOT_DIR).toBe(dir)
+  })
+
+  it('respects a pre-set AGENT_BROWSER_SCREENSHOT_DIR', () => {
+    const env: NodeJS.ProcessEnv = {
+      HOME: '/home/claude',
+      AGENT_BROWSER_SCREENSHOT_DIR: '/custom/shots',
+    }
+    expect(pinScreenshotDir(env)).toBe('/custom/shots')
+    expect(env.AGENT_BROWSER_SCREENSHOT_DIR).toBe('/custom/shots')
+  })
+
+  it('falls back to /home/claude when HOME is unset', () => {
+    const env: NodeJS.ProcessEnv = {}
+    expect(pinScreenshotDir(env)).toBe(
+      '/home/claude/.agent-browser/tmp/screenshots'
+    )
+  })
+})
+
+describe('sweepStaleScreenshots', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'screenshot-janitor-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  async function writeFileAgedMs(name: string, ageMs: number, now: number) {
+    const filePath = path.join(dir, name)
+    await fs.writeFile(filePath, 'png-bytes')
+    const mtime = new Date(now - ageMs)
+    await fs.utimes(filePath, mtime, mtime)
+    return filePath
+  }
+
+  it('deletes files older than the max age and keeps fresh ones', async () => {
+    const now = Date.now()
+    const old = await writeFileAgedMs('screenshot-old.png', SCREENSHOT_MAX_AGE_MS + 60_000, now)
+    const fresh = await writeFileAgedMs('screenshot-fresh.png', 60_000, now)
+
+    const removed = await sweepStaleScreenshots(dir, now)
+
+    expect(removed).toBe(1)
+    await expect(fs.stat(old)).rejects.toThrow()
+    await expect(fs.stat(fresh)).resolves.toBeDefined()
+  })
+
+  it('keeps a file just under the max age', async () => {
+    const now = Date.now()
+    const nearBoundary = await writeFileAgedMs('screenshot-boundary.png', SCREENSHOT_MAX_AGE_MS - 1000, now)
+
+    expect(await sweepStaleScreenshots(dir, now)).toBe(0)
+    await expect(fs.stat(nearBoundary)).resolves.toBeDefined()
+  })
+
+  it('never touches subdirectories', async () => {
+    const now = Date.now()
+    const subdir = path.join(dir, 'nested')
+    await fs.mkdir(subdir)
+    const oldMtime = new Date(now - SCREENSHOT_MAX_AGE_MS - 60_000)
+    await fs.utimes(subdir, oldMtime, oldMtime)
+
+    expect(await sweepStaleScreenshots(dir, now)).toBe(0)
+    await expect(fs.stat(subdir)).resolves.toBeDefined()
+  })
+
+  it('returns 0 when the directory does not exist yet', async () => {
+    const missing = path.join(dir, 'does-not-exist')
+    expect(await sweepStaleScreenshots(missing, Date.now())).toBe(0)
+  })
+
+  it('honors a custom max age', async () => {
+    const now = Date.now()
+    await writeFileAgedMs('screenshot-hourish.png', 2 * 60 * 60 * 1000, now)
+
+    expect(await sweepStaleScreenshots(dir, now, 60 * 60 * 1000)).toBe(1)
+    expect(await fs.readdir(dir)).toEqual([])
+  })
+})

--- a/agent-container/src/screenshot-janitor.ts
+++ b/agent-container/src/screenshot-janitor.ts
@@ -1,0 +1,96 @@
+/**
+ * Screenshot Janitor - Bounds the disk held by agent-browser screenshots
+ *
+ * Every `browser_screenshot` and `browser_get_state` call makes agent-browser
+ * write a uniquely named PNG (~500KB each) that nothing ever deletes. The tool
+ * result advertises the file path and agents read it back after the call, so
+ * files cannot be unlinked eagerly — instead they are kept for a generous
+ * window and swept once clearly abandoned.
+ *
+ * The output directory is pinned via AGENT_BROWSER_SCREENSHOT_DIR (honored by
+ * the agent-browser CLI/daemon) so the janitor's target is deterministic
+ * rather than tracking the CLI's default-path convention across versions.
+ */
+
+import fs from 'fs/promises'
+import path from 'path'
+
+/**
+ * How old a screenshot must be before the janitor deletes it. Screenshots are
+ * referenced by path in tool results and re-read within the same turn or
+ * shortly after; a day is far beyond any legitimate reuse.
+ */
+export const SCREENSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000
+
+export const SWEEP_INTERVAL_MS = 60 * 60 * 1000
+
+/**
+ * Pin agent-browser's screenshot output directory so every spawned
+ * CLI/daemon (which inherit process.env) writes to a location the janitor
+ * knows about. The default mirrors agent-browser's own convention
+ * ($HOME/.agent-browser/tmp/screenshots) so files accumulated before the
+ * pin existed get swept too. A pre-set env var wins.
+ */
+export function pinScreenshotDir(env: NodeJS.ProcessEnv = process.env): string {
+  if (!env.AGENT_BROWSER_SCREENSHOT_DIR) {
+    env.AGENT_BROWSER_SCREENSHOT_DIR = path.join(
+      env.HOME || '/home/claude',
+      '.agent-browser',
+      'tmp',
+      'screenshots'
+    )
+  }
+  return env.AGENT_BROWSER_SCREENSHOT_DIR
+}
+
+/**
+ * Delete files in `dir` older than `maxAgeMs`. Age is measured by mtime —
+ * birthtime is unreliable on some mounts (e.g. S3-backed NFS reports epoch 0)
+ * and screenshots are written once, so mtime is creation time.
+ * @returns number of files removed
+ */
+export async function sweepStaleScreenshots(
+  dir: string,
+  nowMs: number = Date.now(),
+  maxAgeMs: number = SCREENSHOT_MAX_AGE_MS
+): Promise<number> {
+  let names: string[]
+  try {
+    names = await fs.readdir(dir)
+  } catch {
+    // Directory doesn't exist until the first screenshot is taken
+    return 0
+  }
+
+  let removed = 0
+  for (const name of names) {
+    const filePath = path.join(dir, name)
+    try {
+      const stat = await fs.stat(filePath)
+      if (!stat.isFile()) continue
+      if (nowMs - stat.mtimeMs > maxAgeMs) {
+        await fs.unlink(filePath)
+        removed++
+      }
+    } catch {
+      // Raced with a concurrent delete or unreadable entry — skip it
+    }
+  }
+
+  if (removed > 0) {
+    console.log(`[ScreenshotJanitor] Removed ${removed} stale screenshot(s) from ${dir}`)
+  }
+  return removed
+}
+
+/**
+ * Pin the screenshot directory, sweep it once now, and keep sweeping hourly.
+ * Call once at server startup, before any browser command can run.
+ */
+export function startScreenshotJanitor(): void {
+  const dir = pinScreenshotDir()
+  void sweepStaleScreenshots(dir)
+  setInterval(() => {
+    void sweepStaleScreenshots(dir)
+  }, SWEEP_INTERVAL_MS).unref()
+}

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -12,6 +12,7 @@ import { promisify } from 'util';
 import * as dns from 'dns';
 
 import { inputManager } from './input-manager';
+import { startScreenshotJanitor } from './screenshot-janitor';
 import { dashboardManager } from './dashboard-manager';
 import { tabManager } from './tab-manager';
 import { runBrowserUpload } from './browser-upload';
@@ -2411,6 +2412,10 @@ dashboardManager.scanAndStartAll().catch((error) => {
 // forever — pinning dead tool-handler closures and, via the early-result
 // buffer, secret values. TTLs are type-aware inside cleanupStale.
 setInterval(() => inputManager.cleanupStale(), 60_000).unref();
+
+// Pin agent-browser's screenshot directory and sweep stale files (boot +
+// hourly). Every screenshot is a uniquely named PNG nothing else deletes.
+startScreenshotJanitor();
 
 console.log(`Server running on http://localhost:${port}`);
 console.log('Available endpoints:');


### PR DESCRIPTION
Item 3 of the container-lifecycle audit (follow-up to #443, #444).

## Problem
Every `browser_screenshot` and `browser_get_state` call makes agent-browser write a uniquely named ~500KB PNG that nothing ever deletes — proven by months-old files accumulating in `~/.agent-browser/tmp/screenshots/`. `browser_get_state` shoots on every call, so heavy browsing sessions leak disk fast.

## Fix
- **Pin the output directory** via `AGENT_BROWSER_SCREENSHOT_DIR` at server startup (new `screenshot-janitor.ts`), making the janitor's target deterministic instead of guessing the CLI's default-path convention across versions. Verified against the agent-browser 0.27.2 binary that the env var is honored. The pinned default mirrors agent-browser's own convention (`$HOME/.agent-browser/tmp/screenshots`) so files accumulated *before* this change get swept too; a pre-set env var wins.
- **Janitor sweep**: delete files older than 24h, at boot + hourly (unref'd interval), wired next to the InputManager sweep in `server.ts`.

## Why not unlink-after-read
The tool result advertises the file path and agents re-read it (same turn or shortly after) — eager deletion would break that contract. 24h is far beyond any legitimate reuse.

## Details
- Age measured by **mtime**, not birthtime (epoch-0 on some mounts, e.g. S3-backed NFS); screenshots are written once so mtime = creation time.
- Subdirectories are never touched; per-file stat/unlink errors (concurrent-delete races) are skipped.
- Missing directory (no screenshot taken yet) is a no-op.
- `execBrowser` spreads `process.env`, so the pinned var reaches every spawned CLI/daemon; the pin runs in server startup code, before any request can trigger a browser command.

## Tests
- 8 new unit tests: old-deleted / fresh-kept, just-under-boundary kept, subdirs untouched, missing dir no-op, custom max-age, env pinning (default, pre-set wins, HOME fallback).
- Full agent-container suite: 619 passed, 8 skipped.
- tsc + eslint clean (remaining warnings pre-exist on untouched server.ts lines).