### PR TITLE
feat: allow/review/block launch policies for subagents and workflows

### DIFF
--- a/agent-container/src/capability-policies.test.ts
+++ b/agent-container/src/capability-policies.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import {
+  agentCapabilityPoliciesSchema,
+  applyCapabilityPolicies,
+  blockBoundaryChanged,
+  blockedCapabilityMessage,
+  capabilityForTool,
+  capabilityGateFor,
+  parseReviewDecisionScope,
+  reviewDeclinedMessage,
+} from './capability-policies'
+
+const BASE = { allowedTools: ['Skill', 'Task', 'Agent', 'mcp__x__*'], disallowedTools: ['Monitor'] }
+
+describe('capabilityForTool', () => {
+  it('maps both subagent tool names and the workflow tool', () => {
+    expect(capabilityForTool('Task')).toBe('subagents')
+    expect(capabilityForTool('Agent')).toBe('subagents')
+    expect(capabilityForTool('Workflow')).toBe('workflows')
+    expect(capabilityForTool('Bash')).toBeNull()
+    expect(capabilityForTool('TaskOutput')).toBeNull()
+  })
+})
+
+describe('applyCapabilityPolicies', () => {
+  it('leaves everything intact when policies are absent (allow defaults)', () => {
+    const out = applyCapabilityPolicies(undefined, BASE)
+    expect(out.allowedTools).toEqual(BASE.allowedTools)
+    expect(out.disallowedTools).toEqual(BASE.disallowedTools)
+    expect(out.enableWorkflows).toBe(true)
+  })
+
+  it('review policies do not touch tool lists — gating happens at call time', () => {
+    const out = applyCapabilityPolicies({ subagents: 'review', workflows: 'review' }, BASE)
+    expect(out.allowedTools).toEqual(BASE.allowedTools)
+    expect(out.disallowedTools).toEqual(BASE.disallowedTools)
+    expect(out.enableWorkflows).toBe(true)
+  })
+
+  it('block subagents strips Task/Agent from allowed and disallows them', () => {
+    const out = applyCapabilityPolicies({ subagents: 'block' }, BASE)
+    expect(out.allowedTools).toEqual(['Skill', 'mcp__x__*'])
+    expect(out.disallowedTools).toEqual(['Monitor', 'Task', 'Agent'])
+    expect(out.enableWorkflows).toBe(true)
+  })
+
+  it('block workflows disables enableWorkflows and disallows Workflow', () => {
+    const out = applyCapabilityPolicies({ workflows: 'block' }, BASE)
+    expect(out.allowedTools).toEqual(BASE.allowedTools)
+    expect(out.disallowedTools).toEqual(['Monitor', 'Workflow'])
+    expect(out.enableWorkflows).toBe(false)
+  })
+
+  it('does not mutate the base lists', () => {
+    applyCapabilityPolicies({ subagents: 'block', workflows: 'block' }, BASE)
+    expect(BASE.allowedTools).toContain('Task')
+    expect(BASE.disallowedTools).toEqual(['Monitor'])
+  })
+})
+
+describe('capabilityGateFor', () => {
+  const none = new Set<never>() as ReadonlySet<'subagents' | 'workflows'>
+
+  it('passes non-capability tools and allow policies through', () => {
+    expect(capabilityGateFor('Bash', { subagents: 'block', workflows: 'block' }, none)).toBeNull()
+    expect(capabilityGateFor('Task', undefined, none)).toBeNull()
+    expect(capabilityGateFor('Workflow', { workflows: 'allow' }, none)).toBeNull()
+  })
+
+  it('gates review and block launches', () => {
+    expect(capabilityGateFor('Task', { subagents: 'review' }, none)).toEqual({ capability: 'subagents', policy: 'review' })
+    expect(capabilityGateFor('Agent', { subagents: 'review' }, none)).toEqual({ capability: 'subagents', policy: 'review' })
+    expect(capabilityGateFor('Workflow', { workflows: 'block' }, none)).toEqual({ capability: 'workflows', policy: 'block' })
+  })
+
+  it('session grants bypass review but never block', () => {
+    const grants = new Set<'subagents' | 'workflows'>(['workflows'])
+    expect(capabilityGateFor('Workflow', { workflows: 'review' }, grants)).toBeNull()
+    expect(capabilityGateFor('Workflow', { workflows: 'block' }, grants)).toEqual({ capability: 'workflows', policy: 'block' })
+    expect(capabilityGateFor('Task', { subagents: 'review' }, grants)).toEqual({ capability: 'subagents', policy: 'review' })
+  })
+})
+
+describe('blockBoundaryChanged', () => {
+  it('detects crossing into and out of block per capability', () => {
+    expect(blockBoundaryChanged({ workflows: 'review' }, { workflows: 'block' })).toBe(true)
+    expect(blockBoundaryChanged({ subagents: 'block' }, {})).toBe(true)
+    expect(blockBoundaryChanged(undefined, { subagents: 'block' })).toBe(true)
+  })
+
+  it('ignores allow<->review movement', () => {
+    expect(blockBoundaryChanged({ workflows: 'review' }, { workflows: 'allow' })).toBe(false)
+    expect(blockBoundaryChanged(undefined, { subagents: 'review', workflows: 'review' })).toBe(false)
+    expect(blockBoundaryChanged({ workflows: 'block' }, { workflows: 'block' })).toBe(false)
+  })
+})
+
+describe('boundary schemas', () => {
+  it('accepts valid policies and rejects unknown tiers', () => {
+    expect(agentCapabilityPoliciesSchema.parse({ subagents: 'allow', workflows: 'review' })).toEqual({ subagents: 'allow', workflows: 'review' })
+    expect(agentCapabilityPoliciesSchema.parse(undefined)).toBeUndefined()
+    expect(() => agentCapabilityPoliciesSchema.parse({ subagents: 'maybe' })).toThrow()
+  })
+
+  it('parses review decision scope, defaulting anything unknown to once', () => {
+    expect(parseReviewDecisionScope({ scope: 'session' })).toBe('session')
+    expect(parseReviewDecisionScope({ scope: 'once' })).toBe('once')
+    expect(parseReviewDecisionScope({ scope: 'forever' })).toBe('once')
+    expect(parseReviewDecisionScope('approved')).toBe('once')
+    expect(parseReviewDecisionScope(undefined)).toBe('once')
+  })
+})
+
+describe('deny messages', () => {
+  it('names the capability and points the model at direct work', () => {
+    expect(blockedCapabilityMessage('subagents')).toContain('subagent')
+    expect(blockedCapabilityMessage('workflows')).toContain('workflow')
+    expect(reviewDeclinedMessage('workflows')).toContain('declined this workflow launch')
+  })
+
+  it('includes a user-provided reason but drops the generic default', () => {
+    expect(reviewDeclinedMessage('subagents', 'too expensive')).toContain('Reason: too expensive')
+    expect(reviewDeclinedMessage('subagents', 'User declined')).not.toContain('Reason:')
+  })
+})

