### PR TITLE
feat: in-app Apple Container first-install (SUP-413)

### DIFF
--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -7,6 +7,7 @@ import { Hono } from 'hono'
 
 const mockGetSettings = vi.fn()
 const mockUpdateSettings = vi.fn()
+const mockMutateSettings = vi.fn()
 const mockClearSettingsCache = vi.fn()
 const mockGetAnthropicApiKeyStatus = vi.fn()
 const mockGetComposioApiKeyStatus = vi.fn()
@@ -50,6 +51,7 @@ vi.mock('@shared/lib/config/settings', () => ({
   // map it to the same seeded settings the tests already provide.
   loadSettingsStrict: (...args: unknown[]) => mockGetSettings(...args),
   updateSettings: (...args: unknown[]) => mockUpdateSettings(...args),
+  mutateSettings: (...args: unknown[]) => mockMutateSettings(...args),
   clearSettingsCache: (...args: unknown[]) => mockClearSettingsCache(...args),
   getAnthropicApiKeyStatus: (...args: unknown[]) => mockGetAnthropicApiKeyStatus(...args),
   getComposioApiKeyStatus: (...args: unknown[]) => mockGetComposioApiKeyStatus(...args),
@@ -73,6 +75,7 @@ const mockEnsureImageReady = vi.fn()
 const mockGetReadiness = vi.fn()
 const mockResetReadiness = vi.fn()
 const mockMarkRuntimeUnavailable = vi.fn()
+const mockUpdateStartProgress = vi.fn()
 
 vi.mock('@shared/lib/container/container-manager', () => ({
   containerManager: {
@@ -83,6 +86,7 @@ vi.mock('@shared/lib/container/container-manager', () => ({
     getReadiness: (...args: unknown[]) => mockGetReadiness(...args),
     resetReadiness: (...args: unknown[]) => mockResetReadiness(...args),
     markRuntimeUnavailable: (...args: unknown[]) => mockMarkRuntimeUnavailable(...args),
+    updateStartProgress: (...args: unknown[]) => mockUpdateStartProgress(...args),
     stopAll: vi.fn(),
   },
 }))
@@ -95,6 +99,8 @@ vi.mock('@shared/lib/container/client-factory', () => ({
   checkAllRunnersAvailability: (...args: unknown[]) => mockCheckAllRunnersAvailability(...args),
   refreshRunnerAvailability: (...args: unknown[]) => mockRefreshRunnerAvailability(...args),
   startRunner: (...args: unknown[]) => mockStartRunner(...args),
+  restartRunner: (...args: unknown[]) => mockStartRunner(...args),
+  getRunnerDisplayName: (runner: string) => runner,
   getContainerClientClass: (runner: string) => ({
     supportsCustomAgentImage: runner !== 'lambda-microvm',
   }),
@@ -221,6 +227,12 @@ function defaultSettings() {
 
 function setupDefaults() {
   mockGetSettings.mockReturnValue(defaultSettings())
+  mockMutateSettings.mockImplementation((mutator: (s: ReturnType<typeof defaultSettings>) => void) => {
+    const s = mockGetSettings()
+    mutator(s)
+    mockGetSettings.mockReturnValue(s)
+    return s
+  })
   mockHasRunningAgents.mockReturnValue(false)
   mockGetRunningAgentIds.mockResolvedValue([])
   mockCheckAllRunnersAvailability.mockResolvedValue([])
@@ -1910,6 +1922,25 @@ describe('settings route', () => {
         'Failed to start Docker Desktop. Is it installed?',
       )
       expect(mockRefreshRunnerAvailability).toHaveBeenCalled()
+    })
+
+    it('on success persists containerRunner', async () => {
+      vi.useFakeTimers()
+      mockStartRunner.mockResolvedValue({ success: true, message: 'ok' })
+      mockRefreshRunnerAvailability.mockResolvedValue([])
+
+      const pending = app.request('http://localhost/api/settings/start-runner', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ runner: 'podman' }),
+      })
+      await vi.advanceTimersByTimeAsync(2000)
+      const res = await pending
+      vi.useRealTimers()
+
+      expect(res.status).toBe(200)
+      expect(mockMutateSettings).toHaveBeenCalledOnce()
+      expect(mockGetSettings().container.containerRunner).toBe('podman')
     })
   })
 })

--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -71,6 +71,8 @@ const mockGetRunningAgentIds = vi.fn()
 const mockClearClients = vi.fn()
 const mockEnsureImageReady = vi.fn()
 const mockGetReadiness = vi.fn()
+const mockResetReadiness = vi.fn()
+const mockMarkRuntimeUnavailable = vi.fn()
 
 vi.mock('@shared/lib/container/container-manager', () => ({
   containerManager: {
@@ -79,6 +81,8 @@ vi.mock('@shared/lib/container/container-manager', () => ({
     clearClients: (...args: unknown[]) => mockClearClients(...args),
     ensureImageReady: (...args: unknown[]) => mockEnsureImageReady(...args),
     getReadiness: (...args: unknown[]) => mockGetReadiness(...args),
+    resetReadiness: (...args: unknown[]) => mockResetReadiness(...args),
+    markRuntimeUnavailable: (...args: unknown[]) => mockMarkRuntimeUnavailable(...args),
     stopAll: vi.fn(),
   },
 }))
@@ -1866,6 +1870,46 @@ describe('settings route', () => {
         expect(body.webProvider).toBe('exa')
         expect(body.webProviderIsDefault).toBe(false)
       })
+    })
+  })
+
+  // =========================================================================
+  // POST /start-runner failure honesty
+  // =========================================================================
+  describe('POST /start-runner', () => {
+    it('on failure clears CHECKING and returns refreshed runnerAvailability', async () => {
+      const availability = [
+        {
+          runner: 'docker',
+          installed: true,
+          running: false,
+          available: false,
+          canStart: true,
+          supportsCustomAgentImage: true,
+        },
+      ]
+      mockStartRunner.mockResolvedValue({
+        success: false,
+        message: 'Failed to start Docker Desktop. Is it installed?',
+      })
+      mockRefreshRunnerAvailability.mockResolvedValue(availability)
+
+      const res = await app.request('http://localhost/api/settings/start-runner', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ runner: 'docker' }),
+      })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.success).toBe(false)
+      expect(body.message).toMatch(/Docker/i)
+      expect(body.runnerAvailability).toEqual(availability)
+      expect(mockResetReadiness).toHaveBeenCalled()
+      expect(mockMarkRuntimeUnavailable).toHaveBeenCalledWith(
+        'Failed to start Docker Desktop. Is it installed?',
+      )
+      expect(mockRefreshRunnerAvailability).toHaveBeenCalled()
     })
   })
 })

--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -1885,42 +1885,24 @@ describe('settings route', () => {
     })
   })
 
-  // =========================================================================
-  // POST /start-runner failure honesty
-  // =========================================================================
   describe('POST /start-runner', () => {
-    it('on failure clears CHECKING and returns refreshed runnerAvailability', async () => {
-      const availability = [
-        {
-          runner: 'docker',
-          installed: true,
-          running: false,
-          available: false,
-          canStart: true,
-          supportsCustomAgentImage: true,
-        },
-      ]
-      mockStartRunner.mockResolvedValue({
-        success: false,
-        message: 'Failed to start Docker Desktop. Is it installed?',
-      })
-      mockRefreshRunnerAvailability.mockResolvedValue(availability)
-
-      const res = await app.request('http://localhost/api/settings/start-runner', {
+    const postStart = (runner: string) =>
+      app.request('http://localhost/api/settings/start-runner', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ runner: 'docker' }),
+        body: JSON.stringify({ runner }),
       })
 
+    it('on failure clears CHECKING and returns refreshed runnerAvailability', async () => {
+      const availability = [{ runner: 'docker', installed: true, running: false, available: false, canStart: true, supportsCustomAgentImage: true }]
+      mockStartRunner.mockResolvedValue({ success: false, message: 'Failed to start Docker Desktop. Is it installed?' })
+      mockRefreshRunnerAvailability.mockResolvedValue(availability)
+
+      const res = await postStart('docker')
       expect(res.status).toBe(400)
       const body = await res.json()
-      expect(body.success).toBe(false)
-      expect(body.message).toMatch(/Docker/i)
       expect(body.runnerAvailability).toEqual(availability)
-      expect(mockResetReadiness).toHaveBeenCalled()
-      expect(mockMarkRuntimeUnavailable).toHaveBeenCalledWith(
-        'Failed to start Docker Desktop. Is it installed?',
-      )
+      expect(mockMarkRuntimeUnavailable).toHaveBeenCalledWith(expect.stringMatching(/Docker/i))
       expect(mockRefreshRunnerAvailability).toHaveBeenCalled()
     })
 
@@ -1928,18 +1910,11 @@ describe('settings route', () => {
       vi.useFakeTimers()
       mockStartRunner.mockResolvedValue({ success: true, message: 'ok' })
       mockRefreshRunnerAvailability.mockResolvedValue([])
-
-      const pending = app.request('http://localhost/api/settings/start-runner', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ runner: 'podman' }),
-      })
+      const pending = postStart('podman')
       await vi.advanceTimersByTimeAsync(2000)
       const res = await pending
       vi.useRealTimers()
-
       expect(res.status).toBe(200)
-      expect(mockMutateSettings).toHaveBeenCalledOnce()
       expect(mockGetSettings().container.containerRunner).toBe('podman')
     })
   })

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -665,7 +665,11 @@ settings.post('/start-runner', async (c) => {
       })
     }
 
-    return c.json(result, 400)
+    // Failure: clear CHECKING and return fresh availability (install may have
+    // succeeded even when start failed — UI must not keep "Not installed").
+    const runnerAvailability = await refreshRunnerAvailability()
+    containerManager.markRuntimeUnavailable(result.message)
+    return c.json({ ...result, runnerAvailability }, 400)
   } catch (error) {
     console.error('Failed to start runner:', error)
     return c.json({ error: 'Failed to start runner' }, 500)

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -15,6 +15,7 @@ import {
   getSettings,
   loadSettingsStrict,
   updateSettings,
+  mutateSettings,
   clearSettingsCache,
   getBrowserbaseApiKeyStatus,
   getComposioApiKeyStatus,
@@ -42,7 +43,7 @@ import {
   resolveEffectiveWebVendor,
 } from '@shared/lib/web-provider'
 import { containerManager } from '@shared/lib/container/container-manager'
-import { checkAllRunnersAvailability, refreshRunnerAvailability, startRunner, restartRunner, getContainerClientClass, SUPPORTED_RUNNERS, type ContainerRunner } from '@shared/lib/container/client-factory'
+import { checkAllRunnersAvailability, refreshRunnerAvailability, startRunner, restartRunner, getContainerClientClass, getRunnerDisplayName, SUPPORTED_RUNNERS, type ContainerRunner } from '@shared/lib/container/client-factory'
 import { VALID_LIMA_VM_MEMORY_OPTIONS, EFFORT_LEVELS } from '@shared/lib/container/types'
 import { assessVmMemory } from '@shared/lib/container/vm-memory'
 import { customEnvVarsSchema } from '@shared/lib/container/reserved-env-vars'
@@ -645,11 +646,25 @@ settings.post('/start-runner', async (c) => {
     }
 
     // Immediately broadcast CHECKING state so the frontend shows the starting banner
-    containerManager.resetReadiness(`Starting ${runner} runtime...`)
+    containerManager.resetReadiness(`Starting ${getRunnerDisplayName(runner)} runtime...`)
 
-    const result = await startRunner(runner)
+    const result = await startRunner(
+      runner,
+      (progress) => {
+        containerManager.updateStartProgress(progress)
+      },
+      { allowInstall: true },
+    )
 
     if (result.success) {
+      // Make the started/installed runner the configured one (dropdown was snapping back).
+      if (!containerManager.hasRunningAgents() && getSettings().container.containerRunner !== runner) {
+        mutateSettings((s) => {
+          s.container.containerRunner = runner
+        })
+        containerManager.clearClients()
+      }
+
       // Wait a bit for the runtime to start, then refresh availability (clears cache first)
       await new Promise((resolve) => setTimeout(resolve, 2000))
       const runnerAvailability = await refreshRunnerAvailability()
@@ -665,13 +680,20 @@ settings.post('/start-runner', async (c) => {
       })
     }
 
-    // Failure: clear CHECKING and return fresh availability (install may have
-    // succeeded even when start failed — UI must not keep "Not installed").
-    const runnerAvailability = await refreshRunnerAvailability()
+    // Failure: clear CHECKING first so a hung availability probe cannot wedge the UI.
     containerManager.markRuntimeUnavailable(result.message)
+    let runnerAvailability: Awaited<ReturnType<typeof refreshRunnerAvailability>> = []
+    try {
+      runnerAvailability = await refreshRunnerAvailability()
+    } catch (refreshError) {
+      console.error('Failed to refresh runner availability after start failure:', refreshError)
+    }
     return c.json({ ...result, runnerAvailability }, 400)
   } catch (error) {
     console.error('Failed to start runner:', error)
+    containerManager.markRuntimeUnavailable(
+      error instanceof Error ? error.message : 'Failed to start runner',
+    )
     return c.json({ error: 'Failed to start runner' }, 500)
   }
 })
