### PR TITLE
feat: home graph connection editing — elbow connectors, drawing, geometry persistence

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -61,7 +61,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   // The new-agent morph tag lives in NavTransientContext — above the router, so
   // it survives in-app nav and dies on hard reload. justCreatedSlug producer =
   // use-create-untitled-agent.
-  const { justCreatedSlug, setJustCreatedSlug } = useNavTransient()
+  const { justCreatedSlug, setJustCreatedSlug, openAgentSettings, setOpenAgentSettings } = useNavTransient()
   const navigate = useNavigate()
   const [introStagger] = useState(() => {
     if (justCreatedSlug !== agent.slug) return false
@@ -131,6 +131,14 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
     setSettingsTab(tab)
     setSettingsOpen(true)
   }, [])
+  // One-shot from NavTransientContext: another page (e.g. the home graph's
+  // "edit permissions") navigated here asking for a settings tab. Consume
+  // immediately so it can't replay on a later visit.
+  useEffect(() => {
+    if (openAgentSettings?.slug !== agent.slug) return
+    handleOpenSettings(openAgentSettings.tab)
+    setOpenAgentSettings(null)
+  }, [openAgentSettings, agent.slug, handleOpenSettings, setOpenAgentSettings])
 
   const sessions = useMemo(() => {
     if (!Array.isArray(sessionsData)) return []

--- a/src/renderer/components/home/graph/agent-graph.css
+++ b/src/renderer/components/home/graph/agent-graph.css
@@ -1,0 +1,133 @@
+/* Traveling tracer on active (solid) graph edges — the FlowPulse overlay in
+   graph-edges.tsx. Each edge sets its own animation-duration inline (faster
+   = more traffic). The -80px offset equals one TRACER_PERIOD, so the loop
+   is seamless. */
+@keyframes graph-edge-flow {
+  to {
+    stroke-dashoffset: -80;
+  }
+}
+
+/* Perimeter connection ports: hidden until their node (agent circle) or
+   chip (resource) is hovered. The pointer-events gate rides visibility so
+   hidden ports never intercept node drags; dropping a connection still
+   snaps to them via connectionRadius, which uses positions, not hit tests. */
+.react-flow__handle.graph-port {
+  width: 9px;
+  height: 9px;
+  min-width: 0;
+  min-height: 0;
+  border-radius: 9999px;
+  background: hsl(var(--card));
+  border: 1.5px solid rgb(59 130 246);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 150ms;
+}
+.group:hover > .react-flow__handle.graph-port,
+.react-flow__handle.graph-port.connectingfrom,
+.react-flow__handle.graph-port.connectingto {
+  opacity: 1;
+  pointer-events: all;
+}
+
+/* FigJam-style anchor states on connectable ports: plain dot (node hover) →
+   grown circle with an outward arrow (port hover) → filled blue with a white
+   arrow while grabbing/drawing. RF's translate(±50%) centering keeps the
+   growth centered on the node edge. */
+.react-flow__handle.graph-port.connectable {
+  transition:
+    opacity 150ms,
+    width 120ms,
+    height 120ms,
+    background-color 120ms;
+}
+.react-flow__handle.graph-port.connectable::before {
+  content: '→';
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  line-height: 1;
+  font-weight: 600;
+  color: rgb(59 130 246);
+  opacity: 0;
+  transition: opacity 120ms;
+}
+.react-flow__handle-top.graph-port.connectable::before {
+  transform: rotate(-90deg);
+}
+.react-flow__handle-bottom.graph-port.connectable::before {
+  transform: rotate(90deg);
+}
+.react-flow__handle-left.graph-port.connectable::before {
+  transform: rotate(180deg);
+}
+.react-flow__handle.graph-port.connectable:hover,
+.react-flow__handle.graph-port.connectingfrom {
+  width: 20px;
+  height: 20px;
+}
+.react-flow__handle.graph-port.connectable:hover::before {
+  opacity: 1;
+}
+.react-flow__handle.graph-port.connectable:active,
+.react-flow__handle.graph-port.connectingfrom {
+  background: rgb(59 130 246);
+}
+.react-flow__handle.graph-port.connectable:active::before,
+.react-flow__handle.graph-port.connectingfrom::before {
+  opacity: 1;
+  color: #fff;
+}
+
+/* Hover hint on connectable ports: an arrow + what the dot is for. Appears
+   after a beat so passing over a node doesn't flash it; hidden the moment a
+   drag actually starts. Decorative (non-connectable) ports never show it. */
+.react-flow__handle.graph-port.connectable::after {
+  content: '↗ Click and drag to connect';
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: hsl(var(--card));
+  border: 0.5px solid hsl(var(--border) / 0.6);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 0.08);
+  color: hsl(var(--foreground) / 0.75);
+  font-size: 10px;
+  font-weight: 500;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms;
+}
+.react-flow__handle.graph-port.connectable:hover::after {
+  opacity: 1;
+  transition-delay: 250ms;
+}
+.react-flow__handle.graph-port.connectingfrom::after {
+  opacity: 0 !important;
+}
+
+/* Elbow-connector grab handles only exist while the edge is selected
+   (see ElbowControls); fade them in on mount. */
+.elbow-drag-handle {
+  animation: elbow-handle-in 150ms ease-out;
+}
+@keyframes elbow-handle-in {
+  from {
+    opacity: 0;
+  }
+}
+
+/* Reduced motion: hide the pulse entirely (a frozen pulse reads as random
+   bright specks) — usage still shows via the solid blue line + hover label. */
+@media (prefers-reduced-motion: reduce) {
+  .graph-edge-pulse {
+    display: none;
+  }
+}

--- a/src/renderer/components/home/graph/agent-graph.tsx
+++ b/src/renderer/components/home/graph/agent-graph.tsx
@@ -4,66 +4,217 @@
  * Positions: user-dragged coordinates persist to user settings
  * (`graphNodePositions`, debounced PUT, same pattern as `agentOrder`);
  * anything without a saved position gets the deterministic auto-layout.
+ * Dragged connector geometry (elbow offsets, pinned ports) persists the
+ * same way (`graphEdgeGeometry`).
  * Data refreshes (SSE-invalidated queries) rebuild node payloads while
  * preserving whatever positions are currently on screen.
  */
 
 import '@xyflow/react/dist/style.css'
+import './agent-graph.css'
 
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import {
   Background,
   BackgroundVariant,
+  ConnectionMode,
   Controls,
   Panel,
   ReactFlow,
   useNodesState,
-  type Edge,
+  type EdgeMouseHandler,
+  type IsValidConnection,
   type Node,
+  type OnConnect,
+  type OnConnectStart,
+  type OnEdgesChange,
   type NodeMouseHandler,
   type ReactFlowInstance,
 } from '@xyflow/react'
 import { useNavigate } from '@tanstack/react-router'
+import { useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { useNavTransient } from '@renderer/context/nav-transient-context'
 import { Loader2, RotateCcw } from 'lucide-react'
+import { apiFetch } from '@renderer/lib/api'
 import { Button } from '@renderer/components/ui/button'
 import { useUpdateUserSettings, useUserSettings } from '@renderer/hooks/use-user-settings'
 import { AgentGraphNode, ResourceGraphNode } from './graph-nodes'
+import { ElbowEdge, type EdgeGeometryOverride, type GraphEdge } from './graph-edges'
+import { ResourcePanel, resourcePanelItems } from './resource-panel'
 import { computeLayout, type XY } from './layout'
-import { useGraphData, type GraphEdgeVariant, type GraphNodeData } from './use-graph-data'
+import { useGraphData, type GraphEdgeSpec, type GraphNodeData } from './use-graph-data'
 
 type RfNode = Node<GraphNodeData>
 
 const nodeTypes = { agent: AgentGraphNode, resource: ResourceGraphNode }
+const edgeTypes = { elbow: ElbowEdge }
 
-type CSSStyle = { stroke: string; strokeWidth: number; strokeDasharray?: string }
+// Dashed vs solid = "is traffic flowing": never-exercised connections (and
+// bare permissions) are static gray dashes, broken endpoints static red
+// dashes, and recorded traffic is a SOLID blue line with a brighter pulse
+// traveling along it (the FlowPulse overlay in graph-edges.tsx) — the more
+// interactions the faster the pulse, direction following the data flow.
+// Exact counts and problems show on hover.
+const EDGE_DASH = '6 4'
 
-// Interaction counts → stroke width, log-scaled so a 100-fire webhook doesn't
-// render as a bar. Base width per variant, +0..3px with volume.
-function weightedWidth(base: number, weight?: number): number {
-  return base + Math.min(3, Math.log2(1 + (weight ?? 0)))
+// log2-scaled pulse cycle: 1 interaction ≈ a lazy 7s drift, ~100 ≈ the
+// 1.2s floor — so a 10,000-call edge doesn't strobe.
+function pulseDuration(weight: number): number {
+  return Math.max(1.2, 7.2 / Math.log2(1 + weight))
 }
 
-// Connected-but-never-exercised paths render dashed; recorded activity
-// (audit-log calls, trigger fires, chat sessions) makes them solid and
-// scales their width.
-function edgeStyle(variant: GraphEdgeVariant, weight?: number): CSSStyle {
-  switch (variant) {
-    case 'resource':
-      return weight
-        ? { stroke: 'hsl(var(--muted-foreground) / 0.5)', strokeWidth: weightedWidth(1.5, weight) }
-        : { stroke: 'hsl(var(--muted-foreground) / 0.35)', strokeWidth: 1.25, strokeDasharray: '4 4' }
-    case 'trigger':
-      return weight
-        ? { stroke: 'hsl(var(--muted-foreground) / 0.45)', strokeWidth: weightedWidth(1, weight) }
-        : { stroke: 'hsl(var(--muted-foreground) / 0.3)', strokeWidth: 1, strokeDasharray: '4 4' }
-    case 'permission':
-      return { stroke: 'hsl(var(--muted-foreground) / 0.55)', strokeWidth: 1.5, strokeDasharray: '6 4' }
-    case 'activity':
-      return { stroke: 'hsl(var(--muted-foreground) / 0.7)', strokeWidth: weightedWidth(1.5, weight) }
+function edgeStyle(e: GraphEdgeSpec): CSSProperties {
+  // Broken endpoint (expired auth, errored server, disconnected chat): red
+  // dashes, no motion — traffic isn't flowing.
+  if (e.broken) {
+    return { stroke: 'rgb(239 68 68 / 0.7)', strokeWidth: 1.25, strokeDasharray: EDGE_DASH } // red-500, matching the error status dot
   }
+  if (!e.weight) {
+    return { stroke: 'hsl(var(--muted-foreground) / 0.4)', strokeWidth: 1.25, strokeDasharray: EDGE_DASH }
+  }
+  return { stroke: 'rgb(59 130 246 / 0.75)', strokeWidth: 1.25 } // blue-500, matching the unread-notification dot
 }
 
 const PERSIST_DEBOUNCE_MS = 600
+
+// ── Drawing new connections ──────────────────────────────────────────────
+// A drawn edge must create the real relationship behind it: an invoke
+// permission for agent→agent, an account/MCP link for agent↔resource.
+// Webhooks, crons and chat integrations can't be drawn — they're created
+// through their own forms (their ports aren't connectable either).
+
+function nodeKind(nodeId: string): string {
+  return nodeId.slice(0, nodeId.indexOf(':'))
+}
+
+function nodeRef(nodeId: string): string {
+  return nodeId.slice(nodeId.indexOf(':') + 1)
+}
+
+function drawnConnectionKind(source: string, target: string): 'invoke' | 'account' | 'mcp' | null {
+  const kinds = [nodeKind(source), nodeKind(target)].sort()
+  if (kinds[0] === 'agent' && kinds[1] === 'agent') return source !== target ? 'invoke' : null
+  if (kinds[0] === 'account' && kinds[1] === 'agent') return 'account'
+  if (kinds[0] === 'agent' && kinds[1] === 'mcp') return 'mcp'
+  return null
+}
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' }
+
+/**
+ * Remove the relationship behind an edge; true = something changed.
+ * Resource edges unlink the account/MCP; agent↔agent edges revoke invoke
+ * permissions in both directions (invocation history is untouched).
+ */
+async function deleteGraphConnection(edge: GraphEdgeSpec): Promise<boolean> {
+  try {
+    if (edge.variant === 'resource') {
+      // Resource edges are always built agent → resource.
+      const slug = nodeRef(edge.source)
+      const resourceKind = nodeKind(edge.target)
+      const resourceId = nodeRef(edge.target)
+      const res = await apiFetch(
+        resourceKind === 'account'
+          ? `/api/agents/${slug}/connected-accounts/${resourceId}`
+          : `/api/agents/${slug}/remote-mcps/${resourceId}`,
+        { method: 'DELETE' },
+      )
+      if (!res.ok) throw new Error(`Failed to unlink (${res.status})`)
+      toast.success(resourceKind === 'account' ? 'Account unlinked' : 'MCP server unlinked')
+      return true
+    }
+    const a = nodeRef(edge.source)
+    const b = nodeRef(edge.target)
+    let changed = false
+    for (const [caller, target] of [
+      [a, b],
+      [b, a],
+    ] as const) {
+      const res = await apiFetch(`/api/agents/${caller}/x-agent-policies`)
+      if (!res.ok) throw new Error(`Failed to load policies (${res.status})`)
+      const { policies } = (await res.json()) as {
+        policies: { operation: string; targetAgentSlug: string | null; decision: string }[]
+      }
+      const kept = policies.filter((p) => !(p.operation === 'invoke' && p.targetAgentSlug === target))
+      if (kept.length === policies.length) continue
+      const put = await apiFetch(`/api/agents/${caller}/x-agent-policies`, {
+        method: 'PUT',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({
+          policies: kept.map((p) => ({ operation: p.operation, targetSlug: p.targetAgentSlug, decision: p.decision })),
+        }),
+      })
+      if (!put.ok) throw new Error(`Failed to save policies (${put.status})`)
+      changed = true
+    }
+    if (changed) toast.success('Invoke permission revoked')
+    return changed
+  } catch (error) {
+    console.error('Failed to delete connection:', error)
+    toast.error("Couldn't remove the connection")
+    return false
+  }
+}
+
+/** Create the relationship behind a drawn edge; true = something changed. */
+async function createDrawnConnection(source: string, target: string): Promise<boolean> {
+  const kind = drawnConnectionKind(source, target)
+  if (!kind) return false
+  try {
+    if (kind === 'invoke') {
+      // Drag direction = permission direction: source may invoke target.
+      const caller = nodeRef(source)
+      const targetSlug = nodeRef(target)
+      const res = await apiFetch(`/api/agents/${caller}/x-agent-policies`)
+      if (!res.ok) throw new Error(`Failed to load policies (${res.status})`)
+      const { policies } = (await res.json()) as {
+        policies: { operation: string; targetAgentSlug: string | null; decision: string }[]
+      }
+      if (policies.some((p) => p.operation === 'invoke' && p.targetAgentSlug === targetSlug)) {
+        toast.info('These agents are already connected')
+        return false
+      }
+      // The PUT replaces the whole policy list — carry existing rows along.
+      const put = await apiFetch(`/api/agents/${caller}/x-agent-policies`, {
+        method: 'PUT',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({
+          policies: [
+            ...policies.map((p) => ({ operation: p.operation, targetSlug: p.targetAgentSlug, decision: p.decision })),
+            { operation: 'invoke', targetSlug, decision: 'allow' },
+          ],
+        }),
+      })
+      if (!put.ok) throw new Error(`Failed to save policy (${put.status})`)
+      toast.success('Invoke permission added')
+      return true
+    }
+    const agentNodeId = nodeKind(source) === 'agent' ? source : target
+    const resourceNodeId = agentNodeId === source ? target : source
+    const slug = nodeRef(agentNodeId)
+    const resourceId = nodeRef(resourceNodeId)
+    const res =
+      kind === 'account'
+        ? await apiFetch(`/api/agents/${slug}/connected-accounts`, {
+            method: 'POST',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ accountIds: [resourceId] }),
+          })
+        : await apiFetch(`/api/agents/${slug}/remote-mcps`, {
+            method: 'POST',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ mcpIds: [resourceId] }),
+          })
+    if (!res.ok) throw new Error(`Failed to link (${res.status})`)
+    toast.success(kind === 'account' ? 'Account linked to agent' : 'MCP server linked to agent')
+    return true
+  } catch (error) {
+    console.error('Failed to create connection:', error)
+    toast.error("Couldn't create the connection")
+    return false
+  }
+}
 
 export function AgentGraph() {
   const navigate = useNavigate()
@@ -106,6 +257,10 @@ export function AgentGraph() {
 
   const layoutPositions = useMemo(() => computeLayout(graph.nodes, graph.edges), [graph.nodes, graph.edges])
 
+  // Source node of an in-progress connection drag; nodes that can't legally
+  // receive the connection fade while it's set (applied in the node sync).
+  const [connectingFromId, setConnectingFromId] = useState<string | null>(null)
+
   // Render once data is settled (success OR error) — a failed settings fetch
   // degrades to a non-persisting canvas instead of an eternal spinner.
   const ready = !graph.isLoading && !settingsQuery.isLoading
@@ -123,47 +278,68 @@ export function AgentGraph() {
           savedPositionsRef.current?.[spec.id] ??
           layoutPositions[spec.id] ?? { x: 0, y: 0 },
         data: spec.data,
+        // Clicks navigate; selection is a connector-only concept here.
+        selectable: false,
+        // Mid connection-drag, fade anything the drag can't legally land on.
+        className:
+          connectingFromId && spec.id !== connectingFromId && !drawnConnectionKind(connectingFromId, spec.id)
+            ? 'opacity-25 transition-opacity duration-200'
+            : 'transition-opacity duration-200',
       })),
     )
