### PR TITLE
feat(sidebar): replace footer Settings/version buttons with account menu

### DIFF
--- a/e2e/auth/pages/settings.page.ts
+++ b/e2e/auth/pages/settings.page.ts
@@ -19,6 +19,8 @@ export class SettingsPage {
 
   /** Open settings via sidebar footer button */
   async open() {
+    // Settings now lives inside the footer account menu
+    await this.page.locator('[data-testid="user-menu-trigger"]').click()
     await this.page.locator('[data-testid="settings-button"]').click()
     await expect(this.page.locator('[data-testid="global-settings-page"]')).toBeVisible()
   }

--- a/e2e/specs/a11y-audit.spec.ts
+++ b/e2e/specs/a11y-audit.spec.ts
@@ -39,6 +39,8 @@ test.describe('Accessibility Audit', () => {
   })
 
   test('global settings page has no critical a11y violations', async ({ page }) => {
+    // Settings now lives inside the footer account menu
+    await page.locator('[data-testid="user-menu-trigger"]').click()
     await page.locator('[data-testid="settings-button"]').click()
     await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
 

--- a/e2e/specs/account-status.spec.ts
+++ b/e2e/specs/account-status.spec.ts
@@ -92,6 +92,10 @@ async function openConnectionsSettings(page: Page) {
   await appPage.goto()
   await appPage.waitForAgentsLoaded()
 
+  // Settings now lives inside the footer account menu
+
+  await page.locator('[data-testid="user-menu-trigger"]').click()
+
   await page.locator('[data-testid="settings-button"]').click()
   await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
   await page.locator('[data-testid="settings-nav-connections"]').click()

--- a/e2e/specs/connections-page-policy-modal.spec.ts
+++ b/e2e/specs/connections-page-policy-modal.spec.ts
@@ -22,6 +22,8 @@ test.describe('Connections Page — Policy Modal After OAuth', () => {
    */
   test('connecting an API from the connections page opens the scope policy editor', async ({ page, request }) => {
     // 1. Open Settings → Connections
+    // Settings now lives inside the footer account menu
+    await page.locator('[data-testid="user-menu-trigger"]').click()
     await page.locator('[data-testid="settings-button"]').click()
     await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
     await page.locator('[data-testid="settings-nav-connections"]').click()

--- a/e2e/specs/global-connections.spec.ts
+++ b/e2e/specs/global-connections.spec.ts
@@ -47,6 +47,8 @@ test.describe('Global Settings → Connections — Add MCP flow', () => {
 
       try {
         // 1. Open Global Settings → Connections.
+        // Settings now lives inside the footer account menu
+        await page.locator('[data-testid="user-menu-trigger"]').click()
         await page.locator('[data-testid="settings-button"]').click()
         await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
         await page.locator('[data-testid="settings-nav-connections"]').click()

--- a/e2e/specs/policy-settings.spec.ts
+++ b/e2e/specs/policy-settings.spec.ts
@@ -28,6 +28,8 @@ async function createSlackAccount(
  * (the per-row policy pill + dialog were removed in the connections redesign).
  */
 async function openConnectionDetail(page: Page, name: string) {
+  // Settings now lives inside the footer account menu
+  await page.locator('[data-testid="user-menu-trigger"]').click()
   await page.locator('[data-testid="settings-button"]').click()
   await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
   await page.locator('[data-testid="settings-nav-connections"]').click()

--- a/e2e/specs/public-skillset.spec.ts
+++ b/e2e/specs/public-skillset.spec.ts
@@ -15,6 +15,8 @@ test.describe('Public Skillset Provider', () => {
   })
 
   test('public skillset appears in Settings > Skillsets with Public badge', async ({ page }) => {
+    // Settings now lives inside the footer account menu
+    await page.locator('[data-testid="user-menu-trigger"]').click()
     await page.locator('[data-testid="settings-button"]').click()
     // Settings nav items are now links (URL-driven tabs), so target the stable
     // testid rather than a button role.

--- a/e2e/specs/scope-policy-grouping.spec.ts
+++ b/e2e/specs/scope-policy-grouping.spec.ts
@@ -9,6 +9,8 @@ const API = ''
  * (the per-row policy pill + dialog were removed in the connections redesign).
  */
 async function openConnectionDetail(page: Page, name: string) {
+  // Settings now lives inside the footer account menu
+  await page.locator('[data-testid="user-menu-trigger"]').click()
   await page.locator('[data-testid="settings-button"]').click()
   await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
   await page.locator('[data-testid="settings-nav-connections"]').click()

--- a/e2e/specs/settings.spec.ts
+++ b/e2e/specs/settings.spec.ts
@@ -26,6 +26,8 @@ interface UserSettingsSnapshot {
 }
 
 async function openSettings(page: Page) {
+  // Settings now lives inside the footer account menu
+  await page.locator('[data-testid="user-menu-trigger"]').click()
   await page.locator('[data-testid="settings-button"]').click()
   await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
 }
@@ -233,15 +235,15 @@ test.describe('Settings Page', () => {
     await expect(page.locator('[data-testid="app-sidebar"]')).toBeVisible()
 
     await openSettings(page)
-    // App sidebar (and its Settings button) is gone; the settings sidebar replaces it
+    // App sidebar (and its account menu) is gone; the settings sidebar replaces it
     await expect(page.locator('[data-testid="app-sidebar"]')).not.toBeVisible()
-    await expect(page.locator('[data-testid="settings-button"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="user-menu-trigger"]')).not.toBeVisible()
     await expect(page.locator('[data-testid="settings-sidebar"]')).toBeVisible()
 
     await page.locator('[data-testid="settings-back"]').click()
     // App sidebar returns
     await expect(page.locator('[data-testid="app-sidebar"]')).toBeVisible()
-    await expect(page.locator('[data-testid="settings-button"]')).toBeVisible()
+    await expect(page.locator('[data-testid="user-menu-trigger"]')).toBeVisible()
     await expect(page.locator('[data-testid="settings-sidebar"]')).not.toBeVisible()
   })
 
@@ -679,6 +681,8 @@ test.describe('Settings deep-link reset', () => {
 
       // Close, then reopen via the plain Settings button (no tab argument).
       await page.locator('[data-testid="settings-back"]').click()
+      // Settings now lives inside the footer account menu
+      await page.locator('[data-testid="user-menu-trigger"]').click()
       await page.locator('[data-testid="settings-button"]').click()
       await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
 
@@ -713,6 +717,10 @@ test.describe('Settings ?from= close-target', () => {
       await expect(page).toHaveURL(new RegExp(`/agents/${agent.displaySlug}$`))
       const origin = page.url()
 
+      // Settings now lives inside the footer account menu
+
+      await page.locator('[data-testid="user-menu-trigger"]').click()
+
       await page.locator('[data-testid="settings-button"]').click()
       await expect(page).toHaveURL(/\/settings(\/|\?|$)/)
       await page.locator('[data-testid="settings-back"]').click()
@@ -746,6 +754,10 @@ test.describe('Settings ?from= close-target', () => {
       // The URL carries the display slug ({name}-{id}), not the bare canonical id.
       await expect(page).toHaveURL(new RegExp(`/agents/${agent.displaySlug}$`))
       const origin = page.url()
+
+      // Settings now lives inside the footer account menu
+
+      await page.locator('[data-testid="user-menu-trigger"]').click()
 
       await page.locator('[data-testid="settings-button"]').click()
       await expect(page).toHaveURL(/\/settings(\/|\?|$)/)

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -386,9 +386,12 @@ describe('AppSidebar — layout & top nav', () => {
     expect(screen.getByText('Your Agents')).toBeInTheDocument()
   })
 
-  it('renders Settings + version in the footer', () => {
+  it('opens the footer account menu with Settings and the version', async () => {
+    const user = userEvent.setup()
     renderWithProviders(<AppSidebar />)
-    expect(screen.getByTestId('settings-button')).toBeInTheDocument()
+    await user.click(screen.getByTestId('user-menu-trigger'))
+    expect(await screen.findByTestId('settings-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('sign-out-button')).not.toBeInTheDocument()
     expect(screen.getByText('v0.1.0-test')).toBeInTheDocument()
   })
 
@@ -679,13 +682,13 @@ describe('UserMenu action for the current target', () => {
     await userEvent.click(screen.getByTestId('user-menu-trigger'))
   }
 
-  it('offers sign out for a web deployment', async () => {
+  it('does not offer an account action for a web deployment', async () => {
     vi.stubGlobal('__AUTH_MODE__', true)
     setActiveTarget('local', null)
 
     await openUserMenu()
 
-    expect(screen.getByTestId('sign-out-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('sign-out-button')).not.toBeInTheDocument()
     expect(screen.queryByTestId('switch-to-local-button')).not.toBeInTheDocument()
   })
 

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -1,5 +1,5 @@
 
-import { Bell, ChevronDown, ChevronLeft, ChevronRight, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, User, Users, Compass, MoonStar } from 'lucide-react'
+import { Bell, ChevronDown, ChevronLeft, ChevronRight, Plus, Search, AlertTriangle, LayoutGrid, SquareMousePointer, Users, Compass, MoonStar } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 import { cn } from '@shared/lib/utils/cn'
 import { Skeleton } from '@renderer/components/ui/skeleton'
@@ -8,8 +8,6 @@ import { AppLink } from '@renderer/components/ui/app-link'
 import React, { useState, useEffect, useMemo, useCallback } from 'react'
 import { isElectron, getPlatform, openDashboardExternal } from '@renderer/lib/env'
 import { TargetSwitcher } from '@renderer/components/layout/target-switcher'
-import { useTargetSwitch } from '@renderer/hooks/use-target-switch'
-import { hasInteractiveLogin } from '@renderer/lib/auth-mode'
 import { useDialogs } from '@renderer/context/dialog-context'
 import { useFullScreen } from '@renderer/hooks/use-fullscreen'
 import {
@@ -65,11 +63,9 @@ import { useHistoryNavigation } from '@renderer/router/use-history-navigation'
 import { useSearch } from '@renderer/context/search-context'
 import { useCmdHintTarget, CmdHintBadge } from '@renderer/context/cmd-hint-context'
 import { useArtifacts, type ArtifactInfo } from '@renderer/hooks/use-artifacts'
-import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
 import { useIsMobile } from '@renderer/hooks/use-mobile'
 import { useUser } from '@renderer/context/user-context'
-import { useUpdateStatus } from '@renderer/context/update-status-context'
 import { useUnreadNotificationCount } from '@renderer/hooks/use-notifications'
 import { usePlatformUnreadCount } from '@renderer/hooks/use-platform-notifications'
 import { useIsOnline } from '@renderer/context/connectivity-context'
@@ -91,6 +87,7 @@ import {
 } from '@dnd-kit/sortable'
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import { SortableAgentMenuItem } from './sortable-agent-item'
+import { UserMenu } from './user-menu'
 import { applyAgentOrder } from '@renderer/lib/agent-ordering'
 import { useRenderTracker } from '@renderer/lib/perf'
 import { useDiscoverableAgents } from '@renderer/hooks/use-agent-templates'
@@ -605,53 +602,6 @@ function NotificationsMenuButton() {
   )
 }
 
-function UserMenu() {
-  const { isAuthMode, user, signOut } = useUser()
-  // Go through the same switch path as the sidebar's control rather than
-  // calling switchTarget directly: it owns the failure handling, so a switch
-  // that cannot be recorded reports itself instead of rejecting into nothing.
-  const { switching, switchTo } = useTargetSwitch()
-  if (!isAuthMode || !user) return null
-  return (
-    <div className="px-2">
-      <Popover>
-        <PopoverTrigger asChild>
-          <button className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors" data-testid="user-menu-trigger">
-            <User className="h-3 w-3" />
-            <span className="truncate max-w-[140px]">{user.name}</span>
-          </button>
-        </PopoverTrigger>
-        <PopoverContent align="start" className="w-48 p-1">
-          {hasInteractiveLogin() ? (
-            <button
-              onClick={signOut}
-              className="flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded-sm hover:bg-accent transition-colors"
-              data-testid="sign-out-button"
-            >
-              <LogOut className="h-4 w-4" />
-              Sign out
-            </button>
-          ) : (
-            // Cloud workspace: signing out would revoke the deployment session
-            // the desktop's grant is bound to — disruptive, and pointless since
-            // main still holds the platform connection and would just mint
-            // another. Offer the action that actually means something here.
-            <button
-              onClick={() => void switchTo('local')}
-              disabled={switching}
-              className="flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded-sm hover:bg-accent transition-colors disabled:opacity-60"
-              data-testid="switch-to-local-button"
-            >
-              <LogOut className="h-4 w-4" />
-              Use this computer
-            </button>
-          )}
-        </PopoverContent>
-      </Popover>
-    </div>
-  )
-}
-
 /**
  * Shows API key warning only for admins (who can actually fix it).
  * Isolated to avoid calling useSettings() for non-admin users.
@@ -728,8 +678,6 @@ export function AppSidebar() {
   useRenderTracker('AppSidebar')
   const { openSettings } = useDialogs()
   const { createUntitledAgent, isPending: isCreatingAgent } = useCreateUntitledAgent()
-  const updateStatus = useUpdateStatus()
-  const updateAvailable = updateStatus.state === 'available' || updateStatus.state === 'downloaded'
 
   // The "New Agent" menu command is handled centrally by MenuCommandHandler
   // (which calls createUntitledAgent); the sidebar keeps the hook for its own
@@ -1026,30 +974,8 @@ export function AppSidebar() {
         </SidebarContent>
       </ErrorBoundary>
 
-      <SidebarFooter className="border-t p-0 px-2 pt-1 pb-[env(safe-area-inset-bottom)]">
+      <SidebarFooter className="p-1 pb-[max(0.25rem,env(safe-area-inset-bottom))]">
         <UserMenu />
-        <div className="flex items-center justify-between gap-2">
-          <SidebarMenuButton
-            onClick={() => openSettings()}
-            className="w-auto"
-            data-testid="settings-button"
-          >
-            <Settings className="h-4 w-4" />
-            <span>Settings</span>
-          </SidebarMenuButton>
-          <button
-            type="button"
-            onClick={() => openSettings('general')}
-            className="flex items-center gap-1.5 px-2 text-xs text-muted-foreground shrink-0 hover:text-foreground"
-            title={updateAvailable ? `Update available: v${updateStatus.version}` : undefined}
-            data-testid="sidebar-version"
-          >
-            {updateAvailable && (
-              <span className="h-2 w-2 rounded-full bg-blue-500" aria-label="Update available" />
-            )}
-            <span>v{__APP_VERSION__}</span>
-          </button>
-        </div>
       </SidebarFooter>
 
       <SidebarRail />

--- a/src/renderer/components/layout/user-menu.tsx
+++ b/src/renderer/components/layout/user-menu.tsx
@@ -1,0 +1,175 @@
+import {
+  ChevronDown,
+  LogOut,
+  Monitor,
+  Moon,
+  Settings,
+  Sun,
+} from 'lucide-react'
+
+import { cn } from '@shared/lib/utils/cn'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@renderer/components/ui/dropdown-menu'
+import { useDialogs } from '@renderer/context/dialog-context'
+import { useUpdateStatus } from '@renderer/context/update-status-context'
+import { useUser } from '@renderer/context/user-context'
+import { useTargetSwitch } from '@renderer/hooks/use-target-switch'
+import { useUpdateUserSettings, useUserSettings } from '@renderer/hooks/use-user-settings'
+import { hasInteractiveLogin } from '@renderer/lib/auth-mode'
+
+function AvatarInitials({ name, size = 32 }: { name: string; size?: number }) {
+  const initials = name
+    .split(' ')
+    .filter(Boolean)
+    .map((w) => w[0])
+    .slice(0, 2)
+    .join('')
+    .toUpperCase()
+
+  return (
+    <div
+      aria-hidden="true"
+      className="flex shrink-0 items-center justify-center rounded-full border border-border/60 bg-muted text-xs font-semibold"
+      style={{ width: size, height: size }}
+    >
+      {initials}
+    </div>
+  )
+}
+
+const THEME_OPTIONS = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+  { value: 'system', label: 'System', icon: Monitor },
+] as const
+
+// Account-menu theme row: a segmented Light/Dark/System toggle that flips the
+// theme live without closing the menu. Persists via the same user-settings
+// mutation as the Settings → General appearance picker.
+function AppearanceRow() {
+  const { data: userSettings, isLoading } = useUserSettings()
+  const updateUserSettings = useUpdateUserSettings()
+  const theme = userSettings?.theme ?? 'system'
+
+  return (
+    <div className="flex items-center justify-between gap-2 px-2 py-1.5">
+      <span className="text-sm">Appearance</span>
+      <DropdownMenuRadioGroup
+        value={theme}
+        onValueChange={(value) => updateUserSettings.mutate({ theme: value as typeof theme })}
+        className="flex items-center gap-0.5 rounded-md bg-muted/60 p-0.5"
+      >
+        {THEME_OPTIONS.map((opt) => {
+          const active = theme === opt.value
+          return (
+            <DropdownMenuRadioItem
+              key={opt.value}
+              value={opt.value}
+              aria-label={`${opt.label} theme`}
+              disabled={isLoading}
+              onSelect={(event) => event.preventDefault()}
+              className={cn(
+                'flex size-6 cursor-pointer items-center justify-center rounded p-1 transition-colors [&>span]:hidden',
+                active
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              <opt.icon className="size-4" aria-hidden="true" />
+            </DropdownMenuRadioItem>
+          )
+        })}
+      </DropdownMenuRadioGroup>
+    </div>
+  )
+}
+
+// Sidebar-footer account menu, mirroring the platform web app's user menu.
+export function UserMenu() {
+  const { isAuthMode, user } = useUser()
+  const { openSettings } = useDialogs()
+  const { switching, switchTo } = useTargetSwitch()
+  const updateStatus = useUpdateStatus()
+  const updateAvailable = updateStatus.state === 'available' || updateStatus.state === 'downloaded'
+  const showUseThisComputer = isAuthMode && !!user && !hasInteractiveLogin()
+
+  // TODO(iddo): source identity from the connected platform account (name,
+  // email, avatar). The auth-mode session user is used when present so
+  // multi-user deployments keep showing the signed-in user.
+  const displayName = user?.name ?? 'Test Taskew'
+
+  return (
+    /* modal={false}: a modal menu can leave `pointer-events: none` stuck on
+       <body> when it closes mid-navigation (e.g. Settings opening a route),
+       making the whole sidebar unclickable. */
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="Account menu"
+          data-testid="user-menu-trigger"
+          className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-left transition-colors hover:bg-foreground/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground/30 data-[state=open]:bg-foreground/5"
+        >
+          <AvatarInitials name={displayName} />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-foreground">{displayName}</p>
+          </div>
+          <ChevronDown className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent
+        side="top"
+        align="start"
+        sideOffset={6}
+        className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-56 border-sidebar-border/60 bg-popover shadow-lg shadow-black/5"
+      >
+        <DropdownMenuItem
+          onSelect={() => openSettings()}
+          data-testid="settings-button"
+          className="focus:bg-sidebar-accent focus:text-sidebar-accent-foreground"
+        >
+          <Settings className="size-4 text-muted-foreground" aria-hidden="true" />
+          <span className="flex-1">Settings</span>
+        </DropdownMenuItem>
+
+        <DropdownMenuSeparator className="bg-sidebar-border/60" />
+
+        <AppearanceRow />
+
+        <DropdownMenuSeparator className="bg-sidebar-border/60" />
+
+        {showUseThisComputer && (
+          <DropdownMenuItem
+            onSelect={() => void switchTo('local')}
+            disabled={switching}
+            data-testid="switch-to-local-button"
+            className="focus:bg-sidebar-accent focus:text-sidebar-accent-foreground"
+          >
+            <span className="flex-1">Use this computer</span>
+            <LogOut className="size-4 text-muted-foreground" aria-hidden="true" />
+          </DropdownMenuItem>
+        )}
+
+        <DropdownMenuItem
+          onSelect={() => openSettings('general')}
+          data-testid="sidebar-version"
+          title={updateAvailable ? `Update available: v${updateStatus.version}` : undefined}
+          className="justify-between py-1 text-xs text-muted-foreground focus:bg-sidebar-accent focus:text-sidebar-accent-foreground"
+        >
+          <span>v{__APP_VERSION__}</span>
+          {updateAvailable && (
+            <span className="h-2 w-2 rounded-full bg-blue-500" aria-label="Update available" />
+          )}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}


### PR DESCRIPTION
## Summary

Replaces the separate Settings and version controls in the sidebar footer with one account menu while preserving the current target behavior:

- **Settings** opens the settings page
- **Appearance** uses Radix radio-group primitives for keyboard-accessible Light, Dark, and System selection and persists through the existing user-settings mutation
- **Version** keeps the update-available indicator and opens Settings → General
- **Use this computer** remains available for a cloud workspace
- **Sign out** is intentionally not exposed from this menu

The settings E2E helpers now open Settings through the account menu.

**Stack:** PR 2/4 — based on #454; followed by #456 and #661.

## Test plan

- [x] Typecheck
- [x] 34/34 app-sidebar unit tests