### PR TITLE
fix: pull instead of doomed build when the agent image is missing at session start

### DIFF
--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -236,15 +236,6 @@ const BASE_PORT = (() => {
 const HEALTH_PROBE_TIMEOUT_MS = 2000
 
 /**
- * Error thrown by ensureImageExists() when an image build fails, carrying the
- * captured stderr tail and exit code so start()'s catch can surface them to Sentry.
- */
-interface ImageBuildError extends Error {
-  imageBuildStderr?: string
-  imageBuildExitCode?: number | null
-}
-
-/**
  * Parse a memory value string (e.g., "231.2MiB", "1.5GiB", "512MB") to bytes.
  */
 export function parseMemoryValue(value: string): number {
@@ -480,8 +471,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
    * ensureImageReady()'s decision: build from the local agent-container
    * context when it exists (dev), otherwise pull from the registry — the
    * packaged app has no build context, and the bundled Lima VM has no
-   * buildkit, so `build` is never an option there (ensureImageExists()'s
-   * build-only fallback hard-fails on Lima). Lazy import avoids a
+   * buildkit, so `build` is never an option there. Lazy import avoids a
    * base-client ↔ client-factory module cycle.
    */
   protected async recreateImage(image: string): Promise<void> {
@@ -800,8 +790,10 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
       console.log(`Container ${containerName} is now running on port ${port}`)
     } catch (error: any) {
-      // Only capture if not already captured (health check errors are captured above)
-      if (!error.message?.includes('Container failed to become healthy')) {
+      // Only capture if not already captured (health check errors are captured
+      // above; image pull/build failures are captured at their throw site —
+      // they arrive here flagged sentryCaptured).
+      if (!error.message?.includes('Container failed to become healthy') && !error.sentryCaptured) {
         // Port races are a handled, user-environment failure — we retried with
         // fresh ports and only land here after exhausting them. Downgrade to a
         // warning so it doesn't page as a hard error.
@@ -814,10 +806,6 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
             containerName: this.getContainerName(),
             runner: getSettings().container.containerRunner,
             image: getSettings().container.agentImage,
-            // Surface image-build diagnostics when start() failed during
-            // ensureImageExists() (otherwise these are undefined).
-            imageBuildExitCode: error.imageBuildExitCode,
-            imageBuildStderr: error.imageBuildStderr,
           },
         })
       }
@@ -1497,50 +1485,94 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     }
   }
 