-  }, [ready, graph.nodes, layoutPositions, setNodes])
+  }, [ready, graph.nodes, layoutPositions, setNodes, connectingFromId])
 
-  const edges: Edge[] = useMemo(
-    () =>
-      graph.edges.map((e) => ({
-        id: e.id,
-        source: e.source,
-        target: e.target,
-        type: 'straight',
-        style: edgeStyle(e.variant, e.weight),
-        focusable: false,
-        selectable: false,
-      })),
-    [graph.edges],
+  // Hovering an edge surfaces the real numbers (label at the midpoint) and
+  // thickens the stroke so it's clear which line is being read.
+  const [hoveredEdgeId, setHoveredEdgeId] = useState<string | null>(null)
+  const onEdgeMouseEnter: EdgeMouseHandler<GraphEdge> = useCallback((_event, edge) => setHoveredEdgeId(edge.id), [])
+  const onEdgeMouseLeave: EdgeMouseHandler<GraphEdge> = useCallback(() => setHoveredEdgeId(null), [])
+
+  // Hovering a resource in the side panel spotlights its edges: they thicken
+  // while every unrelated line recedes, so the agents using that resource pop.
+  const [hoveredResourceId, setHoveredResourceId] = useState<string | null>(null)
+  const panelItems = useMemo(() => resourcePanelItems(graph.nodes, graph.edges), [graph.nodes, graph.edges])
+  const openConnectionSettings = useCallback(
+    () => void navigate({ to: '/settings/$tab', params: { tab: 'connections' } }),
+    [navigate],
   )
 
-  // Keep fitting the viewport as the per-agent fan-out queries stream nodes
-  // in — but stop the moment the user pans/zooms/drags, so we never yank a
-  // viewport they've taken control of.
-  const rfInstance = useRef<ReactFlowInstance<RfNode, Edge> | null>(null)
-  const userInteracted = useRef(false)
+  // Connector geometry (elbow offsets, pinned ports) dragged this mount,
+  // merged over saved values for rendering and persisted alongside node
+  // positions.
+  const [draggedEdgeGeometry, setDraggedEdgeGeometry] = useState<Record<string, EdgeGeometryOverride>>({})
+  const draggedEdgeGeometryRef = useRef<Record<string, EdgeGeometryOverride>>({})
+  const savedEdgeGeometryRef = useRef<Record<string, EdgeGeometryOverride> | undefined>(undefined)
   useEffect(() => {
-    if (userInteracted.current || nodes.length === 0) return
-    const raf = requestAnimationFrame(() => {
-      if (!userInteracted.current) void rfInstance.current?.fitView({ padding: 0.15, maxZoom: 1 })
-    })
-    return () => cancelAnimationFrame(raf)
-  }, [nodes.length])
+    savedEdgeGeometryRef.current = userSettings?.graphEdgeGeometry
+  }, [userSettings?.graphEdgeGeometry])
 
