### PR TITLE
Send agent ID + name as attribution headers on container LLM requests (SUP-396)

### DIFF
--- a/agent-container/src/attribution-headers.test.ts
+++ b/agent-container/src/attribution-headers.test.ts
@@ -1,47 +1,44 @@
 import { describe, it, expect } from 'vitest'
-import { withAgentAttributionHeaders } from './attribution-headers'
+import {
+  withAgentAttributionHeaders,
+  captureAgentIdentity,
+  isAgentIdentityEnvKey,
+} from './attribution-headers'
 
 describe('withAgentAttributionHeaders', () => {
-  it('returns env unchanged when no agent id is present', () => {
+  it('adds no headers when the identity has no agent id', () => {
     const env = { PATH: '/usr/bin', ANTHROPIC_AUTH_TOKEN: 'tok' }
-    expect(withAgentAttributionHeaders(env)).toBe(env)
+    expect(withAgentAttributionHeaders(env, {})).toEqual(env)
   })
 
-  it('returns env unchanged when the id sanitizes to empty', () => {
-    const env = { SUPERAGENT_AGENT_ID: '!!!' }
-    expect(withAgentAttributionHeaders(env)).toBe(env)
+  it('adds no headers when the id sanitizes to empty', () => {
+    const out = withAgentAttributionHeaders({}, { id: '!!!' })
+    expect(out).not.toHaveProperty('ANTHROPIC_CUSTOM_HEADERS')
   })
 
-  it('composes id and name headers', () => {
-    const out = withAgentAttributionHeaders({
-      SUPERAGENT_AGENT_ID: 'abc123',
-      SUPERAGENT_AGENT_NAME: 'My Agent',
-    })
+  it('composes id and name headers from the identity', () => {
+    const out = withAgentAttributionHeaders({}, { id: 'abc123', name: 'My Agent' })
     expect(out.ANTHROPIC_CUSTOM_HEADERS).toBe(
       'X-Superagent-Agent-Id: abc123\nX-Superagent-Agent-Name: My%20Agent'
     )
   })
 
   it('composes only the id header when the name is missing or blank', () => {
+    expect(withAgentAttributionHeaders({}, { id: 'abc123' }).ANTHROPIC_CUSTOM_HEADERS).toBe(
+      'X-Superagent-Agent-Id: abc123'
+    )
     expect(
-      withAgentAttributionHeaders({ SUPERAGENT_AGENT_ID: 'abc123' }).ANTHROPIC_CUSTOM_HEADERS
-    ).toBe('X-Superagent-Agent-Id: abc123')
-    expect(
-      withAgentAttributionHeaders({ SUPERAGENT_AGENT_ID: 'abc123', SUPERAGENT_AGENT_NAME: '  ' })
-        .ANTHROPIC_CUSTOM_HEADERS
+      withAgentAttributionHeaders({}, { id: 'abc123', name: '  ' }).ANTHROPIC_CUSTOM_HEADERS
     ).toBe('X-Superagent-Agent-Id: abc123')
   })
 
   it('strips unsafe characters from the id', () => {
-    const out = withAgentAttributionHeaders({ SUPERAGENT_AGENT_ID: ' ab\nc: 1é ' })
+    const out = withAgentAttributionHeaders({}, { id: ' ab\nc: 1é ' })
     expect(out.ANTHROPIC_CUSTOM_HEADERS).toBe('X-Superagent-Agent-Id: abc1')
   })
 
   it('percent-encodes the name so header values stay ASCII', () => {
-    const out = withAgentAttributionHeaders({
-      SUPERAGENT_AGENT_ID: 'abc123',
-      SUPERAGENT_AGENT_NAME: 'Ünïcode: Bot\u{1F680}',
-    })
+    const out = withAgentAttributionHeaders({}, { id: 'abc123', name: 'Ünïcode: Bot\u{1F680}' })
     const value = out.ANTHROPIC_CUSTOM_HEADERS!.split('\n')[1].replace('X-Superagent-Agent-Name: ', '')
     // eslint-disable-next-line no-control-regex
     expect(value).toMatch(/^[\x21-\x7e]+$/)
@@ -49,39 +46,84 @@ describe('withAgentAttributionHeaders', () => {
   })
 
   it('caps the name at 200 code points without splitting surrogate pairs', () => {
-    const name = '\u{1F680}'.repeat(300)
-    const out = withAgentAttributionHeaders({
-      SUPERAGENT_AGENT_ID: 'abc123',
-      SUPERAGENT_AGENT_NAME: name,
-    })
+    const out = withAgentAttributionHeaders({}, { id: 'abc123', name: '\u{1F680}'.repeat(300) })
     const value = out.ANTHROPIC_CUSTOM_HEADERS!.split('\n')[1].replace('X-Superagent-Agent-Name: ', '')
     expect(decodeURIComponent(value)).toBe('\u{1F680}'.repeat(200))
   })
 
   it('survives lone surrogates in the name', () => {
-    const out = withAgentAttributionHeaders({
-      SUPERAGENT_AGENT_ID: 'abc123',
-      SUPERAGENT_AGENT_NAME: 'bad\uD800name',
-    })
+    const out = withAgentAttributionHeaders({}, { id: 'abc123', name: 'bad\uD800name' })
     const value = out.ANTHROPIC_CUSTOM_HEADERS!.split('\n')[1].replace('X-Superagent-Agent-Name: ', '')
     expect(decodeURIComponent(value)).toBe('bad�name')
   })
 
-  it('appends after an existing ANTHROPIC_CUSTOM_HEADERS value', () => {
-    const out = withAgentAttributionHeaders({
-      SUPERAGENT_AGENT_ID: 'abc123',
-      SUPERAGENT_AGENT_NAME: 'Bot',
-      ANTHROPIC_CUSTOM_HEADERS: 'X-User-Header: keep-me',
-    })
+  it('appends after existing non-attribution ANTHROPIC_CUSTOM_HEADERS lines', () => {
+    const out = withAgentAttributionHeaders(
+      { ANTHROPIC_CUSTOM_HEADERS: 'X-User-Header: keep-me' },
+      { id: 'abc123', name: 'Bot' }
+    )
     expect(out.ANTHROPIC_CUSTOM_HEADERS).toBe(
       'X-User-Header: keep-me\nX-Superagent-Agent-Id: abc123\nX-Superagent-Agent-Name: Bot'
     )
   })
 
+  it('strips forged attribution headers case-insensitively before appending', () => {
+    const out = withAgentAttributionHeaders(
+      {
+        ANTHROPIC_CUSTOM_HEADERS:
+          'x-superagent-agent-id: victim\nX-SUPERAGENT-AGENT-NAME: fake\nX-User-Header: keep-me',
+      },
+      { id: 'real', name: 'Real Bot' }
+    )
+    expect(out.ANTHROPIC_CUSTOM_HEADERS).toBe(
+      'X-User-Header: keep-me\nX-Superagent-Agent-Id: real\nX-Superagent-Agent-Name: Real%20Bot'
+    )
+  })
+
+  it('strips forged attribution headers even when this container has no identity', () => {
+    const out = withAgentAttributionHeaders(
+      { ANTHROPIC_CUSTOM_HEADERS: 'x-superagent-agent-id: victim\nX-User-Header: keep-me' },
+      {}
+    )
+    expect(out.ANTHROPIC_CUSTOM_HEADERS).toBe('X-User-Header: keep-me')
+  })
+
+  it('forces the identity env keys back to their boot values after merges', () => {
+    const out = withAgentAttributionHeaders(
+      { SUPERAGENT_AGENT_ID: 'spoofed', SUPERAGENT_AGENT_NAME: 'Spoofed' },
+      { id: 'real', name: 'Real Bot' }
+    )
+    expect(out.SUPERAGENT_AGENT_ID).toBe('real')
+    expect(out.SUPERAGENT_AGENT_NAME).toBe('Real Bot')
+  })
+
+  it('removes spoofed identity env keys when the boot identity has none', () => {
+    const out = withAgentAttributionHeaders({ SUPERAGENT_AGENT_ID: 'spoofed' }, {})
+    expect(out).not.toHaveProperty('SUPERAGENT_AGENT_ID')
+    expect(out).not.toHaveProperty('ANTHROPIC_CUSTOM_HEADERS')
+  })
+
   it('does not mutate the input env', () => {
-    const env = { SUPERAGENT_AGENT_ID: 'abc123', OTHER: 'v' }
-    const out = withAgentAttributionHeaders(env)
+    const env = { OTHER: 'v' }
+    const out = withAgentAttributionHeaders(env, { id: 'abc123' })
     expect(env).not.toHaveProperty('ANTHROPIC_CUSTOM_HEADERS')
     expect(out.OTHER).toBe('v')
+  })
+})
+
+describe('captureAgentIdentity', () => {
+  it('reads the identity env keys', () => {
+    expect(
+      captureAgentIdentity({ SUPERAGENT_AGENT_ID: 'a1', SUPERAGENT_AGENT_NAME: 'N', OTHER: 'x' })
+    ).toEqual({ id: 'a1', name: 'N' })
+  })
+})
+
+describe('isAgentIdentityEnvKey', () => {
+  it('flags exactly the identity keys', () => {
+    expect(isAgentIdentityEnvKey('SUPERAGENT_AGENT_ID')).toBe(true)
+    expect(isAgentIdentityEnvKey('SUPERAGENT_AGENT_NAME')).toBe(true)
+    expect(isAgentIdentityEnvKey('SUPERAGENT_AGENT_SLUG')).toBe(false)
+    expect(isAgentIdentityEnvKey('PATH')).toBe(false)
   })
 })

--- a/agent-container/src/attribution-headers.test.ts
+++ b/agent-container/src/attribution-headers.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { withAgentAttributionHeaders } from './attribution-headers'
+
+describe('withAgentAttributionHeaders', () => {
+  it('returns env unchanged when no agent id is present', () => {
+    const env = { PATH: '/usr/bin', ANTHROPIC_AUTH_TOKEN: 'tok' }
+    expect(withAgentAttributionHeaders(env)).toBe(env)
+  })
+
+  it('returns env unchanged when the id sanitizes to empty', () => {
+    const env = { SUPERAGENT_AGENT_ID: '!!!' }
+    expect(withAgentAttributionHeaders(env)).toBe(env)
+  })
+
+  it('composes id and name headers', () => {
+    const out = withAgentAttributionHeaders({
+      SUPERAGENT_AGENT_ID: 'abc123',
+      SUPERAGENT_AGENT_NAME: 'My Agent',
+    })
+    expect(out.ANTHROPIC_CUSTOM_HEADERS).toBe(
+      'X-Superagent-Agent-Id: abc123\nX-Superagent-Agent-Name: My%20Agent'
+    )
+  })
+
+  it('composes only the id header when the name is missing or blank', () => {
+    expect(
+      withAgentAttributionHeaders({ SUPERAGENT_AGENT_ID: 'abc123' }).ANTHROPIC_CUSTOM_HEADERS
+    ).toBe('X-Superagent-Agent-Id: abc123')
+    expect(
+      withAgentAttributionHeaders({ SUPERAGENT_AGENT_ID: 'abc123', SUPERAGENT_AGENT_NAME: '  ' })
+        .ANTHROPIC_CUSTOM_HEADERS
+    ).toBe('X-Superagent-Agent-Id: abc123')
+  })
+
+  it('strips unsafe characters from the id', () => {
+    const out = withAgentAttributionHeaders({ SUPERAGENT_AGENT_ID: ' ab\nc: 1é ' })
+    expect(out.ANTHROPIC_CUSTOM_HEADERS).toBe('X-Superagent-Agent-Id: abc1')
+  })
+
+  it('percent-encodes the name so header values stay ASCII', () => {
+    const out = withAgentAttributionHeaders({
+      SUPERAGENT_AGENT_ID: 'abc123',
+      SUPERAGENT_AGENT_NAME: 'Ünïcode: Bot\u{1F680}',
+    })
+    const value = out.ANTHROPIC_CUSTOM_HEADERS!.split('\n')[1].replace('X-Superagent-Agent-Name: ', '')
+    // eslint-disable-next-line no-control-regex
+    expect(value).toMatch(/^[\x21-\x7e]+$/)
+    expect(decodeURIComponent(value)).toBe('Ünïcode: Bot\u{1F680}')
+  })
+
+  it('caps the name at 200 code points without splitting surrogate pairs', () => {
+    const name = '\u{1F680}'.repeat(300)
+    const out = withAgentAttributionHeaders({
+      SUPERAGENT_AGENT_ID: 'abc123',
+      SUPERAGENT_AGENT_NAME: name,
+    })
+    const value = out.ANTHROPIC_CUSTOM_HEADERS!.split('\n')[1].replace('X-Superagent-Agent-Name: ', '')
+    expect(decodeURIComponent(value)).toBe('\u{1F680}'.repeat(200))
+  })
+
+  it('survives lone surrogates in the name', () => {
+    const out = withAgentAttributionHeaders({
+      SUPERAGENT_AGENT_ID: 'abc123',
+      SUPERAGENT_AGENT_NAME: 'bad\uD800name',
+    })
+    const value = out.ANTHROPIC_CUSTOM_HEADERS!.split('\n')[1].replace('X-Superagent-Agent-Name: ', '')
+    expect(decodeURIComponent(value)).toBe('bad�name')
+  })
+
+  it('appends after an existing ANTHROPIC_CUSTOM_HEADERS value', () => {
+    const out = withAgentAttributionHeaders({
+      SUPERAGENT_AGENT_ID: 'abc123',
+      SUPERAGENT_AGENT_NAME: 'Bot',
+      ANTHROPIC_CUSTOM_HEADERS: 'X-User-Header: keep-me',
+    })
+    expect(out.ANTHROPIC_CUSTOM_HEADERS).toBe(
+      'X-User-Header: keep-me\nX-Superagent-Agent-Id: abc123\nX-Superagent-Agent-Name: Bot'
+    )
+  })
+
+  it('does not mutate the input env', () => {
+    const env = { SUPERAGENT_AGENT_ID: 'abc123', OTHER: 'v' }
+    const out = withAgentAttributionHeaders(env)
+    expect(env).not.toHaveProperty('ANTHROPIC_CUSTOM_HEADERS')
+    expect(out.OTHER).toBe('v')
+  })
+})

--- a/agent-container/src/attribution-headers.ts
+++ b/agent-container/src/attribution-headers.ts
@@ -16,40 +16,86 @@
 const AGENT_ID_HEADER = 'X-Superagent-Agent-Id';
 const AGENT_NAME_HEADER = 'X-Superagent-Agent-Name';
 
+/** Env keys carrying the boot-time agent identity. Rejected by POST /env. */
+export const AGENT_IDENTITY_ENV_KEYS = ['SUPERAGENT_AGENT_ID', 'SUPERAGENT_AGENT_NAME'] as const;
+
+export function isAgentIdentityEnvKey(key: string): boolean {
+  return (AGENT_IDENTITY_ENV_KEYS as readonly string[]).includes(key);
+}
+
+// The X-Superagent-Agent-* header namespace is reserved: any pre-existing line
+// claiming it (e.g. a user-configured ANTHROPIC_CUSTOM_HEADERS) is dropped
+// before the trusted values are appended. Matching is case-insensitive —
+// header names are case-insensitive on the wire, so a lowercase forgery would
+// otherwise survive as a separate object key and get merged into a combined
+// `forged, real` value downstream.
+const ATTRIBUTION_HEADER_LINE = /^\s*x-superagent-agent-(id|name)\s*:/i;
+
+export interface AgentIdentity {
+  id?: string;
+  name?: string;
+}
+
+export function captureAgentIdentity(env: Record<string, string | undefined>): AgentIdentity {
+  return { id: env.SUPERAGENT_AGENT_ID, name: env.SUPERAGENT_AGENT_NAME };
+}
+
+// Snapshotted at module load — i.e. at container-server boot, straight from the
+// Docker-injected env — so the identity can't be rewritten later by per-session
+// customEnvVars (spread over process.env in createQuery) or by the runtime
+// POST /env endpoint. Headers are ONLY ever composed from this snapshot.
+const BOOT_IDENTITY: AgentIdentity = captureAgentIdentity(process.env);
+
 // Cap applied to the raw name before encoding, counted in code points so the
 // cut can't split a surrogate pair (encodeURIComponent throws on lone halves).
 const MAX_NAME_CODE_POINTS = 200;
 
 /**
  * Return a copy of `env` with ANTHROPIC_CUSTOM_HEADERS extended with the agent
- * attribution headers, when the identity env vars are present. An existing
- * ANTHROPIC_CUSTOM_HEADERS value (user-configured) is preserved; the
- * attribution headers are appended after it.
+ * attribution headers composed from the boot-time identity snapshot. Any
+ * pre-existing X-Superagent-Agent-* lines are stripped (case-insensitively) and
+ * the identity env keys themselves are forced back to their boot values, so
+ * neither user config nor runtime env mutation can spoof another agent.
+ * Non-attribution user headers are preserved.
  */
 export function withAgentAttributionHeaders(
-  env: Record<string, string | undefined>
+  env: Record<string, string | undefined>,
+  identity: AgentIdentity = BOOT_IDENTITY
 ): Record<string, string | undefined> {
-  const agentId = (env.SUPERAGENT_AGENT_ID ?? '').trim().replace(/[^A-Za-z0-9._-]/g, '');
-  if (!agentId) return env;
+  const out = { ...env };
 
-  const lines = [`${AGENT_ID_HEADER}: ${agentId}`];
+  // Identity env keys always reflect boot state, never a later override.
+  for (const key of AGENT_IDENTITY_ENV_KEYS) delete out[key];
+  if (identity.id !== undefined) out.SUPERAGENT_AGENT_ID = identity.id;
+  if (identity.name !== undefined) out.SUPERAGENT_AGENT_NAME = identity.name;
 
-  const rawName = (env.SUPERAGENT_AGENT_NAME ?? '').trim();
-  if (rawName) {
-    // Replace lone surrogates with U+FFFD (String.prototype.toWellFormed, hand
-    // rolled — the tsconfig lib predates it): encodeURIComponent throws on
-    // them, which would kill header composition entirely.
-    const wellFormed = rawName.replace(
-      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
-      '�'
-    );
-    const capped = Array.from(wellFormed).slice(0, MAX_NAME_CODE_POINTS).join('');
-    lines.push(`${AGENT_NAME_HEADER}: ${encodeURIComponent(capped)}`);
+  const preserved = (env.ANTHROPIC_CUSTOM_HEADERS ?? '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !ATTRIBUTION_HEADER_LINE.test(line));
+
+  const agentId = (identity.id ?? '').trim().replace(/[^A-Za-z0-9._-]/g, '');
+  const lines = [...preserved];
+  if (agentId) {
+    lines.push(`${AGENT_ID_HEADER}: ${agentId}`);
+    const rawName = (identity.name ?? '').trim();
+    if (rawName) {
+      // Replace lone surrogates with U+FFFD (String.prototype.toWellFormed, hand
+      // rolled — the tsconfig lib predates it): encodeURIComponent throws on
+      // them, which would kill header composition entirely.
+      const wellFormed = rawName.replace(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
+        '�'
+      );
+      const capped = Array.from(wellFormed).slice(0, MAX_NAME_CODE_POINTS).join('');
+      lines.push(`${AGENT_NAME_HEADER}: ${encodeURIComponent(capped)}`);
+    }
   }
 
-  const existing = env.ANTHROPIC_CUSTOM_HEADERS?.trim();
-  return {
-    ...env,
-    ANTHROPIC_CUSTOM_HEADERS: existing ? `${existing}\n${lines.join('\n')}` : lines.join('\n'),
-  };
+  if (lines.length > 0) {
+    out.ANTHROPIC_CUSTOM_HEADERS = lines.join('\n');
+  } else {
+    delete out.ANTHROPIC_CUSTOM_HEADERS;
+  }
+  return out;
 }

--- a/agent-container/src/attribution-headers.ts
+++ b/agent-container/src/attribution-headers.ts
@@ -1,0 +1,55 @@
+/**
+ * Agent attribution headers for LLM requests.
+ *
+ * The host injects the agent's identity as plain env vars (SUPERAGENT_AGENT_ID /
+ * SUPERAGENT_AGENT_NAME) rather than a ready-made ANTHROPIC_CUSTOM_HEADERS value:
+ * the container env travels via a Docker --env-file, whose format cannot carry the
+ * newline that separates multiple `Name: Value` pairs. The headers are composed
+ * here instead and handed to the Agent SDK, which forwards them on every request
+ * to ANTHROPIC_BASE_URL (the platform proxy records them for per-agent usage).
+ *
+ * Header values must stay ASCII-safe — undici rejects non-Latin-1 header values,
+ * which would fail every LLM request, so the display name is ALWAYS percent-encoded
+ * (encodeURIComponent) and the consumer decodes unconditionally.
+ */
+
+const AGENT_ID_HEADER = 'X-Superagent-Agent-Id';
+const AGENT_NAME_HEADER = 'X-Superagent-Agent-Name';
+
+// Cap applied to the raw name before encoding, counted in code points so the
+// cut can't split a surrogate pair (encodeURIComponent throws on lone halves).
+const MAX_NAME_CODE_POINTS = 200;
+
+/**
+ * Return a copy of `env` with ANTHROPIC_CUSTOM_HEADERS extended with the agent
+ * attribution headers, when the identity env vars are present. An existing
+ * ANTHROPIC_CUSTOM_HEADERS value (user-configured) is preserved; the
+ * attribution headers are appended after it.
+ */
+export function withAgentAttributionHeaders(
+  env: Record<string, string | undefined>
+): Record<string, string | undefined> {
+  const agentId = (env.SUPERAGENT_AGENT_ID ?? '').trim().replace(/[^A-Za-z0-9._-]/g, '');
+  if (!agentId) return env;
+
+  const lines = [`${AGENT_ID_HEADER}: ${agentId}`];
+
+  const rawName = (env.SUPERAGENT_AGENT_NAME ?? '').trim();
+  if (rawName) {
+    // Replace lone surrogates with U+FFFD (String.prototype.toWellFormed, hand
+    // rolled — the tsconfig lib predates it): encodeURIComponent throws on
+    // them, which would kill header composition entirely.
+    const wellFormed = rawName.replace(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
+      '�'
+    );
+    const capped = Array.from(wellFormed).slice(0, MAX_NAME_CODE_POINTS).join('');
+    lines.push(`${AGENT_NAME_HEADER}: ${encodeURIComponent(capped)}`);
+  }
+
+  const existing = env.ANTHROPIC_CUSTOM_HEADERS?.trim();
+  return {
+    ...env,
+    ANTHROPIC_CUSTOM_HEADERS: existing ? `${existing}\n${lines.join('\n')}` : lines.join('\n'),
+  };
+}

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -43,6 +43,7 @@ function mcpToolNames(
 }
 import { inputManager } from './input-manager';
 import { sanitizeMcpName } from './sanitize-mcp-name';
+import { withAgentAttributionHeaders } from './attribution-headers';
 import { renderPrompt } from './render-prompt';
 import type { AgentCapabilityPolicies } from './types';
 import {
@@ -586,7 +587,10 @@ export class ClaudeCodeProcess extends EventEmitter {
         ...(this.maxTurns && { maxTurns: this.maxTurns }),
         ...(this.maxBudgetUsd && { maxBudgetUsd: this.maxBudgetUsd }),
         ...(this.effort && { effort: this.effort }),
-        env: {
+        // withAgentAttributionHeaders folds the host-injected agent identity env
+        // vars into ANTHROPIC_CUSTOM_HEADERS (composed here, after the custom-env
+        // merge, so a user-set ANTHROPIC_CUSTOM_HEADERS is appended to, not lost).
+        env: withAgentAttributionHeaders({
           // Agent SDK 0.2.113+ replaces process.env with options.env instead of
           // overlaying it, so we must spread process.env explicitly or the Claude
           // subprocess loses PATH, HOME, ANTHROPIC_API_KEY, connected-account env
@@ -601,7 +605,7 @@ export class ClaudeCodeProcess extends EventEmitter {
           CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: '1',
           // Explicit maxOutputTokens setting takes precedence over custom env var
           ...(this.maxOutputTokens && { CLAUDE_CODE_MAX_OUTPUT_TOKENS: String(this.maxOutputTokens) }),
-        },
+        }),
         mcpServers: {
           'user-input': createUserInputMcpServer(),
           'browser': createBrowserMcpServer(browserMcpTools),

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -23,6 +23,7 @@ import { startTabPolling, stopTabPolling } from './tab-poll';
 import { runBrowserUpload } from './browser-upload';
 import { runBrowserDownload } from './browser-download';
 import { updateEnvFileEntry, healEnvFilePermissions } from './env-file-store';
+import { isAgentIdentityEnvKey } from './attribution-headers';
 
 import { getEditingCommands } from './cdp-editing-commands';
 
@@ -398,6 +399,14 @@ app.post('/env', async (c) => {
     if (!/^[A-Z_][A-Z0-9_]*$/i.test(body.key)) {
       console.error(`[ENV] Invalid env var name: ${body.key}`);
       return c.json({ error: 'Invalid environment variable name' }, 400);
+    }
+
+    // The boot-time agent identity must stay immutable — header composition
+    // reads a boot snapshot anyway, but reject the write outright so the env
+    // never lies about which agent this container is.
+    if (isAgentIdentityEnvKey(body.key)) {
+      console.error(`[ENV] Rejected write to reserved identity env var: ${body.key}`);
+      return c.json({ error: `${body.key} is reserved and cannot be modified` }, 403);
     }
 
     // Set the environment variable in process.env (for Node.js code)

--- a/src/shared/lib/container/base-container-client.test.ts
+++ b/src/shared/lib/container/base-container-client.test.ts
@@ -9,8 +9,9 @@ const enableToolSearch = vi.fn((): boolean | undefined => true)
 vi.mock('@shared/lib/config/settings', () => ({
   getSettings: () => ({ enableToolSearch: enableToolSearch() }),
 }))
+const getContainerEnvVars = vi.fn(() => ({ ANTHROPIC_API_KEY: 'provider-key' }))
 vi.mock('@shared/lib/llm-provider', () => ({
-  getActiveLlmProvider: () => ({ getContainerEnvVars: () => ({ ANTHROPIC_API_KEY: 'provider-key' }) }),
+  getActiveLlmProvider: () => ({ getContainerEnvVars }),
 }))
 
 /** Minimal concrete subclass to exercise protected run-error classification. */
@@ -50,6 +51,13 @@ describe('buildAgentEnv', () => {
     enableToolSearch.mockReturnValue(false)
     const env = new TestContainerClient({ agentId: 'a', envVars: {} }).testBuildAgentEnv()
     expect(env.ENABLE_TOOL_SEARCH).toBe('false')
+  })
+
+  it('passes the agent identity to the provider so it can attribute LLM usage', () => {
+    new TestContainerClient({ agentId: 'my-agent', envVars: {} }).testBuildAgentEnv()
+    expect(getContainerEnvVars).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'my-agent' })
+    )
   })
 })
 

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -24,6 +24,8 @@ import { getAgentWorkspaceDir } from '@shared/lib/config/data-dir'
 import { getContainerHostUrl, getAppPort } from '@shared/lib/proxy/host-url'
 import { getAgentCapabilitySettings, getSettings } from '@shared/lib/config/settings'
 import { getActiveLlmProvider } from '@shared/lib/llm-provider'
+import type { AgentIdentity } from '@shared/lib/llm-provider/base-llm-provider'
+import { readAgentDisplayNameSync } from '@shared/lib/utils/file-storage'
 import { resolveContainerModel, getContainerModelPromptHints } from './resolve-model'
 import { getActiveWebProvider } from '../web-provider'
 import { captureException, captureMessage, addErrorBreadcrumb } from '@shared/lib/error-reporting'
@@ -1544,12 +1546,22 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     }
   }
 
+  // Who this container belongs to, for providers that attribute LLM usage per
+  // agent. The display name is re-read from disk on every env build (i.e. each
+  // container start), so a rename takes effect on the next restart.
+  protected agentIdentityForEnv(): AgentIdentity {
+    return {
+      id: this.config.agentId,
+      name: readAgentDisplayNameSync(this.config.agentId),
+    }
+  }
+
   // The final agent env, transport-agnostic; subclasses only serialize it.
   // Merge order: provider defaults < runtime constants < config.envVars < extra.
   protected buildAgentEnv(extra?: Record<string, string>): Record<string, string> {
     const settings = getSettings()
     const merged: Record<string, string | undefined> = {
-      ...getActiveLlmProvider().getContainerEnvVars(),
+      ...getActiveLlmProvider().getContainerEnvVars(this.agentIdentityForEnv()),
       CLAUDE_CONFIG_DIR: '/workspace/.claude',
       ENABLE_TOOL_SEARCH: settings.enableToolSearch !== false ? 'true' : 'false',
       ...this.config.envVars,

--- a/src/shared/lib/container/lima-container-client.ts
+++ b/src/shared/lib/container/lima-container-client.ts
@@ -415,7 +415,7 @@ export class LimaContainerClient extends BaseContainerClient {
    */
   protected buildEnvFile(additionalEnvVars?: Record<string, string>): { flag: string; cleanup: () => void } {
     const envVars: Record<string, string | undefined> = {
-      ...getActiveLlmProvider().getContainerEnvVars(),
+      ...getActiveLlmProvider().getContainerEnvVars(this.agentIdentityForEnv()),
       CLAUDE_CONFIG_DIR: '/workspace/.claude',
       ...this.config.envVars,
       ...additionalEnvVars,

--- a/src/shared/lib/container/reserved-env-vars.ts
+++ b/src/shared/lib/container/reserved-env-vars.ts
@@ -23,6 +23,10 @@ export const RESERVED_ENV_VAR_KEYS: ReadonlySet<string> = new Set([
   'SUPERAGENT_AGENT_SLUG',
   // Host→container API auth (never agent-visible)
   'SUPERAGENT_HOST_TOKEN',
+  // Agent identity for LLM-usage attribution (platform provider injects these;
+  // the container folds them into ANTHROPIC_CUSTOM_HEADERS)
+  'SUPERAGENT_AGENT_ID',
+  'SUPERAGENT_AGENT_NAME',
   // Account + MCP metadata
   'CONNECTED_ACCOUNTS',
   'REMOTE_MCPS',

--- a/src/shared/lib/container/wsl2-container-client.test.ts
+++ b/src/shared/lib/container/wsl2-container-client.test.ts
@@ -42,6 +42,7 @@ vi.mock('./base-container-client', () => ({
   BaseContainerClient: class {
     config: any
     constructor(config: any) { this.config = config }
+    protected agentIdentityForEnv() { return { id: this.config.agentId } }
   },
   checkCommandAvailable: vi.fn(),
   execWithPath: vi.fn(),

--- a/src/shared/lib/container/wsl2-container-client.ts
+++ b/src/shared/lib/container/wsl2-container-client.ts
@@ -429,7 +429,7 @@ export class WSL2ContainerClient extends BaseContainerClient {
    */
   protected buildEnvFile(additionalEnvVars?: Record<string, string>): { flag: string; cleanup: () => void } {
     const envVars: Record<string, string | undefined> = {
-      ...getActiveLlmProvider().getContainerEnvVars(),
+      ...getActiveLlmProvider().getContainerEnvVars(this.agentIdentityForEnv()),
       CLAUDE_CONFIG_DIR: '/workspace/.claude',
       ...this.config.envVars,
       ...additionalEnvVars,

--- a/src/shared/lib/llm-provider/base-llm-provider.ts
+++ b/src/shared/lib/llm-provider/base-llm-provider.ts
@@ -6,6 +6,18 @@ export type LlmProviderId = 'anthropic' | 'openrouter' | 'bedrock' | 'platform' 
 
 export type ModelPurpose = 'agent' | 'summarizer' | 'browser' | 'dashboard'
 
+/**
+ * Identity of the agent a container belongs to, resolved at env-build time.
+ * Providers that attribute usage per agent (the platform proxy) fold it into
+ * the container env; others ignore it.
+ */
+export interface AgentIdentity {
+  /** The agent's unique id (folder slug, minted [a-z0-9]). */
+  id: string
+  /** Display name from frontmatter; free text, may be missing on parse failure. */
+  name?: string
+}
+
 export abstract class BaseLlmProvider {
   abstract readonly id: LlmProviderId
   abstract readonly name: string
@@ -78,7 +90,7 @@ export abstract class BaseLlmProvider {
   }
 
   /** Get env vars to inject into agent containers. */
-  abstract getContainerEnvVars(): Record<string, string | undefined>
+  abstract getContainerEnvVars(agent?: AgentIdentity): Record<string, string | undefined>
 
   /**
    * Validate an API key. `opts.baseUrl` is only meaningful for providers whose

--- a/src/shared/lib/llm-provider/platform-provider.test.ts
+++ b/src/shared/lib/llm-provider/platform-provider.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Stub everything with side effects: attribution pulls in the DB, auth-service
+// reads settings storage, config resolves the proxy URL from the environment.
+const currentAttribution = vi.fn()
+vi.mock('@shared/lib/platform-attribution', () => ({
+  attribution: { current: () => currentAttribution() },
+}))
+vi.mock('@shared/lib/services/platform-auth-service', () => ({
+  getPlatformAccessToken: () => 'platform-token',
+}))
+vi.mock('@shared/lib/platform-auth/config', () => ({
+  getPlatformProxyBaseUrl: () => 'https://proxy.example/v1',
+}))
+vi.mock('../config/settings', () => ({
+  getSettings: () => ({}),
+}))
+vi.mock('@anthropic-ai/sdk', () => ({ default: class {} }))
+
+import { PlatformLlmProvider, sanitizeAgentName } from './platform-provider'
+
+const provider = new PlatformLlmProvider()
+
+beforeEach(() => {
+  currentAttribution.mockReturnValue(null)
+})
+
+describe('getContainerEnvVars agent identity', () => {
+  it('injects agent id and name env vars when identity is provided', () => {
+    const env = provider.getContainerEnvVars({ id: 'abc123', name: 'My Agent' })
+    expect(env.SUPERAGENT_AGENT_ID).toBe('abc123')
+    expect(env.SUPERAGENT_AGENT_NAME).toBe('My Agent')
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('platform-token')
+  })
+
+  it('omits identity env vars when no identity is provided', () => {
+    const env = provider.getContainerEnvVars()
+    expect(env).not.toHaveProperty('SUPERAGENT_AGENT_ID')
+    expect(env).not.toHaveProperty('SUPERAGENT_AGENT_NAME')
+  })
+
+  it('omits the name var when the name is missing or sanitizes to empty', () => {
+    expect(provider.getContainerEnvVars({ id: 'abc123' })).not.toHaveProperty('SUPERAGENT_AGENT_NAME')
+    expect(provider.getContainerEnvVars({ id: 'abc123', name: '\n\t ' })).not.toHaveProperty(
+      'SUPERAGENT_AGENT_NAME'
+    )
+  })
+
+  it('flattens control characters out of the name', () => {
+    const env = provider.getContainerEnvVars({ id: 'abc123', name: 'Multi\nLine\tBot' })
+    expect(env.SUPERAGENT_AGENT_NAME).toBe('Multi Line Bot')
+  })
+})
+
+describe('sanitizeAgentName', () => {
+  it('collapses runs of control chars and spaces to a single space', () => {
+    expect(sanitizeAgentName('a\r\n\r\nb   c')).toBe('a b c')
+  })
+
+  it('caps at 200 code points without splitting surrogate pairs', () => {
+    const out = sanitizeAgentName('\u{1F680}'.repeat(300))
+    expect(out).toBe('\u{1F680}'.repeat(200))
+  })
+})

--- a/src/shared/lib/llm-provider/platform-provider.ts
+++ b/src/shared/lib/llm-provider/platform-provider.ts
@@ -1,5 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk'
-import { BaseLlmProvider, type ModelPurpose } from './base-llm-provider'
+import { BaseLlmProvider, type AgentIdentity, type ModelPurpose } from './base-llm-provider'
 import { rewriteLoopbackForContainer } from './container-url'
 import type { ModelDefinition } from './model-catalog-schema'
 import { PLATFORM_CATALOG } from './builtin-catalogs'
@@ -7,6 +7,16 @@ import { attribution } from '@shared/lib/platform-attribution'
 import { getPlatformAccessToken } from '@shared/lib/services/platform-auth-service'
 import { getPlatformProxyBaseUrl } from '@shared/lib/platform-auth/config'
 import type { ApiKeyStatus } from '../config/settings'
+
+// Display names are user-controlled free text headed for an HTTP header via
+// an env file: collapse control chars (the env-file writer drops \r\n outright,
+// silently corrupting multi-word values otherwise) and cap by code point so a
+// later slice can't split a surrogate pair.
+export function sanitizeAgentName(name: string): string {
+  // eslint-disable-next-line no-control-regex
+  const flattened = name.replace(/[\x00-\x1f\x7f]+/g, ' ').replace(/ {2,}/g, ' ').trim()
+  return Array.from(flattened).slice(0, 200).join('')
+}
 
 export class PlatformLlmProvider extends BaseLlmProvider {
   readonly id = 'platform' as const
@@ -54,17 +64,27 @@ export class PlatformLlmProvider extends BaseLlmProvider {
     }
   }
 
-  getContainerEnvVars(): Record<string, string | undefined> {
+  getContainerEnvVars(agent?: AgentIdentity): Record<string, string | undefined> {
     const proxyUrl = getPlatformProxyBaseUrl()
     const containerUrl = rewriteLoopbackForContainer(proxyUrl)
 
     const auth = attribution.current()
     const authToken = auth?.bearerToken() ?? this.getEffectiveApiKey()
 
+    // Agent identity rides into the container as plain env vars; the container
+    // folds them into ANTHROPIC_CUSTOM_HEADERS itself (see agent-container/src/
+    // attribution-headers.ts) because the env file transport strips newlines,
+    // which the multi-header ANTHROPIC_CUSTOM_HEADERS format needs.
+    const agentName = agent?.name && sanitizeAgentName(agent.name)
+
     return {
       ANTHROPIC_API_KEY: '',
       ANTHROPIC_BASE_URL: containerUrl,
       ANTHROPIC_AUTH_TOKEN: authToken,
+      ...(agent && {
+        SUPERAGENT_AGENT_ID: agent.id,
+        ...(agentName && { SUPERAGENT_AGENT_NAME: agentName }),
+      }),
     }
   }
 

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -28,6 +28,7 @@ import {
   getAgentEnvPath,
   getAgentSessionMetadataPath,
   getAgentClaudeConfigDir,
+  readAgentDisplayNameSync,
   getAgentSessionsDir,
   getSessionJsonlPath,
 } from './file-storage'
@@ -107,6 +108,45 @@ describe('displaySlug', () => {
   it('returns legacy folder ids verbatim — never re-prettified (would break resolution)', () => {
     expect(displaySlug('Renamed Agent', 'untitled-h45k3n')).toBe('untitled-h45k3n')
     expect(displaySlug('Renamed Agent', 'abc123')).toBe('abc123')
+  })
+})
+
+describe('readAgentDisplayNameSync', () => {
+  let prevDataDir: string | undefined
+
+  beforeEach(async () => {
+    prevDataDir = process.env.SUPERAGENT_DATA_DIR
+    process.env.SUPERAGENT_DATA_DIR = testDir
+    await ensureDirectory(getAgentsDir())
+  })
+
+  afterEach(() => {
+    if (prevDataDir === undefined) delete process.env.SUPERAGENT_DATA_DIR
+    else process.env.SUPERAGENT_DATA_DIR = prevDataDir
+  })
+
+  const writeClaudeMd = async (slug: string, frontmatterName: string) => {
+    await ensureDirectory(getAgentWorkspaceDir(slug))
+    await writeFile(getAgentClaudeMdPath(slug), `---\nname: ${frontmatterName}\n---\nBody`)
+  }
+
+  it('reads the display name from frontmatter', async () => {
+    await writeClaudeMd('agent1', 'My Agent')
+    expect(readAgentDisplayNameSync('agent1')).toBe('My Agent')
+  })
+
+  it('coerces YAML-ambiguous names the parser turned into number/boolean', async () => {
+    await writeClaudeMd('agent2', '123')
+    expect(readAgentDisplayNameSync('agent2')).toBe('123')
+    await writeClaudeMd('agent3', 'true')
+    expect(readAgentDisplayNameSync('agent3')).toBe('true')
+  })
+
+  it('returns undefined when the file or name is missing', async () => {
+    expect(readAgentDisplayNameSync('nonexistent')).toBeUndefined()
+    await ensureDirectory(getAgentWorkspaceDir('agent4'))
+    await writeFile(getAgentClaudeMdPath('agent4'), '---\ndescription: no name\n---\nBody')
+    expect(readAgentDisplayNameSync('agent4')).toBeUndefined()
   })
 })
 

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -446,6 +446,24 @@ export function getAgentClaudeMdPath(slug: string): string {
 }
 
 /**
+ * Read an agent's display name straight from its CLAUDE.md frontmatter,
+ * synchronously. Lives here (not agent-service) so the container layer can
+ * resolve the name at env-build time without importing agent-service, which
+ * would close an import cycle back through container-manager.
+ */
+export function readAgentDisplayNameSync(slug: string): string | undefined {
+  try {
+    const content = fs.readFileSync(getAgentClaudeMdPath(slug), 'utf-8')
+    const { frontmatter } = parseMarkdownWithFrontmatter<{ name?: unknown }>(content)
+    return typeof frontmatter.name === 'string' && frontmatter.name.trim()
+      ? frontmatter.name
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Get .env path for agent secrets
  * ~/.superagent/agents/{slug}/workspace/.env
  */

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -455,9 +455,14 @@ export function readAgentDisplayNameSync(slug: string): string | undefined {
   try {
     const content = fs.readFileSync(getAgentClaudeMdPath(slug), 'utf-8')
     const { frontmatter } = parseMarkdownWithFrontmatter<{ name?: unknown }>(content)
-    return typeof frontmatter.name === 'string' && frontmatter.name.trim()
-      ? frontmatter.name
+    // The frontmatter parser coerces YAML-ambiguous scalars ("123", "true") to
+    // number/boolean; those are still legitimate display names, so coerce back.
+    const raw = frontmatter.name
+    const name =
+      typeof raw === 'string' ? raw
+      : typeof raw === 'number' || typeof raw === 'boolean' ? String(raw)
       : undefined
+    return name?.trim() ? name : undefined
   } catch {
     return undefined
   }


### PR DESCRIPTION
## Summary

App side of per-agent LLM cost attribution (SUP-395 / SUP-396): every container-originated request to the platform proxy now carries the agent's identity as custom headers, so the proxy can record per-agent usage (SUP-397).

```
x-superagent-agent-id: tk0mligft9
x-superagent-agent-name: Attribution%20T%C3%ABst%20Agent
```

## Design

One deviation from the ticket: the host does **not** set `ANTHROPIC_CUSTOM_HEADERS` directly. Container env travels via a Docker `--env-file`, and `writeEnvFile` strips `\r\n` from values — the multi-header format needs a newline between pairs and would be silently flattened into one garbage header. Instead:

- **Host** (platform provider only): `getContainerEnvVars(agent?)` gains an optional `AgentIdentity` param and injects plain `SUPERAGENT_AGENT_ID` / `SUPERAGENT_AGENT_NAME` env vars. Other providers ignore the param, so direct-Anthropic/generic endpoints never receive agent names. Identity resolves at env-build time (container start) via a new cycle-free `readAgentDisplayNameSync` in `file-storage.ts`; renames apply on the next container restart (platform side groups by ID with latest-observed name).
- **Container**: new `attribution-headers.ts` composes `ANTHROPIC_CUSTOM_HEADERS` from those vars, appending after any user-set value. The display name is **always percent-encoded** — undici rejects non-Latin-1 header values, which would fail every LLM request for a non-ASCII agent name. Decode contract documented on SUP-397.
- Both keys added to `RESERVED_ENV_VAR_KEYS` so custom env config can't spoof attribution.
- All runtimes covered: docker/k8s/lambda via `buildAgentEnv`, plus the lima/wsl2 `buildEnvFile` overrides.

Deferred: host-originated calls (session-naming summarizer etc. via `getConfiguredLlmClient()`) send no headers and will show as "Unattributed" — they're app overhead, not agent traffic.

## Testing

- Unit: header composition (10 tests — encoding, capping, lone surrogates, user-header append), provider injection/sanitization (6), `buildAgentEnv` identity passthrough.
- Full suites green: agent-container 642, host container 738, llm-provider 297; `tsc` + eslint clean in both packages.
- **Live E2E**: built the container image from this branch, ran a scratch app instance against a logging MITM proxy in front of the real platform proxy; verified both headers on `POST /v1/messages` (values above), 200 responses, and agent reply — and that the host summarizer path is header-less as expected.