### PR TITLE
Session long sleep: schedule_resume wakes the same session (SUP-30)

### DIFF
--- a/agent-container/src/input-manager.ts
+++ b/agent-container/src/input-manager.ts
@@ -34,6 +34,7 @@ type EarlyResult =
 // means the host handler died mid-request; nobody is coming back for it.
 const AUTOMATED_INPUT_TYPES: ReadonlySet<string> = new Set([
   'schedule_task',
+  'schedule_resume',
   'list_scheduled_tasks',
   'cancel_scheduled_task',
   'pause_scheduled_task',

--- a/agent-container/src/mcp-server.ts
+++ b/agent-container/src/mcp-server.ts
@@ -20,6 +20,7 @@ import {
   pauseScheduledTaskTool,
   resumeScheduledTaskTool,
 } from './tools/schedule-task'
+import { scheduleResumeTool } from './tools/schedule-resume'
 import {
   getAvailableTriggersTool,
   listTriggersTool,
@@ -76,7 +77,7 @@ export function createUserInputMcpServer() {
     tools: [
       requestSecretTool, requestConnectedAccountTool, searchConnectedAccountServicesTool,
       requestRemoteMcpTool, searchRemoteMcpServicesTool,
-      scheduleTaskTool, listScheduledTasksTool, cancelScheduledTaskTool,
+      scheduleTaskTool, scheduleResumeTool, listScheduledTasksTool, cancelScheduledTaskTool,
       pauseScheduledTaskTool, resumeScheduledTaskTool,
       deliverFileTool, deliverSessionTool, requestFileTool, requestBrowserInputTool,
       ...(includeScriptRun ? [requestScriptRunTool] : []),

--- a/agent-container/src/system-prompt-vars.test.ts
+++ b/agent-container/src/system-prompt-vars.test.ts
@@ -40,6 +40,18 @@ describe('generateSystemPrompt rendering', () => {
     expect(out.includes('platform-dependent')).toBe(!composio && !webhook)    // disconnected fallback
   })
 
+  // The pause/resume guidance must always render: without it agents reach for
+  // schedule_task ("new session") when they mean "continue THIS conversation
+  // later", which loses the context the wait was for.
+  it('always teaches schedule_resume and how it differs from schedule_task', () => {
+    const out = generateSystemPrompt()
+    expect(out).toContain('## Pausing and Resuming This Session')
+    expect(out).toContain('mcp__user-input__schedule_resume')
+    // The decision rule both directions
+    expect(out).toContain('THIS SAME conversation')
+    expect(out).toContain('Use `schedule_task` only for genuinely independent work')
+  })
+
   // A heading whose body is entirely gated renders as a title with the next
   // heading directly beneath it. Some headings (`## File Handling`) are static
   // containers of subheadings and are bodyless in every render, which is fine --

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -500,6 +500,19 @@ You can also inspect and manage tasks you've already scheduled:
 - One-time tasks are removed after execution; recurring tasks continue until cancelled
 - Only pending or paused tasks can be cancelled; only recurring tasks can be paused/resumed
 
+## Pausing and Resuming This Session
+
+When you are waiting on something external and the follow-up needs the context you have right now, do NOT schedule a task — pause this session with `mcp__user-input__schedule_resume` instead. It resumes THIS SAME conversation at a future time with full context preserved (it survives restarts and costs nothing while sleeping).
+
+Use `schedule_resume` when the follow-up continues this conversation:
+- You emailed or messaged someone and want to check for a reply later
+- You submitted something for review/approval and want to check its status
+- You kicked off a long-running external process and want to check on it
+
+Use `schedule_task` only for genuinely independent work — a future job that doesn't need this conversation's context, or a recurring schedule.
+
+How it works: call `schedule_resume` with a natural-language `wakeTime` ("tomorrow 9am", "in 72 hours") and a `note` to your future self, then END YOUR TURN. The session resumes at that time with your note echoed back. If what you were waiting for still hasn't happened, you can re-schedule and sleep again. A session holds at most one pending wake — scheduling a new one replaces it — and wakes are one-shot only.
+
 ## Webhook Triggers
 
 <%#composioTriggers%>

--- a/agent-container/src/tools/schedule-resume.test.ts
+++ b/agent-container/src/tools/schedule-resume.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { inputManager } from '../input-manager'
+
+describe('scheduleResumeTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Drain any toolUseId left over from a previous test
+    inputManager.consumeCurrentToolUseId()
+  })
+
+  it('returns error when the note is empty', async () => {
+    const { scheduleResumeTool } = await import('./schedule-resume')
+    const handler = (scheduleResumeTool as any).handler
+
+    const result = await handler({ wakeTime: 'tomorrow 9am', note: '   ' })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('note')
+  })
+
+  it('returns error when the wakeTime is empty', async () => {
+    const { scheduleResumeTool } = await import('./schedule-resume')
+    const handler = (scheduleResumeTool as any).handler
+
+    const result = await handler({ wakeTime: '  ', note: 'Check the email' })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('wakeTime')
+  })
+
+  it('returns error when no toolUseId is available', async () => {
+    const { scheduleResumeTool } = await import('./schedule-resume')
+    const handler = (scheduleResumeTool as any).handler
+
+    const result = await handler({ wakeTime: 'tomorrow 9am', note: 'Check the email' })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('no tool use ID available')
+  })
+
+  it('blocks on the host and returns the resolved confirmation', async () => {
+    const toolUseId = `wake-test-${Date.now()}-1`
+    inputManager.setCurrentToolUseId(toolUseId)
+    inputManager.resolve(toolUseId, 'Scheduled this session to auto-resume at 2027-01-01T09:00:00.000Z')
+
+    const { scheduleResumeTool } = await import('./schedule-resume')
+    const handler = (scheduleResumeTool as any).handler
+
+    const result = await handler({ wakeTime: 'tomorrow 9am', note: 'Check the email' })
+
+    expect(result.isError).toBeUndefined()
+    expect(result.content[0].text).toContain('auto-resume')
+  })
+
+  it('surfaces a host rejection as a tool error', async () => {
+    const toolUseId = `wake-test-${Date.now()}-2`
+    inputManager.setCurrentToolUseId(toolUseId)
+    inputManager.reject(toolUseId, new Error('Scheduled time "at yesterday" is in the past'))
+
+    const { scheduleResumeTool } = await import('./schedule-resume')
+    const handler = (scheduleResumeTool as any).handler
+
+    const result = await handler({ wakeTime: 'yesterday', note: 'Impossible' })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('in the past')
+  })
+})

--- a/agent-container/src/tools/schedule-resume.ts
+++ b/agent-container/src/tools/schedule-resume.ts
@@ -1,0 +1,122 @@
+/**
+ * Schedule Resume Tool - Lets the agent put the CURRENT session to sleep and
+ * have it automatically resumed later, with full context.
+ *
+ * This is deliberately a separate tool from schedule_task: schedule_task spawns
+ * an independent future session; schedule_resume continues THIS conversation.
+ * The actual persistence is handled by the API server, which intercepts this
+ * tool call and saves the wake to the database (same blocking contract as
+ * schedule_task).
+ */
+
+import { tool } from '@anthropic-ai/claude-agent-sdk'
+import { z } from 'zod'
+import { inputManager } from '../input-manager'
+
+/**
+ * How long to wait for the host to confirm the wake before giving up. Like
+ * schedule_task, this blocks only on a fast automated host operation (a DB
+ * write) — a host that never responds means something is wrong, so fail loud
+ * instead of hanging the session.
+ */
+const SCHEDULE_RESUME_HOST_TIMEOUT_MS = 60_000
+
+export const scheduleResumeTool = tool(
+  'schedule_resume',
+  `Pause this session and automatically resume THIS SAME conversation at a future time, with full context preserved.
+
+Use this when you are waiting on something external and want to check back later in the same conversation — for example:
+- You emailed someone and want to check for a reply tomorrow morning
+- You submitted something for review and want to check its status in 72 hours
+- You kicked off a long-running external process and want to check on it later
+
+How it works: after this tool succeeds, END YOUR TURN. The session goes idle (it costs nothing and survives restarts while sleeping) and is resumed at the scheduled time with a system message that echoes your note back to you. If what you were waiting for still hasn't happened when you wake, you can call schedule_resume again to check later.
+
+wakeTime accepts natural language: "tomorrow 9am", "in 72 hours", "next monday 8am", "2027-03-15 14:00".
+
+Constraints:
+- A session holds at most ONE pending wake — scheduling a new one replaces the previous one.
+- One-shot only (no recurring wakes). For recurring checks, re-schedule on each wake, or use schedule_task if the work doesn't need this conversation's context.
+
+This is different from schedule_task, which starts a NEW session with no memory of this conversation. Prefer schedule_resume when the follow-up needs the context you have right now.`,
+  {
+    wakeTime: z
+      .string()
+      .describe(
+        'When to resume this session. Natural language, e.g. "tomorrow 9am", "in 72 hours", "next monday". Interpreted in the timezone parameter (or the owner\'s timezone if omitted).'
+      ),
+    note: z
+      .string()
+      .describe(
+        'Why you are pausing and what to check when you wake. Echoed back to you verbatim in the resume message — write it as a note to your future self.'
+      ),
+    timezone: z
+      .string()
+      .optional()
+      .describe(
+        'Optional IANA timezone for interpreting wakeTime (e.g. "America/New_York"). Defaults to the owner\'s timezone.'
+      ),
+  },
+  async (args) => {
+    console.log(`[schedule_resume] Scheduling session resume: ${args.wakeTime}`)
+
+    if (!args.wakeTime.trim()) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'wakeTime cannot be empty. Provide a time like "tomorrow 9am" or "in 72 hours".',
+          },
+        ],
+        isError: true,
+      }
+    }
+
+    if (!args.note.trim()) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'note cannot be empty. Write a note to your future self: why you are pausing and what to check on wake.',
+          },
+        ],
+        isError: true,
+      }
+    }
+
+    // Blocking: the host persists the wake and resolves this tool only after it
+    // is actually saved, so the agent is never told a false success.
+    const toolUseId = inputManager.consumeCurrentToolUseId()
+    if (!toolUseId) {
+      return {
+        content: [{ type: 'text' as const, text: 'Unable to process request — no tool use ID available.' }],
+        isError: true,
+      }
+    }
+
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+    try {
+      const result = await Promise.race([
+        inputManager.createPendingWithType<string>(toolUseId, 'schedule_resume'),
+        new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(
+            () => reject(new Error('Timed out waiting for the host to confirm the scheduled resume')),
+            SCHEDULE_RESUME_HOST_TIMEOUT_MS,
+          )
+        }),
+      ])
+
+      return {
+        content: [{ type: 'text' as const, text: result }],
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'Unknown error'
+      return {
+        content: [{ type: 'text' as const, text: `Failed to schedule resume: ${msg}` }],
+        isError: true,
+      }
+    } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle)
+    }
+  }
+)

