### PR TITLE
Add secure key detection to message composer

### DIFF
--- a/e2e/specs/composer-secret-detection.spec.ts
+++ b/e2e/specs/composer-secret-detection.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+
+const E2E_DATA_DIR = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
+const RECORDER_FILE = path.join(E2E_DATA_DIR, '.e2e-mock-recorder.jsonl')
+
+interface MockRecord {
+  type: 'sendMessage' | 'createSession'
+  agentSlug: string
+  initialMessage?: string
+  availableEnvVars?: string[]
+}
+
+function readRecords(): MockRecord[] {
+  if (!fs.existsSync(RECORDER_FILE)) return []
+  const records: MockRecord[] = []
+  for (const line of fs.readFileSync(RECORDER_FILE, 'utf-8').trim().split('\n').filter(Boolean)) {
+    try {
+      records.push(JSON.parse(line) as MockRecord)
+    } catch {
+      // A concurrently-appended final line can be incomplete for a moment.
+    }
+  }
+  return records
+}
+
+async function waitForRecord(predicate: (record: MockRecord) => boolean, timeoutMs = 12_000) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    const record = readRecords().find(predicate)
+    if (record) return record
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  throw new Error(`Timed out waiting for mock record. Seen: ${JSON.stringify(readRecords().slice(-10), null, 2)}`)
+}
+
+test.describe('composer secret detection', () => {
+  let agentPage: AgentPage
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    const appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+    await agentPage.createAgent(`Composer Secret ${testInfo.workerIndex}-${Date.now()}`)
+  })
+
+  test('saves a detected key, masks the draft, and sends only the .env placeholder', async ({ page }, testInfo) => {
+    const tag = `W${testInfo.workerIndex}T${Date.now()}`
+    const rawKey = ['sk-', `proj-${tag}-Ab3dEf6hIj9kLm2nOp5qRs8tUv1wXy4z`].join('')
+    const keyName = `Deploy Key ${tag}`
+    const envVar = `DEPLOY_KEY_${tag.toUpperCase()}`
+    const input = page.locator('[data-testid="home-message-input"]')
+
+    await input.fill(`Use this credential:\n${rawKey}`)
+    await expect(page.locator('[data-testid="potential-secret"]')).toHaveText(rawKey)
+    await expect(page.getByText('Is this a Key?')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Send securely to the agent' }).click()
+    const dialog = page.getByRole('dialog', { name: 'Send key securely' })
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByLabel('Secret value')).toHaveValue(rawKey)
+    await dialog.getByLabel('Key name').fill(keyName)
+    await dialog.getByRole('button', { name: 'Save securely' }).click()
+
+    await expect(dialog).not.toBeVisible()
+    await expect(input).toHaveValue(`Use this credential:\n[${keyName} | *********]`)
+    await expect(page.locator('[data-testid="secured-secret"]')).toHaveText(`[${keyName} | *********]`)
+    await expect(page.getByText('Is this a Key?')).toHaveCount(0)
+
+    await page.locator('[data-testid="home-send-button"]').click()
+    await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15_000 })
+
+    const expectedMessage = `Use this credential:\n[Key saved to .env - ${envVar}]`
+    const record = await waitForRecord(
+      (candidate) => candidate.type === 'createSession' && candidate.initialMessage === expectedMessage
+    )
+    expect(record.initialMessage).not.toContain(rawKey)
+    expect(record.availableEnvVars ?? []).toContain(envVar)
+  })
+
+  test('draws a wrapped dotted highlight and dismisses it without editing the key', async ({ page }) => {
+    const rawKey = ['sk-', `proj-${'Ab3dEf6hIj9kLm2nOp5qRs8tUv1wXy4z'.repeat(4)}`].join('')
+    const input = page.locator('[data-testid="home-message-input"]')
+
+    await input.fill(rawKey)
+    const highlight = page.locator('[data-testid="potential-secret"]')
+    await expect(highlight).toBeVisible()
+    expect(await highlight.evaluate((element) => element.getClientRects().length)).toBeGreaterThan(1)
+    expect(await highlight.evaluate((element) => getComputedStyle(element).outlineStyle)).toBe('dotted')
+
+    await page.getByRole('button', { name: 'Dismiss key suggestion' }).click()
+    await expect(highlight).toHaveCount(0)
+    await expect(input).toHaveValue(rawKey)
+  })
+
+  test('removes a saved key pill atomically with Backspace', async ({ page }) => {
+    const rawKey = ['gh', 'p_Ab3dEf6hIj9kLm2nOp5qRs8tUv1wXy4z'].join('')
+    const input = page.locator('[data-testid="home-message-input"]')
+
+    await input.fill(`Before ${rawKey} after`)
+    await page.getByRole('button', { name: 'Send securely to the agent' }).click()
+    const dialog = page.getByRole('dialog', { name: 'Send key securely' })
+    await dialog.getByLabel('Key name').fill('GitHub Token')
+    await dialog.getByRole('button', { name: 'Save securely' }).click()
+
+    const pill = page.locator('[data-testid="secured-secret"]')
+    await expect(pill).toHaveText('[GitHub Token | *********]')
+    await expect(pill).toHaveClass(/outline-amber-500\/70/)
+    await input.press('End')
+    await input.press('ArrowLeft')
+    await input.press('ArrowLeft')
+    await input.press('ArrowLeft')
+    await input.press('ArrowLeft')
+    await input.press('ArrowLeft')
+    await input.press('ArrowLeft')
+    await input.press('Backspace')
+
+    await expect(input).toHaveValue('Before  after')
+    await expect(pill).toHaveCount(0)
+  })
+})

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -195,6 +195,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
     keepMessageUntilComplete: true,
     draftKey: `agent:${agent.slug}`,
     initialAttachments: carryover?.attachments,
+    initialSecuredSecrets: carryover?.securedSecrets,
   })
 
   // Reset the manual-collapse flag once the message clears.
@@ -360,6 +361,14 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
                   rows={2}
                   autoFocus={!isMobile}
                   dataTestId="home-message-input"
