### PR TITLE
fix: stop browser-stream reconnects from leaking the tab-poll timer

### DIFF
--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -15,6 +15,7 @@ import { inputManager } from './input-manager';
 import { startScreenshotJanitor } from './screenshot-janitor';
 import { dashboardManager } from './dashboard-manager';
 import { tabManager } from './tab-manager';
+import { startTabPolling, stopTabPolling } from './tab-poll';
 import { runBrowserUpload } from './browser-upload';
 import { runBrowserDownload } from './browser-download';
 import { updateEnvFileEntry, healEnvFilePermissions } from './env-file-store';
@@ -1850,8 +1851,6 @@ interface BrowserTabInfo {
   active: boolean;
 }
 
-let tabPollInterval: NodeJS.Timeout | null = null;
-
 /** Get ALL CDP page targets across all strategies */
 async function getAllPageTargets(): Promise<PageTarget[]> {
   // Try Chrome's HTTP /json endpoint first (works for local Chrome)
@@ -2266,8 +2265,8 @@ function handleBrowserStreamConnection(ws: WebSocket) {
     ws.close();
   });
 
-  // Start tab list polling
-  tabPollInterval = setInterval(() => broadcastTabList(), 2000);
+  // Start tab list polling for this connection (replaces any previous viewer's timer)
+  const tabPoll = startTabPolling(() => broadcastTabList());
 
   // Forward input events and handle tab control messages from client
   // Protocol: see src/renderer/components/browser/browser-preview.tsx
@@ -2392,12 +2391,12 @@ function handleBrowserStreamConnection(ws: WebSocket) {
   });
 
   ws.on('close', () => {
-    if (tabPollInterval) { clearInterval(tabPollInterval); tabPollInterval = null; }
+    stopTabPolling(tabPoll);
     if (cdpScreencast?.clientWs === ws) cleanupCdpScreencast();
   });
 
   ws.on('error', () => {
-    if (tabPollInterval) { clearInterval(tabPollInterval); tabPollInterval = null; }
+    stopTabPolling(tabPoll);
     if (cdpScreencast?.clientWs === ws) cleanupCdpScreencast();
   });
 }

--- a/agent-container/src/tab-poll.test.ts
+++ b/agent-container/src/tab-poll.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { startTabPolling, stopTabPolling } from './tab-poll'
+
+describe('tab polling ownership', () => {
+  const started: NodeJS.Timeout[] = []
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    // Vacate the module-level slot so state can't leak between tests
+    for (const handle of started.splice(0)) stopTabPolling(handle)
+    vi.useRealTimers()
+  })
+
+  function start(poll: () => void, intervalMs?: number): NodeJS.Timeout {
+    const handle = startTabPolling(poll, intervalMs)
+    started.push(handle)
+    return handle
+  }
+
+  it('polls at the given interval', () => {
+    const poll = vi.fn()
+    start(poll, 2000)
+
+    vi.advanceTimersByTime(6000)
+    expect(poll).toHaveBeenCalledTimes(3)
+  })
+
+  it('a new connection replaces the previous timer instead of leaking it', () => {
+    const pollA = vi.fn()
+    const pollB = vi.fn()
+    start(pollA, 2000)
+    start(pollB, 2000)
+
+    vi.advanceTimersByTime(4000)
+    expect(pollA).not.toHaveBeenCalled()
+    expect(pollB).toHaveBeenCalledTimes(2)
+  })
+
+  it("an old connection's late close does not stop the new viewer's polling", () => {
+    const pollA = vi.fn()
+    const pollB = vi.fn()
+    const handleA = start(pollA, 2000)
+    start(pollB, 2000)
+
+    // Old socket's close event fires after the new viewer already connected
+    stopTabPolling(handleA)
+
+    vi.advanceTimersByTime(4000)
+    expect(pollB).toHaveBeenCalledTimes(2)
+  })
+
+  it('stopping the current viewer stops polling and a later connection starts fresh', () => {
+    const pollA = vi.fn()
+    const handleA = start(pollA, 2000)
+    stopTabPolling(handleA)
+
+    vi.advanceTimersByTime(4000)
+    expect(pollA).not.toHaveBeenCalled()
+
+    const pollB = vi.fn()
+    start(pollB, 2000)
+    vi.advanceTimersByTime(2000)
+    expect(pollB).toHaveBeenCalledTimes(1)
+  })
+
+  it('is safe to stop the same connection twice (error then close)', () => {
+    const pollA = vi.fn()
+    const handleA = start(pollA, 2000)
+    stopTabPolling(handleA)
+    stopTabPolling(handleA)
+
+    const pollB = vi.fn()
+    start(pollB, 2000)
+    vi.advanceTimersByTime(2000)
+    expect(pollB).toHaveBeenCalledTimes(1)
+  })
+
+  it('double-stop of an old handle does not vacate the new viewer', () => {
+    const pollA = vi.fn()
+    const pollB = vi.fn()
+    const handleA = start(pollA, 2000)
+    const handleB = start(pollB, 2000)
+
+    // Old socket fires 'error' then 'close' after B connected
+    stopTabPolling(handleA)
+    stopTabPolling(handleA)
+
+    vi.advanceTimersByTime(2000)
+    expect(pollB).toHaveBeenCalledTimes(1)
+
+    stopTabPolling(handleB)
+    vi.advanceTimersByTime(4000)
+    expect(pollB).toHaveBeenCalledTimes(1)
+  })
+})

