### PR TITLE
feat: VM memory sizing guardrails + surface container death mid-turn

### DIFF
--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -29,6 +29,17 @@ const mockFsPromises = vi.hoisted(() => ({
 const mockAuthenticatedMiddleware = vi.hoisted(() =>
   vi.fn(async (_c: unknown, next: () => Promise<void>) => next()),
 )
+// Host total memory for the VM-memory sizing guard. Default is large enough
+// that every allowlisted option passes; sizing tests shrink it.
+const mockTotalmem = vi.hoisted(() => vi.fn(() => 64 * 1024 ** 3))
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>()
+  return {
+    ...actual,
+    default: { ...actual, totalmem: mockTotalmem },
+    totalmem: mockTotalmem,
+  }
+})
 const mockIsAdminMiddleware = vi.hoisted(() =>
   vi.fn(async (_c: unknown, next: () => Promise<void>) => next()),
 )
@@ -230,6 +241,7 @@ function setupDefaults() {
   mockGetReadiness.mockReturnValue({ ready: true })
   mockEnsureImageReady.mockResolvedValue(undefined)
   mockClearClients.mockReturnValue(undefined)
+  mockTotalmem.mockReturnValue(64 * 1024 ** 3)
 }
 
 // ---------------------------------------------------------------------------
@@ -1199,6 +1211,41 @@ describe('settings route', () => {
       const res = await putSettings({
         container: {
           runtimeSettings: { lima: { somethingElse: 'value' } },
+        },
+      })
+      expect(res.status).toBe(200)
+      expect(mockUpdateSettings).toHaveBeenCalledOnce()
+    })
+
+    it('refuses VM memory equal to host total memory', async () => {
+      mockTotalmem.mockReturnValue(16 * 1024 ** 3)
+      const res = await putSettings({
+        container: {
+          runtimeSettings: { lima: { vmMemory: '16GiB' } },
+        },
+      })
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toContain('total memory')
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it('refuses VM memory above host total memory', async () => {
+      mockTotalmem.mockReturnValue(8 * 1024 ** 3)
+      const res = await putSettings({
+        container: {
+          runtimeSettings: { lima: { vmMemory: '12GiB' } },
+        },
+      })
+      expect(res.status).toBe(400)
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it('accepts VM memory above half of host total (warn is UI-side, not a rejection)', async () => {
+      mockTotalmem.mockReturnValue(16 * 1024 ** 3)
+      const res = await putSettings({
+        container: {
+          runtimeSettings: { lima: { vmMemory: '12GiB' } },
         },
       })
       expect(res.status).toBe(200)

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -1,3 +1,4 @@
+import os from 'os'
 import path from 'path'
 import { randomUUID } from 'crypto'
 import { Hono, type Context } from 'hono'
@@ -38,6 +39,7 @@ import { findWebProvider, getWebProvider } from '@shared/lib/web-provider'
 import { containerManager } from '@shared/lib/container/container-manager'
 import { checkAllRunnersAvailability, refreshRunnerAvailability, startRunner, restartRunner, getContainerClientClass, SUPPORTED_RUNNERS, type ContainerRunner } from '@shared/lib/container/client-factory'
 import { VALID_LIMA_VM_MEMORY_OPTIONS, EFFORT_LEVELS } from '@shared/lib/container/types'
+import { assessVmMemory } from '@shared/lib/container/vm-memory'
 import { customEnvVarsSchema } from '@shared/lib/container/reserved-env-vars'
 import { detectAllProviders } from '../../main/host-browser'
 import { revokePlatformToken } from '@shared/lib/services/platform-auth-service'
@@ -295,6 +297,7 @@ function buildSettingsResponse(
 ): GlobalSettingsResponse {
   return {
     dataDir: getDataDir(),
+    hostTotalMemoryBytes: os.totalmem(),
     container: appSettings.container,
     app: appSettings.app || { showMenuBarIcon: true },
     hasRunningAgents,
@@ -429,6 +432,14 @@ settings.put('/', async (c) => {
       const limaSettings = body.container.runtimeSettings.lima
       if (limaSettings?.vmMemory && !VALID_LIMA_VM_MEMORY_OPTIONS.includes(limaSettings.vmMemory)) {
         return c.json({ error: `Invalid VM memory setting. Must be one of: ${VALID_LIMA_VM_MEMORY_OPTIONS.join(', ')}` }, 400)
+      }
+      // A VM sized at or beyond physical RAM starves the host and gets agents
+      // OOM-killed mid-turn — refuse it here so it can never be persisted.
+      if (limaSettings?.vmMemory) {
+        const assessment = assessVmMemory(limaSettings.vmMemory, os.totalmem())
+        if (assessment.level === 'refuse') {
+          return c.json({ error: assessment.message }, 400)
+        }
       }
     }
 

--- a/src/renderer/components/settings/runtime-tab.test.tsx
+++ b/src/renderer/components/settings/runtime-tab.test.tsx
@@ -20,8 +20,9 @@ const mockSettings = {
         cpu: 1,
         memory: '1g',
       },
-      runtimeSettings: {},
+      runtimeSettings: {} as Record<string, Record<string, string>>,
     },
+    hostTotalMemoryBytes: 64 * 1024 ** 3,
     runnerAvailability: [
       {
         runner: 'docker',
@@ -83,6 +84,8 @@ describe('RuntimeTab', () => {
     vi.clearAllMocks()
     mockSettings.data.container.containerRunner = 'docker'
     mockSettings.data.container.agentImage = 'ghcr.io/skillfulagents/superagent-agent-container-base:latest'
+    mockSettings.data.container.runtimeSettings = {}
+    mockSettings.data.hostTotalMemoryBytes = 64 * 1024 ** 3
     mockSettings.data.customEnvVars = {}
     mockSettings.data.runnerAvailability = [
       {
@@ -228,6 +231,63 @@ describe('RuntimeTab', () => {
         FOO: 'updated',
         BAR: 'two',
       },
+    })
+  })
+
+  describe('Lima VM memory guardrails', () => {
+    beforeEach(() => {
+      mockSettings.data.container.containerRunner = 'lima'
+      mockSettings.data.runnerAvailability = [
+        {
+          runner: 'lima',
+          installed: true,
+          running: true,
+          available: true,
+          canStart: false,
+          supportsCustomAgentImage: true,
+        },
+      ]
+      // A 16 GB machine — the Jessica configuration.
+      mockSettings.data.hostTotalMemoryBytes = 16 * 1024 ** 3
+    })
+
+    it('disables VM memory options at or above the machine total', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<RuntimeTab />)
+
+      const trigger = screen.getByRole('combobox', { name: 'VM Memory' })
+      trigger.focus()
+      await user.keyboard('[Enter]')
+
+      const oversized = await screen.findByRole('option', { name: /16 GB \(exceeds system memory\)/ })
+      expect(oversized).toHaveAttribute('aria-disabled', 'true')
+      // Options that fit stay selectable.
+      const fits = screen.getByRole('option', { name: '8 GB' })
+      expect(fits).not.toHaveAttribute('aria-disabled', 'true')
+    })
+
+    it('warns when the saved VM memory is more than half of the machine total', () => {
+      mockSettings.data.container.runtimeSettings = { lima: { vmMemory: '12GiB' } }
+
+      renderWithProviders(<RuntimeTab />)
+
+      expect(screen.getByText(/more than half of this machine's 16 GB/)).toBeInTheDocument()
+    })
+
+    it('shows no warning at or below half of the machine total', () => {
+      mockSettings.data.container.runtimeSettings = { lima: { vmMemory: '8GiB' } }
+
+      renderWithProviders(<RuntimeTab />)
+
+      expect(screen.queryByText(/more than half/)).not.toBeInTheDocument()
+    })
+
+    it('flags a legacy persisted oversized value (saved before the guardrail existed)', () => {
+      mockSettings.data.container.runtimeSettings = { lima: { vmMemory: '16GiB' } }
+
+      renderWithProviders(<RuntimeTab />)
+
+      expect(screen.getByText(/must be smaller than this machine's total memory/)).toBeInTheDocument()
     })
   })
 

--- a/src/renderer/components/settings/runtime-tab.tsx
+++ b/src/renderer/components/settings/runtime-tab.tsx
@@ -22,6 +22,7 @@ import { useSettings, useUpdateSettings, useStartRunner, useRestartRunner, useRe
 import { AlertCircle, AlertTriangle, Play, Loader2, RefreshCw, Plus, X } from 'lucide-react'
 import { RunnerSetupErrorPanel, getRunnerSetupPayload } from '@renderer/components/settings/runner-setup-error-panel'
 import { DEFAULT_LIMA_VM_MEMORY, VALID_LIMA_VM_MEMORY_OPTIONS } from '@shared/lib/container/types'
+import { assessVmMemory } from '@shared/lib/container/vm-memory'
 import { findReservedEnvVarKeys } from '@shared/lib/container/reserved-env-vars'
 import { getDefaultAgentImage } from '@shared/lib/config/version'
 
@@ -120,6 +121,19 @@ export function RuntimeTab() {
     () => RUNTIME_SETTINGS[containerRunner] ?? [],
     [containerRunner]
   )
+
+  // Sizing guardrail for the built-in runtime's VM memory: options at or above
+  // the machine's physical RAM are disabled (the server refuses them too), and
+  // picks above half of it get an inline warning — that configuration starves
+  // the host and gets agents OOM-killed mid-turn.
+  const hostTotalMemoryBytes = settings?.hostTotalMemoryBytes
+  const assessVmMemoryOption = (value: string) =>
+    hostTotalMemoryBytes ? assessVmMemory(value, hostTotalMemoryBytes) : ({ level: 'ok' } as const)
+  const vmMemoryAssessment = useMemo(() => {
+    const selected = runtimeSettingsForm.vmMemory
+    if (!selected || !hostTotalMemoryBytes) return { level: 'ok' } as const
+    return assessVmMemory(selected, hostTotalMemoryBytes)
+  }, [runtimeSettingsForm.vmMemory, hostTotalMemoryBytes])
 
   // Check if runtime-specific settings have changed
   const runtimeSettingsChanged = useMemo(() => {
@@ -547,11 +561,16 @@ export function RuntimeTab() {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {field.options.map((opt) => (
-                      <SelectItem key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </SelectItem>
-                    ))}
+                    {field.options.map((opt) => {
+                      const oversized =
+                        field.key === 'vmMemory' && assessVmMemoryOption(opt.value).level === 'refuse'
+                      return (
+                        <SelectItem key={opt.value} value={opt.value} disabled={oversized}>
+                          {opt.label}
+                          {oversized ? ' (exceeds system memory)' : ''}
+                        </SelectItem>
+                      )
+                    })}
                   </SelectContent>
                 </Select>
               ) : (
@@ -566,6 +585,14 @@ export function RuntimeTab() {
                 />
               )}
               <p className="text-xs text-muted-foreground">{field.description}</p>
+              {field.key === 'vmMemory' && vmMemoryAssessment.level === 'warn' && (
+                <p className="text-xs text-yellow-600 dark:text-yellow-400">
+                  {vmMemoryAssessment.message}
+                </p>
+              )}
+              {field.key === 'vmMemory' && vmMemoryAssessment.level === 'refuse' && (
+                <p className="text-xs text-destructive">{vmMemoryAssessment.message}</p>
+              )}
             </div>
           ))}
 
@@ -594,7 +621,7 @@ export function RuntimeTab() {
               </Button>
               <Button
                 onClick={handleSaveRuntimeSettings}
-                disabled={isRestarting || runtimeSaveBlocked}
+                disabled={isRestarting || runtimeSaveBlocked || vmMemoryAssessment.level === 'refuse'}
               >
                 {isRestarting ? (
                   <>

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -276,6 +276,8 @@ export type { LlmProviderInfo }
 
 export interface GlobalSettingsResponse {
   dataDir: string
+  /** Host machine's total physical memory — lets the UI warn about oversized VM memory picks. */
+  hostTotalMemoryBytes?: number
   container: ContainerSettings
   app: AppPreferences
   hasRunningAgents: boolean

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -5361,3 +5361,105 @@ describe('MessagePersister.handleConnectionClosed re-subscribe', () => {
     }
   })
 })
+
+// ============================================================================
+// connection lost mid-turn → session_error (not a silent session_idle)
+// ============================================================================
+//
+// When the runtime vanishes while a turn is in flight (container crash, guest
+// OOM kill, VM death), the WebSocket closes and markSessionInactive settles the
+// session. Settling with session_idle presents as the agent just stopping with
+// no explanation — the terminal broadcast must be session_error instead.
+
+describe('MessagePersister connection lost mid-turn', () => {
+  const SESSION_ID = 'mid-turn-death-session'
+  const AGENT_SLUG = 'mid-turn-death-agent'
+
+  let mockClient: ReturnType<typeof createMockClient>
+  let sseEvents: any[]
+  let sseCleanup: () => void
+
+  const dropConnection = async () => {
+    mockClient._messageCallback!({
+      type: 'connection_closed',
+      content: { type: 'connection_closed' },
+      timestamp: new Date(),
+      sessionId: SESSION_ID,
+    })
+    // Let handleConnectionClosed's getSession().then(...) settle
+    // (the default mock getSession resolves null → markSessionInactive).
+    await new Promise((r) => setTimeout(r, 0))
+  }
+
+  beforeEach(async () => {
+    mockClient = createMockClient()
+    await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
+    const sse = collectSSEEvents(SESSION_ID)
+    sseEvents = sse.events
+    sseCleanup = sse.cleanup
+  })
+
+  afterEach(() => {
+    sseCleanup()
+    messagePersister.unsubscribeFromSession(SESSION_ID)
+    vi.clearAllMocks()
+  })
+
+  it('broadcasts session_error (not session_idle) when the connection drops mid-turn', async () => {
+    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    sseEvents.length = 0
+
+    await dropConnection()
+
+    const errors = sseEvents.filter((e) => e.type === 'session_error')
+    expect(errors).toHaveLength(1)
+    expect(errors[0].error).toMatch(/stopped unexpectedly/i)
+    expect(errors[0].error).toMatch(/out of memory/i)
+    expect(errors[0].terminalReason).toBe('connection_lost')
+    expect(errors[0].isActive).toBe(false)
+    expect(sseEvents.filter((e) => e.type === 'session_idle')).toHaveLength(0)
+    // The session still settles: no longer active, activity reads idle.
+    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+    expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('idle')
+  })
+
+  it('also announces the mid-turn death on the global stream (sidebar/notifications)', async () => {
+    const globalEvents: any[] = []
+    const removeGlobal = messagePersister.addGlobalNotificationClient((data) => {
+      globalEvents.push(data)
+    })
+    try {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+
+      await dropConnection()
+
+      const errors = globalEvents.filter((e) => e.type === 'session_error')
+      expect(errors).toHaveLength(1)
+      expect(errors[0].sessionId).toBe(SESSION_ID)
+      expect(errors[0].agentSlug).toBe(AGENT_SLUG)
+      expect(errors[0].terminalReason).toBe('connection_lost')
+    } finally {
+      removeGlobal()
+    }
+  })
+
+  it('settles quietly with session_idle when the connection drops while idle', async () => {
+    // No active turn — e.g. the container auto-slept between turns.
+    sseEvents.length = 0
+
+    await dropConnection()
+
+    expect(sseEvents.filter((e) => e.type === 'session_error')).toHaveLength(0)
+    expect(sseEvents.filter((e) => e.type === 'session_idle')).toHaveLength(1)
+  })
+
+  it('does not report an error when the connection drops after a user interrupt', async () => {
+    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    await messagePersister.markSessionInterrupted(SESSION_ID)
+    sseEvents.length = 0
+
+    await dropConnection()
+
+    expect(sseEvents.filter((e) => e.type === 'session_error')).toHaveLength(0)
+  })
+})

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1579,6 +1579,12 @@ class MessagePersister {
 
   // Mark a session as inactive and broadcast the update
   private markSessionInactive(sessionId: string, state: StreamingState): void {
+    // A session that was mid-turn (user message sent, no result yet) and not
+    // deliberately interrupted didn't finish — its runtime vanished (container
+    // crash, guest OOM kill of the agent process, VM death). Surface that as an
+    // error instead of settling silently: session_idle would render as the turn
+    // just ending with no explanation (and wipes any error client-side).
+    const diedMidTurn = state.isActive && !state.isInterrupted
     state.isStreaming = false
     state.isAwaitingInput = false
     state.currentText = ''
@@ -1587,6 +1593,35 @@ class MessagePersister {
     state.activeSubagents.clear()
     state.activeBackgroundTasks.clear()
     this.stopAllWorkflowTailers(sessionId)
+    if (diedMidTurn) {
+      // Mirror the result-error path: settle isActive BEFORE broadcasting so
+      // the terminal transition is a single non-busy emit (an intermediate
+      // "isActive still true, streaming just cleared" snapshot would read
+      // working=true and race connectors into a stuck indicator), and emit
+      // session_error INSTEAD of session_idle — connectors finalize on either.
+      state.isActive = false
+      const errorMessage =
+        'The agent stopped unexpectedly because the connection to its runtime was lost. ' +
+        'The container may have crashed or run out of memory.'
+      console.error(`[MessagePersister] Session ${sessionId} died mid-turn (connection lost)`)
+      this.broadcastToSSE(sessionId, {
+        type: 'session_error',
+        error: errorMessage,
+        apiErrorCode: null,
+        terminalReason: 'connection_lost',
+        isActive: false,
+      })
+      this.broadcastGlobal({
+        type: 'session_error',
+        sessionId,
+        agentSlug: state.agentSlug,
+        error: errorMessage,
+        apiErrorCode: null,
+        terminalReason: 'connection_lost',
+        isActive: false,
+      })
+      return
+    }
     // finalizeIdle clears isActive and emits the single settling working(false).
     // Don't emit here first: clearing streaming while isActive is still true
     // would read working=true and emit a spurious working(true)→(false) pair

--- a/src/shared/lib/container/vm-memory.test.ts
+++ b/src/shared/lib/container/vm-memory.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { parseVmMemoryBytes, assessVmMemory } from './vm-memory'
+
+const GiB = 1024 ** 3
+
+describe('parseVmMemoryBytes', () => {
+  it('parses whole GiB values', () => {
+    expect(parseVmMemoryBytes('4GiB')).toBe(4 * GiB)
+    expect(parseVmMemoryBytes('16GiB')).toBe(16 * GiB)
+  })
+
+  it('parses fractional GiB values', () => {
+    expect(parseVmMemoryBytes('1.5GiB')).toBe(1.5 * GiB)
+  })
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseVmMemoryBytes(' 8GiB ')).toBe(8 * GiB)
+  })
+
+  it('returns null for other units and malformed strings', () => {
+    expect(parseVmMemoryBytes('4GB')).toBeNull()
+    expect(parseVmMemoryBytes('4g')).toBeNull()
+    expect(parseVmMemoryBytes('GiB')).toBeNull()
+    expect(parseVmMemoryBytes('')).toBeNull()
+    expect(parseVmMemoryBytes('4GiB extra')).toBeNull()
+  })
+})
+
+describe('assessVmMemory', () => {
+  const HOST_16GB = 16 * GiB
+
+  it('refuses a size equal to host total memory', () => {
+    const result = assessVmMemory('16GiB', HOST_16GB)
+    expect(result.level).toBe('refuse')
+    expect(result.level === 'refuse' && result.message).toContain('16 GB')
+    expect(result.level === 'refuse' && result.message).toContain('total memory')
+  })
+
+  it('refuses a size above host total memory', () => {
+    expect(assessVmMemory('16GiB', 8 * GiB).level).toBe('refuse')
+  })
+
+  it('warns above half of host total memory (the Jessica case: 12GiB on a 16GB Mac)', () => {
+    const result = assessVmMemory('12GiB', HOST_16GB)
+    expect(result.level).toBe('warn')
+    expect(result.level === 'warn' && result.message).toContain('more than half')
+  })
+
+  it('does not warn at exactly half of host total memory', () => {
+    expect(assessVmMemory('8GiB', HOST_16GB).level).toBe('ok')
+  })
+
+  it('is ok below half of host total memory', () => {
+    expect(assessVmMemory('4GiB', HOST_16GB).level).toBe('ok')
+    expect(assessVmMemory('2GiB', HOST_16GB).level).toBe('ok')
+  })
+
+  it('assesses unparseable values as ok (shape is the allowlist gate, not this one)', () => {
+    expect(assessVmMemory('not-a-size', HOST_16GB).level).toBe('ok')
+  })
+
+  it('assesses as ok when host memory is unknown or nonsensical', () => {
+    expect(assessVmMemory('16GiB', 0).level).toBe('ok')
+    expect(assessVmMemory('16GiB', -1).level).toBe('ok')
+    expect(assessVmMemory('16GiB', NaN).level).toBe('ok')
+  })
+
+  it('formats fractional host totals with one decimal', () => {
+    const result = assessVmMemory('12GiB', 13.5 * GiB)
+    expect(result.level).toBe('warn')
+    expect(result.level === 'warn' && result.message).toContain('13.5 GB')
+  })
+})

--- a/src/shared/lib/container/vm-memory.ts
+++ b/src/shared/lib/container/vm-memory.ts
@@ -1,0 +1,54 @@
+/**
+ * Guardrails for the built-in runtime's VM memory setting.
+ *
+ * A VM sized at or beyond the machine's physical RAM starves the host, and the
+ * guest OOM killer then SIGKILLs the agent process mid-turn — sessions appear
+ * to just stop for no reason. Sizes are refused when they cannot coexist with
+ * the host and flagged when they squeeze it.
+ *
+ * Host total memory is passed in (not read from `os`) so this module stays
+ * importable from the renderer, which gets the value from the settings API.
+ */
+
+export type VmMemoryAssessment =
+  | { level: 'ok' }
+  | { level: 'warn'; message: string }
+  | { level: 'refuse'; message: string }
+
+/** Parse a Lima-style memory string ('12GiB') into bytes. Null for anything else. */
+export function parseVmMemoryBytes(value: string): number | null {
+  const match = /^(\d+(?:\.\d+)?)GiB$/.exec(value.trim())
+  if (!match) return null
+  return Number(match[1]) * 1024 ** 3
+}
+
+function formatGb(bytes: number): string {
+  const gb = bytes / 1024 ** 3
+  return `${Number.isInteger(gb) ? gb : gb.toFixed(1)} GB`
+}
+
+/**
+ * Assess a requested VM memory size against the host's total memory:
+ * refuse at >= total, warn above half. Unparseable values and unknown host
+ * memory assess as ok — the options allowlist is the shape gate, this is
+ * only the sizing gate.
+ */
+export function assessVmMemory(value: string, hostTotalMemoryBytes: number): VmMemoryAssessment {
+  const requested = parseVmMemoryBytes(value)
+  if (requested === null || !Number.isFinite(hostTotalMemoryBytes) || hostTotalMemoryBytes <= 0) {
+    return { level: 'ok' }
+  }
+  if (requested >= hostTotalMemoryBytes) {
+    return {
+      level: 'refuse',
+      message: `VM memory (${formatGb(requested)}) must be smaller than this machine's total memory (${formatGb(hostTotalMemoryBytes)}).`,
+    }
+  }
+  if (requested > hostTotalMemoryBytes / 2) {
+    return {
+      level: 'warn',
+      message: `${formatGb(requested)} is more than half of this machine's ${formatGb(hostTotalMemoryBytes)} of memory. The host can run out of memory and kill agents mid-task.`,
+    }
+  }
+  return { level: 'ok' }
+}


### PR DESCRIPTION
## Context

From a support investigation (Sentry ELECTRON-61): a user's built-in-runtime VM was sized at 16GiB on a 16GB Mac. The host ran out of memory, the guest OOM killer repeatedly SIGKILLed the agent process mid-turn (1,327 events in 30 days), and sessions presented as "the agent just randomly stops after 1-2 tool calls" with no explanation. Two gaps enabled that: nothing stopped an oversized VM memory setting, and a container dying mid-turn settled the session silently.

## 1. VM memory sizing guardrails

- New `assessVmMemory(value, hostTotalMemoryBytes)` in `src/shared/lib/container/vm-memory.ts`: **refuse** ≥ host total RAM, **warn** above 50%. Takes host memory as a parameter (no `os` import) so the renderer can share it; the host total is exposed via a new optional `GlobalSettingsResponse.hostTotalMemoryBytes`.
- `PUT /api/settings` refuses oversized `vmMemory` with a 400, so the bad configuration can never be persisted again.
- Runtime tab: oversized options are disabled with an "(exceeds system memory)" suffix; picks above half RAM show an inline warning explaining the OOM-kill consequence; a legacy persisted oversized value shows a destructive notice and blocks Save & Restart.

## 2. Container death mid-turn surfaces in the UI

`markSessionInactive` (the terminal path when the WebSocket drops and the session is gone/unreachable) now broadcasts `session_error` (`terminalReason: 'connection_lost'`) instead of a silent `session_idle` when the session was mid-turn and not interrupted:

> The agent stopped unexpectedly because the connection to its runtime was lost. The container may have crashed or run out of memory.

Design notes:
- It **replaces** `session_idle` rather than preceding it — the renderer's idle handler sets `error: null`, so both events would blink the error away. Chat connectors already finalize on either event.
- Deliberate stops can't false-positive: `stop()` removes WS listeners before terminating, `unsubscribeFromSession` deletes streaming state before the async close lands, and interrupted sessions are filtered in `handleMessage`.

## Testing

- 10 unit tests for `assessVmMemory`/`parseVmMemoryBytes` (boundaries: refuse at exactly total, ok at exactly half)
- 3 route tests (refuse at/above host total with mocked `os.totalmem`, accept warn-level sizes)
- 4 component tests (disabled oversized option, >50% warning, no warning at half, legacy oversized value flagged)
- 4 message-persister tests (mid-turn drop → `session_error` + no `session_idle`, global broadcast, quiet idle drop, no error after interrupt)
- **Live-verified**: killed the agent container externally mid-turn → error card renders; the pre-existing in-container SIGKILL path (claude child process killed) still shows its own distinct message