### PR TITLE
fix: render slash-command messages inline instead of two-column

### DIFF
--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -327,12 +327,13 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
             >
               {/* Slash command display */}
               {isSlashCommand && hasText && (
-                <div className="flex items-baseline gap-1.5">
-                  <span className="font-mono font-semibold text-sm">
+                <div className="text-sm">
+                  <span className="font-mono font-semibold">
                     {text.split(' ')[0]}
                   </span>
                   {text.includes(' ') && (
-                    <span className="text-sm opacity-80">
+                    <span className="opacity-80">
+                      {' '}
                       {text.slice(text.indexOf(' ') + 1)}
                     </span>
                   )}


### PR DESCRIPTION
## Summary
Skill/slash-command invocations with long arguments rendered as a two-column layout in the message bubble: the command name (e.g. `/idea-ingest`) sat in a narrow left column with the entire prompt text wrapping in a block beside it.

Cause: the slash-command display in `message-item.tsx` wrapped the command name and the argument text in a `flex items-baseline` row, so the argument span became a side-by-side column instead of flowing after the name.

Fix: drop the flex container and render both parts as plain inline spans (explicit space between them). The command name keeps its mono/semibold styling and the argument text keeps its dimmed styling, but now wraps naturally after the name at full bubble width.

## Testing
- `npx tsc --noEmit` clean
- `message-item.test.tsx` 26/26 passing
- eslint clean on the touched file