### PR TITLE
fix: auto-recover container start from corrupt image snapshots

### DIFF
--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -25,7 +25,7 @@ import { getSettings } from '@shared/lib/config/settings'
 import { getActiveLlmProvider } from '@shared/lib/llm-provider'
 import { resolveContainerModel, getContainerModelPromptHints } from './resolve-model'
 import { getActiveWebProvider } from '../web-provider'
-import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
+import { captureException, captureMessage, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 
 const execAsync = promisify(exec)
 
@@ -436,6 +436,32 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     return null
   }
 
+  /**
+   * Whether a run failure means the image's unpacked snapshot in the runtime's
+   * store is corrupt — containerd's "mount callback failed on /tmp/containerd-
+   * mountNNN: ..." (e.g. ": no users found" when resolving the Dockerfile USER
+   * against a truncated /etc/passwd). Seen after disk exhaustion during image
+   * pull/unpack. The corruption lives in the image store, not in this
+   * container, so retrying the same run can never succeed — recovery is
+   * removing the image (removeCorruptImage) and rebuilding it.
+   */
+  protected isCorruptImageSnapshotError(error: any): boolean {
+    const msg = String(error?.message || error?.stderr || error || '')
+    return /mount callback failed on/i.test(msg)
+  }
+
+  /**
+   * Remove the agent image so the next ensureImageExists() recreates it from
+   * scratch. Base implementation only removes the tagged image — conservative
+   * on user-owned daemons (docker/podman) that may hold unrelated images.
+   * Runtimes that own their whole store (bundled Lima VM) override to also
+   * prune dangling layers and build cache, where the corrupt layer content
+   * would otherwise survive the bare `rmi` and poison the rebuild.
+   */
+  protected async removeCorruptImage(image: string): Promise<void> {
+    await execWithPath(`${this.getRunnerShellCommand()} rmi -f ${image}`)
+  }
+
   protected getContainerName(): string {
     return `superagent-${this.config.agentId}`
   }
@@ -620,12 +646,14 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
       // Bounded retry loop. Each recovery path makes exactly one attempt of
       // progress so the loop can't spin: dropping a mount shrinks `volumes`,
-      // re-picking a port is capped by portRetries, and VM provisioning runs
-      // once. A fresh stop+rm precedes every attempt so we never double-start.
+      // re-picking a port is capped by portRetries, and VM provisioning and
+      // image re-creation each run once. A fresh stop+rm precedes every
+      // attempt so we never double-start.
       const MAX_PORT_RETRIES = 3
       let portRetries = 0
       const triedPorts = new Set<number>([port])
       let vmRecoveryTried = false
