### PR TITLE
feat(llm): add xAI Grok 4.5 to the OpenRouter built-in catalog

### DIFF
--- a/src/renderer/public/model-icons/xai.svg
+++ b/src/renderer/public/model-icons/xai.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" fill-rule="evenodd" aria-hidden="true">
+  <path d="M6.469 8.776L16.512 23h-4.464L2.005 8.776H6.47zm-.004 7.9l2.233 3.164L6.467 23H2l4.465-6.324zM22 2.582V23h-3.659V7.764L22 2.582zM22 1l-9.952 14.095-2.233-3.163L17.533 1H22z"/>
+</svg>

--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -215,6 +215,20 @@ const OPENROUTER_EXTRA_MODELS: ModelDefinition[] = [
     // Baked from OpenRouter's live model list (per-Mtok USD), fetched 2026-06-18.
     pricing: { inputPerMtok: 1.2, outputPerMtok: 4.2 },
   },
+  {
+    id: 'x-ai/grok-4.5',
+    label: 'Grok 4.5',
+    blurb: 'xAI Grok, routed via OpenRouter',
+    family: 'grok',
+    isLatest: true,
+    icon: 'xai',
+    supportedEfforts: NON_CLAUDE_EFFORTS,
+    supportsWebSearch: false,
+    // Baked from OpenRouter's live model list (per-Mtok USD), fetched 2026-07-10.
+    pricing: { inputPerMtok: 2, outputPerMtok: 6 },
+    // OpenRouter-reported context length for x-ai/grok-4.5, fetched 2026-07-10.
+    contextWindow: 500_000,
+  },
 ]
 
 /** OpenRouter — the bare Claude models plus curated non-Claude built-ins. */

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -52,10 +52,11 @@ describe('getProviderCatalog', () => {
     expect(sonnet.supportedEfforts).toEqual(['low', 'medium', 'high'])
   })
 
-  it('exposes the OpenRouter non-Claude built-ins (gpt, glm) with their own icons', () => {
+  it('exposes the OpenRouter non-Claude built-ins (gpt, glm, grok) with their own icons', () => {
     const catalog = getProviderCatalog('openrouter')
     const gpt = catalog.find((m) => m.id === 'openai/gpt-5.5')!
     const glm = catalog.find((m) => m.id === 'z-ai/glm-5.2')!
+    const grok = catalog.find((m) => m.id === 'x-ai/grok-4.5')!
     expect(gpt).toMatchObject({
       family: 'gpt',
       isLatest: true,
@@ -68,8 +69,18 @@ describe('getProviderCatalog', () => {
       icon: 'zai',
       pricing: { inputPerMtok: 1.2, outputPerMtok: 4.2 },
     })
+    expect(grok).toMatchObject({
+      family: 'grok',
+      isLatest: true,
+      icon: 'xai',
+      supportsWebSearch: false,
+      pricing: { inputPerMtok: 2, outputPerMtok: 6 },
+      contextWindow: 500_000,
+    })
     // Anthropic must NOT inherit the OpenRouter-only extras.
     expect(getProviderCatalog('anthropic').some((m) => m.id === 'openai/gpt-5.5')).toBe(false)
+    expect(getProviderCatalog('anthropic').some((m) => m.id === 'x-ai/grok-4.5')).toBe(false)
+    expect(getProviderCatalog('platform').some((m) => m.id === 'x-ai/grok-4.5')).toBe(false)
   })
 
   it('offers both GPT versions, with 5.5 the family latest and 5.4 a pinnable older version', () => {
@@ -389,6 +400,8 @@ describe('resolveModelForProvider', () => {
   it('resolves OpenRouter non-Claude models (gpt alias → latest id, glm slug passthrough)', () => {
     expect(resolveModelForProvider('gpt', 'openrouter', 'agent')).toBe('openai/gpt-5.5')
     expect(resolveModelForProvider('z-ai/glm-5.2', 'openrouter', 'agent')).toBe('z-ai/glm-5.2')
+    expect(resolveModelForProvider('grok', 'openrouter', 'agent')).toBe('x-ai/grok-4.5')
+    expect(resolveModelForProvider('x-ai/grok-4.5', 'openrouter', 'agent')).toBe('x-ai/grok-4.5')
   })
 
   it('resolves Platform GPT models to bare ids and falls back for unsupported glm', () => {

--- a/src/shared/lib/llm-provider/openrouter-provider.test.ts
+++ b/src/shared/lib/llm-provider/openrouter-provider.test.ts
@@ -137,6 +137,15 @@ describe('OpenRouterLlmProvider.searchModels — listing mapping', () => {
     expect(model.family).toBe('glm')
   })
 
+  it('maps the x-ai vendor to the xai icon', async () => {
+    stubFetch({ data: [{ id: 'x-ai/grok-4.5', name: 'xAI: Grok 4.5' }] })
+
+    const [model] = await provider.searchModels('grok')
+
+    expect(model.icon).toBe('xai')
+    expect(model.family).toBe('grok')
+  })
+
   it('omits pricing unless both prompt and completion are present', async () => {
     stubFetch({ data: [{ id: 'x/y', name: 'Y', pricing: { prompt: '0.000001' } }] })
 

--- a/src/shared/lib/llm-provider/openrouter-provider.ts
+++ b/src/shared/lib/llm-provider/openrouter-provider.ts
@@ -82,6 +82,9 @@ function iconForModelId(modelId: string): string | undefined {
     case 'z-ai':
     case 'zai':
       return 'zai'
+    case 'x-ai':
+    case 'xai':
+      return 'xai'
     default:
       return undefined
   }


### PR DESCRIPTION
## What

Adds **xAI Grok 4.5** (`x-ai/grok-4.5`) to the curated OpenRouter built-ins (`OPENROUTER_EXTRA_MODELS`), alongside the existing GPT and GLM entries:

- `family: 'grok'` with `isLatest: true`, so a bare `grok` alias resolves to it
- Pricing $2 in / $6 out per Mtok and a 500K context window, baked from OpenRouter's live model list (fetched 2026-07-10)
- `supportsWebSearch: false` — same reasoning as the other non-Claude entries (the agent's web tools are Anthropic-native server tools)
- Standard three effort levels, matching the other non-Claude models

**Icon**: bundles `model-icons/xai.svg` (xAI/Grok mark, currentColor, from the MIT-licensed LobeHub icon set, restyled to match the sibling SVGs) and maps the `x-ai`/`xai` vendor prefix to it in `iconForModelId`, so both the built-in entry and live model-search results get the logo. OpenRouter-only: the Platform and Anthropic catalogs are unaffected.

## Testing

- Extended `model-catalog.test.ts`: Grok entry shape (family/latest/icon/pricing/context window), absence from the Anthropic and Platform catalogs, and alias resolution (`grok` → `x-ai/grok-4.5`, slug passthrough)
- Extended `openrouter-provider.test.ts`: `x-ai` vendor → `xai` icon in search-result mapping
- 83/83 across the catalog, provider, and catalog-consuming UI suites; typecheck + lint clean