### PR TITLE
Reuse context menus on agent titles and breadcrumbs

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -109,6 +109,11 @@ vi.mock('@renderer/context/nav-transient-context', () => ({
 vi.mock('@renderer/components/agents/agent-settings-dialog', () => ({
   AgentSettingsDialog: () => null,
 }))
+vi.mock('@renderer/components/agents/agent-context-menu', () => ({
+  AgentContextMenu: ({ agent, children }: { agent: ApiAgent; children: React.ReactNode }) => (
+    <div data-testid="agent-title-context-menu" data-agent-slug={agent.slug}>{children}</div>
+  ),
+}))
 vi.mock('@renderer/components/agents/system-prompt-dialog', () => ({
   SystemPromptDialog: () => null,
 }))
@@ -238,6 +243,16 @@ describe('AgentHome', () => {
       <AgentHome agent={testAgent} onSessionCreated={onSessionCreated} />
     )
     expect(screen.getByText('Test Agent')).toBeInTheDocument()
+  })
+
+  it('reuses the agent context menu on the agent title', () => {
+    renderWithProviders(
+      <AgentHome agent={testAgent} onSessionCreated={onSessionCreated} />
+    )
+
+    const contextMenu = screen.getByTestId('agent-title-context-menu')
+    expect(contextMenu).toHaveAttribute('data-agent-slug', 'test-agent')
+    expect(contextMenu).toContainElement(screen.getByTestId('agent-name'))
   })
 
   it('renames the agent inline for owners', async () => {

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -15,6 +15,7 @@ import { useNavTransient } from '@renderer/context/nav-transient-context'
 import { useNavigate } from '@tanstack/react-router'
 import { useUser } from '@renderer/context/user-context'
 import { AgentSettingsDialog } from '@renderer/components/agents/agent-settings-dialog'
+import { AgentContextMenu } from '@renderer/components/agents/agent-context-menu'
 import { SystemPromptDialog } from '@renderer/components/agents/system-prompt-dialog'
 import { toast } from 'sonner'
 import { apiFetch } from '@renderer/lib/api'
@@ -288,28 +289,32 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
         {/* Left Column — Chat composer + Sessions */}
         <div className="space-y-6 w-full min-w-0 xl:min-w-[480px] xl:max-w-[720px]">
           <div className="flex items-center justify-between gap-2 intro-step intro-step-1">
-            <InlineEditableTitle
-              value={agent.name}
-              canEdit={isOwner}
-              isSaving={updateAgent.isPending}
-              onSave={async (name) => {
-                await updateAgent.mutateAsync({ slug: agent.slug, name })
-              }}
-              onError={(error) => {
-                console.error('Failed to rename agent:', error)
-                toast.error('Failed to rename agent', {
-                  description: error instanceof Error ? error.message : 'Please try again.',
-                })
-              }}
-              displayClassName="text-xl font-semibold"
-              inputClassName="h-9 text-xl font-semibold"
-              saveButtonClassName="h-8 w-8"
-              ariaLabel="Rename agent"
-              saveAriaLabel="Save name"
-              displayTestId="agent-name"
-              inputTestId="agent-name-input"
-              saveButtonTestId="agent-name-save"
-            />
+            <AgentContextMenu agent={agent}>
+              <div className="flex-1 min-w-0 cursor-context-menu">
+                <InlineEditableTitle
+                  value={agent.name}
+                  canEdit={isOwner}
+                  isSaving={updateAgent.isPending}
+                  onSave={async (name) => {
+                    await updateAgent.mutateAsync({ slug: agent.slug, name })
+                  }}
+                  onError={(error) => {
+                    console.error('Failed to rename agent:', error)
+                    toast.error('Failed to rename agent', {
+                      description: error instanceof Error ? error.message : 'Please try again.',
+                    })
+                  }}
+                  displayClassName="text-xl font-semibold"
+                  inputClassName="h-9 text-xl font-semibold"
+                  saveButtonClassName="h-8 w-8"
+                  ariaLabel="Rename agent"
+                  saveAriaLabel="Save name"
+                  displayTestId="agent-name"
+                  inputTestId="agent-name-input"
+                  saveButtonTestId="agent-name-save"
+                />
+              </div>
+            </AgentContextMenu>
             {/* AgentHome owns the settings dialog (no onOpenSettings prop), so the
                 gear opens the local handler rather than a parent-supplied one. */}
             <Button type="button" size="icon" variant="ghost" className="h-8 w-8 shrink-0" onClick={() => handleOpenSettings()} aria-label="Agent settings" data-testid="agent-settings-button">

--- a/src/renderer/components/layout/agent-header.test.tsx
+++ b/src/renderer/components/layout/agent-header.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { AgentHeader } from './agent-header'
+import type { ApiAgent } from '@renderer/hooks/use-agents'
+
+const agent: ApiAgent = {
+  slug: 'test-agent',
+  displaySlug: 'test-agent',
+  name: 'Test Agent',
+  description: 'A test agent',
+  createdAt: new Date('2025-01-01'),
+  status: 'running',
+  containerPort: 3000,
+}
+
+vi.mock('@renderer/router/use-route-location', () => ({
+  useRouteLocation: () => ({ view: { kind: 'session', id: 'session-1' } }),
+}))
+
+vi.mock('@renderer/hooks/use-agents', () => ({
+  useAgent: () => ({ data: agent }),
+}))
+
+vi.mock('@renderer/hooks/use-sessions', () => ({
+  useSessions: () => ({ data: [] }),
+  useSession: () => ({
+    data: {
+      id: 'session-1',
+      name: 'Test Session',
+      agentSlug: 'test-agent',
+    },
+  }),
+}))
+
+vi.mock('@renderer/hooks/use-scheduled-tasks', () => ({
+  useScheduledTask: () => ({ data: undefined }),
+}))
+
+vi.mock('@renderer/hooks/use-webhook-triggers', () => ({
+  useWebhookTrigger: () => ({ data: undefined }),
+}))
+
+vi.mock('@renderer/hooks/use-runtime-status', () => ({
+  useRuntimeStatus: () => ({
+    data: {
+      runtimeReadiness: { status: 'READY', message: 'Ready' },
+      apiKeyConfigured: true,
+    },
+    isPending: false,
+  }),
+}))
+
+vi.mock('@renderer/components/ui/app-link', () => ({
+  AppLink: ({
+    children,
+    className,
+    'data-testid': testId,
+  }: {
+    children: ReactNode
+    className?: string
+    'data-testid'?: string
+  }) => <a href="/agents/test-agent" className={className} data-testid={testId}>{children}</a>,
+}))
+
+vi.mock('@renderer/components/agents/agent-context-menu', () => ({
+  AgentContextMenu: ({ agent, children }: { agent: ApiAgent; children: ReactNode }) => (
+    <div data-testid="agent-breadcrumb-context-menu" data-agent-slug={agent.slug}>{children}</div>
+  ),
+}))
+
+vi.mock('@renderer/components/sessions/session-context-menu', () => ({
+  SessionContextMenu: ({
+    sessionId,
+    sessionName,
+    agentSlug,
+    children,
+  }: {
+    sessionId: string
+    sessionName: string
+    agentSlug: string
+    children: ReactNode
+  }) => (
+    <div
+      data-testid="session-breadcrumb-context-menu"
+      data-session-id={sessionId}
+      data-session-name={sessionName}
+      data-agent-slug={agentSlug}
+    >
+      {children}
+    </div>
+  ),
+}))
+
+describe('AgentHeader breadcrumbs', () => {
+  it('reuses the agent and session context menus on their breadcrumbs', () => {
+    const mutation = { mutate: vi.fn(), isPending: false }
+    render(
+      <AgentHeader
+        slug="test-agent"
+        isViewOnly={false}
+        startAgent={mutation as never}
+        stopAgent={mutation as never}
+      />,
+    )
+
+    const agentMenu = screen.getByTestId('agent-breadcrumb-context-menu')
+    expect(agentMenu).toHaveAttribute('data-agent-slug', 'test-agent')
+    expect(agentMenu).toContainElement(screen.getByTestId('agent-breadcrumb'))
+
+    const sessionMenu = screen.getByTestId('session-breadcrumb-context-menu')
+    expect(sessionMenu).toHaveAttribute('data-session-id', 'session-1')
+    expect(sessionMenu).toHaveAttribute('data-session-name', 'Test Session')
+    expect(sessionMenu).toHaveAttribute('data-agent-slug', 'test-agent')
+    expect(sessionMenu).toContainElement(screen.getByTestId('session-breadcrumb'))
+  })
+})

--- a/src/renderer/components/layout/agent-header.tsx
+++ b/src/renderer/components/layout/agent-header.tsx
@@ -9,6 +9,7 @@ import { useConnectedAccounts } from '@renderer/hooks/use-connected-accounts'
 import { useRemoteMcps } from '@renderer/hooks/use-remote-mcps'
 import { useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
 import { AgentStatus } from '@renderer/components/agents/agent-status'
+import { AgentContextMenu } from '@renderer/components/agents/agent-context-menu'
 import { SessionContextMenu } from '@renderer/components/sessions/session-context-menu'
 import { Separator } from '@renderer/components/ui/separator'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
@@ -56,18 +57,33 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
     <>
       <div className="flex flex-col md:flex-row md:items-center gap-0 md:gap-1.5 min-w-0 flex-1">
         <div className="flex items-center gap-2 min-w-0">
-          <AppLink
-            to="/agents/$slug"
-            params={{ slug }}
-            activeOptions={{ exact: true }}
-            noDrag
-            // Route-derived leaf styling: foreground only when this link is the
-            // exact active route (`data-status=active`), muted/clickable otherwise.
-            className="text-sm font-light truncate transition-colors text-muted-foreground hover:text-foreground data-[status=active]:text-foreground"
-            data-testid="agent-breadcrumb"
-          >
-            {agent?.name || 'Loading...'}
-          </AppLink>
+          {agent ? (
+            <AgentContextMenu agent={agent}>
+              <AppLink
+                to="/agents/$slug"
+                params={{ slug }}
+                activeOptions={{ exact: true }}
+                noDrag
+                // Route-derived leaf styling: foreground only when this link is the
+                // exact active route (`data-status=active`), muted/clickable otherwise.
+                className="text-sm font-light truncate transition-colors text-muted-foreground hover:text-foreground data-[status=active]:text-foreground cursor-context-menu"
+                data-testid="agent-breadcrumb"
+              >
+                {agent.name}
+              </AppLink>
+            </AgentContextMenu>
+          ) : (
+            <AppLink
+              to="/agents/$slug"
+              params={{ slug }}
+              activeOptions={{ exact: true }}
+              noDrag
+              className="text-sm font-light truncate transition-colors text-muted-foreground hover:text-foreground data-[status=active]:text-foreground"
+              data-testid="agent-breadcrumb"
+            >
+              Loading...
+            </AppLink>
+          )}
         </div>
         {(() => {
           const taskCrumbId = scheduledTaskId ?? (sessionId ? session?.scheduledTaskId ?? null : null)


### PR DESCRIPTION
## Summary

- reuse the shared agent context menu on the agent-home title
- reuse the shared agent context menu on the top-page agent breadcrumb
- preserve the shared session context menu on the session breadcrumb and add joint regression coverage for both breadcrumb bindings

## Why

Agent and session actions should be available consistently anywhere their primary title appears, not only from the left navigation. Reusing the existing menu components keeps permissions, settings, rename, copy-log, and destructive actions aligned across surfaces.

## Validation

- `npm test -- --run src/renderer/components/agents/agent-home/agent-home.test.tsx src/renderer/components/layout/agent-header.test.tsx` (30 tests passed)
- `npm run typecheck`
- `npx eslint src/renderer/components/agents/agent-home/agent-home.tsx src/renderer/components/agents/agent-home/agent-home.test.tsx src/renderer/components/layout/agent-header.tsx src/renderer/components/layout/agent-header.test.tsx`
- `npm run dev:electron` startup smoke test
