### PR TITLE
feat: surface agent-authored Claude Code hooks (SUP-405)

### DIFF
--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -1,4 +1,4 @@
-import { query, Query, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import { query, Query, SDKMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 import type { UUID } from 'crypto';
 import { EventEmitter } from 'events';
@@ -436,6 +436,17 @@ export class ClaudeCodeProcess extends EventEmitter {
   private disposed = false;
   private userMessageCount: number = 0;
   private isResumedSession: boolean;
+  // Late-join replay state. A turn can complete before the host's WebSocket
+  // attaches (createSession returns at `init`; an instant turn — e.g. a
+  // UserPromptSubmit hook blocking the prompt — emits its result and idle in
+  // the attach gap). Nothing buffers relayed frames, so a late subscriber
+  // would never learn the turn ended and the host would show the session as
+  // working forever. Track the most recent turn's terminal frames so the WS
+  // handler can replay them to late joiners (see getLateJoinReplay).
+  private currentTurnInformationals: SDKMessage[] = [];
+  private lastTurnInformationals: SDKMessage[] = [];
+  private lastResultMessage: SDKMessage | null = null;
+  private lastSessionState: string | null = null;
   public slashCommands: { name: string; description: string; argumentHint: string }[] = [];
 
   constructor(options: ClaudeCodeProcessOptions) {
@@ -1008,6 +1019,7 @@ export class ClaudeCodeProcess extends EventEmitter {
           console.log(`[Session ${this.sessionId}] Query completed`);
         }
 
+        this.trackForLateJoinReplay(message);
         this.emit('message', message);
       }
     } catch (error: any) {
@@ -1317,6 +1329,48 @@ export class ClaudeCodeProcess extends EventEmitter {
 
   isRunning(): boolean {
     return this.isReady && this.isProcessing;
+  }
+
+  /** Record the frames a late-joining WebSocket subscriber must not miss. */
+  private trackForLateJoinReplay(message: SDKMessage): void {
+    const msg = message as { type: string; subtype?: string; state?: string };
+    if (msg.type === 'system' && msg.subtype === 'informational') {
+      this.currentTurnInformationals.push(message);
+    } else if (msg.type === 'result') {
+      this.lastResultMessage = message;
+      this.lastTurnInformationals = this.currentTurnInformationals;
+      this.currentTurnInformationals = [];
+    } else if (msg.type === 'system' && msg.subtype === 'session_state_changed') {
+      this.lastSessionState = msg.state ?? null;
+    }
+  }
+
+  /**
+   * Terminal frames of the most recent turn, for WebSocket subscribers that
+   * attached after the turn already ended. createSession returns at `init`,
+   * so an instant turn (e.g. a UserPromptSubmit hook blocking the prompt)
+   * finishes — result and idle included — before the host's socket exists;
+   * without a replay the host never learns the turn ended and shows the
+   * session as working forever.
+   *
+   * Only replays when the session is currently idle (a running turn will
+   * deliver its own frames live), and marks every frame `replayed: true` so
+   * the host can ignore the catch-up when it already saw the live copies.
+   */
+  getLateJoinReplay(): unknown[] {
+    if (this.lastSessionState !== 'idle' || !this.lastResultMessage) {
+      return [];
+    }
+    return [
+      ...this.lastTurnInformationals,
+      this.lastResultMessage,
+      {
+        type: 'system',
+        subtype: 'session_state_changed',
+        state: 'idle',
+        session_id: this.claudeSessionId || this.sessionId,
+      },
+    ].map((m) => ({ ...(m as Record<string, unknown>), replayed: true }));
   }
 
   async interrupt(): Promise<InterruptOutcome> {

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -1833,6 +1833,19 @@ async function handleWebSocketConnection(ws: WebSocket, sessionId: string) {
     }
   });
 
+  // Catch-up for turns that ended before this socket attached. createSession
+  // returns at `init`, so an instant turn (e.g. a UserPromptSubmit hook
+  // blocking the prompt) emits informational/result/idle into the attach gap
+  // and nothing re-delivers them — the host would show the session as working
+  // forever. Frames are marked `replayed: true`; the host ignores them when it
+  // already processed the live copies. Sent after the subscription so a turn
+  // starting mid-replay still delivers its live frames afterwards (WS is FIFO).
+  for (const frame of sessionManager.getLateJoinReplay(sessionId)) {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(frame));
+    }
+  }
+
   // Handle incoming messages
   ws.on('message', async (data: Buffer) => {
     try {

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -689,6 +689,17 @@ export class SessionManager extends EventEmitter {
     return sessionData.process.isRunning();
   }
 
+  /**
+   * Terminal frames of the session's most recent turn, for a WebSocket
+   * subscriber that attached after the turn already ended. Empty when the
+   * session is live mid-turn (frames arrive normally) or cold.
+   */
+  getLateJoinReplay(sessionId: string): unknown[] {
+    const sessionData = this.sessions.get(sessionId);
+    if (!sessionData) return [];
+    return sessionData.process.getLateJoinReplay();
+  }
+
   // Reads persistence only — never resumes an evicted session the way
   // getSession does. null = unknown session.
   getSessionCapabilityGrants(sessionId: string): Array<'subagents' | 'workflows'> | null {

--- a/e2e/specs/agent-hooks.spec.ts
+++ b/e2e/specs/agent-hooks.spec.ts
@@ -1,0 +1,134 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { test, expect } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+
+const e2eDataDir = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
+
+async function getLatestAgentSlug(page: import('@playwright/test').Page): Promise<string> {
+  const breadcrumb = page.locator('[data-testid="agent-breadcrumb"]')
+  const agentName = await breadcrumb.textContent() || ''
+
+  const response = await page.request.get('/api/agents')
+  const agents = await response.json() as Array<{ slug: string; name: string; createdAt: string }>
+  const match = agents.find(a => a.name === agentName.trim())
+  if (match) return match.slug
+
+  agents.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+  return agents[0]?.slug || ''
+}
+
+function claudeSettingsPath(agentSlug: string): string {
+  return path.join(e2eDataDir, 'agents', agentSlug, 'workspace', '.claude', 'settings.json')
+}
+
+function seedClaudeSettings(agentSlug: string, settings: unknown) {
+  const filePath = claudeSettingsPath(agentSlug)
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, JSON.stringify(settings, null, 2))
+}
+
+// A self-installed prompt gate plus an unrelated CLI-owned setting that must
+// survive hook removal untouched.
+const SEEDED_SETTINGS = {
+  cleanupPeriodDays: 9999,
+  hooks: {
+    UserPromptSubmit: [
+      {
+        hooks: [
+          { type: 'command', command: 'python3 /workspace/.claude/hooks/gate.py', timeout: 10 },
+        ],
+      },
+    ],
+    PreToolUse: [
+      {
+        matcher: 'Bash',
+        hooks: [{ type: 'command', command: 'echo pre-bash-check' }],
+      },
+    ],
+  },
+}
+
+test.describe('Agent hooks', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+
+  test.beforeEach(async ({ page }) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+  })
+
+  test('homepage lists configured hooks with a blocking-hook warning', async ({ page }) => {
+    await agentPage.createAgent(`HooksList ${Date.now()}`)
+    const agentSlug = await getLatestAgentSlug(page)
+    seedClaudeSettings(agentSlug, SEEDED_SETTINGS)
+
+    // The section self-hides when the (already fetched) hook list is empty —
+    // reload so the seeded settings are picked up.
+    await page.reload()
+    await expect(page.getByText('Hooks', { exact: true })).toBeVisible({ timeout: 15000 })
+
+    const rows = page.getByTestId('home-hooks-row')
+    await expect(rows).toHaveCount(2)
+    await expect(rows.filter({ hasText: 'UserPromptSubmit' })).toContainText('gate.py')
+    await expect(rows.filter({ hasText: 'PreToolUse' })).toContainText('echo pre-bash-check')
+
+    // UserPromptSubmit hooks can block all input — the section must warn.
+    await expect(page.getByTestId('home-hooks-warning')).toBeVisible()
+  })
+
+  test('removing a hook rewrites only the hooks key and hides the row', async ({ page }) => {
+    await agentPage.createAgent(`HooksRemove ${Date.now()}`)
+    const agentSlug = await getLatestAgentSlug(page)
+    seedClaudeSettings(agentSlug, SEEDED_SETTINGS)
+    await page.reload()
+
+    const promptRow = page.getByTestId('home-hooks-row').filter({ hasText: 'UserPromptSubmit' })
+    await expect(promptRow).toBeVisible({ timeout: 15000 })
+
+    await promptRow.hover()
+    await promptRow.getByRole('button', { name: 'Hook actions' }).click()
+    await page.getByRole('button', { name: 'Remove Hook' }).click()
+    await page.getByRole('alertdialog').getByRole('button', { name: 'Remove Hook' }).click()
+
+    await expect(page.getByTestId('home-hooks-row')).toHaveCount(1, { timeout: 10000 })
+    await expect(page.getByTestId('home-hooks-warning')).not.toBeVisible()
+
+    // The settings file keeps everything except the removed hook. A parse
+    // failure here fails the test, which is exactly what it should do.
+    let onDisk: { cleanupPeriodDays?: number; hooks?: Record<string, unknown[]> }
+    try {
+      onDisk = JSON.parse(fs.readFileSync(claudeSettingsPath(agentSlug), 'utf-8'))
+    } catch {
+      throw new Error('settings.json was rewritten to invalid JSON')
+    }
+    expect(onDisk.cleanupPeriodDays).toBe(9999)
+    expect(onDisk.hooks?.UserPromptSubmit).toBeUndefined()
+    expect(onDisk.hooks?.PreToolUse).toHaveLength(1)
+  })
+
+  test('a hook-blocked prompt surfaces as a warning card in the transcript', async ({ page }) => {
+    await agentPage.createAgent(`HookBlock ${Date.now()}`)
+
+    // The mock runtime mirrors the CLI's block shape for this phrase: an
+    // informational warning + a num_turns:0 result, with NOTHING written to
+    // the transcript by the runtime itself.
+    await sessionPage.sendMessage('please trip the breaker now')
+
+    const card = page.getByTestId('informational-item')
+    await expect(card).toBeVisible({ timeout: 15000 })
+    await expect(card).toContainText('blocked by hook')
+    await expect(card).toContainText('Original prompt: please trip the breaker now')
+
+    // Reload-safe: the banner was persisted to the transcript, not just streamed.
+    await page.reload()
+    await expect(page.getByTestId('informational-item')).toBeVisible({ timeout: 15000 })
+  })
+})

--- a/e2e/specs/agent-hooks.spec.ts
+++ b/e2e/specs/agent-hooks.spec.ts
@@ -131,4 +131,15 @@ test.describe('Agent hooks', () => {
     await page.reload()
     await expect(page.getByTestId('informational-item')).toBeVisible({ timeout: 15000 })
   })
+
+  test('a hook-blocked prompt settles the session (no stuck working state)', async ({ page }) => {
+    await agentPage.createAgent(`HookSettle ${Date.now()}`)
+
+    await sessionPage.sendMessage('please trip the breaker now')
+    await expect(page.getByTestId('informational-item')).toBeVisible({ timeout: 15000 })
+
+    // The runtime emits result + idle after the block; the session must settle —
+    // a lingering "Working..." here is the wedged-agent bug.
+    await expect(page.getByText('Working...')).not.toBeVisible({ timeout: 10000 })
+  })
 })

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -43,6 +43,8 @@ import {
 } from '@shared/lib/services/session-service'
 import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, getTempUploadsDir, ensureDirectory, removeDirectory, writeJsonFileAtomic, displaySlug } from '@shared/lib/utils/file-storage'
 import { getMountsWithHealth, addMount, removeMount } from '@shared/lib/services/mount-service'
