### PR TITLE
fix: close dashboard log streams on process end + cap dashboard.log growth

### DIFF
--- a/agent-container/src/dashboard-manager.test.ts
+++ b/agent-container/src/dashboard-manager.test.ts
@@ -1,8 +1,47 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import { PassThrough } from 'stream'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
-import { validateSlug, SLUG_REGEX, ARTIFACTS_DIR } from './dashboard-manager'
+import {
+  validateSlug,
+  SLUG_REGEX,
+  ARTIFACTS_DIR,
+  truncateOversizedLog,
+} from './dashboard-manager'
+
+const spawnHolder = vi.hoisted(() => ({
+  impl: null as ((command: string, args: string[], options: unknown) => unknown) | null,
+}))
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>()
+  return {
+    ...actual,
+    spawn: (command: string, args: string[], options: unknown) => {
+      if (!spawnHolder.impl) throw new Error('spawn called before test set an impl')
+      return spawnHolder.impl(command, args, options)
+    },
+  }
+})
+
+class FakeChildProcess extends EventEmitter {
+  stdout = new PassThrough()
+  stderr = new PassThrough()
+  kill = vi.fn((signal?: string) => {
+    setImmediate(() => this.exit(0, signal ?? 'SIGTERM'))
+    return true
+  })
+
+  /** Simulate process termination: stdio flushes, then exit + close fire. */
+  exit(code: number | null, signal: string | null = null) {
+    this.stdout.end()
+    this.stderr.end()
+    this.emit('exit', code, signal)
+    this.emit('close', code, signal)
+  }
+}
 
 describe('validateSlug', () => {
   describe('valid slugs', () => {
@@ -70,58 +109,173 @@ describe('validateSlug', () => {
   })
 })
 
-describe('DashboardManager', () => {
+describe('truncateOversizedLog', () => {
   let testDir: string
-  let DashboardManagerClass: any
-  let manager: any
 
   beforeEach(async () => {
-    testDir = await fs.promises.mkdtemp(
-      path.join(os.tmpdir(), 'dashboard-manager-test-')
-    )
-
-    // Dynamically re-import with mocked ARTIFACTS_DIR would be complex,
-    // so we test createDashboard behavior through the exported class
-    // by directly testing filesystem operations
+    testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'dashboard-log-'))
   })
 
   afterEach(async () => {
     await fs.promises.rm(testDir, { recursive: true, force: true })
   })
 
-  describe('createDashboard existence check', () => {
-    it('throws when dashboard already exists', async () => {
-      // We can't easily call createDashboard with a custom ARTIFACTS_DIR,
-      // but we can verify the logic pattern: if package.json exists, throw
-      const dir = path.join(testDir, 'existing-dash')
-      await fs.promises.mkdir(dir, { recursive: true })
-      await fs.promises.writeFile(
-        path.join(dir, 'package.json'),
-        JSON.stringify({ name: 'test' })
-      )
+  it('leaves a log under the cap untouched', async () => {
+    const logPath = path.join(testDir, 'dashboard.log')
+    await fs.promises.writeFile(logPath, 'small log\n')
 
-      // Verify the file exists (simulating what createDashboard checks)
-      let exists = false
-      try {
-        await fs.promises.access(path.join(dir, 'package.json'))
-        exists = true
-      } catch {
-        exists = false
-      }
-      expect(exists).toBe(true)
-    })
+    expect(await truncateOversizedLog(logPath, 1024, 256)).toBe(false)
+    expect(await fs.promises.readFile(logPath, 'utf-8')).toBe('small log\n')
+  })
 
-    it('does not throw for new slug directory', async () => {
-      const dir = path.join(testDir, 'new-dash')
+  it('keeps only the tail (plus a marker) of an oversized log', async () => {
+    const logPath = path.join(testDir, 'dashboard.log')
+    const content = 'x'.repeat(2000) + 'THE-TAIL'
+    await fs.promises.writeFile(logPath, content)
 
-      let exists = false
-      try {
-        await fs.promises.access(path.join(dir, 'package.json'))
-        exists = true
-      } catch {
-        exists = false
-      }
-      expect(exists).toBe(false)
-    })
+    expect(await truncateOversizedLog(logPath, 1024, 256)).toBe(true)
+
+    const after = await fs.promises.readFile(logPath, 'utf-8')
+    expect(after).toMatch(/^\[DashboardManager\] Log truncated from 2008 bytes/)
+    expect(after.endsWith('THE-TAIL')).toBe(true)
+    // marker line + 256 tail bytes
+    expect(after.length).toBeLessThan(256 + 120)
+  })
+
+  it('is a no-op for a missing file', async () => {
+    expect(await truncateOversizedLog(path.join(testDir, 'nope.log'))).toBe(false)
+  })
+})
+
+describe('DashboardManager log stream lifecycle', () => {
+  let testDir: string
+  let manager: {
+    startDashboard(slug: string): Promise<{
+      status: string
+      logStream: fs.WriteStream | null
+      restartTimestamps: number[]
+    }>
+    stopDashboard(slug: string): Promise<boolean>
+    stopAll(): Promise<void>
+  }
+  let procs: FakeChildProcess[]
+  let slugCounter = 0
+
+  beforeEach(async () => {
+    testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'dashboard-manager-'))
+    procs = []
+    spawnHolder.impl = () => {
+      const proc = new FakeChildProcess()
+      procs.push(proc)
+      return proc
+    }
+
+    // waitForPort probes the port over HTTP — pretend the server is up
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'))
+
+    // Fresh module (and singleton) pointed at the temp artifacts dir
+    vi.resetModules()
+    process.env.ARTIFACTS_DIR = testDir
+    manager = (await import('./dashboard-manager')).dashboardManager
+  })
+
+  afterEach(async () => {
+    await manager.stopAll()
+    delete process.env.ARTIFACTS_DIR
+    spawnHolder.impl = null
+    vi.restoreAllMocks()
+    await fs.promises.rm(testDir, { recursive: true, force: true })
+  })
+
+  /** Scaffold a dashboard dir whose node_modules is fresh (skips bun install). */
+  async function scaffoldDashboard(): Promise<string> {
+    const slug = `dash-${++slugCounter}`
+    const dir = path.join(testDir, slug)
+    await fs.promises.mkdir(path.join(dir, 'node_modules'), { recursive: true })
+    await fs.promises.writeFile(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ name: slug, scripts: { start: 'true' } })
+    )
+    // node_modules must be at least as new as package.json to skip install
+    const future = new Date(Date.now() + 60_000)
+    await fs.promises.utimes(path.join(dir, 'node_modules'), future, future)
+    return slug
+  }
+
+  it('closes the log stream when the process exits cleanly', async () => {
+    const slug = await scaffoldDashboard()
+    const info = await manager.startDashboard(slug)
+    expect(info.status).toBe('running')
+    const stream = info.logStream!
+    expect(stream.writableEnded).toBe(false)
+
+    procs[0].exit(0, null)
+
+    expect(stream.writableEnded).toBe(true)
+    expect(info.logStream).toBeNull()
+  })
+
+  it('closes the log stream on the crash path', async () => {
+    const slug = await scaffoldDashboard()
+    const info = await manager.startDashboard(slug)
+    const stream = info.logStream!
+
+    // Exhaust the restart budget so the crash doesn't schedule a restart
+    info.restartTimestamps.push(Date.now(), Date.now(), Date.now())
+    procs[0].exit(1, null)
+
+    expect(stream.writableEnded).toBe(true)
+    expect(info.logStream).toBeNull()
+    expect(info.status).toBe('crashed')
+  })
+
+  it('closes the log stream when the process errors without exiting', async () => {
+    const slug = await scaffoldDashboard()
+    const info = await manager.startDashboard(slug)
+    const stream = info.logStream!
+
+    procs[0].emit('error', new Error('spawn ENOENT'))
+
+    expect(stream.writableEnded).toBe(true)
+    expect(info.logStream).toBeNull()
+    expect(info.status).toBe('crashed')
+  })
+
+  it('restart-while-running closes the old stream and opens a new one without double-end errors', async () => {
+    const slug = await scaffoldDashboard()
+    const first = await manager.startDashboard(slug)
+    const oldStream = first.logStream!
+
+    // Restarting kills the old process; its exit ALSO triggers the close
+    // handler — the old stream must end exactly once (a second end() would
+    // throw ERR_STREAM_ALREADY_FINISHED as an uncaught exception).
+    const second = await manager.startDashboard(slug)
+
+    expect(oldStream.writableEnded).toBe(true)
+    expect(second.logStream).not.toBe(oldStream)
+    expect(second.logStream!.writableEnded).toBe(false)
+    expect(second.status).toBe('running')
+  })
+
+  it('stopDashboard ends the stream even though the close handler also ran', async () => {
+    const slug = await scaffoldDashboard()
+    const info = await manager.startDashboard(slug)
+    const stream = info.logStream!
+
+    await manager.stopDashboard(slug)
+
+    expect(stream.writableEnded).toBe(true)
+    expect(info.logStream).toBeNull()
+  })
+
+  it('truncates an oversized dashboard.log on start', async () => {
+    const slug = await scaffoldDashboard()
+    const logPath = path.join(testDir, slug, 'dashboard.log')
+    await fs.promises.writeFile(logPath, Buffer.alloc(11 * 1024 * 1024, 0x61))
+
+    await manager.startDashboard(slug)
+
+    const stat = await fs.promises.stat(logPath)
+    expect(stat.size).toBeLessThan(1024 * 1024)
   })
 })

