### PR TITLE
Fix Grok 4.5 browser tool routing

### DIFF
--- a/agent-container/src/claude-code-effort.test.ts
+++ b/agent-container/src/claude-code-effort.test.ts
@@ -356,6 +356,67 @@ describe('ClaudeCodeProcess model prompt hints', () => {
   })
 })
 
+describe('ClaudeCodeProcess agent-browser Bash hook', () => {
+  beforeEach(() => {
+    calls.length = 0
+  })
+
+  it('adds a warning without denying direct agent-browser commands', async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-agent-browser-hook',
+      workingDirectory: '/tmp',
+    })
+
+    await process.start()
+    const hooks = calls[0].options.hooks as {
+      PreToolUse: Array<{
+        matcher: string
+        hooks: Array<(input: unknown) => Promise<Record<string, unknown>>>
+      }>
+    }
+    const bashHook = hooks.PreToolUse.find((hook) => hook.matcher === 'Bash')
+    expect(bashHook).toBeDefined()
+
+    const directResult = await bashHook!.hooks[0]({
+      tool_name: 'Bash',
+      tool_input: { command: 'agent-browser open https://example.com' },
+    })
+    const discoveryResult = await bashHook!.hooks[0]({
+      tool_name: 'Bash',
+      tool_input: { command: 'which agent-browser; agent-browser --help' },
+    })
+    for (const result of [directResult, discoveryResult]) {
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          additionalContext: expect.stringContaining('STRONG WARNING'),
+        },
+      })
+      expect(result).not.toHaveProperty('hookSpecificOutput.permissionDecision')
+    }
+  })
+
+  it('does not add context to ordinary Bash commands', async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-ordinary-bash-hook',
+      workingDirectory: '/tmp',
+    })
+
+    await process.start()
+    const hooks = calls[0].options.hooks as {
+      PreToolUse: Array<{
+        matcher: string
+        hooks: Array<(input: unknown) => Promise<Record<string, unknown>>>
+      }>
+    }
+    const bashHook = hooks.PreToolUse.find((hook) => hook.matcher === 'Bash')!
+    await expect(bashHook.hooks[0]({
+      tool_name: 'Bash',
+      tool_input: { command: 'rg browser src' },
+    })).resolves.toEqual({})
+  })
+})
+
 describe('ClaudeCodeProcess static tool bans', () => {
   beforeEach(() => {
     calls.length = 0

--- a/agent-container/src/claude-code.test.ts
+++ b/agent-container/src/claude-code.test.ts
@@ -1,6 +1,40 @@
 import { describe, it, expect } from 'vitest'
 import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk'
-import { resultNeedsResumeErrorFallback, stillQueuedFromReceipt, MessageQueue } from './claude-code'
+import {
+  AGENT_BROWSER_BASH_WARNING,
+  MessageQueue,
+  resultNeedsResumeErrorFallback,
+  startsWithAgentBrowserCommand,
+  stillQueuedFromReceipt,
+} from './claude-code'
+
+describe('startsWithAgentBrowserCommand', () => {
+  it.each([
+    'agent-browser open https://example.com',
+    '  agent-browser snapshot',
+    'which agent-browser',
+    '\twhich   agent-browser; agent-browser --help',
+  ])('matches a direct agent-browser Bash request: %s', (command) => {
+    expect(startsWithAgentBrowserCommand(command)).toBe(true)
+  })
+
+  it.each([
+    'echo agent-browser',
+    'env | grep -i browser',
+    'which agent-browser-helper',
+    'agent-browser-helper open https://example.com',
+    '',
+    undefined,
+  ])('ignores unrelated Bash requests: %s', (command) => {
+    expect(startsWithAgentBrowserCommand(command)).toBe(false)
+  })
+
+  it('uses a strong but explicitly non-blocking warning', () => {
+    expect(AGENT_BROWSER_BASH_WARNING).toContain('STRONG WARNING')
+    expect(AGENT_BROWSER_BASH_WARNING).toContain('still allowed')
+    expect(AGENT_BROWSER_BASH_WARNING).toContain('mcp__browser__browser_*')
+  })
+})
 
 describe('resultNeedsResumeErrorFallback', () => {
   it('wants the fallback only when the error result carries no text at all', () => {

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -61,6 +61,14 @@ import {
 // Keep in sync with SYSTEM_MESSAGE_PREFIX in src/renderer/components/messages/message-list.tsx
 const SYSTEM_MESSAGE_PREFIX = '[SYSTEM] ';
 
+export const AGENT_BROWSER_BASH_WARNING =
+  'STRONG WARNING: This Bash command is probably bypassing Gamut\'s browser integration. For website work, use the dedicated mcp__browser__browser_* tools; if they are deferred, load their exact full names with ToolSearch. The Bash command is still allowed, but continue with agent-browser only when the dedicated browser tools genuinely cannot perform the operation.';
+
+export function startsWithAgentBrowserCommand(command: unknown): boolean {
+  if (typeof command !== 'string') return false;
+  return /^(?:agent-browser|which\s+agent-browser)(?=$|[\s;&|])/.test(command.trimStart());
+}
+
 // Default values for system-prompt template vars when the host env is unset.
 // Mirror values the host (base-container-client.ts) sets, so out-of-host runs
 // render sensibly.
@@ -767,6 +775,21 @@ export class ClaudeCodeProcess extends EventEmitter {
                     inputManager.setCurrentToolUseId(toolUseId, this.sessionId);
                   }
                   return {};
+                },
+              ],
+            },
+            {
+              matcher: 'Bash',
+              hooks: [
+                async (input) => {
+                  const toolInput = (input as any).tool_input as Record<string, unknown> | undefined;
+                  if (!startsWithAgentBrowserCommand(toolInput?.command)) return {};
+                  return {
+                    hookSpecificOutput: {
+                      hookEventName: 'PreToolUse' as const,
+                      additionalContext: AGENT_BROWSER_BASH_WARNING,
+                    },
+                  };
                 },
               ],
             },

--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -1,6 +1,6 @@
 import type { EffortLevel, SpeedLevel } from '../container/types'
 import type { ModelDefinition } from './model-catalog-schema'
-import { GPT_TOOL_USE_PROMPT_HINTS } from './model-prompt-hints'
+import { GPT_TOOL_USE_PROMPT_HINTS, GROK_BROWSER_TOOL_PROMPT_HINTS } from './model-prompt-hints'
 import { pricingFor } from './model-pricing-lookup'
 
 /**
@@ -268,6 +268,7 @@ const OPENROUTER_EXTRA_MODELS: ModelDefinition[] = [
     pricing: { inputPerMtok: 2, outputPerMtok: 6 },
     // OpenRouter-reported context length for x-ai/grok-4.5, fetched 2026-07-10.
     contextWindow: 500_000,
+    promptHints: GROK_BROWSER_TOOL_PROMPT_HINTS,
   },
 ]
 
@@ -377,6 +378,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     ...PLATFORM_RESPONSES_WEB,
     pricing: { inputPerMtok: 2, outputPerMtok: 6, speedMultipliers: PRIORITY_2X_MULTIPLIERS },
     contextWindow: 500_000,
+    promptHints: GROK_BROWSER_TOOL_PROMPT_HINTS,
   },
 ]
 

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -368,6 +368,18 @@ describe('getModelPromptHints', () => {
     }
   })
 
+  it('returns browser-integration guidance for Platform and OpenRouter Grok 4.5', () => {
+    for (const [providerId, modelId] of [
+      ['platform', 'grok-4.5'],
+      ['openrouter', 'x-ai/grok-4.5'],
+    ] as const) {
+      const hints = getModelPromptHints(modelId, providerId)
+      expect(hints.some((hint) => hint.includes('mcp__browser__browser_*'))).toBe(true)
+      expect(hints.some((hint) => hint.includes('exact full names'))).toBe(true)
+      expect(hints.some((hint) => hint.includes('agent-browser'))).toBe(true)
+    }
+  })
+
   it('returns an empty list for Claude models and unknown ids', () => {
     expect(getModelPromptHints('claude-opus-4-8', 'anthropic')).toEqual([])
     expect(getModelPromptHints('nope', 'platform')).toEqual([])

--- a/src/shared/lib/llm-provider/model-prompt-hints.ts
+++ b/src/shared/lib/llm-provider/model-prompt-hints.ts
@@ -2,3 +2,8 @@ export const GPT_TOOL_USE_PROMPT_HINTS = [
   'When tools are deferred, use ToolSearch before declaring a capability unavailable. For select: queries, use exact full tool names from the deferred-tools reminder, such as mcp__browser__browser_open, not shortened names like browser_open; keyword queries are also valid.',
   'Omit optional tool parameters you are not using — never send an empty value (empty string, empty array, empty object) in their place, as that counts as supplying the field and is often rejected. For example, with Read, omit pages or give a valid range like "1-5" and never send pages as an empty string; and when a tool accepts exactly one of two parameters (e.g. browser_run\'s command vs args), send only the one you use and omit the other rather than passing it as [].',
 ]
+
+export const GROK_BROWSER_TOOL_PROMPT_HINTS = [
+  'For browser or website tasks, use the dedicated mcp__browser__browser_* tools instead of Bash or the agent-browser CLI. Start with mcp__browser__browser_open; for multi-step interactions, delegate to the web-browser agent after opening the browser. Only use agent-browser through Bash when the dedicated browser integration genuinely cannot perform the operation.',
+  'When browser tools are deferred, use ToolSearch with exact full names from the deferred-tools reminder, such as select:mcp__browser__browser_open,mcp__browser__browser_close, not shortened names such as browser_open. A failed search for a shortened name does not mean the browser integration is unavailable.',
+]


### PR DESCRIPTION
## Summary

- add Grok 4.5 model-specific guidance to prefer the dedicated `mcp__browser__browser_*` integration and use exact deferred tool names
- add a non-blocking Bash `PreToolUse` nudge for commands beginning with `agent-browser` or `which agent-browser`
- keep the CLI escape hatch available when the dedicated browser integration genuinely cannot perform an operation
- cover direct commands, shell separators, false positives, prompt lookup, and non-blocking hook behavior

## Why

Grok 4.5 can search for shortened browser tool names, incorrectly conclude the integrated tools are unavailable, and then drive `agent-browser` through Bash. That bypasses the app's browser lifecycle and visibility. The fix reinforces the correct path at prompt time and again when the problematic Bash pattern appears.

## Impact

Browser tasks on Grok 4.5 should remain inside SuperAgent's browser integration. Exceptional direct CLI use is still allowed; the hook only adds strong context and does not deny execution.

## Validation

- `npm run typecheck`
- targeted ESLint on the changed host files
- `npm test -- --run src/shared/lib/llm-provider/model-catalog.test.ts` (41 tests)
- `npm --prefix agent-container run build`
- `npm --prefix agent-container test -- --run src/claude-code.test.ts src/claude-code-effort.test.ts` (36 tests)