+import { readAgentHooks, removeAgentHook } from '@shared/lib/services/agent-hooks-service'
+import { removeAgentHookSchema } from '@shared/lib/services/agent-hooks-schema'
 import {
   listUserSecrets,
   getSecret,
@@ -5143,6 +5145,40 @@ agents.put('/:id/bookmarks', AgentAdmin(), async (c) => {
   } catch (error) {
     console.error('Failed to update bookmarks:', error)
     return c.json({ error: 'Failed to update bookmarks' }, 500)
+  }
+})
+
+// GET /api/agents/:id/hooks - List Claude Code hooks configured in the agent's
+// workspace settings file. Agents can self-install hooks (they own the file),
+// and a UserPromptSubmit hook can silently block all input — so the host
+// surfaces whatever is configured.
+agents.get('/:id/hooks', AgentRead(), async (c) => {
+  try {
+    const agentSlug = getAgentId(c)
+    const hooks = await readAgentHooks(agentSlug)
+    return c.json({ hooks })
+  } catch (error) {
+    console.error('Failed to read agent hooks:', error)
+    return c.json({ hooks: [] })
+  }
+})
+
+// DELETE /api/agents/:id/hooks - Remove one configured hook (identified by
+// event + command + matcher) from the workspace settings file, preserving
+// every other settings key.
+agents.delete('/:id/hooks', AgentAdmin(), async (c) => {
+  const agentSlug = getAgentId(c)
+  const parsed = removeAgentHookSchema.safeParse(await c.req.json().catch(() => null))
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid hook removal target' }, 400)
+  }
+  try {
+    const hooks = await removeAgentHook(agentSlug, parsed.data)
+    return c.json({ hooks })
+  } catch (error) {
+    console.error('Failed to remove agent hook:', error)
+    // Includes the unparseable-settings case: never rewrite a file we couldn't parse.
+    return c.json({ error: 'Failed to update the agent settings file' }, 500)
   }
 })
 

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -33,6 +33,7 @@ import { HomeExtras } from './home-extras'
 import { HomeConnections } from './home-connections'
 import { HomeChatIntegrations } from './home-chat-integrations'
 import { HomeVolumes } from './home-volumes'
+import { HomeHooks } from './home-hooks'
 import { HomeBookmarks } from './home-bookmarks'
 import { DashboardCard } from '@renderer/components/home/dashboard-card'
 import { useUpdateAgent, useDeleteAgent, type ApiAgent } from '@renderer/hooks/use-agents'
@@ -527,6 +528,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
             }} />
             <HomeChatIntegrations className="intro-step intro-step-7" agentSlug={agent.slug} />
             <HomeVolumes className="intro-step intro-step-8" agentSlug={agent.slug} />
+            <HomeHooks className="intro-step intro-step-8" agentSlug={agent.slug} isOwner={isOwner} />
             <HomeDefaultModel className="intro-step intro-step-9" agentSlug={agent.slug} />
             <HomeExtras className="intro-step intro-step-9" agentSlug={agent.slug} onOpenSettings={handleOpenSettings} />
           </div>

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -528,9 +528,9 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
             }} />
             <HomeChatIntegrations className="intro-step intro-step-7" agentSlug={agent.slug} />
             <HomeVolumes className="intro-step intro-step-8" agentSlug={agent.slug} />
-            <HomeHooks className="intro-step intro-step-8" agentSlug={agent.slug} isOwner={isOwner} />
             <HomeDefaultModel className="intro-step intro-step-9" agentSlug={agent.slug} />
             <HomeExtras className="intro-step intro-step-9" agentSlug={agent.slug} onOpenSettings={handleOpenSettings} />
+            <HomeHooks className="intro-step intro-step-9" agentSlug={agent.slug} isOwner={isOwner} />
           </div>
         )}
       </div>

