### PR TITLE
feat: detect firewalled host-browser CDP proxy at launch

### DIFF
--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -764,7 +764,22 @@ async function launchHostBrowserIfNeeded(): Promise<HostBrowserInfo | undefined>
   // (ws://host:port/devtools/browser/<id>), not just ws://host:port.
   // Query Chrome's /json/version endpoint to discover it.
   const cdpHost = `${cdpIp}:${data.port}`;
-  const versionRes = await fetch(`http://${cdpHost}/json/version`);
+  // A network-level failure here (vs. an HTTP error) means the host browser
+  // launched but this container can't reach its debugging port — on Windows
+  // that is almost always the host firewall dropping container→host traffic.
+  // Surface that diagnosis instead of an opaque "fetch failed".
+  let versionRes: Response;
+  try {
+    versionRes = await fetch(`http://${cdpHost}/json/version`);
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `The host browser launched, but its debugging endpoint at ${cdpHost} is unreachable from inside the agent container (${cause}). ` +
+      `This usually means a firewall on the host machine is blocking container-to-host connections ` +
+      `(on Windows: Windows Defender Firewall or antivirus blocking the app on the "vEthernet (WSL)" network). ` +
+      `Ask the user to allow the app through their firewall, or to switch Browser Host to the built-in browser in Settings.`
+    );
+  }
   if (!versionRes.ok) {
     throw new Error(`Failed to query CDP /json/version: ${versionRes.status}`);
   }

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -723,11 +723,28 @@ async function launchHostBrowserIfNeeded(): Promise<HostBrowserInfo | undefined>
   const browserAuthHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
   if (proxyToken) browserAuthHeaders['Authorization'] = `Bearer ${proxyToken}`;
 