+      let imageRecoveryTried = false
       let stdout: string
       try {
         for (;;) {
@@ -661,7 +689,35 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
               continue
             }
 
-            // 3. Subclass recovery (e.g. provisioning a missing VM) — once.
+            // 3. Corrupt image snapshot in the runtime's store — the same run
+            //    can never succeed no matter how often the user retries, so
+            //    remove the image, recreate it, and retry once. Checked before
+            //    the generic subclass recovery because the VM itself is
+            //    healthy in this mode (handleRunError would probe it, find
+            //    nothing wrong, and give up).
+            if (!imageRecoveryTried && this.isCorruptImageSnapshotError(runError)) {
+              imageRecoveryTried = true
+              console.warn(`[Container] Corrupt image snapshot detected, removing ${image} and recreating`)
+              addErrorBreadcrumb({ category: 'container', message: 'Corrupt image snapshot, removing image and recreating', data: { image, agentId: this.config.agentId } })
+              try {
+                await this.removeCorruptImage(image)
+                await this.ensureImageExistsWithRecovery()
+                captureMessage('Recovered from corrupt container image snapshot', {
+                  level: 'warning',
+                  tags: { component: 'container', operation: 'corrupt-image-recovery' },
+                  extra: { agentId: this.config.agentId, image, originalError: String(runError?.message || runError).slice(0, 2000) },
+                })
+                continue
+              } catch (repairError) {
+                captureException(repairError, {
+                  tags: { component: 'container', operation: 'corrupt-image-recovery' },
+                  extra: { agentId: this.config.agentId, image, originalError: String(runError?.message || runError).slice(0, 2000) },
+                })
+                // Fall through — surface the original run error below.
+              }
+            }
+
+            // 4. Subclass recovery (e.g. provisioning a missing VM) — once.
             if (!vmRecoveryTried) {
               vmRecoveryTried = true
               const recovered = await this.handleRunError(runError)

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -462,6 +462,25 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     await execWithPath(`${this.getRunnerShellCommand()} rmi -f ${image}`)
   }
 
+  /**
+   * Recreate the agent image after removeCorruptImage(). Mirrors
+   * ensureImageReady()'s decision: build from the local agent-container
+   * context when it exists (dev), otherwise pull from the registry — the
+   * packaged app has no build context, and the bundled Lima VM has no
+   * buildkit, so `build` is never an option there (ensureImageExists()'s
+   * build-only fallback hard-fails on Lima). Lazy import avoids a
+   * base-client ↔ client-factory module cycle.
+   */
+  protected async recreateImage(image: string): Promise<void> {
+    const { canBuildImage, buildImage, pullImage } = await import('./client-factory')
+    const runner = getSettings().container.containerRunner as import('./client-factory').ContainerRunner
+    if (canBuildImage()) {
+      await buildImage(runner, image)
+    } else {
+      await pullImage(runner, image)
+    }
+  }
+
   protected getContainerName(): string {
     return `superagent-${this.config.agentId}`
   }
@@ -701,7 +720,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
               addErrorBreadcrumb({ category: 'container', message: 'Corrupt image snapshot, removing image and recreating', data: { image, agentId: this.config.agentId } })
               try {
                 await this.removeCorruptImage(image)
-                await this.ensureImageExistsWithRecovery()
+                await this.recreateImage(image)
                 captureMessage('Recovered from corrupt container image snapshot', {
                   level: 'warning',
                   tags: { component: 'container', operation: 'corrupt-image-recovery' },

--- a/src/shared/lib/container/corrupt-image-snapshot-recovery.test.ts
+++ b/src/shared/lib/container/corrupt-image-snapshot-recovery.test.ts
@@ -89,6 +89,18 @@ vi.mock('@shared/lib/error-reporting', () => ({
   addErrorBreadcrumb: vi.fn(),
 }))
 
+// The recovery restores the image via ensureImageReady()'s primitives (build
+// in dev, pull in packaged apps — the bundled Lima VM has no buildkit, so the
+// old build-only ensureImageExists() fallback can never restore it there).
+const pullImageMock = vi.fn((_runner: string, _image: string) => Promise.resolve())
+const buildImageMock = vi.fn((_runner: string, _image: string) => Promise.resolve())
+let canBuild = false
+vi.mock('./client-factory', () => ({
+  canBuildImage: vi.fn(() => canBuild),
+  pullImage: (runner: string, image: string) => pullImageMock(runner, image),
+  buildImage: (runner: string, image: string) => buildImageMock(runner, image),
+}))
+
 vi.mock('@shared/lib/config/settings', () => ({
   getSettings: vi.fn(() => ({
     enableToolSearch: false,
@@ -151,25 +163,43 @@ describe('start() recovers from a corrupt image snapshot', () => {
     execCommands.length = 0
     runScript = []
     runAttempts = 0
+    canBuild = false
+    pullImageMock.mockClear()
+    buildImageMock.mockClear()
   })
 
-  it('removes the image, recreates it, and retries the run once', async () => {
+  it('removes the image, re-pulls it (packaged app), and retries the run once', async () => {
     runScript = [CORRUPT_SNAPSHOT_MSG, 'ok']
     const client = new TestContainerClient({ agentId: 'abc123' } as ContainerConfig)
 
     await client.start()
 
-    const rmiIndex = execCommands.findIndex((c) => c.includes(`rmi -f ${IMAGE}`))
-    expect(rmiIndex).toBeGreaterThanOrEqual(0)
-
-    // ensureImageExists() runs again after the removal (image inspect follows
-    // the rmi), so a rebuilt/re-pulled image backs the retry.
-    const inspectAfterRmi = execCommands
-      .slice(rmiIndex + 1)
-      .some((c) => c.includes(`image inspect ${IMAGE}`))
-    expect(inspectAfterRmi).toBe(true)
-
+    expect(execCommands.some((c) => c.includes(`rmi -f ${IMAGE}`))).toBe(true)
+    // No build context (packaged app) → the registry pull restores the image.
+    expect(pullImageMock).toHaveBeenCalledWith('docker', IMAGE)
+    expect(buildImageMock).not.toHaveBeenCalled()
     expect(countRunAttempts()).toBe(2)
+  })
+
+  it('rebuilds instead of pulling when a local build context exists (dev)', async () => {
+    canBuild = true
+    runScript = [CORRUPT_SNAPSHOT_MSG, 'ok']
+    const client = new TestContainerClient({ agentId: 'abc123' } as ContainerConfig)
+
+    await client.start()
+
+    expect(buildImageMock).toHaveBeenCalledWith('docker', IMAGE)
+    expect(pullImageMock).not.toHaveBeenCalled()
+    expect(countRunAttempts()).toBe(2)
+  })
+
+  it('surfaces the original error when the re-pull itself fails', async () => {
+    pullImageMock.mockRejectedValueOnce(new Error('Image pull failed with exit code 1'))
+    runScript = [CORRUPT_SNAPSHOT_MSG]
+    const client = new TestContainerClient({ agentId: 'abc123' } as ContainerConfig)
+
+    await expect(client.start()).rejects.toThrow(/mount callback failed/i)
+    expect(countRunAttempts()).toBe(1)
   })
 
   it('gives up after one recovery attempt when the corruption persists', async () => {

--- a/src/shared/lib/container/corrupt-image-snapshot-recovery.test.ts
+++ b/src/shared/lib/container/corrupt-image-snapshot-recovery.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ============================================================================
+// Corrupt-image-snapshot recovery in start().
+//
+// When `run` fails with containerd's "mount callback failed on
+// /tmp/containerd-mountNNN: ..." (e.g. ": no users found" resolving the
+// Dockerfile USER against a truncated /etc/passwd), the image's unpacked
+// snapshot in the runtime store is corrupt. Retrying the identical run can
+// never succeed, so start() must remove the image, recreate it, and retry —
+// exactly once, so a rebuild that reproduces the corruption still terminates.
+//
+// These tests record every command handed to child_process.exec and script
+// the `run -d` outcomes per attempt.
+// ============================================================================
+
+const execCommands: string[] = []
+
+// Scripted outcomes for successive `run -d` attempts. Each entry is either
+// 'ok' or an error message to reject with; attempts beyond the script succeed.
+let runScript: (string | 'ok')[] = []
+let runAttempts = 0
+
+const CORRUPT_SNAPSHOT_MSG =
+  'Command failed: /Users/nick/.superagent/bin/lima-nerdctl run -d --name superagent-abc123 ' +
+  'time="2026-07-13T11:33:27-07:00" level=fatal msg="mount callback failed on /tmp/containerd-mount3006401431: no users found"'
+
+vi.mock('child_process', () => {
+  // promisify(exec) calls exec(command, options, callback) and resolves with
+  // the callback's second arg, so every command resolves with { stdout, stderr }
+  // unless the run script says this attempt fails.
+  const exec = (
+    command: string,
+    optionsOrCb: unknown,
+    maybeCb?: (err: Error | null, result?: { stdout: string; stderr: string }) => void
+  ) => {
+    const cb = (typeof optionsOrCb === 'function' ? optionsOrCb : maybeCb) as (
+      err: Error | null,
+      result?: { stdout: string; stderr: string }
+    ) => void
+    execCommands.push(command)
+
+    if (/run\s+-d/.test(command)) {
+      const outcome = runScript[runAttempts] ?? 'ok'
+      runAttempts++
+      if (outcome !== 'ok') {
+        cb(new Error(outcome))
+        return {}
+      }
+      cb(null, { stdout: 'fake-container-id', stderr: '' })
+      return {}
+    }
+
+    // image inspect → found (skip build); ps → no used ports; rmi/prune/stop/rm
+    // → succeed silently.
+    cb(null, { stdout: '', stderr: '' })
+    return {}
+  }
+  return {
+    exec,
+    execSync: vi.fn(),
+    spawn: vi.fn(),
+  }
+})
+
+vi.mock('net', () => {
+  const createServer = vi.fn(() => {
+    const listeners = new Map<string, () => void>()
+    return {
+      once: vi.fn((event: string, callback: () => void) => {
+        listeners.set(event, callback)
+      }),
+      close: vi.fn(),
+      listen: vi.fn(() => {
+        queueMicrotask(() => listeners.get('listening')?.())
+      }),
+    }
+  })
+
+  return {
+    default: { createServer },
+    createServer,
+  }
+})
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addErrorBreadcrumb: vi.fn(),
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: vi.fn(() => ({
+    enableToolSearch: false,
+    container: {
+      agentImage: 'superagent/agent:test',
+      containerRunner: 'docker',
+      resourceLimits: { cpu: 2, memory: '2g' },
+    },
+  })),
+}))
+
+vi.mock('@shared/lib/llm-provider', () => ({
+  getActiveLlmProvider: vi.fn(() => ({
+    getContainerEnvVars: () => ({}),
+  })),
+}))
+
+vi.mock('@shared/lib/config/data-dir', () => ({
+  getAgentWorkspaceDir: vi.fn(() => '/tmp/corrupt-snapshot-workspace'),
+}))
+
+vi.mock('fs', () => {
+  const noop = vi.fn()
+  return {
+    default: { mkdirSync: noop, writeFileSync: noop, unlinkSync: noop },
+    mkdirSync: noop,
+    writeFileSync: noop,
+    unlinkSync: noop,
+  }
+})
+
+import { BaseContainerClient } from './base-container-client'
+import type { ContainerConfig, ContainerInfo } from './types'
+
+/**
+ * Concrete subclass that reports the container as stopped (so start() runs the
+ * full run path instead of short-circuiting) and passes the health check
+ * immediately (so a successful retry resolves without the 60s wait).
+ */
+class TestContainerClient extends BaseContainerClient {
+  protected getRunnerCommand(): string {
+    return 'docker'
+  }
+  async getInfoFromRuntime(): Promise<ContainerInfo> {
+    return { status: 'stopped', port: null }
+  }
+  async waitForHealthy(): Promise<boolean> {
+    return true
+  }
+}
+
+const IMAGE = 'superagent/agent:test'
+
+function countRunAttempts(): number {
+  return execCommands.filter((c) => /run\s+-d/.test(c)).length
+}
+
+describe('start() recovers from a corrupt image snapshot', () => {
+  beforeEach(() => {
+    execCommands.length = 0
+    runScript = []
+    runAttempts = 0
+  })
+
+  it('removes the image, recreates it, and retries the run once', async () => {
+    runScript = [CORRUPT_SNAPSHOT_MSG, 'ok']
+    const client = new TestContainerClient({ agentId: 'abc123' } as ContainerConfig)
+
+    await client.start()
+
+    const rmiIndex = execCommands.findIndex((c) => c.includes(`rmi -f ${IMAGE}`))
+    expect(rmiIndex).toBeGreaterThanOrEqual(0)
+
+    // ensureImageExists() runs again after the removal (image inspect follows
+    // the rmi), so a rebuilt/re-pulled image backs the retry.
+    const inspectAfterRmi = execCommands
+      .slice(rmiIndex + 1)
+      .some((c) => c.includes(`image inspect ${IMAGE}`))
+    expect(inspectAfterRmi).toBe(true)
+
+    expect(countRunAttempts()).toBe(2)
+  })
+
+  it('gives up after one recovery attempt when the corruption persists', async () => {
+    runScript = [CORRUPT_SNAPSHOT_MSG, CORRUPT_SNAPSHOT_MSG]
+    const client = new TestContainerClient({ agentId: 'abc123' } as ContainerConfig)
+
+    await expect(client.start()).rejects.toThrow(/mount callback failed/i)
+
+    // One recovery, two run attempts total — never loops.
+    expect(execCommands.filter((c) => c.includes(`rmi -f ${IMAGE}`))).toHaveLength(1)
+    expect(countRunAttempts()).toBe(2)
+  })
+
+  it('does not remove the image for unrelated run failures', async () => {
+    runScript = ['Command failed: docker run -d ... some unrelated failure']
+    const client = new TestContainerClient({ agentId: 'abc123' } as ContainerConfig)
+
+    await expect(client.start()).rejects.toThrow(/unrelated failure/i)
+
+    expect(execCommands.some((c) => c.includes('rmi'))).toBe(false)
+    expect(countRunAttempts()).toBe(1)
+  })
+})

--- a/src/shared/lib/container/lima-container-client.ts
+++ b/src/shared/lib/container/lima-container-client.ts
@@ -457,6 +457,19 @@ export class LimaContainerClient extends BaseContainerClient {
   }
 
   /**
+   * The bundled Lima VM's containerd store holds nothing but our images, so
+   * beyond removing the tagged image it's safe to prune unused images and
+   * build cache too — the corrupt layer content (e.g. a /etc/passwd truncated
+   * by disk exhaustion during unpack) can survive a bare `rmi` via the build
+   * cache or a shared parent layer and poison the rebuild. Running containers
+   * and bind mounts are untouched; volumes are not pruned.
+   */
+  protected async removeCorruptImage(image: string): Promise<void> {
+    await super.removeCorruptImage(image)
+    await execWithPath(`${this.getRunnerShellCommand()} system prune -af`)
+  }
+
+  /**
    * Handle run errors by provisioning the Lima VM if needed.
    */
   protected async handleRunError(error: any): Promise<boolean> {


### PR DESCRIPTION
## Problem

Two users on 0.4.11 (most recently Nick Moore, plus the recent ELECTRON-H events from rebecalange@) hit a container-start failure that no amount of retrying can fix:

```
lima-nerdctl run ... level=fatal msg="mount callback failed on /tmp/containerd-mount3006401431: no users found"
```

This is containerd mounting the image rootfs to resolve the Dockerfile `USER claude` and finding a truncated `/etc/passwd` — i.e. the image's unpacked snapshot in the runtime store is corrupt (likely disk exhaustion during pull/unpack). The corruption lives in the image store, not the container, so it survives app restarts and every retry. Worse, Lima's `handleRunError` probes the VM, finds it *healthy* (it is — only the snapshot is bad), captures the error, and gives up. Users see "Failed to create session" / "Failed to start the agent container. Please try again." forever; the field workaround was recreating the whole VM.

## Fix

A new recovery branch in `start()`'s bounded retry loop, checked before the generic subclass VM recovery (which would otherwise swallow the attempt):

1. Detect the `mount callback failed on` signature (`isCorruptImageSnapshotError`, overridable).
2. Remove the image (`removeCorruptImage`) — conservative `rmi -f` in the base class (safe on user-owned docker/podman daemons); the Lima override adds `system prune -af` since the bundled VM's store is app-owned and corrupt layer content can survive a bare `rmi` via build cache or a shared parent layer. Running containers, bind mounts, and volumes are untouched.
3. Restore the image (`recreateImage`) mirroring `ensureImageReady()`'s decision: **build** when a local agent-container context exists (dev), otherwise **pull** from the registry (packaged app). The first cut restored via `ensureImageExists()`, which is build-only — and the bundled Lima VM has no buildkit, so on the exact runtime where this failure occurs it could never restore. Caught by live validation (below).
4. Retry the run — **once** (`imageRecoveryTried` guard), so a restore that reproduces the corruption still terminates with the original error.

Successful recoveries are captured as warnings (`component:container, operation:corrupt-image-recovery`); failed repairs capture the repair error and surface the original run error unchanged.

## Live validation (real Lima VM, macOS)

Sandboxed data dir + the repo's dev web server; `~/.superagent/lima` VM; prod-faithful mode (no build context in CWD → registry pull, real ghcr 0.4.11 image).

- **Healthy-path regression**: fresh `ensureImageReady()` pull from ghcr → session create → container start (~5s) → health check → agent message round-trip. Twice (dev-build image and ghcr image).
- **Corruption reproduced**: `truncate -s 0` on `/etc/passwd` inside the image's committed overlayfs snapshot in the VM reproduces the field error byte-for-byte (`mount callback failed on /tmp/containerd-mountNNN: no users found`).
- **Self-heal E2E**: message send → run fails with signature → detection logs → `rmi -f` + `system prune -af` → re-pull from ghcr → retry run → container healthy, runs as `claude`, pending message answered ("Yes, I'm running fine with no corruption detected."). No user intervention.
- **False-positive check**: detection regex tested against the other known run-failure phrasings (EPERM bind-mount stat, port conflict, VM-stopped) — no matches; the inaccessible-mount and port-conflict branches also run first.

## Known bounded limitation

If another container is *running* from the corrupt image, `rmi -f`/prune won't clear the shared snapshot; the re-pull no-ops and the retry fails with the original error (exactly the pre-fix outcome, plus one Sentry warning). Rare in practice — a corrupt snapshot usually prevents siblings from starting too.

## Out of scope (follow-ups)

- The same corruption could in principle fail the image **build** (corrupt base layer / build cache) — `ensureImageExistsWithRecovery` doesn't detect this signature yet.
- `ensureImageExists()`'s build-only fallback on the start path is structurally broken on Lima (no buildkit) — every "Container build failed" Sentry event from Lima users traces to this; worth aligning it with `ensureImageReady()`'s pull/build decision in a follow-up.

## Testing

- 5 unit tests in `corrupt-image-snapshot-recovery.test.ts` using the real field error string: heals via pull (packaged) and build (dev); bounded when corruption persists; unrelated failures untouched; failed re-pull surfaces the original error.
- Full container suite: 26 files / 715 tests green; `tsc --noEmit` and eslint clean.