--- a/src/renderer/components/agents/agent-home/home-hooks.tsx
+++ b/src/renderer/components/agents/agent-home/home-hooks.tsx
@@ -50,15 +50,16 @@ export function HomeHooks({ agentSlug, isOwner, className }: HomeHooksProps) {
       <div className="mt-2 divide-y divide-border/50">
         {hooks.map((hook, index) => (
           <HookRow
-            key={`${hook.event}-${hook.matcher ?? ''}-${hook.command ?? ''}-${index}`}
+            key={`${hook.event}-${hook.matcher ?? ''}-${hook.command ?? hook.prompt ?? ''}-${index}`}
             hook={hook}
             isOwner={isOwner}
             onRemove={() => {
-              if (!hook.command) return
+              if (hook.command === undefined && hook.prompt === undefined) return
               removeHook.mutate({
                 event: hook.event,
-                command: hook.command,
                 ...(hook.matcher !== undefined && { matcher: hook.matcher }),
+                ...(hook.command !== undefined && { command: hook.command }),
+                ...(hook.prompt !== undefined && { prompt: hook.prompt }),
               })
             }}
             isRemoving={removeHook.isPending}
@@ -66,8 +67,8 @@ export function HomeHooks({ agentSlug, isOwner, className }: HomeHooksProps) {
         ))}
       </div>
       <p className="mt-2 px-4 text-xs text-muted-foreground">
-        Hooks are shell commands from this agent&apos;s workspace settings, run automatically at
-        lifecycle events. They are usually written by the agent itself.
+        Hooks come from this agent&apos;s workspace settings and run automatically at lifecycle
+        events — as shell commands or model prompts. They are usually written by the agent itself.
       </p>
     </HomeCollapsible>
   )
@@ -84,6 +85,9 @@ function HookRow({ hook, isOwner, onRemove, isRemoving }: HookRowProps) {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const isBlocking = BLOCKING_HOOK_EVENTS.has(hook.event)
+  // Command hooks run a shell command; prompt hooks run a model prompt.
+  const detail = hook.command ?? hook.prompt
+  const removable = detail !== undefined
 
   const handleDelete = () => {
     onRemove()
@@ -100,16 +104,24 @@ function HookRow({ hook, isOwner, onRemove, isRemoving }: HookRowProps) {
             <Webhook className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
           )}
           <span className="text-xs font-medium truncate">{hook.event}</span>
+          {hook.type === 'prompt' && (
+            <span className="text-2xs px-1.5 py-0 rounded-full bg-muted text-muted-foreground">
+              prompt
+            </span>
+          )}
           {hook.matcher && (
             <span className="text-2xs px-1.5 py-0 rounded-full bg-muted text-muted-foreground truncate" title={hook.matcher}>
               {hook.matcher}
             </span>
           )}
         </div>
-        <div className="text-xs text-muted-foreground mt-0.5 line-clamp-1 font-mono" title={hook.command}>
-          {hook.command || '(no command)'}
+        <div
+          className={`text-xs text-muted-foreground mt-0.5 line-clamp-1 ${hook.command !== undefined ? 'font-mono' : ''}`}
+          title={detail}
+        >
+          {detail || '(empty hook)'}
         </div>
-        {isOwner && hook.command && (
+        {isOwner && removable && (
           <div className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
             <Popover open={menuOpen} onOpenChange={setMenuOpen}>
               <PopoverTrigger asChild>
@@ -145,8 +157,8 @@ function HookRow({ hook, isOwner, onRemove, isRemoving }: HookRowProps) {
           <AlertDialogHeader>
             <AlertDialogTitle>Remove Hook</AlertDialogTitle>
             <AlertDialogDescription>
-              Remove the {hook.event} hook from this agent&apos;s settings? The command it runs
-              will no longer execute. Other settings are untouched.
+              Remove the {hook.event} hook from this agent&apos;s settings? It will no longer run.
+              Other settings are untouched.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/renderer/components/agents/agent-home/home-hooks.tsx
+++ b/src/renderer/components/agents/agent-home/home-hooks.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react'
+import { Button } from '@renderer/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@renderer/components/ui/alert-dialog'
+import { MoreVertical, Webhook, Trash2, TriangleAlert } from 'lucide-react'
+import { HomeCollapsible } from './home-collapsible'
+import { useAgentHooks, useRemoveAgentHook } from '@renderer/hooks/use-agent-hooks'
+import { BLOCKING_HOOK_EVENTS, type AgentHook } from '@shared/lib/services/agent-hooks-schema'
+
+interface HomeHooksProps {
+  agentSlug: string
+  isOwner: boolean
+  className?: string
+}
+
+/**
+ * Claude Code hooks configured in the agent's workspace settings file. Agents
+ * can install these themselves, and a UserPromptSubmit hook can silently block
+ * every incoming message — so any configured hook is worth showing. Hidden
+ * entirely when none are configured (the overwhelmingly common case).
+ */
+export function HomeHooks({ agentSlug, isOwner, className }: HomeHooksProps) {
+  const { data: hooks } = useAgentHooks(agentSlug)
+  const removeHook = useRemoveAgentHook(agentSlug)
+
+  if (!hooks || hooks.length === 0) return null
+
+  const hasBlockingHook = hooks.some((h) => BLOCKING_HOOK_EVENTS.has(h.event))
+
+  return (
+    <HomeCollapsible title="Hooks" className={className}>
+      {hasBlockingHook && (
+        <div className="mt-2 mx-4 flex items-start gap-2 rounded-lg bg-amber-500/10 p-2.5" data-testid="home-hooks-warning">
+          <TriangleAlert className="h-3.5 w-3.5 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
+          <span className="text-xs text-amber-700 dark:text-amber-400">
+            A UserPromptSubmit hook runs before every message and can block it — including yours.
+            If this agent stops responding, remove the hook.
+          </span>
+        </div>
+      )}
+      <div className="mt-2 divide-y divide-border/50">
+        {hooks.map((hook, index) => (
+          <HookRow
+            key={`${hook.event}-${hook.matcher ?? ''}-${hook.command ?? ''}-${index}`}
+            hook={hook}
+            isOwner={isOwner}
+            onRemove={() => {
+              if (!hook.command) return
+              removeHook.mutate({
+                event: hook.event,
+                command: hook.command,
+                ...(hook.matcher !== undefined && { matcher: hook.matcher }),
+              })
+            }}
+            isRemoving={removeHook.isPending}
+          />
+        ))}
+      </div>
+      <p className="mt-2 px-4 text-xs text-muted-foreground">
+        Hooks are shell commands from this agent&apos;s workspace settings, run automatically at
+        lifecycle events. They are usually written by the agent itself.
+      </p>
+    </HomeCollapsible>
+  )
+}
+
+interface HookRowProps {
+  hook: AgentHook
+  isOwner: boolean
+  onRemove: () => void
+  isRemoving: boolean
+}
+
+function HookRow({ hook, isOwner, onRemove, isRemoving }: HookRowProps) {
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const isBlocking = BLOCKING_HOOK_EVENTS.has(hook.event)
+
+  const handleDelete = () => {
+    onRemove()
+    setShowDeleteDialog(false)
+  }
+
+  return (
+    <>
+      <div className="group relative py-3 px-4 hover:bg-muted/50 transition-colors" data-testid="home-hooks-row">
+        <div className="flex items-center gap-2">
+          {isBlocking ? (
+            <TriangleAlert className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400 shrink-0" />
+          ) : (
+            <Webhook className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          )}
+          <span className="text-xs font-medium truncate">{hook.event}</span>
+          {hook.matcher && (
+            <span className="text-2xs px-1.5 py-0 rounded-full bg-muted text-muted-foreground truncate" title={hook.matcher}>
+              {hook.matcher}
+            </span>
+          )}
+        </div>
+        <div className="text-xs text-muted-foreground mt-0.5 line-clamp-1 font-mono" title={hook.command}>
+          {hook.command || '(no command)'}
+        </div>
+        {isOwner && hook.command && (
+          <div className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+            <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="outline"
+                  className="h-6 w-6"
+                  aria-label="Hook actions"
+                >
+                  <MoreVertical className="h-3.5 w-3.5" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-40 p-1">
+                <button
+                  className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-destructive hover:bg-destructive/10 transition-colors"
+                  onClick={() => {
+                    setShowDeleteDialog(true)
+                    setMenuOpen(false)
+                  }}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Remove Hook
+                </button>
+              </PopoverContent>
+            </Popover>
+          </div>
+        )}
+      </div>
+
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove Hook</AlertDialogTitle>
+            <AlertDialogDescription>
+              Remove the {hook.event} hook from this agent&apos;s settings? The command it runs
+              will no longer execute. Other settings are untouched.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep Hook</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isRemoving}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isRemoving ? 'Removing...' : 'Remove Hook'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -84,7 +84,7 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
     const activeMap = new Map(activeSubagents.map(s => [s.parentToolId, s]))
     const items: { id: string; name: string; description: string; status: 'running' | 'completed'; progressSummary: string | null }[] = []
     for (const msg of messages) {
-      if (msg.type === 'compact_boundary' || msg.type === 'memory_recall') continue
+      if (msg.type !== 'user' && msg.type !== 'assistant') continue
       for (const tc of msg.toolCalls || []) {
         if ((tc.name === 'Agent' || tc.name === 'Task') && activeMap.has(tc.id)) {
           if (tc.isError) continue
@@ -125,7 +125,7 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
     let taskCounter = 0
 
     for (const message of messages) {
-      if (message.type === 'compact_boundary' || message.type === 'memory_recall') continue
+      if (message.type !== 'user' && message.type !== 'assistant') continue
       for (const tc of message.toolCalls || []) {
         if (tc.name === 'TaskCreate') {
           taskCounter++
@@ -158,7 +158,7 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
     if (!list) {
       for (let i = messages.length - 1; i >= 0; i--) {
         const message = messages[i]
-        if (message.type === 'compact_boundary' || message.type === 'memory_recall') continue
+        if (message.type !== 'user' && message.type !== 'assistant') continue
         const toolCalls = message.toolCalls || []
         for (let j = toolCalls.length - 1; j >= 0; j--) {
           const toolCall = toolCalls[j]

--- a/src/renderer/components/messages/informational-item.tsx
+++ b/src/renderer/components/messages/informational-item.tsx
@@ -1,0 +1,65 @@
+import { useParams } from '@tanstack/react-router'
+import { TriangleAlert, ArrowUpRight } from 'lucide-react'
+import type { ApiInformational } from '@shared/lib/types/api'
+import { AppLink } from '@renderer/components/ui/app-link'
+
+interface InformationalItemProps {
+  item: ApiInformational
+}
+
+/** The SDK's hook-feedback banners all carry this phrasing (e.g.
+ * "UserPromptSubmit operation blocked by hook: ..."). */
+function isHookBlock(content: string): boolean {
+  return /blocked by hook/i.test(content)
+}
+
+/**
+ * Host-persisted warning banner from the agent loop. The load-bearing case is
+ * a workspace-authored hook blocking a prompt: the model never saw the
+ * message, so without this card the session reads as the agent silently
+ * ignoring the user.
+ */
+export function InformationalItem({ item }: InformationalItemProps) {
+  const params = useParams({ strict: false }) as { slug?: string }
+  const hookBlock = isHookBlock(item.content)
+
+  return (
+    <div
+      className="rounded-[12px] border border-amber-300/70 dark:border-amber-700/60 bg-amber-50/60 dark:bg-amber-950/20 p-4"
+      data-testid="informational-item"
+    >
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-amber-500/15">
+          <TriangleAlert className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h4 className="text-sm font-medium text-foreground">
+            {hookBlock ? 'Message blocked by a hook' : 'Agent notice'}
+          </h4>
+          <p className="mt-1 text-xs text-muted-foreground whitespace-pre-wrap break-words">
+            {item.content}
+          </p>
+          {hookBlock && (
+            <p className="mt-2 text-xs text-muted-foreground">
+              A hook configured in this agent&apos;s workspace intercepted the message before the
+              agent could see it.
+              {params.slug && (
+                <>
+                  {' '}
+                  <AppLink
+                    to="/agents/$slug"
+                    params={{ slug: params.slug }}
+                    className="inline-flex items-center gap-0.5 font-medium text-foreground hover:underline"
+                  >
+                    Review hooks
+                    <ArrowUpRight className="h-3 w-3" />
+                  </AppLink>
+                </>
+              )}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/messages/informational-item.tsx
+++ b/src/renderer/components/messages/informational-item.tsx
@@ -7,10 +7,11 @@ interface InformationalItemProps {
   item: ApiInformational
 }
 
-/** The SDK's hook-feedback banners all carry this phrasing (e.g.
- * "UserPromptSubmit operation blocked by hook: ..."). */
+/** The SDK's hook-feedback banners carry one of two phrasings depending on the
+ * hook's output shape: "... operation blocked by hook: ..." (decision:block)
+ * or "Operation stopped by hook: ..." (continue:false, incl. prompt hooks). */
 function isHookBlock(content: string): boolean {
-  return /blocked by hook/i.test(content)
+  return /(blocked|stopped) by hook/i.test(content)
 }
 
 /**
@@ -36,6 +37,11 @@ export function InformationalItem({ item }: InformationalItemProps) {
           <h4 className="text-sm font-medium text-foreground">
             {hookBlock ? 'Message blocked by a hook' : 'Agent notice'}
           </h4>
+          {hookBlock && (
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              The agent never saw this message.
+            </p>
+          )}
           <p className="mt-1 text-xs text-muted-foreground whitespace-pre-wrap break-words">
             {item.content}
           </p>

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -18,6 +18,7 @@ import { SubAgentBlock } from './subagent-block'
 import { WorkflowBlock } from './workflow-block'
 import { CompactBoundaryItem } from './compact-boundary-item'
 import { MemoryRecallItem } from './memory-recall-item'
+import { InformationalItem } from './informational-item'
 import { MessageErrorBoundary } from './message-error-boundary'
 import { ArrowDown, FileX2, Loader2, MessageSquarePlus, WifiOff } from 'lucide-react'
 import { FileDownloadPill } from '@renderer/components/ui/file-download-pill'
@@ -28,7 +29,7 @@ import { useWorkflow } from '@renderer/context/workflow-context'
 import { useRenderTracker } from '@renderer/lib/perf'
 import { useEffect, useLayoutEffect, useRef, useState, useCallback, useMemo, Fragment, type ReactNode } from 'react'
 import { formatElapsed } from '@renderer/hooks/use-elapsed-timer'
-import type { ApiMessage, ApiCompactBoundary, ApiMemoryRecall } from '@shared/lib/types/api'
+import type { ApiMessage, ApiCompactBoundary, ApiMemoryRecall, ApiInformational } from '@shared/lib/types/api'
 
 // Prefix for system-injected user messages that should be hidden in the UI.
 // Keep in sync with SYSTEM_MESSAGE_PREFIX in agent-container/src/claude-code.ts
@@ -774,6 +775,8 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
               <MemoryRecallItem recall={item as ApiMemoryRecall} />
             ) : item.type === 'compact_boundary' ? (
               <CompactBoundaryItem boundary={item as ApiCompactBoundary} />
+            ) : item.type === 'informational' ? (
+              <InformationalItem item={item as ApiInformational} />
             ) : (
               <>
                 <MessageErrorBoundary kind="message" raw={item} itemId={item.id}>

--- a/src/renderer/hooks/use-agent-hooks.ts
+++ b/src/renderer/hooks/use-agent-hooks.ts
@@ -1,0 +1,38 @@
+import { apiFetch } from '@renderer/lib/api'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AgentHook, RemoveAgentHookTarget } from '@shared/lib/services/agent-hooks-schema'
+
+/** Claude Code hooks configured in the agent workspace settings file. */
+export function useAgentHooks(agentSlug: string | null) {
+  return useQuery<AgentHook[]>({
+    queryKey: ['agent-hooks', agentSlug],
+    queryFn: async () => {
+      const res = await apiFetch(`/api/agents/${agentSlug}/hooks`)
+      if (!res.ok) return []
+      const data = await res.json()
+      return Array.isArray(data?.hooks) ? data.hooks : []
+    },
+    enabled: !!agentSlug,
+    staleTime: 30_000,
+  })
+}
+
+export function useRemoveAgentHook(agentSlug: string | null) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (target: RemoveAgentHookTarget) => {
+      const res = await apiFetch(`/api/agents/${agentSlug}/hooks`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(target),
+      })
+      if (!res.ok) throw new Error('Failed to remove hook')
+      const data = await res.json()
+      return (Array.isArray(data?.hooks) ? data.hooks : []) as AgentHook[]
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(['agent-hooks', agentSlug], data)
+    },
+  })
+}

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -28,6 +28,10 @@ vi.mock('@shared/lib/services/session-service', () => ({
   getSessionMetadata: vi.fn(() => Promise.resolve(null)),
   finalizeAutomationStatus: vi.fn(() => Promise.resolve('updated')),
 }))
+const mockAppendInformationalEntry = vi.fn((..._args: unknown[]) => Promise.resolve())
+vi.mock('@shared/lib/services/session-transcript-append', () => ({
+  appendInformationalEntry: (...args: unknown[]) => mockAppendInformationalEntry(...args),
+}))
 vi.mock('@shared/lib/services/timezone-resolver', () => ({
   resolveTimezoneForAgent: vi.fn(() => 'UTC'),
 }))
@@ -279,6 +283,68 @@ describe('MessagePersister', () => {
     sseCleanup()
     messagePersister.unsubscribeFromSession(SESSION_ID)
     vi.clearAllMocks()
+  })
+
+  // ============================================================================
+  // Informational banners (hook feedback, e.g. UserPromptSubmit blocks)
+  // ============================================================================
+
+  describe('informational system messages', () => {
+    it('persists a warning banner to the transcript and broadcasts messages_updated', async () => {
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'informational',
+        uuid: 'info-uuid-1',
+        content: 'UserPromptSubmit operation blocked by hook:\nCircuit breaker\n\nOriginal prompt: hello',
+        level: 'warning',
+        prevent_continuation: true,
+      })
+
+      expect(mockAppendInformationalEntry).toHaveBeenCalledWith(AGENT_SLUG, SESSION_ID, {
+        uuid: 'info-uuid-1',
+        content: 'UserPromptSubmit operation blocked by hook:\nCircuit breaker\n\nOriginal prompt: hello',
+        level: 'warning',
+      })
+      await vi.waitFor(() => {
+        expect(sseEvents).toContainEqual({ type: 'messages_updated' })
+      })
+    })
+
+    it('persists a blocking banner even without a warning level', async () => {
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'informational',
+        uuid: 'info-uuid-2',
+        content: 'Operation blocked by hook',
+        prevent_continuation: true,
+      })
+
+      expect(mockAppendInformationalEntry).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores info-level chatter (non-blocking status lines)', () => {
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'informational',
+        uuid: 'info-uuid-3',
+        content: 'Loaded 3 skills',
+        level: 'info',
+      })
+
+      expect(mockAppendInformationalEntry).not.toHaveBeenCalled()
+      expect(sseEvents).not.toContainEqual({ type: 'messages_updated' })
+    })
+
+    it('ignores warning banners with no content', () => {
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'informational',
+        uuid: 'info-uuid-4',
+        level: 'warning',
+      })
+
+      expect(mockAppendInformationalEntry).not.toHaveBeenCalled()
+    })
   })
 
   // ============================================================================

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -348,6 +348,77 @@ describe('MessagePersister', () => {
   })
 
   // ============================================================================
+  // Late-join replay (turn ended before the WebSocket attached)
+  // ============================================================================
+
+  describe('late-join replayed frames', () => {
+    const sendCapabilities = () =>
+      mockClient._sendMessage({ type: 'system', subtype: 'capabilities', session_state_events: true })
+
+    it('settles a session whose blocked first turn ended before the socket attached', async () => {
+      // The wedge signature: the route marked the session active, but no live
+      // turn frames ever arrived (they fired into the WS attach gap).
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      sseEvents.length = 0
+      sendCapabilities()
+
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'informational',
+        uuid: 'replay-info-1',
+        content: 'Operation stopped by hook: no hey allowed',
+        level: 'warning',
+        prevent_continuation: true,
+        replayed: true,
+      })
+      mockClient._sendMessage({
+        type: 'result', subtype: 'success', is_error: false, duration_ms: 20, num_turns: 0,
+        usage: { input_tokens: 0, output_tokens: 0 },
+        replayed: true,
+      })
+      mockClient._sendMessage({
+        type: 'system', subtype: 'session_state_changed', state: 'idle', replayed: true,
+      })
+
+      expect(mockAppendInformationalEntry).toHaveBeenCalledTimes(1)
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(sseEvents.some((e) => e.type === 'session_idle')).toBe(true)
+    })
+
+    it('ignores replayed frames when the live copies were already processed', () => {
+      // A full live turn settles the session…
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      sendCapabilities()
+      mockClient._sendMessage({
+        type: 'result', subtype: 'success', is_error: false, duration_ms: 100, num_turns: 1,
+        usage: { input_tokens: 0, output_tokens: 0 },
+      })
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      sseEvents.length = 0
+      vi.clearAllMocks()
+
+      // …then a reconnect replays the same terminal frames: all ignored.
+      mockClient._sendMessage({
+        type: 'system', subtype: 'informational', uuid: 'replay-info-2',
+        content: 'Operation stopped by hook: x', level: 'warning', replayed: true,
+      })
+      mockClient._sendMessage({
+        type: 'result', subtype: 'success', is_error: false, duration_ms: 20, num_turns: 0,
+        usage: { input_tokens: 0, output_tokens: 0 },
+        replayed: true,
+      })
+      mockClient._sendMessage({
+        type: 'system', subtype: 'session_state_changed', state: 'idle', replayed: true,
+      })
+
+      expect(mockAppendInformationalEntry).not.toHaveBeenCalled()
+      expect(sseEvents.filter((e) => e.type === 'session_idle')).toHaveLength(0)
+      expect(sseEvents.filter((e) => e.type === 'turn_output_complete')).toHaveLength(0)
+    })
+  })
+
+  // ============================================================================
   // Sidechain message filtering
   // ============================================================================
 

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1043,6 +1043,17 @@ class MessagePersister {
       return
     }
 
+    // Container late-join catch-up: the runtime replays the last turn's
+    // terminal frames (informational/result/idle, marked `replayed: true`)
+    // when a WebSocket attaches after the turn already ended — e.g. a
+    // hook-blocked prompt completing before createSession's subscriber
+    // exists. Only act on them when this session actually missed the turn
+    // (still marked active); a settled session already processed the live
+    // copies, and replaying them would re-fire terminal broadcasts.
+    if (content.replayed && !state.isActive) {
+      return
+    }
+
     switch (content.type) {
       case 'assistant': {
         // Complete assistant message - JSONL is the source of truth

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1528,14 +1528,14 @@ class MessagePersister {
         state.currentText = ''
         state.lastResultSubtype = typeof content.subtype === 'string' ? content.subtype : null
 
-        // A clean success with zero turns and zero API time means the model
-        // was never called — the signature of a settings-file hook blocking
-        // the prompt. The informational banner (persisted above, when the SDK
-        // emitted one) is the user-facing surface; this is the operator
-        // breadcrumb for shapes that arrive without one.
-        if (!isError && !classification.isInterrupt && content.num_turns === 0 && content.duration_api_ms === 0) {
+        // A clean success with zero turns means the main loop never ran — the
+        // signature of a settings-file hook blocking the prompt. (duration_api_ms
+        // can still be non-zero: prompt-type hooks spend API time on their
+        // model evaluation.) The informational banner is the user-facing
+        // surface; this is the operator breadcrumb.
+        if (!isError && !classification.isInterrupt && content.num_turns === 0 && content.subtype === 'success') {
           console.warn(
-            `[MessagePersister] Session ${sessionId}: turn ended with no model call (num_turns=0) — possible hook-blocked prompt`
+            `[MessagePersister] Session ${sessionId}: turn ended with no model turns (num_turns=0) — possible hook-blocked prompt`
           )
         }
 

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -58,6 +58,7 @@ import { eq } from 'drizzle-orm'
 import { resolveTimezoneForAgent } from '@shared/lib/services/timezone-resolver'
 import { getFrequencyWarning, getScheduleCountWarning, validateScheduleExpression } from '@shared/lib/services/schedule-parser'
 import { finalizeAutomationStatus, getSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
+import { appendInformationalEntry } from '@shared/lib/services/session-transcript-append'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
 import { VALID_SCRIPT_TYPES, getAgentCapabilitySettings } from '@shared/lib/config/settings'
@@ -70,6 +71,7 @@ import { getAgentSessionsDir } from '@shared/lib/utils/file-storage'
 import { WorkflowJournalTailer } from './workflow-journal-tailer'
 import { SubagentCapture } from './subagent-capture'
 import * as path from 'path'
+import { randomUUID } from 'crypto'
 // Per-subagent streaming state (supports multiple concurrent background agents)
 interface SubagentStreamingState {
   agentId: string | null
@@ -914,6 +916,44 @@ class MessagePersister {
       })
   }
 
+  /**
+   * SDK `system`/`informational` banner — the loop's generic text channel
+   * (status lines, hook feedback, slash-command output). The one shape that
+   * MUST surface is a hook block (e.g. a workspace-authored UserPromptSubmit
+   * hook rejecting a prompt): the model never sees the prompt, the CLI writes
+   * nothing to the transcript, and without this the session just goes idle —
+   * an agent that silently ignores input. Persist warning-level banners to the
+   * transcript JSONL (reload-safe), then nudge clients to refetch.
+   */
+  private handleInformational(
+    sessionId: string,
+    state: StreamingState,
+    content: { uuid?: string; content?: string; level?: string; prevent_continuation?: boolean },
+  ): void {
+    const isBlocking = content.prevent_continuation === true
+    const isWarning = content.level === 'warning' || content.level === 'error'
+    // Info-level chatter (non-blocking status lines) stays stream-only.
+    if (!isBlocking && !isWarning) return
+    const text = typeof content.content === 'string' ? content.content : ''
+    if (!text) return
+    if (!state.agentSlug) {
+      console.warn(`[MessagePersister] Dropping informational banner for ${sessionId}: no agent slug`)
+      return
+    }
+    void appendInformationalEntry(state.agentSlug, sessionId, {
+      uuid: content.uuid || randomUUID(),
+      content: text,
+      level: content.level,
+    })
+      .then(() => {
+        // The banner lives in the transcript now — refetch materializes it.
+        this.broadcastToSSE(sessionId, { type: 'messages_updated' })
+      })
+      .catch((err) => {
+        console.error('[MessagePersister] Failed to persist informational banner:', err)
+      })
+  }
+
   // Broadcast an arbitrary event to all SSE clients for a session (public)
   broadcastSessionEvent(sessionId: string, data: unknown): void {
     this.broadcastToSSE(sessionId, data)
@@ -1449,6 +1489,8 @@ class MessagePersister {
             type: 'memory_recall',
             memoryPaths: content.memory_paths || [],
           })
+        } else if (content.subtype === 'informational') {
+          this.handleInformational(sessionId, state, content)
         }
         break
 
@@ -1485,6 +1527,17 @@ class MessagePersister {
         if (isError || classification.isInterrupt) state.isActive = false
         state.currentText = ''
         state.lastResultSubtype = typeof content.subtype === 'string' ? content.subtype : null
+
+        // A clean success with zero turns and zero API time means the model
+        // was never called — the signature of a settings-file hook blocking
+        // the prompt. The informational banner (persisted above, when the SDK
+        // emitted one) is the user-facing surface; this is the operator
+        // breadcrumb for shapes that arrive without one.
+        if (!isError && !classification.isInterrupt && content.num_turns === 0 && content.duration_api_ms === 0) {
+          console.warn(
+            `[MessagePersister] Session ${sessionId}: turn ended with no model call (num_turns=0) — possible hook-blocked prompt`
+          )
+        }
 
         // Extract and persist context usage from result event
         this.handleResultUsage(sessionId, state, content)

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -357,6 +357,41 @@ export class DelayedTextResponseScenario implements MockScenario {
 }
 
 /**
+ * Hook-blocked prompt scenario — mirrors what the CLI emits when a workspace
+ * settings-file hook (e.g. UserPromptSubmit) blocks a prompt: a warning-level
+ * `informational` system message with prevent_continuation, then a success
+ * result with num_turns 0 and no API time. Crucially, the CLI writes NOTHING
+ * to the transcript JSONL for a blocked prompt — the host's message-persister
+ * is responsible for persisting the banner.
+ */
+export class HookBlockScenario implements MockScenario {
+  constructor(private reason: string) {}
+
+  execute(sessionId: string, client: MockContainerClient, userMessage: string): void {
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'system',
+        content: {
+          type: 'system',
+          subtype: 'informational',
+          uuid: randomUUID(),
+          content: `UserPromptSubmit operation blocked by hook:\n${this.reason}\n\nOriginal prompt: ${userMessage}`,
+          level: 'warning',
+          prevent_continuation: true,
+        },
+      })
+    }, 80)
+
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'result',
+        content: { type: 'result', subtype: 'success', num_turns: 0, duration_api_ms: 0 },
+      })
+    }, 160)
+  }
+}
+
+/**
  * Tool use scenario - simulates a tool call with result
  * Event format matches what MessagePersister expects from the real container
  */
@@ -1149,6 +1184,8 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     )],
     // Register a background bash scenario for testing background task tracking
     ['run background', new BackgroundBashScenario(2000, 'done sleeping')],
+    // A workspace hook blocking the prompt before the model sees it
+    ['trip the breaker', new HookBlockScenario('Circuit breaker: too many messages without operator input')],
     // Register a slow response scenario for cross-session tests
     ['slow response', new DelayedTextResponseScenario(
       'This is a delayed mock response.',

--- a/src/shared/lib/services/agent-hooks-schema.ts
+++ b/src/shared/lib/services/agent-hooks-schema.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod'
+
+/**
+ * Boundary schemas for the `hooks` key of the Claude Code CLI settings file in
+ * an agent workspace (`<workspace>/.claude/settings.json`). Hooks are shell
+ * commands the CLI executes at lifecycle events; agents can (and do) write
+ * them into their own settings file, so the host surfaces and manages them.
+ *
+ * Everything is a loose object: we only model what we display/remove, and the
+ * file is shared with the CLI — unknown keys must survive round-trips.
+ */
+
+export const hookCommandSchema = z.looseObject({
+  type: z.string().optional(),
+  command: z.string().optional(),
+  timeout: z.number().optional(),
+})
+
+export const hookMatcherGroupSchema = z.looseObject({
+  matcher: z.string().optional(),
+  hooks: z.array(hookCommandSchema).optional(),
+})
+
+/** The `hooks` key: event name → matcher groups. */
+export const claudeHooksConfigSchema = z.record(z.string(), z.array(hookMatcherGroupSchema))
+
+/** Whole settings file, modeling only `hooks` (passthrough preserves the rest). */
+export const claudeSettingsWithHooksSchema = z.looseObject({
+  hooks: claudeHooksConfigSchema.optional(),
+})
+
+export type ClaudeHooksConfig = z.infer<typeof claudeHooksConfigSchema>
+
+/** One configured hook command, flattened for display. */
+export interface AgentHook {
+  /** Lifecycle event, e.g. "UserPromptSubmit", "PreToolUse". */
+  event: string
+  /** Tool-name matcher (PreToolUse/PostToolUse); empty for events without one. */
+  matcher?: string
+  /** Hook implementation type; command hooks are the only kind the CLI runs from settings. */
+  type?: string
+  command?: string
+  timeout?: number
+}
+
+/** Events that can veto work outright — worth a louder UI treatment. */
+export const BLOCKING_HOOK_EVENTS = new Set(['UserPromptSubmit'])
+
+/** Body of a hook-removal request: identifies hook entries by content, not index. */
+export const removeAgentHookSchema = z.object({
+  event: z.string().min(1),
+  command: z.string().min(1),
+  matcher: z.string().optional(),
+})
+
+export type RemoveAgentHookTarget = z.infer<typeof removeAgentHookSchema>

--- a/src/shared/lib/services/agent-hooks-schema.ts
+++ b/src/shared/lib/services/agent-hooks-schema.ts
@@ -12,7 +12,10 @@ import { z } from 'zod'
 
 export const hookCommandSchema = z.looseObject({
   type: z.string().optional(),
+  // `type: "command"` hooks run a shell command; `type: "prompt"` hooks run a
+  // single-turn model evaluation of `prompt`. Either field identifies the hook.
   command: z.string().optional(),
+  prompt: z.string().optional(),
   timeout: z.number().optional(),
 })
 
@@ -31,26 +34,36 @@ export const claudeSettingsWithHooksSchema = z.looseObject({
 
 export type ClaudeHooksConfig = z.infer<typeof claudeHooksConfigSchema>
 
-/** One configured hook command, flattened for display. */
+/** One configured hook, flattened for display. */
 export interface AgentHook {
   /** Lifecycle event, e.g. "UserPromptSubmit", "PreToolUse". */
   event: string
   /** Tool-name matcher (PreToolUse/PostToolUse); empty for events without one. */
   matcher?: string
-  /** Hook implementation type; command hooks are the only kind the CLI runs from settings. */
+  /** Hook implementation type, e.g. "command" or "prompt". */
   type?: string
   command?: string
+  prompt?: string
   timeout?: number
 }
 
 /** Events that can veto work outright — worth a louder UI treatment. */
 export const BLOCKING_HOOK_EVENTS = new Set(['UserPromptSubmit'])
 
-/** Body of a hook-removal request: identifies hook entries by content, not index. */
-export const removeAgentHookSchema = z.object({
-  event: z.string().min(1),
-  command: z.string().min(1),
-  matcher: z.string().optional(),
-})
+/**
+ * Body of a hook-removal request: identifies hook entries by content, not
+ * index (the file can change between list and remove). At least one of
+ * command/prompt is required — a bare event would wipe unrelated hooks.
+ */
+export const removeAgentHookSchema = z
+  .object({
+    event: z.string().min(1),
+    matcher: z.string().optional(),
+    command: z.string().optional(),
+    prompt: z.string().optional(),
+  })
+  .refine((t) => t.command !== undefined || t.prompt !== undefined, {
+    message: 'command or prompt is required',
+  })
 
 export type RemoveAgentHookTarget = z.infer<typeof removeAgentHookSchema>

--- a/src/shared/lib/services/agent-hooks-service.test.ts
+++ b/src/shared/lib/services/agent-hooks-service.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { readAgentHooks, removeAgentHook } from './agent-hooks-service'
+
+const AGENT = 'test-agent'
+
+describe('agent-hooks-service', () => {
+  let testDir: string
+  let originalEnv: string | undefined
+
+  beforeEach(async () => {
+    testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-hooks-test-'))
+    originalEnv = process.env.SUPERAGENT_DATA_DIR
+    process.env.SUPERAGENT_DATA_DIR = testDir
+  })
+
+  afterEach(async () => {
+    process.env.SUPERAGENT_DATA_DIR = originalEnv
+    await fs.promises.rm(testDir, { recursive: true, force: true })
+  })
+
+  function settingsPath(): string {
+    return path.join(testDir, 'agents', AGENT, 'workspace', '.claude', 'settings.json')
+  }
+
+  function writeSettings(settings: unknown): void {
+    const p = settingsPath()
+    fs.mkdirSync(path.dirname(p), { recursive: true })
+    fs.writeFileSync(p, typeof settings === 'string' ? settings : JSON.stringify(settings))
+  }
+
+  // The incident shape: a self-installed UserPromptSubmit gate plus an
+  // unrelated setting the CLI owns.
+  const INCIDENT_SETTINGS = {
+    cleanupPeriodDays: 9999,
+    hooks: {
+      UserPromptSubmit: [
+        {
+          hooks: [
+            { type: 'command', command: 'python3 /workspace/.claude/hooks/deadping_gate.py', timeout: 10 },
+          ],
+        },
+      ],
+      PreToolUse: [
+        {
+          matcher: 'Bash',
+          hooks: [{ type: 'command', command: 'echo pre-bash' }],
+        },
+      ],
+    },
+  }
+
+  describe('readAgentHooks', () => {
+    it('returns [] when the settings file does not exist', async () => {
+      expect(await readAgentHooks(AGENT)).toEqual([])
+    })
+
+    it('returns [] when the settings file is not valid JSON', async () => {
+      writeSettings('{ not json')
+      expect(await readAgentHooks(AGENT)).toEqual([])
+    })
+
+    it('returns [] when there is no hooks key', async () => {
+      writeSettings({ cleanupPeriodDays: 9999 })
+      expect(await readAgentHooks(AGENT)).toEqual([])
+    })
+
+    it('flattens hooks to one row per command, carrying event/matcher/timeout', async () => {
+      writeSettings(INCIDENT_SETTINGS)
+      const hooks = await readAgentHooks(AGENT)
+      expect(hooks).toEqual([
+        {
+          event: 'UserPromptSubmit',
+          type: 'command',
+          command: 'python3 /workspace/.claude/hooks/deadping_gate.py',
+          timeout: 10,
+        },
+        { event: 'PreToolUse', matcher: 'Bash', type: 'command', command: 'echo pre-bash' },
+      ])
+    })
+
+    it('tolerates unknown hook fields (loose parse)', async () => {
+      writeSettings({
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: 'echo done', unknownField: true }] }],
+        },
+      })
+      const hooks = await readAgentHooks(AGENT)
+      expect(hooks).toHaveLength(1)
+      expect(hooks[0].command).toBe('echo done')
+    })
+  })
+
+  describe('removeAgentHook', () => {
+    it('removes the target hook and preserves every other settings key', async () => {
+      writeSettings(INCIDENT_SETTINGS)
+      const remaining = await removeAgentHook(AGENT, {
+        event: 'UserPromptSubmit',
+        command: 'python3 /workspace/.claude/hooks/deadping_gate.py',
+      })
+      expect(remaining).toEqual([
+        { event: 'PreToolUse', matcher: 'Bash', type: 'command', command: 'echo pre-bash' },
+      ])
+
+      const onDisk = JSON.parse(fs.readFileSync(settingsPath(), 'utf-8'))
+      expect(onDisk.cleanupPeriodDays).toBe(9999)
+      expect(onDisk.hooks.UserPromptSubmit).toBeUndefined()
+      expect(onDisk.hooks.PreToolUse).toHaveLength(1)
+    })
+
+    it('drops the hooks key entirely when the last hook is removed', async () => {
+      writeSettings({
+        cleanupPeriodDays: 9999,
+        hooks: { UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'echo x' }] }] },
+      })
+      const remaining = await removeAgentHook(AGENT, { event: 'UserPromptSubmit', command: 'echo x' })
+      expect(remaining).toEqual([])
+
+      const onDisk = JSON.parse(fs.readFileSync(settingsPath(), 'utf-8'))
+      expect(onDisk.hooks).toBeUndefined()
+      expect(onDisk.cleanupPeriodDays).toBe(9999)
+    })
+
+    it('only removes from the matching matcher group', async () => {
+      writeSettings({
+        hooks: {
+          PreToolUse: [
+            { matcher: 'Bash', hooks: [{ type: 'command', command: 'echo x' }] },
+            { matcher: 'Write', hooks: [{ type: 'command', command: 'echo x' }] },
+          ],
+        },
+      })
+      const remaining = await removeAgentHook(AGENT, {
+        event: 'PreToolUse',
+        command: 'echo x',
+        matcher: 'Bash',
+      })
+      expect(remaining).toEqual([
+        { event: 'PreToolUse', matcher: 'Write', type: 'command', command: 'echo x' },
+      ])
+    })
+
+    it('leaves other hooks in the same group intact', async () => {
+      writeSettings({
+        hooks: {
+          UserPromptSubmit: [
+            { hooks: [{ type: 'command', command: 'echo a' }, { type: 'command', command: 'echo b' }] },
+          ],
+        },
+      })
+      const remaining = await removeAgentHook(AGENT, { event: 'UserPromptSubmit', command: 'echo a' })
+      expect(remaining).toEqual([
+        { event: 'UserPromptSubmit', type: 'command', command: 'echo b' },
+      ])
+    })
+
+    it('throws (and does not rewrite) when the settings file is not valid JSON', async () => {
+      writeSettings('{ definitely not json')
+      await expect(
+        removeAgentHook(AGENT, { event: 'UserPromptSubmit', command: 'echo x' })
+      ).rejects.toThrow('not valid JSON')
+      expect(fs.readFileSync(settingsPath(), 'utf-8')).toBe('{ definitely not json')
+    })
+
+    it('throws when the settings file does not exist', async () => {
+      await expect(
+        removeAgentHook(AGENT, { event: 'UserPromptSubmit', command: 'echo x' })
+      ).rejects.toThrow()
+    })
+  })
+})