-  // Persist only user-dragged positions, merged over previously saved ones —
-  // auto-laid-out nodes stay fluid instead of getting pinned at whatever the
-  // layout said the moment someone dragged something else.
+  // Persist only user-dragged geometry (node positions, elbow offsets),
+  // merged over previously saved values — auto-laid-out elements stay fluid
+  // instead of getting pinned at whatever the layout said the moment
+  // someone dragged something else.
   const persistNow = useCallback(() => {
-    if (!canPersist || Object.keys(draggedPositionsRef.current).length === 0) return
-    const positions: Record<string, XY> = { ...(savedPositionsRef.current ?? {}) }
-    for (const [id, position] of Object.entries(draggedPositionsRef.current)) {
-      positions[id] = { x: Math.round(position.x), y: Math.round(position.y) }
+    if (!canPersist) return
+    const update: {
+      graphNodePositions?: Record<string, XY>
+      graphEdgeGeometry?: Record<string, EdgeGeometryOverride>
+    } = {}
+    if (Object.keys(draggedPositionsRef.current).length > 0) {
+      const positions: Record<string, XY> = { ...(savedPositionsRef.current ?? {}) }
+      for (const [id, position] of Object.entries(draggedPositionsRef.current)) {
+        positions[id] = { x: Math.round(position.x), y: Math.round(position.y) }
+      }
+      update.graphNodePositions = positions
     }
-    mutateSettings({ graphNodePositions: positions })
+    if (Object.keys(draggedEdgeGeometryRef.current).length > 0) {
+      const geometry = { ...(savedEdgeGeometryRef.current ?? {}) }
+      for (const [id, patch] of Object.entries(draggedEdgeGeometryRef.current)) {
+        geometry[id] = { ...geometry[id], ...patch }
+      }
+      update.graphEdgeGeometry = geometry
+    }
+    if (Object.keys(update).length === 0) return
+    mutateSettings(update)
   }, [canPersist, mutateSettings])
 
   const persistTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -192,16 +368,157 @@ export function AgentGraph() {
     [],
   )
 
-  // Reset: forget saved + dragged positions everywhere and re-solve the
+  // Connector drags commit once, on release (live movement renders inside
+  // the edge component), then ride the same debounced persist as node drags.
+  const commitEdgeGeometry = useCallback(
+    (edgeId: string, patch: EdgeGeometryOverride) => {
+      const next = { ...draggedEdgeGeometryRef.current[edgeId], ...patch }
+      draggedEdgeGeometryRef.current[edgeId] = next
+      setDraggedEdgeGeometry((prev) => ({ ...prev, [edgeId]: next }))
+      schedulePersist()
+    },
+    [schedulePersist],
+  )
+
+  // Edges are a controlled prop (derived from graph data), so React Flow's
+  // click-to-select only sticks if we catch the 'select' changes it emits
+  // and fold them back into the derived array.
+  const [selectedEdgeIds, setSelectedEdgeIds] = useState<ReadonlySet<string>>(new Set())
+  const onEdgesChange: OnEdgesChange<GraphEdge> = useCallback((changes) => {
+    setSelectedEdgeIds((prev) => {
+      let next: Set<string> | null = null
+      for (const change of changes) {
+        if (change.type !== 'select') continue
+        next = next ?? new Set(prev)
+        if (change.selected) next.add(change.id)
+        else next.delete(change.id)
+      }
+      return next ?? prev
+    })
+  }, [])
+
+  // Dragging out of a node port draws a new connection; dropping it creates
+  // the real relationship, then the topology refetch draws the edge.
+  const onConnectStart: OnConnectStart = useCallback((_event, params) => setConnectingFromId(params.nodeId), [])
+  const onConnectEnd = useCallback(() => setConnectingFromId(null), [])
+  const queryClient = useQueryClient()
+  const isValidConnection: IsValidConnection<GraphEdge> = useCallback(
+    (connection) => drawnConnectionKind(connection.source, connection.target) !== null,
+    [],
+  )
+  const onConnect: OnConnect = useCallback(
+    (connection) => {
+      void createDrawnConnection(connection.source, connection.target).then((created) => {
+        if (created) void queryClient.invalidateQueries({ queryKey: ['home-graph'] })
+      })
+    },
+    [queryClient],
+  )
+
+  // Deleting a selected connector (toolbar trash or Delete/Backspace)
+  // removes the underlying relationship; the topology refetch redraws.
+  const deleteEdge = useCallback(
+    (edgeId: string) => {
+      const spec = graph.edges.find((e) => e.id === edgeId)
+      if (!spec?.deletable) return
+      void deleteGraphConnection(spec).then((changed) => {
+        if (changed) void queryClient.invalidateQueries({ queryKey: ['home-graph'] })
+      })
+    },
+    [graph.edges, queryClient],
+  )
+  const onEdgesDelete = useCallback(
+    (deleted: GraphEdge[]) => {
+      for (const edge of deleted) deleteEdge(edge.id)
+    },
+    [deleteEdge],
+  )
+  // "Edit permissions" on an agent↔agent connector: go to the caller agent's
+  // page with a one-shot asking it to open the policies tab.
+  const { setOpenAgentSettings } = useNavTransient()
+  const editEdgePermissions = useCallback(
+    (edgeId: string) => {
+      const spec = graph.edges.find((e) => e.id === edgeId)
+      if (!spec?.policyAgentSlug) return
+      setOpenAgentSettings({ slug: spec.policyAgentSlug, tab: 'x-agent-policies' })
+      void navigate({ to: '/agents/$slug', params: { slug: spec.policyAgentSlug } })
+    },
+    [graph.edges, setOpenAgentSettings, navigate],
+  )
+
+  const savedEdgeGeometry = userSettings?.graphEdgeGeometry
+  const edges: GraphEdge[] = useMemo(
+    () =>
+      graph.edges.map((e) => {
+        const hovered = e.id === hoveredEdgeId
+        const inSpotlight = e.source === hoveredResourceId || e.target === hoveredResourceId
+        let style = edgeStyle(e)
+        if (hovered || inSpotlight) style = { ...style, strokeWidth: 2.5 }
+        else if (hoveredResourceId) style = { ...style, opacity: 0.12 }
+        return {
+          id: e.id,
+          source: e.source,
+          target: e.target,
+          type: 'elbow',
+          style,
+          focusable: false,
+          // Clicking a connector reveals its grab handles and endpoint dots;
+          // clicking the canvas deselects (nodes opt out of selection instead
+          // of the canvas, since pane-click deselect is gated on
+          // elementsSelectable).
+          selectable: true,
+          selected: selectedEdgeIds.has(e.id),
+          // Gates the Delete/Backspace path (React Flow skips non-deletables).
+          deletable: !!e.deletable,
+          data: {
+            geometry: { ...savedEdgeGeometry?.[e.id], ...draggedEdgeGeometry[e.id] },
+            onGeometryCommit: commitEdgeGeometry,
+            motion:
+              e.weight && !e.broken ? { duration: pulseDuration(e.weight), flow: e.flow } : undefined,
+            onDelete: e.deletable ? deleteEdge : undefined,
+            onEditPermissions: e.policyAgentSlug ? editEdgePermissions : undefined,
+          },
+        }
+      }),
+    [
+      graph.edges,
+      hoveredEdgeId,
+      hoveredResourceId,
+      draggedEdgeGeometry,
+      savedEdgeGeometry,
+      commitEdgeGeometry,
+      selectedEdgeIds,
+      deleteEdge,
+      editEdgePermissions,
+    ],
+  )
+
+  // Keep fitting the viewport as the per-agent fan-out queries stream nodes
+  // in — but stop the moment the user pans/zooms/drags, so we never yank a
+  // viewport they've taken control of.
+  const rfInstance = useRef<ReactFlowInstance<RfNode, GraphEdge> | null>(null)
+  const userInteracted = useRef(false)
+  useEffect(() => {
+    if (userInteracted.current || nodes.length === 0) return
+    const raf = requestAnimationFrame(() => {
+      if (!userInteracted.current) void rfInstance.current?.fitView({ padding: 0.15, maxZoom: 1 })
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [nodes.length])
+
+  // Reset: forget saved + dragged geometry everywhere and re-solve the
   // auto-layout, then refit the viewport around it.
   const resetLayout = useCallback(() => {
     draggedPositionsRef.current = {}
     savedPositionsRef.current = {}
+    draggedEdgeGeometryRef.current = {}
+    savedEdgeGeometryRef.current = {}
+    setDraggedEdgeGeometry({})
     if (persistTimer.current) {
       clearTimeout(persistTimer.current)
       persistTimer.current = null
     }
-    mutateSettings({ graphNodePositions: {} })
+    mutateSettings({ graphNodePositions: {}, graphEdgeGeometry: {} })
     setNodes((prev) => prev.map((n) => ({ ...n, position: layoutPositions[n.id] ?? { x: 0, y: 0 } })))
     requestAnimationFrame(() => {
       void rfInstance.current?.fitView({ padding: 0.15, maxZoom: 1 })
@@ -264,31 +581,54 @@ export function AgentGraph() {
         userInteracted.current = true
       }}
     >
-      <ReactFlow<RfNode, Edge>
+      <ReactFlow<RfNode, GraphEdge>
         nodes={nodes}
         edges={edges}
         onNodesChange={handleNodesChange}
+        onEdgesChange={onEdgesChange}
         nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
         onNodeClick={onNodeClick}
         onNodeDragStop={schedulePersist}
+        onEdgeMouseEnter={onEdgeMouseEnter}
+        onEdgeMouseLeave={onEdgeMouseLeave}
         onInit={(instance) => {
           rfInstance.current = instance
         }}
-        nodesConnectable={false}
-        elementsSelectable={false}
+        // Loose mode: our ports are all type="source", and a connection may
+        // end on any of them. The generous radius means drops snap to the
+        // nearest port without pixel-hunting.
+        connectionMode={ConnectionMode.Loose}
+        connectionRadius={30}
+        connectionLineStyle={{ stroke: 'rgb(59 130 246 / 0.6)', strokeWidth: 1.5, strokeDasharray: '6 4' }}
+        isValidConnection={isValidConnection}
+        onConnect={onConnect}
+        onConnectStart={onConnectStart}
+        onConnectEnd={onConnectEnd}
+        deleteKeyCode={['Backspace', 'Delete']}
+        onEdgesDelete={onEdgesDelete}
+        // Selected connectors (and their endpoint dots) render above nodes,
+        // so the dots stay visible and grabbable where they dock.
+        elevateEdgesOnSelect
         proOptions={{ hideAttribution: true }}
         nodeDragThreshold={4}
         minZoom={0.15}
         maxZoom={1.75}
-        className="bg-background"
+        // Inline style, not a bg-* class: xyflow's style.css sets its own
+        // background-color on .react-flow (loaded after Tailwind, same
+        // specificity), silently overriding any utility class. 3%
+        // muted-foreground over the app background ≈ a 98%-lightness wash in
+        // light mode — the faintest gray so the white nodes pop.
+        style={{ backgroundColor: 'hsl(var(--muted-foreground) / 0.03)' }}
       >
-        <Background variant={BackgroundVariant.Dots} gap={24} size={1} color="hsl(var(--muted-foreground) / 0.3)" />
+        <Background variant={BackgroundVariant.Dots} gap={14} size={1.5} color="hsl(var(--muted-foreground) / 0.3)" />
         <Controls showInteractive={false} />
-        <Panel position="top-right">
+        <Panel position="top-right" className="flex flex-col items-end gap-2">
           <Button variant="outline" size="sm" onClick={resetLayout} data-testid="graph-reset-layout">
             <RotateCcw className="mr-1 h-3.5 w-3.5" />
             Reset layout
           </Button>
+          <ResourcePanel items={panelItems} onHover={setHoveredResourceId} onSelect={openConnectionSettings} />
         </Panel>
         {graph.topologyFailed && (
           <Panel position="top-left">

--- a/src/renderer/components/home/graph/graph-edges.tsx
+++ b/src/renderer/components/home/graph/graph-edges.tsx
@@ -1,0 +1,633 @@
+/**
+ * Custom React Flow edges for the home connections graph — FigJam-style
+ * orthogonal connectors.
+ *
+ * Every node exposes four ports (the side midpoints of its VISIBLE shape:
+ * the whole circle for agents, just the 40px icon chip for resource nodes —
+ * anchoring the full bounding box would leave connectors stopping short of
+ * the artwork).
+ *
+ * Routes are orthogonal polylines described by `coords`: one cross-axis
+ * coordinate per interior segment. The first/last segments are anchored to
+ * the ports, orientations alternate, and rounded corners are derived — so
+ * the whole route is a handful of numbers, which is what persists. No
+ * stored coords (or a parity mismatch after re-pinning a port) falls back
+ * to the auto route (straight L, or midpoint S between facing sides).
+ *
+ * Manipulation, visible on selection: a pill handle on each segment drags
+ * it perpendicular (dragging an END segment first spawns a short stub bend
+ * at the port, exactly like FigJam); endpoint dots slide freely around the
+ * node's circular perimeter, magnetizing to the four cardinal anchors when
+ * close. Live drags render locally and commit once, on release, through
+ * edge.data.onGeometryCommit.
+ *
+ * Bidirectional data flow renders on the single line: two tracer stacks
+ * travel it in opposite directions.
+ */
+
+import { useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from 'react'
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  useInternalNode,
+  useReactFlow,
+  type Edge,
+  type EdgeProps,
+  type InternalNode,
+} from '@xyflow/react'
+import { Network, Trash2 } from 'lucide-react'
+import type { GraphNodeData } from './use-graph-data'
+
+export type PortSide = 'top' | 'bottom' | 'left' | 'right'
+
+export interface EdgeGeometryOverride {
+  /** Cross-coordinates of the route's interior segments (waypoint model above) */
+  coords?: number[]
+  /** Pinned anchor on the source node's perimeter, degrees (0 = right,
+   *  90 = bottom); absent = auto (facing side) */
+  sourceAngle?: number
+  /** Pinned anchor on the target node's perimeter; absent = auto */
+  targetAngle?: number
+}
+
+export interface EdgeMotion {
+  /** Seconds per tracer cycle — smaller = faster traffic */
+  duration: number
+  /** Data direction: tracers run source→target ('out'), target→source
+   *  ('in'), or both ways at once on the same line ('both') */
+  flow?: 'out' | 'in' | 'both'
+}
+
+export interface ElbowEdgeData extends Record<string, unknown> {
+  geometry?: EdgeGeometryOverride
+  /** Present on active edges: drives the traveling-pulse overlay */
+  motion?: EdgeMotion
+  onGeometryCommit?: (edgeId: string, patch: EdgeGeometryOverride) => void
+  /** Remove the relationship behind this edge (shown as a toolbar button when selected) */
+  onDelete?: (edgeId: string) => void
+  /** Open the caller agent's permission editor (agent↔agent edges) */
+  onEditPermissions?: (edgeId: string) => void
+}
+
+export type GraphEdge = Edge<ElbowEdgeData>
+
+const BORDER_RADIUS = 12
+/** Resource nodes anchor on their icon chip (h-10 w-10 in ResourceGraphNode),
+ *  horizontally centered at the top of the node's layout box. */
+const RESOURCE_CHIP = 40
+/** Length of the port stub spawned when an end segment is dragged. */
+const STUB = 20
+/** Segments shorter than this get no handle — too small to grab. */
+const MIN_GRAB_SEGMENT = 20
+/** Route-complexity cap: stop spawning stub bends past this many coords. */
+const MAX_COORDS = 9
+
+/** Endpoint drags snap to a cardinal anchor within this many degrees;
+ *  in between, the dot rides the perimeter freely. */
+const SNAP_DEGREES = 12
+
+type Axis = 'h' | 'v'
+
+function axisOf(side: PortSide): Axis {
+  return side === 'left' || side === 'right' ? 'h' : 'v'
+}
+
+function outward(side: PortSide): 1 | -1 {
+  return side === 'right' || side === 'bottom' ? 1 : -1
+}
+
+interface Box {
+  cx: number
+  cy: number
+  left: number
+  right: number
+  top: number
+  bottom: number
+}
+
+interface XYPoint {
+  x: number
+  y: number
+}
+
+function visualBox(node: InternalNode): Box {
+  const { x, y } = node.internals.positionAbsolute
+  const w = node.measured?.width ?? 0
+  const h = node.measured?.height ?? 0
+  if ((node.data as GraphNodeData | undefined)?.kind === 'agent') {
+    return { cx: x + w / 2, cy: y + h / 2, left: x, right: x + w, top: y, bottom: y + h }
+  }
+  const left = x + (w - RESOURCE_CHIP) / 2
+  return {
+    cx: left + RESOURCE_CHIP / 2,
+    cy: y + RESOURCE_CHIP / 2,
+    left,
+    right: left + RESOURCE_CHIP,
+    top: y,
+    bottom: y + RESOURCE_CHIP,
+  }
+}
+
+/** Perimeter anchor for an angle: the point on the node's circle plus the
+ *  cardinal side whose axis the route should exit along. */
+function anchorFromAngle(box: Box, angleDeg: number): { point: XYPoint; side: PortSide } {
+  const radius = (box.right - box.left) / 2
+  const rad = (angleDeg * Math.PI) / 180
+  const norm = ((angleDeg % 360) + 360) % 360
+  return {
+    point: { x: box.cx + radius * Math.cos(rad), y: box.cy + radius * Math.sin(rad) },
+    side: norm < 45 || norm >= 315 ? 'right' : norm < 135 ? 'bottom' : norm < 225 ? 'left' : 'top',
+  }
+}
+
+/** Pointer position → perimeter angle, magnetized to the cardinals. */
+function angleForPoint(box: Box, p: XYPoint): number {
+  const deg = (((Math.atan2(p.y - box.cy, p.x - box.cx) * 180) / Math.PI + 360) % 360 + 360) % 360
+  for (const cardinal of [0, 90, 180, 270, 360]) {
+    if (Math.abs(deg - cardinal) <= SNAP_DEGREES) return cardinal % 360
+  }
+  return Math.round(deg)
+}
+
+const SIDE_ANGLE: Record<PortSide, number> = { right: 0, bottom: 90, left: 180, top: 270 }
+
+/** Auto route between two ports: L for perpendicular sides, midpoint S for
+ *  facing sides, an outward bow when both ends leave from the same side. */
+function defaultCoords(sp: XYPoint, sourceSide: PortSide, tp: XYPoint, targetSide: PortSide): number[] {
+  const axis = axisOf(sourceSide)
+  if (axis !== axisOf(targetSide)) return []
+  if (sourceSide !== targetSide) {
+    return [axis === 'h' ? (sp.x + tp.x) / 2 : (sp.y + tp.y) / 2]
+  }
+  const s = axis === 'h' ? sp.x : sp.y
+  const t = axis === 'h' ? tp.x : tp.y
+  return [outward(sourceSide) === 1 ? Math.max(s, t) + 2 * STUB : Math.min(s, t) - 2 * STUB]
+}
+
+function roundedPath(pts: XYPoint[]): string {
+  const parts = [`M ${pts[0].x} ${pts[0].y}`]
+  for (let i = 1; i < pts.length - 1; i++) {
+    const prev = pts[i - 1]
+    const p = pts[i]
+    const next = pts[i + 1]
+    const inLen = Math.hypot(p.x - prev.x, p.y - prev.y)
+    const outLen = Math.hypot(next.x - p.x, next.y - p.y)
+    const r = Math.min(BORDER_RADIUS, inLen / 2, outLen / 2)
+    if (r < 0.5) {
+      parts.push(`L ${p.x} ${p.y}`)
+      continue
+    }
+    const inPt = { x: p.x - ((p.x - prev.x) / inLen) * r, y: p.y - ((p.y - prev.y) / inLen) * r }
+    const outPt = { x: p.x + ((next.x - p.x) / outLen) * r, y: p.y + ((next.y - p.y) / outLen) * r }
+    parts.push(`L ${inPt.x} ${inPt.y}`, `Q ${p.x} ${p.y} ${outPt.x} ${outPt.y}`)
+  }
+  const last = pts[pts.length - 1]
+  parts.push(`L ${last.x} ${last.y}`)
+  return parts.join(' ')
+}
+
+interface RouteSegment {
+  index: number
+  axis: Axis
+  mid: XYPoint
+  length: number
+}
+
+interface ElbowGeometry {
+  path: string
+  /** Hover-label anchor — beside the longest segment, clear of its handle */
+  labelX: number
+  labelY: number
+  segments: RouteSegment[]
+  /** Effective interior coords (validated stored coords, or the auto route) */
+  coords: number[]
+  sourceSide: PortSide
+  targetSide: PortSide
+  sourcePoint: XYPoint
+  targetPoint: XYPoint
+  sourceBox: Box
+  targetBox: Box
+}
+
+function elbowGeometry(
+  sourceNode: InternalNode,
+  targetNode: InternalNode,
+  override: EdgeGeometryOverride,
+): ElbowGeometry {
+  const sourceBox = visualBox(sourceNode)
+  const targetBox = visualBox(targetNode)
+  // Auto sides: whichever sides face each other, so the connector never
+  // doubles back through a node.
+  const horizontal = Math.abs(targetBox.cx - sourceBox.cx) >= Math.abs(targetBox.cy - sourceBox.cy)
+  const forward = horizontal ? targetBox.cx >= sourceBox.cx : targetBox.cy >= sourceBox.cy
+  const autoSourceSide: PortSide = horizontal ? (forward ? 'right' : 'left') : forward ? 'bottom' : 'top'
+  const autoTargetSide: PortSide = horizontal ? (forward ? 'left' : 'right') : forward ? 'top' : 'bottom'
+  // Anchors ride the perimeter (any angle); the route exits along the
+  // nearest cardinal's axis.
+  const sourceAnchor = anchorFromAngle(sourceBox, override.sourceAngle ?? SIDE_ANGLE[autoSourceSide])
+  const targetAnchor = anchorFromAngle(targetBox, override.targetAngle ?? SIDE_ANGLE[autoTargetSide])
+  const sourceSide = sourceAnchor.side
+  const targetSide = targetAnchor.side
+  const sp = sourceAnchor.point
+  const tp = targetAnchor.point
+  const sourceAxis = axisOf(sourceSide)
+  const targetAxis = axisOf(targetSide)
+
+  // Segment count parity is fixed by the port axes; stored coords from
+  // before a port re-pin may no longer fit — fall back to the auto route.
+  const parityOk = override.coords && override.coords.length % 2 === (sourceAxis === targetAxis ? 1 : 0)
+  const coords = parityOk && override.coords ? override.coords : defaultCoords(sp, sourceSide, tp, targetSide)
+
+  // cross[i] = the cross-axis coordinate segment i runs along.
+  const cross = [sourceAxis === 'h' ? sp.y : sp.x, ...coords, targetAxis === 'h' ? tp.y : tp.x]
+  const pts: XYPoint[] = [sp]
+  for (let i = 0; i + 1 < cross.length; i++) {
+    const axis: Axis = i % 2 === 0 ? sourceAxis : sourceAxis === 'h' ? 'v' : 'h'
+    pts.push(axis === 'h' ? { x: cross[i + 1], y: cross[i] } : { x: cross[i], y: cross[i + 1] })
+  }
+  pts.push(tp)
+
+  const segments: RouteSegment[] = []
+  for (let i = 0; i + 1 < pts.length; i++) {
+    const a = pts[i]
+    const b = pts[i + 1]
+    segments.push({
+      index: i,
+      axis: a.y === b.y ? 'h' : 'v',
+      mid: { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 },
+      length: Math.abs(a.x - b.x) + Math.abs(a.y - b.y),
+    })
+  }
+  const longest = segments.reduce((m, s) => (s.length > m.length ? s : m), segments[0])
+
+  return {
+    path: roundedPath(pts),
+    labelX: longest.axis === 'h' ? longest.mid.x : longest.mid.x + 16,
+    labelY: longest.axis === 'h' ? longest.mid.y - 16 : longest.mid.y,
+    segments,
+    coords,
+    sourceSide,
+    targetSide,
+    sourcePoint: sp,
+    targetPoint: tp,
+    sourceBox,
+    targetBox,
+  }
+}
+
+/** Pointer-capture drag plumbing shared by segment pills and endpoint dots. */
+function usePointerDrag(onStart: () => void, onMove: (p: XYPoint) => void, onEnd: () => void) {
+  const { screenToFlowPosition } = useReactFlow()
+  const dragging = useRef(false)
+  return {
+    onPointerDown: (event: ReactPointerEvent<SVGElement>) => {
+      dragging.current = true
+      event.currentTarget.setPointerCapture(event.pointerId)
+      event.stopPropagation()
+      onStart()
+    },
+    onPointerMove: (event: ReactPointerEvent<SVGElement>) => {
+      if (!dragging.current) return
+      onMove(screenToFlowPosition({ x: event.clientX, y: event.clientY }))
+    },
+    onPointerUp: (event: ReactPointerEvent<SVGElement>) => {
+      if (!dragging.current) return
+      dragging.current = false
+      event.currentTarget.releasePointerCapture(event.pointerId)
+      onEnd()
+    },
+  }
+}
+
+const HANDLE_FILL = 'hsl(var(--card))'
+const HANDLE_STROKE = 'rgb(59 130 246)' // blue-500, matching the port dots
+
+/** Tracer sliding along a solid active line — a bright comet head with a
+ *  fading tail, built from stacked dash layers: each layer is a longer,
+ *  dimmer dash, phase-shifted so every layer's leading edge rides with the
+ *  head. One tracer per TRACER_PERIOD px of path; the keyframe offset in
+ *  agent-graph.css must match the period for a seamless loop. */
+const TRACER_PERIOD = 80
+// Tail first (drawn underneath), head last. blue-300 tail, blue-100 head.
+const TRACER_LAYERS = [
+  { length: 30, opacity: 0.15, widthBoost: 0, color: 'rgb(147 197 253)' },
+  { length: 18, opacity: 0.35, widthBoost: 0.25, color: 'rgb(147 197 253)' },
+  { length: 10, opacity: 0.65, widthBoost: 0.5, color: 'rgb(147 197 253)' },
+  { length: 5, opacity: 1, widthBoost: 1, color: 'rgb(219 234 254)' },
+]
+const TRACER_HEAD = TRACER_LAYERS[TRACER_LAYERS.length - 1].length
+
+function TracerStack({
+  path,
+  duration,
+  reversed,
+  baseWidth,
+  baseOpacity,
+}: {
+  path: string
+  duration: number
+  reversed: boolean
+  baseWidth: number
+  baseOpacity: number
+}) {
+  return (
+    <>
+      {TRACER_LAYERS.map((layer, i) => (
+        <path
+          key={i}
+          className="graph-edge-pulse"
+          d={path}
+          fill="none"
+          stroke={layer.color}
+          strokeLinecap="round"
+          strokeDasharray={`${layer.length} ${TRACER_PERIOD - layer.length}`}
+          style={{
+            strokeWidth: baseWidth + layer.widthBoost,
+            opacity: layer.opacity * baseOpacity,
+            pointerEvents: 'none',
+            animationName: 'graph-edge-flow',
+            animationDuration: `${duration}s`,
+            animationTimingFunction: 'linear',
+            animationIterationCount: 'infinite',
+            animationDirection: reversed ? 'reverse' : 'normal',
+            // Forward motion leads with the dash END, so longer tail layers
+            // need a phase shift to ride behind the head; reverse motion
+            // leads with the dash START, where layers already align.
+            animationDelay: reversed
+              ? undefined
+              : `${((layer.length - TRACER_HEAD) / TRACER_PERIOD - 1) * duration}s`,
+          }}
+        />
+      ))}
+    </>
+  )
+}
+
+function FlowPulse({
+  path,
+  motion,
+  baseStyle,
+}: {
+  path: string
+  motion: EdgeMotion | undefined
+  baseStyle: CSSProperties | undefined
+}) {
+  if (!motion) return null
+  const baseWidth = (baseStyle?.strokeWidth as number | undefined) ?? 1.25
+  const baseOpacity = (baseStyle?.opacity as number | undefined) ?? 1
+  const flow = motion.flow ?? 'out'
+  return (
+    <>
+      {flow !== 'in' && (
+        <TracerStack path={path} duration={motion.duration} reversed={false} baseWidth={baseWidth} baseOpacity={baseOpacity} />
+      )}
+      {flow !== 'out' && (
+        <TracerStack path={path} duration={motion.duration} reversed={true} baseWidth={baseWidth} baseOpacity={baseOpacity} />
+      )}
+    </>
+  )
+}
+
+function SegmentHandle({
+  segment,
+  onStart,
+  onMove,
+  onEnd,
+}: {
+  segment: RouteSegment
+  onStart: () => void
+  onMove: (p: XYPoint) => void
+  onEnd: () => void
+}) {
+  const handlers = usePointerDrag(onStart, onMove, onEnd)
+  const along = 18
+  const across = 5.5
+  return (
+    <rect
+      className="elbow-drag-handle"
+      x={segment.mid.x - (segment.axis === 'h' ? along : across) / 2}
+      y={segment.mid.y - (segment.axis === 'h' ? across : along) / 2}
+      width={segment.axis === 'h' ? along : across}
+      height={segment.axis === 'h' ? across : along}
+      rx={across / 2}
+      fill={HANDLE_STROKE}
+      style={{ cursor: segment.axis === 'h' ? 'ns-resize' : 'ew-resize', pointerEvents: 'all' }}
+      {...handlers}
+    />
+  )
+}
+
+function EndpointDot({
+  point,
+  onMove,
+  onEnd,
+}: {
+  point: XYPoint
+  onMove: (p: XYPoint) => void
+  onEnd: () => void
+}) {
+  const handlers = usePointerDrag(() => undefined, onMove, onEnd)
+  return (
+    <circle
+      cx={point.x}
+      cy={point.y}
+      r={4.5}
+      fill={HANDLE_FILL}
+      stroke={HANDLE_STROKE}
+      strokeWidth={1.5}
+      style={{ cursor: 'move', pointerEvents: 'all' }}
+      {...handlers}
+    />
+  )
+}
+
+/** Geometry + live-drag state shared by both edge components. Live drags
+ *  render locally (no parent churn per pointermove) and commit on release —
+ *  React batches the commit with the local reset, so there's no snap-back. */
+function useElbow(id: string, source: string, target: string, data: ElbowEdgeData | undefined) {
+  const sourceNode = useInternalNode(source)
+  const targetNode = useInternalNode(target)
+  const [live, setLive] = useState<EdgeGeometryOverride | null>(null)
+  // Which segment the active drag steers. Dragging an END segment first
+  // restructures the route (a stub bend appears at the port), shifting the
+  // dragged segment's index — the pill that captured the pointer keeps
+  // feeding moves to the right segment through this ref.
+  const dragIndex = useRef<number | null>(null)
+  if (!sourceNode || !targetNode) return null
+
+  const geometry = elbowGeometry(sourceNode, targetNode, { ...data?.geometry, ...live })
+  const commit = (patch: EdgeGeometryOverride) => {
+    data?.onGeometryCommit?.(id, patch)
+    setLive(null)
+  }
+
+  const beginSegmentDrag = (index: number) => {
+    const last = geometry.segments.length - 1
+    dragIndex.current = index
+    if (index !== 0 && index !== last) return
+    if (geometry.coords.length + 2 > MAX_COORDS) {
+      dragIndex.current = null
+      return
+    }
+    if (index === 0) {
+      const axis = axisOf(geometry.sourceSide)
+      const along = axis === 'h' ? geometry.sourcePoint.x : geometry.sourcePoint.y
+      const crossCoord = axis === 'h' ? geometry.sourcePoint.y : geometry.sourcePoint.x
+      setLive((prev) => ({
+        ...prev,
+        coords: [along + outward(geometry.sourceSide) * STUB, crossCoord, ...geometry.coords],
+      }))
+      dragIndex.current = 2
+    } else {
+      const axis = axisOf(geometry.targetSide)
+      const along = axis === 'h' ? geometry.targetPoint.x : geometry.targetPoint.y
+      const crossCoord = axis === 'h' ? geometry.targetPoint.y : geometry.targetPoint.x
+      setLive((prev) => ({
+        ...prev,
+        coords: [...geometry.coords, crossCoord, along + outward(geometry.targetSide) * STUB],
+      }))
+      // The dragged segment keeps its index — the new bends land after it.
+    }
+  }
+
+  const dragSegment = (p: XYPoint) => {
+    const index = dragIndex.current
+    if (index === null) return
+    const segment = geometry.segments[index]
+    if (!segment || index < 1 || index > geometry.coords.length) return
+    const coords = [...geometry.coords]
+    coords[index - 1] = segment.axis === 'h' ? p.y : p.x
+    setLive((prev) => ({ ...prev, coords }))
+  }
+
+  const endSegmentDrag = () => {
+    dragIndex.current = null
+    if (live?.coords) commit({ coords: live.coords.map(Math.round) })
+    else setLive(null)
+  }
+
+  return {
+    geometry,
+    beginSegmentDrag,
+    dragSegment,
+    endSegmentDrag,
+    dragSource: (p: XYPoint) => setLive((prev) => ({ ...prev, sourceAngle: angleForPoint(geometry.sourceBox, p) })),
+    endSource: () => (live?.sourceAngle !== undefined ? commit({ sourceAngle: live.sourceAngle }) : setLive(null)),
+    dragTarget: (p: XYPoint) => setLive((prev) => ({ ...prev, targetAngle: angleForPoint(geometry.targetBox, p) })),
+    endTarget: () => (live?.targetAngle !== undefined ? commit({ targetAngle: live.targetAngle }) : setLive(null)),
+  }
+}
+
+type UseElbowResult = NonNullable<ReturnType<typeof useElbow>>
+
+/** Floating action chip above a selected connector: delete / edit permissions. */
+function EdgeToolbar({
+  id,
+  geometry,
+  data,
+}: {
+  id: string
+  geometry: ElbowGeometry
+  data: ElbowEdgeData | undefined
+}) {
+  if (!data?.onDelete && !data?.onEditPermissions) return null
+  return (
+    <EdgeLabelRenderer>
+      <div
+        className="nodrag nopan absolute flex items-center gap-0.5 rounded-md border border-border/60 bg-card p-0.5 shadow-sm"
+        style={{
+          transform: `translate(-50%, -50%) translate(${geometry.labelX}px, ${geometry.labelY - 24}px)`,
+          pointerEvents: 'all',
+        }}
+      >
+        {data.onEditPermissions && (
+          <button
+            type="button"
+            title="Edit permissions"
+            className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            onClick={() => data.onEditPermissions?.(id)}
+            data-testid="graph-edge-edit"
+          >
+            <Network className="h-3 w-3" />
+          </button>
+        )}
+        {data.onDelete && (
+          <button
+            type="button"
+            title="Remove connection"
+            className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-red-500"
+            onClick={() => data.onDelete?.(id)}
+            data-testid="graph-edge-delete"
+          >
+            <Trash2 className="h-3 w-3" />
+          </button>
+        )}
+      </div>
+    </EdgeLabelRenderer>
+  )
+}
+
+function ElbowControls({ elbow, selected }: { elbow: UseElbowResult; selected?: boolean }) {
+  const { geometry } = elbow
+  // Handles appear only once the connector is clicked (the ~20px interaction
+  // path means "close to it" counts) — hover stays reserved for the usage label.
+  if (!selected) return null
+  return (
+    <>
+      {geometry.segments
+        .filter((s) => s.length >= MIN_GRAB_SEGMENT)
+        .map((s) => (
+          <SegmentHandle
+            key={s.index}
+            segment={s}
+            onStart={() => elbow.beginSegmentDrag(s.index)}
+            onMove={elbow.dragSegment}
+            onEnd={elbow.endSegmentDrag}
+          />
+        ))}
+      <EndpointDot point={geometry.sourcePoint} onMove={elbow.dragSource} onEnd={elbow.endSource} />
+      <EndpointDot point={geometry.targetPoint} onMove={elbow.dragTarget} onEnd={elbow.endTarget} />
+    </>
+  )
+}
+
+type ElbowProps = EdgeProps<GraphEdge>
+
+export function ElbowEdge({
+  id,
+  source,
+  target,
+  style,
+  data,
+  selected,
+  label,
+  labelStyle,
+  labelBgStyle,
+  labelBgPadding,
+  labelBgBorderRadius,
+  interactionWidth,
+}: ElbowProps) {
+  const elbow = useElbow(id, source, target, data)
+  if (!elbow) return null
+  const { geometry } = elbow
+  return (
+    <>
+      <BaseEdge
+        path={geometry.path}
+        style={style}
+        interactionWidth={interactionWidth}
+        label={label}
+        labelX={geometry.labelX}
+        labelY={geometry.labelY}
+        labelStyle={labelStyle}
+        labelBgStyle={labelBgStyle}
+        labelBgPadding={labelBgPadding}
+        labelBgBorderRadius={labelBgBorderRadius}
+      />
+      <FlowPulse path={geometry.path} motion={data?.motion} baseStyle={style} />
+      <ElbowControls elbow={elbow} selected={selected} />
+      {selected && <EdgeToolbar id={id} geometry={geometry} data={data} />}
+    </>
+  )
+}
+

--- a/src/renderer/components/home/graph/graph-nodes.tsx
+++ b/src/renderer/components/home/graph/graph-nodes.tsx
@@ -1,10 +1,10 @@
 /**
  * Custom React Flow nodes for the home connections graph.
  *
- * Agent nodes are small status cards; resource nodes (accounts, MCPs,
- * triggers, chat integrations) are icon chips with a status dot. Both reuse
- * the app's existing status indicators so colors/motion match the rest of
- * the UI. Handles are invisible and centered so straight edges radiate from
+ * Agent nodes are circular status badges; resource nodes (accounts, MCPs,
+ * triggers, chat integrations) are bare icon chips — their health shows
+ * through the edge styling (red dashes) and the hover label, not on the
+ * node itself. Handles are invisible and centered so straight edges radiate from
  * node centers, mind-map style.
  */
 
@@ -43,11 +43,42 @@ function CenterHandles() {
   )
 }
 
+const PORT_POSITIONS: Record<string, Position> = {
+  top: Position.Top,
+  bottom: Position.Bottom,
+  left: Position.Left,
+  right: Position.Right,
+}
+
+/**
+ * The four connection points (N/S/E/W) on the node's visible shape, shown
+ * while it's hovered. Real React Flow handles: when connectable, dragging
+ * one out draws a new connection, FigJam-style (drop targets snap within
+ * ReactFlow's connectionRadius). Visibility/pointer-events gating lives in
+ * agent-graph.css (.graph-port) so hidden ports never block node drags.
+ */
+function ConnectPorts({ connectable }: { connectable: boolean }) {
+  return (
+    <>
+      {(['top', 'bottom', 'left', 'right'] as const).map((side) => (
+        <Handle
+          key={side}
+          id={side}
+          type="source"
+          position={PORT_POSITIONS[side]}
+          className="graph-port"
+          isConnectable={connectable}
+        />
+      ))}
+    </>
+  )
+}
+
 const agentBorder: Record<AgentActivityStatus, string> = {
-  working: 'border-green-500/60',
-  awaiting_input: 'border-orange-500/70',
-  idle: 'border-border',
-  sleeping: 'border-border opacity-70',
+  working: 'border-green-500/50',
+  awaiting_input: 'border-orange-500/60',
+  idle: 'border-border/60',
+  sleeping: 'border-border/60',
 }
 
 export function AgentGraphNode({ data }: NodeProps<Node<AgentNodeData, 'agent'>>) {
@@ -59,7 +90,7 @@ export function AgentGraphNode({ data }: NodeProps<Node<AgentNodeData, 'agent'>>
       aria-label={`Open agent ${agent.name}`}
       onKeyDown={activateOnKey}
       className={cn(
-        'relative w-44 cursor-pointer rounded-lg border bg-card px-3 py-2.5 shadow-sm transition-colors hover:border-accent-foreground/40',
+        'group relative flex h-28 w-28 cursor-pointer flex-col items-center justify-center rounded-full border-[0.5px] bg-card px-3 text-center shadow-sm transition-[box-shadow,transform] duration-300 hover:-translate-y-0.5 hover:shadow-lg',
         agentBorder[
           getAgentActivityStatus(
             agent.status,
@@ -70,30 +101,39 @@ export function AgentGraphNode({ data }: NodeProps<Node<AgentNodeData, 'agent'>>
       )}
       data-testid={`graph-node-agent-${agent.slug}`}
     >
-      {agent.hasUnreadNotifications && (
-        <span className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full bg-blue-500" title="New notifications" />
-      )}
-      <div className="truncate text-sm font-medium">{agent.name}</div>
+      <ConnectPorts connectable />
+      {/* Icon-only status (sidebar-style) floated at the circle's top,
+          tucked just inside the edge */}
       <AgentStatus
         status={agent.status}
         hasActiveSessions={agent.hasActiveSessions ?? false}
         hasSessionsAwaitingInput={agent.hasSessionsAwaitingInput ?? false}
-        size="sm"
-        className="mt-1"
+        iconOnly
+        className="absolute left-1/2 top-3 -translate-x-1/2"
       />
+      <span className="line-clamp-2 max-w-full break-words text-center text-xs">{agent.name}</span>
       <CenterHandles />
     </div>
   )
 }
 
-const toneDot: Record<ResourceTone, string> = {
+export const toneDot: Record<ResourceTone, string> = {
   ok: 'bg-green-500',
   muted: 'bg-muted-foreground/50',
   attention: 'bg-orange-500',
   error: 'bg-red-500',
 }
 
-function ResourceIcon({ data }: { data: ResourceNodeData }) {
+// Usage badge in the hover pill: text matches the dot, chip bg is a faint
+// wash of the same tone.
+const toneBadge: Record<ResourceTone, string> = {
+  ok: 'bg-green-500/10 text-green-500',
+  muted: 'bg-muted-foreground/10 text-muted-foreground',
+  attention: 'bg-orange-500/10 text-orange-500',
+  error: 'bg-red-500/10 text-red-500',
+}
+
+export function ResourceIcon({ data }: { data: ResourceNodeData }) {
   const className = 'h-4 w-4 text-muted-foreground'
   switch (data.kind) {
     case 'account':
@@ -110,29 +150,48 @@ function ResourceIcon({ data }: { data: ResourceNodeData }) {
 }
 
 export function ResourceGraphNode({ data }: NodeProps<Node<ResourceNodeData, 'resource'>>) {
+  // No `title` attr: the OS tooltip would race the fade-in label with the
+  // same text.
   return (
     <div
       role="button"
       tabIndex={0}
       aria-label={`Open ${data.kind} ${data.label} — ${data.statusLabel}`}
       onKeyDown={activateOnKey}
-      className="group flex w-32 cursor-pointer flex-col items-center gap-1"
-      title={data.statusLabel}
+      className="flex w-32 cursor-pointer flex-col items-center gap-1"
       data-testid={`graph-node-${data.kind}-${data.resourceId}`}
     >
-      <div className="relative flex h-10 w-10 items-center justify-center rounded-full border bg-card shadow-sm transition-colors group-hover:border-accent-foreground/40">
+      {/* Only the chip is the hover zone: it's its own `group` (port dots)
+          and a `peer` for the sibling label — hovering the label's empty
+          layout slot below must not light anything up. */}
+      <div className="group peer relative flex h-10 w-10 items-center justify-center rounded-full border-[0.5px] border-border/60 bg-card shadow-sm transition-[box-shadow,transform] duration-300 hover:-translate-y-0.5 hover:shadow-lg">
+        {/* Webhooks/crons/chats are owned by their agent and created through
+            forms — you can't draw one, so their ports stay decorative. */}
+        <ConnectPorts connectable={data.kind === 'account' || data.kind === 'mcp'} />
         <ResourceIcon data={data} />
+      </div>
+      {/* The label keeps its layout slot (opacity, not display) so edge
+          anchors and collision footprints don't shift when it fades in. */}
+      <div className="flex max-w-full flex-col items-start rounded-md bg-card/40 px-1.5 py-0.5 opacity-0 backdrop-blur-sm transition-opacity duration-200 peer-hover:opacity-100">
+        <span className="block max-w-full truncate text-2xs text-foreground/80">{data.label}</span>
+        {data.sublabel && (
+          <span className="block max-w-full truncate text-2xs text-muted-foreground">{data.sublabel}</span>
+        )}
         <span
           className={cn(
-            'absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-background',
-            toneDot[data.tone],
+            'mt-0.5 inline-flex max-w-full items-center gap-1 rounded-full px-1.5 py-px text-[9px] leading-tight',
+            toneBadge[data.tone],
           )}
-        />
+        >
+          <span className={cn('h-1 w-1 shrink-0 rounded-full', toneDot[data.tone])} />
+          <span className="truncate">{data.status}</span>
+        </span>
+        {data.usage && (
+          <span className="mt-0.5 block max-w-full truncate text-[9px] leading-tight text-muted-foreground">
+            {data.usage}
+          </span>
+        )}
       </div>
-      <span className="max-w-full truncate text-center text-2xs text-foreground/80">{data.label}</span>
-      {data.sublabel && (
-        <span className="-mt-1 max-w-full truncate text-center text-2xs text-muted-foreground">{data.sublabel}</span>
-      )}
       <CenterHandles />
     </div>
   )

--- a/src/renderer/components/home/graph/layout.ts
+++ b/src/renderer/components/home/graph/layout.ts
@@ -35,7 +35,7 @@ export interface XY {
   y: number
 }
 
-// Collision radii cover the rendered footprint (agent card ~176×70,
+// Collision radii cover the rendered footprint (agent circle ~112×112,
 // resource chip + label ~128×80) plus breathing room.
 const AGENT_COLLIDE_RADIUS = 135
 const RESOURCE_COLLIDE_RADIUS = 85

--- a/src/renderer/components/home/graph/resource-panel.tsx
+++ b/src/renderer/components/home/graph/resource-panel.tsx
@@ -1,0 +1,106 @@
+/**
+ * Right-hand directory of connectable resources (accounts, MCP servers) for
+ * the home connections graph. Rows mirror the canvas nodes: same icon and
+ * status dot, plus how many agents use the resource. Hovering a row
+ * spotlights that resource's edges on the canvas (AgentGraph fades the
+ * rest); clicking navigates to connection settings, same as the node.
+ */
+
+import { cn } from '@shared/lib/utils/cn'
+import { ResourceIcon, toneDot } from './graph-nodes'
+import type { GraphNodeSpec, ResourceNodeData } from './use-graph-data'
+
+export interface ResourcePanelItem {
+  id: string
+  data: ResourceNodeData
+  agentCount: number
+}
+
+/** Accounts and MCP servers from the graph's node list, with linked-agent counts. */
+export function resourcePanelItems(nodes: GraphNodeSpec[], edges: { target: string }[]): ResourcePanelItem[] {
+  const agentCounts = new Map<string, number>()
+  for (const edge of edges) {
+    agentCounts.set(edge.target, (agentCounts.get(edge.target) ?? 0) + 1)
+  }
+  return nodes.flatMap((n) =>
+    n.data.kind === 'account' || n.data.kind === 'mcp'
+      ? [{ id: n.id, data: n.data, agentCount: agentCounts.get(n.id) ?? 0 }]
+      : [],
+  )
+}
+
+function ResourceGroup({
+  title,
+  items,
+  onHover,
+  onSelect,
+}: {
+  title: string
+  items: ResourcePanelItem[]
+  onHover: (nodeId: string | null) => void
+  onSelect: () => void
+}) {
+  if (items.length === 0) return null
+  return (
+    <div>
+      <div className="px-2 pb-1 pt-2 text-2xs font-medium uppercase tracking-wide text-muted-foreground">{title}</div>
+      {items.map((item) => (
+        <button
+          key={item.id}
+          type="button"
+          className="flex w-full items-center gap-2 px-2 py-1.5 text-left transition-colors hover:bg-muted"
+          onMouseEnter={() => onHover(item.id)}
+          onMouseLeave={() => onHover(null)}
+          onClick={onSelect}
+          title={item.data.statusLabel}
+          data-testid={`graph-panel-${item.data.kind}-${item.data.resourceId}`}
+        >
+          <span className="relative flex h-6 w-6 shrink-0 items-center justify-center">
+            <ResourceIcon data={item.data} />
+            <span
+              className={cn(
+                'absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border-2 border-card',
+                toneDot[item.data.tone],
+              )}
+            />
+          </span>
+          <span className="min-w-0 flex-1 truncate text-xs">{item.data.label}</span>
+          <span className="shrink-0 text-2xs text-muted-foreground">
+            {item.agentCount > 0 ? `${item.agentCount} agent${item.agentCount === 1 ? '' : 's'}` : 'unused'}
+          </span>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export function ResourcePanel({
+  items,
+  onHover,
+  onSelect,
+}: {
+  items: ResourcePanelItem[]
+  onHover: (nodeId: string | null) => void
+  onSelect: () => void
+}) {
+  if (items.length === 0) return null
+  return (
+    <div
+      className="max-h-[55vh] w-56 overflow-y-auto rounded-md border bg-card pb-1 shadow-sm"
+      data-testid="graph-resource-panel"
+    >
+      <ResourceGroup
+        title="Accounts"
+        items={items.filter((i) => i.data.kind === 'account')}
+        onHover={onHover}
+        onSelect={onSelect}
+      />
+      <ResourceGroup
+        title="MCP servers"
+        items={items.filter((i) => i.data.kind === 'mcp')}
+        onHover={onHover}
+        onSelect={onSelect}
+      />
+    </div>
+  )
+}

--- a/src/renderer/components/home/graph/use-graph-data.ts
+++ b/src/renderer/components/home/graph/use-graph-data.ts
@@ -17,6 +17,7 @@ import { apiFetch } from '@renderer/lib/api'
 import { useAgents, type ApiAgent } from '@renderer/hooks/use-agents'
 import { useConnectedAccounts, type ConnectedAccount } from '@renderer/hooks/use-connected-accounts'
 import { useRemoteMcps, type RemoteMcpServer } from '@renderer/hooks/use-remote-mcps'
+import { humanizeCron } from '@renderer/hooks/use-humanized-cron'
 import { homeGraphSchema, type HomeGraphData } from '@shared/lib/types/home-graph-schema'
 
 // ── Domain model ─────────────────────────────────────────────────────────
@@ -34,7 +35,15 @@ export type ResourceNodeData = {
   kind: ResourceKind
   resourceId: string
   label: string
+  /** Second line under the label — only crons use it (their schedule) */
   sublabel?: string
+  /** Short status word for the hover badge ("connected", "expired", "listening") */
+  status: string
+  /**
+   * Usage across all this resource's edges ("23 API calls", "never fired"),
+   * shown as the pill's fine print on hover. Absent while topology loads.
+   */
+  usage?: string
   tone: ResourceTone
   statusLabel: string
   /** Service icon slug (account toolkit / chat provider), when one exists */
@@ -57,8 +66,24 @@ export interface GraphEdgeSpec {
   source: string
   target: string
   variant: GraphEdgeVariant
-  /** Interaction count (API calls, session invocations, trigger fires) — scales stroke width */
+  /** Interaction count (API calls, session invocations, trigger fires) — drives dash-march speed */
   weight?: number
+  /**
+   * Which way traffic moves relative to source→target: agents call out to
+   * accounts/MCPs, triggers fire in, chat integrations carry both ways.
+   * Sets the dash-march direction; omitted for permission edges.
+   */
+  flow?: 'out' | 'in' | 'both'
+  /** Endpoint is in a broken state (needs re-auth, errored, disconnected) — line renders red */
+  broken?: boolean
+  /**
+   * The graph can remove the relationship behind this edge (unlink an
+   * account/MCP, revoke an invoke permission). Trigger edges are not
+   * deletable — that would delete the webhook/cron/chat itself.
+   */
+  deletable?: boolean
+  /** Caller agent whose x-agent policies govern this edge — the edit target */
+  policyAgentSlug?: string
 }
 
 export interface GraphModel {
@@ -108,11 +133,31 @@ const AUTOMATION_TONE: Record<string, ResourceTone> = {
 // ── Graph assembly ───────────────────────────────────────────────────────
 
 /**
- * Agent↔agent edges render as unmarked straight lines, so direction is
- * invisible — everything about a pair (activity in either direction, and
- * whether a permission line would be hidden underneath) must be keyed on
- * the unordered pair.
+ * Agent↔agent edges render as one straight line per unordered pair —
+ * activity in either direction shares the segment (direction shows only in
+ * the dash march), and a permission line is drawn only when no activity
+ * line already occupies it. So pair-level state is keyed unordered.
  */
+function countLabel(n: number, unit: string): string {
+  return `${n} ${unit}${n === 1 ? '' : 's'}`
+}
+
+// Node-hover usage line, per resource kind.
+const USAGE_UNIT: Record<ResourceKind, string> = {
+  account: 'API call',
+  mcp: 'tool call',
+  chat: 'session',
+  webhook: 'fire',
+  cron: 'run',
+}
+const USAGE_IDLE: Record<ResourceKind, string> = {
+  account: 'no calls yet',
+  mcp: 'no calls yet',
+  chat: 'no sessions yet',
+  webhook: 'never fired',
+  cron: 'never run',
+}
+
 function pairKey(a: string, b: string): string {
   return a < b ? `${a}|${b}` : `${b}|${a}`
 }
@@ -134,15 +179,17 @@ export function buildGraph(input: {
   }
 
   const accountIds = new Set<string>()
+  const accountStatus = new Map<string, ConnectedAccount['status']>()
   for (const account of input.accounts) {
     accountIds.add(account.id)
+    accountStatus.set(account.id, account.status)
     nodes.push({
       id: nodeId.account(account.id),
       data: {
         kind: 'account',
         resourceId: account.id,
         label: account.displayName || account.provider?.displayName || account.toolkitSlug,
-        sublabel: account.status !== 'active' ? account.status : undefined,
+        status: account.status === 'active' ? 'connected' : account.status,
         tone: ACCOUNT_TONE[account.status] ?? 'muted',
         statusLabel: `${account.toolkitSlug} · ${account.status}`,
         iconSlug: account.toolkitSlug,
@@ -151,15 +198,17 @@ export function buildGraph(input: {
   }
 
   const mcpIds = new Set<string>()
+  const mcpStatus = new Map<string, RemoteMcpServer['status']>()
   for (const mcp of input.mcps) {
     mcpIds.add(mcp.id)
+    mcpStatus.set(mcp.id, mcp.status)
     nodes.push({
       id: nodeId.mcp(mcp.id),
       data: {
         kind: 'mcp',
         resourceId: mcp.id,
         label: mcp.name,
-        sublabel: mcp.status !== 'active' ? mcp.status.replace('_', ' ') : undefined,
+        status: mcp.status === 'active' ? 'connected' : mcp.status.replace('_', ' '),
         tone: MCP_TONE[mcp.status] ?? 'muted',
         statusLabel: mcp.errorMessage ? `${mcp.status}: ${mcp.errorMessage}` : `MCP · ${mcp.status}`,
       },
@@ -175,12 +224,18 @@ export function buildGraph(input: {
     if (!agentSlugSet.has(link.agentSlug) || !accountIds.has(link.accountId)) continue
     const source = nodeId.agent(link.agentSlug)
     const target = nodeId.account(link.accountId)
+    const calls = topology.accountUsage[`${link.agentSlug}:${link.accountId}`]
+    const status = accountStatus.get(link.accountId)
+    const problem = status === 'expired' ? 'needs re-auth' : status === 'revoked' ? 'revoked' : undefined
     edges.push({
       id: `${source}->${target}`,
       source,
       target,
       variant: 'resource',
-      weight: topology.accountUsage[`${link.agentSlug}:${link.accountId}`],
+      weight: calls,
+      flow: 'out',
+      broken: problem !== undefined,
+      deletable: true,
     })
   }
 
@@ -188,110 +243,182 @@ export function buildGraph(input: {
     if (!agentSlugSet.has(link.agentSlug) || !mcpIds.has(link.mcpId)) continue
     const source = nodeId.agent(link.agentSlug)
     const target = nodeId.mcp(link.mcpId)
+    const calls = topology.mcpUsage[`${link.agentSlug}:${link.mcpId}`]
+    const status = mcpStatus.get(link.mcpId)
+    const problem = status === 'auth_required' ? 'needs auth' : status === 'error' ? 'error' : undefined
     edges.push({
       id: `${source}->${target}`,
       source,
       target,
       variant: 'resource',
-      weight: topology.mcpUsage[`${link.agentSlug}:${link.mcpId}`],
+      weight: calls,
+      flow: 'out',
+      broken: problem !== undefined,
+      deletable: true,
     })
   }
 
   for (const chat of topology.chats) {
     if (!agentSlugSet.has(chat.agentSlug)) continue
     const id = nodeId.chat(chat.id)
+    const tone = chatTone(chat.status, chat.connected)
     nodes.push({
       id,
       data: {
         kind: 'chat',
         resourceId: chat.id,
         label: chat.name || chat.provider,
-        sublabel: chat.provider,
-        tone: chatTone(chat.status, chat.connected),
+        status: chat.connected ? 'listening' : chat.status,
+        tone,
         statusLabel: `${chat.provider} · ${chat.connected ? 'listening' : chat.status}`,
         iconSlug: chat.provider,
         agentSlug: chat.agentSlug,
       },
     })
     const source = nodeId.agent(chat.agentSlug)
-    edges.push({ id: `${source}->${id}`, source, target: id, variant: 'trigger', weight: chat.sessionCount })
+    const problem = tone === 'error' ? 'error' : tone === 'attention' ? 'disconnected' : undefined
+    edges.push({
+      id: `${source}->${id}`,
+      source,
+      target: id,
+      variant: 'trigger',
+      weight: chat.sessionCount,
+      // Messages arrive and replies go back — the one genuinely two-way link.
+      flow: 'both',
+      broken: problem !== undefined,
+    })
   }
 
   for (const webhook of topology.webhooks) {
     if (!agentSlugSet.has(webhook.agentSlug)) continue
     const id = nodeId.webhook(webhook.id)
+    const tone = AUTOMATION_TONE[webhook.status] ?? 'muted'
     nodes.push({
       id,
       data: {
         kind: 'webhook',
         resourceId: webhook.id,
         label: webhook.name || webhook.triggerType,
-        sublabel: webhook.fireCount ? `${webhook.fireCount} fire${webhook.fireCount === 1 ? '' : 's'}` : undefined,
-        tone: AUTOMATION_TONE[webhook.status] ?? 'muted',
+        status: webhook.status,
+        tone,
         statusLabel: `webhook · ${webhook.status}`,
         agentSlug: webhook.agentSlug,
       },
     })
     const source = nodeId.agent(webhook.agentSlug)
-    edges.push({ id: `${source}->${id}`, source, target: id, variant: 'trigger', weight: webhook.fireCount })
+    const problem = tone === 'error' ? 'failing' : undefined
+    edges.push({
+      id: `${source}->${id}`,
+      source,
+      target: id,
+      variant: 'trigger',
+      weight: webhook.fireCount,
+      flow: 'in',
+      broken: problem !== undefined,
+    })
   }
 
   for (const task of topology.crons) {
     if (!agentSlugSet.has(task.agentSlug)) continue
     const id = nodeId.cron(task.id)
+    const tone = AUTOMATION_TONE[task.status] ?? 'muted'
+    // Unnamed tasks show the schedule AS the label, so no sublabel repeat.
+    const schedule = task.isRecurring ? humanizeCron(task.scheduleExpression) : 'one-time'
     nodes.push({
       id,
       data: {
         kind: 'cron',
         resourceId: task.id,
-        label: task.name || task.scheduleExpression,
-        sublabel: task.isRecurring ? task.scheduleExpression : 'one-time',
-        tone: AUTOMATION_TONE[task.status] ?? 'muted',
+        label: task.name || schedule,
+        sublabel: task.name ? schedule : undefined,
+        status: task.status,
+        tone,
         statusLabel: `scheduled · ${task.status}`,
         agentSlug: task.agentSlug,
       },
     })
     const source = nodeId.agent(task.agentSlug)
-    edges.push({ id: `${source}->${id}`, source, target: id, variant: 'trigger', weight: task.executionCount })
+    const problem = tone === 'error' ? 'failing' : undefined
+    edges.push({
+      id: `${source}->${id}`,
+      source,
+      target: id,
+      variant: 'trigger',
+      weight: task.executionCount,
+      flow: 'in',
+      broken: problem !== undefined,
+    })
+  }
+
+  // Permissions per unordered pair (first caller wins as the edit target) —
+  // consulted by both activity edges (delete = revoke the permission
+  // underneath, if any) and the permission-edge pass below.
+  const permissionCallerByPair = new Map<string, string>()
+  for (const perm of topology.permissions) {
+    if (perm.caller === perm.target) continue
+    if (!agentSlugSet.has(perm.caller) || !agentSlugSet.has(perm.target)) continue
+    const key = pairKey(perm.caller, perm.target)
+    if (!permissionCallerByPair.has(key)) permissionCallerByPair.set(key, perm.caller)
   }
 
   // Merge invocations onto unordered pairs (A→B and B→A are visually one
-  // line), then draw one solid activity edge per communicating pair…
-  const activityByPair = new Map<string, number>()
+  // line) but keep per-direction counts — the dash march runs toward the
+  // invoked agent, or runs both ways on the line when both directions have
+  // traffic. Then draw one activity edge per communicating pair…
+  const activityByPair = new Map<string, { aToB: number; bToA: number }>()
   for (const inv of topology.invocations) {
     if (inv.caller === inv.target) continue
     if (!agentSlugSet.has(inv.caller) || !agentSlugSet.has(inv.target)) continue
     const key = pairKey(inv.caller, inv.target)
-    activityByPair.set(key, (activityByPair.get(key) ?? 0) + inv.count)
+    const entry = activityByPair.get(key) ?? { aToB: 0, bToA: 0 }
+    if (inv.caller === key.split('|')[0]) entry.aToB += inv.count
+    else entry.bToA += inv.count
+    activityByPair.set(key, entry)
   }
-  for (const [key, weight] of [...activityByPair].sort(([a], [b]) => a.localeCompare(b))) {
+  for (const [key, { aToB, bToA }] of [...activityByPair].sort(([a], [b]) => a.localeCompare(b))) {
     const [a, b] = key.split('|')
     edges.push({
       id: `${nodeId.agent(a)}=${nodeId.agent(b)}`,
       source: nodeId.agent(a),
       target: nodeId.agent(b),
       variant: 'activity',
-      weight,
+      weight: aToB + bToA,
+      flow: aToB && bToA ? 'both' : aToB ? 'out' : 'in',
+      // Activity is history — deleting the edge only revokes the standing
+      // permission (when one exists); the recorded line stays.
+      deletable: permissionCallerByPair.has(key),
+      policyAgentSlug: permissionCallerByPair.get(key),
     })
   }
 
-  // …and one dashed permission edge per permitted-but-silent pair. Any
+  // …and one idle permission edge per permitted-but-silent pair. Any
   // recorded activity supersedes the permission line: both would occupy the
-  // same straight segment, and the solid stroke hides the dashes.
-  const permissionPairs = new Set<string>()
-  for (const perm of topology.permissions) {
-    if (perm.caller === perm.target) continue
-    if (!agentSlugSet.has(perm.caller) || !agentSlugSet.has(perm.target)) continue
-    const key = pairKey(perm.caller, perm.target)
-    if (activityByPair.has(key) || permissionPairs.has(key)) continue
-    permissionPairs.add(key)
+  // same straight segment and double-draw.
+  for (const [key, caller] of [...permissionCallerByPair].sort(([a], [b]) => a.localeCompare(b))) {
+    if (activityByPair.has(key)) continue
     const [a, b] = key.split('|')
     edges.push({
       id: `${nodeId.agent(a)}~${nodeId.agent(b)}`,
       source: nodeId.agent(a),
       target: nodeId.agent(b),
       variant: 'permission',
+      deletable: true,
+      policyAgentSlug: caller,
     })
+  }
+
+  // Node-level usage: aggregate each resource's edge weights (a shared
+  // account may serve several agents) — the hover pill's fine print.
+  const weightByNode = new Map<string, number>()
+  for (const edge of edges) {
+    if (!edge.weight) continue
+    weightByNode.set(edge.source, (weightByNode.get(edge.source) ?? 0) + edge.weight)
+    weightByNode.set(edge.target, (weightByNode.get(edge.target) ?? 0) + edge.weight)
+  }
+  for (const node of nodes) {
+    if (node.data.kind === 'agent') continue
+    const total = weightByNode.get(node.id) ?? 0
+    node.data.usage = total ? countLabel(total, USAGE_UNIT[node.data.kind]) : USAGE_IDLE[node.data.kind]
   }
 
   return { nodes, edges }

--- a/src/renderer/context/nav-transient-context.tsx
+++ b/src/renderer/context/nav-transient-context.tsx
@@ -1,25 +1,38 @@
 import { createContext, useContext, useState, type ReactNode } from 'react'
 
+interface OpenAgentSettings {
+  slug: string
+  tab: string
+}
+
 interface NavTransientValue {
   justCreatedSlug: string | null
   setJustCreatedSlug: (slug: string | null) => void
+  openAgentSettings: OpenAgentSettings | null
+  setOpenAgentSettings: (value: OpenAgentSettings | null) => void
 }
 
 const NavTransientContext = createContext<NavTransientValue | null>(null)
 
 /**
- * Holds the new-agent "morph" one-shot, which must outlive in-app navigation
- * but die on a hard reload (correct for a one-shot). Mounted ABOVE the router
- * (App.tsx) so a route change never resets it.
+ * Holds one-shots that must outlive in-app navigation but die on a hard
+ * reload (correct for one-shots). Mounted ABOVE the router (App.tsx) so a
+ * route change never resets them.
  *
  * - `justCreatedSlug`: the new-agent "morph" tag. Produced by
  *   `useCreateUntitledAgent` on create and consumed by AgentHome.
+ * - `openAgentSettings`: open the agent settings dialog on a given tab once
+ *   that agent's page mounts. Produced by cross-page affordances (e.g. the
+ *   home graph's "edit permissions" on a connector) and consumed by AgentHome.
  */
 export function NavTransientProvider({ children }: { children: ReactNode }) {
   const [justCreatedSlug, setJustCreatedSlug] = useState<string | null>(null)
+  const [openAgentSettings, setOpenAgentSettings] = useState<OpenAgentSettings | null>(null)
 
   return (
-    <NavTransientContext.Provider value={{ justCreatedSlug, setJustCreatedSlug }}>
+    <NavTransientContext.Provider
+      value={{ justCreatedSlug, setJustCreatedSlug, openAgentSettings, setOpenAgentSettings }}
+    >
       {children}
     </NavTransientContext.Provider>
   )

--- a/src/renderer/hooks/use-humanized-cron.ts
+++ b/src/renderer/hooks/use-humanized-cron.ts
@@ -2,19 +2,21 @@ import { useMemo } from 'react'
 import cronstrue from 'cronstrue'
 
 /**
- * Returns a human-readable description of a cron expression.
- * Falls back to the raw expression if parsing fails.
+ * Human-readable description of a cron expression; falls back to the raw
+ * expression if parsing fails.
  */
+export function humanizeCron(expression: string): string {
+  try {
+    return cronstrue.toString(expression, {
+      use24HourTimeFormat: false,
+      verbose: true,
+    })
+  } catch {
+    return expression
+  }
+}
+
+/** Hook form of {@link humanizeCron} for memoized component use. */
 export function useHumanizedCron(expression: string | null | undefined): string | null {
-  return useMemo(() => {
-    if (!expression) return null
-    try {
-      return cronstrue.toString(expression, {
-        use24HourTimeFormat: false,
-        verbose: true,
-      })
-    } catch {
-      return expression
-    }
-  }, [expression])
+  return useMemo(() => (expression ? humanizeCron(expression) : null), [expression])
 }

--- a/src/shared/lib/services/user-settings-service.ts
+++ b/src/shared/lib/services/user-settings-service.ts
@@ -34,6 +34,19 @@ export const userSettingsSchema = z.object({
   // Home graph view: user-dragged node positions, keyed by stable node id
   // (e.g. 'agent:{slug}', 'account:{id}'). Absent entries fall back to auto-layout.
   graphNodePositions: z.record(z.string(), z.object({ x: z.number(), y: z.number() })).optional(),
+  // Home graph view: user-dragged elbow-connector geometry, keyed by edge id.
+  // coords = cross-coordinates of the route's interior segments (the
+  // orthogonal waypoint model in graph-edges.tsx); sourceAngle/targetAngle =
+  // pinned anchor position on the node's circular perimeter, in degrees
+  // (absent = auto-picked facing side).
+  graphEdgeGeometry: z.record(
+    z.string(),
+    z.object({
+      coords: z.array(z.number()).optional(),
+      sourceAngle: z.number().optional(),
+      targetAngle: z.number().optional(),
+    }),
+  ).optional(),
   defaultApiPolicy: z.enum(['allow', 'review', 'block']).default('review'),
   defaultMcpPolicy: z.enum(['allow', 'review', 'block']).default('review'),
   keepAwakeEnabled: z.boolean().default(false),


### PR DESCRIPTION
## Summary

Interaction layer for the home graph — **part 3 of the stack**, based on `feat/home-graph-view` (#491). West's work, building on Iddo's base from parts 1–2.

- **Elbow connectors**: orthogonal routes (waypoint model: per-segment cross-coords, port-anchored ends, rounded corners) between perimeter anchors on the nodes' visible shapes. Active links carry a traveling comet tracer (speed = log-scaled usage, direction = data flow, two-way = opposing tracers); idle gray / broken red stay static dashes.
- **Editing**: click selects — per-segment pill handles (end-segment drags spawn stub bends), endpoint dots slide the perimeter and magnetize to cardinal ports, floating toolbar deletes the underlying link/permission or jumps to the caller's policy editor. Geometry persists per edge (`graphEdgeGeometry` in user settings) alongside node positions.
- **Drawing**: FigJam-style — ports surface on hover with staged anchor affordances; dragging out draws a connection and creates the real relationship (invoke policy / account / MCP link); invalid targets fade while dragging. Webhooks/crons/chats are owned by their agent and created through forms, so their ports stay decorative.
- **Panel**: right-hand accounts/MCP directory; hovering a row spotlights that resource's edges.
- Supporting changes: `humanizeCron()` extracted as a non-hook form; one-shot `openAgentSettings` in NavTransientContext so "edit permissions" on an edge can navigate to the agent's settings tab without replay on later visits.

## Review notes

- `resource-panel.tsx` (added here) is **removed in part 4**, superseded by on-canvas details — skim it accordingly. It's kept here so each PR matches a real, working stage of the feature.

## Stack

1. `feat/home-graph-endpoint` (#490)
2. `feat/home-graph-view` (#491)
3. 👉 `feat/home-graph-connection-editing` (#492) (this PR)
4. `feat/home-graph-polish` (#493)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
