### PR TITLE
feat: record what changed in settings audit events

### DIFF
--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -134,6 +134,11 @@ vi.mock('@shared/lib/db', () => ({
   db: { delete: () => ({ run: vi.fn() }) },
 }))
 
+const mockLogAuditEvent = vi.hoisted(() => vi.fn())
+vi.mock('@shared/lib/services/audit-log-service', () => ({
+  logAuditEvent: mockLogAuditEvent,
+}))
+
 vi.mock('@shared/lib/db/schema', () => ({
   proxyAuditLog: {},
   proxyTokens: {},
@@ -518,6 +523,37 @@ describe('settings route', () => {
       const saved = mockUpdateSettings.mock.calls[0][0]
       // apiKeys preserved as-is from current settings
       expect(saved.apiKeys).toEqual({ anthropicApiKey: 'sk-existing' })
+    })
+  })
+
+  // =========================================================================
+  // Audit details
+  // =========================================================================
+  describe('audit details', () => {
+    it('logs which fields changed, with API key values redacted', async () => {
+      const res = await putSettings({
+        llmProvider: 'openrouter',
+        apiKeys: { anthropicApiKey: 'sk-brand-new' },
+      })
+
+      expect(res.status).toBe(200)
+      expect(mockLogAuditEvent).toHaveBeenCalledTimes(1)
+      const call = mockLogAuditEvent.mock.calls[0][0]
+      expect(call.object).toBe('settings')
+      expect(call.action).toBe('updated')
+      expect(call.details.sections).toContain('LLM Provider')
+      expect(call.details.changes['llmProvider']).toEqual({ from: null, to: 'openrouter' })
+      expect(call.details.changes['apiKeys.anthropicApiKey']).toBe('updated')
+      expect(JSON.stringify(call.details)).not.toContain('sk-brand-new')
+      expect(JSON.stringify(call.details)).not.toContain('sk-existing')
+    })
+
+    it('omits details when the update is a no-op', async () => {
+      const res = await putSettings({ app: { showMenuBarIcon: true } })
+
+      expect(res.status).toBe(200)
+      expect(mockLogAuditEvent).toHaveBeenCalledTimes(1)
+      expect(mockLogAuditEvent.mock.calls[0][0].details).toBeUndefined()
     })
   })
 

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -11,6 +11,7 @@ import { Authenticated, IsAdmin } from '../middleware/auth'
 import { isAuthMode } from '@shared/lib/auth/mode'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
+import { buildSettingsAuditDetails } from '@shared/lib/services/settings-audit'
 import {
   getSettings,
   loadSettingsStrict,
@@ -626,7 +627,13 @@ settings.put('/', async (c) => {
     }
 
     const runnerAvailability = await checkAllRunnersAvailability()
-    logAuditEvent({ userId: getCurrentUserId(c), object: 'settings', objectId: 'global', action: 'updated' })
+    logAuditEvent({
+      userId: getCurrentUserId(c),
+      object: 'settings',
+      objectId: 'global',
+      action: 'updated',
+      details: buildSettingsAuditDetails(currentSettings, newSettings),
+    })
     return c.json(buildSettingsResponse(newSettings, hasRunningAgents, runnerAvailability))
   } catch (error) {
     console.error('Failed to update settings:', error)

--- a/src/renderer/components/settings/audit-log-tab.tsx
+++ b/src/renderer/components/settings/audit-log-tab.tsx
@@ -35,13 +35,22 @@ function formatTimestamp(date: Date | string | number): string {
   })
 }
 
+function formatDetailValue(value: unknown): string {
+  if (Array.isArray(value)) return value.join(', ')
+  if (typeof value === 'object' && value !== null) {
+    const obj = value as Record<string, unknown>
+    if ('from' in obj && 'to' in obj) return `${obj.from ?? '(unset)'} → ${obj.to ?? '(unset)'}`
+    return Object.entries(obj)
+      .map(([k, v]) => `${k}: ${formatDetailValue(v)}`)
+      .join(', ')
+  }
+  return String(value)
+}
+
 function formatDetails(details: string | null): string {
   if (!details) return ''
   try {
-    const parsed = JSON.parse(details)
-    return Object.entries(parsed)
-      .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(', ') : typeof v === 'object' && v !== null ? JSON.stringify(v) : v}`)
-      .join(', ')
+    return formatDetailValue(JSON.parse(details))
   } catch {
     return details
   }
@@ -188,7 +197,7 @@ export function AuditLogTab() {
                 <TableCell className="text-xs text-muted-foreground truncate max-w-[180px] font-mono">
                   {entry.objectId}
                 </TableCell>
-                <TableCell className="text-xs text-muted-foreground truncate max-w-[240px]">
+                <TableCell className="text-xs text-muted-foreground truncate max-w-[240px]" title={formatDetails(entry.details)}>
                   {formatDetails(entry.details)}
                 </TableCell>
               </TableRow>

--- a/src/shared/lib/services/settings-audit-schema.ts
+++ b/src/shared/lib/services/settings-audit-schema.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod'
+
+/**
+ * A single changed setting in an audit `details` payload: either a from/to
+ * pair for loggable values, or a bare status for redacted fields (secrets)
+ * where only the fact of the change may be recorded.
+ */
+export const settingsAuditChangeSchema = z.union([
+  z.object({
+    from: z.union([z.string(), z.number(), z.boolean(), z.null()]),
+    to: z.union([z.string(), z.number(), z.boolean(), z.null()]),
+  }),
+  z.enum(['set', 'updated', 'removed']),
+])
+
+export const settingsAuditDetailsSchema = z.object({
+  /** Settings-UI tab labels the changed fields belong to. */
+  sections: z.array(z.string()),
+  /** Dotted settings paths → what changed. */
+  changes: z.record(z.string(), settingsAuditChangeSchema),
+})
+
+export type SettingsAuditChange = z.infer<typeof settingsAuditChangeSchema>
+export type SettingsAuditDetails = z.infer<typeof settingsAuditDetailsSchema>

--- a/src/shared/lib/services/settings-audit.test.ts
+++ b/src/shared/lib/services/settings-audit.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import type { AppSettings } from '@shared/lib/config/settings'
+import { buildSettingsAuditDetails } from './settings-audit'
+
+const baseSettings = (): AppSettings => ({
+  container: {
+    containerRunner: 'lima',
+    agentImage: 'superagent:latest',
+    resourceLimits: { memoryMb: 2048, cpus: 2 },
+  },
+  llmProvider: 'anthropic',
+  models: { summarizerModel: 'haiku', agentModel: 'opus', browserModel: 'sonnet', dashboardBuilderModel: 'sonnet' },
+  app: { showMenuBarIcon: true, theme: 'system' },
+} as unknown as AppSettings)
+
+describe('buildSettingsAuditDetails', () => {
+  it('returns undefined when nothing changed', () => {
+    expect(buildSettingsAuditDetails(baseSettings(), baseSettings())).toBeUndefined()
+  })
+
+  it('records from/to for plain value changes with the owning section', () => {
+    const updated = baseSettings()
+    updated.llmProvider = 'openrouter' as AppSettings['llmProvider']
+    updated.container.containerRunner = 'docker'
+
+    const details = buildSettingsAuditDetails(baseSettings(), updated)
+
+    expect(details?.sections).toEqual(['LLM Provider', 'Runtime'])
+    expect(details?.changes['llmProvider']).toEqual({ from: 'anthropic', to: 'openrouter' })
+    expect(details?.changes['container.containerRunner']).toEqual({ from: 'lima', to: 'docker' })
+  })
+
+  it('never logs API key values — only set/updated/removed', () => {
+    const current = baseSettings()
+    current.apiKeys = { anthropicApiKey: 'sk-ant-old-secret', openrouterApiKey: 'sk-or-secret' }
+    const updated = baseSettings()
+    updated.apiKeys = { anthropicApiKey: 'sk-ant-new-secret', exaApiKey: 'exa-secret' }
+
+    const details = buildSettingsAuditDetails(current, updated)
+
+    expect(details?.changes['apiKeys.anthropicApiKey']).toBe('updated')
+    expect(details?.changes['apiKeys.openrouterApiKey']).toBe('removed')
+    expect(details?.changes['apiKeys.exaApiKey']).toBe('set')
+    expect(JSON.stringify(details)).not.toContain('secret')
+    expect(details?.sections).toEqual(['LLM Provider', 'Web'])
+  })
+
+  it('redacts custom env var values but keeps their names', () => {
+    const current = baseSettings()
+    current.customEnvVars = { MY_TOKEN: 'hunter2' }
+    const updated = baseSettings()
+    updated.customEnvVars = { MY_TOKEN: 'hunter3', EXTRA_VAR: 'v' }
+
+    const details = buildSettingsAuditDetails(current, updated)
+
+    expect(details?.changes['customEnvVars.MY_TOKEN']).toBe('updated')
+    expect(details?.changes['customEnvVars.EXTRA_VAR']).toBe('set')
+    expect(JSON.stringify(details)).not.toContain('hunter')
+    expect(details?.sections).toEqual(['Runtime'])
+  })
+
+  it('redacts the favicon blob and ignores its server-stamped timestamp', () => {
+    const current = baseSettings()
+    const updated = baseSettings()
+    updated.app = {
+      ...updated.app,
+      faviconDataUrl: 'data:image/png;base64,AAAA',
+      faviconUpdatedAt: '2026-07-15T00:00:00.000Z',
+    }
+
+    const details = buildSettingsAuditDetails(current, updated)
+
+    expect(details?.changes['app.faviconDataUrl']).toBe('set')
+    expect(details?.changes['app.faviconUpdatedAt']).toBeUndefined()
+    expect(JSON.stringify(details)).not.toContain('base64')
+  })
+
+  it('logs arrays as truncated JSON and maps nested paths to their tabs', () => {
+    const current = baseSettings()
+    current.webAllowedSites = ['a.com']
+    current.auth = { signupMode: 'closed' }
+    const updated = baseSettings()
+    updated.webAllowedSites = ['a.com', 'b.com']
+    updated.auth = { signupMode: 'open' }
+    updated.app = { ...updated.app, notifications: { enabled: false } as never }
+
+    const details = buildSettingsAuditDetails(current, updated)
+
+    expect(details?.changes['webAllowedSites']).toEqual({ from: '["a.com"]', to: '["a.com","b.com"]' })
+    expect(details?.changes['auth.signupMode']).toEqual({ from: 'closed', to: 'open' })
+    expect(details?.sections).toEqual(['Auth', 'Notifications', 'Web'])
+  })
+
+  it('caps oversized values instead of writing them whole', () => {
+    const current = baseSettings()
+    const updated = baseSettings()
+    updated.webBlockedSites = Array.from({ length: 100 }, (_, i) => `blocked-site-${i}.example.com`)
+
+    const details = buildSettingsAuditDetails(current, updated)
+    const change = details?.changes['webBlockedSites'] as { from: unknown; to: string }
+
+    expect(change.from).toBeNull()
+    expect(change.to.length).toBeLessThanOrEqual(201)
+    expect(change.to.endsWith('…')).toBe(true)
+  })
+
+  it('ignores keys the PUT handler cannot change', () => {
+    const current = baseSettings()
+    const updated = baseSettings()
+    updated.skillsets = [{ id: 'x' }] as never
+    updated.platformAuth = { token: 't' } as never
+
+    expect(buildSettingsAuditDetails(current, updated)).toBeUndefined()
+  })
+})

--- a/src/shared/lib/services/settings-audit.ts
+++ b/src/shared/lib/services/settings-audit.ts
@@ -1,0 +1,165 @@
+import type { AppSettings } from '@shared/lib/config/settings'
+import {
+  settingsAuditDetailsSchema,
+  type SettingsAuditChange,
+  type SettingsAuditDetails,
+} from './settings-audit-schema'
+
+/**
+ * Top-level AppSettings keys that PUT /api/settings can change. Keys the
+ * handler carries over verbatim (skillsets, platformAuth, …) are excluded so
+ * internal bookkeeping never surfaces as a user-made change.
+ */
+const AUDITED_KEYS: (keyof AppSettings)[] = [
+  'container',
+  'apiKeys',
+  'llmProvider',
+  'webProvider',
+  'webAllowedSites',
+  'webBlockedSites',
+  'app',
+  'models',
+  'modelCatalog',
+  'agentLimits',
+  'customEnvVars',
+  'auth',
+  'voice',
+  'computerUse',
+  'shareAnalytics',
+  'analyticsTargets',
+  'shareErrorReports',
+  'enableToolSearch',
+  'agentCapabilities',
+]
+
+/**
+ * Paths whose values must NEVER reach the audit log — API keys and custom env
+ * vars are secrets, the favicon data URL is a multi-KB blob. Only the fact of
+ * the change (set/updated/removed) is recorded for these.
+ */
+const REDACTED_PREFIXES = ['apiKeys.', 'customEnvVars.', 'app.faviconDataUrl']
+
+/** Server-stamped alongside faviconDataUrl — noise next to the change that caused it. */
+const IGNORED_PATHS = new Set(['app.faviconUpdatedAt'])
+
+/**
+ * Maps a changed path to the settings-UI tab it is edited on, so the audit log
+ * can say "LLM Provider" instead of making the reader decode dotted paths.
+ * First matching prefix wins — keep specific rules above their catch-alls.
+ */
+const SECTION_RULES: Array<[prefix: string, label: string]> = [
+  ['apiKeys.composio', 'Account Provider'],
+  ['apiKeys.nangoSecretKey', 'Account Provider'],
+  ['apiKeys.accountProviderUserId', 'Account Provider'],
+  ['apiKeys.browserbase', 'Browser Use'],
+  ['apiKeys.deepgramApiKey', 'Voice'],
+  ['apiKeys.openaiApiKey', 'Voice'],
+  ['apiKeys.exaApiKey', 'Web'],
+  ['apiKeys.', 'LLM Provider'],
+  ['llmProvider', 'LLM Provider'],
+  ['models', 'LLM Provider'],
+  ['modelCatalog', 'LLM Provider'],
+  ['enableToolSearch', 'LLM Provider'],
+  ['webProvider', 'Web'],
+  ['webAllowedSites', 'Web'],
+  ['webBlockedSites', 'Web'],
+  ['container', 'Runtime'],
+  ['customEnvVars', 'Runtime'],
+  ['agentLimits', 'Runtime'],
+  ['auth', 'Auth'],
+  ['voice', 'Voice'],
+  ['computerUse', 'Computer Use'],
+  ['agentCapabilities', 'Agent Capabilities'],
+  ['shareAnalytics', 'Analytics'],
+  ['shareErrorReports', 'Analytics'],
+  ['analyticsTargets', 'Analytics'],
+  ['app.notifications', 'Notifications'],
+  ['app.accountProvider', 'Account Provider'],
+  ['app.hostBrowserProvider', 'Browser Use'],
+  ['app.chrome', 'Browser Use'],
+  ['app.maxBrowserTabs', 'Browser Use'],
+  ['app.browserbase', 'Browser Use'],
+  ['app.', 'General'],
+]
+
+/** Cap logged values so a large list/catalog can't bloat an audit row. */
+const MAX_VALUE_LENGTH = 200
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** Flattens nested objects to dotted-path leaves; arrays are leaves. */
+function flattenLeaves(value: unknown, prefix: string, out: Map<string, unknown>): void {
+  if (isPlainObject(value)) {
+    for (const [key, child] of Object.entries(value)) {
+      if (child === undefined) continue
+      flattenLeaves(child, `${prefix}.${key}`, out)
+    }
+  } else if (value !== undefined) {
+    out.set(prefix, value)
+  }
+}
+
+function leavesEqual(a: unknown, b: unknown): boolean {
+  if (Array.isArray(a) || Array.isArray(b)) return JSON.stringify(a) === JSON.stringify(b)
+  return Object.is(a, b)
+}
+
+function truncate(text: string): string {
+  return text.length > MAX_VALUE_LENGTH ? `${text.slice(0, MAX_VALUE_LENGTH)}…` : text
+}
+
+function formatValue(value: unknown): string | number | boolean | null {
+  if (value === null || typeof value === 'number' || typeof value === 'boolean') return value
+  if (typeof value === 'string') return truncate(value)
+  return truncate(JSON.stringify(value) ?? String(value))
+}
+
+function isRedacted(path: string): boolean {
+  return REDACTED_PREFIXES.some((prefix) => path.startsWith(prefix))
+}
+
+function sectionFor(path: string): string {
+  const rule = SECTION_RULES.find(([prefix]) => path.startsWith(prefix))
+  return rule ? rule[1] : 'Other'
+}
+
+/**
+ * Diffs two settings snapshots into an audit `details` payload: which
+ * settings-UI sections were touched and, per dotted path, what changed.
+ * Secret values are reduced to set/updated/removed. Returns undefined when
+ * nothing changed.
+ */
+export function buildSettingsAuditDetails(
+  current: AppSettings,
+  updated: AppSettings,
+): SettingsAuditDetails | undefined {
+  const before = new Map<string, unknown>()
+  const after = new Map<string, unknown>()
+  for (const key of AUDITED_KEYS) {
+    flattenLeaves(current[key], key, before)
+    flattenLeaves(updated[key], key, after)
+  }
+
+  const changes: Record<string, SettingsAuditChange> = {}
+  const sections = new Set<string>()
+
+  for (const path of new Set([...before.keys(), ...after.keys()])) {
+    if (IGNORED_PATHS.has(path)) continue
+    const inBefore = before.has(path)
+    const inAfter = after.has(path)
+    if (inBefore && inAfter && leavesEqual(before.get(path), after.get(path))) continue
+
+    changes[path] = isRedacted(path)
+      ? !inBefore ? 'set' : !inAfter ? 'removed' : 'updated'
+      : {
+          from: inBefore ? formatValue(before.get(path)) : null,
+          to: inAfter ? formatValue(after.get(path)) : null,
+        }
+    sections.add(sectionFor(path))
+  }
+
+  if (Object.keys(changes).length === 0) return undefined
+  return settingsAuditDetailsSchema.parse({ sections: [...sections].sort(), changes })
+}


### PR DESCRIPTION
## Summary

The `settings / global / updated` audit event previously carried no detail — every settings change produced an identical, indistinguishable row. This PR attaches a `details` diff so the audit log says **which tab was touched and what changed**, while guaranteeing secret values never reach the log.

Example payload:

```json
{
  "sections": ["LLM Provider"],
  "changes": {
    "llmProvider": { "from": "anthropic", "to": "openrouter" },
    "models.agentModel": { "from": "opus", "to": "..." },
    "apiKeys.anthropicApiKey": "updated"
  }
}
```

## How it works

- `buildSettingsAuditDetails(current, updated)` (new `src/shared/lib/services/settings-audit.ts`) flattens both `AppSettings` snapshots to dotted-path leaves and diffs them. Output is validated with a Zod schema (`settings-audit-schema.ts`) before storage.
- `sections` maps changed paths to the settings-UI tab labels via a prefix table (`SECTION_RULES`), so a reader sees "LLM Provider" / "Runtime" / "Auth" instead of decoding paths.
- **Redaction is prefix-based and fail-safe:** every `apiKeys.*` and `customEnvVars.*` value is reduced to `set` / `updated` / `removed` — values never enter the payload, and new key fields added later are redacted by default. The favicon data-URL blob is likewise redacted and its server-stamped timestamp ignored.
- Logged values are capped at 200 chars so large lists/catalogs can't bloat an audit row.
- No-op PUTs still log the event, just without details (unchanged behavior).
- Audit log tab: details formatter renders `from → to` instead of raw JSON, and the truncated cell got a hover tooltip.

## Testing

- 8 new unit tests for the diff builder, including assertions that stringified details never contain a secret value
- 2 new route-level tests proving redaction through the real PUT handler
- All 130 tests in the touched test files pass; typecheck + lint clean