### PR TITLE
feat: stall watchdog for image pulls on nerdctl runners

### DIFF
--- a/src/shared/lib/container/client-factory.test.ts
+++ b/src/shared/lib/container/client-factory.test.ts
@@ -117,6 +117,7 @@ import {
   clearRunnerAvailabilityCache,
   pullImage,
   PULL_STALL_TIMEOUT_MS,
+  KILL_STALLED_PULL_TIMEOUT_MS,
   reconcileRunnerState,
   restartRunner,
   shutdownActiveRunner,
@@ -476,6 +477,33 @@ describe('pullImage stall watchdog', () => {
     await assertion
 
     expect(mockCaptureException).toHaveBeenCalledOnce()
+  })
+
+  it('settles the pull even when killStalledPull hangs forever', async () => {
+    // Unresponsive WSL: the cleanup promise never settles
+    mockKillWSL2PullProcesses.mockReturnValue(new Promise(() => {}))
+
+    const promise = pullImage('wsl2', 'ghcr.io/acme/agent:stall-6')
+    const assertion = expect(promise).rejects.toThrow('Image pull stalled')
+
+    await vi.advanceTimersByTimeAsync(PULL_STALL_TIMEOUT_MS + 1)
+    // Pull must not be settled yet — cleanup is still within its time cap
+    expect(proc.kill).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(KILL_STALLED_PULL_TIMEOUT_MS + 1)
+    await assertion
+    expect(proc.kill).toHaveBeenCalled()
+  })
+
+  it('rejects with the stall error even when killStalledPull fails', async () => {
+    mockKillWSL2PullProcesses.mockRejectedValue(new Error('WSL has terminated'))
+
+    const promise = pullImage('wsl2', 'ghcr.io/acme/agent:stall-7')
+    const assertion = expect(promise).rejects.toThrow('Image pull stalled')
+
+    await vi.advanceTimersByTimeAsync(PULL_STALL_TIMEOUT_MS + 1)
+    await assertion
+    expect(proc.kill).toHaveBeenCalled()
   })
 
   it('still rejects with the exit-code error when a wsl2 pull fails before the timeout', async () => {

--- a/src/shared/lib/container/client-factory.test.ts
+++ b/src/shared/lib/container/client-factory.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { EventEmitter } from 'node:events'
 
 // ============================================================================
 // Mocks — must be set up before importing the module under test
@@ -46,6 +47,7 @@ vi.mock('./apple-container-client', () => ({
 
 const mockStopWSL2Distro = vi.fn()
 const mockEnsureWSL2Ready = vi.fn()
+const mockKillWSL2PullProcesses = vi.fn()
 
 vi.mock('./wsl2-container-client', () => ({
   WSL2ContainerClient: {
@@ -56,6 +58,7 @@ vi.mock('./wsl2-container-client', () => ({
   getWSL2NerdctlWrapperPath: vi.fn(() => 'C:\\mock\\wsl-nerdctl.cmd'),
   ensureWSL2Ready: (...args: unknown[]) => mockEnsureWSL2Ready(...args),
   stopWSL2Distro: (...args: unknown[]) => mockStopWSL2Distro(...args),
+  killWSL2PullProcesses: (...args: unknown[]) => mockKillWSL2PullProcesses(...args),
 }))
 
 vi.mock('./mock-container-client', () => ({
@@ -100,12 +103,20 @@ vi.mock('os', () => ({
   platform: vi.fn(() => 'darwin'),
 }))
 
+const mockCaptureException = vi.fn()
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+  addErrorBreadcrumb: vi.fn(),
+}))
+
 // ============================================================================
 // Import module under test — AFTER mocks
 // ============================================================================
 
 import {
   clearRunnerAvailabilityCache,
+  pullImage,
+  PULL_STALL_TIMEOUT_MS,
   reconcileRunnerState,
   restartRunner,
   shutdownActiveRunner,
@@ -386,5 +397,94 @@ describe('image pull progress patterns', () => {
       const percent = total > 0 ? Math.round((0 / total) * 100) : null
       expect(percent).toBeNull()
     })
+  })
+})
+
+// ============================================================================
+// pullImage stall watchdog — silence beyond pullStallTimeoutMs kills the pull
+// (host proc + runner-side processes) and rejects so the caller can retry.
+// Only runners that opt in (nerdctl-based) have a timeout; docker/podman are
+// legitimately silent for minutes mid-layer and must never be killed.
+// ============================================================================
+
+describe('pullImage stall watchdog', () => {
+  class FakePullProc extends EventEmitter {
+    stdout = new EventEmitter()
+    stderr = new EventEmitter()
+    kill = vi.fn()
+  }
+
+  let proc: FakePullProc
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    proc = new FakePullProc()
+    mockSpawnWithPath.mockReturnValue(proc)
+    mockKillWSL2PullProcesses.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('kills a wsl2 pull and rejects after prolonged output silence', async () => {
+    const promise = pullImage('wsl2', 'ghcr.io/acme/agent:stall-1')
+    const assertion = expect(promise).rejects.toThrow('Image pull stalled')
+
+    await vi.advanceTimersByTimeAsync(PULL_STALL_TIMEOUT_MS + 1)
+    await assertion
+
+    expect(mockKillWSL2PullProcesses).toHaveBeenCalledOnce()
+    expect(proc.kill).toHaveBeenCalled()
+    expect(mockCaptureException).toHaveBeenCalledOnce()
+    expect(mockCaptureException.mock.calls[0][1]).toMatchObject({
+      tags: { component: 'container', operation: 'image-pull-stall' },
+    })
+  })
+
+  it('resets the stall timer whenever the CLI produces output', async () => {
+    const promise = pullImage('wsl2', 'ghcr.io/acme/agent:stall-2')
+
+    await vi.advanceTimersByTimeAsync(PULL_STALL_TIMEOUT_MS - 1000)
+    proc.stdout.emit('data', Buffer.from('layer-sha256:abc123: downloading\n'))
+    await vi.advanceTimersByTimeAsync(PULL_STALL_TIMEOUT_MS - 1000)
+    expect(proc.kill).not.toHaveBeenCalled()
+
+    proc.emit('close', 0)
+    await expect(promise).resolves.toBeUndefined()
+    expect(mockCaptureException).not.toHaveBeenCalled()
+  })
+
+  it('does not arm a watchdog for docker (silence is normal mid-layer)', async () => {
+    const promise = pullImage('docker', 'ghcr.io/acme/agent:stall-3')
+
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000)
+    expect(proc.kill).not.toHaveBeenCalled()
+    expect(mockKillWSL2PullProcesses).not.toHaveBeenCalled()
+
+    proc.emit('close', 0)
+    await expect(promise).resolves.toBeUndefined()
+  })
+
+  it('does not double-report when the killed process exits after the stall', async () => {
+    const promise = pullImage('wsl2', 'ghcr.io/acme/agent:stall-4')
+    const assertion = expect(promise).rejects.toThrow('Image pull stalled')
+
+    await vi.advanceTimersByTimeAsync(PULL_STALL_TIMEOUT_MS + 1)
+    proc.emit('close', 1)
+    await assertion
+
+    expect(mockCaptureException).toHaveBeenCalledOnce()
+  })
+
+  it('still rejects with the exit-code error when a wsl2 pull fails before the timeout', async () => {
+    const promise = pullImage('wsl2', 'ghcr.io/acme/agent:stall-5')
+    const assertion = expect(promise).rejects.toThrow('Image pull failed with exit code 1')
+
+    proc.emit('close', 1)
+    await assertion
+
+    expect(mockKillWSL2PullProcesses).not.toHaveBeenCalled()
   })
 })

--- a/src/shared/lib/container/client-factory.ts
+++ b/src/shared/lib/container/client-factory.ts
@@ -4,7 +4,7 @@ import { DockerContainerClient } from './docker-container-client'
 import { PodmanContainerClient } from './podman-container-client'
 import { AppleContainerClient } from './apple-container-client'
 import { LimaContainerClient, getNerdctlWrapperPath, ensureLimaReady, stopLimaVm } from './lima-container-client'
-import { WSL2ContainerClient, getWSL2NerdctlWrapperPath, ensureWSL2Ready, stopWSL2Distro } from './wsl2-container-client'
+import { WSL2ContainerClient, getWSL2NerdctlWrapperPath, ensureWSL2Ready, stopWSL2Distro, killWSL2PullProcesses } from './wsl2-container-client'
 import { PlatformK8sRuntimeClient } from './platform-k8s-runtime'
 import { LambdaMicroVmRuntimeClient } from './lambda-microvm-runtime'
 import { RunnerSetupError, type RunnerSetupRemediation } from './wsl2-setup-errors'
@@ -16,6 +16,14 @@ import * as fs from 'fs'
 import { statfs } from 'fs/promises'
 
 export type ContainerRunner = 'docker' | 'podman' | 'apple-container' | 'lima' | 'wsl2' | 'kubernetes' | 'lambda-microvm'
+
+/**
+ * How long a pull may go without any CLI output before the stall watchdog
+ * kills it (only on runners that opt in via pullStallTimeoutMs). Observed
+ * failure mode: a half-dead HTTPS connection to the registry CDN that stops
+ * delivering bytes but never times out, freezing the pull forever mid-layer.
+ */
+export const PULL_STALL_TIMEOUT_MS = 120_000
 
 export interface RunnerAvailability {
   runner: ContainerRunner
@@ -52,12 +60,26 @@ const ALL_RUNNERS: {
   isRunning: () => Promise<boolean>
   /** Optional cleanup when the app is shutting down (e.g., stop a VM). */
   shutdownRuntime?: () => Promise<void>
+  /**
+   * For CLIs that stream continuous progress output (nerdctl): max output
+   * silence before a pull is declared stalled, killed, and left to the caller
+   * to retry. Leave unset for CLIs that are legitimately quiet for minutes
+   * mid-layer (docker, podman print nothing between layer status changes).
+   */
+  pullStallTimeoutMs?: number
+  /**
+   * Kill pull processes that outlive the host-side CLI process (e.g. nerdctl
+   * inside the WSL2 distro survives its wsl.exe parent and keeps holding
+   * containerd's ingest lock, wedging every later pull of that image).
+   * Invoked by the stall watchdog before killing the local process.
+   */
+  killStalledPull?: () => Promise<void>
 }[] = [
   { name: 'apple-container', cliCommand: 'container', isEligible: () => AppleContainerClient.isEligible(), isAvailable: () => AppleContainerClient.isAvailable(), isRunning: () => AppleContainerClient.isRunning(), shutdownRuntime: () => execWithPath('container system stop').then(() => {}) },
   { name: 'docker', cliCommand: 'docker', isEligible: () => DockerContainerClient.isEligible(), isAvailable: () => DockerContainerClient.isAvailable(), isRunning: () => DockerContainerClient.isRunning() },
   { name: 'podman', cliCommand: 'podman', isEligible: () => PodmanContainerClient.isEligible(), isAvailable: () => PodmanContainerClient.isAvailable(), isRunning: () => PodmanContainerClient.isRunning() },
   { name: 'lima', cliCommand: () => getNerdctlWrapperPath(), isEligible: () => LimaContainerClient.isEligible(), isAvailable: () => LimaContainerClient.isAvailable(), reconcileRuntimeState: () => LimaContainerClient.reconcileRuntimeState(), isRunning: () => LimaContainerClient.isRunning(), shutdownRuntime: () => stopLimaVm() },
-  { name: 'wsl2', cliCommand: () => getWSL2NerdctlWrapperPath(), isEligible: () => WSL2ContainerClient.isEligible(), isAvailable: () => WSL2ContainerClient.isAvailable(), isRunning: () => WSL2ContainerClient.isRunning(), shutdownRuntime: () => stopWSL2Distro() },
+  { name: 'wsl2', cliCommand: () => getWSL2NerdctlWrapperPath(), isEligible: () => WSL2ContainerClient.isEligible(), isAvailable: () => WSL2ContainerClient.isAvailable(), isRunning: () => WSL2ContainerClient.isRunning(), shutdownRuntime: () => stopWSL2Distro(), pullStallTimeoutMs: PULL_STALL_TIMEOUT_MS, killStalledPull: () => killWSL2PullProcesses() },
   { name: 'kubernetes', cliCommand: 'kubernetes', isEligible: () => PlatformK8sRuntimeClient.isEligible(), isAvailable: () => PlatformK8sRuntimeClient.isAvailable(), isRunning: () => PlatformK8sRuntimeClient.isRunning() },
   { name: 'lambda-microvm', cliCommand: 'lambda-microvm', isEligible: () => LambdaMicroVmRuntimeClient.isEligible(), isAvailable: () => LambdaMicroVmRuntimeClient.isAvailable(), isRunning: () => LambdaMicroVmRuntimeClient.isRunning() },
 ]
@@ -457,7 +479,54 @@ function doPullImage(
     // eslint-disable-next-line no-control-regex
     const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '')
 
+    // Stall watchdog. nerdctl redraws its progress bars continuously, so
+    // prolonged output silence means the download is wedged (observed in the
+    // field: a half-dead registry-CDN connection that stops delivering bytes
+    // but never times out, freezing the pull mid-layer forever). Only runners
+    // that opt in via pullStallTimeoutMs get the watchdog — docker/podman
+    // print nothing between layer status changes, so silence is normal there.
+    const runnerEntry = ALL_RUNNERS.find((r) => r.name === runner)
+    const stallTimeoutMs = runnerEntry?.pullStallTimeoutMs
+    let stallTimer: ReturnType<typeof setTimeout> | undefined
+    let stallError: Error | undefined
+    const onStall = async () => {
+      // sentryCaptured: canonical event for the failure, like the exit-code
+      // path below — callers up the stack must not re-capture it.
+      stallError = Object.assign(
+        new Error(`Image pull stalled: no progress output for ${Math.round(stallTimeoutMs! / 1000)}s while pulling ${image}`),
+        { sentryCaptured: true }
+      )
+      captureException(stallError, {
+        tags: { component: 'container', operation: 'image-pull-stall' },
+        extra: {
+          image,
+          runner,
+          stallTimeoutMs,
+          completedLayers: completedLayers.size,
+          totalLayers: allLayers.size,
+        },
+      })
+      // Kill the runner-side pull first: for wsl2 the real nerdctl runs inside
+      // the distro and survives proc.kill() of the host-side wrapper, keeping
+      // containerd's ingest lock held — a retry would wedge behind it.
+      try {
+        await runnerEntry?.killStalledPull?.()
+      } catch (err) {
+        console.warn(`[pullImage] killStalledPull failed for ${runner}:`, err)
+      }
+      proc.kill()
+      reject(stallError)
+    }
+    const armStallTimer = () => {
+      if (!stallTimeoutMs) return
+      clearTimeout(stallTimer)
+      stallTimer = setTimeout(() => { void onStall() }, stallTimeoutMs)
+    }
+    armStallTimer()
+
     const handleData = (data: Buffer) => {
+      if (stallError) return
+      armStallTimer()
       const text = stripAnsi(data.toString())
       const lines = text.split('\n')
       for (const line of lines) {
@@ -508,6 +577,12 @@ function doPullImage(
     })
 
     proc.on('close', (code) => {
+      clearTimeout(stallTimer)
+      if (stallError) {
+        // The watchdog already rejected and reported; this exit is just the
+        // kill landing.
+        return
+      }
       if (code === 0) {
         addErrorBreadcrumb({ category: 'container', message: 'Image pull completed', data: { image, runner } })
         resolve()
@@ -533,6 +608,7 @@ function doPullImage(
       }
     })
     proc.on('error', (err) => {
+      clearTimeout(stallTimer)
       captureException(err, {
         tags: { component: 'container', operation: 'image-pull-spawn' },
         extra: { image, runner },

--- a/src/shared/lib/container/client-factory.ts
+++ b/src/shared/lib/container/client-factory.ts
@@ -25,6 +25,13 @@ export type ContainerRunner = 'docker' | 'podman' | 'apple-container' | 'lima' |
  */
 export const PULL_STALL_TIMEOUT_MS = 120_000
 
+/**
+ * Hard cap on killStalledPull() cleanup. An unresponsive runtime (e.g. a hung
+ * wsl.exe) must not wedge the pull promise — and with it the retry loop —
+ * forever; the watchdog settles the pull once this expires.
+ */
+export const KILL_STALLED_PULL_TIMEOUT_MS = 10_000
+
 export interface RunnerAvailability {
   runner: ContainerRunner
   /** Whether the CLI is installed and found in PATH */
@@ -508,14 +515,27 @@ function doPullImage(
       })
       // Kill the runner-side pull first: for wsl2 the real nerdctl runs inside
       // the distro and survives proc.kill() of the host-side wrapper, keeping
-      // containerd's ingest lock held — a retry would wedge behind it.
+      // containerd's ingest lock held — a retry would wedge behind it. The
+      // cleanup itself is time-capped: if the runtime is unresponsive, the
+      // pull must still settle so the retry loop isn't stuck forever.
+      let killTimer: ReturnType<typeof setTimeout> | undefined
       try {
-        await runnerEntry?.killStalledPull?.()
+        await Promise.race([
+          Promise.resolve(runnerEntry?.killStalledPull?.()),
+          new Promise<never>((_, rejectTimeout) => {
+            killTimer = setTimeout(
+              () => rejectTimeout(new Error(`killStalledPull timed out after ${KILL_STALLED_PULL_TIMEOUT_MS}ms`)),
+              KILL_STALLED_PULL_TIMEOUT_MS
+            )
+          }),
+        ])
       } catch (err) {
         console.warn(`[pullImage] killStalledPull failed for ${runner}:`, err)
+      } finally {
+        clearTimeout(killTimer)
+        proc.kill()
+        reject(stallError)
       }
-      proc.kill()
-      reject(stallError)
     }
     const armStallTimer = () => {
       if (!stallTimeoutMs) return

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -757,6 +757,54 @@ describe('containerManager.ensureImageReady — state machine', () => {
     expect(readiness.message).toContain('Network timeout pulling image')
   })
 
+  it('retries a stalled pull and reaches READY when the retry succeeds', async () => {
+    vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
+      { runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },
+    ])
+    vi.mocked(checkImageExists).mockResolvedValue(false)
+    vi.mocked(canBuildImage).mockReturnValue(false)
+    vi.mocked(pullImage)
+      .mockRejectedValueOnce(new Error('Image pull stalled: no progress output for 120s while pulling img'))
+      .mockResolvedValueOnce(undefined)
+
+    // Fake timers to skip the retry backoff delay
+    vi.useFakeTimers()
+    try {
+      const promise = containerManager.ensureImageReady()
+      await vi.advanceTimersByTimeAsync(10_000)
+      await promise
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect(pullImage).toHaveBeenCalledTimes(2)
+    expect(containerManager.getReadiness().status).toBe('READY')
+  })
+
+  it('transitions to ERROR when the pull keeps stalling after all retries', async () => {
+    vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
+      { runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },
+    ])
+    vi.mocked(checkImageExists).mockResolvedValue(false)
+    vi.mocked(canBuildImage).mockReturnValue(false)
+    vi.mocked(pullImage).mockRejectedValue(new Error('Image pull stalled: no progress output for 120s while pulling img'))
+
+    vi.useFakeTimers()
+    try {
+      const promise = containerManager.ensureImageReady()
+      await vi.advanceTimersByTimeAsync(20_000)
+      await promise
+    } finally {
+      vi.useRealTimers()
+    }
+
+    // Initial attempt + MAX_PULL_RETRIES retries
+    expect(pullImage).toHaveBeenCalledTimes(3)
+    const readiness = containerManager.getReadiness()
+    expect(readiness.status).toBe('ERROR')
+    expect(readiness.message).toContain('Image pull stalled')
+  })
+
   it('transitions to ERROR when build fails', async () => {
     vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
       { runner: 'docker', installed: true, running: true, available: true, canStart: false, supportsCustomAgentImage: true },

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -1028,6 +1028,14 @@ class ContainerManager {
       return msg.includes('exit code 255') || msg.includes('kex_exchange_identification') || msg.includes('Connection reset by peer')
     }
 
+    // Pulls killed by the stall watchdog (pullImage in client-factory) are
+    // retryable: the registry content store keeps completed layers, so a
+    // retry resumes roughly where the wedged download stopped.
+    const isRetryablePullError = (error: unknown): boolean => {
+      const msg = error instanceof Error ? error.message : String(error)
+      return isTransientSshError(error) || msg.includes('Image pull stalled')
+    }
+
     const doImageAction = (onProgress: (progress: ImagePullProgress) => void) => {
       const imageAction = shouldBuild ? buildImage : pullImage
       return imageAction(effectiveRunner, image, onProgress)
@@ -1069,8 +1077,8 @@ class ContainerManager {
       } catch (error) {
         const errMsg = error instanceof Error ? error.message : String(error)
 
-        // Only retry transient SSH errors for pull operations (not builds)
-        if (!shouldBuild && attempt < MAX_PULL_RETRIES && isTransientSshError(error)) {
+        // Only retry transient errors for pull operations (not builds)
+        if (!shouldBuild && attempt < MAX_PULL_RETRIES && isRetryablePullError(error)) {
           console.warn(`[ContainerManager] Image pull failed (attempt ${attempt + 1}/${MAX_PULL_RETRIES + 1}), retrying in ${RETRY_DELAY_MS}ms:`, errMsg)
           addErrorBreadcrumb({ category: 'container', message: 'Image pull transient failure, will retry', data: { attempt, errMsg, runner: effectiveRunner } })
 

--- a/src/shared/lib/container/wsl2-container-client.test.ts
+++ b/src/shared/lib/container/wsl2-container-client.test.ts
@@ -1017,8 +1017,26 @@ describe('killWSL2PullProcesses', () => {
   })
 
   it('resolves quietly when no pull process matched (pkill exit 1)', async () => {
-    vi.mocked(execWithPath).mockRejectedValue(new Error('Command failed: pkill -f "nerdctl [p]ull"'))
+    vi.mocked(execWithPath).mockRejectedValue(
+      Object.assign(new Error('Command failed: pkill -f "nerdctl [p]ull"'), { code: 1 })
+    )
 
     await expect(killWSL2PullProcesses()).resolves.toBeUndefined()
+  })
+
+  it('rethrows failures other than pkill no-match (e.g. WSL not responding)', async () => {
+    vi.mocked(execWithPath).mockRejectedValue(
+      Object.assign(new Error('The Windows Subsystem for Linux instance has terminated.'), { code: 4294967295 })
+    )
+
+    await expect(killWSL2PullProcesses()).rejects.toThrow('has terminated')
+  })
+
+  it('rethrows spawn failures without a numeric exit code', async () => {
+    vi.mocked(execWithPath).mockRejectedValue(
+      Object.assign(new Error('spawn wsl ENOENT'), { code: 'ENOENT' })
+    )
+
+    await expect(killWSL2PullProcesses()).rejects.toThrow('ENOENT')
   })
 })

--- a/src/shared/lib/container/wsl2-container-client.test.ts
+++ b/src/shared/lib/container/wsl2-container-client.test.ts
@@ -77,6 +77,7 @@ import {
   WSL2ContainerClient,
   classifyProbeCurlExit,
   classifyProbeWgetResult,
+  killWSL2PullProcesses,
 } from './wsl2-container-client'
 
 const mockedFs = vi.mocked(fs)
@@ -991,5 +992,33 @@ describe('WSL2ContainerClient.probeHostPortFromRunner', () => {
     )
 
     expect(await createClient().probeHostPortFromRunner('172.22.192.1', 9222)).toBe('unknown')
+  })
+})
+
+// ============================================================================
+// killWSL2PullProcesses — clears in-distro nerdctl pulls that outlive their
+// host-side wsl.exe parent (they hold containerd's ingest lock, wedging any
+// subsequent pull of the same image). Called by the pull stall watchdog.
+// ============================================================================
+
+describe('killWSL2PullProcesses', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('pkills nerdctl pull processes inside the distro', async () => {
+    vi.mocked(execWithPath).mockResolvedValue({ stdout: '', stderr: '' })
+
+    await killWSL2PullProcesses()
+
+    expect(execWithPath).toHaveBeenCalledWith(
+      `wsl -d ${WSL2_DISTRO_NAME} -- pkill -f "nerdctl [p]ull"`
+    )
+  })
+
+  it('resolves quietly when no pull process matched (pkill exit 1)', async () => {
+    vi.mocked(execWithPath).mockRejectedValue(new Error('Command failed: pkill -f "nerdctl [p]ull"'))
+
+    await expect(killWSL2PullProcesses()).resolves.toBeUndefined()
   })
 })

--- a/src/shared/lib/container/wsl2-container-client.ts
+++ b/src/shared/lib/container/wsl2-container-client.ts
@@ -289,8 +289,12 @@ function execWSL(args: string): Promise<{ stdout: string; stderr: string }> {
 export async function killWSL2PullProcesses(): Promise<void> {
   try {
     await execWSL('pkill -f "nerdctl [p]ull"')
-  } catch {
-    // pkill exits 1 when no process matched — nothing to kill is fine.
+  } catch (err) {
+    // pkill exits 1 when no process matched — nothing to kill is fine. Any
+    // other failure (WSL not responding, pkill missing, permissions) must
+    // surface to the caller so it isn't silently mistaken for a clean kill.
+    if ((err as { code?: number | string })?.code === 1) return
+    throw err
   }
 }
 

--- a/src/shared/lib/container/wsl2-container-client.ts
+++ b/src/shared/lib/container/wsl2-container-client.ts
@@ -280,6 +280,21 @@ function execWSL(args: string): Promise<{ stdout: string; stderr: string }> {
 }
 
 /**
+ * Kill any nerdctl pull processes running inside the distro. A pull spawned
+ * through the wrapper outlives its host-side wsl.exe parent, and a wedged one
+ * keeps holding containerd's ingest lock, so every subsequent pull hangs
+ * silently behind it. The pull stall watchdog calls this before retrying.
+ * The [p] regex trick stops pkill from matching its own command line.
+ */
+export async function killWSL2PullProcesses(): Promise<void> {
+  try {
+    await execWSL('pkill -f "nerdctl [p]ull"')
+  } catch {
+    // pkill exits 1 when no process matched — nothing to kill is fine.
+  }
+}
+
+/**
  * Parse wsl --list --verbose output into distro status objects.
  * WSL outputs UTF-16LE on Windows, so we strip null bytes.
  */


### PR DESCRIPTION
## Problem

An image pull can freeze forever mid-layer when the connection to the registry CDN goes half-dead: the TCP connection stays ESTABLISHED, no bytes flow, and neither side ever times out. Observed live today on Windows/WSL2 pulling `agent-container-base:0.4.12-rc.2` — `nerdctl pull` idle for 10+ minutes at 83%, one ESTABLISHED connection to GitHub's blob CDN with empty send/receive queues, content store frozen.

Worse, **restarting the app doesn't recover**: the in-distro `nerdctl` survives its `wsl.exe` parent, and the wedged pull keeps holding containerd's ingest lock — so the relaunched app's new pull silently queues behind it forever.

## Fix

- **`pullImage()` stall watchdog** (`client-factory.ts`): kills the pull after **120s with zero CLI output**, reports to Sentry (`operation: image-pull-stall`), and rejects with a retryable error. Runners opt in via `pullStallTimeoutMs` in the runner registry — only nerdctl streams continuous progress redraws, so silence there really means stalled. **docker/podman stay opted out**: their non-TTY output is legitimately silent for minutes mid-layer, and a watchdog would kill healthy slow pulls (docker also restarts partial layers on retry, so that could loop).
- **In-distro kill for wsl2** (`killWSL2PullProcesses()`): on stall, `pkill -f "nerdctl [p]ull"` inside the distro *before* killing the host-side wrapper — releasing the ingest lock. This also clears pulls orphaned by an app quit (today's exact "relaunch didn't help" case: a fresh pull stalls silently behind the orphan, the watchdog fires, the pkill clears both, the retry succeeds).
- **Retry integration** (`container-manager.ts`): stall errors join transient SSH errors as retryable. containerd's content store keeps completed layers, so retries resume roughly where the download stopped (verified live: the re-pull resumed from ~4.3 GB cached and finished in under a minute).

Lima also runs nerdctl and shares the stall exposure, but is left out for now: its kill semantics (host wrapper → `limactl shell` → VM-side nerdctl) are unverified, and a kill that leaves a lock-holding orphan would make retries worse than the status quo. Follow-up candidate.

## Verification

- 169 tests pass across the three touched test files (5 new watchdog tests with fake timers, 2 retry state-machine tests, 2 pkill tests).
- `pkill -f` pattern quoting through `wsl.exe` verified against the live `superagent` distro (busybox pkill present, regex `[p]` self-exclusion trick works, no-match exits 1).
- `npx tsc --noEmit` — only the known pre-existing `auth/index.ts` failure. eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)