@@ -688,7 +710,7 @@ settings.post('/restart-runner', async (c) => {
 
     // Immediately broadcast CHECKING state so the frontend blocks agent creation
     // and shows the "restarting" banner before the actual restart begins
-    containerManager.resetReadiness(`Restarting ${runner} runtime...`)
+    containerManager.resetReadiness(`Restarting ${getRunnerDisplayName(runner)} runtime...`)
 
     const result = await restartRunner(runner)
 

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -657,7 +657,6 @@ settings.post('/start-runner', async (c) => {
     )
 
     if (result.success) {
-      // Make the started/installed runner the configured one (dropdown was snapping back).
       if (!containerManager.hasRunningAgents() && getSettings().container.containerRunner !== runner) {
         mutateSettings((s) => {
           s.container.containerRunner = runner
@@ -680,7 +679,7 @@ settings.post('/start-runner', async (c) => {
       })
     }
 
-    // Failure: clear CHECKING first so a hung availability probe cannot wedge the UI.
+    // Clear CHECKING before refresh so a hung probe cannot wedge the UI.
     containerManager.markRuntimeUnavailable(result.message)
     let runnerAvailability: Awaited<ReturnType<typeof refreshRunnerAvailability>> = []
     try {

--- a/src/main/keep-awake.ts
+++ b/src/main/keep-awake.ts
@@ -1,6 +1,7 @@
 import { powerSaveBlocker, dialog } from 'electron'
 import { exec, execFile, execFileSync } from 'child_process'
 import fs from 'fs'
+import { runWithAdminPrivileges } from '@shared/lib/run-with-admin-privileges'
 
 let powerSaveBlockerId: number | null = null
 let disableSleepActive = false
@@ -18,15 +19,6 @@ function hasSudoersRule(): boolean {
   } catch {
     return false
   }
-}
-
-function runWithAdminPrivileges(command: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    execFile('osascript', ['-e', `do shell script ${JSON.stringify(command)} with administrator privileges`], (error) => {
-      if (error) reject(error)
-      else resolve()
-    })
-  })
 }
 
 function runPmsetSudo(flag: '0' | '1'): Promise<void> {

--- a/src/renderer/components/layout/agent-banners.tsx
+++ b/src/renderer/components/layout/agent-banners.tsx
@@ -20,25 +20,32 @@ export function AgentBanners({ slug, startAgent }: AgentBannersProps) {
   const { warning: mountWarning, dismiss: dismissMountWarning } = useMountWarnings(slug)
   const { data: runtimeStatus } = useRuntimeStatus()
   const readiness = runtimeStatus?.runtimeReadiness
-  const isPulling = readiness?.status === 'PULLING_IMAGE'
+  const progress = readiness?.pullProgress
+  const showProgress =
+    !!progress &&
+    (readiness?.status === 'PULLING_IMAGE' || readiness?.status === 'CHECKING')
 
   return (
     <>
-      {/* Image pull progress indicator */}
-      {isPulling && readiness?.pullProgress && (
+      {/* Image pull / runtime install progress */}
+      {showProgress && progress && (
         <div className="shrink-0 border-b bg-muted/30 px-4 py-2">
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <Loader2 className="h-3 w-3 animate-spin" />
-            <span>Pulling agent image... {readiness.pullProgress.status}</span>
-            {readiness.pullProgress.percent != null && (
-              <span>({readiness.pullProgress.percent}%)</span>
+            <span>
+              {readiness?.status === 'PULLING_IMAGE'
+                ? `Pulling agent image... ${progress.status}`
+                : progress.status}
+            </span>
+            {progress.percent != null && (
+              <span>({progress.percent}%)</span>
             )}
           </div>
-          {readiness.pullProgress.percent != null && (
+          {progress.percent != null && (
             <div className="mt-1 h-1 w-full bg-muted rounded-full overflow-hidden">
               <div
                 className="h-full bg-primary transition-all duration-300"
-                style={{ width: `${readiness.pullProgress.percent}%` }}
+                style={{ width: `${progress.percent}%` }}
               />
             </div>
           )}

--- a/src/renderer/components/runtime/runtime-provision-progress.tsx
+++ b/src/renderer/components/runtime/runtime-provision-progress.tsx
@@ -1,0 +1,26 @@
+import type { ImagePullProgress } from '@shared/lib/container/types'
+
+/** Compact phase label + optional download bar for runtime install/start. */
+export function RuntimeProvisionProgress({
+  progress,
+}: {
+  progress: Pick<ImagePullProgress, 'status' | 'percent'> | null | undefined
+}) {
+  if (!progress) return null
+  return (
+    <div className="space-y-1">
+      <p className="text-xs text-muted-foreground">
+        {progress.status}
+        {progress.percent != null ? ` (${progress.percent}%)` : ''}
+      </p>
+      {progress.percent != null && (
+        <div className="h-1.5 w-full bg-muted rounded-full overflow-hidden">
+          <div
+            className="h-full bg-primary transition-all duration-300"
+            style={{ width: `${progress.percent}%` }}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/settings/container-setup-dialog.tsx
+++ b/src/renderer/components/settings/container-setup-dialog.tsx
@@ -84,18 +84,6 @@ export function ContainerSetupDialog({ open, onOpenChange }: ContainerSetupDialo
     window.open(url, '_blank', 'noopener,noreferrer')
   }
 
-  const activeRunner = startRunner.variables
-  const readinessStatus = settings?.runtimeReadiness?.status
-  const isProvisioningRunner = (runner: string) =>
-    activeRunner === runner &&
-    (startRunner.isPending ||
-      readinessStatus === 'CHECKING' ||
-      readinessStatus === 'PULLING_IMAGE')
-  const startErrorStale =
-    !!activeRunner &&
-    !!settings?.runnerAvailability?.find((r) => r.runner === activeRunner)?.available
-  const startError = startErrorStale ? null : startRunner.error
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[500px]">
@@ -173,7 +161,7 @@ export function ContainerSetupDialog({ open, onOpenChange }: ContainerSetupDialo
                       {runtime.info.description}
                     </p>
                     <div className="mt-2">
-                      {runtime.available && !isProvisioningRunner(runtime.runner) ? (
+                      {runtime.available && !startRunner.isProvisioning(runtime.runner) ? (
                         <Button
                           size="sm"
                           variant="outline"
@@ -183,7 +171,7 @@ export function ContainerSetupDialog({ open, onOpenChange }: ContainerSetupDialo
                           <Check className="h-3 w-3 mr-1" />
                           Ready to use
                         </Button>
-                      ) : runtime.canStart || isProvisioningRunner(runtime.runner) ? (
+                      ) : runtime.canStart || startRunner.isProvisioning(runtime.runner) ? (
                         <div className="space-y-2">
                           {runtime.canStart && (
                             <Button
@@ -193,7 +181,7 @@ export function ContainerSetupDialog({ open, onOpenChange }: ContainerSetupDialo
                               onClick={() => handleStartRunner(runtime.runner)}
                               disabled={startRunner.isPending}
                             >
-                              {startRunner.isPending && activeRunner === runtime.runner ? (
+                              {startRunner.isPending && startRunner.variables === runtime.runner ? (
                                 <Loader2 className="h-3 w-3 mr-1 animate-spin" />
                               ) : runtime.installed ? (
                                 <Play className="h-3 w-3 mr-1" />
@@ -203,7 +191,7 @@ export function ContainerSetupDialog({ open, onOpenChange }: ContainerSetupDialo
                               {runtime.installed ? `Start ${runtime.info.name}` : `Install ${runtime.info.name}`}
                             </Button>
                           )}
-                          {isProvisioningRunner(runtime.runner) && (
+                          {startRunner.isProvisioning(runtime.runner) && (
                             <RuntimeProvisionProgress
                               progress={settings?.runtimeReadiness?.pullProgress}
                             />
@@ -227,15 +215,15 @@ export function ContainerSetupDialog({ open, onOpenChange }: ContainerSetupDialo
             </div>
           </div>
 
-          {startError && getRunnerSetupPayload(startError) ? (
-            <RunnerSetupErrorPanel error={startError} />
-          ) : startError ? (
+          {startRunner.displayError && getRunnerSetupPayload(startRunner.displayError) ? (
+            <RunnerSetupErrorPanel error={startRunner.displayError} />
+          ) : startRunner.displayError ? (
             <p className="text-sm text-destructive">
-              {startError.message}
+              {startRunner.displayError.message}
             </p>
           ) : null}
 
-          {startRunner.isSuccess && startRunner.data?.message && !startError && (
+          {startRunner.isSuccess && startRunner.data?.message && !startRunner.displayError && (
             <p className="text-sm text-green-600 dark:text-green-400">
               {startRunner.data.message}
             </p>

--- a/src/renderer/components/settings/container-setup-dialog.tsx
+++ b/src/renderer/components/settings/container-setup-dialog.tsx
@@ -12,7 +12,8 @@ import { useSettings, useStartRunner, useRefreshAvailability } from '@renderer/h
 import { getPlatform } from '@renderer/lib/env'
 import { Wsl2InstallGuide } from '@renderer/components/wizard/wsl2-install-guide'
 import { RunnerSetupErrorPanel, getRunnerSetupPayload } from '@renderer/components/settings/runner-setup-error-panel'
-import { Play, Loader2, ExternalLink, Check, RefreshCw } from 'lucide-react'
+import { RuntimeProvisionProgress } from '@renderer/components/runtime/runtime-provision-progress'
+import { Play, Download, Loader2, ExternalLink, Check, RefreshCw } from 'lucide-react'
 
 interface ContainerSetupDialogProps {
   open: boolean
@@ -23,7 +24,7 @@ const RUNTIME_INFO: Record<string, { name: string; description: string; installU
   'apple-container': {
     name: 'macOS Container',
     description: 'Apple\'s container runtime for macOS. Gamut can install it for you (administrator password required).',
-    installUrl: 'https://github.com/apple/container',
+    installUrl: '',
     icon: '🍎',
   },
   docker: {
@@ -71,6 +72,7 @@ export function ContainerSetupDialog({ open, onOpenChange }: ContainerSetupDialo
   const showWsl2Guide = isWindows && wsl2Runtime && !wsl2Runtime.installed
 
   const handleStartRunner = async (runner: string) => {
+    startRunner.reset()
     try {
       await startRunner.mutateAsync(runner)
     } catch (error) {
@@ -81,6 +83,18 @@ export function ContainerSetupDialog({ open, onOpenChange }: ContainerSetupDialo
   const handleOpenInstallLink = (url: string) => {
     window.open(url, '_blank', 'noopener,noreferrer')
   }
+
+  const activeRunner = startRunner.variables
+  const readinessStatus = settings?.runtimeReadiness?.status
+  const isProvisioningRunner = (runner: string) =>
+    activeRunner === runner &&
+    (startRunner.isPending ||
+      readinessStatus === 'CHECKING' ||
+      readinessStatus === 'PULLING_IMAGE')
+  const startErrorStale =
+    !!activeRunner &&
+    !!settings?.runnerAvailability?.find((r) => r.runner === activeRunner)?.available
+  const startError = startErrorStale ? null : startRunner.error
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -159,7 +173,7 @@ export function ContainerSetupDialog({ open, onOpenChange }: ContainerSetupDialo
                       {runtime.info.description}
                     </p>
                     <div className="mt-2">
-                      {runtime.available ? (
+                      {runtime.available && !isProvisioningRunner(runtime.runner) ? (
                         <Button
                           size="sm"
                           variant="outline"
@@ -169,20 +183,32 @@ export function ContainerSetupDialog({ open, onOpenChange }: ContainerSetupDialo
                           <Check className="h-3 w-3 mr-1" />
                           Ready to use
                         </Button>
-                      ) : runtime.canStart ? (
-                        <Button
-                          size="sm"
-                          className="h-7 text-xs"
-                          onClick={() => handleStartRunner(runtime.runner)}
-                          disabled={startRunner.isPending}
-                        >
-                          {startRunner.isPending ? (
-                            <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-                          ) : (
-                            <Play className="h-3 w-3 mr-1" />
+                      ) : runtime.canStart || isProvisioningRunner(runtime.runner) ? (
+                        <div className="space-y-2">
+                          {runtime.canStart && (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="h-7 text-xs"
+                              onClick={() => handleStartRunner(runtime.runner)}
+                              disabled={startRunner.isPending}
+                            >
+                              {startRunner.isPending && activeRunner === runtime.runner ? (
+                                <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                              ) : runtime.installed ? (
+                                <Play className="h-3 w-3 mr-1" />
+                              ) : (
+                                <Download className="h-3 w-3 mr-1" />
+                              )}
+                              {runtime.installed ? `Start ${runtime.info.name}` : `Install ${runtime.info.name}`}
+                            </Button>
                           )}
-                          {runtime.installed ? `Start ${runtime.info.name}` : `Install ${runtime.info.name}`}
-                        </Button>
+                          {isProvisioningRunner(runtime.runner) && (
+                            <RuntimeProvisionProgress
+                              progress={settings?.runtimeReadiness?.pullProgress}
+                            />
+                          )}
+                        </div>
                       ) : runtime.info.installUrl ? (
                         <Button
                           size="sm"
@@ -201,15 +227,15 @@ export function ContainerSetupDialog({ open, onOpenChange }: ContainerSetupDialo
             </div>
           </div>
 
-          {startRunner.error && getRunnerSetupPayload(startRunner.error) ? (
-            <RunnerSetupErrorPanel error={startRunner.error} />
-          ) : startRunner.error ? (
+          {startError && getRunnerSetupPayload(startError) ? (
+            <RunnerSetupErrorPanel error={startError} />
+          ) : startError ? (
             <p className="text-sm text-destructive">
-              {startRunner.error.message}
+              {startError.message}
             </p>
           ) : null}
 
-          {startRunner.isSuccess && startRunner.data?.message && (
+          {startRunner.isSuccess && startRunner.data?.message && !startError && (
             <p className="text-sm text-green-600 dark:text-green-400">
               {startRunner.data.message}
             </p>

--- a/src/renderer/components/settings/container-setup-dialog.tsx
+++ b/src/renderer/components/settings/container-setup-dialog.tsx
@@ -22,7 +22,7 @@ interface ContainerSetupDialogProps {
 const RUNTIME_INFO: Record<string, { name: string; description: string; installUrl: string; icon: string }> = {
   'apple-container': {
     name: 'macOS Container',
-    description: 'Native container runtime built into macOS. Fast and lightweight with no extra software needed.',
+    description: 'Apple\'s container runtime for macOS. Gamut can install it for you (administrator password required).',
     installUrl: 'https://github.com/apple/container',
     icon: '🍎',
   },
@@ -169,7 +169,7 @@ export function ContainerSetupDialog({ open, onOpenChange }: ContainerSetupDialo
                           <Check className="h-3 w-3 mr-1" />
                           Ready to use
                         </Button>
-                      ) : runtime.installed && runtime.canStart ? (
+                      ) : runtime.canStart ? (
                         <Button
                           size="sm"
                           className="h-7 text-xs"
@@ -181,9 +181,9 @@ export function ContainerSetupDialog({ open, onOpenChange }: ContainerSetupDialo
                           ) : (
                             <Play className="h-3 w-3 mr-1" />
                           )}
-                          Start {runtime.info.name}
+                          {runtime.installed ? `Start ${runtime.info.name}` : `Install ${runtime.info.name}`}
                         </Button>
-                      ) : (
+                      ) : runtime.info.installUrl ? (
                         <Button
                           size="sm"
                           variant="outline"
@@ -193,7 +193,7 @@ export function ContainerSetupDialog({ open, onOpenChange }: ContainerSetupDialo
                           <ExternalLink className="h-3 w-3 mr-1" />
                           Install {runtime.info.name}
                         </Button>
-                      )}
+                      ) : null}
                     </div>
                   </div>
                 </div>

--- a/src/renderer/components/settings/container-setup-handler.tsx
+++ b/src/renderer/components/settings/container-setup-handler.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { ContainerSetupDialog } from '@renderer/components/settings/container-setup-dialog'
 import { useUserSettings } from '@renderer/hooks/use-user-settings'
 import { useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
+import { useSettings } from '@renderer/hooks/use-settings'
 
 /**
  * Owns the container-setup dialog lifecycle independently of the sidebar so
@@ -11,18 +12,35 @@ export function ContainerSetupHandler() {
   const [open, setOpen] = useState(false)
   const { data: userSettings } = useUserSettings()
   const { data: runtimeStatus } = useRuntimeStatus()
+  const { data: settings } = useSettings()
   const hasShownInitialSetup = useRef(false)
 
   const readiness = runtimeStatus?.runtimeReadiness
   const isRuntimeUnavailable = readiness?.status === 'RUNTIME_UNAVAILABLE' || readiness?.status === 'ERROR'
+  const availability = settings?.runnerAvailability
+  // Only auto-open when no runner can actually run — a failed Apple install
+  // while Docker is still available must not force this modal.
+  const anyRunnerAvailable = availability?.some((r) => r.available) ?? false
+  const availabilityKnown = Array.isArray(availability)
 
   // Auto-open on first load if runtime is unavailable. Skip until the wizard is done — it covers runtime setup.
   useEffect(() => {
-    if (isRuntimeUnavailable && !hasShownInitialSetup.current && userSettings?.setupCompleted) {
+    if (
+      isRuntimeUnavailable &&
+      availabilityKnown &&
+      !anyRunnerAvailable &&
+      !hasShownInitialSetup.current &&
+      userSettings?.setupCompleted
+    ) {
       hasShownInitialSetup.current = true
       setOpen(true)
     }
-  }, [isRuntimeUnavailable, userSettings?.setupCompleted])
+  }, [
+    isRuntimeUnavailable,
+    availabilityKnown,
+    anyRunnerAvailable,
+    userSettings?.setupCompleted,
+  ])
 
   return <ContainerSetupDialog open={open} onOpenChange={setOpen} />
 }

--- a/src/renderer/components/settings/runtime-tab.tsx
+++ b/src/renderer/components/settings/runtime-tab.tsx
@@ -374,13 +374,6 @@ export function RuntimeTab() {
   const runtimeSaveBlocked = hasRunningAgents
   const isRestarting = restartRunner.isPending || updateSettings.isPending
 
-  // Each surface owns a useStartRunner instance — a cancel here can linger after a
-  // later success in the setup dialog. Drop the error once that runner is available.
-  const startFailedRunner = startRunner.variables
-  const startErrorStale =
-    !!startFailedRunner && !!runnerAvailabilityMap.get(startFailedRunner)?.available
-  const startError = startErrorStale ? null : startRunner.error
-
   return (
     <div className="space-y-6">
       {/* No runners available warning */}
@@ -548,16 +541,16 @@ export function RuntimeTab() {
               Restarting {RUNNER_LABELS[containerRunner] || containerRunner}...
             </span>
           )}
-          {startError && getRunnerSetupPayload(startError) ? (
+          {startRunner.displayError && getRunnerSetupPayload(startRunner.displayError) ? (
             <div className="mt-2">
-              <RunnerSetupErrorPanel error={startError} />
+              <RunnerSetupErrorPanel error={startRunner.displayError} />
             </div>
-          ) : startError ? (
+          ) : startRunner.displayError ? (
             <span className="text-destructive block mt-1">
-              {startError.message}
+              {startRunner.displayError.message}
             </span>
           ) : null}
-          {startRunner.isSuccess && startRunner.data?.message && !startError && (
+          {startRunner.isSuccess && startRunner.data?.message && !startRunner.displayError && (
             <span className="text-green-600 dark:text-green-400 block mt-1">
               {startRunner.data.message}
             </span>

--- a/src/renderer/components/settings/runtime-tab.tsx
+++ b/src/renderer/components/settings/runtime-tab.tsx
@@ -19,8 +19,9 @@ import {
 } from '@renderer/components/ui/select'
 import { Alert, AlertDescription, AlertTitle } from '@renderer/components/ui/alert'
 import { useSettings, useUpdateSettings, useStartRunner, useRestartRunner, useRefreshAvailability } from '@renderer/hooks/use-settings'
-import { AlertCircle, AlertTriangle, Play, Loader2, RefreshCw, Plus, X } from 'lucide-react'
+import { AlertCircle, AlertTriangle, Play, Download, Loader2, RefreshCw, Plus, X } from 'lucide-react'
 import { RunnerSetupErrorPanel, getRunnerSetupPayload } from '@renderer/components/settings/runner-setup-error-panel'
+import { RuntimeProvisionProgress } from '@renderer/components/runtime/runtime-provision-progress'
 import { DEFAULT_LIMA_VM_MEMORY, VALID_LIMA_VM_MEMORY_OPTIONS } from '@shared/lib/container/types'
 import { assessVmMemory } from '@shared/lib/container/vm-memory'
 import { findReservedEnvVarKeys } from '@shared/lib/container/reserved-env-vars'
@@ -186,28 +187,29 @@ export function RuntimeTab() {
     }))
   }, [settings?.runnerAvailability])
 
-  const handleStartRunner = async (runner: string) => {
-    try {
-      await startRunner.mutateAsync(runner)
-    } catch (error) {
-      console.error('Failed to start runner:', error)
-    }
-  }
-
-  // Initialize form values when settings load
+  // Sync each persisted field from its primitive value so availability-only
+  // settings refetches do not reset an in-progress dropdown selection.
   useEffect(() => {
-    if (settings) {
-      setContainerRunner(settings.container.containerRunner)
-      setAgentImage(settings.container.agentImage)
-      setCpuLimit(settings.container.resourceLimits.cpu.toString())
-      setMemoryLimit(settings.container.resourceLimits.memory)
-      if (!updateSettings.isPending) {
-        setCustomEnvVarsDraft(settings.customEnvVars ?? {})
-      }
-      setHasChanges(false)
-      setAutoSleepMinutes(null)
-    }
-  }, [settings])
+    if (!settings) return
+    setContainerRunner(settings.container.containerRunner)
+  }, [settings?.container.containerRunner])
+
+  useEffect(() => {
+    if (!settings) return
+    setAgentImage(settings.container.agentImage)
+    setCpuLimit(settings.container.resourceLimits.cpu.toString())
+    setMemoryLimit(settings.container.resourceLimits.memory)
+    setAutoSleepMinutes(null)
+  }, [
+    settings?.container.agentImage,
+    settings?.container.resourceLimits.cpu,
+    settings?.container.resourceLimits.memory,
+  ])
+
+  useEffect(() => {
+    if (!settings || updateSettings.isPending) return
+    setCustomEnvVarsDraft(settings.customEnvVars ?? {})
+  }, [settings?.customEnvVars, updateSettings.isPending])
 
   // Initialize runtime settings form when runner changes or settings load
   useEffect(() => {
@@ -219,11 +221,11 @@ export function RuntimeTab() {
       form[field.key] = saved[field.key] || field.defaultValue
     }
     setRuntimeSettingsForm(form)
-  }, [containerRunner, settings])
+  }, [containerRunner, settings?.container.runtimeSettings])
 
   // Check for changes (main settings only — runtime settings have their own save)
   useEffect(() => {
-    if (!settings) return
+    if (!settings || !containerRunner) return
 
     const changed =
       containerRunner !== settings.container.containerRunner ||
@@ -238,6 +240,16 @@ export function RuntimeTab() {
   const trimmedAgentImage = agentImage.trim()
   const agentImageMissing = !agentImageLocked && trimmedAgentImage.length === 0
   const isLatestAgentImage = trimmedAgentImage === latestAgentImage
+
+  const handleStartRunner = async (runner: string) => {
+    startRunner.reset()
+    try {
+      await startRunner.mutateAsync(runner)
+      setContainerRunner(runner)
+    } catch (error) {
+      console.error('Failed to start runner:', error)
+    }
+  }
 
   const handleSave = async () => {
     if (agentImageMissing) return
@@ -362,6 +374,13 @@ export function RuntimeTab() {
   const runtimeSaveBlocked = hasRunningAgents
   const isRestarting = restartRunner.isPending || updateSettings.isPending
 
+  // Each surface owns a useStartRunner instance — a cancel here can linger after a
+  // later success in the setup dialog. Drop the error once that runner is available.
+  const startFailedRunner = startRunner.variables
+  const startErrorStale =
+    !!startFailedRunner && !!runnerAvailabilityMap.get(startFailedRunner)?.available
+  const startError = startErrorStale ? null : startRunner.error
+
   return (
     <div className="space-y-6">
       {/* No runners available warning */}
@@ -385,8 +404,10 @@ export function RuntimeTab() {
                     >
                       {startRunner.isPending ? (
                         <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                      ) : (
+                      ) : r.installed ? (
                         <Play className="h-4 w-4 mr-2" />
+                      ) : (
+                        <Download className="h-4 w-4 mr-2" />
                       )}
                       {r.installed ? 'Start' : 'Install'}{' '}
                       {RUNNER_LABELS[r.runner] || r.runner.charAt(0).toUpperCase() + r.runner.slice(1)}
@@ -401,21 +422,23 @@ export function RuntimeTab() {
         </Alert>
       )}
 
-      {/* Image pull progress */}
-      {settings?.runtimeReadiness?.status === 'PULLING_IMAGE' && (
+      {/* Image pull / runtime install progress */}
+      {(settings?.runtimeReadiness?.status === 'PULLING_IMAGE' ||
+        (settings?.runtimeReadiness?.status === 'CHECKING' && settings.runtimeReadiness.pullProgress)) && (
         <Alert>
           <Loader2 className="h-4 w-4 animate-spin" />
-          <AlertTitle>Pulling Agent Image</AlertTitle>
+          <AlertTitle>
+            {settings.runtimeReadiness.status === 'PULLING_IMAGE' ? 'Pulling Agent Image' : 'Setting Up Runtime'}
+          </AlertTitle>
           <AlertDescription className="space-y-2">
-            <p>{settings.runtimeReadiness.pullProgress?.status || 'Downloading...'}</p>
-            {settings.runtimeReadiness.pullProgress?.percent != null && (
-              <div className="mt-2 h-2 w-full bg-muted rounded-full overflow-hidden">
-                <div
-                  className="h-full bg-primary transition-all duration-300"
-                  style={{ width: `${settings.runtimeReadiness.pullProgress.percent}%` }}
-                />
-              </div>
-            )}
+            <RuntimeProvisionProgress
+              progress={
+                settings.runtimeReadiness.pullProgress ?? {
+                  status: settings.runtimeReadiness.message || 'Working...',
+                  percent: null,
+                }
+              }
+            />
           </AlertDescription>
         </Alert>
       )}
@@ -433,13 +456,13 @@ export function RuntimeTab() {
         <div className="flex items-start gap-2 p-3 text-sm bg-yellow-500/10 border border-yellow-500/20 rounded-md">
           <AlertCircle className="h-4 w-4 text-yellow-500 mt-0.5 shrink-0" />
           <p className="text-yellow-700 dark:text-yellow-400">
-            Some settings cannot be changed while agents are running. Stop all agents to modify container runner or resource limits.
+            Some settings cannot be changed while agents are running. Stop all agents to modify container runtime or resource limits.
           </p>
         </div>
       )}
 
       <div className="space-y-2">
-        <Label htmlFor="container-runner">Container Runner</Label>
+        <Label htmlFor="container-runner">Container Runtime</Label>
         <div className="flex gap-2">
           <Select
             value={containerRunner}
@@ -447,7 +470,7 @@ export function RuntimeTab() {
             disabled={isLoading || hasRunningAgents}
           >
             <SelectTrigger id="container-runner" className={`flex-1 ${hasRunningAgents ? 'bg-muted' : ''}`}>
-              <SelectValue placeholder="Select a container runner" />
+              <SelectValue placeholder="Select a container runtime" />
             </SelectTrigger>
             <SelectContent>
               {containerRunners.map((runner) => {
@@ -494,8 +517,10 @@ export function RuntimeTab() {
             >
               {startRunner.isPending ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
+              ) : runnerAvailabilityMap.get(containerRunner)?.installed ? (
                 <Play className="h-4 w-4" />
+              ) : (
+                <Download className="h-4 w-4" />
               )}
             </Button>
           )}
@@ -523,16 +548,16 @@ export function RuntimeTab() {
               Restarting {RUNNER_LABELS[containerRunner] || containerRunner}...
             </span>
           )}
-          {startRunner.error && getRunnerSetupPayload(startRunner.error) ? (
+          {startError && getRunnerSetupPayload(startError) ? (
             <div className="mt-2">
-              <RunnerSetupErrorPanel error={startRunner.error} />
+              <RunnerSetupErrorPanel error={startError} />
             </div>
-          ) : startRunner.error ? (
+          ) : startError ? (
             <span className="text-destructive block mt-1">
-              {startRunner.error.message}
+              {startError.message}
             </span>
           ) : null}
-          {startRunner.isSuccess && startRunner.data?.message && (
+          {startRunner.isSuccess && startRunner.data?.message && !startError && (
             <span className="text-green-600 dark:text-green-400 block mt-1">
               {startRunner.data.message}
             </span>

--- a/src/renderer/components/settings/runtime-tab.tsx
+++ b/src/renderer/components/settings/runtime-tab.tsx
@@ -169,10 +169,10 @@ export function RuntimeTab() {
     return settings.runnerAvailability.every((r) => !r.available)
   }, [settings?.runnerAvailability])
 
-  // Check if any runner is installed but not running
+  // Check if any runner can be started or first-installed via startRunner
   const hasStartableRunner = useMemo(() => {
     if (!settings?.runnerAvailability) return false
-    return settings.runnerAvailability.some((r) => r.installed && !r.running && r.canStart)
+    return settings.runnerAvailability.some((r) => !r.running && r.canStart)
   }, [settings?.runnerAvailability])
 
   // Derive runner list from server-reported availability (only shows eligible runners)
@@ -374,7 +374,7 @@ export function RuntimeTab() {
             {hasStartableRunner && (
               <div className="flex gap-2 mt-2">
                 {settings?.runnerAvailability
-                  ?.filter((r) => r.installed && !r.running && r.canStart)
+                  ?.filter((r) => !r.running && r.canStart)
                   .map((r) => (
                     <Button
                       key={r.runner}
@@ -388,7 +388,8 @@ export function RuntimeTab() {
                       ) : (
                         <Play className="h-4 w-4 mr-2" />
                       )}
-                      Start {r.runner.charAt(0).toUpperCase() + r.runner.slice(1)}
+                      {r.installed ? 'Start' : 'Install'}{' '}
+                      {RUNNER_LABELS[r.runner] || r.runner.charAt(0).toUpperCase() + r.runner.slice(1)}
                     </Button>
                   ))}
               </div>
@@ -477,16 +478,19 @@ export function RuntimeTab() {
               })}
             </SelectContent>
           </Select>
-          {/* Show start button if selected runner is installed but not running */}
-          {runnerAvailabilityMap.get(containerRunner)?.installed &&
-            !runnerAvailabilityMap.get(containerRunner)?.running &&
+          {/* Show start/install when selected runner canStart (incl. apple first-install) */}
+          {!runnerAvailabilityMap.get(containerRunner)?.running &&
             runnerAvailabilityMap.get(containerRunner)?.canStart && (
             <Button
               variant="outline"
               size="icon"
               onClick={() => handleStartRunner(containerRunner)}
               disabled={startRunner.isPending}
-              title={`Start ${containerRunner}`}
+              title={
+                runnerAvailabilityMap.get(containerRunner)?.installed
+                  ? `Start ${containerRunner}`
+                  : `Install ${containerRunner}`
+              }
             >
               {startRunner.isPending ? (
                 <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/renderer/components/wizard/docker-setup-step.tsx
+++ b/src/renderer/components/wizard/docker-setup-step.tsx
@@ -16,7 +16,7 @@ import {
 const RUNTIME_INFO: Record<string, { name: string; description: string; installUrl: string }> = {
   'apple-container': {
     name: 'macOS Container',
-    description: 'Native container runtime built into macOS. Fast and lightweight with no extra software needed.',
+    description: 'Apple\'s container runtime for macOS. Gamut can install it for you (administrator password required).',
     installUrl: 'https://github.com/apple/container',
   },
   docker: {
@@ -198,7 +198,7 @@ export function DockerSetupStep({ onCanProceedChange }: DockerSetupStepProps) {
                         </span>
                         Starting up...
                       </p>
-                    ) : runtime.installed && runtime.canStart ? (
+                    ) : runtime.canStart ? (
                       <Button
                         size="sm"
                         variant="outline"
@@ -211,7 +211,7 @@ export function DockerSetupStep({ onCanProceedChange }: DockerSetupStepProps) {
                         ) : (
                           <Power className="!h-3 !w-3" />
                         )}
-                        Start {runtime.info.name}
+                        {runtime.installed ? `Start ${runtime.info.name}` : `Install ${runtime.info.name}`}
                       </Button>
                     ) : runtime.info.installUrl ? (
                       <Button

--- a/src/renderer/components/wizard/docker-setup-step.tsx
+++ b/src/renderer/components/wizard/docker-setup-step.tsx
@@ -6,9 +6,11 @@ import { getPlatform } from '@renderer/lib/env'
 import { Wsl2InstallGuide } from './wsl2-install-guide'
 import { RequestError } from '@renderer/components/messages/request-error'
 import { RunnerSetupErrorPanel, getRunnerSetupPayload } from '@renderer/components/settings/runner-setup-error-panel'
+import { RuntimeProvisionProgress } from '@renderer/components/runtime/runtime-provision-progress'
 import {
   Loader2,
-  Power,
+  Play,
+  Download,
   ArrowUpRight,
   RefreshCw,
 } from 'lucide-react'
@@ -17,7 +19,7 @@ const RUNTIME_INFO: Record<string, { name: string; description: string; installU
   'apple-container': {
     name: 'macOS Container',
     description: 'Apple\'s container runtime for macOS. Gamut can install it for you (administrator password required).',
-    installUrl: 'https://github.com/apple/container',
+    installUrl: '',
   },
   docker: {
     name: 'Docker Desktop',
@@ -87,13 +89,27 @@ export function DockerSetupStep({ onCanProceedChange }: DockerSetupStepProps) {
   const wsl2Runtime = runtimeStatuses.find((r) => r.runner === 'wsl2')
   const showWsl2Guide = isWindows && wsl2Runtime && !wsl2Runtime.installed
 
-  // Report to parent whether the selected runtime is available and running
+  // Report to parent whether the selected runtime is available and not mid-provision
   const selectedRuntime = runtimeStatuses.find((r) => r.runner === effectiveSelected)
+  const readinessStatus = runtimeStatus?.runtimeReadiness?.status
   useEffect(() => {
-    onCanProceedChange?.(selectedRuntime?.available ?? false)
-  }, [selectedRuntime?.available, onCanProceedChange])
+    const provisioningSelected =
+      startRunner.variables === selectedRuntime?.runner &&
+      (startRunner.isPending ||
+        readinessStatus === 'PULLING_IMAGE' ||
+        readinessStatus === 'CHECKING')
+    onCanProceedChange?.(Boolean(selectedRuntime?.available) && !provisioningSelected)
+  }, [
+    selectedRuntime?.available,
+    selectedRuntime?.runner,
+    readinessStatus,
+    startRunner.variables,
+    startRunner.isPending,
+    onCanProceedChange,
+  ])
 
   const handleStartRunner = async (runner: string) => {
+    startRunner.reset()
     try {
       await startRunner.mutateAsync(runner)
     } catch (error) {
@@ -188,6 +204,12 @@ export function DockerSetupStep({ onCanProceedChange }: DockerSetupStepProps) {
                         onRefresh={() => refreshAvailability.mutate()}
                         isRefreshing={refreshAvailability.isPending}
                       />
+                    ) : runtime.available &&
+                      startRunner.variables === runtime.runner &&
+                      runtimeStatus?.runtimeReadiness?.status === 'PULLING_IMAGE' ? (
+                      <RuntimeProvisionProgress
+                        progress={runtimeStatus.runtimeReadiness.pullProgress}
+                      />
                     ) : runtime.available ? (
                       null
                     ) : isStarting ? (
@@ -199,20 +221,32 @@ export function DockerSetupStep({ onCanProceedChange }: DockerSetupStepProps) {
                         Starting up...
                       </p>
                     ) : runtime.canStart ? (
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="h-7 text-xs pl-[8px]"
-                        onClick={() => handleStartRunner(runtime.runner)}
-                        disabled={startRunner.isPending}
-                      >
-                        {startRunner.isPending ? (
-                          <Loader2 className="h-3 w-3 animate-spin" />
-                        ) : (
-                          <Power className="!h-3 !w-3" />
+                      <div className="space-y-2">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs pl-[8px]"
+                          onClick={() => handleStartRunner(runtime.runner)}
+                          disabled={startRunner.isPending}
+                        >
+                          {startRunner.isPending && startRunner.variables === runtime.runner ? (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          ) : runtime.installed ? (
+                            <Play className="!h-3 !w-3" />
+                          ) : (
+                            <Download className="!h-3 !w-3" />
+                          )}
+                          {runtime.installed ? `Start ${runtime.info.name}` : `Install ${runtime.info.name}`}
+                        </Button>
+                        {startRunner.variables === runtime.runner &&
+                          (startRunner.isPending ||
+                            runtimeStatus?.runtimeReadiness?.status === 'CHECKING' ||
+                            runtimeStatus?.runtimeReadiness?.status === 'PULLING_IMAGE') && (
+                          <RuntimeProvisionProgress
+                            progress={runtimeStatus?.runtimeReadiness?.pullProgress}
+                          />
                         )}
-                        {runtime.installed ? `Start ${runtime.info.name}` : `Install ${runtime.info.name}`}
-                      </Button>
+                      </div>
                     ) : runtime.info.installUrl ? (
                       <Button
                         size="sm"

--- a/src/renderer/components/wizard/docker-setup-step.tsx
+++ b/src/renderer/components/wizard/docker-setup-step.tsx
@@ -91,22 +91,11 @@ export function DockerSetupStep({ onCanProceedChange }: DockerSetupStepProps) {
 
   // Report to parent whether the selected runtime is available and not mid-provision
   const selectedRuntime = runtimeStatuses.find((r) => r.runner === effectiveSelected)
-  const readinessStatus = runtimeStatus?.runtimeReadiness?.status
+  const provisioningSelected =
+    !!selectedRuntime && startRunner.isProvisioning(selectedRuntime.runner)
   useEffect(() => {
-    const provisioningSelected =
-      startRunner.variables === selectedRuntime?.runner &&
-      (startRunner.isPending ||
-        readinessStatus === 'PULLING_IMAGE' ||
-        readinessStatus === 'CHECKING')
     onCanProceedChange?.(Boolean(selectedRuntime?.available) && !provisioningSelected)
-  }, [
-    selectedRuntime?.available,
-    selectedRuntime?.runner,
-    readinessStatus,
-    startRunner.variables,
-    startRunner.isPending,
-    onCanProceedChange,
-  ])
+  }, [selectedRuntime?.available, provisioningSelected, onCanProceedChange])
 
   const handleStartRunner = async (runner: string) => {
     startRunner.reset()
@@ -238,10 +227,7 @@ export function DockerSetupStep({ onCanProceedChange }: DockerSetupStepProps) {
                           )}
                           {runtime.installed ? `Start ${runtime.info.name}` : `Install ${runtime.info.name}`}
                         </Button>
-                        {startRunner.variables === runtime.runner &&
-                          (startRunner.isPending ||
-                            runtimeStatus?.runtimeReadiness?.status === 'CHECKING' ||
-                            runtimeStatus?.runtimeReadiness?.status === 'PULLING_IMAGE') && (
+                        {startRunner.isProvisioning(runtime.runner) && (
                           <RuntimeProvisionProgress
                             progress={runtimeStatus?.runtimeReadiness?.pullProgress}
                           />
@@ -294,13 +280,13 @@ export function DockerSetupStep({ onCanProceedChange }: DockerSetupStepProps) {
         </div>
       )}
 
-      {startRunner.error && getRunnerSetupPayload(startRunner.error) ? (
-        <RunnerSetupErrorPanel error={startRunner.error} />
+      {startRunner.displayError && getRunnerSetupPayload(startRunner.displayError) ? (
+        <RunnerSetupErrorPanel error={startRunner.displayError} />
       ) : (
-        <RequestError message={startRunner.error?.message ?? null} />
+        <RequestError message={startRunner.displayError?.message ?? null} />
       )}
 
-      {startRunner.isSuccess && startRunner.data?.message && (
+      {startRunner.isSuccess && startRunner.data?.message && !startRunner.displayError && (
         <p className="text-sm text-green-600 dark:text-green-400">
           {startRunner.data.message}
         </p>

--- a/src/renderer/hooks/use-settings.ts
+++ b/src/renderer/hooks/use-settings.ts
@@ -201,7 +201,9 @@ export function useStartRunner() {
 
       return data
     },
-    onSuccess: () => {
+    // Re-read settings after success or failure so availability badges match
+    // the server (start-runner refreshes availability on both paths).
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['settings'] })
     },
   })

--- a/src/renderer/hooks/use-settings.ts
+++ b/src/renderer/hooks/use-settings.ts
@@ -180,8 +180,9 @@ export function useRefreshAvailability() {
 
 export function useStartRunner() {
   const queryClient = useQueryClient()
+  const { data: settings } = useSettings()
 
-  return useMutation<StartRunnerResponse, Error, string>({
+  const mutation = useMutation<StartRunnerResponse, Error, string>({
     meta: { skipGlobalErrorToast: true },
     mutationFn: async (runner) => {
       const res = await apiFetch('/api/settings/start-runner', {
@@ -213,6 +214,24 @@ export function useStartRunner() {
       queryClient.invalidateQueries({ queryKey: ['settings'] })
     },
   })
+
+  const activeRunner = mutation.variables
+  const readinessStatus = settings?.runtimeReadiness?.status
+  const isProvisioning = (runner: string) =>
+    activeRunner === runner &&
+    (mutation.isPending ||
+      readinessStatus === 'CHECKING' ||
+      readinessStatus === 'PULLING_IMAGE')
+
+  // Each surface owns its own mutation instance — drop a stale cancel/fail once
+  // that runner is available (e.g. success happened in the setup dialog).
+  const displayError =
+    activeRunner &&
+    settings?.runnerAvailability?.some((r) => r.runner === activeRunner && r.available)
+      ? null
+      : mutation.error
+
+  return { ...mutation, isProvisioning, displayError }
 }
 
 export function useRestartRunner() {

--- a/src/renderer/hooks/use-settings.ts
+++ b/src/renderer/hooks/use-settings.ts
@@ -193,6 +193,12 @@ export function useStartRunner() {
       const data = await res.json()
 
       if (!res.ok) {
+        if (Array.isArray(data?.runnerAvailability)) {
+          queryClient.setQueryData(['settings'], (old: unknown) => {
+            if (!old || typeof old !== 'object') return old
+            return { ...old, runnerAvailability: data.runnerAvailability }
+          })
+        }
         if (data?.setupError) {
           throw new RunnerSetupFailedError(data.setupError)
         }

--- a/src/renderer/hooks/use-settings.ts
+++ b/src/renderer/hooks/use-settings.ts
@@ -208,8 +208,6 @@ export function useStartRunner() {
 
       return data
     },
-    // Re-read settings after success or failure so availability badges match
-    // the server (start-runner refreshes availability on both paths).
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['settings'] })
     },
@@ -223,8 +221,7 @@ export function useStartRunner() {
       readinessStatus === 'CHECKING' ||
       readinessStatus === 'PULLING_IMAGE')
 
-  // Each surface owns its own mutation instance — drop a stale cancel/fail once
-  // that runner is available (e.g. success happened in the setup dialog).
+  // Drop stale cancel/fail once that runner is available (other surface may have succeeded).
   const displayError =
     activeRunner &&
     settings?.runnerAvailability?.some((r) => r.runner === activeRunner && r.available)

--- a/src/shared/lib/container/apple-container-client.test.ts
+++ b/src/shared/lib/container/apple-container-client.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-// ============================================================================
-// Mocks — before importing the module under test
-// ============================================================================
-
 const mockExecSync = vi.fn()
 vi.mock('child_process', () => ({
   execSync: (...args: unknown[]) => mockExecSync(...args),
@@ -86,16 +82,11 @@ describe('AppleContainerClient.isEligible', () => {
 
   it.each([
     { platform: 'darwin', arch: 'arm64', version: '26.0', expected: true, label: 'arm64 macOS 26+' },
-    { platform: 'darwin', arch: 'x64', version: '26.0', expected: false, label: 'Intel' },
     { platform: 'darwin', arch: 'arm64', version: '15.4', expected: false, label: 'macOS < 26' },
-    { platform: 'linux', arch: 'arm64', version: '26.0', expected: false, label: 'non-darwin' },
   ])('isEligible=$expected for $label', ({ platform, arch, version, expected }) => {
     setPlatformArch(platform, arch)
     mockExecSync.mockReturnValue(Buffer.from(`${version}\n`))
     expect(AppleContainerClient.isEligible()).toBe(expected)
-    if (arch !== 'arm64' || platform !== 'darwin') {
-      expect(mockExecSync).not.toHaveBeenCalled()
-    }
   })
 })
 

--- a/src/shared/lib/container/apple-container-client.test.ts
+++ b/src/shared/lib/container/apple-container-client.test.ts
@@ -13,9 +13,12 @@ const mockCheckCommandAvailable = vi.fn()
 const mockExecWithPath = vi.fn()
 vi.mock('./base-container-client', () => ({
   BaseContainerClient: class {
-    config: unknown
-    constructor(config: unknown) {
+    config: { agentId: string }
+    constructor(config: { agentId: string }) {
       this.config = config
+    }
+    getContainerName() {
+      return `superagent-${this.config.agentId}`
     }
   },
   checkCommandAvailable: (...args: unknown[]) => mockCheckCommandAvailable(...args),
@@ -41,6 +44,25 @@ import {
   ensureAppleContainerReady,
   resetAppleContainerClientForTests,
 } from './apple-container-client'
+
+describe('AppleContainerClient.getInfoFromRuntime', () => {
+  it('treats status.state=running as running (Apple Container 1.x inspect shape)', async () => {
+    mockExecWithPath.mockResolvedValue({
+      stdout: JSON.stringify({
+        status: { state: 'running', networks: [] },
+        configuration: {
+          publishedPorts: [{ containerPort: 3000, hostPort: 5001, proto: 'tcp' }],
+        },
+      }),
+    })
+
+    const client = new AppleContainerClient({ agentId: 'abc123' })
+    await expect(client.getInfoFromRuntime()).resolves.toEqual({
+      status: 'running',
+      port: 5001,
+    })
+  })
+})
 
 describe('AppleContainerClient.isEligible', () => {
   const originalPlatform = process.platform
@@ -107,33 +129,69 @@ describe('ensureAppleContainerReady', () => {
     const fetchSpy = vi.fn()
     globalThis.fetch = fetchSpy as unknown as typeof fetch
 
-    await ensureAppleContainerReady()
+    await ensureAppleContainerReady(undefined, { allowInstall: true })
 
     expect(fetchSpy).not.toHaveBeenCalled()
     expect(mockRunWithAdminPrivileges).not.toHaveBeenCalled()
     expect(mockExecWithPath).toHaveBeenCalledWith('container system start --enable-kernel-install')
   })
 
-  it('first-install: download, verify, elevate, start', async () => {
+  it('refuses first-install without allowInstall', async () => {
+    mockCheckCommandAvailable.mockResolvedValue(false)
+
+    await expect(ensureAppleContainerReady()).rejects.toThrow(/Click Install/i)
+    expect(mockRunWithAdminPrivileges).not.toHaveBeenCalled()
+  })
+
+  it('first-install: download, verify, elevate with rehash, start', async () => {
     mockCheckCommandAvailable.mockResolvedValue(false)
     appleContainerProvisionIO.downloadToFile = vi.fn().mockResolvedValue(undefined)
     appleContainerProvisionIO.hashFileSha256 = vi.fn().mockResolvedValue(APPLE_CONTAINER_PKG_SHA256)
     mockRunWithAdminPrivileges.mockResolvedValue(undefined)
     mockExecWithPath.mockResolvedValue({ stdout: '', stderr: '' })
 
-    await ensureAppleContainerReady()
+    await ensureAppleContainerReady(undefined, { allowInstall: true })
 
     expect(appleContainerProvisionIO.downloadToFile).toHaveBeenCalledOnce()
     expect(mockRunWithAdminPrivileges).toHaveBeenCalledOnce()
-    expect(mockRunWithAdminPrivileges.mock.calls[0]?.[0]).toMatch(/^installer -pkg '.*' -target \/$/)
+    const elevateCmd = mockRunWithAdminPrivileges.mock.calls[0]?.[0] as string
+    expect(elevateCmd).toContain('/usr/bin/mktemp')
+    expect(elevateCmd).toContain('trap ')
+    expect(elevateCmd).toContain('/usr/bin/shasum -a 256')
+    expect(elevateCmd).toContain('/usr/sbin/installer -pkg')
+    expect(elevateCmd).toContain(APPLE_CONTAINER_PKG_SHA256)
     expect(mockExecWithPath).toHaveBeenCalledWith('container system start --enable-kernel-install')
+  })
+
+  it('reports download percent then phase labels (no fake overall %)', async () => {
+    mockCheckCommandAvailable.mockResolvedValue(false)
+    appleContainerProvisionIO.downloadToFile = vi.fn(
+      async (_url: string, _dest: string, onBytes?: (downloaded: number, total: number | null) => void) => {
+        onBytes?.(50, 100)
+        onBytes?.(100, 100)
+      },
+    )
+    appleContainerProvisionIO.hashFileSha256 = vi.fn().mockResolvedValue(APPLE_CONTAINER_PKG_SHA256)
+    mockRunWithAdminPrivileges.mockResolvedValue(undefined)
+    mockExecWithPath.mockResolvedValue({ stdout: '', stderr: '' })
+
+    const events: Array<{ status: string; percent: number | null }> = []
+    await ensureAppleContainerReady((p) => events.push(p), { allowInstall: true })
+
+    expect(events.some((e) => e.status.includes('Downloading') && e.percent === 50)).toBe(true)
+    expect(events.some((e) => e.status.includes('Verifying') && e.percent === null)).toBe(true)
+    expect(events.some((e) => e.status.includes('password') && e.percent === null)).toBe(true)
+    expect(events.some((e) => e.status.includes('Starting') && e.percent === null)).toBe(true)
+    // After download, never invent a rising overall percent
+    const afterDownload = events.slice(events.findIndex((e) => e.status.includes('Verifying')))
+    expect(afterDownload.every((e) => e.percent === null)).toBe(true)
   })
 
   it('refuses to provision on ineligible machines', async () => {
     Object.defineProperty(process, 'arch', { value: 'x64', writable: true, configurable: true })
     resetAppleContainerClientForTests()
 
-    await expect(ensureAppleContainerReady()).rejects.toThrow(/Apple silicon|macOS 26/i)
+    await expect(ensureAppleContainerReady(undefined, { allowInstall: true })).rejects.toThrow(/Apple silicon|macOS 26/i)
     expect(mockRunWithAdminPrivileges).not.toHaveBeenCalled()
   })
 
@@ -148,10 +206,11 @@ describe('ensureAppleContainerReady', () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
+      headers: { get: () => null },
       body: badBody,
     }) as unknown as typeof fetch
 
-    await expect(ensureAppleContainerReady()).rejects.toThrow(/integrity check/i)
+    await expect(ensureAppleContainerReady(undefined, { allowInstall: true })).rejects.toThrow(/integrity check/i)
     expect(mockRunWithAdminPrivileges).not.toHaveBeenCalled()
   })
 
@@ -161,7 +220,7 @@ describe('ensureAppleContainerReady', () => {
     appleContainerProvisionIO.hashFileSha256 = vi.fn().mockResolvedValue(APPLE_CONTAINER_PKG_SHA256)
     mockRunWithAdminPrivileges.mockRejectedValue(new Error('User canceled. (-128)'))
 
-    await expect(ensureAppleContainerReady()).rejects.toThrow(/cancelled|canceled/i)
+    await expect(ensureAppleContainerReady(undefined, { allowInstall: true })).rejects.toThrow(/cancelled|canceled/i)
     expect(mockRunWithAdminPrivileges.mock.calls[0]?.[0]).not.toContain('http')
   })
 
@@ -176,8 +235,8 @@ describe('ensureAppleContainerReady', () => {
     })
     mockExecWithPath.mockResolvedValue({ stdout: '', stderr: '' })
 
-    const p1 = ensureAppleContainerReady()
-    const p2 = ensureAppleContainerReady()
+    const p1 = ensureAppleContainerReady(undefined, { allowInstall: true })
+    const p2 = ensureAppleContainerReady(undefined, { allowInstall: true })
     expect(availableCalls).toBe(1)
 
     resolveAvailable?.(true)

--- a/src/shared/lib/container/apple-container-client.test.ts
+++ b/src/shared/lib/container/apple-container-client.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ============================================================================
+// Mocks — before importing the module under test
+// ============================================================================
+
+const mockExecSync = vi.fn()
+vi.mock('child_process', () => ({
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}))
+
+const mockCheckCommandAvailable = vi.fn()
+const mockExecWithPath = vi.fn()
+vi.mock('./base-container-client', () => ({
+  BaseContainerClient: class {
+    config: unknown
+    constructor(config: unknown) {
+      this.config = config
+    }
+  },
+  checkCommandAvailable: (...args: unknown[]) => mockCheckCommandAvailable(...args),
+  execWithPath: (...args: unknown[]) => mockExecWithPath(...args),
+  CONTAINER_INTERNAL_PORT: 3000,
+  shellEscape: (value: string) => `'${value.replace(/'/g, `'\\''`)}'`,
+}))
+
+const mockRunWithAdminPrivileges = vi.fn()
+const mockIsAdminPrivilegeCancelError = vi.fn((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+  return message.includes('User canceled') || message.includes('-128')
+})
+vi.mock('@shared/lib/run-with-admin-privileges', () => ({
+  runWithAdminPrivileges: (...args: unknown[]) => mockRunWithAdminPrivileges(...args),
+  isAdminPrivilegeCancelError: (error: unknown) => mockIsAdminPrivilegeCancelError(error),
+}))
+
+import {
+  AppleContainerClient,
+  APPLE_CONTAINER_PKG_SHA256,
+  appleContainerProvisionIO,
+  ensureAppleContainerReady,
+  resetAppleContainerClientForTests,
+} from './apple-container-client'
+
+describe('AppleContainerClient.isEligible', () => {
+  const originalPlatform = process.platform
+  const originalArch = process.arch
+
+  beforeEach(() => {
+    resetAppleContainerClientForTests()
+    mockExecSync.mockReset()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true, configurable: true })
+    Object.defineProperty(process, 'arch', { value: originalArch, writable: true, configurable: true })
+    resetAppleContainerClientForTests()
+  })
+
+  function setPlatformArch(platform: string, arch: string) {
+    Object.defineProperty(process, 'platform', { value: platform, writable: true, configurable: true })
+    Object.defineProperty(process, 'arch', { value: arch, writable: true, configurable: true })
+  }
+
+  it.each([
+    { platform: 'darwin', arch: 'arm64', version: '26.0', expected: true, label: 'arm64 macOS 26+' },
+    { platform: 'darwin', arch: 'x64', version: '26.0', expected: false, label: 'Intel' },
+    { platform: 'darwin', arch: 'arm64', version: '15.4', expected: false, label: 'macOS < 26' },
+    { platform: 'linux', arch: 'arm64', version: '26.0', expected: false, label: 'non-darwin' },
+  ])('isEligible=$expected for $label', ({ platform, arch, version, expected }) => {
+    setPlatformArch(platform, arch)
+    mockExecSync.mockReturnValue(Buffer.from(`${version}\n`))
+    expect(AppleContainerClient.isEligible()).toBe(expected)
+    if (arch !== 'arm64' || platform !== 'darwin') {
+      expect(mockExecSync).not.toHaveBeenCalled()
+    }
+  })
+})
+
+describe('ensureAppleContainerReady', () => {
+  const originalPlatform = process.platform
+  const originalArch = process.arch
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    resetAppleContainerClientForTests()
+    vi.clearAllMocks()
+    Object.defineProperty(process, 'platform', { value: 'darwin', writable: true, configurable: true })
+    Object.defineProperty(process, 'arch', { value: 'arm64', writable: true, configurable: true })
+    mockExecSync.mockReturnValue(Buffer.from('26.0\n'))
+    mockIsAdminPrivilegeCancelError.mockImplementation((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error ?? '')
+      return message.includes('User canceled') || message.includes('-128')
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true, configurable: true })
+    Object.defineProperty(process, 'arch', { value: originalArch, writable: true, configurable: true })
+    globalThis.fetch = originalFetch
+    resetAppleContainerClientForTests()
+  })
+
+  it('skips download when CLI is already installed', async () => {
+    mockCheckCommandAvailable.mockResolvedValue(true)
+    mockExecWithPath.mockResolvedValue({ stdout: '', stderr: '' })
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+
+    await ensureAppleContainerReady()
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(mockRunWithAdminPrivileges).not.toHaveBeenCalled()
+    expect(mockExecWithPath).toHaveBeenCalledWith('container system start --enable-kernel-install')
+  })
+
+  it('first-install: download, verify, elevate, start', async () => {
+    mockCheckCommandAvailable.mockResolvedValue(false)
+    appleContainerProvisionIO.downloadToFile = vi.fn().mockResolvedValue(undefined)
+    appleContainerProvisionIO.hashFileSha256 = vi.fn().mockResolvedValue(APPLE_CONTAINER_PKG_SHA256)
+    mockRunWithAdminPrivileges.mockResolvedValue(undefined)
+    mockExecWithPath.mockResolvedValue({ stdout: '', stderr: '' })
+
+    await ensureAppleContainerReady()
+
+    expect(appleContainerProvisionIO.downloadToFile).toHaveBeenCalledOnce()
+    expect(mockRunWithAdminPrivileges).toHaveBeenCalledOnce()
+    expect(mockRunWithAdminPrivileges.mock.calls[0]?.[0]).toMatch(/^installer -pkg '.*' -target \/$/)
+    expect(mockExecWithPath).toHaveBeenCalledWith('container system start --enable-kernel-install')
+  })
+
+  it('refuses to provision on ineligible machines', async () => {
+    Object.defineProperty(process, 'arch', { value: 'x64', writable: true, configurable: true })
+    resetAppleContainerClientForTests()
+
+    await expect(ensureAppleContainerReady()).rejects.toThrow(/Apple silicon|macOS 26/i)
+    expect(mockRunWithAdminPrivileges).not.toHaveBeenCalled()
+  })
+
+  it('never elevates when downloaded digest mismatches', async () => {
+    mockCheckCommandAvailable.mockResolvedValue(false)
+    const badBody = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('not-the-installer'))
+        controller.close()
+      },
+    })
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: badBody,
+    }) as unknown as typeof fetch
+
+    await expect(ensureAppleContainerReady()).rejects.toThrow(/integrity check/i)
+    expect(mockRunWithAdminPrivileges).not.toHaveBeenCalled()
+  })
+
+  it('maps admin cancel to a recoverable error', async () => {
+    mockCheckCommandAvailable.mockResolvedValue(false)
+    appleContainerProvisionIO.downloadToFile = vi.fn().mockResolvedValue(undefined)
+    appleContainerProvisionIO.hashFileSha256 = vi.fn().mockResolvedValue(APPLE_CONTAINER_PKG_SHA256)
+    mockRunWithAdminPrivileges.mockRejectedValue(new Error('User canceled. (-128)'))
+
+    await expect(ensureAppleContainerReady()).rejects.toThrow(/cancelled|canceled/i)
+    expect(mockRunWithAdminPrivileges.mock.calls[0]?.[0]).not.toContain('http')
+  })
+
+  it('mutex serializes concurrent ensure calls', async () => {
+    let resolveAvailable: ((v: boolean) => void) | undefined
+    let availableCalls = 0
+    mockCheckCommandAvailable.mockImplementation(() => {
+      availableCalls++
+      return new Promise<boolean>((resolve) => {
+        resolveAvailable = resolve
+      })
+    })
+    mockExecWithPath.mockResolvedValue({ stdout: '', stderr: '' })
+
+    const p1 = ensureAppleContainerReady()
+    const p2 = ensureAppleContainerReady()
+    expect(availableCalls).toBe(1)
+
+    resolveAvailable?.(true)
+    await Promise.all([p1, p2])
+    expect(availableCalls).toBe(1)
+  })
+})

--- a/src/shared/lib/container/apple-container-client.test.ts
+++ b/src/shared/lib/container/apple-container-client.test.ts
@@ -143,27 +143,7 @@ describe('ensureAppleContainerReady', () => {
     expect(mockRunWithAdminPrivileges).not.toHaveBeenCalled()
   })
 
-  it('first-install: download, verify, elevate with rehash, start', async () => {
-    mockCheckCommandAvailable.mockResolvedValue(false)
-    appleContainerProvisionIO.downloadToFile = vi.fn().mockResolvedValue(undefined)
-    appleContainerProvisionIO.hashFileSha256 = vi.fn().mockResolvedValue(APPLE_CONTAINER_PKG_SHA256)
-    mockRunWithAdminPrivileges.mockResolvedValue(undefined)
-    mockExecWithPath.mockResolvedValue({ stdout: '', stderr: '' })
-
-    await ensureAppleContainerReady(undefined, { allowInstall: true })
-
-    expect(appleContainerProvisionIO.downloadToFile).toHaveBeenCalledOnce()
-    expect(mockRunWithAdminPrivileges).toHaveBeenCalledOnce()
-    const elevateCmd = mockRunWithAdminPrivileges.mock.calls[0]?.[0] as string
-    expect(elevateCmd).toContain('/usr/bin/mktemp')
-    expect(elevateCmd).toContain('trap ')
-    expect(elevateCmd).toContain('/usr/bin/shasum -a 256')
-    expect(elevateCmd).toContain('/usr/sbin/installer -pkg')
-    expect(elevateCmd).toContain(APPLE_CONTAINER_PKG_SHA256)
-    expect(mockExecWithPath).toHaveBeenCalledWith('container system start --enable-kernel-install')
-  })
-
-  it('reports download percent then phase labels (no fake overall %)', async () => {
+  it('first-install: download, verify, elevate with rehash, start + progress', async () => {
     mockCheckCommandAvailable.mockResolvedValue(false)
     appleContainerProvisionIO.downloadToFile = vi.fn(
       async (_url: string, _dest: string, onBytes?: (downloaded: number, total: number | null) => void) => {
@@ -178,10 +158,17 @@ describe('ensureAppleContainerReady', () => {
     const events: Array<{ status: string; percent: number | null }> = []
     await ensureAppleContainerReady((p) => events.push(p), { allowInstall: true })
 
+    expect(appleContainerProvisionIO.downloadToFile).toHaveBeenCalledOnce()
+    expect(mockRunWithAdminPrivileges).toHaveBeenCalledOnce()
+    const elevateCmd = mockRunWithAdminPrivileges.mock.calls[0]?.[0] as string
+    expect(elevateCmd).toContain('/usr/bin/mktemp')
+    expect(elevateCmd).toContain('trap ')
+    expect(elevateCmd).toContain('/usr/bin/shasum -a 256')
+    expect(elevateCmd).toContain('/usr/sbin/installer -pkg')
+    expect(elevateCmd).toContain(APPLE_CONTAINER_PKG_SHA256)
+    expect(mockExecWithPath).toHaveBeenCalledWith('container system start --enable-kernel-install')
     expect(events.some((e) => e.status.includes('Downloading') && e.percent === 50)).toBe(true)
     expect(events.some((e) => e.status.includes('Verifying') && e.percent === null)).toBe(true)
-    expect(events.some((e) => e.status.includes('password') && e.percent === null)).toBe(true)
-    expect(events.some((e) => e.status.includes('Starting') && e.percent === null)).toBe(true)
     // After download, never invent a rising overall percent
     const afterDownload = events.slice(events.findIndex((e) => e.status.includes('Verifying')))
     expect(afterDownload.every((e) => e.percent === null)).toBe(true)

--- a/src/shared/lib/container/apple-container-client.ts
+++ b/src/shared/lib/container/apple-container-client.ts
@@ -4,11 +4,14 @@ import { createReadStream, createWriteStream } from 'fs'
 import { mkdtemp, rm } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { Readable } from 'stream'
+import { Readable, Transform } from 'stream'
 import { pipeline } from 'stream/promises'
 import { BaseContainerClient, checkCommandAvailable, execWithPath, CONTAINER_INTERNAL_PORT, shellEscape } from './base-container-client'
-import type { ContainerConfig, ContainerInfo, ContainerStats } from './types'
+import type { ContainerConfig, ContainerInfo, ContainerStats, ImagePullProgress } from './types'
 import { isAdminPrivilegeCancelError, runWithAdminPrivileges } from '@shared/lib/run-with-admin-privileges'
+
+/** Progress for install/start. Reuses ImagePullProgress so readiness UI can share the bar. */
+export type AppleContainerProvisionProgress = Pick<ImagePullProgress, 'status' | 'percent'>
 
 /** Pinned signed installer (bump deliberately; do not follow releases/latest). */
 const APPLE_CONTAINER_VERSION = '1.1.0'
@@ -24,6 +27,8 @@ let cachedMacOSMajorVersion: number | null | undefined = undefined
 
 /** Mutex: concurrent ensureAppleContainerReady callers share one in-flight promise. */
 let appleReadyPromise: Promise<void> | null = null
+/** Whether the in-flight ensure allows first-install (for join rules). */
+let appleReadyAllowsInstall = false
 
 function getMacOSMajorVersion(): number | null {
   if (cachedMacOSMajorVersion !== undefined) {
@@ -35,12 +40,19 @@ function getMacOSMajorVersion(): number | null {
   }
   try {
     const output = execSync('sw_vers -productVersion', { timeout: 5000 }).toString().trim()
-    cachedMacOSMajorVersion = parseInt(output.split('.')[0], 10)
-    return cachedMacOSMajorVersion
+    const major = parseInt(output.split('.')[0], 10)
+    // Don't cache probe failures — refresh can retry eligibility.
+    if (!Number.isFinite(major)) return null
+    cachedMacOSMajorVersion = major
+    return major
   } catch {
-    cachedMacOSMajorVersion = null
     return null
   }
+}
+
+/** Clear macOS version cache so eligibility can be re-probed (e.g. after a failed sw_vers). */
+export function clearMacOSVersionCache(): void {
+  cachedMacOSMajorVersion = undefined
 }
 
 async function hashFileSha256(filePath: string): Promise<string> {
@@ -49,7 +61,11 @@ async function hashFileSha256(filePath: string): Promise<string> {
   return hash.digest('hex')
 }
 
-async function downloadToFile(url: string, destPath: string): Promise<void> {
+async function downloadToFile(
+  url: string,
+  destPath: string,
+  onBytes?: (downloaded: number, total: number | null) => void,
+): Promise<void> {
   let response: Response
   try {
     response = await fetch(url, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) })
@@ -63,9 +79,19 @@ async function downloadToFile(url: string, destPath: string): Promise<void> {
   if (!response.ok || !response.body) {
     throw new Error(`Failed to download Apple Container installer (HTTP ${response.status}).`)
   }
+  const contentLength = Number(response.headers.get('content-length'))
+  const total = Number.isFinite(contentLength) && contentLength > 0 ? contentLength : null
+  let downloaded = 0
   // Node fetch body is a web ReadableStream; bridge to Node for pipeline.
   const nodeStream = Readable.fromWeb(response.body as import('stream/web').ReadableStream)
-  await pipeline(nodeStream, createWriteStream(destPath))
+  const progress = new Transform({
+    transform(chunk, _encoding, callback) {
+      downloaded += chunk.length
+      onBytes?.(downloaded, total)
+      callback(null, chunk)
+    },
+  })
+  await pipeline(nodeStream, progress, createWriteStream(destPath))
 }
 
 /** IO seam for unit tests (install path only). */
@@ -125,8 +151,11 @@ export class AppleContainerClient extends BaseContainerClient {
       // Handle both possible formats: single object or array of objects
       const info = Array.isArray(data) ? data[0] : data
 
-      // Extract running state (Apple uses top-level "status" field)
-      const isRunning = info?.status === 'running'
+      // Apple Container 1.x: status is `{ state: 'running', ... }`.
+      // Older shape used a string; accept both.
+      const state =
+        typeof info?.status === 'string' ? info.status : info?.status?.state
+      const isRunning = state === 'running'
 
       // Extract port mappings (Apple uses configuration.publishedPorts)
       let port: number | null = null
@@ -183,9 +212,9 @@ export class AppleContainerClient extends BaseContainerClient {
   }
 
   /**
-   * Apple Container uses `container image list --format json` + `container image remove`.
+   * Apple Container uses `container image list --format json` + `container image delete`.
+   * Prefer `displayReference` (Apple 1.x); fall back to repository:tag.
    */
-  // TODO test this
   static async removeOldImages(cliCommand: string, registry: string, currentTag: string): Promise<void> {
     try {
       const { stdout } = await execWithPath(`${cliCommand} image list --format json`)
@@ -194,18 +223,23 @@ export class AppleContainerClient extends BaseContainerClient {
 
       const currentImage = `${registry}:${currentTag}`
       const imagesToRemove = images
-        .filter((img: any) => {
-          const ref = `${img.repository}:${img.tag}`
-          return ref !== currentImage && ref.startsWith(registry + ':')
-        })
-        .map((img: any) => `${img.repository}:${img.tag}`)
+        .map((img: any) =>
+          typeof img.displayReference === 'string'
+            ? img.displayReference
+            : img.repository && img.tag
+              ? `${img.repository}:${img.tag}`
+              : null,
+        )
+        .filter((ref: string | null): ref is string =>
+          !!ref && ref !== currentImage && ref.startsWith(registry + ':'),
+        )
 
       if (imagesToRemove.length === 0) return
 
       console.log(`[ContainerManager] Removing ${imagesToRemove.length} old image(s):`, imagesToRemove)
       for (const img of imagesToRemove) {
         try {
-          await execWithPath(`${cliCommand} image remove ${img}`)
+          await execWithPath(`${cliCommand} image delete ${shellEscape(img)}`)
           console.log(`[ContainerManager] Removed ${img}`)
         } catch {
           console.warn(`[ContainerManager] Could not remove ${img} (may be in use)`)
@@ -214,6 +248,11 @@ export class AppleContainerClient extends BaseContainerClient {
     } catch (error) {
       console.warn('[ContainerManager] Failed to remove old images:', error)
     }
+  }
+
+  /** Apple has no `rmi`; corrupt-image recovery uses `image delete`. */
+  protected async removeCorruptImage(image: string): Promise<void> {
+    await execWithPath(`${this.getRunnerShellCommand()} image delete ${shellEscape(image)}`)
   }
 
   /**
@@ -236,7 +275,17 @@ export class AppleContainerClient extends BaseContainerClient {
   }
 }
 
-async function installAppleContainerPkg(): Promise<void> {
+function reportProgress(
+  onProgress: ((progress: AppleContainerProvisionProgress) => void) | undefined,
+  status: string,
+  percent: number | null,
+): void {
+  onProgress?.({ status, percent })
+}
+
+async function installAppleContainerPkg(
+  onProgress?: (progress: AppleContainerProvisionProgress) => void,
+): Promise<void> {
   const url =
     `https://github.com/apple/container/releases/download/${APPLE_CONTAINER_VERSION}` +
     `/container-${APPLE_CONTAINER_VERSION}-installer-signed.pkg`
@@ -245,8 +294,24 @@ async function installAppleContainerPkg(): Promise<void> {
 
   try {
     console.log(`[AppleContainer] Downloading signed installer ${APPLE_CONTAINER_VERSION}...`)
-    await appleContainerProvisionIO.downloadToFile(url, pkgPath)
+    reportProgress(onProgress, 'Downloading macOS Container installer...', 0)
+    let lastPercent = -1
+    let reportedIndeterminate = false
+    await appleContainerProvisionIO.downloadToFile(url, pkgPath, (downloaded, total) => {
+      if (total == null) {
+        if (!reportedIndeterminate) {
+          reportedIndeterminate = true
+          reportProgress(onProgress, 'Downloading macOS Container installer...', null)
+        }
+        return
+      }
+      const percent = Math.min(100, Math.floor((downloaded / total) * 100))
+      if (percent === lastPercent) return
+      lastPercent = percent
+      reportProgress(onProgress, 'Downloading macOS Container installer...', percent)
+    })
 
+    reportProgress(onProgress, 'Verifying installer...', null)
     const actualSha = await appleContainerProvisionIO.hashFileSha256(pkgPath)
     if (actualSha.toLowerCase() !== APPLE_CONTAINER_PKG_SHA256.toLowerCase()) {
       throw new Error(
@@ -254,8 +319,23 @@ async function installAppleContainerPkg(): Promise<void> {
       )
     }
 
+    // Elevate: copy to root tmp, re-hash, then install (closes same-UID TOCTOU
+    // between the Node verify above and privileged installer open).
+    reportProgress(onProgress, 'Installing - enter your password if prompted...', null)
+    const elevateScript = [
+      'set -e',
+      `SRC=${shellEscape(pkgPath)}`,
+      `EXPECTED=${shellEscape(APPLE_CONTAINER_PKG_SHA256)}`,
+      'TMP=$(/usr/bin/mktemp /tmp/superagent-container-XXXXXX.pkg)',
+      'trap \'/bin/rm -f "$TMP"\' EXIT',
+      '/bin/cp "$SRC" "$TMP"',
+      '/bin/chmod 400 "$TMP"',
+      'ACTUAL=$(/usr/bin/shasum -a 256 "$TMP" | /usr/bin/awk \'{print $1}\')',
+      '[ "$ACTUAL" = "$EXPECTED" ]',
+      '/usr/sbin/installer -pkg "$TMP" -target /',
+    ].join('\n')
     try {
-      await runWithAdminPrivileges(`installer -pkg ${shellEscape(pkgPath)} -target /`)
+      await runWithAdminPrivileges(elevateScript)
     } catch (error) {
       if (isAdminPrivilegeCancelError(error)) {
         throw new Error(
@@ -270,16 +350,23 @@ async function installAppleContainerPkg(): Promise<void> {
   }
 }
 
-async function ensureAppleContainerReadyImpl(): Promise<void> {
+async function ensureAppleContainerReadyImpl(
+  onProgress: ((progress: AppleContainerProvisionProgress) => void) | undefined,
+  allowInstall: boolean,
+): Promise<void> {
   if (!AppleContainerClient.isEligible()) {
     throw new Error('macOS Container requires macOS 26 or later on Apple silicon.')
   }
 
   const installed = await AppleContainerClient.isAvailable()
   if (!installed) {
-    await installAppleContainerPkg()
+    if (!allowInstall) {
+      throw new Error('macOS Container is not installed. Click Install to set it up.')
+    }
+    await installAppleContainerPkg(onProgress)
   }
 
+  reportProgress(onProgress, 'Starting macOS Container...', null)
   try {
     await execWithPath('container system start --enable-kernel-install')
   } catch (error: any) {
@@ -297,25 +384,40 @@ async function ensureAppleContainerReadyImpl(): Promise<void> {
 }
 
 /**
- * Ensure the Apple Container CLI is installed (first install only when missing)
- * and the system is started. Called by startRunner('apple-container') on explicit
- * Start/Install click. Serialized: concurrent calls share the same in-flight promise.
+ * Ensure the Apple Container CLI is installed (only when allowInstall) and the
+ * system is started. Install requires an explicit Start/Install click path.
+ * Serialized: concurrent callers share one in-flight promise when compatible.
  */
-export async function ensureAppleContainerReady(): Promise<void> {
-  if (appleReadyPromise) {
+export async function ensureAppleContainerReady(
+  onProgress?: (progress: AppleContainerProvisionProgress) => void,
+  options?: { allowInstall?: boolean },
+): Promise<void> {
+  const allowInstall = options?.allowInstall === true
+  // Join in-flight only if it already allows install, or we don't need install.
+  if (appleReadyPromise && (appleReadyAllowsInstall || !allowInstall)) {
     return appleReadyPromise
   }
-  appleReadyPromise = ensureAppleContainerReadyImpl()
+  if (appleReadyPromise) {
+    try {
+      await appleReadyPromise
+    } catch {
+      // Prior non-install attempt failed; fall through to start our own.
+    }
+  }
+  appleReadyAllowsInstall = allowInstall
+  appleReadyPromise = ensureAppleContainerReadyImpl(onProgress, allowInstall)
   try {
     await appleReadyPromise
   } finally {
     appleReadyPromise = null
+    appleReadyAllowsInstall = false
   }
 }
 
 export function resetAppleContainerClientForTests(): void {
   cachedMacOSMajorVersion = undefined
   appleReadyPromise = null
+  appleReadyAllowsInstall = false
   appleContainerProvisionIO.downloadToFile = downloadToFile
   appleContainerProvisionIO.hashFileSha256 = hashFileSha256
 }

--- a/src/shared/lib/container/apple-container-client.ts
+++ b/src/shared/lib/container/apple-container-client.ts
@@ -10,24 +10,15 @@ import { BaseContainerClient, checkCommandAvailable, execWithPath, CONTAINER_INT
 import type { ContainerConfig, ContainerInfo, ContainerStats, ImagePullProgress } from './types'
 import { isAdminPrivilegeCancelError, runWithAdminPrivileges } from '@shared/lib/run-with-admin-privileges'
 
-/** Progress for install/start. Reuses ImagePullProgress so readiness UI can share the bar. */
 export type AppleContainerProvisionProgress = Pick<ImagePullProgress, 'status' | 'percent'>
 
-/** Pinned signed installer (bump deliberately; do not follow releases/latest). */
-const APPLE_CONTAINER_VERSION = '1.1.0'
-
-/** GitHub release asset digest for container-${VERSION}-installer-signed.pkg at pin time. */
+const APPLE_CONTAINER_VERSION = '1.1.0' // pin; do not follow releases/latest
 export const APPLE_CONTAINER_PKG_SHA256 =
   '0ca1c42a2269c2557efb1d82b1b38ac553e6a3a3da1b1179c439bcee1e7d6714'
-
 const DOWNLOAD_TIMEOUT_MS = 10 * 60 * 1000
 
-/** Cached macOS major version (null = not macOS / failed, undefined = not yet checked) */
-let cachedMacOSMajorVersion: number | null | undefined = undefined
-
-/** Mutex: concurrent ensureAppleContainerReady callers share one in-flight promise. */
+let cachedMacOSMajorVersion: number | null | undefined = undefined // null failures not cached
 let appleReadyPromise: Promise<void> | null = null
-/** Whether the in-flight ensure allows first-install (for join rules). */
 let appleReadyAllowsInstall = false
 
 function getMacOSMajorVersion(): number | null {
@@ -41,7 +32,6 @@ function getMacOSMajorVersion(): number | null {
   try {
     const output = execSync('sw_vers -productVersion', { timeout: 5000 }).toString().trim()
     const major = parseInt(output.split('.')[0], 10)
-    // Don't cache probe failures — refresh can retry eligibility.
     if (!Number.isFinite(major)) return null
     cachedMacOSMajorVersion = major
     return major
@@ -77,7 +67,6 @@ async function downloadToFile(
   const contentLength = Number(response.headers.get('content-length'))
   const total = Number.isFinite(contentLength) && contentLength > 0 ? contentLength : null
   let downloaded = 0
-  // Node fetch body is a web ReadableStream; bridge to Node for pipeline.
   const nodeStream = Readable.fromWeb(response.body as import('stream/web').ReadableStream)
   const progress = new Transform({
     transform(chunk, _encoding, callback) {
@@ -89,7 +78,6 @@ async function downloadToFile(
   await pipeline(nodeStream, progress, createWriteStream(destPath))
 }
 
-/** IO seam for unit tests (install path only). */
 export const appleContainerProvisionIO = {
   downloadToFile,
   hashFileSha256,
@@ -106,9 +94,7 @@ export class AppleContainerClient extends BaseContainerClient {
     super(config)
   }
 
-  /**
-   * Eligible only on Apple silicon running macOS 26+.
-   */
+  /** Apple silicon + macOS 26+. */
   static isEligible(): boolean {
     if (process.arch !== 'arm64') return false
     const version = getMacOSMajorVersion()
@@ -314,8 +300,7 @@ async function installAppleContainerPkg(
       )
     }
 
-    // Elevate: copy to root tmp, re-hash, then install (closes same-UID TOCTOU
-    // between the Node verify above and privileged installer open).
+    // Elevate: copy + re-hash under root before installer (closes same-UID TOCTOU).
     reportProgress(onProgress, 'Installing - enter your password if prompted...', null)
     const elevateScript = [
       'set -e',
@@ -378,17 +363,12 @@ async function ensureAppleContainerReadyImpl(
   }
 }
 
-/**
- * Ensure the Apple Container CLI is installed (only when allowInstall) and the
- * system is started. Install requires an explicit Start/Install click path.
- * Serialized: concurrent callers share one in-flight promise when compatible.
- */
+/** Install (if allowInstall) + start. Serialized; install-capable calls don't join non-install. */
 export async function ensureAppleContainerReady(
   onProgress?: (progress: AppleContainerProvisionProgress) => void,
   options?: { allowInstall?: boolean },
 ): Promise<void> {
   const allowInstall = options?.allowInstall === true
-  // Join in-flight only if it already allows install, or we don't need install.
   if (appleReadyPromise && (appleReadyAllowsInstall || !allowInstall)) {
     return appleReadyPromise
   }
@@ -396,7 +376,7 @@ export async function ensureAppleContainerReady(
     try {
       await appleReadyPromise
     } catch {
-      // Prior non-install attempt failed; fall through to start our own.
+      // Prior non-install failed; start our own.
     }
   }
   appleReadyAllowsInstall = allowInstall

--- a/src/shared/lib/container/apple-container-client.ts
+++ b/src/shared/lib/container/apple-container-client.ts
@@ -50,11 +50,6 @@ function getMacOSMajorVersion(): number | null {
   }
 }
 
-/** Clear macOS version cache so eligibility can be re-probed (e.g. after a failed sw_vers). */
-export function clearMacOSVersionCache(): void {
-  cachedMacOSMajorVersion = undefined
-}
-
 async function hashFileSha256(filePath: string): Promise<string> {
   const hash = createHash('sha256')
   await pipeline(createReadStream(filePath), hash)

--- a/src/shared/lib/container/apple-container-client.ts
+++ b/src/shared/lib/container/apple-container-client.ts
@@ -1,14 +1,30 @@
 import { execSync } from 'child_process'
-import { BaseContainerClient, checkCommandAvailable, execWithPath, CONTAINER_INTERNAL_PORT } from './base-container-client'
+import { createHash } from 'crypto'
+import { createReadStream, createWriteStream } from 'fs'
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { Readable } from 'stream'
+import { pipeline } from 'stream/promises'
+import { BaseContainerClient, checkCommandAvailable, execWithPath, CONTAINER_INTERNAL_PORT, shellEscape } from './base-container-client'
 import type { ContainerConfig, ContainerInfo, ContainerStats } from './types'
+import { isAdminPrivilegeCancelError, runWithAdminPrivileges } from '@shared/lib/run-with-admin-privileges'
 
-/** Cached macOS major version (null = not yet checked, undefined = not macOS) */
+/** Pinned signed installer (bump deliberately; do not follow releases/latest). */
+const APPLE_CONTAINER_VERSION = '1.1.0'
+
+/** GitHub release asset digest for container-${VERSION}-installer-signed.pkg at pin time. */
+export const APPLE_CONTAINER_PKG_SHA256 =
+  '0ca1c42a2269c2557efb1d82b1b38ac553e6a3a3da1b1179c439bcee1e7d6714'
+
+const DOWNLOAD_TIMEOUT_MS = 10 * 60 * 1000
+
+/** Cached macOS major version (null = not macOS / failed, undefined = not yet checked) */
 let cachedMacOSMajorVersion: number | null | undefined = undefined
 
-/**
- * Get the macOS major version number, or null if not on macOS.
- * Result is cached for the lifetime of the process.
- */
+/** Mutex: concurrent ensureAppleContainerReady callers share one in-flight promise. */
+let appleReadyPromise: Promise<void> | null = null
+
 function getMacOSMajorVersion(): number | null {
   if (cachedMacOSMajorVersion !== undefined) {
     return cachedMacOSMajorVersion
@@ -27,9 +43,40 @@ function getMacOSMajorVersion(): number | null {
   }
 }
 
+async function hashFileSha256(filePath: string): Promise<string> {
+  const hash = createHash('sha256')
+  await pipeline(createReadStream(filePath), hash)
+  return hash.digest('hex')
+}
+
+async function downloadToFile(url: string, destPath: string): Promise<void> {
+  let response: Response
+  try {
+    response = await fetch(url, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) })
+  } catch (error) {
+    const name = error instanceof Error ? error.name : ''
+    if (name === 'AbortError' || name === 'TimeoutError') {
+      throw new Error(`Timed out downloading Apple Container installer after ${DOWNLOAD_TIMEOUT_MS / 1000}s. Try again.`)
+    }
+    throw error
+  }
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download Apple Container installer (HTTP ${response.status}).`)
+  }
+  // Node fetch body is a web ReadableStream; bridge to Node for pipeline.
+  const nodeStream = Readable.fromWeb(response.body as import('stream/web').ReadableStream)
+  await pipeline(nodeStream, createWriteStream(destPath))
+}
+
+/** IO seam for unit tests (install path only). */
+export const appleContainerProvisionIO = {
+  downloadToFile,
+  hashFileSha256,
+}
+
 /**
  * Apple Container implementation of ContainerClient.
- * Uses the `container` CLI available on macOS 26+.
+ * Uses the `container` CLI available on macOS 26+ Apple silicon.
  */
 export class AppleContainerClient extends BaseContainerClient {
   static readonly runnerName = 'apple-container'
@@ -39,9 +86,10 @@ export class AppleContainerClient extends BaseContainerClient {
   }
 
   /**
-   * Apple Container is only eligible on macOS 26+.
+   * Eligible only on Apple silicon running macOS 26+.
    */
   static isEligible(): boolean {
+    if (process.arch !== 'arm64') return false
     const version = getMacOSMajorVersion()
     return version !== null && version >= 26
   }
@@ -186,4 +234,88 @@ export class AppleContainerClient extends BaseContainerClient {
       return false
     }
   }
+}
+
+async function installAppleContainerPkg(): Promise<void> {
+  const url =
+    `https://github.com/apple/container/releases/download/${APPLE_CONTAINER_VERSION}` +
+    `/container-${APPLE_CONTAINER_VERSION}-installer-signed.pkg`
+  const tmpDir = await mkdtemp(join(tmpdir(), 'superagent-apple-container-'))
+  const pkgPath = join(tmpDir, `container-${APPLE_CONTAINER_VERSION}-installer-signed.pkg`)
+
+  try {
+    console.log(`[AppleContainer] Downloading signed installer ${APPLE_CONTAINER_VERSION}...`)
+    await appleContainerProvisionIO.downloadToFile(url, pkgPath)
+
+    const actualSha = await appleContainerProvisionIO.hashFileSha256(pkgPath)
+    if (actualSha.toLowerCase() !== APPLE_CONTAINER_PKG_SHA256.toLowerCase()) {
+      throw new Error(
+        'Downloaded Apple Container installer failed integrity check. The file was discarded; try again.',
+      )
+    }
+
+    try {
+      await runWithAdminPrivileges(`installer -pkg ${shellEscape(pkgPath)} -target /`)
+    } catch (error) {
+      if (isAdminPrivilegeCancelError(error)) {
+        throw new Error(
+          'Administrator password prompt was cancelled. macOS Container was not installed.',
+        )
+      }
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`Failed to install Apple Container: ${message}`)
+    }
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+async function ensureAppleContainerReadyImpl(): Promise<void> {
+  if (!AppleContainerClient.isEligible()) {
+    throw new Error('macOS Container requires macOS 26 or later on Apple silicon.')
+  }
+
+  const installed = await AppleContainerClient.isAvailable()
+  if (!installed) {
+    await installAppleContainerPkg()
+  }
+
+  try {
+    await execWithPath('container system start --enable-kernel-install')
+  } catch (error: any) {
+    if (!error?.message?.includes('already running')) {
+      throw new Error(
+        `Failed to start Apple Container runtime: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  }
+
+  const running = await AppleContainerClient.isRunning()
+  if (!running) {
+    throw new Error('Apple Container runtime did not become ready after start.')
+  }
+}
+
+/**
+ * Ensure the Apple Container CLI is installed (first install only when missing)
+ * and the system is started. Called by startRunner('apple-container') on explicit
+ * Start/Install click. Serialized: concurrent calls share the same in-flight promise.
+ */
+export async function ensureAppleContainerReady(): Promise<void> {
+  if (appleReadyPromise) {
+    return appleReadyPromise
+  }
+  appleReadyPromise = ensureAppleContainerReadyImpl()
+  try {
+    await appleReadyPromise
+  } finally {
+    appleReadyPromise = null
+  }
+}
+
+export function resetAppleContainerClientForTests(): void {
+  cachedMacOSMajorVersion = undefined
+  appleReadyPromise = null
+  appleContainerProvisionIO.downloadToFile = downloadToFile
+  appleContainerProvisionIO.hashFileSha256 = hashFileSha256
 }

--- a/src/shared/lib/container/client-factory.test.ts
+++ b/src/shared/lib/container/client-factory.test.ts
@@ -190,12 +190,18 @@ describe('startRunner apple-container', () => {
     mockEnsureAppleContainerReady.mockResolvedValue(undefined)
   })
 
-  it('delegates to ensureAppleContainerReady', async () => {
-    const result = await startRunner('apple-container')
+  it('delegates to ensureAppleContainerReady with allowInstall', async () => {
+    const result = await startRunner('apple-container', undefined, { allowInstall: true })
 
-    expect(mockEnsureAppleContainerReady).toHaveBeenCalledOnce()
+    expect(mockEnsureAppleContainerReady).toHaveBeenCalledWith(undefined, { allowInstall: true })
     expect(result.success).toBe(true)
     expect(result.message).toMatch(/running/i)
+  })
+
+  it('auto-start path does not allow install', async () => {
+    await startRunner('apple-container')
+
+    expect(mockEnsureAppleContainerReady).toHaveBeenCalledWith(undefined, { allowInstall: false })
   })
 
   it('returns ensure failure message', async () => {
@@ -203,7 +209,7 @@ describe('startRunner apple-container', () => {
       new Error('Administrator password prompt was cancelled.'),
     )
 
-    const result = await startRunner('apple-container')
+    const result = await startRunner('apple-container', undefined, { allowInstall: true })
 
     expect(result.success).toBe(false)
     expect(result.message).toMatch(/cancelled/i)

--- a/src/shared/lib/container/client-factory.test.ts
+++ b/src/shared/lib/container/client-factory.test.ts
@@ -37,12 +37,16 @@ vi.mock('./podman-container-client', () => ({
   },
 }))
 
+const mockEnsureAppleContainerReady = vi.fn()
+
 vi.mock('./apple-container-client', () => ({
   AppleContainerClient: {
-    isEligible: vi.fn(() => false),
+    // Eligible at module load so apple is in SUPPORTED_RUNNERS for availability tests.
+    isEligible: vi.fn(() => true),
     isAvailable: vi.fn(() => Promise.resolve(false)),
     isRunning: vi.fn(() => Promise.resolve(false)),
   },
+  ensureAppleContainerReady: (...args: unknown[]) => mockEnsureAppleContainerReady(...args),
 }))
 
 const mockStopWSL2Distro = vi.fn()
@@ -114,6 +118,7 @@ vi.mock('@shared/lib/error-reporting', () => ({
 // ============================================================================
 
 import {
+  checkAllRunnersAvailability,
   clearRunnerAvailabilityCache,
   pullImage,
   PULL_STALL_TIMEOUT_MS,
@@ -121,7 +126,9 @@ import {
   reconcileRunnerState,
   restartRunner,
   shutdownActiveRunner,
+  startRunner,
 } from './client-factory'
+import { AppleContainerClient } from './apple-container-client'
 
 // ============================================================================
 // Tests
@@ -173,6 +180,56 @@ describe('shutdownActiveRunner', () => {
     await shutdownActiveRunner()
 
     expect(mockStopWSL2Distro).toHaveBeenCalledOnce()
+  })
+})
+
+describe('startRunner apple-container', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearRunnerAvailabilityCache()
+    mockEnsureAppleContainerReady.mockResolvedValue(undefined)
+  })
+
+  it('delegates to ensureAppleContainerReady', async () => {
+    const result = await startRunner('apple-container')
+
+    expect(mockEnsureAppleContainerReady).toHaveBeenCalledOnce()
+    expect(result.success).toBe(true)
+    expect(result.message).toMatch(/running/i)
+  })
+
+  it('returns ensure failure message', async () => {
+    mockEnsureAppleContainerReady.mockRejectedValue(
+      new Error('Administrator password prompt was cancelled.'),
+    )
+
+    const result = await startRunner('apple-container')
+
+    expect(result.success).toBe(false)
+    expect(result.message).toMatch(/cancelled/i)
+  })
+})
+
+describe('checkAllRunnersAvailability apple-container canStart', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearRunnerAvailabilityCache()
+    vi.mocked(AppleContainerClient.isEligible).mockReturnValue(true)
+  })
+
+  it('sets canStart true when CLI missing (provisionable)', async () => {
+    vi.mocked(AppleContainerClient.isAvailable).mockResolvedValue(false)
+    vi.mocked(AppleContainerClient.isRunning).mockResolvedValue(false)
+
+    const results = await checkAllRunnersAvailability()
+    const apple = results.find((r) => r.runner === 'apple-container')
+
+    expect(apple).toMatchObject({
+      installed: false,
+      running: false,
+      available: false,
+      canStart: true,
+    })
   })
 })
 

--- a/src/shared/lib/container/client-factory.test.ts
+++ b/src/shared/lib/container/client-factory.test.ts
@@ -203,17 +203,6 @@ describe('startRunner apple-container', () => {
 
     expect(mockEnsureAppleContainerReady).toHaveBeenCalledWith(undefined, { allowInstall: false })
   })
-
-  it('returns ensure failure message', async () => {
-    mockEnsureAppleContainerReady.mockRejectedValue(
-      new Error('Administrator password prompt was cancelled.'),
-    )
-
-    const result = await startRunner('apple-container', undefined, { allowInstall: true })
-
-    expect(result.success).toBe(false)
-    expect(result.message).toMatch(/cancelled/i)
-  })
 })
 
 describe('checkAllRunnersAvailability apple-container canStart', () => {

--- a/src/shared/lib/container/client-factory.ts
+++ b/src/shared/lib/container/client-factory.ts
@@ -104,7 +104,6 @@ export let SUPPORTED_RUNNERS: ContainerRunner[] = ALL_RUNNERS
   .map((r) => r.name)
 
 function recomputeSupportedRunners(): void {
-  // Probe failures are not cached; re-filter so Apple can appear after a transient sw_vers miss.
   SUPPORTED_RUNNERS = ALL_RUNNERS.filter((r) => r.isEligible()).map((r) => r.name)
 }
 

--- a/src/shared/lib/container/client-factory.ts
+++ b/src/shared/lib/container/client-factory.ts
@@ -2,7 +2,7 @@ import type { ContainerClient, ContainerConfig, ImagePullProgress } from './type
 import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 import { DockerContainerClient } from './docker-container-client'
 import { PodmanContainerClient } from './podman-container-client'
-import { AppleContainerClient, ensureAppleContainerReady } from './apple-container-client'
+import { AppleContainerClient, clearMacOSVersionCache, ensureAppleContainerReady } from './apple-container-client'
 import { LimaContainerClient, getNerdctlWrapperPath, ensureLimaReady, stopLimaVm } from './lima-container-client'
 import { WSL2ContainerClient, getWSL2NerdctlWrapperPath, ensureWSL2Ready, stopWSL2Distro, killWSL2PullProcesses } from './wsl2-container-client'
 import { PlatformK8sRuntimeClient } from './platform-k8s-runtime'
@@ -97,10 +97,16 @@ const ALL_RUNNERS: {
 /**
  * Supported container runners on this platform, filtered by eligibility.
  * Order reflects preference (apple-container first on macOS 26+, then docker, then podman).
+ * Recomputed on refresh so a transient sw_vers failure does not hide Apple forever.
  */
-export const SUPPORTED_RUNNERS: ContainerRunner[] = ALL_RUNNERS
+export let SUPPORTED_RUNNERS: ContainerRunner[] = ALL_RUNNERS
   .filter((r) => r.isEligible())
   .map((r) => r.name)
+
+function recomputeSupportedRunners(): void {
+  clearMacOSVersionCache()
+  SUPPORTED_RUNNERS = ALL_RUNNERS.filter((r) => r.isEligible()).map((r) => r.name)
+}
 
 /**
  * User-facing display name for a runner.
@@ -174,12 +180,21 @@ function canAttemptStart(runner: ContainerRunner): boolean {
  * Returns true if start was attempted (not necessarily successful).
  */
 // TODO: disgusting piece of code. The whole idea of having the container client classes is that they should encapsulate all runtime-specific logic, including starting the runtime if needed. We should move this logic into static methods on each client class, e.g., DockerContainerClient.startRuntime(), PodmanContainerClient.startRuntime(), etc. Then this function can just delegate to the appropriate class without needing to know about platform-specific details here. Refactor this in the future to clean up the code and adhere to better separation of concerns.
-export async function startRunner(runner: ContainerRunner): Promise<StartRunnerResult> {
+export async function startRunner(
+  runner: ContainerRunner,
+  onProgress?: (progress: ImagePullProgress) => void,
+  options?: { allowInstall?: boolean },
+): Promise<StartRunnerResult> {
   const os = platform()
 
   if (runner === 'apple-container') {
     try {
-      await ensureAppleContainerReady()
+      await ensureAppleContainerReady(
+        onProgress
+          ? (p) => onProgress({ status: p.status, percent: p.percent, completedLayers: 0, totalLayers: 0 })
+          : undefined,
+        { allowInstall: options?.allowInstall === true },
+      )
       return { success: true, message: 'Apple Container runtime is running.' }
     } catch (error: any) {
       captureException(error, {
@@ -378,6 +393,7 @@ export async function checkAllRunnersAvailability(): Promise<RunnerAvailability[
  * Call this after starting a runner or when user requests refresh.
  */
 export async function refreshRunnerAvailability(): Promise<RunnerAvailability[]> {
+  recomputeSupportedRunners()
   cachedRunnerAvailability = null
   runnerAvailabilityCachedAt = 0
   return checkAllRunnersAvailability()

--- a/src/shared/lib/container/client-factory.ts
+++ b/src/shared/lib/container/client-factory.ts
@@ -2,7 +2,7 @@ import type { ContainerClient, ContainerConfig, ImagePullProgress } from './type
 import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 import { DockerContainerClient } from './docker-container-client'
 import { PodmanContainerClient } from './podman-container-client'
-import { AppleContainerClient } from './apple-container-client'
+import { AppleContainerClient, ensureAppleContainerReady } from './apple-container-client'
 import { LimaContainerClient, getNerdctlWrapperPath, ensureLimaReady, stopLimaVm } from './lima-container-client'
 import { WSL2ContainerClient, getWSL2NerdctlWrapperPath, ensureWSL2Ready, stopWSL2Distro, killWSL2PullProcesses } from './wsl2-container-client'
 import { PlatformK8sRuntimeClient } from './platform-k8s-runtime'
@@ -40,7 +40,10 @@ export interface RunnerAvailability {
   running: boolean
   /** Overall availability (installed AND running) */
   available: boolean
-  /** If installed but not running, can we attempt to start it? */
+  /**
+   * Whether the UI can offer Start/Install via startRunner.
+   * True when the runtime can be started, or (for apple-container) first-installed.
+   */
   canStart: boolean
   /** Whether settings.container.agentImage is honored by this runner. */
   supportsCustomAgentImage: boolean
@@ -176,17 +179,17 @@ export async function startRunner(runner: ContainerRunner): Promise<StartRunnerR
 
   if (runner === 'apple-container') {
     try {
-      await execWithPath('container system start')
-      return { success: true, message: 'Apple Container runtime is starting...' }
+      await ensureAppleContainerReady()
+      return { success: true, message: 'Apple Container runtime is running.' }
     } catch (error: any) {
-      if (error.message?.includes('already running')) {
-        return { success: true, message: 'Apple Container runtime is already running.' }
-      }
       captureException(error, {
         tags: { component: 'runtime', operation: 'start-apple-container' },
         extra: { platform: os },
       })
-      return { success: false, message: `Failed to start Apple Container runtime: ${error.message}` }
+      return {
+        success: false,
+        message: error?.message || 'Failed to start Apple Container runtime.',
+      }
     }
   }
 
@@ -318,12 +321,13 @@ async function checkRunnerDetailedAvailability(runner: ContainerRunner): Promise
   const installed = await entry.isAvailable()
 
   if (!installed) {
+    // apple-container only: Start/Install provisions (other runners keep installUrl fallthrough).
     return {
       runner,
       installed: false,
       running: false,
       available: false,
-      canStart: false,
+      canStart: runner === 'apple-container',
       supportsCustomAgentImage,
     }
   }

--- a/src/shared/lib/container/client-factory.ts
+++ b/src/shared/lib/container/client-factory.ts
@@ -2,7 +2,7 @@ import type { ContainerClient, ContainerConfig, ImagePullProgress } from './type
 import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 import { DockerContainerClient } from './docker-container-client'
 import { PodmanContainerClient } from './podman-container-client'
-import { AppleContainerClient, clearMacOSVersionCache, ensureAppleContainerReady } from './apple-container-client'
+import { AppleContainerClient, ensureAppleContainerReady } from './apple-container-client'
 import { LimaContainerClient, getNerdctlWrapperPath, ensureLimaReady, stopLimaVm } from './lima-container-client'
 import { WSL2ContainerClient, getWSL2NerdctlWrapperPath, ensureWSL2Ready, stopWSL2Distro, killWSL2PullProcesses } from './wsl2-container-client'
 import { PlatformK8sRuntimeClient } from './platform-k8s-runtime'
@@ -104,7 +104,7 @@ export let SUPPORTED_RUNNERS: ContainerRunner[] = ALL_RUNNERS
   .map((r) => r.name)
 
 function recomputeSupportedRunners(): void {
-  clearMacOSVersionCache()
+  // Probe failures are not cached; re-filter so Apple can appear after a transient sw_vers miss.
   SUPPORTED_RUNNERS = ALL_RUNNERS.filter((r) => r.isEligible()).map((r) => r.name)
 }
 

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -1167,6 +1167,45 @@ describe('containerManager.markRuntimeUnavailable', () => {
   })
 })
 
+describe('containerManager.updateStartProgress', () => {
+  it('keeps CHECKING and stores pullProgress', () => {
+    ;(containerManager as any)._readiness = {
+      status: 'CHECKING',
+      message: 'Starting apple-container runtime...',
+      pullProgress: null,
+    }
+
+    containerManager.updateStartProgress({
+      status: 'Downloading macOS Container installer...',
+      percent: 40,
+      completedLayers: 0,
+      totalLayers: 0,
+    })
+
+    const readiness = containerManager.getReadiness()
+    expect(readiness.status).toBe('CHECKING')
+    expect(readiness.pullProgress?.percent).toBe(40)
+    expect(readiness.message).toMatch(/Downloading/)
+  })
+
+  it('does NOT override PULLING_IMAGE', () => {
+    ;(containerManager as any)._readiness = {
+      status: 'PULLING_IMAGE',
+      message: 'Pulling...',
+      pullProgress: { status: 'layer', percent: 10, completedLayers: 1, totalLayers: 3 },
+    }
+
+    containerManager.updateStartProgress({
+      status: 'Downloading...',
+      percent: 50,
+      completedLayers: 0,
+      totalLayers: 0,
+    })
+
+    expect(containerManager.getReadiness().pullProgress?.percent).toBe(10)
+  })
+})
+
 // ============================================================================
 // stopAll — timeout and error isolation
 // ============================================================================

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -1153,18 +1153,6 @@ describe('containerManager.markRuntimeUnavailable', () => {
     expect(readiness.status).toBe('RUNTIME_UNAVAILABLE')
     expect(readiness.message).toMatch(/cancelled/i)
   })
-
-  it('does NOT override PULLING_IMAGE', () => {
-    ;(containerManager as any)._readiness = {
-      status: 'PULLING_IMAGE',
-      message: 'Pulling...',
-      pullProgress: { status: 'layer', percent: 10 },
-    }
-
-    containerManager.markRuntimeUnavailable('should be ignored')
-
-    expect(containerManager.getReadiness().status).toBe('PULLING_IMAGE')
-  })
 })
 
 describe('containerManager.updateStartProgress', () => {
@@ -1187,22 +1175,34 @@ describe('containerManager.updateStartProgress', () => {
     expect(readiness.pullProgress?.percent).toBe(40)
     expect(readiness.message).toMatch(/Downloading/)
   })
+})
 
-  it('does NOT override PULLING_IMAGE', () => {
+describe('containerManager start/fail guards vs PULLING_IMAGE', () => {
+  it.each([
+    {
+      label: 'markRuntimeUnavailable',
+      act: () => containerManager.markRuntimeUnavailable('should be ignored'),
+      assert: () => expect(containerManager.getReadiness().status).toBe('PULLING_IMAGE'),
+    },
+    {
+      label: 'updateStartProgress',
+      act: () =>
+        containerManager.updateStartProgress({
+          status: 'Downloading...',
+          percent: 50,
+          completedLayers: 0,
+          totalLayers: 0,
+        }),
+      assert: () => expect(containerManager.getReadiness().pullProgress?.percent).toBe(10),
+    },
+  ])('$label does NOT override PULLING_IMAGE', ({ act, assert }) => {
     ;(containerManager as any)._readiness = {
       status: 'PULLING_IMAGE',
       message: 'Pulling...',
       pullProgress: { status: 'layer', percent: 10, completedLayers: 1, totalLayers: 3 },
     }
-
-    containerManager.updateStartProgress({
-      status: 'Downloading...',
-      percent: 50,
-      completedLayers: 0,
-      totalLayers: 0,
-    })
-
-    expect(containerManager.getReadiness().pullProgress?.percent).toBe(10)
+    act()
+    assert()
   })
 })
 

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -1139,44 +1139,6 @@ describe('containerManager.resetReadiness', () => {
   })
 })
 
-describe('containerManager.markRuntimeUnavailable', () => {
-  it('sets RUNTIME_UNAVAILABLE from CHECKING', () => {
-    ;(containerManager as any)._readiness = {
-      status: 'CHECKING',
-      message: 'Starting apple-container runtime...',
-      pullProgress: null,
-    }
-
-    containerManager.markRuntimeUnavailable('Administrator password prompt was cancelled.')
-
-    const readiness = containerManager.getReadiness()
-    expect(readiness.status).toBe('RUNTIME_UNAVAILABLE')
-    expect(readiness.message).toMatch(/cancelled/i)
-  })
-})
-
-describe('containerManager.updateStartProgress', () => {
-  it('keeps CHECKING and stores pullProgress', () => {
-    ;(containerManager as any)._readiness = {
-      status: 'CHECKING',
-      message: 'Starting apple-container runtime...',
-      pullProgress: null,
-    }
-
-    containerManager.updateStartProgress({
-      status: 'Downloading macOS Container installer...',
-      percent: 40,
-      completedLayers: 0,
-      totalLayers: 0,
-    })
-
-    const readiness = containerManager.getReadiness()
-    expect(readiness.status).toBe('CHECKING')
-    expect(readiness.pullProgress?.percent).toBe(40)
-    expect(readiness.message).toMatch(/Downloading/)
-  })
-})
-
 describe('containerManager start/fail guards vs PULLING_IMAGE', () => {
   it.each([
     {

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -109,13 +109,23 @@ vi.mock('drizzle-orm', () => ({
   eq: (col: string, val: string) => ({ col, val }),
 }))
 
+const mockSettingsState = {
+  containerRunner: 'docker' as string,
+}
+
 vi.mock('@shared/lib/config/settings', () => ({
-  getSettings: () => ({ container: { agentImage: 'test-image', containerRunner: 'docker' }, app: {} }),
+  getSettings: () => ({
+    container: { agentImage: 'test-image', containerRunner: mockSettingsState.containerRunner },
+    app: {},
+  }),
   updateSettings: vi.fn(),
   // the runner auto-switch now persists via mutateSettings; apply the
   // mutator to a fresh snapshot and return it (matching the real return shape).
   mutateSettings: (mutator: (s: { container: { agentImage: string; containerRunner: string }; app: Record<string, unknown> }) => void) => {
-    const s = { container: { agentImage: 'test-image', containerRunner: 'docker' }, app: {} }
+    const s = {
+      container: { agentImage: 'test-image', containerRunner: mockSettingsState.containerRunner },
+      app: {},
+    }
     mutator(s)
     return s
   },
@@ -647,7 +657,7 @@ describe('containerManager — health warnings', () => {
 // ensureImageReady — state machine (CHECKING -> READY / ERROR / RUNTIME_UNAVAILABLE)
 // ============================================================================
 
-import { checkAllRunnersAvailability, checkImageExists, pullImage, canBuildImage, buildImage } from './client-factory'
+import { checkAllRunnersAvailability, checkImageExists, pullImage, canBuildImage, buildImage, startRunner } from './client-factory'
 
 describe('containerManager.ensureImageReady — state machine', () => {
   const originalE2eMock = process.env.E2E_MOCK
@@ -656,6 +666,7 @@ describe('containerManager.ensureImageReady — state machine', () => {
     vi.clearAllMocks()
     containerManager.clearClients()
     delete process.env.E2E_MOCK
+    mockSettingsState.containerRunner = 'docker'
     // Default: plenty of disk space (100 GB)
     mockStatfs.mockResolvedValue({ bavail: 100 * 1024 * 1024 * 1024 / 4096, bsize: 4096 })
   })
@@ -705,6 +716,26 @@ describe('containerManager.ensureImageReady — state machine', () => {
     const readiness = containerManager.getReadiness()
     expect(readiness.status).toBe('RUNTIME_UNAVAILABLE')
     expect(readiness.message).toContain('docker')
+  })
+
+  it('does not auto-provision apple-container when CLI is missing (no silent elevate)', async () => {
+    mockSettingsState.containerRunner = 'apple-container'
+    vi.mocked(checkAllRunnersAvailability).mockResolvedValue([
+      {
+        runner: 'apple-container',
+        installed: false,
+        running: false,
+        available: false,
+        canStart: true,
+        supportsCustomAgentImage: true,
+      },
+    ])
+
+    await containerManager.ensureImageReady()
+
+    expect(startRunner).not.toHaveBeenCalled()
+    const readiness = containerManager.getReadiness()
+    expect(readiness.status).toBe('RUNTIME_UNAVAILABLE')
   })
 
   it('pulls image when runner available but image does not exist', async () => {
@@ -1105,6 +1136,34 @@ describe('containerManager.resetReadiness', () => {
     containerManager.resetReadiness()
 
     expect(containerManager.getReadiness().message).toBe('Restarting runtime...')
+  })
+})
+
+describe('containerManager.markRuntimeUnavailable', () => {
+  it('sets RUNTIME_UNAVAILABLE from CHECKING', () => {
+    ;(containerManager as any)._readiness = {
+      status: 'CHECKING',
+      message: 'Starting apple-container runtime...',
+      pullProgress: null,
+    }
+
+    containerManager.markRuntimeUnavailable('Administrator password prompt was cancelled.')
+
+    const readiness = containerManager.getReadiness()
+    expect(readiness.status).toBe('RUNTIME_UNAVAILABLE')
+    expect(readiness.message).toMatch(/cancelled/i)
+  })
+
+  it('does NOT override PULLING_IMAGE', () => {
+    ;(containerManager as any)._readiness = {
+      status: 'PULLING_IMAGE',
+      message: 'Pulling...',
+      pullProgress: { status: 'layer', percent: 10 },
+    }
+
+    containerManager.markRuntimeUnavailable('should be ignored')
+
+    expect(containerManager.getReadiness().status).toBe('PULLING_IMAGE')
   })
 })
 

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -808,6 +808,21 @@ class ContainerManager {
     })
   }
 
+  /**
+   * Clear a CHECKING banner after a failed start/install and broadcast.
+   * Skips if an image pull is in progress (same guard as resetReadiness).
+   */
+  markRuntimeUnavailable(message: string): void {
+    if (this._readiness.status === 'PULLING_IMAGE') {
+      return
+    }
+    this.setReadiness({
+      status: 'RUNTIME_UNAVAILABLE',
+      message,
+      pullProgress: null,
+    })
+  }
+
   /** Update readiness state and broadcast change via SSE. */
   private setReadiness(readiness: RuntimeReadiness): void {
     this._readiness = readiness

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -823,6 +823,30 @@ class ContainerManager {
     })
   }
 
+  /**
+   * Broadcast start/install progress while status stays CHECKING.
+   * Reuses pullProgress so existing readiness UI can show phase + optional %.
+   * Skips no-op duplicates and never overrides an in-flight image pull.
+   */
+  updateStartProgress(progress: ImagePullProgress): void {
+    if (this._readiness.status === 'PULLING_IMAGE') {
+      return
+    }
+    const prev = this._readiness.pullProgress
+    if (
+      this._readiness.status === 'CHECKING' &&
+      prev?.status === progress.status &&
+      prev?.percent === progress.percent
+    ) {
+      return
+    }
+    this.setReadiness({
+      status: 'CHECKING',
+      message: progress.status,
+      pullProgress: progress,
+    })
+  }
+
   /** Update readiness state and broadcast change via SSE. */
   private setReadiness(readiness: RuntimeReadiness): void {
     this._readiness = readiness

--- a/src/shared/lib/run-with-admin-privileges.ts
+++ b/src/shared/lib/run-with-admin-privileges.ts
@@ -1,0 +1,28 @@
+import { execFile } from 'child_process'
+
+/**
+ * Run a shell command with macOS administrator privileges via osascript.
+ * Node-only — must not import electron (shared by main + API / startRunner).
+ */
+export function runWithAdminPrivileges(command: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'osascript',
+      ['-e', `do shell script ${JSON.stringify(command)} with administrator privileges`],
+      (error) => {
+        if (error) reject(error)
+        else resolve()
+      },
+    )
+  })
+}
+
+/** True when the user dismissed the macOS password dialog. */
+export function isAdminPrivilegeCancelError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+  return (
+    message.includes('User canceled') ||
+    message.includes('User cancelled') ||
+    message.includes('-128')
+  )
+}


### PR DESCRIPTION
## Summary
- Add in-app first-install for Apple Container on eligible Macs (darwin + arm64 + macOS ≥ 26): pin signed `.pkg` → SHA256 verify → admin elevate with elevated rehash → `container system start` → refresh availability.
- Gate install behind explicit Start/Install (`allowInstall`); no silent provision, no GitHub install fallthrough for Apple.
- Keep setup UI honest: download % then phase labels, progress scoped to the active runner, persist selected runner on success, clear CHECKING on failure, drop stale cancel errors once the runner is available.

## Test plan
- [x] Unit: eligibility, `allowInstall`, digest mismatch never elevates, elevate rehash script, cancel mapping, mutex, startRunner persistence / failure refresh
- [x] Manual smoke (eligible Mac): Install → password → start → send agent message
- [x] Manual: cancel password / cancel mid-download recover without wedging UI; progress only on the Apple card
- [ ] CI green on this draft
- [ ] Confirm Apple option absent on ineligible machines (Windows / Intel / macOS < 26) if a reviewer has one handy