+  /**
+   * Whether the runtime behind this client is reachable right now. Used to
+   * tell "image missing" apart from "runtime down" when `image inspect`
+   * fails — the two need opposite handling. Delegates to the subclass's
+   * canonical static isRunning() probe (e.g. Lima's ha.sock-aware health
+   * probe, `docker info`).
+   */
+  protected isRuntimeReachable(): Promise<boolean> {
+    return (this.constructor as typeof BaseContainerClient).isRunning()
+  }
+
   private async ensureImageExists(): Promise<void> {
     const settings = getSettings()
-    const runner = this.getRunnerCommand()
     const image = settings.container.agentImage
 
     try {
       await execWithPath(`${this.getRunnerShellCommand()} image inspect ${image}`)
       console.log(`Container image ${image} found`)
-    } catch {
-      console.log(`Building container image ${image}...`)
+      return
+    } catch (inspectError) {
+      // `image inspect` fails both when the image is missing (healthy
+      // runtime) and when the runtime itself is unreachable (e.g. a wedged
+      // Lima VM → ssh-style exit 255 with empty stderr). Only the first is
+      // fixable by creating the image; rethrow the second so
+      // ensureImageExistsWithRecovery() heals the runtime and retries,
+      // instead of attempting a build/pull that can only fail.
+      if (!(await this.isRuntimeReachable())) {
+        const detail = inspectError instanceof Error ? inspectError.message : String(inspectError)
+        throw new Error(`Container runtime unreachable while checking for image ${image}: ${detail.slice(-500)}`)
+      }
+    }
 
-      // Pipe (not inherit) stdout/stderr so we can capture the build output —
-      // a bare exit code is undiagnosable in Sentry. Mirrors buildImage() in
-      // client-factory.ts.
-      const buildProcess = spawnWithPath(
-        runner,
-        ['build', '-t', image, AGENT_CONTAINER_PATH]
-      )
+    // Image genuinely missing. Same decision as recreateImage() and startup's
+    // ensureImageReady(): build only where the local agent-container context
+    // exists (dev) — packaged apps have no build context and the bundled Lima
+    // VM has no buildkit, so a build there fails unconditionally ("buildctl
+    // not found in $PATH") — otherwise pull from the registry. Lazy import
+    // avoids a base-client ↔ client-factory module cycle.
+    const { canBuildImage, buildImage, pullImage, checkImageExists, getAvailableDiskSpace, MIN_IMAGE_DISK_SPACE_BYTES } = await import('./client-factory')
+    const runner = settings.container.containerRunner as import('./client-factory').ContainerRunner
 
-      const stderrChunks: string[] = []
-      buildProcess.stdout?.on('data', (data: Buffer) => process.stdout.write(data))
-      buildProcess.stderr?.on('data', (data: Buffer) => {
-        stderrChunks.push(data.toString())
-        process.stderr.write(data)
-      })
-
-      await new Promise<void>((resolve, reject) => {
-        buildProcess.on('close', (code) => {
-          const stderr = stderrChunks.join('').trim()
-          // Treat an "already exists" image as success — a concurrent build
-          // (e.g. ensureImageReady racing the start path) may have created it.
-          if (code === 0 || /already exists/i.test(stderr)) {
-            console.log(`Container image ${image} built successfully`)
-            resolve()
-          } else {
-            const detail = stderr ? `: ${stderr.slice(-500)}` : ''
-            const error = new Error(`Container build failed with code ${code}${detail}`) as ImageBuildError
-            error.imageBuildExitCode = code
-            error.imageBuildStderr = stderr.slice(-2000)
-            reject(error)
-          }
+    // Same pre-flight ensureImageReady() runs at startup: creating the image
+    // on a nearly-full disk is how the containerd store ends up with corrupt
+    // snapshots (truncated layers mid-unpack) that poison every later start.
+    try {
+      const availableBytes = await getAvailableDiskSpace()
+      if (availableBytes < MIN_IMAGE_DISK_SPACE_BYTES) {
+        const availableGB = (availableBytes / (1024 * 1024 * 1024)).toFixed(1)
+        const requiredGB = (MIN_IMAGE_DISK_SPACE_BYTES / (1024 * 1024 * 1024)).toFixed(0)
+        captureMessage('Insufficient disk space for image create at session start', {
+          level: 'info',
+          tags: { component: 'container', operation: 'disk-space-check' },
+          extra: { availableGB: parseFloat(availableGB), requiredGB: parseInt(requiredGB), runner },
         })
-        buildProcess.on('error', reject)
-      })
+        // sentryCaptured: reported via the captureMessage above; start()'s
+        // catch must not add an error-level event for a full disk.
+        throw Object.assign(
+          new Error(`Insufficient disk space: ${availableGB} GB available, at least ${requiredGB} GB required to download the agent image. Free up disk space and try again.`),
+          { sentryCaptured: true, isImageCreateError: true }
+        )
+      }
+    } catch (diskError) {
+      if ((diskError as { isImageCreateError?: boolean }).isImageCreateError) throw diskError
+      console.warn('[Container] Disk space check failed, proceeding anyway:', diskError)
+    }
+
+    try {
+      if (canBuildImage()) {
+        console.log(`Building container image ${image}...`)
+        await buildImage(runner, image)
+        console.log(`Container image ${image} built successfully`)
+      } else {
+        console.log(`Pulling container image ${image}...`)
+        await pullImage(runner, image)
+        console.log(`Container image ${image} pulled successfully`)
+      }
+    } catch (createError) {
+      // A concurrent create (e.g. startup's ensureImageReady racing this
+      // start path) may have produced the image even though our attempt
+      // failed — re-check before propagating.
+      if (await checkImageExists(runner, image)) {
+        console.log(`Container image ${image} appeared concurrently`)
+        return
+      }
+      // isImageCreateError: a registry-level failure (404 "not found", DNS)
+      // must not string-match the VM-issue heuristics in Lima/WSL2
+      // handleRunError — only their health probes should decide recovery.
+      throw Object.assign(createError as object, { isImageCreateError: true })
     }
   }
 

--- a/src/shared/lib/container/client-factory.ts
+++ b/src/shared/lib/container/client-factory.ts
@@ -11,8 +11,9 @@ import { RunnerSetupError, type RunnerSetupRemediation } from './wsl2-setup-erro
 import { MockContainerClient } from './mock-container-client'
 import { getSettings } from '@shared/lib/config/settings'
 import { BaseContainerClient, execWithPath, spawnWithPath, AGENT_CONTAINER_PATH } from './base-container-client'
-import { platform } from 'os'
+import { platform, homedir } from 'os'
 import * as fs from 'fs'
+import { statfs } from 'fs/promises'
 
 export type ContainerRunner = 'docker' | 'podman' | 'apple-container' | 'lima' | 'wsl2' | 'kubernetes' | 'lambda-microvm'
 
@@ -367,6 +368,15 @@ export async function reconcileRunnerState(runner: ContainerRunner): Promise<boo
   return entry.reconcileRuntimeState()
 }
 
+/** Minimum free disk space (in bytes) required before pulling/building an image: 5 GB */
+export const MIN_IMAGE_DISK_SPACE_BYTES = 5 * 1024 * 1024 * 1024
+
+/** Free bytes on the volume the agent image lands on (host home dir). */
+export async function getAvailableDiskSpace(): Promise<number> {
+  const stats = await statfs(homedir())
+  return stats.bavail * stats.bsize
+}
+
 /**
  * Check if a container image exists locally.
  */
@@ -396,7 +406,31 @@ export async function checkImageExists(runner: ContainerRunner, image: string): 
  *
  * We track unique layer/item IDs and completed ones to compute progress.
  */
+/**
+ * In-flight pulls keyed by runner:image. Startup's ensureImageReady() and a
+ * session start's ensureImageExists() can both decide to pull the same image
+ * concurrently; sharing one pull avoids a duplicate multi-GB download and the
+ * loser failing a start the winner was about to satisfy.
+ */
+const inflightPulls = new Map<string, Promise<void>>()
+
 export function pullImage(
+  runner: ContainerRunner,
+  image: string,
+  onProgress?: (progress: ImagePullProgress) => void
+): Promise<void> {
+  const key = `${runner}:${image}`
+  const existing = inflightPulls.get(key)
+  if (existing) {
+    addErrorBreadcrumb({ category: 'container', message: 'Awaiting already in-flight pull of the same image', data: { image, runner } })
+    return existing
+  }
+  const pull = doPullImage(runner, image, onProgress).finally(() => inflightPulls.delete(key))
+  inflightPulls.set(key, pull)
+  return pull
+}
+
+function doPullImage(
   runner: ContainerRunner,
   image: string,
   onProgress?: (progress: ImagePullProgress) => void
@@ -480,7 +514,10 @@ export function pullImage(
       } else {
         const stderr = stderrChunks.join('').trim()
         const detail = stderr ? `: ${stderr.slice(-500)}` : ''
-        const pullError = new Error(`Image pull failed with exit code ${code}${detail}`)
+        // sentryCaptured: this capture is the canonical event for the failure —
+        // callers up the stack (start()'s catch, handleRunError fallthroughs,
+        // ensureImageReady) must not re-capture the same error.
+        const pullError = Object.assign(new Error(`Image pull failed with exit code ${code}${detail}`), { sentryCaptured: true })
         captureException(pullError, {
           tags: { component: 'container', operation: 'image-pull' },
           extra: {
@@ -500,7 +537,7 @@ export function pullImage(
         tags: { component: 'container', operation: 'image-pull-spawn' },
         extra: { image, runner },
       })
-      reject(err)
+      reject(Object.assign(err, { sentryCaptured: true }))
     })
   })
 }
