### PR TITLE
fix: chat integrations permanently died after one failed reconnect

### DIFF
--- a/src/shared/lib/chat-integrations/chat-integration-e2e.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-e2e.test.ts
@@ -159,6 +159,10 @@ describe('Chat integration E2E', () => {
     (containerManager.ensureRunning as any).mockResolvedValue(mockContainerClient)
 
     registeredSessions.clear()
+
+    // connectIntegration cancels itself on a stopped manager; this harness
+    // drives addIntegration directly (no start()), so mark the manager running.
+    ;(chatIntegrationManager as unknown as { isRunning: boolean }).isRunning = true
   })
 
   afterEach(async () => {

--- a/src/shared/lib/chat-integrations/chat-integration-manager-archived-restore.sup233.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager-archived-restore.sup233.test.ts
@@ -89,6 +89,9 @@ describe('SUP-233 reconnect restore ignores archived sessions', () => {
     testSqlite = new Database(':memory:')
     testDb = drizzle(testSqlite, { schema })
     migrate(testDb, { migrationsFolder: path.join(process.cwd(), 'src/shared/lib/db/migrations') })
+    // connectIntegration cancels itself on a stopped manager; this harness
+    // drives it directly (no start()), so mark the manager running.
+    ;(chatIntegrationManager as unknown as { isRunning: boolean }).isRunning = true
   })
 
   afterEach(async () => {

--- a/src/shared/lib/chat-integrations/chat-integration-manager-reconcile.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager-reconcile.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// DB-driven health-check reconcile.
+//
+// The old runHealthChecks iterated the in-memory `connections` map, and both
+// reconnect paths did removeIntegration → connectIntegration. A single failed
+// connect left the integration absent from the map, so no later tick ever saw
+// it again — permanently dead until app restart, with whatever status happened
+// to be in the DB at the time ("stops responding").
+//
+// The reconcile loop instead treats the DB as the work list: every startup-
+// eligible integration (status active/error) is checked each tick, so a failed
+// reconnect is simply retried on the next tick. These tests drive
+// runHealthChecks() directly with the service layer mocked and connectors
+// stubbed, and assert:
+//   1. an orphaned integration (in DB, not in the map) is reconnected,
+//   2. a FAILED reconnect is retried on the next tick (the regression),
+//   3. the failure counter survives ticks so auto-pause is reachable,
+//   4. a present-but-disconnected connector gets a grace window before the
+//      manager tears it down (its own reconnect loop goes first),
+//   5. recovery writes status 'active' back (both via manager reconnect and
+//      via connector self-recovery), so no stale error badge remains,
+//   6. healthy integrations cause zero writes and zero rebuilds,
+//   7. a failed attempt records status 'error' with the attempt count,
+//   8. per-integration in-flight guard: overlapping ticks don't double-connect,
+//   9. an integration paused mid-tick is not reconnected.
+// ---------------------------------------------------------------------------
+
+vi.mock('@shared/lib/services/chat-integration-service', () => ({
+  listStartupChatIntegrations: vi.fn().mockReturnValue([]),
+  getChatIntegration: vi.fn(),
+  updateChatIntegrationStatus: vi.fn(),
+}))
+
+vi.mock('@shared/lib/services/chat-integration-session-service', () => ({
+  getChatIntegrationSession: vi.fn(),
+  getChatIntegrationSessionBySessionId: vi.fn(),
+  createChatIntegrationSession: vi.fn(),
+  updateChatIntegrationSessionName: vi.fn(),
+  archiveChatIntegrationSession: vi.fn(),
+  touchChatIntegrationSession: vi.fn(),
+  listChatIntegrationSessions: vi.fn().mockReturnValue([]),
+  listActiveChatIntegrationSessions: vi.fn().mockReturnValue([]),
+  resolveActiveSession: vi.fn(),
+  getLastDisplayName: vi.fn(),
+}))
+
+vi.mock('@shared/lib/services/chat-integration-access-service', () => ({
+  decideInboundAccess: vi.fn(),
+  isChatAllowed: vi.fn().mockReturnValue(true),
+  getChatAccess: vi.fn(),
+  markNoticeSent: vi.fn(),
+}))
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    addGlobalNotificationClient: vi.fn().mockReturnValue(() => {}),
+    getSessionActivity: vi.fn(),
+  },
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+  addErrorBreadcrumb: vi.fn(),
+}))
+
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerChatIntegrationEvent: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+import { chatIntegrationManager } from './chat-integration-manager'
+import {
+  listStartupChatIntegrations,
+  getChatIntegration,
+  updateChatIntegrationStatus,
+} from '@shared/lib/services/chat-integration-service'
+import { notificationManager } from '@shared/lib/notifications/notification-manager'
+import type { ChatClientConnector } from './base-connector'
+import type { ChatIntegration } from '@shared/lib/db/schema'
+
+const listStartupMock = vi.mocked(listStartupChatIntegrations)
+const getIntegrationMock = vi.mocked(getChatIntegration)
+const updateStatusMock = vi.mocked(updateChatIntegrationStatus)
+
+interface ManagerTestSurface {
+  connections: Map<string, { connector: ChatClientConnector }>
+  chatSessions: Map<string, unknown>
+  messageQueues: Map<string, unknown>
+  disconnectedSince: Map<string, number>
+  consecutiveFailures: Map<string, number>
+  reconcilingIds: Set<string>
+  isRunning: boolean
+  runHealthChecks(): Promise<void>
+  createConnector(integration: unknown): Promise<ChatClientConnector>
+}
+
+const mgr = chatIntegrationManager as unknown as ManagerTestSurface
+
+const INT = 'int-reconcile-test'
+
+function integrationRow(overrides?: Partial<ChatIntegration>): ChatIntegration {
+  return {
+    id: INT,
+    agentSlug: 'test-agent',
+    provider: 'telegram',
+    name: 'Test Bot',
+    status: 'active',
+    statusError: null,
+    requireApproval: true,
+    sessionTimeout: null,
+    createdByUserId: null,
+    config: '{}',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  } as unknown as ChatIntegration
+}
+
+interface FakeConnector extends ChatClientConnector {
+  connectedState: boolean
+}
+
+function fakeConnector(opts?: { connectImpl?: () => Promise<void> }): FakeConnector {
+  const c = {
+    provider: 'telegram',
+    connectedState: true,
+    connect: vi.fn(opts?.connectImpl ?? (async () => {})),
+    disconnect: vi.fn(async () => {}),
+    isConnected: vi.fn(() => c.connectedState),
+    onMessage: vi.fn().mockReturnValue(() => {}),
+    onInteractiveResponse: vi.fn().mockReturnValue(() => {}),
+    onError: vi.fn().mockReturnValue(() => {}),
+    onTypingHint: vi.fn().mockReturnValue(() => {}),
+  }
+  return c as unknown as FakeConnector
+}
+
+/** Seed the DB mocks so `row` is the single startup-eligible integration. */
+function seedRow(row: ChatIntegration): void {
+  listStartupMock.mockReturnValue([row])
+  getIntegrationMock.mockReturnValue(row)
+}
+
+function resetManagerState(): void {
+  mgr.connections.clear()
+  mgr.chatSessions.clear()
+  mgr.messageQueues.clear()
+  mgr.disconnectedSince.clear()
+  mgr.consecutiveFailures.clear()
+  mgr.reconcilingIds?.clear()
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resetManagerState()
+  listStartupMock.mockReturnValue([])
+  mgr.isRunning = true
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  resetManagerState()
+  mgr.isRunning = false
+})
+
+describe('reconcile: DB-driven health check', () => {
+  it('reconnects an orphaned integration (in DB, missing from the connections map)', async () => {
+    const row = integrationRow({ status: 'error' } as Partial<ChatIntegration>)
+    seedRow(row)
+    const connector = fakeConnector()
+    const createSpy = vi.spyOn(mgr, 'createConnector').mockResolvedValue(connector)
+
+    await mgr.runHealthChecks()
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(connector.connect).toHaveBeenCalledTimes(1)
+    expect(mgr.connections.has(INT)).toBe(true)
+  })
+
+  it('REGRESSION: a failed reconnect is retried on the next tick, not orphaned forever', async () => {
+    seedRow(integrationRow())
+    const failing = fakeConnector({ connectImpl: async () => { throw new Error('network down') } })
+    const working = fakeConnector()
+    const createSpy = vi.spyOn(mgr, 'createConnector')
+    createSpy.mockResolvedValueOnce(failing).mockResolvedValueOnce(working)
+
+    // Tick 1: connect fails — integration must NOT silently vanish from the work list.
+    await mgr.runHealthChecks()
+    expect(failing.connect).toHaveBeenCalledTimes(1)
+    expect(mgr.connections.has(INT)).toBe(false)
+
+    // Tick 2: the DB-driven loop tries again and recovers.
+    await mgr.runHealthChecks()
+    expect(working.connect).toHaveBeenCalledTimes(1)
+    expect(mgr.connections.has(INT)).toBe(true)
+  })
+
+  it('failure counter survives ticks; auto-pause fires after the max, then attempts stop', async () => {
+    const row = integrationRow()
+    seedRow(row)
+    vi.spyOn(mgr, 'createConnector').mockImplementation(async () =>
+      fakeConnector({ connectImpl: async () => { throw new Error('still down') } }))
+
+    for (let i = 0; i < 15; i++) {
+      await mgr.runHealthChecks()
+    }
+
+    expect(updateStatusMock).toHaveBeenCalledWith(INT, 'paused', expect.stringContaining('Auto-paused'))
+    expect(mgr.consecutiveFailures.has(INT)).toBe(false)
+
+    // Once paused the service stops listing it — no further attempts.
+    listStartupMock.mockReturnValue([])
+    const attemptsSoFar = vi.mocked(mgr.createConnector).mock.calls.length
+    await mgr.runHealthChecks()
+    expect(vi.mocked(mgr.createConnector).mock.calls.length).toBe(attemptsSoFar)
+  })
+
+  it('gives a present-but-disconnected connector a grace window before rebuilding', async () => {
+    seedRow(integrationRow())
+    const dead = fakeConnector()
+    dead.connectedState = false
+    mgr.connections.set(INT, { connector: dead } as never)
+    const createSpy = vi.spyOn(mgr, 'createConnector').mockResolvedValue(fakeConnector())
+
+    // First tick inside the grace window: the connector's own reconnect loop
+    // (iMessage backoff, Slack socket-mode restart) gets to try first.
+    await mgr.runHealthChecks()
+    expect(createSpy).not.toHaveBeenCalled()
+    expect(mgr.connections.get(INT)?.connector).toBe(dead)
+
+    // Past the grace window the manager steps in and rebuilds.
+    mgr.disconnectedSince.set(INT, Date.now() - 10 * 60 * 1000)
+    await mgr.runHealthChecks()
+    expect(createSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes status active back after a successful manager reconnect of an error-status row', async () => {
+    seedRow(integrationRow({ status: 'error' } as Partial<ChatIntegration>))
+    vi.spyOn(mgr, 'createConnector').mockResolvedValue(fakeConnector())
+
+    await mgr.runHealthChecks()
+
+    expect(updateStatusMock).toHaveBeenCalledWith(INT, 'active', null)
+  })
+
+  it('clears a stale error badge when the connector self-recovered', async () => {
+    seedRow(integrationRow({ status: 'error' } as Partial<ChatIntegration>))
+    const healthy = fakeConnector() // connectedState=true: recovered on its own
+    mgr.connections.set(INT, { connector: healthy } as never)
+    const createSpy = vi.spyOn(mgr, 'createConnector').mockResolvedValue(fakeConnector())
+
+    await mgr.runHealthChecks()
+
+    // No rebuild — just the badge fix.
+    expect(createSpy).not.toHaveBeenCalled()
+    expect(updateStatusMock).toHaveBeenCalledWith(INT, 'active', null)
+  })
+
+  it('does nothing for a healthy active integration', async () => {
+    seedRow(integrationRow())
+    mgr.connections.set(INT, { connector: fakeConnector() } as never)
+    const createSpy = vi.spyOn(mgr, 'createConnector').mockResolvedValue(fakeConnector())
+
+    await mgr.runHealthChecks()
+
+    expect(createSpy).not.toHaveBeenCalled()
+    expect(updateStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('records status error with the attempt count on a failed reconnect', async () => {
+    seedRow(integrationRow())
+    vi.spyOn(mgr, 'createConnector').mockImplementation(async () =>
+      fakeConnector({ connectImpl: async () => { throw new Error('boom') } }))
+
+    await mgr.runHealthChecks()
+    expect(updateStatusMock).toHaveBeenCalledWith(INT, 'error', expect.stringContaining('attempt 1'))
+
+    await mgr.runHealthChecks()
+    expect(updateStatusMock).toHaveBeenCalledWith(INT, 'error', expect.stringContaining('attempt 2'))
+  })
+
+  it('notifies the user on the first failure only, not every tick', async () => {
+    seedRow(integrationRow())
+    vi.spyOn(mgr, 'createConnector').mockImplementation(async () =>
+      fakeConnector({ connectImpl: async () => { throw new Error('boom') } }))
+
+    await mgr.runHealthChecks()
+    await mgr.runHealthChecks()
+    await mgr.runHealthChecks()
+    // Let the fire-and-forget dynamic import in emitNotification settle.
+    await new Promise((r) => setTimeout(r, 0))
+
+    const errorNotifications = vi.mocked(notificationManager.triggerChatIntegrationEvent)
+      .mock.calls.filter((c) => c[3] === 'error')
+    expect(errorNotifications.length).toBe(1)
+  })
+
+  it('in-flight guard: an integration mid-reconnect is skipped by the next tick', async () => {
+    seedRow(integrationRow())
+    let releaseConnect: () => void = () => {}
+    const hanging = fakeConnector({
+      connectImpl: () => new Promise<void>((resolve) => { releaseConnect = resolve }),
+    })
+    const createSpy = vi.spyOn(mgr, 'createConnector').mockResolvedValue(hanging)
+
+    const tick1 = mgr.runHealthChecks()
+    // Give tick1 a chance to enter the connect await.
+    await new Promise((r) => setTimeout(r, 0))
+    await mgr.runHealthChecks() // overlapping tick — must not double-connect
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+
+    releaseConnect()
+    await tick1
+    expect(mgr.connections.has(INT)).toBe(true)
+  })
+
+  it('skips an integration paused between the list snapshot and the attempt', async () => {
+    const row = integrationRow()
+    listStartupMock.mockReturnValue([row])
+    // Fresh re-read says paused — user acted mid-tick.
+    getIntegrationMock.mockReturnValue({ ...row, status: 'paused' } as ChatIntegration)
+    const createSpy = vi.spyOn(mgr, 'createConnector').mockResolvedValue(fakeConnector())
+
+    await mgr.runHealthChecks()
+
+    expect(createSpy).not.toHaveBeenCalled()
+    expect(mgr.connections.has(INT)).toBe(false)
+  })
+})

--- a/src/shared/lib/chat-integrations/chat-integration-manager-reconcile.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager-reconcile.test.ts
@@ -92,9 +92,14 @@ interface ManagerTestSurface {
   disconnectedSince: Map<string, number>
   consecutiveFailures: Map<string, number>
   reconcilingIds: Set<string>
+  generations?: Map<string, number>
   isRunning: boolean
   runHealthChecks(): Promise<void>
   createConnector(integration: unknown): Promise<ChatClientConnector>
+  pauseIntegration(id: string): Promise<void>
+  removeIntegration(id: string): Promise<void>
+  addIntegration(id: string): Promise<void>
+  stop(): void
 }
 
 const mgr = chatIntegrationManager as unknown as ManagerTestSurface
@@ -123,12 +128,15 @@ interface FakeConnector extends ChatClientConnector {
   connectedState: boolean
 }
 
-function fakeConnector(opts?: { connectImpl?: () => Promise<void> }): FakeConnector {
+function fakeConnector(opts?: {
+  connectImpl?: () => Promise<void>
+  disconnectImpl?: () => Promise<void>
+}): FakeConnector {
   const c = {
     provider: 'telegram',
     connectedState: true,
     connect: vi.fn(opts?.connectImpl ?? (async () => {})),
-    disconnect: vi.fn(async () => {}),
+    disconnect: vi.fn(opts?.disconnectImpl ?? (async () => {})),
     isConnected: vi.fn(() => c.connectedState),
     onMessage: vi.fn().mockReturnValue(() => {}),
     onInteractiveResponse: vi.fn().mockReturnValue(() => {}),
@@ -151,6 +159,7 @@ function resetManagerState(): void {
   mgr.disconnectedSince.clear()
   mgr.consecutiveFailures.clear()
   mgr.reconcilingIds?.clear()
+  mgr.generations?.clear()
 }
 
 beforeEach(() => {
@@ -329,5 +338,176 @@ describe('reconcile: DB-driven health check', () => {
 
     expect(createSpy).not.toHaveBeenCalled()
     expect(mgr.connections.has(INT)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Lifecycle operations racing an in-flight rebuild.
+//
+// A rebuild spans two await gaps — the old connector's teardown and the new
+// connector's connect — and user lifecycle operations (pause, delete, config
+// update) can land inside either. Every public lifecycle mutation bumps a
+// per-integration generation; a rebuild captures the generation up front and
+// treats any change as CANCELLATION: no reconnect from its (now stale) row
+// snapshot, no status writes over what the user's operation just wrote, and
+// any socket it opened anyway is torn down. Without this, a background rebuild
+// could resurrect a paused integration or restore pre-update credentials.
+// ---------------------------------------------------------------------------
+
+describe('reconcile: lifecycle operations racing a rebuild', () => {
+  /** Let the microtask queue drain so an in-flight rebuild reaches its next await. */
+  const settle = () => new Promise((r) => setTimeout(r, 0))
+
+  it('a pause landing during the teardown await cancels the rebuild (stale-row reconnect)', async () => {
+    const row = integrationRow()
+    seedRow(row) // getChatIntegration keeps returning the stale ACTIVE row: only the generation can save us
+    let releaseDisconnect: () => void = () => {}
+    const dead = fakeConnector({
+      disconnectImpl: () => new Promise<void>((r) => { releaseDisconnect = r }),
+    })
+    dead.connectedState = false
+    mgr.connections.set(INT, { connector: dead } as never)
+    mgr.disconnectedSince.set(INT, Date.now() - 10 * 60 * 1000) // grace expired
+    const createSpy = vi.spyOn(mgr, 'createConnector').mockResolvedValue(fakeConnector())
+
+    const tick = mgr.runHealthChecks()
+    await settle() // rebuild is now awaiting the old connector's teardown
+
+    await mgr.pauseIntegration(INT) // user pauses; returns successfully
+    releaseDisconnect()
+    await tick
+
+    // The rebuild must stand down completely: no reconnect, no status write
+    // over the pause, nothing left in the map.
+    expect(createSpy).not.toHaveBeenCalled()
+    expect(mgr.connections.has(INT)).toBe(false)
+    expect(updateStatusMock).toHaveBeenCalledWith(INT, 'paused')
+    expect(updateStatusMock).not.toHaveBeenCalledWith(INT, 'error', expect.anything())
+  })
+
+  it('a pause landing during the connect await tears the new connector down and writes no active badge', async () => {
+    seedRow(integrationRow({ status: 'error' } as Partial<ChatIntegration>))
+    let releaseConnect: () => void = () => {}
+    const connector = fakeConnector({
+      connectImpl: () => new Promise<void>((r) => { releaseConnect = r }),
+    })
+    vi.spyOn(mgr, 'createConnector').mockResolvedValue(connector)
+
+    const tick = mgr.runHealthChecks() // orphan rebuild starts, connect in flight
+    await settle()
+
+    await mgr.pauseIntegration(INT)
+    releaseConnect() // the connect "succeeds" — but the user owns the integration now
+    await tick
+
+    expect(mgr.connections.has(INT)).toBe(false)
+    expect(connector.disconnect).toHaveBeenCalled()
+    // The error-row success path must NOT write 'active' over the fresh 'paused'.
+    expect(updateStatusMock).not.toHaveBeenCalledWith(INT, 'active', null)
+  })
+
+  it('a connect FAILURE after a pause writes no error status and counts no failure', async () => {
+    seedRow(integrationRow())
+    let rejectConnect: (e: Error) => void = () => {}
+    const connector = fakeConnector({
+      connectImpl: () => new Promise<void>((_r, rej) => { rejectConnect = rej }),
+    })
+    vi.spyOn(mgr, 'createConnector').mockResolvedValue(connector)
+
+    const tick = mgr.runHealthChecks()
+    await settle()
+
+    await mgr.pauseIntegration(INT)
+    rejectConnect(new Error('socket torn down by the pause'))
+    await tick
+
+    // A cancelled rebuild reports nothing: writing 'error' here would flip the
+    // row back to startup-eligible and resurrect the paused integration.
+    expect(updateStatusMock).not.toHaveBeenCalledWith(INT, 'error', expect.anything())
+    expect(mgr.consecutiveFailures.has(INT)).toBe(false)
+  })
+
+  it('a config update mid-rebuild wins: the stale rebuild does not resurrect the old connector', async () => {
+    const rowV1 = integrationRow({ config: '{"v":1}' } as Partial<ChatIntegration>)
+    const rowV2 = integrationRow({ config: '{"v":2}' } as Partial<ChatIntegration>)
+    seedRow(rowV1)
+
+    let releaseOldConnect: () => void = () => {}
+    const connOld = fakeConnector({
+      connectImpl: () => new Promise<void>((r) => { releaseOldConnect = r }),
+    })
+    const connNew = fakeConnector()
+    let calls = 0
+    vi.spyOn(mgr, 'createConnector').mockImplementation(async () => (++calls === 1 ? connOld : connNew))
+
+    const tick = mgr.runHealthChecks() // rebuild from rowV1, connect in flight
+    await settle()
+
+    // Route-style config update: remove + add with the new row.
+    await mgr.removeIntegration(INT)
+    seedRow(rowV2)
+    await mgr.addIntegration(INT)
+    expect(mgr.connections.get(INT)?.connector).toBe(connNew)
+
+    releaseOldConnect() // the STALE connect (old credentials) resolves late
+    await tick
+
+    // The new-credential connector must still own the integration; the stale
+    // one must be torn down, not installed.
+    expect(mgr.connections.get(INT)?.connector).toBe(connNew)
+    expect(connOld.disconnect).toHaveBeenCalled()
+    expect(connNew.disconnect).not.toHaveBeenCalled()
+  })
+
+  it("a stale rebuild's connect FAILURE must not tear down the winner that replaced it", async () => {
+    const rowV1 = integrationRow({ config: '{"v":1}' } as Partial<ChatIntegration>)
+    const rowV2 = integrationRow({ config: '{"v":2}' } as Partial<ChatIntegration>)
+    seedRow(rowV1)
+
+    let rejectOldConnect: (e: Error) => void = () => {}
+    const connOld = fakeConnector({
+      connectImpl: () => new Promise<void>((_r, rej) => { rejectOldConnect = rej }),
+    })
+    const connNew = fakeConnector()
+    let calls = 0
+    vi.spyOn(mgr, 'createConnector').mockImplementation(async () => (++calls === 1 ? connOld : connNew))
+
+    const tick = mgr.runHealthChecks()
+    await settle()
+
+    await mgr.removeIntegration(INT)
+    seedRow(rowV2)
+    await mgr.addIntegration(INT)
+
+    rejectOldConnect(new Error('old credentials no longer valid'))
+    await tick
+
+    // The loser's failure cleanup must only touch what it owns.
+    expect(mgr.connections.get(INT)?.connector).toBe(connNew)
+    expect(connNew.disconnect).not.toHaveBeenCalled()
+    expect(updateStatusMock).not.toHaveBeenCalledWith(INT, 'error', expect.anything())
+  })
+
+  it('stop() during the teardown await is not resurrected by the in-flight rebuild', async () => {
+    seedRow(integrationRow())
+    let releaseDisconnect: () => void = () => {}
+    const dead = fakeConnector({
+      disconnectImpl: () => new Promise<void>((r) => { releaseDisconnect = r }),
+    })
+    dead.connectedState = false
+    mgr.connections.set(INT, { connector: dead } as never)
+    mgr.disconnectedSince.set(INT, Date.now() - 10 * 60 * 1000)
+    const createSpy = vi.spyOn(mgr, 'createConnector').mockResolvedValue(fakeConnector())
+
+    const tick = mgr.runHealthChecks()
+    await settle() // rebuild parked on the teardown await
+
+    mgr.stop() // app shutdown (or web-server restart)
+    releaseDisconnect()
+    await tick
+
+    // A stopped manager must stay stopped: no fresh connector, empty map.
+    expect(createSpy).not.toHaveBeenCalled()
+    expect(mgr.connections.size).toBe(0)
   })
 })

--- a/src/shared/lib/chat-integrations/chat-integration-manager-restore-filter.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager-restore-filter.test.ts
@@ -52,10 +52,11 @@ import type { ChatClientConnector } from './base-connector'
 const INT = 'int-restore-test'
 
 interface ManagerTestSurface {
-  connectIntegration(integration: unknown): Promise<void>
+  connectIntegration(integration: unknown): Promise<boolean>
   subscribeChatSession(integrationId: string, chatId: string, sessionId: string): void
   createConnector(integration: unknown): Promise<ChatClientConnector>
   connections: Map<string, unknown>
+  isRunning: boolean
 }
 
 const mgr = chatIntegrationManager as unknown as ManagerTestSurface
@@ -127,10 +128,15 @@ describe('ChatIntegrationManager — reconnect restoration filter', () => {
     migrate(testDb, { migrationsFolder: path.join(process.cwd(), 'src/shared/lib/db/migrations') })
     seedIntegration()
     vi.clearAllMocks()
+    // connectIntegration cancels itself on a stopped manager (a stop() racing
+    // an in-flight connect must not be resurrected); this harness drives it
+    // directly, so mark the manager running.
+    mgr.isRunning = true
   })
 
   afterEach(() => {
     mgr.connections.delete(INT)
+    mgr.isRunning = false
     testSqlite?.close()
   })
 

--- a/src/shared/lib/chat-integrations/chat-integration-manager-resume.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager-resume.test.ts
@@ -191,22 +191,37 @@ describe('resume: reconnectAll', () => {
     expect(mgr.connections.get(INT)?.connector).toBe(working)
   })
 
-  it('coalesces concurrent reconnectAll calls into a single pass', async () => {
+  it('coalesces concurrent reconnectAll calls into serial passes, and the second wake still gets a FORCE pass', async () => {
     seedRow(integrationRow())
     let releaseConnect: () => void = () => {}
-    const hanging = fakeConnector({
-      connectImpl: () => new Promise<void>((resolve) => { releaseConnect = resolve }),
+    let calls = 0
+    const createSpy = vi.spyOn(mgr, 'createConnector').mockImplementation(async () => {
+      calls++
+      if (calls === 1) {
+        return fakeConnector({
+          connectImpl: () => new Promise<void>((resolve) => { releaseConnect = resolve }),
+        })
+      }
+      return fakeConnector()
     })
-    const createSpy = vi.spyOn(mgr, 'createConnector').mockResolvedValue(hanging)
 
     const first = mgr.reconnectAll()
     await new Promise((r) => setTimeout(r, 0))
     const second = mgr.reconnectAll()
 
+    // Never concurrent: the second wake must not race a second teardown/rebuild
+    // against the in-flight one (that race was the bolt "reading 'start'" null
+    // deref).
+    expect(createSpy).toHaveBeenCalledTimes(1)
+
     releaseConnect()
     await Promise.all([first, second])
 
-    expect(createSpy).toHaveBeenCalledTimes(1)
+    // …but it must not be silently swallowed either: after the first pass the
+    // second wake's sockets are suspect again and isConnected() can read
+    // stale-true, so exactly one more FORCE pass runs (rebuilding even
+    // "connected" integrations).
+    expect(createSpy).toHaveBeenCalledTimes(2)
     expect(mgr.connections.has(INT)).toBe(true)
   })
 

--- a/src/shared/lib/chat-integrations/chat-integration-manager-resume.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager-resume.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// System-resume reconnect (powerMonitor 'resume' → reconnectAll).
+//
+// The old reconnectAll tore down and rebuilt each live connection with no
+// overlap guard, no awaited teardown, and no failure handling beyond a log:
+//   - a failed wake-time connect (network still down) removed the integration
+//     from the map forever — the Tomer/ELECTRON-3T bug,
+//   - overlapping resume events raced connect against stop (the bolt
+//     "reading 'start'" null deref),
+//   - fire-and-forget disconnect let the old socket fight the new one on
+//     gateways that allow one connection per identity (iMessage code=4000).
+//
+// These tests assert the rebuilt behavior:
+//   1. a wake-time failure is NOT an orphan — the next health tick recovers it,
+//   2. concurrent reconnectAll calls coalesce into one pass,
+//   3. the old connector's disconnect resolves before the new connect starts,
+//   4. resume picks up integrations already orphaned before the wake,
+//   5. an integration removed mid-connect is not resurrected (zombie guard),
+//   6. after a failed force pass, quick follow-up retries run without waiting
+//      for the 5-minute tick.
+// ---------------------------------------------------------------------------
+
+vi.mock('@shared/lib/services/chat-integration-service', () => ({
+  listStartupChatIntegrations: vi.fn().mockReturnValue([]),
+  getChatIntegration: vi.fn(),
+  updateChatIntegrationStatus: vi.fn(),
+}))
+
+vi.mock('@shared/lib/services/chat-integration-session-service', () => ({
+  getChatIntegrationSession: vi.fn(),
+  getChatIntegrationSessionBySessionId: vi.fn(),
+  createChatIntegrationSession: vi.fn(),
+  updateChatIntegrationSessionName: vi.fn(),
+  archiveChatIntegrationSession: vi.fn(),
+  touchChatIntegrationSession: vi.fn(),
+  listChatIntegrationSessions: vi.fn().mockReturnValue([]),
+  listActiveChatIntegrationSessions: vi.fn().mockReturnValue([]),
+  resolveActiveSession: vi.fn(),
+  getLastDisplayName: vi.fn(),
+}))
+
+vi.mock('@shared/lib/services/chat-integration-access-service', () => ({
+  decideInboundAccess: vi.fn(),
+  isChatAllowed: vi.fn().mockReturnValue(true),
+  getChatAccess: vi.fn(),
+  markNoticeSent: vi.fn(),
+}))
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    addGlobalNotificationClient: vi.fn().mockReturnValue(() => {}),
+    getSessionActivity: vi.fn(),
+  },
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+  addErrorBreadcrumb: vi.fn(),
+}))
+
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerChatIntegrationEvent: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+import { chatIntegrationManager } from './chat-integration-manager'
+import {
+  listStartupChatIntegrations,
+  getChatIntegration,
+} from '@shared/lib/services/chat-integration-service'
+import type { ChatClientConnector } from './base-connector'
+import type { ChatIntegration } from '@shared/lib/db/schema'
+
+const listStartupMock = vi.mocked(listStartupChatIntegrations)
+const getIntegrationMock = vi.mocked(getChatIntegration)
+
+interface ManagerTestSurface {
+  connections: Map<string, { connector: ChatClientConnector }>
+  chatSessions: Map<string, unknown>
+  messageQueues: Map<string, unknown>
+  disconnectedSince: Map<string, number>
+  consecutiveFailures: Map<string, number>
+  reconcilingIds: Set<string>
+  isRunning: boolean
+  reconnectAll(): Promise<void>
+  runHealthChecks(): Promise<void>
+  connectIntegration(integration: ChatIntegration): Promise<void>
+  removeIntegration(id: string): Promise<void>
+  createConnector(integration: unknown): Promise<ChatClientConnector>
+}
+
+const mgr = chatIntegrationManager as unknown as ManagerTestSurface
+
+const INT = 'int-resume-test'
+
+function integrationRow(overrides?: Partial<ChatIntegration>): ChatIntegration {
+  return {
+    id: INT,
+    agentSlug: 'test-agent',
+    provider: 'telegram',
+    name: 'Test Bot',
+    status: 'active',
+    statusError: null,
+    requireApproval: true,
+    sessionTimeout: null,
+    createdByUserId: null,
+    config: '{}',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  } as unknown as ChatIntegration
+}
+
+interface FakeConnector extends ChatClientConnector {
+  connectedState: boolean
+}
+
+function fakeConnector(opts?: {
+  connectImpl?: () => Promise<void>
+  disconnectImpl?: () => Promise<void>
+}): FakeConnector {
+  const c = {
+    provider: 'telegram',
+    connectedState: true,
+    connect: vi.fn(opts?.connectImpl ?? (async () => {})),
+    disconnect: vi.fn(opts?.disconnectImpl ?? (async () => {})),
+    isConnected: vi.fn(() => c.connectedState),
+    onMessage: vi.fn().mockReturnValue(() => {}),
+    onInteractiveResponse: vi.fn().mockReturnValue(() => {}),
+    onError: vi.fn().mockReturnValue(() => {}),
+    onTypingHint: vi.fn().mockReturnValue(() => {}),
+  }
+  return c as unknown as FakeConnector
+}
+
+function seedRow(row: ChatIntegration): void {
+  listStartupMock.mockReturnValue([row])
+  getIntegrationMock.mockReturnValue(row)
+}
+
+function resetManagerState(): void {
+  mgr.connections.clear()
+  mgr.chatSessions.clear()
+  mgr.messageQueues.clear()
+  mgr.disconnectedSince.clear()
+  mgr.consecutiveFailures.clear()
+  mgr.reconcilingIds?.clear()
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resetManagerState()
+  listStartupMock.mockReturnValue([])
+  mgr.isRunning = true
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  resetManagerState()
+  mgr.isRunning = false
+})
+
+describe('resume: reconnectAll', () => {
+  it('REGRESSION: wake-time connect failures do not orphan — the next tick recovers', async () => {
+    vi.useFakeTimers()
+    seedRow(integrationRow())
+    const stale = fakeConnector()
+    mgr.connections.set(INT, { connector: stale } as never)
+
+    // Every resume attempt fails: the network stays down through the force
+    // pass AND all quick follow-ups.
+    const createSpy = vi.spyOn(mgr, 'createConnector').mockImplementation(async () =>
+      fakeConnector({ connectImpl: async () => { throw new Error('wifi not up yet') } }))
+
+    const resume = mgr.reconnectAll()
+    await vi.advanceTimersByTimeAsync(150_000) // burn through all follow-up windows
+    await resume
+
+    expect(createSpy.mock.calls.length).toBeGreaterThanOrEqual(1)
+    expect(mgr.connections.has(INT)).toBe(false)
+
+    // Network is back: the next regular health tick recovers it — this is the
+    // exact scenario that used to be a permanent silent death.
+    const working = fakeConnector()
+    createSpy.mockResolvedValue(working)
+    await mgr.runHealthChecks()
+    expect(mgr.connections.get(INT)?.connector).toBe(working)
+  })
+
+  it('coalesces concurrent reconnectAll calls into a single pass', async () => {
+    seedRow(integrationRow())
+    let releaseConnect: () => void = () => {}
+    const hanging = fakeConnector({
+      connectImpl: () => new Promise<void>((resolve) => { releaseConnect = resolve }),
+    })
+    const createSpy = vi.spyOn(mgr, 'createConnector').mockResolvedValue(hanging)
+
+    const first = mgr.reconnectAll()
+    await new Promise((r) => setTimeout(r, 0))
+    const second = mgr.reconnectAll()
+
+    releaseConnect()
+    await Promise.all([first, second])
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(mgr.connections.has(INT)).toBe(true)
+  })
+
+  it('awaits the old connector\'s disconnect before starting the new connect', async () => {
+    seedRow(integrationRow())
+    const order: string[] = []
+
+    const old = fakeConnector({
+      disconnectImpl: async () => {
+        await new Promise((r) => setTimeout(r, 5))
+        order.push('old-disconnect-resolved')
+      },
+    })
+    mgr.connections.set(INT, { connector: old } as never)
+
+    const fresh = fakeConnector({
+      connectImpl: async () => { order.push('new-connect-started') },
+    })
+    vi.spyOn(mgr, 'createConnector').mockResolvedValue(fresh)
+
+    await mgr.reconnectAll()
+
+    expect(order).toEqual(['old-disconnect-resolved', 'new-connect-started'])
+  })
+
+  it('picks up integrations already orphaned before the wake', async () => {
+    seedRow(integrationRow({ status: 'error' } as Partial<ChatIntegration>))
+    const connector = fakeConnector()
+    vi.spyOn(mgr, 'createConnector').mockResolvedValue(connector)
+
+    await mgr.reconnectAll()
+
+    expect(connector.connect).toHaveBeenCalledTimes(1)
+    expect(mgr.connections.has(INT)).toBe(true)
+  })
+
+  it('zombie guard: an integration removed mid-connect is not resurrected', async () => {
+    const row = integrationRow()
+    seedRow(row)
+    let releaseConnect: () => void = () => {}
+    const hanging = fakeConnector({
+      connectImpl: () => new Promise<void>((resolve) => { releaseConnect = resolve }),
+    })
+    vi.spyOn(mgr, 'createConnector').mockResolvedValue(hanging)
+
+    const connecting = mgr.connectIntegration(row)
+    await new Promise((r) => setTimeout(r, 0))
+
+    // User removes/pauses while the connect is in flight.
+    await mgr.removeIntegration(INT)
+    expect(mgr.connections.has(INT)).toBe(false)
+
+    releaseConnect()
+    await connecting
+
+    // The late-resolving connect must not re-register anything, and the
+    // now-ownerless socket must be torn down.
+    expect(mgr.connections.has(INT)).toBe(false)
+    expect(hanging.disconnect).toHaveBeenCalled()
+  })
+
+  it('runs quick follow-up retries after a failed force pass instead of waiting for the tick', async () => {
+    vi.useFakeTimers()
+    seedRow(integrationRow())
+
+    const failing = fakeConnector({ connectImpl: async () => { throw new Error('network still down') } })
+    const working = fakeConnector()
+    const createSpy = vi.spyOn(mgr, 'createConnector')
+    createSpy.mockResolvedValueOnce(failing).mockResolvedValueOnce(working)
+
+    const resume = mgr.reconnectAll()
+    // Let the force pass fail, then advance into the first follow-up window.
+    await vi.advanceTimersByTimeAsync(20_000)
+    await resume
+
+    expect(createSpy).toHaveBeenCalledTimes(2)
+    expect(mgr.connections.has(INT)).toBe(true)
+    expect(mgr.connections.get(INT)?.connector).toBe(working)
+  })
+})

--- a/src/shared/lib/chat-integrations/chat-integration-manager.live.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.live.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+// ---------------------------------------------------------------------------
+// LIVE manager-level validation: the reconcile/resume machinery driving a REAL
+// SlackConnector against a real workspace. Gated: SLACK_LIVE=1 only.
+//
+//   SLACK_LIVE=1 SLACK_LIVE_CONFIG=/path/slack-config.json \
+//   npx vitest run --disableConsoleIntercept \
+//     src/shared/lib/chat-integrations/chat-integration-manager.live.test.ts
+//
+// The service layer is mocked (no real DB writes); the connector, socket, and
+// Slack workspace are real. Validates the exact production failure paths:
+//   1. ORPHAN RECOVERY (the Tomer bug): integration in the DB work list but
+//      absent from the connections map → health tick rebuilds a live, connected
+//      integration and clears the error badge,
+//   2. MANAGER TAKEOVER: a dead socket past the grace window → tick tears down
+//      and rebuilds a fresh connected connector,
+//   3. RESUME: reconnectAll force-rebuilds a live connection (sleep-wake path)
+//      and the rebuilt socket still receives real inbound events.
+// ---------------------------------------------------------------------------
+
+vi.mock('@shared/lib/services/chat-integration-service', () => ({
+  listStartupChatIntegrations: vi.fn().mockReturnValue([]),
+  getChatIntegration: vi.fn(),
+  updateChatIntegrationStatus: vi.fn(),
+}))
+
+vi.mock('@shared/lib/services/chat-integration-session-service', () => ({
+  getChatIntegrationSession: vi.fn(),
+  getChatIntegrationSessionBySessionId: vi.fn(),
+  createChatIntegrationSession: vi.fn(),
+  updateChatIntegrationSessionName: vi.fn(),
+  archiveChatIntegrationSession: vi.fn(),
+  touchChatIntegrationSession: vi.fn(),
+  listChatIntegrationSessions: vi.fn().mockReturnValue([]),
+  listActiveChatIntegrationSessions: vi.fn().mockReturnValue([]),
+  resolveActiveSession: vi.fn(),
+  getLastDisplayName: vi.fn(),
+}))
+
+vi.mock('@shared/lib/services/chat-integration-access-service', () => ({
+  decideInboundAccess: vi.fn(),
+  isChatAllowed: vi.fn().mockReturnValue(true),
+  getChatAccess: vi.fn(),
+  markNoticeSent: vi.fn(),
+}))
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    addGlobalNotificationClient: vi.fn().mockReturnValue(() => {}),
+    getSessionActivity: vi.fn(),
+  },
+}))
+
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerChatIntegrationEvent: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+import { chatIntegrationManager } from './chat-integration-manager'
+import {
+  listStartupChatIntegrations,
+  getChatIntegration,
+  updateChatIntegrationStatus,
+} from '@shared/lib/services/chat-integration-service'
+import type { ChatClientConnector, IncomingMessage } from './base-connector'
+import type { ChatIntegration } from '@shared/lib/db/schema'
+
+const LIVE = process.env.SLACK_LIVE === '1'
+const INT = 'int-live-manager'
+
+const listStartupMock = vi.mocked(listStartupChatIntegrations)
+const getIntegrationMock = vi.mocked(getChatIntegration)
+const updateStatusMock = vi.mocked(updateChatIntegrationStatus)
+
+interface ManagerTestSurface {
+  connections: Map<string, { connector: ChatClientConnector }>
+  disconnectedSince: Map<string, number>
+  consecutiveFailures: Map<string, number>
+  reconcilingIds: Set<string>
+  isRunning: boolean
+  runHealthChecks(): Promise<void>
+  reconnectAll(): Promise<void>
+  enqueueMessage(integrationId: string, message: IncomingMessage): void
+}
+
+const mgr = chatIntegrationManager as unknown as ManagerTestSurface
+
+function liveRow(status: 'active' | 'error'): ChatIntegration {
+  const config = readFileSync(process.env.SLACK_LIVE_CONFIG!, 'utf8')
+  return {
+    id: INT,
+    agentSlug: 'live-agent',
+    provider: 'slack',
+    name: 'Live Manager Test',
+    status,
+    requireApproval: true,
+    sessionTimeout: null,
+    createdByUserId: null,
+    config,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  } as unknown as ChatIntegration
+}
+
+function connectorOf(id: string): ChatClientConnector | undefined {
+  return mgr.connections.get(id)?.connector
+}
+
+function killRawSocket(connector: ChatClientConnector): void {
+  const receiver = (connector as unknown as { receiver: { client: { websocket?: { websocket?: { terminate(): void } } } } }).receiver
+  const raw = receiver?.client?.websocket?.websocket
+  if (!raw) throw new Error('no raw websocket to terminate')
+  raw.terminate()
+}
+
+async function waitFor(label: string, cond: () => boolean, timeoutMs: number, intervalMs = 200): Promise<void> {
+  const start = Date.now()
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error(`Timed out waiting for: ${label}`)
+    await new Promise((r) => setTimeout(r, intervalMs))
+  }
+  console.log(`[live-mgr] ${label} after ${Date.now() - start}ms`)
+}
+
+describe.runIf(LIVE)('ChatIntegrationManager live reconcile against real Slack', () => {
+  beforeAll(() => {
+    mgr.isRunning = true
+  })
+
+  afterAll(async () => {
+    const conn = connectorOf(INT)
+    mgr.connections.delete(INT)
+    await conn?.disconnect().catch(() => {})
+    mgr.isRunning = false
+  })
+
+  it('ORPHAN RECOVERY: a health tick rebuilds an integration missing from the map and clears the badge', async () => {
+    const row = liveRow('error') // orphaned integrations end up badged 'error'
+    listStartupMock.mockReturnValue([row])
+    getIntegrationMock.mockReturnValue(row)
+
+    expect(mgr.connections.has(INT)).toBe(false)
+    await mgr.runHealthChecks()
+
+    const connector = connectorOf(INT)
+    expect(connector).toBeTruthy()
+    expect(connector!.isConnected()).toBe(true)
+    expect(updateStatusMock).toHaveBeenCalledWith(INT, 'active', null)
+    console.log('[live-mgr] orphan rebuilt into a live connected Slack integration')
+  }, 60_000)
+
+  it('MANAGER TAKEOVER: a dead socket past the grace window is torn down and rebuilt connected', async () => {
+    const row = liveRow('active')
+    listStartupMock.mockReturnValue([row])
+    getIntegrationMock.mockReturnValue(row)
+
+    const before = connectorOf(INT)!
+    expect(before.isConnected()).toBe(true)
+
+    // Kill the socket, then immediately claim the grace window already passed —
+    // the tick must land in the window before the connector's own 1s-backoff
+    // loop wins the race, so poll for the disconnect (detection is ~50ms).
+    killRawSocket(before)
+    await waitFor('socket drop visible to isConnected()', () => !before.isConnected(), 5_000, 20)
+    mgr.disconnectedSince.set(INT, Date.now() - 10 * 60 * 1000)
+
+    await mgr.runHealthChecks()
+
+    const after = connectorOf(INT)!
+    expect(after).toBeTruthy()
+    expect(after).not.toBe(before) // genuinely rebuilt, not the old object
+    await waitFor('rebuilt connector connected', () => after.isConnected(), 30_000)
+  }, 90_000)
+
+  it('RESUME: reconnectAll force-rebuilds and the fresh socket receives real inbound events', async () => {
+    const row = liveRow('active')
+    listStartupMock.mockReturnValue([row])
+    getIntegrationMock.mockReturnValue(row)
+
+    const before = connectorOf(INT)!
+    const resume = mgr.reconnectAll()
+    await waitFor('force rebuild swapped the connector', () => {
+      const now = connectorOf(INT)
+      return !!now && now !== before && now.isConnected()
+    }, 60_000)
+    await resume
+
+    // End-to-end: a USER-authored message must reach the manager's inbound
+    // queue through the rebuilt socket.
+    const connectionIds = (process.env.SLACK_LIVE_CONNECTION_ID ?? '').split(',').map((s) => s.trim()).filter(Boolean)
+    const nangoId = connectionIds.find((s) => s.startsWith('nango:'))
+    if (!nangoId) {
+      console.warn('[live-mgr] no nango: connection id — skipping inbound step')
+      return
+    }
+
+    const inbound: IncomingMessage[] = []
+    const enqueueSpy = vi.spyOn(mgr, 'enqueueMessage').mockImplementation((_id, msg) => {
+      console.log(`[live-mgr] inbound reached manager queue: ${JSON.stringify(msg.text.slice(0, 60))}`)
+      inbound.push(msg)
+    })
+
+    try {
+      const { registerAllAccountProviders } = await import('@shared/lib/account-providers/register')
+      const { getAccountProvider } = await import('@shared/lib/account-providers/provider-factory')
+      registerAllAccountProviders()
+      const nango = getAccountProvider('nango')
+
+      const { WebClient } = await import('@slack/web-api')
+      const cfg = JSON.parse(readFileSync(process.env.SLACK_LIVE_CONFIG!, 'utf8')) as { botToken: string }
+      const botClient = new WebClient(cfg.botToken)
+      const convos = await botClient.users.conversations({ types: 'public_channel,private_channel', limit: 100 })
+      const channelId = convos.channels?.[0]?.id
+      if (!channelId) throw new Error('bot is in no channels')
+
+      const marker = `manager live ping ${Date.now()}`
+      const payload = new TextEncoder().encode(JSON.stringify({ channel: channelId, text: marker }))
+      const res = await nango.makeApiCall({
+        providerConnectionId: nangoId.slice('nango:'.length),
+        toolkitSlug: 'slack',
+        targetUrl: 'https://slack.com/api/chat.postMessage',
+        method: 'POST',
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+        body: payload.buffer.slice(payload.byteOffset, payload.byteOffset + payload.byteLength) as ArrayBuffer,
+      })
+      const data = await res.json() as { ok?: boolean; error?: string }
+      if (!data.ok) throw new Error(`user-send failed: ${data.error}`)
+
+      await waitFor('inbound user message in manager queue', () => inbound.some((m) => m.text.includes(marker)), 20_000)
+    } finally {
+      enqueueSpy.mockRestore()
+    }
+  }, 120_000)
+})

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -164,6 +164,16 @@ class ChatIntegrationManager {
   private globalNotificationUnsubscribe: (() => void) | null = null
   private disconnectedSince: Map<string, number> = new Map()
   private consecutiveFailures: Map<string, number> = new Map()
+  // Integrations with a rebuild in flight. Reconcile passes (5-min tick, resume,
+  // resume follow-ups) can overlap when a connect hangs; this keeps any one
+  // integration from being torn down by one pass while another is mid-connect.
+  private reconcilingIds: Set<string> = new Set()
+  // In-flight system-resume pass; concurrent reconnectAll calls coalesce onto it.
+  private resumeReconcile: Promise<void> | null = null
+  // Follow-up delays after the resume force pass, while anything is still down.
+  private static readonly RESUME_RETRY_DELAYS_MS = [15_000, 30_000, 60_000]
+  // Upper bound on waiting for an old connector to tear down before rebuilding.
+  private static readonly DISCONNECT_TIMEOUT_MS = 5_000
   // Per-(integration,chat) serialized tail promise. Entries self-evict once their
   // chain settles (see scheduleQueueEviction), so the map stays bounded.
   private messageQueues: Map<string, Promise<void>> = new Map()
@@ -225,13 +235,14 @@ class ChatIntegrationManager {
     }
     this.chatSessions.clear()
 
-    // Disconnect all integrations
+    // Disconnect all integrations (fire-and-forget: stop() is shutdown-path sync)
     for (const [, conn] of this.connections) {
-      this.disconnectConnection(conn)
+      void this.disconnectConnection(conn)
     }
     this.connections.clear()
     this.disconnectedSince.clear()
     this.consecutiveFailures.clear()
+    this.reconcilingIds.clear()
     this.messageQueues.clear()
     this.isRunning = false
   }
@@ -240,22 +251,36 @@ class ChatIntegrationManager {
 
   async reconnectAll(): Promise<void> {
     if (!this.isRunning) return
-    console.log('[ChatIntegrationManager] Reconnecting all integrations (system resume)')
+    // Overlap guard: resume events can fire in quick bursts (short lid cycles);
+    // racing two full teardown/rebuild passes produced concurrent connect/stop
+    // on the same integration. Coalesce onto the in-flight pass.
+    if (this.resumeReconcile) return this.resumeReconcile
 
-    const entries = [...this.connections.entries()]
-    for (const [id, conn] of entries) {
+    console.log('[ChatIntegrationManager] Reconnecting all integrations (system resume)')
+    this.resumeReconcile = (async () => {
       try {
-        const integration = getChatIntegration(id)
-        if (!integration || integration.status === 'paused') continue
-        await this.removeIntegration(id)
-        await this.connectIntegration(integration)
-        this.disconnectedSince.delete(id)
-        this.consecutiveFailures.delete(id)
-      } catch (err) {
-        console.error(`[ChatIntegrationManager] Resume reconnect failed for ${id}:`, err)
-        reportError(err, 'resume-reconnect', { integrationId: id, provider: conn.integration.provider })
+        await this.reconcileIntegrations({ force: true })
+        // The force pass races the network coming back up, so failures are
+        // expected; they're no longer orphans, but the next regular tick is up
+        // to 5 minutes out — too long right after opening the lid. Run a few
+        // quick follow-ups while anything is still down.
+        for (const delayMs of ChatIntegrationManager.RESUME_RETRY_DELAYS_MS) {
+          if (!this.hasDisconnectedIntegrations()) break
+          await new Promise<void>((resolve) => setTimeout(resolve, delayMs))
+          if (!this.isRunning) return
+          await this.reconcileIntegrations({ force: false })
+        }
+      } finally {
+        this.resumeReconcile = null
       }
-    }
+    })()
+    return this.resumeReconcile
+  }
+
+  private hasDisconnectedIntegrations(): boolean {
+    return listStartupChatIntegrations().some(
+      (i) => !(this.connections.get(i.id)?.connector.isConnected() ?? false),
+    )
   }
 
   async addIntegration(id: string): Promise<void> {
@@ -272,11 +297,17 @@ class ChatIntegrationManager {
         this.chatSessions.delete(key)
       }
     }
-    // Remove the connection
+    // Remove the connection. The teardown is awaited (bounded) so a rebuild
+    // can't start while the old socket is still live — gateways that allow one
+    // connection per identity kick whichever side loses the race (the iMessage
+    // code=4000 "replaced by another connection" fights).
     const conn = this.connections.get(id)
     if (conn) {
-      this.disconnectConnection(conn)
       this.connections.delete(id)
+      await Promise.race([
+        this.disconnectConnection(conn),
+        new Promise<void>((resolve) => setTimeout(resolve, ChatIntegrationManager.DISCONNECT_TIMEOUT_MS)),
+      ])
     }
     this.disconnectedSince.delete(id)
     this.consecutiveFailures.delete(id)
@@ -427,6 +458,13 @@ class ChatIntegrationManager {
       await this.removeIntegration(integration.id)
       throw err
     }
+    // A pause/remove that raced the connect owns the teardown now: don't
+    // resurrect subscriptions for a connection the user just removed, and tear
+    // down the freshly opened, now-ownerless socket.
+    if (this.connections.get(integration.id) !== conn) {
+      connector.disconnect().catch(() => {})
+      return
+    }
     this.disconnectedSince.delete(integration.id)
     breadcrumb('Integration connected', { integrationId: integration.id, provider: integration.provider })
     this.emitNotification(integration, 'connected')
@@ -469,12 +507,12 @@ class ChatIntegrationManager {
     }
   }
 
-  private disconnectConnection(conn: IntegrationConnection): void {
+  private disconnectConnection(conn: IntegrationConnection): Promise<void> {
     conn.messageUnsubscribe?.()
     conn.interactiveUnsubscribe?.()
     conn.errorUnsubscribe?.()
     conn.typingHintUnsubscribe?.()
-    conn.connector.disconnect().catch((err) => {
+    return conn.connector.disconnect().catch((err) => {
       console.error(`[ChatIntegrationManager] Error disconnecting:`, err)
       reportError(err, 'disconnect', { integrationId: conn.integration.id, provider: conn.integration.provider })
     })
@@ -562,8 +600,6 @@ class ChatIntegrationManager {
   // ── Health monitoring ───────────────────────────────────────────────
 
   private async runHealthChecks(): Promise<void> {
-    const now = Date.now()
-
     // Backstop: re-arm any subscribed session that reads busy but has no tick — an
     // unforeseen missed wake (e.g. a process restart that re-subscribed mid-turn). Rides
     // this existing timer, so it adds NO new timer, and leaves idle sessions asleep (zero
@@ -575,49 +611,100 @@ class ChatIntegrationManager {
       armIndicatorIfBusy(session, sessionId, messagePersister.getSessionActivity(sessionId))
     }
 
-    for (const [id, conn] of this.connections) {
-      const connected = conn.connector.isConnected()
+    await this.reconcileIntegrations({ force: false })
+  }
 
-      if (connected) {
+  /**
+   * Reconcile live connections against the DB work list.
+   *
+   * The DB (every startup-eligible integration: status active/error) is the
+   * source of truth, NOT the in-memory connections map — an integration whose
+   * reconnect failed has no map entry, and iterating the map is exactly what
+   * used to orphan it forever. Here a missing entry just means "rebuild now",
+   * so every failure is retried on the next pass.
+   *
+   * force=false (health tick): rebuild orphans immediately; give a present-but-
+   * disconnected connector a grace window first, so its own faster reconnect
+   * loop (iMessage backoff, Slack socket restart) wins when the outage is short.
+   * force=true (system resume): rebuild everything — sockets are suspect after
+   * sleep and honest isConnected() may lag a half-open TCP connection by up to
+   * a ping cycle.
+   *
+   * Rebuilds run serially: connects fail fast (connector-level timeouts), and
+   * one integration hammering a dead network shouldn't be parallelized anyway.
+   */
+  private async reconcileIntegrations(opts: { force: boolean }): Promise<void> {
+    const now = Date.now()
+    for (const integration of listStartupChatIntegrations()) {
+      // A stop() mid-pass (app shutdown) must not resurrect connections it
+      // just tore down.
+      if (!this.isRunning) return
+      const id = integration.id
+      if (this.reconcilingIds.has(id)) continue
+
+      const conn = this.connections.get(id)
+      const connected = conn?.connector.isConnected() ?? false
+
+      if (connected && !opts.force) {
         this.disconnectedSince.delete(id)
         this.consecutiveFailures.delete(id)
+        if (integration.status === 'error') {
+          // The connector recovered on its own — clear the stale error badge.
+          try { updateChatIntegrationStatus(id, 'active', null) } catch { /* best-effort */ }
+        }
         continue
       }
 
-      if (!this.disconnectedSince.has(id)) {
-        this.disconnectedSince.set(id, now)
+      if (conn && !connected && !opts.force) {
+        if (!this.disconnectedSince.has(id)) this.disconnectedSince.set(id, now)
+        if (now - this.disconnectedSince.get(id)! < HEALTH_CHECK_ERROR_THRESHOLD_MS) continue
       }
 
-      const disconnectedFor = now - this.disconnectedSince.get(id)!
+      await this.rebuildIntegration(id, opts.force ? 'resume-reconnect' : 'health-check-reconnect')
+    }
+  }
 
-      if (disconnectedFor >= HEALTH_CHECK_ERROR_THRESHOLD_MS) {
-        const integration = getChatIntegration(id)
-        if (!integration || integration.status === 'paused') continue
+  /** Tear down and reconnect one integration, with retry/auto-pause accounting. */
+  private async rebuildIntegration(id: string, operation: string): Promise<void> {
+    this.reconcilingIds.add(id)
+    try {
+      // Fresh read: the user may have paused or deleted it since the list snapshot.
+      const integration = getChatIntegration(id)
+      if (!integration || integration.status === 'paused') return
 
-        const failures = (this.consecutiveFailures.get(id) ?? 0) + 1
+      // removeIntegration wipes the failure counter (correct for user-initiated
+      // removal); capture it first so retry accounting survives the teardown.
+      const prevFailures = this.consecutiveFailures.get(id) ?? 0
+      try {
+        await this.removeIntegration(id)
+        await this.connectIntegration(integration)
+        this.disconnectedSince.delete(id)
+        this.consecutiveFailures.delete(id)
+        if (integration.status === 'error') {
+          try { updateChatIntegrationStatus(id, 'active', null) } catch { /* best-effort */ }
+        }
+      } catch (err) {
+        const failures = prevFailures + 1
         this.consecutiveFailures.set(id, failures)
+        console.error(`[ChatIntegrationManager] Reconnect failed for ${id} (attempt ${failures}):`, err)
+        reportError(err, operation, { integrationId: id, provider: integration.provider, attempt: failures })
 
         if (failures >= HEALTH_CHECK_MAX_CONSECUTIVE_FAILURES) {
           console.error(`[ChatIntegrationManager] ${id}: ${failures} consecutive reconnect failures — pausing`)
-          reportError(new Error(`Auto-paused after ${failures} failures`), 'health-check-auto-pause', { integrationId: id, provider: conn.integration.provider, failures }, 'warning')
-          try { await this.removeIntegration(id) } catch { /* best-effort */ }
+          reportError(new Error(`Auto-paused after ${failures} failures`), 'health-check-auto-pause', { integrationId: id, provider: integration.provider, failures }, 'warning')
           try { updateChatIntegrationStatus(id, 'paused', `Auto-paused after ${failures} failed reconnection attempts`) } catch { /* best-effort */ }
-          this.emitNotification(conn.integration, 'error', `Auto-paused after ${failures} failed reconnect attempts`)
-          continue
+          this.emitNotification(integration, 'error', `Auto-paused after ${failures} failed reconnect attempts`)
+          this.disconnectedSince.delete(id)
+          this.consecutiveFailures.delete(id)
+          return
         }
 
-        try { updateChatIntegrationStatus(id, 'error', 'Connection lost — attempting reconnect') } catch { /* best-effort */ }
-        this.emitNotification(conn.integration, 'error', 'Connection lost')
-
-        try {
-          await this.removeIntegration(id)
-          await this.connectIntegration(integration)
-        } catch (err) {
-          console.error(`[ChatIntegrationManager] Reconnect failed for ${id} (attempt ${failures}):`, err)
-          reportError(err, 'health-check-reconnect', { integrationId: id, provider: conn.integration.provider, attempt: failures })
-          try { updateChatIntegrationStatus(id, 'error', `Reconnect failed (attempt ${failures}): ${err}`) } catch { /* best-effort */ }
-        }
+        try { updateChatIntegrationStatus(id, 'error', `Reconnect failed (attempt ${failures}): ${err}`) } catch { /* best-effort */ }
+        // Notify once per outage, not once per 5-minute tick.
+        if (failures === 1) this.emitNotification(integration, 'error', 'Connection lost')
       }
+    } finally {
+      this.reconcilingIds.delete(id)
     }
   }
 

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -168,8 +168,21 @@ class ChatIntegrationManager {
   // resume follow-ups) can overlap when a connect hangs; this keeps any one
   // integration from being torn down by one pass while another is mid-connect.
   private reconcilingIds: Set<string> = new Set()
+  // Per-integration lifecycle generation. Every PUBLIC lifecycle mutation
+  // (add/remove/pause/resume — and config update, which is remove+add) bumps
+  // it; background work (rebuilds, in-flight connects) captures the value up
+  // front and treats any change as CANCELLATION. A rebuild spans two await
+  // gaps (teardown, connect) and a user operation landing in either used to
+  // let the rebuild reconnect from its stale row snapshot — resurrecting a
+  // paused integration or restoring pre-update credentials — and clobber the
+  // status the user's operation just wrote.
+  private generations: Map<string, number> = new Map()
   // In-flight system-resume pass; concurrent reconnectAll calls coalesce onto it.
   private resumeReconcile: Promise<void> | null = null
+  // A resume arrived while a pass was in flight: run one more FORCE pass when
+  // the current one finishes (its follow-ups are force:false, and the second
+  // wake's sockets are suspect again — isConnected() can read stale-true).
+  private resumeQueued = false
   // Follow-up delays after the resume force pass, while anything is still down.
   private static readonly RESUME_RETRY_DELAYS_MS = [15_000, 30_000, 60_000]
   // Upper bound on waiting for an old connector to tear down before rebuilding.
@@ -189,9 +202,9 @@ class ChatIntegrationManager {
 
     for (const integration of integrations) {
       try {
-        await this.connectIntegration(integration)
+        const connected = await this.connectIntegration(integration)
         // Clear error status on successful reconnect
-        if (integration.status === 'error') {
+        if (connected && integration.status === 'error') {
           try { updateChatIntegrationStatus(integration.id, 'active', null) } catch { /* best-effort */ }
         }
       } catch (err) {
@@ -243,8 +256,21 @@ class ChatIntegrationManager {
     this.disconnectedSince.clear()
     this.consecutiveFailures.clear()
     this.reconcilingIds.clear()
+    this.generations.clear()
     this.messageQueues.clear()
     this.isRunning = false
+  }
+
+  // ── Lifecycle generations ───────────────────────────────────────────
+
+  private bumpGeneration(id: string): number {
+    const next = (this.generations.get(id) ?? 0) + 1
+    this.generations.set(id, next)
+    return next
+  }
+
+  private generationOf(id: string): number {
+    return this.generations.get(id) ?? 0
   }
 
   // ── Public API ──────────────────────────────────────────────────────
@@ -253,25 +279,35 @@ class ChatIntegrationManager {
     if (!this.isRunning) return
     // Overlap guard: resume events can fire in quick bursts (short lid cycles);
     // racing two full teardown/rebuild passes produced concurrent connect/stop
-    // on the same integration. Coalesce onto the in-flight pass.
-    if (this.resumeReconcile) return this.resumeReconcile
+    // on the same integration. Coalesce onto the in-flight pass — but queue one
+    // more FORCE pass, because the in-flight pass's follow-ups are force:false
+    // and can't be trusted to rebuild sockets the second sleep re-broke.
+    if (this.resumeReconcile) {
+      this.resumeQueued = true
+      return this.resumeReconcile
+    }
 
     console.log('[ChatIntegrationManager] Reconnecting all integrations (system resume)')
     this.resumeReconcile = (async () => {
       try {
-        await this.reconcileIntegrations({ force: true })
-        // The force pass races the network coming back up, so failures are
-        // expected; they're no longer orphans, but the next regular tick is up
-        // to 5 minutes out — too long right after opening the lid. Run a few
-        // quick follow-ups while anything is still down.
-        for (const delayMs of ChatIntegrationManager.RESUME_RETRY_DELAYS_MS) {
-          if (!this.hasDisconnectedIntegrations()) break
-          await new Promise<void>((resolve) => setTimeout(resolve, delayMs))
-          if (!this.isRunning) return
-          await this.reconcileIntegrations({ force: false })
-        }
+        do {
+          this.resumeQueued = false
+          await this.reconcileIntegrations({ force: true })
+          // The force pass races the network coming back up, so failures are
+          // expected; they're no longer orphans, but the next regular tick is up
+          // to 5 minutes out — too long right after opening the lid. Run a few
+          // quick follow-ups while anything is still down.
+          for (const delayMs of ChatIntegrationManager.RESUME_RETRY_DELAYS_MS) {
+            if (this.resumeQueued) break // a fresh wake wants a full force pass instead
+            if (!this.hasDisconnectedIntegrations()) break
+            await new Promise<void>((resolve) => setTimeout(resolve, delayMs))
+            if (!this.isRunning) return
+            await this.reconcileIntegrations({ force: false })
+          }
+        } while (this.resumeQueued && this.isRunning)
       } finally {
         this.resumeReconcile = null
+        this.resumeQueued = false
       }
     })()
     return this.resumeReconcile
@@ -290,6 +326,15 @@ class ChatIntegrationManager {
   }
 
   async removeIntegration(id: string): Promise<void> {
+    // Public removal (delete, pause, config update): this operation owns the
+    // integration from here on — any in-flight background rebuild or connect
+    // for the same id must cancel itself rather than resurrect it.
+    this.bumpGeneration(id)
+    await this.teardownConnection(id)
+  }
+
+  /** Internal teardown: no generation bump — rebuilds tear down without ceding ownership. */
+  private async teardownConnection(id: string): Promise<void> {
     // Remove all chat sessions for this integration
     for (const [key, session] of this.chatSessions) {
       if (key.startsWith(`${id}:`)) {
@@ -304,10 +349,12 @@ class ChatIntegrationManager {
     const conn = this.connections.get(id)
     if (conn) {
       this.connections.delete(id)
+      let timer: ReturnType<typeof setTimeout> | undefined
       await Promise.race([
         this.disconnectConnection(conn),
-        new Promise<void>((resolve) => setTimeout(resolve, ChatIntegrationManager.DISCONNECT_TIMEOUT_MS)),
+        new Promise<void>((resolve) => { timer = setTimeout(resolve, ChatIntegrationManager.DISCONNECT_TIMEOUT_MS) }),
       ])
+      clearTimeout(timer)
     }
     this.disconnectedSince.delete(id)
     this.consecutiveFailures.delete(id)
@@ -407,9 +454,26 @@ class ChatIntegrationManager {
 
   // ── Connection setup ────────────────────────────────────────────────
 
-  private async connectIntegration(integration: ChatIntegration): Promise<void> {
-    if (this.connections.has(integration.id)) {
-      await this.removeIntegration(integration.id)
+  /**
+   * Build, register, and connect a connector for `integration`.
+   *
+   * Returns true when the connection is live AND this call still owns the
+   * integration; false when the connect was CANCELLED — a newer lifecycle
+   * operation (pause/remove/config update/newer connect) took ownership while
+   * we were mid-flight, and its socket (if one opened) has been torn down.
+   * Callers must treat false as "stand down", not as success.
+   *
+   * `expectedGeneration` is passed by rebuilds that captured the generation
+   * earlier; user-driven calls omit it and take ownership here via a bump.
+   */
+  private async connectIntegration(integration: ChatIntegration, expectedGeneration?: number): Promise<boolean> {
+    const id = integration.id
+    const generation = expectedGeneration ?? this.bumpGeneration(id)
+
+    if (this.connections.has(id)) {
+      await this.teardownConnection(id)
+      // A newer lifecycle operation landed while we waited on the teardown.
+      if (this.generationOf(id) !== generation) return false
     }
 
     const connector = await this.createConnector(integration)
@@ -455,15 +519,26 @@ class ChatIntegrationManager {
     try {
       await connector.connect()
     } catch (err) {
-      await this.removeIntegration(integration.id)
+      // Tear down only what we still own: a newer connect may have replaced
+      // our map entry while this one was failing, and removing THAT would
+      // silently kill the healthy winner.
+      if (this.connections.get(id) === conn) {
+        this.connections.delete(id)
+        void this.disconnectConnection(conn)
+      } else {
+        connector.disconnect().catch(() => {})
+      }
       throw err
     }
-    // A pause/remove that raced the connect owns the teardown now: don't
-    // resurrect subscriptions for a connection the user just removed, and tear
-    // down the freshly opened, now-ownerless socket.
-    if (this.connections.get(integration.id) !== conn) {
-      connector.disconnect().catch(() => {})
-      return
+    // A pause/remove/newer-connect that raced the connect owns the teardown
+    // now (generation moved, or the map entry is no longer ours) — and a
+    // stopped manager must not be resurrected past its stop(). Don't wire up
+    // subscriptions for a connection the user just removed; tear down the
+    // freshly opened, now-ownerless socket.
+    if (this.connections.get(id) !== conn || this.generationOf(id) !== generation || !this.isRunning) {
+      if (this.connections.get(id) === conn) this.connections.delete(id)
+      void this.disconnectConnection(conn)
+      return false
     }
     this.disconnectedSince.delete(integration.id)
     breadcrumb('Integration connected', { integrationId: integration.id, provider: integration.provider })
@@ -478,6 +553,7 @@ class ChatIntegrationManager {
       if (!isChatAllowed(integration.id, session.externalChatId)) continue
       this.subscribeChatSession(integration.id, session.externalChatId, session.sessionId)
     }
+    return true
   }
 
   private async createConnector(integration: ChatIntegration): Promise<ChatClientConnector> {
@@ -668,22 +744,42 @@ class ChatIntegrationManager {
   private async rebuildIntegration(id: string, operation: string): Promise<void> {
     this.reconcilingIds.add(id)
     try {
+      // Capture the lifecycle generation before anything else: any user
+      // operation from here on (pause, delete, config update) bumps it, and
+      // this rebuild must then CANCEL — reconnecting from the row snapshot
+      // below would resurrect a paused integration or restore pre-update
+      // credentials, and writing status would clobber what the user's
+      // operation just wrote.
+      const generation = this.generationOf(id)
+
       // Fresh read: the user may have paused or deleted it since the list snapshot.
       const integration = getChatIntegration(id)
       if (!integration || integration.status === 'paused') return
 
-      // removeIntegration wipes the failure counter (correct for user-initiated
-      // removal); capture it first so retry accounting survives the teardown.
+      // The teardown wipes the failure counter (correct for user-initiated
+      // removal); capture it first so retry accounting survives.
       const prevFailures = this.consecutiveFailures.get(id) ?? 0
       try {
-        await this.removeIntegration(id)
-        await this.connectIntegration(integration)
+        await this.teardownConnection(id)
+        // Re-read after the teardown await — a user operation may have landed
+        // in the gap, and the manager may have been stopped.
+        if (!this.isRunning || this.generationOf(id) !== generation) return
+        const fresh = getChatIntegration(id)
+        if (!fresh || fresh.status === 'paused') return
+
+        const connected = await this.connectIntegration(fresh, generation)
+        if (!connected) return // ownership lost mid-connect — cancelled, not successful
         this.disconnectedSince.delete(id)
         this.consecutiveFailures.delete(id)
-        if (integration.status === 'error') {
+        if (fresh.status === 'error') {
           try { updateChatIntegrationStatus(id, 'active', null) } catch { /* best-effort */ }
         }
       } catch (err) {
+        // A cancelled rebuild reports nothing: the failure was (or may have
+        // been) caused by the user's own operation tearing our connect down,
+        // and an 'error' write would flip their fresh 'paused' back to a
+        // startup-eligible status.
+        if (!this.isRunning || this.generationOf(id) !== generation) return
         const failures = prevFailures + 1
         this.consecutiveFailures.set(id, failures)
         console.error(`[ChatIntegrationManager] Reconnect failed for ${id} (attempt ${failures}):`, err)

--- a/src/shared/lib/chat-integrations/chat-integration-model-resolution.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-model-resolution.test.ts
@@ -139,6 +139,10 @@ describe('chat integration model and effort resolution', () => {
 
     mockReadAgentPreferences.mockReset()
     mockReadAgentPreferences.mockResolvedValue({})
+
+    // connectIntegration cancels itself on a stopped manager; this harness
+    // drives addIntegration directly (no start()), so mark the manager running.
+    ;(chatIntegrationManager as unknown as { isRunning: boolean }).isRunning = true
   })
 
   afterEach(async () => {

--- a/src/shared/lib/chat-integrations/slack-connector-lifecycle.test.ts
+++ b/src/shared/lib/chat-integrations/slack-connector-lifecycle.test.ts
@@ -26,6 +26,10 @@ const hoisted = vi.hoisted(() => ({
   receivers: [] as Array<{ opts: Record<string, unknown>; client: unknown }>,
   apps: [] as Array<{ opts: Record<string, unknown> }>,
   failNextClientStart: false,
+  // When true, client.start() parks until the pushed deferred is resolved —
+  // simulates apps.connections.open hanging while a disconnect() races it.
+  deferClientStart: false,
+  pendingStarts: [] as Array<{ resolve: () => void; reject: (e: unknown) => void }>,
 }))
 
 vi.mock('@slack/bolt', async () => {
@@ -36,6 +40,11 @@ vi.mock('@slack/bolt', async () => {
       if (hoisted.failNextClientStart) {
         hoisted.failNextClientStart = false
         throw new Error('simulated start failure')
+      }
+      if (hoisted.deferClientStart) {
+        await new Promise<void>((resolve, reject) => {
+          hoisted.pendingStarts.push({ resolve, reject })
+        })
       }
       this.emit('connected')
     })
@@ -116,6 +125,8 @@ beforeEach(() => {
   hoisted.receivers.length = 0
   hoisted.apps.length = 0
   hoisted.failNextClientStart = false
+  hoisted.deferClientStart = false
+  hoisted.pendingStarts.length = 0
 })
 
 afterEach(() => {
@@ -248,5 +259,70 @@ describe('SlackConnector socket lifecycle', () => {
     // Dead workspace: retrying is pointless, the loop must stop for good.
     await vi.advanceTimersByTimeAsync(600_000)
     expect(client.start).toHaveBeenCalledTimes(1)
+  })
+
+  // ── disconnect() racing an in-flight start ──────────────────────────
+  //
+  // SocketModeClient.start() awaiting apps.connections.open has no websocket
+  // yet, so client.disconnect() resolves immediately — and the pending start
+  // then continues and OPENS A SOCKET AFTER TEARDOWN FINISHED. Left alone,
+  // that ownerless socket keeps acking its share of round-robin events (the
+  // old bolt app's catch-all still listens), silently eating messages meant
+  // for the replacement connector. The connector must track the in-flight
+  // restart and close whatever it opens once teardown has begun.
+
+  it('disconnect() during an in-flight restart closes the late-opening socket', async () => {
+    const connector = makeConnector()
+    await connector.connect()
+    const client = lastClient()
+    client.start.mockClear()
+
+    hoisted.deferClientStart = true
+    client.emit('disconnected')
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(client.start).toHaveBeenCalledTimes(1) // restart parked mid-flight
+
+    const disconnectsBefore = client.disconnect.mock.calls.length
+    const teardown = connector.disconnect()
+    hoisted.pendingStarts.shift()!.resolve() // apps.connections.open finally returns — socket opens late
+    await teardown
+
+    // The late socket must be closed, and the 'connected' it emitted must not
+    // flip state back on a connector that is already torn down.
+    expect(connector.isConnected()).toBe(false)
+    expect(client.disconnect.mock.calls.length).toBeGreaterThanOrEqual(disconnectsBefore + 2) // app.stop + late-socket close
+  })
+
+  it("a late 'connected' event after disconnect() cannot flip state back", async () => {
+    const connector = makeConnector()
+    await connector.connect()
+    const client = lastClient()
+
+    await connector.disconnect()
+    client.emit('connected')
+
+    expect(connector.isConnected()).toBe(false)
+  })
+
+  it('disconnect() racing the initial connect() rejects the connect and leaves no socket', async () => {
+    hoisted.deferClientStart = true
+    const connector = makeConnector()
+
+    const connecting = connector.connect()
+    await vi.advanceTimersByTimeAsync(0) // auth.test done; app.start() parked
+    expect(hoisted.pendingStarts).toHaveLength(1)
+
+    await connector.disconnect() // user pause / manager teardown wins the race
+    hoisted.pendingStarts.shift()!.resolve() // the socket still opens afterwards
+
+    await expect(connecting).rejects.toThrow(/disconnected during connect/i)
+    expect(connector.isConnected()).toBe(false)
+
+    // And the aborted connect must not leave a reconnect loop behind.
+    const client = lastClient()
+    client.start.mockClear()
+    client.emit('disconnected')
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(client.start).not.toHaveBeenCalled()
   })
 })

--- a/src/shared/lib/chat-integrations/slack-connector-lifecycle.test.ts
+++ b/src/shared/lib/chat-integrations/slack-connector-lifecycle.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// SlackConnector socket lifecycle.
+//
+// The old connector set `connected = true` after app.start() and only ever set
+// it false in disconnect(), so a dead socket was invisible to the manager's
+// health check ("stops responding" with an active badge). It also left
+// reconnects to @slack/socket-mode's internal loop, which leaks unrecoverable
+// failures as unhandled promise rejections (delayReconnectAttempt has no
+// .catch) — fatal at the app level.
+//
+// The rebuilt connector owns its Socket Mode lifecycle:
+//   1. the receiver is constructed with autoReconnectEnabled: false — the leaky
+//      internal reconnect path must never run,
+//   2. isConnected() tracks the client's connected/disconnected state events,
+//   3. an unexpected disconnect schedules our own exponential-backoff restart,
+//   4. transient restart failures keep backing off; success resets,
+//   5. disconnect() stops the loop — no reconnect after an intentional stop,
+//   6. a failed INITIAL connect never leaves a reconnect loop behind (the
+//      manager owns retries for that connector object's whole lifetime),
+//   7. an unrecoverable auth error stops the loop and surfaces via onError.
+// ---------------------------------------------------------------------------
+
+const hoisted = vi.hoisted(() => ({
+  receivers: [] as Array<{ opts: Record<string, unknown>; client: unknown }>,
+  apps: [] as Array<{ opts: Record<string, unknown> }>,
+  failNextClientStart: false,
+}))
+
+vi.mock('@slack/bolt', async () => {
+  const { EventEmitter } = await import('node:events')
+
+  class FakeClient extends EventEmitter {
+    start = vi.fn(async () => {
+      if (hoisted.failNextClientStart) {
+        hoisted.failNextClientStart = false
+        throw new Error('simulated start failure')
+      }
+      this.emit('connected')
+    })
+
+    disconnect = vi.fn(async () => {
+      this.emit('disconnected')
+    })
+  }
+
+  class SocketModeReceiver {
+    opts: Record<string, unknown>
+    client = new FakeClient()
+    constructor(opts: Record<string, unknown>) {
+      this.opts = opts
+      hoisted.receivers.push(this)
+    }
+    init(): void {}
+    async start(): Promise<void> { await this.client.start() }
+    async stop(): Promise<void> { await this.client.disconnect() }
+  }
+
+  class App {
+    opts: Record<string, unknown>
+    receiver: SocketModeReceiver
+    client = {
+      auth: { test: vi.fn(async () => ({ ok: true, user_id: 'U-bot', user: 'bot', team: 'T-test' })) },
+    }
+    constructor(opts: Record<string, unknown>) {
+      this.opts = opts
+      this.receiver = opts.receiver as SocketModeReceiver
+      hoisted.apps.push(this)
+    }
+    event(): void {}
+    message(): void {}
+    action(): void {}
+    async start(): Promise<void> { await this.receiver.client.start() }
+    async stop(): Promise<void> { await this.receiver.client.disconnect() }
+  }
+
+  return { App, SocketModeReceiver }
+})
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+  addErrorBreadcrumb: vi.fn(),
+}))
+
+import { SlackConnector } from './slack-connector'
+
+interface FakeClientHandle {
+  start: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
+  emit(event: string): boolean
+}
+
+function lastClient(): FakeClientHandle {
+  const receiver = hoisted.receivers.at(-1)
+  if (!receiver) throw new Error('no receiver constructed')
+  return receiver.client as FakeClientHandle
+}
+
+function makeConnector(): SlackConnector {
+  return new SlackConnector({ botToken: 'xoxb-test', appToken: 'xapp-test' })
+}
+
+function unrecoverableAuthError(): Error {
+  const err = new Error('An API error occurred: invalid_auth') as Error & {
+    code: string
+    data: { ok: false; error: string }
+  }
+  err.code = 'slack_webapi_platform_error'
+  err.data = { ok: false, error: 'invalid_auth' }
+  return err
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  hoisted.receivers.length = 0
+  hoisted.apps.length = 0
+  hoisted.failNextClientStart = false
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+describe('SlackConnector socket lifecycle', () => {
+  it('owns the receiver with autoReconnectEnabled: false (the leaky internal loop must never run)', async () => {
+    const connector = makeConnector()
+    await connector.connect()
+
+    expect(hoisted.receivers).toHaveLength(1)
+    const receiverOpts = hoisted.receivers[0].opts
+    expect(receiverOpts.appToken).toBe('xapp-test')
+    expect(receiverOpts.autoReconnectEnabled).toBe(false)
+
+    // The App must be built AROUND our receiver, not its own.
+    expect(hoisted.apps).toHaveLength(1)
+    expect(hoisted.apps[0].opts.receiver).toBe(hoisted.receivers[0])
+    expect(hoisted.apps[0].opts.token).toBe('xoxb-test')
+
+    expect(connector.isConnected()).toBe(true)
+  })
+
+  it('tracks the socket state: an unexpected disconnect flips isConnected() to false', async () => {
+    const connector = makeConnector()
+    await connector.connect()
+    expect(connector.isConnected()).toBe(true)
+
+    lastClient().emit('disconnected')
+
+    expect(connector.isConnected()).toBe(false)
+  })
+
+  it('restarts the socket with backoff after an unexpected disconnect', async () => {
+    const connector = makeConnector()
+    await connector.connect()
+    const client = lastClient()
+    client.start.mockClear()
+
+    client.emit('disconnected')
+    expect(connector.isConnected()).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(client.start).toHaveBeenCalledTimes(1)
+    // The fake start emits 'connected' — state must recover.
+    expect(connector.isConnected()).toBe(true)
+  })
+
+  it('keeps backing off on transient failures and resets after success', async () => {
+    const connector = makeConnector()
+    await connector.connect()
+    const client = lastClient()
+    client.start.mockClear()
+
+    const transient = new Error('A request error occurred: ENOTFOUND') as Error & { code: string }
+    transient.code = 'slack_webapi_request_error'
+    client.start
+      .mockRejectedValueOnce(transient)
+      .mockRejectedValueOnce(transient)
+
+    client.emit('disconnected')
+
+    await vi.advanceTimersByTimeAsync(1_000) // attempt 1 fails
+    expect(client.start).toHaveBeenCalledTimes(1)
+    expect(connector.isConnected()).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(2_000) // attempt 2 fails
+    expect(client.start).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(4_000) // attempt 3 succeeds
+    expect(client.start).toHaveBeenCalledTimes(3)
+    expect(connector.isConnected()).toBe(true)
+
+    // Success reset the ladder: the next outage starts back at the base delay.
+    client.start.mockClear()
+    client.emit('disconnected')
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(client.start).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reconnect after an intentional disconnect()', async () => {
+    const connector = makeConnector()
+    await connector.connect()
+    const client = lastClient()
+    client.start.mockClear()
+
+    await connector.disconnect()
+    expect(connector.isConnected()).toBe(false)
+
+    // app.stop() emitted 'disconnected'; a pending timer must not restart us.
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(client.start).not.toHaveBeenCalled()
+  })
+
+  it('a failed initial connect leaves no reconnect loop behind', async () => {
+    hoisted.failNextClientStart = true
+    const connector = makeConnector()
+
+    await expect(connector.connect()).rejects.toThrow('Slack Socket Mode failed to start')
+
+    // The manager discarded this connector; a late 'disconnected' from the
+    // half-open socket must not start a zombie loop on it.
+    const client = lastClient()
+    client.start.mockClear()
+    client.emit('disconnected')
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(client.start).not.toHaveBeenCalled()
+  })
+
+  it('stops the loop and surfaces onError for an unrecoverable auth error', async () => {
+    const connector = makeConnector()
+    await connector.connect()
+    const client = lastClient()
+    client.start.mockClear()
+    client.start.mockRejectedValue(unrecoverableAuthError())
+
+    const errors: Error[] = []
+    connector.onError((err) => { errors.push(err) })
+
+    client.emit('disconnected')
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(client.start).toHaveBeenCalledTimes(1)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain('invalid_auth')
+
+    // Dead workspace: retrying is pointless, the loop must stop for good.
+    await vi.advanceTimersByTimeAsync(600_000)
+    expect(client.start).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/shared/lib/chat-integrations/slack-connector.live.test.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.live.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { WebClient } from '@slack/web-api'
+import { SlackConnector } from './slack-connector'
+import type { IncomingMessage } from './base-connector'
+
+// ---------------------------------------------------------------------------
+// LIVE Slack connector validation. Gated: runs only with SLACK_LIVE=1 and real
+// credentials — never in CI.
+//
+//   SLACK_LIVE=1 \
+//   SLACK_LIVE_CONFIG=/path/to/slack-config.json \        # {botToken, appToken}
+//   SLACK_LIVE_CONNECTION_ID=<composio connected acct> \  # optional: user-send step
+//   SUPERAGENT_DATA_DIR="$HOME/Library/Application Support/Superagent-Dev" \
+//   npx vitest run src/shared/lib/chat-integrations/slack-connector.live.test.ts
+//
+// Validates, against a real Slack workspace:
+//   1. connect with honest isConnected(),
+//   2. a hard websocket kill (sleep/network-cut simulation) is detected and
+//      self-healed by the connector's own reconnect loop,
+//   3. the recovered socket actually delivers events (raw envelope check),
+//   4. a USER-authored message (sent via the Composio connected account, i.e.
+//      "on the user's behalf") flows through the full inbound path to
+//      onMessage,
+//   5. outbound sendMessage works on the recovered connection.
+//
+// NOTE: if another app instance holds a Socket Mode connection for the same
+// Slack app, Slack load-balances events across connections — event-delivery
+// assertions retry several sends to tolerate that.
+// ---------------------------------------------------------------------------
+
+const LIVE = process.env.SLACK_LIVE === '1'
+
+interface LiveConfig { botToken: string; appToken: string }
+
+function loadConfig(): LiveConfig {
+  const path = process.env.SLACK_LIVE_CONFIG
+  if (!path) throw new Error('SLACK_LIVE_CONFIG not set')
+  return JSON.parse(readFileSync(path, 'utf8')) as LiveConfig
+}
+
+async function waitFor(
+  label: string,
+  cond: () => boolean,
+  timeoutMs: number,
+  intervalMs = 250,
+): Promise<void> {
+  const start = Date.now()
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error(`Timed out waiting for: ${label}`)
+    await new Promise((r) => setTimeout(r, intervalMs))
+  }
+  console.log(`[live] ${label} after ${Date.now() - start}ms`)
+}
+
+describe.runIf(LIVE)('SlackConnector live validation', () => {
+  let config: LiveConfig
+  let connector: SlackConnector
+  let botClient: WebClient
+  let channelId: string
+  const received: IncomingMessage[] = []
+  const rawEnvelopes: Array<{ type: string; ts: number }> = []
+
+  /** The Socket Mode client inside the connector's receiver. */
+  function socketClient(): {
+    on: (ev: string, cb: (...a: unknown[]) => void) => void
+    websocket?: { websocket?: { terminate: () => void } }
+  } {
+    const receiver = (connector as unknown as { receiver: { client: unknown } }).receiver
+    if (!receiver) throw new Error('connector has no receiver')
+    return receiver.client as ReturnType<typeof socketClient>
+  }
+
+  beforeAll(async () => {
+    config = loadConfig()
+    connector = new SlackConnector({ botToken: config.botToken, appToken: config.appToken })
+    connector.onMessage((msg) => {
+      console.log(`[live] onMessage: chat=${msg.chatId} user=${msg.userName ?? msg.userId} text=${JSON.stringify(msg.text.slice(0, 80))}`)
+      received.push(msg)
+    })
+
+    botClient = new WebClient(config.botToken)
+
+    await connector.connect()
+
+    // Observe raw envelopes: proves transport delivery independent of Bolt's
+    // self-message filtering.
+    socketClient().on('slack_event', (...args: unknown[]) => {
+      const evt = args[0] as { body?: { event?: { type?: string } } }
+      const type = evt?.body?.event?.type ?? 'unknown'
+      rawEnvelopes.push({ type, ts: Date.now() })
+    })
+
+    // Find a channel the bot is a member of.
+    const convos = await botClient.users.conversations({
+      types: 'public_channel,private_channel',
+      limit: 100,
+    })
+    const first = convos.channels?.[0]
+    if (!first?.id) throw new Error('Bot is not a member of any channel — invite it to one first')
+    channelId = first.id
+    console.log(`[live] using channel ${channelId} (#${first.name}); bot channels: ${convos.channels?.length}`)
+  }, 60_000)
+
+  afterAll(async () => {
+    await connector?.disconnect()
+  })
+
+  /** Post as the BOT and wait for any raw envelope to arrive on our socket. */
+  async function proveTransportDelivers(tag: string): Promise<void> {
+    const before = rawEnvelopes.length
+    for (let attempt = 1; attempt <= 4; attempt++) {
+      await botClient.chat.postMessage({ channel: channelId, text: `:satellite: harness transport ping ${tag} #${attempt}` })
+      try {
+        await waitFor(`raw envelope (${tag}, attempt ${attempt})`, () => rawEnvelopes.length > before, 8_000)
+        return
+      } catch {
+        console.log(`[live] no envelope on attempt ${attempt} — possible competing Socket Mode connection, retrying`)
+      }
+    }
+    throw new Error(`No raw envelope arrived after 4 sends (${tag})`)
+  }
+
+  it('connects with honest state', async () => {
+    expect(connector.isConnected()).toBe(true)
+    await proveTransportDelivers('baseline')
+  }, 60_000)
+
+  it('detects a hard socket kill and self-heals via its own reconnect loop', async () => {
+    const client = socketClient()
+    const raw = client.websocket?.websocket
+    if (!raw) throw new Error('no underlying websocket to terminate')
+
+    console.log('[live] terminating raw websocket (sleep/network-cut simulation)')
+    raw.terminate()
+
+    // Honest state: the drop must be visible…
+    await waitFor('isConnected() === false after kill', () => !connector.isConnected(), 10_000, 50)
+
+    // …and the connector's own loop must restore it without any manager help.
+    await waitFor('isConnected() === true after self-reconnect', () => connector.isConnected(), 30_000)
+
+    await proveTransportDelivers('post-recovery')
+  }, 90_000)
+
+  it('delivers a USER-authored message through the full inbound path after recovery', async () => {
+    const connectionIds = (process.env.SLACK_LIVE_CONNECTION_ID ?? '').split(',').map((s) => s.trim()).filter(Boolean)
+    if (connectionIds.length === 0) {
+      console.warn('[live] SLACK_LIVE_CONNECTION_ID not set — skipping user-send step')
+      return
+    }
+
+    const { getConnectionToken, proxyExecute } = await import('@shared/lib/composio/client')
+
+    const sendAsUserVia = async (connectionId: string, text: string): Promise<void> => {
+      // "nango:<provider_connection_id>" → direct-forward via the Nango provider
+      // (used for connections whose auth lives in Nango rather than Composio).
+      if (connectionId.startsWith('nango:')) {
+        const { registerAllAccountProviders } = await import('@shared/lib/account-providers/register')
+        const { getAccountProvider } = await import('@shared/lib/account-providers/provider-factory')
+        registerAllAccountProviders()
+        const nango = getAccountProvider('nango')
+        const payload = new TextEncoder().encode(JSON.stringify({ channel: channelId, text }))
+        const res = await nango.makeApiCall({
+          providerConnectionId: connectionId.slice('nango:'.length),
+          toolkitSlug: 'slack',
+          targetUrl: 'https://slack.com/api/chat.postMessage',
+          method: 'POST',
+          headers: new Headers({ 'Content-Type': 'application/json' }),
+          body: payload.buffer.slice(payload.byteOffset, payload.byteOffset + payload.byteLength) as ArrayBuffer,
+        })
+        const data = await res.json() as { ok?: boolean; error?: string; ts?: string }
+        console.log(`[live] user-send via nango (${connectionId}) status=${res.status} ok=${data?.ok} error=${data?.error ?? ''} ts=${data?.ts ?? ''}`)
+        if (!data?.ok) throw new Error(`nango user-send failed: ${data?.error}`)
+        return
+      }
+      try {
+        const { accessToken } = await getConnectionToken(connectionId)
+        const userClient = new WebClient(accessToken)
+        const res = await userClient.chat.postMessage({ channel: channelId, text })
+        console.log(`[live] user-send via token (${connectionId}) ok=${res.ok} ts=${res.ts}`)
+      } catch (err) {
+        console.log(`[live] token path unavailable for ${connectionId} (${err instanceof Error ? err.message.slice(0, 80) : err}) — using composio proxy`)
+        const res = await proxyExecute({
+          endpoint: 'https://slack.com/api/chat.postMessage',
+          method: 'POST',
+          connectedAccountId: connectionId,
+          body: { channel: channelId, text },
+        })
+        const data = res.data as { ok?: boolean; error?: string }
+        console.log(`[live] user-send via proxy (${connectionId}) status=${res.status} ok=${data?.ok} error=${data?.error ?? ''}`)
+        if (!data?.ok) throw new Error(`proxy user-send failed: ${data?.error}`)
+      }
+    }
+
+    // Multiple candidate connected accounts may exist; use the first that works.
+    let workingId: string | null = null
+    const sendAsUser = async (text: string): Promise<void> => {
+      if (workingId) return sendAsUserVia(workingId, text)
+      let lastErr: unknown
+      for (const id of connectionIds) {
+        try {
+          await sendAsUserVia(id, text)
+          workingId = id
+          return
+        } catch (err) {
+          lastErr = err
+        }
+      }
+      throw lastErr
+    }
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      const marker = `harness user ping ${Date.now()}#${attempt}`
+      const before = received.length
+      await sendAsUser(marker)
+      try {
+        await waitFor(
+          `onMessage with marker (attempt ${attempt})`,
+          () => received.slice(before).some((m) => m.text.includes(marker)),
+          15_000,
+        )
+        const match = received.slice(before).find((m) => m.text.includes(marker))!
+        expect(match.chatId).toBe(channelId)
+        expect(match.userId).toBeTruthy()
+        return
+      } catch {
+        console.log(`[live] marker not received on attempt ${attempt} — possible competing connection, retrying`)
+      }
+    }
+    throw new Error('User-authored message never reached onMessage in 3 attempts')
+  }, 120_000)
+
+  it('sends outbound on the recovered connection', async () => {
+    const ts = await connector.sendMessage(channelId, {
+      text: ':white_check_mark: harness outbound after recovery',
+    })
+    expect(ts).toBeTruthy()
+    console.log(`[live] outbound ok ts=${ts}`)
+  }, 30_000)
+})

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -7,11 +7,12 @@
  * Typing indicator via emoji reactions (Slack doesn't support bot typing).
  */
 
-import { App as SlackApp } from '@slack/bolt'
+import { App as SlackApp, SocketModeReceiver } from '@slack/bolt'
 import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
 import type { SessionActivity } from '@shared/lib/types/agent'
 import { ChatClientConnector, type OutgoingMessage } from './base-connector'
 import { describeUnsupportedRequest, isUnsupportedInChat, splitChatMessage } from './utils'
+import { isUnrecoverableSlackError } from './slack-error'
 import { captureException } from '@shared/lib/error-reporting'
 
 // ── Config ──────────────────────────────────────────────────────────────
@@ -256,8 +257,24 @@ export class SlackConnector extends ChatClientConnector {
   readonly provider = 'slack' as const
 
   private app: SlackApp | null = null
+  private receiver: SocketModeReceiver | null = null
   private connected = false
   private botUserId: string | null = null
+
+  // Own reconnect loop (mirrors IMessageConnector). The receiver is built with
+  // autoReconnectEnabled: false, so every socket drop lands here instead of in
+  // @slack/socket-mode's internal loop — which leaks unrecoverable reconnect
+  // failures as unhandled promise rejections (delayReconnectAttempt's
+  // `cb.apply(this).then(res)` has no .catch), fatal at the app level.
+  private disconnecting = false
+  // Only reconnect a socket that fully started once: a failed INITIAL connect
+  // is the manager's to retry — its late 'disconnected' event must not start a
+  // zombie loop on a connector object the manager already discarded.
+  private started = false
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectAttempts = 0
+  private static readonly BASE_RECONNECT_DELAY_MS = 1_000
+  private static readonly MAX_RECONNECT_DELAY_MS = 60_000
 
   // Track action_id → toolUseId mappings for interactive responses
   private actionDataMap: Map<string, { toolUseId: string; value: unknown; ts: number }> = new Map()
@@ -293,11 +310,25 @@ export class SlackConnector extends ChatClientConnector {
   // ── Lifecycle ───────────────────────────────────────────────────────
 
   async connect(): Promise<void> {
+    this.disconnecting = false
+    this.started = false
+    this.reconnectAttempts = 0
+
+    // Fail fast on the underlying API calls (auth.test, apps.connections.open):
+    // retry pacing belongs to our loop below and to the manager's health-check
+    // backstop, not to a WebClient silently retrying for half an hour while the
+    // manager waits on connect().
+    this.receiver = new SocketModeReceiver({
+      appToken: this.config.appToken,
+      autoReconnectEnabled: false,
+      logLevel: 'warn' as any,
+      installerOptions: { clientOptions: { retryConfig: { retries: 2 } } },
+    })
     this.app = new SlackApp({
       token: this.config.botToken,
-      appToken: this.config.appToken,
-      socketMode: true,
+      receiver: this.receiver,
       logLevel: 'warn' as any,
+      clientOptions: { retryConfig: { retries: 2 } },
     })
 
     // Catch-all for events we don't explicitly handle (Bolt requires ack for all events)
@@ -448,6 +479,18 @@ export class SlackConnector extends ChatClientConnector {
       throw new Error(`Slack bot token invalid: ${msg}`)
     }
 
+    // Track the real socket state so isConnected() is honest — the manager's
+    // health check is blind without this.
+    const client = this.receiver.client
+    client.on('connected', () => {
+      this.connected = true
+      this.reconnectAttempts = 0
+    })
+    client.on('disconnected', () => {
+      this.connected = false
+      if (!this.disconnecting && this.started) this.scheduleReconnect()
+    })
+
     // Start Socket Mode (requires valid app-level token with connections:write)
     try {
       await this.app.start()
@@ -455,12 +498,54 @@ export class SlackConnector extends ChatClientConnector {
       const msg = err instanceof Error ? err.message : String(err)
       throw new Error(`Slack Socket Mode failed to start (check app-level token and connections:write scope): ${msg}`)
     }
+    this.started = true
     this.connected = true
     console.log('[SlackConnector] Socket Mode connected')
   }
 
+  /**
+   * Restart the Socket Mode client with exponential backoff after an
+   * unexpected disconnect. Transient failures re-schedule; unrecoverable auth
+   * failures (dead workspace / revoked tokens) stop the loop and surface via
+   * onError so the manager can badge the integration and eventually auto-pause.
+   */
+  private scheduleReconnect(): void {
+    if (this.disconnecting || this.reconnectTimer) return
+    this.reconnectAttempts++
+    const delay = Math.min(
+      SlackConnector.BASE_RECONNECT_DELAY_MS * 2 ** (this.reconnectAttempts - 1),
+      SlackConnector.MAX_RECONNECT_DELAY_MS,
+    )
+    console.log(`[SlackConnector] Socket closed — reconnecting in ${delay}ms (attempt ${this.reconnectAttempts})`)
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      if (this.disconnecting || !this.receiver) return
+      this.receiver.client.start()
+        .then(() => {
+          // The 'connected' listener already restored state.
+          console.log('[SlackConnector] Socket Mode reconnected')
+        })
+        .catch((err: unknown) => {
+          if (this.disconnecting) return
+          if (isUnrecoverableSlackError(err)) {
+            console.error('[SlackConnector] Unrecoverable Slack error — stopping reconnect loop:', err)
+            this.emitError(err instanceof Error ? err : new Error(String(err)))
+            return
+          }
+          console.warn(`[SlackConnector] Reconnect attempt ${this.reconnectAttempts} failed:`, err instanceof Error ? err.message : err)
+          this.scheduleReconnect()
+        })
+    }, delay)
+  }
+
   async disconnect(): Promise<void> {
+    this.disconnecting = true
     this.connected = false
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
 
     // Remove any active reactions (before clearing thread context needed to resolve channels)
     for (const key of this.activeReactions) {
@@ -481,6 +566,7 @@ export class SlackConnector extends ChatClientConnector {
       await this.app.stop()
       this.app = null
     }
+    this.receiver = null
     console.log('[SlackConnector] Disconnected')
   }
 

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -272,6 +272,13 @@ export class SlackConnector extends ChatClientConnector {
   // zombie loop on a connector object the manager already discarded.
   private started = false
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  // The restart attempt currently in flight, if any. disconnect() can only
+  // clear the TIMER; an attempt already awaiting apps.connections.open has no
+  // socket yet, so socket-mode's disconnect() resolves without touching it —
+  // and the pending start would otherwise OPEN a socket after teardown
+  // finished. That ownerless socket still acks its share of round-robin
+  // events, silently eating messages meant for the replacement connector.
+  private restartInFlight: Promise<void> | null = null
   private reconnectAttempts = 0
   private static readonly BASE_RECONNECT_DELAY_MS = 1_000
   private static readonly MAX_RECONNECT_DELAY_MS = 60_000
@@ -317,27 +324,35 @@ export class SlackConnector extends ChatClientConnector {
     // Fail fast on the underlying API calls (auth.test, apps.connections.open):
     // retry pacing belongs to our loop below and to the manager's health-check
     // backstop, not to a WebClient silently retrying for half an hour while the
-    // manager waits on connect().
-    this.receiver = new SocketModeReceiver({
+    // manager waits on connect(). The 30s timeout matters too: WebClient's
+    // default is 0 (unbounded), so a blackholed request would otherwise wedge
+    // a connect/reconnect attempt for as long as the OS keeps the TCP open.
+    //
+    // Locals throughout this method: disconnect() nulls this.app/this.receiver,
+    // and a disconnect racing this connect used to turn that into a TypeError
+    // ("Cannot read properties of null") mid-flight (ELECTRON-3T's signature).
+    const receiver = new SocketModeReceiver({
       appToken: this.config.appToken,
       autoReconnectEnabled: false,
       logLevel: 'warn' as any,
-      installerOptions: { clientOptions: { retryConfig: { retries: 2 } } },
+      installerOptions: { clientOptions: { retryConfig: { retries: 2 }, timeout: 30_000 } },
     })
-    this.app = new SlackApp({
+    const app = new SlackApp({
       token: this.config.botToken,
-      receiver: this.receiver,
+      receiver,
       logLevel: 'warn' as any,
-      clientOptions: { retryConfig: { retries: 2 } },
+      clientOptions: { retryConfig: { retries: 2 }, timeout: 30_000 },
     })
+    this.receiver = receiver
+    this.app = app
 
     // Catch-all for events we don't explicitly handle (Bolt requires ack for all events)
-    this.app.event(/.*/, async (_ctx: any) => {
+    app.event(/.*/, async (_ctx: any) => {
       // No-op — just acknowledge so Slack doesn't retry/disconnect
     })
 
     // Handle incoming messages
-    this.app.message(async ({ message, say: _say }: { message: any; say: any }) => {
+    app.message(async ({ message, say: _say }: { message: any; say: any }) => {
       // Skip bot messages, edits, etc. — but allow file_share (user sent an image/file)
       const subtype = (message as any).subtype
       if (!message || (subtype && subtype !== 'file_share')) return
@@ -417,7 +432,7 @@ export class SlackConnector extends ChatClientConnector {
     })
 
     // Handle button clicks (interactive actions)
-    this.app.action(/^cb_\d+$/, async ({ ack, action, body }: { ack: any; action: any; body: any }) => {
+    app.action(/^cb_\d+$/, async ({ ack, action, body }: { ack: any; action: any; body: any }) => {
       await ack()
 
       const actionId = (action as any).action_id
@@ -468,7 +483,7 @@ export class SlackConnector extends ChatClientConnector {
 
     // Validate tokens before starting Socket Mode
     try {
-      const authResult = await this.app.client.auth.test()
+      const authResult = await app.client.auth.test()
       if (!authResult.ok) {
         throw new Error(`Slack auth.test failed: ${authResult.error}`)
       }
@@ -481,8 +496,12 @@ export class SlackConnector extends ChatClientConnector {
 
     // Track the real socket state so isConnected() is honest — the manager's
     // health check is blind without this.
-    const client = this.receiver.client
+    const client = receiver.client
     client.on('connected', () => {
+      // A 'connected' arriving after disconnect() began is a socket that
+      // outlived its owner (a start() that was mid-flight during teardown) —
+      // it is being closed, and must not flip a torn-down connector "live".
+      if (this.disconnecting) return
       this.connected = true
       this.reconnectAttempts = 0
     })
@@ -493,10 +512,17 @@ export class SlackConnector extends ChatClientConnector {
 
     // Start Socket Mode (requires valid app-level token with connections:write)
     try {
-      await this.app.start()
+      await app.start()
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       throw new Error(`Slack Socket Mode failed to start (check app-level token and connections:write scope): ${msg}`)
+    }
+    // disconnect() may have raced this connect (user pause, manager teardown):
+    // its app.stop() ran against a socket that didn't exist yet, so the one
+    // that just opened is ownerless — close it and report the connect failed.
+    if (this.disconnecting) {
+      await app.stop().catch(() => {})
+      throw new Error('Slack connector was disconnected during connect')
     }
     this.started = true
     this.connected = true
@@ -520,8 +546,16 @@ export class SlackConnector extends ChatClientConnector {
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null
       if (this.disconnecting || !this.receiver) return
-      this.receiver.client.start()
+      const client = this.receiver.client
+      const attempt = client.start()
         .then(() => {
+          if (this.disconnecting) {
+            // Teardown began while this attempt was awaiting its connection —
+            // the socket that just opened has no owner. Close it (socket-mode's
+            // disconnect() never rejects).
+            void client.disconnect()
+            return
+          }
           // The 'connected' listener already restored state.
           console.log('[SlackConnector] Socket Mode reconnected')
         })
@@ -532,9 +566,15 @@ export class SlackConnector extends ChatClientConnector {
             this.emitError(err instanceof Error ? err : new Error(String(err)))
             return
           }
-          console.warn(`[SlackConnector] Reconnect attempt ${this.reconnectAttempts} failed:`, err instanceof Error ? err.message : err)
+          // A websocket-stage failure rejects with undefined (socket-mode's
+          // close handler carries no error) — name it for the log.
+          console.warn(`[SlackConnector] Reconnect attempt ${this.reconnectAttempts} failed:`, err instanceof Error ? err.message : err ?? 'socket closed before connecting')
           this.scheduleReconnect()
         })
+        .finally(() => {
+          if (this.restartInFlight === attempt) this.restartInFlight = null
+        })
+      this.restartInFlight = attempt
     }, delay)
   }
 
@@ -546,6 +586,10 @@ export class SlackConnector extends ChatClientConnector {
       clearTimeout(this.reconnectTimer)
       this.reconnectTimer = null
     }
+    // Capture any restart already past its timer: it can't be cancelled, only
+    // waited out — its own success handler closes the socket it opens now that
+    // disconnecting is set (see restartInFlight).
+    const restart = this.restartInFlight
 
     // Remove any active reactions (before clearing thread context needed to resolve channels)
     for (const key of this.activeReactions) {
@@ -567,6 +611,12 @@ export class SlackConnector extends ChatClientConnector {
       this.app = null
     }
     this.receiver = null
+    // Wait for a mid-flight restart to settle: app.stop() resolves while the
+    // pending start is still awaiting apps.connections.open (no socket exists
+    // for it to close), and the start can OPEN a socket after this point. Its
+    // success handler tears that late socket down; don't report "disconnected"
+    // until it has.
+    if (restart) await restart.catch(() => {})
     console.log('[SlackConnector] Disconnected')
   }
 

--- a/src/shared/lib/chat-integrations/slack-error.test.ts
+++ b/src/shared/lib/chat-integrations/slack-error.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { isUnrecoverableSlackError } from './slack-error'
+
+// The five codes @slack/socket-mode classifies as UnrecoverableSocketModeStartError:
+// a workspace/app in this state will never reconnect no matter how often we retry,
+// so the connector must stop its loop and surface the error instead.
+const UNRECOVERABLE_CODES = [
+  'not_authed',
+  'invalid_auth',
+  'account_inactive',
+  'user_removed_from_team',
+  'team_disabled',
+]
+
+function platformError(code: string): Error {
+  const err = new Error(`An API error occurred: ${code}`) as Error & {
+    code: string
+    data: { ok: false; error: string }
+  }
+  err.code = 'slack_webapi_platform_error'
+  err.data = { ok: false, error: code }
+  return err
+}
+
+describe('isUnrecoverableSlackError', () => {
+  it.each(UNRECOVERABLE_CODES)('flags platform error %s as unrecoverable', (code) => {
+    expect(isUnrecoverableSlackError(platformError(code))).toBe(true)
+  })
+
+  it('does not flag other platform errors (transient / recoverable)', () => {
+    expect(isUnrecoverableSlackError(platformError('ratelimited'))).toBe(false)
+    expect(isUnrecoverableSlackError(platformError('internal_error'))).toBe(false)
+  })
+
+  it('does not flag network-level request errors — those are retryable', () => {
+    const err = new Error('A request error occurred: getaddrinfo ENOTFOUND slack.com') as Error & { code: string }
+    err.code = 'slack_webapi_request_error'
+    expect(isUnrecoverableSlackError(err)).toBe(false)
+  })
+
+  it('does not flag HTTP errors — Slack outages and proxies recover', () => {
+    const err = new Error('An HTTP protocol error occurred: statusCode = 503') as Error & { code: string }
+    err.code = 'slack_webapi_http_error'
+    expect(isUnrecoverableSlackError(err)).toBe(false)
+  })
+
+  it('handles plain errors, null, and malformed shapes', () => {
+    expect(isUnrecoverableSlackError(new Error('boom'))).toBe(false)
+    expect(isUnrecoverableSlackError(null)).toBe(false)
+    expect(isUnrecoverableSlackError(undefined)).toBe(false)
+    expect(isUnrecoverableSlackError('invalid_auth')).toBe(false)
+    expect(isUnrecoverableSlackError({ code: 'slack_webapi_platform_error' })).toBe(false)
+    expect(isUnrecoverableSlackError({ code: 'slack_webapi_platform_error', data: { error: 42 } })).toBe(false)
+  })
+})

--- a/src/shared/lib/chat-integrations/slack-error.ts
+++ b/src/shared/lib/chat-integrations/slack-error.ts
@@ -1,0 +1,33 @@
+/**
+ * Slack error classification for the connector's reconnect loop.
+ *
+ * The five codes below are what @slack/socket-mode calls
+ * UnrecoverableSocketModeStartError: a workspace/app in this state will never
+ * come back no matter how often we retry (revoked token, deactivated account,
+ * disabled workspace). The connector must stop its reconnect loop and surface
+ * the failure instead of hammering Slack forever.
+ *
+ * Everything else — network-level request errors, HTTP errors, other platform
+ * errors — is treated as transient and retried with backoff.
+ */
+
+const UNRECOVERABLE_SLACK_ERROR_CODES = new Set([
+  'not_authed',
+  'invalid_auth',
+  'account_inactive',
+  'user_removed_from_team',
+  'team_disabled',
+])
+
+/** @slack/web-api ErrorCode.PlatformError — an ok:false API response. */
+const SLACK_PLATFORM_ERROR_CODE = 'slack_webapi_platform_error'
+
+export function isUnrecoverableSlackError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const e = err as { code?: unknown; data?: { error?: unknown } }
+  return (
+    e.code === SLACK_PLATFORM_ERROR_CODE &&
+    typeof e.data?.error === 'string' &&
+    UNRECOVERABLE_SLACK_ERROR_CODES.has(e.data.error)
+  )
+}


### PR DESCRIPTION
## Problem

Field report (Tomer / TYP Buyers): Slack chat integration "occasionally stops responding" on the desktop app; iMessage integration stuck flagged in error state. Sentry corroborates fleet-wide: ELECTRON-3T (`SlackConnector.connect` via `reconnectAll`, 150 events / 11 users since May 26), plus the ELECTRON-3V `code=4000` bursts and ELECTRON-3G gateway timeouts on iMessage.

Root cause: **one failed reconnect attempt permanently orphaned the integration.** Both reconnect paths (`powerMonitor.resume` → `reconnectAll`, and the health-check) did `removeIntegration` → `connectIntegration`; if the connect threw (typical right after wake, while Wi-Fi is still re-associating), the integration vanished from the in-memory `connections` map — and every recovery mechanism iterated only that map. Compounding it:

- `SlackConnector.isConnected()` always returned `true` until an explicit `disconnect()`, so the health check was blind to dead Slack sockets → silent death with an `active` badge.
- No path ever wrote status `active` back after recovery → iMessage wore a permanent stale `error` badge even when its own reconnect loop had recovered.
- `removeIntegration` wiped the failure counter, making the 15-strike auto-pause unreachable.
- Fire-and-forget disconnect let old and new sockets fight over one-connection-per-identity gateways (the iMessage `code=4000` "replaced by another connection" bursts).
- `@slack/socket-mode` 2.0.6's internal reconnect leaks unrecoverable failures as unhandled promise rejections (`delayReconnectAttempt` has no `.catch`) — fatal at the app level (SUP-305).

## Fix

1. **DB-driven reconcile** — the health check's work list is now every startup-eligible integration (status `active`/`error`) from the DB, not the map. Orphans rebuild immediately; present-but-disconnected connectors get a grace window so their own faster loop goes first; failed reconnects retry every tick; the failure counter survives teardown so auto-pause actually fires (once per outage notification, not per tick).
2. **Slack connector owns its socket** — `SocketModeReceiver` built with `autoReconnectEnabled: false` (the leaky internal reconnect path never runs), own 1s→60s backoff restart loop, event-driven honest `isConnected()`, unrecoverable auth codes (`slack-error.ts`) stop the loop and surface via `onError`. Fail-fast `retryConfig` so the manager loop owns pacing.
3. **Status truth** — successful manager reconnects and connector self-recovery write `active` back.
4. **Race hardening** — `reconnectAll` coalesces overlapping resume bursts, force-reconciles, then retries at 15/30/60s instead of leaving wake failures to the 5-minute tick; `removeIntegration` awaits old-socket teardown (5s cap) before rebuild; a post-connect identity check tears down sockets whose owner was removed mid-connect.

## Testing

- **TDD throughout** — 33 new unit tests written red-first: reconcile (11), resume (6), Slack lifecycle (7), slack-error (9). Headline regressions pinned: "failed reconnect retried next tick", "wake-time failure recovers on next tick".
- **Regression** — full unit suite green; 650 tests across all files touching these modules; tsc + eslint clean.
- **Live against real Slack** (gated `*.live.test.ts`, `SLACK_LIVE=1`, never in CI):
  - Connector: raw websocket kill → drop detected in ~50ms → self-reconnect in ~1.5s → events flow post-recovery → user-authored message through the full inbound path → outbound OK.
  - Manager: orphan recovery (DB row + empty map → tick → connected + `active` writeback), takeover of a dead socket past grace (fresh connected connector), `reconnectAll` force-rebuild in ~600ms with a real inbound user message reaching the manager queue 1.8s later.

Not covered live: the one-line `powerMonitor.on('resume')` wiring (unchanged, needs a physical lid-close), real DB status writes (service fn unchanged; call contract unit-tested), iMessage connector internals (unchanged; benefits via the manager fixes).

After release, ELECTRON-3T / ELECTRON-3V / ELECTRON-3G going quiet is the field signal to watch.

https://claude.ai/code/session_01Tba7Jg6eGvxzCWvBS92HxY