--- a/agent-container/src/tab-poll.ts
+++ b/agent-container/src/tab-poll.ts
@@ -1,0 +1,31 @@
+/**
+ * Ownership-tracked tab-list polling for the single-viewer browser stream.
+ *
+ * The stream endpoint allows one viewer at a time, but connections can
+ * overlap during a reconnect: the new socket attaches before the old one's
+ * close event fires. A bare module-level interval slot breaks both ways in
+ * that window — assigning on connect leaks the previous timer (it polls
+ * forever), and clearing the slot on the OLD socket's late close kills the
+ * NEW viewer's polling. Each connection therefore keeps its own handle;
+ * the shared slot only tracks which handle is current.
+ */
+
+let currentPoll: NodeJS.Timeout | null = null;
+
+/** Start polling for a new viewer connection, replacing any previous viewer's timer. */
+export function startTabPolling(poll: () => void, intervalMs = 2000): NodeJS.Timeout {
+  const handle = setInterval(poll, intervalMs);
+  if (currentPoll) clearInterval(currentPoll);
+  currentPoll = handle;
+  return handle;
+}
+
+/**
+ * Stop one connection's polling. Only vacates the shared slot if that
+ * connection is still the current viewer. Safe to call twice (a socket can
+ * fire both 'error' and 'close').
+ */
+export function stopTabPolling(handle: NodeJS.Timeout): void {
+  clearInterval(handle);
+  if (currentPoll === handle) currentPoll = null;
+}


### PR DESCRIPTION
Item 5 of the agent-container lifecycle audit (after #443, #444, #445, #448).

## Problem

`handleBrowserStreamConnection` stored its 2s tab-list poll in a single module-level `tabPollInterval` slot, assigned unconditionally on connect and cleared unconditionally on that socket's `close`/`error`. Connections overlap during a reconnect (the new socket attaches before the old one's close event fires), which broke both ways in that window:

- the assignment on connect **leaked the previous connection's interval** — it polls `broadcastTabList()` every 2s forever (one leaked timer per overlapping reconnect), and
- the old socket's late close handler **cleared the new viewer's timer**, silently killing tab-list updates for the live viewer.

## Fix

Ownership-tracked polling in a new `tab-poll.ts` module: each connection keeps its own interval handle, `startTabPolling` clears-and-replaces the shared slot on connect, and `stopTabPolling` clears the connection's own handle and only vacates the slot if that connection is still the current viewer. Safe against a socket firing both `error` and `close`.

Behavior-preserving for the single-viewer case: `broadcastTabList` only sends to the singleton `cdpScreencast.clientWs`, so clearing a superseded connection's timer changes no observable output.

## Tests

New `tab-poll.test.ts` (fake timers, 6 tests): interval cadence, reconnect replaces instead of leaking, **late close after reconnect keeps the new viewer polling**, stop-then-restart, and double-stop (error-then-close) both for the current viewer and for a superseded handle.

Validation: `tsc --noEmit` clean, container suite 632 passed / 8 skipped, eslint 0 errors (3 pre-existing warnings on untouched lines).