@@ -561,7 +598,8 @@ export function buildImage(
       } else {
         const stderr = stderrChunks.join('').trim()
         const detail = stderr ? `: ${stderr.slice(-500)}` : ''
-        const buildError = new Error(`Image build failed with exit code ${code}${detail}`)
+        // sentryCaptured: canonical event — see pullImage.
+        const buildError = Object.assign(new Error(`Image build failed with exit code ${code}${detail}`), { sentryCaptured: true })
         captureException(buildError, {
           tags: { component: 'container', operation: 'image-build' },
           extra: { image, runner, exitCode: code, stderr: stderr.slice(-2000) },
@@ -574,7 +612,7 @@ export function buildImage(
         tags: { component: 'container', operation: 'image-build-spawn' },
         extra: { image, runner },
       })
-      reject(err)
+      reject(Object.assign(err, { sentryCaptured: true }))
     })
   })
 }

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -38,6 +38,13 @@ vi.mock('./client-factory', () => ({
   clearRunnerAvailabilityCache: (...args: unknown[]) => mockClearRunnerAvailabilityCache(...args),
   getRunnerDisplayName: (runner: string) => runner,
   reconcileRunnerState: vi.fn().mockResolvedValue(false),
+  // Routed through the same statfs mock the old module-local helper used, so
+  // the per-test disk-space overrides below keep working.
+  getAvailableDiskSpace: async () => {
+    const stats = await mockStatfs()
+    return stats.bavail * stats.bsize
+  },
+  MIN_IMAGE_DISK_SPACE_BYTES: 5 * 1024 * 1024 * 1024,
 }))
 
 const mockGetOrCreateProxyToken = vi.fn()

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -1,7 +1,5 @@
 import path from 'path'
-import { statfs } from 'node:fs/promises'
-import os from 'os'
-import { createContainerClient, checkAllRunnersAvailability, checkImageExists, pullImage, canBuildImage, buildImage, startRunner, refreshRunnerAvailability, clearRunnerAvailabilityCache, reconcileRunnerState, getRunnerDisplayName, getContainerClientClass, getCliCommand, type ContainerRunner } from './client-factory'
+import { createContainerClient, checkAllRunnersAvailability, checkImageExists, pullImage, canBuildImage, buildImage, startRunner, refreshRunnerAvailability, clearRunnerAvailabilityCache, reconcileRunnerState, getRunnerDisplayName, getContainerClientClass, getCliCommand, getAvailableDiskSpace, MIN_IMAGE_DISK_SPACE_BYTES, type ContainerRunner } from './client-factory'
 import { ensureLimaReady } from './lima-container-client'
 import type { ContainerClient, ContainerConfig, ContainerInfo, HealthCheckResult, ImagePullProgress, RuntimeReadiness, StopOptions } from './types'
 import { healthMonitor } from './health-monitor'
@@ -35,8 +33,6 @@ const HEALTH_CHECK_INTERVAL_MS = parseInt(
   10
 ) * 1000
 