-  const response = await fetch(`${hostAppUrl}/api/browser/launch-host-browser`, {
-    method: 'POST',
-    headers: browserAuthHeaders,
-    body: JSON.stringify({ agentId: agentId || 'default' }),
-  });
+  // A network-level failure here means the launch request never reached the
+  // host app at all — the host never launches Chrome and never reports to
+  // Sentry, so this bare 'fetch failed' used to be the only trace. On Windows
+  // it is almost always Windows Firewall blocking the app's API port for
+  // container (WSL2) traffic, e.g. after the first-run firewall prompt was
+  // dismissed. Surface that diagnosis instead.
+  let response: Response;
+  try {
+    response = await fetch(`${hostAppUrl}/api/browser/launch-host-browser`, {
+      method: 'POST',
+      headers: browserAuthHeaders,
+      body: JSON.stringify({ agentId: agentId || 'default' }),
+    });
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Could not reach the host app at ${hostAppUrl} to launch the browser (${cause}). ` +
+      `Connections from the agent container to the host machine appear to be blocked — on Windows this is usually ` +
+      `Windows Defender Firewall blocking the app (open "Allow an app through Windows Firewall" and enable it for both Private and Public networks), ` +
+      `or third-party antivirus. Ask the user to allow the app through their firewall, then try again.`
+    );
+  }
 
   if (!response.ok) {
     const body = await response.text();

--- a/src/main/host-browser/chrome-provider.sup217.test.ts
+++ b/src/main/host-browser/chrome-provider.sup217.test.ts
@@ -98,6 +98,13 @@ const h = vi.hoisted(() => {
   const getHostBridgeIp = vi.fn(() => hostBridgeIp)
   function setHostBridgeIp(ip: string | null) { hostBridgeIp = ip }
 
+  // Verdict of the runner-side reachability probe ChromeProvider runs against
+  // the CDP proxy after launch (firewall detection). Default 'unknown' = probe
+  // can't tell, launch proceeds.
+  let probeResult: 'reachable' | 'unreachable' | 'unknown' = 'unknown'
+  const probeHostPortFromRunner = vi.fn(async () => probeResult)
+  function setProbeResult(r: 'reachable' | 'unreachable' | 'unknown') { probeResult = r }
+
   // Which IPs this host "has" as local interfaces — controls whether ChromeProvider
   // treats a reported bridge IP as bindable (run the proxy) or virtual (skip the
   // proxy, loopback-direct). A virtual user-mode gateway (e.g. Lima 192.168.5.2) is
@@ -119,6 +126,8 @@ const h = vi.hoisted(() => {
     proxyCloseCount = 0
     hostBridgeIp = null
     localIps = []
+    probeResult = 'unknown'
+    probeHostPortFromRunner.mockClear()
     getHostBridgeIp.mockClear()
     spawnMock.mockClear().mockImplementation((_cmd: string, _args: string[]) => makeChild(4321))
     execSyncMock.mockClear().mockImplementation(() => 'default via 172.22.192.1 dev eth0')
@@ -130,6 +139,7 @@ const h = vi.hoisted(() => {
     listenCalls, createServer, connect, netMock, spawnMock, execSyncMock,
     getHostBridgeIp, setHostBridgeIp, networkInterfaces, setLocalIps, reset,
     killedPids,
+    probeHostPortFromRunner, setProbeResult,
     setFailProxyListen: (v: boolean) => { failProxyListen = v },
     getProxyCloseCount: () => proxyCloseCount,
   }
@@ -194,7 +204,10 @@ vi.mock('@shared/lib/error-reporting', () => ({
 // manager so each test controls that answer without loading container-manager.
 vi.mock('@shared/lib/container/container-manager', () => ({
   containerManager: {
-    getClient: () => ({ getHostBridgeIp: h.getHostBridgeIp }),
+    getClient: () => ({
+      getHostBridgeIp: h.getHostBridgeIp,
+      probeHostPortFromRunner: h.probeHostPortFromRunner,
+    }),
   },
 }))
 
@@ -357,5 +370,66 @@ describe('ChromeProvider CDP bind address (SUP-217)', () => {
 
     await provider.stop('agent1')
     expect(h.getProxyCloseCount()).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Runner-side CDP proxy reachability probe. A launched Chrome + bound proxy
+// can still be unreachable from the container when the host firewall drops
+// runner→host traffic (Windows Defender on the vEthernet (WSL) interface is
+// the common case). The probe must fail the launch loudly on a proven block,
+// and must never fail it on an inconclusive result.
+// ---------------------------------------------------------------------------
+
+describe('ChromeProvider CDP proxy reachability probe', () => {
+  let provider: ChromeProvider
+
+  beforeEach(() => {
+    h.reset()
+    provider = new ChromeProvider()
+  })
+
+  afterEach(() => {
+    setPlatform(originalPlatform)
+  })
+
+  function setupBridgedWin32() {
+    setPlatform('win32')
+    h.setHostBridgeIp('172.22.192.1')
+    h.setLocalIps(['172.22.192.1'])
+  }
+
+  it('fails the launch with a firewall diagnosis when the proxy is unreachable from the runner', async () => {
+    setupBridgedWin32()
+    h.setProbeResult('unreachable')
+
+    await expect(provider.launch('agent1')).rejects.toThrow(/firewall/i)
+    expect(h.probeHostPortFromRunner).toHaveBeenCalled()
+    // Chrome and the proxy must be torn down — no orphan browser behind a dead launch.
+    expect(h.killedPids).toContain(4321)
+    expect(h.getProxyCloseCount()).toBeGreaterThan(0)
+  })
+
+  it('proceeds when the probe verdict is unknown (probe may be broken; never fail a working setup)', async () => {
+    setupBridgedWin32()
+    h.setProbeResult('unknown')
+
+    await expect(provider.launch('agent1')).resolves.toMatchObject({ port: expect.any(Number) })
+  })
+
+  it('proceeds when the proxy is reachable', async () => {
+    setupBridgedWin32()
+    h.setProbeResult('reachable')
+
+    await expect(provider.launch('agent1')).resolves.toMatchObject({ port: expect.any(Number) })
+  })
+
+  it('does not probe loopback-direct runners (no proxy to test)', async () => {
+    setPlatform('linux')
+    h.setHostBridgeIp(null)
+
+    await provider.launch('agent1')
+
+    expect(h.probeHostPortFromRunner).not.toHaveBeenCalled()
   })
 })

--- a/src/main/host-browser/chrome-provider.ts
+++ b/src/main/host-browser/chrome-provider.ts
@@ -622,6 +622,31 @@ export class ChromeProvider implements HostBrowserProvider {
       }, 1000)
     }
 
+    // Chrome is up and the proxy is bound, but on bridged runners the container
+    // still has to cross the host firewall to reach the proxy (on Windows,
+    // Defender or third-party AV commonly drops WSL2→host traffic on the
+    // vEthernet interface). That block only manifests at connect time inside
+    // the container, where nothing reports to Sentry — so probe the proxy from
+    // the runner's network side and fail the launch loudly with an actionable
+    // message instead.
+    if (proxyHost && proxyPort) {
+      const probe = await this.probeProxyFromRunner(instanceId, proxyHost, proxyPort)
+      if (probe === 'unreachable') {
+        const err = new Error(
+          `Chrome launched on the host, but the agent cannot reach it: connections from the container network to the browser's debugging proxy on ${proxyHost}:${proxyPort} are being blocked — most likely by a firewall on the host machine` +
+          (process.platform === 'win32'
+            ? ' (Windows Defender Firewall or third-party antivirus blocking inbound connections on the "vEthernet (WSL)" interface). Ask the user to allow this app through Windows Firewall for all network profiles (including Public), then try again — or switch Browser Host to the built-in browser in Settings.'
+            : '. Ask the user to allow this app through the host firewall, or switch Browser Host to the built-in browser in Settings.'),
+        )
+        captureException(err, {
+          tags: { component: 'browser', operation: 'cdp-proxy-reachability' },
+          extra: { instanceId, proxyHost, proxyPort, chromePort: port, platform: process.platform },
+        })
+        await this.stop(instanceId)
+        throw err
+      }
+    }
+
     const exposedPort = proxyPort ?? port
 
     console.log(`[ChromeProvider] Chrome CDP on ${CDP_LOOPBACK_ADDRESS}:${port}${proxyPort ? `, proxy on ${proxyHost}:${proxyPort}` : ''} for instance ${instanceId} (pid ${chromePid})`)