--- a/e2e/specs/session-long-sleep.spec.ts
+++ b/e2e/specs/session-long-sleep.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+
+function getCurrentAgentSlug(page: Page) {
+  const match = page.url().match(/\/agents\/([^/?#]+)/)
+  expect(match).toBeTruthy()
+  return match![1]
+}
+
+function getCurrentSessionId(page: Page) {
+  const match = page.url().match(/\/sessions\/([^/?#]+)/)
+  expect(match).toBeTruthy()
+  return match![1]
+}
+
+interface SessionWithWake {
+  id: string
+  pendingWakeAt?: string
+  pendingWakeTaskId?: string
+  pendingWakeNote?: string
+}
+
+async function waitForPendingWake(
+  request: APIRequestContext,
+  agentSlug: string,
+  sessionId: string
+): Promise<SessionWithWake> {
+  let session: SessionWithWake | undefined
+
+  await expect.poll(async () => {
+    const response = await request.get(`/api/agents/${agentSlug}/sessions`)
+    if (!response.ok()) return false
+    const sessions = (await response.json()) as SessionWithWake[]
+    session = sessions.find((s) => s.id === sessionId)
+    return Boolean(session?.pendingWakeTaskId)
+  }, { timeout: 20000 }).toBe(true)
+
+  return session!
+}
+
+test.describe('Session long sleep (schedule_resume)', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+
+  test.beforeEach(async ({ page }) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+  })
+
+  async function scheduleResumeInNewSession(page: Page) {
+    const agentName = `Sleep Agent ${Date.now()}`
+    await agentPage.createAgent(agentName, { waitForSidebarName: false })
+
+    await sessionPage.sendMessage('schedule resume until the review is approved')
+    await sessionPage.expectToolCall('mcp__user-input__schedule_resume', 15000)
+
+    const agentSlug = getCurrentAgentSlug(page)
+    const sessionId = getCurrentSessionId(page)
+    return { agentSlug, sessionId }
+  }
+
+  test('schedule_resume creates a pending wake with banner and sidebar badge', async ({ page, request }) => {
+    const { agentSlug, sessionId } = await scheduleResumeInNewSession(page)
+
+    // A real wake row is persisted, targeting THIS session
+    const session = await waitForPendingWake(request, agentSlug, sessionId)
+    expect(session.pendingWakeNote).toBe('Check whether the review has been approved')
+    expect(new Date(session.pendingWakeAt!).getTime()).toBeGreaterThan(Date.now())
+
+    // The auto-resume banner shows above the composer with the note + actions
+    const banner = page.locator('[data-testid="pending-wake-banner"]')
+    await expect(banner).toBeVisible({ timeout: 15000 })
+    await expect(banner).toContainText('auto-resume')
+    await expect(banner).toContainText('Check whether the review has been approved')
+
+    // The sidebar session row shows the pending-wake (moon) indicator
+    await expect(
+      page.locator(`[data-testid="session-pending-wake-${sessionId}"]`)
+    ).toBeVisible({ timeout: 15000 })
+
+    // Wakes are session-scoped: they must NOT appear in the agent-level
+    // scheduled tasks (home triggers) list
+    const tasksResponse = await request.get(`/api/agents/${agentSlug}/scheduled-tasks`)
+    expect(tasksResponse.ok()).toBe(true)
+    const tasks = (await tasksResponse.json()) as Array<{ id: string }>
+    expect(tasks.find((t) => t.id === session.pendingWakeTaskId)).toBeUndefined()
+  })
+
+  test('Wake now resumes the session and clears the wake', async ({ page, request }) => {
+    const { agentSlug, sessionId } = await scheduleResumeInNewSession(page)
+    const session = await waitForPendingWake(request, agentSlug, sessionId)
+
+    const banner = page.locator('[data-testid="pending-wake-banner"]')
+    await expect(banner).toBeVisible({ timeout: 15000 })
+    await page.locator('[data-testid="pending-wake-wake-now"]').click()
+
+    // The wake task is executed against the SAME session (no new session)
+    await expect.poll(async () => {
+      const res = await request.get(`/api/scheduled-tasks/${session.pendingWakeTaskId}`)
+      if (!res.ok()) return null
+      const task = (await res.json()) as { status: string; lastSessionId?: string }
+      return task.status
+    }, { timeout: 15000 }).toBe('executed')
+
+    const taskRes = await request.get(`/api/scheduled-tasks/${session.pendingWakeTaskId}`)
+    const task = (await taskRes.json()) as { lastSessionId?: string }
+    expect(task.lastSessionId).toBe(sessionId)
+
+    // Banner clears once the wake is gone
+    await expect(banner).not.toBeVisible({ timeout: 15000 })
+
+    // The wake message lands in this session as a system-prefixed turn and the
+    // mock agent responds — the transcript grows in place.
+    await expect(sessionPage.getAssistantMessages().nth(1)).toBeVisible({ timeout: 15000 })
+  })
+
+  test('Cancel clears the pending wake without resuming', async ({ page, request }) => {
+    const { agentSlug, sessionId } = await scheduleResumeInNewSession(page)
+    const session = await waitForPendingWake(request, agentSlug, sessionId)
+
+    const banner = page.locator('[data-testid="pending-wake-banner"]')
+    await expect(banner).toBeVisible({ timeout: 15000 })
+    await page.locator('[data-testid="pending-wake-cancel"]').click()
+
+    await expect.poll(async () => {
+      const res = await request.get(`/api/scheduled-tasks/${session.pendingWakeTaskId}`)
+      if (!res.ok()) return null
+      const task = (await res.json()) as { status: string }
+      return task.status
+    }, { timeout: 15000 }).toBe('cancelled')
+
+    await expect(banner).not.toBeVisible({ timeout: 15000 })
+
+    // No wake left on the session in the list API
+    const response = await request.get(`/api/agents/${agentSlug}/sessions`)
+    const sessions = (await response.json()) as SessionWithWake[]
+    const updated = sessions.find((s) => s.id === sessionId)
+    expect(updated?.pendingWakeTaskId).toBeUndefined()
+  })
+})

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -254,6 +254,9 @@ vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   listPendingScheduledTasks: vi.fn(),
   listPendingScheduledTasksByAgents: vi.fn(() => Promise.resolve(new Map())),
   listCancelledScheduledTasks: vi.fn(),
+  listPendingWakesByAgent: vi.fn(() => Promise.resolve([])),
+  getPendingWakeForSession: vi.fn(() => Promise.resolve(null)),
+  cancelPendingWakeForSession: vi.fn(() => Promise.resolve(false)),
 }))
 
 vi.mock('@shared/lib/account-providers', () => ({

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -57,6 +57,9 @@ import {
   listPendingScheduledTasks,
   listPendingScheduledTasksByAgents,
   listCancelledScheduledTasks,
+  cancelPendingWakeForSession,
+  getPendingWakeForSession,
+  listPendingWakesByAgent,
 } from '@shared/lib/services/scheduled-task-service'
 import { db } from '@shared/lib/db'
 import { connectedAccounts, agentConnectedAccounts, proxyAuditLog, remoteMcpServers, agentRemoteMcps, mcpAuditLog, agentAcl, user as userTable, messageAuthor, apiScopePolicies, mcpToolPolicies } from '@shared/lib/db/schema'
@@ -178,7 +181,9 @@ async function enrichAgentsWithSummary(agents: ApiAgent[]): Promise<ApiAgent[]> 
       ])
 
       const unreadSessionIds = unreadByAgent.get(agent.slug) ?? new Set<string>()
-      const pendingTasks = tasksByAgent.get(agent.slug) ?? []
+      // Session wakes are excluded from the agent-level automation summary —
+      // they belong to a session, not the agent's schedule.
+      const pendingTasks = (tasksByAgent.get(agent.slug) ?? []).filter((t) => !t.resumeSessionId)
 
       // Compute session flags from in-memory state (no I/O needed).
       // `unreadByAgent` is already filtered to user-actionable notification types
@@ -1289,13 +1294,23 @@ agents.get('/:id/sessions', AgentRead(), async (c) => {
     const sessionList = await listSessions(slug, { excludeAutomated: true })
     const unreadSessionIds = await getSessionIdsWithUnreadNotifications(slug)
     const hasAgentLevelReviews = reviewManager.getPendingReviewsForAgent(slug).length > 0
+    const pendingWakes = await listPendingWakesByAgent(slug)
+    const wakesBySession = new Map(pendingWakes.map((w) => [w.resumeSessionId!, w]))
     const sessionsWithStatus = sessionList.map((session) => {
       const isActive = messagePersister.isSessionActive(session.id)
+      const wake = wakesBySession.get(session.id)
       return {
         ...session,
         isActive,
         isAwaitingInput: messagePersister.isSessionAwaitingInput(session.id) || (isActive && hasAgentLevelReviews),
         hasUnreadNotifications: unreadSessionIds.has(session.id),
+        ...(wake
+          ? {
+              pendingWakeAt: wake.nextExecutionAt.toISOString(),
+              pendingWakeTaskId: wake.id,
+              pendingWakeNote: wake.prompt,
+            }
+          : {}),
       }
     })
 
@@ -1734,6 +1749,7 @@ agents.get('/:id/sessions/:sessionId', AgentRead(), async (c) => {
 
     const isActive = messagePersister.isSessionActive(sessionId)
     const metadata = await getSessionMetadata(agentSlug, sessionId)
+    const pendingWake = await getPendingWakeForSession(agentSlug, sessionId)
 
     return c.json({
       id: session.id,
@@ -1750,6 +1766,13 @@ agents.get('/:id/sessions/:sessionId', AgentRead(), async (c) => {
       webhookTriggerName: metadata?.webhookTriggerName,
       effort: metadata?.effort,
       model: metadata?.model,
+      ...(pendingWake
+        ? {
+            pendingWakeAt: pendingWake.nextExecutionAt.toISOString(),
+            pendingWakeTaskId: pendingWake.id,
+            pendingWakeNote: pendingWake.prompt,
+          }
+        : {}),
     })
   } catch (error) {
     console.error('Failed to fetch session:', error)
@@ -1810,6 +1833,12 @@ agents.delete('/:id/sessions/:sessionId', AgentAdmin(), async (c) => {
     if (!deleted) {
       return c.json({ error: 'Session not found' }, 404)
     }
+
+    // A pending wake targeting this session would otherwise fire into nothing
+    // and be marked failed — cancel it alongside the session.
+    await cancelPendingWakeForSession(agentSlug, sessionId).catch((error) => {
+      console.error('Failed to cancel pending wake for deleted session:', error)
+    })
 
     // Clean up message author records for this session (auth mode only).
     if (isAuthMode()) {
@@ -2769,6 +2798,10 @@ agents.get('/:id/scheduled-tasks', AgentRead(), async (c) => {
     } else {
       tasks = await listScheduledTasks(slug)
     }
+
+    // Session wakes are session-scoped (surfaced on the session row/banner),
+    // not agent-level automations — keep them out of this list.
+    tasks = tasks.filter((t) => !t.resumeSessionId)
 
     return c.json(tasks)
   } catch (error) {

--- a/src/api/routes/scheduled-tasks.test.ts
+++ b/src/api/routes/scheduled-tasks.test.ts
@@ -58,6 +58,10 @@ const mockMessagePersister = vi.hoisted(() => ({
   isSessionActive: vi.fn(),
   subscribeToSession: vi.fn(),
   markSessionActive: vi.fn(),
+  isSubscribed: vi.fn(() => false),
+  cancelAwaitingInput: vi.fn(() => Promise.resolve()),
+  broadcastGlobal: vi.fn(),
+  broadcastSessionUpdate: vi.fn(),
 }))
 
 vi.mock('@shared/lib/container/message-persister', () => ({
@@ -258,6 +262,91 @@ describe('scheduled-tasks route', () => {
     expect(mockRegisterSession).toHaveBeenCalledWith('agent-one', 'container-session-1', 'Scheduled Task (Run Now)')
     expect(mockMarkTaskExecuted).toHaveBeenCalledWith('task-1', 'container-session-1')
     expect(mockRecordManualExecution).not.toHaveBeenCalled()
+  })
+
+  describe('session wakes (resume tasks)', () => {
+    function createWakeTask(overrides: Record<string, unknown> = {}) {
+      return createTask({
+        scheduleType: 'at',
+        scheduleExpression: 'at tomorrow 9am',
+        isRecurring: false,
+        name: null,
+        prompt: 'Check whether Dana replied',
+        resumeSessionId: 'sleeping-session-1',
+        createdBySessionId: 'sleeping-session-1',
+        nextExecutionAt: new Date('2027-01-01T09:00:00.000Z'),
+        createdAt: new Date('2026-12-30T09:00:00.000Z'),
+        timezone: null,
+        ...overrides,
+      })
+    }
+
+    it('run-now resumes the target session instead of creating a new one', async () => {
+      task = createWakeTask()
+      const mockSendMessage = vi.fn()
+      mockEnsureRunning.mockResolvedValue({
+        createSession: mockCreateSession,
+        sendMessage: mockSendMessage,
+      })
+
+      const res = await app.request('http://localhost/api/scheduled-tasks/task-1/run-now', {
+        method: 'POST',
+      })
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.sessionId).toBe('sleeping-session-1')
+
+      expect(mockCreateSession).not.toHaveBeenCalled()
+      expect(mockRegisterSession).not.toHaveBeenCalled()
+
+      expect(mockSendMessage).toHaveBeenCalledTimes(1)
+      const [sessionId, content, , options] = mockSendMessage.mock.calls[0]
+      expect(sessionId).toBe('sleeping-session-1')
+      expect(content.startsWith('[SYSTEM] ')).toBe(true)
+      expect(content).toContain('Check whether Dana replied')
+      expect(options).toEqual({ shouldQuery: true })
+
+      expect(mockUpdateSessionMetadata).toHaveBeenCalledWith(
+        'agent-one',
+        'sleeping-session-1',
+        expect.objectContaining({
+          lastWake: expect.objectContaining({ taskId: 'task-1' }),
+        })
+      )
+      expect(mockMarkTaskExecuted).toHaveBeenCalledWith('task-1', 'sleeping-session-1')
+      expect(mockMessagePersister.broadcastGlobal).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'session_updated', sessionId: 'sleeping-session-1' })
+      )
+    })
+
+    it('cancelling a wake broadcasts session_updated so badges clear', async () => {
+      task = createWakeTask()
+      mockCancelScheduledTask.mockResolvedValue(true)
+
+      const res = await app.request('http://localhost/api/scheduled-tasks/task-1', {
+        method: 'DELETE',
+      })
+
+      expect(res.status).toBe(204)
+      expect(mockMessagePersister.broadcastGlobal).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'session_updated', sessionId: 'sleeping-session-1' })
+      )
+    })
+
+    it('cancelling a regular task does not broadcast session_updated', async () => {
+      task = createTask()
+      mockCancelScheduledTask.mockResolvedValue(true)
+
+      const res = await app.request('http://localhost/api/scheduled-tasks/task-1', {
+        method: 'DELETE',
+      })
+
+      expect(res.status).toBe(204)
+      expect(mockMessagePersister.broadcastGlobal).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'session_updated' })
+      )
+    })
   })
 
   describe('run-now model and effort resolution', () => {

--- a/src/api/routes/scheduled-tasks.test.ts
+++ b/src/api/routes/scheduled-tasks.test.ts
@@ -32,11 +32,26 @@ vi.mock('@shared/lib/services/scheduled-task-service', () => ({
 const mockGetSessionsByScheduledTask = vi.fn()
 const mockRegisterSession = vi.fn()
 const mockUpdateSessionMetadata = vi.fn()
+const mockGetSessionMetadata = vi.fn((..._args: unknown[]) => Promise.resolve({ name: 'Sleeping session' }))
 
 vi.mock('@shared/lib/services/session-service', () => ({
   getSessionsByScheduledTask: (...args: unknown[]) => mockGetSessionsByScheduledTask(...args),
   registerSession: (...args: unknown[]) => mockRegisterSession(...args),
   updateSessionMetadata: (...args: unknown[]) => mockUpdateSessionMetadata(...args),
+  getSessionMetadata: (...args: unknown[]) => mockGetSessionMetadata(...args),
+}))
+
+vi.mock('@shared/lib/services/agent-service', () => ({
+  agentExists: () => Promise.resolve(true),
+}))
+
+const mockTriggerScheduledSessionResumed = vi.fn((..._args: unknown[]) => Promise.resolve())
+
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerScheduledSessionResumed: (...args: unknown[]) =>
+      mockTriggerScheduledSessionResumed(...args),
+  },
 }))
 
 const mockGetSecretEnvVars = vi.fn()
@@ -58,6 +73,7 @@ const mockMessagePersister = vi.hoisted(() => ({
   isSessionActive: vi.fn(),
   subscribeToSession: vi.fn(),
   markSessionActive: vi.fn(),
+  markSessionIdle: vi.fn(),
   isSubscribed: vi.fn(() => false),
   cancelAwaitingInput: vi.fn(() => Promise.resolve()),
   broadcastGlobal: vi.fn(),

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -38,8 +38,7 @@ import { RuntimeOptionsSchema } from '@shared/lib/container/runtime-options'
 import type { EffortLevel } from '@shared/lib/container/types'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
-import { buildWakeMessage } from '@shared/lib/scheduler/wake-message'
-import { randomUUID } from 'crypto'
+import { deliverSessionWake } from '@shared/lib/scheduler/wake-delivery'
 import { Authenticated, EntityAgentRole } from '../middleware/auth'
 
 const scheduledTasksRouter = new Hono()
@@ -283,37 +282,26 @@ scheduledTasksRouter.post('/:taskId/run-now', TaskAgentRole('user'), async (c) =
     }
 
     // Session wake ("Wake now"): resume the target session instead of creating
-    // a new one — the manual mirror of the scheduler's wake branch.
+    // a new one. deliverSessionWake is the same claimed path the scheduler
+    // uses, so a poll firing at the same instant can never double-deliver.
     if (task.resumeSessionId) {
-      const sessionId = task.resumeSessionId
-      const client = await containerManager.ensureRunning(task.agentSlug)
+      const result = await deliverSessionWake(task, 'manual')
 
-      if (!messagePersister.isSubscribed(sessionId)) {
-        await messagePersister.subscribeToSession(sessionId, client, sessionId, task.agentSlug)
+      if (result.outcome === 'delivered' || result.outcome === 'reconciled') {
+        const updated = await getScheduledTask(task.id)
+        return c.json({ sessionId: result.sessionId, agentSlug: task.agentSlug, task: updated }, 201)
       }
-      // Clear any stale blocking user-input request so the wake message starts
-      // a fresh turn instead of deadlocking behind it.
-      await messagePersister.cancelAwaitingInput(sessionId, task.agentSlug)
-      messagePersister.markSessionActive(sessionId, task.agentSlug)
-
-      await client.sendMessage(sessionId, buildWakeMessage(task, 'manual'), randomUUID(), {
-        shouldQuery: true,
-      })
-
-      await updateSessionMetadata(task.agentSlug, sessionId, {
-        lastWake: { taskId: task.id, executionAt: task.nextExecutionAt.toISOString() },
-      })
-      await markTaskExecuted(task.id, sessionId)
-
-      messagePersister.broadcastGlobal({
-        type: 'session_updated',
-        sessionId,
-        agentSlug: task.agentSlug,
-      })
-      messagePersister.broadcastSessionUpdate(sessionId)
-
-      const updated = await getScheduledTask(task.id)
-      return c.json({ sessionId, agentSlug: task.agentSlug, task: updated }, 201)
+      if (result.outcome === 'in-flight') {
+        return c.json({ error: 'This wake is already being delivered' }, 409)
+      }
+      if (result.outcome === 'session-missing') {
+        return c.json({ error: 'The session this wake resumes no longer exists' }, 404)
+      }
+      if (result.outcome === 'agent-missing') {
+        return c.json({ error: 'Agent no longer exists' }, 404)
+      }
+      // not-pending: a concurrent delivery just finished, or the wake was cancelled
+      return c.json({ error: 'Task is not pending' }, 400)
     }
 
     const client = await containerManager.ensureRunning(task.agentSlug)

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -38,6 +38,8 @@ import { RuntimeOptionsSchema } from '@shared/lib/container/runtime-options'
 import type { EffortLevel } from '@shared/lib/container/types'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
+import { buildWakeMessage } from '@shared/lib/scheduler/wake-message'
+import { randomUUID } from 'crypto'
 import { Authenticated, EntityAgentRole } from '../middleware/auth'
 
 const scheduledTasksRouter = new Hono()
@@ -89,6 +91,16 @@ scheduledTasksRouter.delete('/:taskId', TaskAgentRole('user'), async (c) => {
     }
 
     logAuditEvent({ userId: getCurrentUserId(c), object: 'task', objectId: task!.id, action: 'deleted' })
+
+    // Cancelling a session wake changes that session's list/badge state.
+    if (task!.resumeSessionId) {
+      messagePersister.broadcastGlobal({
+        type: 'session_updated',
+        sessionId: task!.resumeSessionId,
+        agentSlug: task!.agentSlug,
+      })
+      messagePersister.broadcastSessionUpdate(task!.resumeSessionId)
+    }
 
     return c.body(null, 204)
   } catch (error) {
@@ -268,6 +280,40 @@ scheduledTasksRouter.post('/:taskId/run-now', TaskAgentRole('user'), async (c) =
     const task = c.get('scheduledTask' as never) as Awaited<ReturnType<typeof getScheduledTask>>
     if (!task || (task.status !== 'pending' && task.status !== 'paused')) {
       return c.json({ error: 'Task is not pending' }, 400)
+    }
+
+    // Session wake ("Wake now"): resume the target session instead of creating
+    // a new one — the manual mirror of the scheduler's wake branch.
+    if (task.resumeSessionId) {
+      const sessionId = task.resumeSessionId
+      const client = await containerManager.ensureRunning(task.agentSlug)
+
+      if (!messagePersister.isSubscribed(sessionId)) {
+        await messagePersister.subscribeToSession(sessionId, client, sessionId, task.agentSlug)
+      }
+      // Clear any stale blocking user-input request so the wake message starts
+      // a fresh turn instead of deadlocking behind it.
+      await messagePersister.cancelAwaitingInput(sessionId, task.agentSlug)
+      messagePersister.markSessionActive(sessionId, task.agentSlug)
+
+      await client.sendMessage(sessionId, buildWakeMessage(task, 'manual'), randomUUID(), {
+        shouldQuery: true,
+      })
+
+      await updateSessionMetadata(task.agentSlug, sessionId, {
+        lastWake: { taskId: task.id, executionAt: task.nextExecutionAt.toISOString() },
+      })
+      await markTaskExecuted(task.id, sessionId)
+
+      messagePersister.broadcastGlobal({
+        type: 'session_updated',
+        sessionId,
+        agentSlug: task.agentSlug,
+      })
+      messagePersister.broadcastSessionUpdate(sessionId)
+
+      const updated = await getScheduledTask(task.id)
+      return c.json({ sessionId, agentSlug: task.agentSlug, task: updated }, 201)
     }
 
     const client = await containerManager.ensureRunning(task.agentSlug)

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -1,5 +1,6 @@
 
-import { Bell, ChevronDown, ChevronLeft, ChevronRight, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, User, Users, Compass } from 'lucide-react'
+import { Bell, ChevronDown, ChevronLeft, ChevronRight, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, User, Users, Compass, MoonStar } from 'lucide-react'
+import { formatDistanceToNow } from 'date-fns'
 import { cn } from '@shared/lib/utils/cn'
 import { Skeleton } from '@renderer/components/ui/skeleton'
 import { ErrorBoundary } from '@renderer/components/ui/error-boundary'
@@ -138,6 +139,10 @@ function SessionSubItem({
   const isWorking = (session.isActive || isStreaming) && !session.isAwaitingInput
   const isAwaitingInput = session.isAwaitingInput
   const hasUnread = !session.isActive && !session.isAwaitingInput && session.hasUnreadNotifications
+  // Pending-wake (long sleep) indicator: shown alongside the unread dot, but
+  // suppressed while the session is actively working/awaiting (momentarily
+  // redundant — the session clearly isn't asleep).
+  const showPendingWake = !!session.pendingWakeAt && !isWorking && !isAwaitingInput
   const { ref: hintRef, hint } = useCmdHintTarget()
 
   return (
@@ -162,7 +167,18 @@ function SessionSubItem({
             {hint !== null ? (
               <CmdHintBadge hint={hint} />
             ) : (
-              <span className="flex items-center justify-center w-4 shrink-0">
+              <span className="flex items-center justify-center gap-1 min-w-4 shrink-0">
+                {showPendingWake && (
+                  <span
+                    className="flex items-center"
+                    role="img"
+                    aria-label="scheduled to resume"
+                    title={`Resumes ${formatDistanceToNow(new Date(session.pendingWakeAt!), { addSuffix: true })}`}
+                    data-testid={`session-pending-wake-${session.id}`}
+                  >
+                    <MoonStar className="h-3 w-3 text-muted-foreground" />
+                  </span>
+                )}
                 {isAwaitingInput ? (
                   <AwaitingDot />
                 ) : isWorking ? (

--- a/src/renderer/components/layout/session-chat-column.tsx
+++ b/src/renderer/components/layout/session-chat-column.tsx
@@ -5,6 +5,7 @@ import { renderPendingRequest, type RenderContext } from '@renderer/components/m
 import { PendingRequestErrorBoundary } from '@renderer/components/messages/pending-request-error-boundary'
 import { usePendingRequests } from '@renderer/components/messages/use-pending-requests'
 import { StaleSessionNotice } from '@renderer/components/messages/stale-session-notice'
+import { PendingWakeBanner } from '@renderer/components/messages/pending-wake-banner'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useScreenWakeLock } from '@renderer/hooks/use-screen-wake-lock'
 import { useFileDeliveryWatcher } from '@renderer/hooks/use-file-delivery-watcher'
@@ -32,6 +33,10 @@ interface SessionChatColumnProps {
   onMessageFailed: (localId: string) => void
   lastActivityAt?: Date | null
   contextUsage?: SessionUsage | null
+  // Pending scheduled wake (long sleep) — renders the auto-resume banner
+  pendingWakeAt?: string
+  pendingWakeTaskId?: string
+  pendingWakeNote?: string
 }
 
 export function SessionChatColumn({
@@ -49,6 +54,9 @@ export function SessionChatColumn({
   onMessageFailed,
   lastActivityAt,
   contextUsage,
+  pendingWakeAt,
+  pendingWakeTaskId,
+  pendingWakeNote,
 }: SessionChatColumnProps) {
   const { isActive, browserActive, isWaitingBackground } = useMessageStream(sessionId, agentSlug)
   // Keep the phone awake (PWA only) while this session is actively working.
@@ -104,6 +112,16 @@ export function SessionChatColumn({
           </div>
         ) : (
           <>
+            {pendingWakeAt && pendingWakeTaskId && !isActive && (
+              <PendingWakeBanner
+                sessionId={sessionId}
+                agentSlug={agentSlug}
+                wakeAt={pendingWakeAt}
+                taskId={pendingWakeTaskId}
+                note={pendingWakeNote}
+                readOnly={isViewOnly}
+              />
+            )}
             {staleSession.showNotice && (
               <StaleSessionNotice
                 onIgnore={staleSession.ignore}

--- a/src/renderer/components/layout/session-view.tsx
+++ b/src/renderer/components/layout/session-view.tsx
@@ -148,6 +148,9 @@ export function SessionView({ agentSlug, sessionId }: SessionViewProps) {
               onMessageFailed={onPendingMessageAppeared}
               lastActivityAt={session?.lastActivityAt ? new Date(session.lastActivityAt) : null}
               contextUsage={contextUsage}
+              pendingWakeAt={session?.pendingWakeAt}
+              pendingWakeTaskId={session?.pendingWakeTaskId}
+              pendingWakeNote={session?.pendingWakeNote}
             />
           </div>
         </WorkflowProvider>

--- a/src/renderer/components/messages/pending-wake-banner.tsx
+++ b/src/renderer/components/messages/pending-wake-banner.tsx
@@ -1,0 +1,103 @@
+import { MoonStar, X, Play } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
+import { formatDistanceToNow, format } from 'date-fns'
+import { Button } from '@renderer/components/ui/button'
+import { apiFetch } from '@renderer/lib/api'
+import { useMutation } from '@tanstack/react-query'
+
+interface PendingWakeBannerProps {
+  sessionId: string
+  agentSlug: string
+  wakeAt: string
+  taskId: string
+  note?: string
+  readOnly?: boolean
+}
+
+/**
+ * Bar shown above the composer while the session has a pending scheduled wake
+ * (long sleep): when it will auto-resume, the agent's note-to-self, and
+ * Wake now / Cancel actions.
+ */
+export function PendingWakeBanner({
+  sessionId,
+  agentSlug,
+  wakeAt,
+  taskId,
+  note,
+  readOnly,
+}: PendingWakeBannerProps) {
+  const queryClient = useQueryClient()
+
+  const invalidateSession = () => {
+    queryClient.invalidateQueries({ queryKey: ['session', sessionId] })
+    queryClient.invalidateQueries({ queryKey: ['sessions', agentSlug] })
+  }
+
+  const wakeNow = useMutation({
+    mutationFn: async () => {
+      const res = await apiFetch(`/api/scheduled-tasks/${taskId}/run-now`, { method: 'POST' })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(err.error || 'Failed to wake session')
+      }
+      return res.json()
+    },
+    onSuccess: invalidateSession,
+  })
+
+  const cancelWake = useMutation({
+    mutationFn: async () => {
+      const res = await apiFetch(`/api/scheduled-tasks/${taskId}`, { method: 'DELETE' })
+      if (!res.ok && res.status !== 404) {
+        throw new Error('Failed to cancel scheduled resume')
+      }
+    },
+    onSuccess: invalidateSession,
+  })
+
+  const wakeDate = new Date(wakeAt)
+  const isPending = wakeNow.isPending || cancelWake.isPending
+
+  return (
+    <div
+      className="mx-4 mb-2 flex items-center gap-2 rounded-lg border bg-muted/50 px-3 py-2 text-xs text-muted-foreground"
+      data-testid="pending-wake-banner"
+    >
+      <MoonStar className="h-3.5 w-3.5 shrink-0" />
+      <span className="min-w-0 flex-1 truncate">
+        This session will auto-resume{' '}
+        <span className="font-medium text-foreground" title={format(wakeDate, 'PPpp')}>
+          {formatDistanceToNow(wakeDate, { addSuffix: true })}
+        </span>
+        {note ? <> — &ldquo;{note}&rdquo;</> : null}
+      </span>
+      {!readOnly && (
+        <span className="flex shrink-0 items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 gap-1 px-2 text-xs"
+            disabled={isPending}
+            onClick={() => wakeNow.mutate()}
+            data-testid="pending-wake-wake-now"
+          >
+            <Play className="h-3 w-3" />
+            Wake now
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 gap-1 px-2 text-xs"
+            disabled={isPending}
+            onClick={() => cancelWake.mutate()}
+            data-testid="pending-wake-cancel"
+          >
+            <X className="h-3 w-3" />
+            Cancel
+          </Button>
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/messages/tool-renderers/index.ts
+++ b/src/renderer/components/messages/tool-renderers/index.ts
@@ -11,6 +11,7 @@ import { askUserQuestionRenderer } from './ask-user-question'
 import { requestSecretRenderer } from './request-secret'
 import { requestConnectedAccountRenderer } from './request-connected-account'
 import { scheduleTaskRenderer } from './schedule-task'
+import { scheduleResumeRenderer } from './schedule-resume'
 import { deliverFileRenderer } from './deliver-file'
 import { deliverSessionRenderer } from './deliver-session'
 import { requestFileRenderer } from './request-file'
@@ -99,6 +100,7 @@ const toolRenderers: Record<string, ToolRenderer> = {
   'mcp__user-input__request_secret': requestSecretRenderer,
   'mcp__user-input__request_connected_account': requestConnectedAccountRenderer,
   'mcp__user-input__schedule_task': scheduleTaskRenderer,
+  'mcp__user-input__schedule_resume': scheduleResumeRenderer,
   'mcp__user-input__deliver_file': deliverFileRenderer,
   'mcp__user-input__deliver_session': deliverSessionRenderer,
   'mcp__user-input__request_file': requestFileRenderer,

--- a/src/renderer/components/messages/tool-renderers/schedule-resume.tsx
+++ b/src/renderer/components/messages/tool-renderers/schedule-resume.tsx
@@ -1,0 +1,71 @@
+import { MoonStar, Globe } from 'lucide-react'
+import type { ToolRenderer, ToolRendererProps, StreamingToolRendererProps } from './types'
+import { Field, ResultField } from './shared'
+import { scheduleResumeDef, type ScheduleResumeInput } from '@shared/lib/tool-definitions/schedule-resume'
+
+const parseScheduleResumeInput = scheduleResumeDef.parseInput
+
+function ExpandedView({ input, result, isError }: ToolRendererProps) {
+  const { wakeTime, note, timezone } = parseScheduleResumeInput(input)
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-4 text-xs">
+        <div className="flex items-center gap-1.5">
+          <MoonStar className="h-3 w-3 text-foreground" />
+          <span className="font-medium">Auto-resume</span>
+        </div>
+        {wakeTime && (
+          <div className="text-muted-foreground">{wakeTime.replace(/^at\s+/i, '')}</div>
+        )}
+        {timezone && (
+          <div className="flex items-center gap-1 text-muted-foreground">
+            <Globe className="h-3 w-3" />
+            <span>{timezone.replace(/_/g, ' ')}</span>
+          </div>
+        )}
+      </div>
+
+      {note && <Field label="Wake Note" className="whitespace-pre-wrap">{note}</Field>}
+      {result && <ResultField result={result} isError={isError} />}
+    </div>
+  )
+}
+
+function StreamingView({ partialInput }: StreamingToolRendererProps) {
+  let parsed: ScheduleResumeInput = {}
+  try {
+    parsed = JSON.parse(partialInput)
+  } catch {
+    // Still streaming
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 text-xs">
+        <MoonStar className="h-3 w-3 text-foreground" />
+        <span className="font-medium">Auto-resume</span>
+        {parsed.wakeTime ? (
+          <span className="text-muted-foreground">{parsed.wakeTime.replace(/^at\s+/i, '')}</span>
+        ) : (
+          <span className="text-muted-foreground italic">Scheduling resume...</span>
+        )}
+      </div>
+
+      {parsed.note && (
+        <Field label="Wake Note" className="whitespace-pre-wrap">
+          {parsed.note}
+          <span className="animate-pulse">|</span>
+        </Field>
+      )}
+    </div>
+  )
+}
+
+export const scheduleResumeRenderer: ToolRenderer = {
+  displayName: 'Schedule Resume',
+  icon: MoonStar,
+  getSummary: scheduleResumeDef.getSummary,
+  ExpandedView,
+  StreamingView,
+}

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -377,6 +377,23 @@ export function GlobalNotificationHandler() {
             break
           }
 
+          case 'session_updated': {
+            // Session-level state changed outside a session stream (e.g. a
+            // pending wake was created/cancelled/fired) — refresh session
+            // lists so sidebar badges and the resume banner stay current.
+            const agentSlug = data.agentSlug as string | undefined
+            const sessionId = data.sessionId as string | undefined
+            if (agentSlug) {
+              queryClient.invalidateQueries({ queryKey: ['sessions', agentSlug] })
+            } else {
+              queryClient.invalidateQueries({ queryKey: ['sessions'] })
+            }
+            if (sessionId) {
+              queryClient.invalidateQueries({ queryKey: ['session', sessionId] })
+            }
+            break
+          }
+
           case 'webhook_trigger_created':
           case 'webhook_trigger_cancelled': {
             const agentSlug = data.agentSlug as string | undefined

--- a/src/renderer/components/sessions/related-sessions.tsx
+++ b/src/renderer/components/sessions/related-sessions.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useState } from 'react'
-import { MessageSquare, ChevronLeft, ChevronRight, MoreVertical, Pencil, ClipboardCopy, Trash2 } from 'lucide-react'
+import { MessageSquare, ChevronLeft, ChevronRight, MoreVertical, MoonStar, Pencil, ClipboardCopy, Trash2 } from 'lucide-react'
+import { formatDistanceToNow } from 'date-fns'
 import { WorkingDots, AwaitingDot } from '@renderer/components/agents/status-indicators'
 import { HighlightMatch } from '@renderer/components/ui/highlight-match'
 import { Button } from '@renderer/components/ui/button'
@@ -43,6 +44,7 @@ interface SessionItem {
   isActive?: boolean
   isAwaitingInput?: boolean
   hasUnreadNotifications?: boolean
+  pendingWakeAt?: string
 }
 
 interface RelatedSessionsProps {
@@ -248,6 +250,15 @@ function SessionRow({ session, showIcon, formatDate, agentSlug: agentSlugProp, s
             ) : session.hasUnreadNotifications ? (
               <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500" />
             ) : null}
+            {session.pendingWakeAt && !session.isActive && !session.isAwaitingInput && (
+              <span
+                className="flex items-center gap-1 shrink-0 text-muted-foreground font-normal"
+                title={`Resumes ${formatDistanceToNow(new Date(session.pendingWakeAt), { addSuffix: true })}`}
+              >
+                <MoonStar className="h-3 w-3" />
+                {formatDistanceToNow(new Date(session.pendingWakeAt), { addSuffix: true })}
+              </span>
+            )}
             {dateAsTitle ? (
               <>
                 <span>{formatDate(session.createdAt)}</span>

--- a/src/renderer/components/sessions/session-list.tsx
+++ b/src/renderer/components/sessions/session-list.tsx
@@ -3,7 +3,8 @@ import { useSessions, type ApiSession } from '@renderer/hooks/use-sessions'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { ScrollArea, ScrollBar } from '@renderer/components/ui/scroll-area'
 import { cn } from '@shared/lib/utils/cn'
-import { Loader2 } from 'lucide-react'
+import { Loader2, MoonStar } from 'lucide-react'
+import { formatDistanceToNow } from 'date-fns'
 
 interface SessionListProps {
   agentSlug: string
@@ -50,6 +51,13 @@ function SessionTab({
         <span className="relative flex h-2 w-2">
           <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-current opacity-75"></span>
           <span className="relative inline-flex rounded-full h-2 w-2 bg-current"></span>
+        </span>
+      ) : session.pendingWakeAt ? (
+        <span
+          title={`Resumes ${formatDistanceToNow(new Date(session.pendingWakeAt), { addSuffix: true })}`}
+          className="flex items-center"
+        >
+          <MoonStar className="h-3 w-3" />
         </span>
       ) : null}
       {session.name}

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -9,10 +9,14 @@ const mockCancelScheduledTask = vi.fn<SchedMockFn>(() => Promise.resolve(true))
 const mockPauseScheduledTask = vi.fn<SchedMockFn>(() => Promise.resolve(true))
 const mockResumeScheduledTask = vi.fn<SchedMockFn>(() => Promise.resolve(true))
 const mockCreateScheduledTask = vi.fn<SchedMockFn>(() => Promise.resolve('task_new_id'))
+const mockCreateSessionWake = vi.fn<SchedMockFn>(() =>
+  Promise.resolve({ taskId: 'wake_new_id', replaced: null })
+)
 
 // Mock external dependencies before importing
 vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   createScheduledTask: (...args: unknown[]) => mockCreateScheduledTask(...args),
+  createSessionWake: (...args: unknown[]) => mockCreateSessionWake(...args),
   listPendingScheduledTasks: (...args: unknown[]) => mockListPendingScheduledTasks(...args),
   getScheduledTask: (...args: unknown[]) => mockGetScheduledTask(...args),
   cancelScheduledTask: (...args: unknown[]) => mockCancelScheduledTask(...args),
@@ -1669,6 +1673,153 @@ describe('MessagePersister', () => {
       const toolReady = sseEvents.filter(e => e.type === 'tool_use_ready')
       expect(toolReady).toHaveLength(1)
       expect(toolReady[0].toolName).toBe('mcp__user-input__request_remote_mcp')
+    })
+  })
+
+  // ============================================================================
+  // schedule_resume tool handling
+  // ============================================================================
+
+  describe('schedule_resume tool handling', () => {
+    function simulateScheduleResumeToolUse(toolId: string, input: Record<string, unknown>) {
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          content_block: { type: 'tool_use', id: toolId, name: 'mcp__user-input__schedule_resume' },
+        },
+      })
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) },
+        },
+      })
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_stop' },
+      })
+    }
+
+    function resolveCalls() {
+      return mockContainerClientFetch.mock.calls.filter((c) =>
+        String(c[0]).includes('/resolve')
+      )
+    }
+
+    function rejectCalls() {
+      return mockContainerClientFetch.mock.calls.filter((c) =>
+        String(c[0]).includes('/reject')
+      )
+    }
+
+    beforeEach(() => {
+      mockCreateSessionWake.mockResolvedValue({ taskId: 'wake_new_id', replaced: null })
+    })
+
+    it('creates a session wake and resolves the tool with the note echoed back', async () => {
+      simulateScheduleResumeToolUse('wake-tool-1', {
+        wakeTime: 'at tomorrow 9am',
+        note: 'Check whether Dana replied',
+      })
+
+      await vi.waitFor(() => expect(resolveCalls()).toHaveLength(1))
+
+      expect(mockCreateSessionWake).toHaveBeenCalledWith({
+        agentSlug: AGENT_SLUG,
+        scheduleExpression: 'at tomorrow 9am',
+        note: 'Check whether Dana replied',
+        sessionId: SESSION_ID,
+        createdByUserId: undefined,
+        timezone: 'UTC',
+      })
+
+      const body = JSON.parse(resolveCalls()[0][1].body)
+      expect(body.value).toContain('Check whether Dana replied')
+      expect(body.value).toContain('auto-resume')
+    })
+
+    it('normalizes a wakeTime without the "at " prefix', async () => {
+      simulateScheduleResumeToolUse('wake-tool-2', {
+        wakeTime: 'in 72 hours',
+        note: 'Check app review status',
+      })
+
+      await vi.waitFor(() => expect(resolveCalls()).toHaveLength(1))
+
+      expect(mockCreateSessionWake).toHaveBeenCalledWith(
+        expect.objectContaining({ scheduleExpression: 'at in 72 hours' })
+      )
+    })
+
+    it('mentions the replaced wake in the tool result', async () => {
+      mockCreateSessionWake.mockResolvedValue({
+        taskId: 'wake_new_id',
+        replaced: {
+          id: 'wake_old_id',
+          nextExecutionAt: new Date('2027-01-01T09:00:00.000Z'),
+          prompt: 'Old note',
+        },
+      })
+
+      simulateScheduleResumeToolUse('wake-tool-3', {
+        wakeTime: 'at tomorrow 9am',
+        note: 'New plan',
+      })
+
+      await vi.waitFor(() => expect(resolveCalls()).toHaveLength(1))
+
+      const body = JSON.parse(resolveCalls()[0][1].body)
+      expect(body.value).toContain('Replaced')
+      expect(body.value).toContain('2027-01-01T09:00:00.000Z')
+    })
+
+    it('rejects when the note is missing', async () => {
+      simulateScheduleResumeToolUse('wake-tool-4', {
+        wakeTime: 'at tomorrow 9am',
+        note: '   ',
+      })
+
+      await vi.waitFor(() => expect(rejectCalls()).toHaveLength(1))
+      expect(mockCreateSessionWake).not.toHaveBeenCalled()
+    })
+
+    it('rejects when the wakeTime is missing', async () => {
+      simulateScheduleResumeToolUse('wake-tool-5', { note: 'A note' })
+
+      await vi.waitFor(() => expect(rejectCalls()).toHaveLength(1))
+      expect(mockCreateSessionWake).not.toHaveBeenCalled()
+    })
+
+    it('rejects when wake creation fails (e.g. time in the past)', async () => {
+      mockCreateSessionWake.mockRejectedValue(
+        new Error('Scheduled time "at yesterday" is in the past')
+      )
+
+      simulateScheduleResumeToolUse('wake-tool-6', {
+        wakeTime: 'at yesterday',
+        note: 'Impossible wake',
+      })
+
+      await vi.waitFor(() => expect(rejectCalls()).toHaveLength(1))
+      const body = JSON.parse(rejectCalls()[0][1].body)
+      expect(body.reason).toContain('in the past')
+    })
+
+    it('broadcasts scheduled_task_created and session_updated', async () => {
+      sseEvents.length = 0
+
+      simulateScheduleResumeToolUse('wake-tool-7', {
+        wakeTime: 'at tomorrow 9am',
+        note: 'Check back',
+      })
+
+      await vi.waitFor(() => expect(resolveCalls()).toHaveLength(1))
+      await vi.waitFor(() => {
+        expect(sseEvents.filter((e) => e.type === 'scheduled_task_created')).toHaveLength(1)
+        expect(sseEvents.filter((e) => e.type === 'session_updated')).toHaveLength(1)
+      })
     })
   })
 

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -1677,6 +1677,31 @@ describe('MessagePersister', () => {
   })
 
   // ============================================================================
+  // markSessionIdle (optimistic-active revert)
+  // ============================================================================
+
+  describe('markSessionIdle', () => {
+    it('flips an active session back to idle and broadcasts session_idle', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      sseEvents.length = 0
+
+      messagePersister.markSessionIdle(SESSION_ID)
+
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(sseEvents.filter((e) => e.type === 'session_idle')).toHaveLength(1)
+    })
+
+    it('is a no-op on an already-idle session', () => {
+      sseEvents.length = 0
+
+      messagePersister.markSessionIdle(SESSION_ID)
+
+      expect(sseEvents).toHaveLength(0)
+    })
+  })
+
+  // ============================================================================
   // schedule_resume tool handling
   // ============================================================================
 

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -14,6 +14,7 @@ import { parseCommandLifecycle } from './command-lifecycle'
 import { captureException } from '@shared/lib/error-reporting'
 import {
   createScheduledTask,
+  createSessionWake,
   listPendingScheduledTasks,
   getScheduledTask,
   cancelScheduledTask,
@@ -2196,6 +2197,16 @@ class MessagePersister {
             )
           }
 
+          // Schedule resume (session wake) tool - blocking
+          if (state.currentToolUse.name === 'mcp__user-input__schedule_resume') {
+            this.handleScheduleResumeTool(
+              sessionId,
+              state.currentToolUse.id,
+              state.currentToolInput,
+              state.agentSlug
+            )
+          }
+
           // List scheduled tasks tool - blocking
           if (state.currentToolUse.name === 'mcp__user-input__list_scheduled_tasks') {
             this.handleListScheduledTasksTool(
@@ -2616,6 +2627,109 @@ class MessagePersister {
   }
 
   /**
+   * Handle schedule_resume: persist a session wake (a one-shot scheduled task
+   * that resumes THIS session instead of creating a new one), then resolve the
+   * blocking container tool. Mirrors handleScheduleTaskTool's persist-then-
+   * resolve contract: a persistence failure rejects; a delivery failure after
+   * persistence never does.
+   */
+  private handleScheduleResumeTool(
+    sessionId: string,
+    toolUseId: string,
+    toolInput: string,
+    agentSlug?: string
+  ): void {
+    ;(async () => {
+      if (!agentSlug) {
+        console.error('[MessagePersister] Schedule resume missing agentSlug')
+        return
+      }
+
+      let input: { wakeTime?: string; note?: string; timezone?: string }
+      try {
+        input = JSON.parse(toolInput)
+      } catch {
+        console.error('[MessagePersister] Failed to parse schedule resume input:', toolInput)
+        await this.rejectContainerInput(agentSlug, toolUseId, 'Invalid tool input').catch(console.error)
+        return
+      }
+
+      if (!input.wakeTime?.trim() || !input.note?.trim()) {
+        await this.rejectContainerInput(
+          agentSlug,
+          toolUseId,
+          'Missing required fields: wakeTime and note are required'
+        ).catch(console.error)
+        return
+      }
+
+      // Accept both "at tomorrow 9am" and bare "tomorrow 9am" — the parser's
+      // 'at' syntax needs the prefix.
+      const trimmed = input.wakeTime.trim()
+      const scheduleExpression = /^at\s/i.test(trimmed) ? trimmed : `at ${trimmed}`
+
+      let taskId: string
+      let replaced: ScheduledTask | null
+      let timezone: string | undefined
+      try {
+        timezone = input.timezone || resolveTimezoneForAgent(agentSlug)
+        const sessionOwnerId = (await getSessionMetadata(agentSlug, sessionId))?.createdByUserId
+        ;({ taskId, replaced } = await createSessionWake({
+          agentSlug,
+          scheduleExpression,
+          note: input.note,
+          sessionId,
+          createdByUserId: sessionOwnerId ?? undefined,
+          timezone,
+        }))
+      } catch (error) {
+        console.error('[MessagePersister] Error handling schedule resume:', error)
+        const msg = error instanceof Error ? error.message : String(error)
+        await this.rejectContainerInput(agentSlug, toolUseId, `Failed to schedule resume: ${msg}`).catch(console.error)
+        return
+      }
+
+      // Persisted — everything past here is best-effort delivery.
+      try {
+        this.broadcastToSSE(sessionId, {
+          type: 'scheduled_task_created',
+          toolUseId,
+          taskId,
+          scheduleType: 'at',
+          scheduleExpression,
+          agentSlug,
+          resumeSessionId: sessionId,
+        })
+        this.broadcastGlobal({
+          type: 'scheduled_task_created',
+          taskId,
+          agentSlug,
+          resumeSessionId: sessionId,
+        })
+        // The pending wake is session-level state (badges, resume banner) —
+        // nudge session lists to refetch.
+        this.broadcastToSSE(sessionId, { type: 'session_updated' })
+        this.broadcastGlobal({ type: 'session_updated', sessionId, agentSlug })
+
+        const parsed = validateScheduleExpression('at', scheduleExpression, timezone)
+        const resolvedTime = parsed.nextTime ? parsed.nextTime.toISOString() : scheduleExpression
+        let resultMessage =
+          `Scheduled this session to auto-resume at ${resolvedTime}${timezone ? ` (${timezone})` : ''} (wake ID: ${taskId}).\n\n` +
+          `Your note (echoed back to you on wake): "${input.note}"`
+        if (replaced) {
+          resultMessage += `\n\nReplaced this session's previous pending wake (was scheduled for ${replaced.nextExecutionAt.toISOString()}). A session holds at most one pending wake.`
+        }
+        resultMessage +=
+          '\n\nEnd your turn now. This conversation will resume automatically at the scheduled time with full context; while sleeping it costs nothing and survives restarts.'
+
+        await this.resolveContainerInput(agentSlug, toolUseId, resultMessage)
+      } catch (deliveryError) {
+        console.error('[MessagePersister] Wake persisted but result delivery failed:', deliveryError)
+      }
+    })()
+  }
+
+  /**
    * Build the success message returned to the agent after a schedule is persisted,
    * appending a too-frequent-interval warning for recurring schedules below the
    * recommended minimum.
@@ -2672,10 +2786,12 @@ ${continuation}`
     if (count > 0) {
       const list = tasks
         .map((t) => {
-          const kind = t.scheduleType === 'cron' ? 'recurring' : 'one-time'
+          const kind = t.resumeSessionId
+            ? 'session wake'
+            : t.scheduleType === 'cron' ? 'recurring' : 'one-time'
           const next = t.nextExecutionAt ? t.nextExecutionAt.toISOString() : 'unknown'
           const status = t.status === 'paused' ? ' [PAUSED]' : ''
-          return `- **${t.name || 'Scheduled Task'}** (ID: ${t.id})${status} — ${kind} (${t.scheduleExpression}), next run ${next}${t.timezone ? ` (${t.timezone})` : ''}`
+          return `- **${t.name || (t.resumeSessionId ? 'Session Wake' : 'Scheduled Task')}** (ID: ${t.id})${status} — ${kind} (${t.scheduleExpression}), next run ${next}${t.timezone ? ` (${t.timezone})` : ''}`
         })
         .join('\n')
       summary += `\n\n${list}`
@@ -2702,10 +2818,12 @@ ${continuation}`
         const formatted = tasks.length === 0
           ? 'No scheduled tasks on the schedule for this agent.'
           : `Scheduled tasks:\n\n${tasks.map((t) => {
-              const kind = t.scheduleType === 'cron' ? 'recurring' : 'one-time'
+              const kind = t.resumeSessionId
+                ? `session wake (resumes session ${t.resumeSessionId})`
+                : t.scheduleType === 'cron' ? 'recurring' : 'one-time'
               const next = t.nextExecutionAt ? t.nextExecutionAt.toISOString() : 'unknown'
               const status = t.status === 'paused' ? ' [PAUSED]' : ''
-              return `- **${t.name || 'Scheduled Task'}** (ID: ${t.id})${status}\n  Type: ${kind} (${t.scheduleExpression})\n  Next run: ${next}${t.timezone ? ` (${t.timezone})` : ''}\n  Prompt: ${t.prompt.substring(0, 80)}${t.prompt.length > 80 ? '...' : ''}`
+              return `- **${t.name || (t.resumeSessionId ? 'Session Wake' : 'Scheduled Task')}** (ID: ${t.id})${status}\n  Type: ${kind} (${t.scheduleExpression})\n  Next run: ${next}${t.timezone ? ` (${t.timezone})` : ''}\n  ${t.resumeSessionId ? 'Note' : 'Prompt'}: ${t.prompt.substring(0, 80)}${t.prompt.length > 80 ? '...' : ''}`
             }).join('\n\n')}`
 
         await this.resolveContainerInput(agentSlug, toolUseId, formatted)

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -358,6 +358,16 @@ class MessagePersister {
     })
   }
 
+  // Revert an optimistic markSessionActive when a host-initiated send fails
+  // before reaching the container (e.g. a scheduled wake delivery error). The
+  // session never actually started a turn, so flip it back to idle rather than
+  // leaving a phantom "working" state until some later retry succeeds.
+  markSessionIdle(sessionId: string): void {
+    const state = this.streamingStates.get(sessionId)
+    if (!state?.isActive) return
+    this.finalizeIdle(sessionId, state)
+  }
+
   // Check if a session is currently active (processing user request)
   isSessionActive(sessionId: string): boolean {
     const state = this.streamingStates.get(sessionId)

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1376,6 +1376,18 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     // API error scenarios
     ['auth error', new ApiErrorScenario('authentication_failed', 'Invalid API key')],
     ['rate limit error', new ApiErrorScenario('rate_limit', 'Rate limit exceeded, please try again later')],
+    // Schedule resume (session long-sleep) scenario — the host interceptor
+    // persists a real wake row targeting this session, so E2E can exercise the
+    // pending-wake banner, sidebar badge, and Wake now / Cancel actions.
+    ['schedule resume', new ToolUseScenario(
+      'mcp__user-input__schedule_resume',
+      {
+        wakeTime: 'at now + 2 hours',
+        note: 'Check whether the review has been approved',
+      },
+      'Scheduled this session to auto-resume in 2 hours.',
+      'I\'ll pause here and check back in 2 hours.'
+    )],
     // Schedule task scenario
     ['schedule task', new ToolUseScenario(
       'mcp__user-input__schedule_task',

--- a/src/shared/lib/db/migrations/0028_yielding_galactus.sql
+++ b/src/shared/lib/db/migrations/0028_yielding_galactus.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `scheduled_tasks` ADD `resume_session_id` text;

--- a/src/shared/lib/db/migrations/0029_polite_sister_grimm.sql
+++ b/src/shared/lib/db/migrations/0029_polite_sister_grimm.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX `scheduled_tasks_pending_wake_unique` ON `scheduled_tasks` (`resume_session_id`) WHERE status = 'pending' AND resume_session_id IS NOT NULL;

--- a/src/shared/lib/db/migrations/meta/0028_snapshot.json
+++ b/src/shared/lib/db/migrations/meta/0028_snapshot.json
@@ -1,0 +1,2390 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b297a043-f5f7-4d76-a6cf-cdc7e4486347",
+  "prevId": "0d593c96-7ffe-45ec-9868-b0b6d82fd0fc",
+  "tables": {
+    "agent_acl": {
+      "name": "agent_acl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_acl_user_agent_unique": {
+          "name": "agent_acl_user_agent_unique",
+          "columns": [
+            "user_id",
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "agent_acl_agent_slug_idx": {
+          "name": "agent_acl_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_acl_user_id_user_id_fk": {
+          "name": "agent_acl_user_id_user_id_fk",
+          "tableFrom": "agent_acl",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_connected_accounts": {
+      "name": "agent_connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_connected_accounts_unique": {
+          "name": "agent_connected_accounts_unique",
+          "columns": [
+            "agent_slug",
+            "connected_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_connected_accounts_connected_account_id_connected_accounts_id_fk": {
+          "name": "agent_connected_accounts_connected_account_id_connected_accounts_id_fk",
+          "tableFrom": "agent_connected_accounts",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "connected_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_remote_mcps": {
+      "name": "agent_remote_mcps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_remote_mcps_unique": {
+          "name": "agent_remote_mcps_unique",
+          "columns": [
+            "agent_slug",
+            "remote_mcp_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "agent_remote_mcps",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "remote_mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_scope_policies": {
+      "name": "api_scope_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_scope_policies_unique": {
+          "name": "api_scope_policies_unique",
+          "columns": [
+            "account_id",
+            "scope"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_scope_policies_account_id_connected_accounts_id_fk": {
+          "name": "api_scope_policies_account_id_connected_accounts_id_fk",
+          "tableFrom": "api_scope_policies",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_log_object_idx": {
+          "name": "audit_log_object_idx",
+          "columns": [
+            "object"
+          ],
+          "isUnique": false
+        },
+        "audit_log_user_id_idx": {
+          "name": "audit_log_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integration_access": {
+      "name": "chat_integration_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "approval_source": {
+          "name": "approval_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_id": {
+          "name": "first_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_name": {
+          "name": "first_user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message_preview": {
+          "name": "first_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_notice_sent_at": {
+          "name": "request_notice_sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_access_unique": {
+          "name": "chat_integration_access_unique",
+          "columns": [
+            "integration_id",
+            "external_chat_id"
+          ],
+          "isUnique": true
+        },
+        "chat_integration_access_status_idx": {
+          "name": "chat_integration_access_status_idx",
+          "columns": [
+            "integration_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_access_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_access_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_access",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chat_integration_access_status_check": {
+          "name": "chat_integration_access_status_check",
+          "value": "\"chat_integration_access\".\"status\" in ('pending','allowed','denied')"
+        },
+        "chat_integration_access_chat_type_check": {
+          "name": "chat_integration_access_chat_type_check",
+          "value": "\"chat_integration_access\".\"chat_type\" is null or \"chat_integration_access\".\"chat_type\" in ('private','group','supergroup')"
+        },
+        "chat_integration_access_source_check": {
+          "name": "chat_integration_access_source_check",
+          "value": "\"chat_integration_access\".\"approval_source\" is null or \"chat_integration_access\".\"approval_source\" in ('auto_first_contact','owner','migration')"
+        }
+      }
+    },
+    "chat_integration_sessions": {
+      "name": "chat_integration_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_sessions_integration_id_idx": {
+          "name": "chat_integration_sessions_integration_id_idx",
+          "columns": [
+            "integration_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_sessions_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_sessions_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_sessions",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integrations": {
+      "name": "chat_integrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "show_tool_calls": {
+          "name": "show_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "require_approval": {
+          "name": "require_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_timeout": {
+          "name": "session_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integrations_agent_slug_idx": {
+          "name": "chat_integrations_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "chat_integrations_status_idx": {
+          "name": "chat_integrations_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connected_accounts": {
+      "name": "connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_connection_id": {
+          "name": "provider_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "toolkit_slug": {
+          "name": "toolkit_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connected_accounts_provider_connection_id_unique": {
+          "name": "connected_accounts_provider_connection_id_unique",
+          "columns": [
+            "provider_connection_id"
+          ],
+          "isUnique": true
+        },
+        "connected_accounts_userId_idx": {
+          "name": "connected_accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connected_accounts_user_id_user_id_fk": {
+          "name": "connected_accounts_user_id_user_id_fk",
+          "tableFrom": "connected_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_name": {
+          "name": "remote_mcp_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_tool": {
+          "name": "matched_tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_audit_log_agent_slug_created_at_idx": {
+          "name": "mcp_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "mcp_audit_log_remote_mcp_id_created_at_idx": {
+          "name": "mcp_audit_log_remote_mcp_id_created_at_idx",
+          "columns": [
+            "remote_mcp_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_policies": {
+      "name": "mcp_tool_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_tool_policies_unique": {
+          "name": "mcp_tool_policies_unique",
+          "columns": [
+            "mcp_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_policies",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message_author": {
+      "name": "message_author",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "message_author_session_idx": {
+          "name": "message_author_session_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_author_user_id_user_id_fk": {
+          "name": "message_author_user_id_user_id_fk",
+          "tableFrom": "message_author",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_agent_slug_is_read_idx": {
+          "name": "notifications_agent_slug_is_read_idx",
+          "columns": [
+            "agent_slug",
+            "is_read"
+          ],
+          "isUnique": false
+        },
+        "notifications_session_id_idx": {
+          "name": "notifications_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_audit_log": {
+      "name": "proxy_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_scopes": {
+          "name": "matched_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_audit_log_agent_slug_created_at_idx": {
+          "name": "proxy_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "proxy_audit_log_account_id_created_at_idx": {
+          "name": "proxy_audit_log_account_id_created_at_idx",
+          "columns": [
+            "account_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_tokens": {
+      "name": "proxy_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_tokens_agent_slug_unique": {
+          "name": "proxy_tokens_agent_slug_unique",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "proxy_tokens_token_unique": {
+          "name": "proxy_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_mcp_servers": {
+      "name": "remote_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token_endpoint": {
+          "name": "oauth_token_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_resource": {
+          "name": "oauth_resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_discovered_at": {
+          "name": "tools_discovered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "remote_mcp_servers_user_id_user_id_fk": {
+          "name": "remote_mcp_servers_user_id_user_id_fk",
+          "tableFrom": "remote_mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_expression": {
+          "name": "schedule_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "next_execution_at": {
+          "name": "next_execution_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "execution_count": {
+          "name": "execution_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resume_session_id": {
+          "name": "resume_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_triggers": {
+      "name": "webhook_triggers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "composio_trigger_id": {
+          "name": "composio_trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fire_count": {
+          "name": "fire_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_triggers_agent_slug_idx": {
+          "name": "webhook_triggers_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_status_idx": {
+          "name": "webhook_triggers_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_composio_idx": {
+          "name": "webhook_triggers_composio_idx",
+          "columns": [
+            "composio_trigger_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "x_agent_policies": {
+      "name": "x_agent_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_agent_slug": {
+          "name": "caller_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_agent_slug": {
+          "name": "target_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "x_agent_policies_unique": {
+          "name": "x_agent_policies_unique",
+          "columns": [
+            "caller_agent_slug",
+            "target_agent_slug",
+            "operation"
+          ],
+          "isUnique": true
+        },
+        "x_agent_policies_caller_idx": {
+          "name": "x_agent_policies_caller_idx",
+          "columns": [
+            "caller_agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/shared/lib/db/migrations/meta/0029_snapshot.json
+++ b/src/shared/lib/db/migrations/meta/0029_snapshot.json
@@ -1,0 +1,2399 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c1eee63f-11cd-459d-994d-0b25d834248b",
+  "prevId": "b297a043-f5f7-4d76-a6cf-cdc7e4486347",
+  "tables": {
+    "agent_acl": {
+      "name": "agent_acl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_acl_user_agent_unique": {
+          "name": "agent_acl_user_agent_unique",
+          "columns": [
+            "user_id",
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "agent_acl_agent_slug_idx": {
+          "name": "agent_acl_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_acl_user_id_user_id_fk": {
+          "name": "agent_acl_user_id_user_id_fk",
+          "tableFrom": "agent_acl",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_connected_accounts": {
+      "name": "agent_connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_connected_accounts_unique": {
+          "name": "agent_connected_accounts_unique",
+          "columns": [
+            "agent_slug",
+            "connected_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_connected_accounts_connected_account_id_connected_accounts_id_fk": {
+          "name": "agent_connected_accounts_connected_account_id_connected_accounts_id_fk",
+          "tableFrom": "agent_connected_accounts",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "connected_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_remote_mcps": {
+      "name": "agent_remote_mcps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_remote_mcps_unique": {
+          "name": "agent_remote_mcps_unique",
+          "columns": [
+            "agent_slug",
+            "remote_mcp_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "agent_remote_mcps",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "remote_mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_scope_policies": {
+      "name": "api_scope_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_scope_policies_unique": {
+          "name": "api_scope_policies_unique",
+          "columns": [
+            "account_id",
+            "scope"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_scope_policies_account_id_connected_accounts_id_fk": {
+          "name": "api_scope_policies_account_id_connected_accounts_id_fk",
+          "tableFrom": "api_scope_policies",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_log_object_idx": {
+          "name": "audit_log_object_idx",
+          "columns": [
+            "object"
+          ],
+          "isUnique": false
+        },
+        "audit_log_user_id_idx": {
+          "name": "audit_log_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integration_access": {
+      "name": "chat_integration_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "approval_source": {
+          "name": "approval_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_id": {
+          "name": "first_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_name": {
+          "name": "first_user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message_preview": {
+          "name": "first_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_notice_sent_at": {
+          "name": "request_notice_sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_access_unique": {
+          "name": "chat_integration_access_unique",
+          "columns": [
+            "integration_id",
+            "external_chat_id"
+          ],
+          "isUnique": true
+        },
+        "chat_integration_access_status_idx": {
+          "name": "chat_integration_access_status_idx",
+          "columns": [
+            "integration_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_access_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_access_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_access",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chat_integration_access_status_check": {
+          "name": "chat_integration_access_status_check",
+          "value": "\"chat_integration_access\".\"status\" in ('pending','allowed','denied')"
+        },
+        "chat_integration_access_chat_type_check": {
+          "name": "chat_integration_access_chat_type_check",
+          "value": "\"chat_integration_access\".\"chat_type\" is null or \"chat_integration_access\".\"chat_type\" in ('private','group','supergroup')"
+        },
+        "chat_integration_access_source_check": {
+          "name": "chat_integration_access_source_check",
+          "value": "\"chat_integration_access\".\"approval_source\" is null or \"chat_integration_access\".\"approval_source\" in ('auto_first_contact','owner','migration')"
+        }
+      }
+    },
+    "chat_integration_sessions": {
+      "name": "chat_integration_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_sessions_integration_id_idx": {
+          "name": "chat_integration_sessions_integration_id_idx",
+          "columns": [
+            "integration_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_sessions_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_sessions_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_sessions",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integrations": {
+      "name": "chat_integrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "show_tool_calls": {
+          "name": "show_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "require_approval": {
+          "name": "require_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_timeout": {
+          "name": "session_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integrations_agent_slug_idx": {
+          "name": "chat_integrations_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "chat_integrations_status_idx": {
+          "name": "chat_integrations_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connected_accounts": {
+      "name": "connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_connection_id": {
+          "name": "provider_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "toolkit_slug": {
+          "name": "toolkit_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connected_accounts_provider_connection_id_unique": {
+          "name": "connected_accounts_provider_connection_id_unique",
+          "columns": [
+            "provider_connection_id"
+          ],
+          "isUnique": true
+        },
+        "connected_accounts_userId_idx": {
+          "name": "connected_accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connected_accounts_user_id_user_id_fk": {
+          "name": "connected_accounts_user_id_user_id_fk",
+          "tableFrom": "connected_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_name": {
+          "name": "remote_mcp_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_tool": {
+          "name": "matched_tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_audit_log_agent_slug_created_at_idx": {
+          "name": "mcp_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "mcp_audit_log_remote_mcp_id_created_at_idx": {
+          "name": "mcp_audit_log_remote_mcp_id_created_at_idx",
+          "columns": [
+            "remote_mcp_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_policies": {
+      "name": "mcp_tool_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_tool_policies_unique": {
+          "name": "mcp_tool_policies_unique",
+          "columns": [
+            "mcp_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_policies",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message_author": {
+      "name": "message_author",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "message_author_session_idx": {
+          "name": "message_author_session_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_author_user_id_user_id_fk": {
+          "name": "message_author_user_id_user_id_fk",
+          "tableFrom": "message_author",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_agent_slug_is_read_idx": {
+          "name": "notifications_agent_slug_is_read_idx",
+          "columns": [
+            "agent_slug",
+            "is_read"
+          ],
+          "isUnique": false
+        },
+        "notifications_session_id_idx": {
+          "name": "notifications_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_audit_log": {
+      "name": "proxy_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_scopes": {
+          "name": "matched_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_audit_log_agent_slug_created_at_idx": {
+          "name": "proxy_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "proxy_audit_log_account_id_created_at_idx": {
+          "name": "proxy_audit_log_account_id_created_at_idx",
+          "columns": [
+            "account_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_tokens": {
+      "name": "proxy_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_tokens_agent_slug_unique": {
+          "name": "proxy_tokens_agent_slug_unique",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "proxy_tokens_token_unique": {
+          "name": "proxy_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_mcp_servers": {
+      "name": "remote_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token_endpoint": {
+          "name": "oauth_token_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_resource": {
+          "name": "oauth_resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_discovered_at": {
+          "name": "tools_discovered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "remote_mcp_servers_user_id_user_id_fk": {
+          "name": "remote_mcp_servers_user_id_user_id_fk",
+          "tableFrom": "remote_mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_expression": {
+          "name": "schedule_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "next_execution_at": {
+          "name": "next_execution_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "execution_count": {
+          "name": "execution_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resume_session_id": {
+          "name": "resume_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_tasks_pending_wake_unique": {
+          "name": "scheduled_tasks_pending_wake_unique",
+          "columns": [
+            "resume_session_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'pending' AND resume_session_id IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_triggers": {
+      "name": "webhook_triggers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "composio_trigger_id": {
+          "name": "composio_trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fire_count": {
+          "name": "fire_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_triggers_agent_slug_idx": {
+          "name": "webhook_triggers_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_status_idx": {
+          "name": "webhook_triggers_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_composio_idx": {
+          "name": "webhook_triggers_composio_idx",
+          "columns": [
+            "composio_trigger_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "x_agent_policies": {
+      "name": "x_agent_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_agent_slug": {
+          "name": "caller_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_agent_slug": {
+          "name": "target_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "x_agent_policies_unique": {
+          "name": "x_agent_policies_unique",
+          "columns": [
+            "caller_agent_slug",
+            "target_agent_slug",
+            "operation"
+          ],
+          "isUnique": true
+        },
+        "x_agent_policies_caller_idx": {
+          "name": "x_agent_policies_caller_idx",
+          "columns": [
+            "caller_agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/shared/lib/db/migrations/meta/_journal.json
+++ b/src/shared/lib/db/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1784043298646,
       "tag": "0028_yielding_galactus",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "6",
+      "when": 1784054072546,
+      "tag": "0029_polite_sister_grimm",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/lib/db/migrations/meta/_journal.json
+++ b/src/shared/lib/db/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1783649401734,
       "tag": "0027_shallow_legion",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "6",
+      "when": 1784043298646,
+      "tag": "0028_yielding_galactus",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/lib/db/schema.ts
+++ b/src/shared/lib/db/schema.ts
@@ -176,7 +176,15 @@ export const scheduledTasks = sqliteTable('scheduled_tasks', {
   createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
   cancelledAt: integer('cancelled_at', { mode: 'timestamp_ms' }),
   pausedAt: integer('paused_at', { mode: 'timestamp_ms' }),
-})
+}, (table) => ({
+  // One pending wake per session, enforced at the storage layer: the
+  // replace-on-create logic in createSessionWake runs in a transaction, and
+  // this partial index makes any interleaving that slips past it a hard
+  // constraint error instead of a silent duplicate wake.
+  pendingWakePerSession: uniqueIndex('scheduled_tasks_pending_wake_unique')
+    .on(table.resumeSessionId)
+    .where(sql`status = 'pending' AND resume_session_id IS NOT NULL`),
+}))
 
 // Notifications - user notifications for session events
 export const notifications = sqliteTable('notifications', {

--- a/src/shared/lib/db/schema.ts
+++ b/src/shared/lib/db/schema.ts
@@ -161,6 +161,9 @@ export const scheduledTasks = sqliteTable('scheduled_tasks', {
   lastSessionId: text('last_session_id'),
   createdBySessionId: text('created_by_session_id'),
   createdByUserId: text('created_by_user_id'), // For ACL purposes in auth mode
+  // When set, this task is a session "wake": firing resumes the referenced
+  // existing session (sendMessage into it) instead of creating a new one.
+  resumeSessionId: text('resume_session_id'),
 
   // Timezone (IANA identifier, e.g. 'America/New_York')
   timezone: text('timezone'),

--- a/src/shared/lib/notifications/notification-manager.ts
+++ b/src/shared/lib/notifications/notification-manager.ts
@@ -260,6 +260,31 @@ class NotificationManager {
   }
 
   /**
+   * Trigger notification when a scheduled wake resumes an existing session.
+   * Reuses the session_scheduled type — a wake is a scheduled execution whose
+   * target happens to be an existing session.
+   */
+  async triggerScheduledSessionResumed(
+    sessionId: string,
+    agentSlug: string,
+    taskId: string,
+    sessionName?: string,
+    agentName?: string
+  ): Promise<void> {
+    const displayName = agentName || await this.getAgentDisplayName(agentSlug)
+    const sessionDisplay = sessionName || 'Session'
+
+    await this.triggerNotification({
+      type: 'session_scheduled',
+      sessionId,
+      agentSlug,
+      title: 'Session Resumed',
+      body: `${sessionDisplay} resumed as scheduled for ${displayName}`,
+      extra: { taskId },
+    })
+  }
+
+  /**
    * Trigger notification for chat integration events (connected, disconnected, error)
    */
   async triggerChatIntegrationEvent(

--- a/src/shared/lib/scheduler/session-auto-delete-monitor.test.ts
+++ b/src/shared/lib/scheduler/session-auto-delete-monitor.test.ts
@@ -47,6 +47,15 @@ vi.mock('@shared/lib/container/message-persister', () => ({
   },
 }))
 
+const mockListSessionIdsWithPendingWakes = vi.fn((_slug: string) =>
+  Promise.resolve(new Set<string>())
+)
+
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  listSessionIdsWithPendingWakes: (slug: string) =>
+    mockListSessionIdsWithPendingWakes(slug),
+}))
+
 vi.mock('@shared/lib/db', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   db: { delete: (...args: any[]) => mockDbDelete(...args) },
@@ -240,6 +249,24 @@ describe('SessionAutoDeleteMonitor', () => {
     expect(mockDeleteSessionsBatch).toHaveBeenCalledWith('test-agent', [
       'inactive',
     ])
+  })
+
+  it('preserves sessions with a pending scheduled wake', async () => {
+    const now = Date.now()
+    const oldSleeping = makeSession('sleeping', new Date(now - 60 * 86_400_000))
+    const oldNormal = makeSession('normal', new Date(now - 60 * 86_400_000))
+
+    mockGetSettings.mockReturnValue({ app: { autoDeleteInactiveDays: 30 } })
+    mockListAgents.mockResolvedValue([makeAgent('test-agent')])
+    mockReadAgentPreferences.mockResolvedValue({})
+    mockListSessions.mockResolvedValue([oldSleeping, oldNormal])
+    mockReadSessionMetadata.mockResolvedValue({})
+    mockListSessionIdsWithPendingWakes.mockResolvedValue(new Set(['sleeping']))
+
+    await startAndTrigger()
+
+    expect(mockListSessionIdsWithPendingWakes).toHaveBeenCalledWith('test-agent')
+    expect(mockDeleteSessionsBatch).toHaveBeenCalledWith('test-agent', ['normal'])
   })
 
   it('does not delete when no sessions exceed threshold', async () => {

--- a/src/shared/lib/scheduler/session-auto-delete-monitor.ts
+++ b/src/shared/lib/scheduler/session-auto-delete-monitor.ts
@@ -6,6 +6,7 @@ import {
 } from '@shared/lib/services/session-service'
 import { readAgentPreferences } from '@shared/lib/services/agent-preferences-service'
 import { deleteNotificationsBySessionIds } from '@shared/lib/services/notification-service'
+import { listSessionIdsWithPendingWakes } from '@shared/lib/services/scheduled-task-service'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { getSettings } from '@shared/lib/config/settings'
 import { isAuthMode } from '@shared/lib/auth/mode'
@@ -97,12 +98,16 @@ class SessionAutoDeleteMonitor {
 
     const metadata = await readSessionMetadata(agentSlug)
     const cutoff = Date.now() - inactiveDays * 86_400_000
+    // A long-sleeping session can be inactive far past the cutoff by design —
+    // deleting it would silently destroy the very session its wake resumes.
+    const pendingWakeSessionIds = await listSessionIdsWithPendingWakes(agentSlug)
 
     const toDelete = sessions
       .filter((s) => {
         if (s.lastActivityAt.getTime() >= cutoff) return false
         if (metadata[s.id]?.starred) return false
         if (messagePersister.isSessionActive(s.id)) return false
+        if (pendingWakeSessionIds.has(s.id)) return false
         return true
       })
       .map((s) => s.id)

--- a/src/shared/lib/scheduler/session-auto-delete.sup228.test.ts
+++ b/src/shared/lib/scheduler/session-auto-delete.sup228.test.ts
@@ -79,6 +79,10 @@ vi.mock('@shared/lib/container/message-persister', () => ({
   },
 }))
 
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  listSessionIdsWithPendingWakes: () => Promise.resolve(new Set<string>()),
+}))
+
 vi.mock('@shared/lib/db', () => ({
   db: { delete: (table: unknown) => mockDbDelete(table) },
 }))

--- a/src/shared/lib/scheduler/task-scheduler.duplicate-guard.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.duplicate-guard.test.ts
@@ -8,6 +8,7 @@ const mockUpdateNextExecution = vi.fn()
 
 vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   getDueTasks: (...args: unknown[]) => mockGetDueTasks(...args),
+  getScheduledTask: vi.fn(() => Promise.resolve(null)),
   markTaskExecuted: (...args: unknown[]) => mockMarkTaskExecuted(...args),
   markTaskFailed: (...args: unknown[]) => mockMarkTaskFailed(...args),
   updateNextExecution: (...args: unknown[]) => mockUpdateNextExecution(...args),
@@ -54,6 +55,7 @@ const mockRegisterSession = vi.fn()
 const mockUpdateSessionMetadata = vi.fn()
 
 vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionMetadata: vi.fn(() => Promise.resolve(null)),
   getSessionForScheduledExecution: (...args: unknown[]) =>
     mockGetSessionForScheduledExecution(...args),
   registerSession: (...args: unknown[]) => mockRegisterSession(...args),

--- a/src/shared/lib/scheduler/task-scheduler.duplicate-guard.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.duplicate-guard.test.ts
@@ -117,6 +117,7 @@ function createTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     timezone: 'America/Los_Angeles',
     model: null,
     effort: null,
+    resumeSessionId: null,
     createdAt: new Date('2026-06-26T16:00:00.000Z'),
     cancelledAt: null,
     pausedAt: null,

--- a/src/shared/lib/scheduler/task-scheduler.model-resolution.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.model-resolution.test.ts
@@ -8,6 +8,7 @@ const mockUpdateNextExecution = vi.fn()
 
 vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   getDueTasks: (...args: unknown[]) => mockGetDueTasks(...args),
+  getScheduledTask: vi.fn(() => Promise.resolve(null)),
   markTaskExecuted: (...args: unknown[]) => mockMarkTaskExecuted(...args),
   markTaskFailed: (...args: unknown[]) => mockMarkTaskFailed(...args),
   updateNextExecution: (...args: unknown[]) => mockUpdateNextExecution(...args),
@@ -59,6 +60,7 @@ const mockGetSessionForScheduledExecution = vi.fn()
 const mockRegisterSession = vi.fn()
 
 vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionMetadata: vi.fn(() => Promise.resolve(null)),
   getSessionForScheduledExecution: (...args: unknown[]) =>
     mockGetSessionForScheduledExecution(...args),
   registerSession: (...args: unknown[]) => mockRegisterSession(...args),

--- a/src/shared/lib/scheduler/task-scheduler.model-resolution.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.model-resolution.test.ts
@@ -113,6 +113,7 @@ function createTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     timezone: 'America/Los_Angeles',
     model: null,
     effort: null,
+    resumeSessionId: null,
     createdAt: new Date('2026-06-26T16:00:00.000Z'),
     cancelledAt: null,
     pausedAt: null,

--- a/src/shared/lib/scheduler/task-scheduler.session-wake.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.session-wake.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { ScheduledTask } from '@shared/lib/services/scheduled-task-service'
+
+const mockGetDueTasks = vi.fn()
+const mockMarkTaskExecuted = vi.fn()
+const mockMarkTaskFailed = vi.fn()
+const mockUpdateNextExecution = vi.fn()
+
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  getDueTasks: (...args: unknown[]) => mockGetDueTasks(...args),
+  markTaskExecuted: (...args: unknown[]) => mockMarkTaskExecuted(...args),
+  markTaskFailed: (...args: unknown[]) => mockMarkTaskFailed(...args),
+  updateNextExecution: (...args: unknown[]) => mockUpdateNextExecution(...args),
+}))
+
+const mockCreateSession = vi.fn()
+const mockSendMessage = vi.fn()
+const mockEnsureRunning = vi.fn()
+
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: {
+    ensureRunning: (...args: unknown[]) => mockEnsureRunning(...args),
+  },
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getEffectiveModels: () => ({
+    agentModel: 'claude-sonnet-4-20250514',
+    browserModel: 'claude-sonnet-4-20250514',
+    dashboardBuilderModel: 'claude-sonnet-4-20250514',
+  }),
+}))
+
+vi.mock('@shared/lib/services/agent-preferences-service', () => ({
+  readAgentPreferences: () => Promise.resolve({}),
+}))
+
+const mockSubscribeToSession = vi.fn()
+const mockMarkSessionActive = vi.fn()
+const mockIsSubscribed = vi.fn()
+const mockCancelAwaitingInput = vi.fn()
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    subscribeToSession: (...args: unknown[]) => mockSubscribeToSession(...args),
+    markSessionActive: (...args: unknown[]) => mockMarkSessionActive(...args),
+    isSubscribed: (...args: unknown[]) => mockIsSubscribed(...args),
+    cancelAwaitingInput: (...args: unknown[]) => mockCancelAwaitingInput(...args),
+  },
+}))
+
+const mockTriggerScheduledSessionStarted = vi.fn()
+const mockTriggerScheduledSessionResumed = vi.fn()
+
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerScheduledSessionStarted: (...args: unknown[]) =>
+      mockTriggerScheduledSessionStarted(...args),
+    triggerScheduledSessionResumed: (...args: unknown[]) =>
+      mockTriggerScheduledSessionResumed(...args),
+  },
+}))
+
+const mockGetSessionForScheduledExecution = vi.fn()
+const mockRegisterSession = vi.fn()
+const mockUpdateSessionMetadata = vi.fn()
+const mockGetSessionMetadata = vi.fn()
+
+vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionForScheduledExecution: (...args: unknown[]) =>
+    mockGetSessionForScheduledExecution(...args),
+  registerSession: (...args: unknown[]) => mockRegisterSession(...args),
+  updateSessionMetadata: (...args: unknown[]) => mockUpdateSessionMetadata(...args),
+  getSessionMetadata: (...args: unknown[]) => mockGetSessionMetadata(...args),
+}))
+
+const mockGetSecretEnvVars = vi.fn()
+
+vi.mock('@shared/lib/services/secrets-service', () => ({
+  getSecretEnvVars: (...args: unknown[]) => mockGetSecretEnvVars(...args),
+}))
+
+const mockAgentExists = vi.fn()
+
+vi.mock('@shared/lib/services/agent-service', () => ({
+  agentExists: (...args: unknown[]) => mockAgentExists(...args),
+}))
+
+const mockGetNextCronTime = vi.fn()
+
+vi.mock('@shared/lib/services/schedule-parser', () => ({
+  getNextCronTime: (...args: unknown[]) => mockGetNextCronTime(...args),
+}))
+
+vi.mock('@shared/lib/platform-attribution', () => ({
+  runWithOptionalUser: (_userId: string | null | undefined, fn: () => unknown) => fn(),
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+}))
+
+import { taskScheduler } from './task-scheduler'
+
+const wakeExecutionAt = new Date('2026-06-26T17:00:00.000Z')
+
+function createWakeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
+  return {
+    id: 'wake-task-1',
+    agentSlug: 'agent-one',
+    scheduleType: 'at',
+    scheduleExpression: 'at tomorrow 9am',
+    prompt: 'Check whether Dana replied to the intro email',
+    name: null,
+    status: 'pending',
+    nextExecutionAt: wakeExecutionAt,
+    lastExecutedAt: null,
+    isRecurring: false,
+    executionCount: 0,
+    lastSessionId: null,
+    createdBySessionId: 'sleeping-session-1',
+    createdByUserId: 'user-1',
+    timezone: 'America/Los_Angeles',
+    model: null,
+    effort: null,
+    resumeSessionId: 'sleeping-session-1',
+    createdAt: new Date('2026-06-25T16:00:00.000Z'),
+    cancelledAt: null,
+    pausedAt: null,
+    ...overrides,
+  }
+}
+
+describe('TaskScheduler session wake (resume) branch', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    taskScheduler.stop()
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    // 5 minutes after the wake was due — well within the retry window
+    vi.setSystemTime(new Date('2026-06-26T17:05:00.000Z'))
+
+    mockGetDueTasks.mockResolvedValue([])
+    mockEnsureRunning.mockResolvedValue({
+      createSession: mockCreateSession,
+      sendMessage: mockSendMessage,
+    })
+    mockCreateSession.mockResolvedValue({ id: 'new-session-should-not-happen' })
+    mockSendMessage.mockResolvedValue(undefined)
+    mockSubscribeToSession.mockResolvedValue(undefined)
+    mockIsSubscribed.mockReturnValue(false)
+    mockCancelAwaitingInput.mockResolvedValue(undefined)
+    mockTriggerScheduledSessionStarted.mockResolvedValue(undefined)
+    mockTriggerScheduledSessionResumed.mockResolvedValue(undefined)
+    mockRegisterSession.mockResolvedValue(undefined)
+    mockUpdateSessionMetadata.mockResolvedValue(undefined)
+    mockGetSessionMetadata.mockResolvedValue({
+      name: 'Email follow-up',
+      createdAt: '2026-06-20T10:00:00.000Z',
+    })
+    mockGetSecretEnvVars.mockResolvedValue([])
+    mockAgentExists.mockResolvedValue(true)
+    mockGetSessionForScheduledExecution.mockResolvedValue(null)
+    mockMarkTaskExecuted.mockResolvedValue(undefined)
+    mockMarkTaskFailed.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    taskScheduler.stop()
+    vi.useRealTimers()
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('resumes the existing session instead of creating a new one', async () => {
+    mockGetDueTasks.mockResolvedValue([createWakeTask()])
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockCreateSession).not.toHaveBeenCalled()
+    expect(mockRegisterSession).not.toHaveBeenCalled()
+    expect(mockEnsureRunning).toHaveBeenCalledWith('agent-one')
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(1)
+    const [sessionId, content, uuid, options] = mockSendMessage.mock.calls[0]
+    expect(sessionId).toBe('sleeping-session-1')
+    expect(content.startsWith('[SYSTEM] ')).toBe(true)
+    expect(content).toContain('resuming as scheduled')
+    expect(content).toContain('Check whether Dana replied to the intro email')
+    expect(typeof uuid).toBe('string')
+    expect(options).toEqual({ shouldQuery: true })
+
+    expect(mockMarkSessionActive).toHaveBeenCalledWith('sleeping-session-1', 'agent-one')
+    expect(mockMarkTaskExecuted).toHaveBeenCalledWith('wake-task-1', 'sleeping-session-1')
+  })
+
+  it('subscribes the session for SSE when not already subscribed', async () => {
+    mockGetDueTasks.mockResolvedValue([createWakeTask()])
+    mockIsSubscribed.mockReturnValue(false)
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockSubscribeToSession).toHaveBeenCalledWith(
+      'sleeping-session-1',
+      expect.anything(),
+      'sleeping-session-1',
+      'agent-one'
+    )
+  })
+
+  it('does not re-subscribe an already-subscribed session', async () => {
+    mockGetDueTasks.mockResolvedValue([createWakeTask()])
+    mockIsSubscribed.mockReturnValue(true)
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockSubscribeToSession).not.toHaveBeenCalled()
+    expect(mockSendMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels a stale awaiting-input state before sending the wake message', async () => {
+    mockGetDueTasks.mockResolvedValue([createWakeTask()])
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockCancelAwaitingInput).toHaveBeenCalledWith('sleeping-session-1', 'agent-one')
+    expect(mockCancelAwaitingInput.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSendMessage.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('records the wake in session metadata after sending (duplicate-fire guard state)', async () => {
+    mockGetDueTasks.mockResolvedValue([createWakeTask()])
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockUpdateSessionMetadata).toHaveBeenCalledWith(
+      'agent-one',
+      'sleeping-session-1',
+      {
+        lastWake: {
+          taskId: 'wake-task-1',
+          executionAt: wakeExecutionAt.toISOString(),
+        },
+      }
+    )
+    // Side effect first, record after — mirrors the create path's crash-window semantics
+    expect(mockSendMessage.mock.invocationCallOrder[0]).toBeLessThan(
+      mockUpdateSessionMetadata.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('reconciles instead of double-sending when the wake already fired for this slot', async () => {
+    mockGetDueTasks.mockResolvedValue([createWakeTask()])
+    mockGetSessionMetadata.mockResolvedValue({
+      name: 'Email follow-up',
+      lastWake: {
+        taskId: 'wake-task-1',
+        executionAt: wakeExecutionAt.toISOString(),
+      },
+    })
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockSendMessage).not.toHaveBeenCalled()
+    expect(mockEnsureRunning).not.toHaveBeenCalled()
+    expect(mockMarkTaskExecuted).toHaveBeenCalledWith('wake-task-1', 'sleeping-session-1')
+  })
+
+  it('still fires when the last recorded wake was for a previous sleep cycle', async () => {
+    mockGetDueTasks.mockResolvedValue([createWakeTask()])
+    mockGetSessionMetadata.mockResolvedValue({
+      name: 'Email follow-up',
+      lastWake: {
+        taskId: 'an-earlier-wake-task',
+        executionAt: '2026-06-25T17:00:00.000Z',
+      },
+    })
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(1)
+    expect(mockMarkTaskExecuted).toHaveBeenCalledWith('wake-task-1', 'sleeping-session-1')
+  })
+
+  it('fails the wake when the target session no longer exists', async () => {
+    mockGetDueTasks.mockResolvedValue([createWakeTask()])
+    mockGetSessionMetadata.mockResolvedValue(null)
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockSendMessage).not.toHaveBeenCalled()
+    expect(mockEnsureRunning).not.toHaveBeenCalled()
+    expect(mockMarkTaskFailed).toHaveBeenCalledWith(
+      'wake-task-1',
+      expect.stringContaining('no longer exists')
+    )
+  })
+
+  it('fails the wake when the agent no longer exists', async () => {
+    mockGetDueTasks.mockResolvedValue([createWakeTask()])
+    mockAgentExists.mockResolvedValue(false)
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockSendMessage).not.toHaveBeenCalled()
+    expect(mockMarkTaskFailed).toHaveBeenCalledWith(
+      'wake-task-1',
+      expect.stringContaining('Agent no longer exists')
+    )
+  })
+
+  it('leaves a recently-due wake pending on transient failure so the poll retries it', async () => {
+    mockGetDueTasks.mockResolvedValue([createWakeTask()])
+    mockSendMessage.mockRejectedValue(new Error('container is restarting'))
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockMarkTaskFailed).not.toHaveBeenCalled()
+    expect(mockMarkTaskExecuted).not.toHaveBeenCalled()
+  })
+
+  it('fails a wake once it has been retrying past the retry window', async () => {
+    // 7 hours past due — beyond the 6h retry window
+    vi.setSystemTime(new Date('2026-06-27T00:00:00.000Z'))
+    mockGetDueTasks.mockResolvedValue([createWakeTask()])
+    mockSendMessage.mockRejectedValue(new Error('container is restarting'))
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockMarkTaskFailed).toHaveBeenCalledWith('wake-task-1', expect.any(String))
+  })
+
+  it('still fails a regular one-shot task immediately on error', async () => {
+    const regularTask = createWakeTask({
+      id: 'regular-task-1',
+      resumeSessionId: null,
+      createdBySessionId: null,
+    })
+    mockGetDueTasks.mockResolvedValue([regularTask])
+    mockCreateSession.mockRejectedValue(new Error('boom'))
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockMarkTaskFailed).toHaveBeenCalledWith('regular-task-1', expect.any(String))
+  })
+
+  it('triggers the resumed notification, not the started one', async () => {
+    mockGetDueTasks.mockResolvedValue([createWakeTask()])
+
+    await taskScheduler.triggerExecution()
+
+    expect(mockTriggerScheduledSessionResumed).toHaveBeenCalledWith(
+      'sleeping-session-1',
+      'agent-one',
+      'wake-task-1',
+      expect.anything()
+    )
+    expect(mockTriggerScheduledSessionStarted).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/lib/scheduler/task-scheduler.session-wake.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.session-wake.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { ScheduledTask } from '@shared/lib/services/scheduled-task-service'
 
 const mockGetDueTasks = vi.fn()
+const mockGetScheduledTask = vi.fn()
 const mockMarkTaskExecuted = vi.fn()
 const mockMarkTaskFailed = vi.fn()
 const mockUpdateNextExecution = vi.fn()
 
 vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   getDueTasks: (...args: unknown[]) => mockGetDueTasks(...args),
+  getScheduledTask: (...args: unknown[]) => mockGetScheduledTask(...args),
   markTaskExecuted: (...args: unknown[]) => mockMarkTaskExecuted(...args),
   markTaskFailed: (...args: unknown[]) => mockMarkTaskFailed(...args),
   updateNextExecution: (...args: unknown[]) => mockUpdateNextExecution(...args),
@@ -37,15 +39,21 @@ vi.mock('@shared/lib/services/agent-preferences-service', () => ({
 
 const mockSubscribeToSession = vi.fn()
 const mockMarkSessionActive = vi.fn()
+const mockMarkSessionIdle = vi.fn()
 const mockIsSubscribed = vi.fn()
 const mockCancelAwaitingInput = vi.fn()
+const mockBroadcastGlobal = vi.fn()
+const mockBroadcastSessionUpdate = vi.fn()
 
 vi.mock('@shared/lib/container/message-persister', () => ({
   messagePersister: {
     subscribeToSession: (...args: unknown[]) => mockSubscribeToSession(...args),
     markSessionActive: (...args: unknown[]) => mockMarkSessionActive(...args),
+    markSessionIdle: (...args: unknown[]) => mockMarkSessionIdle(...args),
     isSubscribed: (...args: unknown[]) => mockIsSubscribed(...args),
     cancelAwaitingInput: (...args: unknown[]) => mockCancelAwaitingInput(...args),
+    broadcastGlobal: (...args: unknown[]) => mockBroadcastGlobal(...args),
+    broadcastSessionUpdate: (...args: unknown[]) => mockBroadcastSessionUpdate(...args),
   },
 }))
 
@@ -144,6 +152,11 @@ describe('TaskScheduler session wake (resume) branch', () => {
     vi.setSystemTime(new Date('2026-06-26T17:05:00.000Z'))
 
     mockGetDueTasks.mockResolvedValue([])
+    // The delivery path re-reads the task under its claim; serve the same task
+    // the due-batch returned so each test primes one place.
+    mockGetScheduledTask.mockImplementation(
+      async (id: string) => ((await mockGetDueTasks()) as ScheduledTask[]).find((t) => t.id === id) ?? null
+    )
     mockEnsureRunning.mockResolvedValue({
       createSession: mockCreateSession,
       sendMessage: mockSendMessage,
@@ -320,6 +333,9 @@ describe('TaskScheduler session wake (resume) branch', () => {
 
     expect(mockMarkTaskFailed).not.toHaveBeenCalled()
     expect(mockMarkTaskExecuted).not.toHaveBeenCalled()
+    // The optimistic active flag is reverted — a failed delivery must not
+    // leave the session looking busy until the retry lands.
+    expect(mockMarkSessionIdle).toHaveBeenCalledWith('sleeping-session-1')
   })
 
   it('fails a wake once it has been retrying past the retry window', async () => {

--- a/src/shared/lib/scheduler/task-scheduler.sup224.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.sup224.test.ts
@@ -22,6 +22,7 @@ const mockUpdateNextExecution = vi.fn().mockResolvedValue(undefined)
 
 vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   getDueTasks: (...args: unknown[]) => mockGetDueTasks(...args),
+  getScheduledTask: vi.fn(() => Promise.resolve(null)),
   markTaskExecuted: (...args: unknown[]) => mockMarkTaskExecuted(...args),
   markTaskFailed: (...args: unknown[]) => mockMarkTaskFailed(...args),
   updateNextExecution: (...args: unknown[]) => mockUpdateNextExecution(...args),

--- a/src/shared/lib/scheduler/task-scheduler.ts
+++ b/src/shared/lib/scheduler/task-scheduler.ts
@@ -22,15 +22,12 @@ import type { EffortLevel } from '@shared/lib/container/types'
 import { getNextCronTime } from '@shared/lib/services/schedule-parser'
 import {
   getSessionForScheduledExecution,
-  getSessionMetadata,
   registerSession,
-  updateSessionMetadata,
 } from '@shared/lib/services/session-service'
 import { getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { agentExists } from '@shared/lib/services/agent-service'
 import { captureException } from '@shared/lib/error-reporting'
-import { buildWakeMessage } from './wake-message'
-import { randomUUID } from 'crypto'
+import { deliverSessionWake } from './wake-delivery'
 
 /**
  * How long an overdue session wake keeps retrying (via the normal poll loop)
@@ -276,84 +273,46 @@ class TaskScheduler {
 
   /**
    * Fire a session wake: resume the existing target session with a system
-   * message instead of creating a new session. The wake message starts a real
-   * turn (shouldQuery) so the agent acts on its own note; the [SYSTEM] prefix
-   * keeps it from counting as a human message.
+   * message instead of creating a new session. Delivery (claim, guards, send,
+   * record) lives in deliverSessionWake, shared with the manual "Wake now"
+   * route so the two paths can never double-deliver. Transient delivery
+   * errors propagate to the caller's retry handling.
    */
   private async executeSessionWake(task: ScheduledTask, sessionId: string): Promise<void> {
-    // Session-exists guard: the wake outlives most session lifecycles, so the
-    // target may have been deleted while sleeping.
-    const sessionMeta = await getSessionMetadata(task.agentSlug, sessionId)
-    if (!sessionMeta) {
-      console.error(
-        `[TaskScheduler] Wake ${task.id} target session ${sessionId} no longer exists`
-      )
-      await markTaskFailed(task.id, 'Session no longer exists')
-      return
+    const result = await deliverSessionWake(task, 'scheduled')
+
+    switch (result.outcome) {
+      case 'delivered':
+        console.log(`[TaskScheduler] Wake ${task.id} resumed session ${sessionId}`)
+        break
+      case 'reconciled':
+        console.log(
+          `[TaskScheduler] Wake ${task.id} already delivered to session ${sessionId}; reconciled task status`
+        )
+        break
+      case 'in-flight':
+        // Another delivery (e.g. a "Wake now" click) holds the claim — its
+        // completion records the execution; nothing to do here.
+        console.log(`[TaskScheduler] Wake ${task.id} delivery already in flight; skipping`)
+        break
+      case 'not-pending':
+        // Fresh read shows the task already reached a terminal state (a manual
+        // wake won the race) — the due-task batch was just stale.
+        console.log(`[TaskScheduler] Wake ${task.id} is ${result.status}; skipping`)
+        break
+      case 'session-missing':
+        console.error(
+          `[TaskScheduler] Wake ${task.id} target session ${sessionId} no longer exists`
+        )
+        await markTaskFailed(task.id, 'Session no longer exists')
+        break
+      case 'agent-missing':
+        console.error(
+          `[TaskScheduler] Agent ${task.agentSlug} no longer exists, marking wake as failed`
+        )
+        await markTaskFailed(task.id, 'Agent no longer exists')
+        break
     }
-
-    // Duplicate-fire guard (mirrors getSessionForScheduledExecution on the
-    // create path): if this exact wake slot was already delivered, the send
-    // succeeded but recording the execution didn't — just reconcile.
-    const executionAt = task.nextExecutionAt.toISOString()
-    if (
-      sessionMeta.lastWake?.taskId === task.id &&
-      sessionMeta.lastWake.executionAt === executionAt
-    ) {
-      console.log(
-        `[TaskScheduler] Wake ${task.id} already delivered to session ${sessionId}; reconciling task status`
-      )
-      await this.recordTaskExecution(task, sessionId)
-      return
-    }
-
-    if (!(await agentExists(task.agentSlug))) {
-      console.error(
-        `[TaskScheduler] Agent ${task.agentSlug} no longer exists, marking wake as failed`
-      )
-      await markTaskFailed(task.id, 'Agent no longer exists')
-      return
-    }
-
-    // Cold start is fine: sendMessage into a session with no live process
-    // resumes it from the container's session descriptor.
-    const client = await containerManager.ensureRunning(task.agentSlug)
-
-    if (!messagePersister.isSubscribed(sessionId)) {
-      await messagePersister.subscribeToSession(sessionId, client, sessionId, task.agentSlug)
-    }
-
-    // If the session went to sleep with a blocking user-input request still
-    // open (agent asked, nobody answered), cancel it so the wake message
-    // starts a fresh turn instead of deadlocking behind the blocked tool.
-    await messagePersister.cancelAwaitingInput(sessionId, task.agentSlug)
-
-    const wakeMessage = buildWakeMessage(task, 'scheduled')
-
-    messagePersister.markSessionActive(sessionId, task.agentSlug)
-
-    await client.sendMessage(sessionId, wakeMessage, randomUUID(), { shouldQuery: true })
-
-    // Side effect landed; record the slot so a crash between here and
-    // recordTaskExecution can't double-deliver on the next poll.
-    await updateSessionMetadata(task.agentSlug, sessionId, {
-      lastWake: { taskId: task.id, executionAt },
-    })
-
-    console.log(
-      `[TaskScheduler] Wake ${task.id} resumed session ${sessionId}`
-    )
-
-    notificationManager.triggerScheduledSessionResumed(
-      sessionId,
-      task.agentSlug,
-      task.id,
-      sessionMeta.name
-    ).catch((err) => {
-      console.error('[TaskScheduler] Failed to trigger resume notification:', err)
-    })
-
-    await this.recordTaskExecution(task, sessionId)
   }
 
   private async recordTaskExecution(task: ScheduledTask, sessionId: string): Promise<void> {

--- a/src/shared/lib/scheduler/task-scheduler.ts
+++ b/src/shared/lib/scheduler/task-scheduler.ts
@@ -22,12 +22,23 @@ import type { EffortLevel } from '@shared/lib/container/types'
 import { getNextCronTime } from '@shared/lib/services/schedule-parser'
 import {
   getSessionForScheduledExecution,
+  getSessionMetadata,
   registerSession,
+  updateSessionMetadata,
 } from '@shared/lib/services/session-service'
 import { getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { agentExists } from '@shared/lib/services/agent-service'
 import { captureException } from '@shared/lib/error-reporting'
+import { buildWakeMessage } from './wake-message'
+import { randomUUID } from 'crypto'
 
+/**
+ * How long an overdue session wake keeps retrying (via the normal poll loop)
+ * before being marked failed. Unlike regular one-shot tasks, a wake may be
+ * days in the making — a transient failure at fire time (runtime restarting,
+ * machine waking from sleep) must not permanently kill it.
+ */
+const WAKE_RETRY_WINDOW_MS = 6 * 60 * 60 * 1000
 
 class TaskScheduler {
   private intervalId: NodeJS.Timeout | null = null
@@ -132,7 +143,14 @@ class TaskScheduler {
           })
           // For recurring tasks, schedule next execution even on failure
           // For one-time tasks, mark as failed
-          if (task.isRecurring) {
+          if (!task.isRecurring && task.resumeSessionId &&
+              Date.now() - task.nextExecutionAt.getTime() < WAKE_RETRY_WINDOW_MS) {
+            // Session wakes stay pending on transient failure so the poll loop
+            // retries them; they only fail once overdue past the retry window.
+            console.log(
+              `[TaskScheduler] Wake ${task.id} failed transiently; leaving pending for retry`
+            )
+          } else if (task.isRecurring) {
             try {
               const nextTime = getNextCronTime(task.scheduleExpression, task.timezone || undefined)
               await updateNextExecution(task.id, nextTime, '')
@@ -168,6 +186,11 @@ class TaskScheduler {
     console.log(
       `[TaskScheduler] Executing task ${task.id} for agent ${task.agentSlug}`
     )
+
+    if (task.resumeSessionId) {
+      await this.executeSessionWake(task, task.resumeSessionId)
+      return
+    }
 
     const existingSession = await getSessionForScheduledExecution(
       task.agentSlug,
@@ -246,6 +269,88 @@ class TaskScheduler {
       task.name || undefined
     ).catch((err) => {
       console.error('[TaskScheduler] Failed to trigger scheduled notification:', err)
+    })
+
+    await this.recordTaskExecution(task, sessionId)
+  }
+
+  /**
+   * Fire a session wake: resume the existing target session with a system
+   * message instead of creating a new session. The wake message starts a real
+   * turn (shouldQuery) so the agent acts on its own note; the [SYSTEM] prefix
+   * keeps it from counting as a human message.
+   */
+  private async executeSessionWake(task: ScheduledTask, sessionId: string): Promise<void> {
+    // Session-exists guard: the wake outlives most session lifecycles, so the
+    // target may have been deleted while sleeping.
+    const sessionMeta = await getSessionMetadata(task.agentSlug, sessionId)
+    if (!sessionMeta) {
+      console.error(
+        `[TaskScheduler] Wake ${task.id} target session ${sessionId} no longer exists`
+      )
+      await markTaskFailed(task.id, 'Session no longer exists')
+      return
+    }
+
+    // Duplicate-fire guard (mirrors getSessionForScheduledExecution on the
+    // create path): if this exact wake slot was already delivered, the send
+    // succeeded but recording the execution didn't — just reconcile.
+    const executionAt = task.nextExecutionAt.toISOString()
+    if (
+      sessionMeta.lastWake?.taskId === task.id &&
+      sessionMeta.lastWake.executionAt === executionAt
+    ) {
+      console.log(
+        `[TaskScheduler] Wake ${task.id} already delivered to session ${sessionId}; reconciling task status`
+      )
+      await this.recordTaskExecution(task, sessionId)
+      return
+    }
+
+    if (!(await agentExists(task.agentSlug))) {
+      console.error(
+        `[TaskScheduler] Agent ${task.agentSlug} no longer exists, marking wake as failed`
+      )
+      await markTaskFailed(task.id, 'Agent no longer exists')
+      return
+    }
+
+    // Cold start is fine: sendMessage into a session with no live process
+    // resumes it from the container's session descriptor.
+    const client = await containerManager.ensureRunning(task.agentSlug)
+
+    if (!messagePersister.isSubscribed(sessionId)) {
+      await messagePersister.subscribeToSession(sessionId, client, sessionId, task.agentSlug)
+    }
+
+    // If the session went to sleep with a blocking user-input request still
+    // open (agent asked, nobody answered), cancel it so the wake message
+    // starts a fresh turn instead of deadlocking behind the blocked tool.
+    await messagePersister.cancelAwaitingInput(sessionId, task.agentSlug)
+
+    const wakeMessage = buildWakeMessage(task, 'scheduled')
+
+    messagePersister.markSessionActive(sessionId, task.agentSlug)
+
+    await client.sendMessage(sessionId, wakeMessage, randomUUID(), { shouldQuery: true })
+
+    // Side effect landed; record the slot so a crash between here and
+    // recordTaskExecution can't double-deliver on the next poll.
+    await updateSessionMetadata(task.agentSlug, sessionId, {
+      lastWake: { taskId: task.id, executionAt },
+    })
+
+    console.log(
+      `[TaskScheduler] Wake ${task.id} resumed session ${sessionId}`
+    )
+
+    notificationManager.triggerScheduledSessionResumed(
+      sessionId,
+      task.agentSlug,
+      task.id,
+      sessionMeta.name
+    ).catch((err) => {
+      console.error('[TaskScheduler] Failed to trigger resume notification:', err)
     })
 
     await this.recordTaskExecution(task, sessionId)

--- a/src/shared/lib/scheduler/wake-delivery.test.ts
+++ b/src/shared/lib/scheduler/wake-delivery.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ScheduledTask } from '@shared/lib/services/scheduled-task-service'
+
+const mockGetScheduledTask = vi.fn()
+const mockMarkTaskExecuted = vi.fn()
+
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  getScheduledTask: (...args: unknown[]) => mockGetScheduledTask(...args),
+  markTaskExecuted: (...args: unknown[]) => mockMarkTaskExecuted(...args),
+}))
+
+const mockSendMessage = vi.fn()
+const mockEnsureRunning = vi.fn()
+
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: {
+    ensureRunning: (...args: unknown[]) => mockEnsureRunning(...args),
+  },
+}))
+
+const mockSubscribeToSession = vi.fn()
+const mockMarkSessionActive = vi.fn()
+const mockMarkSessionIdle = vi.fn()
+const mockIsSubscribed = vi.fn()
+const mockCancelAwaitingInput = vi.fn()
+const mockBroadcastGlobal = vi.fn()
+const mockBroadcastSessionUpdate = vi.fn()
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    subscribeToSession: (...args: unknown[]) => mockSubscribeToSession(...args),
+    markSessionActive: (...args: unknown[]) => mockMarkSessionActive(...args),
+    markSessionIdle: (...args: unknown[]) => mockMarkSessionIdle(...args),
+    isSubscribed: (...args: unknown[]) => mockIsSubscribed(...args),
+    cancelAwaitingInput: (...args: unknown[]) => mockCancelAwaitingInput(...args),
+    broadcastGlobal: (...args: unknown[]) => mockBroadcastGlobal(...args),
+    broadcastSessionUpdate: (...args: unknown[]) => mockBroadcastSessionUpdate(...args),
+  },
+}))
+
+const mockTriggerScheduledSessionResumed = vi.fn()
+
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerScheduledSessionResumed: (...args: unknown[]) =>
+      mockTriggerScheduledSessionResumed(...args),
+  },
+}))
+
+const mockGetSessionMetadata = vi.fn()
+const mockUpdateSessionMetadata = vi.fn()
+
+vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionMetadata: (...args: unknown[]) => mockGetSessionMetadata(...args),
+  updateSessionMetadata: (...args: unknown[]) => mockUpdateSessionMetadata(...args),
+}))
+
+const mockAgentExists = vi.fn()
+
+vi.mock('@shared/lib/services/agent-service', () => ({
+  agentExists: (...args: unknown[]) => mockAgentExists(...args),
+}))
+
+import { deliverSessionWake } from './wake-delivery'
+
+const wakeExecutionAt = new Date('2026-06-26T17:00:00.000Z')
+
+function createWakeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
+  return {
+    id: 'wake-task-1',
+    agentSlug: 'agent-one',
+    scheduleType: 'at',
+    scheduleExpression: 'at tomorrow 9am',
+    prompt: 'Check whether Dana replied',
+    name: null,
+    status: 'pending',
+    nextExecutionAt: wakeExecutionAt,
+    lastExecutedAt: null,
+    isRecurring: false,
+    executionCount: 0,
+    lastSessionId: null,
+    createdBySessionId: 'sleeping-session-1',
+    createdByUserId: null,
+    timezone: null,
+    model: null,
+    effort: null,
+    resumeSessionId: 'sleeping-session-1',
+    createdAt: new Date('2026-06-25T16:00:00.000Z'),
+    cancelledAt: null,
+    pausedAt: null,
+    ...overrides,
+  }
+}
+
+describe('deliverSessionWake', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetScheduledTask.mockImplementation(async () => createWakeTask())
+    mockMarkTaskExecuted.mockResolvedValue(undefined)
+    mockEnsureRunning.mockResolvedValue({ sendMessage: mockSendMessage })
+    mockSendMessage.mockResolvedValue(undefined)
+    mockSubscribeToSession.mockResolvedValue(undefined)
+    mockIsSubscribed.mockReturnValue(false)
+    mockCancelAwaitingInput.mockResolvedValue(undefined)
+    mockTriggerScheduledSessionResumed.mockResolvedValue(undefined)
+    mockGetSessionMetadata.mockResolvedValue({ name: 'Email follow-up' })
+    mockUpdateSessionMetadata.mockResolvedValue(undefined)
+    mockAgentExists.mockResolvedValue(true)
+  })
+
+  it('delivers the wake into the target session', async () => {
+    const result = await deliverSessionWake(createWakeTask(), 'scheduled')
+
+    expect(result.outcome).toBe('delivered')
+    expect(mockSendMessage).toHaveBeenCalledTimes(1)
+    const [sessionId, content, , options] = mockSendMessage.mock.calls[0]
+    expect(sessionId).toBe('sleeping-session-1')
+    expect(content.startsWith('[SYSTEM] ')).toBe(true)
+    expect(options).toEqual({ shouldQuery: true })
+    expect(mockUpdateSessionMetadata).toHaveBeenCalledWith(
+      'agent-one',
+      'sleeping-session-1',
+      { lastWake: { taskId: 'wake-task-1', executionAt: wakeExecutionAt.toISOString() } }
+    )
+    expect(mockMarkTaskExecuted).toHaveBeenCalledWith('wake-task-1', 'sleeping-session-1')
+    expect(mockTriggerScheduledSessionResumed).toHaveBeenCalled()
+    expect(mockBroadcastGlobal).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'session_updated', sessionId: 'sleeping-session-1' })
+    )
+  })
+
+  it('does not notify on manual (Wake now) delivery', async () => {
+    const result = await deliverSessionWake(createWakeTask(), 'manual')
+
+    expect(result.outcome).toBe('delivered')
+    expect(mockSendMessage).toHaveBeenCalledTimes(1)
+    expect(mockTriggerScheduledSessionResumed).not.toHaveBeenCalled()
+  })
+
+  it('only one of two simultaneous deliveries sends — the other is turned away in-flight', async () => {
+    // Slow send: both callers are inside deliverSessionWake at the same time
+    let releaseSend!: () => void
+    mockSendMessage.mockImplementation(
+      () => new Promise<void>((resolve) => { releaseSend = () => resolve() })
+    )
+
+    const task = createWakeTask()
+    const first = deliverSessionWake(task, 'scheduled')
+    const second = deliverSessionWake(task, 'manual')
+
+    // The second caller bounces off the claim immediately
+    const secondResult = await second
+    expect(secondResult.outcome).toBe('in-flight')
+
+    // Let the first progress through its guards to the (held) send, then release
+    await vi.waitFor(() => expect(mockSendMessage).toHaveBeenCalled())
+    releaseSend()
+    const firstResult = await first
+    expect(firstResult.outcome).toBe('delivered')
+    expect(mockSendMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-reads task status under the claim and skips a task that is no longer pending', async () => {
+    // Caller holds a stale pending copy; the fresh read says executed
+    mockGetScheduledTask.mockResolvedValue(createWakeTask({ status: 'executed' }))
+
+    const result = await deliverSessionWake(createWakeTask(), 'scheduled')
+
+    expect(result.outcome).toBe('not-pending')
+    expect(mockSendMessage).not.toHaveBeenCalled()
+    expect(mockMarkTaskExecuted).not.toHaveBeenCalled()
+  })
+
+  it('reconciles an already-delivered wake slot without re-sending', async () => {
+    mockGetSessionMetadata.mockResolvedValue({
+      name: 'Email follow-up',
+      lastWake: { taskId: 'wake-task-1', executionAt: wakeExecutionAt.toISOString() },
+    })
+
+    const result = await deliverSessionWake(createWakeTask(), 'scheduled')
+
+    expect(result.outcome).toBe('reconciled')
+    expect(mockSendMessage).not.toHaveBeenCalled()
+    expect(mockEnsureRunning).not.toHaveBeenCalled()
+    expect(mockMarkTaskExecuted).toHaveBeenCalledWith('wake-task-1', 'sleeping-session-1')
+  })
+
+  it('reports a missing session without sending', async () => {
+    mockGetSessionMetadata.mockResolvedValue(null)
+
+    const result = await deliverSessionWake(createWakeTask(), 'scheduled')
+
+    expect(result.outcome).toBe('session-missing')
+    expect(mockSendMessage).not.toHaveBeenCalled()
+  })
+
+  it('reports a missing agent without sending', async () => {
+    mockAgentExists.mockResolvedValue(false)
+
+    const result = await deliverSessionWake(createWakeTask(), 'scheduled')
+
+    expect(result.outcome).toBe('agent-missing')
+    expect(mockSendMessage).not.toHaveBeenCalled()
+  })
+
+  it('reverts the optimistic active flag when the send fails, then rethrows', async () => {
+    mockSendMessage.mockRejectedValue(new Error('container is restarting'))
+
+    await expect(deliverSessionWake(createWakeTask(), 'scheduled')).rejects.toThrow(
+      'container is restarting'
+    )
+
+    expect(mockMarkSessionActive).toHaveBeenCalledWith('sleeping-session-1', 'agent-one')
+    expect(mockMarkSessionIdle).toHaveBeenCalledWith('sleeping-session-1')
+    expect(mockMarkTaskExecuted).not.toHaveBeenCalled()
+    expect(mockUpdateSessionMetadata).not.toHaveBeenCalled()
+  })
+
+  it('releases the claim after a failed delivery so the retry can proceed', async () => {
+    mockSendMessage.mockRejectedValueOnce(new Error('transient'))
+
+    await expect(deliverSessionWake(createWakeTask(), 'scheduled')).rejects.toThrow('transient')
+
+    const retry = await deliverSessionWake(createWakeTask(), 'scheduled')
+    expect(retry.outcome).toBe('delivered')
+    expect(mockSendMessage).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/shared/lib/scheduler/wake-delivery.ts
+++ b/src/shared/lib/scheduler/wake-delivery.ts
@@ -1,0 +1,151 @@
+/**
+ * Session wake delivery — the single path that resumes a sleeping session,
+ * shared by the scheduler's wake branch and the manual "Wake now" route.
+ *
+ * Both callers run in the same process (the scheduler singleton and the HTTP
+ * routes live in one API server), so a per-task in-process claim makes
+ * check-status → send → record a critical section: a scheduler poll and a
+ * "Wake now" click landing simultaneously can never both deliver. The claim is
+ * taken before delivery and the task status is re-read under it, while the
+ * durable status flip (markTaskExecuted) stays AFTER the send — a crash
+ * between send and record is caught by the lastWake metadata guard on the next
+ * attempt, and a crash before the send loses nothing.
+ */
+
+import { containerManager } from '@shared/lib/container/container-manager'
+import { messagePersister } from '@shared/lib/container/message-persister'
+import { notificationManager } from '@shared/lib/notifications/notification-manager'
+import {
+  getScheduledTask,
+  markTaskExecuted,
+  type ScheduledTask,
+} from '@shared/lib/services/scheduled-task-service'
+import {
+  getSessionMetadata,
+  updateSessionMetadata,
+} from '@shared/lib/services/session-service'
+import { agentExists } from '@shared/lib/services/agent-service'
+import { buildWakeMessage } from './wake-message'
+import { randomUUID } from 'crypto'
+
+export type WakeDeliveryResult =
+  | { outcome: 'delivered'; sessionId: string }
+  // Already delivered for this exact slot (lastWake matches); task status reconciled
+  | { outcome: 'reconciled'; sessionId: string }
+  // Another caller holds the claim right now — nothing sent, nothing changed
+  | { outcome: 'in-flight' }
+  // Fresh read shows the task is no longer deliverable (executed/cancelled/failed/missing)
+  | { outcome: 'not-pending'; status: string }
+  | { outcome: 'session-missing' }
+  | { outcome: 'agent-missing' }
+
+// Task ids currently being delivered. In-process is sufficient: all delivery
+// callers share this process, and cross-restart duplication is covered by the
+// lastWake metadata guard.
+const inFlightWakes = new Set<string>()
+
+/**
+ * Deliver a session wake. Throws on transient delivery failure (container
+ * unreachable, send error) with the task left pending — callers decide the
+ * retry policy. The optimistic active flag is reverted before rethrowing so a
+ * failed delivery never leaves the session looking busy.
+ */
+export async function deliverSessionWake(
+  staleTask: ScheduledTask,
+  trigger: 'scheduled' | 'manual'
+): Promise<WakeDeliveryResult> {
+  const sessionId = staleTask.resumeSessionId
+  if (!sessionId) {
+    throw new Error(`Task ${staleTask.id} is not a session wake`)
+  }
+
+  if (inFlightWakes.has(staleTask.id)) {
+    return { outcome: 'in-flight' }
+  }
+  inFlightWakes.add(staleTask.id)
+
+  try {
+    // Re-read under the claim: the caller's copy may predate the other path's
+    // delivery (a due-task batch loaded just before a "Wake now", or vice versa).
+    const task = await getScheduledTask(staleTask.id)
+    if (!task || (task.status !== 'pending' && task.status !== 'paused')) {
+      return { outcome: 'not-pending', status: task?.status ?? 'missing' }
+    }
+
+    // Session-exists guard: the wake outlives most session lifecycles, so the
+    // target may have been deleted while sleeping.
+    const sessionMeta = await getSessionMetadata(task.agentSlug, sessionId)
+    if (!sessionMeta) {
+      return { outcome: 'session-missing' }
+    }
+
+    // Duplicate-fire guard (mirrors getSessionForScheduledExecution on the
+    // create path): if this exact wake slot was already delivered, the send
+    // succeeded but recording the execution didn't — just reconcile.
+    const executionAt = task.nextExecutionAt.toISOString()
+    if (
+      sessionMeta.lastWake?.taskId === task.id &&
+      sessionMeta.lastWake.executionAt === executionAt
+    ) {
+      await markTaskExecuted(task.id, sessionId)
+      return { outcome: 'reconciled', sessionId }
+    }
+
+    if (!(await agentExists(task.agentSlug))) {
+      return { outcome: 'agent-missing' }
+    }
+
+    // Cold start is fine: sendMessage into a session with no live process
+    // resumes it from the container's session descriptor.
+    const client = await containerManager.ensureRunning(task.agentSlug)
+
+    if (!messagePersister.isSubscribed(sessionId)) {
+      await messagePersister.subscribeToSession(sessionId, client, sessionId, task.agentSlug)
+    }
+
+    // If the session went to sleep with a blocking user-input request still
+    // open (agent asked, nobody answered), cancel it so the wake message
+    // starts a fresh turn instead of deadlocking behind the blocked tool.
+    await messagePersister.cancelAwaitingInput(sessionId, task.agentSlug)
+
+    messagePersister.markSessionActive(sessionId, task.agentSlug)
+    try {
+      await client.sendMessage(sessionId, buildWakeMessage(task, trigger), randomUUID(), {
+        shouldQuery: true,
+      })
+    } catch (error) {
+      // The turn never started — clear the optimistic active flag so the UI
+      // doesn't show a phantom "working" session while the wake awaits retry.
+      messagePersister.markSessionIdle(sessionId)
+      throw error
+    }
+
+    // Side effect landed; record the slot so a crash between here and
+    // markTaskExecuted can't double-deliver on the next attempt.
+    await updateSessionMetadata(task.agentSlug, sessionId, {
+      lastWake: { taskId: task.id, executionAt },
+    })
+    await markTaskExecuted(task.id, sessionId)
+
+    if (trigger === 'scheduled') {
+      notificationManager
+        .triggerScheduledSessionResumed(sessionId, task.agentSlug, task.id, sessionMeta.name)
+        .catch((err) => {
+          console.error('[WakeDelivery] Failed to trigger resume notification:', err)
+        })
+    }
+
+    // The pending wake is session-level state (badges, resume banner) — nudge
+    // session lists and the open session view to refetch.
+    messagePersister.broadcastGlobal({
+      type: 'session_updated',
+      sessionId,
+      agentSlug: task.agentSlug,
+    })
+    messagePersister.broadcastSessionUpdate(sessionId)
+
+    return { outcome: 'delivered', sessionId }
+  } finally {
+    inFlightWakes.delete(staleTask.id)
+  }
+}

--- a/src/shared/lib/scheduler/wake-message.ts
+++ b/src/shared/lib/scheduler/wake-message.ts
@@ -1,0 +1,22 @@
+import type { ScheduledTask } from '@shared/lib/services/scheduled-task-service'
+
+/**
+ * Build the system message delivered when a session wake fires. The [SYSTEM]
+ * prefix renders it as a system message and keeps it from counting as a human
+ * message (so it never promotes an automated session to the interactive
+ * eviction class). The agent's own note is echoed back verbatim.
+ *
+ * Shared by the scheduler's wake branch and the run-now ("Wake now") route so
+ * both deliver the same shape.
+ */
+export function buildWakeMessage(
+  task: ScheduledTask,
+  trigger: 'scheduled' | 'manual' = 'scheduled'
+): string {
+  const scheduledFor = `${task.nextExecutionAt.toISOString()}${task.timezone ? ` (${task.timezone})` : ''}`
+  const intro =
+    trigger === 'manual'
+      ? `This session is resuming now — the user chose to wake it early (it was scheduled to resume at ${scheduledFor}).`
+      : `This session is resuming as scheduled. You asked (on ${task.createdAt.toISOString()}) to be woken at ${scheduledFor}.`
+  return `[SYSTEM] ${intro}\nYour note: ${task.prompt}`
+}

--- a/src/shared/lib/services/scheduled-task-service.ts
+++ b/src/shared/lib/services/scheduled-task-service.ts
@@ -7,7 +7,7 @@
 
 import { db } from '@shared/lib/db'
 import { scheduledTasks, type ScheduledTask, type NewScheduledTask } from '@shared/lib/db/schema'
-import { eq, and, lte, inArray } from 'drizzle-orm'
+import { eq, and, lte, inArray, isNotNull } from 'drizzle-orm'
 import { getNextCronTime, parseAtSyntax } from './schedule-parser'
 import { trackServerEvent } from '../analytics/server-analytics'
 
@@ -29,6 +29,23 @@ export interface CreateScheduledTaskParams {
   timezone?: string
   model?: string
   effort?: string
+  // When set, firing this task resumes the referenced session instead of
+  // creating a new one. Prefer createSessionWake(), which also enforces the
+  // one-pending-wake-per-session invariant.
+  resumeSessionId?: string
+}
+
+export interface CreateSessionWakeParams {
+  agentSlug: string
+  // 'at' syntax expression, e.g. "at tomorrow 9am"
+  scheduleExpression: string
+  // Why the session is sleeping / what to check on wake — echoed back verbatim
+  // in the wake message. Stored as the task prompt.
+  note: string
+  sessionId: string
+  name?: string
+  createdByUserId?: string
+  timezone?: string
 }
 
 export interface UpdateNextExecutionParams {
@@ -75,6 +92,7 @@ export async function createScheduledTask(
     timezone: params.timezone || null,
     model: params.model || null,
     effort: params.effort || null,
+    resumeSessionId: params.resumeSessionId || null,
   }
 
   await db.insert(scheduledTasks).values(newTask)
@@ -89,9 +107,84 @@ export async function createScheduledTask(
   return id
 }
 
+/**
+ * Create a session wake: a one-shot task that resumes an existing session when
+ * it fires. A session can hold at most one pending wake — creating a new one
+ * cancels and replaces any existing pending wake for the same session, and the
+ * replaced task is returned so callers can surface the swap.
+ */
+export async function createSessionWake(
+  params: CreateSessionWakeParams
+): Promise<{ taskId: string; replaced: ScheduledTask | null }> {
+  const existing = await getPendingWakeForSession(params.agentSlug, params.sessionId)
+  const replaced = existing && (await cancelScheduledTask(existing.id)) ? existing : null
+
+  const taskId = await createScheduledTask({
+    agentSlug: params.agentSlug,
+    scheduleType: 'at',
+    scheduleExpression: params.scheduleExpression,
+    prompt: params.note,
+    name: params.name,
+    createdBySessionId: params.sessionId,
+    createdByUserId: params.createdByUserId,
+    timezone: params.timezone,
+    resumeSessionId: params.sessionId,
+  })
+
+  return { taskId, replaced }
+}
+
 // ============================================================================
 // Read Operations
 // ============================================================================
+
+/**
+ * Get the pending wake for a session, if any. There is at most one — the
+ * one-pending-wake-per-session invariant is enforced by createSessionWake.
+ */
+export async function getPendingWakeForSession(
+  agentSlug: string,
+  sessionId: string
+): Promise<ScheduledTask | null> {
+  const results = await db
+    .select()
+    .from(scheduledTasks)
+    .where(
+      and(
+        eq(scheduledTasks.agentSlug, agentSlug),
+        eq(scheduledTasks.resumeSessionId, sessionId),
+        eq(scheduledTasks.status, 'pending')
+      )
+    )
+
+  return results[0] || null
+}
+
+/**
+ * List all pending session wakes for an agent (tasks that resume an existing
+ * session rather than create a new one).
+ */
+export async function listPendingWakesByAgent(agentSlug: string): Promise<ScheduledTask[]> {
+  return db
+    .select()
+    .from(scheduledTasks)
+    .where(
+      and(
+        eq(scheduledTasks.agentSlug, agentSlug),
+        isNotNull(scheduledTasks.resumeSessionId),
+        eq(scheduledTasks.status, 'pending')
+      )
+    )
+}
+
+/**
+ * Session ids with a pending wake for an agent. Used by cleanup paths (e.g.
+ * auto-delete) that must not destroy a session scheduled to resume.
+ */
+export async function listSessionIdsWithPendingWakes(agentSlug: string): Promise<Set<string>> {
+  const wakes = await listPendingWakesByAgent(agentSlug)
+  return new Set(wakes.map((w) => w.resumeSessionId!))
+}
 
 /**
  * Get a single scheduled task by ID
@@ -209,6 +302,19 @@ export async function cancelScheduledTask(taskId: string): Promise<boolean> {
     )
 
   return (result.changes ?? 0) > 0
+}
+
+/**
+ * Cancel the pending wake targeting a session, if any. Called when the session
+ * is deleted so the scheduler never fires a wake at a session that's gone.
+ */
+export async function cancelPendingWakeForSession(
+  agentSlug: string,
+  sessionId: string
+): Promise<boolean> {
+  const wake = await getPendingWakeForSession(agentSlug, sessionId)
+  if (!wake) return false
+  return cancelScheduledTask(wake.id)
 }
 
 /**

--- a/src/shared/lib/services/scheduled-task-service.ts
+++ b/src/shared/lib/services/scheduled-task-service.ts
@@ -112,26 +112,74 @@ export async function createScheduledTask(
  * it fires. A session can hold at most one pending wake — creating a new one
  * cancels and replaces any existing pending wake for the same session, and the
  * replaced task is returned so callers can surface the swap.
+ *
+ * The schedule expression is validated BEFORE any mutation (a bad wakeTime
+ * must never cancel the session's valid wake), and the cancel+insert pair runs
+ * in a transaction so concurrent calls can't interleave into duplicate pending
+ * wakes. A partial unique index on pending wakes backstops both.
  */
 export async function createSessionWake(
   params: CreateSessionWakeParams
 ): Promise<{ taskId: string; replaced: ScheduledTask | null }> {
-  const existing = await getPendingWakeForSession(params.agentSlug, params.sessionId)
-  const replaced = existing && (await cancelScheduledTask(existing.id)) ? existing : null
+  // Throws on unparseable/past expressions — before existing state is touched.
+  const nextExecutionAt = parseAtSyntax(params.scheduleExpression, params.timezone || undefined)
 
-  const taskId = await createScheduledTask({
+  const id = crypto.randomUUID()
+  const now = new Date()
+  const newTask: NewScheduledTask = {
+    id,
     agentSlug: params.agentSlug,
     scheduleType: 'at',
     scheduleExpression: params.scheduleExpression,
     prompt: params.note,
     name: params.name,
+    status: 'pending',
+    nextExecutionAt,
+    isRecurring: false,
+    executionCount: 0,
+    createdAt: now,
     createdBySessionId: params.sessionId,
     createdByUserId: params.createdByUserId,
-    timezone: params.timezone,
+    timezone: params.timezone || null,
     resumeSessionId: params.sessionId,
+  }
+
+  // Synchronous better-sqlite3 transaction: read-existing → cancel → insert is
+  // one atomic unit, so no other caller can observe (or create) an
+  // intermediate state.
+  const replaced = db.transaction((tx) => {
+    const existing = tx
+      .select()
+      .from(scheduledTasks)
+      .where(
+        and(
+          eq(scheduledTasks.agentSlug, params.agentSlug),
+          eq(scheduledTasks.resumeSessionId, params.sessionId),
+          eq(scheduledTasks.status, 'pending')
+        )
+      )
+      .all()
+
+    for (const wake of existing) {
+      tx.update(scheduledTasks)
+        .set({ status: 'cancelled', cancelledAt: now })
+        .where(eq(scheduledTasks.id, wake.id))
+        .run()
+    }
+
+    tx.insert(scheduledTasks).values(newTask).run()
+
+    return existing[0] ?? null
   })
 
-  return { taskId, replaced }
+  trackServerEvent('task_scheduled', {
+    scheduleType: 'at',
+    isRecurring: false,
+    scheduleExpression: params.scheduleExpression,
+    agentSlug: params.agentSlug,
+  })
+
+  return { taskId: id, replaced }
 }
 
 // ============================================================================

--- a/src/shared/lib/services/scheduled-task-service.wakes.test.ts
+++ b/src/shared/lib/services/scheduled-task-service.wakes.test.ts
@@ -186,6 +186,70 @@ describe('scheduled-task-service session wakes', () => {
       expect(regular!.status).toBe('pending')
     })
 
+    it('rejects an invalid wakeTime without touching the existing wake', async () => {
+      const first = await createSessionWake({
+        agentSlug: 'test-agent',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Valid wake',
+        sessionId: 'session-abc',
+      })
+
+      await expect(
+        createSessionWake({
+          agentSlug: 'test-agent',
+          scheduleExpression: 'at total gibberish %%%',
+          note: 'Broken wake',
+          sessionId: 'session-abc',
+        })
+      ).rejects.toThrow()
+
+      // The valid wake must survive a failed replacement attempt
+      const existing = await getScheduledTask(first.taskId)
+      expect(existing!.status).toBe('pending')
+      expect(await getPendingWakeForSession('test-agent', 'session-abc')).not.toBeNull()
+    })
+
+    it('rejects a past wakeTime without touching the existing wake', async () => {
+      const first = await createSessionWake({
+        agentSlug: 'test-agent',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Valid wake',
+        sessionId: 'session-abc',
+      })
+
+      await expect(
+        createSessionWake({
+          agentSlug: 'test-agent',
+          scheduleExpression: 'at 2020-01-01 09:00',
+          note: 'Time traveler',
+          sessionId: 'session-abc',
+        })
+      ).rejects.toThrow(/past/)
+
+      const existing = await getScheduledTask(first.taskId)
+      expect(existing!.status).toBe('pending')
+    })
+
+    it('never leaves more than one pending wake under concurrent creation', async () => {
+      const results = await Promise.allSettled(
+        Array.from({ length: 5 }, (_, i) =>
+          createSessionWake({
+            agentSlug: 'test-agent',
+            scheduleExpression: 'at now + 24 hours',
+            note: `Concurrent wake ${i}`,
+            sessionId: 'session-abc',
+          })
+        )
+      )
+
+      // At least one creation must succeed; a loser rejected by the uniqueness
+      // guard is acceptable, silent duplication is not.
+      expect(results.some((r) => r.status === 'fulfilled')).toBe(true)
+
+      const pending = await listPendingWakesByAgent('test-agent')
+      expect(pending).toHaveLength(1)
+    })
+
     it('does not treat cancelled or executed wakes as replaceable', async () => {
       const first = await createSessionWake({
         agentSlug: 'test-agent',

--- a/src/shared/lib/services/scheduled-task-service.wakes.test.ts
+++ b/src/shared/lib/services/scheduled-task-service.wakes.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as path from 'path'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import * as schema from '../db/schema'
+
+// We need to set up a test database before importing the service
+let testDb: ReturnType<typeof drizzle>
+let testSqlite: InstanceType<typeof Database>
+
+// Mock the db module
+vi.mock('../db', async () => {
+  return {
+    get db() {
+      return testDb
+    },
+    get sqlite() {
+      return testSqlite
+    },
+  }
+})
+
+// Import after mocking
+import {
+  cancelPendingWakeForSession,
+  createScheduledTask,
+  createSessionWake,
+  getPendingWakeForSession,
+  getScheduledTask,
+  listPendingWakesByAgent,
+  listPendingScheduledTasks,
+  listSessionIdsWithPendingWakes,
+  cancelScheduledTask,
+  markTaskExecuted,
+  getDueTasks,
+} from './scheduled-task-service'
+
+describe('scheduled-task-service session wakes', () => {
+  beforeEach(async () => {
+    testSqlite = new Database(':memory:')
+    testDb = drizzle(testSqlite, { schema })
+
+    const migrationsFolder = path.join(process.cwd(), 'src/shared/lib/db/migrations')
+    migrate(testDb, { migrationsFolder })
+
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-06-15T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    testSqlite?.close()
+  })
+
+  describe('createScheduledTask with resumeSessionId', () => {
+    it('persists resumeSessionId when provided', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Check for the email reply',
+        resumeSessionId: 'session-abc',
+      })
+
+      const task = await getScheduledTask(taskId)
+      expect(task!.resumeSessionId).toBe('session-abc')
+    })
+
+    it('leaves resumeSessionId null for regular tasks', async () => {
+      const taskId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 1 hour',
+        prompt: 'Regular task',
+      })
+
+      const task = await getScheduledTask(taskId)
+      expect(task!.resumeSessionId).toBeNull()
+    })
+  })
+
+  describe('createSessionWake', () => {
+    it('creates a pending one-shot wake targeting the session', async () => {
+      const { taskId, replaced } = await createSessionWake({
+        agentSlug: 'test-agent',
+        scheduleExpression: 'at tomorrow 9am',
+        note: 'Check whether Dana replied to the intro email',
+        sessionId: 'session-abc',
+        createdByUserId: 'user-1',
+      })
+
+      expect(replaced).toBeNull()
+
+      const task = await getScheduledTask(taskId)
+      expect(task).not.toBeNull()
+      expect(task!.scheduleType).toBe('at')
+      expect(task!.isRecurring).toBe(false)
+      expect(task!.status).toBe('pending')
+      expect(task!.resumeSessionId).toBe('session-abc')
+      expect(task!.createdBySessionId).toBe('session-abc')
+      expect(task!.createdByUserId).toBe('user-1')
+      expect(task!.prompt).toBe('Check whether Dana replied to the intro email')
+    })
+
+    it('appears in getDueTasks once its time arrives', async () => {
+      await createSessionWake({
+        agentSlug: 'test-agent',
+        scheduleExpression: 'at now + 30 minutes',
+        note: 'Follow up',
+        sessionId: 'session-abc',
+      })
+
+      expect(await getDueTasks()).toHaveLength(0)
+
+      vi.setSystemTime(new Date('2024-06-15T13:00:00.000Z'))
+      const due = await getDueTasks()
+      expect(due).toHaveLength(1)
+      expect(due[0].resumeSessionId).toBe('session-abc')
+    })
+
+    it('replaces an existing pending wake for the same session', async () => {
+      const first = await createSessionWake({
+        agentSlug: 'test-agent',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Check tomorrow',
+        sessionId: 'session-abc',
+      })
+
+      const second = await createSessionWake({
+        agentSlug: 'test-agent',
+        scheduleExpression: 'at now + 72 hours',
+        note: 'Actually check in 3 days',
+        sessionId: 'session-abc',
+      })
+
+      expect(second.replaced).not.toBeNull()
+      expect(second.replaced!.id).toBe(first.taskId)
+
+      const oldTask = await getScheduledTask(first.taskId)
+      expect(oldTask!.status).toBe('cancelled')
+
+      const newTask = await getScheduledTask(second.taskId)
+      expect(newTask!.status).toBe('pending')
+      expect(newTask!.prompt).toBe('Actually check in 3 days')
+    })
+
+    it('does not replace wakes belonging to other sessions', async () => {
+      const other = await createSessionWake({
+        agentSlug: 'test-agent',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Other session wake',
+        sessionId: 'session-other',
+      })
+
+      const { replaced } = await createSessionWake({
+        agentSlug: 'test-agent',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'My wake',
+        sessionId: 'session-abc',
+      })
+
+      expect(replaced).toBeNull()
+      const otherTask = await getScheduledTask(other.taskId)
+      expect(otherTask!.status).toBe('pending')
+    })
+
+    it('does not replace regular scheduled tasks created by the same session', async () => {
+      const regularId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 24 hours',
+        prompt: 'Independent job',
+        createdBySessionId: 'session-abc',
+      })
+
+      const { replaced } = await createSessionWake({
+        agentSlug: 'test-agent',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'My wake',
+        sessionId: 'session-abc',
+      })
+
+      expect(replaced).toBeNull()
+      const regular = await getScheduledTask(regularId)
+      expect(regular!.status).toBe('pending')
+    })
+
+    it('does not treat cancelled or executed wakes as replaceable', async () => {
+      const first = await createSessionWake({
+        agentSlug: 'test-agent',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Cancelled wake',
+        sessionId: 'session-abc',
+      })
+      await cancelScheduledTask(first.taskId)
+
+      const second = await createSessionWake({
+        agentSlug: 'test-agent',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Executed wake',
+        sessionId: 'session-abc',
+      })
+      await markTaskExecuted(second.taskId, 'session-abc')
+
+      const third = await createSessionWake({
+        agentSlug: 'test-agent',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Fresh wake',
+        sessionId: 'session-abc',
+      })
+
+      expect(third.replaced).toBeNull()
+    })
+  })
+
+  describe('getPendingWakeForSession', () => {
+    it('returns the pending wake for a session', async () => {
+      const { taskId } = await createSessionWake({
+        agentSlug: 'test-agent',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Check tomorrow',
+        sessionId: 'session-abc',
+      })
+
+      const wake = await getPendingWakeForSession('test-agent', 'session-abc')
+      expect(wake).not.toBeNull()
+      expect(wake!.id).toBe(taskId)
+    })
+
+    it('returns null when the wake was cancelled', async () => {
+      const { taskId } = await createSessionWake({
+        agentSlug: 'test-agent',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Check tomorrow',
+        sessionId: 'session-abc',
+      })
+      await cancelScheduledTask(taskId)
+
+      expect(await getPendingWakeForSession('test-agent', 'session-abc')).toBeNull()
+    })
+
+    it('returns null for sessions without wakes', async () => {
+      expect(await getPendingWakeForSession('test-agent', 'no-such-session')).toBeNull()
+    })
+  })
+
+  describe('listPendingWakesByAgent', () => {
+    it('returns only pending wakes for the given agent', async () => {
+      await createSessionWake({
+        agentSlug: 'agent-a',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Wake A',
+        sessionId: 'session-a',
+      })
+      await createSessionWake({
+        agentSlug: 'agent-b',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Wake B',
+        sessionId: 'session-b',
+      })
+      // Regular task should not appear
+      await createScheduledTask({
+        agentSlug: 'agent-a',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 24 hours',
+        prompt: 'Regular task',
+      })
+
+      const wakes = await listPendingWakesByAgent('agent-a')
+      expect(wakes).toHaveLength(1)
+      expect(wakes[0].resumeSessionId).toBe('session-a')
+    })
+
+    it('excludes executed and cancelled wakes', async () => {
+      const first = await createSessionWake({
+        agentSlug: 'agent-a',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Wake 1',
+        sessionId: 'session-1',
+      })
+      await markTaskExecuted(first.taskId, 'session-1')
+
+      const second = await createSessionWake({
+        agentSlug: 'agent-a',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Wake 2',
+        sessionId: 'session-2',
+      })
+      await cancelScheduledTask(second.taskId)
+
+      expect(await listPendingWakesByAgent('agent-a')).toHaveLength(0)
+    })
+  })
+
+  describe('listSessionIdsWithPendingWakes', () => {
+    it('returns the set of session ids with pending wakes for an agent', async () => {
+      await createSessionWake({
+        agentSlug: 'agent-a',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Wake 1',
+        sessionId: 'session-1',
+      })
+      await createSessionWake({
+        agentSlug: 'agent-a',
+        scheduleExpression: 'at now + 48 hours',
+        note: 'Wake 2',
+        sessionId: 'session-2',
+      })
+      await createSessionWake({
+        agentSlug: 'agent-b',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Other agent',
+        sessionId: 'session-3',
+      })
+
+      const ids = await listSessionIdsWithPendingWakes('agent-a')
+      expect(ids).toEqual(new Set(['session-1', 'session-2']))
+    })
+
+    it('returns an empty set when there are no pending wakes', async () => {
+      expect(await listSessionIdsWithPendingWakes('agent-a')).toEqual(new Set())
+    })
+  })
+
+  describe('cancelPendingWakeForSession', () => {
+    it('cancels the pending wake for a session', async () => {
+      const { taskId } = await createSessionWake({
+        agentSlug: 'test-agent',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Check tomorrow',
+        sessionId: 'session-abc',
+      })
+
+      const cancelled = await cancelPendingWakeForSession('test-agent', 'session-abc')
+      expect(cancelled).toBe(true)
+
+      const task = await getScheduledTask(taskId)
+      expect(task!.status).toBe('cancelled')
+    })
+
+    it('returns false when the session has no pending wake', async () => {
+      expect(await cancelPendingWakeForSession('test-agent', 'session-abc')).toBe(false)
+    })
+
+    it('leaves regular tasks created by the session untouched', async () => {
+      const regularId = await createScheduledTask({
+        agentSlug: 'test-agent',
+        scheduleType: 'at',
+        scheduleExpression: 'at now + 24 hours',
+        prompt: 'Independent job',
+        createdBySessionId: 'session-abc',
+      })
+
+      await cancelPendingWakeForSession('test-agent', 'session-abc')
+
+      const regular = await getScheduledTask(regularId)
+      expect(regular!.status).toBe('pending')
+    })
+  })
+
+  describe('listPendingScheduledTasks interplay', () => {
+    it('still includes wakes (callers that need agent-level automations filter them)', async () => {
+      await createSessionWake({
+        agentSlug: 'agent-a',
+        scheduleExpression: 'at now + 24 hours',
+        note: 'Wake',
+        sessionId: 'session-1',
+      })
+
+      const all = await listPendingScheduledTasks('agent-a')
+      expect(all).toHaveLength(1)
+      expect(all[0].resumeSessionId).toBe('session-1')
+    })
+  })
+})

--- a/src/shared/lib/tool-definitions/registry.ts
+++ b/src/shared/lib/tool-definitions/registry.ts
@@ -19,6 +19,7 @@ import { askUserQuestionDef } from './ask-user-question'
 import { requestSecretDef } from './request-secret'
 import { requestConnectedAccountDef } from './request-connected-account'
 import { scheduleTaskDef } from './schedule-task'
+import { scheduleResumeDef } from './schedule-resume'
 import { deliverFileDef } from './deliver-file'
 import { deliverSessionDef } from './deliver-session'
 import { requestFileDef } from './request-file'
@@ -100,6 +101,7 @@ const definitions: Record<string, ToolDefinition> = {
   'mcp__user-input__request_secret': requestSecretDef,
   'mcp__user-input__request_connected_account': requestConnectedAccountDef,
   'mcp__user-input__schedule_task': scheduleTaskDef,
+  'mcp__user-input__schedule_resume': scheduleResumeDef,
   'mcp__user-input__deliver_file': deliverFileDef,
   'mcp__user-input__deliver_session': deliverSessionDef,
   'mcp__user-input__request_file': requestFileDef,

--- a/src/shared/lib/tool-definitions/schedule-resume.ts
+++ b/src/shared/lib/tool-definitions/schedule-resume.ts
@@ -1,0 +1,22 @@
+export interface ScheduleResumeInput {
+  wakeTime?: string
+  note?: string
+  timezone?: string
+}
+
+function parseInput(input: unknown): ScheduleResumeInput {
+  return typeof input === 'object' && input !== null ? (input as ScheduleResumeInput) : {}
+}
+
+function getSummary(input: unknown): string | null {
+  const { wakeTime, note, timezone } = parseInput(input)
+  const time = wakeTime?.replace(/^at\s+/i, '')
+  const tzSuffix = timezone ? ` (${timezone.replace(/_/g, ' ')})` : ''
+
+  if (time && note) return `${time}${tzSuffix} · ${note}`
+  if (time) return `${time}${tzSuffix}`
+  if (note) return note
+  return null
+}
+
+export const scheduleResumeDef = { displayName: 'Schedule Resume', parseInput, getSummary } as const

--- a/src/shared/lib/types/agent.ts
+++ b/src/shared/lib/types/agent.ts
@@ -100,6 +100,9 @@ export interface SessionMetadata {
   // Set when an automated session is promoted to interactive (e.g. agent asked a user question).
   // The original automation flags above are preserved for provenance.
   promotedToInteractive?: boolean
+  // Last scheduled wake delivered to this session. Duplicate-fire guard: the
+  // scheduler skips re-sending a wake whose task id + execution slot match.
+  lastWake?: { taskId: string; executionAt: string }
   // Context window usage from the last completed turn
   lastUsage?: SessionUsage
   // Available slash commands from the agent SDK

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -105,6 +105,11 @@ export interface ApiSession {
   effort?: EffortLevel
   // Last model used on this session (seeds the composer selector)
   model?: string
+  // Present when the session has a pending scheduled wake (long sleep):
+  // it will auto-resume at pendingWakeAt with pendingWakeNote echoed back.
+  pendingWakeAt?: string
+  pendingWakeTaskId?: string
+  pendingWakeNote?: string
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Lets a session do extended waits (hours → multi-day) and resume **the same session with full context**, surviving container restarts, app restarts, and GC. Closes SUP-30 — the ticket description is the canonical spec.

A "wake" is a one-shot `scheduled_tasks` row with a new nullable `resumeSessionId` (migration `0028`). When it fires, the scheduler branches: instead of `createSession`, it sends a `[SYSTEM]` resume message (echoing the agent's own wake note) into the existing session with `shouldQuery: true`. Cold-container revival is inherited from the existing lazy-resume path, so restart survival comes for free.

### What's included

- **Service**: `createSessionWake` with replace semantics (one pending wake per session — a new one cancels and returns the old), `getPendingWakeForSession`, `listPendingWakesByAgent`, `listSessionIdsWithPendingWakes`, `cancelPendingWakeForSession`
- **Scheduler**: `executeSessionWake` with session-exists guard, duplicate-fire guard (`lastWake` slot in session metadata, mirroring `getSessionForScheduledExecution`), agent-exists guard, and `cancelAwaitingInput` before send. Transient failures leave the wake `pending` for poll retry; it only fails after 6h overdue
- **Agent tool**: `schedule_resume` (container blocking tool + host interceptor beside `handleScheduleTaskTool`) — deliberately separate from `schedule_task` so agents distinguish "resume THIS conversation" from "spawn an independent session". Wakes are labeled `session wake` in `list_scheduled_tasks`
- **Protections**: auto-delete monitor skips sessions with pending wakes; deleting a session cancels its wake; wakes are filtered out of agent-level automation lists and summary counts
- **Routes**: `/run-now` gained a wake branch (resumes the session — "Wake now" exercises the same delivery as the scheduler via shared `buildWakeMessage`); `DELETE` broadcasts `session_updated` for wakes
- **UI**: `pendingWakeAt/TaskId/Note` on `ApiSession`; MoonStar indicator in sidebar (alongside the unread dot), session tabs, and related-sessions rows; `PendingWakeBanner` above the composer with the wake note + **Wake now** / **Cancel**; `schedule_resume` tool renderer; `session_updated` global SSE invalidation

## Validation

All tests written TDD (red first):
- Host unit suite **6,872 passed** · container suite **637 passed** · typecheck + lint clean
- Full mock E2E suite **245 passed, 0 failed**, including new `session-long-sleep.spec.ts` (banner, sidebar badge, Wake now, Cancel, home-triggers exclusion) + a `schedule resume` MockContainerClient scenario

**Live end-to-end validation** (real dev server, real Docker container, real LLM, isolated data dir):
1. **Warm wake** — agent was told a secret word, called `schedule_resume` for +2 min, went idle; scheduler fired 26s after due; the same session replied *"The secret word is PINEAPPLE. WAKE-OK"*
2. **Re-sleep + replace** — on wake, agent scheduled a 45-min wake then replaced it with a 2-min one; DB confirmed the placeholder `cancelled` with exactly one `pending` wake
3. **Cold wake** — dev server killed and the container `docker rm -f`'d with the wake pending; wake time passed while fully offline; on restart the catch-up scan fired it within seconds, cold-started a fresh container, SDK-resumed, and the agent replied *"The secret word is PINEAPPLE. COLD-WAKE-OK"* — exactly one session existed throughout