### PR TITLE
Prompt users to start fresh in stale sessions

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -2,9 +2,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen, act, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useState, type ReactNode } from 'react'
 import { AgentHome } from './agent-home'
 import { renderWithProviders } from '@renderer/test/test-utils'
 import type { ApiAgent } from '@renderer/hooks/use-agents'
+import { useDraftsStore } from '@renderer/context/drafts-context'
+import {
+  newSessionCarryoverKey,
+  type NewSessionCarryover,
+} from '@renderer/lib/new-session-carryover'
 
 // --- Mock data ---
 
@@ -143,6 +149,15 @@ const mockComposer = {
 }
 
 let capturedComposerOptions: any
+
+function CarryoverSeeder({ value, children }: { value: NewSessionCarryover; children: ReactNode }) {
+  const store = useDraftsStore()
+  useState(() => {
+    store.set(newSessionCarryoverKey(testAgent.slug), value)
+    return null
+  })
+  return children
+}
 
 vi.mock('@renderer/hooks/use-message-composer', () => ({
   useMessageComposer: (opts: any) => {
@@ -482,6 +497,28 @@ describe('AgentHome', () => {
       <AgentHome agent={testAgent} onSessionCreated={onSessionCreated} />
     )
     expect(capturedComposerOptions.draftKey).toBe('agent:test-agent')
+  })
+
+  it('hydrates a carried composer and sends its model and effort on the new session', async () => {
+    const attachment = {
+      type: 'file' as const,
+      id: 'file-1',
+      file: new File(['hello'], 'hello.txt', { type: 'text/plain' }),
+    }
+    renderWithProviders(
+      <CarryoverSeeder value={{ attachments: [attachment], model: 'opus', effort: 'high' }}>
+        <AgentHome agent={testAgent} onSessionCreated={onSessionCreated} />
+      </CarryoverSeeder>,
+    )
+
+    expect(capturedComposerOptions.initialAttachments).toEqual([attachment])
+    await act(() => capturedComposerOptions.onSubmit('Continue in a new session'))
+    expect(mockCreateSession.mutateAsync).toHaveBeenCalledWith({
+      agentSlug: 'test-agent',
+      message: 'Continue in a new session',
+      model: 'opus',
+      effort: 'high',
+    })
   })
 
   it('passes submitDisabled based on createSession.isPending and runtime readiness', () => {

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -48,6 +48,7 @@ import { UNTITLED_AGENT_NAME } from '@renderer/hooks/use-create-untitled-agent'
 import { useRenameUntitledAgent } from '@renderer/hooks/use-rename-untitled-agent'
 import { useRenderTracker } from '@renderer/lib/perf'
 import { formatDistanceToNow } from 'date-fns'
+import { useNewSessionCarryover } from '@renderer/lib/new-session-carryover'
 
 interface AgentHomeProps {
   agent: ApiAgent
@@ -89,7 +90,10 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   const [sessionSort, setSessionSort] = useState<SortOrder>('newest')
   const { data: sessionsData } = useSessions(agent.slug)
   const { data: agentPrefs } = useAgentPreferences(agent.slug)
+  const carryover = useNewSessionCarryover(agent.slug)
   const composerOptions = useComposerOptions({
+    initialModel: carryover?.model,
+    initialEffort: carryover?.effort,
     agentDefaultModel: agentPrefs?.defaultModel,
     agentDefaultEffort: agentPrefs?.defaultEffort,
     agentKey: agent.slug,
@@ -187,6 +191,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
     submitDisabled: createSession.isPending || !isRuntimeReady,
     keepMessageUntilComplete: true,
     draftKey: `agent:${agent.slug}`,
+    initialAttachments: carryover?.attachments,
   })
 
   // Reset the manual-collapse flag once the message clears.

--- a/src/renderer/components/layout/session-chat-column.test.tsx
+++ b/src/renderer/components/layout/session-chat-column.test.tsx
@@ -138,4 +138,22 @@ describe('SessionChatColumn composer swap', () => {
     expect(screen.queryByText('Send')).not.toBeInTheDocument()
     expect(screen.queryByText('New line')).not.toBeInTheDocument()
   })
+
+  it('shows the new-conversation notice for an old session with a large context', () => {
+    renderWithProviders(
+      <SessionChatColumn
+        {...baseProps}
+        lastActivityAt={new Date(Date.now() - 7 * 60 * 60 * 1000)}
+        contextUsage={{
+          inputTokens: 110_000,
+          outputTokens: 1_000,
+          cacheReadInputTokens: 0,
+          cacheCreationInputTokens: 0,
+          contextWindow: 200_000,
+        }}
+      />,
+    )
+
+    expect(screen.getByTestId('stale-toast')).toBeInTheDocument()
+  })
 })

--- a/src/renderer/components/layout/session-chat-column.tsx
+++ b/src/renderer/components/layout/session-chat-column.tsx
@@ -4,17 +4,23 @@ import { PendingRequestStack } from '@renderer/components/messages/pending-reque
 import { renderPendingRequest, type RenderContext } from '@renderer/components/messages/pending-request-renderer'
 import { PendingRequestErrorBoundary } from '@renderer/components/messages/pending-request-error-boundary'
 import { usePendingRequests } from '@renderer/components/messages/use-pending-requests'
+import { StaleSessionNotice } from '@renderer/components/messages/stale-session-notice'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useScreenWakeLock } from '@renderer/hooks/use-screen-wake-lock'
 import { useFileDeliveryWatcher } from '@renderer/hooks/use-file-delivery-watcher'
+import { useStaleSession } from '@renderer/hooks/use-stale-session'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
 import { DonutChart } from '@renderer/components/ui/donut-chart'
 import type { EffortLevel } from '@shared/lib/container/types'
 import type { PendingMessage } from '@renderer/components/messages/pending-message'
+import type { SessionUsage } from '@shared/lib/types/agent'
 
 interface SessionChatColumnProps {
   sessionId: string
+  /** Route slug used by session APIs and navigation. */
   agentSlug: string
+  /** Stable agent ID used by agent-scoped draft storage. */
+  agentId?: string
   pendingUserMessages: PendingMessage[]
   isViewOnly: boolean
   contextPercent: number | null
@@ -24,11 +30,14 @@ interface SessionChatColumnProps {
   onMessageSent: (content: string, localId: string, queued: boolean) => void
   onMessageUuidAssigned: (localId: string, uuid: string, queued: boolean) => void
   onMessageFailed: (localId: string) => void
+  lastActivityAt?: Date | null
+  contextUsage?: SessionUsage | null
 }
 
 export function SessionChatColumn({
   sessionId,
   agentSlug,
+  agentId,
   pendingUserMessages,
   isViewOnly,
   contextPercent,
@@ -38,6 +47,8 @@ export function SessionChatColumn({
   onMessageSent,
   onMessageUuidAssigned,
   onMessageFailed,
+  lastActivityAt,
+  contextUsage,
 }: SessionChatColumnProps) {
   const { isActive, browserActive, isWaitingBackground } = useMessageStream(sessionId, agentSlug)
   // Keep the phone awake (PWA only) while this session is actively working.
@@ -51,6 +62,18 @@ export function SessionChatColumn({
 
   const renderCtx: RenderContext = { sessionId, agentSlug, readOnly: isViewOnly }
 
+  const staleSession = useStaleSession({
+    sessionId,
+    agentSlug: agentId ?? agentSlug,
+    routeAgentSlug: agentSlug,
+    isActive,
+    isWaitingBackground,
+    isAwaitingInput: pendingRequestCount > 0,
+    isViewOnly,
+    lastActivityAt,
+    contextUsage,
+  })
+
   return (
     <SessionThread
       sessionId={sessionId}
@@ -59,6 +82,7 @@ export function SessionChatColumn({
       pendingUserMessages={pendingUserMessages}
       pendingRequestCount={pendingRequestCount}
       onPendingMessageAppeared={onPendingMessageAppeared}
+      suppressScrollToBottom={staleSession.learnMoreOpen}
       footerClassName="bg-background max-w-[740px] mx-auto w-full"
       footer={
         pendingRequestCount > 0 ? (
@@ -80,6 +104,13 @@ export function SessionChatColumn({
           </div>
         ) : (
           <>
+            {staleSession.showNotice && (
+              <StaleSessionNotice
+                onIgnore={staleSession.ignore}
+                onStartFresh={staleSession.startFresh}
+                onLearnMoreOpenChange={staleSession.setLearnMoreOpen}
+              />
+            )}
             <MessageInput
               key={sessionId}
               sessionId={sessionId}
@@ -89,6 +120,7 @@ export function SessionChatColumn({
               onMessageFailed={onMessageFailed}
               initialEffort={effort}
               initialModel={model}
+              registerSnapshot={staleSession.registerSnapshot}
             />
             <div className="flex justify-between items-center gap-1.5 px-6 py-3">
               {contextPercent != null ? (

--- a/src/renderer/components/layout/session-view.tsx
+++ b/src/renderer/components/layout/session-view.tsx
@@ -136,6 +136,7 @@ export function SessionView({ agentSlug, sessionId }: SessionViewProps) {
             <SessionChatColumn
               sessionId={sessionId}
               agentSlug={agentSlug}
+              agentId={session?.agentSlug}
               pendingUserMessages={getPendingMessages(sessionId)}
               isViewOnly={isViewOnly}
               contextPercent={contextPercent}
@@ -145,6 +146,8 @@ export function SessionView({ agentSlug, sessionId }: SessionViewProps) {
               onMessageSent={onMessageSent}
               onMessageUuidAssigned={onMessageUuidAssigned}
               onMessageFailed={onPendingMessageAppeared}
+              lastActivityAt={session?.lastActivityAt ? new Date(session.lastActivityAt) : null}
+              contextUsage={contextUsage}
             />
           </div>
         </WorkflowProvider>

--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -261,6 +261,33 @@ describe('MessageInput', () => {
     expect(screen.getByTestId('send-button')).toBeEnabled()
   })
 
+  it('registers a getter for the live composer and deregisters on unmount', async () => {
+    const user = userEvent.setup()
+    const registerSnapshot = vi.fn()
+    const { unmount } = renderWithProviders(
+      <MessageInput
+        sessionId="s-1"
+        agentSlug="agent-1"
+        initialModel="sonnet"
+        initialEffort="high"
+        registerSnapshot={registerSnapshot}
+      />,
+    )
+
+    const getSnapshot = registerSnapshot.mock.calls.find(([value]) => typeof value === 'function')?.[0]
+    expect(getSnapshot).toEqual(expect.any(Function))
+    await user.type(screen.getByTestId('message-input'), 'Move this draft')
+
+    expect(getSnapshot()).toMatchObject({
+      text: 'Move this draft',
+      attachments: [],
+      model: 'sonnet',
+      effort: 'high',
+    })
+    unmount()
+    expect(registerSnapshot).toHaveBeenLastCalledWith(null)
+  })
+
   it('submits message on send button click', async () => {
     const user = userEvent.setup()
     renderWithProviders(

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -19,6 +19,7 @@ import { ComposerOptions, useComposerOptions } from './composer-options'
 import { useAgentPreferences } from '@renderer/hooks/use-agent-preferences'
 import { useRenderTracker } from '@renderer/lib/perf'
 import type { EffortLevel } from '@shared/lib/container/types'
+import type { ComposerSnapshot } from '@renderer/lib/new-session-carryover'
 
 interface MessageInputProps {
   sessionId: string
@@ -33,9 +34,11 @@ interface MessageInputProps {
   initialEffort?: EffortLevel
   /** Model last used on this session; seeds the composer selector. Defaults to provider's agent default. */
   initialModel?: string
+  /** Registers a getter so the stale-session prompt can move the live draft. */
+  registerSnapshot?: (getSnapshot: (() => ComposerSnapshot) | null) => void
 }
 
-export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUuidAssigned, onMessageFailed, initialEffort, initialModel }: MessageInputProps) {
+export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUuidAssigned, onMessageFailed, initialEffort, initialModel, registerSnapshot }: MessageInputProps) {
   useRenderTracker('MessageInput')
   const { canUseAgent, isAuthMode } = useUser()
   const isViewOnly = !canUseAgent(agentSlug)
@@ -110,6 +113,24 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
     submitDisabled: sendMessage.isPending || isOffline || !isRuntimeReady,
     draftKey: `session:${sessionId}`,
   })
+
+  const snapshotRef = useRef<ComposerSnapshot>({
+    text: '',
+    attachments: [],
+    model: undefined,
+    effort: composerOptions.effort,
+  })
+  snapshotRef.current = {
+    text: composer.message,
+    attachments: composer.attachments,
+    model: composerOptions.model,
+    effort: composerOptions.effort,
+  }
+  useEffect(() => {
+    if (!registerSnapshot) return
+    registerSnapshot(() => snapshotRef.current)
+    return () => registerSnapshot(null)
+  }, [registerSnapshot])
 
   // Extract the slash command prefix being typed (e.g. "co" from "/co")
   const slashFilter = useMemo(() => {

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -64,9 +64,11 @@ interface MessageListProps {
   /** Read-only mirror (chat-integration replay): suppress edit/delete actions and
    *  lift the connector's inline sender prefix into a label. */
   readOnly?: boolean
+  /** Hide the scroll affordance while a footer popover overlaps it. */
+  suppressScrollToBottom?: boolean
 }
 
-export function MessageList({ sessionId, agentSlug, pendingUserMessages, pendingRequestCount = 0, onPendingMessageAppeared, readOnly }: MessageListProps) {
+export function MessageList({ sessionId, agentSlug, pendingUserMessages, pendingRequestCount = 0, onPendingMessageAppeared, readOnly, suppressScrollToBottom = false }: MessageListProps) {
   useRenderTracker('MessageList')
   const { data: messages, isLoading, error } = useMessages(sessionId, agentSlug)
   const deleteMessage = useDeleteMessage()
@@ -950,7 +952,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
         {/* Pending interactive requests render in the composer slot — see SessionChatColumn. */}
         </div>
       </div>
-      {showScrollToBottom && (
+      {showScrollToBottom && !suppressScrollToBottom && (
         <button
           onClick={scrollToBottom}
           className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5 rounded-full bg-primary text-primary-foreground px-3 py-1.5 text-xs font-medium shadow-lg hover:bg-primary/90 transition-opacity cursor-pointer"

--- a/src/renderer/components/messages/session-thread.tsx
+++ b/src/renderer/components/messages/session-thread.tsx
@@ -19,6 +19,7 @@ interface SessionThreadProps {
   pendingUserMessages?: PendingMessage[]
   pendingRequestCount?: number
   onPendingMessageAppeared?: (localId: string) => void
+  suppressScrollToBottom?: boolean
 }
 
 /**
@@ -40,6 +41,7 @@ export function SessionThread({
   pendingUserMessages,
   pendingRequestCount,
   onPendingMessageAppeared,
+  suppressScrollToBottom,
 }: SessionThreadProps) {
   return (
     <div className="relative flex-1 flex min-h-0">
@@ -53,6 +55,7 @@ export function SessionThread({
           pendingUserMessages={pendingUserMessages}
           pendingRequestCount={pendingRequestCount}
           onPendingMessageAppeared={onPendingMessageAppeared}
+          suppressScrollToBottom={suppressScrollToBottom}
         />
         <div className={`${footerClassName} pb-[env(safe-area-inset-bottom)]`} data-composer-footer>
           <AgentActivityIndicator sessionId={sessionId} agentSlug={agentSlug} />

--- a/src/renderer/components/messages/stale-session-notice.test.tsx
+++ b/src/renderer/components/messages/stale-session-notice.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders, userEvent } from '@renderer/test/test-utils'
+import { StaleSessionNotice } from './stale-session-notice'
+
+describe('StaleSessionNotice', () => {
+  it('offers to ignore the prompt or start a new conversation', async () => {
+    const user = userEvent.setup()
+    const onIgnore = vi.fn()
+    const onStartFresh = vi.fn()
+    renderWithProviders(
+      <StaleSessionNotice onIgnore={onIgnore} onStartFresh={onStartFresh} />,
+    )
+
+    expect(screen.getByText('Start a new conversation?')).toBeInTheDocument()
+    await user.click(screen.getByTestId('stale-toast-ignore'))
+    await user.click(screen.getByTestId('stale-new-chat'))
+    expect(onIgnore).toHaveBeenCalledOnce()
+    expect(onStartFresh).toHaveBeenCalledOnce()
+  })
+
+  it('explains why focused conversations work better', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <StaleSessionNotice onIgnore={vi.fn()} onStartFresh={vi.fn()} />,
+    )
+
+    await user.click(screen.getByTestId('stale-learn-more-trigger'))
+    expect(screen.getByText('Your agent can handle many conversations at once.')).toBeInTheDocument()
+    expect(screen.getByText('Agents re-read everything each time they reply.')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/messages/stale-session-notice.tsx
+++ b/src/renderer/components/messages/stale-session-notice.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import { Button } from '@renderer/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+
+export interface StaleSessionNoticeProps {
+  onIgnore: () => void
+  onStartFresh: () => void
+  onLearnMoreOpenChange?: (open: boolean) => void
+}
+
+function TeachingPoint({ lead, children }: { lead: string; children: ReactNode }) {
+  return (
+    <div className="text-xs">
+      <p className="font-semibold text-foreground">{lead}</p>
+      <p className="text-muted-foreground">{children}</p>
+    </div>
+  )
+}
+
+/** Non-blocking prompt shown above the composer for an old, large conversation. */
+export function StaleSessionNotice({
+  onIgnore,
+  onStartFresh,
+  onLearnMoreOpenChange,
+}: StaleSessionNoticeProps) {
+  const [learnMoreOpen, setLearnMoreOpen] = useState(false)
+
+  useEffect(() => {
+    onLearnMoreOpenChange?.(learnMoreOpen)
+    return () => onLearnMoreOpenChange?.(false)
+  }, [learnMoreOpen, onLearnMoreOpenChange])
+
+  return (
+    <div data-testid="stale-toast" className="mx-auto -mb-1 w-full max-w-[740px] px-4">
+      <div className="flex items-center justify-between gap-4 rounded-2xl border bg-muted/50 p-4">
+        <div className="flex min-w-0 max-w-[60%] flex-col gap-1.5">
+          <p className="text-sm font-medium">Start a new conversation?</p>
+          <p className="text-xs text-muted-foreground">
+            This conversation is getting pretty long. It may be cheaper, faster, and more effective to
+            start a new conversation.{' '}
+            <Popover open={learnMoreOpen} onOpenChange={setLearnMoreOpen}>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  data-testid="stale-learn-more-trigger"
+                  className="text-foreground underline underline-offset-2 transition-colors hover:text-foreground/80"
+                >
+                  Learn more
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                side="top"
+                align="start"
+                onOpenAutoFocus={(event) => event.preventDefault()}
+                onCloseAutoFocus={(event) => event.preventDefault()}
+                className="flex w-80 flex-col gap-1.5 rounded-lg px-4 py-3"
+                data-testid="stale-learn-more-popover"
+              >
+                <TeachingPoint lead="Your agent can handle many conversations at once.">
+                  It works better and smarter with focused conversations. We recommend starting a new
+                  conversation with your agent for each task so it isn&apos;t wasting time or tokens on
+                  unrelated chat history.
+                </TeachingPoint>
+                <TeachingPoint lead="Agents re-read everything each time they reply.">
+                  That&apos;s why long conversations slow down and get expensive. Start fresh to keep the
+                  agent fast and sharp.
+                </TeachingPoint>
+              </PopoverContent>
+            </Popover>
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onIgnore}
+            data-testid="stale-toast-ignore"
+          >
+            Ignore
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={onStartFresh}
+            data-testid="stale-new-chat"
+          >
+            New conversation
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/hooks/use-attachments.test.tsx
+++ b/src/renderer/hooks/use-attachments.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { Attachment } from '@renderer/components/messages/attachment-preview'
+import { useAttachments } from './use-attachments'
+
+describe('useAttachments initial attachments', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('recreates and later revokes a carried image preview', () => {
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:new-preview')
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    const attachment: Attachment = {
+      type: 'file',
+      id: 'image-1',
+      file: new File(['image'], 'image.png', { type: 'image/png' }),
+    }
+
+    const { result, unmount } = renderHook(() =>
+      useAttachments({ initialAttachments: [attachment] }),
+    )
+
+    expect(createObjectURL).toHaveBeenCalledWith(attachment.file)
+    expect(result.current.attachments[0]).toEqual({ ...attachment, preview: 'blob:new-preview' })
+    unmount()
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:new-preview')
+  })
+})

--- a/src/renderer/hooks/use-attachments.ts
+++ b/src/renderer/hooks/use-attachments.ts
@@ -7,10 +7,17 @@ const MAX_WEB_FOLDER_SIZE = 500 * 1024 * 1024
 
 interface UseAttachmentsOptions {
   onFoldersReceived?: (folders: FolderGroup[]) => void
+  initialAttachments?: Attachment[]
 }
 
 export function useAttachments(options?: UseAttachmentsOptions) {
-  const [attachments, setAttachments] = useState<Attachment[]>([])
+  const [attachments, setAttachments] = useState<Attachment[]>(() =>
+    (options?.initialAttachments ?? []).map((attachment) =>
+      attachment.type === 'file' && attachment.file.type.startsWith('image/') && !attachment.preview
+        ? { ...attachment, preview: URL.createObjectURL(attachment.file) }
+        : attachment,
+    ),
+  )
   const [isDragOver, setIsDragOver] = useState(false)
 
   const addFiles = useCallback((files: FileWithPath[]) => {

--- a/src/renderer/hooks/use-message-composer.ts
+++ b/src/renderer/hooks/use-message-composer.ts
@@ -6,6 +6,7 @@ import { useAddMount } from './use-mounts'
 import { useDraft } from '@renderer/context/drafts-context'
 import { appendAttachedFiles, appendMountedFolders } from '@shared/lib/utils/attached-files'
 import { zipFolderFiles, type FolderGroup } from '@renderer/lib/file-utils'
+import type { Attachment } from '@renderer/components/messages/attachment-preview'
 
 interface UseMessageComposerOptions {
   agentSlug: string
@@ -21,6 +22,8 @@ interface UseMessageComposerOptions {
   keepMessageUntilComplete?: boolean
   /** If provided, the composer persists its draft under this key via DraftsContext so it survives unmount. */
   draftKey?: string
+  /** One-shot attachment seed, used when moving a draft into a new session. */
+  initialAttachments?: Attachment[]
 }
 
 export function useMessageComposer(options: UseMessageComposerOptions) {
@@ -74,7 +77,10 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     handleFileSelect,
     handleFolderSelect,
     dragHandlers,
-  } = useAttachments({ onFoldersReceived: isElectron ? handleFoldersReceived : undefined })
+  } = useAttachments({
+    onFoldersReceived: isElectron ? handleFoldersReceived : undefined,
+    initialAttachments: options.initialAttachments,
+  })
 
   const voiceInput = useVoiceInput({
     onTranscriptUpdate: useCallback((text: string) => {

--- a/src/renderer/hooks/use-stale-session.test.tsx
+++ b/src/renderer/hooks/use-stale-session.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DraftsProvider, useDraftsStore } from '@renderer/context/drafts-context'
+import {
+  newSessionCarryoverKey,
+  type NewSessionCarryover,
+} from '@renderer/lib/new-session-carryover'
+import type { SessionUsage } from '@shared/lib/types/agent'
+import { useStaleSession } from './use-stale-session'
+
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }))
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return { ...actual, useNavigate: () => navigate }
+})
+
+const staleUsage: SessionUsage = {
+  inputTokens: 10_000,
+  outputTokens: 1_000,
+  cacheReadInputTokens: 100_000,
+  cacheCreationInputTokens: 0,
+  contextWindow: 200_000,
+}
+
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(DraftsProvider, null, children)
+
+function renderStale(overrides: Partial<Parameters<typeof useStaleSession>[0]> = {}) {
+  const args = {
+    sessionId: 'session-1',
+    agentSlug: 'abc123def4',
+    routeAgentSlug: 'friendly-agent-abc123def4',
+    isActive: false,
+    isWaitingBackground: false,
+    isAwaitingInput: false,
+    isViewOnly: false,
+    lastActivityAt: new Date(Date.now() - 7 * 60 * 60 * 1000),
+    contextUsage: staleUsage,
+    ...overrides,
+  }
+  return renderHook(() => ({ stale: useStaleSession(args), store: useDraftsStore() }), { wrapper })
+}
+
+describe('useStaleSession', () => {
+  beforeEach(() => navigate.mockClear())
+
+  it('shows for an old, large session at rest and hides when ignored', () => {
+    const { result } = renderStale()
+    expect(result.current.stale.showNotice).toBe(true)
+    act(() => result.current.stale.ignore())
+    expect(result.current.stale.showNotice).toBe(false)
+  })
+
+  it('does not show while active or for view-only users', () => {
+    expect(renderStale({ isActive: true }).result.current.stale.showNotice).toBe(false)
+    expect(renderStale({ isViewOnly: true }).result.current.stale.showNotice).toBe(false)
+  })
+
+  it('moves the live composer into a new conversation and navigates home', () => {
+    const { result } = renderStale()
+    act(() => result.current.stale.registerSnapshot(() => ({
+      text: 'Continue as a new task',
+      attachments: [],
+      model: 'sonnet',
+      effort: 'high',
+    })))
+    act(() => result.current.stale.startFresh())
+
+    expect(result.current.store.get('agent:abc123def4')).toBe('Continue as a new task')
+    expect(result.current.store.get<NewSessionCarryover>(newSessionCarryoverKey('abc123def4'))).toEqual({
+      attachments: [],
+      model: 'sonnet',
+      effort: 'high',
+    })
+    expect(result.current.store.get('session:session-1')).toBeUndefined()
+    expect(navigate).toHaveBeenCalledWith({
+      to: '/agents/$slug',
+      params: { slug: 'friendly-agent-abc123def4' },
+    })
+  })
+})

--- a/src/renderer/hooks/use-stale-session.ts
+++ b/src/renderer/hooks/use-stale-session.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { useDraftsStore } from '@renderer/context/drafts-context'
+import {
+  newSessionCarryoverKey,
+  splitComposerSnapshot,
+  type ComposerSnapshot,
+} from '@renderer/lib/new-session-carryover'
+import { computeContextTokens } from '@shared/lib/utils/context-usage'
+import { shouldPromptForNewSession } from '@shared/lib/stale-session/stale-session-trigger'
+import type { SessionUsage } from '@shared/lib/types/agent'
+
+interface UseStaleSessionArgs {
+  sessionId: string
+  /** Canonical agent ID used by the destination composer's draft keys. */
+  agentSlug: string
+  /** Decorative route slug to preserve in the destination URL. */
+  routeAgentSlug?: string
+  isActive: boolean
+  isWaitingBackground: boolean
+  isAwaitingInput: boolean
+  isViewOnly: boolean
+  lastActivityAt?: Date | null
+  contextUsage?: SessionUsage | null
+}
+
+/** Detection and draft handoff for the old/large-session prompt. */
+export function useStaleSession({
+  sessionId,
+  agentSlug,
+  routeAgentSlug,
+  isActive,
+  isWaitingBackground,
+  isAwaitingInput,
+  isViewOnly,
+  lastActivityAt,
+  contextUsage,
+}: UseStaleSessionArgs) {
+  const navigate = useNavigate()
+  const draftsStore = useDraftsStore()
+  const [ignored, setIgnored] = useState(false)
+  const [learnMoreOpen, setLearnMoreOpen] = useState(false)
+  const [liveActivityAt, setLiveActivityAt] = useState<number | null>(null)
+  const wasActiveRef = useRef(isActive)
+  const composerSnapshotRef = useRef<(() => ComposerSnapshot) | null>(null)
+
+  // Persisted activity can lag a just-completed turn. Stamp active -> idle locally
+  // so the prompt does not immediately return after the user continues the session.
+  useEffect(() => {
+    if (isActive || wasActiveRef.current) setLiveActivityAt(Date.now())
+    wasActiveRef.current = isActive
+  }, [isActive])
+
+  // SessionChatColumn can survive a sibling-session navigation, so local prompt
+  // state must be scoped explicitly to the current session.
+  useEffect(() => {
+    setIgnored(false)
+    setLearnMoreOpen(false)
+    setLiveActivityAt(null)
+    wasActiveRef.current = isActive
+  }, [sessionId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const shouldPrompt = useMemo(() => {
+    const activityAt = Math.max(lastActivityAt?.getTime() ?? 0, liveActivityAt ?? 0)
+    return shouldPromptForNewSession({
+      idleMs: activityAt ? Date.now() - activityAt : 0,
+      contextTokens: contextUsage ? computeContextTokens(contextUsage) : 0,
+      isAwaitingInput,
+      isRunning: isActive && !isWaitingBackground,
+    })
+  }, [contextUsage, isActive, isAwaitingInput, isWaitingBackground, lastActivityAt, liveActivityAt])
+
+  const registerSnapshot = useCallback((getSnapshot: (() => ComposerSnapshot) | null) => {
+    composerSnapshotRef.current = getSnapshot
+  }, [])
+
+  const startFresh = useCallback(() => {
+    const { draftText, carryover } = splitComposerSnapshot(composerSnapshotRef.current?.())
+    if (draftText !== undefined) draftsStore.set(`agent:${agentSlug}`, draftText)
+    draftsStore.set(newSessionCarryoverKey(agentSlug), carryover)
+    draftsStore.set(`session:${sessionId}`, undefined)
+    void navigate({ to: '/agents/$slug', params: { slug: routeAgentSlug ?? agentSlug } })
+  }, [agentSlug, draftsStore, navigate, routeAgentSlug, sessionId])
+
+  return {
+    showNotice: shouldPrompt && !isActive && !isViewOnly && !ignored,
+    ignore: useCallback(() => setIgnored(true), []),
+    learnMoreOpen,
+    setLearnMoreOpen,
+    registerSnapshot,
+    startFresh,
+  }
+}

--- a/src/renderer/lib/new-session-carryover.test.tsx
+++ b/src/renderer/lib/new-session-carryover.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import type { Attachment } from '@renderer/components/messages/attachment-preview'
+import { splitComposerSnapshot } from './new-session-carryover'
+
+describe('splitComposerSnapshot', () => {
+  it('moves text, attachments, model, and effort without retaining object URLs', () => {
+    const attachment: Attachment = {
+      type: 'file',
+      id: 'image-1',
+      file: new File(['image'], 'image.png', { type: 'image/png' }),
+      preview: 'blob:source-preview',
+    }
+
+    const result = splitComposerSnapshot({
+      text: '  keep this text  ',
+      attachments: [attachment],
+      model: 'sonnet',
+      effort: 'high',
+    })
+
+    expect(result.draftText).toBe('  keep this text  ')
+    expect(result.carryover).toEqual({
+      attachments: [{ ...attachment, preview: undefined }],
+      model: 'sonnet',
+      effort: 'high',
+    })
+    expect(attachment.preview).toBe('blob:source-preview')
+  })
+
+  it('does not overwrite an existing destination draft with blank text', () => {
+    expect(splitComposerSnapshot({
+      text: '   ',
+      attachments: [],
+      model: 'opus',
+      effort: 'medium',
+    }).draftText).toBeUndefined()
+  })
+})

--- a/src/renderer/lib/new-session-carryover.ts
+++ b/src/renderer/lib/new-session-carryover.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react'
+import type { Attachment } from '@renderer/components/messages/attachment-preview'
+import { useDraftsStore } from '@renderer/context/drafts-context'
+import type { EffortLevel } from '@shared/lib/container/types'
+
+export interface ComposerSnapshot {
+  text: string
+  attachments: Attachment[]
+  model: string | undefined
+  effort: EffortLevel
+}
+
+export interface NewSessionCarryover {
+  attachments: Attachment[]
+  model: string | undefined
+  effort: EffortLevel
+}
+
+export const newSessionCarryoverKey = (agentSlug: string) => `new-session-carryover:${agentSlug}`
+
+function stripObjectUrls(attachments: Attachment[]): Attachment[] {
+  return attachments.map((attachment) =>
+    attachment.type === 'file' && attachment.preview
+      ? { ...attachment, preview: undefined }
+      : attachment,
+  )
+}
+
+export function splitComposerSnapshot(snapshot: ComposerSnapshot | undefined): {
+  draftText: string | undefined
+  carryover: NewSessionCarryover | undefined
+} {
+  if (!snapshot) return { draftText: undefined, carryover: undefined }
+
+  return {
+    draftText: snapshot.text.trim() ? snapshot.text : undefined,
+    carryover: {
+      attachments: stripObjectUrls(snapshot.attachments),
+      model: snapshot.model,
+      effort: snapshot.effort,
+    },
+  }
+}
+
+/** Consume a pending composer handoff exactly once when the agent home mounts. */
+export function useNewSessionCarryover(agentSlug: string): NewSessionCarryover | undefined {
+  const store = useDraftsStore()
+  const key = newSessionCarryoverKey(agentSlug)
+  const [carryover] = useState(() => store.get<NewSessionCarryover>(key))
+
+  useEffect(() => {
+    store.set(key, undefined)
+  }, [key, store])
+
+  return carryover
+}

--- a/src/shared/lib/stale-session/stale-session-config.ts
+++ b/src/shared/lib/stale-session/stale-session-config.ts
@@ -1,0 +1,5 @@
+/** Idle gap after which a returning user may be prompted. */
+export const STALE_TIME_GAP_MS = 6 * 60 * 60 * 1000
+
+/** Current context occupancy above which continuing the session is expensive. */
+export const STALE_CONTEXT_TOKENS = 100_000

--- a/src/shared/lib/stale-session/stale-session-trigger.test.ts
+++ b/src/shared/lib/stale-session/stale-session-trigger.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { STALE_CONTEXT_TOKENS, STALE_TIME_GAP_MS } from './stale-session-config'
+import { shouldPromptForNewSession } from './stale-session-trigger'
+
+const base = {
+  idleMs: 0,
+  contextTokens: 0,
+  isAwaitingInput: false,
+  isRunning: false,
+}
+
+describe('shouldPromptForNewSession', () => {
+  it('requires both an old session and a large context', () => {
+    expect(shouldPromptForNewSession({ ...base, idleMs: STALE_TIME_GAP_MS + 1 })).toBe(false)
+    expect(shouldPromptForNewSession({ ...base, contextTokens: STALE_CONTEXT_TOKENS + 1 })).toBe(false)
+    expect(shouldPromptForNewSession({
+      ...base,
+      idleMs: STALE_TIME_GAP_MS + 1,
+      contextTokens: STALE_CONTEXT_TOKENS + 1,
+    })).toBe(true)
+  })
+
+  it('does not prompt while the session is running or awaiting input', () => {
+    const stale = {
+      ...base,
+      idleMs: STALE_TIME_GAP_MS + 1,
+      contextTokens: STALE_CONTEXT_TOKENS + 1,
+    }
+
+    expect(shouldPromptForNewSession({ ...stale, isRunning: true })).toBe(false)
+    expect(shouldPromptForNewSession({ ...stale, isAwaitingInput: true })).toBe(false)
+  })
+})

--- a/src/shared/lib/stale-session/stale-session-trigger.ts
+++ b/src/shared/lib/stale-session/stale-session-trigger.ts
@@ -1,0 +1,15 @@
+import { STALE_CONTEXT_TOKENS, STALE_TIME_GAP_MS } from './stale-session-config'
+
+export interface StaleInput {
+  idleMs: number
+  contextTokens: number
+  isAwaitingInput: boolean
+  isRunning: boolean
+}
+
+/** Pure predicate for deciding whether a stale-session prompt is appropriate. */
+export function shouldPromptForNewSession(input: StaleInput): boolean {
+  if (input.isAwaitingInput || input.isRunning) return false
+
+  return input.idleMs > STALE_TIME_GAP_MS && input.contextTokens > STALE_CONTEXT_TOKENS
+}

--- a/src/shared/lib/utils/context-usage.test.ts
+++ b/src/shared/lib/utils/context-usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computeContextPercent } from './context-usage'
+import { computeContextPercent, computeContextTokens } from './context-usage'
 import type { SessionUsage } from '@shared/lib/types/agent'
 
 function usage(overrides: Partial<SessionUsage> = {}): SessionUsage {
@@ -129,5 +129,23 @@ describe('computeContextPercent', () => {
       }))
       expect(result).toBe(33)
     })
+  })
+})
+
+describe('computeContextTokens', () => {
+  it('does not double-count cache subsets in the new API format', () => {
+    expect(computeContextTokens(usage({
+      inputTokens: 110_000,
+      cacheCreationInputTokens: 10_000,
+      cacheReadInputTokens: 90_000,
+    }))).toBe(110_000)
+  })
+
+  it('adds cache fields in the old API format', () => {
+    expect(computeContextTokens(usage({
+      inputTokens: 10_000,
+      cacheCreationInputTokens: 10_000,
+      cacheReadInputTokens: 90_000,
+    }))).toBe(110_000)
   })
 })

--- a/src/shared/lib/utils/context-usage.ts
+++ b/src/shared/lib/utils/context-usage.ts
@@ -1,6 +1,21 @@
 import type { SessionUsage } from '@shared/lib/types/agent'
 
 /**
+ * Compute current context occupancy across both Anthropic usage formats:
+ * older responses report uncached input separately, while newer responses may
+ * report inputTokens as the total with cache fields as subsets.
+ */
+export function computeContextTokens(
+  usage: Pick<SessionUsage, 'inputTokens' | 'cacheCreationInputTokens' | 'cacheReadInputTokens'>,
+): number {
+  const { inputTokens, cacheCreationInputTokens, cacheReadInputTokens } = usage
+  const cacheTotal = cacheCreationInputTokens + cacheReadInputTokens
+  return cacheTotal > 0 && inputTokens >= cacheTotal
+    ? inputTokens
+    : inputTokens + cacheTotal
+}
+
+/**
  * Compute the context window usage percentage from token usage fields.
  *
  * The Anthropic API has two formats:
@@ -12,11 +27,7 @@ import type { SessionUsage } from '@shared/lib/types/agent'
  * Returns null if contextWindow is invalid (zero or negative).
  */
 export function computeContextPercent(usage: SessionUsage): number | null {
-  const { inputTokens, cacheCreationInputTokens, cacheReadInputTokens, contextWindow } = usage
+  const { contextWindow } = usage
   if (contextWindow <= 0) return null
-  const cacheTotal = cacheCreationInputTokens + cacheReadInputTokens
-  const totalTokens = (cacheTotal > 0 && inputTokens >= cacheTotal)
-    ? inputTokens                    // New format: input_tokens is already the total
-    : inputTokens + cacheTotal       // Old format: add cache fields
-  return Math.round((totalTokens / contextWindow) * 100)
+  return Math.round((computeContextTokens(usage) / contextWindow) * 100)
 }


### PR DESCRIPTION
## Why

Users can keep messaging an agent in the same long-running session without realizing that the growing context makes subsequent turns slower and more expensive.

This extracts the stale-session prompt behavior from #276 into a focused change with no summarization flow.

## What changed

- Show the reference non-blocking “Start a new conversation?” prompt when a session has been idle for more than 6 hours **and** its current context exceeds 100,000 tokens.
- Suppress the prompt while the session is running, awaiting interactive input, or opened by a view-only user.
- Keep Ignore local to the mounted session view, matching the reference behavior.
- Explain focused-session behavior through the Learn more popover.
- Move the live composer draft—text, attachments, model, and effort—to the agent’s new-conversation composer when the user starts fresh.
- Create the new session only when the user sends from that composer.

## Review hardening

- Handle both usage formats so cached tokens are not double-counted.
- Keep agent-scoped draft handoff keyed by the canonical agent ID while preserving the decorative display slug in navigation.
- Recreate image object URLs after attachment handoff.

## Validation

- All 6,642 runnable repository tests pass (22 skipped, 1 existing todo).
- TypeScript typecheck passes.
- ESLint passes for all touched files.
- Production renderer build succeeds.
- `git diff --check` passes.
