### PR TITLE
feat: processing-speed selector in the composer model picker

### DIFF
--- a/src/renderer/components/messages/composer-options-popover.test.tsx
+++ b/src/renderer/components/messages/composer-options-popover.test.tsx
@@ -163,4 +163,38 @@ describe('ComposerOptionsPopover', () => {
     render(<Harness disabled initialModel="claude-opus-4-8" />)
     expect(screen.getByTestId('composer-options-trigger')).toBeDisabled()
   })
+
+  it('orders the sections Model → Effort → Speed', async () => {
+    const user = userEvent.setup()
+    render(<Harness initialModel="claude-opus-4-8" />)
+    await user.click(screen.getByTestId('composer-options-trigger'))
+    const models = await screen.findByText('Models')
+    const effort = screen.getByText('Effort')
+    const speed = screen.getByText('Speed')
+    // DOM order == visual order (no col-reverse): Models, then Effort, then Speed.
+    expect(models.compareDocumentPosition(effort) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(effort.compareDocumentPosition(speed) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('offers only Normal/Fast speeds for an Anthropic model', async () => {
+    const user = userEvent.setup()
+    render(<Harness initialModel="claude-opus-4-8" />)
+    await user.click(screen.getByTestId('composer-options-trigger'))
+    expect(await screen.findByTestId('speed-option-normal')).toBeInTheDocument()
+    expect(screen.getByTestId('speed-option-fast')).toBeInTheDocument()
+    expect(screen.queryByTestId('speed-option-slow')).not.toBeInTheDocument()
+  })
+
+  it('adds the Slow speed for a GPT (non-Anthropic) model', async () => {
+    const user = userEvent.setup()
+    const catalog: ModelDefinition[] = [
+      ...CATALOG,
+      { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', family: 'gpt', isLatest: true, icon: 'openai', supportedEfforts: STD },
+    ]
+    render(<Harness catalog={catalog} initialModel="gpt-5.6-sol" />)
+    await user.click(screen.getByTestId('composer-options-trigger'))
+    expect(await screen.findByTestId('speed-option-slow')).toBeInTheDocument()
+    expect(screen.getByTestId('speed-option-normal')).toBeInTheDocument()
+    expect(screen.getByTestId('speed-option-fast')).toBeInTheDocument()
+  })
 })

--- a/src/renderer/components/messages/composer-options-popover.tsx
+++ b/src/renderer/components/messages/composer-options-popover.tsx
@@ -1,13 +1,115 @@
-import { memo } from 'react'
-import { ChevronDown } from 'lucide-react'
+import { memo, useEffect, useState } from 'react'
+import { ChevronDown, HelpCircle } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { Separator } from '@renderer/components/ui/separator'
 import { ModelIcon } from '@renderer/components/ui/model-icon'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@renderer/components/ui/tooltip'
+import { cn } from '@shared/lib/utils'
 import { EFFORT_LEVELS } from '@shared/lib/container/types'
+import type { ModelDefinition } from '@shared/lib/llm-provider'
 import { type ComposerOptionsState } from './composer-options'
 import { ModelFamilyList, findCatalogModel } from './model-family-list'
 import { EFFORT_LABELS, EffortSection, useEffortClamp } from './effort-slider'
+
+// ---- Processing speed (UI exploration; local-only, not yet a runtime option) ----
+type ProcessingSpeed = 'slow' | 'normal' | 'fast'
+
+const SPEED_LABELS: Record<ProcessingSpeed, string> = {
+  slow: 'Slow',
+  normal: 'Normal',
+  fast: 'Fast',
+}
+
+/**
+ * Which speeds a model exposes depends on its vendor: Anthropic models offer
+ * Normal/Fast, while every other vendor (OpenAI, xAI, Z.AI, …) adds the more
+ * deliberate 'slow' tier. Normal is the universal default, so it's always a
+ * safe reset target when a model switch drops the current pick. An undefined
+ * model resolves as Anthropic — the composer's default vendor.
+ */
+function availableSpeeds(model: ModelDefinition | undefined): ProcessingSpeed[] {
+  const isAnthropic = !model || model.icon === 'anthropic'
+  return isAnthropic ? ['normal', 'fast'] : ['slow', 'normal', 'fast']
+}
+
+/**
+ * Speed block mirroring EffortSection's header pattern ("Speed · Normal", value
+ * in the accent blue, help tooltip on the right) over a segmented control in
+ * the same visual language as the vendor tab bar above (muted pill, active
+ * segment lifted with bg + shadow). A segment reads as a toggle, so picks never
+ * dismiss the popover — consistent with model/effort picks here.
+ */
+function SpeedSection({
+  speeds,
+  value,
+  onChange,
+}: {
+  speeds: ProcessingSpeed[]
+  value: ProcessingSpeed
+  onChange: (speed: ProcessingSpeed) => void
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between px-2 pt-1 pb-1 text-[11px] font-medium text-muted-foreground/70">
+        <span>
+          <span>Speed</span>
+          <span className="text-[#007DED] dark:text-[#4EB3FF]"> · {SPEED_LABELS[value]}</span>
+        </span>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="About speed"
+                data-testid="speed-help"
+                className="inline-flex shrink-0 hover:text-foreground"
+              >
+                <HelpCircle className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-60">
+              Faster processing returns replies sooner. Slower processing gives the model more
+              room to work. Available speeds depend on the model.
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+      <div className="px-2 pb-1">
+        <div
+          role="radiogroup"
+          aria-label="Processing speed"
+          className="flex rounded-lg bg-muted p-0.5 text-muted-foreground"
+        >
+          {speeds.map((level) => {
+            const isActive = level === value
+            return (
+              <button
+                key={level}
+                type="button"
+                role="radio"
+                aria-checked={isActive}
+                data-testid={`speed-option-${level}`}
+                onClick={() => onChange(level)}
+                className={cn(
+                  'flex-1 rounded-md px-2 py-1 text-xs transition-all hover:bg-background/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                  isActive && 'bg-background text-foreground shadow'
+                )}
+              >
+                {SPEED_LABELS[level]}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
 
 interface ComposerOptionsPopoverProps {
   state: ComposerOptionsState
@@ -34,10 +136,21 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: C
     selectedModel ? selectedModel.supportedEfforts.includes(level) : true
   )
 
+  // Speed is local-only (UI exploration): options are gated by the selected
+  // model's vendor, and a model switch that drops the current pick snaps back
+  // to Normal — same clamp shape as useEffortClamp.
+  const [speed, setSpeed] = useState<ProcessingSpeed>('normal')
+  const visibleSpeeds = availableSpeeds(selectedModel)
+  useEffect(() => {
+    if (!availableSpeeds(selectedModel).includes(speed)) setSpeed('normal')
+  }, [selectedModel, speed])
+
   const effortLabel = EFFORT_LABELS[effort]
+  // Keep the trigger uncluttered: surface speed only when it's off the default.
+  const speedSuffix = speed === 'normal' ? '' : ` · ${SPEED_LABELS[speed]}`
   const selectedModelLabel = selectedModel?.label
   const triggerAriaLabel = includeEffort
-    ? (selectedModelLabel ? `${selectedModelLabel} · ${effortLabel}` : effortLabel)
+    ? (selectedModelLabel ? `${selectedModelLabel} · ${effortLabel}${speedSuffix}` : `${effortLabel}${speedSuffix}`)
     : (selectedModelLabel ?? 'Model')
 
   return (
@@ -59,7 +172,7 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: C
             {selectedModelLabel}
             {includeEffort && (
               <span className="text-muted-foreground">
-                {selectedModelLabel ? ' · ' : ''}{effortLabel}
+                {selectedModelLabel ? ' · ' : ''}{effortLabel}{speedSuffix}
               </span>
             )}
           </span>
@@ -67,7 +180,10 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: C
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="flex w-64 flex-col px-1 py-2 data-[side=bottom]:flex-col-reverse"
+        // Fixed reading order Model → Effort → Speed in both open directions —
+        // no col-reverse (unlike the settings picker, which flips to keep Effort
+        // by the trigger). Speed is the tertiary knob, so it stays at the bottom.
+        className="flex w-64 flex-col px-1 py-2"
         align="start"
         // Don't auto-focus the first element (a vendor tab) on open — focusing
         // it pops its name tooltip instantly. Keyboard users can Tab in.
@@ -91,6 +207,15 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: C
         )}
         {includeEffort && (
           <EffortSection levels={visibleEfforts} value={effort} onChange={setEffort} />
+        )}
+        {/* Speed rides the same gate as Effort: model-only pickers (summarizer)
+            show neither. Rendered last so it sits below Effort in the fixed
+            Model → Effort → Speed order. */}
+        {includeEffort && (
+          <>
+            <Separator className="my-2 bg-border/50" />
+            <SpeedSection speeds={visibleSpeeds} value={speed} onChange={setSpeed} />
+          </>
         )}
       </PopoverContent>
     </Popover>

--- a/src/renderer/components/messages/effort-slider.test.tsx
+++ b/src/renderer/components/messages/effort-slider.test.tsx
@@ -9,11 +9,13 @@ const ALL = [...EFFORT_LEVELS] as EffortLevel[]
 const STD: EffortLevel[] = ['low', 'medium', 'high']
 
 describe('EffortSlider', () => {
-  it('renders a tick per allowed level, labeling only the Faster/Smarter poles', () => {
+  it('renders a tick per allowed level, with no text labels on the bar itself', () => {
     render(<EffortSlider levels={ALL} value="medium" onChange={vi.fn()} />)
     for (const level of ALL) expect(screen.getByTestId(`effort-option-${level}`)).toBeInTheDocument()
-    expect(screen.getByText('Faster')).toBeInTheDocument()
-    expect(screen.getByText('Smarter')).toBeInTheDocument()
+    // The Faster/Smarter poles moved to EffortSection's header (shown mid-drag),
+    // so the bar carries no pole text of its own.
+    expect(screen.queryByText('Faster')).not.toBeInTheDocument()
+    expect(screen.queryByText('Smarter')).not.toBeInTheDocument()
     // No per-level names on the bar — they live in aria labels only, spelled
     // out in full for screen readers.
     expect(screen.queryByText('Medium')).not.toBeInTheDocument()
@@ -144,6 +146,37 @@ describe('EffortSlider', () => {
     fireEvent.pointerUp(track)
     expect(onChange).toHaveBeenCalledTimes(1)
     expect(onChange).toHaveBeenCalledWith('max')
+  })
+
+  it('EffortSection: the poles cross-fade in over the Effort header while dragging', () => {
+    render(<EffortSection levels={ALL} value="high" onChange={vi.fn()} />)
+    const track = screen.getByTestId('effort-slider').querySelector('.touch-none') as HTMLElement
+    vi.spyOn(track, 'getBoundingClientRect').mockReturnValue({ left: 0, width: 120 } as DOMRect)
+    // Both layers stay mounted (so the motion can play both ways) — the swap is
+    // an opacity/transform cross-fade, not a mount/unmount.
+    const restingLayer = () => screen.getByText('Effort').closest('div') as HTMLElement
+    const polesLayer = () => screen.getByText('Faster').closest('div') as HTMLElement
+    // At rest the header is opaque and the poles are transparent.
+    expect(restingLayer().className).toContain('opacity-100')
+    expect(polesLayer().className).toContain('opacity-0')
+    // Mid-drag the opacities swap.
+    fireEvent.pointerDown(track, { clientX: 60 })
+    expect(restingLayer().className).toContain('opacity-0')
+    expect(polesLayer().className).toContain('opacity-100')
+    // Release restores the resting header.
+    fireEvent.pointerUp(track)
+    expect(restingLayer().className).toContain('opacity-100')
+    expect(polesLayer().className).toContain('opacity-0')
+  })
+
+  it('EffortSection: a cancelled drag fades the resting header back in', () => {
+    render(<EffortSection levels={ALL} value="high" onChange={vi.fn()} />)
+    const track = screen.getByTestId('effort-slider').querySelector('.touch-none') as HTMLElement
+    const restingLayer = () => screen.getByText('Effort').closest('div') as HTMLElement
+    fireEvent.pointerDown(track, { clientX: 0 })
+    expect(restingLayer().className).toContain('opacity-0')
+    fireEvent.pointerCancel(track)
+    expect(restingLayer().className).toContain('opacity-100')
   })
 
   it('EffortSection: releasing back where the drag started persists nothing', () => {

--- a/src/renderer/components/messages/effort-slider.tsx
+++ b/src/renderer/components/messages/effort-slider.tsx
@@ -43,6 +43,9 @@ interface EffortSliderProps {
    *  should follow it (EffortSection feeds it back) so the thumb tracks the
    *  finger — nothing is persisted until onChange settles. */
   onPreview?: (level: EffortLevel | null) => void
+  /** True while a pointer drag is in flight (down → up/cancel). Lets the host
+   *  swap its header for the Faster/Smarter poles only during the drag. */
+  onInteractingChange?: (interacting: boolean) => void
 }
 
 /**
@@ -51,7 +54,7 @@ interface EffortSliderProps {
  * `data-testid="effort-option-<level>"` and selects that level on click, so it's a
  * drop-in for the old button list. Purely controlled — keeps no state of its own.
  */
-export function EffortSlider({ levels, value, onChange, onPreview }: EffortSliderProps) {
+export function EffortSlider({ levels, value, onChange, onPreview, onInteractingChange }: EffortSliderProps) {
   const trackRef = useRef<HTMLDivElement>(null)
   const dragging = useRef(false)
   // Last level previewed during the current gesture: dedups pointermove (which
@@ -89,6 +92,7 @@ export function EffortSlider({ levels, value, onChange, onPreview }: EffortSlide
   const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
     e.preventDefault()
     dragging.current = true
+    onInteractingChange?.(true)
     // Seed with the current value so pressing at the thumb's own stop previews nothing.
     lastPreview.current = value
     e.currentTarget.setPointerCapture?.(e.pointerId)
@@ -105,6 +109,7 @@ export function EffortSlider({ levels, value, onChange, onPreview }: EffortSlide
   const handlePointerUp = () => {
     if (!dragging.current) return
     dragging.current = false
+    onInteractingChange?.(false)
     const settled = lastPreview.current
     lastPreview.current = null
     if (settled !== null) onChange(settled)
@@ -117,6 +122,7 @@ export function EffortSlider({ levels, value, onChange, onPreview }: EffortSlide
   const handlePointerCancel = () => {
     if (!dragging.current) return
     dragging.current = false
+    onInteractingChange?.(false)
     lastPreview.current = null
     onPreview?.(null)
   }
@@ -135,20 +141,11 @@ export function EffortSlider({ levels, value, onChange, onPreview }: EffortSlide
 
   return (
     <div className="px-2 pt-1 pb-2" data-testid="effort-slider">
-      {/* Only the two poles are labeled — the ticks below carry the levels.
-          Each pole pairs the speed/quality trade-off with its cost ($ vs $$$),
-          slightly dimmer so the words stay primary. Color matches the section
-          headers (e.g. "Effort · Medium"). */}
-      <div className="mb-2 flex items-center justify-between text-[11px] text-muted-foreground/70">
-        <span>
-          Faster <span className="text-muted-foreground/50">· $</span>
-        </span>
-        <span>
-          Smarter <span className="text-muted-foreground/50">· $$$</span>
-        </span>
-      </div>
       {/* Track + thumb. The track is a pill slightly taller than the knob, so the
-          knob nestles inside it (toggle style) rather than riding a thin rail. */}
+          knob nestles inside it (toggle style) rather than riding a thin rail.
+          The Faster/Smarter poles used to sit above the track; they now live in
+          EffortSection's header, surfaced only mid-drag where they replace the
+          "Effort · level" label + help toggle to keep the block compact. */}
       <div
         ref={trackRef}
         onPointerDown={handlePointerDown}
@@ -272,39 +269,72 @@ export function EffortSection({
   const [preview, setPreview] = useState<EffortLevel | null>(null)
   useEffect(() => setPreview(null), [value])
   const shown = preview ?? value
+  // While a drag is in flight the header row becomes the Faster/Smarter poles;
+  // at rest it's the "Effort · level" label + help toggle. One row either way —
+  // the poles no longer take a permanent second line above the track.
+  const [dragging, setDragging] = useState(false)
 
   return (
     // A real wrapper (not a fragment): hosts reverse the popover column to keep
     // this section nearest the trigger, and a fragment's children would get
     // reordered individually (slider above its own header).
     <div>
-      <div className="flex items-center justify-between px-2 pt-1 pb-1 text-[11px] font-medium text-muted-foreground/70">
-        <span>
-          <span>Effort</span>
-          <span className="text-[#007DED] dark:text-[#4EB3FF]"> · {EFFORT_LABELS[shown]}</span>
-        </span>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                aria-label="About effort"
-                data-testid="effort-help"
-                className="inline-flex shrink-0 hover:text-foreground"
-              >
-                <HelpCircle className="h-3 w-3" aria-hidden="true" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent className="max-w-60">
-              Higher effort means more thorough responses, but takes longer and is more expensive.
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+      {/* One row, two stacked layers that cross-fade + slide as `dragging` flips.
+          Both stay mounted so the motion plays in both directions: the resting
+          layer sits in flow (defining the row height) and slides up + out; the
+          poles overlay it, sliding up from the slider bar below into its place. */}
+      <div className="relative px-2 pt-1 pb-1 text-[11px] font-medium text-muted-foreground/70">
+        <div
+          className={cn(
+            'flex items-center justify-between transition-[transform,opacity] duration-200 ease-out',
+            dragging ? '-translate-y-1 opacity-0 pointer-events-none' : 'translate-y-0 opacity-100',
+          )}
+        >
+          <span>
+            <span>Effort</span>
+            <span className="text-[#007DED] dark:text-[#4EB3FF]"> · {EFFORT_LABELS[shown]}</span>
+          </span>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="About effort"
+                  data-testid="effort-help"
+                  className="inline-flex shrink-0 hover:text-foreground"
+                >
+                  <HelpCircle className="h-3 w-3" aria-hidden="true" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-60">
+                Higher effort means more thorough responses, but takes longer and is more expensive.
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+        {/* Poles: pair the speed/quality trade-off with its cost ($ vs $$$), the
+            cost dimmer so the words stay primary. Decorative (the slider thumb
+            carries the real semantics), so aria-hidden while at rest. */}
+        <div
+          aria-hidden={!dragging}
+          className={cn(
+            'absolute inset-x-2 top-1 flex items-center justify-between transition-[transform,opacity] duration-200 ease-out',
+            dragging ? 'translate-y-0 opacity-100' : 'translate-y-1 opacity-0 pointer-events-none',
+          )}
+        >
+          <span>
+            Faster <span className="text-muted-foreground/50">· $</span>
+          </span>
+          <span>
+            Smarter <span className="text-muted-foreground/50">· $$$</span>
+          </span>
+        </div>
       </div>
       <EffortSlider
         levels={levels}
         value={shown}
         onPreview={setPreview}
+        onInteractingChange={setDragging}
         onChange={(level) => {
           setPreview(level)
           // The slider can't no-op-guard settles itself (its value prop tracks


### PR DESCRIPTION
## What

Adds a per-message **Speed** control (Slow / Normal / Fast) to the composer's model + effort popover, plus two small refinements to the effort block.

> [!NOTE]
> This is a **UI exploration**. Speed is local component state only — it is **not yet threaded into runtime options / the wire**, so selecting a speed has no backend effect yet. Opening as a draft to review the interaction and look.

## Changes

**Speed selector** (`composer-options-popover.tsx`)
- New `Speed` section below Effort, as a segmented control in the same visual language as the model vendor tab bar (muted pill, active segment lifted with bg + shadow). Header mirrors Effort (`Speed · Normal`, value in accent blue, help tooltip).
- Vendor-gated options: **Anthropic → Normal / Fast**; **every other vendor (OpenAI, xAI, Z.AI, …) → Slow / Normal / Fast**. Normal is the universal default.
- Switching to a model that doesn't offer the current speed snaps back to Normal (same clamp shape as effort).
- Trigger stays uncluttered: speed is appended to the button label (`Opus 4.8 · High · Fast`) only when it's off the default.
- Picks don't dismiss the popover — consistent with model/effort picks.

**Effort block refinements** (`effort-slider.tsx`)
- The `Faster / Smarter` poles move out of the slider into the section header, shown **only during a pointer drag**: they cross-fade + slide up from the slider bar and replace the `Effort · level` label + help toggle. This removes a permanently-visible row and keeps the block compact. `EffortSlider` gains an `onInteractingChange` callback to drive it; keyboard/AT changes don't trigger the swap.
- Composer popover now uses a fixed **Model → Effort → Speed** order by dropping the downward-open `col-reverse` (the settings picker keeps its reverse, since it has no Speed section and benefits from keeping Effort near the trigger).

## Testing

- `composer-options-popover.test.tsx`: section order is Model → Effort → Speed; Anthropic offers only Normal/Fast; a GPT (non-Anthropic) model adds Slow.
- `effort-slider.test.tsx`: poles cross-fade in over the Effort header only while dragging; a cancelled drag restores the resting header.
- `tsc --noEmit` and `eslint` clean; 29 unit tests pass across the two suites.

## Not included / follow-ups

- Wiring speed into `RuntimeOptions` + session persistence + the container (needs a product decision on what each speed maps to).
- Applying the same fixed order to the settings model-picker, if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