--- a/src/shared/lib/services/agent-hooks-service.test.ts
+++ b/src/shared/lib/services/agent-hooks-service.test.ts
@@ -81,6 +81,20 @@ describe('agent-hooks-service', () => {
       ])
     })
 
+    it('flattens prompt-type hooks (no command field)', async () => {
+      writeSettings({
+        hooks: {
+          UserPromptSubmit: [
+            { matcher: '', hooks: [{ type: 'prompt', prompt: 'Reject messages starting with hey' }] },
+          ],
+        },
+      })
+      const hooks = await readAgentHooks(AGENT)
+      expect(hooks).toEqual([
+        { event: 'UserPromptSubmit', matcher: '', type: 'prompt', prompt: 'Reject messages starting with hey' },
+      ])
+    })
+
     it('tolerates unknown hook fields (loose parse)', async () => {
       writeSettings({
         hooks: {
@@ -153,6 +167,25 @@ describe('agent-hooks-service', () => {
       const remaining = await removeAgentHook(AGENT, { event: 'UserPromptSubmit', command: 'echo a' })
       expect(remaining).toEqual([
         { event: 'UserPromptSubmit', type: 'command', command: 'echo b' },
+      ])
+    })
+
+    it('removes a prompt-type hook by prompt', async () => {
+      writeSettings({
+        hooks: {
+          UserPromptSubmit: [
+            { matcher: '', hooks: [{ type: 'prompt', prompt: 'Reject hey' }] },
+            { matcher: '', hooks: [{ type: 'command', command: 'echo gate' }] },
+          ],
+        },
+      })
+      const remaining = await removeAgentHook(AGENT, {
+        event: 'UserPromptSubmit',
+        matcher: '',
+        prompt: 'Reject hey',
+      })
+      expect(remaining).toEqual([
+        { event: 'UserPromptSubmit', matcher: '', type: 'command', command: 'echo gate' },
       ])
     })
 

--- a/src/shared/lib/services/agent-hooks-service.ts
+++ b/src/shared/lib/services/agent-hooks-service.ts
@@ -1,0 +1,116 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { getAgentWorkspaceDir, writeJsonFileAtomic } from '@shared/lib/utils/file-storage'
+import {
+  claudeSettingsWithHooksSchema,
+  type AgentHook,
+  type ClaudeHooksConfig,
+  type RemoveAgentHookTarget,
+} from './agent-hooks-schema'
+
+/**
+ * Reads and edits the `hooks` key of an agent workspace's Claude settings file
+ * (`<workspace>/.claude/settings.json`). The workspace is host-mounted, so
+ * this works whether the agent container is running or cold. The file is
+ * shared with the CLI (and with the agent itself, which can write it), so
+ * edits touch ONLY the `hooks` key and preserve everything else.
+ */
+
+function getClaudeSettingsPath(agentSlug: string): string {
+  return path.join(getAgentWorkspaceDir(agentSlug), '.claude', 'settings.json')
+}
+
+function flattenHooks(config: ClaudeHooksConfig): AgentHook[] {
+  const rows: AgentHook[] = []
+  for (const [event, groups] of Object.entries(config)) {
+    for (const group of groups) {
+      for (const hook of group.hooks ?? []) {
+        rows.push({
+          event,
+          ...(group.matcher !== undefined && { matcher: group.matcher }),
+          ...(hook.type !== undefined && { type: hook.type }),
+          ...(hook.command !== undefined && { command: hook.command }),
+          ...(hook.timeout !== undefined && { timeout: hook.timeout }),
+        })
+      }
+    }
+  }
+  return rows
+}
+
+/**
+ * List the hooks configured in the agent's workspace settings file, flattened
+ * to one row per hook command. Returns [] when the file is missing, is not
+ * valid JSON, or has no hooks key.
+ */
+export async function readAgentHooks(agentSlug: string): Promise<AgentHook[]> {
+  const settingsPath = getClaudeSettingsPath(agentSlug)
+  const content = await fs.promises.readFile(settingsPath, 'utf-8').catch(() => null)
+  if (!content) return []
+
+  let raw: unknown
+  try {
+    raw = JSON.parse(content)
+  } catch {
+    return []
+  }
+  const parsed = claudeSettingsWithHooksSchema.safeParse(raw)
+  if (!parsed.success || !parsed.data.hooks) return []
+  return flattenHooks(parsed.data.hooks)
+}
+
+/**
+ * Remove every hook command matching the target (event + command + matcher)
+ * from the agent's workspace settings file. Matcher-less groups match a
+ * matcher-less target. Empty matcher groups and empty event arrays are pruned;
+ * all other settings keys round-trip untouched. Throws when the settings file
+ * is unreadable or not valid JSON — a removal must never silently rewrite a
+ * file it couldn't faithfully parse.
+ */
+export async function removeAgentHook(
+  agentSlug: string,
+  target: RemoveAgentHookTarget
+): Promise<AgentHook[]> {
+  const settingsPath = getClaudeSettingsPath(agentSlug)
+  const content = await fs.promises.readFile(settingsPath, 'utf-8')
+  let raw: unknown
+  try {
+    raw = JSON.parse(content)
+  } catch {
+    throw new Error('Agent settings file is not valid JSON; refusing to rewrite it')
+  }
+  // Parse with the boundary schema; passthrough keeps every key we don't model.
+  const settings = claudeSettingsWithHooksSchema.parse(raw)
+  if (!settings.hooks) return []
+
+  const targetMatcher = target.matcher ?? ''
+  const updatedHooks: ClaudeHooksConfig = {}
+  for (const [event, groups] of Object.entries(settings.hooks)) {
+    if (event !== target.event) {
+      updatedHooks[event] = groups
+      continue
+    }
+    const updatedGroups = groups
+      .map((group) => {
+        if ((group.matcher ?? '') !== targetMatcher) return group
+        return {
+          ...group,
+          hooks: (group.hooks ?? []).filter((hook) => hook.command !== target.command),
+        }
+      })
+      .filter((group) => (group.hooks ?? []).length > 0)
+    if (updatedGroups.length > 0) {
+      updatedHooks[event] = updatedGroups
+    }
+  }
+
+  const updatedSettings: Record<string, unknown> = { ...settings }
+  if (Object.keys(updatedHooks).length > 0) {
+    updatedSettings.hooks = updatedHooks
+  } else {
+    delete updatedSettings.hooks
+  }
+
+  await writeJsonFileAtomic(settingsPath, updatedSettings)
+  return Object.keys(updatedHooks).length > 0 ? flattenHooks(updatedHooks) : []
+}

--- a/src/shared/lib/services/agent-hooks-service.ts
+++ b/src/shared/lib/services/agent-hooks-service.ts
@@ -30,6 +30,7 @@ function flattenHooks(config: ClaudeHooksConfig): AgentHook[] {
           ...(group.matcher !== undefined && { matcher: group.matcher }),
           ...(hook.type !== undefined && { type: hook.type }),
           ...(hook.command !== undefined && { command: hook.command }),
+          ...(hook.prompt !== undefined && { prompt: hook.prompt }),
           ...(hook.timeout !== undefined && { timeout: hook.timeout }),
         })
       }
@@ -60,7 +61,7 @@ export async function readAgentHooks(agentSlug: string): Promise<AgentHook[]> {
 }
 
 /**
- * Remove every hook command matching the target (event + command + matcher)
+ * Remove every hook matching the target (event + matcher + command/prompt)
  * from the agent's workspace settings file. Matcher-less groups match a
  * matcher-less target. Empty matcher groups and empty event arrays are pruned;
  * all other settings keys round-trip untouched. Throws when the settings file
@@ -84,6 +85,10 @@ export async function removeAgentHook(
   if (!settings.hooks) return []
 
   const targetMatcher = target.matcher ?? ''
+  // Every provided discriminator must match (schema guarantees at least one).
+  const matchesTarget = (hook: { command?: string; prompt?: string }): boolean =>
+    (target.command === undefined || hook.command === target.command) &&
+    (target.prompt === undefined || hook.prompt === target.prompt)
   const updatedHooks: ClaudeHooksConfig = {}
   for (const [event, groups] of Object.entries(settings.hooks)) {
     if (event !== target.event) {
@@ -95,7 +100,7 @@ export async function removeAgentHook(
         if ((group.matcher ?? '') !== targetMatcher) return group
         return {
           ...group,
-          hooks: (group.hooks ?? []).filter((hook) => hook.command !== target.command),
+          hooks: (group.hooks ?? []).filter((hook) => !matchesTarget(hook)),
         }
       })
       .filter((group) => (group.hooks ?? []).length > 0)

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -514,7 +514,7 @@ function isMessageOrSystemDisplayEntry(
   if (entry.type === 'user' || entry.type === 'assistant') return true
   if (entry.type === 'system') {
     const subtype = (entry as JsonlSystemEntry).subtype
-    return subtype === 'compact_boundary' || subtype === 'memory_recall'
+    return subtype === 'compact_boundary' || subtype === 'memory_recall' || subtype === 'informational'
   }
   return false
 }

--- a/src/shared/lib/services/session-transcript-append.ts
+++ b/src/shared/lib/services/session-transcript-append.ts
@@ -1,0 +1,34 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { getSessionJsonlPath } from '@shared/lib/utils/file-storage'
+import type { JsonlSystemEntry } from '@shared/lib/types/agent'
+
+/**
+ * Append a host-authored `system`/`informational` entry to a session's JSONL
+ * transcript. The CLI writes nothing to the transcript when a UserPromptSubmit
+ * hook blocks a prompt — the warning exists only on the live SDK stream — so
+ * the host persists it here to make the block visible (and reload-safe) in the
+ * transcript. Creates the transcript file (and parent dirs) if the block
+ * happened before the CLI ever wrote one.
+ *
+ * Lives in its own module (not session-service) so the many tests that mock
+ * session-service with explicit factories keep working unchanged.
+ */
+export async function appendInformationalEntry(
+  agentSlug: string,
+  sessionId: string,
+  entry: { uuid: string; content: string; level?: string }
+): Promise<void> {
+  const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
+  const jsonlEntry: JsonlSystemEntry = {
+    uuid: entry.uuid,
+    type: 'system',
+    subtype: 'informational',
+    content: entry.content,
+    level: entry.level,
+    isMeta: false,
+    timestamp: new Date().toISOString(),
+  }
+  await fs.promises.mkdir(path.dirname(jsonlPath), { recursive: true })
+  await fs.promises.appendFile(jsonlPath, JSON.stringify(jsonlEntry) + '\n', 'utf-8')
+}

--- a/src/shared/lib/services/session-transcript-append.ts
+++ b/src/shared/lib/services/session-transcript-append.ts
@@ -20,6 +20,11 @@ export async function appendInformationalEntry(
   entry: { uuid: string; content: string; level?: string }
 ): Promise<void> {
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
+  // Idempotent by uuid: some hook shapes (continue:false) make the CLI persist
+  // the banner itself with the streamed uuid, and the container's late-join
+  // replay can deliver the same frame twice — never write a duplicate line.
+  const existing = await fs.promises.readFile(jsonlPath, 'utf-8').catch(() => null)
+  if (existing?.includes(`"${entry.uuid}"`)) return
   const jsonlEntry: JsonlSystemEntry = {
     uuid: entry.uuid,
     type: 'system',

--- a/src/shared/lib/types/agent.ts
+++ b/src/shared/lib/types/agent.ts
@@ -198,6 +198,9 @@ export interface JsonlSystemEntry {
     preTokens: number
   }
   memory_paths?: string[]
+  // Severity for `informational` entries (host-persisted loop banners, e.g. a
+  // hook blocking a prompt). Mirrors the SDK's informational message `level`.
+  level?: string
 }
 
 /**

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -209,9 +209,21 @@ export interface ApiMemoryRecall {
 }
 
 /**
+ * Host-persisted informational banner in API response (e.g. a hook blocked a
+ * prompt before it reached the model)
+ */
+export interface ApiInformational {
+  id: string
+  type: 'informational'
+  content: string
+  level?: string
+  createdAt: Date
+}
+
+/**
  * Union type for all message-like items in the API response
  */
-export type ApiMessageOrBoundary = ApiMessage | ApiCompactBoundary | ApiMemoryRecall
+export type ApiMessageOrBoundary = ApiMessage | ApiCompactBoundary | ApiMemoryRecall | ApiInformational
 
 // ============================================================================
 // Secret API Types

--- a/src/shared/lib/utils/message-transform.test.ts
+++ b/src/shared/lib/utils/message-transform.test.ts
@@ -6,7 +6,7 @@ import {
   parseCommandMessage,
   TransformedMessage,
 } from './message-transform'
-import { JsonlMessageEntry, ContentBlock } from '@shared/lib/types/agent'
+import { JsonlMessageEntry, JsonlSystemEntry, ContentBlock } from '@shared/lib/types/agent'
 
 /** Helper to narrow TransformedItem to TransformedMessage in tests */
 function asMessage(item: unknown): TransformedMessage {
@@ -1670,6 +1670,63 @@ describe('parseCommandMessage', () => {
       ])
       const result = transformMessages([entry])
       expect(asMessage(result[0]).apiError).toBeUndefined()
+    })
+  })
+
+  // ============================================================================
+  // Informational banners (host-persisted, e.g. hook-blocked prompts)
+  // ============================================================================
+
+  describe('informational entries', () => {
+    function createInformational(
+      uuid: string,
+      content: string,
+      timestamp: string = '2026-01-24T10:00:00.500Z'
+    ): JsonlSystemEntry {
+      return {
+        type: 'system',
+        subtype: 'informational',
+        uuid,
+        content,
+        level: 'warning',
+        isMeta: false,
+        timestamp,
+      }
+    }
+
+    it('emits a trailing informational item when nothing follows it (blocked prompt)', () => {
+      const entries = [
+        createUserMessage('user-1', 'Hello'),
+        createAssistantMessage('asst-1', 'msg-1', [{ type: 'text', text: 'Hi!' }]),
+        createInformational('info-1', 'UserPromptSubmit operation blocked by hook:\nCircuit breaker'),
+      ]
+      const result = transformMessages(entries)
+      expect(result).toHaveLength(3)
+      const last = result[2] as { type: string; content: string; level?: string; id: string }
+      expect(last.type).toBe('informational')
+      expect(last.content).toContain('blocked by hook')
+      expect(last.level).toBe('warning')
+      expect(last.id).toBe('info-1')
+    })
+
+    it('anchors an informational item before the next message', () => {
+      const entries = [
+        createUserMessage('user-1', 'First'),
+        createInformational('info-1', 'Prompt blocked'),
+        createUserMessage('user-2', 'iman please respond', '2026-01-24T10:00:02.000Z'),
+      ]
+      const result = transformMessages(entries)
+      expect(result.map((r) => r.type)).toEqual(['user', 'informational', 'user'])
+    })
+
+    it('preserves multiple trailing informational items in order', () => {
+      const entries = [
+        createUserMessage('user-1', 'Hello'),
+        createInformational('info-1', 'Blocked once'),
+        createInformational('info-2', 'Blocked twice', '2026-01-24T10:00:01.000Z'),
+      ]
+      const result = transformMessages(entries)
+      expect(result.map((r) => r.id)).toEqual(['user-1', 'info-1', 'info-2'])
     })
   })
 })