--- a/agent-container/src/dashboard-manager.ts
+++ b/agent-container/src/dashboard-manager.ts
@@ -5,11 +5,56 @@ import { captureDashboardScreenshot, type ScreenshotResult } from './dashboard-s
 
 const SCREENSHOT_FILENAME = 'screenshot.png'
 
-export const ARTIFACTS_DIR = '/workspace/artifacts'
+// Env override exists so tests can point the manager at a temp directory.
+export const ARTIFACTS_DIR = process.env.ARTIFACTS_DIR || '/workspace/artifacts'
 const DASHBOARD_BASE_PORT = 5000
 const MAX_RESTARTS = 3
 const RESTART_WINDOW_MS = 5 * 60 * 1000 // 5 minutes
 export const SLUG_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
+
+// dashboard.log is append-only across every start/crash/restart; without a
+// cap a chatty or crash-looping dashboard grows it forever.
+export const MAX_LOG_SIZE_BYTES = 10 * 1024 * 1024
+export const LOG_TAIL_KEEP_BYTES = 256 * 1024
+
+/**
+ * If the log exceeds `maxBytes`, rewrite it to a marker line plus the last
+ * `keepBytes` of content (the recent output is what debugging needs).
+ * Only call while no stream has the file open for append.
+ * @returns true if the file was truncated
+ */
+export async function truncateOversizedLog(
+  logPath: string,
+  maxBytes: number = MAX_LOG_SIZE_BYTES,
+  keepBytes: number = LOG_TAIL_KEEP_BYTES
+): Promise<boolean> {
+  try {
+    const stat = await fs.promises.stat(logPath)
+    if (stat.size <= maxBytes) return false
+
+    const fd = await fs.promises.open(logPath, 'r')
+    let tail: Buffer
+    try {
+      const buf = Buffer.alloc(Math.min(keepBytes, stat.size))
+      const { bytesRead } = await fd.read(buf, 0, buf.length, stat.size - buf.length)
+      tail = buf.subarray(0, bytesRead)
+    } finally {
+      await fd.close()
+    }
+
+    await fs.promises.writeFile(
+      logPath,
+      Buffer.concat([
+        Buffer.from(`[DashboardManager] Log truncated from ${stat.size} bytes, keeping the last ${tail.length}\n`),
+        tail,
+      ])
+    )
+    return true
+  } catch {
+    // ENOENT (no log yet) or a read/write failure — leave the file alone
+    return false
+  }
+}
 
 export function validateSlug(slug: string): void {
   if (!SLUG_REGEX.test(slug)) {
@@ -39,6 +84,18 @@ interface DashboardInfo {
 class DashboardManager {
   private dashboards: Map<string, DashboardInfo> = new Map()
   private nextPort = DASHBOARD_BASE_PORT
+
+  /**
+   * End a dashboard's log stream exactly once. Nulls the field BEFORE ending:
+   * a second end() on a finished WriteStream emits ERR_STREAM_ALREADY_FINISHED,
+   * which would be an uncaught exception. Every close site must go through
+   * this — the process 'close' handler, stop paths, and restarts can overlap.
+   */
+  private closeLogStream(info: DashboardInfo): void {
+    const stream = info.logStream
+    info.logStream = null
+    stream?.end()
+  }
 
   async scanAndStartAll(): Promise<void> {
     try {
@@ -110,7 +167,7 @@ class DashboardManager {
           resolve()
         }
       })
-      existing.logStream?.end()
+      this.closeLogStream(existing)
     }
 
     const { name, description } = this.readPackageJson(slug)
@@ -133,8 +190,16 @@ class DashboardManager {
     this.dashboards.set(slug, info)
 
     try {
+      // Bound the append-only log before reopening it
+      await truncateOversizedLog(logPath)
+
       // Open log stream early so install errors are captured
       info.logStream = fs.createWriteStream(logPath, { flags: 'a' })
+      // A write failure (e.g. ENOSPC) must not take down the server — a
+      // WriteStream 'error' with no listener throws as an uncaught exception.
+      info.logStream.on('error', (error) => {
+        console.error(`[DashboardManager] Log stream error for ${slug}:`, error)
+      })
 
       // Run bun install only if node_modules is missing or package.json is newer than it
       await this.runBunInstallIfNeeded(dashboardDir, info.logStream)
@@ -166,11 +231,22 @@ class DashboardManager {
         }
       })
 
+      // 'close' (not 'exit') is when stdout/stderr have finished flushing into
+      // the log, so ending here can't drop the process's final output. Without
+      // this, every exit leaked the stream's fd — a crash-looping dashboard
+      // accumulated them until EMFILE.
+      proc.on('close', () => {
+        this.closeLogStream(info)
+      })
+
       proc.on('error', (error) => {
         console.error(`[DashboardManager] Dashboard ${slug} process error:`, error)
         info.logStream?.write(`[process error] ${error.message}\n`)
         info.status = 'crashed'
         info.process = null
+        // On spawn failure 'close' isn't guaranteed — close here too (no-op if
+        // the 'close' handler already ran).
+        this.closeLogStream(info)
       })
 
       console.log(`[DashboardManager] Starting dashboard ${slug} on port ${port}, waiting for port...`)
@@ -193,8 +269,7 @@ class DashboardManager {
     } catch (error: any) {
       console.error(`[DashboardManager] Failed to start dashboard ${slug}:`, error)
       info.logStream?.write(`[DashboardManager] Failed to start: ${error?.message || error}\n`)
-      info.logStream?.end()
-      info.logStream = null
+      this.closeLogStream(info)
       info.status = 'crashed'
     }
 
@@ -366,7 +441,7 @@ class DashboardManager {
       })
     }
 
-    info.logStream?.end()
+    this.closeLogStream(info)
     this.dashboards.delete(slug)
     return true
   }