+                  secureSecrets={{
+                    agentSlug: agent.slug,
+                    potentialSecrets: composer.potentialSecrets,
+                    securedSecrets: composer.securedSecrets,
+                    onDismiss: composer.dismissPotentialSecret,
+                    onSecure: composer.securePotentialSecret,
+                    onRemove: composer.removeSecuredSecrets,
+                  }}
                   textareaClassName={`transition-[min-height] duration-300 ease-in-out ${isExpanded ? 'min-h-[50vh] max-h-[50vh]' : 'min-h-[60px] max-h-[120px]'}`}
                   leftActions={(
                     <>

--- a/src/renderer/components/messages/chat-composer-box.tsx
+++ b/src/renderer/components/messages/chat-composer-box.tsx
@@ -1,6 +1,29 @@
-import type { ChangeEventHandler, ClipboardEventHandler, FocusEventHandler, KeyboardEventHandler, ReactNode, Ref } from 'react'
+import { useCallback, useRef } from 'react'
+import type {
+  ChangeEventHandler,
+  ClipboardEventHandler,
+  FocusEventHandler,
+  KeyboardEventHandler,
+  MutableRefObject,
+  ReactNode,
+  Ref,
+} from 'react'
 import { cn } from '@shared/lib/utils'
 import { AttachmentPreview, type Attachment } from './attachment-preview'
+import { SecretDetectionPrompt } from './secret-detection-prompt'
+import type { PotentialSecret, SecuredSecret } from '@renderer/lib/secret-detection'
+
+const EMPTY_POTENTIAL_SECRETS: PotentialSecret[] = []
+const EMPTY_SECURED_SECRETS: SecuredSecret[] = []
+
+interface SecureSecretsProps {
+  agentSlug: string
+  potentialSecrets?: PotentialSecret[]
+  securedSecrets?: SecuredSecret[]
+  onDismiss: (candidate: PotentialSecret) => void
+  onSecure: (candidate: PotentialSecret, secret: { key: string; envVar: string }) => void
+  onRemove: (secrets: SecuredSecret[], range: { start: number; end: number }) => void
+}
 
 interface ChatComposerBoxProps {
   attachments: Attachment[]
@@ -24,6 +47,84 @@ interface ChatComposerBoxProps {
   footer?: ReactNode
   className?: string
   textareaClassName?: string
+  secureSecrets?: SecureSecretsProps
+}
+
+interface Decoration {
+  id: string
+  kind: 'potential' | 'secured'
+  start: number
+  end: number
+  secret?: SecuredSecret
+}
+
+function findDecorations(
+  value: string,
+  potentialSecrets: PotentialSecret[],
+  securedSecrets: SecuredSecret[]
+): Decoration[] {
+  const decorations: Decoration[] = potentialSecrets
+    .filter((candidate) => value.slice(candidate.start, candidate.end) === candidate.value)
+    .map((candidate) => ({
+      id: candidate.id,
+      kind: 'potential' as const,
+      start: candidate.start,
+      end: candidate.end,
+    }))
+
+  const occupied = decorations.map(({ start, end }) => ({ start, end }))
+  for (const secret of securedSecrets) {
+    let searchFrom = 0
+    let start = value.indexOf(secret.displayText, searchFrom)
+    while (start !== -1 && occupied.some((range) => start < range.end && start + secret.displayText.length > range.start)) {
+      searchFrom = start + secret.displayText.length
+      start = value.indexOf(secret.displayText, searchFrom)
+    }
+    if (start === -1) continue
+    const end = start + secret.displayText.length
+    decorations.push({ id: secret.id, kind: 'secured', start, end, secret })
+    occupied.push({ start, end })
+  }
+
+  return decorations.sort((a, b) => a.start - b.start)
+}
+
+function DecoratedText({
+  value,
+  potentialSecrets,
+  securedSecrets,
+}: {
+  value: string
+  potentialSecrets: PotentialSecret[]
+  securedSecrets: SecuredSecret[]
+}) {
+  const decorations = findDecorations(value, potentialSecrets, securedSecrets)
+  const content: ReactNode[] = []
+  let cursor = 0
+
+  for (const decoration of decorations) {
+    if (decoration.start > cursor) {
+      content.push(<span key={`text-${cursor}`}>{value.slice(cursor, decoration.start)}</span>)
+    }
+    content.push(
+      <span
+        key={decoration.id}
+        data-testid={decoration.kind === 'potential' ? 'potential-secret' : 'secured-secret'}
+        className={cn(
+          'rounded-[3px] [box-decoration-break:clone] [-webkit-box-decoration-break:clone]',
+          decoration.kind === 'potential'
+            ? 'outline outline-1 outline-dotted outline-amber-500/90'
+            : 'bg-amber-500/10 outline outline-1 outline-amber-500/70'
+        )}
+      >
+        {value.slice(decoration.start, decoration.end)}
+      </span>
+    )
+    cursor = decoration.end
+  }
+  if (cursor < value.length) content.push(<span key={`text-${cursor}`}>{value.slice(cursor)}</span>)
+
+  return <>{content}</>
 }
 
 export function ChatComposerBox({
@@ -48,7 +149,57 @@ export function ChatComposerBox({
   footer,
   className,
   textareaClassName,
+  secureSecrets,
 }: ChatComposerBoxProps) {
+  const internalTextareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const mirrorRef = useRef<HTMLDivElement | null>(null)
+  const setTextareaRef = useCallback((node: HTMLTextAreaElement | null) => {
+    internalTextareaRef.current = node
+    if (typeof textareaRef === 'function') {
+      textareaRef(node)
+    } else if (textareaRef) {
+      (textareaRef as MutableRefObject<HTMLTextAreaElement | null>).current = node
+    }
+  }, [textareaRef])
+
+  const potentialSecrets = secureSecrets?.potentialSecrets ?? EMPTY_POTENTIAL_SECRETS
+  const securedSecrets = secureSecrets?.securedSecrets ?? EMPTY_SECURED_SECRETS
+  const hasDecorations = potentialSecrets.length > 0 || securedSecrets.length > 0
+  const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = useCallback((event) => {
+    const isDeleteKey = event.key === 'Backspace' || event.key === 'Delete'
+    if (secureSecrets && isDeleteKey && !event.nativeEvent.isComposing) {
+      const { selectionStart, selectionEnd } = event.currentTarget
+      const securedDecorations = findDecorations(value, potentialSecrets, securedSecrets)
+        .filter((decoration) => decoration.kind === 'secured' && decoration.secret)
+      const affected = securedDecorations.filter((decoration) => {
+        if (selectionStart !== selectionEnd) {
+          return decoration.start < selectionEnd && decoration.end > selectionStart
+        }
+        return event.key === 'Backspace'
+          ? decoration.start < selectionStart && decoration.end >= selectionStart
+          : decoration.start <= selectionStart && decoration.end > selectionStart
+      })
+
+      if (affected.length > 0) {
+        event.preventDefault()
+        const range = {
+          start: Math.min(selectionStart, ...affected.map((decoration) => decoration.start)),
+          end: Math.max(selectionEnd, ...affected.map((decoration) => decoration.end)),
+        }
+        secureSecrets.onRemove(
+          affected.flatMap((decoration) => decoration.secret ? [decoration.secret] : []),
+          range
+        )
+        requestAnimationFrame(() => {
+          internalTextareaRef.current?.setSelectionRange(range.start, range.start)
+        })
+        return
+      }
+    }
+
+    onKeyDown?.(event)
+  }, [onKeyDown, potentialSecrets, secureSecrets, securedSecrets, value])
+
   return (
     <div className={cn(
       'group relative mx-auto w-full rounded-2xl border border-border/60 bg-background/95 px-3 py-3 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/80',
@@ -58,16 +209,38 @@ export function ChatComposerBox({
         <div className="absolute top-2 right-2 z-10 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 touch:opacity-100">{topRightActions}</div>
       )}
       <AttachmentPreview attachments={attachments} onRemove={onRemoveAttachment} />
-      <div className={attachments.length > 0 ? 'mt-2' : ''}>
+      <div className={cn('relative', attachments.length > 0 && 'mt-2')}>
+        {hasDecorations && (
+          <div
+            ref={mirrorRef}
+            aria-hidden="true"
+            className={cn(
+              'pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap [overflow-wrap:anywhere] rounded-md pl-1 pr-4 py-0 text-sm leading-5 text-transparent',
+              textareaClassName
+            )}
+          >
+            <DecoratedText
+              value={value}
+              potentialSecrets={potentialSecrets}
+              securedSecrets={securedSecrets}
+            />
+          </div>
+        )}
         <textarea
-          ref={textareaRef}
+          ref={setTextareaRef}
           dir="auto"
           value={value}
           onChange={onChange}
-          onKeyDown={onKeyDown}
+          onKeyDown={handleKeyDown}
           onPaste={onPaste}
           onFocus={onFocus}
           onBlur={onBlur}
+          onScroll={(event) => {
+            if (mirrorRef.current) {
+              mirrorRef.current.scrollTop = event.currentTarget.scrollTop
+              mirrorRef.current.scrollLeft = event.currentTarget.scrollLeft
+            }
+          }}
           placeholder={placeholder}
           disabled={disabled}
           rows={rows}
@@ -75,11 +248,19 @@ export function ChatComposerBox({
           autoFocus={autoFocus}
           data-testid={dataTestId}
           className={cn(
-            'w-full resize-none rounded-md bg-background pl-1 pr-4 py-0 text-sm placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 max-h-[200px] overflow-y-auto [field-sizing:content]',
+            'relative w-full resize-none rounded-md bg-transparent pl-1 pr-4 py-0 text-sm leading-5 placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 max-h-[200px] overflow-y-auto [field-sizing:content]',
             textareaClassName
           )}
         />
       </div>
+      {secureSecrets && potentialSecrets[0] && (
+        <SecretDetectionPrompt
+          agentSlug={secureSecrets.agentSlug}
+          candidate={potentialSecrets[0]}
+          onDismiss={secureSecrets.onDismiss}
+          onSecure={secureSecrets.onSecure}
+        />
+      )}
       <div className="mt-1 flex items-center justify-between gap-2">
         <div className="flex items-center gap-1">{leftActions}</div>
         <div className="flex items-center gap-2">{rightActions}</div>

--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -19,11 +19,20 @@ const mockInterruptSession = {
   isPending: false,
 }
 
+const mockCreateSecret = {
+  mutateAsync: vi.fn(),
+  isPending: false,
+}
+
 vi.mock('@renderer/hooks/use-messages', () => ({
   useSendMessage: () => mockSendMessage,
   useUploadFile: () => mockUploadFile,
   useUploadFolder: () => mockUploadFolder,
   useInterruptSession: () => mockInterruptSession,
+}))
+
+vi.mock('@renderer/hooks/use-secrets', () => ({
+  useCreateSecret: () => mockCreateSecret,
 }))
 
 const mockStreamState = {
@@ -87,6 +96,13 @@ describe('MessageInput', () => {
     mockIsOnline = true
     mockRuntimeStatus.data.runtimeReadiness.status = 'READY'
     mockRuntimeStatus.isPending = false
+    mockCreateSecret.isPending = false
+    mockCreateSecret.mutateAsync.mockResolvedValue({
+      id: 'GITHUB_TOKEN',
+      key: 'GitHub Token',
+      envVar: 'GITHUB_TOKEN',
+      hasValue: true,
+    })
   })
 
   it('renders textarea with placeholder', () => {
@@ -259,6 +275,98 @@ describe('MessageInput', () => {
     await user.type(input, 'Hello')
 
     expect(screen.getByTestId('send-button')).toBeEnabled()
+  })
+
+  it('saves a detected key securely, masks it in the composer, and sends only a placeholder', async () => {
+    const user = userEvent.setup()
+    const key = ['gh', 'p_Ab3dEf6hIj9kLm2nOp5qRs8tUv1wXy4z'].join('')
+    renderWithProviders(
+      <MessageInput sessionId="s-1" agentSlug="agent-1" />
+    )
+
+    const input = screen.getByTestId('message-input')
+    await user.type(input, `Use this token:\n${key}`)
+
+    expect(screen.getByTestId('potential-secret')).toHaveTextContent(key)
+    expect(screen.getByText('Is this a Key?')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Send securely to the agent' }))
+    expect(screen.getByRole('dialog', { name: 'Send key securely' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Key name')).toHaveValue('')
+    expect(screen.getByLabelText('Secret value')).toHaveValue(key)
+
+    await user.type(screen.getByLabelText('Key name'), 'GitHub Token')
+    await user.click(screen.getByRole('button', { name: 'Save securely' }))
+
+    await waitFor(() => {
+      expect(mockCreateSecret.mutateAsync).toHaveBeenCalledWith({
+        agentSlug: 'agent-1',
+        key: 'GitHub Token',
+        value: key,
+        location: 'composer',
+      })
+    })
+    expect(input).toHaveValue('Use this token:\n[GitHub Token | *********]')
+    expect(screen.getByTestId('secured-secret')).toHaveTextContent('[GitHub Token | *********]')
+    expect(screen.getByTestId('secured-secret')).toHaveClass(
+      'bg-amber-500/10',
+      'outline-amber-500/70'
+    )
+    expect(screen.queryByText('Is this a Key?')).not.toBeInTheDocument()
+
+    await user.click(screen.getByTestId('send-button'))
+
+    await waitFor(() => {
+      expect(mockSendMessage.mutateAsync).toHaveBeenCalledWith(expect.objectContaining({
+        content: 'Use this token:\n[Key saved to .env - GITHUB_TOKEN]',
+      }))
+    })
+    expect(mockSendMessage.mutateAsync).not.toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining(key) })
+    )
+  })
+
+  it.each([
+    { pressedKey: '{Backspace}', caretEdge: 'end' as const },
+    { pressedKey: '{Delete}', caretEdge: 'start' as const },
+  ])('removes a secured pill atomically with $pressedKey', async ({ pressedKey, caretEdge }) => {
+    const user = userEvent.setup()
+    const key = ['gh', 'p_Ab3dEf6hIj9kLm2nOp5qRs8tUv1wXy4z'].join('')
+    const pill = '[GitHub Token | *********]'
+    renderWithProviders(
+      <MessageInput sessionId="s-1" agentSlug="agent-1" />
+    )
+
+    const input = screen.getByTestId('message-input') as HTMLTextAreaElement
+    await user.type(input, `Before ${key} after`)
+    await user.click(screen.getByRole('button', { name: 'Send securely to the agent' }))
+    await user.type(screen.getByLabelText('Key name'), 'GitHub Token')
+    await user.click(screen.getByRole('button', { name: 'Save securely' }))
+
+    await waitFor(() => expect(input).toHaveValue(`Before ${pill} after`))
+    const pillStart = input.value.indexOf(pill)
+    const caret = caretEdge === 'end' ? pillStart + pill.length : pillStart
+    input.focus()
+    input.setSelectionRange(caret, caret)
+    await user.keyboard(pressedKey)
+
+    expect(input).toHaveValue('Before  after')
+    expect(screen.queryByTestId('secured-secret')).not.toBeInTheDocument()
+  })
+
+  it('dismisses a key suggestion without changing the draft', async () => {
+    const user = userEvent.setup()
+    const key = ['sk-', 'proj-Ab3dEf6hIj9kLm2nOp5qRs8tUv1wXy4z'].join('')
+    renderWithProviders(
+      <MessageInput sessionId="s-1" agentSlug="agent-1" />
+    )
+
+    const input = screen.getByTestId('message-input')
+    await user.type(input, key)
+    await user.click(screen.getByRole('button', { name: 'Dismiss key suggestion' }))
+
+    expect(screen.queryByTestId('potential-secret')).not.toBeInTheDocument()
+    expect(input).toHaveValue(key)
   })
 
   it('registers a getter for the live composer and deregisters on unmount', async () => {

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -124,6 +124,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
     model: undefined,
     effort: composerOptions.effort,
     speed: composerOptions.speed,
+    securedSecrets: [],
   })
   snapshotRef.current = {
     text: composer.message,
@@ -131,6 +132,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
     model: composerOptions.model,
     effort: composerOptions.effort,
     speed: composerOptions.speed,
+    securedSecrets: composer.securedSecrets,
   }
   useEffect(() => {
     if (!registerSnapshot) return
@@ -282,6 +284,14 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
         rows={2}
         enterKeyHint="enter"
         dataTestId="message-input"
+        secureSecrets={{
+          agentSlug,
+          potentialSecrets: composer.potentialSecrets,
+          securedSecrets: composer.securedSecrets,
+          onDismiss: composer.dismissPotentialSecret,
+          onSecure: composer.securePotentialSecret,
+          onRemove: composer.removeSecuredSecrets,
+        }}
         leftActions={(
           <>
             <AttachmentPicker

--- a/src/renderer/components/messages/secret-detection-prompt.tsx
+++ b/src/renderer/components/messages/secret-detection-prompt.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useId, useState } from 'react'
+import { KeyRound, X } from 'lucide-react'
+import { Button } from '@renderer/components/ui/button'
+import { Input } from '@renderer/components/ui/input'
+import { Label } from '@renderer/components/ui/label'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@renderer/components/ui/dialog'
+import { useCreateSecret } from '@renderer/hooks/use-secrets'
+import { isReservedEnvVar } from '@shared/lib/container/reserved-env-vars'
+import { keyToEnvVar } from '@shared/lib/utils/secrets'
+import type { PotentialSecret } from '@renderer/lib/secret-detection'
+
+interface SecretDetectionPromptProps {
+  agentSlug: string
+  candidate: PotentialSecret
+  onDismiss: (candidate: PotentialSecret) => void
+  onSecure: (candidate: PotentialSecret, secret: { key: string; envVar: string }) => void
+}
+
+export function SecretDetectionPrompt({
+  agentSlug,
+  candidate,
+  onDismiss,
+  onSecure,
+}: SecretDetectionPromptProps) {
+  const [open, setOpen] = useState(false)
+  const [key, setKey] = useState('')
+  const [value, setValue] = useState(candidate.value)
+  const [error, setError] = useState('')
+  const createSecret = useCreateSecret()
+  const id = useId()
+  const keyInputId = `${id}-key-name`
+  const valueInputId = `${id}-secret-value`
+  const envVar = keyToEnvVar(key.trim())
+  const isReserved = !!envVar && isReservedEnvVar(envVar)
+
+  useEffect(() => {
+    if (!open) return
+    setKey('')
+    setValue(candidate.value)
+    setError('')
+  }, [candidate, open])
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    // The dialog is portalled in the DOM but still bubbles through React's
+    // component tree, which otherwise submits the surrounding chat composer.
+    event.stopPropagation()
+    if (!key.trim() || !value || isReserved) return
+    setError('')
+
+    try {
+      const saved = await createSecret.mutateAsync({
+        agentSlug,
+        key: key.trim(),
+        value,
+        location: 'composer',
+      })
+      onSecure(candidate, { key: saved.key, envVar: saved.envVar })
+      setOpen(false)
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Failed to save the key securely')
+    }
+  }
+
+  return (
+    <div
+      data-testid="secret-detection-prompt"
+      className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 rounded-lg border border-dotted border-amber-500/70 bg-amber-500/5 px-2.5 py-2 text-xs"
+    >
+      <span className="flex items-center gap-1.5 font-medium">
+        <KeyRound className="h-3.5 w-3.5 text-amber-600" />
+        Is this a Key?
+      </span>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>
+          <button type="button" className="font-medium text-primary underline-offset-2 hover:underline">
+            Send securely to the agent
+          </button>
+        </DialogTrigger>
+        <DialogContent className="sm:max-w-md">
+          <form onSubmit={handleSubmit} className="grid gap-4">
+            <DialogHeader>
+              <DialogTitle>Send key securely</DialogTitle>
+              <DialogDescription>
+                Save this value to the agent&apos;s .env file. The message will contain only the environment variable name.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-3">
+              <div className="grid gap-1.5">
+                <Label htmlFor={keyInputId}>Key name</Label>
+                <Input
+                  id={keyInputId}
+                  value={key}
+                  onChange={(event) => setKey(event.target.value)}
+                  placeholder="e.g., GitHub Token"
+                  autoFocus
+                />
+                {envVar && (
+                  <span className={isReserved ? 'text-xs font-mono text-destructive' : 'text-xs font-mono text-muted-foreground'}>
+                    ENV: {envVar}{isReserved ? ' (reserved)' : ''}
+                  </span>
+                )}
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor={valueInputId}>Secret value</Label>
+                <Input
+                  id={valueInputId}
+                  type="password"
+                  value={value}
+                  onChange={(event) => setValue(event.target.value)}
+                  autoComplete="off"
+                  className="font-mono"
+                />
+              </div>
+              {error && <p role="alert" className="text-sm text-destructive">{error}</p>}
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+              <Button type="submit" disabled={!key.trim() || !value || isReserved || createSecret.isPending}>
+                {createSecret.isPending ? 'Saving...' : 'Save securely'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+      <span className="text-muted-foreground">or</span>
+      <button
+        type="button"
+        aria-label="Dismiss key suggestion"
+        onClick={() => onDismiss(candidate)}
+        className="inline-flex items-center gap-1 text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+      >
+        dismiss
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/hooks/use-message-composer.test.tsx
+++ b/src/renderer/hooks/use-message-composer.test.tsx
@@ -126,6 +126,45 @@ describe('useMessageComposer', () => {
     expect(result.current.canSubmit).toBe(true)
   })
 
+  it('detects, dismisses, and re-detects a potential secret after it is removed', () => {
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+    const key = ['sk-', 'proj-Ab3dEf6hIj9kLm2nOp5qRs8tUv1wXy4z'].join('')
+
+    act(() => result.current.setMessage(`Use ${key}`))
+    expect(result.current.potentialSecrets).toHaveLength(1)
+
+    act(() => result.current.dismissPotentialSecret(result.current.potentialSecrets[0]))
+    expect(result.current.potentialSecrets).toEqual([])
+
+    act(() => result.current.setMessage(''))
+    act(() => result.current.setMessage(key))
+    expect(result.current.potentialSecrets).toHaveLength(1)
+  })
+
+  it('replaces a secured key with a masked pill and submits only the .env placeholder', async () => {
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+    const key = ['gh', 'p_Ab3dEf6hIj9kLm2nOp5qRs8tUv1wXy4z'].join('')
+
+    act(() => result.current.setMessage(`Use ${key} please`))
+    act(() => result.current.securePotentialSecret(result.current.potentialSecrets[0], {
+      key: 'GitHub Token',
+      envVar: 'GITHUB_TOKEN',
+    }))
+
+    expect(result.current.message).toBe('Use [GitHub Token | *********] please')
+    expect(result.current.securedSecrets).toHaveLength(1)
+    expect(JSON.stringify(result.current.securedSecrets)).not.toContain(key)
+
+    await act(async () => {
+      await result.current.handleSubmit({ preventDefault: vi.fn() } as any)
+    })
+
+    expect(opts.onSubmit).toHaveBeenCalledWith('Use [Key saved to .env - GITHUB_TOKEN] please')
+    expect(opts.onSubmit).not.toHaveBeenCalledWith(expect.stringContaining(key))
+  })
+
   // --- canSubmit ---
 
   it('canSubmit is true when message has content', () => {

--- a/src/renderer/hooks/use-message-composer.ts
+++ b/src/renderer/hooks/use-message-composer.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { captureRendererException } from '@renderer/lib/error-reporting'
 import { useAttachments } from './use-attachments'
 import { useVoiceInput } from './use-voice-input'
@@ -7,6 +7,13 @@ import { useDraft } from '@renderer/context/drafts-context'
 import { appendAttachedFiles, appendMountedFolders } from '@shared/lib/utils/attached-files'
 import { zipFolderFiles, type FolderGroup } from '@renderer/lib/file-utils'
 import type { Attachment } from '@renderer/components/messages/attachment-preview'
+import {
+  findPotentialSecrets,
+  replaceSecuredSecrets,
+  secretDisplayText,
+  type PotentialSecret,
+  type SecuredSecret,
+} from '@renderer/lib/secret-detection'
 
 interface UseMessageComposerOptions {
   agentSlug: string
@@ -24,13 +31,21 @@ interface UseMessageComposerOptions {
   draftKey?: string
   /** One-shot attachment seed, used when moving a draft into a new session. */
   initialAttachments?: Attachment[]
+  /** One-shot secure-pill seed, used when moving a draft into a new session. */
+  initialSecuredSecrets?: SecuredSecret[]
 }
 
 export function useMessageComposer(options: UseMessageComposerOptions) {
   const { agentSlug, onSubmit, submitDisabled, keepMessageUntilComplete, draftKey } = options
 
   const [draft, setDraft] = useDraft<string>(draftKey)
+  const securedDraftKey = draftKey ? `${draftKey}:secured-secrets` : undefined
+  const [draftSecuredSecrets, setDraftSecuredSecrets] = useDraft<SecuredSecret[]>(securedDraftKey)
   const [message, setMessage] = useState(draft ?? '')
+  const [dismissedSecretValues, setDismissedSecretValues] = useState<Set<string>>(() => new Set())
+  const [securedSecrets, setSecuredSecrets] = useState<SecuredSecret[]>(
+    () => options.initialSecuredSecrets ?? draftSecuredSecrets ?? []
+  )
   const [isUploading, setIsUploading] = useState(false)
   const [uploadError, setUploadError] = useState<string | null>(null)
   const addMountMutation = useAddMount()
@@ -48,6 +63,10 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     setDraft(message || undefined)
   }, [message, setDraft])
 
+  useEffect(() => {
+    setDraftSecuredSecrets(securedSecrets.length > 0 ? securedSecrets : undefined)
+  }, [securedSecrets, setDraftSecuredSecrets])
+
   // Sync externally-injected drafts (e.g. voice feedback) into the local message.
   useEffect(() => {
     if (draft !== undefined && draft !== message) {
@@ -55,6 +74,56 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- only react to external draft changes
   }, [draft])
+
+  // A dismissal lasts while that exact value remains in the draft. Removing it
+  // and pasting/typing it again is treated as a fresh safety signal.
+  useEffect(() => {
+    setDismissedSecretValues((current) => {
+      const next = new Set([...current].filter((value) => message.includes(value)))
+      if (next.size === current.size) return current
+      return next
+    })
+  }, [message])
+
+  const potentialSecrets = useMemo(
+    () => findPotentialSecrets(message).filter((candidate) => !dismissedSecretValues.has(candidate.value)),
+    [message, dismissedSecretValues]
+  )
+
+  const dismissPotentialSecret = useCallback((candidate: PotentialSecret) => {
+    setDismissedSecretValues((current) => {
+      const next = new Set(current)
+      next.add(candidate.value)
+      return next
+    })
+  }, [])
+
+  const securePotentialSecret = useCallback((
+    candidate: PotentialSecret,
+    savedSecret: { key: string; envVar: string }
+  ) => {
+    setMessage((current) => {
+      if (current.slice(candidate.start, candidate.end) !== candidate.value) return current
+      const displayText = secretDisplayText(savedSecret.key)
+      const securedSecret: SecuredSecret = {
+        id: `${candidate.id}:${savedSecret.envVar}`,
+        key: savedSecret.key,
+        envVar: savedSecret.envVar,
+        displayText,
+      }
+      setSecuredSecrets((existing) => [...existing, securedSecret])
+      return `${current.slice(0, candidate.start)}${displayText}${current.slice(candidate.end)}`
+    })
+  }, [])
+
+  const removeSecuredSecrets = useCallback((
+    secrets: SecuredSecret[],
+    range: { start: number; end: number }
+  ) => {
+    const secretIds = new Set(secrets.map((secret) => secret.id))
+    setMessage((current) => `${current.slice(0, range.start)}${current.slice(range.end)}`)
+    setSecuredSecrets((current) => current.filter((secret) => !secretIds.has(secret.id)))
+  }, [])
 
   // Mount choice dialog state
   const [pendingFolders, setPendingFolders] = useState<FolderGroup[]>([])
@@ -202,13 +271,16 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
       clearAttachments()
     }
 
+    const editableContent = content
+    const submittedContent = replaceSecuredSecrets(content, securedSecrets)
+
     try {
-      await onSubmit(content)
+      await onSubmit(submittedContent)
     } catch (error) {
       console.error('Failed to submit:', error)
       if (!keepMessageUntilComplete) {
         // Restore message so the user doesn't lose their text
-        setMessage(content)
+        setMessage(editableContent)
       }
       return
     }
@@ -218,6 +290,7 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
       setDraft(undefined)
       clearAttachments()
     }
+    setSecuredSecrets([])
   }
 
   const canSubmit = (!!message.trim() || attachments.length > 0 || voiceInput.isRecording) && !isUploading && !submitDisabled
@@ -226,6 +299,11 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     // Message state
     message,
     setMessage,
+    potentialSecrets,
+    securedSecrets,
+    dismissPotentialSecret,
+    securePotentialSecret,
+    removeSecuredSecrets,
 
     // Attachments
     attachments,

--- a/src/renderer/hooks/use-secrets.ts
+++ b/src/renderer/hooks/use-secrets.ts
@@ -32,6 +32,7 @@ export function useCreateSecret() {
       agentSlug: string
       key: string
       value: string
+      location?: 'settings' | 'composer'
     }) => {
       const res = await apiFetch(`/api/agents/${agentSlug}/secrets`, {
         method: 'POST',
@@ -45,7 +46,7 @@ export function useCreateSecret() {
       return res.json() as Promise<ApiSecretDisplay>
     },
     onSuccess: (_, variables) => {
-      track('secret_added', { location: 'settings' })
+      track('secret_added', { location: variables.location ?? 'settings' })
       queryClient.invalidateQueries({
         queryKey: ['agent-secrets', variables.agentSlug],
       })

--- a/src/renderer/lib/new-session-carryover.test.tsx
+++ b/src/renderer/lib/new-session-carryover.test.tsx
@@ -2,6 +2,7 @@
 import { describe, expect, it } from 'vitest'
 import type { Attachment } from '@renderer/components/messages/attachment-preview'
 import { splitComposerSnapshot } from './new-session-carryover'
+import type { SecuredSecret } from './secret-detection'
 
 describe('splitComposerSnapshot', () => {
   it('moves text, attachments, model, and effort without retaining object URLs', () => {
@@ -38,5 +39,29 @@ describe('splitComposerSnapshot', () => {
       effort: 'medium',
       speed: 'normal',
     }).draftText).toBeUndefined()
+  })
+
+  it('carries secure-pill metadata so a moved draft still sends an environment placeholder', () => {
+    const securedSecret: SecuredSecret = {
+      id: 'secret-1',
+      key: 'GitHub Token',
+      envVar: 'GITHUB_TOKEN',
+      displayText: '[GitHub Token | *********]',
+    }
+
+    expect(splitComposerSnapshot({
+      text: 'Use [GitHub Token | *********]',
+      attachments: [],
+      model: 'sonnet',
+      effort: 'high',
+      speed: 'normal',
+      securedSecrets: [securedSecret],
+    }).carryover).toEqual({
+      attachments: [],
+      model: 'sonnet',
+      effort: 'high',
+      speed: 'normal',
+      securedSecrets: [securedSecret],
+    })
   })
 })

--- a/src/renderer/lib/new-session-carryover.ts
+++ b/src/renderer/lib/new-session-carryover.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import type { Attachment } from '@renderer/components/messages/attachment-preview'
 import { useDraftsStore } from '@renderer/context/drafts-context'
 import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
+import type { SecuredSecret } from '@renderer/lib/secret-detection'
 
 export interface ComposerSnapshot {
   text: string
@@ -9,6 +10,7 @@ export interface ComposerSnapshot {
   model: string | undefined
   effort: EffortLevel
   speed: SpeedLevel
+  securedSecrets?: SecuredSecret[]
 }
 
 export interface NewSessionCarryover {
@@ -16,6 +18,7 @@ export interface NewSessionCarryover {
   model: string | undefined
   effort: EffortLevel
   speed: SpeedLevel
+  securedSecrets?: SecuredSecret[]
 }
 
 export const newSessionCarryoverKey = (agentSlug: string) => `new-session-carryover:${agentSlug}`
@@ -41,6 +44,7 @@ export function splitComposerSnapshot(snapshot: ComposerSnapshot | undefined): {
       model: snapshot.model,
       effort: snapshot.effort,
       speed: snapshot.speed,
+      ...(snapshot.securedSecrets?.length ? { securedSecrets: snapshot.securedSecrets } : {}),
     },
   }
 }

--- a/src/renderer/lib/secret-detection.test.ts
+++ b/src/renderer/lib/secret-detection.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findPotentialSecrets,
+  replaceSecuredSecrets,
+  type SecuredSecret,
+} from './secret-detection'
+
+describe('findPotentialSecrets', () => {
+  it('detects provider-prefixed and high-entropy generic keys', () => {
+    const providerKey = ['sk-', 'proj-Ab3dEf6hIj9kLm2nOp5qRs8tUv1wXy4z'].join('')
+    const genericKey = 'bL8cN2vQ9xR4sT7uW3yZ6aD1fG5hJ8k'
+    const text = `provider=${providerKey} generic=${genericKey}`
+
+    expect(findPotentialSecrets(text).map((candidate) => candidate.value)).toEqual([
+      providerKey,
+      genericKey,
+    ])
+  })
+
+  it('ignores prose, URLs, placeholders, and low-entropy repeated strings', () => {
+    const text = [
+      'characteristically is a long normal word',
+      'https://example.com/documentation/getting-started',
+      '[Saved key | *********]',
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    ].join('\n')
+
+    expect(findPotentialSecrets(text)).toEqual([])
+  })
+
+  it('returns exact offsets for a key after a line break without swallowing punctuation', () => {
+    const key = ['gh', 'p_Ab3dEf6hIj9kLm2nOp5qRs8tUv1wXy4z'].join('')
+    const text = `Paste it below:\n${key}, then continue.`
+
+    expect(findPotentialSecrets(text)).toEqual([
+      {
+        id: `${text.indexOf(key)}:${text.indexOf(key) + key.length}`,
+        value: key,
+        start: text.indexOf(key),
+        end: text.indexOf(key) + key.length,
+      },
+    ])
+  })
+})
+
+describe('replaceSecuredSecrets', () => {
+  it('turns masked composer pills into agent-facing .env placeholders', () => {
+    const secured: SecuredSecret[] = [
+      {
+        id: 'secret-1',
+        key: 'GitHub Token',
+        envVar: 'GITHUB_TOKEN',
+        displayText: '[GitHub Token | *********]',
+      },
+    ]
+
+    expect(replaceSecuredSecrets('Use [GitHub Token | *********] for this task', secured))
+      .toBe('Use [Key saved to .env - GITHUB_TOKEN] for this task')
+  })
+
+  it('leaves edited or unrelated bracketed text alone', () => {
+    const secured: SecuredSecret[] = [
+      {
+        id: 'secret-1',
+        key: 'GitHub Token',
+        envVar: 'GITHUB_TOKEN',
+        displayText: '[GitHub Token | *********]',
+      },
+    ]
+
+    expect(replaceSecuredSecrets('Use [GitHub Token | edited] and [other]', secured))
+      .toBe('Use [GitHub Token | edited] and [other]')
+  })
+})

--- a/src/renderer/lib/secret-detection.ts
+++ b/src/renderer/lib/secret-detection.ts
@@ -1,0 +1,115 @@
+const MIN_SECRET_LENGTH = 20
+const MASK = '*********'
+
+export interface PotentialSecret {
+  id: string
+  value: string
+  start: number
+  end: number
+}
+
+export interface SecuredSecret {
+  id: string
+  key: string
+  envVar: string
+  displayText: string
+}
+
+const KNOWN_SECRET_PREFIX = /^(?:sk[-_]|pk[-_]|gh[pousr]_|github_pat_|xox[baprs]-|AIza|AKIA|ASIA|eyJ|SG\.|sq0atp-|npm_)/i
+const HEX_SECRET = /^[a-f0-9]{32,}$/i
+const TOKEN_PATTERN = /[A-Za-z0-9][A-Za-z0-9_+=./-]{18,}[A-Za-z0-9_+=/-]/g
+const SECURED_DISPLAY_PATTERN = /\[[^\]\n]*\|\s*\*{4,}\]/g
+
+function shannonEntropy(value: string): number {
+  const counts = new Map<string, number>()
+  for (const character of value) {
+    counts.set(character, (counts.get(character) ?? 0) + 1)
+  }
+
+  let entropy = 0
+  for (const count of counts.values()) {
+    const probability = count / value.length
+    entropy -= probability * Math.log2(probability)
+  }
+  return entropy
+}
+
+function overlaps(start: number, end: number, ranges: Array<{ start: number; end: number }>): boolean {
+  return ranges.some((range) => start < range.end && end > range.start)
+}
+
+function looksLikeSecret(value: string, precedingText: string): boolean {
+  if (value.length < MIN_SECRET_LENGTH) return false
+  if (KNOWN_SECRET_PREFIX.test(value)) return true
+
+  const entropy = shannonEntropy(value)
+  if (HEX_SECRET.test(value)) return entropy >= 2.5
+
+  // Long URL/path segments are common in prompts and are not credentials by
+  // themselves. Provider-prefixed values above still win this check.
+  if (precedingText.endsWith('://') || (value.includes('/') && value.includes('.'))) return false
+
+  const hasLower = /[a-z]/.test(value)
+  const hasUpper = /[A-Z]/.test(value)
+  const hasDigit = /\d/.test(value)
+  const hasSymbol = /[_+=./-]/.test(value)
+  if (!hasDigit || !hasLower || entropy < 3.3) return false
+  if (hasUpper || hasSymbol) return true
+
+  // Lowercase alphanumeric tokens need to be longer and more random-looking
+  // to avoid flagging ordinary words with a year or version suffix.
+  return value.length >= 32 && entropy >= 3.5
+}
+
+/**
+ * Find contiguous, high-entropy words that are likely API keys or tokens.
+ * Offsets are UTF-16 string offsets, matching textarea selection/range APIs.
+ */
+export function findPotentialSecrets(text: string): PotentialSecret[] {
+  const protectedRanges: Array<{ start: number; end: number }> = []
+  for (const match of text.matchAll(SECURED_DISPLAY_PATTERN)) {
+    const start = match.index
+    protectedRanges.push({ start, end: start + match[0].length })
+  }
+
+  const candidates: PotentialSecret[] = []
+  for (const match of text.matchAll(TOKEN_PATTERN)) {
+    let value = match[0]
+    let start = match.index
+    // Assignment labels often sit directly beside the value (`token=sk-...`).
+    // Keep the label out of the highlight without splitting base64 padding.
+    const assignment = value.match(/^([A-Za-z_][A-Za-z0-9_-]{0,15})=(.{20,})$/)
+    if (assignment) {
+      start += assignment[1].length + 1
+      value = assignment[2]
+    }
+    const end = start + value.length
+    if (overlaps(start, end, protectedRanges)) continue
+    if (!looksLikeSecret(value, text.slice(Math.max(0, start - 3), start))) continue
+    candidates.push({
+      // IDs are persisted alongside secured draft pills, so they must never
+      // contain the credential itself. The range is unique within a draft.
+      id: `${start}:${end}`,
+      value,
+      start,
+      end,
+    })
+  }
+  return candidates
+}
+
+export function secretDisplayText(key: string): string {
+  return `[${key} | ${MASK}]`
+}
+
+/** Replace only pills created by this composer; arbitrary bracketed text is untouched. */
+export function replaceSecuredSecrets(message: string, securedSecrets: SecuredSecret[]): string {
+  let result = message
+  for (const secret of securedSecrets) {
+    const index = result.indexOf(secret.displayText)
+    if (index === -1) continue
+    const placeholder = `[Key saved to .env - ${secret.envVar}]`
+    result = `${result.slice(0, index)}${placeholder}${result.slice(index + secret.displayText.length)}`
+  }
+  return result
+}


### PR DESCRIPTION
## Summary

- detect provider-prefixed and high-entropy API keys or tokens in both message composers
- highlight potential keys across wrapped lines and offer secure save or dismissal
- save confirmed values through the existing secrets API, replace plaintext with an amber masked pill, and send only an environment-variable placeholder to the agent
- make secured pills atomic for Backspace, Delete, and intersecting text selections
- preserve secured-pill metadata when drafts move into a fresh session without retaining the raw credential

## Why

Users sometimes paste API keys and tokens directly into prompts. This change steers those values into the existing secure secrets facility while keeping the agent message free of plaintext credentials.

## User impact

After a key is saved, the composer displays `[Key Name | *********]` and the agent receives `[Key saved to .env - ENV_KEY_NAME]`. The key remains available to the agent through its `.env` file.

## Review notes

The final security review found that the initial internal pill identifier included the detected raw value. The identifier now uses only source offsets and the regression suite asserts that persisted secured metadata does not contain the credential.

## Validation

- `npm test -- --run src/renderer/lib/secret-detection.test.ts src/renderer/lib/new-session-carryover.test.tsx src/renderer/hooks/use-message-composer.test.tsx src/renderer/components/messages/message-input.test.tsx src/renderer/components/agents/agent-home/agent-home.test.tsx` — 128 passed
- `npm run test:e2e -- e2e/specs/composer-secret-detection.spec.ts` — 3 passed in Chromium
- `npm run typecheck`
- focused ESLint for all changed files
- `npm run build:web`
