### PR TITLE
feat(llm): add Grok 4.5 to the Platform provider catalog

### DIFF
--- a/src/renderer/components/messages/model-family-list.test.tsx
+++ b/src/renderer/components/messages/model-family-list.test.tsx
@@ -60,14 +60,42 @@ describe('longContextWarningText', () => {
 })
 
 describe('webToolsWarning', () => {
-  it('warns and points to a provider when web tools are unavailable', () => {
-    const w = webToolsWarning(true)!
+  it('warns for both when supportsWebSearch is false and no vendor is set', () => {
+    const w = webToolsWarning(CATALOG.find((m) => m.id === 'openai/gpt-5.5'), false)!
     expect(w).toMatch(/Web search and fetch aren.t available on this model/)
     expect(w).toMatch(/Set a provider under Settings . Web to use them on any model/)
   })
 
-  it('returns null (no banner) when web tools are available', () => {
-    expect(webToolsWarning(false)).toBeNull()
+  it('warns fetch-only when search works but native fetch does not', () => {
+    const w = webToolsWarning(
+      {
+        id: 'gpt-5.5',
+        label: 'GPT-5.5',
+        supportedEfforts: STD,
+        supportsWebSearch: true,
+        supportsWebFetch: false,
+      },
+      false,
+    )!
+    expect(w).toMatch(/Native web fetch isn.t available/)
+    expect(w).toMatch(/search still works/)
+  })
+
+  it('returns null for Claude, when both are supported, or when a vendor is set', () => {
+    expect(webToolsWarning(CATALOG.find((m) => m.id === 'claude-sonnet-4-6'), false)).toBeNull()
+    expect(
+      webToolsWarning(
+        {
+          id: 'gpt-5.5',
+          label: 'GPT-5.5',
+          supportedEfforts: STD,
+          supportsWebSearch: true,
+          supportsWebFetch: true,
+        },
+        false,
+      ),
+    ).toBeNull()
+    expect(webToolsWarning(CATALOG.find((m) => m.id === 'openai/gpt-5.5'), true)).toBeNull()
   })
 })
 
@@ -150,6 +178,32 @@ describe('ModelFamilyList', () => {
     expect(screen.getByTestId('model-no-websearch-warning')).toHaveTextContent(/search and fetch/)
 
     rerender(<ModelFamilyList catalog={CATALOG} value="claude-opus-4-8" onPick={vi.fn()} />)
+    expect(screen.queryByTestId('model-no-websearch-warning')).not.toBeInTheDocument()
+  })
+
+  it('warns fetch-only for Platform Responses models (search works, native fetch does not)', () => {
+    const platformCatalog: ModelDefinition[] = [
+      {
+        id: 'grok-4.5',
+        label: 'Grok 4.5',
+        family: 'grok',
+        isLatest: true,
+        icon: 'xai',
+        supportedEfforts: STD,
+        supportsWebSearch: true,
+        supportsWebFetch: false,
+        contextWindow: 500_000,
+      },
+    ]
+    const { rerender } = render(
+      <ModelFamilyList catalog={platformCatalog} value="grok-4.5" onPick={vi.fn()} />,
+    )
+    expect(screen.getByTestId('model-no-websearch-warning')).toHaveTextContent(/Native web fetch/)
+    expect(screen.getByTestId('model-no-websearch-warning')).toHaveTextContent(/search still works/)
+
+    rerender(
+      <ModelFamilyList catalog={platformCatalog} value="grok-4.5" onPick={vi.fn()} webProvider="exa" />,
+    )
     expect(screen.queryByTestId('model-no-websearch-warning')).not.toBeInTheDocument()
   })
 

--- a/src/renderer/components/messages/model-family-list.tsx
+++ b/src/renderer/components/messages/model-family-list.tsx
@@ -23,19 +23,19 @@ export function formatTokenThreshold(tokens: number): string {
   return String(tokens)
 }
 
-/**
- * Warning copy for a model that can't do web tools, or null when they work (no banner). Native web
- * tools depend on the model's own support (Claude, and GPT over the Platform); a configured host vendor exposes the `mcp__web__*` tools to ANY model, so
- * they are "unavailable" only when the model lacks native support AND no vendor is set - the caller
- * passes that one boolean. INVARIANT: the single boolean assumes every registered vendor implements
- * BOTH operations (Exa does). The backend seam is per-tool (optional search?()/fetch?(), the MCP
- * gate, the container derivation), but the client only knows the vendor *id*, not its capabilities.
- * If a search-only or fetch-only vendor is ever added, re-split this into per-tool booleans and
- * plumb the vendor's capabilities to the client - else this banner would misreport the missing side.
- */
-export function webToolsWarning(unavailable: boolean): string | null {
-  if (!unavailable) return null
-  return 'Web search and fetch aren’t available on this model. Set a provider under Settings → Web to use them on any model.'
+// Picker banner for missing native web tools. A host vendor (Exa) covers both; omit/undefined fetch follows search.
+export function webToolsWarning(
+  model: ModelDefinition | undefined,
+  webVendorSet: boolean,
+): string | null {
+  if (!model || webVendorSet) return null
+  if (model.supportsWebSearch === false) {
+    return 'Web search and fetch aren’t available on this model. Set a provider under Settings → Web to use them on any model.'
+  }
+  if (model.supportsWebFetch === false) {
+    return 'Native web fetch isn’t available on this model. Set a provider under Settings → Web to use fetch (search still works).'
+  }
+  return null
 }
 
 type LongContextCliff = NonNullable<ModelDefinition['longContextPriceCliff']>
@@ -93,10 +93,8 @@ interface ModelFamilyListProps {
    */
   onSelectFamilyLatest?: (latestId: string, family: string) => void
   /**
-   * Active host web-provider id from global settings. Native web search/fetch depend on the model
-   * (the `supportsWebSearch` flag; Claude and GPT-over-Platform have them); a configured vendor
-   * exposes the `mcp__web__*` tools to ANY model, so the
-   * "not available" warning clears once a vendor is set. Undefined / 'native' = no host vendor.
+   * Active host web-provider id. Native gaps come from supportsWebSearch / supportsWebFetch;
+   * a vendor (Exa) clears the warning. Undefined / 'native' = no host vendor.
    */
   webProvider?: string
 }
@@ -186,12 +184,9 @@ export function ModelFamilyList({
   const [expanded, setExpanded] = useState<string | null | undefined>(undefined)
   const openFamily = expanded === undefined ? selectedFamily : expanded
 
-  // Native web tools depend on the model's own support (Claude, GPT-over-Platform); a configured host vendor makes them work on ANY model, so web
-  // tools are unavailable only when the model lacks native support AND no vendor is set.
-  // `native`/undefined means no host vendor.
-  const nativeWebUnavailable = resolved?.supportsWebSearch === false
+  // `native`/undefined means no host vendor — only then surface the model's native gap.
   const webVendorSet = !!webProvider && webProvider !== 'native'
-  const webWarning = webToolsWarning(nativeWebUnavailable && !webVendorSet)
+  const webWarning = webToolsWarning(resolved, webVendorSet)
 
   return (
     <div className="flex flex-col gap-0.5">

--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -239,9 +239,12 @@ export const OPENROUTER_CATALOG: ModelDefinition[] = [
 
 /**
  * Non-Claude models the Platform proxy can serve. Unlike OpenRouter these use
- * BARE ids (`gpt-5.5`): the proxy's routing/pricing all key off bare ids, so a
- * vendor-prefixed slug would miss every match.
+ * BARE ids (`gpt-5.5`, `grok-4.5`): the proxy's routing/pricing all key off bare
+ * ids, so a vendor-prefixed slug would miss every match.
  */
+// Responses hosts web_search but not web_fetch — fetch needs a Settings → Web vendor (Exa).
+const PLATFORM_RESPONSES_WEB = { supportsWebSearch: true, supportsWebFetch: false } as const
+
 const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
   {
     id: 'gpt-5.4',
@@ -250,9 +253,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     family: 'gpt',
     icon: 'openai',
     supportedEfforts: NON_CLAUDE_EFFORTS,
-    // Platform serves gpt over the OpenAI Responses wire, which maps the agent's
-    // web_search server tool to the native web_search tool — so search works.
-    supportsWebSearch: true,
+    ...PLATFORM_RESPONSES_WEB,
     pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.4).
     contextWindow: 1_050_000,
@@ -266,7 +267,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     family: 'gpt',
     icon: 'openai',
     supportedEfforts: NON_CLAUDE_EFFORTS,
-    supportsWebSearch: true,
+    ...PLATFORM_RESPONSES_WEB,
     pricing: { inputPerMtok: 5, outputPerMtok: 30 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.5).
     contextWindow: 1_050_000,
@@ -280,7 +281,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     family: 'gpt',
     icon: 'openai',
     supportedEfforts: NON_CLAUDE_EFFORTS,
-    supportsWebSearch: true,
+    ...PLATFORM_RESPONSES_WEB,
     pricing: { inputPerMtok: 1, outputPerMtok: 6 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.6-luna).
     contextWindow: 1_050_000,
@@ -294,7 +295,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     family: 'gpt',
     icon: 'openai',
     supportedEfforts: NON_CLAUDE_EFFORTS,
-    supportsWebSearch: true,
+    ...PLATFORM_RESPONSES_WEB,
     pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.6-terra).
     contextWindow: 1_050_000,
@@ -310,16 +311,29 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     isLatest: true,
     icon: 'openai',
     supportedEfforts: NON_CLAUDE_EFFORTS,
-    supportsWebSearch: true,
+    ...PLATFORM_RESPONSES_WEB,
     pricing: { inputPerMtok: 5, outputPerMtok: 30 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.6-sol).
     contextWindow: 1_050_000,
     longContextPriceCliff: GPT_LONG_CONTEXT_CLIFF,
     promptHints: GPT_TOOL_USE_PROMPT_HINTS,
   },
+  {
+    // Bare id matches the platform proxy's grok-* → xai-responses route.
+    id: 'grok-4.5',
+    label: 'Grok 4.5',
+    blurb: 'xAI Grok, served via Platform',
+    family: 'grok',
+    isLatest: true,
+    icon: 'xai',
+    supportedEfforts: NON_CLAUDE_EFFORTS,
+    ...PLATFORM_RESPONSES_WEB,
+    pricing: { inputPerMtok: 2, outputPerMtok: 6 },
+    contextWindow: 500_000,
+  },
 ]
 
-/** Platform — bare Claude models plus the GPT models the proxy serves. */
+/** Platform — bare Claude models plus the GPT/Grok models the proxy serves. */
 export const PLATFORM_CATALOG: ModelDefinition[] = [
   ...CLAUDE_BARE_CATALOG,
   ...PLATFORM_EXTRA_MODELS,

--- a/src/shared/lib/llm-provider/model-catalog-schema.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.test.ts
@@ -88,6 +88,16 @@ describe('modelDefinitionSchema', () => {
     expect(() => modelDefinitionSchema.parse({ ...base, promptHints: [''] })).toThrow()
   })
 
+  it('accepts supportsWebFetch independently of supportsWebSearch', () => {
+    expect(
+      modelDefinitionSchema.parse({
+        ...base,
+        supportsWebSearch: true,
+        supportsWebFetch: false,
+      }),
+    ).toMatchObject({ supportsWebSearch: true, supportsWebFetch: false })
+  })
+
   it('validates a catalog array', () => {
     expect(modelCatalogSchema.parse([base])).toHaveLength(1)
   })

--- a/src/shared/lib/llm-provider/model-catalog-schema.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.ts
@@ -29,17 +29,11 @@ export const modelDefinitionSchema = z.object({
   family: z.string().optional(),
   /** This id is what the bare `family` alias resolves to (newest in the family). */
   isLatest: z.boolean().optional(),
-  /**
-   * Whether this model supports the agent's web search / fetch path (the
-   * Anthropic-native server tools, which only work when Anthropic serves the
-   * request). Omit/undefined ⇒ supported (all Claude models). Set `false` for
-   * non-Claude models routed via OpenRouter so the picker can warn.
-   */
+  // Omit/undefined ⇒ supported (Claude). false ⇒ OpenRouter non-Claude, etc.
   supportsWebSearch: z.boolean().optional(),
-  /**
-   * Whether the model accepts image input (vision). Populated from a provider's
-   * advertised input modalities during model search. Omit/undefined ⇒ unknown.
-   */
+  // Omit/undefined ⇒ follow supportsWebSearch. false when search works but fetch does not (Platform Responses).
+  supportsWebFetch: z.boolean().optional(),
+  // Vision. Populated from provider modalities during model search; omit ⇒ unknown.
   supportsImageInput: z.boolean().optional(),
   /** Extra system-prompt guidance needed by model families with weaker tool priors. */
   promptHints: z.array(z.string().min(1)).optional(),

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -105,6 +105,7 @@ describe('getProviderCatalog', () => {
       family: 'gpt',
       icon: 'openai',
       supportsWebSearch: true,
+      supportsWebFetch: false,
       pricing: { inputPerMtok: 5, outputPerMtok: 30 },
     })
     expect(gpt.isLatest).toBeFalsy()
@@ -112,25 +113,39 @@ describe('getProviderCatalog', () => {
     expect(catalog.find((m) => m.id === 'gpt-5.6-luna')).toMatchObject({
       family: 'gpt',
       supportsWebSearch: true,
+      supportsWebFetch: false,
       pricing: { inputPerMtok: 1, outputPerMtok: 6 },
     })
     expect(catalog.find((m) => m.id === 'gpt-5.6-terra')).toMatchObject({
       family: 'gpt',
       supportsWebSearch: true,
+      supportsWebFetch: false,
       pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
     })
     expect(catalog.find((m) => m.id === 'gpt-5.6-sol')).toMatchObject({
       family: 'gpt',
       isLatest: true,
       supportsWebSearch: true,
+      supportsWebFetch: false,
       pricing: { inputPerMtok: 5, outputPerMtok: 30 },
     })
     const gptLatest = catalog.filter((m) => m.family === 'gpt' && m.isLatest)
     expect(gptLatest.map((m) => m.id)).toEqual(['gpt-5.6-sol'])
+    // Grok rides the same Responses wire (xai-responses upstream); bare id only.
+    expect(catalog.find((m) => m.id === 'grok-4.5')).toMatchObject({
+      family: 'grok',
+      isLatest: true,
+      icon: 'xai',
+      supportsWebSearch: true,
+      supportsWebFetch: false,
+      pricing: { inputPerMtok: 2, outputPerMtok: 6 },
+      contextWindow: 500_000,
+    })
     // Platform keys off bare ids, never the OpenRouter vendor-prefixed slugs.
     expect(catalog.some((m) => m.id === 'openai/gpt-5.5')).toBe(false)
     expect(catalog.some((m) => m.id === 'z-ai/glm-5.2')).toBe(false)
     expect(catalog.some((m) => m.id === 'glm-5.2')).toBe(false)
+    expect(catalog.some((m) => m.id === 'x-ai/grok-4.5')).toBe(false)
   })
 })
 
@@ -323,6 +338,10 @@ describe('getModelContextWindow', () => {
     expect(getModelContextWindow('gpt-5.6-sol', 'platform')).toBe(1_050_000)
   })
 
+  it('returns the catalog window for Platform Grok models', () => {
+    expect(getModelContextWindow('grok-4.5', 'platform')).toBe(500_000)
+  })
+
   it('returns the catalog window for OpenRouter GPT models', () => {
     expect(getModelContextWindow('openai/gpt-5.5', 'openrouter')).toBe(1_050_000)
     expect(getModelContextWindow('z-ai/glm-5.2', 'openrouter')).toBeUndefined()
@@ -404,10 +423,12 @@ describe('resolveModelForProvider', () => {
     expect(resolveModelForProvider('x-ai/grok-4.5', 'openrouter', 'agent')).toBe('x-ai/grok-4.5')
   })
 
-  it('resolves Platform GPT models to bare ids and falls back for unsupported glm', () => {
+  it('resolves Platform GPT/Grok models to bare ids and falls back for unsupported glm', () => {
     expect(resolveModelForProvider('gpt', 'platform', 'agent')).toBe('gpt-5.6-sol')
     expect(resolveModelForProvider('gpt-5.4', 'platform', 'agent')).toBe('gpt-5.4')
     expect(resolveModelForProvider('gpt-5.6-luna', 'platform', 'agent')).toBe('gpt-5.6-luna')
+    expect(resolveModelForProvider('grok', 'platform', 'agent')).toBe('grok-4.5')
+    expect(resolveModelForProvider('grok-4.5', 'platform', 'agent')).toBe('grok-4.5')
     expect(resolveModelForProvider('glm', 'platform', 'agent')).toBe('claude-opus-4-8')
   })
 

--- a/src/shared/lib/services/model-pricing.json
+++ b/src/shared/lib/services/model-pricing.json
@@ -202,6 +202,12 @@
       "cacheRead": 0.5
     }
   },
+  "grok-4.5": {
+    "input": 2,
+    "output": 6,
+    "cacheCreation": 2,
+    "cacheRead": 0.2
+  },
   "openai/gpt-5.4": {
     "input": 2.5,
     "output": 15,


### PR DESCRIPTION
## Summary
- Add bare `grok-4.5` to the Platform built-in catalog (`family: grok`, `icon: xai`, 500K context, $2/$6 per Mtok, web search enabled via the Responses wire).
- Add matching `grok-4.5` rates to `model-pricing.json` for local usage/cost display.
- Cover catalog presence, context window, and `grok` / `grok-4.5` alias resolution in `model-catalog.test.ts`.

Pairs with the platform proxy xAI Responses / `grok-4.5` routing (platform PR #155). OpenRouter already ships `x-ai/grok-4.5` (#447); this is the Platform bare-id counterpart.

## Test plan
- [x] `npx vitest run src/shared/lib/llm-provider/model-catalog.test.ts`
- [ ] With Platform provider active, confirm Grok 4.5 appears in the model picker under the Grok family with the xAI icon
- [ ] Select Grok 4.5 and send a short message against a staging proxy that has `XAI_API_KEY` set
- [ ] Confirm bare alias `grok` resolves to `grok-4.5` (Platform only; OpenRouter still uses `x-ai/grok-4.5`)


Made with [Cursor](https://cursor.com)