### PR TITLE
Unify effort UI across pickers; explicit Latest chips; popover positioning

### DIFF
--- a/e2e/specs/agent-default-model.spec.ts
+++ b/e2e/specs/agent-default-model.spec.ts
@@ -67,20 +67,20 @@ test.describe('Per-agent default model', () => {
     await expect(card).toBeVisible()
     await expect(page.locator('[data-testid="home-default-model-reset"]')).not.toBeVisible()
 
-    // The flat list shows a "Haiku · latest" row (stores the bare alias) …
+    // Picks keep the popover open, so alias, pin, and effort all happen in ONE
+    // visit. The "Haiku" row (and its Latest chip) stores the bare alias …
     await card.locator('[data-testid="settings-model-trigger"]').click()
     await page.locator('[data-testid="model-latest-haiku"]').click()
     await expect(card.locator('[data-testid="settings-model-trigger"]')).toContainText('Haiku · latest')
 
-    // … and the concrete versions right below it, so pinning one is one tap away.
-    await card.locator('[data-testid="settings-model-trigger"]').click()
+    // … its version chip pins the concrete release …
     await page.locator(`[data-testid="model-pinned-${HAIKU_PINNED}"]`).click()
     await expect(card.locator('[data-testid="settings-model-trigger"]')).toContainText('Haiku 4.5')
 
-    // Pick a default effort too.
-    await card.locator('[data-testid="settings-model-trigger"]').click()
+    // … and the effort slider sets the default effort. Then dismiss.
     await page.locator('[data-testid="effort-option-high"]').click()
     await expect(card.locator('[data-testid="settings-model-trigger"]')).toContainText('High')
+    await page.keyboard.press('Escape')
 
     // A custom default surfaces the reset-to-global affordance.
     await expect(page.locator('[data-testid="home-default-model-reset"]')).toBeVisible()

--- a/src/renderer/components/messages/composer-options-popover.tsx
+++ b/src/renderer/components/messages/composer-options-popover.tsx
@@ -73,7 +73,7 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: C
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-64 px-1 py-2"
+        className="flex w-64 flex-col px-1 py-2 data-[side=bottom]:flex-col-reverse"
         align="start"
         // Don't auto-focus the first element (a vendor tab) on open — focusing
         // it pops its name tooltip instantly. Keyboard users can Tab in.

--- a/src/renderer/components/messages/model-family-list.test.tsx
+++ b/src/renderer/components/messages/model-family-list.test.tsx
@@ -235,9 +235,12 @@ describe('ModelFamilyList', () => {
     expect(screen.queryByTestId('model-long-context-cliff-warning')).not.toBeInTheDocument()
   })
 
-  it('labels a lineage row "· latest" in settings mode, where the row stores the alias', () => {
+  it('marks alias semantics with the Latest chip in settings mode, not a "· latest" label suffix', () => {
+    // The chip replaced the interim text suffix — the row label must stay bare
+    // so the chip is the single latest-vs-pin signal.
     render(<ModelFamilyList catalog={CATALOG} value="opus" onPick={vi.fn()} offerLatest />)
-    expect(screen.getByTestId('model-latest-opus')).toHaveTextContent('Opus · latest')
+    expect(screen.getByTestId('model-latest-opus')).not.toHaveTextContent('· latest')
+    expect(screen.getByTestId('model-latest-chip-opus')).toBeInTheDocument()
   })
 
   it('hides version chips on touch, where a gear on the selected row opens a nested version menu', async () => {

--- a/src/renderer/components/messages/model-family-list.test.tsx
+++ b/src/renderer/components/messages/model-family-list.test.tsx
@@ -348,6 +348,43 @@ describe('ModelFamilyList', () => {
     expect(screen.getByTestId('model-long-context-cliff-warning')).toBeInTheDocument()
   })
 
+  it('shows a Latest chip on lineage rows in settings mode: lit for alias, unlit for pin', async () => {
+    const user = userEvent.setup()
+    const onPick = vi.fn()
+    // Alias selected: Latest chip is the active one, no version chip lit.
+    const { rerender } = render(<ModelFamilyList catalog={CATALOG} value="opus" onPick={onPick} offerLatest />)
+    const latestChip = screen.getByTestId('model-latest-chip-opus')
+    expect(latestChip).toHaveTextContent('Latest')
+    expect(latestChip.className).toContain('shadow-sm')
+    expect(screen.getByTestId('model-pinned-claude-opus-4-8').className).not.toContain('shadow-sm')
+    await user.click(latestChip)
+    expect(onPick).toHaveBeenLastCalledWith('opus')
+
+    // Pinned: the version chip is lit instead of Latest.
+    rerender(<ModelFamilyList catalog={CATALOG} value="claude-opus-4-7" onPick={onPick} offerLatest />)
+    expect(screen.getByTestId('model-latest-chip-opus').className).not.toContain('shadow-sm')
+    expect(screen.getByTestId('model-pinned-claude-opus-4-7').className).toContain('shadow-sm')
+  })
+
+  it('renders the family alias as a "GPT · Latest" chip row in settings mode, versions unsuffixed', async () => {
+    const user = userEvent.setup()
+    const onPick = vi.fn()
+    render(<ModelFamilyList catalog={CATALOG} value="gpt" onPick={onPick} offerLatest />)
+    // Alias row: label + Latest chip, no "· latest" text suffix.
+    const aliasRow = screen.getByTestId('model-latest-gpt')
+    expect(aliasRow).toHaveTextContent('GPT')
+    expect(aliasRow).not.toHaveTextContent('· latest')
+    await user.click(screen.getByTestId('model-latest-chip-gpt'))
+    expect(onPick).toHaveBeenLastCalledWith('gpt')
+    // Version rows drop the "· pinned" suffix; state reads from highlights.
+    expect(screen.getByTestId('model-pinned-openai/gpt-5.5')).not.toHaveTextContent('pinned')
+  })
+
+  it('omits Latest chips in composer mode (concrete picks only)', () => {
+    render(<ModelFamilyList catalog={CATALOG} value="claude-opus-4-8" onPick={vi.fn()} />)
+    expect(screen.queryByTestId('model-latest-chip-opus')).not.toBeInTheDocument()
+  })
+
   it('offers a "latest" row only when offerLatest is set', async () => {
     const user = userEvent.setup()
     const onPick = vi.fn()

--- a/src/renderer/components/messages/model-family-list.tsx
+++ b/src/renderer/components/messages/model-family-list.tsx
@@ -253,7 +253,7 @@ function LineRow({
   activeId,
   chipLabel,
   onPickModel,
-  latestSuffix,
+  latestChip,
 }: {
   label: string
   models: ModelDefinition[]
@@ -264,9 +264,12 @@ function LineRow({
   activeId?: string
   chipLabel: (m: ModelDefinition) => string
   onPickModel: (id: string) => void
-  /** Append "· latest" to the label — set when the row click stores the bare
-   *  alias (settings mode), so the alias-vs-pin semantics are visible. */
-  latestSuffix?: boolean
+  /**
+   * Explicit "Latest" chip ahead of the version chips (offerLatest surfaces):
+   * picks the bare alias, highlighted while the alias is the stored selection —
+   * making latest-vs-pinned readable at a glance. Row clicks pick it too.
+   */
+  latestChip?: { onPick: () => void; active: boolean; testId: string }
 }) {
   // Touch-only nested version menu, toggled by the gear on the selected row.
   // Deselecting must actually CLOSE it (not just hide it): stale-open state
@@ -277,6 +280,11 @@ function LineRow({
   // The row label picks the line's main value; a version row pins one. When no
   // listed version is the pinned selection, the "latest" row is the selected one.
   const pinnedVersionShown = models.some((m) => m.id === activeId)
+  const chipClass = (active: boolean) =>
+    cn(
+      'rounded px-1 py-0.5 text-[10px] tabular-nums text-muted-foreground hover:bg-background/80 hover:text-foreground',
+      active && 'bg-background text-foreground shadow-sm'
+    )
   return (
     <>
       <div
@@ -291,10 +299,7 @@ function LineRow({
           onClick={onRowPick}
           className="flex min-w-0 items-center py-1 pl-2 text-left text-xs"
         >
-          <span className="truncate">
-            {label}
-            {latestSuffix && <span className="text-muted-foreground"> · latest</span>}
-          </span>
+          <span className="truncate">{label}</span>
         </button>
         <span
           className={cn(
@@ -302,6 +307,17 @@ function LineRow({
             selected && 'opacity-100'
           )}
         >
+          {latestChip && (
+            <button
+              type="button"
+              data-testid={latestChip.testId}
+              aria-label={`${label} — latest`}
+              onClick={latestChip.onPick}
+              className={chipClass(latestChip.active)}
+            >
+              Latest
+            </button>
+          )}
           {models.map((m) => (
             <button
               key={m.id}
@@ -309,10 +325,7 @@ function LineRow({
               data-testid={`model-pinned-${m.id}`}
               aria-label={m.label}
               onClick={() => onPickModel(m.id)}
-              className={cn(
-                'rounded px-1 py-0.5 text-[10px] tabular-nums text-muted-foreground hover:bg-background/80 hover:text-foreground',
-                activeId === m.id && 'bg-background text-foreground shadow-sm'
-              )}
+              className={chipClass(activeId === m.id)}
             >
               {chipLabel(m)}
             </button>
@@ -327,7 +340,8 @@ function LineRow({
           onClick={onRowPick}
           className="h-6 min-w-0 flex-1 cursor-pointer"
         />
-        {selected && (
+        {/* No gear for a bare alias row (models=[]) — there's nothing to pin. */}
+        {selected && models.length > 0 && (
           <button
             type="button"
             data-testid={`${rowTestId}-versions`}
@@ -372,9 +386,10 @@ function LineRow({
  * to one vendor. Lineage families (Opus, Sonnet, …) collapse to one row with
  * per-version pin chips revealed on hover/selection, and non-lineage models whose
  * labels share a versioned base ("GPT-5.6 Sol/Terra/Luna") collapse the same way;
- * remaining models render one row each, newest-first. When `offerLatest` is set, a
- * lineage row's label stores the bare alias (rides upgrades) and non-lineage
- * families gain a "· latest" alias row; otherwise labels pick the latest concrete
+ * remaining models render one row each, newest-first. When `offerLatest` is set,
+ * rows carry an explicit "Latest" chip storing the bare alias (rides upgrades) —
+ * lit when the alias is the stored selection, while a lit version chip means a
+ * pin; row clicks store the alias too. Otherwise labels pick the latest concrete
  * version. Keeps no popover state of its own — the parent owns open/close and
  * renders any effort section.
  */
@@ -519,18 +534,38 @@ export function ModelFamilyList({
               activeId={!isLatestSelected ? resolved?.id : undefined}
               chipLabel={(m) => versionChipLabel(m.label, group.displayName)}
               onPickModel={onPick}
-              latestSuffix={offerLatest}
+              // Alias surfaces get an explicit Latest chip so latest-vs-pinned
+              // is readable at a glance (Latest lit = alias; version lit = pin).
+              latestChip={
+                offerLatest
+                  ? {
+                      onPick: () => onPick(group.family),
+                      active: isLatestSelected && familyHasSelection,
+                      testId: `model-latest-chip-${group.family}`,
+                    }
+                  : undefined
+              }
             />
           )
         }
         return (
           <div key={group.family} className="flex flex-col gap-0.5">
             {offerLatest && (
-              <Row
-                testId={`model-latest-${group.family}`}
-                label={<span>{group.displayName} <span className="text-muted-foreground">· latest</span></span>}
-                isSelected={familyHasSelection && isLatestSelected}
-                onClick={() => onPick(group.family)}
+              // Family alias row in the same chip language as lineage rows:
+              // "GPT  [Latest]" — the row and its chip both store the alias.
+              <LineRow
+                label={group.displayName}
+                models={[]}
+                rowTestId={`model-latest-${group.family}`}
+                onRowPick={() => onPick(group.family)}
+                selected={familyHasSelection && isLatestSelected}
+                chipLabel={() => ''}
+                onPickModel={onPick}
+                latestChip={{
+                  onPick: () => onPick(group.family),
+                  active: isLatestSelected && familyHasSelection,
+                  testId: `model-latest-chip-${group.family}`,
+                }}
               />
             )}
             {splitIntoLines(group.versions).map((line) => {
@@ -557,11 +592,7 @@ export function ModelFamilyList({
                 <Row
                   key={version.id}
                   testId={`model-pinned-${version.id}`}
-                  label={
-                    offerLatest
-                      ? <span>{version.label} <span className="text-muted-foreground">· pinned</span></span>
-                      : version.label
-                  }
+                  label={version.label}
                   isSelected={!isLatestSelected && resolved?.id === version.id}
                   onClick={() => onPick(version.id)}
                 />

--- a/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
@@ -3,7 +3,8 @@ import { AtSign, Check, FileIcon, FolderOpen, Loader2, Search } from 'lucide-rea
 import { cn } from '@shared/lib/utils'
 import { ModelFamilyList } from '@renderer/components/messages/model-family-list'
 import { findCatalogModel, type ComposerOptionsState } from '@renderer/components/messages/composer-options'
-import { EFFORT_LEVELS, type EffortLevel } from '@shared/lib/container/types'
+import { EffortSection } from '@renderer/components/messages/effort-slider'
+import { EFFORT_LEVELS } from '@shared/lib/container/types'
 import { FileTypeIcon } from '@renderer/components/ui/file-type-icon'
 import type { ApiAgent } from '@renderer/hooks/use-agents'
 import { readLocalFileAsFile } from '@renderer/lib/read-local-file'
@@ -12,14 +13,6 @@ import { readLocalFileAsFile } from '@renderer/lib/read-local-file'
 // app's floating popovers, these render INSIDE the panel's flex column so the
 // frameless window grows to fit them (Raycast-style) — the whole frosted area
 // is filled by the menu, never an empty frosted surround.
-
-export const EFFORT_LABELS: Record<EffortLevel, string> = {
-  low: 'Low',
-  medium: 'Medium',
-  high: 'High',
-  xhigh: 'Extra High',
-  max: 'Max',
-}
 
 function SectionHeader({ children }: { children: ReactNode }) {
   return (
@@ -107,10 +100,10 @@ export function ModelEffortMenu({ state, maxHeight }: { state: ComposerOptionsSt
   const efforts = EFFORT_LEVELS.filter((l) => (selected ? selected.supportedEfforts.includes(l) : true))
 
   return (
-    // Only the model list scrolls; the effort row is pinned to the bottom so
+    // Only the model list scrolls; the effort section is pinned to the bottom so
     // it's always reachable however long the catalog is. `maxHeight` (not a
     // fixed height) keeps the menu content-sized when short — no dead gap above
-    // the pinned effort row; `min-h-0` lets the list actually shrink to scroll.
+    // the pinned effort section; `min-h-0` lets the list actually shrink to scroll.
     <div className="flex flex-col" style={{ maxHeight }}>
       <div className="min-h-0 flex-1 overflow-y-auto px-1 pt-2">
         {/* webProvider silences the web-tools warning when a configured host
@@ -119,23 +112,7 @@ export function ModelEffortMenu({ state, maxHeight }: { state: ComposerOptionsSt
         <ModelFamilyList header="Model" catalog={catalog} value={model} onPick={setModel} webProvider={webProvider} />
       </div>
       <div className="shrink-0 px-1 pb-1 pt-2">
-        <SectionHeader>Effort</SectionHeader>
-        <div className="flex flex-wrap gap-1 px-2">
-          {efforts.map((l) => (
-            <button
-              key={l}
-              type="button"
-              onClick={() => setEffort(l)}
-              data-testid={`effort-option-${l}`}
-              className={cn(
-                'rounded-md px-2.5 py-1 text-xs hover:bg-accent',
-                effort === l ? 'bg-accent font-medium' : 'text-muted-foreground',
-              )}
-            >
-              {EFFORT_LABELS[l]}
-            </button>
-          ))}
-        </div>
+        <EffortSection levels={efforts} value={effort} onChange={setEffort} />
       </div>
     </div>
   )

--- a/src/renderer/components/quick-dispatch/quick-dispatch.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.tsx
@@ -17,7 +17,8 @@ import { useIsVoiceConfigured } from '@renderer/hooks/use-voice-input'
 import { UploadError } from '@renderer/components/ui/upload-error'
 import { MountChoiceDialog } from '@renderer/components/ui/mount-choice-dialog'
 import { toast } from 'sonner'
-import { AgentMenu, AttachMenu, ModelEffortMenu, EFFORT_LABELS } from './quick-dispatch-menus'
+import { AgentMenu, AttachMenu, ModelEffortMenu } from './quick-dispatch-menus'
+import { EFFORT_LABELS } from '@renderer/components/messages/effort-slider'
 
 type OpenMenu = 'agent' | 'model' | 'attach' | null
 

--- a/src/renderer/components/settings/settings-model-select.tsx
+++ b/src/renderer/components/settings/settings-model-select.tsx
@@ -1,12 +1,12 @@
 import { memo, useEffect, useMemo, useState } from 'react'
-import { Check, ChevronDown } from 'lucide-react'
+import { ChevronDown } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { Separator } from '@renderer/components/ui/separator'
 import { ModelIcon } from '@renderer/components/ui/model-icon'
 import { useSettings } from '@renderer/hooks/use-settings'
 import { ModelFamilyList, findCatalogModel, familyDisplayName } from '@renderer/components/messages/model-family-list'
-import { cn } from '@shared/lib/utils'
+import { EFFORT_LABELS, EffortSection } from '@renderer/components/messages/effort-slider'
 import { EFFORT_LEVELS, type EffortLevel } from '@shared/lib/container/types'
 import type { LlmProviderId } from '@shared/lib/config/settings'
 
@@ -19,36 +19,14 @@ interface SettingsModelSelectProps {
   effort?: EffortLevel
   onEffortChange?: (effort: EffortLevel) => void
   disabled?: boolean
-}
-
-const EFFORT_LABEL: Record<EffortLevel, string> = {
-  low: 'Low',
-  medium: 'Medium',
-  high: 'High',
-  xhigh: 'Extra High',
-  max: 'Max',
-}
-
-function EffortRow({ label, isSelected, onClick, testId }: {
-  label: string
-  isSelected: boolean
-  onClick: () => void
-  testId: string
-}) {
-  return (
-    <button
-      type="button"
-      data-testid={testId}
-      onClick={onClick}
-      className={cn(
-        'flex items-center justify-between gap-2 rounded-sm px-2 py-1 text-left text-xs hover:bg-accent',
-        isSelected && 'bg-accent'
-      )}
-    >
-      <span className="truncate">{label}</span>
-      {isSelected && <Check className="h-3.5 w-3.5 shrink-0 text-foreground" />}
-    </button>
-  )
+  /**
+   * Which trigger edge the popover anchors to. Picks rewrite the trigger label
+   * live, so its width changes while the popover is open — anchor to the edge
+   * the host layout keeps FIXED or the popover slides on every selection.
+   * 'end' (default) for right-aligned rows (settings rows, the agent-home
+   * card); 'start' for left-aligned hosts (the trigger/cron runtime card).
+   */
+  align?: 'start' | 'end'
 }
 
 /**
@@ -68,6 +46,7 @@ function SettingsModelSelectImpl({
   effort = 'medium',
   onEffortChange,
   disabled,
+  align = 'end',
 }: SettingsModelSelectProps) {
   const { data: settings } = useSettings()
   const [open, setOpen] = useState(false)
@@ -99,9 +78,10 @@ function SettingsModelSelectImpl({
   else if (resolved?.family) triggerLabel = `${resolved.label} · pinned`
   else if (resolved) triggerLabel = resolved.label
 
+  // Picks never dismiss (matching the composer): model and effort get set in
+  // one visit; the popover closes on outside click / Escape / trigger toggle.
   const pick = (value: string) => {
     onModelChange(value)
-    setOpen(false)
   }
 
   return (
@@ -121,7 +101,7 @@ function SettingsModelSelectImpl({
             {triggerLabel ?? 'Select model'}
             {includeEffort && (
               <span className="text-muted-foreground">
-                {' · '}{EFFORT_LABEL[effort]}
+                {' · '}{EFFORT_LABELS[effort]}
               </span>
             )}
           </span>
@@ -129,8 +109,9 @@ function SettingsModelSelectImpl({
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-64 px-1 py-2"
-        align="start"
+        className="flex w-64 flex-col px-1 py-2 data-[side=bottom]:flex-col-reverse"
+        align={align}
+        collisionPadding={8}
         // Don't auto-focus the first element (a vendor tab) on open — focusing
         // it pops its name tooltip instantly. Keyboard users can Tab in.
         onOpenAutoFocus={(e) => e.preventDefault()}
@@ -146,23 +127,11 @@ function SettingsModelSelectImpl({
         {includeEffort && (
           <>
             <Separator className="my-2 bg-border/50" />
-            <div className="px-2 pb-1 text-[11px] font-medium text-muted-foreground/70">
-              Effort
-            </div>
-            <div className="flex flex-col gap-0.5">
-              {visibleEfforts.map((level) => (
-                <EffortRow
-                  key={level}
-                  label={EFFORT_LABEL[level]}
-                  isSelected={effort === level}
-                  onClick={() => {
-                    onEffortChange?.(level)
-                    setOpen(false)
-                  }}
-                  testId={`effort-option-${level}`}
-                />
-              ))}
-            </div>
+            <EffortSection
+              levels={visibleEfforts}
+              value={effort}
+              onChange={(level) => onEffortChange?.(level)}
+            />
           </>
         )}
       </PopoverContent>

--- a/src/renderer/components/triggers/runtime-options-card.tsx
+++ b/src/renderer/components/triggers/runtime-options-card.tsx
@@ -82,6 +82,9 @@ export function RuntimeOptionsCard({ model, effort, disabled, onUpdate }: Runtim
           effort={localEffort}
           onEffortChange={handleSetEffort}
           disabled={disabled}
+          // This trigger is left-aligned in its card, so its LEFT edge is the
+          // stable anchor while picks rewrite the label width.
+          align="start"
         />
         {!hasCustom && <span className="text-xs text-muted-foreground">Using defaults</span>}
       </div>


### PR DESCRIPTION
**Stack 4/4** (base: model-picker-3-list-redesign) · replaces part of #457

- `EffortSection` adopted by the settings model selector (LLM tab ×3, browser tab, agent-home default card, chat integrations, trigger runtime card) and quick-dispatch; settings popovers adopt keep-open.
- Settings-mode rows get an explicit **Latest** chip (lit = alias stored, rides upgrades; lit version chip = pinned); the GPT family alias row speaks the same chip language, replacing the "· latest / · pinned" suffixed rows.
- Effort section always renders nearest the trigger (side-aware column reversal), and the settings picker anchors to the trigger edge its host keeps fixed (`align` prop) so live label rewrites don't jitter the popover.

Final tree is identical to #457's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)