### PR TITLE
chore: log x-agent invoke failures to Sentry with stage tags

### DIFF
--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -146,6 +146,11 @@ vi.mock('@shared/lib/proxy/review-manager', () => ({
   },
 }))
 
+const mockCaptureException = vi.fn()
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}))
+
 // ----------------------------------------------------------------------------
 // Imports (after mocks)
 // ----------------------------------------------------------------------------
@@ -469,6 +474,44 @@ describe('/invoke', () => {
     expect(body.error).toMatch(/disk full/i)
     // Container session should have been deleted to avoid burning model budget on an orphan
     expect(mockDeleteSession).toHaveBeenCalledWith('new-sess-id')
+    expect(mockCaptureException).toHaveBeenCalled()
+  })
+
+  it('returns 500 with stage=ensure_running when target container start fails', async () => {
+    reviewDecisions.push('allow')
+    mockEnsureRunning.mockRejectedValueOnce(new Error('Failed to start container: 500'))
+
+    const res = await authedFetch('/x-agent/invoke', { slug: TARGET_SLUG, prompt: 'hello' })
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toMatch(/ensure_running/)
+    expect(body.error).toMatch(/Failed to start container: 500/)
+    expect(mockCreateSession).not.toHaveBeenCalled()
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({ area: 'x-agent', op: 'invoke', stage: 'ensure_running' }),
+      }),
+    )
+  })
+
+  it('returns 500 with stage=create_session when session create fails after start', async () => {
+    reviewDecisions.push('allow')
+    mockCreateSession.mockRejectedValueOnce(
+      new Error('Failed to start session - request timed out'),
+    )
+
+    const res = await authedFetch('/x-agent/invoke', { slug: TARGET_SLUG, prompt: 'hello' })
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toMatch(/create_session/)
+    expect(body.error).toMatch(/timed out/)
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({ stage: 'create_session' }),
+      }),
+    )
   })
 
   it('returns running + error (200, not 500) when sync=true and waitForIdle rejects', async () => {

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -476,13 +476,9 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
 
   // Resolve display slug → canonical id so ACL / policy / runtime all use ids.
   const targetSlug = await resolveAgentId(rawTargetSlug)
-  if (!targetSlug) {
-    console.warn('[x-agent] invoke rejected', { callerSlug, rawTargetSlug, reason: 'target_not_found', status: 404 })
-    return c.json({ error: 'Target agent not found' }, 404)
-  }
+  if (!targetSlug) return c.json({ error: 'Target agent not found' }, 404)
 
   if (targetSlug === callerSlug) {
-    console.warn('[x-agent] invoke rejected', { callerSlug, targetSlug, reason: 'self_invoke', status: 400 })
     return c.json({ error: 'Agent cannot invoke itself' }, 400)
   }
 
@@ -491,13 +487,6 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
     ? await getSessionMetadata(callerSlug, _callerSessionId)
     : null
   if (callerMeta?.invokedByAgentSlug) {
-    console.warn('[x-agent] invoke rejected', {
-      callerSlug,
-      targetSlug,
-      reason: 'one_hop',
-      invokedBy: callerMeta.invokedByAgentSlug,
-      status: 403,
-    })
     return c.json(
       {
         error:
@@ -509,13 +498,9 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
   }
 
   const target = await getAgent(targetSlug)
-  if (!target) {
-    console.warn('[x-agent] invoke rejected', { callerSlug, targetSlug, reason: 'target_missing', status: 404 })
-    return c.json({ error: 'Target agent not found' }, 404)
-  }
+  if (!target) return c.json({ error: 'Target agent not found' }, 404)
 
   if (!(await callerOwnerHasRoleOnTarget(callerSlug, targetSlug, 'user'))) {
-    console.warn('[x-agent] invoke rejected', { callerSlug, targetSlug, reason: 'acl', status: 403 })
     return c.json({ error: 'Forbidden: caller has no user access to target agent' }, 403)
   }
 
@@ -527,13 +512,6 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
     prompt.slice(0, 200),
   )
   if (!policy.allowed) {
-    console.warn('[x-agent] invoke rejected', {
-      callerSlug,
-      targetSlug,
-      reason: 'policy',
-      detail: policy.reason ?? 'Forbidden',
-      status: 403,
-    })
     return c.json({ error: policy.reason ?? 'Forbidden' }, 403)
   }
 
@@ -543,26 +521,12 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
     attributedUserId = (await getOwnersOfAgent(callerSlug))[0]
   }
 
-  console.info('[x-agent] invoke start', {
-    callerSlug,
-    targetSlug,
-    existingSessionId: existingSessionId ?? null,
-    sync: !!sync,
-  })
-
   return runWithOptionalUser(attributedUserId, async () => {
-    // Stages for runtime failures: ensure_running → create_session / send_message.
+    // Stages for runtime 500s: ensure_running → create_session / send_message.
     let stage = 'ensure_running'
     try {
       if (existingSessionId) {
         if (messagePersister.isSessionActive(existingSessionId)) {
-          console.warn('[x-agent] invoke rejected', {
-            callerSlug,
-            targetSlug,
-            existingSessionId,
-            reason: 'session_busy',
-            status: 409,
-          })
           return c.json({ error: 'Target session is currently running' }, 409)
         }
         stage = 'ensure_running'
@@ -580,12 +544,6 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
             stage = 'wait_for_idle'
             await messagePersister.waitForIdle(existingSessionId)
           } catch (error) {
-            console.warn('[x-agent] invoke sync wait incomplete', {
-              callerSlug,
-              targetSlug,
-              sessionId: existingSessionId,
-              error: error instanceof Error ? error.message : String(error),
-            })
             return c.json({
               sessionId: existingSessionId,
               status: 'running',
@@ -593,26 +551,12 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
             })
           }
           const lastMessage = await readLastAssistantMessage(targetSlug, existingSessionId)
-          console.info('[x-agent] invoke ok', {
-            callerSlug,
-            targetSlug,
-            sessionId: existingSessionId,
-            mode: 'existing',
-            sync: true,
-          })
           return c.json({
             sessionId: existingSessionId,
             status: 'completed',
             lastMessage: lastMessage?.content,
           })
         }
-        console.info('[x-agent] invoke ok', {
-          callerSlug,
-          targetSlug,
-          sessionId: existingSessionId,
-          mode: 'existing',
-          sync: false,
-        })
         return c.json({ sessionId: existingSessionId, status: 'running' })
       }
 
@@ -694,12 +638,6 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
           stage = 'wait_for_idle'
           await messagePersister.waitForIdle(newSessionId)
         } catch (error) {
-          console.warn('[x-agent] invoke sync wait incomplete', {
-            callerSlug,
-            targetSlug,
-            sessionId: newSessionId,
-            error: error instanceof Error ? error.message : String(error),
-          })
           return c.json({
             sessionId: newSessionId,
             status: 'running',
@@ -707,26 +645,12 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
           })
         }
         const lastMessage = await readLastAssistantMessage(targetSlug, newSessionId)
-        console.info('[x-agent] invoke ok', {
-          callerSlug,
-          targetSlug,
-          sessionId: newSessionId,
-          mode: 'new',
-          sync: true,
-        })
         return c.json({
           sessionId: newSessionId,
           status: 'completed',
           lastMessage: lastMessage?.content,
         })
       }
-      console.info('[x-agent] invoke ok', {
-        callerSlug,
-        targetSlug,
-        sessionId: newSessionId,
-        mode: 'new',
-        sync: false,
-      })
       return c.json({ sessionId: newSessionId, status: 'running' })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -44,7 +44,10 @@ import {
 import { getEffectiveModels, getEffectiveAgentLimits, getCustomEnvVars, getSettings } from '@shared/lib/config/settings'
 import { getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { readAgentPreferences } from '@shared/lib/services/agent-preferences-service'
+import { captureException } from '@shared/lib/error-reporting'
 import type { JsonlMessageEntry, JsonlSystemEntry } from '@shared/lib/types/agent'
+
+const X_AGENT_SENTRY = { area: 'x-agent', op: 'invoke' } as const
 
 // Typed context variables for the x-agent router. Using Hono's generic instead
 // of `as never` casts gives us type safety on c.get/c.set.
@@ -471,22 +474,30 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
   const callerSlug = getCallerSlug(c)
   const { slug: rawTargetSlug, prompt, sessionId: existingSessionId, sync, _callerSessionId } = c.req.valid('json')
 
-  // Resolve the model-supplied display slug to the canonical id and rebind, so
-  // the self-invoke guard and every ACL / policy / runtime call below use ids.
+  // Resolve display slug → canonical id so ACL / policy / runtime all use ids.
   const targetSlug = await resolveAgentId(rawTargetSlug)
-  if (!targetSlug) return c.json({ error: 'Target agent not found' }, 404)
+  if (!targetSlug) {
+    console.warn('[x-agent] invoke rejected', { callerSlug, rawTargetSlug, reason: 'target_not_found', status: 404 })
+    return c.json({ error: 'Target agent not found' }, 404)
+  }
 
   if (targetSlug === callerSlug) {
+    console.warn('[x-agent] invoke rejected', { callerSlug, targetSlug, reason: 'self_invoke', status: 400 })
     return c.json({ error: 'Agent cannot invoke itself' }, 400)
   }
 
-  // One-hop rule: a session that was started by another agent cannot itself
-  // start invocations into other agents. Prevents A→B→C chains and A→B→A
-  // cycles transitively. Hoisted out so attribution lookup below can reuse it.
+  // One-hop rule: sessions started by another agent cannot invoke further.
   const callerMeta = _callerSessionId
     ? await getSessionMetadata(callerSlug, _callerSessionId)
     : null
   if (callerMeta?.invokedByAgentSlug) {
+    console.warn('[x-agent] invoke rejected', {
+      callerSlug,
+      targetSlug,
+      reason: 'one_hop',
+      invokedBy: callerMeta.invokedByAgentSlug,
+      status: 403,
+    })
     return c.json(
       {
         error:
@@ -498,9 +509,13 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
   }
 
   const target = await getAgent(targetSlug)
-  if (!target) return c.json({ error: 'Target agent not found' }, 404)
+  if (!target) {
+    console.warn('[x-agent] invoke rejected', { callerSlug, targetSlug, reason: 'target_missing', status: 404 })
+    return c.json({ error: 'Target agent not found' }, 404)
+  }
 
   if (!(await callerOwnerHasRoleOnTarget(callerSlug, targetSlug, 'user'))) {
+    console.warn('[x-agent] invoke rejected', { callerSlug, targetSlug, reason: 'acl', status: 403 })
     return c.json({ error: 'Forbidden: caller has no user access to target agent' }, 403)
   }
 
@@ -512,130 +527,222 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
     prompt.slice(0, 200),
   )
   if (!policy.allowed) {
+    console.warn('[x-agent] invoke rejected', {
+      callerSlug,
+      targetSlug,
+      reason: 'policy',
+      detail: policy.reason ?? 'Forbidden',
+      status: 403,
+    })
     return c.json({ error: policy.reason ?? 'Forbidden' }, 403)
   }
 
-  // Attribute to the originating user: caller session's creator → caller
-  // agent's first owner (legacy fallback for pre-attribution sessions).
+  // Attribute to session creator → caller agent's first owner (auth-mode fallback).
   let attributedUserId: string | undefined = callerMeta?.createdByUserId
   if (!attributedUserId && isAuthMode()) {
     attributedUserId = (await getOwnersOfAgent(callerSlug))[0]
   }
 
-  return runWithOptionalUser(attributedUserId, async () => {
-  // Existing session: must exist, must not be running
-  if (existingSessionId) {
-    if (messagePersister.isSessionActive(existingSessionId)) {
-      return c.json({ error: 'Target session is currently running' }, 409)
-    }
-    const client = await containerManager.ensureRunning(targetSlug)
-    if (!messagePersister.isSubscribed(existingSessionId)) {
-      await messagePersister.subscribeToSession(existingSessionId, client, existingSessionId, targetSlug)
-    }
-    messagePersister.markSessionActive(existingSessionId, targetSlug)
-    await client.sendMessage(existingSessionId, prompt)
+  console.info('[x-agent] invoke start', {
+    callerSlug,
+    targetSlug,
+    existingSessionId: existingSessionId ?? null,
+    sync: !!sync,
+  })
 
-    if (sync) {
-      try {
-        await messagePersister.waitForIdle(existingSessionId)
-      } catch (error) {
-        return c.json({
+  return runWithOptionalUser(attributedUserId, async () => {
+    // Stages for runtime failures: ensure_running → create_session / send_message.
+    let stage = 'ensure_running'
+    try {
+      if (existingSessionId) {
+        if (messagePersister.isSessionActive(existingSessionId)) {
+          console.warn('[x-agent] invoke rejected', {
+            callerSlug,
+            targetSlug,
+            existingSessionId,
+            reason: 'session_busy',
+            status: 409,
+          })
+          return c.json({ error: 'Target session is currently running' }, 409)
+        }
+        stage = 'ensure_running'
+        const client = await containerManager.ensureRunning(targetSlug)
+        stage = 'subscribe'
+        if (!messagePersister.isSubscribed(existingSessionId)) {
+          await messagePersister.subscribeToSession(existingSessionId, client, existingSessionId, targetSlug)
+        }
+        messagePersister.markSessionActive(existingSessionId, targetSlug)
+        stage = 'send_message'
+        await client.sendMessage(existingSessionId, prompt)
+
+        if (sync) {
+          try {
+            stage = 'wait_for_idle'
+            await messagePersister.waitForIdle(existingSessionId)
+          } catch (error) {
+            console.warn('[x-agent] invoke sync wait incomplete', {
+              callerSlug,
+              targetSlug,
+              sessionId: existingSessionId,
+              error: error instanceof Error ? error.message : String(error),
+            })
+            return c.json({
+              sessionId: existingSessionId,
+              status: 'running',
+              error: error instanceof Error ? error.message : String(error),
+            })
+          }
+          const lastMessage = await readLastAssistantMessage(targetSlug, existingSessionId)
+          console.info('[x-agent] invoke ok', {
+            callerSlug,
+            targetSlug,
+            sessionId: existingSessionId,
+            mode: 'existing',
+            sync: true,
+          })
+          return c.json({
+            sessionId: existingSessionId,
+            status: 'completed',
+            lastMessage: lastMessage?.content,
+          })
+        }
+        console.info('[x-agent] invoke ok', {
+          callerSlug,
+          targetSlug,
           sessionId: existingSessionId,
-          status: 'running',
-          error: error instanceof Error ? error.message : String(error),
+          mode: 'existing',
+          sync: false,
+        })
+        return c.json({ sessionId: existingSessionId, status: 'running' })
+      }
+
+      stage = 'ensure_running'
+      const client = await containerManager.ensureRunning(targetSlug)
+      const availableEnvVars = await getSecretEnvVars(targetSlug)
+      const agentLimits = getEffectiveAgentLimits()
+      const customEnvVars = getCustomEnvVars()
+      const targetPrefs = await readAgentPreferences(targetSlug)
+
+      stage = 'create_session'
+      const containerSession = await client.createSession({
+        availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
+        initialMessage: prompt,
+        model: targetPrefs.defaultModel ?? getEffectiveModels().agentModel,
+        browserModel: getEffectiveModels().browserModel,
+        dashboardBuilderModel: getEffectiveModels().dashboardBuilderModel,
+        ...(targetPrefs.defaultEffort ? { effort: targetPrefs.defaultEffort } : {}),
+        ...(targetPrefs.defaultSpeed ? { speed: targetPrefs.defaultSpeed } : {}),
+        maxOutputTokens: agentLimits.maxOutputTokens,
+        maxThinkingTokens: agentLimits.maxThinkingTokens,
+        maxTurns: agentLimits.maxTurns,
+        maxBudgetUsd: agentLimits.maxBudgetUsd,
+        customEnvVars: Object.keys(customEnvVars).length > 0 ? customEnvVars : undefined,
+        maxBrowserTabs: getSettings().app?.maxBrowserTabs,
+      })
+      const newSessionId = containerSession.id
+      // Mark active before any await so waitForIdle sees state if result arrives early.
+      messagePersister.markSessionActive(newSessionId, targetSlug)
+
+      stage = 'register_session'
+      try {
+        await registerSession(targetSlug, newSessionId, `Invoked by ${callerSlug}`)
+      } catch (registerErr) {
+        const message = registerErr instanceof Error ? registerErr.message : String(registerErr)
+        console.error('[x-agent] invoke failed', {
+          callerSlug,
+          targetSlug,
+          sessionId: newSessionId,
+          stage,
+          error: message,
+        })
+        captureException(registerErr, {
+          tags: { ...X_AGENT_SENTRY, stage },
+          extra: { callerSlug, targetSlug, sessionId: newSessionId },
+        })
+        await client.deleteSession(newSessionId).catch((cleanupErr) => {
+          console.error('[x-agent] failed to clean up orphaned container session', {
+            sessionId: newSessionId,
+            error: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+          })
+        })
+        messagePersister.unsubscribeFromSession(newSessionId)
+        return c.json({ error: `Failed to register invoked session: ${message}` }, 500)
+      }
+
+      try {
+        await updateSessionMetadata(targetSlug, newSessionId, {
+          invokedByAgentSlug: callerSlug,
+          ...(attributedUserId ? { createdByUserId: attributedUserId } : {}),
+        })
+      } catch (metaErr) {
+        console.warn('[x-agent] updateSessionMetadata failed (session usable, provenance not recorded)', {
+          callerSlug,
+          targetSlug,
+          sessionId: newSessionId,
+          error: metaErr instanceof Error ? metaErr.message : String(metaErr),
         })
       }
-      const lastMessage = await readLastAssistantMessage(targetSlug, existingSessionId)
-      return c.json({
-        sessionId: existingSessionId,
-        status: 'completed',
-        lastMessage: lastMessage?.content,
-      })
-    }
-    return c.json({ sessionId: existingSessionId, status: 'running' })
-  }
 
-  // New session
-  const client = await containerManager.ensureRunning(targetSlug)
-  const availableEnvVars = await getSecretEnvVars(targetSlug)
-  const agentLimits = getEffectiveAgentLimits()
-  const customEnvVars = getCustomEnvVars()
+      stage = 'subscribe'
+      await messagePersister.subscribeToSession(newSessionId, client, newSessionId, targetSlug)
+      if (containerSession.slashCommands && containerSession.slashCommands.length > 0) {
+        messagePersister.setSlashCommands(newSessionId, containerSession.slashCommands)
+      }
 
-  // Model/effort/speed preference order: target agent's default > global default.
-  const targetPrefs = await readAgentPreferences(targetSlug)
-
-  const containerSession = await client.createSession({
-    availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
-    initialMessage: prompt,
-    model: targetPrefs.defaultModel ?? getEffectiveModels().agentModel,
-    browserModel: getEffectiveModels().browserModel,
-    dashboardBuilderModel: getEffectiveModels().dashboardBuilderModel,
-    ...(targetPrefs.defaultEffort ? { effort: targetPrefs.defaultEffort } : {}),
-    ...(targetPrefs.defaultSpeed ? { speed: targetPrefs.defaultSpeed } : {}),
-    maxOutputTokens: agentLimits.maxOutputTokens,
-    maxThinkingTokens: agentLimits.maxThinkingTokens,
-    maxTurns: agentLimits.maxTurns,
-    maxBudgetUsd: agentLimits.maxBudgetUsd,
-    customEnvVars: Object.keys(customEnvVars).length > 0 ? customEnvVars : undefined,
-    maxBrowserTabs: getSettings().app?.maxBrowserTabs,
-  })
-  const newSessionId = containerSession.id
-  // Mark active synchronously before any await so waitForIdle has state to observe
-  // even if the SDK's 'result' event lands before subscribeToSession completes.
-  messagePersister.markSessionActive(newSessionId, targetSlug)
-
-  // Register on the host. If this fails, the container is already holding a
-  // running session — clean it up so we don't leave orphans burning model budget.
-  try {
-    await registerSession(targetSlug, newSessionId, `Invoked by ${callerSlug}`)
-  } catch (registerErr) {
-    console.error('[x-agent] registerSession failed; cleaning up container session', registerErr)
-    await client.deleteSession(newSessionId).catch((cleanupErr) => {
-      // Container was unreachable or session already gone — nothing more we can do
-      console.error('[x-agent] failed to clean up orphaned container session', newSessionId, cleanupErr)
-    })
-    messagePersister.unsubscribeFromSession(newSessionId)
-    return c.json(
-      { error: `Failed to register invoked session: ${registerErr instanceof Error ? registerErr.message : String(registerErr)}` },
-      500,
-    )
-  }
-
-  // Metadata write failure shouldn't fail the invoke (the session is still
-  // usable), but don't silently swallow — log so we can debug missing
-  // cross-agent provenance later.
-  try {
-    await updateSessionMetadata(targetSlug, newSessionId, {
-      invokedByAgentSlug: callerSlug,
-      ...(attributedUserId ? { createdByUserId: attributedUserId } : {}),
-    })
-  } catch (metaErr) {
-    console.warn('[x-agent] updateSessionMetadata failed (session usable, provenance not recorded)', metaErr)
-  }
-
-  await messagePersister.subscribeToSession(newSessionId, client, newSessionId, targetSlug)
-  if (containerSession.slashCommands && containerSession.slashCommands.length > 0) {
-    messagePersister.setSlashCommands(newSessionId, containerSession.slashCommands)
-  }
-
-  if (sync) {
-    try {
-      await messagePersister.waitForIdle(newSessionId)
-    } catch (error) {
-      return c.json({
+      if (sync) {
+        try {
+          stage = 'wait_for_idle'
+          await messagePersister.waitForIdle(newSessionId)
+        } catch (error) {
+          console.warn('[x-agent] invoke sync wait incomplete', {
+            callerSlug,
+            targetSlug,
+            sessionId: newSessionId,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          return c.json({
+            sessionId: newSessionId,
+            status: 'running',
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+        const lastMessage = await readLastAssistantMessage(targetSlug, newSessionId)
+        console.info('[x-agent] invoke ok', {
+          callerSlug,
+          targetSlug,
+          sessionId: newSessionId,
+          mode: 'new',
+          sync: true,
+        })
+        return c.json({
+          sessionId: newSessionId,
+          status: 'completed',
+          lastMessage: lastMessage?.content,
+        })
+      }
+      console.info('[x-agent] invoke ok', {
+        callerSlug,
+        targetSlug,
         sessionId: newSessionId,
-        status: 'running',
-        error: error instanceof Error ? error.message : String(error),
+        mode: 'new',
+        sync: false,
       })
+      return c.json({ sessionId: newSessionId, status: 'running' })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error('[x-agent] invoke failed', {
+        callerSlug,
+        targetSlug,
+        existingSessionId: existingSessionId ?? null,
+        stage,
+        error: message,
+      })
+      captureException(err, {
+        tags: { ...X_AGENT_SENTRY, stage },
+        extra: { callerSlug, targetSlug, existingSessionId: existingSessionId ?? null },
+      })
+      return c.json({ error: `Failed to invoke agent (${stage}): ${message}` }, 500)
     }
-    const lastMessage = await readLastAssistantMessage(targetSlug, newSessionId)
-    return c.json({
-      sessionId: newSessionId,
-      status: 'completed',
-      lastMessage: lastMessage?.content,
-    })
-  }
-  return c.json({ sessionId: newSessionId, status: 'running' })
   })
 })
 


### PR DESCRIPTION
## Summary
- Add structured `[x-agent]` logs for invoke start / ok / rejected / failed on `POST /api/x-agent/invoke`
- Capture unexpected runtime failures to Sentry with tags `{ area: 'x-agent', op: 'invoke', stage }`
- Return 500 bodies that include the failing stage (e.g. `ensure_running`, `create_session`) so retries and support can see where the call broke

## Why
Cross-agent invoke failures currently surface as opaque Internal Server Errors with almost no host breadcrumbs (only `registerSession` had an `[x-agent]` log). This makes production reports hard to confirm.

## Test plan
- [x] `npm test -- --run src/api/routes/x-agent.test.ts` (48 passed)
- [x] New coverage: `ensure_running` failure → 500 + Sentry stage tag; `create_session` failure → 500 + stage tag
- [ ] After deploy: filter CloudWatch for `[x-agent] invoke` on a failing cross-agent call and confirm Sentry issue tags include `stage`


Made with [Cursor](https://cursor.com)