### PR TITLE
fix: interrupted turns clumped all thinking cards below the interrupt marker

### DIFF
--- a/e2e/specs/stop-session.spec.ts
+++ b/e2e/specs/stop-session.spec.ts
@@ -94,13 +94,16 @@ test.describe('Stop button interrupts the working agent', () => {
 
     // The aborted turn's tail never landed: no completion text, no steering
     // acknowledgements, no phantom reactivation, and the transcript holds
-    // exactly the warm-up turn and the two fresh follow-up turns.
+    // exactly the warm-up turn, the interrupted turn (its user message plus
+    // the "[Request interrupted by user]" marker the abort appended), and the
+    // two fresh follow-up turns.
     await expect(sessionPage.getAssistantMessages().filter({ hasText: 'Finished the slow work.' })).toHaveCount(0)
     await expect(sessionPage.getAssistantMessages().filter({ hasText: 'Adjusting based on:' })).toHaveCount(0)
     await expect(sessionPage.getAssistantMessages()).toHaveCount(3)
     await expect(sessionPage.getStopButton()).not.toBeVisible()
-    await sessionPage.waitForUserMessageCount(4)
+    await sessionPage.waitForUserMessageCount(5)
     await sessionPage.expectUserMessage('please work slowly for the stop test', 1)
+    await sessionPage.expectUserMessage('[Request interrupted by user]', 2)
   })
 
   test('stopping with a queued message rescues its text into the composer for resend', async ({ page }) => {
@@ -134,9 +137,11 @@ test.describe('Stop button interrupts the working agent', () => {
       .filter({ hasText: 'This is a delayed mock response.' })
     await sessionPage.getSendButton().click()
     await expect(delayedResponses).toHaveCount(1, { timeout: 15000 })
-    await sessionPage.waitForUserMessageCount(2, 15000)
+    // The abort appended the interrupt marker after the slow-work user message
+    await sessionPage.waitForUserMessageCount(3, 15000)
     await sessionPage.expectUserMessage('please work slowly for the draft rescue test', 0)
-    await sessionPage.expectUserMessage(queuedText, 1)
+    await sessionPage.expectUserMessage('[Request interrupted by user]', 1)
+    await sessionPage.expectUserMessage(queuedText, 2)
 
     // Chain two more 3s turns: with the resend gated on the 1.5s rescue grace,
     // finishing three chained turns is provably past both cancelled timers
@@ -152,10 +157,11 @@ test.describe('Stop button interrupts the working agent', () => {
     await expect(delayedResponses).toHaveCount(3, { timeout: 15000 })
 
     // Neither cancelled timer fired: no steering acknowledgement, no
-    // completion text, no duplicate of the rescued message.
+    // completion text, no duplicate of the rescued message. (5 = slow-work
+    // message + interrupt marker + rescued resend + the two check turns.)
     await expect(sessionPage.getAssistantMessages().filter({ hasText: 'Adjusting based on:' })).toHaveCount(0)
     await expect(sessionPage.getAssistantMessages().filter({ hasText: 'Finished the slow work.' })).toHaveCount(0)
-    await expect(sessionPage.getUserMessages()).toHaveCount(4)
+    await expect(sessionPage.getUserMessages()).toHaveCount(5)
     await expect(sessionPage.getStopButton()).not.toBeVisible()
   })
 
@@ -186,7 +192,8 @@ test.describe('Stop button interrupts the working agent', () => {
     await expect(composer).toHaveValue(new RegExp('first rescue candidate'), { timeout: 10000 })
     await expect(composer).toHaveValue(new RegExp('second rescue candidate'))
 
-    // Neither queued message ever reached the transcript.
-    await expect(sessionPage.getUserMessages()).toHaveCount(1)
+    // Neither queued message ever reached the transcript — only the original
+    // send and the interrupt marker the abort appended.
+    await expect(sessionPage.getUserMessages()).toHaveCount(2)
   })
 })

--- a/e2e/specs/thinking-display.spec.ts
+++ b/e2e/specs/thinking-display.spec.ts
@@ -93,6 +93,44 @@ test.describe('Thinking Display', () => {
     await sessionPage.waitForInputEnabled(30000)
   })
 
+  test('interrupting mid-turn does not clump thinking cards below the interrupt marker', async ({ page, request }, testInfo) => {
+    // Chains a multi-pass thinking turn (~7s of scheduled streaming) with an
+    // interrupt landing mid-turn — needs headroom on a loaded CI runner.
+    test.slow()
+    const { sessionPage } = await setupThinkingTest(page, request, testInfo, 'Interrupt')
+
+    // Multi-pass mock scenario: three thinking blocks, each persisted to the
+    // transcript as its own assistant entry the moment it completes — so an
+    // interrupt leaves earlier passes persisted while later ones die.
+    await sessionPage.sendMessage('please think in passes about this')
+
+    // Wait for the second pass to start streaming: the first pass is then
+    // already persisted in the JSONL, giving the post-interrupt transcript
+    // both persisted thinking AND live blocks still held by the stream store.
+    await expect(page.getByTestId('thinking-block')).toHaveCount(2, { timeout: 15000 })
+
+    await sessionPage.getStopButton().click()
+    await expect(sessionPage.getStopButton()).not.toBeVisible({ timeout: 10000 })
+
+    // The CLI appends the interrupt marker as a user message ending the turn
+    const marker = sessionPage.getUserMessages().filter({ hasText: '[Request interrupted by user]' })
+    await expect(marker).toBeVisible({ timeout: 10000 })
+
+    // The persisted passes stay inline above the marker...
+    await expect(page.getByTestId('thinking-block').first()).toBeVisible()
+    // ...and nothing renders below it: the interrupted turn's live blocks must
+    // not re-render clumped at the end of the transcript (the marker is a user
+    // message, so the dedup scan must not mistake it for a new turn's start).
+    const cardsBelowMarker = page.locator(
+      'xpath=//*[@data-testid="message-user" and contains(., "Request interrupted by user")]/following::*[@data-testid="thinking-block"]'
+    )
+    await expect(cardsBelowMarker).toHaveCount(0)
+
+    // The interrupted turn's tail stays dead: the final answer never lands.
+    await sessionPage.waitForInputEnabled(15000)
+    await expect(page.getByText('Done with all thinking passes')).not.toBeVisible()
+  })
+
   test('thinking persists in the transcript across a reopen', async ({ page, request }, testInfo) => {
     const { appPage, sessionPage, agent, setupSession } = await setupThinkingTest(page, request, testInfo, 'Persist')
 

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -1889,6 +1889,43 @@ describe('MessageList', () => {
       expect(screen.queryByText('divergent streamed fragment')).not.toBeInTheDocument()
     })
 
+    it('drops leftover live cards after an interrupt instead of clumping them below the marker', () => {
+      // Interrupting a turn appends a "[Request interrupted by user]" USER
+      // message to the transcript. The dedup scan must not treat it as the
+      // start of a new turn — otherwise it collects no persisted thinking and
+      // every live block from the interrupted turn re-renders at the end.
+      mockMessagesData.data = [
+        createUserMessage({ content: { text: 'Question' } }),
+        createAssistantMessage({ content: { text: '' }, thinking: [{ text: 'first reasoning pass' }] }),
+        createAssistantMessage({ content: { text: '' }, thinking: [{ text: 'second reasoning pass' }] }),
+        createUserMessage({ content: { text: '[Request interrupted by user]' } }),
+      ]
+      mockStreamState.isActive = false
+      mockStreamState.thinkingBlocks = [
+        { id: 1, text: 'first reasoning pass', startedAt: Date.now() - 9000, endedAt: Date.now() - 7000 },
+        { id: 2, text: 'second reasoning pass', startedAt: Date.now() - 6000, endedAt: Date.now() - 4000 },
+      ]
+
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      // Only the two persisted cards — the live copies must not double-render.
+      expect(screen.getAllByTestId('thinking-block')).toHaveLength(2)
+    })
+
+    it('drops a live card at idle after an interrupt even when its thinking never persisted', () => {
+      // Interrupted mid-first-block: the SDK discards the partial thinking, so
+      // there is no persisted counterpart and the live card would strand below
+      // the interrupt marker forever.
+      mockMessagesData.data = [
+        createUserMessage({ content: { text: 'Question' } }),
+        createUserMessage({ content: { text: '[Request interrupted by user for tool use]' } }),
+      ]
+      mockStreamState.isActive = false
+      mockStreamState.thinkingBlocks = [liveBlock('partial discarded reasoning', Date.now())]
+
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.queryByTestId('thinking-block')).not.toBeInTheDocument()
+    })
+
     it('keeps an empty-text live block while active but drops it at idle', () => {
       mockMessagesData.data = [
         createUserMessage({ content: { text: 'Question' } }),

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -10,7 +10,7 @@ import {
   clearPeerUserMessages,
   consumeDiscardedCommand,
 } from '@renderer/hooks/use-message-stream'
-import { isTurnStartingUserMessage, type PendingMessage } from './pending-message'
+import { isInterruptMarkerMessage, isTurnStartingUserMessage, type PendingMessage } from './pending-message'
 import { MessageItem } from './message-item'
 import { ToolCallItem, StreamingToolCallItem } from './tool-call-item'
 import { ThinkingBlockItem } from './thinking-block-item'
@@ -434,8 +434,17 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   const unpersistedThinkingBlocks = useMemo(() => {
     if (!thinkingBlocks.length || !messages?.length) return thinkingBlocks
     const persisted: string[] = []
+    let interrupted = false
     for (let i = messages.length - 1; i >= 0; i--) {
       const m = messages[i]
+      // The "[Request interrupted by user]" marker is a user message that ENDS
+      // the interrupted turn — breaking on it would collect none of that
+      // turn's persisted thinking and let every live block re-render at the
+      // end. Keep scanning into the turn it terminated.
+      if (isInterruptMarkerMessage(m)) {
+        interrupted = true
+        continue
+      }
       if (isTurnStartingUserMessage(m)) break
       if (m.type === 'assistant' && Array.isArray((m as ApiMessage).thinking)) {
         for (const t of (m as ApiMessage).thinking!) {
@@ -448,7 +457,9 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     // streamed text diverged from the transcript (e.g. an SSE reconnect
     // dropped deltas) — text matching would miss them and the leftover card
     // would strand below the persisted message, appearing to "jump" there.
-    if (!isActive && persisted.length) return []
+    // An interrupted turn is over even when nothing persisted: the SDK
+    // discarded whatever the leftover live blocks hold, so they'd strand.
+    if (!isActive && (persisted.length || interrupted)) return []
     return thinkingBlocks.filter(b => {
       const t = b.text.trim()
       // Blocks with no streamed text (display option off) have no persisted

--- a/src/renderer/components/messages/pending-message.ts
+++ b/src/renderer/components/messages/pending-message.ts
@@ -30,3 +30,13 @@ export interface PendingMessage {
 export function isTurnStartingUserMessage(m: { type: string; queued?: boolean }): boolean {
   return m.type === 'user' && !m.queued
 }
+
+/**
+ * True for the synthetic "[Request interrupted by user]" / "[Request
+ * interrupted by user for tool use]" user message the CLI appends when a turn
+ * is interrupted. It ENDS the interrupted turn rather than starting a new one.
+ */
+export function isInterruptMarkerMessage(m: { type: string; content?: { text?: string } | string }): boolean {
+  if (m.type !== 'user' || typeof m.content !== 'object') return false
+  return m.content?.text?.startsWith('[Request interrupted by user') ?? false
+}

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -230,6 +230,101 @@ export class ThinkingResponseScenario implements MockScenario {
 }
 
 /**
+ * Multi-pass extended-thinking scenario — streams several thinking blocks in
+ * one turn, persisting each block's assistant JSONL entry as it completes
+ * (the real CLI writes one transcript entry per assistant message mid-turn).
+ * Interrupting mid-turn therefore leaves the earlier passes in the transcript
+ * while the later ones die with the scenario epoch — the transcript shape
+ * behind the "thinking cards clump below the interrupt marker" regression.
+ */
+export class MultiPassThinkingScenario implements MockScenario {
+  constructor(
+    private passes: string[],
+    private responseText: string,
+    /** Delay between thinking chunks — sets how long each pass streams. */
+    private chunkDelayMs = 200
+  ) {}
+
+  execute(sessionId: string, client: MockContainerClient, userMessage: string): void {
+    setTimeout(() => {
+      client.writeJsonlEntry(sessionId, {
+        type: 'user',
+        message: { content: userMessage },
+        timestamp: new Date().toISOString(),
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'message_start' } },
+      })
+    }, 10)
+
+    let offset = 20
+    for (const passText of this.passes) {
+      const passStart = offset
+      const chunks = passText.split(' ')
+      setTimeout(() => {
+        client.emitStreamMessage(sessionId, {
+          type: 'stream_event',
+          content: { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'thinking' } } },
+        })
+      }, passStart)
+      chunks.forEach((word, i) => {
+        setTimeout(() => {
+          client.emitStreamMessage(sessionId, {
+            type: 'stream_event',
+            content: { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: (i > 0 ? ' ' : '') + word } } },
+          })
+        }, passStart + 10 + i * this.chunkDelayMs)
+      })
+      const passEnd = passStart + 20 + chunks.length * this.chunkDelayMs
+      setTimeout(() => {
+        client.emitStreamMessage(sessionId, {
+          type: 'stream_event',
+          content: { type: 'stream_event', event: { type: 'content_block_stop' } },
+        })
+        // Each pass persists as its own assistant entry, like the real CLI
+        client.writeJsonlEntry(sessionId, {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'thinking', thinking: passText, signature: 'mock-signature' }],
+          },
+          timestamp: new Date().toISOString(),
+        })
+      }, passEnd)
+      offset = passEnd + 100
+    }
+
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'text' } } },
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: this.responseText } } },
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_stop' } },
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'message_stop' } },
+      })
+      client.writeJsonlEntry(sessionId, {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: this.responseText }] },
+        timestamp: new Date().toISOString(),
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'result',
+        content: { type: 'result', subtype: 'success' },
+      })
+    }, offset)
+  }
+}
+
+/**
  * Slow scenario for message-queueing E2E tests: holds the session in the
  * working state long enough for the test to send mid-turn messages, which the
  * mock records as queued_command attachments (mirroring the real CLI's
@@ -1169,6 +1264,15 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
   static scenarios = new Map<string, MockScenario>([
     // Slow response window for message-queueing tests (send mid-turn → queued)
     ['work slowly', new SlowWorkScenario()],
+    // Several thinking passes persisted one-by-one — an interruptible thinking turn
+    ['think in passes', new MultiPassThinkingScenario(
+      [
+        'First pass: survey the problem space and list the moving parts before committing to anything.',
+        'Second pass: weigh the tradeoffs between the candidate approaches and pick the sturdiest one.',
+        'Third pass: sanity-check the chosen approach against the edge cases before answering.',
+      ],
+      'Done with all thinking passes — here is the answer.'
+    )],
     // Extended-thinking card in the transcript (expanded while streaming, then collapsed)
     ['think out loud', new ThinkingResponseScenario(
       'Let me reason about this. The user wants a demonstration of extended thinking, ' +
@@ -2185,11 +2289,26 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     const session = this.sessions.get(sessionId)
     if (!session) return false
 
+    const hadTurnInFlight = this.busySessions.has(sessionId)
+
     // Supersede the in-flight scenario so its pending timers can't finish the
     // turn after the abort (see scenarioView), and let the next send start a
     // fresh turn instead of taking the mid-turn steering path.
     this.interruptEpochs.set(sessionId, (this.interruptEpochs.get(sessionId) ?? 0) + 1)
     this.busySessions.delete(sessionId)
+
+    // Aborting an active turn appends a "[Request interrupted by user]" USER
+    // entry to the transcript in the real CLI — it renders as the interrupt
+    // bubble and, being a user message, exercises turn-boundary logic in the
+    // renderer (e.g. thinking-card dedup). Mirror it so E2E sees the real
+    // post-interrupt transcript shape.
+    if (hadTurnInFlight) {
+      this.writeJsonlEntry(sessionId, {
+        type: 'user',
+        message: { content: '[Request interrupted by user]' },
+        timestamp: new Date().toISOString(),
+      })
+    }
 
     // Queued steering messages die with the turn — the real CLI never picks
     // them up after an abort. Mirror the real container: it names each dead


### PR DESCRIPTION
## Problem

Interrupting a session mid-turn rendered every thinking card from the turn clumped at the end of the transcript, right below the `[Request interrupted by user]` bubble (screenshot-verified).

## Root cause

Two parts, both needed:

1. Live thinking blocks live in a module-level stream store (`use-message-stream.ts`) that is only cleared on the **next** `session_active` — on `session_idle` (which interrupt fires) they are merely closed so their timers freeze.
2. The `unpersistedThinkingBlocks` dedup memo in `message-list.tsx` normally suppresses those live cards once the refetched transcript carries the same thinking inline. It scans the transcript backward and breaks at the first turn-starting user message — but the CLI's interrupt marker **is** a non-queued user message and is the last transcript entry after an interrupt, so the scan collected zero persisted thinking and the filter kept every live block. They all re-rendered at the end.

## Fix

- New `isInterruptMarkerMessage()` in `pending-message.ts` (covers the "for tool use" variant).
- The dedup scan skips the marker and keeps scanning into the interrupted turn, so persisted thinking is found and the existing "turn is over → persisted cards own the display" guard clears the live copies. It also drops live blocks at idle when the turn was interrupted even if nothing persisted — the SDK discards that partial thinking, so the card would otherwise strand forever.
- `turnElapsedTimes` & co. still treat the marker as a turn boundary (correct for "Worked for Xs" placement) — deliberately unchanged.

## Tests

- **Unit** (`message-list.test.tsx`): two regression tests, both red before the fix (duplicate cards / stranded card), green after.
- **E2E**: the mock's `interruptSession` never persisted the interrupt marker to JSONL — the fidelity gap that hid this bug from e2e. It now mirrors the real CLI (marker written when a turn was in flight). New `MultiPassThinkingScenario` (three thinking blocks, each persisted mid-turn) + a regression test in `thinking-display.spec.ts` asserting zero thinking cards render below the marker. Red-proofed against the pre-fix renderer: the failure screenshot reproduces the reported bug exactly.
- The now-persisted marker adds one user message per interrupt, so `stop-session.spec.ts` counts were updated (with explicit marker-position assertions).

Validated: tsc + eslint clean, 82/82 message-list unit tests, 718 tests across messages components, 23/23 e2e across all interrupt-touching specs (`thinking-display`, `stop-session`, `pending-request-reconnect`, `proxy-review`).