-/** Minimum free disk space (in bytes) required before pulling an image: 5 GB */
-const MIN_DISK_SPACE_BYTES = 5 * 1024 * 1024 * 1024
 
 /**
  * Max age (in ms) of a cached 'running' status before ensureRunning re-verifies
@@ -49,11 +45,6 @@ const RUNNING_STATUS_TTL_MS = parseInt(
   process.env.CONTAINER_RUNNING_STATUS_TTL_SECONDS || '10',
   10
 ) * 1000
-
-async function getAvailableDiskSpace(): Promise<number> {
-  const stats = await statfs(os.homedir())
-  return stats.bavail * stats.bsize
-}
 
 /** Cached container status */
 interface CachedContainerStatus {
@@ -995,9 +986,9 @@ class ContainerManager {
     // Step 3: Pre-flight disk space check
     try {
       const availableBytes = await getAvailableDiskSpace()
-      if (availableBytes < MIN_DISK_SPACE_BYTES) {
+      if (availableBytes < MIN_IMAGE_DISK_SPACE_BYTES) {
         const availableGB = (availableBytes / (1024 * 1024 * 1024)).toFixed(1)
-        const requiredGB = (MIN_DISK_SPACE_BYTES / (1024 * 1024 * 1024)).toFixed(0)
+        const requiredGB = (MIN_IMAGE_DISK_SPACE_BYTES / (1024 * 1024 * 1024)).toFixed(0)
         captureMessage('Insufficient disk space for image pull', {
           level: 'info',
           tags: { component: 'runtime', operation: 'disk-space-check' },
@@ -1103,9 +1094,11 @@ class ContainerManager {
           continue
         }
 
-        // Non-retryable or exhausted retries
+        // Non-retryable or exhausted retries. pullImage/buildImage capture
+        // their own failures at the throw site (flagged sentryCaptured) —
+        // don't emit a second event for the same error.
         console.error(`[ContainerManager] Failed to ${actionLabel.toLowerCase()} image ${image}:`, errMsg)
-        captureException(error, {
+        if (!(error as { sentryCaptured?: boolean })?.sentryCaptured) captureException(error, {
           tags: { component: 'runtime', operation: shouldBuild ? 'image-build' : 'image-pull' },
           extra: { image, runner: effectiveRunner, attempt },
         })

--- a/src/shared/lib/container/ensure-image-exists.lima-live.e2e.test.ts
+++ b/src/shared/lib/container/ensure-image-exists.lima-live.e2e.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
+import os from 'os'
+import fs from 'fs'
+import path from 'path'
+import { execFileSync } from 'child_process'
+
+// ============================================================================
+// Live validation of ensureImageExists() against the REAL bundled Lima VM.
+// Gated by RUN_LIMA_IMAGE_E2E=1 so it never runs in CI:
+//
+//   RUN_LIMA_IMAGE_E2E=1 npx vitest run \
+//     src/shared/lib/container/ensure-image-exists.lima-live.e2e.test.ts
+//
+// Requirements: the bundled Lima VM ("superagent" instance under
+// ~/.superagent/lima) exists, and either the packaged app's bundled limactl
+// is present (/Applications/Gamut.app) or limactl is on PATH.
+//
+// WARNING: the wedged-VM test STOPS the shared Lima VM (killing any agent
+// containers inside it) and asserts the fix restarts it. Only run on a
+// machine where that is acceptable. A running production app may race the
+// heal by restarting the VM itself; the assertions hold either way.
+// ============================================================================
+
+const enabled = process.env.RUN_LIMA_IMAGE_E2E === '1'
+
+// Keep Sentry quiet — these paths capture on failure.
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addErrorBreadcrumb: vi.fn(),
+}))
+vi.mock('@shared/lib/llm-provider', () => ({
+  getActiveLlmProvider: () => ({ getContainerEnvVars: () => ({}) }),
+}))
+
+// Real Lima runner, tiny throwaway image for the pull test. The mock is
+// mutable so each test picks its image.
+const settingsState = {
+  agentImage: 'docker.io/library/alpine:3.20',
+}
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({
+    enableToolSearch: false,
+    container: {
+      containerRunner: 'lima',
+      agentImage: settingsState.agentImage,
+      resourceLimits: { cpu: 2, memory: '2g' },
+      // No runtimeSettings.lima.vmMemory: an explicit value that differs from
+      // the live VM would make ensureLimaReady() RECREATE (wipe) it.
+    },
+  }),
+}))
+
+import { LimaContainerClient, getLimaHome, getLimactlPath, getNerdctlWrapperPath } from './lima-container-client'
+import type { ContainerConfig } from './types'
+
+class LiveClient extends LimaContainerClient {
+  ensureImage(): Promise<void> {
+    return this.ensureImageExistsWithRecovery()
+  }
+}
+
+const ALPINE = 'docker.io/library/alpine:3.20'
+const VM_NAME = 'superagent'
+
+function limactl(args: string[]): string {
+  return execFileSync(getLimactlPath(), args, {
+    env: { ...process.env, LIMA_HOME: getLimaHome() },
+    encoding: 'utf-8',
+    timeout: 180_000,
+  })
+}
+
+function nerdctl(args: string[]): string {
+  return execFileSync(getNerdctlWrapperPath(), args, { encoding: 'utf-8', timeout: 120_000 })
+}
+
+function vmStatus(): string {
+  const line = limactl(['list', '--json']).trim().split('\n').find((l) => l.includes(`"${VM_NAME}"`))
+  return line ? JSON.parse(line).status : 'Missing'
+}
+
+describe.skipIf(!enabled)('ensureImageExists against the live Lima VM', () => {
+  const originalCwd = process.cwd()
+  const originalResourcesPath = process.resourcesPath
+  let logSpy: ReturnType<typeof vi.spyOn>
+
+  beforeAll(() => {
+    // Impersonate the packaged app: bundled limactl via process.resourcesPath...
+    const gamutResources = '/Applications/Gamut.app/Contents/Resources'
+    if (fs.existsSync(path.join(gamutResources, 'lima', 'bin', 'limactl'))) {
+      ;(process as any).resourcesPath = gamutResources
+    }
+    // ...and no local build context in cwd, so canBuildImage() is false and
+    // the missing-image path must PULL (the packaged-app decision under test).
+    const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'ensure-image-live-'))
+    process.chdir(scratch)
+    expect(fs.existsSync('./agent-container')).toBe(false)
+
+    logSpy = vi.spyOn(console, 'log')
+  })
+
+  afterAll(() => {
+    process.chdir(originalCwd)
+    ;(process as any).resourcesPath = originalResourcesPath
+    // Leave the VM as we found it: running, without the throwaway image.
+    try { nerdctl(['rmi', '-f', ALPINE]) } catch { /* not present */ }
+  })
+
+  it('pulls (never builds) when the image is missing — ELECTRON-4T/5B path', async () => {
+    settingsState.agentImage = ALPINE
+    try { nerdctl(['rmi', '-f', ALPINE]) } catch { /* not present */ }
+    logSpy.mockClear()
+
+    const client = new LiveClient({ agentId: 'live-e2e' } as ContainerConfig)
+    await client.ensureImage()
+
+    // The image is now really in the VM's containerd store.
+    expect(nerdctl(['images', '--format', '{{.Repository}}:{{.Tag}}'])).toContain('alpine')
+    const logs = logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n')
+    expect(logs).toContain(`Pulling container image ${ALPINE}`)
+    expect(logs).not.toContain('Building container image')
+  }, 300_000)
+
+  it('heals a stopped VM and retries instead of build/pull — ELECTRON-4S path', async () => {
+    // Use an image already present in the VM so a correct run needs NO create.
+    const existing = nerdctl(['images', '--format', '{{.Repository}}:{{.Tag}}'])
+      .split('\n').map((l) => l.trim()).filter((l) => l && !l.includes('<none>'))[0]
+    expect(existing).toBeTruthy()
+    settingsState.agentImage = existing
+
+    limactl(['stop', VM_NAME])
+    expect(vmStatus()).toBe('Stopped')
+    logSpy.mockClear()
+
+    const client = new LiveClient({ agentId: 'live-e2e' } as ContainerConfig)
+    await client.ensureImage()
+
+    // The fix healed the runtime (limactl start) and found the image on retry.
+    expect(vmStatus()).toBe('Running')
+    const logs = logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n')
+    expect(logs).toContain(`Container image ${existing} found`)
+    expect(logs).not.toContain('Building container image')
+    // No pull either — the image was never missing. (Tolerated if a racing
+    // production app healed the VM before our probe ran; the log assertion
+    // above still guarantees the inspect retry succeeded.)
+    expect(logs).not.toContain(`Pulling container image ${existing}`)
+  }, 300_000)
+})

--- a/src/shared/lib/container/ensure-image-exists.test.ts
+++ b/src/shared/lib/container/ensure-image-exists.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ============================================================================
+// ensureImageExists() — pull-vs-build decision and runtime discrimination.
+//
+// `image inspect` fails both when the image is missing (healthy runtime) and
+// when the runtime is unreachable (wedged Lima VM → ssh exit 255). The old
+// code treated every inspect failure as image-missing and ran a bare
+// `<runner> build`, which is doomed in packaged apps (no build context; the
+// bundled Lima VM has no buildkit → "buildctl not found in $PATH") and doomed
+// on a wedged VM (exit 255 with empty stderr).
+//
+// The fixed path must:
+//   - pull from the registry when there is no local build context
+//   - build only in dev (local agent-container context exists)
+//   - rethrow runtime-unreachable instead of attempting a create, so
+//     ensureImageExistsWithRecovery() can heal the runtime and retry
+//   - tolerate a concurrent create (startup's ensureImageReady racing it)
+// ============================================================================
+
+const execCommands: string[] = []
+
+// Scripted outcomes for successive `image inspect` calls. Each entry is
+// either 'ok' or an error message to reject with; calls beyond the script
+// succeed. Reset per test.
+let inspectScript: (string | 'ok')[] = []
+let inspectAttempts = 0
+
+// Whether the (fake) runtime is currently reachable — drives the test
+// client's static isRunning() probe.
+let runtimeReachable = true
+
+// When true, handleRunError() "heals" the runtime (marks it reachable and
+// makes subsequent inspects succeed) and reports recovery.
+let healOnRunError = false
+let handleRunErrorCalls = 0
+
+vi.mock('child_process', () => {
+  const exec = (
+    command: string,
+    optionsOrCb: unknown,
+    maybeCb?: (err: Error | null, result?: { stdout: string; stderr: string }) => void
+  ) => {
+    const cb = (typeof optionsOrCb === 'function' ? optionsOrCb : maybeCb) as (
+      err: Error | null,
+      result?: { stdout: string; stderr: string }
+    ) => void
+    execCommands.push(command)
+
+    if (/image inspect/.test(command)) {
+      const outcome = inspectScript[inspectAttempts] ?? 'ok'
+      inspectAttempts++
+      if (outcome !== 'ok') {
+        cb(new Error(outcome))
+        return {}
+      }
+      cb(null, { stdout: '[]', stderr: '' })
+      return {}
+    }
+
+    if (/run\s+-d/.test(command)) {
+      cb(null, { stdout: 'fake-container-id', stderr: '' })
+      return {}
+    }
+
+    // ps → no used ports; stop/rm → succeed silently.
+    cb(null, { stdout: '', stderr: '' })
+    return {}
+  }
+  return {
+    exec,
+    execSync: vi.fn(),
+    spawn: vi.fn(),
+  }
+})
+
+vi.mock('net', () => {
+  const createServer = vi.fn(() => {
+    const listeners = new Map<string, () => void>()
+    return {
+      once: vi.fn((event: string, callback: () => void) => {
+        listeners.set(event, callback)
+      }),
+      close: vi.fn(),
+      listen: vi.fn(() => {
+        queueMicrotask(() => listeners.get('listening')?.())
+      }),
+    }
+  })
+
+  return {
+    default: { createServer },
+    createServer,
+  }
+})
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addErrorBreadcrumb: vi.fn(),
+}))
+
+const pullImageMock = vi.fn((_runner: string, _image: string) => Promise.resolve())
+const buildImageMock = vi.fn((_runner: string, _image: string) => Promise.resolve())
+const checkImageExistsMock = vi.fn((_runner: string, _image: string) => Promise.resolve(false))
+let canBuild = false
+let availableDiskBytes = 100 * 1024 * 1024 * 1024
+vi.mock('./client-factory', () => ({
+  canBuildImage: vi.fn(() => canBuild),
+  pullImage: (runner: string, image: string) => pullImageMock(runner, image),
+  buildImage: (runner: string, image: string) => buildImageMock(runner, image),
+  checkImageExists: (runner: string, image: string) => checkImageExistsMock(runner, image),
+  getAvailableDiskSpace: vi.fn(() => Promise.resolve(availableDiskBytes)),
+  MIN_IMAGE_DISK_SPACE_BYTES: 5 * 1024 * 1024 * 1024,
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: vi.fn(() => ({
+    enableToolSearch: false,
+    container: {
+      agentImage: 'superagent/agent:test',
+      containerRunner: 'docker',
+      resourceLimits: { cpu: 2, memory: '2g' },
+    },
+  })),
+}))
+
+vi.mock('@shared/lib/llm-provider', () => ({
+  getActiveLlmProvider: vi.fn(() => ({
+    getContainerEnvVars: () => ({}),
+  })),
+}))
+
+vi.mock('@shared/lib/config/data-dir', () => ({
+  getAgentWorkspaceDir: vi.fn(() => '/tmp/ensure-image-workspace'),
+}))
+
+vi.mock('fs', () => {
+  const noop = vi.fn()
+  return {
+    default: { mkdirSync: noop, writeFileSync: noop, unlinkSync: noop },
+    mkdirSync: noop,
+    writeFileSync: noop,
+    unlinkSync: noop,
+  }
+})
+
+import { BaseContainerClient } from './base-container-client'
+import type { ContainerConfig, ContainerInfo } from './types'
+
+// Failure shapes lifted from real Sentry events: the Lima nerdctl wrapper
+// delegates over limactl/ssh, so a wedged VM fails ANY command with exit 255
+// and empty stderr — indistinguishable from image-missing by exit code alone.
+const WEDGED_VM_INSPECT_MSG =
+  'Command failed: /Users/nick/.superagent/bin/lima-nerdctl image inspect superagent/agent:test'
+const IMAGE_MISSING_INSPECT_MSG =
+  'Command failed: docker image inspect superagent/agent:test\nError: No such image: superagent/agent:test'
+
+class TestContainerClient extends BaseContainerClient {
+  protected getRunnerCommand(): string {
+    return 'docker'
+  }
+  static async isRunning(): Promise<boolean> {
+    return runtimeReachable
+  }
+  protected async handleRunError(_error: any): Promise<boolean> {
+    handleRunErrorCalls++
+    if (healOnRunError) {
+      runtimeReachable = true
+      inspectScript = [] // healed → inspects succeed from now on
+      return true
+    }
+    return false
+  }
+  async getInfoFromRuntime(): Promise<ContainerInfo> {
+    return { status: 'stopped', port: null }
+  }
+  async waitForHealthy(): Promise<boolean> {
+    return true
+  }
+}
+
+const IMAGE = 'superagent/agent:test'
+
+function makeClient(): TestContainerClient {
+  return new TestContainerClient({ agentId: 'abc123' } as ContainerConfig)
+}
+
+function buildExecAttempted(): boolean {
+  return execCommands.some((c) => /\bbuild\b/.test(c))
+}
+
+describe('ensureImageExists via start()', () => {
+  beforeEach(() => {
+    execCommands.length = 0
+    inspectScript = []
+    inspectAttempts = 0
+    runtimeReachable = true
+    healOnRunError = false
+    handleRunErrorCalls = 0
+    canBuild = false
+    availableDiskBytes = 100 * 1024 * 1024 * 1024
+    pullImageMock.mockClear()
+    pullImageMock.mockResolvedValue(undefined)
+    buildImageMock.mockClear()
+    checkImageExistsMock.mockClear()
+    checkImageExistsMock.mockResolvedValue(false)
+  })
+
+  it('starts without creating anything when the image exists', async () => {
+    await makeClient().start()
+
+    expect(pullImageMock).not.toHaveBeenCalled()
+    expect(buildImageMock).not.toHaveBeenCalled()
+    expect(buildExecAttempted()).toBe(false)
+  })
+
+  it('pulls (never builds) when the image is missing and no build context exists (packaged app)', async () => {
+    inspectScript = [IMAGE_MISSING_INSPECT_MSG]
+
+    await makeClient().start()
+
+    expect(pullImageMock).toHaveBeenCalledWith('docker', IMAGE)
+    expect(buildImageMock).not.toHaveBeenCalled()
+    // The old doomed fallback shelled out to `<runner> build` — must be gone.
+    expect(buildExecAttempted()).toBe(false)
+  })
+
+  it('builds when the local agent-container context exists (dev)', async () => {
+    canBuild = true
+    inspectScript = [IMAGE_MISSING_INSPECT_MSG]
+
+    await makeClient().start()
+
+    expect(buildImageMock).toHaveBeenCalledWith('docker', IMAGE)
+    expect(pullImageMock).not.toHaveBeenCalled()
+  })
+
+  it('does not attempt build/pull when the runtime is unreachable; heals and retries instead', async () => {
+    // Wedged VM: every command fails until handleRunError() heals it.
+    inspectScript = [WEDGED_VM_INSPECT_MSG, WEDGED_VM_INSPECT_MSG]
+    runtimeReachable = false
+    healOnRunError = true
+
+    await makeClient().start()
+
+    expect(handleRunErrorCalls).toBe(1)
+    // The image was never missing — after healing, no create must happen.
+    expect(pullImageMock).not.toHaveBeenCalled()
+    expect(buildImageMock).not.toHaveBeenCalled()
+    expect(buildExecAttempted()).toBe(false)
+  })
+
+  it('surfaces a runtime-unreachable error (not a build error) when healing fails', async () => {
+    inspectScript = [WEDGED_VM_INSPECT_MSG, WEDGED_VM_INSPECT_MSG]
+    runtimeReachable = false
+    healOnRunError = false
+
+    await expect(makeClient().start()).rejects.toThrow(/runtime unreachable/i)
+
+    expect(pullImageMock).not.toHaveBeenCalled()
+    expect(buildImageMock).not.toHaveBeenCalled()
+    expect(buildExecAttempted()).toBe(false)
+  })
+
+  it('succeeds when a concurrent create produced the image despite our pull failing', async () => {
+    inspectScript = [IMAGE_MISSING_INSPECT_MSG]
+    pullImageMock.mockRejectedValueOnce(new Error('Image pull failed with exit code 1: connection reset'))
+    checkImageExistsMock.mockResolvedValueOnce(true)
+
+    await makeClient().start()
+
+    expect(checkImageExistsMock).toHaveBeenCalledWith('docker', IMAGE)
+  })
+
+  it('propagates the pull error when the image is genuinely missing and the pull fails', async () => {
+    // Both the initial attempt and the post-recovery retry fail the pull.
+    inspectScript = [IMAGE_MISSING_INSPECT_MSG, IMAGE_MISSING_INSPECT_MSG]
+    pullImageMock.mockRejectedValue(new Error('Image pull failed with exit code 1: no route to host'))
+
+    await expect(makeClient().start()).rejects.toThrow(/Image pull failed/i)
+
+    expect(buildImageMock).not.toHaveBeenCalled()
+    expect(buildExecAttempted()).toBe(false)
+  })
+
+  it('refuses to create the image on a nearly-full disk instead of corrupting the store', async () => {
+    inspectScript = [IMAGE_MISSING_INSPECT_MSG, IMAGE_MISSING_INSPECT_MSG]
+    availableDiskBytes = 1 * 1024 * 1024 * 1024
+
+    await expect(makeClient().start()).rejects.toThrow(/Insufficient disk space/i)
+
+    expect(pullImageMock).not.toHaveBeenCalled()
+    expect(buildImageMock).not.toHaveBeenCalled()
+  })
+
+  it('tags create failures so runner heuristics never mistake registry errors for VM issues', async () => {
+    inspectScript = [IMAGE_MISSING_INSPECT_MSG, IMAGE_MISSING_INSPECT_MSG]
+    // Canonical registry-404 text: contains "not found", which Lima/WSL2
+    // handleRunError would otherwise string-match as a VM issue.
+    pullImageMock.mockRejectedValue(new Error('Image pull failed with exit code 1: ghcr.io/x/y:9.9.9: not found'))
+
+    let caught: unknown
+    await makeClient().start().catch((e) => { caught = e })
+
+    expect(caught).toBeInstanceOf(Error)
+    expect((caught as { isImageCreateError?: boolean }).isImageCreateError).toBe(true)
+  })
+
+  it('retries the pull once after the runtime self-heals mid-pull', async () => {
+    // First pass: image missing on a reachable runtime, but the pull fails
+    // (e.g. containerd hiccup). handleRunError() heals; the retry's inspect
+    // still misses so the pull runs again and succeeds.
+    inspectScript = [IMAGE_MISSING_INSPECT_MSG, IMAGE_MISSING_INSPECT_MSG]
+    healOnRunError = true
+    pullImageMock.mockRejectedValueOnce(new Error('Image pull failed with exit code 255'))
+
+    const client = makeClient()
+    // Healing resets inspectScript to [] which would make the retry's inspect
+    // succeed — keep the image missing so the retry exercises the pull.
+    const origHandle = (client as any).handleRunError.bind(client)
+    ;(client as any).handleRunError = async (err: any) => {
+      const result = await origHandle(err)
+      inspectScript = [IMAGE_MISSING_INSPECT_MSG]
+      inspectAttempts = 0
+      return result
+    }
+
+    await client.start()
+
+    expect(pullImageMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/shared/lib/container/lima-container-client.test.ts
+++ b/src/shared/lib/container/lima-container-client.test.ts
@@ -702,6 +702,36 @@ describe('LimaContainerClient.handleRunError', () => {
     expect(execCmds().some((c) => c.includes(' start '))).toBe(false)
   })
 
+  it('treats an untagged "not found" error as a known VM issue (control for the tag below)', async () => {
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 ** 3 }], guestReachable: true })
+    mockFsState({ version: 'v99.0.0', haSockExists: true })
+
+    const recovered = await makeClient().handleRunError(
+      new Error('Image pull failed with exit code 1: ghcr.io/x/y:9.9.9: not found')
+    )
+
+    // String-match short-circuits to ensureLimaReady, which no-ops on the
+    // healthy VM and reports "recovered" — triggering a pointless retry.
+    expect(recovered).toBe(true)
+  })
+
+  it('never treats a registry "not found" from an image create as a VM issue', async () => {
+    mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 ** 3 }], guestReachable: true })
+    mockFsState({ version: 'v99.0.0', haSockExists: true })
+
+    const recovered = await makeClient().handleRunError(
+      Object.assign(new Error('Image pull failed with exit code 1: ghcr.io/x/y:9.9.9: not found'), {
+        isImageCreateError: true,
+        sentryCaptured: true,
+      })
+    )
+
+    // Tagged create errors defer to the health probe; the VM is healthy, so
+    // there is nothing to recover and the pull error surfaces immediately.
+    expect(recovered).toBe(false)
+    expect(execCmds().some((c) => c.includes(' start '))).toBe(false)
+  })
+
   it('does NOT rebuild a wedged VM — recovery surfaces it and reports unrecovered', async () => {
     mockExec({ list: [{ name: LIMA_VM_NAME, status: 'Running', memory: 4 * 1024 ** 3 }], guestReachable: false })
     mockFsState({ version: 'v99.0.0', haSockExists: true, haPid: '777' })

--- a/src/shared/lib/container/lima-container-client.ts
+++ b/src/shared/lib/container/lima-container-client.ts
@@ -488,13 +488,18 @@ export class LimaContainerClient extends BaseContainerClient {
       return false
     }
 
-    const isKnownVmIssue =
+    // Image create (pull/build) failures carry registry-level text ("ghcr.io/
+    // x/y:z: not found") that would false-match the VM-issue patterns below —
+    // for those, only the health probe may decide recovery.
+    const isImageCreateError = error?.isImageCreateError === true
+    const isKnownVmIssue = !isImageCreateError && (
       msg.includes('ENOENT') ||
       msg.includes('not found') ||
       msg.includes('does not exist') ||
       msg.includes('not running') ||
       msg.includes('No such file') ||
       msg.includes('EACCES')
+    )
 
     // Check if the VM is actually unusable — if so, recovery is worth attempting
     // even for unexpected error messages (e.g. "Bad port '0'"). Use the real
@@ -527,10 +532,14 @@ export class LimaContainerClient extends BaseContainerClient {
       }
     }
 
-    captureException(error, {
-      tags: { component: 'lima', operation: 'container-run' },
-      extra: { agentId: this.config.agentId, ...collectLimaDiagnostics() },
-    })
+    // Skip errors whose throw site already captured them (e.g. pullImage) —
+    // re-capturing here inflates event counts without adding signal.
+    if (!error?.sentryCaptured) {
+      captureException(error, {
+        tags: { component: 'lima', operation: 'container-run' },
+        extra: { agentId: this.config.agentId, ...collectLimaDiagnostics() },
+      })
+    }
     return false
   }
 

