### PR TITLE
fix: self-heal corrupt skillset caches via nuke-and-reclone, keep offline refreshes quiet

### DIFF
--- a/src/shared/lib/services/skillset-service.test.ts
+++ b/src/shared/lib/services/skillset-service.test.ts
@@ -13,6 +13,20 @@ import type {
 // Hoisted Mocks
 // ============================================================================
 
+const mockCaptureException = vi.hoisted(() => vi.fn())
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: mockCaptureException,
+  captureMessage: vi.fn(),
+  addErrorBreadcrumb: vi.fn(),
+  setErrorTag: vi.fn(),
+  setErrorContext: vi.fn(),
+  setErrorReportingUser: vi.fn(),
+  initErrorReporting: vi.fn(),
+  getErrorReporter: vi.fn(() => null),
+  flushErrorReporting: vi.fn(async () => true),
+}))
+
 const { mockExecFile, mockAnthropicCreate, mockGetApiKey, mockGetModels } = vi.hoisted(() => {
   const mockExecFile = vi.fn<
     (cmd: string, args: string[], opts?: unknown) =>
@@ -845,7 +859,7 @@ Instructions here`
       expect(updated.originalContentHash).toBe(hashTestSkillPackage({ 'SKILL.md': skillContent }))
     })
 
-    it('gitPull reports unexpected fetch errors to Sentry', async () => {
+    it('gitPull keeps the stale cache quietly when the fetch fails offline', async () => {
       const skillContent = '# Test Skill\nOriginal content'
       const meta = buildMetadata({ originalContentHash: contentHash(skillContent) })
       const config = buildSkillsetConfig()
@@ -865,9 +879,188 @@ Instructions here`
         return { stdout: '', stderr: '' }
       })
 
+      // Remote unavailable is environmental — no Sentry report, refresh keeps
+      // serving the stale cache.
+      await expect(refreshAgentSkills('test-agent', [config])).resolves.toBeUndefined()
+      expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+
+    it('gitPull reports unexpected fetch errors to Sentry', async () => {
+      const skillContent = '# Test Skill\nOriginal content'
+      const meta = buildMetadata({ originalContentHash: contentHash(skillContent) })
+      const config = buildSkillsetConfig()
+      const index = buildIndex({
+        skills: [{ name: 'Test Skill', path: meta.skillPath, description: 'desc', version: '1.0.0' }],
+      })
+      await createSkillDir('test-agent', 'test-skill', skillContent, meta)
+      await createSkillsetCache(config.id, index, { [meta.skillPath]: skillContent })
+
+      mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'symbolic-ref') {
+          return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
+        }
+        if (cmd === 'git' && args[0] === 'fetch') {
+          throw new Error('fatal: index-pack failed')
+        }
+        return { stdout: '', stderr: '' }
+      })
+
       // Unexpected errors are surfaced (captured + rethrown) but refreshAgentSkills
       // catches per-skillset so the overall call still resolves.
       await expect(refreshAgentSkills('test-agent', [config])).resolves.toBeUndefined()
