### PR TITLE
0.4.13-rc.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "superagent",
-  "version": "0.4.13-rc.1",
+  "version": "0.4.13-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "superagent",
-      "version": "0.4.13-rc.1",
+      "version": "0.4.13-rc.2",
       "license": "MIT",
       "dependencies": {
         "@analytics/amplitude": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent",
-  "version": "0.4.13-rc.1",
+  "version": "0.4.13-rc.2",
   "description": "AI agent management platform",
   "author": "Datawizz Inc.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Version bump to `0.4.13-rc.2` so we can release main (includes #481 mid-session remote MCP talk-back URL fix) into GHCR + staging release-ingest.

## Test plan
- [ ] Release workflow publishes `:0.4.13-rc.2-auth` to GHCR
- [ ] Manual `release-ingest` registers + promotes staging `release_channel.latest_version`


Made with [Cursor](https://cursor.com)