### PR TITLE
fix: mask MicroVM WebSocket keepalive pings

### DIFF
--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import http from 'http'
 import net from 'net'
 import { PassThrough } from 'stream'
+import { WebSocketServer } from 'ws'
 
 const sendMock = vi.fn()
 const responses: Record<string, unknown> = {}
@@ -52,8 +53,8 @@ import {
   LambdaMicroVmRuntimeClient,
   LocalAuthForwardProxy,
   MICROVM_STREAM_KEEPALIVE_MS,
-  MICROVM_WS_PING_FRAME,
   attachMicrovmUpstreamKeepalive,
+  createMicrovmWebSocketPingFrame,
   resetMicrovmRuntimeForTests,
   resolveMicrovmRuntimeConfigOrNull,
   isMicrovmRuntimeConfigured,
@@ -686,7 +687,7 @@ describe('attachMicrovmUpstreamKeepalive', () => {
     vi.useRealTimers()
   })
 
-  it('writes a WS ping frame on the MicroVM keepalive interval', () => {
+  it('writes a masked client WS ping frame on the MicroVM keepalive interval', () => {
     const write = vi.fn()
     const upstream = { destroyed: false, write } as unknown as import('net').Socket
     const dispose = attachMicrovmUpstreamKeepalive(upstream)
@@ -695,13 +696,57 @@ describe('attachMicrovmUpstreamKeepalive', () => {
     expect(write).not.toHaveBeenCalled()
     vi.advanceTimersByTime(1)
     expect(write).toHaveBeenCalledTimes(1)
-    expect(write.mock.calls[0][0]).toEqual(MICROVM_WS_PING_FRAME)
+    const frame = write.mock.calls[0][0] as Buffer
+    expect(frame).toHaveLength(6)
+    expect(frame[0]).toBe(0x89)
+    expect(frame[1]).toBe(0x80)
     vi.advanceTimersByTime(MICROVM_STREAM_KEEPALIVE_MS)
     expect(write).toHaveBeenCalledTimes(2)
 
     dispose()
     vi.advanceTimersByTime(MICROVM_STREAM_KEEPALIVE_MS * 2)
     expect(write).toHaveBeenCalledTimes(2)
+  })
+
+  it('creates a client ping accepted by a WebSocket server', async () => {
+    vi.useRealTimers()
+    const server = http.createServer()
+    const wss = new WebSocketServer({ server })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const port = (server.address() as net.AddressInfo).port
+    const socket = net.connect(port, '127.0.0.1')
+    const connected = new Promise<import('ws').WebSocket>((resolve) => wss.once('connection', resolve))
+    let websocket: import('ws').WebSocket | undefined
+    try {
+      await new Promise<void>((resolve) => socket.once('connect', resolve))
+      socket.write([
+        'GET / HTTP/1.1',
+        'Host: 127.0.0.1',
+        'Upgrade: websocket',
+        'Connection: Upgrade',
+        'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==',
+        'Sec-WebSocket-Version: 13',
+        '',
+        '',
+      ].join('\r\n'))
+
+      websocket = await connected
+      const ping = new Promise<Buffer>((resolve, reject) => {
+        websocket!.once('ping', resolve)
+        websocket!.once('error', reject)
+      })
+      socket.write(createMicrovmWebSocketPingFrame())
+      await expect(ping).resolves.toEqual(Buffer.alloc(0))
+    } finally {
+      socket.destroy()
+      websocket?.terminate()
+      await new Promise<void>((resolve) => wss.close(() => resolve()))
+      if (server.listening) {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => error ? reject(error) : resolve())
+        })
+      }
+    }
   })
 
   it('skips write when the upstream socket is destroyed', () => {

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -2,7 +2,7 @@ import http from 'http'
 import https from 'https'
 import tls from 'tls'
 import net, { AddressInfo } from 'net'
-import { randomUUID } from 'crypto'
+import { randomBytes, randomUUID } from 'crypto'
 import { z } from 'zod'
 import {
   LambdaMicrovmsClient,
@@ -41,15 +41,18 @@ const UPSTREAM_IDLE_TIMEOUT_MS = 30_000
 const ECS_METADATA_TIMEOUT_MS = 2_000
 // Quiet session streams through MicroVM ingress die at ~60s without traffic.
 export const MICROVM_STREAM_KEEPALIVE_MS = 25_000
-// Empty WebSocket ping frame (FIN + opcode 0x9, zero-length payload).
-export const MICROVM_WS_PING_FRAME = Buffer.from([0x89, 0x00])
+
+export function createMicrovmWebSocketPingFrame(): Buffer {
+  // Client-to-server frames require a fresh masking key, even with no payload.
+  return Buffer.concat([Buffer.from([0x89, 0x80]), randomBytes(4)])
+}
 
 /** Keep MicroVM ingress from idle-cutting a quiet proxied WS stream. */
 export function attachMicrovmUpstreamKeepalive(upstream: net.Socket): () => void {
   const timer = setInterval(() => {
     if (upstream.destroyed) return
     try {
-      upstream.write(MICROVM_WS_PING_FRAME)
+      upstream.write(createMicrovmWebSocketPingFrame())
     } catch (error) {
       console.warn('[LocalAuthForwardProxy] WebSocket ping failed:', error)
     }


### PR DESCRIPTION
## Bug

The MicroVM auth-forward proxy injected an unmasked client WebSocket ping every 25 seconds. WebSocket servers require client-to-server frames to be masked, so the agent rejected the first keepalive with `Invalid WebSocket frame: MASK must be set`, closed the stream, and triggered reconnect loops and host health degradation.

Repro: open a MicroVM session stream through the proxy and leave it connected for 25 seconds. Before this fix, the first keepalive closes the stream; production guest logs recorded more than 1,500 invalid-frame errors after the keepalive rollout and none before it.

## What changed

- Generate each empty ping with the MASK bit and a fresh four-byte masking key.
- Add a protocol-level regression test that feeds the generated frame to a real WebSocket server parser.

## Test plan

- [x] `npx vitest run src/shared/lib/container/lambda-microvm-runtime.test.ts` — 47/47 passed
- [x] ESLint on both modified files
- [x] Same 47/47 tests passed inside the exact staging image
- [x] Staging canary rollout completed on pinned image digest
- [x] Three parallel cold MicroVM starts: all proxied streams stayed open for 130 seconds and received five pong responses each
- [x] No-ping control disconnected at 60.3 seconds, confirming the keepalive preserves the ingress stream
- [x] Staging guest logs: zero invalid frames and zero WebSocket errors
- [x] Staging canary: ten consecutive health checks returned 200 and no post-start health failures
- [ ] Repository-wide `npm run typecheck` remains blocked by pre-existing errors outside these files (`react-hook-form`, auth options, optional tool dependencies, and Vitest config)

Made with [Cursor](https://cursor.com)