+      expect(mockCaptureException).toHaveBeenCalled()
+    })
+  })
+
+  // ============================================================================
+  // Cache Corruption Recovery (nuke-and-reclone)
+  // ============================================================================
+
+  describe('skillset cache corruption recovery', () => {
+    function buildRef(config: SkillsetConfig) {
+      return {
+        skillsetId: config.id,
+        skillsetUrl: config.url,
+        provider: config.provider,
+        providerData: config.providerData,
+      }
+    }
+
+    /** Mock a clone that materializes a healthy repo (with index.json). */
+    function mockCloneMaterializing(index: SkillsetIndex | null, cloneCalls: string[]) {
+      return (cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'clone') {
+          const dest = args[4]
+          cloneCalls.push(dest)
+          fs.mkdirSync(path.join(dest, '.git'), { recursive: true })
+          if (index) {
+            fs.writeFileSync(path.join(dest, 'index.json'), JSON.stringify(index), 'utf-8')
+          }
+          return { stdout: '', stderr: '' }
+        }
+        return null
+      }
+    }
+
+    it('nukes and re-clones a half-cloned cache when origin/HEAD is unresolvable and the remote answers', async () => {
+      const config = buildSkillsetConfig()
+      const index = buildIndex()
+      // Half-cloned cache: .git exists but the tree is empty (no index.json).
+      const repoDir = getSkillsetRepoDir(config.id)
+      await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true })
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const cloneCalls: string[] = []
+      const clone = mockCloneMaterializing(index, cloneCalls)
+      mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'symbolic-ref') {
+          throw new Error('fatal: ref refs/remotes/origin/HEAD is not a symbolic ref')
+        }
+        if (cmd === 'git' && args[0] === 'remote' && args[1] === 'set-head') {
+          throw new Error('error: Cannot determine remote HEAD')
+        }
+        return clone(cmd, args) ?? { stdout: '', stderr: '' }
+      })
+
+      await expect(refreshSkillset(buildRef(config))).resolves.toEqual(index)
+      expect(cloneCalls).toEqual([repoDir])
+      // The set-head failure is logged, not silently swallowed.
+      expect(warnSpy.mock.calls.some(
+        (c) => String(c[0]).includes('set-head') && String(c[1]).includes('Cannot determine remote HEAD'),
+      )).toBe(true)
+      warnSpy.mockRestore()
+    })
+
+    it('serves the stale cache without nuking when origin/HEAD is unresolvable offline', async () => {
+      const config = buildSkillsetConfig()
+      const index = buildIndex()
+      await createSkillsetCache(config.id, index)
+
+      const gitCalls: string[][] = []
+      mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+        gitCalls.push([cmd, ...args])
+        if (cmd === 'git' && args[0] === 'symbolic-ref') {
+          throw new Error('fatal: ref refs/remotes/origin/HEAD is not a symbolic ref')
+        }
+        if (cmd === 'git' && args[0] === 'remote' && args[1] === 'set-head') {
+          throw new Error("fatal: unable to access 'https://github.com/TestOrg/skills/': Could not resolve host: github.com")
+        }
+        return { stdout: '', stderr: '' }
+      })
+
+      await expect(refreshSkillset(buildRef(config))).resolves.toEqual(index)
+      expect(gitCalls.some((c) => c[1] === 'clone')).toBe(false)
+      expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+
+    it('does not nuke an incomplete cache while the remote is unavailable, and skips Sentry', async () => {
+      const config = buildSkillsetConfig()
+      const repoDir = getSkillsetRepoDir(config.id)
+      await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true })
+
+      const gitCalls: string[][] = []
+      mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+        gitCalls.push([cmd, ...args])
+        if (cmd === 'git' && args[0] === 'symbolic-ref') {
+          throw new Error('fatal: ref refs/remotes/origin/HEAD is not a symbolic ref')
+        }
+        if (cmd === 'git' && args[0] === 'remote' && args[1] === 'set-head') {
+          throw new Error("fatal: unable to access 'https://github.com/TestOrg/skills/': Could not resolve host: github.com")
+        }
+        return { stdout: '', stderr: '' }
+      })
+
+      await expect(refreshSkillset(buildRef(config))).rejects.toThrow(/remote is unreachable/)
+      // Cache untouched — recovery is deferred to a refresh with connectivity.
+      expect(fs.existsSync(path.join(repoDir, '.git'))).toBe(true)
+      expect(gitCalls.some((c) => c[1] === 'clone')).toBe(false)
+
+      // Through refreshAgentSkills the failure is per-skillset and not reported.
+      await expect(refreshAgentSkills('test-agent', [config])).resolves.toBeUndefined()
+      expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+
+    it('re-clones when a successful pull still leaves the cache without index.json', async () => {
+      const config = buildSkillsetConfig()
+      const index = buildIndex()
+      const repoDir = getSkillsetRepoDir(config.id)
+      await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true })
+
+      const cloneCalls: string[] = []
+      const clone = mockCloneMaterializing(index, cloneCalls)
+      mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'symbolic-ref') {
+          return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
+        }
+        return clone(cmd, args) ?? { stdout: '', stderr: '' }
+      })
+
+      await expect(refreshSkillset(buildRef(config))).resolves.toEqual(index)
+      expect(cloneCalls).toEqual([repoDir])
+    })
+
+    it('throws a distinct error when the re-cloned repo still has no index.json', async () => {
+      const config = buildSkillsetConfig()
+      const repoDir = getSkillsetRepoDir(config.id)
+      await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true })
+
+      const cloneCalls: string[] = []
+      // Clone "succeeds" but the repo genuinely has no index.json (e.g. an
+      // empty platform skillset repo) — that's a remote-content problem, not
+      // a cache problem, and must not loop into further re-clones.
+      const clone = mockCloneMaterializing(null, cloneCalls)
+      mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'symbolic-ref') {
+          throw new Error('fatal: ref refs/remotes/origin/HEAD is not a symbolic ref')
+        }
+        if (cmd === 'git' && args[0] === 'remote' && args[1] === 'set-head') {
+          throw new Error('error: Cannot determine remote HEAD')
+        }
+        return clone(cmd, args) ?? { stdout: '', stderr: '' }
+      })
+
+      await expect(refreshSkillset(buildRef(config))).rejects.toThrow(/has no index\.json at its root/)
+      expect(cloneCalls).toEqual([repoDir])
     })
   })
 