--- a/src/shared/lib/container/wsl2-container-client.test.ts
+++ b/src/shared/lib/container/wsl2-container-client.test.ts
@@ -752,12 +752,60 @@ describe('WSL2ContainerClient.handleRunError', () => {
     expect(result).toBe(true)
   })
 
-  it('returns false on unrecognized error (e.g., network error)', async () => {
+  /** Health-probe (static isRunning) sequence: wsl --list --verbose, then nerdctl version. */
+  function mockHealthProbe(distroState: 'Running' | 'Stopped') {
+    const header = '  NAME                   STATE           VERSION'
+    const line = `  ${WSL2_DISTRO_NAME.padEnd(23)}${distroState}         2`
+    mockedExecWithPath.mockResolvedValueOnce({ stdout: `${header}\n${line}`, stderr: '' })
+    if (distroState === 'Running') {
+      mockedExecWithPath.mockResolvedValueOnce({ stdout: 'ok', stderr: '' })
+    }
+  }
+
+  it('returns false on unrecognized error when the distro is healthy (probe decides)', async () => {
+    mockHealthProbe('Running')
     const client = createClient()
     const result = await client.testHandleRunError(new Error('Connection refused'))
     expect(result).toBe(false)
-    // Should not have called ensureWSL2Ready
-    expect(mockedExecWithPath).not.toHaveBeenCalled()
+    // Only the two probe commands ran — no provisioning.
+    expect(mockedExecWithPath).toHaveBeenCalledTimes(2)
+  })
+
+  it('provisions on an unrecognized error when the probe finds the distro down', async () => {
+    mockHealthProbe('Stopped')
+    mockEnsureWSL2ReadySuccess()
+    const client = createClient()
+    const result = await client.testHandleRunError(new Error('Connection refused'))
+    expect(result).toBe(true)
+  })
+
+  it('provisions on a tagged image-create failure when the distro died mid-pull', async () => {
+    // The pull error text ("not running") would string-match, but tagged
+    // errors defer to the probe — which finds the distro genuinely down.
+    mockHealthProbe('Stopped')
+    mockEnsureWSL2ReadySuccess()
+    const client = createClient()
+    const result = await client.testHandleRunError(
+      Object.assign(new Error('Image pull failed with exit code 1: The distro is not running'), {
+        isImageCreateError: true,
+        sentryCaptured: true,
+      })
+    )
+    expect(result).toBe(true)
+  })
+
+  it('never provisions for a registry "not found" create failure on a healthy distro', async () => {
+    mockHealthProbe('Running')
+    const client = createClient()
+    const result = await client.testHandleRunError(
+      Object.assign(new Error('Image pull failed with exit code 1: ghcr.io/x/y:9.9.9: not found'), {
+        isImageCreateError: true,
+        sentryCaptured: true,
+      })
+    )
+    expect(result).toBe(false)
+    // Only the two probe commands ran — no provisioning for a registry 404.
+    expect(mockedExecWithPath).toHaveBeenCalledTimes(2)
   })
 
   it('returns false when provisioning fails', async () => {

--- a/src/shared/lib/container/wsl2-container-client.ts
+++ b/src/shared/lib/container/wsl2-container-client.ts
@@ -450,14 +450,18 @@ export class WSL2ContainerClient extends BaseContainerClient {
   protected async handleRunError(error: any): Promise<boolean> {
     const msg = error.message || error.stderr || String(error)
     addErrorBreadcrumb({ category: 'wsl2', message: 'Container run error', data: { error: msg, agentId: this.config.agentId } })
+    // Image create (pull/build) failures carry registry-level text that would
+    // false-match the patterns below — never reprovision the distro for those.
     if (
-      msg.includes('ENOENT') ||
-      msg.includes('not found') ||
-      msg.includes('does not exist') ||
-      msg.includes('not running') ||
-      msg.includes('No such file') ||
-      msg.includes('EACCES') ||
-      msg.includes('is not recognized')
+      error?.isImageCreateError !== true && (
+        msg.includes('ENOENT') ||
+        msg.includes('not found') ||
+        msg.includes('does not exist') ||
+        msg.includes('not running') ||
+        msg.includes('No such file') ||
+        msg.includes('EACCES') ||
+        msg.includes('is not recognized')
+      )
     ) {
       console.log('WSL2 distro not ready, attempting to provision...')
       try {
@@ -472,10 +476,13 @@ export class WSL2ContainerClient extends BaseContainerClient {
         return false
       }
     }
-    captureException(error, {
-      tags: { component: 'wsl2', operation: 'container-run' },
-      extra: { agentId: this.config.agentId, ...collectWSL2Diagnostics() },
-    })
+    // Skip errors whose throw site already captured them (e.g. pullImage).
+    if (!error?.sentryCaptured) {
+      captureException(error, {
+        tags: { component: 'wsl2', operation: 'container-run' },
+        extra: { agentId: this.config.agentId, ...collectWSL2Diagnostics() },
+      })
+    }
     return false
   }
 

--- a/src/shared/lib/container/wsl2-container-client.ts
+++ b/src/shared/lib/container/wsl2-container-client.ts
@@ -451,8 +451,9 @@ export class WSL2ContainerClient extends BaseContainerClient {
     const msg = error.message || error.stderr || String(error)
     addErrorBreadcrumb({ category: 'wsl2', message: 'Container run error', data: { error: msg, agentId: this.config.agentId } })
     // Image create (pull/build) failures carry registry-level text that would
-    // false-match the patterns below — never reprovision the distro for those.
-    if (
+    // false-match the patterns below — for those, only the health probe may
+    // decide recovery.
+    const isKnownVmIssue =
       error?.isImageCreateError !== true && (
         msg.includes('ENOENT') ||
         msg.includes('not found') ||
@@ -462,8 +463,22 @@ export class WSL2ContainerClient extends BaseContainerClient {
         msg.includes('EACCES') ||
         msg.includes('is not recognized')
       )
-    ) {
-      console.log('WSL2 distro not ready, attempting to provision...')
+
+    // Mirror Lima (SUP-291): when the string match doesn't decide — including
+    // tagged image-create errors, whose runtime may have died mid-pull — let
+    // the real health probe decide, so recovery is driven by actual distro
+    // state rather than error text.
+    let distroUnhealthy = false
+    if (!isKnownVmIssue) {
+      try {
+        distroUnhealthy = !(await WSL2ContainerClient.isRunning())
+      } catch {
+        distroUnhealthy = true
+      }
+    }
+
+    if (isKnownVmIssue || distroUnhealthy) {
+      console.log(`WSL2 distro not ready (${distroUnhealthy ? 'unhealthy distro' : 'known issue'}), attempting to provision...`)
       try {
         await ensureWSL2Ready()
         return true


### PR DESCRIPTION
## Problem

Fixes the Sentry cluster ELECTRON-4S (199 events / 21 users), ELECTRON-4T (15 ev / 10 users), and ELECTRON-5B (renderer duplicate of 4T).

`ensureImageExists()` treated **any** `image inspect` failure as "image missing" and fell into a bare `<runner> build -t <image> ./agent-container`. That build is doomed in two distinct ways:

- **Packaged apps** have no build context on disk and the bundled Lima VM has no buildkit → `buildctl not found in $PATH` (4T/5B), every time a release's version-tagged image isn't pulled yet.
- **A wedged/unreachable Lima VM** fails both the inspect and the build with ssh-style exit 255 and empty stderr (4S) — the inspect failure never meant the image was missing at all.

## Fix

`ensureImageExists()` now:

1. **Discriminates runtime-down from image-missing**: on inspect failure, a new `isRuntimeReachable()` (delegates to each subclass's canonical `static isRunning()` — Lima's is the ha.sock-aware health probe) decides. Runtime down → throw runtime-unreachable so `ensureImageExistsWithRecovery()` heals (e.g. `ensureLimaReady`) and retries; the doomed build/pull never runs.
2. **Pulls instead of building in packaged apps**: creation uses the same `canBuildImage() ? buildImage : pullImage` decision as `recreateImage()` (#460) and startup's `ensureImageReady()`.
3. **Runs the startup disk-space pre-flight** (5 GB, shared helper extracted to client-factory) before creating — a full disk mid-unpack is the known corrupt-snapshot vector.
4. **Tolerates concurrent creates**: re-checks `checkImageExists()` after a failed create (startup pull racing a session start), and `pullImage()` now dedupes in-flight pulls of the same image via a shared promise.

## Sentry semantics (from adversarial review)

- Pull/build failures were about to emit up to **3 error events each** on Lima/WSL2 (throw-site capture + `handleRunError` fallthrough + `start()` catch). Errors are now flagged `sentryCaptured` at the canonical throw site and every downstream capture skips them — this also removes the pre-existing double-capture in `ensureImageReady`.
- Registry-level failures ("ghcr.io/x/y:z: **not found**") string-matched Lima/WSL2's known-VM-issue heuristics and triggered a pointless heal + duplicate pull; create errors are now tagged `isImageCreateError` and only the health probe decides recovery.
- Deleted the dead `ImageBuildError` plumbing (stderr/exit-code now ride the image-pull/image-build events).

Known deferral: an in-request session-start pull has no `PULLING_IMAGE` progress broadcast (slow success with a frozen-looking UI). Needs a manager↔client bridge; follow-up.

## Validation

This went through a validation-centric pass:

- **Unit** — new `ensure-image-exists.test.ts` (10 tests) scripting each failure mode with real Sentry-event message shapes: wedged-VM 255 → heal+retry with zero create attempts; missing image → pull (packaged) / build (dev); heal-fails → runtime-unreachable error (not "build failed"); registry 404 tagged `isImageCreateError`; full disk refuses create; concurrent-create rescue; self-heal mid-pull retries once. Plus 2 new Lima `handleRunError` cases (tag honored vs. string-match control). Container suite: **750 passing**; tsc + eslint clean.
- **Adversarial workflow** — 5 reviewers (per-runner regressions, dev-build, recovery-loop termination, Sentry semantics, races/UX) + independent verification of every finding: 6 confirmed (all addressed above except the noted deferral), 3 refuted. Verified: bounded retries (no heal loops), `static isRunning()` dispatch correct for all five runners, `getCliCommand` maps to the same CLIs the clients use, k8s/microvm runtimes never reach this path, in-request pulls can't be aborted mid-flight (slow success, not a new failure).
- **Live on a real machine** (gated `RUN_LIMA_IMAGE_E2E=1` e2e, kept in-repo): against the actual bundled Lima VM with packaged-app semantics — (1) missing image → real registry pull through the nerdctl wrapper, image landed in the containerd store, no build attempted; (2) VM stopped out from under the client → probed unreachable, real heal ran (`limactl start`), inspect retry found the image; 34s end-to-end, no build, no pull.