### PR TITLE
fix(llm): generic provider base-URL validation + URL-only revalidation UX

### DIFF
--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Hono } from 'hono'
 
 // ---------------------------------------------------------------------------
@@ -940,6 +940,70 @@ describe('settings route', () => {
       const body = await res.json()
       expect(body.valid).toBe(false)
       expect(body.error).toBe('Network timeout')
+    })
+  })
+
+  // =========================================================================
+  // LLM key validation (uses the REAL provider classes over mocked settings)
+  // =========================================================================
+  describe('POST /validate-llm-key', () => {
+    async function validateLlmKey(body: Record<string, unknown>): Promise<Response> {
+      return app.request('http://localhost/api/settings/validate-llm-key', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+    }
+
+    const savedGenericKeyEnv = process.env.GENERIC_API_KEY
+    beforeEach(() => {
+      delete process.env.GENERIC_API_KEY
+    })
+    afterEach(() => {
+      if (savedGenericKeyEnv === undefined) delete process.env.GENERIC_API_KEY
+      else process.env.GENERIC_API_KEY = savedGenericKeyEnv
+      vi.unstubAllGlobals()
+    })
+
+    it('returns 400 for an empty apiKey on a non-generic provider', async () => {
+      const res = await validateLlmKey({ provider: 'openrouter', apiKey: '' })
+      expect(res.status).toBe(400)
+      expect((await res.json()).error).toContain('API key is required')
+    })
+
+    it('lets the generic provider revalidate a base-URL-only change with the saved key', async () => {
+      mockGetSettings.mockReturnValue({
+        ...defaultSettings(),
+        apiKeys: { genericApiKey: 'saved-key', genericBaseUrl: 'http://old.example.com:4000' },
+      })
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const res = await validateLlmKey({
+        provider: 'generic',
+        apiKey: '',
+        baseUrl: 'http://ollama.example.com:11434',
+      })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ valid: true })
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+      expect(url).toBe('http://ollama.example.com:11434/v1/models')
+      expect(init.headers).toMatchObject({ Authorization: 'Bearer saved-key' })
+    })
+
+    it('reports a key requirement for generic when no key is given or saved', async () => {
+      mockGetSettings.mockReturnValue({ ...defaultSettings(), apiKeys: {} })
+      const res = await validateLlmKey({ provider: 'generic', apiKey: '', baseUrl: 'http://ollama.example.com:11434' })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ valid: false, error: 'API key is required' })
+    })
+
+    it('rejects a bare single-label hostname for the generic provider', async () => {
+      const res = await validateLlmKey({ provider: 'generic', apiKey: 'k', baseUrl: 'http://my-gpu-box:11434' })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.valid).toBe(false)
+      expect(body.error).toContain('bare hostname')
     })
   })
 

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -699,11 +699,14 @@ settings.post('/validate-anthropic-key', async (c) => {
 settings.post('/validate-llm-key', async (c) => {
   try {
     const { provider, apiKey, baseUrl } = await c.req.json()
-    if (!apiKey || typeof apiKey !== 'string') {
-      return c.json({ valid: false, error: 'API key is required' }, 400)
-    }
     if (!provider || typeof provider !== 'string') {
       return c.json({ valid: false, error: 'Provider is required' }, 400)
+    }
+    // The generic provider accepts an empty key and revalidates with the saved
+    // one — the renderer never holds the saved secret, so a base-URL-only
+    // change couldn't resend it.
+    if (typeof apiKey !== 'string' || (!apiKey && provider !== 'generic')) {
+      return c.json({ valid: false, error: 'API key is required' }, 400)
     }
     if (
       provider !== 'anthropic' &&

--- a/src/renderer/components/settings/generic-credentials-input.tsx
+++ b/src/renderer/components/settings/generic-credentials-input.tsx
@@ -39,25 +39,34 @@ export function GenericCredentialsInput({ disabled = false }: GenericCredentials
 
   const apiKeyStatus: ApiKeyStatus | undefined = settings?.apiKeyStatus?.generic
   const isBusy = isValidating || isRemoving
+  // A URL-only change is validatable against the already-saved key (the server
+  // falls back to it), so the key field only gates the button on first setup.
+  const hasSavedKey = apiKeyStatus?.isConfigured ?? false
+  const canValidate = Boolean(baseUrl.trim()) && (Boolean(apiKeyInput.trim()) || hasSavedKey)
 
   const handleValidateAndSave = async () => {
     const trimmedUrl = baseUrl.trim()
     const trimmedKey = apiKeyInput.trim()
-    if (!trimmedUrl || !trimmedKey) return
+    if (!trimmedUrl || (!trimmedKey && !hasSavedKey)) return
     setIsValidating(true)
     setValidationResult(null)
     try {
       const res = await apiFetch('/api/settings/validate-llm-key', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        // An empty apiKey tells the server to revalidate with the saved key.
         body: JSON.stringify({ provider: 'generic', apiKey: trimmedKey, baseUrl: trimmedUrl }),
       })
       const result = await res.json()
       setValidationResult(result)
       if (result.valid) {
         try {
+          // Omit genericApiKey when the field is empty — in the settings PUT,
+          // absent means keep and '' means delete the saved key.
           await updateSettings.mutateAsync({
-            apiKeys: { genericBaseUrl: trimmedUrl, genericApiKey: trimmedKey },
+            apiKeys: trimmedKey
+              ? { genericBaseUrl: trimmedUrl, genericApiKey: trimmedKey }
+              : { genericBaseUrl: trimmedUrl },
           })
           setApiKeyInput('')
         } catch {
@@ -138,7 +147,7 @@ export function GenericCredentialsInput({ disabled = false }: GenericCredentials
       </div>
 
       <div className="flex gap-2">
-        {baseUrl.trim() && apiKeyInput.trim() && (
+        {canValidate && (
           <Button size="sm" onClick={handleValidateAndSave} disabled={isBusy}>
             {isValidating ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Validating...</> : 'Validate & Save'}
           </Button>

--- a/src/shared/lib/llm-provider/container-url.test.ts
+++ b/src/shared/lib/llm-provider/container-url.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { isHostOnlyHostname, rewriteLoopbackForContainer } from './container-url'
+
+describe('rewriteLoopbackForContainer', () => {
+  it('rewrites the bracketed IPv6 loopback literal (URL.hostname keeps brackets)', () => {
+    expect(rewriteLoopbackForContainer('http://[::1]:11434')).toBe('http://host.docker.internal:11434')
+  })
+
+  it('rewrites localhost and IPv4 loopback', () => {
+    expect(rewriteLoopbackForContainer('http://localhost:4000')).toBe('http://host.docker.internal:4000')
+    expect(rewriteLoopbackForContainer('http://127.0.0.1:4000')).toBe('http://host.docker.internal:4000')
+  })
+
+  it('leaves non-loopback URLs untouched', () => {
+    expect(rewriteLoopbackForContainer('http://ollama.example.com:11434')).toBe('http://ollama.example.com:11434')
+  })
+})
+
+describe('isHostOnlyHostname', () => {
+  it('flags single-label hostnames (host-resolver-only names like Tailscale MagicDNS)', () => {
+    expect(isHostOnlyHostname('iddo-gino-gputer')).toBe(true)
+    expect(isHostOnlyHostname('gputer')).toBe(true)
+  })
+
+  it('accepts fully-qualified domain names', () => {
+    expect(isHostOnlyHostname('iddo-gino-gputer.taila37989.ts.net')).toBe(false)
+    expect(isHostOnlyHostname('ollama.local')).toBe(false)
+  })
+
+  it('accepts IP literals', () => {
+    expect(isHostOnlyHostname('192.168.1.5')).toBe(false)
+    expect(isHostOnlyHostname('[::1]')).toBe(false)
+    expect(isHostOnlyHostname('[fe80::1]')).toBe(false)
+  })
+
+  it('accepts loopback names — the container rewrite handles those', () => {
+    expect(isHostOnlyHostname('localhost')).toBe(false)
+    expect(isHostOnlyHostname('127.0.0.1')).toBe(false)
+  })
+})

--- a/src/shared/lib/llm-provider/container-url.ts
+++ b/src/shared/lib/llm-provider/container-url.ts
@@ -3,7 +3,9 @@
  * container these point at the container, not the host, so a host-reachable
  * URL using them is unreachable from the container.
  */
-const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1'])
+// URL.hostname keeps the brackets on IPv6 literals, so '[::1]' (not '::1') is
+// what a parsed loopback IPv6 URL yields.
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1', '[::1]'])
 
 /**
  * Rewrite a loopback URL to the container-reachable host gateway
@@ -13,6 +15,21 @@ const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1'])
  * (e.g. localhost.mycorp.dev) are left alone. Non-URL input passes through
  * unchanged.
  */
+/**
+ * True when a parsed URL hostname is a single-label name (no dots) that only
+ * resolves through host-side mechanisms Docker's DNS forwarder does not apply
+ * — the host's search domains and scoped resolvers (Tailscale MagicDNS, mDNS
+ * without the .local suffix). Such a URL works on the host but is
+ * unresolvable inside the agent container. Loopback names are excluded
+ * because rewriteLoopbackForContainer translates them, and bracketed IPv6
+ * literals are dot-free without being hostnames at all.
+ */
+export function isHostOnlyHostname(hostname: string): boolean {
+  if (LOOPBACK_HOSTNAMES.has(hostname)) return false
+  if (hostname.startsWith('[')) return false
+  return !hostname.includes('.')
+}
+
 export function rewriteLoopbackForContainer(url: string | undefined): string | undefined {
   if (!url) return url
   let parsed: URL

--- a/src/shared/lib/llm-provider/generic-provider.test.ts
+++ b/src/shared/lib/llm-provider/generic-provider.test.ts
@@ -284,6 +284,56 @@ describe('GenericLlmProvider.validateKey', () => {
     expect(await provider.validateKey('key')).toEqual({ valid: false, error: 'Base URL is required' })
   })
 
+  it('falls back to the saved key when called with an empty key (base-URL-only change)', async () => {
+    const fetchMock = stubFetch({ ok: true, status: 200 })
+    const result = await provider.validateKey('', { baseUrl: 'http://ollama.example.com:11434' })
+    expect(result).toEqual({ valid: true })
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer test-key' })
+  })
+
+  it('requires a key when none is provided and none is saved', async () => {
+    settingsMock.mockReturnValue({ apiKeys: { genericBaseUrl: 'https://proxy.example' } })
+    const fetchMock = stubFetch()
+    expect(await provider.validateKey('')).toEqual({ valid: false, error: 'API key is required' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a bare single-label hostname without probing the network', async () => {
+    settingsMock.mockReturnValue({ apiKeys: {} })
+    const fetchMock = stubFetch()
+    const result = await provider.validateKey('key', { baseUrl: 'http://my-gpu-box:11434' })
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('"my-gpu-box" is a bare hostname')
+    expect(result.error).toContain('fully-qualified domain name')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('accepts loopback and IP-literal base URLs (containers reach those via the rewrite/routing)', async () => {
+    settingsMock.mockReturnValue({ apiKeys: {} })
+    stubFetch({ ok: true, status: 200 })
+    expect(await provider.validateKey('key', { baseUrl: 'http://127.0.0.1:11434' })).toEqual({ valid: true })
+    expect(await provider.validateKey('key', { baseUrl: 'http://100.92.209.99:11434' })).toEqual({ valid: true })
+  })
+
+  it('rejects an unparseable base URL with scheme guidance', async () => {
+    settingsMock.mockReturnValue({ apiKeys: {} })
+    const fetchMock = stubFetch()
+    const result = await provider.validateKey('key', { baseUrl: 'http://' })
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('not a valid URL')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a scheme-less base URL (parses as a URL with a bogus protocol)', async () => {
+    settingsMock.mockReturnValue({ apiKeys: {} })
+    const fetchMock = stubFetch()
+    const result = await provider.validateKey('key', { baseUrl: 'my-gpu-box:11434' })
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('must start with http:// or https://')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('probes /v1/models on the inline baseURL and reports success without needing a real model id', async () => {
     settingsMock.mockReturnValue({ apiKeys: {} })
     const fetchMock = stubFetch({ ok: true, status: 200 })

--- a/src/shared/lib/llm-provider/generic-provider.ts
+++ b/src/shared/lib/llm-provider/generic-provider.ts
@@ -3,7 +3,7 @@ import { BaseLlmProvider, type ModelPurpose } from './base-llm-provider'
 import type { ModelDefinition, ModelSearchResult } from './model-catalog-schema'
 import type { EffortLevel } from '../container/types'
 import { getSettings, getModelCatalogSettings, type ApiKeyStatus } from '../config/settings'
-import { rewriteLoopbackForContainer } from './container-url'
+import { isHostOnlyHostname, rewriteLoopbackForContainer } from './container-url'
 
 const BASE_URL_ENV = 'GENERIC_BASE_URL'
 const DEFAULT_MODEL_ENV = 'GENERIC_DEFAULT_MODEL'
@@ -147,17 +147,42 @@ export class GenericLlmProvider extends BaseLlmProvider {
    * added: 200 means auth + connectivity both work, 401/403 pinpoints an auth
    * failure, and a 404 is treated as a soft-warn (endpoint reachable but
    * doesn't expose /v1/models — the user can still add models manually).
+   *
+   * An empty apiKey means "revalidate with the saved key" — the renderer never
+   * holds the saved secret, so a base-URL-only change can't resend it.
    */
   async validateKey(
     apiKey: string,
     opts?: { baseUrl?: string },
   ): Promise<{ valid: boolean; error?: string }> {
+    const effectiveKey = apiKey || this.getEffectiveApiKey()
+    if (!effectiveKey) return { valid: false, error: 'API key is required' }
     // baseURL may not be saved yet during first-time setup, so accept it inline.
     const baseURL = opts?.baseUrl?.trim() || this.getEffectiveBaseUrl()
     if (!baseURL) return { valid: false, error: 'Base URL is required' }
+    // Validation probes from the HOST, where the OS resolver qualifies bare
+    // hostnames via search domains and scoped resolvers (Tailscale MagicDNS,
+    // mDNS). Agent containers get none of that, so a single-label hostname
+    // passes validation and then fails on every agent request. Reject it here
+    // with the fix instead of letting it save.
+    let parsedUrl: URL
+    try {
+      parsedUrl = new URL(baseURL)
+    } catch {
+      return { valid: false, error: 'Base URL is not a valid URL — include the scheme, e.g. http://my-host.example.com:11434' }
+    }
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      return { valid: false, error: 'Base URL must start with http:// or https://' }
+    }
+    if (isHostOnlyHostname(parsedUrl.hostname)) {
+      return {
+        valid: false,
+        error: `"${parsedUrl.hostname}" is a bare hostname that agent containers cannot resolve — use its fully-qualified domain name or IP address instead (localhost is fine; it is rewritten for containers automatically).`,
+      }
+    }
     let response: Response
     try {
-      response = await fetchModelsList(baseURL, apiKey)
+      response = await fetchModelsList(baseURL, effectiveKey)
     } catch (error) {
       const message = error instanceof Error && error.name === 'AbortError'
         ? `Timed out after ${REQUEST_TIMEOUT_MS / 1000}s — check the base URL is reachable.`
@@ -177,7 +202,7 @@ export class GenericLlmProvider extends BaseLlmProvider {
       const stripped = trimmed.replace(/\/v1$/i, '')
       if (stripped !== trimmed) {
         try {
-          const retry = await fetchModelsList(stripped, apiKey)
+          const retry = await fetchModelsList(stripped, effectiveKey)
           if (retry.ok) {
             return { valid: false, error: `Base URL should not include the /v1 suffix — use ${stripped}` }
           }


### PR DESCRIPTION
## Why

Configuring the generic provider with a bare hostname (e.g. `http://iddo-gino-gputer:11434`) passes validation and then fails on every agent request: validation probes from the **host**, where the OS resolver qualifies single-label names via search domains and scoped resolvers (Tailscale MagicDNS, mDNS) — agent containers get none of that, so the CLI inside the container retries (`api_retry` × N) and dies with `error_during_execution`. Reproduced live against an Ollama box reachable only through Tailscale.

Separately, the settings UX made a base-URL-only change impossible to save: the Validate & Save button only rendered when the API key field was non-empty, and the renderer never holds the saved secret to resend.

## What

**Validation (`generic-provider.ts`, `container-url.ts`)**
- `validateKey` now rejects, pre-probe and with guidance:
  - single-label hostnames (`isHostOnlyHostname`) → "use its fully-qualified domain name or IP address (localhost is fine; it is rewritten for containers automatically)"
  - unparseable URLs and non-http(s) schemes (a scheme-less `host:port` parses as a bogus protocol)
- IPv6 loopback rewrite fix: `URL.hostname` keeps brackets, so the `'::1'` entry in `LOOPBACK_HOSTNAMES` never matched — added `'[::1]'`, so `http://[::1]:port` now rewrites to `host.docker.internal` like the other loopbacks.

**URL-only revalidation (`generic-credentials-input.tsx`, `settings.ts` route)**
- Validate & Save shows whenever a URL is present and a key is typed **or already saved** (with saved credentials it also acts as a re-test-connection button).
- `/validate-llm-key` accepts an empty `apiKey` for provider `generic` only; `GenericLlmProvider.validateKey('')` falls back to the saved/env key, and returns "API key is required" if none exists anywhere.
- A URL-only save **omits** `genericApiKey` from the PUT payload — the settings PUT treats an absent field as keep but `''` as delete, so sending the empty string would have wiped the saved key.

## Testing

- New unit coverage: `container-url.test.ts` (hostname classifier + IPv6 rewrite), `generic-provider.test.ts` (guard rejections without network probes, saved-key fallback), `settings.test.ts` (route-level empty-key gate for generic vs 400 for others, FQDN rejection through the route).
- 161/161 across the three touched suites; typecheck + lint clean.
- The one E2E driving "Validate & Save" (`provider-api-key.spec.ts`) targets the Anthropic input and is unaffected.