### PR TITLE
Composer effort slider with cost cues and Max rainbow

### DIFF
--- a/e2e/specs/model-selection.spec.ts
+++ b/e2e/specs/model-selection.spec.ts
@@ -143,6 +143,8 @@ test.describe('Model selection', () => {
     await pickModel(page, 'haiku', HAIKU)
     await page.locator('[data-testid="composer-options-trigger"]').click()
     await page.locator('[data-testid="effort-option-low"]').click()
+    // Effort picks keep the popover open now — dismiss before sending.
+    await page.keyboard.press('Escape')
 
     await sessionPage.sendMessage(followUp)
 
@@ -163,6 +165,8 @@ test.describe('Model selection', () => {
     await pickModel(page, 'opus', OPUS_LATEST)
     await page.locator('[data-testid="composer-options-trigger"]').click()
     await page.locator('[data-testid="effort-option-xhigh"]').click()
+    // Effort picks keep the popover open now — dismiss before re-opening.
+    await page.keyboard.press('Escape')
 
     // Switch to Sonnet — the popover's auto-reset clamps effort back to Medium
     // since Sonnet doesn't allow xhigh.

--- a/src/renderer/components/messages/composer-options-popover.test.tsx
+++ b/src/renderer/components/messages/composer-options-popover.test.tsx
@@ -100,7 +100,7 @@ describe('ComposerOptionsPopover', () => {
     expect(screen.queryByText('Models')).not.toBeInTheDocument()
   })
 
-  it('selecting an effort calls setEffort and closes the popover', async () => {
+  it('selecting an effort calls setEffort and keeps the popover open', async () => {
     const user = userEvent.setup()
     const setEffort = vi.fn()
     render(
@@ -118,7 +118,8 @@ describe('ComposerOptionsPopover', () => {
     await user.click(screen.getByTestId('composer-options-trigger'))
     await user.click(await screen.findByTestId('effort-option-low'))
     expect(setEffort).toHaveBeenCalledWith('low')
-    expect(screen.queryByText('Effort')).not.toBeInTheDocument()
+    // The slider stays put so effort can be adjusted repeatedly.
+    expect(screen.getByText('Effort')).toBeInTheDocument()
   })
 
   it('hides Extra High and Max when a non-Opus model is selected', async () => {

--- a/src/renderer/components/messages/composer-options-popover.tsx
+++ b/src/renderer/components/messages/composer-options-popover.tsx
@@ -1,66 +1,19 @@
 import { memo, useEffect, useState, type ReactNode } from 'react'
-import { Check, ChevronDown } from 'lucide-react'
+import { ChevronDown } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { Separator } from '@renderer/components/ui/separator'
 import { ModelIcon } from '@renderer/components/ui/model-icon'
-import { cn } from '@shared/lib/utils'
-import { EFFORT_LEVELS, type EffortLevel } from '@shared/lib/container/types'
+import { EFFORT_LEVELS } from '@shared/lib/container/types'
 import { type ComposerOptionsState } from './composer-options'
 import { ModelFamilyList, findCatalogModel } from './model-family-list'
-
-const EFFORT_META: Record<EffortLevel, { label: string; blurb: string }> = {
-  low: { label: 'Low', blurb: 'Fastest. Minimal thinking, terse answers.' },
-  medium: { label: 'Medium', blurb: 'Default. Balanced thinking and response depth.' },
-  high: { label: 'High', blurb: 'Thorough planning and explanations.' },
-  xhigh: { label: 'Extra High', blurb: 'Deep reasoning for long-horizon work.' },
-  max: { label: 'Max', blurb: 'Highest effort.' },
-}
+import { EFFORT_LABELS, EffortSection } from './effort-slider'
 
 function SectionHeader({ children }: { children: ReactNode }) {
   return (
     <div className="px-2 pt-1 pb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
       {children}
     </div>
-  )
-}
-
-interface EffortRowProps {
-  label: string
-  blurb: string
-  isSelected: boolean
-  onClick: () => void
-  testId: string
-}
-
-function EffortRow({ label, blurb, isSelected, onClick, testId }: EffortRowProps) {
-  return (
-    <button
-      type="button"
-      data-testid={testId}
-      onClick={onClick}
-      className={cn(
-        'group flex items-start justify-between gap-2 rounded-sm px-2 py-1 text-left hover:bg-accent',
-        isSelected && 'bg-accent'
-      )}
-    >
-      <span className="flex min-w-0 flex-col">
-        <span className="text-xs font-normal">{label}</span>
-        <span
-          className={cn(
-            'overflow-hidden text-xs font-normal text-muted-foreground transition-[max-height,opacity,margin-top] duration-500 ease-out',
-            isSelected
-              ? 'mt-0.5 max-h-16 opacity-100'
-              : 'mt-0 max-h-0 opacity-0 group-hover:mt-0.5 group-hover:max-h-16 group-hover:opacity-100'
-          )}
-        >
-          {blurb}
-        </span>
-      </span>
-      {isSelected && (
-        <Check className="h-3.5 w-3.5 shrink-0 self-center text-foreground" />
-      )}
-    </button>
   )
 }
 
@@ -97,7 +50,7 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: C
     selectedModel ? selectedModel.supportedEfforts.includes(level) : true
   )
 
-  const effortLabel = EFFORT_META[effort].label
+  const effortLabel = EFFORT_LABELS[effort]
   const selectedModelLabel = selectedModel?.label
   const triggerAriaLabel = includeEffort
     ? (selectedModelLabel ? `${selectedModelLabel} · ${effortLabel}` : effortLabel)
@@ -148,24 +101,8 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: C
           </>
         )}
         {includeEffort && (
-          <>
-            <SectionHeader>Effort</SectionHeader>
-            <div className="flex flex-col gap-1">
-              {visibleEfforts.map((level) => (
-                <EffortRow
-                  key={level}
-                  label={EFFORT_META[level].label}
-                  blurb={EFFORT_META[level].blurb}
-                  isSelected={effort === level}
-                  onClick={() => {
-                    setEffort(level)
-                    setOpen(false)
-                  }}
-                  testId={`effort-option-${level}`}
-                />
-              ))}
-            </div>
-          </>
+          /* Effort changes never dismiss — the slider invites adjustment. */
+          <EffortSection levels={visibleEfforts} value={effort} onChange={setEffort} />
         )}
       </PopoverContent>
     </Popover>

--- a/src/renderer/components/messages/effort-slider.test.tsx
+++ b/src/renderer/components/messages/effort-slider.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { EffortSlider } from './effort-slider'
 import { EFFORT_LEVELS, type EffortLevel } from '@shared/lib/container/types'
@@ -14,10 +14,11 @@ describe('EffortSlider', () => {
     for (const level of ALL) expect(screen.getByTestId(`effort-option-${level}`)).toBeInTheDocument()
     expect(screen.getByText('Faster')).toBeInTheDocument()
     expect(screen.getByText('Smarter')).toBeInTheDocument()
-    // No per-level names on the bar — they live in aria labels only.
-    expect(screen.queryByText('Med')).not.toBeInTheDocument()
-    expect(screen.queryByText('X-High')).not.toBeInTheDocument()
-    expect(screen.getByTestId('effort-option-xhigh')).toHaveAccessibleName('X-High')
+    // No per-level names on the bar — they live in aria labels only, spelled
+    // out in full for screen readers.
+    expect(screen.queryByText('Medium')).not.toBeInTheDocument()
+    expect(screen.queryByText('Extra High')).not.toBeInTheDocument()
+    expect(screen.getByTestId('effort-option-xhigh')).toHaveAccessibleName('Extra High')
   })
 
   it('only renders the levels it is given (3-effort model has no xhigh/max)', () => {
@@ -69,6 +70,24 @@ describe('EffortSlider', () => {
     // At Max the blue crossfades out (inverse mask) as the rainbow fades in.
     expect(screen.getByTestId('effort-fill').className).toContain('effort-fill-fade')
     expect(screen.getByTestId('effort-fill-rainbow').className).toContain('effort-rainbow')
+  })
+
+  it('the rainbow overlay never hit-tests over the tick buttons', () => {
+    render(<EffortSlider levels={ALL} value="max" onChange={vi.fn()} />)
+    // Decorative only — without this, the overlay covers every tick at Max and
+    // intercepts clicks targeted at the effort-option-* buttons.
+    expect(screen.getByTestId('effort-fill-rainbow').className).toContain('pointer-events-none')
+  })
+
+  it('a cancelled drag stops tracking — later hovers no longer change the value', () => {
+    const onChange = vi.fn()
+    render(<EffortSlider levels={ALL} value="medium" onChange={onChange} />)
+    const track = screen.getByTestId('effort-slider').querySelector('.touch-none')!
+    fireEvent.pointerDown(track, { clientX: 0 })
+    expect(onChange).toHaveBeenCalledTimes(1)
+    fireEvent.pointerCancel(track)
+    fireEvent.pointerMove(track, { clientX: 50 })
+    expect(onChange).toHaveBeenCalledTimes(1) // the post-cancel hover changed nothing
   })
 
   it('does not step past the ends', async () => {

--- a/src/renderer/components/messages/effort-slider.test.tsx
+++ b/src/renderer/components/messages/effort-slider.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { EffortSlider } from './effort-slider'
+import { EFFORT_LEVELS, type EffortLevel } from '@shared/lib/container/types'
+
+const ALL = [...EFFORT_LEVELS] as EffortLevel[]
+const STD: EffortLevel[] = ['low', 'medium', 'high']
+
+describe('EffortSlider', () => {
+  it('renders a tick per allowed level, labeling only the Faster/Smarter poles', () => {
+    render(<EffortSlider levels={ALL} value="medium" onChange={vi.fn()} />)
+    for (const level of ALL) expect(screen.getByTestId(`effort-option-${level}`)).toBeInTheDocument()
+    expect(screen.getByText('Faster')).toBeInTheDocument()
+    expect(screen.getByText('Smarter')).toBeInTheDocument()
+    // No per-level names on the bar — they live in aria labels only.
+    expect(screen.queryByText('Med')).not.toBeInTheDocument()
+    expect(screen.queryByText('X-High')).not.toBeInTheDocument()
+    expect(screen.getByTestId('effort-option-xhigh')).toHaveAccessibleName('X-High')
+  })
+
+  it('only renders the levels it is given (3-effort model has no xhigh/max)', () => {
+    render(<EffortSlider levels={STD} value="medium" onChange={vi.fn()} />)
+    expect(screen.getByTestId('effort-option-high')).toBeInTheDocument()
+    expect(screen.queryByTestId('effort-option-xhigh')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('effort-option-max')).not.toBeInTheDocument()
+  })
+
+  it('clicking a stop fires onChange then onCommit for that level', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const onCommit = vi.fn()
+    render(<EffortSlider levels={ALL} value="medium" onChange={onChange} onCommit={onCommit} />)
+    await user.click(screen.getByTestId('effort-option-max'))
+    expect(onChange).toHaveBeenCalledWith('max')
+    expect(onCommit).toHaveBeenCalledWith('max')
+  })
+
+  it('exposes the thumb as a slider with the active index and label', () => {
+    render(<EffortSlider levels={ALL} value="high" onChange={vi.fn()} />)
+    const thumb = screen.getByRole('slider')
+    expect(thumb).toHaveAttribute('aria-valuenow', '2') // high = index 2 of low/medium/high/…
+    expect(thumb).toHaveAttribute('aria-valuemax', '4') // 5 levels → 0..4
+    expect(thumb).toHaveAttribute('aria-valuetext', 'High')
+  })
+
+  it('arrow keys step the value via onChange without committing (popover stays open)', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const onCommit = vi.fn()
+    render(<EffortSlider levels={ALL} value="medium" onChange={onChange} onCommit={onCommit} />)
+    const thumb = screen.getByRole('slider')
+    thumb.focus()
+    await user.keyboard('{ArrowRight}')
+    expect(onChange).toHaveBeenLastCalledWith('high')
+    await user.keyboard('{ArrowLeft}{ArrowLeft}')
+    expect(onChange).toHaveBeenLastCalledWith('low')
+    expect(onCommit).not.toHaveBeenCalled()
+  })
+
+  it('keeps a blue fill, overlaying the rainbow only at Max', () => {
+    const { rerender } = render(<EffortSlider levels={ALL} value="high" onChange={vi.fn()} />)
+    // The base fill is always the blue fill; the rainbow is a separate overlay.
+    expect(screen.getByTestId('effort-fill').className).toContain('bg-[#0099FF]')
+    expect(screen.queryByTestId('effort-fill-rainbow')).not.toBeInTheDocument()
+
+    rerender(<EffortSlider levels={ALL} value="max" onChange={vi.fn()} />)
+    // At Max the blue crossfades out (inverse mask) as the rainbow fades in.
+    expect(screen.getByTestId('effort-fill').className).toContain('effort-fill-fade')
+    expect(screen.getByTestId('effort-fill-rainbow').className).toContain('effort-rainbow')
+  })
+
+  it('does not step past the ends', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<EffortSlider levels={STD} value="high" onChange={onChange} />)
+    screen.getByRole('slider').focus()
+    await user.keyboard('{ArrowRight}') // already at the top
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/messages/effort-slider.tsx
+++ b/src/renderer/components/messages/effort-slider.tsx
@@ -1,0 +1,246 @@
+import { useRef, type PointerEvent as ReactPointerEvent, type KeyboardEvent as ReactKeyboardEvent } from 'react'
+import { HelpCircle } from 'lucide-react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@renderer/components/ui/tooltip'
+import { cn } from '@shared/lib/utils'
+import { type EffortLevel } from '@shared/lib/container/types'
+
+/** Full per-level names, shared by trigger buttons and the EffortSection header. */
+export const EFFORT_LABELS: Record<EffortLevel, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  xhigh: 'Extra High',
+  max: 'Max',
+}
+
+/** Per-level names, used for accessibility only (aria-valuetext, tick aria-labels)
+ *  — the bar itself shows just Faster/Smarter end labels; the current selection
+ *  is displayed in the section header. */
+export const SHORT_EFFORT_LABELS: Record<EffortLevel, string> = {
+  low: 'Low',
+  medium: 'Med',
+  high: 'High',
+  xhigh: 'X-High',
+  max: 'Max',
+}
+
+// Half the track-pill height in px. Stops inset by this on each end so an end
+// stop's knob and the fill's rounded cap sit fully inside the pill. All stop
+// math (labels, dots, fill, thumb, and the click→index inverse) uses it, so the
+// layers stay pixel-aligned regardless of the parent's padding. The knob (18px)
+// is a hair smaller than the 20px track, so it nestles inside toggle-style.
+const TRACK_R = 10
+
+interface EffortSliderProps {
+  /** Allowed efforts, low→high. One discrete stop each; length drives the geometry. */
+  levels: EffortLevel[]
+  /** Current value; must be one of `levels` (caller resets out-of-range values). */
+  value: EffortLevel
+  /** Live value change — fires on every click, drag step, and arrow key. */
+  onChange: (level: EffortLevel) => void
+  /** Settle — fires on click and on drag release, NOT on keyboard. The composer
+   *  closes its popover here so arrow-keying doesn't dismiss it mid-adjust. */
+  onCommit?: (level: EffortLevel) => void
+  labels?: Record<EffortLevel, string>
+}
+
+/**
+ * Discrete effort slider: a labeled stop per allowed level, a filled track up to
+ * the current thumb, draggable/clickable/keyboard-driven. Each stop label carries
+ * `data-testid="effort-option-<level>"` and selects that level on click, so it's a
+ * drop-in for the old button list. Purely controlled — keeps no state of its own.
+ */
+export function EffortSlider({
+  levels,
+  value,
+  onChange,
+  onCommit,
+  labels = SHORT_EFFORT_LABELS,
+}: EffortSliderProps) {
+  const trackRef = useRef<HTMLDivElement>(null)
+  const dragging = useRef(false)
+
+  const n = levels.length
+  const activeIndex = Math.max(0, levels.indexOf(value))
+  // Top tier ("Max") gets a celebratory animated rainbow-mesh fill; everything
+  // below is a blue fill on a light-blue track.
+  const maxedOut = value === 'max'
+  const frac = (i: number) => (n > 1 ? i / (n - 1) : 0)
+  // Stop i's center x, inset by the track radius on both ends.
+  const pos = (i: number) => `calc(${TRACK_R}px + ${frac(i)} * (100% - ${TRACK_R * 2}px))`
+  // Fill runs from the left edge to half a track-height past the active stop's
+  // center, so its rounded right cap is CONCENTRIC with the knob (same center),
+  // not tucked a cap-radius behind it. = pos(active) + TRACK_R.
+  const fillWidth = `calc(${TRACK_R * 2}px + ${frac(activeIndex)} * (100% - ${TRACK_R * 2}px))`
+
+  const indexFromClientX = (clientX: number): number => {
+    const el = trackRef.current
+    if (!el) return activeIndex
+    const rect = el.getBoundingClientRect()
+    const usable = rect.width - TRACK_R * 2
+    const t = usable > 0 ? (clientX - rect.left - TRACK_R) / usable : 0
+    return Math.min(n - 1, Math.max(0, Math.round(t * (n - 1))))
+  }
+
+  const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    dragging.current = true
+    e.currentTarget.setPointerCapture?.(e.pointerId)
+    onChange(levels[indexFromClientX(e.clientX)])
+  }
+  const handlePointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (!dragging.current) return
+    onChange(levels[indexFromClientX(e.clientX)])
+  }
+  const handlePointerUp = (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (!dragging.current) return
+    dragging.current = false
+    onCommit?.(levels[indexFromClientX(e.clientX)])
+  }
+
+  const handleKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    let next = activeIndex
+    if (e.key === 'ArrowRight' || e.key === 'ArrowUp') next = activeIndex + 1
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') next = activeIndex - 1
+    else if (e.key === 'Home') next = 0
+    else if (e.key === 'End') next = n - 1
+    else return
+    e.preventDefault()
+    next = Math.min(n - 1, Math.max(0, next))
+    if (next !== activeIndex) onChange(levels[next])
+  }
+
+  return (
+    <div className="px-2 pt-1 pb-2" data-testid="effort-slider">
+      {/* Only the two poles are labeled — the ticks below carry the levels.
+          Each pole pairs the speed/quality trade-off with its cost ($ vs $$$),
+          slightly dimmer so the words stay primary. Color matches the section
+          headers (e.g. "Effort · Medium"). */}
+      <div className="mb-2 flex items-center justify-between text-[11px] text-muted-foreground/70">
+        <span>
+          Faster <span className="text-muted-foreground/50">· $</span>
+        </span>
+        <span>
+          Smarter <span className="text-muted-foreground/50">· $$$</span>
+        </span>
+      </div>
+      {/* Track + thumb. The track is a pill slightly taller than the knob, so the
+          knob nestles inside it (toggle style) rather than riding a thin rail. */}
+      <div
+        ref={trackRef}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        className="relative h-5 cursor-pointer touch-none"
+      >
+        <div className="absolute inset-0 rounded-full bg-[#E1F6FF]" />
+        <div
+          data-testid="effort-fill"
+          className={cn(
+            'absolute inset-y-0 left-0 rounded-full bg-[#0099FF]',
+            // Crossfade with the rainbow: the gray fades OUT exactly where the
+            // rainbow fades IN, so the two never stack (stacking muddied the
+            // rainbow's fade zone into a dingy blend).
+            maxedOut && 'effort-fill-fade'
+          )}
+          style={{ width: fillWidth }}
+        />
+        {/* Tick dots: one per level, each a small click target for that level.
+            They sit UNDER the rainbow overlay so they don't show through it —
+            the opaque rainbow covers them, and they re-emerge where it fades
+            out toward the left. stopPropagation keeps the track's pointer
+            handler from double-firing on the same press. */}
+        {levels.map((level, i) => (
+          <button
+            key={level}
+            type="button"
+            data-testid={`effort-option-${level}`}
+            aria-label={labels[level]}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={() => {
+              onChange(level)
+              onCommit?.(level)
+            }}
+            style={{ left: pos(i) }}
+            className="group/tick absolute top-1/2 flex h-4 w-4 -translate-x-1/2 -translate-y-1/2 items-center justify-center"
+          >
+            <span className="h-1 w-1 rounded-full bg-[#007DED] transition-transform duration-150 group-hover/tick:scale-150" />
+          </button>
+        ))}
+        {maxedOut && (
+          <div
+            data-testid="effort-fill-rainbow"
+            aria-hidden="true"
+            className="absolute inset-y-0 left-0 rounded-full effort-rainbow"
+            style={{ width: fillWidth }}
+          />
+        )}
+        <div
+          role="slider"
+          tabIndex={0}
+          aria-label="Effort"
+          aria-valuemin={0}
+          aria-valuemax={n - 1}
+          aria-valuenow={activeIndex}
+          aria-valuetext={labels[value]}
+          onKeyDown={handleKeyDown}
+          style={{ left: pos(activeIndex) }}
+          className="absolute top-1/2 h-[18px] w-[18px] -translate-x-1/2 -translate-y-1/2 rounded-full border border-border bg-background shadow-md ring-offset-background transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The complete effort block shared by every picker popover/menu: a header row
+ * naming the selection ("Effort · Medium", value in the accent blue) with a
+ * help tooltip explaining the trade-off, above the slider. No commit concept —
+ * changes apply live and never dismiss the surface that hosts it.
+ */
+export function EffortSection({
+  levels,
+  value,
+  onChange,
+}: {
+  levels: EffortLevel[]
+  value: EffortLevel
+  onChange: (level: EffortLevel) => void
+}) {
+  return (
+    // A real wrapper (not a fragment): hosts reverse the popover column to keep
+    // this section nearest the trigger, and a fragment's children would get
+    // reordered individually (slider above its own header).
+    <div>
+      <div className="flex items-center justify-between px-2 pt-1 pb-1 text-[11px] font-medium text-muted-foreground/70">
+        <span>
+          <span>Effort</span>
+          <span className="text-[#007DED]"> · {EFFORT_LABELS[value]}</span>
+        </span>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="About effort"
+                data-testid="effort-help"
+                className="inline-flex shrink-0 hover:text-foreground"
+              >
+                <HelpCircle className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-60">
+              Higher effort means more thorough responses, but takes longer and is more expensive.
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+      <EffortSlider levels={levels} value={value} onChange={onChange} />
+    </div>
+  )
+}

--- a/src/renderer/components/messages/effort-slider.tsx
+++ b/src/renderer/components/messages/effort-slider.tsx
@@ -9,23 +9,15 @@ import {
 import { cn } from '@shared/lib/utils'
 import { type EffortLevel } from '@shared/lib/container/types'
 
-/** Full per-level names, shared by trigger buttons and the EffortSection header. */
+/** Full per-level names, shared by trigger buttons, the EffortSection header,
+ *  and the slider's accessibility strings (aria-valuetext, tick aria-labels) —
+ *  the bar itself shows just Faster/Smarter end labels; the current selection
+ *  is displayed in the section header. */
 export const EFFORT_LABELS: Record<EffortLevel, string> = {
   low: 'Low',
   medium: 'Medium',
   high: 'High',
   xhigh: 'Extra High',
-  max: 'Max',
-}
-
-/** Per-level names, used for accessibility only (aria-valuetext, tick aria-labels)
- *  — the bar itself shows just Faster/Smarter end labels; the current selection
- *  is displayed in the section header. */
-export const SHORT_EFFORT_LABELS: Record<EffortLevel, string> = {
-  low: 'Low',
-  medium: 'Med',
-  high: 'High',
-  xhigh: 'X-High',
   max: 'Max',
 }
 
@@ -60,7 +52,7 @@ export function EffortSlider({
   value,
   onChange,
   onCommit,
-  labels = SHORT_EFFORT_LABELS,
+  labels = EFFORT_LABELS,
 }: EffortSliderProps) {
   const trackRef = useRef<HTMLDivElement>(null)
   const dragging = useRef(false)
@@ -102,6 +94,12 @@ export function EffortSlider({
     dragging.current = false
     onCommit?.(levels[indexFromClientX(e.clientX)])
   }
+  // An aborted gesture (touch interruption, OS gesture) never delivers pointerup.
+  // Without this reset, `dragging` sticks true and plain hovers keep changing the
+  // effort until the next press. No commit — onChange already applied the value.
+  const handlePointerCancel = () => {
+    dragging.current = false
+  }
 
   const handleKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
     let next = activeIndex
@@ -136,9 +134,11 @@ export function EffortSlider({
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+        onLostPointerCapture={handlePointerCancel}
         className="relative h-5 cursor-pointer touch-none"
       >
-        <div className="absolute inset-0 rounded-full bg-[#E1F6FF]" />
+        <div className="absolute inset-0 rounded-full bg-[#E1F6FF] dark:bg-[#15384F]" />
         <div
           data-testid="effort-fill"
           className={cn(
@@ -169,14 +169,17 @@ export function EffortSlider({
             style={{ left: pos(i) }}
             className="group/tick absolute top-1/2 flex h-4 w-4 -translate-x-1/2 -translate-y-1/2 items-center justify-center"
           >
-            <span className="h-1 w-1 rounded-full bg-[#007DED] transition-transform duration-150 group-hover/tick:scale-150" />
+            <span className="h-1 w-1 rounded-full bg-[#007DED] transition-transform duration-150 group-hover/tick:scale-150 dark:bg-[#4EB3FF]" />
           </button>
         ))}
         {maxedOut && (
           <div
             data-testid="effort-fill-rainbow"
             aria-hidden="true"
-            className="absolute inset-y-0 left-0 rounded-full effort-rainbow"
+            // pointer-events-none: purely decorative — without it this overlay
+            // hit-tests over the tick buttons (killing their hover feedback and
+            // failing automated clicks on effort-option-* while at Max).
+            className="pointer-events-none absolute inset-y-0 left-0 rounded-full effort-rainbow"
             style={{ width: fillWidth }}
           />
         )}
@@ -220,7 +223,7 @@ export function EffortSection({
       <div className="flex items-center justify-between px-2 pt-1 pb-1 text-[11px] font-medium text-muted-foreground/70">
         <span>
           <span>Effort</span>
-          <span className="text-[#007DED]"> · {EFFORT_LABELS[value]}</span>
+          <span className="text-[#007DED] dark:text-[#4EB3FF]"> · {EFFORT_LABELS[value]}</span>
         </span>
         <TooltipProvider>
           <Tooltip>

--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -781,10 +781,10 @@ describe('MessageInput', () => {
       <MessageInput sessionId="s-1" agentSlug="agent-1" />
     )
 
-    // Picking an option closes the popover, so reopen between picks.
+    // Effort keeps the popover open, so the model pick follows in the same
+    // visit (the model pick is what closes it).
     await user.click(screen.getByTestId('composer-options-trigger'))
     await user.click(await screen.findByTestId('effort-option-low'))
-    await user.click(screen.getByTestId('composer-options-trigger'))
     await user.click(await screen.findByTestId('model-family-sonnet'))
     await user.click(await screen.findByTestId('model-pinned-claude-sonnet-4-6'))
 

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -280,6 +280,110 @@ html[data-keyboard-open] [data-composer-footer] {
   animation: browser-glow-pulse 4s ease-in-out infinite;
 }
 
+/* Effort slider — animated rainbow mesh overlaid on the right of the maxed-out
+   ("Max") fill. The mesh lives on a double-width ::before whose background tiles
+   every container-width; translating it by exactly one tile per loop (marquee
+   trick) gives a seamless, ALWAYS-LEFTWARD flow — emanating from the thumb, never
+   reversing, no hard line at the loop point. hue-rotate cycles the colors on top
+   (0deg == 360deg, also seamless). A left-fading mask on the host keeps the
+   rainbow from running the full width — it fades out around the Med–High marks.
+   GPU-friendly (transform + filter only). */
+@keyframes effort-rainbow-hue {
+  from { filter: hue-rotate(0deg) saturate(1.15); }
+  to   { filter: hue-rotate(360deg) saturate(1.15); }
+}
+@keyframes effort-rainbow-drift {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); } /* one tile — wraps invisibly */
+}
+/* Entry sweep, shared by the rainbow and the gray fill's inverse fade: both
+   masks are 200%-wide no-repeat gradients, so sliding mask-position 0%→100%
+   sweeps the reveal leftward from the thumb. At 0% the element reads the mask's
+   left half (rainbow: all transparent = hidden; gray: all opaque = untouched);
+   at 100% the right half = the steady-state fade profile (28%→58%). Runs once
+   per mount — the overlay mounts on selecting Max, so picking Max replays it. */
+@keyframes effort-mask-sweep {
+  from { -webkit-mask-position: 0% 0; mask-position: 0% 0; }
+  to   { -webkit-mask-position: 100% 0; mask-position: 100% 0; }
+}
+
+.effort-rainbow {
+  overflow: hidden;
+  /* Stops at 64%/79% of the 200%-wide mask == 28%/58% of the element once the
+     sweep lands at mask-position 100%. */
+  -webkit-mask-image: linear-gradient(to right, transparent 64%, #000 79%);
+  mask-image: linear-gradient(to right, transparent 64%, #000 79%);
+  -webkit-mask-size: 200% 100%;
+  mask-size: 200% 100%;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  will-change: filter;
+  animation:
+    effort-rainbow-hue 6s linear infinite,
+    effort-mask-sweep 4s cubic-bezier(0.22, 0.6, 0.36, 1) both;
+}
+
+.effort-rainbow::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 200%;
+  /* One full 360° hue sweep per tile, in wheel order — every neighboring pair
+     (including the wrap, magenta→magenta) is analogous, so blends stay clean:
+     no complementary adjacencies like red→green that mud into brown. The white
+     radial blobs add the organic vapor depth; white only tints, never muddies.
+     Blob extents stay inside [0%,100%] of the tile so tiles join seamlessly. */
+  background-image:
+    radial-gradient(20% 80% at 22% 30%, rgba(255, 255, 255, 0.28), transparent),
+    radial-gradient(18% 75% at 58% 70%, rgba(255, 255, 255, 0.22), transparent),
+    radial-gradient(15% 70% at 85% 35%, rgba(255, 255, 255, 0.18), transparent),
+    linear-gradient(
+      90deg,
+      #ff0080 0%,
+      #ff8c00 14%,
+      #ffd300 28%,
+      #35d435 42%,
+      #00cfcf 56%,
+      #2b6cff 70%,
+      #8a2be2 85%,
+      #ff0080 100%
+    );
+  /* Tile = half this double-width layer = one container width. */
+  background-size: 50% 100%;
+  background-repeat: repeat;
+  will-change: transform;
+  animation: effort-rainbow-drift 5s linear infinite;
+}
+
+/* Inverse of the rainbow's mask, applied to the gray base fill at Max: gray
+   fades out exactly where the rainbow fades in, a clean crossfade instead of
+   the rainbow blending over gray (which muddied its colors). Shares the entry
+   sweep so the crossfade travels leftward with the rainbow instead of the gray
+   vanishing instantly. */
+.effort-fill-fade {
+  -webkit-mask-image: linear-gradient(to right, #000 64%, transparent 79%);
+  mask-image: linear-gradient(to right, #000 64%, transparent 79%);
+  -webkit-mask-size: 200% 100%;
+  mask-size: 200% 100%;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  animation: effort-mask-sweep 4s cubic-bezier(0.22, 0.6, 0.36, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .effort-rainbow,
+  .effort-rainbow::before,
+  .effort-fill-fade {
+    animation: none;
+    /* The sweep normally lands the mask here; without it, pin the end state so
+       the rainbow isn't stuck hidden behind the sweep's start position. */
+    -webkit-mask-position: 100% 0;
+    mask-position: 100% 0;
+  }
+}
+
 /* Voice agent orb — glowing sphere with radial depth and amp-driven reactivity.
    --orb-amp (0..1) is set on the element via JS, driven by the active analyser
    when speaking or a slow sinusoidal breath when idle. */


### PR DESCRIPTION
**Stack 2/4** (base: model-picker-1-icons) · replaces part of #457

New `EffortSlider`/`EffortSection` replacing the composer's effort button list: toggle-style pill track with the blue palette, Faster · \$ / Smarter · \$\$\$ pole labels, selection named in the header with a trade-off help tooltip, drag/click/keyboard input, and an animated rainbow-mesh fill at Max (seamless leftward drift, vapor entry sweep, reduced-motion safe). Effort picks keep the popover open. `effort-option-*` testids preserved; e2e adjusted for keep-open.

Independent of the list redesign — touches only the effort section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)