@@ -507,8 +582,10 @@ console.log(\`Dashboard server running on http://localhost:\${port}\`);
     for (const info of this.dashboards.values()) {
       if (info.process) {
         info.process.kill('SIGTERM')
-        info.logStream?.end()
       }
+      // The stream can outlive the process (crashed dashboards keep it for a
+      // final write) — close it regardless of process state.
+      this.closeLogStream(info)
     }
     this.dashboards.clear()
   }


### PR DESCRIPTION
Item 4 of the container-lifecycle audit (follow-up to #443, #444, #445).

## Problem
The dashboard exit handler never closed `logStream`, so every crash-restart cycle leaked one fd — a dashboard crashing every ~2 minutes reaches EMFILE in days. Separately, `dashboard.log` is opened with `flags: 'a'` on every start and nothing ever bounds it, so it grows forever.

## Fix
**Stream lifecycle**
- End the stream in the child's **`close`** handler, not `exit` — `exit` can fire while stdout/stderr pipes are still flushing their final buffered output (the crash's last lines, exactly what debugging needs), so ending there could drop them or write-after-end.
- All close sites (the `close` handler, a spawn-`error` fallback for the case where `close` never fires, both stop paths, restart-while-running, and the start-failure catch) go through one `closeLogStream` helper that **nulls the field before ending**. This matters: a second `end()` on a finished WriteStream emits `ERR_STREAM_ALREADY_FINISHED`, and the stream had no error listener, so any double-end (e.g. `stopDashboard` racing the close handler) would have been an uncaught exception taking down the container server.
- The stream now gets an `error` listener at creation, so a runtime write failure (ENOSPC etc.) logs instead of crashing the process.
- The restart path's pre-existing `existing.logStream?.end()` is now redundant with the close handler but harmless — it routes through the same idempotent helper.

**Log cap**
- On every start (including crash-restarts, the high-frequency writer), if `dashboard.log` exceeds **10MB**, it's rewritten to a marker line plus the **last 256KB** before the append stream reopens. Truncation runs only while no stream has the file open.

**Test hook**
- `ARTIFACTS_DIR` gains an env override (`process.env.ARTIFACTS_DIR || '/workspace/artifacts'`) — the existing test file explicitly noted lifecycle testing was impossible with the hardcoded path. No production behavior change.

## Tests
9 new tests (34 total in file): a fake child process (EventEmitter + PassThrough stdio) drives clean exit, crash path (restart budget exhausted), spawn error without exit, restart-while-running (the double-end regression case), stopDashboard-after-close-handler, plus `truncateOversizedLog` unit coverage (under-cap untouched, tail+marker kept, missing file no-op) and an oversized-log-truncated-on-start integration check.

Full agent-container suite: 626 passed, 8 skipped. tsc + eslint clean (the two remaining warnings are pre-existing lines that shifted).