### PR TITLE
Flat model list: vendor tabs, version pin chips, plain-language cliff note

### DIFF
--- a/e2e/specs/agent-default-model.spec.ts
+++ b/e2e/specs/agent-default-model.spec.ts
@@ -67,13 +67,13 @@ test.describe('Per-agent default model', () => {
     await expect(card).toBeVisible()
     await expect(page.locator('[data-testid="home-default-model-reset"]')).not.toBeVisible()
 
-    // One click on the family header selects that family's latest (bare alias)
-    // and keeps the popover open...
+    // The flat list shows a "Haiku · latest" row (stores the bare alias) …
     await card.locator('[data-testid="settings-model-trigger"]').click()
-    await page.locator('[data-testid="model-family-haiku"]').click()
+    await page.locator('[data-testid="model-latest-haiku"]').click()
     await expect(card.locator('[data-testid="settings-model-trigger"]')).toContainText('Haiku · latest')
 
-    // ...with the versions expanded, so pinning a concrete one is one tap away.
+    // … and the concrete versions right below it, so pinning one is one tap away.
+    await card.locator('[data-testid="settings-model-trigger"]').click()
     await page.locator(`[data-testid="model-pinned-${HAIKU_PINNED}"]`).click()
     await expect(card.locator('[data-testid="settings-model-trigger"]')).toContainText('Haiku 4.5')
 

--- a/e2e/specs/model-selection.spec.ts
+++ b/e2e/specs/model-selection.spec.ts
@@ -51,20 +51,17 @@ const OPUS_PINNED_OLDER = 'claude-opus-4-7'
 const SONNET = 'claude-sonnet-4-6'
 const HAIKU = 'claude-haiku-4-5'
 
-// The composer model picker is grouped by family: open the popover, expand the
-// family, then pick the concrete version (no "latest" row in the composer).
-// The currently-selected family auto-expands, so only click the family header
-// when the target version isn't already visible — clicking an open family
-// collapses it.
-async function pickModel(page: Page, family: string, modelId: string) {
+// Open the composer popover and pick a concrete version directly (no "latest"
+// row in the composer; versions are pin chips on their family row, revealed by
+// the hover Playwright performs before clicking). Picking no longer dismisses
+// the popover, so close it explicitly — callers assume a closed postcondition.
+// The `family` arg is kept for call-site readability only.
+async function pickModel(page: Page, _family: string, modelId: string) {
   await page.locator('[data-testid="composer-options-trigger"]').click()
-  const familyRow = page.locator(`[data-testid="model-family-${family}"]`)
-  await familyRow.waitFor({ state: 'visible' })
   const version = page.locator(`[data-testid="model-pinned-${modelId}"]`)
-  if (!(await version.isVisible())) {
-    await familyRow.click()
-  }
+  await version.waitFor({ state: 'visible' })
   await version.click()
+  await page.keyboard.press('Escape')
 }
 
 test.describe('Model selection', () => {
@@ -140,10 +137,10 @@ test.describe('Model selection', () => {
     await expect(page.locator('[data-testid="message-list"]')).toBeVisible()
 
     // Switch to Haiku in the in-session composer, then drop effort to low.
+    // Effort no longer auto-closes the popover, so dismiss it before sending.
     await pickModel(page, 'haiku', HAIKU)
     await page.locator('[data-testid="composer-options-trigger"]').click()
     await page.locator('[data-testid="effort-option-low"]').click()
-    // Effort picks keep the popover open now — dismiss before sending.
     await page.keyboard.press('Escape')
 
     await sessionPage.sendMessage(followUp)
@@ -165,12 +162,12 @@ test.describe('Model selection', () => {
     await pickModel(page, 'opus', OPUS_LATEST)
     await page.locator('[data-testid="composer-options-trigger"]').click()
     await page.locator('[data-testid="effort-option-xhigh"]').click()
-    // Effort picks keep the popover open now — dismiss before re-opening.
-    await page.keyboard.press('Escape')
 
-    // Switch to Sonnet — the popover's auto-reset clamps effort back to Medium
-    // since Sonnet doesn't allow xhigh.
-    await pickModel(page, 'sonnet', SONNET)
+    // Picks keep the popover open, so the model list is right there — pick
+    // Sonnet directly, then dismiss. The popover's auto-reset clamps effort
+    // back to Medium since Sonnet doesn't allow xhigh.
+    await page.locator(`[data-testid="model-pinned-${SONNET}"]`).click()
+    await page.keyboard.press('Escape')
 
     await expect(page.locator('[data-testid="composer-options-trigger"]')).toContainText('Medium')
     await expect(page.locator('[data-testid="composer-options-trigger"]')).not.toContainText('Extra High')
@@ -220,10 +217,9 @@ test.describe('Model selection', () => {
     await expect(page.locator('[data-testid="effort-option-xhigh"]')).toBeVisible()
     await expect(page.locator('[data-testid="effort-option-max"]')).toBeVisible()
 
-    // Switch to Sonnet (popover already open), reopen, and confirm xhigh/max disappear.
-    await page.locator('[data-testid="model-family-sonnet"]').click()
+    // Switch to Sonnet — the pick keeps the popover open, so the effort ticks
+    // swap in place: xhigh/max disappear immediately.
     await page.locator(`[data-testid="model-pinned-${SONNET}"]`).click()
-    await page.locator('[data-testid="composer-options-trigger"]').click()
     await expect(page.locator('[data-testid="effort-option-low"]')).toBeVisible()
     await expect(page.locator('[data-testid="effort-option-medium"]')).toBeVisible()
     await expect(page.locator('[data-testid="effort-option-high"]')).toBeVisible()

--- a/src/renderer/components/chat-integrations/integration-settings-controls.test.tsx
+++ b/src/renderer/components/chat-integrations/integration-settings-controls.test.tsx
@@ -73,7 +73,6 @@ describe('IntegrationModelEffort', () => {
     render(<IntegrationModelEffort integration={makeIntegration({ model: 'sonnet' })} />)
 
     await user.click(screen.getByTestId('settings-model-trigger'))
-    await user.click(await screen.findByTestId('model-family-opus'))
     await user.click(await screen.findByTestId('model-latest-opus'))
 
     expect(mutateMock).toHaveBeenCalledWith({ id: 'int-1', model: 'opus' })
@@ -84,7 +83,6 @@ describe('IntegrationModelEffort', () => {
     render(<IntegrationModelEffort integration={makeIntegration({ model: 'sonnet' })} />)
 
     await user.click(screen.getByTestId('settings-model-trigger'))
-    await user.click(await screen.findByTestId('model-family-opus'))
     await user.click(await screen.findByTestId('model-pinned-claude-opus-4-8'))
 
     expect(mutateMock).toHaveBeenCalledWith({ id: 'int-1', model: 'claude-opus-4-8' })
@@ -105,7 +103,6 @@ describe('IntegrationModelEffort', () => {
     render(<IntegrationModelEffort integration={makeIntegration({ id: 'custom-id', model: 'sonnet' })} />)
 
     await user.click(screen.getByTestId('settings-model-trigger'))
-    await user.click(await screen.findByTestId('model-family-haiku'))
     await user.click(await screen.findByTestId('model-latest-haiku'))
 
     expect(mutateMock).toHaveBeenCalledWith({ id: 'custom-id', model: 'haiku' })

--- a/src/renderer/components/messages/composer-options-popover.test.tsx
+++ b/src/renderer/components/messages/composer-options-popover.test.tsx
@@ -71,14 +71,15 @@ describe('ComposerOptionsPopover', () => {
     await user.click(screen.getByTestId('composer-options-trigger'))
     expect(await screen.findByText('Models')).toBeInTheDocument()
     expect(screen.getByText('Effort')).toBeInTheDocument()
-    expect(screen.getByTestId('model-family-haiku')).toBeInTheDocument()
-    expect(screen.getByTestId('model-family-sonnet')).toBeInTheDocument()
-    expect(screen.getByTestId('model-family-opus')).toBeInTheDocument()
+    // Flat list: concrete versions are top-level rows, no family headers.
+    expect(screen.getByTestId('model-pinned-claude-haiku-4-5')).toBeInTheDocument()
+    expect(screen.getByTestId('model-pinned-claude-sonnet-4-6')).toBeInTheDocument()
+    expect(screen.getByTestId('model-pinned-claude-opus-4-8')).toBeInTheDocument()
     // Composer never offers the bare-alias "latest" row.
     expect(screen.queryByTestId('model-latest-opus')).not.toBeInTheDocument()
   })
 
-  it('expanding a family and picking a version calls setModel with the concrete id', async () => {
+  it('picking a version calls setModel with the concrete id and keeps the popover open', async () => {
     const user = userEvent.setup()
     const setModel = vi.fn()
     render(
@@ -94,10 +95,10 @@ describe('ComposerOptionsPopover', () => {
       />
     )
     await user.click(screen.getByTestId('composer-options-trigger'))
-    await user.click(await screen.findByTestId('model-family-opus'))
     await user.click(await screen.findByTestId('model-pinned-claude-opus-4-8'))
     expect(setModel).toHaveBeenCalledWith('claude-opus-4-8')
-    expect(screen.queryByText('Models')).not.toBeInTheDocument()
+    // Stays open so model + effort can be tuned together.
+    expect(screen.getByText('Models')).toBeInTheDocument()
   })
 
   it('selecting an effort calls setEffort and keeps the popover open', async () => {
@@ -118,7 +119,7 @@ describe('ComposerOptionsPopover', () => {
     await user.click(screen.getByTestId('composer-options-trigger'))
     await user.click(await screen.findByTestId('effort-option-low'))
     expect(setEffort).toHaveBeenCalledWith('low')
-    // The slider stays put so effort can be adjusted repeatedly.
+    // The slider stays put so you can keep adjusting model + effort together.
     expect(screen.getByText('Effort')).toBeInTheDocument()
   })
 
@@ -145,7 +146,6 @@ describe('ComposerOptionsPopover', () => {
     render(<Harness initialModel="claude-opus-4-8" initialEffort="xhigh" />)
     expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Opus 4.8 · Extra High')
     await user.click(screen.getByTestId('composer-options-trigger'))
-    await user.click(await screen.findByTestId('model-family-sonnet'))
     await user.click(await screen.findByTestId('model-pinned-claude-sonnet-4-6'))
     expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Sonnet 4.6 · Medium')
   })

--- a/src/renderer/components/messages/composer-options-popover.tsx
+++ b/src/renderer/components/messages/composer-options-popover.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState, type ReactNode } from 'react'
+import { memo, useEffect, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
@@ -8,14 +8,6 @@ import { EFFORT_LEVELS } from '@shared/lib/container/types'
 import { type ComposerOptionsState } from './composer-options'
 import { ModelFamilyList, findCatalogModel } from './model-family-list'
 import { EFFORT_LABELS, EffortSection } from './effort-slider'
-
-function SectionHeader({ children }: { children: ReactNode }) {
-  return (
-    <div className="px-2 pt-1 pb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-      {children}
-    </div>
-  )
-}
 
 interface ComposerOptionsPopoverProps {
   state: ComposerOptionsState
@@ -80,28 +72,30 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: C
           <ChevronDown className="h-3.5 w-3.5" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-80 px-1 py-2" align="start">
+      <PopoverContent
+        className="w-64 px-1 py-2"
+        align="start"
+        // Don't auto-focus the first element (a vendor tab) on open — focusing
+        // it pops its name tooltip instantly. Keyboard users can Tab in.
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
         {selectedModel && (
           <>
-            <SectionHeader>Models</SectionHeader>
-            {/* Grouped by family, no "latest" — per-message picks a concrete version. */}
+            {/* Flat list, no "latest" — per-message picks a concrete version.
+                The "Models" label renders inside, below the vendor tabs.
+                Picks never dismiss: model and effort get tuned together, and the
+                popover closes only on outside click / Escape / trigger toggle. */}
             <ModelFamilyList
+              header="Models"
               catalog={catalog}
               value={model}
-              onPick={(value) => {
-                setModel(value)
-                setOpen(false)
-              }}
-              // One click on a family selects its latest and expands (no close),
-              // so the 90% who just want the latest are done in a single click.
-              onSelectFamilyLatest={(value) => setModel(value)}
+              onPick={setModel}
               webProvider={webProvider}
             />
-            {includeEffort && <Separator className="my-2" />}
+            {includeEffort && <Separator className="my-2 bg-border/50" />}
           </>
         )}
         {includeEffort && (
-          /* Effort changes never dismiss — the slider invites adjustment. */
           <EffortSection levels={visibleEfforts} value={effort} onChange={setEffort} />
         )}
       </PopoverContent>

--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -758,7 +758,6 @@ describe('MessageInput', () => {
     )
 
     await user.click(screen.getByTestId('composer-options-trigger'))
-    await user.click(await screen.findByTestId('model-family-haiku'))
     await user.click(await screen.findByTestId('model-pinned-claude-haiku-4-5'))
 
     const input = screen.getByTestId('message-input')
@@ -781,11 +780,9 @@ describe('MessageInput', () => {
       <MessageInput sessionId="s-1" agentSlug="agent-1" />
     )
 
-    // Effort keeps the popover open, so the model pick follows in the same
-    // visit (the model pick is what closes it).
+    // Neither pick dismisses the popover, so both knobs get set in one session.
     await user.click(screen.getByTestId('composer-options-trigger'))
     await user.click(await screen.findByTestId('effort-option-low'))
-    await user.click(await screen.findByTestId('model-family-sonnet'))
     await user.click(await screen.findByTestId('model-pinned-claude-sonnet-4-6'))
 
     const input = screen.getByTestId('message-input')

--- a/src/renderer/components/messages/model-family-list.test.tsx
+++ b/src/renderer/components/messages/model-family-list.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
+import { useState } from 'react'
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   ModelFamilyList,
@@ -244,16 +245,18 @@ describe('ModelFamilyList', () => {
     const onPick = vi.fn()
     render(<ModelFamilyList catalog={CATALOG} value="claude-opus-4-8" onPick={onPick} />)
 
-    // Chips are display-none on coarse pointers — invisible chips must never
-    // be tap targets (a tap on one silently pinned an unseen version).
+    // Chips are display-none whenever ANY coarse pointer exists (has-touch:,
+    // any-pointer — not the primary-pointer touch: variant): invisible chips
+    // must never be tap targets, and on hybrid touch laptops the primary
+    // pointer is a fine mouse while the finger is still there to mis-tap.
     expect(screen.getByTestId('model-pinned-claude-opus-4-7').parentElement!.className).toContain(
-      'touch:hidden',
+      'has-touch:hidden',
     )
 
     // Only the selected row gets the gear; it's touch-only via CSS.
     expect(screen.queryByTestId('model-family-sonnet-versions')).not.toBeInTheDocument()
     const gear = screen.getByTestId('model-family-opus-versions')
-    expect(gear.className).toContain('touch:inline-flex')
+    expect(gear.className).toContain('has-touch:inline-flex')
 
     // Gear toggles the nested menu: a "· latest" row plus one row per version.
     expect(screen.queryByTestId('model-version-claude-opus-4-7')).not.toBeInTheDocument()
@@ -268,6 +271,47 @@ describe('ModelFamilyList', () => {
     // …and toggles closed.
     await user.click(gear)
     expect(screen.queryByTestId('model-version-claude-opus-4-7')).not.toBeInTheDocument()
+  })
+
+  it('closes the nested version menu when the selection leaves the row', async () => {
+    const user = userEvent.setup()
+    const onPick = vi.fn()
+    // Stateful harness: picking really moves the selection between rows.
+    function Harness() {
+      const [value, setValue] = useState('claude-opus-4-8')
+      return (
+        <ModelFamilyList
+          catalog={CATALOG}
+          value={value}
+          onPick={(v) => {
+            onPick(v)
+            setValue(v)
+          }}
+        />
+      )
+    }
+    render(<Harness />)
+    await user.click(screen.getByTestId('model-family-opus-versions'))
+    expect(screen.getByTestId('model-version-claude-opus-4-7')).toBeInTheDocument()
+
+    // Move the selection to Sonnet, then back to Opus: the menu must come back
+    // CLOSED — stale-open state would shift the rows mid-interaction.
+    await user.click(screen.getByTestId('model-family-sonnet'))
+    expect(screen.queryByTestId('model-version-claude-opus-4-7')).not.toBeInTheDocument()
+    await user.click(screen.getByTestId('model-family-opus'))
+    expect(screen.queryByTestId('model-version-claude-opus-4-7')).not.toBeInTheDocument()
+  })
+
+  it('standalone models keep their own brand icon on the row', () => {
+    const withStandalone: ModelDefinition[] = [
+      ...CATALOG,
+      { id: 'local-llama', label: 'Llama 3 8B', icon: 'uploaded:my-provider.png', supportedEfforts: STD },
+    ]
+    render(<ModelFamilyList catalog={withStandalone} value="claude-opus-4-8" onPick={vi.fn()} />)
+    // Uploaded icons pool the model under the "Other" tab, where the row icon
+    // is the only thing distinguishing same-named custom-provider models.
+    fireEvent.click(screen.getByTestId('model-vendor-tab-other'))
+    expect(screen.getByTestId('model-option-local-llama').querySelector('img, svg')).not.toBeNull()
   })
 
   it('the nested version menu stores the bare alias from its latest row in settings mode', async () => {

--- a/src/renderer/components/messages/model-family-list.test.tsx
+++ b/src/renderer/components/messages/model-family-list.test.tsx
@@ -234,6 +234,64 @@ describe('ModelFamilyList', () => {
     expect(screen.queryByTestId('model-long-context-cliff-warning')).not.toBeInTheDocument()
   })
 
+  it('labels a lineage row "· latest" in settings mode, where the row stores the alias', () => {
+    render(<ModelFamilyList catalog={CATALOG} value="opus" onPick={vi.fn()} offerLatest />)
+    expect(screen.getByTestId('model-latest-opus')).toHaveTextContent('Opus · latest')
+  })
+
+  it('hides version chips on touch, where a gear on the selected row opens a nested version menu', async () => {
+    const user = userEvent.setup()
+    const onPick = vi.fn()
+    render(<ModelFamilyList catalog={CATALOG} value="claude-opus-4-8" onPick={onPick} />)
+
+    // Chips are display-none on coarse pointers — invisible chips must never
+    // be tap targets (a tap on one silently pinned an unseen version).
+    expect(screen.getByTestId('model-pinned-claude-opus-4-7').parentElement!.className).toContain(
+      'touch:hidden',
+    )
+
+    // Only the selected row gets the gear; it's touch-only via CSS.
+    expect(screen.queryByTestId('model-family-sonnet-versions')).not.toBeInTheDocument()
+    const gear = screen.getByTestId('model-family-opus-versions')
+    expect(gear.className).toContain('touch:inline-flex')
+
+    // Gear toggles the nested menu: a "· latest" row plus one row per version.
+    expect(screen.queryByTestId('model-version-claude-opus-4-7')).not.toBeInTheDocument()
+    await user.click(gear)
+    expect(screen.getByTestId('model-family-opus-menu-latest')).toHaveTextContent('Opus · latest')
+    await user.click(screen.getByTestId('model-version-claude-opus-4-7'))
+    expect(onPick).toHaveBeenLastCalledWith('claude-opus-4-7')
+    // The latest menu row repeats the row-label action (latest concrete id in
+    // composer mode).
+    await user.click(screen.getByTestId('model-family-opus-menu-latest'))
+    expect(onPick).toHaveBeenLastCalledWith('claude-opus-4-8')
+    // …and toggles closed.
+    await user.click(gear)
+    expect(screen.queryByTestId('model-version-claude-opus-4-7')).not.toBeInTheDocument()
+  })
+
+  it('the nested version menu stores the bare alias from its latest row in settings mode', async () => {
+    const user = userEvent.setup()
+    const onPick = vi.fn()
+    render(<ModelFamilyList catalog={CATALOG} value="claude-opus-4-7" onPick={onPick} offerLatest />)
+    await user.click(screen.getByTestId('model-latest-opus-versions'))
+    // The pinned selection's version row carries the check, not the latest row.
+    await user.click(screen.getByTestId('model-latest-opus-menu-latest'))
+    expect(onPick).toHaveBeenLastCalledWith('opus')
+  })
+
+  it('hides the web-tools warning when browsing a tab that does not own the selection', async () => {
+    const user = userEvent.setup()
+    render(<ModelFamilyList catalog={CATALOG} value="openai/gpt-5.5" onPick={vi.fn()} />)
+    expect(screen.getByTestId('model-no-websearch-warning')).toBeInTheDocument()
+    // On the Anthropic tab the warning's "this model" copy would read as being
+    // about the Claude models on screen — hide it like the cliff note.
+    await user.click(screen.getByTestId('model-vendor-tab-anthropic'))
+    expect(screen.queryByTestId('model-no-websearch-warning')).not.toBeInTheDocument()
+    await user.click(screen.getByTestId('model-vendor-tab-openai'))
+    expect(screen.getByTestId('model-no-websearch-warning')).toBeInTheDocument()
+  })
+
   it('hides the cliff note when browsing a tab that does not own the selection', async () => {
     const user = userEvent.setup()
     render(<ModelFamilyList catalog={CATALOG} value="openai/gpt-5.5" onPick={vi.fn()} />)

--- a/src/renderer/components/messages/model-family-list.test.tsx
+++ b/src/renderer/components/messages/model-family-list.test.tsx
@@ -48,13 +48,13 @@ describe('longContextWarningText', () => {
 
   it('frames the threshold as a share of the context window when known', () => {
     expect(longContextWarningText(cliff, 1_050_000)).toBe(
-      'Note: beyond about 26% of the context window, input pricing rises 2× and output 1.5×.',
+      'Beyond about 26% of the context window, requests cost roughly 2× as much. Starting a new session resets this.',
     )
   })
 
   it('falls back to a token count when the context window is unknown', () => {
     expect(longContextWarningText(cliff)).toBe(
-      'Note: beyond ~272K tokens of context, input pricing rises 2× and output 1.5×.',
+      'Beyond ~272K tokens of context, requests cost roughly 2× as much. Starting a new session resets this.',
     )
   })
 })
@@ -85,21 +85,34 @@ describe('findCatalogModel', () => {
 })
 
 describe('ModelFamilyList', () => {
-  it('lists versions newest-first within a family', async () => {
-    // Opus owns the selection → auto-expanded. Read the pinned rows in DOM order.
-    const { container } = render(<ModelFamilyList catalog={CATALOG} value="opus" onPick={vi.fn()} />)
-    await screen.findByTestId('model-pinned-claude-opus-4-8')
-    const ids = Array.from(container.querySelectorAll('[data-testid^="model-pinned-"]')).map((el) =>
-      el.getAttribute('data-testid'),
+  it('collapses a lineage family to one row with version pin chips, newest-first', async () => {
+    const onPick = vi.fn()
+    const user = userEvent.setup()
+    const { container } = render(<ModelFamilyList catalog={CATALOG} value="opus" onPick={onPick} />)
+    // One row for the whole Opus line…
+    const row = screen.getByTestId('model-family-opus')
+    expect(row).toHaveTextContent('Opus')
+    // …with a chip per version (family prefix stripped), newest-first.
+    const ids = Array.from(container.querySelectorAll('[data-testid^="model-pinned-claude-opus"]')).map(
+      (el) => el.getAttribute('data-testid'),
     )
     expect(ids).toEqual([
       'model-pinned-claude-opus-4-8',
       'model-pinned-claude-opus-4-7',
       'model-pinned-claude-opus-4-6',
     ])
+    expect(screen.getByTestId('model-pinned-claude-opus-4-7')).toHaveTextContent('4.7')
+    // Chip pins that concrete version; the row label picks the family latest.
+    await user.click(screen.getByTestId('model-pinned-claude-opus-4-7'))
+    expect(onPick).toHaveBeenLastCalledWith('claude-opus-4-7')
+    await user.click(row)
+    expect(onPick).toHaveBeenLastCalledWith('claude-opus-4-8')
+    // Clicking the row's empty stretch (not a chip) also picks the latest.
+    await user.click(screen.getByTestId('model-family-opus-fill'))
+    expect(onPick).toHaveBeenLastCalledWith('claude-opus-4-8')
   })
 
-  it('picks the concrete id of a chosen version', async () => {
+  it('picks the concrete id of a chosen version directly, no drill-in', async () => {
     const user = userEvent.setup()
     const onPick = vi.fn()
     render(<ModelFamilyList catalog={CATALOG} value="opus" onPick={onPick} />)
@@ -107,42 +120,84 @@ describe('ModelFamilyList', () => {
     expect(onPick).toHaveBeenCalledWith('claude-opus-4-7')
   })
 
-  it('one-click on a family selects its latest and expands, without closing (composer mode)', async () => {
-    const user = userEvent.setup()
-    const onPick = vi.fn()
-    const onSelectFamilyLatest = vi.fn()
-    // Sonnet is selected, so opus starts collapsed.
-    render(
-      <ModelFamilyList
-        catalog={CATALOG}
-        value="claude-sonnet-4-6"
-        onPick={onPick}
-        onSelectFamilyLatest={onSelectFamilyLatest}
-      />,
-    )
-    expect(screen.queryByTestId('model-pinned-claude-opus-4-8')).not.toBeInTheDocument()
-    await user.click(screen.getByTestId('model-family-opus'))
-    // selects the family's latest concrete id (family alias alongside, for
-    // callers that store "latest" as the bare alias), and does NOT take the close path
-    expect(onSelectFamilyLatest).toHaveBeenCalledWith('claude-opus-4-8', 'opus')
-    expect(onPick).not.toHaveBeenCalled()
-    // and expands so the rest are one tap away
-    expect(await screen.findByTestId('model-pinned-claude-opus-4-7')).toBeInTheDocument()
+  it('shows all vendor models flat at once (Sonnet selected still lists every Opus version)', () => {
+    render(<ModelFamilyList catalog={CATALOG} value="claude-sonnet-4-6" onPick={vi.fn()} />)
+    // Nothing is collapsed: a different family's versions are present without a click.
+    expect(screen.getByTestId('model-pinned-claude-opus-4-8')).toBeInTheDocument()
+    expect(screen.getByTestId('model-pinned-claude-sonnet-4-6')).toBeInTheDocument()
   })
 
-  it('without onSelectFamilyLatest a family click only toggles expansion (settings mode)', async () => {
+  it('collapses non-lineage models sharing a versioned label base (GPT-5.6 tiers) into one chip row', async () => {
     const user = userEvent.setup()
     const onPick = vi.fn()
-    render(<ModelFamilyList catalog={CATALOG} value="claude-sonnet-4-6" onPick={onPick} offerLatest />)
-    expect(screen.queryByTestId('model-pinned-claude-opus-4-8')).not.toBeInTheDocument()
-    await user.click(screen.getByTestId('model-family-opus'))
-    expect(onPick).not.toHaveBeenCalled() // expanding alone doesn't select
-    expect(await screen.findByTestId('model-pinned-claude-opus-4-8')).toBeInTheDocument()
+    const platformStyle: ModelDefinition[] = [
+      { id: 'gpt-5.4', label: 'GPT-5.4', family: 'gpt', icon: 'openai', supportedEfforts: STD },
+      { id: 'gpt-5.5', label: 'GPT-5.5', family: 'gpt', icon: 'openai', supportedEfforts: STD },
+      { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', family: 'gpt', icon: 'openai', supportedEfforts: STD },
+      { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', family: 'gpt', icon: 'openai', supportedEfforts: STD },
+      { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', family: 'gpt', isLatest: true, icon: 'openai', supportedEfforts: STD },
+    ]
+    render(<ModelFamilyList catalog={platformStyle} value="gpt-5.5" onPick={onPick} />)
+    // One row for the 5.6 line, chips per tier (newest-first), suffix-only labels.
+    const row = screen.getByTestId('model-family-gpt-5.6')
+    expect(row).toHaveTextContent('GPT-5.6')
+    expect(screen.getByTestId('model-pinned-gpt-5.6-sol')).toHaveTextContent('Sol')
+    expect(screen.getByTestId('model-pinned-gpt-5.6-terra')).toHaveTextContent('Terra')
+    expect(screen.getByTestId('model-pinned-gpt-5.6-luna')).toHaveTextContent('Luna')
+    // 5.5 and 5.4 stay single rows (their labels carry no variant word).
+    expect(screen.getByTestId('model-pinned-gpt-5.5')).toHaveTextContent('GPT-5.5')
+    expect(screen.getByTestId('model-pinned-gpt-5.4')).toHaveTextContent('GPT-5.4')
+    // Row click picks the line's latest tier; a chip pins a specific one.
+    await user.click(row)
+    expect(onPick).toHaveBeenLastCalledWith('gpt-5.6-sol')
+    await user.click(screen.getByTestId('model-pinned-gpt-5.6-luna'))
+    expect(onPick).toHaveBeenLastCalledWith('gpt-5.6-luna')
   })
 
-  it('renders acronym family headers upper-cased (GPT)', () => {
+  it('offers a per-family "latest" alias row in settings mode', async () => {
+    const user = userEvent.setup()
+    const onPick = vi.fn()
+    render(<ModelFamilyList catalog={CATALOG} value="openai/gpt-5.5" onPick={onPick} offerLatest />)
+    await user.click(screen.getByTestId('model-latest-gpt'))
+    expect(onPick).toHaveBeenCalledWith('gpt') // stores the bare alias (rides upgrades)
+  })
+
+  it('hides vendor tabs when the catalog has a single vendor', () => {
+    const claudeOnly = CATALOG.filter((m) => m.icon === 'anthropic')
+    render(<ModelFamilyList catalog={claudeOnly} value="claude-opus-4-8" onPick={vi.fn()} />)
+    expect(screen.queryByTestId('model-vendor-tab-anthropic')).not.toBeInTheDocument()
+  })
+
+  it('vendor tabs are icon-only with the name as accessible label', () => {
     render(<ModelFamilyList catalog={CATALOG} value="claude-opus-4-8" onPick={vi.fn()} />)
-    expect(screen.getByTestId('model-family-gpt')).toHaveTextContent('GPT')
+    const tab = screen.getByTestId('model-vendor-tab-openai')
+    expect(tab).toHaveAccessibleName('OpenAI')
+    expect(tab).not.toHaveTextContent(/OpenAI/) // name lives in the tooltip, not the tab
+    expect(screen.getByTestId('model-vendor-tab-anthropic')).toHaveAccessibleName('Anthropic')
+  })
+
+  it('opens on the selection vendor tab and filters the list to it', () => {
+    render(<ModelFamilyList catalog={CATALOG} value="openai/gpt-5.5" onPick={vi.fn()} />)
+    expect(screen.getByTestId('model-vendor-tab-openai')).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByTestId('model-pinned-openai/gpt-5.5')).toBeInTheDocument()
+    expect(screen.queryByTestId('model-pinned-claude-opus-4-8')).not.toBeInTheDocument()
+  })
+
+  it('switching vendor tab swaps the model list without picking a model', async () => {
+    const user = userEvent.setup()
+    const onPick = vi.fn()
+    render(<ModelFamilyList catalog={CATALOG} value="claude-opus-4-8" onPick={onPick} />)
+    expect(screen.getByTestId('model-pinned-claude-opus-4-8')).toBeInTheDocument()
+    expect(screen.queryByTestId('model-pinned-openai/gpt-5.5')).not.toBeInTheDocument()
+
+    await user.click(screen.getByTestId('model-vendor-tab-openai'))
+    expect(screen.getByTestId('model-pinned-openai/gpt-5.5')).toBeInTheDocument()
+    expect(screen.queryByTestId('model-pinned-claude-opus-4-8')).not.toBeInTheDocument()
+    expect(onPick).not.toHaveBeenCalled()
+
+    // Round-trip back: the Anthropic models return, selection intact.
+    await user.click(screen.getByTestId('model-vendor-tab-anthropic'))
+    expect(screen.getByTestId('model-pinned-claude-opus-4-8')).toBeInTheDocument()
   })
 
   it('warns when a non-Claude model lacks web tools and no vendor is set, and not for Claude', () => {
@@ -167,15 +222,28 @@ describe('ModelFamilyList', () => {
     expect(screen.getByTestId('model-no-websearch-warning')).toBeInTheDocument()
   })
 
-  it('warns about the long-context price cliff for GPT, and not for flat-priced Claude', () => {
+  it('notes the long-context price cliff for GPT at the end of the list, and not for flat-priced Claude', () => {
     const { rerender } = render(<ModelFamilyList catalog={CATALOG} value="openai/gpt-5.5" onPick={vi.fn()} />)
-    const warning = screen.getByTestId('model-long-context-cliff-warning')
-    // 272K / 1.05M ≈ 26% of the context window; input/output multipliers spelled out.
-    expect(warning).toHaveTextContent('26% of the context window')
-    expect(warning).toHaveTextContent('input pricing rises 2× and output 1.5×')
+    const note = screen.getByTestId('model-long-context-cliff-warning')
+    // Plain-language footnote naming the family generation (shared label
+    // prefix); mechanics live behind the hover tooltip.
+    expect(note).toHaveTextContent('Long chats cost more on GPT-5 models')
+    expect(screen.getByTestId('model-long-context-cliff-info')).toBeInTheDocument()
 
     rerender(<ModelFamilyList catalog={CATALOG} value="claude-opus-4-8" onPick={vi.fn()} />)
     expect(screen.queryByTestId('model-long-context-cliff-warning')).not.toBeInTheDocument()
+  })
+
+  it('hides the cliff note when browsing a tab that does not own the selection', async () => {
+    const user = userEvent.setup()
+    render(<ModelFamilyList catalog={CATALOG} value="openai/gpt-5.5" onPick={vi.fn()} />)
+    expect(screen.getByTestId('model-long-context-cliff-warning')).toBeInTheDocument()
+    // Switch to the Anthropic tab — the GPT selection's note would read as
+    // being about Claude models, so it hides until you're back on OpenAI.
+    await user.click(screen.getByTestId('model-vendor-tab-anthropic'))
+    expect(screen.queryByTestId('model-long-context-cliff-warning')).not.toBeInTheDocument()
+    await user.click(screen.getByTestId('model-vendor-tab-openai'))
+    expect(screen.getByTestId('model-long-context-cliff-warning')).toBeInTheDocument()
   })
 
   it('offers a "latest" row only when offerLatest is set', async () => {

--- a/src/renderer/components/messages/model-family-list.tsx
+++ b/src/renderer/components/messages/model-family-list.tsx
@@ -193,12 +193,17 @@ interface ModelFamilyListProps {
 
 function Row({
   label,
+  icon,
   isSelected,
   indent,
   onClick,
   testId,
 }: {
   label: ReactNode
+  /** Optional leading brand icon. Family/lineage rows omit it (the vendor tab
+   *  already says the brand), but standalone models — especially "Other"-tab
+   *  models with uploaded icons — need it to stay distinguishable. */
+  icon?: ReactNode
   isSelected: boolean
   indent?: boolean
   onClick: () => void
@@ -215,7 +220,10 @@ function Row({
         isSelected && 'bg-accent'
       )}
     >
-      <span className="min-w-0 truncate">{label}</span>
+      <span className="flex min-w-0 items-center gap-2">
+        {icon}
+        <span className="truncate">{label}</span>
+      </span>
       {isSelected && <Check className="h-3.5 w-3.5 shrink-0 text-foreground" />}
     </button>
   )
@@ -227,11 +235,14 @@ function Row({
  * pin a specific entry. Chips are siblings of the label button (buttons can't
  * nest); the spacer pushes the check to the row's right edge.
  *
- * Touch devices have no hover to reveal chips — worse, invisible chips would
- * still be tap targets, silently pinning a version the user never saw. So on
- * coarse pointers (`touch:` variant) the chips are display-none and the
- * selected row instead gains a gear that expands a nested menu below the row:
- * a "· latest" row (same action as the row label) plus one row per version.
+ * Touch has no hover to reveal chips — worse, invisible chips would still be
+ * tap targets, silently pinning a version the user never saw. Hover-gating
+ * can't fix that (a tap's compat `mouseover` fires before its `click`, so the
+ * chips would wake up mid-gesture), so wherever a finger EXISTS (`has-touch:`,
+ * any-pointer coarse — phones AND hybrid touch laptops) the chips are
+ * display-none and the selected row instead gains a gear that expands a nested
+ * menu below the row: a "· latest" row (same action as the row label) plus one
+ * row per version.
  */
 function LineRow({
   label,
@@ -258,8 +269,11 @@ function LineRow({
   latestSuffix?: boolean
 }) {
   // Touch-only nested version menu, toggled by the gear on the selected row.
-  // Rendered only while selected, so switching families auto-collapses it.
+  // Deselecting must actually CLOSE it (not just hide it): stale-open state
+  // would make the menu spring back expanded on re-selection, shifting the
+  // rows under the user's finger mid-interaction.
   const [versionsOpen, setVersionsOpen] = useState(false)
+  if (versionsOpen && !selected) setVersionsOpen(false)
   // The row label picks the line's main value; a version row pins one. When no
   // listed version is the pinned selection, the "latest" row is the selected one.
   const pinnedVersionShown = models.some((m) => m.id === activeId)
@@ -284,7 +298,7 @@ function LineRow({
         </button>
         <span
           className={cn(
-            'flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 touch:hidden',
+            'flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 has-touch:hidden',
             selected && 'opacity-100'
           )}
         >
@@ -320,7 +334,7 @@ function LineRow({
             aria-label={`${label} versions`}
             aria-expanded={versionsOpen}
             onClick={() => setVersionsOpen((open) => !open)}
-            className="hidden shrink-0 rounded-sm p-1 text-muted-foreground hover:text-foreground touch:inline-flex"
+            className="hidden shrink-0 rounded-sm p-1 text-muted-foreground hover:text-foreground has-touch:inline-flex"
           >
             <Settings className="h-3.5 w-3.5" aria-hidden="true" />
           </button>
@@ -560,6 +574,10 @@ export function ModelFamilyList({
         <Row
           key={m.id}
           testId={`model-option-${m.id}`}
+          // Standalone models keep their own icon: under the pooled "Other"
+          // tab (uploaded/missing brand icons) it's the only thing telling two
+          // same-named custom-provider models apart.
+          icon={<ModelIcon icon={m.icon} className="h-3.5 w-3.5 shrink-0" />}
           label={m.label}
           isSelected={resolved?.id === m.id}
           onClick={() => onPick(m.id)}

--- a/src/renderer/components/messages/model-family-list.tsx
+++ b/src/renderer/components/messages/model-family-list.tsx
@@ -1,6 +1,12 @@
 import { useMemo, useState, type ReactNode } from 'react'
-import { Check, ChevronDown, ChevronRight, TriangleAlert } from 'lucide-react'
+import { Check, HelpCircle, TriangleAlert } from 'lucide-react'
 import { ModelIcon } from '@renderer/components/ui/model-icon'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@renderer/components/ui/tooltip'
 import { cn } from '@shared/lib/utils'
 import type { ModelDefinition } from '@shared/lib/llm-provider'
 
@@ -14,6 +20,88 @@ const FAMILY_LABELS: Record<string, string> = { gpt: 'GPT', glm: 'GLM' }
 /** Display name for a family key, special-casing acronyms. */
 export function familyDisplayName(family: string): string {
   return FAMILY_LABELS[family] ?? capitalize(family)
+}
+
+// Vendor tabs are keyed by the catalog entry's brand-icon key, same as the
+// model rows' icons — the catalog has no separate vendor field.
+const VENDOR_LABELS: Record<string, string> = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  zai: 'Z.AI',
+  xai: 'xAI',
+}
+
+const NO_VENDOR = 'other'
+
+/** Tab-grouping key for a model: its brand-icon key; uploaded or missing icons pool under "other". */
+function vendorKey(m: ModelDefinition): string {
+  if (!m.icon || m.icon.startsWith('uploaded:')) return NO_VENDOR
+  return m.icon
+}
+
+/** Display name for a vendor tab key. */
+export function vendorDisplayName(key: string): string {
+  if (key === NO_VENDOR) return 'Other'
+  return VENDOR_LABELS[key] ?? capitalize(key)
+}
+
+/**
+ * Families whose entries are versions of one product line. These collapse to a
+ * single row ("Opus") with per-version pin chips revealed on hover/selection.
+ * Families outside this set (e.g. 'gpt', where each entry is a distinct tier)
+ * keep one row per concrete model.
+ */
+const LINEAGE_FAMILIES = new Set(['fable', 'opus', 'sonnet', 'haiku'])
+
+/** Chip label for a version: its label minus the family prefix ("Opus 4.8" → "4.8"). */
+function versionChipLabel(label: string, familyName: string): string {
+  if (label.toLowerCase().startsWith(familyName.toLowerCase())) {
+    return label.slice(familyName.length).trim() || label
+  }
+  return label
+}
+
+/**
+ * Base of a label's product line: the label minus a trailing variant word, when
+ * what remains ends in a digit — "GPT-5.6 Sol" → "GPT-5.6", but "GPT-5.5" (no
+ * variant word) and "Sonnet 4.6" ("Sonnet" doesn't end in a digit) stay whole.
+ * Non-lineage models sharing a base collapse to one row with variant chips.
+ */
+function lineBase(label: string): string {
+  const match = label.match(/^(.*\d)\s+\S+$/)
+  return match ? match[1] : label
+}
+
+/** Partition models into label-derived lines, preserving order of first appearance. */
+function splitIntoLines(models: ModelDefinition[]): { base: string; models: ModelDefinition[] }[] {
+  const byBase = new Map<string, ModelDefinition[]>()
+  for (const m of models) {
+    const base = lineBase(m.label)
+    if (!byBase.has(base)) byBase.set(base, [])
+    byBase.get(base)!.push(m)
+  }
+  return [...byBase.entries()].map(([base, lineModels]) => ({ base, models: lineModels }))
+}
+
+/** Row-suffix slug for a line base: "GPT-5.6" → "gpt-5.6". */
+function lineSlug(base: string): string {
+  return base.toLowerCase().replace(/\s+/g, '-')
+}
+
+/**
+ * Shared label prefix of a set of models, trimmed of trailing punctuation —
+ * "GPT-5.4"/"GPT-5.5"/"GPT-5.6 Sol" → "GPT-5". For copy describing a
+ * family-wide trait at the right generation grain; falls back when empty.
+ */
+function familyLabelPrefix(models: ModelDefinition[], fallback: string): string {
+  const labels = models.map((m) => m.label)
+  if (labels.length === 0) return fallback
+  let prefix = labels[0]
+  for (const label of labels.slice(1)) {
+    while (prefix && !label.startsWith(prefix)) prefix = prefix.slice(0, -1)
+  }
+  prefix = prefix.replace(/[^A-Za-z0-9]+$/, '')
+  return prefix || fallback
 }
 
 /** Compact token-count label for warnings, e.g. 272000 → "272K", 1_050_000 → "1.05M". */
@@ -40,13 +128,16 @@ export function webToolsWarning(unavailable: boolean): string | null {
 
 type LongContextCliff = NonNullable<ModelDefinition['longContextPriceCliff']>
 
-// Picker copy for a model's long-context price step; frames the threshold as a
-// share of the context window when known, else as a raw token count.
+// Detail copy behind the cliff banner's info icon: the consequence in plain
+// terms plus the one lever the user has (a fresh session). Frames the threshold
+// as a share of the context window when known, else as a raw token count. The
+// input multiplier stands in for the whole step — input tokens dominate cost in
+// long conversations, which is why the cliff exists at all.
 export function longContextWarningText(cliff: LongContextCliff, contextWindow?: number): string {
   const where = contextWindow
-    ? `beyond about ${Math.round((cliff.thresholdTokens / contextWindow) * 100)}% of the context window`
-    : `beyond ~${formatTokenThreshold(cliff.thresholdTokens)} tokens of context`
-  return `Note: ${where}, input pricing rises ${cliff.inputMultiplier}× and output ${cliff.outputMultiplier}×.`
+    ? `about ${Math.round((cliff.thresholdTokens / contextWindow) * 100)}% of the context window`
+    : `~${formatTokenThreshold(cliff.thresholdTokens)} tokens of context`
+  return `Beyond ${where}, requests cost roughly ${cliff.inputMultiplier}× as much. Starting a new session resets this.`
 }
 
 /**
@@ -70,6 +161,8 @@ interface FamilyGroup {
   family: string
   displayName: string
   versions: ModelDefinition[]
+  /** One collapsed row with version pin chips vs one row per model. */
+  lineage: boolean
 }
 
 interface ModelFamilyListProps {
@@ -79,19 +172,16 @@ interface ModelFamilyListProps {
   /** Called with the value to store: a concrete id, or a bare alias for the "latest" row. */
   onPick: (value: string) => void
   /**
+   * Section label (e.g. "Models") rendered INSIDE the picker, above the vendor
+   * tabs — passed in by the parent so the label and tabs stack as one block.
+   */
+  header?: ReactNode
+  /**
    * Offer a "· latest" row per family that stores the bare alias (rides upgrades).
    * ON for saved-setting selectors; OFF for the per-message composer, where
    * latest-vs-pinned has no meaning — you pick a concrete version to send now.
    */
   offerLatest?: boolean
-  /**
-   * When set, clicking a family header also selects that family's latest (without
-   * closing) and expands it — one click gets the latest, the rest stay visible for
-   * refinement. Called with the latest concrete version id and the bare family
-   * alias: the composer stores the concrete id (per-message picks are concrete);
-   * the settings picker stores the alias (a saved "latest" rides upgrades).
-   */
-  onSelectFamilyLatest?: (latestId: string, family: string) => void
   /**
    * Active host web-provider id from global settings. Native web search/fetch depend on the model
    * (the `supportsWebSearch` flag; Claude and GPT-over-Platform have them); a configured vendor
@@ -103,14 +193,12 @@ interface ModelFamilyListProps {
 
 function Row({
   label,
-  icon,
   isSelected,
   indent,
   onClick,
   testId,
 }: {
   label: ReactNode
-  icon?: ReactNode
   isSelected: boolean
   indent?: boolean
   onClick: () => void
@@ -127,36 +215,138 @@ function Row({
         isSelected && 'bg-accent'
       )}
     >
-      <span className="flex min-w-0 items-center gap-2">
-        {icon}
-        <span className="truncate">{label}</span>
-      </span>
+      <span className="min-w-0 truncate">{label}</span>
       {isSelected && <Check className="h-3.5 w-3.5 shrink-0 text-foreground" />}
     </button>
   )
 }
 
 /**
- * Grouped model picker shared by the saved-setting selector and the per-message
- * composer. Layer 1 lists each family (and any family-less models); picking a
- * family expands it to its versions. When `offerLatest` is set, each family also
- * gets a "· latest" row that stores the bare alias; otherwise only concrete
- * versions are selectable. Keeps no popover state of its own — the parent owns
- * open/close and renders any effort section.
+ * Collapsed row for a product line: the label picks the line's main value, and
+ * per-model pin chips — revealed on hover, keyboard focus, or while selected —
+ * pin a specific entry. Chips are siblings of the label button (buttons can't
+ * nest); the spacer pushes the check to the row's right edge.
+ */
+function LineRow({
+  label,
+  models,
+  rowTestId,
+  onRowPick,
+  selected,
+  activeId,
+  chipLabel,
+  onPickModel,
+}: {
+  label: string
+  models: ModelDefinition[]
+  rowTestId: string
+  onRowPick: () => void
+  selected: boolean
+  /** Concrete id whose chip renders highlighted (the pinned selection). */
+  activeId?: string
+  chipLabel: (m: ModelDefinition) => string
+  onPickModel: (id: string) => void
+}) {
+  return (
+    <div
+      className={cn(
+        'group flex items-center gap-1 rounded-sm pr-2 hover:bg-accent',
+        selected && 'bg-accent'
+      )}
+    >
+      <button
+        type="button"
+        data-testid={rowTestId}
+        onClick={onRowPick}
+        className="flex min-w-0 items-center py-1 pl-2 text-left text-xs"
+      >
+        <span className="truncate">{label}</span>
+      </button>
+      <span
+        className={cn(
+          'flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100',
+          selected && 'opacity-100'
+        )}
+      >
+        {models.map((m) => (
+          <button
+            key={m.id}
+            type="button"
+            data-testid={`model-pinned-${m.id}`}
+            aria-label={m.label}
+            onClick={() => onPickModel(m.id)}
+            className={cn(
+              'rounded px-1 py-0.5 text-[10px] tabular-nums text-muted-foreground hover:bg-background/80 hover:text-foreground',
+              activeId === m.id && 'bg-background text-foreground shadow-sm'
+            )}
+          >
+            {chipLabel(m)}
+          </button>
+        ))}
+      </span>
+      {/* The rest of the row is also a "pick the default" target, so clicking
+          anywhere that isn't a version chip selects the latest. Hidden from
+          the a11y tree (tabIndex -1) — the label button is the semantic one. */}
+      <button
+        type="button"
+        tabIndex={-1}
+        aria-hidden="true"
+        data-testid={`${rowTestId}-fill`}
+        onClick={onRowPick}
+        className="h-6 min-w-0 flex-1 cursor-pointer"
+      />
+      {selected && <Check className="h-3.5 w-3.5 shrink-0 text-foreground" />}
+    </div>
+  )
+}
+
+/**
+ * Flat model picker shared by the saved-setting selector and the per-message
+ * composer. A vendor tab bar (when the catalog spans more than one brand) filters
+ * to one vendor. Lineage families (Opus, Sonnet, …) collapse to one row with
+ * per-version pin chips revealed on hover/selection, and non-lineage models whose
+ * labels share a versioned base ("GPT-5.6 Sol/Terra/Luna") collapse the same way;
+ * remaining models render one row each, newest-first. When `offerLatest` is set, a
+ * lineage row's label stores the bare alias (rides upgrades) and non-lineage
+ * families gain a "· latest" alias row; otherwise labels pick the latest concrete
+ * version. Keeps no popover state of its own — the parent owns open/close and
+ * renders any effort section.
  */
 export function ModelFamilyList({
   catalog,
   value,
   onPick,
+  header,
   offerLatest = false,
-  onSelectFamilyLatest,
   webProvider,
 }: ModelFamilyListProps) {
+  // Resolve the current selection (exact id, or a bare alias → its latest) for
+  // highlighting and default vendor tab.
+  const resolved = findCatalogModel(value, catalog)
+
+  // Vendor tabs, in catalog order of first appearance. Until the user picks a
+  // tab, follow the selection's vendor so opening the picker lands on the tab
+  // that owns the highlighted model.
+  const vendors = useMemo(() => {
+    const seen: string[] = []
+    for (const m of catalog) {
+      const key = vendorKey(m)
+      if (!seen.includes(key)) seen.push(key)
+    }
+    return seen
+  }, [catalog])
+  const [pickedVendor, setPickedVendor] = useState<string | null>(null)
+  const activeVendor =
+    (pickedVendor && vendors.includes(pickedVendor) ? pickedVendor : undefined) ??
+    (resolved ? vendorKey(resolved) : undefined) ??
+    vendors[0]
+
   const { families, standalone } = useMemo(() => {
     const order: string[] = []
     const byFamily = new Map<string, ModelDefinition[]>()
     const loose: ModelDefinition[] = []
     for (const m of catalog) {
+      if (vendorKey(m) !== activeVendor) continue
       if (!m.family) {
         loose.push(m)
         continue
@@ -172,19 +362,12 @@ export function ModelFamilyList({
       displayName: familyDisplayName(family),
       // Catalogs are authored oldest→newest; show versions newest-first.
       versions: [...byFamily.get(family)!].reverse(),
+      lineage: LINEAGE_FAMILIES.has(family),
     }))
     return { families: groups, standalone: loose }
-  }, [catalog])
-
-  // Resolve the current selection (exact id, or a bare alias → its latest) for
-  // highlighting + auto-expand.
-  const resolved = findCatalogModel(value, catalog)
+  }, [catalog, activeVendor])
   const isLatestSelected = offerLatest && value !== undefined && families.some((g) => g.family === value)
   const selectedFamily = isLatestSelected ? value : resolved?.family
-
-  // Auto-expand the selected family; let the user toggle from there.
-  const [expanded, setExpanded] = useState<string | null | undefined>(undefined)
-  const openFamily = expanded === undefined ? selectedFamily : expanded
 
   // Native web tools depend on the model's own support (Claude, GPT-over-Platform); a configured host vendor makes them work on ANY model, so web
   // tools are unavailable only when the model lacks native support AND no vendor is set.
@@ -195,6 +378,52 @@ export function ModelFamilyList({
 
   return (
     <div className="flex flex-col gap-0.5">
+      {(header !== undefined || vendors.length > 1) && (
+        // One row: section label left, vendor tabs right. The tab bar is an
+        // icon-only single-select segmented control, mirroring the Appearance
+        // picker in general settings (intentionally not Radix Tabs — see that
+        // comment). Names live in standard-delay tooltips so the bar scales to
+        // many vendors without crowding.
+        <div className="flex items-center justify-between gap-2 pb-1 pl-2 pr-1 pt-1">
+          <span className="min-w-0 truncate text-[11px] font-medium text-muted-foreground/70">
+            {header}
+          </span>
+          {vendors.length > 1 && (
+            <TooltipProvider>
+              <div
+                role="radiogroup"
+                aria-label="Model vendor"
+                className="inline-flex shrink-0 items-center rounded-lg bg-muted p-0.5 text-muted-foreground"
+              >
+                {vendors.map((key) => {
+                  const isActive = key === activeVendor
+                  return (
+                    <Tooltip key={key}>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          role="radio"
+                          aria-checked={isActive}
+                          aria-label={vendorDisplayName(key)}
+                          data-testid={`model-vendor-tab-${key}`}
+                          onClick={() => setPickedVendor(key)}
+                          className={cn(
+                            'inline-flex h-6 w-8 items-center justify-center rounded-md transition-all hover:bg-background/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                            isActive && 'bg-background text-foreground shadow'
+                          )}
+                        >
+                          <ModelIcon icon={key === NO_VENDOR ? undefined : key} className="h-3.5 w-3.5 shrink-0" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>{vendorDisplayName(key)}</TooltipContent>
+                    </Tooltip>
+                  )
+                })}
+              </div>
+            </TooltipProvider>
+          )}
+        </div>
+      )}
       {webWarning && (
         <div
           data-testid="model-no-websearch-warning"
@@ -204,76 +433,70 @@ export function ModelFamilyList({
           <span>{webWarning}</span>
         </div>
       )}
-      {resolved?.longContextPriceCliff && (
-        <div
-          data-testid="model-long-context-cliff-warning"
-          className="mx-1 mb-1 flex items-start gap-1.5 rounded-sm bg-amber-500/10 px-2 py-1 text-[11px] text-amber-600 dark:text-amber-500"
-        >
-          <TriangleAlert className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
-          <span>{longContextWarningText(resolved.longContextPriceCliff, resolved.contextWindow)}</span>
-        </div>
-      )}
       {families.map((group) => {
-        const isOpen = openFamily === group.family
         const familyHasSelection = selectedFamily === group.family
-        const latestVersion = group.versions.find((v) => v.isLatest) ?? group.versions[0]
+        if (group.lineage) {
+          const latestVersion = group.versions.find((v) => v.isLatest) ?? group.versions[0]
+          return (
+            <LineRow
+              key={group.family}
+              label={group.displayName}
+              models={group.versions}
+              rowTestId={offerLatest ? `model-latest-${group.family}` : `model-family-${group.family}`}
+              // Bare alias in settings (rides upgrades); latest concrete id in
+              // the composer (per-message picks are concrete).
+              onRowPick={() => onPick(offerLatest ? group.family : latestVersion.id)}
+              selected={familyHasSelection}
+              activeId={!isLatestSelected ? resolved?.id : undefined}
+              chipLabel={(m) => versionChipLabel(m.label, group.displayName)}
+              onPickModel={onPick}
+            />
+          )
+        }
         return (
           <div key={group.family} className="flex flex-col gap-0.5">
-            <button
-              type="button"
-              data-testid={`model-family-${group.family}`}
-              onClick={() => {
-                if (onSelectFamilyLatest && latestVersion) {
-                  // One-click latest: expand and select the family's newest
-                  // version without closing, so refinement stays one tap away.
-                  setExpanded(group.family)
-                  onSelectFamilyLatest(latestVersion.id, group.family)
-                } else {
-                  setExpanded(isOpen ? null : group.family)
-                }
-              }}
-              className={cn(
-                'flex items-center justify-between gap-2 rounded-sm px-2 py-1 text-left text-xs hover:bg-accent',
-                familyHasSelection && !isOpen && 'bg-accent/60'
-              )}
-            >
-              <span className="flex min-w-0 items-center gap-2">
-                <ModelIcon icon={latestVersion?.icon} className="h-3.5 w-3.5 shrink-0" />
-                <span className="truncate">{group.displayName}</span>
-              </span>
-              {isOpen ? (
-                <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              ) : (
-                <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              )}
-            </button>
-            {isOpen && (
-              <div className="flex flex-col gap-0.5 pb-1">
-                {offerLatest && (
-                  <Row
-                    indent
-                    testId={`model-latest-${group.family}`}
-                    label={<span>{group.displayName} <span className="text-muted-foreground">· latest</span></span>}
-                    isSelected={familyHasSelection && isLatestSelected}
-                    onClick={() => onPick(group.family)}
-                  />
-                )}
-                {group.versions.map((version) => (
-                  <Row
-                    key={version.id}
-                    indent
-                    testId={`model-pinned-${version.id}`}
-                    label={
-                      offerLatest
-                        ? <span>{version.label} <span className="text-muted-foreground">· pinned</span></span>
-                        : version.label
-                    }
-                    isSelected={!isLatestSelected && resolved?.id === version.id}
-                    onClick={() => onPick(version.id)}
-                  />
-                ))}
-              </div>
+            {offerLatest && (
+              <Row
+                testId={`model-latest-${group.family}`}
+                label={<span>{group.displayName} <span className="text-muted-foreground">· latest</span></span>}
+                isSelected={familyHasSelection && isLatestSelected}
+                onClick={() => onPick(group.family)}
+              />
             )}
+            {splitIntoLines(group.versions).map((line) => {
+              if (line.models.length > 1) {
+                const lineLatest = line.models.find((m) => m.isLatest) ?? line.models[0]
+                return (
+                  <LineRow
+                    key={line.base}
+                    label={line.base}
+                    models={line.models}
+                    rowTestId={`model-family-${lineSlug(line.base)}`}
+                    // No bare alias exists for a sub-line, so both modes pin
+                    // the line's newest concrete id.
+                    onRowPick={() => onPick(lineLatest.id)}
+                    selected={!isLatestSelected && line.models.some((m) => m.id === resolved?.id)}
+                    activeId={!isLatestSelected ? resolved?.id : undefined}
+                    chipLabel={(m) => versionChipLabel(m.label, line.base)}
+                    onPickModel={onPick}
+                  />
+                )
+              }
+              const version = line.models[0]
+              return (
+                <Row
+                  key={version.id}
+                  testId={`model-pinned-${version.id}`}
+                  label={
+                    offerLatest
+                      ? <span>{version.label} <span className="text-muted-foreground">· pinned</span></span>
+                      : version.label
+                  }
+                  isSelected={!isLatestSelected && resolved?.id === version.id}
+                  onClick={() => onPick(version.id)}
+                />
+              )
+            })}
           </div>
         )
       })}
@@ -281,12 +504,51 @@ export function ModelFamilyList({
         <Row
           key={m.id}
           testId={`model-option-${m.id}`}
-          icon={<ModelIcon icon={m.icon} className="h-3.5 w-3.5 shrink-0" />}
           label={m.label}
           isSelected={resolved?.id === m.id}
           onClick={() => onPick(m.id)}
         />
       ))}
+      {/* End-of-list footnote — only on the tab that owns the selection, else
+          it reads as being about the listed models. Blue text, no fill: it's
+          informational, not the web-tools warning's amber alert. Hovering
+          ANYWHERE on the line shows the explanation. */}
+      {resolved?.longContextPriceCliff && vendorKey(resolved) === activeVendor && (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                data-testid="model-long-context-cliff-warning"
+                // px-2 (no margin) lines the text up with the row labels above.
+                // Same blue as the effort slider's accents (#007DED).
+                className="mt-1 flex cursor-default items-center gap-1 rounded-sm px-2 py-1 text-left text-[11px] text-[#007DED]"
+              >
+                {/* The cliff is a family-wide trait (every GPT entry shares
+                    it), so name the family's generation ("GPT-5 models")
+                    rather than the picked version. */}
+                <span className="min-w-0 flex-1 truncate">
+                  Long chats cost more on{' '}
+                  {resolved.family
+                    ? `${familyLabelPrefix(
+                        catalog.filter((m) => m.family === resolved.family),
+                        familyDisplayName(resolved.family),
+                      )} models`
+                    : resolved.label}
+                </span>
+                <HelpCircle
+                  data-testid="model-long-context-cliff-info"
+                  className="h-3 w-3 shrink-0"
+                  aria-hidden="true"
+                />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-60">
+              {longContextWarningText(resolved.longContextPriceCliff, resolved.contextWindow)}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
     </div>
   )
 }

--- a/src/renderer/components/messages/model-family-list.tsx
+++ b/src/renderer/components/messages/model-family-list.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type ReactNode } from 'react'
-import { Check, HelpCircle, TriangleAlert } from 'lucide-react'
+import { Check, HelpCircle, Settings, TriangleAlert } from 'lucide-react'
 import { ModelIcon } from '@renderer/components/ui/model-icon'
 import {
   Tooltip,
@@ -226,6 +226,12 @@ function Row({
  * per-model pin chips — revealed on hover, keyboard focus, or while selected —
  * pin a specific entry. Chips are siblings of the label button (buttons can't
  * nest); the spacer pushes the check to the row's right edge.
+ *
+ * Touch devices have no hover to reveal chips — worse, invisible chips would
+ * still be tap targets, silently pinning a version the user never saw. So on
+ * coarse pointers (`touch:` variant) the chips are display-none and the
+ * selected row instead gains a gear that expands a nested menu below the row:
+ * a "· latest" row (same action as the row label) plus one row per version.
  */
 function LineRow({
   label,
@@ -236,6 +242,7 @@ function LineRow({
   activeId,
   chipLabel,
   onPickModel,
+  latestSuffix,
 }: {
   label: string
   models: ModelDefinition[]
@@ -246,57 +253,102 @@ function LineRow({
   activeId?: string
   chipLabel: (m: ModelDefinition) => string
   onPickModel: (id: string) => void
+  /** Append "· latest" to the label — set when the row click stores the bare
+   *  alias (settings mode), so the alias-vs-pin semantics are visible. */
+  latestSuffix?: boolean
 }) {
+  // Touch-only nested version menu, toggled by the gear on the selected row.
+  // Rendered only while selected, so switching families auto-collapses it.
+  const [versionsOpen, setVersionsOpen] = useState(false)
+  // The row label picks the line's main value; a version row pins one. When no
+  // listed version is the pinned selection, the "latest" row is the selected one.
+  const pinnedVersionShown = models.some((m) => m.id === activeId)
   return (
-    <div
-      className={cn(
-        'group flex items-center gap-1 rounded-sm pr-2 hover:bg-accent',
-        selected && 'bg-accent'
-      )}
-    >
-      <button
-        type="button"
-        data-testid={rowTestId}
-        onClick={onRowPick}
-        className="flex min-w-0 items-center py-1 pl-2 text-left text-xs"
-      >
-        <span className="truncate">{label}</span>
-      </button>
-      <span
+    <>
+      <div
         className={cn(
-          'flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100',
-          selected && 'opacity-100'
+          'group flex items-center gap-1 rounded-sm pr-2 hover:bg-accent',
+          selected && 'bg-accent'
         )}
       >
-        {models.map((m) => (
+        <button
+          type="button"
+          data-testid={rowTestId}
+          onClick={onRowPick}
+          className="flex min-w-0 items-center py-1 pl-2 text-left text-xs"
+        >
+          <span className="truncate">
+            {label}
+            {latestSuffix && <span className="text-muted-foreground"> · latest</span>}
+          </span>
+        </button>
+        <span
+          className={cn(
+            'flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 touch:hidden',
+            selected && 'opacity-100'
+          )}
+        >
+          {models.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              data-testid={`model-pinned-${m.id}`}
+              aria-label={m.label}
+              onClick={() => onPickModel(m.id)}
+              className={cn(
+                'rounded px-1 py-0.5 text-[10px] tabular-nums text-muted-foreground hover:bg-background/80 hover:text-foreground',
+                activeId === m.id && 'bg-background text-foreground shadow-sm'
+              )}
+            >
+              {chipLabel(m)}
+            </button>
+          ))}
+        </span>
+        {/* The rest of the row is also a "pick the default" target, so clicking
+            anywhere that isn't a version chip selects the latest. A plain div —
+            the label button is the semantic click target. */}
+        <div
+          aria-hidden="true"
+          data-testid={`${rowTestId}-fill`}
+          onClick={onRowPick}
+          className="h-6 min-w-0 flex-1 cursor-pointer"
+        />
+        {selected && (
           <button
-            key={m.id}
             type="button"
-            data-testid={`model-pinned-${m.id}`}
-            aria-label={m.label}
-            onClick={() => onPickModel(m.id)}
-            className={cn(
-              'rounded px-1 py-0.5 text-[10px] tabular-nums text-muted-foreground hover:bg-background/80 hover:text-foreground',
-              activeId === m.id && 'bg-background text-foreground shadow-sm'
-            )}
+            data-testid={`${rowTestId}-versions`}
+            aria-label={`${label} versions`}
+            aria-expanded={versionsOpen}
+            onClick={() => setVersionsOpen((open) => !open)}
+            className="hidden shrink-0 rounded-sm p-1 text-muted-foreground hover:text-foreground touch:inline-flex"
           >
-            {chipLabel(m)}
+            <Settings className="h-3.5 w-3.5" aria-hidden="true" />
           </button>
-        ))}
-      </span>
-      {/* The rest of the row is also a "pick the default" target, so clicking
-          anywhere that isn't a version chip selects the latest. Hidden from
-          the a11y tree (tabIndex -1) — the label button is the semantic one. */}
-      <button
-        type="button"
-        tabIndex={-1}
-        aria-hidden="true"
-        data-testid={`${rowTestId}-fill`}
-        onClick={onRowPick}
-        className="h-6 min-w-0 flex-1 cursor-pointer"
-      />
-      {selected && <Check className="h-3.5 w-3.5 shrink-0 text-foreground" />}
-    </div>
+        )}
+        {selected && <Check className="h-3.5 w-3.5 shrink-0 text-foreground" />}
+      </div>
+      {selected && versionsOpen && (
+        <div className="flex flex-col gap-0.5">
+          <Row
+            indent
+            testId={`${rowTestId}-menu-latest`}
+            label={<span>{label} <span className="text-muted-foreground">· latest</span></span>}
+            isSelected={!pinnedVersionShown}
+            onClick={onRowPick}
+          />
+          {models.map((m) => (
+            <Row
+              key={m.id}
+              indent
+              testId={`model-version-${m.id}`}
+              label={m.label}
+              isSelected={activeId === m.id}
+              onClick={() => onPickModel(m.id)}
+            />
+          ))}
+        </div>
+      )}
+    </>
   )
 }
 
@@ -424,7 +476,10 @@ export function ModelFamilyList({
           )}
         </div>
       )}
-      {webWarning && (
+      {/* Like the cliff note below, scoped to the tab that owns the selection —
+          on any other tab its "this model" copy would read as being about the
+          listed models. */}
+      {webWarning && resolved && vendorKey(resolved) === activeVendor && (
         <div
           data-testid="model-no-websearch-warning"
           className="mx-1 mb-1 flex items-start gap-1.5 rounded-sm bg-amber-500/10 px-2 py-1 text-[11px] text-amber-600 dark:text-amber-500"
@@ -450,6 +505,7 @@ export function ModelFamilyList({
               activeId={!isLatestSelected ? resolved?.id : undefined}
               chipLabel={(m) => versionChipLabel(m.label, group.displayName)}
               onPickModel={onPick}
+              latestSuffix={offerLatest}
             />
           )
         }
@@ -521,8 +577,8 @@ export function ModelFamilyList({
                 type="button"
                 data-testid="model-long-context-cliff-warning"
                 // px-2 (no margin) lines the text up with the row labels above.
-                // Same blue as the effort slider's accents (#007DED).
-                className="mt-1 flex cursor-default items-center gap-1 rounded-sm px-2 py-1 text-left text-[11px] text-[#007DED]"
+                // Same blues as the effort slider's accents (light/dark pair).
+                className="mt-1 flex cursor-default items-center gap-1 rounded-sm px-2 py-1 text-left text-[11px] text-[#007DED] dark:text-[#4EB3FF]"
               >
                 {/* The cliff is a family-wide trait (every GPT entry shares
                     it), so name the family's generation ("GPT-5 models")

--- a/src/renderer/components/quick-dispatch/quick-dispatch-menus.test.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch-menus.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ModelEffortMenu } from './quick-dispatch-menus'
+import type { ComposerOptionsState } from '@renderer/components/messages/composer-options'
+import type { ModelDefinition } from '@shared/lib/llm-provider'
+import type { EffortLevel } from '@shared/lib/container/types'
+
+const STD: EffortLevel[] = ['low', 'medium', 'high']
+
+const CATALOG: ModelDefinition[] = [
+  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', family: 'sonnet', isLatest: true, icon: 'anthropic', supportedEfforts: STD },
+  { id: 'openai/gpt-5.5', label: 'GPT-5.5', family: 'gpt', isLatest: true, icon: 'openai', supportedEfforts: STD, supportsWebSearch: false },
+]
+
+function makeState(overrides: Partial<ComposerOptionsState>): ComposerOptionsState {
+  return {
+    effort: 'medium',
+    setEffort: vi.fn(),
+    model: 'claude-sonnet-4-6',
+    setModel: vi.fn(),
+    catalog: CATALOG,
+    toRuntimeOptions: () => ({}),
+    ...overrides,
+  }
+}
+
+describe('ModelEffortMenu', () => {
+  it('shows the web-tools warning for a searchless model when no web vendor is set', () => {
+    render(<ModelEffortMenu state={makeState({ model: 'openai/gpt-5.5' })} maxHeight={400} />)
+    expect(screen.getByTestId('model-no-websearch-warning')).toBeInTheDocument()
+  })
+
+  it('passes webProvider through, silencing the warning when a vendor covers all models', () => {
+    // Regression: this menu once dropped webProvider, contradicting the
+    // composer popover for users with a configured web vendor.
+    render(
+      <ModelEffortMenu state={makeState({ model: 'openai/gpt-5.5', webProvider: 'exa' })} maxHeight={400} />
+    )
+    expect(screen.queryByTestId('model-no-websearch-warning')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
@@ -23,7 +23,7 @@ export const EFFORT_LABELS: Record<EffortLevel, string> = {
 
 function SectionHeader({ children }: { children: ReactNode }) {
   return (
-    <div className="px-2 pt-1 pb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+    <div className="px-2 pt-1 pb-1 text-[11px] font-medium text-muted-foreground/70">
       {children}
     </div>
   )
@@ -113,8 +113,7 @@ export function ModelEffortMenu({ state, maxHeight }: { state: ComposerOptionsSt
     // the pinned effort row; `min-h-0` lets the list actually shrink to scroll.
     <div className="flex flex-col" style={{ maxHeight }}>
       <div className="min-h-0 flex-1 overflow-y-auto px-1 pt-2">
-        <SectionHeader>Model</SectionHeader>
-        <ModelFamilyList catalog={catalog} value={model} onPick={setModel} onSelectFamilyLatest={setModel} />
+        <ModelFamilyList header="Model" catalog={catalog} value={model} onPick={setModel} />
       </div>
       <div className="shrink-0 px-1 pb-1 pt-2">
         <SectionHeader>Effort</SectionHeader>

--- a/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
@@ -101,7 +101,7 @@ export function AgentMenu({
 }
 
 export function ModelEffortMenu({ state, maxHeight }: { state: ComposerOptionsState; maxHeight: number }) {
-  const { effort, setEffort, model, setModel, catalog } = state
+  const { effort, setEffort, model, setModel, catalog, webProvider } = state
   const selected =
     findCatalogModel(model, catalog) ?? catalog.find((m) => m.family === 'sonnet' && m.isLatest) ?? catalog[0]
   const efforts = EFFORT_LEVELS.filter((l) => (selected ? selected.supportedEfforts.includes(l) : true))
@@ -113,7 +113,10 @@ export function ModelEffortMenu({ state, maxHeight }: { state: ComposerOptionsSt
     // the pinned effort row; `min-h-0` lets the list actually shrink to scroll.
     <div className="flex flex-col" style={{ maxHeight }}>
       <div className="min-h-0 flex-1 overflow-y-auto px-1 pt-2">
-        <ModelFamilyList header="Model" catalog={catalog} value={model} onPick={setModel} />
+        {/* webProvider silences the web-tools warning when a configured host
+            vendor already makes web tools work on any model — without it this
+            picker contradicted the composer's. */}
+        <ModelFamilyList header="Model" catalog={catalog} value={model} onPick={setModel} webProvider={webProvider} />
       </div>
       <div className="shrink-0 px-1 pb-1 pt-2">
         <SectionHeader>Effort</SectionHeader>

--- a/src/renderer/components/settings/settings-model-select.test.tsx
+++ b/src/renderer/components/settings/settings-model-select.test.tsx
@@ -37,14 +37,13 @@ beforeEach(() => {
   })
 })
 
-describe('SettingsModelSelect (two-layered)', () => {
+describe('SettingsModelSelect (flat picker)', () => {
   it('stores the bare family alias when "latest" is picked', async () => {
     const user = userEvent.setup()
     const onModelChange = vi.fn()
     render(<SettingsModelSelect model="claude-haiku-4-5" onModelChange={onModelChange} />)
 
     await user.click(screen.getByTestId('settings-model-trigger'))
-    await user.click(await screen.findByTestId('model-family-opus'))
     await user.click(await screen.findByTestId('model-latest-opus'))
 
     expect(onModelChange).toHaveBeenCalledWith('opus')
@@ -56,7 +55,6 @@ describe('SettingsModelSelect (two-layered)', () => {
     render(<SettingsModelSelect model="claude-haiku-4-5" onModelChange={onModelChange} />)
 
     await user.click(screen.getByTestId('settings-model-trigger'))
-    await user.click(await screen.findByTestId('model-family-opus'))
     await user.click(await screen.findByTestId('model-pinned-claude-opus-4-7'))
 
     expect(onModelChange).toHaveBeenCalledWith('claude-opus-4-7')

--- a/src/renderer/components/settings/settings-model-select.tsx
+++ b/src/renderer/components/settings/settings-model-select.tsx
@@ -55,11 +55,11 @@ function EffortRow({ label, isSelected, onClick, testId }: {
  * The two-layered model picker used by saved-setting selectors (default model,
  * summarizer, browser, scheduled-job/trigger, chat integration).
  *
- * The grouped family/version list is the shared {@link ModelFamilyList}, here
- * with `offerLatest` on: each family expands to **Latest** (stores the bare
- * alias, rides upgrades) plus **specific versions** (store the concrete id,
- * pinned), labeled `· latest` / `· pinned`. Reads and writes the raw selection
- * string — resolution happens host-side.
+ * The flat model list is the shared {@link ModelFamilyList}, here with
+ * `offerLatest` on: each family shows a **Latest** row (stores the bare alias,
+ * rides upgrades) plus its **specific versions** (store the concrete id, pinned),
+ * labeled `· latest` / `· pinned`. Reads and writes the raw selection string —
+ * resolution happens host-side.
  */
 function SettingsModelSelectImpl({
   model,
@@ -128,24 +128,25 @@ function SettingsModelSelectImpl({
           <ChevronDown className="h-3.5 w-3.5" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-80 px-1 py-2" align="start">
-        <div className="px-2 pb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-          Model
-        </div>
+      <PopoverContent
+        className="w-64 px-1 py-2"
+        align="start"
+        // Don't auto-focus the first element (a vendor tab) on open — focusing
+        // it pops its name tooltip instantly. Keyboard users can Tab in.
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
         <ModelFamilyList
+          header="Model"
           catalog={catalog}
           value={model}
           onPick={pick}
           offerLatest
-          // Family click = that family's latest, stored as the bare alias (same
-          // as the "· latest" row). Stays open so a pinned version is one tap away.
-          onSelectFamilyLatest={(_latestId, family) => onModelChange(family)}
           webProvider={settings?.webProvider}
         />
         {includeEffort && (
           <>
-            <Separator className="my-2" />
-            <div className="px-2 pb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            <Separator className="my-2 bg-border/50" />
+            <div className="px-2 pb-1 text-[11px] font-medium text-muted-foreground/70">
               Effort
             </div>
             <div className="flex flex-col gap-0.5">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -135,6 +135,12 @@ const config: Config = {
       // built-in; we're on 3.4, so register our own. The `touch` alias reads as
       // intent at the call sites; the query is the standard no-hover/coarse pair.)
       addVariant('touch', '@media (hover: none) and (pointer: coarse)')
+      // `has-touch:` — SOME pointer is coarse, including hybrids (touchscreen
+      // laptops) whose PRIMARY pointer is a fine hover-capable mouse and so
+      // never match `touch:`. For affordances that must account for fingers
+      // existing at all — e.g. hover-revealed controls that would otherwise be
+      // invisible-but-tappable ghosts under a finger.
+      addVariant('has-touch', '@media (any-pointer: coarse)')
     }),
   ],
 }


### PR DESCRIPTION
**Stack 3/4** (base: model-picker-2-effort-slider) · replaces part of #457 — the core review

Rework of the shared `ModelFamilyList` (composer, settings selectors, quick-dispatch):
- Icon-only vendor tabs (label row, right-aligned) from the catalog's brand-icon key; hidden for single-vendor catalogs.
- Flat rows replace family drill-in: lineage families collapse to one row with hover-revealed version pin chips; row click (anywhere off-chip) picks latest; GPT-5.6-style tiers group by shared label base automatically.
- Long-context price-cliff note as a plain-language footnote with a whole-line tooltip, scoped to the owning vendor tab. Copy verified against OpenAI's model docs.
- Model picks keep the composer popover open; popovers stop auto-focusing on open; w-64.

E2E updated for the flat picker. This is the PR deserving the real review attention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)