### PR TITLE
fix: folder-picker mounts send empty hostPath (File.path removed in Electron 32)

### DIFF
--- a/src/renderer/components/messages/attachment-preview.test.tsx
+++ b/src/renderer/components/messages/attachment-preview.test.tsx
@@ -177,6 +177,20 @@ describe('AttachmentPreview', () => {
     expect(screen.getByText('mounted, read-write')).toBeInTheDocument()
   })
 
+  it('renders "mount failed" instead of the success label when a mount has an error', () => {
+    const attachment: MountAttachment = {
+      type: 'mount',
+      id: 'mount-1',
+      folderName: 'my-data',
+      hostPath: '/Users/joe/my-data',
+      error: 'hostPath is required',
+    }
+    render(<AttachmentPreview attachments={[attachment]} onRemove={vi.fn()} />)
+    expect(screen.getByText('mount failed')).toBeInTheDocument()
+    expect(screen.getByText('mount failed')).toHaveAttribute('title', 'hostPath is required')
+    expect(screen.queryByText('mounted, read-write')).not.toBeInTheDocument()
+  })
+
   it('calls onRemove with mount id when remove button is clicked', async () => {
     const user = userEvent.setup()
     const onRemove = vi.fn()

--- a/src/renderer/components/messages/attachment-preview.tsx
+++ b/src/renderer/components/messages/attachment-preview.tsx
@@ -1,4 +1,5 @@
 import { X, FolderIcon, Link2 } from 'lucide-react'
+import { cn } from '@shared/lib/utils'
 import { FileTypeIcon } from '@renderer/components/ui/file-type-icon'
 
 export interface FileAttachment {
@@ -6,6 +7,8 @@ export interface FileAttachment {
   id: string
   file: File
   preview?: string
+  /** Set when submitting this attachment failed; renders the chip in an error state. */
+  error?: string
 }
 
 export interface FolderAttachment {
@@ -15,6 +18,8 @@ export interface FolderAttachment {
   folderPath?: string
   files: { file: File; relativePath: string }[]
   totalSize: number
+  /** Set when submitting this attachment failed; renders the chip in an error state. */
+  error?: string
 }
 
 export interface MountAttachment {
@@ -22,6 +27,8 @@ export interface MountAttachment {
   id: string
   folderName: string
   hostPath: string
+  /** Set when submitting this attachment failed; renders the chip in an error state. */
+  error?: string
 }
 
 export type Attachment = FileAttachment | FolderAttachment | MountAttachment
@@ -49,10 +56,14 @@ export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewPr
       {attachments.map((attachment) => (
         <div
           key={attachment.id}
-          className="flex items-center gap-2 rounded-md border bg-muted/50 px-2 py-1.5 text-xs"
+          className={cn(
+            'flex items-center gap-2 rounded-md border bg-muted/50 px-2 py-1.5 text-xs',
+            attachment.error && 'border-destructive/50 bg-destructive/10'
+          )}
           data-testid="attachment-preview"
           data-attachment-name={attachmentName(attachment)}
           data-attachment-type={attachment.type}
+          data-attachment-error={attachment.error || undefined}
         >
           {attachment.type === 'mount' ? (
             <>
@@ -64,7 +75,13 @@ export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewPr
                 <span className="truncate max-w-[160px] font-medium" title={attachment.folderName}>
                   {attachment.folderName}
                 </span>
-                <span className="text-muted-foreground">mounted, read-write</span>
+                {attachment.error ? (
+                  <span className="text-destructive truncate max-w-[160px]" title={attachment.error}>
+                    mount failed
+                  </span>
+                ) : (
+                  <span className="text-muted-foreground">mounted, read-write</span>
+                )}
               </div>
             </>
           ) : attachment.type === 'folder' ? (
@@ -74,7 +91,11 @@ export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewPr
                 <span className="truncate max-w-[160px] font-medium" title={attachment.folderName}>
                   {attachment.folderName}
                 </span>
-                {attachment.files.length > 0 && (
+                {attachment.error ? (
+                  <span className="text-destructive truncate max-w-[160px]" title={attachment.error}>
+                    upload failed
+                  </span>
+                ) : attachment.files.length > 0 && (
                   <span className="text-muted-foreground">
                     {attachment.files.length} file{attachment.files.length !== 1 ? 's' : ''} &middot; {formatFileSize(attachment.totalSize)}
                   </span>
@@ -96,9 +117,15 @@ export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewPr
                 <span className="truncate max-w-[160px] font-medium" title={attachment.file.name}>
                   {attachment.file.name}
                 </span>
-                <span className="text-muted-foreground">
-                  {formatFileSize(attachment.file.size)}
-                </span>
+                {attachment.error ? (
+                  <span className="text-destructive truncate max-w-[160px]" title={attachment.error}>
+                    upload failed
+                  </span>
+                ) : (
+                  <span className="text-muted-foreground">
+                    {formatFileSize(attachment.file.size)}
+                  </span>
+                )}
               </div>
             </>
           )}

--- a/src/renderer/hooks/use-attachments.ts
+++ b/src/renderer/hooks/use-attachments.ts
@@ -73,6 +73,14 @@ export function useAttachments(options?: UseAttachmentsOptions) {
     setAttachments((prev) => [...prev, ...newAttachments])
   }, [])
 
+  const setAttachmentError = useCallback((id: string, error: string | undefined) => {
+    setAttachments((prev) => prev.map((a) => (a.id === id ? { ...a, error } : a)))
+  }, [])
+
+  const clearAttachmentErrors = useCallback(() => {
+    setAttachments((prev) => (prev.some((a) => a.error) ? prev.map((a) => (a.error ? { ...a, error: undefined } : a)) : prev))
+  }, [])
+
   const removeAttachment = useCallback((id: string) => {
     setAttachments((prev) => {
       const removed = prev.find((a) => a.id === id)
@@ -158,6 +166,8 @@ export function useAttachments(options?: UseAttachmentsOptions) {
     addFiles,
     addFolders,
     addMounts,
+    setAttachmentError,
+    clearAttachmentErrors,
     removeAttachment,
     clearAttachments,
     handleFileSelect,

--- a/src/renderer/hooks/use-message-composer.test.tsx
+++ b/src/renderer/hooks/use-message-composer.test.tsx
@@ -37,6 +37,8 @@ const mockAttachments = {
   addFiles: vi.fn(),
   addFolders: vi.fn(),
   addMounts: vi.fn(),
+  setAttachmentError: vi.fn(),
+  clearAttachmentErrors: vi.fn(),
   removeAttachment: vi.fn(),
   clearAttachments: vi.fn(),
   handleFileSelect: vi.fn(),
@@ -337,6 +339,27 @@ describe('useMessageComposer', () => {
     expect(opts.onSubmit).toHaveBeenCalledWith(expect.stringContaining('[Mounted folders:]'))
   })
 
+  it('flags the mount chip and aborts submit when the mount request fails', async () => {
+    mockAttachments.attachments = [
+      { type: 'mount', folderName: 'data', hostPath: '/data/shared', id: 'm1' },
+    ]
+    mockAddMount.mutateAsync.mockRejectedValueOnce(new Error('hostPath is required'))
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+
+    act(() => result.current.setMessage('Mount this'))
+
+    await act(async () => {
+      await result.current.handleSubmit({ preventDefault: vi.fn() } as any)
+    })
+
+    expect(opts.onSubmit).not.toHaveBeenCalled()
+    expect(mockAttachments.setAttachmentError).toHaveBeenCalledWith('m1', 'hostPath is required')
+    expect(result.current.uploadError).toBe('hostPath is required')
+    // Stale chip errors are cleared at the start of the next attempt
+    expect(mockAttachments.clearAttachmentErrors).toHaveBeenCalled()
+  })
+
   it('appends mounts before files in content', async () => {
     const { appendMountedFolders, appendAttachedFiles } = await import('@shared/lib/utils/attached-files')
     mockAttachments.attachments = [
@@ -375,6 +398,8 @@ describe('useMessageComposer', () => {
     expect(opts.onSubmit).not.toHaveBeenCalled()
     // Message should NOT be cleared since upload failed
     expect(result.current.message).toBe('Will fail')
+    // The failing attachment's chip is flagged so it doesn't keep looking successful
+    expect(mockAttachments.setAttachmentError).toHaveBeenCalledWith('1', 'Network error')
   })
 
   it('preserves message when onSubmit fails', async () => {
@@ -486,6 +511,26 @@ describe('useMessageComposer', () => {
 
     expect(mockAttachments.addMounts).toHaveBeenCalledWith([{ folderName: 'dir', hostPath: '/p' }])
     expect(result.current.mountDialog.open).toBe(false)
+
+    delete (window as any).electronAPI
+  })
+
+  it('mount dialog mount choice falls back to upload for folders without a resolved path', () => {
+    ;(window as any).electronAPI = {}
+
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+
+    const withPath = { folderName: 'dir', folderPath: '/p', files: [] }
+    const withoutPath = { folderName: 'pathless', folderPath: undefined, files: [] }
+    act(() => {
+      capturedOnFoldersReceived!([withPath, withoutPath])
+    })
+
+    act(() => result.current.mountDialog.onChoice('mount'))
+
+    expect(mockAttachments.addMounts).toHaveBeenCalledWith([{ folderName: 'dir', hostPath: '/p' }])
+    expect(mockAttachments.addFolders).toHaveBeenCalledWith([withoutPath])
 
     delete (window as any).electronAPI
   })

--- a/src/renderer/hooks/use-message-composer.ts
+++ b/src/renderer/hooks/use-message-composer.ts
@@ -72,6 +72,8 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     addFiles,
     addFolders: addFoldersDirectly,
     addMounts,
+    setAttachmentError,
+    clearAttachmentErrors,
     removeAttachment,
     clearAttachments,
     handleFileSelect,
@@ -93,10 +95,17 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     if (choice === 'upload') {
       addFoldersDirectly(pendingFolders)
     } else if (choice === 'mount') {
-      addMounts(pendingFolders.map((f) => ({
+      // A folder without a resolved absolute path can't be mounted — fall back
+      // to upload for it rather than POSTing a mount with no hostPath.
+      const mountable = pendingFolders.filter((f) => f.folderPath)
+      const pathless = pendingFolders.filter((f) => !f.folderPath)
+      addMounts(mountable.map((f) => ({
         folderName: f.folderName,
         hostPath: f.folderPath!,
       })))
+      if (pathless.length > 0) {
+        addFoldersDirectly(pathless)
+      }
     }
     setPendingFolders([])
   }, [pendingFolders, addFoldersDirectly, addMounts])
@@ -140,11 +149,15 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     if (attachments.length > 0) {
       setIsUploading(true)
       setUploadError(null)
+      clearAttachmentErrors()
+      // Tracks the attachment being processed so the catch can flag its chip
+      let inFlightAttachment: Attachment | null = null
       try {
         const uploadResults: { path: string }[] = []
         const mountResults: { containerPath: string; hostPath: string }[] = []
 
         for (const a of attachments) {
+          inFlightAttachment = a
           if (a.type === 'mount') {
             const result = await addMountMutation.mutateAsync({ agentSlug, hostPath: a.hostPath, restart: true })
             mountResults.push({ containerPath: result.containerPath, hostPath: a.hostPath })
@@ -171,7 +184,11 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
       } catch (error) {
         console.error('Failed to upload attachments:', error)
         captureRendererException(error, { tags: { source: 'attachment-upload' }, extra: { agentSlug } })
-        setUploadError(error instanceof Error ? error.message : 'Upload failed. Please try again.')
+        const message = error instanceof Error ? error.message : 'Upload failed. Please try again.'
+        if (inFlightAttachment) {
+          setAttachmentError(inFlightAttachment.id, message)
+        }
+        setUploadError(message)
         setIsUploading(false)
         return
       }

--- a/src/renderer/hooks/use-mounts.ts
+++ b/src/renderer/hooks/use-mounts.ts
@@ -30,6 +30,9 @@ export function useAddMount() {
 
   return useMutation({
     mutationFn: async (data: { agentSlug: string; hostPath: string; restart?: boolean }) => {
+      if (!data.hostPath) {
+        throw new Error('Could not determine the folder’s location on disk. Try dragging the folder in, or attach it as an upload.')
+      }
       const res = await apiFetch(`/api/agents/${data.agentSlug}/mounts`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/src/renderer/lib/file-utils.folder-upload.test.ts
+++ b/src/renderer/lib/file-utils.folder-upload.test.ts
@@ -94,7 +94,23 @@ function createMockFileEntry(
 // ============================================================================
 
 describe('getFolderFromDirectoryInput — Electron folderPath', () => {
-  it('extracts folderPath on macOS/Linux when File has .path (Electron)', () => {
+  let originalElectronAPI: typeof window.electronAPI
+
+  beforeEach(() => {
+    originalElectronAPI = window.electronAPI
+    // Electron resolves absolute paths via the preload's webUtils.getPathForFile
+    // (File.path was removed in Electron 32). The mock reads back the `path`
+    // stamped on the test File objects.
+    window.electronAPI = {
+      getPathForFile: vi.fn((f: File) => (f as File & { path?: string }).path ?? ''),
+    } as any
+  })
+
+  afterEach(() => {
+    window.electronAPI = originalElectronAPI
+  })
+
+  it('extracts folderPath on macOS/Linux via getPathForFile (Electron)', () => {
     const fileList = createMockFileList([
       {
         name: 'index.ts',
@@ -114,7 +130,7 @@ describe('getFolderFromDirectoryInput — Electron folderPath', () => {
     expect(result!.folderName).toBe('my-project')
   })
 
-  it('extracts folderPath on Windows when File has .path (Electron)', () => {
+  it('extracts folderPath on Windows via getPathForFile (Electron)', () => {
     const fileList = createMockFileList([
       {
         name: 'index.ts',
@@ -141,7 +157,9 @@ describe('getFolderFromDirectoryInput — Electron folderPath', () => {
     expect(result!.folderPath).toBe('/Users/joe/my-project')
   })
 
-  it('returns undefined folderPath when File has no .path (browser)', () => {
+  it('returns undefined folderPath when electronAPI is not available (browser)', () => {
+    window.electronAPI = undefined
+
     const fileList = createMockFileList([
       { name: 'index.ts', webkitRelativePath: 'my-project/src/index.ts' },
     ])
@@ -150,6 +168,21 @@ describe('getFolderFromDirectoryInput — Electron folderPath', () => {
     expect(result).not.toBeNull()
     expect(result!.folderPath).toBeUndefined()
     // Files should still be enumerated for zip fallback
+    expect(result!.files).toHaveLength(1)
+  })
+
+  it('returns undefined folderPath when getPathForFile returns empty string', () => {
+    window.electronAPI = {
+      getPathForFile: vi.fn(() => ''),
+    } as any
+
+    const fileList = createMockFileList([
+      { name: 'index.ts', webkitRelativePath: 'my-project/src/index.ts' },
+    ])
+
+    const result = getFolderFromDirectoryInput(fileList)
+    expect(result).not.toBeNull()
+    expect(result!.folderPath).toBeUndefined()
     expect(result!.files).toHaveLength(1)
   })
 })

--- a/src/renderer/lib/file-utils.ts
+++ b/src/renderer/lib/file-utils.ts
@@ -114,18 +114,18 @@ export async function getItemsFromDataTransfer(
 }
 
 /**
- * In Electron, File objects from <input> have a non-standard .path property
- * with the absolute filesystem path. Extract the folder's absolute path
- * by stripping inner path components from the first file's absolute path.
+ * In Electron, resolve a file's absolute path via webUtils.getPathForFile
+ * (exposed on the preload bridge — File.path was removed in Electron 32),
+ * then extract the folder's absolute path by stripping inner path components.
  * Works on macOS, Linux, and Windows (handles both / and \ separators).
  */
 function getElectronFolderPath(firstFile: File, relativePath?: string): string | null {
-  const f = firstFile as File & { path?: string }
-  const rel = relativePath ?? f.webkitRelativePath
-  if (!f.path || !rel) return null
+  const rel = relativePath ?? firstFile.webkitRelativePath
+  const absPath = window.electronAPI?.getPathForFile(firstFile)
+  if (!absPath || !rel) return null
 
   const relParts = rel.split('/')
-  let folderPath = f.path
+  let folderPath = absPath
   for (let i = relParts.length - 1; i >= 1; i--) {
     const lastSep = Math.max(folderPath.lastIndexOf('/'), folderPath.lastIndexOf('\\'))
     if (lastSep === -1) return null


### PR DESCRIPTION
## Problem

Attaching a folder via the paperclip → folder picker and choosing **Mount** always fails with `hostPath is required` (31 events in Sentry over the last 14 days, macOS + Windows, still occurring on 0.4.11).

Two entry paths feed the mount dialog:
- **Drag-and-drop** resolves absolute paths through the preload's `webUtils.getPathForFile()` — works.
- **The `<input webkitdirectory>` picker** went through `getElectronFolderPath`, which read the non-standard `File.path` — removed in Electron 32 (we're on 41). Every picked folder got `folderPath: undefined`, and `handleMountChoice` force-asserted it into `hostPath: f.folderPath!`, POSTing `undefined` to `/mounts` → 400.

Worse, the chip kept showing **"mounted, read-write"** after the failure, so a sent message silently had no folder.

## Fix

- `getElectronFolderPath` now resolves the absolute path via `window.electronAPI.getPathForFile()` (same preload API the drag path already uses).
- `handleMountChoice` drops the `folderPath!` assertion: folders without a resolved path fall back to the upload flow instead of enqueueing a doomed mount.
- **Chip error state**: attachments carry an `error` field; when a mount/upload fails at submit, the failing chip flips to a red "mount failed" / "upload failed" state with the server message as tooltip, and clears on the next attempt.
- `useAddMount` throws a human-readable client-side error if `hostPath` is ever falsy, so the raw server 400 can't reach users (or Sentry) from this path again.

## Testing

- Picker-path unit tests rewritten to mock `getPathForFile` (plus empty-string and no-Electron fallbacks)
- New composer tests: pathless-mount → upload fallback; failed mount flags the chip and aborts submit
- New render test for the "mount failed" chip state
- `tsc --noEmit` + eslint clean; 68 tests passing across the touched suites
- Repro confirmed live before the fix (picker + Mount → red "hostPath is required"); drag-and-drop mount verified working