@@ -768,6 +793,22 @@ export class ChromeProvider implements HostBrowserProvider {
       else if (pid > 0) process.kill(pid)
     } catch {
       /* already gone */
+    }
+  }
+
+  /** Ask the active runner to probe the CDP proxy from its network side.
+   *  Any failure to run the probe itself means 'unknown' — only a positive
+   *  "connection refused / timed out" verdict may fail a launch. */
+  private async probeProxyFromRunner(
+    instanceId: string,
+    host: string,
+    port: number,
+  ): Promise<'reachable' | 'unreachable' | 'unknown'> {
+    try {
+      return await containerManager.getClient(instanceId).probeHostPortFromRunner(host, port)
+    } catch (error) {
+      console.warn('[ChromeProvider] CDP proxy reachability probe failed to run:', error)
+      return 'unknown'
     }
   }
 

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -13,6 +13,7 @@ import type {
   ContainerSession,
   ContainerStats,
   CreateSessionOptions,
+  HostPortProbeResult,
   StartOptions,
   StopOptions,
   StopResult,
@@ -362,6 +363,17 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
    */
   getHostBridgeIp(): string | null {
     return null
+  }
+
+  /**
+   * Probe whether a host-side TCP endpoint is reachable from the runner's
+   * network side. Default 'unknown' — most runtimes have no vantage point
+   * inside the runner network to test from. Runners that do (WSL2) override
+   * this so a host firewall blocking container→host traffic can be detected
+   * at launch time instead of failing opaquely inside the container.
+   */
+  async probeHostPortFromRunner(_host: string, _port: number): Promise<HostPortProbeResult> {
+    return 'unknown'
   }
 
   /**

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1630,6 +1630,11 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     return null
   }
 
+  // No runner network to probe from in mock mode.
+  async probeHostPortFromRunner(_host: string, _port: number): Promise<'reachable' | 'unreachable' | 'unknown'> {
+    return 'unknown'
+  }
+
   // Lifecycle management
 
   async start(options?: StartOptions): Promise<void> {

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -116,6 +116,10 @@ export interface StopResult {
   stopped: boolean
 }
 
+// Verdict from probing a host-side TCP endpoint from the runner's network side.
+// Only 'unreachable' is a proven block; 'unknown' must never fail a launch.
+export type HostPortProbeResult = 'reachable' | 'unreachable' | 'unknown'
+
 export interface ContainerClient {
   // Lifecycle management
   start(options?: StartOptions): Promise<void>
@@ -131,6 +135,13 @@ export interface ContainerClient {
   // forward an unauthenticated host CDP port to the container without ever binding
   // it on 0.0.0.0 (SUP-217).
   getHostBridgeIp(): string | null
+
+  // Probe whether a host-side TCP endpoint (e.g. the CDP proxy bound to
+  // getHostBridgeIp()) is actually reachable from the runner's network side,
+  // where container-originated traffic comes from. 'unknown' means the runner
+  // has no vantage point to test from — callers must treat it as "proceed",
+  // never as a failure.
+  probeHostPortFromRunner(host: string, port: number): Promise<HostPortProbeResult>
 
   // Query the container runtime for current state (spawns CLI process)
   // Use containerManager.getCachedInfo() for cached status instead

--- a/src/shared/lib/container/wsl2-container-client.test.ts
+++ b/src/shared/lib/container/wsl2-container-client.test.ts
@@ -76,6 +76,7 @@ import {
   stopWSL2Distro,
   WSL2ContainerClient,
   classifyProbeCurlExit,
+  classifyProbeWgetResult,
 } from './wsl2-container-client'
 
 const mockedFs = vi.mocked(fs)
@@ -809,6 +810,40 @@ describe('classifyProbeCurlExit', () => {
   })
 })
 
+describe('classifyProbeWgetResult', () => {
+  // stderr strings below are verbatim busybox v1.37.0 output from the shipped distro
+  it('maps exit 0 to reachable', () => {
+    expect(classifyProbeWgetResult(0, '')).toBe('reachable')
+  })
+
+  it('maps connection-refused stderr to unreachable', () => {
+    const stderr =
+      "Connecting to 127.0.0.1:1 (127.0.0.1:1)\nwget: can't connect to remote host (127.0.0.1): Connection refused"
+    expect(classifyProbeWgetResult(1, stderr)).toBe('unreachable')
+  })
+
+  it('maps timeout stderr (firewall drop) to unreachable', () => {
+    expect(classifyProbeWgetResult(1, 'wget: download timed out')).toBe('unreachable')
+    expect(
+      classifyProbeWgetResult(1, "wget: can't connect to remote host: Connection timed out"),
+    ).toBe('unreachable')
+  })
+
+  it('maps an HTTP error response to reachable (the server answered)', () => {
+    expect(
+      classifyProbeWgetResult(1, 'wget: server returned error: HTTP/1.1 404 Not Found'),
+    ).toBe('reachable')
+  })
+
+  it('maps everything else to unknown so a broken probe cannot fail a working setup', () => {
+    expect(classifyProbeWgetResult(127, 'wget: not found')).toBe('unknown') // wget missing too
+    expect(classifyProbeWgetResult(1, "wget: bad address 'no-such-host:1'")).toBe('unknown')
+    expect(classifyProbeWgetResult(1, '')).toBe('unknown')
+    expect(classifyProbeWgetResult(null, '')).toBe('unknown')
+    expect(classifyProbeWgetResult(undefined, '')).toBe('unknown')
+  })
+})
+
 describe('WSL2ContainerClient.probeHostPortFromRunner', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -818,45 +853,94 @@ describe('WSL2ContainerClient.probeHostPortFromRunner', () => {
     return new WSL2ContainerClient({ agentId: 'test-agent' } as any)
   }
 
-  function mockCurlResult(err: Error | null) {
-    mockExecFile.mockImplementation((...args: any[]) => {
-      const cb = args[args.length - 1]
-      cb(err, err ? undefined : { stdout: '', stderr: '' })
-    })
+  function mockProbeResults(...errs: (Error | null)[]) {
+    for (const err of errs) {
+      mockExecFile.mockImplementationOnce((...args: any[]) => {
+        const cb = args[args.length - 1]
+        cb(err, err ? undefined : { stdout: '', stderr: '' })
+      })
+    }
   }
 
+  const curlMissing = () =>
+    Object.assign(new Error('curl: not found'), { code: 127, stderr: '/bin/sh: curl: not found' })
+
   it('probes the endpoint via curl inside the distro', async () => {
-    mockCurlResult(null)
+    mockProbeResults(null)
 
     const result = await createClient().probeHostPortFromRunner('172.22.192.1', 9222)
 
     expect(result).toBe('reachable')
+    expect(mockExecFile).toHaveBeenCalledTimes(1)
     const [file, cmdArgs] = mockExecFile.mock.calls[0]
     expect(file).toBe('wsl')
     expect(cmdArgs).toContain(WSL2_DISTRO_NAME)
+    expect(cmdArgs).toContain('curl')
     expect(cmdArgs).toContain('http://172.22.192.1:9222/json/version')
   })
 
-  it('reports unreachable when curl times out (firewall drop)', async () => {
-    mockCurlResult(Object.assign(new Error('curl timed out'), { code: 28 }))
+  it('reports unreachable when curl times out (firewall drop) without falling back', async () => {
+    mockProbeResults(Object.assign(new Error('curl timed out'), { code: 28 }))
 
     expect(await createClient().probeHostPortFromRunner('172.22.192.1', 9222)).toBe('unreachable')
+    expect(mockExecFile).toHaveBeenCalledTimes(1)
   })
 
   it('reports unreachable when the connection is refused', async () => {
-    mockCurlResult(Object.assign(new Error('connection refused'), { code: 7 }))
+    mockProbeResults(Object.assign(new Error('connection refused'), { code: 7 }))
 
     expect(await createClient().probeHostPortFromRunner('172.22.192.1', 9222)).toBe('unreachable')
   })
 
-  it('reports unknown when curl is missing from the distro', async () => {
-    mockCurlResult(Object.assign(new Error('curl: not found'), { code: 127 }))
+  it('reports unknown when wsl itself cannot run (non-numeric error code)', async () => {
+    mockProbeResults(Object.assign(new Error('spawn wsl ENOENT'), { code: 'ENOENT' }))
 
     expect(await createClient().probeHostPortFromRunner('172.22.192.1', 9222)).toBe('unknown')
+    expect(mockExecFile).toHaveBeenCalledTimes(1)
   })
 
-  it('reports unknown when wsl itself cannot run (non-numeric error code)', async () => {
-    mockCurlResult(Object.assign(new Error('spawn wsl ENOENT'), { code: 'ENOENT' }))
+  it('falls back to busybox wget when curl is missing and reports reachable on success', async () => {
+    mockProbeResults(curlMissing(), null)
+
+    const result = await createClient().probeHostPortFromRunner('172.22.192.1', 9222)
+
+    expect(result).toBe('reachable')
+    expect(mockExecFile).toHaveBeenCalledTimes(2)
+    const [file, cmdArgs] = mockExecFile.mock.calls[1]
+    expect(file).toBe('wsl')
+    expect(cmdArgs).toContain('wget')
+    expect(cmdArgs).toContain('http://172.22.192.1:9222/json/version')
+    // -q would swallow the stderr the classifier needs
+    expect(cmdArgs).not.toContain('-q')
+  })
+
+  it('reports unreachable when the wget fallback is refused', async () => {
+    mockProbeResults(
+      curlMissing(),
+      Object.assign(new Error('wget failed'), {
+        code: 1,
+        stderr:
+          "Connecting to 172.22.192.1:9222 (172.22.192.1:9222)\nwget: can't connect to remote host (172.22.192.1): Connection refused",
+      }),
+    )
+
+    expect(await createClient().probeHostPortFromRunner('172.22.192.1', 9222)).toBe('unreachable')
+  })
+
+  it('reports unreachable when the wget fallback times out (firewall drop)', async () => {
+    mockProbeResults(
+      curlMissing(),
+      Object.assign(new Error('wget failed'), { code: 1, stderr: 'wget: download timed out' }),
+    )
+
+    expect(await createClient().probeHostPortFromRunner('172.22.192.1', 9222)).toBe('unreachable')
+  })
+
+  it('reports unknown when wget is missing as well', async () => {
+    mockProbeResults(
+      curlMissing(),
+      Object.assign(new Error('wget: not found'), { code: 127, stderr: '/bin/sh: wget: not found' }),
+    )
 
     expect(await createClient().probeHostPortFromRunner('172.22.192.1', 9222)).toBe('unknown')
   })

--- a/src/shared/lib/container/wsl2-container-client.test.ts
+++ b/src/shared/lib/container/wsl2-container-client.test.ts
@@ -5,9 +5,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 // ============================================================================
 
 const mockSpawn = vi.fn()
+const mockExecFile = vi.fn()
 vi.mock('child_process', () => ({
   execSync: vi.fn(),
   spawn: (...args: any[]) => mockSpawn(...args),
+  execFile: (...args: any[]) => mockExecFile(...args),
 }))
 
 vi.mock('fs', () => ({
@@ -73,6 +75,7 @@ import {
   ensureWSL2Ready,
   stopWSL2Distro,
   WSL2ContainerClient,
+  classifyProbeCurlExit,
 } from './wsl2-container-client'
 
 const mockedFs = vi.mocked(fs)
@@ -779,5 +782,82 @@ describe('WSL2ContainerClient.handleRunError', () => {
     const client = createClient()
     const result = await client.testHandleRunError('some random string error')
     expect(result).toBe(false)
+  })
+})
+
+// ============================================================================
+// Host-port reachability probe (firewall detection for the host-browser
+// CDP proxy)
+// ============================================================================
+
+describe('classifyProbeCurlExit', () => {
+  it('maps exit 0 to reachable', () => {
+    expect(classifyProbeCurlExit(0)).toBe('reachable')
+  })
+
+  it('maps connection-refused (7) and timeout (28) to unreachable', () => {
+    expect(classifyProbeCurlExit(7)).toBe('unreachable')
+    expect(classifyProbeCurlExit(28)).toBe('unreachable')
+  })
+
+  it('maps everything else to unknown so a broken probe cannot fail a working setup', () => {
+    expect(classifyProbeCurlExit(127)).toBe('unknown') // curl not installed
+    expect(classifyProbeCurlExit(56)).toBe('unknown') // TCP connected, transfer broke
+    expect(classifyProbeCurlExit(1)).toBe('unknown')
+    expect(classifyProbeCurlExit(null)).toBe('unknown')
+    expect(classifyProbeCurlExit(undefined)).toBe('unknown')
+  })
+})
+
+describe('WSL2ContainerClient.probeHostPortFromRunner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function createClient() {
+    return new WSL2ContainerClient({ agentId: 'test-agent' } as any)
+  }
+
+  function mockCurlResult(err: Error | null) {
+    mockExecFile.mockImplementation((...args: any[]) => {
+      const cb = args[args.length - 1]
+      cb(err, err ? undefined : { stdout: '', stderr: '' })
+    })
+  }
+
+  it('probes the endpoint via curl inside the distro', async () => {
+    mockCurlResult(null)
+
+    const result = await createClient().probeHostPortFromRunner('172.22.192.1', 9222)
+
+    expect(result).toBe('reachable')
+    const [file, cmdArgs] = mockExecFile.mock.calls[0]
+    expect(file).toBe('wsl')
+    expect(cmdArgs).toContain(WSL2_DISTRO_NAME)
+    expect(cmdArgs).toContain('http://172.22.192.1:9222/json/version')
+  })
+
+  it('reports unreachable when curl times out (firewall drop)', async () => {
+    mockCurlResult(Object.assign(new Error('curl timed out'), { code: 28 }))
+
+    expect(await createClient().probeHostPortFromRunner('172.22.192.1', 9222)).toBe('unreachable')
+  })
+
+  it('reports unreachable when the connection is refused', async () => {
+    mockCurlResult(Object.assign(new Error('connection refused'), { code: 7 }))
+
+    expect(await createClient().probeHostPortFromRunner('172.22.192.1', 9222)).toBe('unreachable')
+  })
+
+  it('reports unknown when curl is missing from the distro', async () => {
+    mockCurlResult(Object.assign(new Error('curl: not found'), { code: 127 }))
+
+    expect(await createClient().probeHostPortFromRunner('172.22.192.1', 9222)).toBe('unknown')
+  })
+
+  it('reports unknown when wsl itself cannot run (non-numeric error code)', async () => {
+    mockCurlResult(Object.assign(new Error('spawn wsl ENOENT'), { code: 'ENOENT' }))
+
+    expect(await createClient().probeHostPortFromRunner('172.22.192.1', 9222)).toBe('unknown')
   })
 })

--- a/src/shared/lib/container/wsl2-container-client.ts
+++ b/src/shared/lib/container/wsl2-container-client.ts
@@ -138,6 +138,31 @@ export function classifyProbeCurlExit(exitCode: number | null | undefined): Host
 }
 
 /**
+ * Map a busybox-wget probe result to a verdict. The bundled Alpine distro
+ * ships busybox wget but no curl, so this is the fallback classifier. Busybox
+ * wget exits 1 for nearly every failure, so the verdict comes from stderr
+ * (messages observed against busybox v1.37.0 in the shipped distro):
+ *   - "Connection refused" → nothing listening: unreachable
+ *   - "timed out" ("download timed out" / kernel "Connection timed out") —
+ *     how a firewall silently dropping WSL2→host traffic surfaces: unreachable
+ *   - "server returned error: HTTP/..." → TCP+HTTP round-trip completed, so
+ *     the port is reachable (matches curl-without--f semantics)
+ * Anything else (wget missing, bad address, wsl broken) is 'unknown' so a
+ * broken probe can never fail a working setup.
+ */
+export function classifyProbeWgetResult(
+  exitCode: number | null | undefined,
+  stderr: string,
+): HostPortProbeResult {
+  if (exitCode === 0) return 'reachable'
+  if (exitCode !== 1) return 'unknown'
+  if (/connection refused/i.test(stderr)) return 'unreachable'
+  if (/timed out/i.test(stderr)) return 'unreachable'
+  if (/server returned error/i.test(stderr)) return 'reachable'
+  return 'unknown'
+}
+
+/**
  * Pre-flight: check if hardware virtualization is enabled in firmware (BIOS).
  * Returns null if enabled or undetermined; returns a typed error if we can
  * confirm it's disabled. WSL2 cannot run without this, so fail fast with
@@ -342,20 +367,37 @@ export class WSL2ContainerClient extends BaseContainerClient {
    * hit when it tries to connect.
    */
   async probeHostPortFromRunner(host: string, port: number): Promise<HostPortProbeResult> {
+    const url = `http://${host}:${port}/json/version`
+    let curlExit: number | null
     try {
       await execFileAsync(
         'wsl',
         [
           '-d', WSL2_DISTRO_NAME, '--',
           'curl', '--silent', '--output', '/dev/null', '--max-time', '4',
-          `http://${host}:${port}/json/version`,
+          url,
         ],
         { timeout: 15000 },
       )
       return 'reachable'
     } catch (err) {
       const code = (err as { code?: number | string }).code
-      return classifyProbeCurlExit(typeof code === 'number' ? code : null)
+      curlExit = typeof code === 'number' ? code : null
+    }
+    // 126/127 = curl absent or not executable in the distro. The bundled
+    // Alpine rootfs ships no curl, so this is the common case — fall back to
+    // busybox wget (no -q: the verdict is classified from its stderr).
+    if (curlExit !== 126 && curlExit !== 127) return classifyProbeCurlExit(curlExit)
+    try {
+      await execFileAsync(
+        'wsl',
+        ['-d', WSL2_DISTRO_NAME, '--', 'wget', '-O', '/dev/null', '-T', '4', url],
+        { timeout: 15000 },
+      )
+      return 'reachable'
+    } catch (err) {
+      const { code, stderr } = err as { code?: number | string; stderr?: string }
+      return classifyProbeWgetResult(typeof code === 'number' ? code : null, stderr ?? '')
     }
   }
 

--- a/src/shared/lib/container/wsl2-container-client.ts
+++ b/src/shared/lib/container/wsl2-container-client.ts
@@ -1,10 +1,11 @@
-import { execSync, spawn } from 'child_process'
+import { execFile, execSync, spawn } from 'child_process'
+import { promisify } from 'util'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
 import { BaseContainerClient, checkCommandAvailable, execWithPath, writeEnvFile } from './base-container-client'
 import { getActiveLlmProvider } from '@shared/lib/llm-provider'
-import type { ContainerConfig } from './types'
+import type { ContainerConfig, HostPortProbeResult } from './types'
 import { getDataDir } from '@shared/lib/config/data-dir'
 import { captureException, captureMessage, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 import {
@@ -120,6 +121,21 @@ function collectWSL2Diagnostics(): Record<string, unknown> {
 }
 
 export const WSL2_DISTRO_NAME = 'superagent'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * Map a curl exit code from the in-distro reachability probe to a verdict.
+ * Only "couldn't connect" (7) and "timed out" (28) prove the path is blocked —
+ * a firewall silently dropping WSL2→host traffic surfaces as 28. Anything else
+ * (curl missing, wsl broken, HTTP-level errors, mid-transfer resets) is
+ * 'unknown' so a broken probe can never fail a working setup.
+ */
+export function classifyProbeCurlExit(exitCode: number | null | undefined): HostPortProbeResult {
+  if (exitCode === 0) return 'reachable'
+  if (exitCode === 7 || exitCode === 28) return 'unreachable'
+  return 'unknown'
+}
 
 /**
  * Pre-flight: check if hardware virtualization is enabled in firmware (BIOS).
@@ -316,6 +332,31 @@ export class WSL2ContainerClient extends BaseContainerClient {
       console.warn('Failed to detect host IP for WSL2 distro:', e)
     }
     return null
+  }
+
+  /**
+   * Probe a host-side TCP endpoint from inside the WSL2 distro. Containers are
+   * NATed through the distro's eth0, so distro→host traffic crosses the same
+   * Windows Firewall boundary (the vEthernet (WSL) interface) as
+   * container→host traffic — a block here is exactly what the container will
+   * hit when it tries to connect.
+   */
+  async probeHostPortFromRunner(host: string, port: number): Promise<HostPortProbeResult> {
+    try {
+      await execFileAsync(
+        'wsl',
+        [
+          '-d', WSL2_DISTRO_NAME, '--',
+          'curl', '--silent', '--output', '/dev/null', '--max-time', '4',
+          `http://${host}:${port}/json/version`,
+        ],
+        { timeout: 15000 },
+      )
+      return 'reachable'
+    } catch (err) {
+      const code = (err as { code?: number | string }).code
+      return classifyProbeCurlExit(typeof code === 'number' ? code : null)
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

When Browser Host = Google Chrome on Windows, the browser tool can fail with an opaque error while **nothing reaches Sentry**. Root cause chain (from a support investigation of a Windows user whose browser tool couldn't even reach google.com):

- Chrome launches fine on the host and the CDP proxy binds the WSL2 gateway IP — every failure on *that* side is already instrumented.
- The container then connects to `host.docker.internal:<proxyPort>`. Windows Defender Firewall (or third-party AV) commonly drops WSL2→host traffic on the vEthernet (WSL) interface, so this hop times out.
- That failure surfaced only as a raw `fetch failed` inside the agent container: no Sentry event, no actionable message for the agent or user.

## Fix

**1. Probe the proxy from the runner's network side at launch** (`ChromeProvider.launch`)
- New `ContainerClient.probeHostPortFromRunner(host, port)` → `'reachable' | 'unreachable' | 'unknown'`. Base default is `'unknown'`; WSL2 implements it by running `curl --max-time 4 http://<bridgeIp>:<proxyPort>/json/version` inside the distro — containers NAT through the distro's eth0, so this crosses exactly the firewall boundary the container will hit.
- Only a **proven** block fails the launch: curl exit 7 (refused) or 28 (timed out — the firewall-drop signature). It then reports to Sentry (`component:browser`, `operation:cdp-proxy-reachability`), tears down Chrome + proxy, and throws a message naming Windows Firewall on the vEthernet (WSL) interface with the remediation.
- Anything inconclusive (curl missing, wsl broken, TCP reset) is `'unknown'` and proceeds — a broken probe can never fail a working setup.

**2. Clear agent-facing error as backstop** (`agent-container/src/server.ts`)
- A network-level failure fetching `/json/version` now throws a firewall diagnosis with next steps (allow the app through the firewall / switch Browser Host to the built-in browser) instead of `fetch failed`. Covers non-WSL2 runners and anything the probe can't prove.

The launch error flows through the existing `/api/browser/launch-host-browser` 503 → container → agent path, so the agent sees the actionable message either way.

## Testing

- 9 new tests: curl-exit classifier + WSL2 probe behavior (`wsl2-container-client.test.ts`), and the ChromeProvider gate — unreachable fails with teardown (no orphan Chrome), unknown/reachable proceed, loopback-direct runners never probe (`chrome-provider.sup217.test.ts`).
- All 64 tests in the touched test files pass; 118 related container-client tests pass; typecheck + lint clean on touched files.

## Note

The probe assumes `curl` exists in the bundled WSL2 Alpine distro — if absent it degrades to `'unknown'` (fail-safe, behavior unchanged) but the probe is inert. Worth a one-time check that the rootfs ships curl.