### PR TITLE
Model speed modes: slow/normal/fast end-to-end (SUP-406)

### DIFF
--- a/agent-container/src/attribution-headers.test.ts
+++ b/agent-container/src/attribution-headers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   withAgentAttributionHeaders,
+  withSpeedHeader,
   captureAgentIdentity,
   isAgentIdentityEnvKey,
 } from './attribution-headers'
@@ -106,6 +107,71 @@ describe('withAgentAttributionHeaders', () => {
   it('does not mutate the input env', () => {
     const env = { OTHER: 'v' }
     const out = withAgentAttributionHeaders(env, { id: 'abc123' })
+    expect(env).not.toHaveProperty('ANTHROPIC_CUSTOM_HEADERS')
+    expect(out.OTHER).toBe('v')
+  })
+})
+
+describe('withSpeedHeader', () => {
+  it('adds no header for undefined speed', () => {
+    const env = { PATH: '/usr/bin' }
+    expect(withSpeedHeader(env, undefined)).toEqual(env)
+  })
+
+  it("adds no header for 'normal' — absence IS the wire default", () => {
+    const out = withSpeedHeader({}, 'normal')
+    expect(out).not.toHaveProperty('ANTHROPIC_CUSTOM_HEADERS')
+  })
+
+  it('emits the speed header for fast and slow', () => {
+    expect(withSpeedHeader({}, 'fast').ANTHROPIC_CUSTOM_HEADERS).toBe('X-Superagent-Speed: fast')
+    expect(withSpeedHeader({}, 'slow').ANTHROPIC_CUSTOM_HEADERS).toBe('X-Superagent-Speed: slow')
+  })
+
+  it('appends after existing lines, preserving them', () => {
+    const out = withSpeedHeader(
+      { ANTHROPIC_CUSTOM_HEADERS: 'X-Superagent-Agent-Id: abc123' },
+      'fast'
+    )
+    expect(out.ANTHROPIC_CUSTOM_HEADERS).toBe(
+      'X-Superagent-Agent-Id: abc123\nX-Superagent-Speed: fast'
+    )
+  })
+
+  it('strips pre-existing speed lines case-insensitively before appending', () => {
+    const out = withSpeedHeader(
+      { ANTHROPIC_CUSTOM_HEADERS: 'x-superagent-speed: fast\nX-User-Header: keep-me' },
+      'slow'
+    )
+    expect(out.ANTHROPIC_CUSTOM_HEADERS).toBe('X-User-Header: keep-me\nX-Superagent-Speed: slow')
+  })
+
+  it("strips a stale speed line when reverting to 'normal'", () => {
+    const out = withSpeedHeader(
+      { ANTHROPIC_CUSTOM_HEADERS: 'X-Superagent-Speed: fast\nX-User-Header: keep-me' },
+      'normal'
+    )
+    expect(out.ANTHROPIC_CUSTOM_HEADERS).toBe('X-User-Header: keep-me')
+  })
+
+  it('removes ANTHROPIC_CUSTOM_HEADERS entirely when nothing remains', () => {
+    const out = withSpeedHeader({ ANTHROPIC_CUSTOM_HEADERS: 'X-Superagent-Speed: fast' }, 'normal')
+    expect(out).not.toHaveProperty('ANTHROPIC_CUSTOM_HEADERS')
+  })
+
+  it('composes with withAgentAttributionHeaders', () => {
+    const out = withSpeedHeader(
+      withAgentAttributionHeaders({}, { id: 'abc123', name: 'Bot' }),
+      'fast'
+    )
+    expect(out.ANTHROPIC_CUSTOM_HEADERS).toBe(
+      'X-Superagent-Agent-Id: abc123\nX-Superagent-Agent-Name: Bot\nX-Superagent-Speed: fast'
+    )
+  })
+
+  it('does not mutate the input env', () => {
+    const env = { OTHER: 'v' }
+    const out = withSpeedHeader(env, 'fast')
     expect(env).not.toHaveProperty('ANTHROPIC_CUSTOM_HEADERS')
     expect(out.OTHER).toBe('v')
   })

--- a/agent-container/src/attribution-headers.ts
+++ b/agent-container/src/attribution-headers.ts
@@ -15,6 +15,7 @@
 
 const AGENT_ID_HEADER = 'X-Superagent-Agent-Id';
 const AGENT_NAME_HEADER = 'X-Superagent-Agent-Name';
+const SPEED_HEADER = 'X-Superagent-Speed';
 
 /** Env keys carrying the boot-time agent identity. Rejected by POST /env. */
 export const AGENT_IDENTITY_ENV_KEYS = ['SUPERAGENT_AGENT_ID', 'SUPERAGENT_AGENT_NAME'] as const;
@@ -90,6 +91,44 @@ export function withAgentAttributionHeaders(
       const capped = Array.from(wellFormed).slice(0, MAX_NAME_CODE_POINTS).join('');
       lines.push(`${AGENT_NAME_HEADER}: ${encodeURIComponent(capped)}`);
     }
+  }
+
+  if (lines.length > 0) {
+    out.ANTHROPIC_CUSTOM_HEADERS = lines.join('\n');
+  } else {
+    delete out.ANTHROPIC_CUSTOM_HEADERS;
+  }
+  return out;
+}
+
+// Like the attribution namespace above, X-Superagent-Speed is reserved: a
+// pre-existing line (user-configured ANTHROPIC_CUSTOM_HEADERS, or a stale
+// value from a previous query generation) is dropped before the current
+// session speed is appended.
+const SPEED_HEADER_LINE = /^\s*x-superagent-speed\s*:/i;
+
+/**
+ * Return a copy of `env` with ANTHROPIC_CUSTOM_HEADERS carrying the session's
+ * processing-speed tier. 'normal' (or unset) is the wire default and emits no
+ * header — the absence of X-Superagent-Speed means standard processing. The
+ * platform proxy maps the header to the provider's mechanism (OpenAI/xAI
+ * `service_tier`, Anthropic fast mode); other upstreams ignore it harmlessly.
+ * Values are a closed enum, so no encoding is needed.
+ */
+export function withSpeedHeader(
+  env: Record<string, string | undefined>,
+  speed: 'slow' | 'normal' | 'fast' | undefined
+): Record<string, string | undefined> {
+  const out = { ...env };
+
+  const preserved = (env.ANTHROPIC_CUSTOM_HEADERS ?? '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !SPEED_HEADER_LINE.test(line));
+
+  const lines = [...preserved];
+  if (speed && speed !== 'normal') {
+    lines.push(`${SPEED_HEADER}: ${speed}`);
   }
 
   if (lines.length > 0) {

--- a/agent-container/src/capability-policies.test.ts
+++ b/agent-container/src/capability-policies.test.ts
@@ -8,6 +8,7 @@ import {
   capabilityGateFor,
   parseReviewDecisionScope,
   reviewDeclinedMessage,
+  speedLevelSchema,
 } from './capability-policies'
 
 const BASE = { allowedTools: ['Skill', 'Task', 'Agent', 'mcp__x__*'], disallowedTools: ['Monitor'] }
@@ -100,6 +101,26 @@ describe('boundary schemas', () => {
     expect(agentCapabilityPoliciesSchema.parse({ subagents: 'allow', workflows: 'review' })).toEqual({ subagents: 'allow', workflows: 'review' })
     expect(agentCapabilityPoliciesSchema.parse(undefined)).toBeUndefined()
     expect(() => agentCapabilityPoliciesSchema.parse({ subagents: 'maybe' })).toThrow()
+  })
+
+  it('accepts the closed speed enum and absence', () => {
+    expect(speedLevelSchema.parse('slow')).toBe('slow')
+    expect(speedLevelSchema.parse('normal')).toBe('normal')
+    expect(speedLevelSchema.parse('fast')).toBe('fast')
+    expect(speedLevelSchema.parse(undefined)).toBeUndefined()
+  })
+
+  it('rejects off-enum speeds, including values carrying header-line separators', () => {
+    // Speed is composed into the newline-joined ANTHROPIC_CUSTOM_HEADERS
+    // string, so the boundary must reject anything off the enum — regardless
+    // of whether the specific payload could smuggle a header line.
+    expect(() => speedLevelSchema.parse('turbo')).toThrow()
+    expect(() => speedLevelSchema.parse('fast\nX-Superagent-Agent-Id: forged')).toThrow()
+    expect(() => speedLevelSchema.parse('FAST')).toThrow()
+    expect(() => speedLevelSchema.parse('')).toThrow()
+    expect(() => speedLevelSchema.parse(1)).toThrow()
+    expect(() => speedLevelSchema.parse(null)).toThrow()
+    expect(() => speedLevelSchema.parse({ speed: 'fast' })).toThrow()
   })
 
   it('parses review decision scope, defaulting anything unknown to once', () => {

--- a/agent-container/src/capability-policies.ts
+++ b/agent-container/src/capability-policies.ts
@@ -19,6 +19,13 @@ export const agentCapabilityPoliciesSchema = z
   })
   .optional()
 
+// Boundary schema for the processing-speed tier arriving over HTTP (create-
+// session / send-message bodies). The value is interpolated into the
+// newline-joined ANTHROPIC_CUSTOM_HEADERS string (withSpeedHeader), so
+// anything off the closed enum — a newline especially — must fail the request
+// instead of reaching header composition.
+export const speedLevelSchema = z.enum(['slow', 'normal', 'fast']).optional()
+
 // Boundary schema for the resolve payload of a capability review (host answers
 // via POST /inputs/:toolUseId/resolve). Unknown shapes count as a plain
 // one-time approval — the approval itself was explicit, only the scope is soft.

--- a/agent-container/src/claude-code-effort.test.ts
+++ b/agent-container/src/claude-code-effort.test.ts
@@ -159,6 +159,88 @@ describe('ClaudeCodeProcess effort handling', () => {
   })
 })
 
+describe('ClaudeCodeProcess speed handling', () => {
+  beforeEach(() => {
+    calls.length = 0
+  })
+
+  const speedHeaderOf = (call: MockQueryCall): string | undefined => {
+    const env = call.options.env as Record<string, string | undefined>
+    return env.ANTHROPIC_CUSTOM_HEADERS?.split('\n').find((l) => l.startsWith('X-Superagent-Speed:'))
+  }
+
+  it('bakes the speed header into the query env at creation', async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-speed-1',
+      workingDirectory: '/tmp',
+      speed: 'fast',
+    })
+
+    await process.start()
+    expect(calls).toHaveLength(1)
+    expect(speedHeaderOf(calls[0])).toBe('X-Superagent-Speed: fast')
+  })
+
+  it("emits no speed header for 'normal' or unset speed", async () => {
+    const p1 = new ClaudeCodeProcess({ sessionId: 'test-speed-2a', workingDirectory: '/tmp', speed: 'normal' })
+    await p1.start()
+    const p2 = new ClaudeCodeProcess({ sessionId: 'test-speed-2b', workingDirectory: '/tmp' })
+    await p2.start()
+    expect(calls).toHaveLength(2)
+    expect(speedHeaderOf(calls[0])).toBeUndefined()
+    expect(speedHeaderOf(calls[1])).toBeUndefined()
+  })
+
+  it('rebuilds the query with the new header when speed changes', { timeout: 15000 }, async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-speed-3',
+      workingDirectory: '/tmp',
+      speed: 'normal',
+    })
+
+    await process.start()
+    expect(calls).toHaveLength(1)
+
+    await process.sendMessage('hello', undefined, { speed: 'fast' })
+
+    expect(calls).toHaveLength(2)
+    expect(speedHeaderOf(calls[1])).toBe('X-Superagent-Speed: fast')
+  })
+
+  it('does not rebuild the query when the same speed is passed', async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-speed-4',
+      workingDirectory: '/tmp',
+      speed: 'fast',
+    })
+
+    await process.start()
+    expect(calls).toHaveLength(1)
+
+    await process.sendMessage('hello', undefined, { speed: 'fast' })
+    expect(calls).toHaveLength(1)
+  })
+
+  it("treats undefined stored speed as 'normal' so a first normal message does not restart", { timeout: 15000 }, async () => {
+    // Simulates a session created before this feature (no persisted speed).
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-speed-5',
+      workingDirectory: '/tmp',
+      // speed intentionally omitted
+    })
+
+    await process.start()
+    expect(calls).toHaveLength(1)
+
+    await process.sendMessage('hello', undefined, { speed: 'normal' })
+    expect(calls).toHaveLength(1)
+
+    await process.sendMessage('hello again', undefined, { speed: 'slow' })
+    expect(calls).toHaveLength(2)
+    expect(speedHeaderOf(calls[1])).toBe('X-Superagent-Speed: slow')
+  })
+})
+
 describe('ClaudeCodeProcess model handling', () => {
   beforeEach(() => {
     calls.length = 0

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -4,7 +4,7 @@ import type { UUID } from 'crypto';
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import * as path from 'path';
-import type { EffortLevel } from './types';
+import type { EffortLevel, SpeedLevel } from './types';
 import { createUserInputMcpServer, createBrowserMcpServer, createComputerUseMcpServer, createDashboardsMcpServer, createAgentsMcpServer, createChatMcpServer, createWebMcpServer } from './mcp-server';
 import { createBrowserTools } from './tools/browser';
 import { renameBrowserSession } from './browser-state';
@@ -43,7 +43,7 @@ function mcpToolNames(
 }
 import { inputManager } from './input-manager';
 import { sanitizeMcpName } from './sanitize-mcp-name';
-import { withAgentAttributionHeaders } from './attribution-headers';
+import { withAgentAttributionHeaders, withSpeedHeader } from './attribution-headers';
 import { renderPrompt } from './render-prompt';
 import type { AgentCapabilityPolicies } from './types';
 import {
@@ -378,6 +378,7 @@ export interface ClaudeCodeProcessOptions {
   maxBudgetUsd?: number;
   customEnvVars?: Record<string, string>;
   effort?: EffortLevel;
+  speed?: SpeedLevel;
   capabilityPolicies?: AgentCapabilityPolicies;
   sessionCapabilityGrants?: Capability[];
 }
@@ -401,6 +402,7 @@ export class ClaudeCodeProcess extends EventEmitter {
   private maxBudgetUsd: number | undefined;
   private customEnvVars: Record<string, string> | undefined;
   private effort: EffortLevel | undefined;
+  private speed: SpeedLevel | undefined;
   private capabilityPolicies: AgentCapabilityPolicies | undefined;
   // Session-scoped review grants ("Allow for this session"). Scoped to the
   // SESSION, not the process: they must survive idle-eviction + resume (the
@@ -458,6 +460,7 @@ export class ClaudeCodeProcess extends EventEmitter {
     this.maxBudgetUsd = options.maxBudgetUsd;
     this.customEnvVars = options.customEnvVars;
     this.effort = options.effort;
+    this.speed = options.speed;
     this.capabilityPolicies = options.capabilityPolicies;
     this.sessionCapabilityGrants = new Set(options.sessionCapabilityGrants ?? []);
     this.availableEnvVars = options.availableEnvVars;
@@ -538,7 +541,7 @@ export class ClaudeCodeProcess extends EventEmitter {
     // shared across sessions stranded browser calls on the ownership lock.
     const browserMcpTools = createBrowserTools(() => this.sessionId);
 
-    console.log(`[Session ${this.sessionId}] createQuery: model=${this.model ?? '(default)'}, effort=${this.effort ?? '(default)'}`);
+    console.log(`[Session ${this.sessionId}] createQuery: model=${this.model ?? '(default)'}, effort=${this.effort ?? '(default)'}, speed=${this.speed ?? '(default)'}`);
 
     // Block-tier policies remove the capability at the source: the tool is
     // stripped from the query (and the system prompt stops advertising it)
@@ -590,7 +593,8 @@ export class ClaudeCodeProcess extends EventEmitter {
         // withAgentAttributionHeaders folds the host-injected agent identity env
         // vars into ANTHROPIC_CUSTOM_HEADERS (composed here, after the custom-env
         // merge, so a user-set ANTHROPIC_CUSTOM_HEADERS is appended to, not lost).
-        env: withAgentAttributionHeaders({
+        // withSpeedHeader then appends X-Superagent-Speed for non-normal tiers.
+        env: withSpeedHeader(withAgentAttributionHeaders({
           // Agent SDK 0.2.113+ replaces process.env with options.env instead of
           // overlaying it, so we must spread process.env explicitly or the Claude
           // subprocess loses PATH, HOME, ANTHROPIC_API_KEY, connected-account env
@@ -605,7 +609,7 @@ export class ClaudeCodeProcess extends EventEmitter {
           CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: '1',
           // Explicit maxOutputTokens setting takes precedence over custom env var
           ...(this.maxOutputTokens && { CLAUDE_CODE_MAX_OUTPUT_TOKENS: String(this.maxOutputTokens) }),
-        }),
+        }), this.speed),
         mcpServers: {
           'user-input': createUserInputMcpServer(),
           'browser': createBrowserMcpServer(browserMcpTools),
@@ -1066,14 +1070,20 @@ export class ClaudeCodeProcess extends EventEmitter {
     }
   }
 
-  async sendMessage(content: string, uuid?: UUID, options?: { effort?: EffortLevel; model?: string; shouldQuery?: boolean; capabilityPolicies?: AgentCapabilityPolicies }): Promise<void> {
+  async sendMessage(content: string, uuid?: UUID, options?: { effort?: EffortLevel; speed?: SpeedLevel; model?: string; shouldQuery?: boolean; capabilityPolicies?: AgentCapabilityPolicies }): Promise<void> {
     const effort = options?.effort;
+    const speed = options?.speed;
     const model = options?.model;
 
     // Treat undefined stored effort as 'high' so pre-existing sessions (created before
     // this feature) don't trigger a spurious restart on their first post-upgrade message.
     const currentEffort: EffortLevel = this.effort ?? 'high';
     const effortChanged = effort !== undefined && effort !== currentEffort;
+
+    // Same undefined-vs-default trick: an unset speed IS 'normal' on the wire
+    // (no header), so an explicit 'normal' on a pre-speed session is a no-op.
+    const currentSpeed: SpeedLevel = this.speed ?? 'normal';
+    const speedChanged = speed !== undefined && speed !== currentSpeed;
 
     // The host resolves selections to concrete wire ids before sending, so
     // compare ids directly. Switching between two pinned versions of a family
@@ -1104,6 +1114,9 @@ export class ClaudeCodeProcess extends EventEmitter {
     if (effortChanged) {
       this.effort = effort;
     }
+    if (speedChanged) {
+      this.speed = speed;
+    }
     if (modelChanged) {
       this.model = model;
     }
@@ -1117,14 +1130,16 @@ export class ClaudeCodeProcess extends EventEmitter {
         await this.currentStop.catch(() => undefined);
       }
       await this.restart();
-    } else if (effortChanged || capabilityBlockChanged) {
+    } else if (effortChanged || speedChanged || capabilityBlockChanged) {
       // Effort can only be set at query creation time — the SDK has no setEffort
-      // facility — so any effort change forces an interrupt + re-query. The new
-      // model (if also changed) is picked up by the same restart. A capability
-      // block boundary flip re-queries for the same reason: the tool lists and
-      // system prompt only apply at query creation.
+      // facility — so any effort change forces an interrupt + re-query. Speed
+      // lives in the query env (ANTHROPIC_CUSTOM_HEADERS), which is likewise
+      // baked at query creation. The new model (if also changed) is picked up by
+      // the same restart. A capability block boundary flip re-queries for the
+      // same reason: the tool lists and system prompt only apply at query creation.
       const reasons: string[] = [];
       if (effortChanged) reasons.push(`effort ${currentEffort} -> ${effort}`);
+      if (speedChanged) reasons.push(`speed ${currentSpeed} -> ${speed}`);
       if (capabilityBlockChanged) reasons.push('capability block boundary changed');
       if (modelChanged) reasons.push(`model -> ${this.model}`);
       console.log(`[Session ${this.sessionId}] Restarting query (${reasons.join(', ')})`);

--- a/agent-container/src/file-hooks/agent-preferences-hook.ts
+++ b/agent-container/src/file-hooks/agent-preferences-hook.ts
@@ -6,6 +6,7 @@ const agentPreferencesSchema = z.object({
   autoDeleteInactiveDays: z.number().int().positive().optional(),
   defaultModel: z.string().trim().min(1).optional(),
   defaultEffort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
+  defaultSpeed: z.enum(['slow', 'normal', 'fast']).optional(),
 })
 
 const PREFERENCES_PATH = '/workspace/agent-preferences.json'
@@ -16,6 +17,7 @@ Format: a JSON object with optional fields:
 - "autoDeleteInactiveDays" (positive integer, optional): Automatically delete sessions inactive for this many days. Starred sessions are preserved.
 - "defaultModel" (string, optional): Default model for this agent's new sessions — a concrete model id or a bare family alias. Per-session and per-trigger picks still win.
 - "defaultEffort" (one of "low" | "medium" | "high" | "xhigh" | "max", optional): Default reasoning effort for this agent's new sessions.
+- "defaultSpeed" (one of "slow" | "normal" | "fast", optional): Default processing speed for this agent's new sessions. Only speeds the model's serving path supports take effect.
 
 Example:
 {

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -5,7 +5,7 @@ import { serve } from '@hono/node-server';
 import { HOST_TOKEN_HEADER, hostAuthEnabled, isValidHostToken } from './host-auth';
 import { SessionManager } from './session-manager';
 import { CreateSessionRequest, SendMessageRequest } from './types';
-import { agentCapabilityPoliciesSchema } from './capability-policies';
+import { agentCapabilityPoliciesSchema, speedLevelSchema } from './capability-policies';
 import type { UUID } from 'crypto';
 import * as http from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
@@ -172,6 +172,7 @@ app.post('/sessions/:id/messages', async (c) => {
 
     await sessionManager.sendMessage(sessionId, content, body.uuid, {
       effort: body.effort,
+      speed: speedLevelSchema.parse(body.speed),
       model: body.model,
       shouldQuery: body.shouldQuery,
       capabilityPolicies: agentCapabilityPoliciesSchema.parse(body.capabilityPolicies),
@@ -1841,6 +1842,7 @@ async function handleWebSocketConnection(ws: WebSocket, sessionId: string) {
 
       await sessionManager.sendMessage(sessionId, content, payload.uuid, {
         effort: payload.effort,
+        speed: speedLevelSchema.parse(payload.speed),
         model: payload.model,
         capabilityPolicies: agentCapabilityPoliciesSchema.parse(payload.capabilityPolicies),
       });

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { UUID } from 'crypto';
-import { Session, SDKMessage, CreateSessionRequest, EffortLevel, AgentCapabilityPolicies } from './types';
-import { agentCapabilityPoliciesSchema } from './capability-policies';
+import { Session, SDKMessage, CreateSessionRequest, EffortLevel, SpeedLevel, AgentCapabilityPolicies } from './types';
+import { agentCapabilityPoliciesSchema, speedLevelSchema } from './capability-policies';
 import { ClaudeCodeProcess } from './claude-code';
 import { SessionPersistence } from './session-persistence';
 import { EventEmitter } from 'events';
@@ -171,8 +171,10 @@ export class SessionManager extends EventEmitter {
     const workingDirectory = request.workingDirectory || this.baseWorkingDirectory;
 
     // Boundary validation: a malformed policy must fail the request loudly,
-    // never silently degrade a block to allow.
+    // never silently degrade a block to allow. Speed likewise — it ends up
+    // interpolated into the ANTHROPIC_CUSTOM_HEADERS string.
     const capabilityPolicies = agentCapabilityPoliciesSchema.parse(request.capabilityPolicies);
+    const speed = speedLevelSchema.parse(request.speed);
 
     // Ensure working directory exists
     if (!fs.existsSync(workingDirectory)) {
@@ -196,6 +198,7 @@ export class SessionManager extends EventEmitter {
       maxBudgetUsd: request.maxBudgetUsd,
       customEnvVars: request.customEnvVars,
       effort: request.effort,
+      speed,
       capabilityPolicies,
     });
 
@@ -324,6 +327,7 @@ export class SessionManager extends EventEmitter {
       maxBudgetUsd: request.maxBudgetUsd,
       customEnvVars: request.customEnvVars,
       effort: request.effort,
+      speed,
       capabilityPolicies,
       metadata: request.metadata,
     });
@@ -383,6 +387,7 @@ export class SessionManager extends EventEmitter {
         maxBudgetUsd: persisted.maxBudgetUsd,
         customEnvVars: persisted.customEnvVars,
         effort: persisted.effort,
+        speed: persisted.speed,
         capabilityPolicies: persisted.capabilityPolicies,
         sessionCapabilityGrants: persisted.sessionCapabilityGrants,
       });
@@ -513,7 +518,7 @@ export class SessionManager extends EventEmitter {
     sessionId: string,
     content: string,
     uuid?: UUID,
-    options?: { effort?: EffortLevel; model?: string; shouldQuery?: boolean; capabilityPolicies?: AgentCapabilityPolicies }
+    options?: { effort?: EffortLevel; speed?: SpeedLevel; model?: string; shouldQuery?: boolean; capabilityPolicies?: AgentCapabilityPolicies }
   ): Promise<void> {
     let sessionData = this.sessions.get(sessionId);
 
@@ -553,6 +558,9 @@ export class SessionManager extends EventEmitter {
     // Persist runtime-options changes so resume after eviction uses the latest values
     if (options?.effort !== undefined) {
       this.persistence.updateEffort(sessionId, options.effort);
+    }
+    if (options?.speed !== undefined) {
+      this.persistence.updateSpeed(sessionId, options.speed);
     }
     if (options?.model !== undefined) {
       this.persistence.updateModel(sessionId, options.model);

--- a/agent-container/src/session-persistence.ts
+++ b/agent-container/src/session-persistence.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import { writeFileAtomicSync } from './atomic-file';
-import type { AgentCapabilityPolicies, EffortLevel } from './types';
+import type { AgentCapabilityPolicies, EffortLevel, SpeedLevel } from './types';
 
 interface SessionMetadata {
   sessionId: string;
@@ -22,6 +22,7 @@ interface SessionMetadata {
   maxBudgetUsd?: number;
   customEnvVars?: Record<string, string>;
   effort?: EffortLevel;
+  speed?: SpeedLevel;
   // Must survive resume: doResumeSession starts the query straight from these
   // options, so an unpersisted block policy would briefly re-expose the tools.
   capabilityPolicies?: AgentCapabilityPolicies;
@@ -118,6 +119,14 @@ export class SessionPersistence {
     const session = this.sessions.get(sessionId);
     if (session) {
       session.effort = effort;
+      this.save();
+    }
+  }
+
+  updateSpeed(sessionId: string, speed: SpeedLevel | undefined): void {
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      session.speed = speed;
       this.save();
     }
   }

--- a/agent-container/src/tools/schedule-task.ts
+++ b/agent-container/src/tools/schedule-task.ts
@@ -98,6 +98,12 @@ Avoid recurring intervals shorter than 15 minutes unless truly necessary: freque
       .describe(
         'Optional effort level for this task. If not specified, uses the global default.'
       ),
+    speed: z
+      .enum(['slow', 'normal', 'fast'])
+      .optional()
+      .describe(
+        'Optional processing-speed tier for this task. If not specified, uses the global default.'
+      ),
   },
   async (args) => {
     console.log(`[schedule_task] Scheduling ${args.scheduleType} task: ${args.scheduleExpression}`)

--- a/agent-container/src/tools/webhook-triggers.ts
+++ b/agent-container/src/tools/webhook-triggers.ts
@@ -172,6 +172,10 @@ Use get_available_triggers first to discover what triggers are available for an 
       .enum(['low', 'medium', 'high', 'xhigh', 'max'])
       .optional()
       .describe('Optional effort level when this trigger fires. If not specified, uses the global default.'),
+    speed: z
+      .enum(['slow', 'normal', 'fast'])
+      .optional()
+      .describe('Optional processing-speed tier when this trigger fires. If not specified, uses the global default.'),
   },
   async (args) => {
     console.log(`[setup_trigger] Setting up ${args.trigger_type} trigger`)
@@ -203,6 +207,7 @@ Use get_available_triggers first to discover what triggers are available for an 
           trigger_config: args.trigger_config,
           model: args.model,
           effort: args.effort,
+          speed: args.speed,
         },
       )
 
@@ -243,6 +248,10 @@ If the service reveals a signing secret only AFTER registration, attach it after
       .enum(['low', 'medium', 'high', 'xhigh', 'max'])
       .optional()
       .describe('Optional effort level when this endpoint fires. If not specified, uses the global default.'),
+    speed: z
+      .enum(['slow', 'normal', 'fast'])
+      .optional()
+      .describe('Optional processing-speed tier when this endpoint fires. If not specified, uses the global default.'),
   },
   async (args) => {
     console.log(`[create_webhook_endpoint] Minting endpoint "${args.name}"`)
@@ -273,6 +282,7 @@ If the service reveals a signing secret only AFTER registration, attach it after
           filter_exp: args.filter_exp,
           model: args.model,
           effort: args.effort,
+          speed: args.speed,
         },
       )
 

--- a/agent-container/src/types.ts
+++ b/agent-container/src/types.ts
@@ -1,6 +1,13 @@
 import type { UUID } from 'crypto';
 import type { EffortLevel } from '@anthropic-ai/claude-agent-sdk';
 
+// Normalized processing-speed tiers (slow/normal/fast). Not an SDK concept:
+// the speed is signaled upstream via the X-Superagent-Speed custom header,
+// which the platform proxy maps to the provider's tier (OpenAI/xAI
+// service_tier, Anthropic fast mode). Keep in sync with
+// src/shared/lib/container/types.ts SPEED_LEVELS.
+export type SpeedLevel = 'slow' | 'normal' | 'fast';
+
 // Re-export types from Claude Agent SDK
 export type {
   SDKMessage,
@@ -82,6 +89,7 @@ export interface CreateSessionRequest {
   customEnvVars?: Record<string, string>; // User-defined env vars for the agent process
   maxBrowserTabs?: number; // Max browser tabs allowed (default 10)
   effort?: EffortLevel; // Initial thinking effort level
+  speed?: SpeedLevel; // Initial processing-speed tier (emitted as X-Superagent-Speed)
   capabilityPolicies?: AgentCapabilityPolicies; // Launch policies for subagents/workflows (absent = allow)
 }
 
@@ -90,6 +98,7 @@ export interface SendMessageRequest {
   type?: 'user' | 'system';
   uuid?: UUID;
   effort?: EffortLevel; // If set and different from current session effort, triggers interrupt+restart with new effort
+  speed?: SpeedLevel; // If set and different from current session speed, triggers interrupt+restart with new speed
   model?: string; // If set and different from current session model, triggers interrupt+restart with new model
   shouldQuery?: boolean; // When false, appends to transcript without triggering an assistant turn
   capabilityPolicies?: AgentCapabilityPolicies; // Current launch policies; a block-boundary change triggers interrupt+restart

--- a/e2e/setup-e2e-data.js
+++ b/e2e/setup-e2e-data.js
@@ -150,6 +150,18 @@ const settings = {
   app: { setupCompleted: true },
   // E2E runs must never emit real analytics events.
   shareAnalytics: false,
+  // The direct-Anthropic builtin catalog deliberately declares no
+  // supportedSpeeds (no proxy maps the X-Superagent-Speed header in direct
+  // mode), so the composer's Speed section would never render under the mock.
+  // Expose one via a user-level catalog override — E2E data only, the builtin
+  // catalog stays speed-free.
+  modelCatalog: {
+    anthropic: {
+      overrides: [
+        { id: 'claude-opus-4-8', supportedSpeeds: ['slow', 'normal', 'fast'] },
+      ],
+    },
+  },
   skillsets: [
     {
       id: SKILLSET_ID,

--- a/e2e/specs/speed-selection.spec.ts
+++ b/e2e/specs/speed-selection.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect, type Page } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+
+const E2E_DATA_DIR = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
+const RECORDER_FILE = path.join(E2E_DATA_DIR, '.e2e-mock-recorder.jsonl')
+
+interface MockRecord {
+  type: 'sendMessage' | 'createSession'
+  agentSlug: string
+  sessionId?: string
+  content?: string
+  initialMessage?: string
+  effort?: string
+  speed?: string
+  model?: string
+  timestamp: string
+}
+
+function readRecords(): MockRecord[] {
+  if (!fs.existsSync(RECORDER_FILE)) return []
+  const lines = fs.readFileSync(RECORDER_FILE, 'utf-8').trim().split('\n').filter(Boolean)
+  return lines.map((l) => JSON.parse(l) as MockRecord)
+}
+
+/**
+ * Wait for a matching record. The recorder file is shared across Playwright
+ * workers and across all tests in this spec, so callers must filter by a
+ * test-unique attribute (agentSlug or unique content) — never truncate the
+ * file or assume it's empty at start.
+ */
+async function waitForRecord(
+  predicate: (r: MockRecord) => boolean,
+  timeoutMs = 10000
+): Promise<MockRecord> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    const found = readRecords().find(predicate)
+    if (found) return found
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  throw new Error(`Timed out waiting for matching record. Records seen: ${JSON.stringify(readRecords(), null, 2)}`)
+}
+
+// The E2E seed (setup-e2e-data.js) grants Opus 4.8 a speed choice via a
+// user-level catalog override; every other model keeps the builtin
+// direct-Anthropic shape with no supportedSpeeds.
+const OPUS_LATEST = 'claude-opus-4-8'
+const HAIKU = 'claude-haiku-4-5'
+
+// Open the composer popover and pick a concrete version. Picks don't dismiss
+// the popover, so close it explicitly — callers assume a closed postcondition.
+async function pickModel(page: Page, modelId: string) {
+  await page.locator('[data-testid="composer-options-trigger"]').click()
+  const version = page.locator(`[data-testid="model-pinned-${modelId}"]`)
+  await version.waitFor({ state: 'visible' })
+  await version.click()
+  await page.keyboard.press('Escape')
+}
+
+async function pickSpeed(page: Page, speed: 'slow' | 'normal' | 'fast') {
+  await page.locator('[data-testid="composer-options-trigger"]').click()
+  await page.locator(`[data-testid="speed-option-${speed}"]`).click()
+  await page.keyboard.press('Escape')
+}
+
+test.describe('Speed selection', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+  let testAgentName: string
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    // NOTE: do NOT truncate the recorder file — it's shared across Playwright
+    // workers under one SUPERAGENT_DATA_DIR. Tests filter records by their
+    // unique agent slug or message content instead.
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+
+    testAgentName = `Speed Agent ${testInfo.workerIndex}-${Date.now()}`
+  })
+
+  test('picking Fast in the composer sends the speed with the created session', async ({ page }, testInfo) => {
+    const tag = `${testInfo.workerIndex}-${Date.now()}`
+    const initialMessage = `Fast speed first message ${tag}`
+
+    await agentPage.clickCreateAgent()
+    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
+
+    // The default model resolves to Opus latest, which carries the speed
+    // override — the Speed section must render and Fast must go on the wire.
+    await pickSpeed(page, 'fast')
+    await expect(page.locator('[data-testid="composer-options-trigger"]')).toContainText('Fast')
+
+    await page.locator('[data-testid="home-message-input"]').fill(initialMessage)
+    await page.locator('[data-testid="home-send-button"]').click()
+    await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
+
+    const record = await waitForRecord(
+      (r) => r.type === 'createSession' && r.initialMessage === initialMessage
+    )
+    expect(record.speed).toBe('fast')
+  })
+
+  test('an untouched speed selector sends no speed (server default wins)', async ({ page }, testInfo) => {
+    const tag = `${testInfo.workerIndex}-${Date.now()}`
+    const initialMessage = `Untouched speed message ${tag}`
+
+    await agentPage.clickCreateAgent()
+    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
+
+    await page.locator('[data-testid="home-message-input"]').fill(initialMessage)
+    await page.locator('[data-testid="home-send-button"]').click()
+    await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
+
+    const record = await waitForRecord(
+      (r) => r.type === 'createSession' && r.initialMessage === initialMessage
+    )
+    expect(record.speed).toBeUndefined()
+  })
+
+  test('changing speed mid-session sends the new speed on the next message', async ({ page }, testInfo) => {
+    const tag = `${testInfo.workerIndex}-${Date.now()}`
+    const followUp = `Now going fast ${tag}`
+
+    await agentPage.createAgent(testAgentName)
+    await agentPage.expandAgent(testAgentName)
+    const sessionLink = page.locator('[data-testid^="session-item-"]').first()
+    await sessionLink.click()
+    await expect(page.locator('[data-testid="message-list"]')).toBeVisible()
+
+    // Pin the speed-capable model explicitly, then flip the speed to Fast.
+    await pickModel(page, OPUS_LATEST)
+    await pickSpeed(page, 'fast')
+
+    await sessionPage.sendMessage(followUp)
+
+    const sendRecord = await waitForRecord(
+      (r) => r.type === 'sendMessage' && r.content === followUp
+    )
+    expect(sendRecord.speed).toBe('fast')
+    expect(sendRecord.model).toBe(OPUS_LATEST)
+  })
+
+  test('the Speed section is hidden for models without a speed choice', async ({ page }) => {
+    await agentPage.clickCreateAgent()
+    await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
+
+    // Opus (speed override) shows the section...
+    await page.locator('[data-testid="composer-options-trigger"]').click()
+    await expect(page.locator('[data-testid="speed-option-fast"]')).toBeVisible()
+
+    // ...switching to Haiku (builtin shape, no supportedSpeeds) hides it in place.
+    await page.locator(`[data-testid="model-pinned-${HAIKU}"]`).click()
+    await expect(page.locator('[data-testid="speed-option-fast"]')).toHaveCount(0)
+    await page.keyboard.press('Escape')
+  })
+})

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1350,7 +1350,7 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
     // the client can materialize its optimistic copy by exact id match.
     const initialMessageUuid = randomUUID()
 
-    // Model/effort preference order: explicit per-session pick > agent default > global default.
+    // Model/effort/speed preference order: explicit per-session pick > agent default > global default.
     const agentPrefs = await readAgentPreferences(slug)
     const sessionModel = runtimeOptions.model ?? agentPrefs.defaultModel ?? getEffectiveModels().agentModel
 
@@ -1368,6 +1368,7 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
       customEnvVars: Object.keys(customEnvVars).length > 0 ? customEnvVars : undefined,
       maxBrowserTabs: getSettings().app?.maxBrowserTabs,
       effort: runtimeOptions.effort ?? agentPrefs.defaultEffort,
+      speed: runtimeOptions.speed ?? agentPrefs.defaultSpeed,
     })
     const sessionId = containerSession.id
 
@@ -1406,6 +1407,7 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
     // reflected when the composer reloads.
     const initialMetadata: Parameters<typeof updateSessionMetadata>[2] = {}
     if (runtimeOptions.effort) initialMetadata.effort = runtimeOptions.effort
+    if (runtimeOptions.speed) initialMetadata.speed = runtimeOptions.speed
     if (runtimeOptions.model) initialMetadata.model = runtimeOptions.model
     if (isAuthMode()) initialMetadata.createdByUserId = getCurrentUserId(c)
     if (Object.keys(initialMetadata).length > 0) {
@@ -1643,13 +1645,14 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
 
     messagePersister.markSessionActive(sessionId, agentSlug)
 
-    // A mid-turn send must not carry model/effort: the container treats a
+    // A mid-turn send must not carry model/effort/speed: the container treats a
     // parameter change as interrupt/restart of the in-flight query. The
     // composer strips these client-side, but its view of "active" comes from
     // SSE and can be stale (reconnect, second window, shared-session peer) —
     // the server's check is authoritative.
     if (wasQueued) {
       delete runtimeOptions.effort
+      delete runtimeOptions.speed
       delete runtimeOptions.model
     }
 
@@ -1686,6 +1689,7 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
     await client.sendMessage(sessionId, content.trim(), messageUuid, runtimeOptions)
     const updates: Parameters<typeof updateSessionMetadata>[2] = {}
     if (runtimeOptions.effort) updates.effort = runtimeOptions.effort
+    if (runtimeOptions.speed) updates.speed = runtimeOptions.speed
     if (runtimeOptions.model) updates.model = runtimeOptions.model
     if (Object.keys(updates).length > 0) {
       updateSessionMetadata(agentSlug, sessionId, updates).catch(console.error)
@@ -1765,6 +1769,7 @@ agents.get('/:id/sessions/:sessionId', AgentRead(), async (c) => {
       webhookTriggerId: metadata?.webhookTriggerId,
       webhookTriggerName: metadata?.webhookTriggerName,
       effort: metadata?.effort,
+      speed: metadata?.speed,
       model: metadata?.model,
       ...(pendingWake
         ? {

--- a/src/api/routes/chat-integrations.ts
+++ b/src/api/routes/chat-integrations.ts
@@ -30,8 +30,12 @@ import { getCurrentUserId } from '@shared/lib/auth/config'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
 import { Authenticated, AgentUser, EntityAgentRole, ResolveAgent, getAgentId } from '../middleware/auth'
 import { captureException } from '@shared/lib/error-reporting'
+import { SPEED_LEVELS } from '@shared/lib/container/types'
 
 const SENTRY_TAGS = { component: 'chat-integration' } as const
+
+// Speed override carried on create/update bodies: a level, null to clear, or absent.
+const speedOverrideSchema = z.enum(SPEED_LEVELS).nullable().optional()
 
 const chatIntegrationsRouter = new Hono()
 
@@ -131,6 +135,10 @@ chatIntegrationsRouter.post('/:id', ResolveAgent(), AgentUser(), async (c) => {
     const agentSlug = getAgentId(c)
     const body = await c.req.json()
     const { provider, name, config, showToolCalls, sessionTimeout, model, effort } = body
+    const parsedSpeed = speedOverrideSchema.safeParse(body.speed)
+    if (!parsedSpeed.success) {
+      return c.json({ error: `Invalid speed. Must be one of: ${SPEED_LEVELS.join(', ')}` }, 400)
+    }
     // requireApproval is intentionally NOT accepted here: making a bot public is
     // owner-only and must go through PATCH /:integrationId/require-approval. New
     // integrations default to requireApproval=true (private).
@@ -196,6 +204,7 @@ chatIntegrationsRouter.post('/:id', ResolveAgent(), AgentUser(), async (c) => {
         sessionTimeout: sessionTimeout ?? null,
         model: model ?? null,
         effort: effort ?? null,
+        speed: parsedSpeed.data ?? null,
         createdByUserId,
       })
     } catch (err) {
@@ -245,6 +254,10 @@ chatIntegrationsRouter.patch('/:integrationId', IntegrationAgentRole('user'), as
     const id = c.req.param('integrationId')
     const body = await c.req.json()
     const { name, config, showToolCalls, sessionTimeout, model, effort, status } = body
+    const parsedSpeed = speedOverrideSchema.safeParse(body.speed)
+    if (!parsedSpeed.success) {
+      return c.json({ error: `Invalid speed. Must be one of: ${SPEED_LEVELS.join(', ')}` }, 400)
+    }
 
     // Validate config if provided
     if (config !== undefined) {
@@ -267,6 +280,7 @@ chatIntegrationsRouter.patch('/:integrationId', IntegrationAgentRole('user'), as
     if (sessionTimeout !== undefined) updates.sessionTimeout = sessionTimeout
     if (model !== undefined) updates.model = model
     if (effort !== undefined) updates.effort = effort
+    if (body.speed !== undefined) updates.speed = parsedSpeed.data ?? null
 
     if (Object.keys(updates).length > 0) {
       updateChatIntegration(id, updates)

--- a/src/api/routes/scheduled-tasks.test.ts
+++ b/src/api/routes/scheduled-tasks.test.ts
@@ -179,6 +179,7 @@ function createTask(overrides: Record<string, unknown> = {}) {
     isRecurring: true,
     model: null,
     effort: null,
+    speed: null,
     ...overrides,
   }
 }
@@ -365,7 +366,7 @@ describe('scheduled-tasks route', () => {
     })
   })
 
-  describe('run-now model and effort resolution', () => {
+  describe('run-now model, effort, and speed resolution', () => {
     // Preference order: task override > agent default > global default.
     async function runNow(overrides: Record<string, unknown> = {}) {
       task = createTask(overrides)
@@ -381,21 +382,30 @@ describe('scheduled-tasks route', () => {
       const args = await runNow()
       expect(args.model).toBe('claude-agent')
       expect(args.effort).toBeUndefined()
+      expect(args.speed).toBeUndefined()
     })
 
     it('falls back to the agent default over the global default', async () => {
-      mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
+      mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high', defaultSpeed: 'slow' })
       const args = await runNow()
       expect(mockReadAgentPreferences).toHaveBeenCalledWith('agent-one')
       expect(args.model).toBe('opus')
       expect(args.effort).toBe('high')
+      expect(args.speed).toBe('slow')
     })
 
     it('prefers the task override over the agent default', async () => {
-      mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
-      const args = await runNow({ model: 'claude-haiku-4-5-20251001', effort: 'low' })
+      mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high', defaultSpeed: 'fast' })
+      const args = await runNow({ model: 'claude-haiku-4-5-20251001', effort: 'low', speed: 'slow' })
       expect(args.model).toBe('claude-haiku-4-5-20251001')
       expect(args.effort).toBe('low')
+      expect(args.speed).toBe('slow')
+    })
+
+    it('a stored normal speed override beats a non-normal agent default', async () => {
+      mockReadAgentPreferences.mockResolvedValue({ defaultSpeed: 'fast' })
+      const args = await runNow({ speed: 'normal' })
+      expect(args.speed).toBe('normal')
     })
   })
 
@@ -408,22 +418,39 @@ describe('scheduled-tasks route', () => {
       })
     }
 
-    it('updates model and effort', async () => {
+    it('updates model, effort, and speed', async () => {
       mockUpdateTaskRuntimeOptions.mockResolvedValue(true)
 
-      const res = await patchRuntimeOptions({ model: 'claude-haiku-4-5', effort: 'low' })
+      const res = await patchRuntimeOptions({ model: 'claude-haiku-4-5', effort: 'low', speed: 'slow' })
 
       expect(res.status).toBe(200)
       expect(mockUpdateTaskRuntimeOptions).toHaveBeenCalledWith('task-1', {
         model: 'claude-haiku-4-5',
         effort: 'low',
+        speed: 'slow',
       })
     })
 
-    it('rejects a speed override instead of silently dropping it', async () => {
-      // Per-task speed is a deliberate non-feature; the schema must say so
-      // rather than 200-ing a no-op.
+    it('accepts a speed-only update', async () => {
+      mockUpdateTaskRuntimeOptions.mockResolvedValue(true)
+
       const res = await patchRuntimeOptions({ speed: 'fast' })
+
+      expect(res.status).toBe(200)
+      expect(mockUpdateTaskRuntimeOptions).toHaveBeenCalledWith('task-1', { speed: 'fast' })
+    })
+
+    it('clears speed back to the default via null', async () => {
+      mockUpdateTaskRuntimeOptions.mockResolvedValue(true)
+
+      const res = await patchRuntimeOptions({ speed: null })
+
+      expect(res.status).toBe(200)
+      expect(mockUpdateTaskRuntimeOptions).toHaveBeenCalledWith('task-1', { speed: null })
+    })
+
+    it('rejects an invalid speed value', async () => {
+      const res = await patchRuntimeOptions({ speed: 'ludicrous' })
 
       expect(res.status).toBe(400)
       expect(mockUpdateTaskRuntimeOptions).not.toHaveBeenCalled()

--- a/src/api/routes/scheduled-tasks.test.ts
+++ b/src/api/routes/scheduled-tasks.test.ts
@@ -399,6 +399,37 @@ describe('scheduled-tasks route', () => {
     })
   })
 
+  describe('runtime-options PATCH contract', () => {
+    async function patchRuntimeOptions(body: Record<string, unknown>) {
+      return app.request('http://localhost/api/scheduled-tasks/task-1/runtime-options', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+    }
+
+    it('updates model and effort', async () => {
+      mockUpdateTaskRuntimeOptions.mockResolvedValue(true)
+
+      const res = await patchRuntimeOptions({ model: 'claude-haiku-4-5', effort: 'low' })
+
+      expect(res.status).toBe(200)
+      expect(mockUpdateTaskRuntimeOptions).toHaveBeenCalledWith('task-1', {
+        model: 'claude-haiku-4-5',
+        effort: 'low',
+      })
+    })
+
+    it('rejects a speed override instead of silently dropping it', async () => {
+      // Per-task speed is a deliberate non-feature; the schema must say so
+      // rather than 200-ing a no-op.
+      const res = await patchRuntimeOptions({ speed: 'fast' })
+
+      expect(res.status).toBe(400)
+      expect(mockUpdateTaskRuntimeOptions).not.toHaveBeenCalled()
+    })
+  })
+
   it('does not start a container for non-runnable task statuses', async () => {
     task = createTask({ status: 'cancelled' })
 

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -250,7 +250,10 @@ scheduledTasksRouter.patch('/:taskId/runtime-options', TaskAgentRole('user'), as
   try {
     const task = c.get('scheduledTask' as never) as Awaited<ReturnType<typeof getScheduledTask>>
     const body = await c.req.json().catch(() => ({}))
-    const parsed = RuntimeOptionsSchema.partial().safeParse(body)
+    // Per-task speed overrides are a deliberate non-feature: omit speed so a
+    // PATCH carrying it fails validation (strict schema) instead of returning
+    // 200 while silently dropping it.
+    const parsed = RuntimeOptionsSchema.omit({ speed: true }).partial().safeParse(body)
     if (!parsed.success) {
       return c.json({ error: parsed.error.issues[0]?.message ?? 'Invalid runtime options' }, 400)
     }
@@ -318,6 +321,7 @@ scheduledTasksRouter.post('/:taskId/run-now', TaskAgentRole('user'), async (c) =
       browserModel: models.browserModel,
       dashboardBuilderModel: models.dashboardBuilderModel,
       ...(effort ? { effort: effort as EffortLevel } : {}),
+      ...(agentPrefs.defaultSpeed ? { speed: agentPrefs.defaultSpeed } : {}),
     })
 
     const sessionId = containerSession.id

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -34,8 +34,8 @@ import { messagePersister } from '@shared/lib/container/message-persister'
 import { getEffectiveModels } from '@shared/lib/config/settings'
 import { readAgentPreferences } from '@shared/lib/services/agent-preferences-service'
 import { validateCronExpression, getFrequencyWarning } from '@shared/lib/services/schedule-parser'
-import { RuntimeOptionsSchema } from '@shared/lib/container/runtime-options'
-import type { EffortLevel } from '@shared/lib/container/types'
+import { RuntimeOptionsPatchSchema } from '@shared/lib/container/runtime-options'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
 import { deliverSessionWake } from '@shared/lib/scheduler/wake-delivery'
@@ -245,22 +245,20 @@ scheduledTasksRouter.patch('/:taskId/timezone', TaskAgentRole('user'), async (c)
   }
 })
 
-// PATCH /api/scheduled-tasks/:taskId/runtime-options - Update model and/or effort
+// PATCH /api/scheduled-tasks/:taskId/runtime-options - Update model, effort, and/or speed
 scheduledTasksRouter.patch('/:taskId/runtime-options', TaskAgentRole('user'), async (c) => {
   try {
     const task = c.get('scheduledTask' as never) as Awaited<ReturnType<typeof getScheduledTask>>
     const body = await c.req.json().catch(() => ({}))
-    // Per-task speed overrides are a deliberate non-feature: omit speed so a
-    // PATCH carrying it fails validation (strict schema) instead of returning
-    // 200 while silently dropping it.
-    const parsed = RuntimeOptionsSchema.omit({ speed: true }).partial().safeParse(body)
+    const parsed = RuntimeOptionsPatchSchema.safeParse(body)
     if (!parsed.success) {
       return c.json({ error: parsed.error.issues[0]?.message ?? 'Invalid runtime options' }, 400)
     }
 
-    const updates: { model?: string | null; effort?: string | null } = {}
+    const updates: { model?: string | null; effort?: string | null; speed?: string | null } = {}
     if ('model' in body) updates.model = parsed.data.model ?? null
     if ('effort' in body) updates.effort = parsed.data.effort ?? null
+    if ('speed' in body) updates.speed = parsed.data.speed ?? null
 
     const updated = await updateTaskRuntimeOptions(task!.id, updates)
     if (!updated) {
@@ -309,10 +307,11 @@ scheduledTasksRouter.post('/:taskId/run-now', TaskAgentRole('user'), async (c) =
 
     const client = await containerManager.ensureRunning(task.agentSlug)
     const availableEnvVars = await getSecretEnvVars(task.agentSlug)
-    // Model/effort preference order: task override > agent default > global default.
+    // Model/effort/speed preference order: task override > agent default > global default.
     const models = getEffectiveModels()
     const agentPrefs = await readAgentPreferences(task.agentSlug)
     const effort = task.effort ?? agentPrefs.defaultEffort
+    const speed = task.speed ?? agentPrefs.defaultSpeed
 
     const containerSession = await client.createSession({
       availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
@@ -321,7 +320,7 @@ scheduledTasksRouter.post('/:taskId/run-now', TaskAgentRole('user'), async (c) =
       browserModel: models.browserModel,
       dashboardBuilderModel: models.dashboardBuilderModel,
       ...(effort ? { effort: effort as EffortLevel } : {}),
-      ...(agentPrefs.defaultSpeed ? { speed: agentPrefs.defaultSpeed } : {}),
+      ...(speed ? { speed: speed as SpeedLevel } : {}),
     })
 
     const sessionId = containerSession.id

--- a/src/api/routes/webhook-triggers.ts
+++ b/src/api/routes/webhook-triggers.ts
@@ -15,7 +15,7 @@ import {
   updateWebhookTriggerRuntimeOptions,
 } from '@shared/lib/services/webhook-trigger-service'
 import { promptUpdateSchema } from './trigger-prompt-schema'
-import { RuntimeOptionsSchema } from '@shared/lib/container/runtime-options'
+import { RuntimeOptionsPatchSchema } from '@shared/lib/container/runtime-options'
 import {
   getSessionsByWebhookTrigger,
 } from '@shared/lib/services/session-service'
@@ -120,19 +120,20 @@ webhookTriggersRouter.patch('/:triggerId/prompt', TriggerAgentRole('user'), asyn
   }
 })
 
-// PATCH /api/webhook-triggers/:triggerId/runtime-options - Update model and/or effort
+// PATCH /api/webhook-triggers/:triggerId/runtime-options - Update model, effort, and/or speed
 webhookTriggersRouter.patch('/:triggerId/runtime-options', TriggerAgentRole('user'), async (c) => {
   try {
     const trigger = c.get('webhookTrigger' as never) as Awaited<ReturnType<typeof getWebhookTrigger>>
     const body = await c.req.json().catch(() => ({}))
-    const parsed = RuntimeOptionsSchema.partial().safeParse(body)
+    const parsed = RuntimeOptionsPatchSchema.safeParse(body)
     if (!parsed.success) {
       return c.json({ error: parsed.error.issues[0]?.message ?? 'Invalid runtime options' }, 400)
     }
 
-    const updates: { model?: string | null; effort?: string | null } = {}
+    const updates: { model?: string | null; effort?: string | null; speed?: string | null } = {}
     if ('model' in body) updates.model = parsed.data.model ?? null
     if ('effort' in body) updates.effort = parsed.data.effort ?? null
+    if ('speed' in body) updates.speed = parsed.data.speed ?? null
 
     const updated = await updateWebhookTriggerRuntimeOptions(trigger!.id, updates)
     if (!updated) {

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -561,7 +561,7 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
   const agentLimits = getEffectiveAgentLimits()
   const customEnvVars = getCustomEnvVars()
 
-  // Model/effort preference order: target agent's default > global default.
+  // Model/effort/speed preference order: target agent's default > global default.
   const targetPrefs = await readAgentPreferences(targetSlug)
 
   const containerSession = await client.createSession({
@@ -571,6 +571,7 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
     browserModel: getEffectiveModels().browserModel,
     dashboardBuilderModel: getEffectiveModels().dashboardBuilderModel,
     ...(targetPrefs.defaultEffort ? { effort: targetPrefs.defaultEffort } : {}),
+    ...(targetPrefs.defaultSpeed ? { speed: targetPrefs.defaultSpeed } : {}),
     maxOutputTokens: agentLimits.maxOutputTokens,
     maxThinkingTokens: agentLimits.maxThinkingTokens,
     maxTurns: agentLimits.maxTurns,

--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -506,7 +506,7 @@ describe('AgentHome', () => {
       file: new File(['hello'], 'hello.txt', { type: 'text/plain' }),
     }
     renderWithProviders(
-      <CarryoverSeeder value={{ attachments: [attachment], model: 'opus', effort: 'high' }}>
+      <CarryoverSeeder value={{ attachments: [attachment], model: 'opus', effort: 'high', speed: 'normal' }}>
         <AgentHome agent={testAgent} onSessionCreated={onSessionCreated} />
       </CarryoverSeeder>,
     )
@@ -518,6 +518,8 @@ describe('AgentHome', () => {
       message: 'Continue in a new session',
       model: 'opus',
       effort: 'high',
+      // A carried speed is an explicit (session-seeded) value, so it rides along.
+      speed: 'normal',
     })
   })
 

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -94,8 +94,10 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   const composerOptions = useComposerOptions({
     initialModel: carryover?.model,
     initialEffort: carryover?.effort,
+    initialSpeed: carryover?.speed,
     agentDefaultModel: agentPrefs?.defaultModel,
     agentDefaultEffort: agentPrefs?.defaultEffort,
+    agentDefaultSpeed: agentPrefs?.defaultSpeed,
     agentKey: agent.slug,
     // The default-model card sits next to this composer; an untouched selection
     // must visibly track it, including a reset back to the global default.

--- a/src/renderer/components/agents/agent-home/home-chat-integrations.test.tsx
+++ b/src/renderer/components/agents/agent-home/home-chat-integrations.test.tsx
@@ -52,6 +52,7 @@ const INTEGRATION: ListItem = {
   sessionTimeout: null,
   model: null,
   effort: null,
+  speed: null,
   status: 'active',
   errorMessage: null,
   createdByUserId: null,

--- a/src/renderer/components/agents/agent-home/home-default-model.test.tsx
+++ b/src/renderer/components/agents/agent-home/home-default-model.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const useSettingsMock = vi.fn()
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useSettings: () => useSettingsMock(),
+}))
+
+const usePreferencesMock = vi.fn()
+const mutateMock = vi.fn()
+vi.mock('@renderer/hooks/use-agent-preferences', () => ({
+  useAgentPreferences: () => usePreferencesMock(),
+  useUpdateAgentPreferences: () => ({ mutate: mutateMock, isPending: false }),
+}))
+
+import { HomeDefaultModel } from './home-default-model'
+
+const ALL = ['low', 'medium', 'high', 'xhigh', 'max']
+const SPEEDY_CATALOG = [
+  {
+    id: 'claude-opus-4-8',
+    label: 'Opus 4.8',
+    family: 'opus',
+    isLatest: true,
+    icon: 'anthropic',
+    supportedEfforts: ALL,
+    supportedSpeeds: ['slow', 'normal', 'fast'],
+  },
+]
+const NO_SPEED_CATALOG = [
+  {
+    id: 'claude-opus-4-8',
+    label: 'Opus 4.8',
+    family: 'opus',
+    isLatest: true,
+    icon: 'anthropic',
+    supportedEfforts: ALL,
+  },
+]
+
+function mockSettings(catalog: unknown[]) {
+  useSettingsMock.mockReturnValue({
+    data: {
+      llmProvider: 'anthropic',
+      llmProviderStatus: [
+        {
+          id: 'anthropic',
+          name: 'Anthropic',
+          isConfigured: true,
+          catalog,
+          defaultModels: { agent: 'opus', summarizer: 'haiku', browser: 'sonnet' },
+        },
+      ],
+      models: { agentModel: 'claude-opus-4-8', agentEffort: 'medium' },
+    },
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockSettings(SPEEDY_CATALOG)
+  usePreferencesMock.mockReturnValue({ data: {} })
+})
+
+describe('HomeDefaultModel speed override', () => {
+  it('stores an off-default speed pick as the agent default', async () => {
+    const user = userEvent.setup()
+    render(<HomeDefaultModel agentSlug="agent-one" />)
+
+    await user.click(screen.getByTestId('settings-model-trigger'))
+    await user.click(await screen.findByTestId('speed-option-fast'))
+
+    expect(mutateMock).toHaveBeenCalledWith({ defaultSpeed: 'fast' })
+  })
+
+  it('picking Normal clears the override instead of persisting the literal value', async () => {
+    usePreferencesMock.mockReturnValue({ data: { defaultSpeed: 'fast' } })
+    const user = userEvent.setup()
+    render(<HomeDefaultModel agentSlug="agent-one" />)
+
+    await user.click(screen.getByTestId('settings-model-trigger'))
+    await user.click(await screen.findByTestId('speed-option-normal'))
+
+    expect(mutateMock).toHaveBeenCalledWith({ defaultSpeed: null })
+  })
+
+  it('clears the override (not a literal normal) when the speed clamp auto-fires', async () => {
+    // A stored 'fast' on a model whose serving path offers no speed choice
+    // gets clamped on render — the clamp write must clear the key too.
+    mockSettings(NO_SPEED_CATALOG)
+    usePreferencesMock.mockReturnValue({ data: { defaultSpeed: 'fast' } })
+    render(<HomeDefaultModel agentSlug="agent-one" />)
+
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledWith({ defaultSpeed: null }))
+  })
+
+  it('shows the Custom reset affordance only for a real override', () => {
+    usePreferencesMock.mockReturnValue({ data: {} })
+    const { rerender } = render(<HomeDefaultModel agentSlug="agent-one" />)
+    expect(screen.queryByTestId('home-default-model-reset')).not.toBeInTheDocument()
+    expect(screen.getByText('Global')).toBeInTheDocument()
+
+    usePreferencesMock.mockReturnValue({ data: { defaultSpeed: 'fast' } })
+    rerender(<HomeDefaultModel agentSlug="agent-one" />)
+    expect(screen.getByTestId('home-default-model-reset')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/agents/agent-home/home-default-model.tsx
+++ b/src/renderer/components/agents/agent-home/home-default-model.tsx
@@ -4,7 +4,7 @@ import { Button } from '@renderer/components/ui/button'
 import { useSettings } from '@renderer/hooks/use-settings'
 import { useAgentPreferences, useUpdateAgentPreferences } from '@renderer/hooks/use-agent-preferences'
 import { SettingsModelSelect } from '@renderer/components/settings/settings-model-select'
-import type { EffortLevel } from '@shared/lib/container/types'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 
 interface HomeDefaultModelProps {
   agentSlug: string
@@ -22,9 +22,10 @@ export function HomeDefaultModel({ agentSlug, className }: HomeDefaultModelProps
   const { data: prefs } = useAgentPreferences(agentSlug)
   const updatePreferences = useUpdateAgentPreferences(agentSlug)
 
-  const hasCustom = Boolean(prefs?.defaultModel || prefs?.defaultEffort)
+  const hasCustom = Boolean(prefs?.defaultModel || prefs?.defaultEffort || prefs?.defaultSpeed)
   const displayModel = prefs?.defaultModel ?? settings?.models?.agentModel
   const displayEffort = prefs?.defaultEffort ?? settings?.models?.agentEffort ?? 'medium'
+  const displaySpeed = prefs?.defaultSpeed ?? 'normal'
 
   return (
     <div
@@ -41,7 +42,7 @@ export function HomeDefaultModel({ agentSlug, className }: HomeDefaultModelProps
             aria-label="Reset to global default"
             title="Reset to global default"
             data-testid="home-default-model-reset"
-            onClick={() => updatePreferences.mutate({ defaultModel: null, defaultEffort: null })}
+            onClick={() => updatePreferences.mutate({ defaultModel: null, defaultEffort: null, defaultSpeed: null })}
           >
             <RotateCcw className="h-3.5 w-3.5" />
           </Button>
@@ -54,6 +55,12 @@ export function HomeDefaultModel({ agentSlug, className }: HomeDefaultModelProps
           includeEffort
           effort={displayEffort as EffortLevel}
           onEffortChange={(e) => updatePreferences.mutate({ defaultEffort: e })}
+          includeSpeed
+          speed={displaySpeed as SpeedLevel}
+          // 'normal' is the built-in default, not an override: store null (clear
+          // the key, like reset does) so it never flips the Custom badge on —
+          // including when useSpeedClamp auto-fires after a model switch.
+          onSpeedChange={(s) => updatePreferences.mutate({ defaultSpeed: s === 'normal' ? null : s })}
           disabled={updatePreferences.isPending}
         />
       </div>

--- a/src/renderer/components/agents/agent-home/home-triggers.test.tsx
+++ b/src/renderer/components/agents/agent-home/home-triggers.test.tsx
@@ -58,6 +58,7 @@ const task: ApiScheduledTask = {
   timezone: 'UTC',
   model: null,
   effort: null,
+  speed: null,
   createdAt: new Date('2026-07-01T00:00:00.000Z'),
   cancelledAt: null,
   pausedAt: null,

--- a/src/renderer/components/chat-integrations/integration-settings-controls.test.tsx
+++ b/src/renderer/components/chat-integrations/integration-settings-controls.test.tsx
@@ -12,7 +12,7 @@ const STD: EffortLevel[] = ['low', 'medium', 'high']
 
 const CATALOG: ModelDefinition[] = [
   { id: 'claude-haiku-4-5', label: 'Haiku 4.5', family: 'haiku', isLatest: true, icon: 'anthropic', supportedEfforts: STD },
-  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', family: 'sonnet', isLatest: true, icon: 'anthropic', supportedEfforts: STD },
+  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', family: 'sonnet', isLatest: true, icon: 'anthropic', supportedEfforts: STD, supportedSpeeds: ['slow', 'normal', 'fast'] },
   { id: 'claude-opus-4-8', label: 'Opus 4.8', family: 'opus', isLatest: true, icon: 'anthropic', supportedEfforts: ALL },
 ]
 
@@ -96,6 +96,26 @@ describe('IntegrationModelEffort', () => {
     await user.click(await screen.findByTestId('effort-option-low'))
 
     expect(mutateMock).toHaveBeenCalledWith({ id: 'int-1', effort: 'low' })
+  })
+
+  it('calls mutate with speed when user selects a speed', async () => {
+    const user = userEvent.setup()
+    render(<IntegrationModelEffort integration={makeIntegration({ model: 'sonnet' })} />)
+
+    await user.click(screen.getByTestId('settings-model-trigger'))
+    await user.click(await screen.findByTestId('speed-option-slow'))
+
+    expect(mutateMock).toHaveBeenCalledWith({ id: 'int-1', speed: 'slow' })
+  })
+
+  it('hides the speed picker for models without a speed choice', async () => {
+    const user = userEvent.setup()
+    render(<IntegrationModelEffort integration={makeIntegration({ model: 'opus' })} />)
+
+    await user.click(screen.getByTestId('settings-model-trigger'))
+    await screen.findByTestId('effort-option-low')
+
+    expect(screen.queryByTestId('speed-option-normal')).not.toBeInTheDocument()
   })
 
   it('uses the correct integration id in mutation calls', async () => {

--- a/src/renderer/components/chat-integrations/integration-settings-controls.tsx
+++ b/src/renderer/components/chat-integrations/integration-settings-controls.tsx
@@ -10,7 +10,7 @@ import {
 } from '@renderer/components/ui/select'
 import { useUpdateChatIntegration } from '@renderer/hooks/use-chat-integrations'
 import { SettingsModelSelect } from '@renderer/components/settings/settings-model-select'
-import type { EffortLevel } from '@shared/lib/container/types'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 import type { ChatIntegration } from '@shared/lib/db/schema'
 
 export function ToggleRow({ label, helperText, checked, onCheckedChange, disabled }: {
@@ -146,6 +146,9 @@ export function IntegrationModelEffort({ integration }: { integration: ChatInteg
       includeEffort
       effort={(integration.effort as EffortLevel) ?? 'medium'}
       onEffortChange={(e) => updateIntegration.mutate({ id: integration.id, effort: e })}
+      includeSpeed
+      speed={(integration.speed as SpeedLevel) ?? 'normal'}
+      onSpeedChange={(s) => updateIntegration.mutate({ id: integration.id, speed: s })}
       // Left-aligned in its DetailCard, so the LEFT edge is the fixed one —
       // anchoring 'end' would slide the popover on every pick.
       align="start"

--- a/src/renderer/components/chat-integrations/test-factories.ts
+++ b/src/renderer/components/chat-integrations/test-factories.ts
@@ -13,6 +13,7 @@ export function makeChatIntegration(overrides: Partial<ChatIntegration> = {}): C
     sessionTimeout: null,
     model: null,
     effort: null,
+    speed: null,
     status: 'active',
     errorMessage: null,
     createdByUserId: null,

--- a/src/renderer/components/layout/session-chat-column.tsx
+++ b/src/renderer/components/layout/session-chat-column.tsx
@@ -12,7 +12,7 @@ import { useFileDeliveryWatcher } from '@renderer/hooks/use-file-delivery-watche
 import { useStaleSession } from '@renderer/hooks/use-stale-session'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
 import { DonutChart } from '@renderer/components/ui/donut-chart'
-import type { EffortLevel } from '@shared/lib/container/types'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 import type { PendingMessage } from '@renderer/components/messages/pending-message'
 import type { SessionUsage } from '@shared/lib/types/agent'
 
@@ -26,6 +26,7 @@ interface SessionChatColumnProps {
   isViewOnly: boolean
   contextPercent: number | null
   effort?: EffortLevel
+  speed?: SpeedLevel
   model?: string
   onPendingMessageAppeared: (localId: string) => void
   onMessageSent: (content: string, localId: string, queued: boolean) => void
@@ -47,6 +48,7 @@ export function SessionChatColumn({
   isViewOnly,
   contextPercent,
   effort,
+  speed,
   model,
   onPendingMessageAppeared,
   onMessageSent,
@@ -137,6 +139,7 @@ export function SessionChatColumn({
               onMessageUuidAssigned={onMessageUuidAssigned}
               onMessageFailed={onMessageFailed}
               initialEffort={effort}
+              initialSpeed={speed}
               initialModel={model}
               registerSnapshot={staleSession.registerSnapshot}
             />

--- a/src/renderer/components/layout/session-view.tsx
+++ b/src/renderer/components/layout/session-view.tsx
@@ -141,6 +141,7 @@ export function SessionView({ agentSlug, sessionId }: SessionViewProps) {
               isViewOnly={isViewOnly}
               contextPercent={contextPercent}
               effort={session?.effort}
+              speed={session?.speed}
               model={session?.model}
               onPendingMessageAppeared={onPendingMessageAppeared}
               onMessageSent={onMessageSent}

--- a/src/renderer/components/messages/composer-options-popover.test.tsx
+++ b/src/renderer/components/messages/composer-options-popover.test.tsx
@@ -163,4 +163,38 @@ describe('ComposerOptionsPopover', () => {
     render(<Harness disabled initialModel="claude-opus-4-8" />)
     expect(screen.getByTestId('composer-options-trigger')).toBeDisabled()
   })
+
+  it('orders the sections Model → Effort → Speed', async () => {
+    const user = userEvent.setup()
+    render(<Harness initialModel="claude-opus-4-8" />)
+    await user.click(screen.getByTestId('composer-options-trigger'))
+    const models = await screen.findByText('Models')
+    const effort = screen.getByText('Effort')
+    const speed = screen.getByText('Speed')
+    // DOM order == visual order (no col-reverse): Models, then Effort, then Speed.
+    expect(models.compareDocumentPosition(effort) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(effort.compareDocumentPosition(speed) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('offers only Normal/Fast speeds for an Anthropic model', async () => {
+    const user = userEvent.setup()
+    render(<Harness initialModel="claude-opus-4-8" />)
+    await user.click(screen.getByTestId('composer-options-trigger'))
+    expect(await screen.findByTestId('speed-option-normal')).toBeInTheDocument()
+    expect(screen.getByTestId('speed-option-fast')).toBeInTheDocument()
+    expect(screen.queryByTestId('speed-option-slow')).not.toBeInTheDocument()
+  })
+
+  it('adds the Slow speed for a GPT (non-Anthropic) model', async () => {
+    const user = userEvent.setup()
+    const catalog: ModelDefinition[] = [
+      ...CATALOG,
+      { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', family: 'gpt', isLatest: true, icon: 'openai', supportedEfforts: STD },
+    ]
+    render(<Harness catalog={catalog} initialModel="gpt-5.6-sol" />)
+    await user.click(screen.getByTestId('composer-options-trigger'))
+    expect(await screen.findByTestId('speed-option-slow')).toBeInTheDocument()
+    expect(screen.getByTestId('speed-option-normal')).toBeInTheDocument()
+    expect(screen.getByTestId('speed-option-fast')).toBeInTheDocument()
+  })
 })

--- a/src/renderer/components/messages/composer-options-popover.test.tsx
+++ b/src/renderer/components/messages/composer-options-popover.test.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event'
 import { ComposerOptionsPopover } from './composer-options-popover'
 import type { ComposerOptionsState } from './composer-options'
 import type { ModelDefinition } from '@shared/lib/llm-provider'
-import type { EffortLevel } from '@shared/lib/container/types'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 
 const ALL: EffortLevel[] = ['low', 'medium', 'high', 'xhigh', 'max']
 const STD: EffortLevel[] = ['low', 'medium', 'high']
@@ -15,11 +15,13 @@ const CATALOG: ModelDefinition[] = [
   { id: 'claude-haiku-4-5', label: 'Haiku 4.5', family: 'haiku', isLatest: true, icon: 'anthropic', supportedEfforts: STD },
   { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', family: 'sonnet', isLatest: true, icon: 'anthropic', supportedEfforts: STD },
   { id: 'claude-opus-4-7', label: 'Opus 4.7', family: 'opus', icon: 'anthropic', supportedEfforts: ALL },
-  { id: 'claude-opus-4-8', label: 'Opus 4.8', family: 'opus', isLatest: true, icon: 'anthropic', supportedEfforts: ALL },
+  // Speeds are catalog-declared per model: Opus 4.8 offers fast mode.
+  { id: 'claude-opus-4-8', label: 'Opus 4.8', family: 'opus', isLatest: true, icon: 'anthropic', supportedEfforts: ALL, supportedSpeeds: ['normal', 'fast'] },
 ]
 
 interface HarnessProps {
   initialEffort?: EffortLevel
+  initialSpeed?: SpeedLevel
   initialModel?: string
   catalog?: ModelDefinition[]
   onState?: (state: ComposerOptionsState) => void
@@ -30,20 +32,24 @@ interface HarnessProps {
 // transitions need a real React state holder to observe correctly.
 function Harness({
   initialEffort = 'high',
+  initialSpeed = 'normal',
   initialModel,
   catalog = CATALOG,
   onState,
   disabled,
 }: HarnessProps) {
   const [effort, setEffort] = useState<EffortLevel>(initialEffort)
+  const [speed, setSpeed] = useState<SpeedLevel>(initialSpeed)
   const [model, setModel] = useState<string | undefined>(initialModel)
   const state: ComposerOptionsState = {
     effort,
     setEffort,
+    speed,
+    setSpeed,
     model,
     setModel,
     catalog,
-    toRuntimeOptions: () => ({ effort, ...(model ? { model } : {}) }),
+    toRuntimeOptions: () => ({ effort, speed, ...(model ? { model } : {}) }),
   }
   onState?.(state)
   return <ComposerOptionsPopover state={state} disabled={disabled} />
@@ -87,6 +93,8 @@ describe('ComposerOptionsPopover', () => {
         state={{
           effort: 'high',
           setEffort: vi.fn(),
+          speed: 'normal',
+          setSpeed: vi.fn(),
           model: 'claude-sonnet-4-6',
           setModel,
           catalog: CATALOG,
@@ -109,6 +117,8 @@ describe('ComposerOptionsPopover', () => {
         state={{
           effort: 'high',
           setEffort,
+          speed: 'normal',
+          setSpeed: vi.fn(),
           model: 'claude-opus-4-8',
           setModel: vi.fn(),
           catalog: CATALOG,
@@ -176,7 +186,7 @@ describe('ComposerOptionsPopover', () => {
     expect(effort.compareDocumentPosition(speed) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
-  it('offers only Normal/Fast speeds for an Anthropic model', async () => {
+  it('offers exactly the catalog-declared speeds for the selected model', async () => {
     const user = userEvent.setup()
     render(<Harness initialModel="claude-opus-4-8" />)
     await user.click(screen.getByTestId('composer-options-trigger'))
@@ -185,16 +195,36 @@ describe('ComposerOptionsPopover', () => {
     expect(screen.queryByTestId('speed-option-slow')).not.toBeInTheDocument()
   })
 
-  it('adds the Slow speed for a GPT (non-Anthropic) model', async () => {
+  it('shows all three speeds for a model declaring slow/normal/fast', async () => {
     const user = userEvent.setup()
     const catalog: ModelDefinition[] = [
       ...CATALOG,
-      { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', family: 'gpt', isLatest: true, icon: 'openai', supportedEfforts: STD },
+      { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', family: 'gpt', isLatest: true, icon: 'openai', supportedEfforts: STD, supportedSpeeds: ['slow', 'normal', 'fast'] },
     ]
     render(<Harness catalog={catalog} initialModel="gpt-5.6-sol" />)
     await user.click(screen.getByTestId('composer-options-trigger'))
     expect(await screen.findByTestId('speed-option-slow')).toBeInTheDocument()
     expect(screen.getByTestId('speed-option-normal')).toBeInTheDocument()
     expect(screen.getByTestId('speed-option-fast')).toBeInTheDocument()
+  })
+
+  it('hides the Speed section for a model with no declared speeds (normal-only)', async () => {
+    const user = userEvent.setup()
+    render(<Harness initialModel="claude-sonnet-4-6" />)
+    await user.click(screen.getByTestId('composer-options-trigger'))
+    expect(await screen.findByText('Effort')).toBeInTheDocument()
+    expect(screen.queryByText('Speed')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('speed-option-normal')).not.toBeInTheDocument()
+  })
+
+  it('auto-resets speed to Normal when switching to a model without the current speed', async () => {
+    const user = userEvent.setup()
+    render(<Harness initialModel="claude-opus-4-8" initialSpeed="fast" />)
+    expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Opus 4.8 · High · Fast')
+    await user.click(screen.getByTestId('composer-options-trigger'))
+    await user.click(await screen.findByTestId('model-pinned-claude-sonnet-4-6'))
+    // Sonnet declares no speeds → the pick snaps back to Normal (no suffix).
+    expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Sonnet 4.6 · High')
+    expect(screen.getByTestId('composer-options-trigger')).not.toHaveTextContent('Fast')
   })
 })

--- a/src/renderer/components/messages/composer-options-popover.tsx
+++ b/src/renderer/components/messages/composer-options-popover.tsx
@@ -1,115 +1,14 @@
-import { memo, useEffect, useState } from 'react'
-import { ChevronDown, HelpCircle } from 'lucide-react'
+import { memo } from 'react'
+import { ChevronDown } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { Separator } from '@renderer/components/ui/separator'
 import { ModelIcon } from '@renderer/components/ui/model-icon'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@renderer/components/ui/tooltip'
-import { cn } from '@shared/lib/utils'
 import { EFFORT_LEVELS } from '@shared/lib/container/types'
-import type { ModelDefinition } from '@shared/lib/llm-provider'
 import { type ComposerOptionsState } from './composer-options'
 import { ModelFamilyList, findCatalogModel } from './model-family-list'
 import { EFFORT_LABELS, EffortSection, useEffortClamp } from './effort-slider'
-
-// ---- Processing speed (UI exploration; local-only, not yet a runtime option) ----
-type ProcessingSpeed = 'slow' | 'normal' | 'fast'
-
-const SPEED_LABELS: Record<ProcessingSpeed, string> = {
-  slow: 'Slow',
-  normal: 'Normal',
-  fast: 'Fast',
-}
-
-/**
- * Which speeds a model exposes depends on its vendor: Anthropic models offer
- * Normal/Fast, while every other vendor (OpenAI, xAI, Z.AI, …) adds the more
- * deliberate 'slow' tier. Normal is the universal default, so it's always a
- * safe reset target when a model switch drops the current pick. An undefined
- * model resolves as Anthropic — the composer's default vendor.
- */
-function availableSpeeds(model: ModelDefinition | undefined): ProcessingSpeed[] {
-  const isAnthropic = !model || model.icon === 'anthropic'
-  return isAnthropic ? ['normal', 'fast'] : ['slow', 'normal', 'fast']
-}
-
-/**
- * Speed block mirroring EffortSection's header pattern ("Speed · Normal", value
- * in the accent blue, help tooltip on the right) over a segmented control in
- * the same visual language as the vendor tab bar above (muted pill, active
- * segment lifted with bg + shadow). A segment reads as a toggle, so picks never
- * dismiss the popover — consistent with model/effort picks here.
- */
-function SpeedSection({
-  speeds,
-  value,
-  onChange,
-}: {
-  speeds: ProcessingSpeed[]
-  value: ProcessingSpeed
-  onChange: (speed: ProcessingSpeed) => void
-}) {
-  return (
-    <div>
-      <div className="flex items-center justify-between px-2 pt-1 pb-1 text-[11px] font-medium text-muted-foreground/70">
-        <span>
-          <span>Speed</span>
-          <span className="text-[#007DED] dark:text-[#4EB3FF]"> · {SPEED_LABELS[value]}</span>
-        </span>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                aria-label="About speed"
-                data-testid="speed-help"
-                className="inline-flex shrink-0 hover:text-foreground"
-              >
-                <HelpCircle className="h-3 w-3" aria-hidden="true" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent className="max-w-60">
-              Faster processing returns replies sooner. Slower processing gives the model more
-              room to work. Available speeds depend on the model.
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      </div>
-      <div className="px-2 pb-1">
-        <div
-          role="radiogroup"
-          aria-label="Processing speed"
-          className="flex rounded-lg bg-muted p-0.5 text-muted-foreground"
-        >
-          {speeds.map((level) => {
-            const isActive = level === value
-            return (
-              <button
-                key={level}
-                type="button"
-                role="radio"
-                aria-checked={isActive}
-                data-testid={`speed-option-${level}`}
-                onClick={() => onChange(level)}
-                className={cn(
-                  'flex-1 rounded-md px-2 py-1 text-xs transition-all hover:bg-background/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                  isActive && 'bg-background text-foreground shadow'
-                )}
-              >
-                {SPEED_LABELS[level]}
-              </button>
-            )
-          })}
-        </div>
-      </div>
-    </div>
-  )
-}
+import { SPEED_LABELS, SpeedSection, availableSpeeds, useSpeedClamp } from './speed-section'
 
 interface ComposerOptionsPopoverProps {
   state: ComposerOptionsState
@@ -119,7 +18,7 @@ interface ComposerOptionsPopoverProps {
 }
 
 function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: ComposerOptionsPopoverProps) {
-  const { effort, setEffort, model, setModel, catalog, webProvider } = state
+  const { effort, setEffort, speed, setSpeed, model, setModel, catalog, webProvider } = state
 
   // Trigger display fallback for the brief window before useComposerOptions
   // seeds `model`. Order: resolve the selection against the catalog (exact id
@@ -136,18 +35,18 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: C
     selectedModel ? selectedModel.supportedEfforts.includes(level) : true
   )
 
-  // Speed is local-only (UI exploration): options are gated by the selected
-  // model's vendor, and a model switch that drops the current pick snaps back
-  // to Normal — same clamp shape as useEffortClamp.
-  const [speed, setSpeed] = useState<ProcessingSpeed>('normal')
+  // Speed options come from the selected model's catalog entry; a model switch
+  // that drops the current pick snaps back to Normal.
   const visibleSpeeds = availableSpeeds(selectedModel)
-  useEffect(() => {
-    if (!availableSpeeds(selectedModel).includes(speed)) setSpeed('normal')
-  }, [selectedModel, speed])
+  useSpeedClamp(includeEffort ? selectedModel : undefined, speed, setSpeed)
 
   const effortLabel = EFFORT_LABELS[effort]
   // Keep the trigger uncluttered: surface speed only when it's off the default.
-  const speedSuffix = speed === 'normal' ? '' : ` · ${SPEED_LABELS[speed]}`
+  // Session metadata deliberately persists speed as an open string (forward
+  // compat), so an off-enum value can reach here — render no suffix rather
+  // than "· undefined".
+  const speedLabel: string | undefined = SPEED_LABELS[speed]
+  const speedSuffix = speed !== 'normal' && speedLabel ? ` · ${speedLabel}` : ''
   const selectedModelLabel = selectedModel?.label
   const triggerAriaLabel = includeEffort
     ? (selectedModelLabel ? `${selectedModelLabel} · ${effortLabel}${speedSuffix}` : `${effortLabel}${speedSuffix}`)
@@ -209,9 +108,10 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: C
           <EffortSection levels={visibleEfforts} value={effort} onChange={setEffort} />
         )}
         {/* Speed rides the same gate as Effort: model-only pickers (summarizer)
-            show neither. Rendered last so it sits below Effort in the fixed
-            Model → Effort → Speed order. */}
-        {includeEffort && (
+            show neither. Hidden entirely for models whose serving path offers
+            no speed choice (normal-only). Rendered last so it sits below
+            Effort in the fixed Model → Effort → Speed order. */}
+        {includeEffort && visibleSpeeds.length > 1 && (
           <>
             <Separator className="my-2 bg-border/50" />
             <SpeedSection speeds={visibleSpeeds} value={speed} onChange={setSpeed} />

--- a/src/renderer/components/messages/composer-options-popover.tsx
+++ b/src/renderer/components/messages/composer-options-popover.tsx
@@ -1,13 +1,115 @@
-import { memo } from 'react'
-import { ChevronDown } from 'lucide-react'
+import { memo, useEffect, useState } from 'react'
+import { ChevronDown, HelpCircle } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { Separator } from '@renderer/components/ui/separator'
 import { ModelIcon } from '@renderer/components/ui/model-icon'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@renderer/components/ui/tooltip'
+import { cn } from '@shared/lib/utils'
 import { EFFORT_LEVELS } from '@shared/lib/container/types'
+import type { ModelDefinition } from '@shared/lib/llm-provider'
 import { type ComposerOptionsState } from './composer-options'
 import { ModelFamilyList, findCatalogModel } from './model-family-list'
 import { EFFORT_LABELS, EffortSection, useEffortClamp } from './effort-slider'
+
+// ---- Processing speed (UI exploration; local-only, not yet a runtime option) ----
+type ProcessingSpeed = 'slow' | 'normal' | 'fast'
+
+const SPEED_LABELS: Record<ProcessingSpeed, string> = {
+  slow: 'Slow',
+  normal: 'Normal',
+  fast: 'Fast',
+}
+
+/**
+ * Which speeds a model exposes depends on its vendor: Anthropic models offer
+ * Normal/Fast, while every other vendor (OpenAI, xAI, Z.AI, …) adds the more
+ * deliberate 'slow' tier. Normal is the universal default, so it's always a
+ * safe reset target when a model switch drops the current pick. An undefined
+ * model resolves as Anthropic — the composer's default vendor.
+ */
+function availableSpeeds(model: ModelDefinition | undefined): ProcessingSpeed[] {
+  const isAnthropic = !model || model.icon === 'anthropic'
+  return isAnthropic ? ['normal', 'fast'] : ['slow', 'normal', 'fast']
+}
+
+/**
+ * Speed block mirroring EffortSection's header pattern ("Speed · Normal", value
+ * in the accent blue, help tooltip on the right) over a segmented control in
+ * the same visual language as the vendor tab bar above (muted pill, active
+ * segment lifted with bg + shadow). A segment reads as a toggle, so picks never
+ * dismiss the popover — consistent with model/effort picks here.
+ */
+function SpeedSection({
+  speeds,
+  value,
+  onChange,
+}: {
+  speeds: ProcessingSpeed[]
+  value: ProcessingSpeed
+  onChange: (speed: ProcessingSpeed) => void
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between px-2 pt-1 pb-1 text-[11px] font-medium text-muted-foreground/70">
+        <span>
+          <span>Speed</span>
+          <span className="text-[#007DED] dark:text-[#4EB3FF]"> · {SPEED_LABELS[value]}</span>
+        </span>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="About speed"
+                data-testid="speed-help"
+                className="inline-flex shrink-0 hover:text-foreground"
+              >
+                <HelpCircle className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-60">
+              Faster processing returns replies sooner. Slower processing gives the model more
+              room to work. Available speeds depend on the model.
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+      <div className="px-2 pb-1">
+        <div
+          role="radiogroup"
+          aria-label="Processing speed"
+          className="flex rounded-lg bg-muted p-0.5 text-muted-foreground"
+        >
+          {speeds.map((level) => {
+            const isActive = level === value
+            return (
+              <button
+                key={level}
+                type="button"
+                role="radio"
+                aria-checked={isActive}
+                data-testid={`speed-option-${level}`}
+                onClick={() => onChange(level)}
+                className={cn(
+                  'flex-1 rounded-md px-2 py-1 text-xs transition-all hover:bg-background/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                  isActive && 'bg-background text-foreground shadow'
+                )}
+              >
+                {SPEED_LABELS[level]}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
 
 interface ComposerOptionsPopoverProps {
   state: ComposerOptionsState
@@ -34,10 +136,21 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: C
     selectedModel ? selectedModel.supportedEfforts.includes(level) : true
   )
 
+  // Speed is local-only (UI exploration): options are gated by the selected
+  // model's vendor, and a model switch that drops the current pick snaps back
+  // to Normal — same clamp shape as useEffortClamp.
+  const [speed, setSpeed] = useState<ProcessingSpeed>('normal')
+  const visibleSpeeds = availableSpeeds(selectedModel)
+  useEffect(() => {
+    if (!availableSpeeds(selectedModel).includes(speed)) setSpeed('normal')
+  }, [selectedModel, speed])
+
   const effortLabel = EFFORT_LABELS[effort]
+  // Keep the trigger uncluttered: surface speed only when it's off the default.
+  const speedSuffix = speed === 'normal' ? '' : ` · ${SPEED_LABELS[speed]}`
   const selectedModelLabel = selectedModel?.label
   const triggerAriaLabel = includeEffort
-    ? (selectedModelLabel ? `${selectedModelLabel} · ${effortLabel}` : effortLabel)
+    ? (selectedModelLabel ? `${selectedModelLabel} · ${effortLabel}${speedSuffix}` : `${effortLabel}${speedSuffix}`)
     : (selectedModelLabel ?? 'Model')
 
   return (
@@ -59,7 +172,7 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: C
             {selectedModelLabel}
             {includeEffort && (
               <span className="text-muted-foreground">
-                {selectedModelLabel ? ' · ' : ''}{effortLabel}
+                {selectedModelLabel ? ' · ' : ''}{effortLabel}{speedSuffix}
               </span>
             )}
           </span>
@@ -67,7 +180,10 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: C
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="flex w-64 flex-col px-1 py-2 data-[side=bottom]:flex-col-reverse"
+        // Fixed reading order Model → Effort → Speed in both open directions —
+        // no col-reverse (unlike the settings picker, which flips to keep Effort
+        // by the trigger). Speed is the tertiary knob, so it stays at the bottom.
+        className="flex w-64 flex-col px-1 py-2"
         align="start"
         // Don't auto-focus the first element (a vendor tab) on open — focusing
         // it pops its name tooltip instantly. Keyboard users can Tab in.
@@ -91,6 +207,15 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: C
         )}
         {includeEffort && (
           <EffortSection levels={visibleEfforts} value={effort} onChange={setEffort} />
+        )}
+        {/* Speed rides the same gate as Effort: model-only pickers (summarizer)
+            show neither. Rendered last so it sits below Effort in the fixed
+            Model → Effort → Speed order. */}
+        {includeEffort && (
+          <>
+            <Separator className="my-2 bg-border/50" />
+            <SpeedSection speeds={visibleSpeeds} value={speed} onChange={setSpeed} />
+          </>
         )}
       </PopoverContent>
     </Popover>

--- a/src/renderer/components/messages/composer-options.test.tsx
+++ b/src/renderer/components/messages/composer-options.test.tsx
@@ -157,6 +157,15 @@ describe('useComposerOptions default adoption', () => {
     })
   })
 
+  it('serializes an explicitly picked speed so the dispatch payload carries it', () => {
+    const { result } = render({ agentKey: 'a', agentDefaultsReady: true })
+    expect(result.current.toRuntimeOptions()).toEqual({})
+    act(() => {
+      result.current.setSpeed('fast')
+    })
+    expect(result.current.toRuntimeOptions()).toEqual({ speed: 'fast' })
+  })
+
   it('session-seeded initial values win over defaults', () => {
     const { result } = render({
       initialModel: 'claude-opus-4-6',

--- a/src/renderer/components/messages/composer-options.tsx
+++ b/src/renderer/components/messages/composer-options.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSettings } from '@renderer/hooks/use-settings'
 import { ComposerOptionsPopover } from './composer-options-popover'
-import type { EffortLevel } from '@shared/lib/container/types'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 import type { ModelDefinition } from '@shared/lib/llm-provider'
 import type { LlmProviderId } from '@shared/lib/config/settings'
 
@@ -19,10 +19,13 @@ import type { LlmProviderId } from '@shared/lib/config/settings'
  */
 
 const DEFAULT_EFFORT: EffortLevel = 'medium'
+const DEFAULT_SPEED: SpeedLevel = 'normal'
 
 export interface ComposerOptionsState {
   effort: EffortLevel
   setEffort: (e: EffortLevel) => void
+  speed: SpeedLevel
+  setSpeed: (s: SpeedLevel) => void
   /** Raw selection — a concrete model id or a bare family alias; undefined while settings load. */
   model: string | undefined
   setModel: (m: string) => void
@@ -39,7 +42,7 @@ export interface ComposerOptionsState {
    * a still-loading preferences query — and would override the actual model of
    * a session that carries none in its metadata (e.g. trigger-created).
    */
-  toRuntimeOptions(): { effort?: EffortLevel; model?: string }
+  toRuntimeOptions(): { effort?: EffortLevel; speed?: SpeedLevel; model?: string }
 }
 
 /**
@@ -61,12 +64,16 @@ export function findCatalogModel(
 export interface UseComposerOptionsArgs {
   /** Effort last used on this session, seeds the selector once if provided. */
   initialEffort?: EffortLevel
+  /** Speed last used on this session, seeds the selector once if provided. */
+  initialSpeed?: SpeedLevel
   /** Model last used on this session, seeds the selector once if provided. */
   initialModel?: string
   /** The agent's own default model, if set. Slots between a session's initial model and the app-wide default. */
   agentDefaultModel?: string
   /** The agent's own default effort, if set. Slots between a session's initial effort and the app-wide default. */
   agentDefaultEffort?: EffortLevel
+  /** The agent's own default speed, if set. Slots between a session's initial speed and the built-in 'normal'. */
+  agentDefaultSpeed?: SpeedLevel
   /**
    * Identity of the agent the defaults belong to. When it changes (quick-dispatch
    * switching agents) a locked, untouched selection unlocks and re-adopts the new
@@ -93,9 +100,11 @@ export interface UseComposerOptionsArgs {
 export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerOptionsState {
   const {
     initialEffort,
+    initialSpeed,
     initialModel,
     agentDefaultModel,
     agentDefaultEffort,
+    agentDefaultSpeed,
     agentKey,
     agentDefaultsReady = true,
     followDefaults = false,
@@ -118,6 +127,20 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
   const setEffort = useCallback((e: EffortLevel) => {
     effortSeededRef.current = true
     setEffortState(e)
+  }, [])
+
+  // ---- Speed ---- (same seeding/locking shape as effort)
+  const [speed, setSpeedState] = useState<SpeedLevel>(initialSpeed ?? DEFAULT_SPEED)
+  const speedSeededRef = useRef(initialSpeed !== undefined)
+  useEffect(() => {
+    if (!speedSeededRef.current && initialSpeed !== undefined) {
+      setSpeedState(initialSpeed)
+      speedSeededRef.current = true
+    }
+  }, [initialSpeed])
+  const setSpeed = useCallback((sp: SpeedLevel) => {
+    speedSeededRef.current = true
+    setSpeedState(sp)
   }, [])
 
   // ---- Catalog from active provider ----
@@ -169,6 +192,7 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
   const adoptionKeyRef = useRef(agentKey)
   const fallbackEffort =
     agentDefaultEffort ?? settings?.models?.agentEffort ?? (settings ? DEFAULT_EFFORT : undefined)
+  const fallbackSpeed = agentDefaultSpeed ?? (settings ? DEFAULT_SPEED : undefined)
   useEffect(() => {
     if (adoptionKeyRef.current !== agentKey) {
       adoptionKeyRef.current = agentKey
@@ -186,6 +210,14 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
     ) {
       setEffortState(fallbackEffort)
     }
+    if (
+      !speedSeededRef.current &&
+      initialSpeed === undefined &&
+      fallbackSpeed &&
+      speed !== fallbackSpeed
+    ) {
+      setSpeedState(fallbackSpeed)
+    }
     if (!followDefaults && settings && agentDefaultsReady) {
       adoptionLockedRef.current = true
     }
@@ -196,6 +228,9 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
     effort,
     fallbackEffort,
     initialEffort,
+    speed,
+    fallbackSpeed,
+    initialSpeed,
     settings,
     agentDefaultsReady,
     followDefaults,
@@ -206,22 +241,25 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
   const toRuntimeOptions = useCallback(
     () => ({
       ...(effortSeededRef.current ? { effort } : {}),
+      ...(speedSeededRef.current ? { speed } : {}),
       ...(modelSeededRef.current && model ? { model } : {}),
     }),
-    [effort, model],
+    [effort, speed, model],
   )
 
   return useMemo(
     () => ({
       effort,
       setEffort,
+      speed,
+      setSpeed,
       model,
       setModel,
       catalog,
       webProvider: settings?.webProvider,
       toRuntimeOptions,
     }),
-    [effort, setEffort, model, setModel, catalog, settings, toRuntimeOptions],
+    [effort, setEffort, speed, setSpeed, model, setModel, catalog, settings, toRuntimeOptions],
   )
 }
 

--- a/src/renderer/components/messages/effort-slider.test.tsx
+++ b/src/renderer/components/messages/effort-slider.test.tsx
@@ -9,11 +9,13 @@ const ALL = [...EFFORT_LEVELS] as EffortLevel[]
 const STD: EffortLevel[] = ['low', 'medium', 'high']
 
 describe('EffortSlider', () => {
-  it('renders a tick per allowed level, labeling only the Faster/Smarter poles', () => {
+  it('renders a tick per allowed level, with no text labels on the bar itself', () => {
     render(<EffortSlider levels={ALL} value="medium" onChange={vi.fn()} />)
     for (const level of ALL) expect(screen.getByTestId(`effort-option-${level}`)).toBeInTheDocument()
-    expect(screen.getByText('Faster')).toBeInTheDocument()
-    expect(screen.getByText('Smarter')).toBeInTheDocument()
+    // The Faster/Smarter poles moved to EffortSection's header (shown mid-drag),
+    // so the bar carries no pole text of its own.
+    expect(screen.queryByText('Faster')).not.toBeInTheDocument()
+    expect(screen.queryByText('Smarter')).not.toBeInTheDocument()
     // No per-level names on the bar — they live in aria labels only, spelled
     // out in full for screen readers.
     expect(screen.queryByText('Medium')).not.toBeInTheDocument()
@@ -144,6 +146,37 @@ describe('EffortSlider', () => {
     fireEvent.pointerUp(track)
     expect(onChange).toHaveBeenCalledTimes(1)
     expect(onChange).toHaveBeenCalledWith('max')
+  })
+
+  it('EffortSection: the poles cross-fade in over the Effort header while dragging', () => {
+    render(<EffortSection levels={ALL} value="high" onChange={vi.fn()} />)
+    const track = screen.getByTestId('effort-slider').querySelector('.touch-none') as HTMLElement
+    vi.spyOn(track, 'getBoundingClientRect').mockReturnValue({ left: 0, width: 120 } as DOMRect)
+    // Both layers stay mounted (so the motion can play both ways) — the swap is
+    // an opacity/transform cross-fade, not a mount/unmount.
+    const restingLayer = () => screen.getByText('Effort').closest('div') as HTMLElement
+    const polesLayer = () => screen.getByText('Faster').closest('div') as HTMLElement
+    // At rest the header is opaque and the poles are transparent.
+    expect(restingLayer().className).toContain('opacity-100')
+    expect(polesLayer().className).toContain('opacity-0')
+    // Mid-drag the opacities swap.
+    fireEvent.pointerDown(track, { clientX: 60 })
+    expect(restingLayer().className).toContain('opacity-0')
+    expect(polesLayer().className).toContain('opacity-100')
+    // Release restores the resting header.
+    fireEvent.pointerUp(track)
+    expect(restingLayer().className).toContain('opacity-100')
+    expect(polesLayer().className).toContain('opacity-0')
+  })
+
+  it('EffortSection: a cancelled drag fades the resting header back in', () => {
+    render(<EffortSection levels={ALL} value="high" onChange={vi.fn()} />)
+    const track = screen.getByTestId('effort-slider').querySelector('.touch-none') as HTMLElement
+    const restingLayer = () => screen.getByText('Effort').closest('div') as HTMLElement
+    fireEvent.pointerDown(track, { clientX: 0 })
+    expect(restingLayer().className).toContain('opacity-0')
+    fireEvent.pointerCancel(track)
+    expect(restingLayer().className).toContain('opacity-100')
   })
 
   it('EffortSection: releasing back where the drag started persists nothing', () => {

--- a/src/renderer/components/messages/effort-slider.tsx
+++ b/src/renderer/components/messages/effort-slider.tsx
@@ -43,6 +43,9 @@ interface EffortSliderProps {
    *  should follow it (EffortSection feeds it back) so the thumb tracks the
    *  finger — nothing is persisted until onChange settles. */
   onPreview?: (level: EffortLevel | null) => void
+  /** True while a pointer drag is in flight (down → up/cancel). Lets the host
+   *  swap its header for the Faster/Smarter poles only during the drag. */
+  onInteractingChange?: (interacting: boolean) => void
 }
 
 /**
@@ -51,7 +54,7 @@ interface EffortSliderProps {
  * `data-testid="effort-option-<level>"` and selects that level on click, so it's a
  * drop-in for the old button list. Purely controlled — keeps no state of its own.
  */
-export function EffortSlider({ levels, value, onChange, onPreview }: EffortSliderProps) {
+export function EffortSlider({ levels, value, onChange, onPreview, onInteractingChange }: EffortSliderProps) {
   const trackRef = useRef<HTMLDivElement>(null)
   const dragging = useRef(false)
   // Last level previewed during the current gesture: dedups pointermove (which
@@ -89,6 +92,7 @@ export function EffortSlider({ levels, value, onChange, onPreview }: EffortSlide
   const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
     e.preventDefault()
     dragging.current = true
+    onInteractingChange?.(true)
     // Seed with the current value so pressing at the thumb's own stop previews nothing.
     lastPreview.current = value
     e.currentTarget.setPointerCapture?.(e.pointerId)
@@ -105,6 +109,7 @@ export function EffortSlider({ levels, value, onChange, onPreview }: EffortSlide
   const handlePointerUp = () => {
     if (!dragging.current) return
     dragging.current = false
+    onInteractingChange?.(false)
     const settled = lastPreview.current
     lastPreview.current = null
     if (settled !== null) onChange(settled)
@@ -117,6 +122,7 @@ export function EffortSlider({ levels, value, onChange, onPreview }: EffortSlide
   const handlePointerCancel = () => {
     if (!dragging.current) return
     dragging.current = false
+    onInteractingChange?.(false)
     lastPreview.current = null
     onPreview?.(null)
   }
@@ -135,20 +141,11 @@ export function EffortSlider({ levels, value, onChange, onPreview }: EffortSlide
 
   return (
     <div className="px-2 pt-1 pb-2" data-testid="effort-slider">
-      {/* Only the two poles are labeled — the ticks below carry the levels.
-          Each pole pairs the speed/quality trade-off with its cost ($ vs $$$),
-          slightly dimmer so the words stay primary. Color matches the section
-          headers (e.g. "Effort · Medium"). */}
-      <div className="mb-2 flex items-center justify-between text-[11px] text-muted-foreground/70">
-        <span>
-          Faster <span className="text-muted-foreground/50">· $</span>
-        </span>
-        <span>
-          Smarter <span className="text-muted-foreground/50">· $$$</span>
-        </span>
-      </div>
       {/* Track + thumb. The track is a pill slightly taller than the knob, so the
-          knob nestles inside it (toggle style) rather than riding a thin rail. */}
+          knob nestles inside it (toggle style) rather than riding a thin rail.
+          The Faster/Smarter poles used to sit above the track; they now live in
+          EffortSection's header, surfaced only mid-drag where they replace the
+          "Effort · level" label + help toggle to keep the block compact. */}
       <div
         ref={trackRef}
         onPointerDown={handlePointerDown}
@@ -272,39 +269,72 @@ export function EffortSection({
   const [preview, setPreview] = useState<EffortLevel | null>(null)
   useEffect(() => setPreview(null), [value])
   const shown = preview ?? value
+  // While a drag is in flight the header row becomes the Faster/Smarter poles;
+  // at rest it's the "Effort · level" label + help toggle. One row either way —
+  // the poles no longer take a permanent second line above the track.
+  const [dragging, setDragging] = useState(false)
 
   return (
     // A real wrapper (not a fragment): hosts reverse the popover column to keep
     // this section nearest the trigger, and a fragment's children would get
     // reordered individually (slider above its own header).
     <div>
-      <div className="flex items-center justify-between px-2 pt-1 pb-1 text-[11px] font-medium text-muted-foreground/70">
-        <span>
-          <span>Effort</span>
-          <span className="text-[#007DED] dark:text-[#4EB3FF]"> · {EFFORT_LABELS[shown]}</span>
-        </span>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                aria-label="About effort"
-                data-testid="effort-help"
-                className="inline-flex shrink-0 hover:text-foreground"
-              >
-                <HelpCircle className="h-3 w-3" aria-hidden="true" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent className="max-w-60">
-              Higher effort means more thorough responses, but takes longer and is more expensive.
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+      {/* One row, two stacked layers that cross-fade + slide as `dragging` flips.
+          Both stay mounted so the motion plays in both directions: the resting
+          layer sits in flow (defining the row height) and slides up + out; the
+          poles overlay it, sliding up from the slider bar below into its place. */}
+      <div className="relative px-2 pt-1 pb-1 text-[11px] font-medium text-muted-foreground/70">
+        <div
+          className={cn(
+            'flex items-center justify-between transition-[transform,opacity] duration-200 ease-out',
+            dragging ? '-translate-y-1 opacity-0 pointer-events-none' : 'translate-y-0 opacity-100',
+          )}
+        >
+          <span>
+            <span>Effort</span>
+            <span className="text-[#007DED] dark:text-[#4EB3FF]"> · {EFFORT_LABELS[shown]}</span>
+          </span>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="About effort"
+                  data-testid="effort-help"
+                  className="inline-flex shrink-0 hover:text-foreground"
+                >
+                  <HelpCircle className="h-3 w-3" aria-hidden="true" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-60">
+                Higher effort means more thorough responses, but takes longer and is more expensive.
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+        {/* Poles: pair the speed/quality trade-off with its cost ($ vs $$$), the
+            cost dimmer so the words stay primary. Decorative (the slider thumb
+            carries the real semantics), so aria-hidden while at rest. */}
+        <div
+          aria-hidden={!dragging}
+          className={cn(
+            'absolute inset-x-2 top-1 flex items-center justify-between transition-[transform,opacity] duration-200 ease-out',
+            dragging ? 'translate-y-0 opacity-100' : 'translate-y-1 opacity-0 pointer-events-none',
+          )}
+        >
+          <span>
+            Faster <span className="text-muted-foreground/50">· $</span>
+          </span>
+          <span>
+            Smarter <span className="text-muted-foreground/50">· $$$</span>
+          </span>
+        </div>
       </div>
       <EffortSlider
         levels={levels}
         value={shown}
         onPreview={setPreview}
+        onInteractingChange={setDragging}
         onChange={(level) => {
           setPreview(level)
           // The slider can't no-op-guard settles itself (its value prop tracks

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -18,7 +18,7 @@ import { ChatComposerBox } from './chat-composer-box'
 import { ComposerOptions, useComposerOptions } from './composer-options'
 import { useAgentPreferences } from '@renderer/hooks/use-agent-preferences'
 import { useRenderTracker } from '@renderer/lib/perf'
-import type { EffortLevel } from '@shared/lib/container/types'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 import type { ComposerSnapshot } from '@renderer/lib/new-session-carryover'
 
 interface MessageInputProps {
@@ -32,13 +32,15 @@ interface MessageInputProps {
   onMessageFailed?: (localId: string) => void
   /** Effort level last used on this session; seeds the composer selector. Defaults to 'high' when absent. */
   initialEffort?: EffortLevel
+  /** Speed last used on this session; seeds the composer selector. Defaults to 'normal' when absent. */
+  initialSpeed?: SpeedLevel
   /** Model last used on this session; seeds the composer selector. Defaults to provider's agent default. */
   initialModel?: string
   /** Registers a getter so the stale-session prompt can move the live draft. */
   registerSnapshot?: (getSnapshot: (() => ComposerSnapshot) | null) => void
 }
 
-export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUuidAssigned, onMessageFailed, initialEffort, initialModel, registerSnapshot }: MessageInputProps) {
+export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUuidAssigned, onMessageFailed, initialEffort, initialSpeed, initialModel, registerSnapshot }: MessageInputProps) {
   useRenderTracker('MessageInput')
   const { canUseAgent, isAuthMode } = useUser()
   const isViewOnly = !canUseAgent(agentSlug)
@@ -48,9 +50,11 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
   const { data: agentPrefs, isFetched: agentPrefsFetched } = useAgentPreferences(agentSlug)
   const composerOptions = useComposerOptions({
     initialEffort,
+    initialSpeed,
     initialModel,
     agentDefaultModel: agentPrefs?.defaultModel,
     agentDefaultEffort: agentPrefs?.defaultEffort,
+    agentDefaultSpeed: agentPrefs?.defaultSpeed,
     agentKey: agentSlug,
     agentDefaultsReady: agentPrefsFetched,
   })
@@ -119,12 +123,14 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
     attachments: [],
     model: undefined,
     effort: composerOptions.effort,
+    speed: composerOptions.speed,
   })
   snapshotRef.current = {
     text: composer.message,
     attachments: composer.attachments,
     model: composerOptions.model,
     effort: composerOptions.effort,
+    speed: composerOptions.speed,
   }
   useEffect(() => {
     if (!registerSnapshot) return

--- a/src/renderer/components/messages/speed-section.tsx
+++ b/src/renderer/components/messages/speed-section.tsx
@@ -1,0 +1,118 @@
+import { useEffect } from 'react'
+import { HelpCircle } from 'lucide-react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@renderer/components/ui/tooltip'
+import { cn } from '@shared/lib/utils'
+import type { SpeedLevel } from '@shared/lib/container/types'
+import type { ModelDefinition } from '@shared/lib/llm-provider'
+
+export const SPEED_LABELS: Record<SpeedLevel, string> = {
+  slow: 'Slow',
+  normal: 'Normal',
+  fast: 'Fast',
+}
+
+const NORMAL_ONLY: SpeedLevel[] = ['normal']
+
+/**
+ * Speeds come from the catalog entry: `supportedSpeeds` declares what the
+ * model's serving path can actually honor (see builtin-catalogs.ts). Omitted
+ * means no speed choice — 'normal' only. Normal is the universal default, so
+ * it's always a safe reset target when a model switch drops the current pick.
+ */
+export function availableSpeeds(model: ModelDefinition | undefined): SpeedLevel[] {
+  return (model?.supportedSpeeds as SpeedLevel[] | undefined) ?? NORMAL_ONLY
+}
+
+/**
+ * Snap speed back to 'normal' when a model switch drops the current pick —
+ * same clamp shape as useEffortClamp. Pass `undefined` as the model to
+ * disable (e.g. when the speed picker isn't rendered).
+ */
+export function useSpeedClamp(
+  model: ModelDefinition | undefined,
+  speed: SpeedLevel,
+  onSpeedChange: ((s: SpeedLevel) => void) | undefined,
+): void {
+  useEffect(() => {
+    if (!model || !onSpeedChange) return
+    if (!availableSpeeds(model).includes(speed)) onSpeedChange('normal')
+  }, [model, speed, onSpeedChange])
+}
+
+/**
+ * Speed block mirroring EffortSection's header pattern ("Speed · Normal", value
+ * in the accent blue, help tooltip on the right) over a segmented control in
+ * the same visual language as the vendor tab bar (muted pill, active segment
+ * lifted with bg + shadow). A segment reads as a toggle, so picks never
+ * dismiss the popover — consistent with model/effort picks.
+ */
+export function SpeedSection({
+  speeds,
+  value,
+  onChange,
+}: {
+  speeds: SpeedLevel[]
+  value: SpeedLevel
+  onChange: (speed: SpeedLevel) => void
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between px-2 pt-1 pb-1 text-[11px] font-medium text-muted-foreground/70">
+        <span>
+          <span>Speed</span>
+          <span className="text-[#007DED] dark:text-[#4EB3FF]"> · {SPEED_LABELS[value]}</span>
+        </span>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="About speed"
+                data-testid="speed-help"
+                className="inline-flex shrink-0 hover:text-foreground"
+              >
+                <HelpCircle className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-60">
+              Faster processing returns replies sooner at a higher price. Slower processing costs
+              less but may wait for capacity. Available speeds depend on the model.
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+      <div className="px-2 pb-1">
+        <div
+          role="radiogroup"
+          aria-label="Processing speed"
+          className="flex rounded-lg bg-muted p-0.5 text-muted-foreground"
+        >
+          {speeds.map((level) => {
+            const isActive = level === value
+            return (
+              <button
+                key={level}
+                type="button"
+                role="radio"
+                aria-checked={isActive}
+                data-testid={`speed-option-${level}`}
+                onClick={() => onChange(level)}
+                className={cn(
+                  'flex-1 rounded-md px-2 py-1 text-xs transition-all hover:bg-background/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                  isActive && 'bg-background text-foreground shadow'
+                )}
+              >
+                {SPEED_LABELS[level]}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/quick-dispatch/quick-dispatch-menus.test.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch-menus.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { ModelEffortMenu } from './quick-dispatch-menus'
 import type { ComposerOptionsState } from '@renderer/components/messages/composer-options'
 import type { ModelDefinition } from '@shared/lib/llm-provider'
@@ -10,7 +10,7 @@ const STD: EffortLevel[] = ['low', 'medium', 'high']
 
 const CATALOG: ModelDefinition[] = [
   { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', family: 'sonnet', isLatest: true, icon: 'anthropic', supportedEfforts: STD },
-  { id: 'openai/gpt-5.5', label: 'GPT-5.5', family: 'gpt', isLatest: true, icon: 'openai', supportedEfforts: STD, supportsWebSearch: false },
+  { id: 'openai/gpt-5.5', label: 'GPT-5.5', family: 'gpt', isLatest: true, icon: 'openai', supportedEfforts: STD, supportsWebSearch: false, supportedSpeeds: ['slow', 'normal', 'fast'] },
   // Custom models can declare effort subsets that exclude medium.
   { id: 'custom/tiny', label: 'Tiny', isLatest: true, supportedEfforts: ['low'] },
 ]
@@ -66,5 +66,40 @@ describe('ModelEffortMenu', () => {
       <ModelEffortMenu state={makeState({ model: 'openai/gpt-5.5', webProvider: 'exa' })} maxHeight={400} />
     )
     expect(screen.queryByTestId('model-no-websearch-warning')).not.toBeInTheDocument()
+  })
+
+  it('shows the catalog-declared speeds for a speed-capable model', () => {
+    render(<ModelEffortMenu state={makeState({ model: 'openai/gpt-5.5' })} maxHeight={400} />)
+    expect(screen.getByTestId('speed-option-slow')).toBeInTheDocument()
+    expect(screen.getByTestId('speed-option-normal')).toBeInTheDocument()
+    expect(screen.getByTestId('speed-option-fast')).toBeInTheDocument()
+  })
+
+  it('hides the speed section for a model with no declared speeds (normal-only)', () => {
+    render(<ModelEffortMenu state={makeState({ model: 'claude-sonnet-4-6' })} maxHeight={400} />)
+    expect(screen.queryByText('Speed')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('speed-option-normal')).not.toBeInTheDocument()
+  })
+
+  it('picking a speed forwards it to setSpeed (dispatch payload rides toRuntimeOptions)', () => {
+    const setSpeed = vi.fn()
+    render(<ModelEffortMenu state={makeState({ model: 'openai/gpt-5.5', setSpeed })} maxHeight={400} />)
+    fireEvent.click(screen.getByTestId('speed-option-fast'))
+    expect(setSpeed).toHaveBeenCalledWith('fast')
+  })
+
+  it('clamps a speed the selected model does not support back to normal', () => {
+    // Parity with the composer popover: without the clamp this menu would keep
+    // (and dispatch) a stale 'fast' after switching to a normal-only model,
+    // with the section hidden so there'd be no way to see or fix it.
+    const setSpeed = vi.fn()
+    render(<ModelEffortMenu state={makeState({ model: 'claude-sonnet-4-6', speed: 'fast', setSpeed })} maxHeight={400} />)
+    expect(setSpeed).toHaveBeenCalledWith('normal')
+  })
+
+  it('leaves a supported speed alone', () => {
+    const setSpeed = vi.fn()
+    render(<ModelEffortMenu state={makeState({ model: 'openai/gpt-5.5', speed: 'fast', setSpeed })} maxHeight={400} />)
+    expect(setSpeed).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/quick-dispatch/quick-dispatch-menus.test.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch-menus.test.tsx
@@ -19,6 +19,8 @@ function makeState(overrides: Partial<ComposerOptionsState>): ComposerOptionsSta
   return {
     effort: 'medium',
     setEffort: vi.fn(),
+    speed: 'normal',
+    setSpeed: vi.fn(),
     model: 'claude-sonnet-4-6',
     setModel: vi.fn(),
     catalog: CATALOG,

--- a/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
@@ -4,6 +4,7 @@ import { cn } from '@shared/lib/utils'
 import { ModelFamilyList } from '@renderer/components/messages/model-family-list'
 import { findCatalogModel, type ComposerOptionsState } from '@renderer/components/messages/composer-options'
 import { EffortSection, useEffortClamp } from '@renderer/components/messages/effort-slider'
+import { SpeedSection, availableSpeeds, useSpeedClamp } from '@renderer/components/messages/speed-section'
 import { EFFORT_LEVELS } from '@shared/lib/container/types'
 import { FileTypeIcon } from '@renderer/components/ui/file-type-icon'
 import type { ApiAgent } from '@renderer/hooks/use-agents'
@@ -94,13 +95,18 @@ export function AgentMenu({
 }
 
 export function ModelEffortMenu({ state, maxHeight }: { state: ComposerOptionsState; maxHeight: number }) {
-  const { effort, setEffort, model, setModel, catalog, webProvider } = state
+  const { effort, setEffort, speed, setSpeed, model, setModel, catalog, webProvider } = state
   const selected =
     findCatalogModel(model, catalog) ?? catalog.find((m) => m.family === 'sonnet' && m.isLatest) ?? catalog[0]
   const efforts = EFFORT_LEVELS.filter((l) => (selected ? selected.supportedEfforts.includes(l) : true))
   // Without the clamp this menu kept (and dispatched) an unsupported effort
   // after a model switch, while the slider silently rendered at Low.
   useEffortClamp(selected, effort, setEffort)
+  // Speed mirrors the composer popover exactly: catalog-declared options,
+  // hidden for normal-only models, snap back to Normal on a model switch that
+  // drops the pick — otherwise a stale 'fast' (2x price) would dispatch silently.
+  const speeds = availableSpeeds(selected)
+  useSpeedClamp(selected, speed, setSpeed)
 
   return (
     // Only the model list scrolls; the effort section is pinned to the bottom so
@@ -116,6 +122,8 @@ export function ModelEffortMenu({ state, maxHeight }: { state: ComposerOptionsSt
       </div>
       <div className="shrink-0 px-1 pb-1 pt-2">
         <EffortSection levels={efforts} value={effort} onChange={setEffort} />
+        {/* Same gate and Effort → Speed order as the composer popover. */}
+        {speeds.length > 1 && <SpeedSection speeds={speeds} value={speed} onChange={setSpeed} />}
       </div>
     </div>
   )

--- a/src/renderer/components/quick-dispatch/quick-dispatch.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.tsx
@@ -91,6 +91,7 @@ export function QuickDispatch() {
   const composerOptions = useComposerOptions({
     agentDefaultModel: agentPrefs?.defaultModel,
     agentDefaultEffort: agentPrefs?.defaultEffort,
+    agentDefaultSpeed: agentPrefs?.defaultSpeed,
     agentKey: agentSlug,
     agentDefaultsReady: agentPrefsFetched,
   })

--- a/src/renderer/components/scheduled-tasks/scheduled-task-view.test.tsx
+++ b/src/renderer/components/scheduled-tasks/scheduled-task-view.test.tsx
@@ -109,6 +109,7 @@ function createTask(overrides: Partial<ApiScheduledTask> = {}): ApiScheduledTask
     timezone: 'UTC',
     model: null,
     effort: null,
+    speed: null,
     createdAt: new Date('2026-06-15T16:00:00.000Z'),
     cancelledAt: null,
     pausedAt: null,

--- a/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
+++ b/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
@@ -464,6 +464,7 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
           <RuntimeOptionsCard
             model={task.model}
             effort={task.effort}
+            speed={task.speed}
             disabled={!canCancel || !isActive}
             onUpdate={(options) => {
               updateRuntimeOptions.mutate({ taskId, agentSlug, ...options })

--- a/src/renderer/components/settings/settings-model-select.tsx
+++ b/src/renderer/components/settings/settings-model-select.tsx
@@ -7,7 +7,8 @@ import { ModelIcon } from '@renderer/components/ui/model-icon'
 import { useSettings } from '@renderer/hooks/use-settings'
 import { ModelFamilyList, findCatalogModel, familyDisplayName } from '@renderer/components/messages/model-family-list'
 import { EFFORT_LABELS, EffortSection, useEffortClamp } from '@renderer/components/messages/effort-slider'
-import { EFFORT_LEVELS, type EffortLevel } from '@shared/lib/container/types'
+import { SPEED_LABELS, SpeedSection, availableSpeeds, useSpeedClamp } from '@renderer/components/messages/speed-section'
+import { EFFORT_LEVELS, type EffortLevel, type SpeedLevel } from '@shared/lib/container/types'
 import type { LlmProviderId } from '@shared/lib/config/settings'
 
 interface SettingsModelSelectProps {
@@ -18,6 +19,10 @@ interface SettingsModelSelectProps {
   includeEffort?: boolean
   effort?: EffortLevel
   onEffortChange?: (effort: EffortLevel) => void
+  /** Show the speed picker (only renders when the model offers a choice). Off by default. */
+  includeSpeed?: boolean
+  speed?: SpeedLevel
+  onSpeedChange?: (speed: SpeedLevel) => void
   disabled?: boolean
   /**
    * Which trigger edge the popover anchors to. Picks rewrite the trigger label
@@ -45,6 +50,9 @@ function SettingsModelSelectImpl({
   includeEffort = false,
   effort = 'medium',
   onEffortChange,
+  includeSpeed = false,
+  speed = 'normal',
+  onSpeedChange,
   disabled,
   align = 'end',
 }: SettingsModelSelectProps) {
@@ -61,10 +69,12 @@ function SettingsModelSelectImpl({
   const selectedFamily = isLatestSelected ? model : resolved?.family
 
   useEffortClamp(includeEffort ? resolved : undefined, effort, onEffortChange)
+  useSpeedClamp(includeSpeed ? resolved : undefined, speed, onSpeedChange)
 
   const visibleEfforts = EFFORT_LEVELS.filter((level) =>
     resolved ? resolved.supportedEfforts.includes(level) : true
   )
+  const visibleSpeeds = availableSpeeds(resolved)
 
   let triggerLabel: string | undefined
   if (isLatestSelected && selectedFamily) triggerLabel = `${familyDisplayName(selectedFamily)} · latest`
@@ -92,6 +102,7 @@ function SettingsModelSelectImpl({
             {includeEffort && (
               <span className="text-muted-foreground">
                 {' · '}{EFFORT_LABELS[effort]}
+                {includeSpeed && speed !== 'normal' ? ` · ${SPEED_LABELS[speed]}` : ''}
               </span>
             )}
           </span>
@@ -121,6 +132,17 @@ function SettingsModelSelectImpl({
               levels={visibleEfforts}
               value={effort}
               onChange={(level) => onEffortChange?.(level)}
+            />
+          </>
+        )}
+        {/* Hidden entirely for models whose serving path offers no speed choice. */}
+        {includeSpeed && visibleSpeeds.length > 1 && (
+          <>
+            <Separator className="my-2 bg-border/50" />
+            <SpeedSection
+              speeds={visibleSpeeds}
+              value={speed}
+              onChange={(level) => onSpeedChange?.(level)}
             />
           </>
         )}

--- a/src/renderer/components/triggers/runtime-options-card.tsx
+++ b/src/renderer/components/triggers/runtime-options-card.tsx
@@ -4,22 +4,24 @@ import { Button } from '@renderer/components/ui/button'
 import { useSettings } from '@renderer/hooks/use-settings'
 import { SettingsModelSelect } from '@renderer/components/settings/settings-model-select'
 import { DetailCard } from './detail-card'
-import type { EffortLevel } from '@shared/lib/container/types'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 
 interface RuntimeOptionsCardProps {
   model: string | null
   effort: string | null
+  speed: string | null
   disabled?: boolean
-  onUpdate: (options: { model?: string | null; effort?: string | null }) => void
+  onUpdate: (options: { model?: string | null; effort?: string | null; speed?: string | null }) => void
 }
 
-export function RuntimeOptionsCard({ model, effort, disabled, onUpdate }: RuntimeOptionsCardProps) {
+export function RuntimeOptionsCard({ model, effort, speed, disabled, onUpdate }: RuntimeOptionsCardProps) {
   const { data: settings } = useSettings()
   // The override falls back to the user's default-model setting (a bare alias
   // or pinned id) when no per-run model is set. The picker resolves it for display.
   const fallbackModel = settings?.models?.agentModel
 
   const [localEffort, setLocalEffort] = useState<EffortLevel>((effort as EffortLevel) || 'high')
+  const [localSpeed, setLocalSpeed] = useState<SpeedLevel>((speed as SpeedLevel) || 'normal')
   const [localModel, setLocalModel] = useState<string | undefined>(model || fallbackModel)
 
   useEffect(() => {
@@ -33,6 +35,10 @@ export function RuntimeOptionsCard({ model, effort, disabled, onUpdate }: Runtim
   }, [effort])
 
   useEffect(() => {
+    setLocalSpeed((speed as SpeedLevel) || 'normal')
+  }, [speed])
+
+  useEffect(() => {
     if (model) {
       setLocalModel(model)
     }
@@ -43,6 +49,11 @@ export function RuntimeOptionsCard({ model, effort, disabled, onUpdate }: Runtim
     onUpdate({ effort: e })
   }, [onUpdate])
 
+  const handleSetSpeed = useCallback((s: SpeedLevel) => {
+    setLocalSpeed(s)
+    onUpdate({ speed: s })
+  }, [onUpdate])
+
   const handleSetModel = useCallback((m: string) => {
     setLocalModel(m)
     onUpdate({ model: m })
@@ -50,11 +61,12 @@ export function RuntimeOptionsCard({ model, effort, disabled, onUpdate }: Runtim
 
   const handleReset = useCallback(() => {
     setLocalEffort('high')
+    setLocalSpeed('normal')
     setLocalModel(fallbackModel)
-    onUpdate({ model: null, effort: null })
+    onUpdate({ model: null, effort: null, speed: null })
   }, [onUpdate, fallbackModel])
 
-  const hasCustom = model !== null || effort !== null
+  const hasCustom = model !== null || effort !== null || speed !== null
 
   const headerActions = useMemo(
     () =>
@@ -81,6 +93,9 @@ export function RuntimeOptionsCard({ model, effort, disabled, onUpdate }: Runtim
           includeEffort
           effort={localEffort}
           onEffortChange={handleSetEffort}
+          includeSpeed
+          speed={localSpeed}
+          onSpeedChange={handleSetSpeed}
           disabled={disabled}
           // This trigger is left-aligned in its card, so its LEFT edge is the
           // stable anchor while picks rewrite the label width.

--- a/src/renderer/components/webhook-triggers/webhook-trigger-view.tsx
+++ b/src/renderer/components/webhook-triggers/webhook-trigger-view.tsx
@@ -380,6 +380,7 @@ export function WebhookTriggerView({ triggerId, agentSlug }: WebhookTriggerViewP
           <RuntimeOptionsCard
             model={trigger.model ?? null}
             effort={trigger.effort ?? null}
+            speed={trigger.speed ?? null}
             disabled={!canCancel || !isActive}
             onUpdate={(options) => {
               updateRuntimeOptions.mutate({ triggerId, agentSlug, ...options })

--- a/src/renderer/hooks/use-chat-integrations.ts
+++ b/src/renderer/hooks/use-chat-integrations.ts
@@ -163,6 +163,7 @@ export function useCreateChatIntegration() {
       sessionTimeout?: number | null
       model?: string | null
       effort?: string | null
+      speed?: string | null
     }) => {
       const { agentSlug, ...body } = params
       const res = await apiFetch(`/api/chat-integrations/${agentSlug}`, {
@@ -211,6 +212,7 @@ export function useUpdateChatIntegration() {
       sessionTimeout?: number | null
       model?: string | null
       effort?: string | null
+      speed?: string | null
       status?: 'active' | 'paused'
     }) => {
       const res = await apiFetch(`/api/chat-integrations/${id}`, {

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -2,7 +2,7 @@ import { apiFetch } from '@renderer/lib/api'
 import { uploadFileChunked } from '@renderer/lib/upload'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiMessage, ApiMessageOrBoundary } from '@shared/lib/types/api'
-import type { EffortLevel } from '@shared/lib/container/types'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 import type { WorkflowTree } from '@shared/lib/workflows/workflow-schemas'
 
 // Re-export for convenience
@@ -45,13 +45,14 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
 
 export function useSendMessage() {
   return useMutation({
-    mutationFn: async (data: { sessionId: string; agentSlug: string; content: string; effort?: EffortLevel; model?: string }) => {
+    mutationFn: async (data: { sessionId: string; agentSlug: string; content: string; effort?: EffortLevel; speed?: SpeedLevel; model?: string }) => {
       const res = await apiFetch(`/api/agents/${data.agentSlug}/sessions/${data.sessionId}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           content: data.content,
           ...(data.effort ? { effort: data.effort } : {}),
+          ...(data.speed ? { speed: data.speed } : {}),
           ...(data.model ? { model: data.model } : {}),
         }),
       })

--- a/src/renderer/hooks/use-scheduled-tasks.ts
+++ b/src/renderer/hooks/use-scheduled-tasks.ts
@@ -237,16 +237,17 @@ export function useUpdateScheduledTaskName() {
 }
 
 /**
- * Update a scheduled task's runtime options (model and/or effort)
+ * Update a scheduled task's runtime options (model, effort, and/or speed)
  */
 export function useUpdateScheduledTaskRuntimeOptions() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ taskId, model, effort }: { taskId: string; agentSlug: string; model?: string | null; effort?: string | null }) => {
+    mutationFn: async ({ taskId, model, effort, speed }: { taskId: string; agentSlug: string; model?: string | null; effort?: string | null; speed?: string | null }) => {
       const body: Record<string, string | null> = {}
       if (model !== undefined) body.model = model
       if (effort !== undefined) body.effort = effort
+      if (speed !== undefined) body.speed = speed
       const res = await apiFetch(`/api/scheduled-tasks/${taskId}/runtime-options`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },

--- a/src/renderer/hooks/use-sessions.ts
+++ b/src/renderer/hooks/use-sessions.ts
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient, type QueryClient } from '@tansta
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { useAgents, resolveRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
 import type { ApiSession } from '@shared/lib/types/api'
-import type { EffortLevel } from '@shared/lib/container/types'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 
 // Re-export for convenience
 export type { ApiSession }
@@ -62,13 +62,14 @@ export function useCreateSession() {
   const { track } = useAnalyticsTracking()
 
   return useMutation({
-    mutationFn: async (data: { agentSlug: string; message: string; effort?: EffortLevel; model?: string }) => {
+    mutationFn: async (data: { agentSlug: string; message: string; effort?: EffortLevel; speed?: SpeedLevel; model?: string }) => {
       const res = await apiFetch(`/api/agents/${data.agentSlug}/sessions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           message: data.message,
           ...(data.effort ? { effort: data.effort } : {}),
+          ...(data.speed ? { speed: data.speed } : {}),
           ...(data.model ? { model: data.model } : {}),
         }),
       })

--- a/src/renderer/hooks/use-stale-session.test.tsx
+++ b/src/renderer/hooks/use-stale-session.test.tsx
@@ -65,6 +65,7 @@ describe('useStaleSession', () => {
       attachments: [],
       model: 'sonnet',
       effort: 'high',
+      speed: 'normal',
     })))
     act(() => result.current.stale.startFresh())
 
@@ -73,6 +74,7 @@ describe('useStaleSession', () => {
       attachments: [],
       model: 'sonnet',
       effort: 'high',
+      speed: 'normal',
     })
     expect(result.current.store.get('session:session-1')).toBeUndefined()
     expect(navigate).toHaveBeenCalledWith({

--- a/src/renderer/hooks/use-webhook-triggers.ts
+++ b/src/renderer/hooks/use-webhook-triggers.ts
@@ -83,10 +83,11 @@ export function useUpdateWebhookTriggerRuntimeOptions() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ triggerId, model, effort }: { triggerId: string; agentSlug: string; model?: string | null; effort?: string | null }) => {
+    mutationFn: async ({ triggerId, model, effort, speed }: { triggerId: string; agentSlug: string; model?: string | null; effort?: string | null; speed?: string | null }) => {
       const body: Record<string, string | null> = {}
       if (model !== undefined) body.model = model
       if (effort !== undefined) body.effort = effort
+      if (speed !== undefined) body.speed = speed
       const res = await apiFetch(`/api/webhook-triggers/${triggerId}/runtime-options`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },

--- a/src/renderer/lib/new-session-carryover.test.tsx
+++ b/src/renderer/lib/new-session-carryover.test.tsx
@@ -17,6 +17,7 @@ describe('splitComposerSnapshot', () => {
       attachments: [attachment],
       model: 'sonnet',
       effort: 'high',
+      speed: 'fast',
     })
 
     expect(result.draftText).toBe('  keep this text  ')
@@ -24,6 +25,7 @@ describe('splitComposerSnapshot', () => {
       attachments: [{ ...attachment, preview: undefined }],
       model: 'sonnet',
       effort: 'high',
+      speed: 'fast',
     })
     expect(attachment.preview).toBe('blob:source-preview')
   })
@@ -34,6 +36,7 @@ describe('splitComposerSnapshot', () => {
       attachments: [],
       model: 'opus',
       effort: 'medium',
+      speed: 'normal',
     }).draftText).toBeUndefined()
   })
 })

--- a/src/renderer/lib/new-session-carryover.ts
+++ b/src/renderer/lib/new-session-carryover.ts
@@ -1,19 +1,21 @@
 import { useEffect, useState } from 'react'
 import type { Attachment } from '@renderer/components/messages/attachment-preview'
 import { useDraftsStore } from '@renderer/context/drafts-context'
-import type { EffortLevel } from '@shared/lib/container/types'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 
 export interface ComposerSnapshot {
   text: string
   attachments: Attachment[]
   model: string | undefined
   effort: EffortLevel
+  speed: SpeedLevel
 }
 
 export interface NewSessionCarryover {
   attachments: Attachment[]
   model: string | undefined
   effort: EffortLevel
+  speed: SpeedLevel
 }
 
 export const newSessionCarryoverKey = (agentSlug: string) => `new-session-carryover:${agentSlug}`
@@ -38,6 +40,7 @@ export function splitComposerSnapshot(snapshot: ComposerSnapshot | undefined): {
       attachments: stripObjectUrls(snapshot.attachments),
       model: snapshot.model,
       effort: snapshot.effort,
+      speed: snapshot.speed,
     },
   }
 }

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -935,6 +935,7 @@ class ChatIntegrationManager {
       browserModel: models.browserModel,
       dashboardBuilderModel: models.dashboardBuilderModel,
       ...(effort ? { effort: effort as EffortLevel } : {}),
+      ...(agentPrefs.defaultSpeed ? { speed: agentPrefs.defaultSpeed } : {}),
       ...(integration.provider === 'imessage' ? { systemPrompt: IMESSAGE_SYSTEM_PROMPT } : {}),
     })
 

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -37,7 +37,7 @@ import {
 } from '@shared/lib/services/chat-integration-session-service'
 import { assertPathWithinDir, isPathWithinDir, sanitizeUploadFilename } from '@shared/lib/utils/path-safety'
 import { isHostOrSubdomain, tryParseUrl } from '@shared/lib/utils/url-safety'
-import type { EffortLevel, ContainerClient } from '@shared/lib/container/types'
+import type { EffortLevel, SpeedLevel, ContainerClient } from '@shared/lib/container/types'
 import type { ChatIntegration } from '@shared/lib/db/schema'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { runWithOptionalUser } from '@shared/lib/platform-attribution'
@@ -923,10 +923,11 @@ class ChatIntegrationManager {
     const { readAgentPreferences } = await import('@shared/lib/services/agent-preferences-service')
 
     const availableEnvVars = await getSecretEnvVars(integration.agentSlug)
-    // Model/effort preference order: integration override > agent default > global default.
+    // Model/effort/speed preference order: integration override > agent default > global default.
     const models = getEffectiveModels()
     const agentPrefs = await readAgentPreferences(integration.agentSlug)
     const effort = integration.effort ?? agentPrefs.defaultEffort
+    const speed = integration.speed ?? agentPrefs.defaultSpeed
 
     const containerSession = await client.createSession({
       availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
@@ -935,7 +936,7 @@ class ChatIntegrationManager {
       browserModel: models.browserModel,
       dashboardBuilderModel: models.dashboardBuilderModel,
       ...(effort ? { effort: effort as EffortLevel } : {}),
-      ...(agentPrefs.defaultSpeed ? { speed: agentPrefs.defaultSpeed } : {}),
+      ...(speed ? { speed: speed as SpeedLevel } : {}),
       ...(integration.provider === 'imessage' ? { systemPrompt: IMESSAGE_SYSTEM_PROMPT } : {}),
     })
 

--- a/src/shared/lib/chat-integrations/chat-integration-model-resolution.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-model-resolution.test.ts
@@ -171,22 +171,31 @@ describe('chat integration model and effort resolution', () => {
   it('uses the global default when neither integration nor agent set one', async () => {
     const args = await startSession()
     expect(args.model).toBe('claude-sonnet-4-20250514')
-    // Effort must be omitted entirely, not sent as undefined.
+    // Effort/speed must be omitted entirely, not sent as undefined.
     expect('effort' in args).toBe(false)
+    expect('speed' in args).toBe(false)
   })
 
   it('falls back to the agent default over the global default', async () => {
-    mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
+    mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high', defaultSpeed: 'slow' })
     const args = await startSession()
     expect(mockReadAgentPreferences).toHaveBeenCalledWith('test-agent')
     expect(args.model).toBe('opus')
     expect(args.effort).toBe('high')
+    expect(args.speed).toBe('slow')
   })
 
   it('prefers the integration override over the agent default', async () => {
-    mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
-    const args = await startSession({ model: 'claude-haiku-4-5-20251001', effort: 'low' })
+    mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high', defaultSpeed: 'fast' })
+    const args = await startSession({ model: 'claude-haiku-4-5-20251001', effort: 'low', speed: 'slow' })
     expect(args.model).toBe('claude-haiku-4-5-20251001')
     expect(args.effort).toBe('low')
+    expect(args.speed).toBe('slow')
+  })
+
+  it('a stored normal integration speed beats a non-normal agent default', async () => {
+    mockReadAgentPreferences.mockResolvedValue({ defaultSpeed: 'fast' })
+    const args = await startSession({ speed: 'normal' })
+    expect(args.speed).toBe('normal')
   })
 })

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -1135,6 +1135,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
           customEnvVars: options.customEnvVars,
           maxBrowserTabs: options.maxBrowserTabs,
           effort: options.effort,
+          speed: options.speed,
           capabilityPolicies,
         }),
         signal: controller.signal,
@@ -1232,6 +1233,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     const port = await this.getPortOrThrow()
     const timeoutMs = 30000 // 30 second timeout
     const effort = options?.effort
+    const speed = options?.speed
     const model = resolveContainerModel(options?.model, 'agent')
     const shouldQuery = options?.shouldQuery
     // Refreshed on every message so a long-lived session tracks settings
@@ -1251,6 +1253,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
             content,
             ...(uuid ? { uuid } : {}),
             ...(effort ? { effort } : {}),
+            ...(speed ? { speed } : {}),
             ...(model ? { model } : {}),
             ...(shouldQuery !== undefined ? { shouldQuery } : {}),
             capabilityPolicies,

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -2610,6 +2610,7 @@ class MessagePersister {
         timezone?: string
         model?: string
         effort?: string
+        speed?: string
       }
       try {
         input = JSON.parse(toolInput)
@@ -2651,6 +2652,7 @@ class MessagePersister {
           timezone,
           model: input.model,
           effort: input.effort,
+          speed: input.speed,
         })
       } catch (error) {
         console.error('[MessagePersister] Error handling schedule task:', error)
@@ -3191,6 +3193,7 @@ ${continuation}`
           trigger_config?: Record<string, unknown>
           model?: string
           effort?: string
+          speed?: string
         }
         try {
           input = JSON.parse(toolInput)
@@ -3253,6 +3256,7 @@ ${continuation}`
             createdByUserId: triggerOwnerId ?? undefined,
             model: input.model,
             effort: input.effort,
+            speed: input.speed,
           })
         } catch (dbError) {
           // Rollback Composio trigger
@@ -3373,6 +3377,7 @@ ${continuation}`
             createdByUserId: triggerOwnerId ?? undefined,
             model: input.model,
             effort: input.effort,
+            speed: input.speed,
           })
         } catch (dbError) {
           console.error('[MessagePersister] SQLite save failed, disabling platform endpoint:', dbError)

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1453,21 +1453,25 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     sessionId: string
     content: string
     effort?: string
+    speed?: string
     model?: string
   } | null = null
   static sendMessageCalls: Array<{
     sessionId: string
     content: string
     effort?: string
+    speed?: string
     model?: string
   }> = []
   static lastCreateSessionCall: {
     effort?: string
+    speed?: string
     model?: string
     initialMessage?: string
   } | null = null
   static createSessionCalls: Array<{
     effort?: string
+    speed?: string
     model?: string
     initialMessage?: string
   }> = []
@@ -1873,11 +1877,13 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     // Record for E2E test assertions
     MockContainerClient.lastCreateSessionCall = {
       effort: options.effort,
+      speed: options.speed,
       model,
       initialMessage: options.initialMessage,
     }
     MockContainerClient.createSessionCalls.push({
       effort: options.effort,
+      speed: options.speed,
       model,
       initialMessage: options.initialMessage,
     })
@@ -1885,6 +1891,7 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
       type: 'createSession',
       agentSlug: this.config.agentId,
       effort: options.effort,
+      speed: options.speed,
       model,
       initialMessage: options.initialMessage,
       // Secret env var NAMES the host resolved from the agent .env and passed to
@@ -1986,12 +1993,14 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
       sessionId,
       content,
       effort: options?.effort,
+      speed: options?.speed,
       model,
     }
     MockContainerClient.sendMessageCalls.push({
       sessionId,
       content,
       effort: options?.effort,
+      speed: options?.speed,
       model,
     })
     this.writeMockRecord({
@@ -2000,6 +2009,7 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
       sessionId,
       content,
       effort: options?.effort,
+      speed: options?.speed,
       model,
       timestamp: new Date().toISOString(),
     })

--- a/src/shared/lib/container/runtime-options.ts
+++ b/src/shared/lib/container/runtime-options.ts
@@ -21,6 +21,20 @@ export const RuntimeOptionsSchema = z
 export type RuntimeOptions = z.infer<typeof RuntimeOptionsSchema>
 
 /**
+ * PATCH-body shape for stored per-entity runtime overrides (scheduled tasks,
+ * webhook triggers): each field may carry a value, be null (explicitly clears
+ * the override back to the default), or be absent (left untouched). Strict so
+ * an unsupported knob fails loudly instead of 200-ing as a silent no-op.
+ */
+export const RuntimeOptionsPatchSchema = z
+  .object({
+    effort: z.enum(EFFORT_LEVELS).nullish(),
+    speed: z.enum(SPEED_LEVELS).nullish(),
+    model: z.string().nullish(),
+  })
+  .strict()
+
+/**
  * Lenient parser: returns whatever fields are individually valid and drops
  * the rest. Used at request boundaries where we'd rather honor the well-formed
  * pieces than reject the whole call.

--- a/src/shared/lib/container/runtime-options.ts
+++ b/src/shared/lib/container/runtime-options.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { EFFORT_LEVELS, type EffortLevel } from './types'
+import { EFFORT_LEVELS, SPEED_LEVELS, type EffortLevel, type SpeedLevel } from './types'
 
 /**
  * Runtime options sent alongside a message: the per-invocation knobs that
@@ -12,6 +12,7 @@ import { EFFORT_LEVELS, type EffortLevel } from './types'
 export const RuntimeOptionsSchema = z
   .object({
     effort: z.enum(EFFORT_LEVELS).optional(),
+    speed: z.enum(SPEED_LEVELS).optional(),
     model: z.string().optional(),
     shouldQuery: z.boolean().optional(),
   })
@@ -31,6 +32,9 @@ export function parseRuntimeOptions(raw: unknown): RuntimeOptions {
   const result: RuntimeOptions = {}
   const effortResult = z.enum(EFFORT_LEVELS).safeParse(obj.effort)
   if (effortResult.success) result.effort = effortResult.data as EffortLevel
+
+  const speedResult = z.enum(SPEED_LEVELS).safeParse(obj.speed)
+  if (speedResult.success) result.speed = speedResult.data as SpeedLevel
 
   if (typeof obj.model === 'string' && obj.model.length > 0) {
     result.model = obj.model

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -7,6 +7,12 @@ export type ContainerStatus = 'stopped' | 'running'
 export const EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const
 export type EffortLevel = typeof EFFORT_LEVELS[number]
 
+// Normalized processing-speed tiers across providers. 'fast' maps to
+// Anthropic fast mode / OpenAI priority; 'slow' maps to OpenAI flex.
+// 'normal' is the universal default and the only tier every model supports.
+export const SPEED_LEVELS = ['slow', 'normal', 'fast'] as const
+export type SpeedLevel = typeof SPEED_LEVELS[number]
+
 // Info returned from Docker
 export interface ContainerInfo {
   status: ContainerStatus
@@ -57,6 +63,7 @@ export interface CreateSessionOptions {
   customEnvVars?: Record<string, string> // User-defined env vars for the agent process
   maxBrowserTabs?: number // Max browser tabs allowed (default 10)
   effort?: EffortLevel // Initial thinking effort level
+  speed?: SpeedLevel // Initial processing speed tier
 }
 
 export interface StartOptions {

--- a/src/shared/lib/db/migrations/0030_spooky_earthquake.sql
+++ b/src/shared/lib/db/migrations/0030_spooky_earthquake.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `chat_integrations` ADD `speed` text;--> statement-breakpoint
+ALTER TABLE `scheduled_tasks` ADD `speed` text;--> statement-breakpoint
+ALTER TABLE `webhook_triggers` ADD `speed` text;

--- a/src/shared/lib/db/migrations/meta/0030_snapshot.json
+++ b/src/shared/lib/db/migrations/meta/0030_snapshot.json
@@ -1,0 +1,2420 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "48540196-e0fa-4a1a-975b-07785c1e9b60",
+  "prevId": "c1eee63f-11cd-459d-994d-0b25d834248b",
+  "tables": {
+    "agent_acl": {
+      "name": "agent_acl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_acl_user_agent_unique": {
+          "name": "agent_acl_user_agent_unique",
+          "columns": [
+            "user_id",
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "agent_acl_agent_slug_idx": {
+          "name": "agent_acl_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_acl_user_id_user_id_fk": {
+          "name": "agent_acl_user_id_user_id_fk",
+          "tableFrom": "agent_acl",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_connected_accounts": {
+      "name": "agent_connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_connected_accounts_unique": {
+          "name": "agent_connected_accounts_unique",
+          "columns": [
+            "agent_slug",
+            "connected_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_connected_accounts_connected_account_id_connected_accounts_id_fk": {
+          "name": "agent_connected_accounts_connected_account_id_connected_accounts_id_fk",
+          "tableFrom": "agent_connected_accounts",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "connected_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_remote_mcps": {
+      "name": "agent_remote_mcps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_remote_mcps_unique": {
+          "name": "agent_remote_mcps_unique",
+          "columns": [
+            "agent_slug",
+            "remote_mcp_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "agent_remote_mcps",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "remote_mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_scope_policies": {
+      "name": "api_scope_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_scope_policies_unique": {
+          "name": "api_scope_policies_unique",
+          "columns": [
+            "account_id",
+            "scope"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_scope_policies_account_id_connected_accounts_id_fk": {
+          "name": "api_scope_policies_account_id_connected_accounts_id_fk",
+          "tableFrom": "api_scope_policies",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_log_object_idx": {
+          "name": "audit_log_object_idx",
+          "columns": [
+            "object"
+          ],
+          "isUnique": false
+        },
+        "audit_log_user_id_idx": {
+          "name": "audit_log_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integration_access": {
+      "name": "chat_integration_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "approval_source": {
+          "name": "approval_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_id": {
+          "name": "first_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_name": {
+          "name": "first_user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message_preview": {
+          "name": "first_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_notice_sent_at": {
+          "name": "request_notice_sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_access_unique": {
+          "name": "chat_integration_access_unique",
+          "columns": [
+            "integration_id",
+            "external_chat_id"
+          ],
+          "isUnique": true
+        },
+        "chat_integration_access_status_idx": {
+          "name": "chat_integration_access_status_idx",
+          "columns": [
+            "integration_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_access_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_access_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_access",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chat_integration_access_status_check": {
+          "name": "chat_integration_access_status_check",
+          "value": "\"chat_integration_access\".\"status\" in ('pending','allowed','denied')"
+        },
+        "chat_integration_access_chat_type_check": {
+          "name": "chat_integration_access_chat_type_check",
+          "value": "\"chat_integration_access\".\"chat_type\" is null or \"chat_integration_access\".\"chat_type\" in ('private','group','supergroup')"
+        },
+        "chat_integration_access_source_check": {
+          "name": "chat_integration_access_source_check",
+          "value": "\"chat_integration_access\".\"approval_source\" is null or \"chat_integration_access\".\"approval_source\" in ('auto_first_contact','owner','migration')"
+        }
+      }
+    },
+    "chat_integration_sessions": {
+      "name": "chat_integration_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_sessions_integration_id_idx": {
+          "name": "chat_integration_sessions_integration_id_idx",
+          "columns": [
+            "integration_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_sessions_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_sessions_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_sessions",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integrations": {
+      "name": "chat_integrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "show_tool_calls": {
+          "name": "show_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "require_approval": {
+          "name": "require_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_timeout": {
+          "name": "session_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integrations_agent_slug_idx": {
+          "name": "chat_integrations_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "chat_integrations_status_idx": {
+          "name": "chat_integrations_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connected_accounts": {
+      "name": "connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_connection_id": {
+          "name": "provider_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "toolkit_slug": {
+          "name": "toolkit_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connected_accounts_provider_connection_id_unique": {
+          "name": "connected_accounts_provider_connection_id_unique",
+          "columns": [
+            "provider_connection_id"
+          ],
+          "isUnique": true
+        },
+        "connected_accounts_userId_idx": {
+          "name": "connected_accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connected_accounts_user_id_user_id_fk": {
+          "name": "connected_accounts_user_id_user_id_fk",
+          "tableFrom": "connected_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_name": {
+          "name": "remote_mcp_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_tool": {
+          "name": "matched_tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_audit_log_agent_slug_created_at_idx": {
+          "name": "mcp_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "mcp_audit_log_remote_mcp_id_created_at_idx": {
+          "name": "mcp_audit_log_remote_mcp_id_created_at_idx",
+          "columns": [
+            "remote_mcp_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_policies": {
+      "name": "mcp_tool_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_tool_policies_unique": {
+          "name": "mcp_tool_policies_unique",
+          "columns": [
+            "mcp_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_policies",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message_author": {
+      "name": "message_author",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "message_author_session_idx": {
+          "name": "message_author_session_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_author_user_id_user_id_fk": {
+          "name": "message_author_user_id_user_id_fk",
+          "tableFrom": "message_author",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_agent_slug_is_read_idx": {
+          "name": "notifications_agent_slug_is_read_idx",
+          "columns": [
+            "agent_slug",
+            "is_read"
+          ],
+          "isUnique": false
+        },
+        "notifications_session_id_idx": {
+          "name": "notifications_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_audit_log": {
+      "name": "proxy_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_scopes": {
+          "name": "matched_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_audit_log_agent_slug_created_at_idx": {
+          "name": "proxy_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "proxy_audit_log_account_id_created_at_idx": {
+          "name": "proxy_audit_log_account_id_created_at_idx",
+          "columns": [
+            "account_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_tokens": {
+      "name": "proxy_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_tokens_agent_slug_unique": {
+          "name": "proxy_tokens_agent_slug_unique",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "proxy_tokens_token_unique": {
+          "name": "proxy_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_mcp_servers": {
+      "name": "remote_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token_endpoint": {
+          "name": "oauth_token_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_resource": {
+          "name": "oauth_resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_discovered_at": {
+          "name": "tools_discovered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "remote_mcp_servers_user_id_user_id_fk": {
+          "name": "remote_mcp_servers_user_id_user_id_fk",
+          "tableFrom": "remote_mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_expression": {
+          "name": "schedule_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "next_execution_at": {
+          "name": "next_execution_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "execution_count": {
+          "name": "execution_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resume_session_id": {
+          "name": "resume_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_tasks_pending_wake_unique": {
+          "name": "scheduled_tasks_pending_wake_unique",
+          "columns": [
+            "resume_session_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'pending' AND resume_session_id IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_triggers": {
+      "name": "webhook_triggers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "composio_trigger_id": {
+          "name": "composio_trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fire_count": {
+          "name": "fire_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_triggers_agent_slug_idx": {
+          "name": "webhook_triggers_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_status_idx": {
+          "name": "webhook_triggers_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_composio_idx": {
+          "name": "webhook_triggers_composio_idx",
+          "columns": [
+            "composio_trigger_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "x_agent_policies": {
+      "name": "x_agent_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_agent_slug": {
+          "name": "caller_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_agent_slug": {
+          "name": "target_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "x_agent_policies_unique": {
+          "name": "x_agent_policies_unique",
+          "columns": [
+            "caller_agent_slug",
+            "target_agent_slug",
+            "operation"
+          ],
+          "isUnique": true
+        },
+        "x_agent_policies_caller_idx": {
+          "name": "x_agent_policies_caller_idx",
+          "columns": [
+            "caller_agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/shared/lib/db/migrations/meta/_journal.json
+++ b/src/shared/lib/db/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1784054072546,
       "tag": "0029_polite_sister_grimm",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "6",
+      "when": 1784149867035,
+      "tag": "0030_spooky_earthquake",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/lib/db/schema.ts
+++ b/src/shared/lib/db/schema.ts
@@ -171,6 +171,7 @@ export const scheduledTasks = sqliteTable('scheduled_tasks', {
   // Runtime options (override global defaults when set)
   model: text('model'),
   effort: text('effort'),
+  speed: text('speed'),
 
   // Timestamps
   createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
@@ -419,6 +420,7 @@ export const webhookTriggers = sqliteTable('webhook_triggers', {
   // Runtime options (override global defaults when set)
   model: text('model'),
   effort: text('effort'),
+  speed: text('speed'),
 
   // Timestamps
   createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
@@ -446,6 +448,7 @@ export const chatIntegrations = sqliteTable('chat_integrations', {
   sessionTimeout: integer('session_timeout'), // Hours; null/0 = single persistent session
   model: text('model'), // Claude model override; null = use default
   effort: text('effort'), // Effort level override; null = use default
+  speed: text('speed'), // Speed level override; null = use default
 
   // Status
   status: text('status', { enum: ['active', 'paused', 'error', 'disconnected'] })

--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -39,6 +39,16 @@ const NON_CLAUDE_EFFORTS: EffortLevel[] = ['low', 'medium', 'high']
 const FLEX_AND_PRIORITY_SPEEDS: SpeedLevel[] = ['slow', 'normal', 'fast']
 const PRIORITY_ONLY_SPEEDS: SpeedLevel[] = ['normal', 'fast']
 
+/**
+ * Served-tier billing multipliers, mirroring the Platform proxy's pricing:
+ * OpenAI flex bills 0.5x and priority 2x (2.5x on gpt-5.5); xAI priority and
+ * Anthropic fast mode bill 2x. Standard tier (absent speed) is always 1x.
+ * Claude entries get theirs from model-pricing.json via pricingFor().
+ */
+const GPT_SPEED_MULTIPLIERS = { slow: 0.5, fast: 2 } as const
+const GPT_55_SPEED_MULTIPLIERS = { slow: 0.5, fast: 2.5 } as const
+const PRIORITY_2X_MULTIPLIERS = { fast: 2 } as const
+
 // Anthropic fast mode is Opus 4.8 only (4.7's is deprecated, removal 2026-07-24).
 const FAST_MODE_CLAUDE_IDS = new Set(['claude-opus-4-8'])
 
@@ -285,7 +295,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     supportedEfforts: NON_CLAUDE_EFFORTS,
     supportedSpeeds: FLEX_AND_PRIORITY_SPEEDS,
     ...PLATFORM_RESPONSES_WEB,
-    pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
+    pricing: { inputPerMtok: 2.5, outputPerMtok: 15, speedMultipliers: GPT_SPEED_MULTIPLIERS },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.4).
     contextWindow: 1_050_000,
     longContextPriceCliff: GPT_LONG_CONTEXT_CLIFF,
@@ -300,7 +310,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     supportedEfforts: NON_CLAUDE_EFFORTS,
     supportedSpeeds: FLEX_AND_PRIORITY_SPEEDS,
     ...PLATFORM_RESPONSES_WEB,
-    pricing: { inputPerMtok: 5, outputPerMtok: 30 },
+    pricing: { inputPerMtok: 5, outputPerMtok: 30, speedMultipliers: GPT_55_SPEED_MULTIPLIERS },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.5).
     contextWindow: 1_050_000,
     longContextPriceCliff: GPT_LONG_CONTEXT_CLIFF,
@@ -315,7 +325,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     supportedEfforts: NON_CLAUDE_EFFORTS,
     supportedSpeeds: FLEX_AND_PRIORITY_SPEEDS,
     ...PLATFORM_RESPONSES_WEB,
-    pricing: { inputPerMtok: 1, outputPerMtok: 6 },
+    pricing: { inputPerMtok: 1, outputPerMtok: 6, speedMultipliers: GPT_SPEED_MULTIPLIERS },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.6-luna).
     contextWindow: 1_050_000,
     longContextPriceCliff: GPT_LONG_CONTEXT_CLIFF,
@@ -330,7 +340,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     supportedEfforts: NON_CLAUDE_EFFORTS,
     supportedSpeeds: FLEX_AND_PRIORITY_SPEEDS,
     ...PLATFORM_RESPONSES_WEB,
-    pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
+    pricing: { inputPerMtok: 2.5, outputPerMtok: 15, speedMultipliers: GPT_SPEED_MULTIPLIERS },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.6-terra).
     contextWindow: 1_050_000,
     longContextPriceCliff: GPT_LONG_CONTEXT_CLIFF,
@@ -347,7 +357,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     supportedEfforts: NON_CLAUDE_EFFORTS,
     supportedSpeeds: FLEX_AND_PRIORITY_SPEEDS,
     ...PLATFORM_RESPONSES_WEB,
-    pricing: { inputPerMtok: 5, outputPerMtok: 30 },
+    pricing: { inputPerMtok: 5, outputPerMtok: 30, speedMultipliers: GPT_SPEED_MULTIPLIERS },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.6-sol).
     contextWindow: 1_050_000,
     longContextPriceCliff: GPT_LONG_CONTEXT_CLIFF,
@@ -365,7 +375,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     // xAI offers priority but no flex tier — cost-sensitive work goes to their Batch API.
     supportedSpeeds: PRIORITY_ONLY_SPEEDS,
     ...PLATFORM_RESPONSES_WEB,
-    pricing: { inputPerMtok: 2, outputPerMtok: 6 },
+    pricing: { inputPerMtok: 2, outputPerMtok: 6, speedMultipliers: PRIORITY_2X_MULTIPLIERS },
     contextWindow: 500_000,
   },
 ]

--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -1,4 +1,4 @@
-import type { EffortLevel } from '../container/types'
+import type { EffortLevel, SpeedLevel } from '../container/types'
 import type { ModelDefinition } from './model-catalog-schema'
 import { GPT_TOOL_USE_PROMPT_HINTS } from './model-prompt-hints'
 import { pricingFor } from './model-pricing-lookup'
@@ -18,6 +18,36 @@ const ALL_EFFORTS: EffortLevel[] = ['low', 'medium', 'high', 'xhigh', 'max']
 const STANDARD_EFFORTS: EffortLevel[] = ['low', 'medium', 'high']
 // xhigh/max are Anthropic-only reasoning tiers; non-Claude models get the standard three.
 const NON_CLAUDE_EFFORTS: EffortLevel[] = ['low', 'medium', 'high']
+
+/**
+ * Processing-speed tiers, normalized to slow/normal/fast. `supportedSpeeds`
+ * reflects what OUR serving path can honor, not the vendor's raw feature list:
+ * the agent signals speed via the X-Superagent-Speed custom header, which only
+ * the Platform proxy consumes (mapping it to OpenAI/xAI `service_tier` or
+ * Anthropic fast mode). Direct Anthropic (body param + gated beta on the
+ * user's own key), OpenRouter (ignores our header; Anthropic fast exists there
+ * only as separate `-fast` model slugs), and Bedrock (no fast mode) can't
+ * honor a pick, so their entries omit speeds entirely.
+ *
+ * Vendor mapping, verified 2026-07-14:
+ *   - OpenAI GPT-5.x: `service_tier` flex (0.5x price, slower) / priority
+ *     (2x, 2.5x on gpt-5.5) → slow/normal/fast.
+ *   - xAI grok-4.5: `service_tier` priority only (2x when granted) → normal/fast.
+ *   - Anthropic: fast mode (research preview) on Opus 4.8 only → normal/fast.
+ *   - Z.AI GLM: no request-level tier → normal only.
+ */
+const FLEX_AND_PRIORITY_SPEEDS: SpeedLevel[] = ['slow', 'normal', 'fast']
+const PRIORITY_ONLY_SPEEDS: SpeedLevel[] = ['normal', 'fast']
+
+// Anthropic fast mode is Opus 4.8 only (4.7's is deprecated, removal 2026-07-24).
+const FAST_MODE_CLAUDE_IDS = new Set(['claude-opus-4-8'])
+
+/** Claude entries with the speed tiers the Platform proxy can request. */
+function withPlatformClaudeSpeeds(catalog: ModelDefinition[]): ModelDefinition[] {
+  return catalog.map((m) =>
+    FAST_MODE_CLAUDE_IDS.has(m.id) ? { ...m, supportedSpeeds: PRIORITY_ONLY_SPEEDS } : m,
+  )
+}
 
 // OpenAI GPT-5.x reprice the whole request 2x input / 1.5x output once prompt
 // input crosses 272K tokens. Shared by every GPT entry so the picker can warn.
@@ -253,6 +283,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     family: 'gpt',
     icon: 'openai',
     supportedEfforts: NON_CLAUDE_EFFORTS,
+    supportedSpeeds: FLEX_AND_PRIORITY_SPEEDS,
     ...PLATFORM_RESPONSES_WEB,
     pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.4).
@@ -267,6 +298,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     family: 'gpt',
     icon: 'openai',
     supportedEfforts: NON_CLAUDE_EFFORTS,
+    supportedSpeeds: FLEX_AND_PRIORITY_SPEEDS,
     ...PLATFORM_RESPONSES_WEB,
     pricing: { inputPerMtok: 5, outputPerMtok: 30 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.5).
@@ -281,6 +313,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     family: 'gpt',
     icon: 'openai',
     supportedEfforts: NON_CLAUDE_EFFORTS,
+    supportedSpeeds: FLEX_AND_PRIORITY_SPEEDS,
     ...PLATFORM_RESPONSES_WEB,
     pricing: { inputPerMtok: 1, outputPerMtok: 6 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.6-luna).
@@ -295,6 +328,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     family: 'gpt',
     icon: 'openai',
     supportedEfforts: NON_CLAUDE_EFFORTS,
+    supportedSpeeds: FLEX_AND_PRIORITY_SPEEDS,
     ...PLATFORM_RESPONSES_WEB,
     pricing: { inputPerMtok: 2.5, outputPerMtok: 15 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.6-terra).
@@ -311,6 +345,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     isLatest: true,
     icon: 'openai',
     supportedEfforts: NON_CLAUDE_EFFORTS,
+    supportedSpeeds: FLEX_AND_PRIORITY_SPEEDS,
     ...PLATFORM_RESPONSES_WEB,
     pricing: { inputPerMtok: 5, outputPerMtok: 30 },
     // OpenAI API context window (developers.openai.com/api/docs/models/gpt-5.6-sol).
@@ -327,6 +362,8 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     isLatest: true,
     icon: 'xai',
     supportedEfforts: NON_CLAUDE_EFFORTS,
+    // xAI offers priority but no flex tier — cost-sensitive work goes to their Batch API.
+    supportedSpeeds: PRIORITY_ONLY_SPEEDS,
     ...PLATFORM_RESPONSES_WEB,
     pricing: { inputPerMtok: 2, outputPerMtok: 6 },
     contextWindow: 500_000,
@@ -335,6 +372,6 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
 
 /** Platform — bare Claude models plus the GPT/Grok models the proxy serves. */
 export const PLATFORM_CATALOG: ModelDefinition[] = [
-  ...CLAUDE_BARE_CATALOG,
+  ...withPlatformClaudeSpeeds(CLAUDE_BARE_CATALOG),
   ...PLATFORM_EXTRA_MODELS,
 ]

--- a/src/shared/lib/llm-provider/model-catalog-schema.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.test.ts
@@ -72,6 +72,40 @@ describe('modelDefinitionSchema', () => {
     ).toThrow()
   })
 
+  it('accepts pricing with speedMultipliers (full or partial) and omits cleanly', () => {
+    expect(
+      modelDefinitionSchema.parse({
+        ...base,
+        pricing: { inputPerMtok: 5, outputPerMtok: 25, speedMultipliers: { slow: 0.5, fast: 2 } },
+      }),
+    ).toMatchObject({ pricing: { speedMultipliers: { slow: 0.5, fast: 2 } } })
+    expect(
+      modelDefinitionSchema.parse({
+        ...base,
+        pricing: { inputPerMtok: 5, outputPerMtok: 25, speedMultipliers: { fast: 2 } },
+      }),
+    ).toMatchObject({ pricing: { speedMultipliers: { fast: 2 } } })
+    expect(
+      modelDefinitionSchema.parse({ ...base, pricing: { inputPerMtok: 5, outputPerMtok: 25 } })
+        .pricing?.speedMultipliers,
+    ).toBeUndefined()
+  })
+
+  it('rejects zero or negative speedMultipliers', () => {
+    expect(() =>
+      modelDefinitionSchema.parse({
+        ...base,
+        pricing: { inputPerMtok: 5, outputPerMtok: 25, speedMultipliers: { fast: 0 } },
+      }),
+    ).toThrow()
+    expect(() =>
+      modelDefinitionSchema.parse({
+        ...base,
+        pricing: { inputPerMtok: 5, outputPerMtok: 25, speedMultipliers: { slow: -0.5 } },
+      }),
+    ).toThrow()
+  })
+
   it('accepts an optional positive-int contextWindow and omits cleanly', () => {
     expect(modelDefinitionSchema.parse({ ...base, contextWindow: 1_050_000 })).toMatchObject({
       contextWindow: 1_050_000,

--- a/src/shared/lib/llm-provider/model-catalog-schema.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.test.ts
@@ -39,6 +39,33 @@ describe('modelDefinitionSchema', () => {
     expect(() => modelDefinitionSchema.parse({ ...base, supportedEfforts: ['turbo'] })).toThrow()
   })
 
+  it('accepts supportedSpeeds that include normal, and omits cleanly', () => {
+    expect(
+      modelDefinitionSchema.parse({ ...base, supportedSpeeds: ['normal', 'fast'] }),
+    ).toMatchObject({ supportedSpeeds: ['normal', 'fast'] })
+    expect(modelDefinitionSchema.parse(base).supportedSpeeds).toBeUndefined()
+  })
+
+  it("rejects supportedSpeeds without 'normal'", () => {
+    // The speed UI clamps unsupported picks to 'normal' and hides the section
+    // at one visible option — a list like ['fast'] would clamp to a speed the
+    // model rejects with no way to see or fix it.
+    expect(() => modelDefinitionSchema.parse({ ...base, supportedSpeeds: ['fast'] })).toThrow(
+      /must include 'normal'/,
+    )
+    expect(() =>
+      modelDefinitionSchema.parse({ ...base, supportedSpeeds: ['slow', 'fast'] }),
+    ).toThrow(/must include 'normal'/)
+  })
+
+  it('rejects duplicate, empty, and off-enum supportedSpeeds', () => {
+    expect(() =>
+      modelDefinitionSchema.parse({ ...base, supportedSpeeds: ['normal', 'fast', 'fast'] }),
+    ).toThrow(/duplicate/)
+    expect(() => modelDefinitionSchema.parse({ ...base, supportedSpeeds: [] })).toThrow()
+    expect(() => modelDefinitionSchema.parse({ ...base, supportedSpeeds: ['turbo'] })).toThrow()
+  })
+
   it('rejects negative pricing', () => {
     expect(() =>
       modelDefinitionSchema.parse({ ...base, pricing: { inputPerMtok: -1, outputPerMtok: 25 } }),
@@ -125,6 +152,15 @@ describe('catalogOverrideEntrySchema', () => {
   it('rejects wrong-typed fields and invalid effort values', () => {
     expect(() => catalogOverrideEntrySchema.parse({ id: 'x', pricing: 'cheap' })).toThrow()
     expect(() => catalogOverrideEntrySchema.parse({ id: 'x', supportedEfforts: ['turbo'] })).toThrow()
+  })
+
+  it("applies the supportedSpeeds 'normal' rule to override patches too", () => {
+    expect(() => catalogOverrideEntrySchema.parse({ id: 'x', supportedSpeeds: ['fast'] })).toThrow(
+      /must include 'normal'/,
+    )
+    expect(
+      catalogOverrideEntrySchema.parse({ id: 'x', supportedSpeeds: ['normal', 'fast'] }),
+    ).toMatchObject({ supportedSpeeds: ['normal', 'fast'] })
   })
 })
 

--- a/src/shared/lib/llm-provider/model-catalog-schema.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.ts
@@ -28,9 +28,22 @@ export const modelDefinitionSchema = z.object({
   /**
    * Processing-speed tiers this model accepts on its serving path (normalized
    * to slow/normal/fast). Omit ⇒ ['normal'] — a speed knob is the exception,
-   * not the rule, so absence means "no speed choice".
+   * not the rule, so absence means "no speed choice". An explicit list MUST
+   * include 'normal': the speed UI treats it as the always-available reset
+   * target (useSpeedClamp snaps unsupported picks to it), so a list like
+   * ['fast'] would clamp to a speed the model rejects while the picker hides.
    */
-  supportedSpeeds: z.array(z.enum(SPEED_LEVELS)).min(1).optional(),
+  supportedSpeeds: z
+    .array(z.enum(SPEED_LEVELS))
+    .min(1)
+    .refine((speeds) => speeds.includes('normal'), {
+      message:
+        "supportedSpeeds must include 'normal' — the speed UI clamps unsupported picks to 'normal', so it must always be a valid choice",
+    })
+    .refine((speeds) => new Set(speeds).size === speeds.length, {
+      message: 'supportedSpeeds must not contain duplicate entries',
+    })
+    .optional(),
   /** Grouping key and bare alias for this lineage, e.g. 'opus'. */
   family: z.string().optional(),
   /** This id is what the bare `family` alias resolves to (newest in the family). */

--- a/src/shared/lib/llm-provider/model-catalog-schema.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.ts
@@ -64,6 +64,18 @@ export const modelDefinitionSchema = z.object({
     .object({
       inputPerMtok: z.number().nonnegative(),
       outputPerMtok: z.number().nonnegative(),
+      /**
+       * Served-tier billing multipliers for the slow/fast speed tiers (e.g.
+       * OpenAI flex 0.5x / priority 2x, Anthropic fast mode 2x). Applied on
+       * top of whichever rate set (base or long-context) a request lands on.
+       * An absent tier bills standard (1x).
+       */
+      speedMultipliers: z
+        .object({
+          slow: z.number().positive().optional(),
+          fast: z.number().positive().optional(),
+        })
+        .optional(),
     })
     .optional(),
   // Static context window (tokens) for non-Claude models. The SDK reports a

--- a/src/shared/lib/llm-provider/model-catalog-schema.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { EFFORT_LEVELS } from '../container/types'
+import { EFFORT_LEVELS, SPEED_LEVELS } from '../container/types'
 
 /**
  * A concrete, versioned model offered by a provider's catalog.
@@ -25,6 +25,12 @@ export const modelDefinitionSchema = z.object({
    * family-keyed EFFORT_FAMILY_REQUIREMENTS — now declared per model.
    */
   supportedEfforts: z.array(z.enum(EFFORT_LEVELS)).min(1),
+  /**
+   * Processing-speed tiers this model accepts on its serving path (normalized
+   * to slow/normal/fast). Omit ⇒ ['normal'] — a speed knob is the exception,
+   * not the rule, so absence means "no speed choice".
+   */
+  supportedSpeeds: z.array(z.enum(SPEED_LEVELS)).min(1).optional(),
   /** Grouping key and bare alias for this lineage, e.g. 'opus'. */
   family: z.string().optional(),
   /** This id is what the bare `family` alias resolves to (newest in the family). */

--- a/src/shared/lib/llm-provider/model-pricing-lookup.ts
+++ b/src/shared/lib/llm-provider/model-pricing-lookup.ts
@@ -1,10 +1,16 @@
 import MODEL_PRICING from '../services/model-pricing.json'
 
+interface SpeedMultipliers {
+  slow?: number
+  fast?: number
+}
+
 interface PricingEntry {
   input: number
   output: number
   cacheCreation: number
   cacheRead: number
+  speedMultipliers?: SpeedMultipliers
 }
 
 const PRICING = MODEL_PRICING as Record<string, PricingEntry>
@@ -14,11 +20,20 @@ const PRICING = MODEL_PRICING as Record<string, PricingEntry>
  * Returns undefined when the id has no known pricing (e.g. region-prefixed
  * Bedrock ids that aren't keyed there) — callers should pass a bare id for
  * Bedrock entries so display pricing still resolves.
+ *
+ * Served-tier speed multipliers ride along so catalog entries seeded here
+ * (e.g. Opus 4.8's 2x fast mode) bill speed rows correctly.
  */
 export function pricingFor(
   id: string,
-): { inputPerMtok: number; outputPerMtok: number } | undefined {
+):
+  | { inputPerMtok: number; outputPerMtok: number; speedMultipliers?: SpeedMultipliers }
+  | undefined {
   const entry = PRICING[id]
   if (!entry) return undefined
-  return { inputPerMtok: entry.input, outputPerMtok: entry.output }
+  return {
+    inputPerMtok: entry.input,
+    outputPerMtok: entry.output,
+    ...(entry.speedMultipliers ? { speedMultipliers: entry.speedMultipliers } : {}),
+  }
 }

--- a/src/shared/lib/scheduler/task-scheduler.duplicate-guard.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.duplicate-guard.test.ts
@@ -119,6 +119,7 @@ function createTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     timezone: 'America/Los_Angeles',
     model: null,
     effort: null,
+    speed: null,
     resumeSessionId: null,
     createdAt: new Date('2026-06-26T16:00:00.000Z'),
     cancelledAt: null,

--- a/src/shared/lib/scheduler/task-scheduler.model-resolution.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.model-resolution.test.ts
@@ -115,6 +115,7 @@ function createTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     timezone: 'America/Los_Angeles',
     model: null,
     effort: null,
+    speed: null,
     resumeSessionId: null,
     createdAt: new Date('2026-06-26T16:00:00.000Z'),
     cancelledAt: null,
@@ -123,7 +124,7 @@ function createTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
   }
 }
 
-describe('TaskScheduler model and effort resolution', () => {
+describe('TaskScheduler model, effort, and speed resolution', () => {
   beforeEach(() => {
     taskScheduler.stop()
     vi.clearAllMocks()
@@ -158,20 +159,29 @@ describe('TaskScheduler model and effort resolution', () => {
     const args = await executeTask()
     expect(args.model).toBe('claude-sonnet-4-20250514')
     expect(args.effort).toBeUndefined()
+    expect(args.speed).toBeUndefined()
   })
 
   it('falls back to the agent default over the global default', async () => {
-    mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
+    mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high', defaultSpeed: 'slow' })
     const args = await executeTask()
     expect(mockReadAgentPreferences).toHaveBeenCalledWith('agent-one')
     expect(args.model).toBe('opus')
     expect(args.effort).toBe('high')
+    expect(args.speed).toBe('slow')
   })
 
   it('prefers the task override over the agent default', async () => {
-    mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
-    const args = await executeTask({ model: 'claude-haiku-4-5-20251001', effort: 'low' })
+    mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high', defaultSpeed: 'fast' })
+    const args = await executeTask({ model: 'claude-haiku-4-5-20251001', effort: 'low', speed: 'slow' })
     expect(args.model).toBe('claude-haiku-4-5-20251001')
     expect(args.effort).toBe('low')
+    expect(args.speed).toBe('slow')
+  })
+
+  it('a stored normal task speed beats a non-normal agent default', async () => {
+    mockReadAgentPreferences.mockResolvedValue({ defaultSpeed: 'fast' })
+    const args = await executeTask({ speed: 'normal' })
+    expect(args.speed).toBe('normal')
   })
 })

--- a/src/shared/lib/scheduler/task-scheduler.session-wake.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.session-wake.test.ts
@@ -131,6 +131,7 @@ function createWakeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     timezone: 'America/Los_Angeles',
     model: null,
     effort: null,
+    speed: null,
     resumeSessionId: 'sleeping-session-1',
     createdAt: new Date('2026-06-25T16:00:00.000Z'),
     cancelledAt: null,

--- a/src/shared/lib/scheduler/task-scheduler.ts
+++ b/src/shared/lib/scheduler/task-scheduler.ts
@@ -18,7 +18,7 @@ import {
   updateNextExecution,
 } from '@shared/lib/services/scheduled-task-service'
 import type { ScheduledTask } from '@shared/lib/services/scheduled-task-service'
-import type { EffortLevel } from '@shared/lib/container/types'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 import { getNextCronTime } from '@shared/lib/services/schedule-parser'
 import {
   getSessionForScheduledExecution,
@@ -219,10 +219,11 @@ class TaskScheduler {
     const availableEnvVars = await getSecretEnvVars(task.agentSlug)
 
     // Create a new session with the scheduled prompt.
-    // Model/effort preference order: task override > agent default > global default.
+    // Model/effort/speed preference order: task override > agent default > global default.
     const models = getEffectiveModels()
     const agentPrefs = await readAgentPreferences(task.agentSlug)
     const effort = task.effort ?? agentPrefs.defaultEffort
+    const speed = task.speed ?? agentPrefs.defaultSpeed
     const containerSession = await client.createSession({
       availableEnvVars:
         availableEnvVars.length > 0 ? availableEnvVars : undefined,
@@ -232,7 +233,7 @@ class TaskScheduler {
       dashboardBuilderModel: models.dashboardBuilderModel,
       metadata: { isAutomated: true },
       ...(effort ? { effort: effort as EffortLevel } : {}),
-      ...(agentPrefs.defaultSpeed ? { speed: agentPrefs.defaultSpeed } : {}),
+      ...(speed ? { speed: speed as SpeedLevel } : {}),
     })
 
     const sessionId = containerSession.id

--- a/src/shared/lib/scheduler/task-scheduler.ts
+++ b/src/shared/lib/scheduler/task-scheduler.ts
@@ -232,6 +232,7 @@ class TaskScheduler {
       dashboardBuilderModel: models.dashboardBuilderModel,
       metadata: { isAutomated: true },
       ...(effort ? { effort: effort as EffortLevel } : {}),
+      ...(agentPrefs.defaultSpeed ? { speed: agentPrefs.defaultSpeed } : {}),
     })
 
     const sessionId = containerSession.id

--- a/src/shared/lib/scheduler/trigger-manager.test.ts
+++ b/src/shared/lib/scheduler/trigger-manager.test.ts
@@ -354,7 +354,7 @@ describe('TriggerManager', () => {
     })
   })
 
-  describe('model and effort resolution', () => {
+  describe('model, effort, and speed resolution', () => {
     // Preference order: trigger override > agent default > global default.
     async function fireTrigger(overrides: Record<string, unknown> = {}) {
       mockPollAndClaimEvents.mockResolvedValue({
@@ -372,6 +372,7 @@ describe('TriggerManager', () => {
         fireCount: 0,
         model: null,
         effort: null,
+        speed: null,
         ...overrides,
       }])
       await triggerManager.start()
@@ -384,21 +385,30 @@ describe('TriggerManager', () => {
       const args = await fireTrigger()
       expect(args.model).toBe('claude-sonnet-4-20250514')
       expect(args.effort).toBeUndefined()
+      expect(args.speed).toBeUndefined()
     })
 
     it('falls back to the agent default over the global default', async () => {
-      mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
+      mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high', defaultSpeed: 'slow' })
       const args = await fireTrigger()
       expect(mockReadAgentPreferences).toHaveBeenCalledWith('test-agent')
       expect(args.model).toBe('opus')
       expect(args.effort).toBe('high')
+      expect(args.speed).toBe('slow')
     })
 
     it('prefers the trigger override over the agent default', async () => {
-      mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
-      const args = await fireTrigger({ model: 'claude-haiku-4-5-20251001', effort: 'low' })
+      mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high', defaultSpeed: 'fast' })
+      const args = await fireTrigger({ model: 'claude-haiku-4-5-20251001', effort: 'low', speed: 'slow' })
       expect(args.model).toBe('claude-haiku-4-5-20251001')
       expect(args.effort).toBe('low')
+      expect(args.speed).toBe('slow')
+    })
+
+    it('a stored normal trigger speed beats a non-normal agent default', async () => {
+      mockReadAgentPreferences.mockResolvedValue({ defaultSpeed: 'fast' })
+      const args = await fireTrigger({ speed: 'normal' })
+      expect(args.speed).toBe('normal')
     })
   })
 

--- a/src/shared/lib/scheduler/trigger-manager.ts
+++ b/src/shared/lib/scheduler/trigger-manager.ts
@@ -368,6 +368,7 @@ class TriggerManager {
       dashboardBuilderModel: models.dashboardBuilderModel,
       metadata: { isAutomated: true },
       ...(effort ? { effort: effort as EffortLevel } : {}),
+      ...(agentPrefs.defaultSpeed ? { speed: agentPrefs.defaultSpeed } : {}),
     })
 
     const sessionId = containerSession.id

--- a/src/shared/lib/scheduler/trigger-manager.ts
+++ b/src/shared/lib/scheduler/trigger-manager.ts
@@ -27,7 +27,7 @@ import {
   resolvePlatformMemberForCandidates,
 } from '@shared/lib/services/webhook-trigger-service'
 import type { WebhookTrigger } from '@shared/lib/services/webhook-trigger-service'
-import type { EffortLevel } from '@shared/lib/container/types'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 import { registerSession } from '@shared/lib/services/session-service'
 import { getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { agentExists } from '@shared/lib/services/agent-service'
@@ -356,10 +356,11 @@ class TriggerManager {
     const client = await containerManager.ensureRunning(trigger.agentSlug)
     const availableEnvVars = await getSecretEnvVars(trigger.agentSlug)
 
-    // Model/effort preference order: trigger override > agent default > global default.
+    // Model/effort/speed preference order: trigger override > agent default > global default.
     const models = getEffectiveModels()
     const agentPrefs = await readAgentPreferences(trigger.agentSlug)
     const effort = trigger.effort ?? agentPrefs.defaultEffort
+    const speed = trigger.speed ?? agentPrefs.defaultSpeed
     const containerSession = await client.createSession({
       availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
       initialMessage: prompt,
@@ -368,7 +369,7 @@ class TriggerManager {
       dashboardBuilderModel: models.dashboardBuilderModel,
       metadata: { isAutomated: true },
       ...(effort ? { effort: effort as EffortLevel } : {}),
-      ...(agentPrefs.defaultSpeed ? { speed: agentPrefs.defaultSpeed } : {}),
+      ...(speed ? { speed: speed as SpeedLevel } : {}),
     })
 
     const sessionId = containerSession.id

--- a/src/shared/lib/scheduler/wake-delivery.test.ts
+++ b/src/shared/lib/scheduler/wake-delivery.test.ts
@@ -84,6 +84,7 @@ function createWakeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     timezone: null,
     model: null,
     effort: null,
+    speed: null,
     resumeSessionId: 'sleeping-session-1',
     createdAt: new Date('2026-06-25T16:00:00.000Z'),
     cancelledAt: null,

--- a/src/shared/lib/services/chat-integration-service.ts
+++ b/src/shared/lib/services/chat-integration-service.ts
@@ -32,6 +32,7 @@ export interface CreateChatIntegrationParams {
   sessionTimeout?: number | null
   model?: string | null
   effort?: string | null
+  speed?: string | null
   createdByUserId?: string
 }
 
@@ -43,6 +44,7 @@ export interface UpdateChatIntegrationParams {
   sessionTimeout?: number | null
   model?: string | null
   effort?: string | null
+  speed?: string | null
   status?: 'active' | 'paused' | 'error' | 'disconnected'
   errorMessage?: string | null
 }
@@ -74,6 +76,7 @@ export function createChatIntegration(params: CreateChatIntegrationParams): stri
     sessionTimeout: params.sessionTimeout ?? null,
     model: params.model ?? null,
     effort: params.effort ?? null,
+    speed: params.speed ?? null,
     createdByUserId: params.createdByUserId ?? null,
     createdAt: now,
     updatedAt: now,
@@ -240,6 +243,7 @@ export function updateChatIntegration(id: string, params: UpdateChatIntegrationP
   if (params.sessionTimeout !== undefined) updates.sessionTimeout = params.sessionTimeout
   if (params.model !== undefined) updates.model = params.model
   if (params.effort !== undefined) updates.effort = params.effort
+  if (params.speed !== undefined) updates.speed = params.speed
   if (params.status !== undefined) updates.status = params.status
   if (params.errorMessage !== undefined) updates.errorMessage = params.errorMessage
 

--- a/src/shared/lib/services/model-pricing.json
+++ b/src/shared/lib/services/model-pricing.json
@@ -99,7 +99,10 @@
     "input": 5,
     "output": 25,
     "cacheCreation": 6.25,
-    "cacheRead": 0.5
+    "cacheRead": 0.5,
+    "speedMultipliers": {
+      "fast": 2
+    }
   },
   "claude-sonnet-4-20250514": {
     "input": 3,
@@ -142,6 +145,10 @@
     "output": 15,
     "cacheCreation": 2.5,
     "cacheRead": 0.25,
+    "speedMultipliers": {
+      "slow": 0.5,
+      "fast": 2
+    },
     "longContext": {
       "thresholdTokens": 272000,
       "input": 5,
@@ -155,6 +162,10 @@
     "output": 30,
     "cacheCreation": 5,
     "cacheRead": 0.5,
+    "speedMultipliers": {
+      "slow": 0.5,
+      "fast": 2.5
+    },
     "longContext": {
       "thresholdTokens": 272000,
       "input": 10,
@@ -168,6 +179,10 @@
     "output": 6,
     "cacheCreation": 1,
     "cacheRead": 0.1,
+    "speedMultipliers": {
+      "slow": 0.5,
+      "fast": 2
+    },
     "longContext": {
       "thresholdTokens": 272000,
       "input": 2,
@@ -181,6 +196,10 @@
     "output": 30,
     "cacheCreation": 5,
     "cacheRead": 0.5,
+    "speedMultipliers": {
+      "slow": 0.5,
+      "fast": 2
+    },
     "longContext": {
       "thresholdTokens": 272000,
       "input": 10,
@@ -194,6 +213,10 @@
     "output": 15,
     "cacheCreation": 2.5,
     "cacheRead": 0.25,
+    "speedMultipliers": {
+      "slow": 0.5,
+      "fast": 2
+    },
     "longContext": {
       "thresholdTokens": 272000,
       "input": 5,
@@ -206,7 +229,10 @@
     "input": 2,
     "output": 6,
     "cacheCreation": 2,
-    "cacheRead": 0.2
+    "cacheRead": 0.2,
+    "speedMultipliers": {
+      "fast": 2
+    }
   },
   "openai/gpt-5.4": {
     "input": 2.5,

--- a/src/shared/lib/services/scheduled-task-service.ts
+++ b/src/shared/lib/services/scheduled-task-service.ts
@@ -29,6 +29,7 @@ export interface CreateScheduledTaskParams {
   timezone?: string
   model?: string
   effort?: string
+  speed?: string
   // When set, firing this task resumes the referenced session instead of
   // creating a new one. Prefer createSessionWake(), which also enforces the
   // one-pending-wake-per-session invariant.
@@ -92,6 +93,7 @@ export async function createScheduledTask(
     timezone: params.timezone || null,
     model: params.model || null,
     effort: params.effort || null,
+    speed: params.speed || null,
     resumeSessionId: params.resumeSessionId || null,
   }
 
@@ -602,12 +604,12 @@ export async function recordManualExecution(
 }
 
 /**
- * Update a task's runtime options (model and/or effort).
+ * Update a task's runtime options (model, effort, and/or speed).
  * Pass null to clear a field back to the global default.
  */
 export async function updateTaskRuntimeOptions(
   taskId: string,
-  options: { model?: string | null; effort?: string | null },
+  options: { model?: string | null; effort?: string | null; speed?: string | null },
 ): Promise<boolean> {
   const task = await getScheduledTask(taskId)
   if (!task || (task.status !== 'pending' && task.status !== 'paused')) return false
@@ -615,6 +617,7 @@ export async function updateTaskRuntimeOptions(
   const updates: Record<string, string | null> = {}
   if ('model' in options) updates.model = options.model ?? null
   if ('effort' in options) updates.effort = options.effort ?? null
+  if ('speed' in options) updates.speed = options.speed ?? null
 
   const result = await db
     .update(scheduledTasks)

--- a/src/shared/lib/services/session-metadata-schema.ts
+++ b/src/shared/lib/services/session-metadata-schema.ts
@@ -59,9 +59,10 @@ export const sessionMetadataSchema = z
     // here risks false-rejecting a valid file and refusing to persist names.
     lastUsage: sessionUsageSchema.optional(),
     slashCommands: z.array(slashCommandInfoSchema).optional(),
-    // `effort`/`model` are intentionally bare strings (not the EffortLevel enum)
+    // `effort`/`speed`/`model` are intentionally bare strings (not the enums)
     // so a newly-added level/id from a newer build never fails an older reader.
     effort: z.string().optional(),
+    speed: z.string().optional(),
     model: z.string().optional(),
     invokedByAgentSlug: z.string().optional(),
   })

--- a/src/shared/lib/services/usage-service.test.ts
+++ b/src/shared/lib/services/usage-service.test.ts
@@ -498,6 +498,151 @@ describe('usage-service', () => {
     })
   })
 
+  describe('loadDailyUsageData — served speed tiers', () => {
+    let seq = 0
+
+    interface EntryOpts {
+      speed?: string
+      costUSD?: number
+      input?: number
+      output?: number
+      cacheCreation?: number
+      cacheRead?: number
+    }
+
+    function makeEntry(model: string, opts: EntryOpts = {}) {
+      seq += 1
+      return {
+        timestamp: '2026-07-01T12:00:00.000Z',
+        requestId: `req-${seq}`,
+        ...(opts.costUSD !== undefined ? { costUSD: opts.costUSD } : {}),
+        message: {
+          id: `msg-${seq}`,
+          model,
+          usage: {
+            input_tokens: opts.input ?? 100_000,
+            output_tokens: opts.output ?? 1_000,
+            ...(opts.cacheCreation !== undefined
+              ? { cache_creation_input_tokens: opts.cacheCreation }
+              : {}),
+            ...(opts.cacheRead !== undefined ? { cache_read_input_tokens: opts.cacheRead } : {}),
+            ...(opts.speed !== undefined ? { speed: opts.speed } : {}),
+          },
+        },
+      }
+    }
+
+    /** Load a single synthetic entry and return its total cost. */
+    async function costOf(
+      model: string,
+      opts: EntryOpts = {},
+      providerId?: 'platform' | 'anthropic',
+    ): Promise<number> {
+      const dir = mkdtempSync(path.join(tmpdir(), 'usage-speed-'))
+      try {
+        mkdirSync(path.join(dir, 'projects'), { recursive: true })
+        writeFileSync(
+          path.join(dir, 'projects', 'session.jsonl'),
+          `${JSON.stringify(makeEntry(model, opts))}\n`,
+        )
+        const result = await loadDailyUsageDataLightweight({
+          claudePath: dir,
+          ...(providerId ? { providerId } : {}),
+        })
+        expect(result).toHaveLength(1)
+        return result[0].totalCost
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }
+
+    // gpt-5.4 base: $2.5/Mtok input, $15/Mtok output.
+    const GPT54_BASE = (100_000 * 2.5 + 1_000 * 15) / 1_000_000
+
+    it('bills a fast row at exactly 2x its no-speed twin (platform catalog)', async () => {
+      expect(await costOf('gpt-5.4', {}, 'platform')).toBeCloseTo(GPT54_BASE, 9)
+      expect(await costOf('gpt-5.4', { speed: 'fast' }, 'platform')).toBeCloseTo(GPT54_BASE * 2, 9)
+    })
+
+    it('bills a slow row at exactly 0.5x its no-speed twin', async () => {
+      expect(await costOf('gpt-5.4', { speed: 'slow' }, 'platform')).toBeCloseTo(GPT54_BASE * 0.5, 9)
+    })
+
+    it('bills unknown speed values at 1x (forward-compat)', async () => {
+      expect(await costOf('gpt-5.4', { speed: 'turbo' }, 'platform')).toBeCloseTo(GPT54_BASE, 9)
+    })
+
+    it('applies the multiplier via the static pricing table too (no provider), across all four rates', async () => {
+      // gpt-5.4 static: input 2.5, output 15, cacheCreation 2.5, cacheRead 0.25.
+      const base =
+        (100_000 * 2.5 + 1_000 * 15 + 10_000 * 2.5 + 50_000 * 0.25) / 1_000_000
+      expect(await costOf('gpt-5.4', { cacheCreation: 10_000, cacheRead: 50_000 })).toBeCloseTo(
+        base,
+        9,
+      )
+      expect(
+        await costOf('gpt-5.4', { speed: 'fast', cacheCreation: 10_000, cacheRead: 50_000 }),
+      ).toBeCloseTo(base * 2, 9)
+    })
+
+    it('composes the multiplier on top of the long-context cliff rates', async () => {
+      // 300K input trips the 272K cliff: gpt-5.4 reprices to $5 in / $22.5 out,
+      // then the fast tier doubles the whole thing.
+      const cliffed = (300_000 * 5 + 2_000 * 22.5) / 1_000_000
+      expect(await costOf('gpt-5.4', { input: 300_000, output: 2_000 }, 'platform')).toBeCloseTo(
+        cliffed,
+        9,
+      )
+      expect(
+        await costOf('gpt-5.4', { input: 300_000, output: 2_000, speed: 'fast' }, 'platform'),
+      ).toBeCloseTo(cliffed * 2, 9)
+    })
+
+    it('bills gpt-5.5 fast at 2.5x and Opus 4.8 / Grok fast at 2x', async () => {
+      const gpt55Base = (100_000 * 5 + 1_000 * 30) / 1_000_000
+      expect(await costOf('gpt-5.5', { speed: 'fast' }, 'platform')).toBeCloseTo(
+        gpt55Base * 2.5,
+        9,
+      )
+      const opusBase = (100_000 * 5 + 1_000 * 25) / 1_000_000
+      expect(await costOf('claude-opus-4-8', { speed: 'fast' }, 'platform')).toBeCloseTo(
+        opusBase * 2,
+        9,
+      )
+      // Anthropic serves fast mode natively, so its catalog carries the multiplier too.
+      expect(await costOf('claude-opus-4-8', { speed: 'fast' }, 'anthropic')).toBeCloseTo(
+        opusBase * 2,
+        9,
+      )
+      const grokBase = (100_000 * 2 + 1_000 * 6) / 1_000_000
+      expect(await costOf('grok-4.5', { speed: 'fast' }, 'platform')).toBeCloseTo(grokBase * 2, 9)
+    })
+
+    it('prefers the local computation over tier-blind costUSD when a multiplier applies', async () => {
+      expect(await costOf('gpt-5.4', { speed: 'fast', costUSD: 9.99 }, 'platform')).toBeCloseTo(
+        GPT54_BASE * 2,
+        9,
+      )
+    })
+
+    it('keeps costUSD precedence when speed is absent or the model has no multipliers', async () => {
+      expect(await costOf('gpt-5.4', { costUSD: 9.99 }, 'platform')).toBeCloseTo(9.99, 9)
+      // claude-sonnet-5 has no speedMultipliers → costUSD still wins even with speed set.
+      expect(
+        await costOf('claude-sonnet-5', { speed: 'fast', costUSD: 9.99 }, 'platform'),
+      ).toBeCloseTo(9.99, 9)
+    })
+
+    it('bills a model with no speedMultipliers at 1x even for fast rows', async () => {
+      // claude-sonnet-5: $3/Mtok input, $15/Mtok output, no fast tier.
+      const sonnetBase = (100_000 * 3 + 1_000 * 15) / 1_000_000
+      expect(await costOf('claude-sonnet-5', { speed: 'fast' }, 'platform')).toBeCloseTo(
+        sonnetBase,
+        9,
+      )
+    })
+  })
+
   describe('loadDailyUsageData — provider catalog pricing (per-line)', () => {
     it('prices a custom catalog model via the once-built map, and 0 without a provider', async () => {
       settingsMock.mockReturnValue({

--- a/src/shared/lib/services/usage-service.ts
+++ b/src/shared/lib/services/usage-service.ts
@@ -32,6 +32,10 @@ interface UsageEntry {
       output_tokens?: number
       cache_creation_input_tokens?: number
       cache_read_input_tokens?: number
+      // Served speed tier echoed into the transcript ('slow'/'fast'; natively
+      // by Anthropic fast mode, by the platform proxy for translated OpenAI/xAI
+      // usage). Absent ⇒ standard tier.
+      speed?: string
     }
   }
   requestId?: string
@@ -67,10 +71,19 @@ interface RateCard {
   cacheRead: number
 }
 
+interface SpeedMultipliers {
+  slow?: number
+  fast?: number
+}
+
 interface PricingEntry extends RateCard {
   // OpenAI GPT-5.x 272K cliff: above `thresholdTokens` of prompt input the whole
   // request reprices at these rates. Mirror of the proxy's pricing table.
   longContext?: RateCard & { thresholdTokens: number }
+  // Served-tier billing multipliers (flex/priority/fast mode). Applied on top
+  // of whichever rate set (base or longContext) a request lands on; an absent
+  // tier bills standard (1x). Mirror of the proxy's pricing table.
+  speedMultipliers?: SpeedMultipliers
 }
 
 function deriveInputRelatedRate(
@@ -95,6 +108,12 @@ function rateCardFromCatalogModel(
   const cacheCreation = deriveInputRelatedRate(input, staticPricing, 'cacheCreation')
   const cacheRead = deriveInputRelatedRate(input, staticPricing, 'cacheRead')
   const pricing: PricingEntry = { input, output, cacheCreation, cacheRead }
+
+  // Catalog-declared multipliers win; fall back to the static table's (same
+  // pattern as the cache rates above) so a pricing patch that only overrides
+  // the per-Mtok rates keeps billing speed tiers correctly.
+  const speedMultipliers = model.pricing.speedMultipliers ?? staticPricing?.speedMultipliers
+  if (speedMultipliers) pricing.speedMultipliers = speedMultipliers
 
   if (model.longContextPriceCliff) {
     pricing.longContext = {
@@ -148,6 +167,7 @@ function costFromRateCard(
   outputTokens: number,
   cacheCreationTokens: number,
   cacheReadTokens: number,
+  speed?: keyof SpeedMultipliers,
 ): number {
   if (!pricing) return 0
 
@@ -158,11 +178,17 @@ function costFromRateCard(
       ? pricing.longContext
       : pricing
 
+  // Served-tier multiplier scales all four rates ON TOP of the base-vs-cliff
+  // selection above — same composition as the platform's computeCost. A tier
+  // with no configured multiplier bills standard (1x).
+  const multiplier = (speed !== undefined ? pricing.speedMultipliers?.[speed] : undefined) ?? 1
+
   return (
-    (inputTokens * rates.input +
-      outputTokens * rates.output +
-      cacheCreationTokens * rates.cacheCreation +
-      cacheReadTokens * rates.cacheRead) /
+    (multiplier *
+      (inputTokens * rates.input +
+        outputTokens * rates.output +
+        cacheCreationTokens * rates.cacheCreation +
+        cacheReadTokens * rates.cacheRead)) /
     1_000_000
   )
 }
@@ -364,14 +390,23 @@ export async function loadDailyUsageData(options: LoadOptions): Promise<DailyUsa
     const outputTokens = usage.output_tokens || 0
     const cacheCreationTokens = usage.cache_creation_input_tokens || 0
     const cacheReadTokens = usage.cache_read_input_tokens || 0
-    const cost = entry.costUSD ??
-      costFromRateCard(
-        resolveRateCard(model, catalogPricing),
-        inputTokens,
-        outputTokens,
-        cacheCreationTokens,
-        cacheReadTokens,
-      )
+
+    // Only the exact tier strings select a multiplier; anything else (absent,
+    // unknown future tiers) bills standard.
+    const speed = usage.speed === 'slow' || usage.speed === 'fast' ? usage.speed : undefined
+    const rateCard = resolveRateCard(model, catalogPricing)
+    const speedMultiplier = speed !== undefined ? rateCard?.speedMultipliers?.[speed] : undefined
+    const computedCost = costFromRateCard(
+      rateCard,
+      inputTokens,
+      outputTokens,
+      cacheCreationTokens,
+      cacheReadTokens,
+      speed,
+    )
+    // entry.costUSD is the CLI's own estimate and is tier-blind, so a row
+    // served on a tier we can price locally must not use it.
+    const cost = speedMultiplier !== undefined ? computedCost : (entry.costUSD ?? computedCost)
 
     const countedUsage: CountedUsage = {
       date,

--- a/src/shared/lib/services/webhook-endpoint-schema.ts
+++ b/src/shared/lib/services/webhook-endpoint-schema.ts
@@ -62,7 +62,7 @@ export const filterExpressionSchema = z.string().trim().min(1).max(2048)
 /**
  * Container tool inputs, validated host-side before anything is minted or
  * stored (the container is not a trusted boundary). Unknown keys are dropped;
- * model/effort reuse the shared runtime-options shape.
+ * model/effort/speed reuse the shared runtime-options shape.
  */
 export const createWebhookEndpointInputSchema = z.object({
   name: z.string().trim().min(1),
@@ -71,6 +71,7 @@ export const createWebhookEndpointInputSchema = z.object({
   filter_exp: filterExpressionSchema.nullish(),
   model: RuntimeOptionsSchema.shape.model,
   effort: RuntimeOptionsSchema.shape.effort,
+  speed: RuntimeOptionsSchema.shape.speed,
 })
 
 export const updateWebhookEndpointInputSchema = z.object({

--- a/src/shared/lib/services/webhook-trigger-service.ts
+++ b/src/shared/lib/services/webhook-trigger-service.ts
@@ -150,6 +150,7 @@ export interface CreateWebhookTriggerParams {
   createdByUserId?: string
   model?: string
   effort?: string
+  speed?: string
 }
 
 // ============================================================================
@@ -175,6 +176,7 @@ export async function createWebhookTrigger(params: CreateWebhookTriggerParams): 
     createdByUserId: params.createdByUserId ?? null,
     model: params.model ?? null,
     effort: params.effort ?? null,
+    speed: params.speed ?? null,
     createdAt: new Date(),
   }
 
@@ -574,12 +576,12 @@ export async function updateWebhookTriggerName(
 }
 
 /**
- * Update a webhook trigger's runtime options (model and/or effort).
+ * Update a webhook trigger's runtime options (model, effort, and/or speed).
  * Pass null to clear a field back to the global default.
  */
 export async function updateWebhookTriggerRuntimeOptions(
   triggerId: string,
-  options: { model?: string | null; effort?: string | null },
+  options: { model?: string | null; effort?: string | null; speed?: string | null },
 ): Promise<boolean> {
   const trigger = await getWebhookTrigger(triggerId)
   if (!trigger || trigger.status === 'cancelled') return false
@@ -587,6 +589,7 @@ export async function updateWebhookTriggerRuntimeOptions(
   const updates: Record<string, string | null> = {}
   if ('model' in options) updates.model = options.model ?? null
   if ('effort' in options) updates.effort = options.effort ?? null
+  if ('speed' in options) updates.speed = options.speed ?? null
 
   const result = await db
     .update(webhookTriggers)

--- a/src/shared/lib/types/agent-preferences.ts
+++ b/src/shared/lib/types/agent-preferences.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { EFFORT_LEVELS } from '@shared/lib/container/types'
+import { EFFORT_LEVELS, SPEED_LEVELS } from '@shared/lib/container/types'
 
 // Keep in sync with agent-container/src/file-hooks/agent-preferences-hook.ts
 export const agentPreferencesSchema = z.object({
@@ -8,6 +8,8 @@ export const agentPreferencesSchema = z.object({
   defaultModel: z.string().trim().min(1).optional(),
   /** Default effort for new sessions. Overrides the global default; per-session/trigger picks still win. */
   defaultEffort: z.enum(EFFORT_LEVELS).optional(),
+  /** Default processing speed for new sessions. Overrides the global default; per-session/trigger picks still win. */
+  defaultSpeed: z.enum(SPEED_LEVELS).optional(),
 })
 
 export type AgentPreferences = z.infer<typeof agentPreferencesSchema>
@@ -20,6 +22,7 @@ export const agentPreferencesUpdateSchema = z.object({
   autoDeleteInactiveDays: z.number().int().positive().nullish(),
   defaultModel: z.string().trim().min(1).nullish(),
   defaultEffort: z.enum(EFFORT_LEVELS).nullish(),
+  defaultSpeed: z.enum(SPEED_LEVELS).nullish(),
 })
 
 export type AgentPreferencesUpdate = z.infer<typeof agentPreferencesUpdateSchema>

--- a/src/shared/lib/types/agent.ts
+++ b/src/shared/lib/types/agent.ts
@@ -4,7 +4,7 @@
  * Type definitions for file-based agent storage
  */
 
-import type { EffortLevel, SlashCommandInfo } from '../container/types'
+import type { EffortLevel, SlashCommandInfo, SpeedLevel } from '../container/types'
 
 // ============================================================================
 // Agent Roles
@@ -109,6 +109,8 @@ export interface SessionMetadata {
   slashCommands?: SlashCommandInfo[]
   // Last effort level used by the user on this session (seeds the composer on reload)
   effort?: EffortLevel
+  // Last processing speed used by the user on this session (seeds the composer on reload)
+  speed?: SpeedLevel
   // Last model used by the user on this session (seeds the composer on reload).
   // Stored as the provider's pinned ID, not the family.
   model?: string

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -327,6 +327,7 @@ export interface ApiScheduledTask {
   timezone: string | null
   model: string | null
   effort: string | null
+  speed: string | null
   createdAt: Date
   cancelledAt: Date | null
   pausedAt: Date | null

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -5,7 +5,7 @@
  * These types represent the "flattened" format returned by API routes.
  */
 
-import type { EffortLevel, HealthCheckResult } from '@shared/lib/container/types'
+import type { EffortLevel, HealthCheckResult , SpeedLevel } from '@shared/lib/container/types'
 import type { SessionUsage } from '@shared/lib/types/agent'
 
 // ============================================================================
@@ -103,6 +103,8 @@ export interface ApiSession {
   webhookTriggerName?: string
   // Last effort level used on this session (seeds the composer selector)
   effort?: EffortLevel
+  // Last processing speed used on this session (seeds the composer selector)
+  speed?: SpeedLevel
   // Last model used on this session (seeds the composer selector)
   model?: string
   // Present when the session has a pending scheduled wake (long sleep):


### PR DESCRIPTION
## Summary

Adds model processing-speed modes (slow / normal / fast), mirroring the effort-level plumbing end-to-end. Includes West's composer speed-selector UI (#476, cherry-picked) rewired from vendor inference to catalog-declared support.

- **Catalog**: `supportedSpeeds` per model (platform catalog: Opus 4.8 / GPT / Grok tiers); the direct-Anthropic builtin catalog deliberately declares none — without the platform proxy there is nothing to map the header
- **Selection**: speed rides RuntimeOptions, session metadata, and per-agent prefs (`defaultSpeed`); resolution = explicit pick > agent default > global default; `useSpeedClamp` snaps unsupported picks to normal on model switch
- **Container**: composes `X-Superagent-Speed: fast|slow` into `ANTHROPIC_CUSTOM_HEADERS` per query (`normal` = no header). Only the agent query is speed-aware — summarizer/title/aux calls can't inherit it. The value is Zod-validated (`z.enum`) at all three container ingress points (createSession, sendMessage route, WS handler) since it's interpolated into a newline-joined header string
- **Mid-session change** = interrupt + re-query, same as effort; speed survives container resume and session carryover
- The platform proxy maps the header to vendor tiers and bills by served tier (SkillfulAgents/platform#191)

## Validation

- Typecheck clean (app + agent-container); container 59 + renderer 88 unit tests pass, incl. header-composition, boundary-rejection (newline/off-enum speed values), resolution-chain, and Custom-badge tests
- New E2E spec `speed-selection.spec.ts` (4 passing): fast pick reaches createSession, untouched selector sends nothing, mid-session flip reaches the next sendMessage, section hidden for models without supportedSpeeds (E2E exposes speeds via a user-level catalog override in the seed — the builtin catalog stays speed-free)
- Live-validated against the platform proxy branch: agent turn on Opus 4.8 fast billed exactly 2x incl. cache writes, mid-session fast→normal re-query billed 1x with no header, summarizer sent no header