--- a/src/shared/lib/utils/message-transform.test.ts
+++ b/src/shared/lib/utils/message-transform.test.ts
@@ -1753,6 +1753,21 @@ describe('parseCommandMessage', () => {
       expect(result.map((r) => r.id)).toEqual(['user-1', 'info-1'])
     })
 
+    it('hides the synthetic stop-reason user entry even when it precedes the duplicate banner copy', () => {
+      // Write-order race: the host's appended banner lands BEFORE the CLI's
+      // own copy, so the CLI's synthetic user entry sits next to the copy
+      // that uuid-dedupe drops — it must still be hidden.
+      const stopText = "Operation stopped by hook: Messages starting with 'hey' are not allowed."
+      const entries = [
+        createUserMessage('user-1', 'hey'),
+        createInformational('info-dup', stopText, '2026-01-24T10:00:01.000Z'),
+        createUserMessage('user-2', stopText, '2026-01-24T10:00:01.100Z'),
+        createInformational('info-dup', stopText, '2026-01-24T10:00:01.200Z'),
+      ]
+      const result = transformMessages(entries)
+      expect(result.map((r) => r.id)).toEqual(['user-1', 'info-dup'])
+    })
+
     it('keeps a preceding user message whose content differs from the banner', () => {
       const entries = [
         createUserMessage('user-1', 'hey'),

--- a/src/shared/lib/utils/message-transform.test.ts
+++ b/src/shared/lib/utils/message-transform.test.ts
@@ -1728,5 +1728,38 @@ describe('parseCommandMessage', () => {
       const result = transformMessages(entries)
       expect(result.map((r) => r.id)).toEqual(['user-1', 'info-1', 'info-2'])
     })
+
+    it('dedupes informational entries sharing a uuid (CLI copy + host copy)', () => {
+      // continue:false hooks: the CLI persists the banner itself AND the host
+      // appends its own copy from the stream — both carry the frame's uuid.
+      const entries = [
+        createUserMessage('user-1', 'hey'),
+        createInformational('info-dup', 'Operation stopped by hook: no hey'),
+        createInformational('info-dup', 'Operation stopped by hook: no hey', '2026-01-24T10:00:01.000Z'),
+      ]
+      const result = transformMessages(entries)
+      expect(result.filter((r) => r.type === 'informational')).toHaveLength(1)
+    })
+
+    it('hides the synthetic stop-reason user entry that mirrors the banner', () => {
+      // The CLI records the stop text as a user entry right before the banner.
+      const stopText = "Operation stopped by hook: Messages starting with 'hey' are not allowed."
+      const entries = [
+        createUserMessage('user-1', 'hey'),
+        createUserMessage('user-2', stopText, '2026-01-24T10:00:01.000Z'),
+        createInformational('info-1', stopText, '2026-01-24T10:00:01.100Z'),
+      ]
+      const result = transformMessages(entries)
+      expect(result.map((r) => r.id)).toEqual(['user-1', 'info-1'])
+    })
+
+    it('keeps a preceding user message whose content differs from the banner', () => {
+      const entries = [
+        createUserMessage('user-1', 'hey'),
+        createInformational('info-1', 'Operation stopped by hook: nope'),
+      ]
+      const result = transformMessages(entries)
+      expect(result.map((r) => r.id)).toEqual(['user-1', 'info-1'])
+    })
   })
 })