--- a/agent-container/src/capability-policies.ts
+++ b/agent-container/src/capability-policies.ts
@@ -1,0 +1,113 @@
+import { z } from 'zod'
+import type { AgentCapabilityPolicies, CapabilityPolicy } from './types'
+
+export type Capability = 'subagents' | 'workflows'
+
+// The SDK exposes subagent spawning as `Task` (legacy) and `Agent` (its rename);
+// both names gate as the same capability.
+export const SUBAGENT_TOOL_NAMES: ReadonlySet<string> = new Set(['Task', 'Agent'])
+export const WORKFLOW_TOOL_NAME = 'Workflow'
+
+// Boundary schema for policies arriving over HTTP (create-session / send-message
+// bodies). `.parse()` at the seam so a malformed value fails loudly instead of
+// silently degrading a block to allow.
+export const capabilityPolicySchema = z.enum(['allow', 'review', 'block'])
+export const agentCapabilityPoliciesSchema = z
+  .object({
+    subagents: capabilityPolicySchema.optional(),
+    workflows: capabilityPolicySchema.optional(),
+  })
+  .optional()
+
+// Boundary schema for the resolve payload of a capability review (host answers
+// via POST /inputs/:toolUseId/resolve). Unknown shapes count as a plain
+// one-time approval — the approval itself was explicit, only the scope is soft.
+const reviewDecisionSchema = z.object({ scope: z.enum(['once', 'session']).catch('once') })
+
+export function parseReviewDecisionScope(value: unknown): 'once' | 'session' {
+  const parsed = reviewDecisionSchema.safeParse(value)
+  return parsed.success ? parsed.data.scope : 'once'
+}
+
+export function capabilityForTool(toolName: string): Capability | null {
+  if (SUBAGENT_TOOL_NAMES.has(toolName)) return 'subagents'
+  if (toolName === WORKFLOW_TOOL_NAME) return 'workflows'
+  return null
+}
+
+export function policyFor(
+  policies: AgentCapabilityPolicies | undefined,
+  capability: Capability,
+): CapabilityPolicy {
+  return policies?.[capability] ?? 'allow'
+}
+
+/**
+ * Applies block policies to the query's tool lists. Blocked capabilities are
+ * removed from allowedTools AND added to disallowedTools so the model never
+ * sees the tool; blocked workflows additionally turn off the enableWorkflows
+ * settings flag that surfaces the Workflow tool in headless mode.
+ */
+export function applyCapabilityPolicies(
+  policies: AgentCapabilityPolicies | undefined,
+  base: { allowedTools: string[]; disallowedTools: string[] },
+): { allowedTools: string[]; disallowedTools: string[]; enableWorkflows: boolean } {
+  const subagents = policyFor(policies, 'subagents')
+  const workflows = policyFor(policies, 'workflows')
+  const allowedTools =
+    subagents === 'block'
+      ? base.allowedTools.filter(t => !SUBAGENT_TOOL_NAMES.has(t))
+      : [...base.allowedTools]
+  const disallowedTools = [...base.disallowedTools]
+  if (subagents === 'block') disallowedTools.push(...SUBAGENT_TOOL_NAMES)
+  if (workflows === 'block') disallowedTools.push(WORKFLOW_TOOL_NAME)
+  return { allowedTools, disallowedTools, enableWorkflows: workflows !== 'block' }
+}
+
+/**
+ * Decides whether a tool call must be gated. Returns null when the call may
+ * proceed (not a capability launch, policy is allow, or a session-scoped
+ * grant covers it). A grant never overrides block.
+ */
+export function capabilityGateFor(
+  toolName: string,
+  policies: AgentCapabilityPolicies | undefined,
+  sessionGrants: ReadonlySet<Capability>,
+): { capability: Capability; policy: 'review' | 'block' } | null {
+  const capability = capabilityForTool(toolName)
+  if (!capability) return null
+  const policy = policyFor(policies, capability)
+  if (policy === 'allow') return null
+  if (policy === 'review' && sessionGrants.has(capability)) return null
+  return { capability, policy }
+}
+
+/**
+ * True when a policy update flips the block boundary for either capability.
+ * Block is baked into the query options (tool lists + system prompt), so
+ * crossing it requires an interrupt+restart; allow<->review does not.
+ */
+export function blockBoundaryChanged(
+  current: AgentCapabilityPolicies | undefined,
+  next: AgentCapabilityPolicies | undefined,
+): boolean {
+  const capabilities: Capability[] = ['subagents', 'workflows']
+  return capabilities.some(
+    c => (policyFor(current, c) === 'block') !== (policyFor(next, c) === 'block'),
+  )
+}
+
+const CAPABILITY_LABELS: Record<Capability, string> = {
+  subagents: 'subagent',
+  workflows: 'workflow',
+}
+
+export function blockedCapabilityMessage(capability: Capability): string {
+  return `Launching ${CAPABILITY_LABELS[capability]}s is disabled in this app's settings. Do the work directly in this session instead of delegating it.`
+}
+
+export function reviewDeclinedMessage(capability: Capability, reason?: string): string {
+  const base = `The user declined this ${CAPABILITY_LABELS[capability]} launch.`
+  const suffix = ' Continue the task without it — do the work directly in this session, or ask the user how they would like to proceed.'
+  return reason && reason !== 'User declined' ? `${base} Reason: ${reason}.${suffix}` : `${base}${suffix}`
+}

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -44,6 +44,17 @@ function mcpToolNames(
 import { inputManager } from './input-manager';
 import { sanitizeMcpName } from './sanitize-mcp-name';
 import { renderPrompt } from './render-prompt';
+import type { AgentCapabilityPolicies } from './types';
+import {
+  applyCapabilityPolicies,
+  blockBoundaryChanged,
+  blockedCapabilityMessage,
+  capabilityGateFor,
+  parseReviewDecisionScope,
+  policyFor,
+  reviewDeclinedMessage,
+  type Capability,
+} from './capability-policies';
 
 // Prefix for system-injected user messages that should be hidden in the UI.
 // Keep in sync with SYSTEM_MESSAGE_PREFIX in src/renderer/components/messages/message-list.tsx
@@ -199,6 +210,7 @@ export interface SystemPromptVars {
   CLAUDE_CONFIG_DIR: string;
   webSearchToolName: string;
   webFetchToolName: string;
+  subagentsEnabled: boolean;
   composioTriggers: boolean;
   webhookEndpoints: boolean;
   anyTriggers: boolean;
@@ -226,6 +238,7 @@ export function buildSystemPromptVars(
   modelPromptHints?: string[],
   webSearchProvider?: string,
   webFetchProvider?: string,
+  capabilityPolicies?: AgentCapabilityPolicies,
 ): SystemPromptVars {
   const composioTriggers = process.env.COMPOSIO_PLATFORM_MODE === 'true';
   const webhookEndpoints = process.env.PLATFORM_AUTH_ACTIVE === 'true';
@@ -238,6 +251,9 @@ export function buildSystemPromptVars(
     CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR || PROMPT_ENV_DEFAULTS.CLAUDE_CONFIG_DIR,
     webSearchToolName: webSearchProvider ? 'mcp__web__web_search' : 'WebSearch',
     webFetchToolName: webFetchProvider ? 'mcp__web__web_fetch' : 'WebFetch',
+    // Blocked subagents must not be advertised anywhere in the prompt; review
+    // still advertises them (the gate happens at call time).
+    subagentsEnabled: policyFor(capabilityPolicies, 'subagents') !== 'block',
     composioTriggers,
     webhookEndpoints,
     anyTriggers: composioTriggers || webhookEndpoints,
@@ -265,8 +281,9 @@ export function generateSystemPrompt(
   modelPromptHints?: string[],
   webSearchProvider?: string,
   webFetchProvider?: string,
+  capabilityPolicies?: AgentCapabilityPolicies,
 ): string {
-  const vars = buildSystemPromptVars(availableEnvVars, userSystemPrompt, modelPromptHints, webSearchProvider, webFetchProvider);
+  const vars = buildSystemPromptVars(availableEnvVars, userSystemPrompt, modelPromptHints, webSearchProvider, webFetchProvider, capabilityPolicies);
   return renderPrompt(SYSTEM_PROMPT, vars);
 }
 
@@ -360,6 +377,8 @@ export interface ClaudeCodeProcessOptions {
   maxBudgetUsd?: number;
   customEnvVars?: Record<string, string>;
   effort?: EffortLevel;
+  capabilityPolicies?: AgentCapabilityPolicies;
+  sessionCapabilityGrants?: Capability[];
 }
 
 export class ClaudeCodeProcess extends EventEmitter {
@@ -381,6 +400,17 @@ export class ClaudeCodeProcess extends EventEmitter {
   private maxBudgetUsd: number | undefined;
   private customEnvVars: Record<string, string> | undefined;
   private effort: EffortLevel | undefined;
+  private capabilityPolicies: AgentCapabilityPolicies | undefined;
+  // Session-scoped review grants ("Allow for this session"). Scoped to the
+  // SESSION, not the process: they must survive idle-eviction + resume (the
+  // session-manager persists them via the 'capability-grant' event), or the
+  // host's grant record diverges and a gated launch hangs with no card.
+  private sessionCapabilityGrants: Set<Capability>;
+  // Kept so the system prompt can be regenerated when a capability block
+  // boundary flips mid-session (the prompt gates delegation sections on it).
+  private availableEnvVars: string[] | undefined;
+  private userSystemPrompt: string | undefined;
+  private modelPromptHints: string[] | undefined;
   private isReady: boolean = false;
   private isProcessing: boolean = false;
   // Monotonic id of the current query; bumped by initializeQuery. A previous
@@ -427,12 +457,18 @@ export class ClaudeCodeProcess extends EventEmitter {
     this.maxBudgetUsd = options.maxBudgetUsd;
     this.customEnvVars = options.customEnvVars;
     this.effort = options.effort;
+    this.capabilityPolicies = options.capabilityPolicies;
+    this.sessionCapabilityGrants = new Set(options.sessionCapabilityGrants ?? []);
+    this.availableEnvVars = options.availableEnvVars;
+    this.userSystemPrompt = options.userSystemPrompt;
+    this.modelPromptHints = options.modelPromptHints;
     this.systemPrompt = generateSystemPrompt(
       options.availableEnvVars,
       options.userSystemPrompt,
       options.modelPromptHints,
       options.webSearchProvider,
-      options.webFetchProvider
+      options.webFetchProvider,
+      options.capabilityPolicies
     );
     // Set module-level reference for tools that need access to the process
     currentProcess = this;
@@ -503,6 +539,23 @@ export class ClaudeCodeProcess extends EventEmitter {
 
     console.log(`[Session ${this.sessionId}] createQuery: model=${this.model ?? '(default)'}, effort=${this.effort ?? '(default)'}`);
 
+    // Block-tier policies remove the capability at the source: the tool is
+    // stripped from the query (and the system prompt stops advertising it)
+    // rather than denied call-by-call. Review-tier gating happens in canUseTool.
+    const capabilityTools = applyCapabilityPolicies(this.capabilityPolicies, {
+      allowedTools: ['Skill', 'Task', 'Agent', ...remoteMcpToolPatterns],
+      disallowedTools: [
+        'TaskOutput', 'Monitor', 'DesignSync',
+        'CronCreate', 'CronDelete', 'CronList',
+        'ScheduleWakeup', 'RemoteTrigger', 'PushNotification',
+        'EnterWorktree', 'ExitWorktree',
+        // Suppress native WebSearch only when a host vendor is active; it's replaced by mcp__web__web_search.
+        ...(this.webSearchProvider ? ['WebSearch'] : []),
+        // Same for native WebFetch → mcp__web__web_fetch when a host fetch vendor is active.
+        ...(this.webFetchProvider ? ['WebFetch'] : []),
+      ],
+    });
+
     return query({
       prompt: this.messageQueue!,
       options: {
@@ -520,19 +573,10 @@ export class ClaudeCodeProcess extends EventEmitter {
         // the `settings` flag layer (`enableWorkflows` is a Settings field, not a
         // top-level Option). Without it the model can't see a Workflow tool at all
         // and falls back to simulating with Agent subagents.
-        settings: { enableWorkflows: true },
+        settings: { enableWorkflows: capabilityTools.enableWorkflows },
         settingSources: ['user', 'project'],
-        allowedTools: ['Skill', 'Task', 'Agent', ...remoteMcpToolPatterns],
-        disallowedTools: [
-          'TaskOutput', 'Monitor', 'DesignSync',
-          'CronCreate', 'CronDelete', 'CronList',
-          'ScheduleWakeup', 'RemoteTrigger', 'PushNotification',
-          'EnterWorktree', 'ExitWorktree',
-          // Suppress native WebSearch only when a host vendor is active; it's replaced by mcp__web__web_search.
-          ...(this.webSearchProvider ? ['WebSearch'] : []),
-          // Same for native WebFetch → mcp__web__web_fetch when a host fetch vendor is active.
-          ...(this.webFetchProvider ? ['WebFetch'] : []),
-        ],
+        allowedTools: capabilityTools.allowedTools,
+        disallowedTools: capabilityTools.disallowedTools,
         // Request summarized thinking so reasoning text streams to the UI. Without an
         // explicit `display`, Opus 4.8/4.7 default to `omitted` — thinking_delta events
         // arrive empty (only a signature), so the UI can show "Thinking" but no text.
@@ -704,6 +748,68 @@ export class ClaudeCodeProcess extends EventEmitter {
                     inputManager.setCurrentToolUseId(toolUseId, this.sessionId);
                   }
                   return {};
+                },
+              ],
+            },
+            {
+              // Three-tier launch policy for subagents (Task/Agent) and
+              // workflows (Workflow). This MUST be a PreToolUse hook, not a
+              // canUseTool branch: under permissionMode 'bypassPermissions'
+              // the SDK auto-approves every regular tool call before
+              // canUseTool is consulted (CLAUDE_SDK_CAN_USE_TOOL_SHADOWED) —
+              // only hook denies still apply. Review parks the launch on a
+              // pending input (same round-trip as AskUserQuestion): the host
+              // renders the approval card and answers via
+              // /inputs/:toolUseId/resolve|reject. Block is enforced at query
+              // creation (tools stripped); the deny here is the backstop for
+              // a policy that tightened mid-session.
+              matcher: '^(Task|Agent|Workflow)$',
+              hooks: [
+                async (input, toolUseId) => {
+                  const hookToolName = (input as any).tool_name as string | undefined;
+                  const gate = capabilityGateFor(hookToolName ?? '', this.capabilityPolicies, this.sessionCapabilityGrants);
+                  if (!gate) return {};
+                  if (gate.policy === 'block') {
+                    console.log(`[PreToolUse] Denying ${hookToolName} (${gate.capability} blocked)`);
+                    return {
+                      hookSpecificOutput: {
+                        hookEventName: 'PreToolUse' as const,
+                        permissionDecision: 'deny' as const,
+                        permissionDecisionReason: blockedCapabilityMessage(gate.capability),
+                      },
+                    };
+                  }
+
+                  const requestId = toolUseId || `capability-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+                  console.log(`[PreToolUse] Capability review for ${hookToolName} (${gate.capability}), toolUseId: ${requestId}`);
+                  try {
+                    // Park until the user decides via the approval card
+                    const decision = await inputManager.createPendingWithType<Record<string, string>>(
+                      requestId,
+                      'capability_review',
+                      { capability: gate.capability, toolName: hookToolName },
+                      this.sessionId
+                    );
+                    if (parseReviewDecisionScope(decision) === 'session') {
+                      console.log(`[PreToolUse] Session-scoped grant for ${gate.capability}`);
+                      this.sessionCapabilityGrants.add(gate.capability);
+                      // Session-manager persists it so the grant survives eviction+resume.
+                      this.emit('capability-grant', { capability: gate.capability });
+                    }
+                    return {};
+                  } catch (error) {
+                    console.log(`[PreToolUse] Capability launch declined:`, error);
+                    return {
+                      hookSpecificOutput: {
+                        hookEventName: 'PreToolUse' as const,
+                        permissionDecision: 'deny' as const,
+                        permissionDecisionReason: reviewDeclinedMessage(
+                          gate.capability,
+                          error instanceof Error ? error.message : undefined
+                        ),
+                      },
+                    };
+                  }
                 },
               ],
             },
@@ -956,7 +1062,7 @@ export class ClaudeCodeProcess extends EventEmitter {
     }
   }
 
-  async sendMessage(content: string, uuid?: UUID, options?: { effort?: EffortLevel; model?: string; shouldQuery?: boolean }): Promise<void> {
+  async sendMessage(content: string, uuid?: UUID, options?: { effort?: EffortLevel; model?: string; shouldQuery?: boolean; capabilityPolicies?: AgentCapabilityPolicies }): Promise<void> {
     const effort = options?.effort;
     const model = options?.model;
 
@@ -969,6 +1075,27 @@ export class ClaudeCodeProcess extends EventEmitter {
     // compare ids directly. Switching between two pinned versions of a family
     // (e.g. opus-4-6 -> opus-4-7) is now a real, intentional switch.
     const modelChanged = model !== undefined && model !== this.model;
+
+    // Capability policies follow the host's CURRENT settings, refreshed on
+    // every message so a long-lived session tracks settings changes. Review
+    // and the block backstop read the field at call time; only a block
+    // boundary flip needs a re-query (tool lists + prompt are baked in).
+    const nextPolicies = options?.capabilityPolicies;
+    const capabilityBlockChanged = nextPolicies !== undefined && blockBoundaryChanged(this.capabilityPolicies, nextPolicies);
+    if (nextPolicies !== undefined) {
+      this.capabilityPolicies = nextPolicies;
+      if (capabilityBlockChanged) {
+        this.systemPrompt = generateSystemPrompt(
+          this.availableEnvVars,
+          this.userSystemPrompt,
+          this.modelPromptHints,
+          this.webSearchProvider,
+          this.webFetchProvider,
+          nextPolicies
+        );
+      }
+      this.reconcilePendingCapabilityReviews();
+    }
 
     if (effortChanged) {
       this.effort = effort;
@@ -986,11 +1113,15 @@ export class ClaudeCodeProcess extends EventEmitter {
         await this.currentStop.catch(() => undefined);
       }
       await this.restart();
-    } else if (effortChanged) {
+    } else if (effortChanged || capabilityBlockChanged) {
       // Effort can only be set at query creation time — the SDK has no setEffort
       // facility — so any effort change forces an interrupt + re-query. The new
-      // model (if also changed) is picked up by the same restart.
-      const reasons: string[] = [`effort ${currentEffort} -> ${effort}`];
+      // model (if also changed) is picked up by the same restart. A capability
+      // block boundary flip re-queries for the same reason: the tool lists and
+      // system prompt only apply at query creation.
+      const reasons: string[] = [];
+      if (effortChanged) reasons.push(`effort ${currentEffort} -> ${effort}`);
+      if (capabilityBlockChanged) reasons.push('capability block boundary changed');
       if (modelChanged) reasons.push(`model -> ${this.model}`);
       console.log(`[Session ${this.sessionId}] Restarting query (${reasons.join(', ')})`);
       await this.interrupt();
@@ -1039,6 +1170,29 @@ export class ClaudeCodeProcess extends EventEmitter {
     // the tracker reads settled leaves the reaper free to kill the turn it
     // just started.
     this.emit('outbound-message', { expectsResponse: shouldQuery !== false });
+  }
+
+  /**
+   * Settles pending capability reviews that a policy change made moot: a
+   * capability now on 'allow' auto-approves them (one-time), one now on
+   * 'block' rejects them. Without this, loosening the policy would strand
+   * the paused launch — the host stops rendering a card the container is
+   * still waiting on.
+   */
+  private reconcilePendingCapabilityReviews(): void {
+    for (const pending of inputManager.getAllPending()) {
+      if (pending.inputType !== 'capability_review' || pending.sessionId !== this.sessionId) continue;
+      const capability = (pending.metadata as { capability?: Capability } | undefined)?.capability;
+      if (capability !== 'subagents' && capability !== 'workflows') continue;
+      const policy = policyFor(this.capabilityPolicies, capability);
+      if (policy === 'allow') {
+        console.log(`[Session ${this.sessionId}] Auto-approving pending ${capability} review ${pending.toolUseId} (policy now allow)`);
+        inputManager.resolve(pending.toolUseId, { scope: 'once' });
+      } else if (policy === 'block') {
+        console.log(`[Session ${this.sessionId}] Rejecting pending ${capability} review ${pending.toolUseId} (policy now block)`);
+        inputManager.reject(pending.toolUseId, blockedCapabilityMessage(capability));
+      }
+    }
   }
 
   /**

--- a/agent-container/src/host-auth.test.ts
+++ b/agent-container/src/host-auth.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// host-auth captures SUPERAGENT_HOST_TOKEN at module load and deletes it from
+// process.env, so each test re-imports a fresh module instance.
+async function loadHostAuth(token: string | undefined) {
+  vi.resetModules();
+  if (token === undefined) {
+    delete process.env.SUPERAGENT_HOST_TOKEN;
+  } else {
+    process.env.SUPERAGENT_HOST_TOKEN = token;
+  }
+  return await import('./host-auth');
+}
+
+describe('host-auth', () => {
+  beforeEach(() => {
+    delete process.env.SUPERAGENT_HOST_TOKEN;
+  });
+
+  it('captures the token and strips it from process.env so children cannot inherit it', async () => {
+    const hostAuth = await loadHostAuth('hostc_secret');
+
+    expect(process.env.SUPERAGENT_HOST_TOKEN).toBeUndefined();
+    expect(hostAuth.hostAuthEnabled()).toBe(true);
+    expect(hostAuth.hostAuthHeaders()).toEqual({ 'x-superagent-host-token': 'hostc_secret' });
+  });
+
+  it('accepts only the exact token', async () => {
+    const hostAuth = await loadHostAuth('hostc_secret');
+
+    expect(hostAuth.isValidHostToken('hostc_secret')).toBe(true);
+    expect(hostAuth.isValidHostToken('hostc_wrong')).toBe(false);
+    expect(hostAuth.isValidHostToken('')).toBe(false);
+    expect(hostAuth.isValidHostToken(undefined)).toBe(false);
+  });
+
+  it('disables auth when no token was provided (older host)', async () => {
+    const hostAuth = await loadHostAuth(undefined);
+
+    expect(hostAuth.hostAuthEnabled()).toBe(false);
+    expect(hostAuth.hostAuthHeaders()).toEqual({});
+    expect(hostAuth.isValidHostToken(undefined)).toBe(true);
+    expect(hostAuth.isValidHostToken('anything')).toBe(true);
+  });
+});

--- a/agent-container/src/host-auth.ts
+++ b/agent-container/src/host-auth.ts
@@ -1,0 +1,43 @@
+import crypto from 'crypto';
+
+/**
+ * Host→container API authentication.
+ *
+ * The container API is reachable from inside the container (the agent's Bash
+ * shares the network namespace), so anything policy-bearing — session creation,
+ * message sends with capabilityPolicies, input resolve/reject — must prove it
+ * came from the host. The host passes a per-agent secret via the
+ * SUPERAGENT_HOST_TOKEN env var; we capture it at module load and delete it
+ * from process.env so no child process (the Claude CLI and every Bash/tool it
+ * spawns — they inherit `...process.env`) ever sees it.
+ *
+ * Residual exposure: the boot-time environment stays readable at
+ * /proc/1/environ for same-uid processes, so this raises the bar rather than
+ * providing hard isolation. Hard isolation needs a uid split between the
+ * server and the CLI.
+ *
+ * When the env var is absent (older host, dev setups), auth is disabled and
+ * the API behaves as before.
+ */
+const HOST_API_TOKEN: string | undefined = process.env.SUPERAGENT_HOST_TOKEN || undefined;
+delete process.env.SUPERAGENT_HOST_TOKEN;
+
+export const HOST_TOKEN_HEADER = 'x-superagent-host-token';
+
+export function hostAuthEnabled(): boolean {
+  return HOST_API_TOKEN !== undefined;
+}
+
+/** Headers for in-process code that calls the container's own API (e.g. browser tools). */
+export function hostAuthHeaders(): Record<string, string> {
+  return HOST_API_TOKEN ? { [HOST_TOKEN_HEADER]: HOST_API_TOKEN } : {};
+}
+
+export function isValidHostToken(presented: string | undefined): boolean {
+  if (!HOST_API_TOKEN) return true;
+  if (!presented) return false;
+  // Hash both sides so timingSafeEqual gets equal-length buffers.
+  const a = crypto.createHash('sha256').update(presented).digest();
+  const b = crypto.createHash('sha256').update(HOST_API_TOKEN).digest();
+  return crypto.timingSafeEqual(a, b);
+}

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { serve } from '@hono/node-server';
 import { SessionManager } from './session-manager';
 import { CreateSessionRequest, SendMessageRequest } from './types';
+import { agentCapabilityPoliciesSchema } from './capability-policies';
 import type { UUID } from 'crypto';
 import * as http from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
@@ -147,6 +148,7 @@ app.post('/sessions/:id/messages', async (c) => {
       effort: body.effort,
       model: body.model,
       shouldQuery: body.shouldQuery,
+      capabilityPolicies: agentCapabilityPoliciesSchema.parse(body.capabilityPolicies),
     });
 
     return c.json({ success: true }, 201);
@@ -1766,6 +1768,7 @@ async function handleWebSocketConnection(ws: WebSocket, sessionId: string) {
       await sessionManager.sendMessage(sessionId, content, payload.uuid, {
         effort: payload.effort,
         model: payload.model,
+        capabilityPolicies: agentCapabilityPoliciesSchema.parse(payload.capabilityPolicies),
       });
     } catch (error: any) {
       console.error('Error handling WebSocket message:', error);

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -1,5 +1,8 @@
 import { Hono } from 'hono';
 import { serve } from '@hono/node-server';
+// Captures SUPERAGENT_HOST_TOKEN and strips it from process.env — import early
+// so no later module can snapshot an environment that still contains it.
+import { HOST_TOKEN_HEADER, hostAuthEnabled, isValidHostToken } from './host-auth';
 import { SessionManager } from './session-manager';
 import { CreateSessionRequest, SendMessageRequest } from './types';
 import { agentCapabilityPoliciesSchema } from './capability-policies';
@@ -51,6 +54,17 @@ const app = new Hono();
 const sessionManager = new SessionManager();
 const WORKSPACE_DOWNLOADS_DIR = '/workspace/downloads';
 
+// The agent's own Bash can reach this API (shared network namespace), so every
+// endpoint that could loosen policy or self-approve an input must prove the
+// caller is the host. /health stays open for the Docker HEALTHCHECK.
+app.use('*', async (c, next) => {
+  if (!hostAuthEnabled() || c.req.path === '/health') return next();
+  if (!isValidHostToken(c.req.header(HOST_TOKEN_HEADER))) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+  return next();
+});
+
 // Health check endpoint
 app.get('/health', (c) => {
   return c.json({ status: 'ok', timestamp: new Date().toISOString() });
@@ -88,6 +102,17 @@ app.get('/sessions/:id', async (c) => {
     ...session,
     isRunning: sessionManager.isSessionRunning(sessionId),
   });
+});
+
+// Persisted "Allow for this session" review grants. The host consults this when
+// its in-memory grant mirror is cold (fresh host process against a live
+// container) before broadcasting a review card the container isn't waiting on.
+app.get('/sessions/:id/capability-grants', (c) => {
+  const grants = sessionManager.getSessionCapabilityGrants(c.req.param('id'));
+  if (grants === null) {
+    return c.json({ error: 'Session not found' }, 404);
+  }
+  return c.json({ grants });
 });
 
 app.get('/sessions', (c) => {
@@ -1698,6 +1723,14 @@ const browserWss = new WebSocketServer({ noServer: true });
 
 // Handle WebSocket upgrade
 server.on('upgrade', (request: http.IncomingMessage, socket: any, head: Buffer) => {
+  // Upgrades bypass the Hono middleware chain — enforce host auth here too.
+  const presentedToken = request.headers[HOST_TOKEN_HEADER];
+  if (!isValidHostToken(Array.isArray(presentedToken) ? presentedToken[0] : presentedToken)) {
+    socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+    socket.destroy();
+    return;
+  }
+
   const url = new URL(request.url || '', `http://${request.headers.host}`);
   const pathname = url.pathname;
 

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { UUID } from 'crypto';
-import { Session, SDKMessage, CreateSessionRequest, EffortLevel } from './types';
+import { Session, SDKMessage, CreateSessionRequest, EffortLevel, AgentCapabilityPolicies } from './types';
+import { agentCapabilityPoliciesSchema } from './capability-policies';
 import { ClaudeCodeProcess } from './claude-code';
 import { SessionPersistence } from './session-persistence';
 import { EventEmitter } from 'events';
@@ -169,6 +170,10 @@ export class SessionManager extends EventEmitter {
     // All sessions share the same working directory
     const workingDirectory = request.workingDirectory || this.baseWorkingDirectory;
 
+    // Boundary validation: a malformed policy must fail the request loudly,
+    // never silently degrade a block to allow.
+    const capabilityPolicies = agentCapabilityPoliciesSchema.parse(request.capabilityPolicies);
+
     // Ensure working directory exists
     if (!fs.existsSync(workingDirectory)) {
       fs.mkdirSync(workingDirectory, { recursive: true });
@@ -191,6 +196,7 @@ export class SessionManager extends EventEmitter {
       maxBudgetUsd: request.maxBudgetUsd,
       customEnvVars: request.customEnvVars,
       effort: request.effort,
+      capabilityPolicies,
     });
 
     // Promise to capture Claude's session ID and slash commands (emitted after first message is sent)
@@ -292,6 +298,11 @@ export class SessionManager extends EventEmitter {
       console.log(`Session ${sessionId} exited with code ${code}`);
     });
 
+    // Session-scoped review grants must survive eviction+resume.
+    process.on('capability-grant', ({ capability }: { capability: 'subagents' | 'workflows' }) => {
+      this.persistence.addSessionCapabilityGrant(sessionId, capability);
+    });
+
     // Persist the session
     this.persistence.saveSession({
       sessionId,
@@ -313,6 +324,7 @@ export class SessionManager extends EventEmitter {
       maxBudgetUsd: request.maxBudgetUsd,
       customEnvVars: request.customEnvVars,
       effort: request.effort,
+      capabilityPolicies,
       metadata: request.metadata,
     });
 
@@ -371,6 +383,8 @@ export class SessionManager extends EventEmitter {
         maxBudgetUsd: persisted.maxBudgetUsd,
         customEnvVars: persisted.customEnvVars,
         effort: persisted.effort,
+        capabilityPolicies: persisted.capabilityPolicies,
+        sessionCapabilityGrants: persisted.sessionCapabilityGrants,
       });
 
       const session: Session = {
@@ -420,6 +434,10 @@ export class SessionManager extends EventEmitter {
 
       process.on('exit', (code: number | null) => {
         console.log(`Resumed session ${sessionId} exited with code ${code}`);
+      });
+
+      process.on('capability-grant', ({ capability }: { capability: 'subagents' | 'workflows' }) => {
+        this.persistence.addSessionCapabilityGrant(sessionId, capability);
       });
 
       // Start the process (which will resume the Claude session)
@@ -495,7 +513,7 @@ export class SessionManager extends EventEmitter {
     sessionId: string,
     content: string,
     uuid?: UUID,
-    options?: { effort?: EffortLevel; model?: string; shouldQuery?: boolean }
+    options?: { effort?: EffortLevel; model?: string; shouldQuery?: boolean; capabilityPolicies?: AgentCapabilityPolicies }
   ): Promise<void> {
     let sessionData = this.sessions.get(sessionId);
 
@@ -538,6 +556,9 @@ export class SessionManager extends EventEmitter {
     }
     if (options?.model !== undefined) {
       this.persistence.updateModel(sessionId, options.model);
+    }
+    if (options?.capabilityPolicies !== undefined) {
+      this.persistence.updateCapabilityPolicies(sessionId, options.capabilityPolicies);
     }
 
     // Send to Claude Code process (messages are stored via handleMessage)

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -689,6 +689,12 @@ export class SessionManager extends EventEmitter {
     return sessionData.process.isRunning();
   }
 
+  // Reads persistence only — never resumes an evicted session the way
+  // getSession does. null = unknown session.
+  getSessionCapabilityGrants(sessionId: string): Array<'subagents' | 'workflows'> | null {
+    return this.persistence.getSessionCapabilityGrants(sessionId);
+  }
+
   async interruptSession(sessionId: string): Promise<{ found: boolean; discardedUuids: string[] }> {
     const sessionData = this.sessions.get(sessionId);
     if (!sessionData) {

--- a/agent-container/src/session-persistence.ts
+++ b/agent-container/src/session-persistence.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import { writeFileAtomicSync } from './atomic-file';
-import type { EffortLevel } from './types';
+import type { AgentCapabilityPolicies, EffortLevel } from './types';
 
 interface SessionMetadata {
   sessionId: string;
@@ -22,6 +22,12 @@ interface SessionMetadata {
   maxBudgetUsd?: number;
   customEnvVars?: Record<string, string>;
   effort?: EffortLevel;
+  // Must survive resume: doResumeSession starts the query straight from these
+  // options, so an unpersisted block policy would briefly re-expose the tools.
+  capabilityPolicies?: AgentCapabilityPolicies;
+  // "Allow for this session" review grants — session-scoped, so they must
+  // survive eviction+resume (the host's grant record assumes they do).
+  sessionCapabilityGrants?: Array<'subagents' | 'workflows'>;
   // Session classification (e.g. isAutomated) — must survive resume so the
   // idle-eviction class and browser-lock-on-result behavior stay correct.
   metadata?: Record<string, unknown>;
@@ -128,6 +134,22 @@ export class SessionPersistence {
     const session = this.sessions.get(sessionId);
     if (session) {
       session.model = model;
+      this.save();
+    }
+  }
+
+  updateCapabilityPolicies(sessionId: string, policies: AgentCapabilityPolicies | undefined): void {
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      session.capabilityPolicies = policies;
+      this.save();
+    }
+  }
+
+  addSessionCapabilityGrant(sessionId: string, capability: 'subagents' | 'workflows'): void {
+    const session = this.sessions.get(sessionId);
+    if (session && !session.sessionCapabilityGrants?.includes(capability)) {
+      session.sessionCapabilityGrants = [...(session.sessionCapabilityGrants ?? []), capability];
       this.save();
     }
   }

--- a/agent-container/src/session-persistence.ts
+++ b/agent-container/src/session-persistence.ts
@@ -153,4 +153,10 @@ export class SessionPersistence {
       this.save();
     }
   }
+
+  getSessionCapabilityGrants(sessionId: string): Array<'subagents' | 'workflows'> | null {
+    const session = this.sessions.get(sessionId);
+    if (!session) return null;
+    return session.sessionCapabilityGrants ?? [];
+  }
 }

--- a/agent-container/src/system-prompt-vars.test.ts
+++ b/agent-container/src/system-prompt-vars.test.ts
@@ -166,3 +166,55 @@ describe('generateSystemPrompt rendering', () => {
     expect(template).not.toMatch(/\$\{[A-Za-z_]+\}/)
   })
 })
+
+describe('subagent capability gating', () => {
+  const render = (policies?: { subagents?: 'allow' | 'review' | 'block'; workflows?: 'allow' | 'review' | 'block' }) =>
+    generateSystemPrompt(undefined, undefined, undefined, undefined, undefined, policies)
+
+  it.each([
+    { label: 'no policies', policies: undefined },
+    { label: 'subagents allow', policies: { subagents: 'allow' as const } },
+    { label: 'subagents review', policies: { subagents: 'review' as const } },
+  ])('$label: delegation sections render', ({ policies }) => {
+    const out = render(policies)
+    expect(out).toContain('Use the Agent tool with specialized agents')
+    expect(out).toContain('### Web Browser Agent (delegate browsing tasks)')
+    expect(out).toContain('## Dashboard Builder Agent')
+    expect(out).not.toContain('## Building Dashboards')
+    expect(out).not.toMatch(/<%|%>/)
+  })
+
+  it('subagents block: no delegation mention survives anywhere in the prompt', () => {
+    process.env.HOST_PLATFORM = 'darwin' // include the computer-use block too
+    const out = render({ subagents: 'block' })
+    expect(out).not.toMatch(/subagent/i)
+    expect(out).not.toContain('Agent tool')
+    expect(out).not.toContain('Task(')
+    // "don't delegate further" (cross-agent invocation) legitimately survives;
+    // every instruction TO delegate must not.
+    expect(out).not.toMatch(/delegate to the|Delegate:|delegating|delegations/i)
+    // Direct-work fallbacks take the delegation sections' place
+    expect(out).toContain('### Browsing Workflow')
+    expect(out).toContain('## Building Dashboards')
+    expect(out).not.toMatch(/<%|%>/)
+  })
+
+  it('workflow policy does not affect the prompt (the Workflow tool self-describes)', () => {
+    expect(render({ workflows: 'block' })).toBe(render(undefined))
+  })
+
+  it('blocking subagents orphans no heading', () => {
+    const bodyless = (prompt: string) => {
+      const lines = prompt.split('\n')
+      return lines.filter((line, i) => {
+        if (!/^#{1,4} /.test(line)) return false
+        const next = lines.slice(i + 1).find(l => l.trim() !== '')
+        return next !== undefined && /^#{1,4} /.test(next)
+      })
+    }
+    for (const desktop of [true, false]) {
+      process.env.HOST_PLATFORM = desktop ? 'darwin' : 'linux'
+      expect(bodyless(render({ subagents: 'block' }))).toEqual(bodyless(render(undefined)))
+    }
+  })
+})

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -85,8 +85,10 @@ Match responses to the task: a simple question gets a direct answer, not headers
 In code: default to writing no comments. Never write multi-paragraph docstrings or multi-line comment blocks — one short line max. Don't create planning, decision, or analysis documents unless the user asks for them — work from conversation context, not intermediate files.
 
 # Session-specific guidance
+<%#subagentsEnabled%>
  - Use the Agent tool with specialized agents when the task at hand matches the agent's description. Subagents are valuable for parallelizing independent queries or for protecting the main context window from excessive results, but they should not be used excessively when not needed. Importantly, avoid duplicating work that subagents are already doing - if you delegate research to a subagent, do not also perform the same searches yourself.
  - For broad codebase exploration or research that'll take more than 3 queries, spawn Agent with subagent_type=Explore. Explore is read-only search; don't use it for code review, design-doc auditing, or open-ended analysis that needs whole-file context.
+<%/subagentsEnabled%>
  - When the user types `/<skill-name>`, invoke it via Skill. Only use skills listed in the user-invocable skills section — don't guess.
 
 # auto memory
@@ -656,10 +658,11 @@ The file is a JSON array — each item has a `name` and either a `link` (https:/
 You have a web browser for interacting with websites. The user can see the browser live and interact with it directly.
 
 ### Browser Lifecycle Tools (use these directly)
-- `browser_open(url)` — Open browser and navigate to URL. Call this before delegating to the web-browser agent.
+- `browser_open(url)` — Open browser and navigate to URL. Call this before any browsing work.
 - `browser_close()` — Close the browser and free resources. Call when done with all browsing.
 - `browser_get_state()` — Get the current URL, a screenshot, and accessibility snapshot in one call. Use to check what the browser is showing.
 
+<%#subagentsEnabled%>
 ### Web Browser Agent (delegate browsing tasks)
 For any multi-step web interaction (navigating, filling forms, clicking, searching, extracting data), **delegate to the web-browser agent** using the Task tool. This agent runs on a cheaper model and handles all detailed browser interactions autonomously.
 
@@ -683,7 +686,20 @@ The web-browser agent:
 - Track the URLs reported by the agent so you know where the browser is
 - Remember to close the browser when you're done to free resources
 - Downloads triggered in the browser will be saved to `/workspace/downloads/`
+<%/subagentsEnabled%>
+<%^subagentsEnabled%>
+### Browsing Workflow
+1. **Use web search** if you are unsure about the URL or need to find the correct page
+2. `browser_open("https://correct-url.com")` — Open the browser
+3. Interact directly with the browser tools (`mcp__browser__*`): use `browser_get_state()` to observe, then click/fill/scroll as needed
+4. `browser_close()` — Close when done with all browsing
 
+### Tips
+- If you encounter a login page, CAPTCHA, or 2FA, call `mcp__user-input__request_browser_input` to prompt the user
+- Downloads triggered in the browser will be saved to `/workspace/downloads/`
+<%/subagentsEnabled%>
+
+<%#subagentsEnabled%>
 ## Dashboard Builder Agent
 
 For creating, editing, or debugging dashboards (artifacts), **delegate to the dashboard-builder agent** using the Task tool. This agent runs on Opus and handles the full dashboard lifecycle: scaffolding, coding, starting, verifying via screenshots, and iterating.
@@ -710,6 +726,12 @@ The dashboard-builder agent:
 - Be specific about what data the dashboard should show and where it comes from
 - For edits, mention the dashboard slug and what specifically needs to change
 - The agent will iterate on its own — it starts the dashboard, checks the screenshot, and fixes issues autonomously
+<%/subagentsEnabled%>
+<%^subagentsEnabled%>
+## Building Dashboards
+
+For creating, editing, or debugging dashboards (artifacts), use the dashboard tools directly: `mcp__dashboards__create_dashboard` to scaffold, file tools (Read, Write, Edit, Bash) to code, `mcp__dashboards__start_dashboard` to run it, and `mcp__dashboards__get_dashboard_logs` to debug. Verify your work via the screenshot returned by `start_dashboard` and iterate until it looks right. Both plain (Bun.serve) and React (Vite) dashboards are supported. When editing an existing dashboard, find its slug via `mcp__dashboards__list_dashboards` first.
+<%/subagentsEnabled%>
 
 <%#computerUse%>
 ## Computer Use (macOS and Windows)
@@ -717,13 +739,14 @@ The dashboard-builder agent:
 You can control native desktop applications on the user's computer. The user can see a visual halo around any app you're controlling.
 
 ### App Lifecycle Tools (use these directly)
-- `computer_launch(name)` — Launch an app and grab it (locks onto it, shows halo). Call this before delegating to the computer-use agent.
+- `computer_launch(name)` — Launch an app and grab it (locks onto it, shows halo). Call this before any app interaction work.
 - `computer_quit(name)` — Quit an app. Call when done with it.
 - `computer_ungrab()` — Release the currently grabbed app (removes halo). Call when done with all computer use.
 - `computer_apps()` — List running applications.
 - `computer_windows(app?)` — List open windows.
 - `computer_snapshot(interactive: true, compact: true)` — Get the accessibility tree with actionable refs. Use this for all observation needs, screenshots as fallback for pixel-level content only or when the snapshots are off.
 
+<%#subagentsEnabled%>
 ### Computer Use Agent (delegate app interaction tasks)
 For any multi-step app interaction (clicking buttons, filling forms, reading content, navigating menus), **delegate to the computer-use agent** using the Task tool. This agent runs on a cheaper model and handles all detailed app interactions autonomously.
 
@@ -747,6 +770,20 @@ The computer-use agent:
 - The computer-use agent will re-snapshot after every interaction to stay in sync with the UI
 - Menu actions (`computer_menu("File > Save")`) are often more reliable than clicking toolbar buttons
 - Always ungrab the app window when you're done to remove the halo and free resources - only keep it after responding if you are still mid task (like waiting for user input or in the middle of a multi-step interaction)
+<%/subagentsEnabled%>
+<%^subagentsEnabled%>
+### Workflow
+1. `computer_launch("AppName")` — Launch and grab the app
+2. Interact directly with the app interaction tools (click, fill, type, key, scroll, snapshot, screenshot, menu, etc.), re-snapshotting after every interaction to stay in sync with the UI
+3. `computer_ungrab()` — Release the app when done
+4. `computer_quit("AppName")` — Quit if no longer needed
+
+### Tips
+- Use `computer_grab(app)` to switch to a different app without launching it
+- Use the snapshot tool first before taking screenshots. Snapshot provides a structured representation of the app's UI, which is more reliable for interaction than raw screenshots.
+- Menu actions (`computer_menu("File > Save")`) are often more reliable than clicking toolbar buttons
+- Always ungrab the app window when you're done to remove the halo and free resources - only keep it after responding if you are still mid task (like waiting for user input or in the middle of a multi-step interaction)
+<%/subagentsEnabled%>
 
 <%/computerUse%>
 ## Language Guidelines for User-Facing Requests

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -10,6 +10,7 @@ import { tool } from '@anthropic-ai/claude-agent-sdk'
 import { readFile } from 'fs/promises'
 import { z } from 'zod'
 import { resizeScreenshot } from '../image-utils'
+import { hostAuthHeaders } from '../host-auth'
 import { tabManager } from '../tab-manager'
 import { formatUrlDigest, formatUrlDigestBrief, formatFillReadback, formatScrollDigest, type UrlDigest, type ScrollInfo } from '../browser-digest'
 
@@ -66,9 +67,11 @@ export function createBrowserTools(getSessionId: () => string | null) {
     body: Record<string, unknown>
   ): Promise<{ success: boolean; data?: unknown; error?: string }> {
     try {
+      // In-process self-call to our own server: needs the host token now that
+      // the API rejects unauthenticated callers.
       const response = await fetch(`${CONTAINER_URL}/browser/${endpoint}`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...hostAuthHeaders() },
         body: JSON.stringify({ sessionId: getSessionId(), ...body }),
       })
       const data = await response.json() as Record<string, unknown>

--- a/agent-container/src/types.ts
+++ b/agent-container/src/types.ts
@@ -51,6 +51,16 @@ export interface FileTree {
   children?: FileTree[];
 }
 
+// Three-tier launch policy for a delegation capability. 'review' holds each
+// launch until the user approves it; 'block' removes the capability from the
+// session entirely (tools + prompt), with a call-time deny as backstop.
+export type CapabilityPolicy = 'allow' | 'review' | 'block';
+
+export interface AgentCapabilityPolicies {
+  subagents?: CapabilityPolicy;
+  workflows?: CapabilityPolicy;
+}
+
 export interface CreateSessionRequest {
   metadata?: Record<string, any>;
   workingDirectory?: string;
@@ -72,6 +82,7 @@ export interface CreateSessionRequest {
   customEnvVars?: Record<string, string>; // User-defined env vars for the agent process
   maxBrowserTabs?: number; // Max browser tabs allowed (default 10)
   effort?: EffortLevel; // Initial thinking effort level
+  capabilityPolicies?: AgentCapabilityPolicies; // Launch policies for subagents/workflows (absent = allow)
 }
 
 export interface SendMessageRequest {
@@ -81,4 +92,5 @@ export interface SendMessageRequest {
   effort?: EffortLevel; // If set and different from current session effort, triggers interrupt+restart with new effort
   model?: string; // If set and different from current session model, triggers interrupt+restart with new model
   shouldQuery?: boolean; // When false, appends to transcript without triggering an assistant turn
+  capabilityPolicies?: AgentCapabilityPolicies; // Current launch policies; a block-boundary change triggers interrupt+restart
 }

--- a/e2e/specs/capability-review.spec.ts
+++ b/e2e/specs/capability-review.spec.ts
@@ -84,17 +84,19 @@ test.describe('Capability launch review', () => {
     await sessionPage.waitForInputEnabled(15000)
 
     // Second launch in the same session: the host-side grant suppresses the
-    // review broadcast entirely.
+    // review broadcast entirely. Wait for the full turn to settle — an
+    // unwanted card would still be showing (nothing ever resolves it).
     await sessionPage.sendMessage('launch workflow')
-    await page.waitForTimeout(4000)
+    await sessionPage.waitForInputEnabled(15000)
     await expect(reviewCard(page)).toHaveCount(0)
   })
 
   test('subagent launches do not prompt under the default allow policy', async ({ page }) => {
     await sessionPage.sendMessage('launch subagent')
 
-    // Give the stream time to deliver the Task tool_use, then assert no card.
-    await page.waitForTimeout(4000)
+    // Wait for the whole turn (including the Task tool_use) to settle — an
+    // unwanted card would still be showing (nothing ever resolves it).
+    await sessionPage.waitForInputEnabled(15000)
     await expect(reviewCard(page)).toHaveCount(0)
   })
 })

--- a/e2e/specs/capability-review.spec.ts
+++ b/e2e/specs/capability-review.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+
+/**
+ * Allow/review/block launch policies for subagents (Task) and workflows.
+ *
+ * The mock scenarios stream a `Workflow` / `Task` tool_use through the real
+ * MessagePersister, which applies the real policy gate (defaults: subagents
+ * allow, workflows review) and broadcasts `capability_review_request`. The
+ * card's decisions hit the real /capability-review route, which resolves or
+ * rejects the mock container's pending input — same wiring as production.
+ *
+ * Sequential (opts out of fullyParallel): the settings test temporarily
+ * flips GLOBAL policies, which would race the review-card tests in sibling
+ * workers.
+ */
+test.describe.configure({ mode: 'default' })
+test.describe('Capability launch review', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+  let testAgentName: string
+
+  const reviewCard = (page: import('@playwright/test').Page) =>
+    page.locator('[data-testid="capability-review-request"]')
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+
+    testAgentName = `Capability Agent ${testInfo.workerIndex}-${Date.now()}`
+    await agentPage.createAgent(testAgentName)
+  })
+
+  test('workflow launch under default settings shows the rich review card', async ({ page }) => {
+    await sessionPage.sendMessage('launch workflow')
+
+    const card = reviewCard(page)
+    await expect(card).toBeVisible({ timeout: 15000 })
+
+    // Rich pre-flight display parsed from the script meta
+    await expect(card).toContainText('sample-audit')
+    await expect(card).toContainText('Audit the sample data set')
+    await expect(card).toContainText('2 phases')
+    await expect(card).toContainText('Scan')
+    await expect(card).toContainText('Verify')
+  })
+
+  test('Run approves the launch and the turn completes', async ({ page }) => {
+    await sessionPage.sendMessage('launch workflow')
+    await expect(reviewCard(page)).toBeVisible({ timeout: 15000 })
+
+    await page.locator('[data-testid="capability-review-run-btn"]').click()
+
+    await expect(reviewCard(page)).toHaveCount(0, { timeout: 10000 })
+    await sessionPage.waitForInputEnabled(15000)
+  })
+
+  test('Block declines the launch and the turn continues', async ({ page }) => {
+    await sessionPage.sendMessage('launch workflow')
+    await expect(reviewCard(page)).toBeVisible({ timeout: 15000 })
+
+    await page.locator('[data-testid="capability-review-block-btn"]').click()
+
+    await expect(reviewCard(page)).toHaveCount(0, { timeout: 10000 })
+    // The deny is a tool result the model adapts to — the session must settle,
+    // not error out.
+    await sessionPage.waitForInputEnabled(15000)
+  })
+
+  test('Allow for this session suppresses the next review prompt', async ({ page }) => {
+    await sessionPage.sendMessage('launch workflow')
+    await expect(reviewCard(page)).toBeVisible({ timeout: 15000 })
+
+    await page.locator('[data-testid="capability-review-run-btn-chevron"]').click()
+    await page.locator('[data-testid="capability-review-allow-session-btn"]').click()
+    await expect(reviewCard(page)).toHaveCount(0, { timeout: 10000 })
+    await sessionPage.waitForInputEnabled(15000)
+
+    // Second launch in the same session: the host-side grant suppresses the
+    // review broadcast entirely.
+    await sessionPage.sendMessage('launch workflow')
+    await page.waitForTimeout(4000)
+    await expect(reviewCard(page)).toHaveCount(0)
+  })
+
+  test('subagent launches do not prompt under the default allow policy', async ({ page }) => {
+    await sessionPage.sendMessage('launch subagent')
+
+    // Give the stream time to deliver the Task tool_use, then assert no card.
+    await page.waitForTimeout(4000)
+    await expect(reviewCard(page)).toHaveCount(0)
+  })
+})
+
+test.describe('Capability policy settings', () => {
+  test('three-way controls persist and blocking subagents warns first', async ({ page }) => {
+    const appPage = new AppPage(page)
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+
+    await page.locator('[data-testid="settings-button"]').click()
+    await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
+    await page.locator('[data-testid="settings-nav-capabilities"]').click()
+
+    const subagentsToggle = page.locator('[data-testid="capability-policy-subagents"]')
+    const workflowsToggle = page.locator('[data-testid="capability-policy-workflows"]')
+
+    // Defaults: subagents allow, workflows review
+    await expect(subagentsToggle.locator('[data-testid="policy-toggle-allow"]')).toHaveAttribute('data-active', 'true')
+    await expect(workflowsToggle.locator('[data-testid="policy-toggle-review"]')).toHaveAttribute('data-active', 'true')
+
+    // Selecting block for subagents opens the warning instead of applying
+    await subagentsToggle.locator('[data-testid="policy-toggle-block"]').click()
+    await expect(page.locator('[data-testid="block-subagents-use-review"]')).toBeVisible()
+
+    // Cancel applies nothing
+    await page.locator('[data-testid="block-subagents-cancel"]').click()
+    await expect(page.locator('[data-testid="block-subagents-use-review"]')).toHaveCount(0)
+    await expect(subagentsToggle.locator('[data-testid="policy-toggle-allow"]')).toHaveAttribute('data-active', 'true')
+
+    // Take the recommended path — review is applied, not block
+    await subagentsToggle.locator('[data-testid="policy-toggle-block"]').click()
+    await expect(page.locator('[data-testid="block-subagents-use-review"]')).toBeVisible()
+    await page.locator('[data-testid="block-subagents-use-review"]').click()
+    await expect(subagentsToggle.locator('[data-testid="policy-toggle-review"]')).toHaveAttribute('data-active', 'true', { timeout: 10000 })
+    await expect(subagentsToggle.locator('[data-testid="policy-toggle-block"]')).toHaveAttribute('data-active', 'false')
+
+    // Workflows -> allow persists across reload
+    await workflowsToggle.locator('[data-testid="policy-toggle-allow"]').click()
+    await expect(workflowsToggle.locator('[data-testid="policy-toggle-allow"]')).toHaveAttribute('data-active', 'true', { timeout: 10000 })
+
+    await page.reload()
+    await expect(page.locator('[data-testid="global-settings-page"]')).toBeVisible()
+    await expect(page.locator('[data-testid="capability-policy-workflows"] [data-testid="policy-toggle-allow"]')).toHaveAttribute('data-active', 'true', { timeout: 10000 })
+
+    // Restore defaults so other specs see the stock policy
+    await page.locator('[data-testid="capability-policy-workflows"] [data-testid="policy-toggle-review"]').click()
+    await expect(page.locator('[data-testid="capability-policy-workflows"] [data-testid="policy-toggle-review"]')).toHaveAttribute('data-active', 'true', { timeout: 10000 })
+    const subagents = page.locator('[data-testid="capability-policy-subagents"]')
+    await subagents.locator('[data-testid="policy-toggle-allow"]').click()
+    await expect(subagents.locator('[data-testid="policy-toggle-allow"]')).toHaveAttribute('data-active', 'true', { timeout: 10000 })
+  })
+})

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2346,6 +2346,84 @@ agents.post('/:id/sessions/:sessionId/answer-question', AgentUser(), async (c) =
   }
 })
 
+// POST /api/agents/:id/sessions/:sessionId/capability-review - Approve or block a
+// subagent/workflow launch paused by a 'review' policy. Approve resolves the
+// container's pending input ({ scope: 'once' | 'session' }); block rejects it
+// (the reason becomes the deny message the model adapts to).
+agents.post('/:id/sessions/:sessionId/capability-review', AgentUser(), async (c) => {
+  try {
+    const agentSlug = getAgentId(c)
+    const sessionId = c.req.param('sessionId')
+    const body = await c.req.json()
+    const { toolUseId, capability, decline, declineReason } = body
+    const scope = body.scope === 'session' ? 'session' : 'once'
+
+    if (!toolUseId) {
+      return c.json({ error: 'toolUseId is required' }, 400)
+    }
+    if (capability !== 'subagents' && capability !== 'workflows') {
+      return c.json({ error: 'capability must be subagents or workflows' }, 400)
+    }
+
+    const client = containerManager.getClient(agentSlug)
+
+    if (decline) {
+      const reason = declineReason || 'User declined'
+
+      const rejectResponse = await client.fetch(
+        `/inputs/${encodeURIComponent(toolUseId)}/reject`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reason }),
+        }
+      )
+
+      if (!rejectResponse.ok) {
+        const error = await rejectResponse.json()
+        console.error('Failed to reject capability launch:', error)
+        return c.json({ error: 'Failed to reject capability launch' }, 500)
+      }
+
+      trackServerEvent('request_declined', { type: 'capability_review', capability, withReason: !!declineReason })
+      return c.json({ success: true, declined: true })
+    }
+
+    const resolveResponse = await client.fetch(
+      `/inputs/${encodeURIComponent(toolUseId)}/resolve`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: { scope } }),
+      }
+    )
+
+    if (!resolveResponse.ok) {
+      let errorDetails = 'Unknown error'
+      try {
+        const error = await resolveResponse.json()
+        errorDetails = JSON.stringify(error)
+      } catch {
+        errorDetails = await resolveResponse.text()
+      }
+      console.error(`[capability-review] Failed to resolve request: ${errorDetails}`)
+      return c.json({ error: 'Failed to approve launch' }, 500)
+    }
+
+    // Mirror the container's grant so later launches in this session don't
+    // produce review cards nothing is waiting on.
+    if (scope === 'session') {
+      messagePersister.grantSessionCapability(sessionId, capability)
+    }
+
+    trackServerEvent('capability_launch_approved', { capability, scope })
+    return c.json({ success: true })
+  } catch (error) {
+    console.error('Failed to handle capability review:', error)
+    return c.json({ error: 'Failed to handle capability review' }, 500)
+  }
+})
+
 // POST /api/agents/:id/sessions/:sessionId/complete-browser-input - Complete or cancel a browser input request
 agents.post('/:id/sessions/:sessionId/complete-browser-input', AgentUser(), async (c) => {
   try {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2385,6 +2385,7 @@ agents.post('/:id/sessions/:sessionId/capability-review', AgentUser(), async (c)
         return c.json({ error: 'Failed to reject capability launch' }, 500)
       }
 
+      messagePersister.completeCapabilityReview(sessionId, toolUseId)
       trackServerEvent('request_declined', { type: 'capability_review', capability, withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }
@@ -2415,6 +2416,7 @@ agents.post('/:id/sessions/:sessionId/capability-review', AgentUser(), async (c)
     if (scope === 'session') {
       messagePersister.grantSessionCapability(sessionId, capability)
     }
+    messagePersister.completeCapabilityReview(sessionId, toolUseId)
 
     trackServerEvent('capability_launch_approved', { capability, scope })
     return c.json({ success: true })

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -31,6 +31,7 @@ import {
   type ContainerSettings,
   type GlobalSettingsResponse,
 } from '@shared/lib/config/settings'
+import { agentCapabilitySettingsPatchSchema, DEFAULT_AGENT_CAPABILITIES } from '@shared/lib/config/capability-policy-schema'
 import { validateFaviconDataUrl } from '@shared/lib/config/favicon'
 import { isValidAccelerator } from '@shared/lib/config/shortcuts'
 import { getTenantId } from '@shared/lib/analytics/tenant-id'
@@ -336,6 +337,7 @@ function buildSettingsResponse(
     analyticsTargets: appSettings.analyticsTargets,
     shareErrorReports: appSettings.shareErrorReports !== false,
     enableToolSearch: appSettings.enableToolSearch !== false,
+    agentCapabilities: appSettings.agentCapabilities ?? DEFAULT_AGENT_CAPABILITIES,
   }
 }
 
@@ -412,6 +414,14 @@ settings.put('/', async (c) => {
     // Validate agentEffort if provided
     if (body.models?.agentEffort !== undefined && !EFFORT_LEVELS.includes(body.models.agentEffort)) {
       return c.json({ error: `agentEffort must be one of: ${EFFORT_LEVELS.join(', ')}` }, 400)
+    }
+
+    // Validate agentCapabilities if provided (partial patch of allow/review/block tiers)
+    if (body.agentCapabilities !== undefined) {
+      const parsed = agentCapabilitySettingsPatchSchema.safeParse(body.agentCapabilities)
+      if (!parsed.success) {
+        return c.json({ error: 'agentCapabilities values must be one of: allow, review, block' }, 400)
+      }
     }
 
     // Validate the quick-dispatch global shortcut accelerator. Empty string is
@@ -542,6 +552,9 @@ settings.put('/', async (c) => {
       computerUse: body.computerUse !== undefined
         ? { ...currentSettings.computerUse, ...body.computerUse }
         : currentSettings.computerUse,
+      agentCapabilities: body.agentCapabilities !== undefined
+        ? { ...DEFAULT_AGENT_CAPABILITIES, ...currentSettings.agentCapabilities, ...body.agentCapabilities }
+        : currentSettings.agentCapabilities,
       analyticsTargets: body.analyticsTargets !== undefined ? body.analyticsTargets : currentSettings.analyticsTargets,
     }
 

--- a/src/main/browser-stream-proxy.ts
+++ b/src/main/browser-stream-proxy.ts
@@ -132,7 +132,7 @@ export function setupBrowserStreamProxy(server: ServerType): void {
 
         const wsUrl = `${client.getWebSocketBaseUrl(info.port)}/browser/stream`
         console.log(`[BrowserProxy] Connecting upstream to: ${wsUrl}`)
-        const upstream = new WebSocket(wsUrl)
+        const upstream = new WebSocket(wsUrl, { headers: client.getHostAuthHeaders() })
 
         upstream.on('open', () => {
           console.log(`[BrowserProxy] Connected to container stream for agent ${agentSlug}`)

--- a/src/renderer/components/messages/capability-review-request-item.tsx
+++ b/src/renderer/components/messages/capability-review-request-item.tsx
@@ -1,0 +1,232 @@
+import { apiFetch } from '@renderer/lib/api'
+import { useMemo, useState } from 'react'
+import { GitBranch, Bot, ChevronDown } from 'lucide-react'
+import { Button } from '@renderer/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+import { cn } from '@shared/lib/utils/cn'
+import { parseWorkflowScript } from '@shared/lib/workflows/workflow-script-parser'
+import type { ParsedScript } from '@shared/lib/workflows/workflow-schemas'
+import { DeclineButton } from './decline-button'
+import { RequestItemShell } from './request-item-shell'
+import { RequestItemActions } from './request-item-actions'
+
+interface CapabilityReviewRequestItemProps {
+  toolUseId: string
+  capability: 'subagents' | 'workflows'
+  toolName: string
+  input: Record<string, unknown>
+  sessionId: string
+  agentSlug: string
+  readOnly?: boolean
+  onComplete: () => void
+}
+
+type RequestStatus = 'pending' | 'submitting' | 'approved' | 'blocked'
+
+function str(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined
+}
+
+// Pre-flight summary of the workflow script: name, description, phases and
+// agent-call sites. Workflow internals never pass back through the permission
+// layer once launched, so this parse IS the review surface.
+function useParsedWorkflow(capability: string, input: Record<string, unknown>): ParsedScript | null {
+  return useMemo(() => {
+    if (capability !== 'workflows') return null
+    const script = str(input.script)
+    if (!script) return null
+    try {
+      return parseWorkflowScript(script)
+    } catch {
+      return null
+    }
+  }, [capability, input])
+}
+
+export function CapabilityReviewRequestItem({
+  toolUseId,
+  capability,
+  input,
+  sessionId,
+  agentSlug,
+  readOnly,
+  onComplete,
+}: CapabilityReviewRequestItemProps) {
+  const [status, setStatus] = useState<RequestStatus>('pending')
+  const [error, setError] = useState<string | null>(null)
+  const [runMenuOpen, setRunMenuOpen] = useState(false)
+
+  const isWorkflow = capability === 'workflows'
+  const parsed = useParsedWorkflow(capability, input)
+
+  const workflowName = parsed?.name ?? str(input.name)
+  const subagentType = str(input.subagent_type)
+  const description = str(input.description) ?? parsed?.description ?? undefined
+  const prompt = str(input.prompt)
+
+  const submit = async (body: Record<string, unknown>, nextStatus: 'approved' | 'blocked') => {
+    setStatus('submitting')
+    setError(null)
+    try {
+      const response = await apiFetch(
+        `/api/agents/${agentSlug}/sessions/${sessionId}/capability-review`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ toolUseId, capability, ...body }),
+        }
+      )
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || `Request failed (${response.status})`)
+      }
+      setStatus(nextStatus)
+      onComplete()
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to submit decision')
+      setStatus('pending')
+    }
+  }
+
+  const handleRun = (scope: 'once' | 'session') => submit({ scope }, 'approved')
+  const handleBlock = (reason?: string) => submit({ decline: true, declineReason: reason }, 'blocked')
+
+  const isCompleted = status === 'approved' || status === 'blocked'
+  const Icon = isWorkflow ? GitBranch : Bot
+
+  const title = isWorkflow
+    ? workflowName
+      ? `Run the workflow "${workflowName}"?`
+      : 'Run this workflow?'
+    : subagentType
+      ? `Launch a ${subagentType} subagent?`
+      : 'Launch a subagent?'
+
+  const subtitle = isWorkflow
+    ? 'Workflows can fan out into many agents. Review the plan before it runs — once launched, its internal agents run without further approval.'
+    : 'Subagents run autonomously and use additional tokens.'
+
+  const detailBlock = (
+    <div className="pt-4 space-y-2">
+      {description && (
+        <p className="text-sm text-foreground/85">{description}</p>
+      )}
+      {isWorkflow && parsed && parsed.phases.length > 0 && (
+        <div className="overflow-hidden rounded-md border border-border bg-white dark:bg-background p-2">
+          <p className="mb-1 text-xs font-medium text-foreground/80">
+            {parsed.phases.length} {parsed.phases.length === 1 ? 'phase' : 'phases'}
+            {parsed.agentCalls.length > 0 && (
+              <> · {parsed.agentCalls.length} agent {parsed.agentCalls.length === 1 ? 'call site' : 'call sites'}
+              {parsed.agentCalls.some((c) => c.inParallel) ? ' (some fan out in parallel)' : ''}</>
+            )}
+          </p>
+          <ol className="space-y-0.5 text-xs text-foreground/70">
+            {parsed.phases.map((phase, i) => (
+              <li key={i} className="flex gap-1.5">
+                <span className="text-foreground/50">{i + 1}.</span>
+                <span>
+                  {phase.title}
+                  {phase.detail ? <span className="text-foreground/50"> — {phase.detail}</span> : null}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+      {!isWorkflow && prompt && (
+        <div className="overflow-hidden rounded-md border border-border bg-white dark:bg-background">
+          <pre className="max-h-40 overflow-y-auto overflow-x-auto whitespace-pre-wrap break-words p-2 text-xs font-mono text-foreground/75">
+            <code>{prompt}</code>
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+
+  return (
+    <RequestItemShell
+      title={title}
+      subtitle={subtitle}
+      theme="orange"
+      sessionId={sessionId}
+      agentSlug={agentSlug}
+      waitingText="Waiting for approval"
+      error={error}
+      data-testid={isCompleted ? 'capability-review-request-completed' : 'capability-review-request'}
+      data-status={isCompleted ? status : undefined}
+      completed={
+        isCompleted
+          ? {
+              icon: (
+                <Icon
+                  className={cn(
+                    'h-4 w-4 shrink-0',
+                    status === 'approved' ? 'text-green-500' : 'text-red-500'
+                  )}
+                />
+              ),
+              label: <>{isWorkflow ? workflowName || 'Workflow' : subagentType || 'Subagent'}</>,
+              statusLabel: status === 'approved' ? 'Approved' : 'Blocked',
+              isSuccess: status === 'approved',
+            }
+          : null
+      }
+      readOnly={
+        readOnly
+          ? { extraContent: detailBlock }
+          : false
+      }
+    >
+      {detailBlock}
+
+      <RequestItemActions>
+        <DeclineButton
+          onDecline={handleBlock}
+          disabled={status === 'submitting'}
+          label="Block"
+          showIcon={false}
+          className="bg-transparent border-border dark:border-white/20 text-foreground hover:bg-muted"
+          data-testid="capability-review-block-btn"
+        />
+
+        <div className="flex items-stretch">
+          <Button
+            onClick={() => handleRun('once')}
+            loading={status === 'submitting'}
+            size="xs"
+            className="min-w-20 rounded-r-none border-r-0 bg-orange-600 text-white hover:bg-orange-700"
+            data-testid="capability-review-run-btn"
+          >
+            Run
+          </Button>
+          <Popover open={runMenuOpen} onOpenChange={setRunMenuOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                disabled={status === 'submitting'}
+                size="xs"
+                className="rounded-l-none border-l border-l-orange-500 bg-orange-600 px-1.5 text-white hover:bg-orange-700"
+                data-testid="capability-review-run-btn-chevron"
+              >
+                <ChevronDown className="h-3.5 w-3.5" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-52 p-1">
+              <Button
+                onClick={() => {
+                  setRunMenuOpen(false)
+                  handleRun('session')
+                }}
+                variant="ghost"
+                size="xs"
+                className="w-full justify-start text-foreground hover:bg-muted"
+                data-testid="capability-review-allow-session-btn"
+              >
+                Allow for this session
+              </Button>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </RequestItemActions>
+    </RequestItemShell>
+  )
+}

--- a/src/renderer/components/messages/pending-request-renderer.tsx
+++ b/src/renderer/components/messages/pending-request-renderer.tsx
@@ -7,6 +7,7 @@ import { FileRequestItem } from './file-request-item'
 import { BrowserInputRequestItem } from './browser-input-request-item'
 import { ScriptRunRequestItem } from './script-run-request-item'
 import { ComputerUseRequestItem } from './computer-use-request-item'
+import { CapabilityReviewRequestItem } from './capability-review-request-item'
 import { ProxyReviewRequestItem } from './proxy-review-request-item'
 import { XAgentReviewRequestItem } from './x-agent-review-request-item'
 import type { PendingRequestDescriptor } from './use-pending-requests'
@@ -124,6 +125,20 @@ export function renderPendingRequest(
           params={d.params}
           permissionLevel={d.permissionLevel}
           appName={d.appName}
+          sessionId={ctx.sessionId}
+          agentSlug={ctx.agentSlug}
+          readOnly={ctx.readOnly}
+          onComplete={d.onComplete}
+        />
+      )
+    case 'capability_review':
+      return (
+        <CapabilityReviewRequestItem
+          key={d.key}
+          toolUseId={d.toolUseId}
+          capability={d.capability}
+          toolName={d.toolName}
+          input={d.input}
           sessionId={ctx.sessionId}
           agentSlug={ctx.agentSlug}
           readOnly={ctx.readOnly}

--- a/src/renderer/components/messages/use-pending-requests.test.tsx
+++ b/src/renderer/components/messages/use-pending-requests.test.tsx
@@ -26,6 +26,7 @@ const mockStreamState = {
   pendingBrowserInputRequests: [] as Array<{ toolUseId: string; message: string; requirements: string[] }>,
   pendingScriptRunRequests: [] as Array<{ toolUseId: string; script: string; explanation: string; scriptType: 'applescript' | 'shell' | 'powershell' }>,
   pendingComputerUseRequests: [] as Array<{ toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string }>,
+  pendingCapabilityReviewRequests: [] as Array<{ toolUseId: string; capability: 'subagents' | 'workflows'; toolName: string; input: Record<string, unknown> }>,
   streamingToolUses: [] as Array<{ id: string; name: string; partialInput: string; ready?: boolean }>,
   autoApprovedScriptRunIds: new Set<string>(),
   autoApprovedComputerUseIds: new Set<string>(),
@@ -40,6 +41,7 @@ const mockRemovers = {
   removeBrowserInputRequest: vi.fn(),
   removeScriptRunRequest: vi.fn(),
   removeComputerUseRequest: vi.fn(),
+  removeCapabilityReviewRequest: vi.fn(),
 }
 
 vi.mock('@renderer/hooks/use-message-stream', () => ({
@@ -52,6 +54,7 @@ vi.mock('@renderer/hooks/use-message-stream', () => ({
   removeBrowserInputRequest: (...args: unknown[]) => mockRemovers.removeBrowserInputRequest(...args),
   removeScriptRunRequest: (...args: unknown[]) => mockRemovers.removeScriptRunRequest(...args),
   removeComputerUseRequest: (...args: unknown[]) => mockRemovers.removeComputerUseRequest(...args),
+  removeCapabilityReviewRequest: (...args: unknown[]) => mockRemovers.removeCapabilityReviewRequest(...args),
 }))
 
 // Mock proxy reviews — mutable per test
@@ -106,6 +109,7 @@ describe('usePendingRequests', () => {
       pendingBrowserInputRequests: [],
       pendingScriptRunRequests: [],
       pendingComputerUseRequests: [],
+      pendingCapabilityReviewRequests: [],
       streamingToolUses: [],
       autoApprovedScriptRunIds: new Set<string>(),
       autoApprovedComputerUseIds: new Set<string>(),
@@ -851,5 +855,41 @@ describe('usePendingRequests', () => {
       'tu-file',
       'tu-secret-2',
     ])
+  })
+
+  it('returns SSE-based capability review requests while active', () => {
+    mockStreamState.isActive = true
+    mockMessagesData.data = []
+    mockStreamState.pendingCapabilityReviewRequests = [
+      { toolUseId: 'tu-cap-1', capability: 'workflows', toolName: 'Workflow', input: { name: 'audit' } },
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    const matches = ofKind(result.current.items, 'capability_review')
+    expect(matches).toHaveLength(1)
+    expect(matches[0].capability).toBe('workflows')
+    expect(matches[0].input).toEqual({ name: 'audit' })
+  })
+
+  it('does NOT derive capability reviews from message history — a running Task without a result is not an approval', () => {
+    mockStreamState.isActive = true
+    mockMessagesData.data = [
+      createAssistantMessage({
+        content: { text: '' },
+        toolCalls: [
+          createToolCall({
+            id: 'tc-task',
+            name: 'Task',
+            input: { subagent_type: 'Explore', prompt: 'look around' },
+            result: undefined,
+          }),
+        ],
+      }),
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    expect(ofKind(result.current.items, 'capability_review')).toHaveLength(0)
   })
 })

--- a/src/renderer/components/messages/use-pending-requests.tsx
+++ b/src/renderer/components/messages/use-pending-requests.tsx
@@ -9,6 +9,7 @@ import {
   removeBrowserInputRequest,
   removeScriptRunRequest,
   removeComputerUseRequest,
+  removeCapabilityReviewRequest,
 } from '@renderer/hooks/use-message-stream'
 import { useMessages } from '@renderer/hooks/use-messages'
 import { usePendingProxyReviews, type PendingReview } from '@renderer/hooks/use-proxy-reviews'
@@ -177,6 +178,7 @@ export type PendingRequestDescriptor =
   | { kind: 'browser_input'; key: string; toolUseId: string; message: string; requirements: string[]; onComplete: () => void }
   | { kind: 'script_run'; key: string; toolUseId: string; script: string; explanation: string; scriptType: 'applescript' | 'shell' | 'powershell'; onComplete: () => void }
   | { kind: 'computer_use'; key: string; toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string; onComplete: () => void }
+  | { kind: 'capability_review'; key: string; toolUseId: string; capability: 'subagents' | 'workflows'; toolName: string; input: Record<string, unknown>; onComplete: () => void }
   | { kind: 'proxy_review'; key: string; reviewId: string; accountId: string; toolkit: string; method: string; targetPath: string; matchedScopes: string[]; scopeDescriptions: Record<string, string>; displayText?: string; onComplete: () => void }
   | { kind: 'x_agent_review'; key: string; reviewId: string; xAgent: NonNullable<PendingReview['xAgent']>; onComplete: () => void }
 
@@ -204,6 +206,7 @@ export function usePendingRequests({
     pendingBrowserInputRequests: sseBrowserInputRequests,
     pendingScriptRunRequests: sseScriptRunRequests,
     pendingComputerUseRequests: sseComputerUseRequests,
+    pendingCapabilityReviewRequests: sseCapabilityReviewRequests,
     streamingToolUses,
     autoApprovedScriptRunIds,
     autoApprovedComputerUseIds,
@@ -393,6 +396,16 @@ export function usePendingRequests({
     return merged
   }, [sseComputerUseRequests, streamingBasedPendingRequests.computerUseRequests, messagesBasedPendingRequests.computerUseRequests, isActive, autoApprovedComputerUseIds])
 
+  // Capability reviews come from SSE (+ the server's reconnect replay map)
+  // ONLY — no message-history or streaming recovery. A Task/Workflow call
+  // without a result usually means the launch is RUNNING (allow policy or an
+  // active session grant), not awaiting approval; only the host knows which,
+  // and its replay map already covers refresh/reconnect.
+  const pendingCapabilityReviewRequests = useMemo(() => {
+    if (!isActive) return []
+    return sseCapabilityReviewRequests.filter((r) => !dismissedRequestIds.current.has(r.toolUseId))
+  }, [sseCapabilityReviewRequests, isActive])
+
   // Track arrival order so the stack is chronological. Each id gets a
   // monotonically increasing sequence number the first time it appears.
   const arrivalOrder = useRef(new Map<string, number>())
@@ -409,6 +422,7 @@ export function usePendingRequests({
       pendingBrowserInputRequests,
       pendingScriptRunRequests,
       pendingComputerUseRequests,
+      pendingCapabilityReviewRequests,
     ]) {
       for (const req of arr) ids.push(req.toolUseId)
     }
@@ -417,7 +431,7 @@ export function usePendingRequests({
   }, [
     pendingSecretRequests, pendingConnectedAccountRequests, pendingRemoteMcpRequests,
     pendingQuestionRequests, pendingFileRequests, pendingBrowserInputRequests,
-    pendingScriptRunRequests, pendingComputerUseRequests, pendingProxyReviews,
+    pendingScriptRunRequests, pendingComputerUseRequests, pendingCapabilityReviewRequests, pendingProxyReviews,
   ])
 
   // Effect — not useMemo — because we mutate refs. useMemo may re-run for the
@@ -477,6 +491,11 @@ export function usePendingRequests({
   const handleBrowserInputRequestComplete = useCallback((toolUseId: string) => {
     dismissedRequestIds.current.add(toolUseId)
     removeBrowserInputRequest(sessionId, toolUseId)
+  }, [sessionId])
+
+  const handleCapabilityReviewRequestComplete = useCallback((toolUseId: string) => {
+    dismissedRequestIds.current.add(toolUseId)
+    removeCapabilityReviewRequest(sessionId, toolUseId)
   }, [sessionId])
 
   const handleProxyReviewComplete = useCallback(() => {
@@ -569,6 +588,17 @@ export function usePendingRequests({
         onComplete: () => handleComputerUseRequestComplete(r.toolUseId),
       })
     }
+    for (const r of pendingCapabilityReviewRequests) {
+      all.push({
+        kind: 'capability_review',
+        key: r.toolUseId,
+        toolUseId: r.toolUseId,
+        capability: r.capability,
+        toolName: r.toolName,
+        input: r.input,
+        onComplete: () => handleCapabilityReviewRequestComplete(r.toolUseId),
+      })
+    }
     for (const review of pendingProxyReviews) {
       if (review.xAgent) {
         all.push({
@@ -598,13 +628,13 @@ export function usePendingRequests({
   }, [
     pendingSecretRequests, pendingConnectedAccountRequests, pendingRemoteMcpRequests,
     pendingQuestionRequests, pendingFileRequests, pendingBrowserInputRequests,
-    pendingScriptRunRequests, pendingComputerUseRequests, pendingProxyReviews,
+    pendingScriptRunRequests, pendingComputerUseRequests, pendingCapabilityReviewRequests, pendingProxyReviews,
     getArrivalOrder,
     handleSecretRequestComplete, handleConnectedAccountRequestComplete,
     handleRemoteMcpRequestComplete, handleQuestionRequestComplete,
     handleFileRequestComplete, handleBrowserInputRequestComplete,
     handleScriptRunRequestComplete, handleComputerUseRequestComplete,
-    handleProxyReviewComplete,
+    handleCapabilityReviewRequestComplete, handleProxyReviewComplete,
   ])
 
   return { items, count: items.length }

--- a/src/renderer/components/settings/capabilities-tab.tsx
+++ b/src/renderer/components/settings/capabilities-tab.tsx
@@ -1,0 +1,141 @@
+import { useState, type ReactNode } from 'react'
+import { AlertTriangle } from 'lucide-react'
+import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
+import { PolicyDecisionToggle } from '@renderer/components/ui/policy-decision-toggle'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@renderer/components/ui/alert-dialog'
+import type { CapabilityPolicy } from '@shared/lib/config/settings'
+
+const CARD_CLASS = 'rounded-xl border bg-background divide-y divide-border/50 overflow-hidden'
+const SECTION_HEADING = 'text-xs font-medium text-muted-foreground px-1'
+
+interface SettingRowProps {
+  name: string
+  subtitle?: ReactNode
+  right: ReactNode
+}
+
+function SettingRow({ name, subtitle, right }: SettingRowProps) {
+  return (
+    <div className="py-3 px-4">
+      <div className="flex items-center gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-medium truncate">{name}</div>
+          {subtitle && (
+            <div className="text-[11px] text-muted-foreground mt-0.5">{subtitle}</div>
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">{right}</div>
+      </div>
+    </div>
+  )
+}
+
+export function CapabilitiesTab() {
+  const { data: settings, isLoading } = useSettings()
+  const updateSettings = useUpdateSettings()
+  // Blocking subagents cripples genuinely useful delegation (browsing,
+  // dashboards) — confirm before applying and steer toward review instead.
+  const [confirmBlockSubagents, setConfirmBlockSubagents] = useState(false)
+
+  const capabilities = settings?.agentCapabilities ?? { subagents: 'allow', workflows: 'review' }
+
+  const setPolicy = (capability: 'subagents' | 'workflows', policy: CapabilityPolicy) => {
+    updateSettings.mutate({ agentCapabilities: { [capability]: policy } })
+  }
+
+  const handleSubagentsChange = (value: string) => {
+    if (value !== 'allow' && value !== 'review' && value !== 'block') return
+    if (value === 'block') {
+      setConfirmBlockSubagents(true)
+      return
+    }
+    setPolicy('subagents', value)
+  }
+
+  const handleWorkflowsChange = (value: string) => {
+    if (value !== 'allow' && value !== 'review' && value !== 'block') return
+    setPolicy('workflows', value)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h3 className={SECTION_HEADING}>Launch policies</h3>
+        <div className={CARD_CLASS}>
+          <SettingRow
+            name="Subagents"
+            subtitle="Delegated agents launched with the Task tool — browsing, dashboards, research fan-outs. Review pauses each launch for your approval; Block removes the capability entirely."
+            right={
+              <div data-testid="capability-policy-subagents" className={isLoading ? 'pointer-events-none opacity-50' : undefined}>
+                <PolicyDecisionToggle
+                  value={capabilities.subagents}
+                  onChange={handleSubagentsChange}
+                  allowDeselect={false}
+                />
+              </div>
+            }
+          />
+          <SettingRow
+            name="Workflows"
+            subtitle="Multi-agent orchestrations launched with the Workflow tool. A single workflow can fan out into dozens of agents, so these default to Review."
+            right={
+              <div data-testid="capability-policy-workflows" className={isLoading ? 'pointer-events-none opacity-50' : undefined}>
+                <PolicyDecisionToggle
+                  value={capabilities.workflows}
+                  onChange={handleWorkflowsChange}
+                  allowDeselect={false}
+                />
+              </div>
+            }
+          />
+        </div>
+        <p className="px-1 text-[11px] text-muted-foreground leading-relaxed">
+          Policies apply to every agent. Under Review, approving with &ldquo;Allow for this session&rdquo; stops
+          repeat prompts within that conversation. Changes take effect from each session&apos;s next message.
+        </p>
+      </div>
+
+      <AlertDialog open={confirmBlockSubagents} onOpenChange={setConfirmBlockSubagents}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-amber-500" />
+              Block subagents everywhere?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Subagents power core features — web browsing, dashboard building, and desktop
+              automation all delegate to them. Blocking removes those abilities from every agent.
+              If cost control is the goal, <span className="font-medium text-foreground">Review</span> keeps
+              the capability while letting you approve each launch.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel data-testid="block-subagents-cancel">Keep current setting</AlertDialogCancel>
+            <AlertDialogAction
+              data-testid="block-subagents-use-review"
+              onClick={() => setPolicy('subagents', 'review')}
+            >
+              Use Review instead
+            </AlertDialogAction>
+            <AlertDialogAction
+              data-testid="block-subagents-confirm"
+              className="bg-orange-600 text-white hover:bg-orange-700"
+              onClick={() => setPolicy('subagents', 'block')}
+            >
+              Block anyway
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/src/renderer/components/settings/global-settings-page.tsx
+++ b/src/renderer/components/settings/global-settings-page.tsx
@@ -1,4 +1,4 @@
-import { Settings, Container, Bell, Globe, Library, BarChart3, Plug, Brain, Users, Shield, ShieldEllipsis, User, Mic, Activity, Terminal, BadgeCheck, ClipboardList, Search } from 'lucide-react'
+import { Settings, Container, Bell, Globe, Library, BarChart3, Plug, Brain, Users, Shield, ShieldEllipsis, User, Mic, Activity, Terminal, BadgeCheck, ClipboardList, Search, Bot } from 'lucide-react'
 import { SettingsPage, type SettingsPageSection, type SettingsPageSectionGroup } from '@renderer/components/settings/settings-page'
 import { type LinkProps } from '@tanstack/react-router'
 import { ProfileTab } from './profile-tab'
@@ -20,6 +20,7 @@ import { WebTab } from './web-tab'
 import { AnalyticsTab } from './analytics-tab'
 import { PlatformTab } from './platform-tab'
 import { ComputerUseTab } from './computer-use-tab'
+import { CapabilitiesTab } from './capabilities-tab'
 import { AuditLogTab } from './audit-log-tab'
 import { useUser } from '@renderer/context/user-context'
 import { isElectron } from '@renderer/lib/env'
@@ -52,6 +53,7 @@ export function GlobalSettingsPage({ onClose, onOpenWizard, initialSection, onSe
     { id: 'runtime', label: 'Runtime', icon: <Container className="h-4 w-4" />, render: () => <RuntimeTab /> },
     { id: 'browser', label: 'Browser Use', icon: <Globe className="h-4 w-4" />, render: () => <BrowserTab /> },
     { id: 'web', label: 'Web', icon: <Search className="h-4 w-4" />, render: () => <WebTab /> },
+    { id: 'capabilities', label: 'Agent Capabilities', icon: <Bot className="h-4 w-4" />, render: () => <CapabilitiesTab /> },
     ...(isElectron() ? [{ id: 'computer-use', label: 'Computer Use', icon: <Terminal className="h-4 w-4" />, render: () => <ComputerUseTab /> }] : []),
     { id: 'account-provider', label: 'Account Provider', icon: <ShieldEllipsis className="h-4 w-4" />, render: () => <AccountProviderTab /> },
     { id: 'voice', label: 'Voice', icon: <Mic className="h-4 w-4" />, render: () => <VoiceTab /> },

--- a/src/renderer/components/ui/policy-decision-toggle.tsx
+++ b/src/renderer/components/ui/policy-decision-toggle.tsx
@@ -13,6 +13,11 @@ interface PolicyDecisionToggleProps {
   value: PolicyDecision
   onChange: (value: PolicyDecision) => void
   size?: 'sm' | 'md'
+  /**
+   * When false, clicking the active option is a no-op instead of resetting to
+   * 'default' — for strict three-way policies with no inherit tier.
+   */
+  allowDeselect?: boolean
 }
 
 const options = [
@@ -43,6 +48,7 @@ export function PolicyDecisionToggle({
   value,
   onChange,
   size = 'sm',
+  allowDeselect = true,
 }: PolicyDecisionToggleProps) {
   const iconSize = size === 'sm' ? 'h-3.5 w-3.5' : 'h-4 w-4'
   const btnSize = size === 'sm' ? 'h-6 w-7' : 'h-7 w-8'
@@ -62,7 +68,10 @@ export function PolicyDecisionToggle({
                   data-active={isActive}
                   aria-label={opt.label}
                   aria-pressed={isActive}
-                  onClick={() => onChange(isActive ? 'default' : opt.value)}
+                  onClick={() => {
+                    if (isActive && !allowDeselect) return
+                    onChange(isActive ? 'default' : opt.value)
+                  }}
                   className={cn(
                     'inline-flex items-center justify-center rounded-sm transition-colors',
                     btnSize,
@@ -73,7 +82,7 @@ export function PolicyDecisionToggle({
                 </button>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="text-xs">
-                {isActive ? `Remove ${opt.label.toLowerCase()} (set to default)` : opt.label}
+                {isActive && allowDeselect ? `Remove ${opt.label.toLowerCase()} (set to default)` : opt.label}
               </TooltipContent>
             </Tooltip>
           )

--- a/src/renderer/hooks/use-document-title.ts
+++ b/src/renderer/hooks/use-document-title.ts
@@ -21,6 +21,7 @@ const SETTINGS_TAB_TITLES = {
   runtime: 'Runtime',
   browser: 'Browser Use',
   web: 'Web',
+  capabilities: 'Agent Capabilities',
   'computer-use': 'Computer Use',
   'account-provider': 'Account Provider',
   voice: 'Voice',

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -1037,6 +1037,18 @@ function getOrCreateEventSource(
           queryClient.invalidateQueries({ queryKey: ['sessions'] })
         }
       }
+      else if (data.type === 'capability_review_resolved') {
+        // Decided (possibly in another window) — close the card everywhere now.
+        // The launched Task/Workflow's tool_result can be minutes away.
+        if (current?.pendingCapabilityReviewRequests.some(r => r.toolUseId === data.toolUseId)) {
+          streamStates.set(sessionId, {
+            ...current,
+            pendingCapabilityReviewRequests: current.pendingCapabilityReviewRequests.filter(
+              r => r.toolUseId !== data.toolUseId
+            ),
+          })
+        }
+      }
       else if (data.type === 'file_request') {
         // Agent is requesting a file from the user
         const newRequest: FileRequest = {

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -65,6 +65,16 @@ export interface ComputerUseRequest {
   appName?: string
 }
 
+// A subagent (Task/Agent) or workflow (Workflow) launch paused by a 'review'
+// policy, awaiting the user's Run / Block / Allow-for-session decision.
+export interface CapabilityReviewRequest {
+  toolUseId: string
+  capability: 'subagents' | 'workflows'
+  toolName: string
+  /** The launching tool's input (subagent_type/description/prompt for Task; name/script for Workflow). */
+  input: Record<string, unknown>
+}
+
 export interface SubagentInfo {
   parentToolId: string | null
   agentId: string | null
@@ -112,6 +122,7 @@ interface StreamState {
   pendingBrowserInputRequests: BrowserInputRequest[]
   pendingScriptRunRequests: ScriptRunRequest[]
   pendingComputerUseRequests: ComputerUseRequest[]
+  pendingCapabilityReviewRequests: CapabilityReviewRequest[]
   error: string | null // Error message if session encountered an error
   /** SDK error code from the LLM provider (e.g., 'authentication_failed', 'rate_limit', 'server_error') */
   apiErrorCode: string | null
@@ -160,6 +171,7 @@ const EMPTY_STREAM_STATE: StreamState = {
   pendingBrowserInputRequests: [],
   pendingScriptRunRequests: [],
   pendingComputerUseRequests: [],
+  pendingCapabilityReviewRequests: [],
   error: null,
   apiErrorCode: null,
   browserActive: false,
@@ -393,6 +405,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
           pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
+          pendingCapabilityReviewRequests: current?.pendingCapabilityReviewRequests ?? [],
           error: null,
           apiErrorCode: null,
           browserActive: current?.browserActive ?? false,
@@ -451,6 +464,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
           pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
+          pendingCapabilityReviewRequests: current?.pendingCapabilityReviewRequests ?? [],
           error: null, // Clear any previous error when starting new request
           apiErrorCode: null,
           browserActive: current?.browserActive ?? false,
@@ -497,6 +511,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: [],
           pendingScriptRunRequests: [],
           pendingComputerUseRequests: [],
+          pendingCapabilityReviewRequests: [],
           error: null,
           // Preserve apiErrorCode — it was set from the assistant message's error field
           // and is still valid context for the last turn. Cleared on next session_active.
@@ -550,6 +565,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: [],
           pendingScriptRunRequests: [],
           pendingComputerUseRequests: [],
+          pendingCapabilityReviewRequests: [],
           error: data.error || 'An unknown error occurred',
           apiErrorCode: data.apiErrorCode || null,
           browserActive: current?.browserActive ?? false,
@@ -703,6 +719,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
           pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
+          pendingCapabilityReviewRequests: current?.pendingCapabilityReviewRequests ?? [],
           error: null,
           apiErrorCode: null,
           browserActive: current?.browserActive ?? false,
@@ -735,6 +752,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
           pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
+          pendingCapabilityReviewRequests: current?.pendingCapabilityReviewRequests ?? [],
           error: current?.error ?? null,
           apiErrorCode: data.apiErrorCode || current?.apiErrorCode || null,
           browserActive: current?.browserActive ?? false,
@@ -783,6 +801,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
           pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
+          pendingCapabilityReviewRequests: current?.pendingCapabilityReviewRequests ?? [],
           error: current?.error ?? null,
           apiErrorCode: current?.apiErrorCode ?? null,
           browserActive: current?.browserActive ?? false,
@@ -831,6 +850,7 @@ function getOrCreateEventSource(
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
           pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
           pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
+          pendingCapabilityReviewRequests: current?.pendingCapabilityReviewRequests ?? [],
           error: current?.error ?? null,
           apiErrorCode: current?.apiErrorCode ?? null,
           browserActive: current?.browserActive ?? false,
@@ -997,6 +1017,22 @@ function getOrCreateEventSource(
           streamStates.set(sessionId, {
             ...current,
             pendingQuestionRequests: [...current.pendingQuestionRequests, newRequest],
+          })
+          queryClient.invalidateQueries({ queryKey: ['sessions'] })
+        }
+      }
+      else if (data.type === 'capability_review_request') {
+        // A subagent/workflow launch is paused awaiting the user's decision
+        const newRequest: CapabilityReviewRequest = {
+          toolUseId: data.toolUseId,
+          capability: data.capability,
+          toolName: data.toolName,
+          input: data.input ?? {},
+        }
+        if (current && !current.pendingCapabilityReviewRequests.some(r => r.toolUseId === data.toolUseId)) {
+          streamStates.set(sessionId, {
+            ...current,
+            pendingCapabilityReviewRequests: [...current.pendingCapabilityReviewRequests, newRequest],
           })
           queryClient.invalidateQueries({ queryKey: ['sessions'] })
         }
@@ -1426,6 +1462,7 @@ function removePendingRequestsByToolUseId(sessionId: string, toolUseId: string):
     pendingBrowserInputRequests: strip(current.pendingBrowserInputRequests),
     pendingScriptRunRequests: strip(current.pendingScriptRunRequests),
     pendingComputerUseRequests: strip(current.pendingComputerUseRequests),
+    pendingCapabilityReviewRequests: strip(current.pendingCapabilityReviewRequests),
   }
   const changed =
     next.pendingSecretRequests !== current.pendingSecretRequests ||
@@ -1435,7 +1472,8 @@ function removePendingRequestsByToolUseId(sessionId: string, toolUseId: string):
     next.pendingRemoteMcpRequests !== current.pendingRemoteMcpRequests ||
     next.pendingBrowserInputRequests !== current.pendingBrowserInputRequests ||
     next.pendingScriptRunRequests !== current.pendingScriptRunRequests ||
-    next.pendingComputerUseRequests !== current.pendingComputerUseRequests
+    next.pendingComputerUseRequests !== current.pendingComputerUseRequests ||
+    next.pendingCapabilityReviewRequests !== current.pendingCapabilityReviewRequests
   if (changed) {
     streamStates.set(sessionId, next)
     streamListeners.get(sessionId)?.forEach((listener) => listener())
@@ -1552,6 +1590,19 @@ export function removeComputerUseRequest(sessionId: string, toolUseId: string): 
     streamStates.set(sessionId, {
       ...current,
       pendingComputerUseRequests: current.pendingComputerUseRequests.filter(
+        (r) => r.toolUseId !== toolUseId
+      ),
+    })
+    streamListeners.get(sessionId)?.forEach((listener) => listener())
+  }
+}
+
+export function removeCapabilityReviewRequest(sessionId: string, toolUseId: string): void {
+  const current = streamStates.get(sessionId)
+  if (current) {
+    streamStates.set(sessionId, {
+      ...current,
+      pendingCapabilityReviewRequests: current.pendingCapabilityReviewRequests.filter(
         (r) => r.toolUseId !== toolUseId
       ),
     })

--- a/src/renderer/hooks/use-settings.ts
+++ b/src/renderer/hooks/use-settings.ts
@@ -11,6 +11,7 @@ import type {
   AnalyticsTarget,
   LlmProviderId,
   WebProviderId,
+  AgentCapabilitySettings,
 } from '@shared/lib/config/settings'
 import type { ComputerUseSettings } from '@shared/lib/computer-use/types'
 import type { RunnerAvailability } from '@shared/lib/container/client-factory'
@@ -88,6 +89,7 @@ export interface UpdateSettingsParams {
   analyticsTargets?: AnalyticsTarget[]
   shareErrorReports?: boolean
   enableToolSearch?: boolean
+  agentCapabilities?: Partial<AgentCapabilitySettings>
 }
 
 export interface UpdateSettingsError {

--- a/src/renderer/router/search-schemas.test.ts
+++ b/src/renderer/router/search-schemas.test.ts
@@ -81,8 +81,9 @@ describe('settingsTabSchema', () => {
     expect(settingsTabSchema.safeParse('system-prompt').success).toBe(false)
     expect(settingsTabSchema.safeParse('secrets').success).toBe(false)
   })
-  it('has 19 tabs', () => {
-    expect(SETTINGS_TABS).toHaveLength(19)
+  it('has 20 tabs', () => {
+    expect(SETTINGS_TABS).toHaveLength(20)
+    expect(settingsTabSchema.safeParse('capabilities').success).toBe(true)
   })
 })
 

--- a/src/renderer/router/search-schemas.ts
+++ b/src/renderer/router/search-schemas.ts
@@ -77,6 +77,7 @@ export const SETTINGS_TABS = [
   'runtime',
   'browser',
   'web',
+  'capabilities',
   'computer-use',
   'account-provider',
   'voice',

--- a/src/shared/lib/config/capability-policy-schema.ts
+++ b/src/shared/lib/config/capability-policy-schema.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+/**
+ * Three-tier launch policy for the agent's delegation capabilities:
+ * - allow: launches run without asking
+ * - review: each launch pauses on an approval card until the user decides
+ * - block: the capability is removed from the session (tools + prompt)
+ */
+export const capabilityPolicySchema = z.enum(['allow', 'review', 'block'])
+export type CapabilityPolicy = z.infer<typeof capabilityPolicySchema>
+
+export const agentCapabilitySettingsSchema = z.object({
+  subagents: capabilityPolicySchema,
+  workflows: capabilityPolicySchema,
+})
+export type AgentCapabilitySettings = z.infer<typeof agentCapabilitySettingsSchema>
+
+/** Partial patch shape accepted by PUT /settings. */
+export const agentCapabilitySettingsPatchSchema = agentCapabilitySettingsSchema.partial()
+
+// Subagents default open (they are core to browsing/dashboards and cheap-tier
+// delegation); workflows default to review (a single launch can fan out into
+// dozens of agents).
+export const DEFAULT_AGENT_CAPABILITIES: AgentCapabilitySettings = {
+  subagents: 'allow',
+  workflows: 'review',
+}

--- a/src/shared/lib/config/capability-policy-schema.ts
+++ b/src/shared/lib/config/capability-policy-schema.ts
@@ -18,6 +18,11 @@ export type AgentCapabilitySettings = z.infer<typeof agentCapabilitySettingsSche
 /** Partial patch shape accepted by PUT /settings. */
 export const agentCapabilitySettingsPatchSchema = agentCapabilitySettingsSchema.partial()
 
+/** Response of the container's GET /sessions/:id/capability-grants. */
+export const sessionCapabilityGrantsResponseSchema = z.object({
+  grants: z.array(z.enum(['subagents', 'workflows'])),
+})
+
 // Subagents default open (they are core to browsing/dashboards and cheap-tier
 // delegation); workflows default to review (a single launch can fan out into
 // dozens of agents).

--- a/src/shared/lib/config/settings.test.ts
+++ b/src/shared/lib/config/settings.test.ts
@@ -1558,9 +1558,14 @@ describe('agentCapabilities', () => {
     expect(loadSettings().agentCapabilities).toEqual({ subagents: 'review', workflows: 'allow' })
   })
 
-  it('falls back to defaults when a stored tier is invalid', () => {
-    mockSettingsFile(JSON.stringify({ agentCapabilities: { subagents: 'maybe', workflows: 'review' } }))
-    expect(loadSettings().agentCapabilities).toEqual({ subagents: 'allow', workflows: 'review' })
+  it('defaults only the invalid field, keeping valid siblings', () => {
+    mockSettingsFile(JSON.stringify({ agentCapabilities: { subagents: 'maybe', workflows: 'allow' } }))
+    expect(loadSettings().agentCapabilities).toEqual({ subagents: 'allow', workflows: 'allow' })
+  })
+
+  it('an invalid field never lifts a valid block on the other capability', () => {
+    mockSettingsFile(JSON.stringify({ agentCapabilities: { subagents: 'block', workflows: 'future-tier' } }))
+    expect(loadSettings().agentCapabilities).toEqual({ subagents: 'block', workflows: 'review' })
   })
 
   it('DEFAULT_SETTINGS carries the section so new files persist it', () => {

--- a/src/shared/lib/config/settings.test.ts
+++ b/src/shared/lib/config/settings.test.ts
@@ -1537,3 +1537,33 @@ describe('runtimeSettings migration', () => {
     expect(reloaded.container.runtimeSettings?.lima?.vmMemory).toBe('16GiB')
   })
 })
+
+// ============================================================================
+// agentCapabilities (subagent/workflow launch policies)
+// ============================================================================
+
+describe('agentCapabilities', () => {
+  it('defaults to allow subagents / review workflows when the file is absent', () => {
+    mockNoSettingsFile()
+    expect(loadSettings().agentCapabilities).toEqual({ subagents: 'allow', workflows: 'review' })
+  })
+
+  it('fills a partial stored section from the defaults', () => {
+    mockSettingsFile(JSON.stringify({ agentCapabilities: { subagents: 'block' } }))
+    expect(loadSettings().agentCapabilities).toEqual({ subagents: 'block', workflows: 'review' })
+  })
+
+  it('preserves a fully customized section', () => {
+    mockSettingsFile(JSON.stringify({ agentCapabilities: { subagents: 'review', workflows: 'allow' } }))
+    expect(loadSettings().agentCapabilities).toEqual({ subagents: 'review', workflows: 'allow' })
+  })
+
+  it('falls back to defaults when a stored tier is invalid', () => {
+    mockSettingsFile(JSON.stringify({ agentCapabilities: { subagents: 'maybe', workflows: 'review' } }))
+    expect(loadSettings().agentCapabilities).toEqual({ subagents: 'allow', workflows: 'review' })
+  })
+
+  it('DEFAULT_SETTINGS carries the section so new files persist it', () => {
+    expect(DEFAULT_SETTINGS.agentCapabilities).toEqual({ subagents: 'allow', workflows: 'review' })
+  })
+})

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -20,7 +20,7 @@ import {
   type ModelCatalogSettings,
 } from '../llm-provider/model-catalog-schema'
 import {
-  agentCapabilitySettingsSchema,
+  capabilityPolicySchema,
   DEFAULT_AGENT_CAPABILITIES,
   type AgentCapabilitySettings,
 } from './capability-policy-schema'
@@ -501,13 +501,18 @@ function mergeLoadedSettings(loaded: Record<string, any>): AppSettings {
     platformNotifications: loaded.platformNotifications,
     enableToolSearch: loaded.enableToolSearch ?? DEFAULT_SETTINGS.enableToolSearch,
     // Sanitize per-field: an unknown tier (hand-edited file, future version)
-    // falls back to that field's default instead of poisoning the section.
+    // falls back to that field's default instead of poisoning the section —
+    // resetting the whole section would silently lift a valid 'block'.
     agentCapabilities: (() => {
-      const merged = { ...DEFAULT_AGENT_CAPABILITIES, ...loaded.agentCapabilities }
-      const parsed = agentCapabilitySettingsSchema.safeParse(merged)
-      if (parsed.success) return parsed.data
-      console.warn('Invalid agentCapabilities in settings.json; using defaults:', parsed.error.message)
-      return structuredClone(DEFAULT_AGENT_CAPABILITIES)
+      const out = structuredClone(DEFAULT_AGENT_CAPABILITIES)
+      for (const key of Object.keys(out) as (keyof AgentCapabilitySettings)[]) {
+        const raw = loaded.agentCapabilities?.[key]
+        if (raw === undefined) continue
+        const parsed = capabilityPolicySchema.safeParse(raw)
+        if (parsed.success) out[key] = parsed.data
+        else console.warn(`Invalid agentCapabilities.${key} in settings.json; using default:`, raw)
+      }
+      return out
     })(),
   }
 }

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -19,6 +19,13 @@ import {
   modelCatalogSettingsSchema,
   type ModelCatalogSettings,
 } from '../llm-provider/model-catalog-schema'
+import {
+  agentCapabilitySettingsSchema,
+  DEFAULT_AGENT_CAPABILITIES,
+  type AgentCapabilitySettings,
+} from './capability-policy-schema'
+
+export type { AgentCapabilitySettings, CapabilityPolicy } from './capability-policy-schema'
 
 export interface ContainerSettings {
   containerRunner: string
@@ -237,6 +244,8 @@ export interface AppSettings {
   platformNotifications?: PlatformNotificationsSettings
   /** Anthropic SDK tool search — defaults on; passed as `ENABLE_TOOL_SEARCH` to the container. */
   enableToolSearch?: boolean
+  /** Launch policies for subagents (Task/Agent) and workflows (Workflow tool). */
+  agentCapabilities?: AgentCapabilitySettings
 }
 
 export interface PlatformNotificationsSettings {
@@ -317,6 +326,7 @@ export interface GlobalSettingsResponse {
   analyticsTargets?: AnalyticsTarget[]
   shareErrorReports: boolean
   enableToolSearch: boolean
+  agentCapabilities: AgentCapabilitySettings
 }
 
 /**
@@ -363,6 +373,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     agentEffort: 'medium',
   },
   enableToolSearch: true,
+  agentCapabilities: DEFAULT_AGENT_CAPABILITIES,
   skillsets: [DEFAULT_PUBLIC_SKILLSET],
 }
 
@@ -489,6 +500,15 @@ function mergeLoadedSettings(loaded: Record<string, any>): AppSettings {
     platformAuth: loaded.platformAuth,
     platformNotifications: loaded.platformNotifications,
     enableToolSearch: loaded.enableToolSearch ?? DEFAULT_SETTINGS.enableToolSearch,
+    // Sanitize per-field: an unknown tier (hand-edited file, future version)
+    // falls back to that field's default instead of poisoning the section.
+    agentCapabilities: (() => {
+      const merged = { ...DEFAULT_AGENT_CAPABILITIES, ...loaded.agentCapabilities }
+      const parsed = agentCapabilitySettingsSchema.safeParse(merged)
+      if (parsed.success) return parsed.data
+      console.warn('Invalid agentCapabilities in settings.json; using defaults:', parsed.error.message)
+      return structuredClone(DEFAULT_AGENT_CAPABILITIES)
+    })(),
   }
 }
 
@@ -814,6 +834,12 @@ export function getCustomEnvVars(): Record<string, string> {
 export function getVoiceSettings(): VoiceSettings {
   const settings = getSettings()
   return settings.voice ?? {}
+}
+
+/** Resolved launch policies for subagents/workflows (defaults applied). */
+export function getAgentCapabilitySettings(): AgentCapabilitySettings {
+  const settings = getSettings()
+  return settings.agentCapabilities ?? DEFAULT_AGENT_CAPABILITIES
 }
 
 export { DEFAULT_SETTINGS }

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -21,7 +21,7 @@ import type {
 import type { RuntimeOptions } from './runtime-options'
 import { getAgentWorkspaceDir } from '@shared/lib/config/data-dir'
 import { getContainerHostUrl, getAppPort } from '@shared/lib/proxy/host-url'
-import { getSettings } from '@shared/lib/config/settings'
+import { getAgentCapabilitySettings, getSettings } from '@shared/lib/config/settings'
 import { getActiveLlmProvider } from '@shared/lib/llm-provider'
 import { resolveContainerModel, getContainerModelPromptHints } from './resolve-model'
 import { getActiveWebProvider } from '../web-provider'
@@ -1011,6 +1011,11 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     const activeWebProvider = getActiveWebProvider()
     const webSearchProvider = activeWebProvider?.search ? activeWebProvider.id : undefined
     const webFetchProvider = activeWebProvider?.fetch ? activeWebProvider.id : undefined
+    // Host-authoritative launch policies (allow/review/block for subagents and
+    // workflows), resolved from global settings here so every session-creation
+    // caller inherits them. Never taken from the request — a caller (or the
+    // agent itself) must not be able to loosen its own policy.
+    const capabilityPolicies = getAgentCapabilitySettings()
 
     try {
       const controller = new AbortController()
@@ -1038,6 +1043,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
           customEnvVars: options.customEnvVars,
           maxBrowserTabs: options.maxBrowserTabs,
           effort: options.effort,
+          capabilityPolicies,
         }),
         signal: controller.signal,
       })
@@ -1135,6 +1141,9 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     const effort = options?.effort
     const model = resolveContainerModel(options?.model, 'agent')
     const shouldQuery = options?.shouldQuery
+    // Refreshed on every message so a long-lived session tracks settings
+    // changes; the container restarts its query only on a block-boundary flip.
+    const capabilityPolicies = getAgentCapabilitySettings()
 
     try {
       const controller = new AbortController()
@@ -1151,6 +1160,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
             ...(effort ? { effort } : {}),
             ...(model ? { model } : {}),
             ...(shouldQuery !== undefined ? { shouldQuery } : {}),
+            capabilityPolicies,
           }),
           signal: controller.signal,
         }

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -26,6 +26,7 @@ import { getActiveLlmProvider } from '@shared/lib/llm-provider'
 import { resolveContainerModel, getContainerModelPromptHints } from './resolve-model'
 import { getActiveWebProvider } from '../web-provider'
 import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
+import { getOrCreateHostToken } from './host-token-store'
 
 const execAsync = promisify(exec)
 
@@ -940,6 +941,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       // hanging the fetch — and the caller — indefinitely without this.
       const response = await fetch(`${this.getBaseUrl(port)}/health`, {
         signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+        headers: this.getHostAuthHeaders(),
       })
       return response.ok
     } catch {
@@ -975,13 +977,26 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     return `http://${getContainerHostUrl()}:${getAppPort()}`
   }
 
+  // Proves to the container API that the caller is the host, not the agent's
+  // own Bash reaching the server over the shared network namespace.
+  private hostAuthHeadersCache?: Record<string, string>
+  getHostAuthHeaders(): Record<string, string> {
+    this.hostAuthHeadersCache ??= {
+      'x-superagent-host-token': getOrCreateHostToken(this.config.agentId),
+    }
+    return this.hostAuthHeadersCache
+  }
+
   async fetch(path: string, init?: RequestInit): Promise<Response> {
     const port = await this.getPortOrThrow()
     const baseUrl = this.getBaseUrl(port)
     const url = `${baseUrl}${path.startsWith('/') ? path : '/' + path}`
 
     try {
-      return await fetch(url, init)
+      return await fetch(url, {
+        ...init,
+        headers: { ...this.getHostAuthHeaders(), ...(init?.headers as Record<string, string> | undefined) },
+      })
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error))
 
@@ -1023,7 +1038,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
       const response = await fetch(`${this.getBaseUrl(port)}/sessions`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...this.getHostAuthHeaders() },
         body: JSON.stringify({
           metadata: options.metadata,
           systemPrompt: options.systemPrompt,
@@ -1106,7 +1121,8 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     const port = await this.getPortOrThrow()
 
     const response = await fetch(
-      `${this.getBaseUrl(port)}/sessions/${sessionId}`
+      `${this.getBaseUrl(port)}/sessions/${sessionId}`,
+      { headers: this.getHostAuthHeaders() }
     )
 
     if (response.status === 404) return null
@@ -1129,7 +1145,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
     const response = await fetch(
       `${this.getBaseUrl(port)}/sessions/${sessionId}`,
-      { method: 'DELETE' }
+      { method: 'DELETE', headers: this.getHostAuthHeaders() }
     )
 
     return response.ok
@@ -1153,7 +1169,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
         `${this.getBaseUrl(port)}/sessions/${sessionId}/messages`,
         {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', ...this.getHostAuthHeaders() },
           body: JSON.stringify({
             content,
             ...(uuid ? { uuid } : {}),
@@ -1210,7 +1226,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
     const response = await fetch(
       `http://127.0.0.1:${port}/sessions/${sessionId}/queued-messages/${encodeURIComponent(uuid)}`,
-      { method: 'DELETE' }
+      { method: 'DELETE', headers: this.getHostAuthHeaders() }
     )
     if (response.status === 404) {
       // Route missing = the container is running a build that predates the
@@ -1234,7 +1250,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
     const response = await fetch(
       `${this.getBaseUrl(port)}/sessions/${sessionId}/interrupt`,
-      { method: 'POST' }
+      { method: 'POST', headers: this.getHostAuthHeaders() }
     )
 
     return response.ok
@@ -1260,7 +1276,8 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       }
 
       const ws = new WebSocket(
-        `${this.getWebSocketBaseUrl(port)}/sessions/${sessionId}/stream`
+        `${this.getWebSocketBaseUrl(port)}/sessions/${sessionId}/stream`,
+        { headers: this.getHostAuthHeaders() }
       )
 
       ws.on('open', () => {

--- a/src/shared/lib/container/container-manager-concurrency.test.ts
+++ b/src/shared/lib/container/container-manager-concurrency.test.ts
@@ -53,6 +53,10 @@ vi.mock('@shared/lib/proxy/token-store', () => ({
   getOrCreateProxyToken: vi.fn().mockResolvedValue('test-token'),
 }))
 
+vi.mock('@shared/lib/container/host-token-store', () => ({
+  getOrCreateHostToken: vi.fn(() => 'test-host-token'),
+}))
+
 vi.mock('@shared/lib/proxy/host-url', () => ({
   getContainerHostUrl: () => '127.0.0.1',
   getAppPort: () => 3000,

--- a/src/shared/lib/container/container-manager.reserved-env.sup210.test.ts
+++ b/src/shared/lib/container/container-manager.reserved-env.sup210.test.ts
@@ -47,6 +47,11 @@ vi.mock('@shared/lib/proxy/token-store', () => ({
   getOrCreateProxyToken: (...args: unknown[]) => mockGetOrCreateProxyToken(...args),
 }))
 
+const mockGetOrCreateHostToken = vi.fn(() => 'real-host-token')
+vi.mock('@shared/lib/container/host-token-store', () => ({
+  getOrCreateHostToken: (...args: unknown[]) => mockGetOrCreateHostToken(...args),
+}))
+
 const mockGetContainerHostUrl = vi.fn()
 const mockGetAppPort = vi.fn()
 vi.mock('@shared/lib/proxy/host-url', () => ({
@@ -178,6 +183,7 @@ describe('SUP-210 — customEnvVars cannot override reserved runtime env vars', 
         PROXY_BASE_URL: 'http://evil.example/api/proxy/spoofed',
         SUPERAGENT_AGENT_SLUG: 'not-the-real-agent',
         SUPERAGENT_HOST_API_URL: 'http://evil.example/api',
+        SUPERAGENT_HOST_TOKEN: 'attacker-host-token',
         CONNECTED_ACCOUNTS: '{"gmail":[{"name":"spoof","id":"x"}]}',
         TZ: 'Antarctica/Troll',
         HOST_PLATFORM: 'spoofed-os',
@@ -202,6 +208,7 @@ describe('SUP-210 — customEnvVars cannot override reserved runtime env vars', 
     expect(envVars.PROXY_BASE_URL).toBe('http://192.168.1.100:3000/api/proxy/test-agent')
     expect(envVars.SUPERAGENT_AGENT_SLUG).toBe('test-agent')
     expect(envVars.SUPERAGENT_HOST_API_URL).toBe('http://192.168.1.100:3000/api')
+    expect(envVars.SUPERAGENT_HOST_TOKEN).toBe('real-host-token')
     // No active accounts -> empty object, not the spoofed metadata.
     expect(envVars.CONNECTED_ACCOUNTS).toBe('{}')
   })

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -45,6 +45,11 @@ vi.mock('@shared/lib/proxy/token-store', () => ({
   getOrCreateProxyToken: (...args: unknown[]) => mockGetOrCreateProxyToken(...args),
 }))
 
+const mockGetOrCreateHostToken = vi.fn(() => 'hostc_test-token')
+vi.mock('@shared/lib/container/host-token-store', () => ({
+  getOrCreateHostToken: (...args: unknown[]) => mockGetOrCreateHostToken(...args),
+}))
+
 const mockGetContainerHostUrl = vi.fn()
 const mockGetAppPort = vi.fn()
 vi.mock('@shared/lib/proxy/host-url', () => ({
@@ -223,6 +228,16 @@ describe('containerManager.ensureRunning — env var construction', () => {
     const startOpts = mockStart.mock.calls[0][0]
     expect(startOpts.envVars.PROXY_TOKEN).toBe('custom-proxy-token')
     expect(mockGetOrCreateProxyToken).toHaveBeenCalledWith('test-agent')
+  })
+
+  it('sets SUPERAGENT_HOST_TOKEN so the container can authenticate host API calls', async () => {
+    setupAccountMocks([])
+
+    await containerManager.ensureRunning('test-agent')
+
+    const startOpts = mockStart.mock.calls[0][0]
+    expect(startOpts.envVars.SUPERAGENT_HOST_TOKEN).toBe('hostc_test-token')
+    expect(mockGetOrCreateHostToken).toHaveBeenCalledWith('test-agent')
   })
 
   it('CONNECTED_ACCOUNTS includes only active accounts, grouped by toolkitSlug', async () => {

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -9,6 +9,7 @@ import { db } from '@shared/lib/db'
 import { agentConnectedAccounts, connectedAccounts, agentRemoteMcps, remoteMcpServers } from '@shared/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { getOrCreateProxyToken } from '@shared/lib/proxy/token-store'
+import { getOrCreateHostToken } from '@shared/lib/container/host-token-store'
 import { getSettings, mutateSettings } from '@shared/lib/config/settings'
 import { getAgentWorkspaceDir } from '@shared/lib/config/data-dir'
 import { copyChromeProfileData } from '@shared/lib/browser/chrome-profile'
@@ -524,6 +525,11 @@ class ContainerManager {
       // X-Agent Work: cross-agent calls. Container POSTs to host with PROXY_TOKEN.
       envVars['SUPERAGENT_HOST_API_URL'] = `${hostApiBaseUrl}/api`
       envVars['SUPERAGENT_AGENT_SLUG'] = agentId
+
+      // Authenticates the HOST to the container API (the reverse direction of
+      // PROXY_TOKEN, which the agent legitimately holds). The container server
+      // strips this from its env before spawning the CLI.
+      envVars['SUPERAGENT_HOST_TOKEN'] = getOrCreateHostToken(agentId)
 
       // Fetch connected accounts for this agent
       const accountMappings = await db

--- a/src/shared/lib/container/host-token-store.test.ts
+++ b/src/shared/lib/container/host-token-store.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+let tempDir: string
+
+vi.mock('@shared/lib/config/data-dir', () => ({
+  getDataDir: () => tempDir,
+}))
+
+import { getOrCreateHostToken } from './host-token-store'
+
+describe('host-token-store', () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'host-token-store-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('creates a token per agent and returns the same one on later calls', () => {
+    const first = getOrCreateHostToken('agent-a')
+    expect(first).toMatch(/^hostc_[0-9a-f]{64}$/)
+    expect(getOrCreateHostToken('agent-a')).toBe(first)
+    expect(getOrCreateHostToken('agent-b')).not.toBe(first)
+  })
+
+  it('persists tokens across reads (survives a host restart)', () => {
+    const token = getOrCreateHostToken('agent-a')
+    const onDisk = JSON.parse(fs.readFileSync(path.join(tempDir, 'host-container-tokens.json'), 'utf-8'))
+    expect(onDisk['agent-a']).toBe(token)
+  })
+
+  it('writes the token file owner-read/write only', () => {
+    getOrCreateHostToken('agent-a')
+    const mode = fs.statSync(path.join(tempDir, 'host-container-tokens.json')).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+
+  it('regenerates from scratch when the file is corrupt', () => {
+    fs.writeFileSync(path.join(tempDir, 'host-container-tokens.json'), 'not-json')
+    const token = getOrCreateHostToken('agent-a')
+    expect(token).toMatch(/^hostc_/)
+    expect(getOrCreateHostToken('agent-a')).toBe(token)
+  })
+})

--- a/src/shared/lib/container/host-token-store.ts
+++ b/src/shared/lib/container/host-token-store.ts
@@ -1,0 +1,50 @@
+import crypto from 'crypto'
+import * as fs from 'fs'
+import * as path from 'path'
+import { z } from 'zod'
+import { getDataDir } from '@shared/lib/config/data-dir'
+
+/**
+ * Per-agent secrets that authenticate the HOST to the agent's container API
+ * (the reverse of PROXY_TOKEN, which authenticates the container/agent to the
+ * host and is deliberately agent-visible). The container refuses policy-bearing
+ * requests — session creation, sends carrying capabilityPolicies, input
+ * resolve/reject — without this token, so an agent can't loosen its own launch
+ * policy or self-approve a parked review through the in-container API.
+ *
+ * Lives in the host data dir (never mounted into containers). Must survive
+ * host restarts: containers outlive the host process and keep requiring the
+ * token they were started with.
+ */
+const hostTokensSchema = z.record(z.string(), z.string())
+type HostTokens = z.infer<typeof hostTokensSchema>
+
+const FILE_NAME = 'host-container-tokens.json'
+
+function tokensFilePath(): string {
+  return path.join(getDataDir(), FILE_NAME)
+}
+
+function readTokens(): HostTokens {
+  try {
+    const raw = fs.readFileSync(tokensFilePath(), 'utf-8')
+    return hostTokensSchema.parse(JSON.parse(raw))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.warn('[host-token-store] Unreadable token file; regenerating tokens:', error)
+    }
+    return {}
+  }
+}
+
+export function getOrCreateHostToken(agentSlug: string): string {
+  const tokens = readTokens()
+  const existing = tokens[agentSlug]
+  if (existing) return existing
+
+  const token = `hostc_${crypto.randomBytes(32).toString('hex')}`
+  tokens[agentSlug] = token
+  fs.mkdirSync(getDataDir(), { recursive: true })
+  fs.writeFileSync(tokensFilePath(), JSON.stringify(tokens, null, 2), { mode: 0o600 })
+  return token
+}

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -34,8 +34,13 @@ vi.mock('@shared/lib/notifications/notification-manager', () => ({
 }))
 
 const mockGetSettings = vi.fn((): Record<string, unknown> => ({}))
+const mockAgentCapabilities: Record<'subagents' | 'workflows', 'allow' | 'review' | 'block'> = {
+  subagents: 'allow',
+  workflows: 'review',
+}
 vi.mock('@shared/lib/config/settings', () => ({
   getSettings: () => mockGetSettings(),
+  getAgentCapabilitySettings: () => ({ ...mockAgentCapabilities }),
   getModelCatalogSettings: () => mockGetSettings().modelCatalog ?? {},
   VALID_SCRIPT_TYPES: {
     darwin: ['applescript', 'shell'],
@@ -2677,6 +2682,118 @@ describe('MessagePersister', () => {
 
     it('is idle for an unknown session', () => {
       expect(messagePersister.getSessionActivity('nope')).toBe('idle')
+    })
+  })
+
+  // ============================================================================
+  // Capability review lifecycle
+  // ============================================================================
+
+  describe('capability review lifecycle', () => {
+    function simulateToolUse(toolName: string, toolId: string, input: Record<string, unknown>) {
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          content_block: { type: 'tool_use', id: toolId, name: toolName },
+        },
+      })
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) },
+        },
+      })
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_stop' },
+      })
+    }
+
+    beforeEach(() => {
+      mockAgentCapabilities.subagents = 'allow'
+      mockAgentCapabilities.workflows = 'review'
+      // Grant lookup on the container: default to "no persisted grants".
+      vi.mocked(mockClient.fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({ grants: [] }),
+      } as unknown as Response)
+    })
+
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+    it('broadcasts a review card and stores it for reconnect replay', async () => {
+      simulateToolUse('Workflow', 'wf-1', { script: 'export const meta = {}' })
+
+      await vi.waitFor(() => {
+        expect(sseEvents.filter(e => e.type === 'capability_review_request')).toHaveLength(1)
+      })
+      expect(sseEvents.filter(e => e.type === 'capability_review_request')[0]).toMatchObject({
+        toolUseId: 'wf-1',
+        capability: 'workflows',
+      })
+      expect(messagePersister.getPendingInputRequests(SESSION_ID).map(r => r.toolUseId)).toContain('wf-1')
+    })
+
+    it('completeCapabilityReview clears the replay store immediately and notifies live clients', async () => {
+      simulateToolUse('Workflow', 'wf-1', { script: 'export const meta = {}' })
+      await vi.waitFor(() => {
+        expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(1)
+      })
+
+      // The decision route calls this on approve AND reject. Waiting for the
+      // launched Workflow's tool_result would leave the card replaying to any
+      // reconnecting client for the whole (possibly minutes-long) run.
+      messagePersister.completeCapabilityReview(SESSION_ID, 'wf-1')
+
+      expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
+      const resolved = sseEvents.filter(e => e.type === 'capability_review_resolved')
+      expect(resolved).toHaveLength(1)
+      expect(resolved[0]).toMatchObject({ toolUseId: 'wf-1' })
+    })
+
+    it('a session-scope grant in the host mirror suppresses review cards without a container query', async () => {
+      messagePersister.grantSessionCapability(SESSION_ID, 'workflows')
+      simulateToolUse('Workflow', 'wf-2', { script: 'export const meta = {}' })
+
+      await flush()
+      expect(sseEvents.filter(e => e.type === 'capability_review_request')).toHaveLength(0)
+      expect(mockClient.fetch).not.toHaveBeenCalled()
+    })
+
+    it('consults the container-persisted grants when the host mirror is cold', async () => {
+      // Fresh host process, live granted session: the container reports the
+      // grant, so no phantom card — and the mirror is repopulated for next time.
+      vi.mocked(mockClient.fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({ grants: ['workflows'] }),
+      } as unknown as Response)
+
+      simulateToolUse('Workflow', 'wf-3', { script: 'export const meta = {}' })
+
+      await vi.waitFor(() => {
+        expect(messagePersister.hasSessionCapabilityGrant(SESSION_ID, 'workflows')).toBe(true)
+      })
+      expect(sseEvents.filter(e => e.type === 'capability_review_request')).toHaveLength(0)
+    })
+
+    it('still shows the card when the grant lookup fails', async () => {
+      vi.mocked(mockClient.fetch).mockRejectedValue(new Error('container gone'))
+
+      simulateToolUse('Workflow', 'wf-4', { script: 'export const meta = {}' })
+
+      await vi.waitFor(() => {
+        expect(sseEvents.filter(e => e.type === 'capability_review_request')).toHaveLength(1)
+      })
+    })
+
+    it('subagent launches under allow policy broadcast nothing', async () => {
+      simulateToolUse('Task', 'task-1', { prompt: 'go', subagent_type: 'Explore' })
+
+      await flush()
+      expect(sseEvents.filter(e => e.type === 'capability_review_request')).toHaveLength(0)
+      expect(mockClient.fetch).not.toHaveBeenCalled()
     })
   })
 

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -60,6 +60,7 @@ import { getSessionMetadata, updateSessionMetadata } from '@shared/lib/services/
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
 import { VALID_SCRIPT_TYPES, getAgentCapabilitySettings } from '@shared/lib/config/settings'
+import { sessionCapabilityGrantsResponseSchema } from '@shared/lib/config/capability-policy-schema'
 import { getActiveLlmProvider, getModelContextWindow } from '@shared/lib/llm-provider'
 import { computerUsePermissionManager } from '@shared/lib/computer-use/permission-manager'
 import { resolveAppFromWindowRef } from '@shared/lib/computer-use/executor'
@@ -330,6 +331,9 @@ class MessagePersister {
     }
     this.streamingStates.delete(sessionId)
     this.containerClients.delete(sessionId)
+    // Safe to drop: the container's persisted grants are authoritative, so a
+    // resubscribed session repopulates this on the next launch with one GET.
+    this.sessionCapabilityGrants.delete(sessionId)
   }
 
   // Single idle finalizer — flips state and broadcasts to session + global
@@ -488,6 +492,25 @@ class MessagePersister {
 
   hasSessionCapabilityGrant(sessionId: string, capability: 'subagents' | 'workflows'): boolean {
     return this.sessionCapabilityGrants.get(sessionId)?.has(capability) ?? false
+  }
+
+  // Drop a decided capability review from the reconnect-replay store and tell live
+  // clients to close the card. Unlike other input requests this can't wait for the
+  // tool_result cleanup at handleToolResult — an approved Task/Workflow runs for
+  // minutes before its result arrives, and until then a refresh would replay (and
+  // other connected clients would keep) a stale approval card.
+  completeCapabilityReview(sessionId: string, toolUseId: string): void {
+    const state = this.streamingStates.get(sessionId)
+    if (!state) return
+    state.pendingInputRequests.delete(toolUseId)
+    this.broadcastToSSE(sessionId, { type: 'capability_review_resolved', toolUseId })
+    if (state.pendingInputRequests.size === 0) {
+      this.broadcastGlobal({
+        type: 'session_input_provided',
+        sessionId,
+        agentSlug: state.agentSlug,
+      })
+    }
   }
 
   // Clear a pending computer use request (after approval/rejection)
@@ -2029,7 +2052,7 @@ class MessagePersister {
           // A nested launch from inside a subagent pauses in canUseTool too —
           // it needs the same approval card as a top-level one.
           if (['Task', 'Agent', 'Workflow'].includes(sub.currentToolUse.name)) {
-            this.handleCapabilityReviewTool(
+            void this.handleCapabilityReviewTool(
               sessionId,
               sub.currentToolUse.id,
               sub.currentToolUse.name,
@@ -2317,7 +2340,7 @@ class MessagePersister {
           // policy — surface the approval card. The handler itself checks the
           // policy and session grants (no-op under allow/block/granted).
           if (['Task', 'Agent', 'Workflow'].includes(state.currentToolUse.name)) {
-            this.handleCapabilityReviewTool(
+            void this.handleCapabilityReviewTool(
               sessionId,
               state.currentToolUse.id,
               state.currentToolUse.name,
@@ -3579,17 +3602,42 @@ ${continuation}`
   // decision route answers it via /inputs/:toolUseId/resolve|reject. Under
   // 'allow' or an active session grant the container never pauses, and under
   // 'block' it denies outright — no card in any of those cases.
-  private handleCapabilityReviewTool(
+  private async handleCapabilityReviewTool(
     sessionId: string,
     toolUseId: string,
     toolName: string,
     toolInput: string,
     agentSlug?: string
-  ): void {
+  ): Promise<void> {
     try {
       const capability = toolName === 'Workflow' ? 'workflows' : 'subagents'
       if (getAgentCapabilitySettings()[capability] !== 'review') return
       if (this.hasSessionCapabilityGrant(sessionId, capability)) return
+
+      // The in-memory mirror above is only a fast path — the container's
+      // persisted grants are authoritative. A fresh host process against a
+      // live granted session would otherwise render a phantom review card
+      // while the container runs the launch without waiting.
+      const client = this.containerClients.get(sessionId)
+      if (client) {
+        try {
+          const response = await client.fetch(
+            `/sessions/${encodeURIComponent(sessionId)}/capability-grants`,
+            { method: 'GET' }
+          )
+          if (response.ok) {
+            const { grants } = sessionCapabilityGrantsResponseSchema.parse(await response.json())
+            if (grants.includes(capability)) {
+              this.grantSessionCapability(sessionId, capability)
+              return
+            }
+          }
+        } catch (error) {
+          // Fail toward showing the card: a review the container isn't waiting
+          // on beats a launch that silently skips review.
+          console.warn('[MessagePersister] Capability grant lookup failed; showing review card:', error)
+        }
+      }
 
       let input: Record<string, unknown> = {}
       try {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -59,7 +59,7 @@ import { getFrequencyWarning, getScheduleCountWarning, validateScheduleExpressio
 import { getSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
-import { VALID_SCRIPT_TYPES } from '@shared/lib/config/settings'
+import { VALID_SCRIPT_TYPES, getAgentCapabilitySettings } from '@shared/lib/config/settings'
 import { getActiveLlmProvider, getModelContextWindow } from '@shared/lib/llm-provider'
 import { computerUsePermissionManager } from '@shared/lib/computer-use/permission-manager'
 import { resolveAppFromWindowRef } from '@shared/lib/computer-use/executor'
@@ -210,6 +210,11 @@ export function redactStreamedToolInput(toolName: string | undefined, partialInp
 // TODO this file is too big, this class is HUGE. Needs breaking up
 class MessagePersister {
   private streamingStates: Map<string, StreamingState> = new Map()
+  // "Allow for this session" capability grants, keyed by sessionId. Display
+  // bookkeeping ONLY — enforcement lives in the container (which persists its
+  // copy with the session). Once granted, launches auto-allow container-side
+  // with no pending entry, so we must stop broadcasting review cards for them.
+  private sessionCapabilityGrants: Map<string, Set<'subagents' | 'workflows'>> = new Map()
   private subscriptions: Map<string, () => void> = new Map()
   private sseClients: Map<string, Set<(data: unknown) => void>> = new Map()
   // Per-run journal tailers driving the live workflow drawer, keyed `${sessionId}::${runId}`
@@ -470,6 +475,19 @@ class MessagePersister {
     const state = this.streamingStates.get(sessionId)
     if (!state) return []
     return Array.from(state.pendingInputRequests.values())
+  }
+
+  // Record an "Allow for this session" capability grant (decision route calls
+  // this when the user picks session scope) so later launches in the session
+  // don't produce review cards the container will never wait on.
+  grantSessionCapability(sessionId: string, capability: 'subagents' | 'workflows'): void {
+    const grants = this.sessionCapabilityGrants.get(sessionId) ?? new Set()
+    grants.add(capability)
+    this.sessionCapabilityGrants.set(sessionId, grants)
+  }
+
+  hasSessionCapabilityGrant(sessionId: string, capability: 'subagents' | 'workflows'): boolean {
+    return this.sessionCapabilityGrants.get(sessionId)?.has(capability) ?? false
   }
 
   // Clear a pending computer use request (after approval/rejection)
@@ -839,6 +857,7 @@ class MessagePersister {
     'remote_mcp_request',
     'script_run_request',
     'browser_input_request',
+    'capability_review_request',
   ])
 
   // Broadcast to SSE clients
@@ -2007,6 +2026,18 @@ class MessagePersister {
             )
           }
 
+          // A nested launch from inside a subagent pauses in canUseTool too —
+          // it needs the same approval card as a top-level one.
+          if (['Task', 'Agent', 'Workflow'].includes(sub.currentToolUse.name)) {
+            this.handleCapabilityReviewTool(
+              sessionId,
+              sub.currentToolUse.id,
+              sub.currentToolUse.name,
+              sub.currentToolInput,
+              state.agentSlug
+            )
+          }
+
           this.broadcastToSSE(sessionId, {
             type: 'subagent_tool_use_ready',
             parentToolId,
@@ -2274,6 +2305,19 @@ class MessagePersister {
 
           if (state.currentToolUse.name.startsWith('mcp__computer-use__')) {
             this.handleComputerUseRequestTool(
+              sessionId,
+              state.currentToolUse.id,
+              state.currentToolUse.name,
+              state.currentToolInput,
+              state.agentSlug
+            )
+          }
+
+          // Subagent/workflow launches pause in the container under a 'review'
+          // policy — surface the approval card. The handler itself checks the
+          // policy and session grants (no-op under allow/block/granted).
+          if (['Task', 'Agent', 'Workflow'].includes(state.currentToolUse.name)) {
+            this.handleCapabilityReviewTool(
               sessionId,
               state.currentToolUse.id,
               state.currentToolUse.name,
@@ -3526,6 +3570,51 @@ ${continuation}`
       }
     } catch (error) {
       console.error('[MessagePersister] Error handling AskUserQuestion:', error)
+    }
+  }
+
+  // Handle a subagent (Task/Agent) or workflow (Workflow) launch under a
+  // 'review' policy: broadcast the approval card. The container's canUseTool
+  // has paused the launch on a pending input keyed by the same toolUseId; the
+  // decision route answers it via /inputs/:toolUseId/resolve|reject. Under
+  // 'allow' or an active session grant the container never pauses, and under
+  // 'block' it denies outright — no card in any of those cases.
+  private handleCapabilityReviewTool(
+    sessionId: string,
+    toolUseId: string,
+    toolName: string,
+    toolInput: string,
+    agentSlug?: string
+  ): void {
+    try {
+      const capability = toolName === 'Workflow' ? 'workflows' : 'subagents'
+      if (getAgentCapabilitySettings()[capability] !== 'review') return
+      if (this.hasSessionCapabilityGrant(sessionId, capability)) return
+
+      let input: Record<string, unknown> = {}
+      try {
+        input = JSON.parse(toolInput)
+      } catch {
+        // Launches with unparseable input still need a decision — show the card with what we have.
+      }
+
+      this.broadcastToSSE(sessionId, {
+        type: 'capability_review_request',
+        toolUseId,
+        capability,
+        toolName,
+        input,
+        agentSlug,
+      })
+      this.markSessionAwaitingInput(sessionId)
+
+      if (agentSlug) {
+        notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'capability_review').catch((err) => {
+          console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
+        })
+      }
+    } catch (error) {
+      console.error('[MessagePersister] Error handling capability review:', error)
     }
   }
 

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1716,6 +1716,10 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     return this.getInfoFromRuntime()
   }
 
+  getHostAuthHeaders(): Record<string, string> {
+    return {}
+  }
+
   async fetch(fetchPath: string, _init?: RequestInit): Promise<Response> {
     // Mock fetch - return appropriate empty responses based on path
 

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1293,6 +1293,37 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
         },
       },
     ])],
+    // Capability review scenarios: the streamed Task/Workflow tool_use flows
+    // through the real MessagePersister policy gate (workflows default to
+    // review, subagents to allow), and the decision route answers via the
+    // mock's /inputs resolve/reject just like the real container.
+    ['launch workflow', new UserInputRequestScenario([
+      {
+        name: 'Workflow',
+        input: {
+          name: 'sample-audit',
+          script: [
+            "export const meta = {",
+            "  name: 'sample-audit',",
+            "  description: 'Audit the sample data set',",
+            "  phases: [",
+            "    { title: 'Scan', detail: 'collect candidates' },",
+            "    { title: 'Verify', detail: 'adversarially check each' },",
+            "  ],",
+            "}",
+            "const found = await parallel([() => agent('scan part one'), () => agent('scan part two')])",
+            "const verified = await agent('verify: ' + JSON.stringify(found))",
+            "return verified",
+          ].join('\n'),
+        },
+      },
+    ])],
+    ['launch subagent', new UserInputRequestScenario([
+      {
+        name: 'Task',
+        input: { subagent_type: 'Explore', description: 'Scan the repo', prompt: 'Look at the files and report back' },
+      },
+    ])],
     // Proxy review scenario for E2E tests
     ['proxy review', new ProxyReviewScenario(
       'slack',

--- a/src/shared/lib/container/reserved-env-vars.ts
+++ b/src/shared/lib/container/reserved-env-vars.ts
@@ -21,6 +21,8 @@ export const RESERVED_ENV_VAR_KEYS: ReadonlySet<string> = new Set([
   // Cross-agent / host API wiring
   'SUPERAGENT_HOST_API_URL',
   'SUPERAGENT_AGENT_SLUG',
+  // Host→container API auth (never agent-visible)
+  'SUPERAGENT_HOST_TOKEN',
   // Account + MCP metadata
   'CONNECTED_ACCOUNTS',
   'REMOTE_MCPS',

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -143,6 +143,11 @@ export interface ContainerClient {
   // Throws if container is not running
   fetch(path: string, init?: RequestInit): Promise<Response>
 
+  // Headers proving the caller is the host — required by the container API,
+  // which is also reachable from the agent's own Bash. Callers that dial the
+  // container directly (e.g. WebSocket upgrades) must attach these.
+  getHostAuthHeaders(): Record<string, string>
+
   getWebSocketBaseUrl(port: number): string
   getHostApiBaseUrl(): string | Promise<string>
 

--- a/src/shared/lib/notifications/notification-manager.ts
+++ b/src/shared/lib/notifications/notification-manager.ts
@@ -154,7 +154,7 @@ class NotificationManager {
   async triggerSessionWaitingInput(
     sessionId: string,
     agentSlug: string,
-    waitingFor: 'secret' | 'connected_account' | 'question' | 'file' | 'remote_mcp' | 'browser_input' | 'script_run' | 'computer_use',
+    waitingFor: 'secret' | 'connected_account' | 'question' | 'file' | 'remote_mcp' | 'browser_input' | 'script_run' | 'computer_use' | 'capability_review',
     agentName?: string
   ): Promise<void> {
     const displayName = agentName || await this.getAgentDisplayName(agentSlug)
@@ -183,6 +183,9 @@ class NotificationManager {
         break
       case 'computer_use':
         waitingMessage = 'wants to control your computer'
+        break
+      case 'capability_review':
+        waitingMessage = 'wants to launch agents'
         break
     }
 


### PR DESCRIPTION
Implements SUP-393 (Phase 1 of SUP-392): a global three-tier launch policy — allow / review / block — for subagents (Task/Agent) and workflows (Workflow), enforced end-to-end. Defaults: subagents **allow**, workflows **review**.

## How it works

**Policy source (host-authoritative).** `settings.agentCapabilities` in settings.json, validated with Zod at every boundary. The host resolves the policy from current global settings in `createSession` *and* every `sendMessage` — never from the request — so an agent can't loosen its own policy, and settings changes apply from the next message without restarting anything.

**Block = capability removal, not call-time deny.** Task/Agent/Workflow are stripped from `allowedTools` (+ `enableWorkflows: false`), and the system prompt's delegation sections (web-browser, dashboard-builder, computer-use, Agent-tool guidance) are mustache-gated behind `subagentsEnabled`, each with a direct-tools fallback so no orphaned instructions remain. Crossing a block boundary mid-session triggers the same interrupt+restart path as an effort change and regenerates the prompt.

**Review = park the launch on a PreToolUse hook.** ⚠️ Deviation from the ticket: `canUseTool` is **shadowed under `bypassPermissions`** (SDK warns `CLAUDE_SDK_CAN_USE_TOOL_SHADOWED`; only AskUserQuestion is special-cased) — proven live, the gate never fired there. The gate is a PreToolUse hook (`matcher: '^(Task|Agent|Workflow)$'`) that awaits a host-side decision via the existing input-manager round-trip; hook denies still bind under bypass.

**Review UX.** A rich pre-flight card renders in the session: parsed workflow name/description/phases/agent-call-sites (via `workflow-script-parser`) or the subagent type + prompt preview, with **Run / Block (with optional reason) / Allow for this session**. Cards are SSE + server-replay only (reconnect-safe); deliberately *not* derived from message history, since a Task without a result usually means a running subagent. Session grants are persisted container-side and mirrored host-side, so an evicted+resumed process can't strand a launch. Policy flips auto-resolve or reject stranded pending reviews.

**Settings UI.** New "Agent Capabilities" tab with three-way toggles; blocking subagents warns first and recommends review instead.

## Validation

- Live-validated against a real container + real model: review park, SSE broadcast + reconnect replay, approve (once + session scope), decline-with-reason handled gracefully by the model, block strips tools (agent-confirmed) and prompt reads clean, default-allow subagent runs unprompted.
- Container: 653 unit tests, tsc clean. Host: 6708 unit tests, tsc + eslint clean.
- New E2E `capability-review.spec.ts` (6 scenarios, sequential — settings mutations race fullyParallel); full suite 243 passed.