### PR TITLE
fix(microvm): forward host token on WS upgrade through LocalAuthForwardProxy

### DIFF
--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -601,7 +601,8 @@ describe('LocalAuthForwardProxy', () => {
     const client = net.connect(port, '127.0.0.1', () => {
       client.write(
         'GET /sessions/s1/stream HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n' +
-          'Sec-WebSocket-Key: thekey\r\nSec-WebSocket-Version: 13\r\n\r\n',
+          'Sec-WebSocket-Key: thekey\r\nSec-WebSocket-Version: 13\r\n' +
+          'x-superagent-host-token: hostc_secret\r\n\r\n',
       )
     })
     await ready
@@ -611,6 +612,8 @@ describe('LocalAuthForwardProxy', () => {
     expect(written.toLowerCase()).toContain('sec-websocket-key: thekey')
     expect(written.toLowerCase()).toContain('x-aws-proxy-auth: tokws')
     expect(written.toLowerCase()).toContain('x-aws-proxy-port: 3000')
+    // Host→agent auth must survive the upgrade pipe (HTTP path already forwards it).
+    expect(written.toLowerCase()).toContain('x-superagent-host-token: hostc_secret')
   })
 
   it('sets an idle timeout on the upstream request to guard against a silent hang', async () => {

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -390,12 +390,22 @@ export class LocalAuthForwardProxy {
     }
     const upstream = tls.connect({ host: this.options.endpoint, port: 443, servername: this.options.endpoint }, () => {
       clearConnectTimer()
+      // Keep WS handshake headers (HOP_BY_HOP would drop upgrade/connection) and
+      // forward the same application headers HTTP uses — especially
+      // x-superagent-host-token. Stripping it makes the agent return 401 on
+      // upgrade while createSession (HTTP) still succeeds.
       const headerLines = [`GET ${req.url} HTTP/1.1`, `Host: ${this.options.endpoint}`]
       for (const [key, value] of Object.entries(req.headers)) {
         const lower = key.toLowerCase()
-        if (lower.startsWith('sec-websocket') || lower === 'upgrade' || lower === 'connection' || lower === 'origin') {
-          headerLines.push(`${key}: ${Array.isArray(value) ? value.join(', ') : value}`)
-        }
+        if (value === undefined) continue
+        const keep =
+          lower.startsWith('sec-websocket') ||
+          lower === 'upgrade' ||
+          lower === 'connection' ||
+          lower === 'origin' ||
+          !HOP_BY_HOP.has(lower)
+        if (!keep) continue
+        headerLines.push(`${key}: ${Array.isArray(value) ? value.join(', ') : value}`)
       }
       for (const [key, value] of Object.entries(auth)) headerLines.push(`${key}: ${value}`)
       upstream.write(headerLines.join('\r\n') + '\r\n\r\n')


### PR DESCRIPTION
## Summary
- After #467, the agent rejects WebSocket upgrades without `x-superagent-host-token` (returns **401**).
- `LocalAuthForwardProxy.handleRequest` (HTTP) already forwarded that header, so `createSession` succeeded; `handleUpgrade` dropped it, so subscribe failed with `Unexpected server response: 401` while the session already existed (Jeremy org / MicroVM).
- Forward the same non-hop-by-hop application headers on WS upgrade that HTTP already sends (includes host token).

## Repro (pre-fix)
1. MicroVM runtime + host-app ≥ `0.4.12` (host auth from #467).
2. Create a session → HTTP 201, agent turn may run.
3. Host `subscribeToStream` → WS 401; UI shows Failed to create session / Working… forever; re-subscribe storm.

## What changed
- `lambda-microvm-runtime.ts` `handleUpgrade`: keep WS handshake headers **and** forwardable app headers (not only `sec-websocket*` / `upgrade` / `connection` / `origin`).
- Unit test asserts `x-superagent-host-token` is written on the upstream upgrade.

## Prod smoke (Jeremy org)
- Built `gamut-host-app:ws-host-token-fix-auth` + SOCI `…-auth-soci`, registered task def **:4**, force-deployed `gamut-host-app-org-0dfd48ab-…`.
- Task **HEALTHY** on the new image.
- Post-deploy CloudWatch: `WebSocket connected for session …` (no new 401 storm in that window).

## Test plan
- [x] `npm test -- --run src/shared/lib/container/lambda-microvm-runtime.test.ts`
- [x] ECR SOCI image deployed to Jeremy org; WS connect logs observed
- [ ] Merge → release/ingest so all MicroVM orgs get the fix (this PR alone does not roll every org)


Made with [Cursor](https://cursor.com)