--- a/src/shared/lib/utils/message-transform.ts
+++ b/src/shared/lib/utils/message-transform.ts
@@ -174,8 +174,27 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
       memoryRecalls.set(i, entry as JsonlSystemEntry)
       skipIndices.add(i)
     } else if (entry.type === 'system' && (entry as JsonlSystemEntry).subtype === 'informational') {
-      informationals.set(i, entry as JsonlSystemEntry)
+      const sysEntry = entry as JsonlSystemEntry
       skipIndices.add(i)
+      // Dedupe by uuid: for some hook shapes (continue:false) the CLI persists
+      // the banner itself with the SAME uuid it streamed, and the host appends
+      // its own copy from the stream — keep whichever landed first.
+      const isDuplicate = [...informationals.values()].some((e) => e.uuid === sysEntry.uuid)
+      if (!isDuplicate) {
+        informationals.set(i, sysEntry)
+        // The CLI also records a synthetic user entry carrying the same stop
+        // text just before the banner ("Operation stopped by hook: ...") —
+        // hide it; the banner is the user-facing surface.
+        const prev = i > 0 ? entries[i - 1] : null
+        if (
+          prev &&
+          prev.type === 'user' &&
+          typeof (prev as JsonlMessageEntry).message.content === 'string' &&
+          (prev as JsonlMessageEntry).message.content === sysEntry.content
+        ) {
+          skipIndices.add(i - 1)
+        }
+      }
     } else if (entry.type === 'system' && (entry as JsonlSystemEntry).subtype === 'compact_boundary') {
       const sysEntry = entry as JsonlSystemEntry
       let summaryContent = ''

--- a/src/shared/lib/utils/message-transform.ts
+++ b/src/shared/lib/utils/message-transform.ts
@@ -182,18 +182,20 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
       const isDuplicate = [...informationals.values()].some((e) => e.uuid === sysEntry.uuid)
       if (!isDuplicate) {
         informationals.set(i, sysEntry)
-        // The CLI also records a synthetic user entry carrying the same stop
-        // text just before the banner ("Operation stopped by hook: ...") —
-        // hide it; the banner is the user-facing surface.
-        const prev = i > 0 ? entries[i - 1] : null
-        if (
-          prev &&
-          prev.type === 'user' &&
-          typeof (prev as JsonlMessageEntry).message.content === 'string' &&
-          (prev as JsonlMessageEntry).message.content === sysEntry.content
-        ) {
-          skipIndices.add(i - 1)
-        }
+      }
+      // The CLI also records a synthetic user entry carrying the same stop
+      // text just before the banner ("Operation stopped by hook: ...") —
+      // hide it; the banner is the user-facing surface. Checked for duplicate
+      // copies too: when the host's appended banner lands before the CLI's,
+      // the synthetic user entry precedes the CLI copy that dedupe drops.
+      const prev = i > 0 ? entries[i - 1] : null
+      if (
+        prev &&
+        prev.type === 'user' &&
+        typeof (prev as JsonlMessageEntry).message.content === 'string' &&
+        (prev as JsonlMessageEntry).message.content === sysEntry.content
+      ) {
+        skipIndices.add(i - 1)
       }
     } else if (entry.type === 'system' && (entry as JsonlSystemEntry).subtype === 'compact_boundary') {
       const sysEntry = entry as JsonlSystemEntry

--- a/src/shared/lib/utils/message-transform.ts
+++ b/src/shared/lib/utils/message-transform.ts
@@ -60,7 +60,20 @@ export interface TransformedMemoryRecall {
   createdAt: Date
 }
 
-export type TransformedItem = TransformedMessage | TransformedCompactBoundary | TransformedMemoryRecall
+/**
+ * Host-persisted informational banner (e.g. "prompt blocked by hook"). The CLI
+ * emits these on the live stream only; the host appends them to the transcript
+ * so they survive reloads.
+ */
+export interface TransformedInformational {
+  id: string
+  type: 'informational'
+  content: string
+  level?: string
+  createdAt: Date
+}
+
+export type TransformedItem = TransformedMessage | TransformedCompactBoundary | TransformedMemoryRecall | TransformedInformational
 
 /**
  * Parse a user message that may contain SDK-injected slash command XML tags.
@@ -152,12 +165,16 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
   // Pre-pass: identify compact boundaries, memory recalls, and pair them with their summary messages
   const compactBoundaries = new Map<number, { boundary: JsonlSystemEntry; summaryContent: string }>()
   const memoryRecalls = new Map<number, JsonlSystemEntry>()
+  const informationals = new Map<number, JsonlSystemEntry>()
   const skipIndices = new Set<number>()
 
   for (let i = 0; i < entries.length; i++) {
     const entry = entries[i]
     if (entry.type === 'system' && (entry as JsonlSystemEntry).subtype === 'memory_recall') {
       memoryRecalls.set(i, entry as JsonlSystemEntry)
+      skipIndices.add(i)
+    } else if (entry.type === 'system' && (entry as JsonlSystemEntry).subtype === 'informational') {
+      informationals.set(i, entry as JsonlSystemEntry)
       skipIndices.add(i)
     } else if (entry.type === 'system' && (entry as JsonlSystemEntry).subtype === 'compact_boundary') {
       const sysEntry = entry as JsonlSystemEntry
@@ -310,9 +327,11 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
   // This allows us to insert boundaries/recalls at the correct position in the output
   const boundaryBeforeUuid = new Map<string, TransformedCompactBoundary>()
   const recallBeforeUuid = new Map<string, TransformedMemoryRecall[]>()
+  const informationalBeforeUuid = new Map<string, TransformedInformational[]>()
   // Also track items that appear at the very end (no following message)
   const trailingBoundaries: TransformedCompactBoundary[] = []
   const trailingRecalls: TransformedMemoryRecall[] = []
+  const trailingInformationals: TransformedInformational[] = []
 
   for (const [idx, { boundary, summaryContent }] of compactBoundaries) {
     const item: TransformedCompactBoundary = {
@@ -369,6 +388,34 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
     }
   }
 
+  for (const [idx, sysEntry] of informationals) {
+    const item: TransformedInformational = {
+      id: sysEntry.uuid,
+      type: 'informational',
+      content: sysEntry.content || '',
+      level: sysEntry.level,
+      createdAt: new Date(sysEntry.timestamp),
+    }
+
+    let nextUuid: string | null = null
+    for (let j = idx + 1; j < entries.length; j++) {
+      if (skipIndices.has(j)) continue
+      const nextEntry = entries[j]
+      if (nextEntry.type === 'user' || nextEntry.type === 'assistant') {
+        nextUuid = (nextEntry as JsonlMessageEntry).uuid
+        break
+      }
+    }
+
+    if (nextUuid) {
+      const existing = informationalBeforeUuid.get(nextUuid) || []
+      existing.push(item)
+      informationalBeforeUuid.set(nextUuid, existing)
+    } else {
+      trailingInformationals.push(item)
+    }
+  }
+
   // Transform merged message entries, inserting boundaries at correct positions
   const result: TransformedItem[] = []
 
@@ -383,6 +430,12 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
     const boundary = boundaryBeforeUuid.get(entry.uuid)
     if (boundary) {
       result.push(boundary)
+    }
+
+    // Insert any informational banners that precede this message
+    const infos = informationalBeforeUuid.get(entry.uuid)
+    if (infos) {
+      result.push(...infos)
     }
 
     // Skip user messages that only contain tool results
@@ -462,6 +515,7 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
   // Append any system items that appear after all messages
   result.push(...trailingRecalls)
   result.push(...trailingBoundaries)
+  result.push(...trailingInformationals)
 
   return result
 }


### PR DESCRIPTION
## Background

Agents can self-install Claude Code hooks by writing their own workspace `.claude/settings.json` — and one already bricked a production deployment: a self-authored `UserPromptSubmit` "circuit breaker" hook blocked **all** input (human included) for most of 12 days, with zero UI signal. The CLI writes nothing to the transcript for a blocked prompt and the host dropped the SDK's warning on the floor, so the agent just read as silently ignoring everyone.

Fixes SUP-405.

## What this does

### 1. Hooks inspector on the agent homepage
- New `HomeHooks` right-column section listing hooks from the workspace settings file: event, matcher, command, timeout. Self-hides when no hooks are configured (the common case renders nothing).
- `UserPromptSubmit` hooks get an explicit amber warning — they run before every message and can block it.
- One-click remove (owner-only, AlertDialog confirm) via `DELETE /api/agents/:id/hooks`: rewrites **only** the `hooks` key, preserves every other settings key, prunes empty groups, refuses to touch a file it can't parse, writes atomically.
- `GET /api/agents/:id/hooks` reads the host-mounted workspace directly (works with a cold container), Zod-validated at the boundary (`agent-hooks-schema.ts`).

### 2. Hook-blocked prompts surface in the transcript
- `message-persister` now handles the SDK's `system`/`informational` messages: warning-level / `prevent_continuation` banners (the hook-block shape, verified against SDK 0.3.206) are **persisted to the session transcript JSONL** via a new `appendInformationalEntry`, then `messages_updated` is broadcast so the card appears live.
- New `informational` transcript subtype through the whole read path (display filter → transform → API union → renderer). The `InformationalItem` warning card shows the block reason + original prompt and links "Review hooks" to the agent homepage. Persisted, so it survives reload.
- A clean result with `num_turns: 0` + `duration_api_ms: 0` (model never called) logs an operator breadcrumb as a fallback signal.

### Notes for review
- `appendInformationalEntry` lives in its own module (`session-transcript-append.ts`), NOT `session-service` — many tests partially mock session-service with explicit factories, and a new export there breaks them.
- `MockContainerClient` gains a `HookBlockScenario` ("trip the breaker") that mirrors the real CLI block shape exactly, including writing nothing to the transcript — so E2E exercises the host's persistence path for real.
- Deliberately **not** included: stripping/banning agent-authored hooks (separate policy decision), and `disableAllHooks` (it would also kill our programmatic PreToolUse capability gate from #467).

## Testing
- Unit: full suite passes (6970 tests). New coverage: persister informational gating, transform anchoring/trailing, hooks service round-trips (incident-shaped settings, matcher-scoped removal, invalid-JSON refusal).
- E2E (`agent-hooks.spec.ts`, 3/3): homepage lists seeded hooks with warning; removal rewrites only the hooks key on disk; blocked prompt renders the warning card and survives reload.
- `tsc --noEmit` and eslint clean on all touched files.