--- a/src/shared/lib/services/skillset-service.test.ts
+++ b/src/shared/lib/services/skillset-service.test.ts
@@ -69,7 +69,13 @@ vi.mock('child_process', () => {
     const result = await mockExecFile(...callArgs)
     return { stdout: result?.stdout ?? '', stderr: result?.stderr ?? '' }
   }
-  return { execFile: execFileFn }
+  return {
+    execFile: execFileFn,
+    // The platform provider probes git availability with execFileSync at
+    // module load to pick git-clone vs archive caching. Succeed so tests
+    // exercise the git path, matching machines with git installed.
+    execFileSync: () => '',
+  }
 })
 
 vi.mock('@anthropic-ai/sdk', () => ({
@@ -92,6 +98,7 @@ vi.mock('@shared/lib/config/settings', () => ({
 // Bypass retry delays in tests
 vi.mock('@shared/lib/utils/retry', () => ({
   withRetry: async (fn: () => Promise<unknown>) => fn(),
+  NonRetryableError: class NonRetryableError extends Error {},
 }))
 
 const mockGetPlatformAuthStatus = vi.fn(
@@ -1061,6 +1068,105 @@ Instructions here`
 
       await expect(refreshSkillset(buildRef(config))).rejects.toThrow(/has no index\.json at its root/)
       expect(cloneCalls).toEqual([repoDir])
+    })
+
+    it('treats a set-head killed by its timeout as remote-unavailable, not corruption', async () => {
+      const config = buildSkillsetConfig()
+      const index = buildIndex()
+      await createSkillsetCache(config.id, index)
+
+      const gitCalls: string[][] = []
+      mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+        gitCalls.push([cmd, ...args])
+        if (cmd === 'git' && args[0] === 'symbolic-ref') {
+          throw new Error('fatal: ref refs/remotes/origin/HEAD is not a symbolic ref')
+        }
+        if (cmd === 'git' && args[0] === 'remote' && args[1] === 'set-head') {
+          // Node's execFile timeout kill: bare "Command failed" message, the
+          // evidence lives only in killed/signal metadata.
+          throw Object.assign(new Error('Command failed: git remote set-head origin --auto\n'), {
+            killed: true,
+            signal: 'SIGTERM',
+            code: null,
+          })
+        }
+        return { stdout: '', stderr: '' }
+      })
+
+      // A hung network op must never delete a healthy cache.
+      await expect(refreshSkillset(buildRef(config))).resolves.toEqual(index)
+      expect(gitCalls.some((c) => c[1] === 'clone')).toBe(false)
+      expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+
+    it('recovers a cache whose origin remote is missing via nuke-and-reclone', async () => {
+      const config = buildSkillsetConfig()
+      const index = buildIndex()
+      await createSkillsetCache(config.id, index)
+
+      const cloneCalls: string[] = []
+      const clone = mockCloneMaterializing(index, cloneCalls)
+      mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'remote' && args[1] === 'set-url') {
+          throw new Error("error: No such remote 'origin'")
+        }
+        return clone(cmd, args) ?? { stdout: '', stderr: '' }
+      })
+
+      await expect(refreshSkillset(buildRef(config))).resolves.toEqual(index)
+      expect(cloneCalls).toEqual([getSkillsetRepoDir(config.id)])
+    })
+
+    it('platform: offline git-url resolution skips Sentry and keeps the cache', async () => {
+      mockGetPlatformAuthStatus.mockReturnValue({ connected: true, source: 'settings', orgId: 'org_A' })
+      const config = buildSkillsetConfig({
+        id: 'platform--repo--test',
+        provider: 'platform',
+        providerData: { orgId: 'org_A', repoId: 'platform--repo' },
+      })
+      const index = buildIndex()
+      await createSkillsetCache('platform--repo', index)
+
+      const platformAuthMod = await import('@shared/lib/services/platform-auth-service')
+      vi.mocked(platformAuthMod.getPlatformAccessToken).mockReturnValue('plat_test_xx')
+      const proxyMod = await import('@shared/lib/platform-auth/config')
+      vi.mocked(proxyMod.getPlatformProxyBaseUrl).mockReturnValue('https://platform.example')
+
+      // Undici's offline shape: "fetch failed" with the errno only on cause.
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(Object.assign(new TypeError('fetch failed'), {
+        cause: Object.assign(new Error('getaddrinfo ENOTFOUND platform.example'), { code: 'ENOTFOUND' }),
+      })))
+
+      await expect(refreshAgentSkills('test-agent', [config])).resolves.toBeUndefined()
+      vi.unstubAllGlobals()
+
+      expect(mockCaptureException).not.toHaveBeenCalled()
+      expect(fs.existsSync(path.join(getSkillsetRepoDir('platform--repo'), '.git'))).toBe(true)
+    })
+
+    it('platform: expired-auth git-url resolution (401) skips Sentry', async () => {
+      mockGetPlatformAuthStatus.mockReturnValue({ connected: true, source: 'settings', orgId: 'org_A' })
+      const config = buildSkillsetConfig({
+        id: 'platform--repo--test',
+        provider: 'platform',
+        providerData: { orgId: 'org_A', repoId: 'platform--repo' },
+      })
+      await createSkillsetCache('platform--repo', buildIndex())
+
+      const platformAuthMod = await import('@shared/lib/services/platform-auth-service')
+      vi.mocked(platformAuthMod.getPlatformAccessToken).mockReturnValue('plat_test_xx')
+      const proxyMod = await import('@shared/lib/platform-auth/config')
+      vi.mocked(proxyMod.getPlatformProxyBaseUrl).mockReturnValue('https://platform.example')
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false, status: 401, statusText: 'Unauthorized',
+        json: async () => ({}), text: async () => '',
+      }))
+
+      await expect(refreshAgentSkills('test-agent', [config])).resolves.toBeUndefined()
+      vi.unstubAllGlobals()
+
+      expect(mockCaptureException).not.toHaveBeenCalled()
     })
   })
 

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -444,7 +444,38 @@ function isExpectedGitDriftError(msg: string): boolean {
  * nuke-and-reclone and are not worth reporting to Sentry per-refresh.
  */
 function isRemoteUnavailableGitError(msg: string): boolean {
-  return /Could not resolve host|unable to access|Connection (timed out|refused|reset)|Network is unreachable|Could not read from remote|Failed to connect|Operation timed out|timed? ?out|Permission denied|Could not access repository|remote is unreachable/i.test(msg)
+  return /Could not resolve host|unable to access|Connection (timed out|refused|reset)|Network is unreachable|Could not read from remote|Failed to connect|Operation timed out|timed? ?out|Permission denied|Could not access repository|remote is unreachable|fetch failed|Failed to get platform Git URL: (401|403|407|408|429|5\d\d)|Not authorized to download platform skillset|Platform not connected|Platform server error while downloading/i.test(msg)
+}
+
+const NETWORK_ERROR_CODES = new Set([
+  'ENOTFOUND', 'EAI_AGAIN', 'ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT',
+  'ENETUNREACH', 'ENETDOWN', 'EHOSTUNREACH', 'EPIPE',
+  'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_SOCKET',
+])
+
+/** Walk error → cause → AggregateError.errors looking for a network errno. */
+function hasNetworkErrorCode(error: unknown, depth = 0): boolean {
+  if (!error || typeof error !== 'object' || depth > 4) return false
+  const e = error as { code?: unknown; cause?: unknown; errors?: unknown }
+  if (typeof e.code === 'string' && NETWORK_ERROR_CODES.has(e.code)) return true
+  if (Array.isArray(e.errors) && e.errors.some((sub) => hasNetworkErrorCode(sub, depth + 1))) return true
+  return hasNetworkErrorCode(e.cause, depth + 1)
+}
+
+/**
+ * Object-aware remote-unavailability check. The message alone is not enough:
+ * an execFile timeout kills the child (`killed`/`signal` set) with a bare
+ * "Command failed: git …" message, and undici surfaces DNS failures as
+ * "fetch failed" with the errno only on `cause`.
+ */
+function isRemoteUnavailableError(error: unknown): boolean {
+  if (error && typeof error === 'object') {
+    const e = error as { killed?: unknown; signal?: unknown }
+    if (e.killed === true || (typeof e.signal === 'string' && e.signal.length > 0)) return true
+    if (hasNetworkErrorCode(error)) return true
+  }
+  const msg = error instanceof Error ? error.message : String(error)
+  return isRemoteUnavailableGitError(msg)
 }
 
 /**
@@ -488,29 +519,33 @@ async function resolveDefaultBranch(repoDir: string): Promise<DefaultBranchResol
   if (existing) return { branch: existing }
 
   // The symref isn't set locally — ask the remote for its HEAD once, then
-  // re-read. The failure detail matters: it tells offline apart from a cache
-  // whose origin/HEAD genuinely can't be resolved (half-clone, empty repo).
-  let setHeadError: string | null = null
+  // re-read. The failure matters: it tells offline apart from a cache whose
+  // origin/HEAD genuinely can't be resolved (half-clone, empty repo). Keep
+  // the error object, not just its message — a hung set-head killed by the
+  // execFile timeout only carries `killed`/`signal`, not a network message.
+  let setHeadError: unknown = null
   try {
     await execFileAsync('git', ['remote', 'set-head', 'origin', '--auto'], {
       cwd: repoDir, timeout: 10000, env: GIT_ENV,
     })
   } catch (err) {
-    setHeadError = err instanceof Error ? err.message : String(err)
-    console.warn(`[resolveDefaultBranch] set-head --auto failed in ${repoDir}:`, setHeadError)
+    setHeadError = err
+    console.warn(
+      `[resolveDefaultBranch] set-head --auto failed in ${repoDir}:`,
+      err instanceof Error ? err.message : String(err),
+    )
   }
 
   const branch = await readSymref()
   if (branch) return { branch }
 
-  if (setHeadError && isRemoteUnavailableGitError(setHeadError)) {
-    return { branch: null, reason: 'offline', detail: setHeadError }
+  const detail = setHeadError instanceof Error
+    ? setHeadError.message
+    : setHeadError ? String(setHeadError) : 'origin/HEAD still unset after set-head --auto'
+  if (setHeadError && isRemoteUnavailableError(setHeadError)) {
+    return { branch: null, reason: 'offline', detail }
   }
-  return {
-    branch: null,
-    reason: 'unresolvable',
-    detail: setHeadError ?? 'origin/HEAD still unset after set-head --auto',
-  }
+  return { branch: null, reason: 'unresolvable', detail }
 }
 
 type GitPullResult = 'pulled' | 'skipped-offline'
@@ -571,8 +606,8 @@ async function gitPull(repoDir: string): Promise<GitPullResult> {
       console.warn(`[gitPull] fetch/reset drift (recoverable) in ${repoDir}:`, msg)
       return 'pulled'
     }
-    if (isRemoteUnavailableGitError(msg)) {
-      // Offline/auth — the stale cache remains usable; skip quietly.
+    if (isRemoteUnavailableError(error)) {
+      // Offline/auth/timeout — the stale cache remains usable; skip quietly.
       console.warn(`[gitPull] Remote unavailable; keeping stale cache in ${repoDir}:`, msg)
       return 'skipped-offline'
     }
@@ -770,16 +805,22 @@ async function refreshSkillsetCache(
     // For platform, the URL embeds a short-lived token that needs refreshing.
     // For github, set-url is a cheap no-op when unchanged.
     const freshUrl = await hostingProvider.resolveCloneUrl(ref.skillsetUrl, ref)
-    await execFileAsync('git', ['remote', 'set-url', 'origin', freshUrl], {
-      cwd: repoDir, timeout: 5000, env: GIT_ENV,
-    })
 
     let pullResult: GitPullResult
     try {
+      // A cache whose `origin` remote is missing entirely (interrupted clone,
+      // mangled config) fails set-url with "No such remote" — that's the same
+      // corrupt-cache shape as an unresolvable origin/HEAD, so it recovers
+      // through the same nuke-and-reclone.
+      await execFileAsync('git', ['remote', 'set-url', 'origin', freshUrl], {
+        cwd: repoDir, timeout: 5000, env: GIT_ENV,
+      })
       pullResult = await gitPull(repoDir)
     } catch (error) {
-      if (!(error instanceof SkillsetCacheCorruptError)) throw error
-      await recloneSkillsetCache(ref, repoDir, error.message)
+      const msg = error instanceof Error ? error.message : String(error)
+      const isCorrupt = error instanceof SkillsetCacheCorruptError || /No such remote/i.test(msg)
+      if (!isCorrupt) throw error
+      await recloneSkillsetCache(ref, repoDir, msg)
       return readIndexJson(repoDir)
     }
 
@@ -1157,7 +1198,7 @@ export async function refreshAgentSkills(
     } catch (error) {
       console.warn(`Failed to refresh skillset ${ss.id}:`, error)
       const msg = error instanceof Error ? error.message : String(error)
-      if (!isExpectedGitDriftError(msg) && !isRemoteUnavailableGitError(msg)) {
+      if (!isExpectedGitDriftError(msg) && !isRemoteUnavailableError(error)) {
         captureException(error, { tags: { area: 'skillset-refresh', op: 'pull' }, extra: { skillsetId: ss.id } })
       }
     }
@@ -1216,7 +1257,7 @@ export async function refreshAgentSkills(
             await refreshSkillset(toSkillsetRefFromMeta(meta))
           } catch (error) {
             const msg = error instanceof Error ? error.message : String(error)
-            if (!isExpectedGitDriftError(msg) && !isRemoteUnavailableGitError(msg)) {
+            if (!isExpectedGitDriftError(msg) && !isRemoteUnavailableError(error)) {
               captureException(error, { tags: { area: 'skillset-refresh', op: 'queue-merged-pull' }, extra: { skillsetId: meta.skillsetId } })
             }
           }

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -438,12 +438,39 @@ function isExpectedGitDriftError(msg: string): boolean {
 }
 
 /**
+ * Git errors that mean the remote is unavailable to us right now — offline,
+ * DNS/connect failures, timeouts, or auth problems. These are environmental,
+ * not a sign the local cache is corrupt, so they must never trigger a
+ * nuke-and-reclone and are not worth reporting to Sentry per-refresh.
+ */
+function isRemoteUnavailableGitError(msg: string): boolean {
+  return /Could not resolve host|unable to access|Connection (timed out|refused|reset)|Network is unreachable|Could not read from remote|Failed to connect|Operation timed out|timed? ?out|Permission denied|Could not access repository|remote is unreachable/i.test(msg)
+}
+
+/**
+ * Thrown when the remote is reachable but the cache is unusable as a git
+ * clone (no resolvable origin/HEAD). Signals `refreshSkillsetCache` to nuke
+ * the directory and re-clone instead of failing every refresh forever.
+ */
+class SkillsetCacheCorruptError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SkillsetCacheCorruptError'
+  }
+}
+
+type DefaultBranchResolution =
+  | { branch: string }
+  | { branch: null; reason: 'offline' | 'unresolvable'; detail: string }
+
+/**
  * Resolve the repo's real default branch from its origin remote. Falls back to
  * `set-head --auto` (which queries the remote's HEAD) when the local
  * `refs/remotes/origin/HEAD` symref is missing — common on shallow clones.
- * Returns null if it can't be determined.
+ * When it can't be determined, says whether that's because the remote is
+ * unavailable (offline/auth) or the cache itself is unresolvable.
  */
-async function resolveDefaultBranch(repoDir: string): Promise<string | null> {
+async function resolveDefaultBranch(repoDir: string): Promise<DefaultBranchResolution> {
   const readSymref = async (): Promise<string | null> => {
     try {
       const { stdout } = await execFileAsync(
@@ -458,37 +485,56 @@ async function resolveDefaultBranch(repoDir: string): Promise<string | null> {
   }
 
   const existing = await readSymref()
-  if (existing) return existing
+  if (existing) return { branch: existing }
 
   // The symref isn't set locally — ask the remote for its HEAD once, then
-  // re-read. `set-head --auto` is a no-op if it can't reach the remote.
+  // re-read. The failure detail matters: it tells offline apart from a cache
+  // whose origin/HEAD genuinely can't be resolved (half-clone, empty repo).
+  let setHeadError: string | null = null
   try {
     await execFileAsync('git', ['remote', 'set-head', 'origin', '--auto'], {
       cwd: repoDir, timeout: 10000, env: GIT_ENV,
     })
-  } catch {
-    // Ignore — readSymref below will return null and the caller handles it.
+  } catch (err) {
+    setHeadError = err instanceof Error ? err.message : String(err)
+    console.warn(`[resolveDefaultBranch] set-head --auto failed in ${repoDir}:`, setHeadError)
   }
-  return readSymref()
+
+  const branch = await readSymref()
+  if (branch) return { branch }
+
+  if (setHeadError && isRemoteUnavailableGitError(setHeadError)) {
+    return { branch: null, reason: 'offline', detail: setHeadError }
+  }
+  return {
+    branch: null,
+    reason: 'unresolvable',
+    detail: setHeadError ?? 'origin/HEAD still unset after set-head --auto',
+  }
 }
 
-async function gitPull(repoDir: string): Promise<void> {
+type GitPullResult = 'pulled' | 'skipped-offline'
+
+async function gitPull(repoDir: string): Promise<GitPullResult> {
   // Resolve the repo's real default branch instead of guessing main/master.
   // After a PR flow the repo may be left on a detached HEAD, a stale branch,
   // or with a drifted branch.<name>.merge config.
-  const defaultBranch = await resolveDefaultBranch(repoDir)
+  const resolved = await resolveDefaultBranch(repoDir)
 
-  if (!defaultBranch) {
-    // Without a known default branch we can't deterministically refresh. This
-    // happens on caches whose origin/HEAD can't be resolved (offline, etc.).
-    const msg = `[gitPull] Could not resolve default branch in ${repoDir}`
-    console.warn(msg)
-    captureException(new Error(msg), {
-      tags: { area: 'skillset-git', op: 'resolve-default-branch' },
-      extra: { repoDir },
-    })
-    return
+  if (resolved.branch === null) {
+    if (resolved.reason === 'offline') {
+      // Remote unavailable — the cache is stale but usable; skip quietly.
+      console.warn(`[gitPull] Remote unavailable; skipping refresh in ${repoDir}:`, resolved.detail)
+      return 'skipped-offline'
+    }
+    // The remote answered (or the symref is simply broken) yet origin/HEAD is
+    // unresolvable — a half-cloned or corrupted cache that will never heal on
+    // its own. Let the caller nuke and re-clone.
+    throw new SkillsetCacheCorruptError(
+      `Could not resolve default branch in ${repoDir}: ${resolved.detail}`,
+    )
   }
+  const defaultBranch = resolved.branch
 
   try {
     await execFileAsync('git', ['checkout', defaultBranch], {
@@ -523,11 +569,17 @@ async function gitPull(repoDir: string): Promise<void> {
       // Expected drift on shallow single-branch caches — already handled, no
       // user-facing impact, so don't report to Sentry.
       console.warn(`[gitPull] fetch/reset drift (recoverable) in ${repoDir}:`, msg)
-      return
+      return 'pulled'
+    }
+    if (isRemoteUnavailableGitError(msg)) {
+      // Offline/auth — the stale cache remains usable; skip quietly.
+      console.warn(`[gitPull] Remote unavailable; keeping stale cache in ${repoDir}:`, msg)
+      return 'skipped-offline'
     }
     captureException(error, { tags: { area: 'skillset-git', op: 'fetch-reset' }, extra: { repoDir } })
     throw error
   }
+  return 'pulled'
 }
 
 async function isGitRepo(dir: string): Promise<boolean> {
@@ -684,6 +736,25 @@ export async function refreshSkillset(ref: SkillsetRef): Promise<SkillsetIndex> 
   }
 }
 
+/**
+ * Nuke a corrupt git cache and re-clone it from scratch. A half-cloned cache
+ * (no resolvable origin/HEAD, or `.git` present with an empty tree) makes
+ * every refresh fail forever; the cache holds nothing of value, so recovery
+ * is a fresh clone. Throws a distinct error if the freshly cloned repo still
+ * has no index.json — that means the remote content itself is broken, not
+ * the cache.
+ */
+async function recloneSkillsetCache(ref: SkillsetRef, repoDir: string, cause: string): Promise<void> {
+  console.warn(`[refreshSkillset] Re-cloning corrupt skillset cache at ${repoDir}: ${cause}`)
+  await fs.promises.rm(repoDir, { recursive: true, force: true })
+  await ensureSkillsetCached(ref)
+  if (!fs.existsSync(path.join(repoDir, 'index.json'))) {
+    throw new Error(
+      `Skillset repository has no index.json at its root (re-cloned ${repoDir} after: ${cause})`,
+    )
+  }
+}
+
 async function refreshSkillsetCache(
   ref: SkillsetRef,
   hostingProvider: ReturnType<typeof getSkillsetProvider>,
@@ -702,9 +773,33 @@ async function refreshSkillsetCache(
     await execFileAsync('git', ['remote', 'set-url', 'origin', freshUrl], {
       cwd: repoDir, timeout: 5000, env: GIT_ENV,
     })
-    await gitPull(repoDir)
+
+    let pullResult: GitPullResult
+    try {
+      pullResult = await gitPull(repoDir)
+    } catch (error) {
+      if (!(error instanceof SkillsetCacheCorruptError)) throw error
+      await recloneSkillsetCache(ref, repoDir, error.message)
+      return readIndexJson(repoDir)
+    }
+
+    if (!fs.existsSync(path.join(repoDir, 'index.json'))) {
+      if (pullResult === 'skipped-offline') {
+        // The cache is incomplete but we can't re-clone right now. Don't nuke
+        // it while offline — retry on the next refresh instead.
+        throw new Error(
+          `Skillset cache at ${repoDir} has no index.json and the remote is unreachable; will retry on next refresh`,
+        )
+      }
+      await recloneSkillsetCache(ref, repoDir, 'index.json missing after successful pull')
+    }
   } else {
     await ensureSkillsetCached(ref)
+    if (!fs.existsSync(path.join(repoDir, 'index.json'))) {
+      throw new Error(
+        `Skillset repository has no index.json at its root (fresh clone at ${repoDir})`,
+      )
+    }
   }
 
   return readIndexJson(repoDir)
@@ -1062,7 +1157,7 @@ export async function refreshAgentSkills(
     } catch (error) {
       console.warn(`Failed to refresh skillset ${ss.id}:`, error)
       const msg = error instanceof Error ? error.message : String(error)
-      if (!isExpectedGitDriftError(msg)) {
+      if (!isExpectedGitDriftError(msg) && !isRemoteUnavailableGitError(msg)) {
         captureException(error, { tags: { area: 'skillset-refresh', op: 'pull' }, extra: { skillsetId: ss.id } })
       }
     }
@@ -1121,7 +1216,7 @@ export async function refreshAgentSkills(
             await refreshSkillset(toSkillsetRefFromMeta(meta))
           } catch (error) {
             const msg = error instanceof Error ? error.message : String(error)
-            if (!isExpectedGitDriftError(msg)) {
+            if (!isExpectedGitDriftError(msg) && !isRemoteUnavailableGitError(msg)) {
               captureException(error, { tags: { area: 'skillset-refresh', op: 'queue-merged-pull' }, extra: { skillsetId: meta.skillsetId } })
             }
           }


### PR DESCRIPTION
## Problem

A half-cloned skillset cache — `.git` present but no resolvable `origin/HEAD`, or an empty tree with no `index.json` — breaks every skills refresh **forever**:

1. `gitPull` can't resolve the default branch, captures to Sentry, and silently no-ops (ELECTRON-4K, 968 events / 9 users)
2. `readIndexJson` then throws on the missing `index.json` (ELECTRON-4M, 662 events; ELECTRON-AF on Windows)

Both fire on every refresh for the same user (4K and 4M share trace IDs), and nothing ever repairs the directory. Probing real git shows the likely origin of the state: cloning an **empty** platform skillset repo leaves exactly this shape — `git remote set-head origin --auto` fails with `error: Cannot determine remote HEAD`, so `origin/HEAD` never resolves.

## Fix

- **`resolveDefaultBranch` distinguishes offline from unresolvable.** The `set-head --auto` stderr is no longer swallowed — it's logged and classified against real git messages (verified live: offline → `Could not resolve host` / `unable to access …`; empty/corrupt repo → `Cannot determine remote HEAD`).
- **Unresolvable → nuke and re-clone once.** `refreshSkillsetCache` removes the repo dir and re-runs `ensureSkillsetCached(ref)`. Same recovery when a successful pull still leaves no `index.json` (git-cached providers only).
- **Offline never nukes.** Intact cache → serve stale quietly. Incomplete cache → defer recovery to the next refresh with connectivity. Remote-unavailable errors (network and auth) are no longer captured to Sentry in `gitPull` or either `refreshAgentSkills` capture site — they're environmental, not actionable.
- **Re-clone still empty → distinct error** ("Skillset repository has no index.json at its root"). That's a broken-remote-content signal (e.g. an empty platform skillset repo), a new fingerprint separate from cache corruption, and it does not loop into further re-clones.

Addresses ELECTRON-4K, ELECTRON-4M, ELECTRON-AF (to be resolved in Sentry once the carrying release shows zero events, per the sweep process — intentionally not using auto-close keywords).

## Validation

- 5 new recovery tests: half-clone heal (asserts one `git clone` + set-head warning logged), offline with intact cache (stale served, no clone, no capture), offline with incomplete cache (no nuke, no capture, retried later), missing-index-after-pull re-clone, and re-clone-still-empty distinct error (no re-clone loop).
- Reworked the fetch-error tests: the old "unexpected fetch error" fixture was actually a network timeout — now split into an offline test asserting **no** Sentry capture and a genuine-error test asserting capture.
- Error classification cross-checked against **real git** output for both the empty-remote and unreachable-host cases.
- 172 tests green in the service suite, 490 across dependent suites (skillsets/agents routes, providers, templates); tsc + eslint clean on top of latest main.