### PR TITLE
fix: phantom unread indicators from notifications on hidden automated sessions

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -239,6 +239,7 @@ vi.mock('@shared/lib/services/session-service', () => ({
   removeMessage: vi.fn(),
   removeToolCall: vi.fn(),
   getSessionSummary: vi.fn().mockResolvedValue({ sessionIds: [], sessionCount: 0, lastActivityAt: null }),
+  readSessionMetadata: vi.fn(() => Promise.resolve({})),
 }))
 
 const mockLoadSessionUsageTotals = vi.fn()
@@ -427,10 +428,10 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, deleteSession, getSession } from '@shared/lib/services/session-service'
+import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, deleteSession, getSession, readSessionMetadata } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks, listPendingScheduledTasksByAgents } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
-import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications } from '@shared/lib/services/notification-service'
+import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { containerManager } from '@shared/lib/container/container-manager'
 import { listUserSecrets, setSecret, getSecret, keyToEnvVar, getSecretEnvVars } from '@shared/lib/services/secrets-service'
@@ -2605,6 +2606,60 @@ describe('GET /api/agents (enriched summary)', () => {
     const body = await res.json()
 
     expect(body[0].hasSessionsAwaitingInput).toBe(true)
+  })
+
+  it('raises hasUnreadNotifications for an unread on a visible session', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+    vi.mocked(getSessionSummary).mockResolvedValue({
+      sessionIds: ['sess-1'],
+      sessionCount: 1,
+      lastActivityAt: new Date(),
+    })
+    vi.mocked(getUnreadNotificationsByAgents).mockResolvedValue(new Map([['agent-1', new Set(['sess-1'])]]))
+
+    const res = await getReq(app, '/api/agents')
+    const body = await res.json()
+
+    expect(body[0].hasUnreadNotifications).toBe(true)
+  })
+
+  it('ignores unread notifications on hidden automated sessions — no session list shows them', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+    vi.mocked(getSessionSummary).mockResolvedValue({
+      sessionIds: ['sess-chat', 'sess-cron'],
+      sessionCount: 2,
+      lastActivityAt: new Date(),
+    })
+    vi.mocked(getUnreadNotificationsByAgents).mockResolvedValue(
+      new Map([['agent-1', new Set(['sess-chat', 'sess-cron'])]]),
+    )
+    vi.mocked(readSessionMetadata).mockResolvedValue({
+      'sess-chat': { isChatIntegrationSession: true },
+      'sess-cron': { isScheduledExecution: true },
+    })
+
+    const res = await getReq(app, '/api/agents')
+    const body = await res.json()
+
+    expect(body[0].hasUnreadNotifications).toBe(false)
+  })
+
+  it('counts unread on a promoted automated session — it is visible again', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+    vi.mocked(getSessionSummary).mockResolvedValue({
+      sessionIds: ['sess-cron'],
+      sessionCount: 1,
+      lastActivityAt: new Date(),
+    })
+    vi.mocked(getUnreadNotificationsByAgents).mockResolvedValue(new Map([['agent-1', new Set(['sess-cron'])]]))
+    vi.mocked(readSessionMetadata).mockResolvedValue({
+      'sess-cron': { isScheduledExecution: true, promotedToInteractive: true },
+    })
+
+    const res = await getReq(app, '/api/agents')
+    const body = await res.json()
+
+    expect(body[0].hasUnreadNotifications).toBe(true)
   })
 
   it('detects awaiting input from agent-level proxy reviews on active sessions', async () => {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -31,6 +31,7 @@ import {
   listSessions,
   listSessionsByIds,
   getSessionSummary,
+  readSessionMetadata,
   updateSessionName,
   registerSession,
   getSessionMessagesWithCompact,
@@ -90,6 +91,7 @@ import {
 } from '@shared/lib/services/skillset-service'
 import { type ArtifactInfo, listArtifactsFromFilesystem, deleteArtifactFromFilesystem, renameArtifactOnFilesystem } from '@shared/lib/services/artifact-service'
 import { getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents, deleteNotificationsBySessionIds } from '@shared/lib/services/notification-service'
+import { isHiddenAutomatedSession } from '@shared/lib/services/session-visibility'
 import { reviewManager } from '@shared/lib/proxy/review-manager'
 import { isValidApiScope } from '@shared/lib/proxy/scope-matcher'
 import { isLabelDefaultKey } from '@shared/lib/proxy/policy-sentinels'
@@ -180,10 +182,11 @@ async function enrichAgentsWithSummary(agents: ApiAgent[]): Promise<ApiAgent[]> 
   return Promise.all(
     agents.map((agent) => limit(async () => {
       // Only FS operations remain per-agent (parallelized)
-      const [sessionSummary, artifacts, agentPrefs] = await Promise.all([
+      const [sessionSummary, artifacts, agentPrefs, sessionMetadata] = await Promise.all([
         getSessionSummary(agent.slug),
         listArtifactsFromFilesystem(agent.slug),
         readAgentPreferences(agent.slug),
+        readSessionMetadata(agent.slug),
       ])
 
       const unreadSessionIds = unreadByAgent.get(agent.slug) ?? new Set<string>()
@@ -193,9 +196,12 @@ async function enrichAgentsWithSummary(agents: ApiAgent[]): Promise<ApiAgent[]> 
 
       // Compute session flags from in-memory state (no I/O needed).
       // `unreadByAgent` is already filtered to user-actionable notification types
-      // (session_complete / session_waiting); session_complete on automated sessions
-      // is suppressed at creation time, so any unread that lands here is one the
-      // user genuinely needs to see.
+      // (session_complete / session_waiting). Unread notifications on hidden
+      // automated sessions are skipped: those sessions are excluded from every
+      // session list (`excludeAutomated`), so a flag raised by them would show
+      // an unread indicator with nothing visible behind it — and no way to ever
+      // clear it. (Legacy rows exist from before creation-time suppression;
+      // session_waiting now promotes the session first, but old rows remain.)
       let hasActiveSessions = false
       let hasSessionsAwaitingInput = false
       let hasUnreadNotifications = false
@@ -208,7 +214,7 @@ async function enrichAgentsWithSummary(agents: ApiAgent[]): Promise<ApiAgent[]> 
         if (messagePersister.isSessionAwaitingInput(sessionId)) {
           hasSessionsAwaitingInput = true
         }
-        if (unreadSessionIds.has(sessionId)) {
+        if (unreadSessionIds.has(sessionId) && !isHiddenAutomatedSession(sessionMetadata[sessionId])) {
           hasUnreadNotifications = true
         }
       }

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -58,6 +58,7 @@ import { eq } from 'drizzle-orm'
 import { resolveTimezoneForAgent } from '@shared/lib/services/timezone-resolver'
 import { getFrequencyWarning, getScheduleCountWarning, validateScheduleExpression } from '@shared/lib/services/schedule-parser'
 import { finalizeAutomationStatus, getSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
+import { isHiddenAutomatedSession } from '@shared/lib/services/session-visibility'
 import { appendInformationalEntry } from '@shared/lib/services/session-transcript-append'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
@@ -876,12 +877,12 @@ class MessagePersister {
   }
 
   // Promote an automated session (cron/webhook/chat) to a regular session so it
-  // appears in the sidebar and receives completion notifications.
-  private async promoteAutomatedSession(sessionId: string, agentSlug: string): Promise<void> {
+  // appears in the sidebar and receives completion notifications. Public: the
+  // notification manager promotes on session_waiting so blocked automations
+  // surface in session lists instead of accruing unread rows nothing displays.
+  async promoteAutomatedSession(sessionId: string, agentSlug: string): Promise<void> {
     const meta = await getSessionMetadata(agentSlug, sessionId)
-    if (!meta) return
-    if (meta.promotedToInteractive) return
-    if (!meta.isScheduledExecution && !meta.isWebhookExecution && !meta.isChatIntegrationSession) return
+    if (!isHiddenAutomatedSession(meta)) return
 
     await updateSessionMetadata(agentSlug, sessionId, {
       promotedToInteractive: true,

--- a/src/shared/lib/notifications/notification-manager.test.ts
+++ b/src/shared/lib/notifications/notification-manager.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
     },
   })),
   broadcastGlobal: vi.fn(),
+  promoteAutomatedSession: vi.fn(async () => {}),
 }))
 
 vi.mock('@shared/lib/services/notification-service', () => ({
@@ -33,12 +34,16 @@ vi.mock('@shared/lib/auth/mode', () => ({
   isAuthMode: () => false,
 }))
 vi.mock('@shared/lib/container/message-persister', () => ({
-  messagePersister: { broadcastGlobal: mocks.broadcastGlobal },
+  messagePersister: {
+    broadcastGlobal: mocks.broadcastGlobal,
+    promoteAutomatedSession: mocks.promoteAutomatedSession,
+  },
 }))
 
 const mockCreateNotification = mocks.createNotification
 const mockGetSessionMetadata = mocks.getSessionMetadata
 const mockBroadcastGlobal = mocks.broadcastGlobal
+const mockPromoteAutomatedSession = mocks.promoteAutomatedSession
 
 import { notificationManager } from './notification-manager'
 
@@ -160,6 +165,53 @@ describe('triggerSessionWaitingInput — NOT gated by automated-session flag', (
     mockGetSessionMetadata.mockResolvedValue({ isChatIntegrationSession: true })
     await notificationManager.triggerSessionWaitingInput('sess-1', 'agent-x', 'file')
     expect(mockCreateNotification).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('session_waiting promotes automated sessions to interactive', () => {
+  // Session lists exclude non-promoted automated sessions, so a session_waiting
+  // notification on one would raise unread indicators that point at nothing —
+  // and could never be cleared. Every session_waiting must promote first.
+  it('triggerSessionWaitingInput promotes before creating the notification', async () => {
+    await notificationManager.triggerSessionWaitingInput('sess-1', 'agent-x', 'secret')
+
+    expect(mockPromoteAutomatedSession).toHaveBeenCalledWith('sess-1', 'agent-x')
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1)
+    expect(mockPromoteAutomatedSession.mock.invocationCallOrder[0]).toBeLessThan(
+      mockCreateNotification.mock.invocationCallOrder[0],
+    )
+  })
+
+  it('triggerSessionApiReviewWaiting promotes too — the proxy-review path was the original gap', async () => {
+    await notificationManager.triggerSessionApiReviewWaiting('sess-1', 'agent-x', 'review-1', 'Allow?')
+
+    expect(mockPromoteAutomatedSession).toHaveBeenCalledWith('sess-1', 'agent-x')
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1)
+  })
+
+  it('triggerSessionComplete does not promote', async () => {
+    await notificationManager.triggerSessionComplete('sess-1', 'agent-x')
+    expect(mockPromoteAutomatedSession).not.toHaveBeenCalled()
+  })
+
+  it('a promotion failure does not block the notification', async () => {
+    mockPromoteAutomatedSession.mockRejectedValueOnce(new Error('disk full'))
+    await notificationManager.triggerSessionWaitingInput('sess-1', 'agent-x', 'question')
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1)
+  })
+
+  it('promotes even when session_waiting notifications are disabled in settings', async () => {
+    mocks.getUserSettings.mockReturnValueOnce({
+      notifications: {
+        enabled: true,
+        sessionComplete: true,
+        sessionWaiting: false,
+        sessionScheduled: true,
+      },
+    })
+    await notificationManager.triggerSessionWaitingInput('sess-1', 'agent-x', 'secret')
+    expect(mockPromoteAutomatedSession).toHaveBeenCalledWith('sess-1', 'agent-x')
+    expect(mockCreateNotification).not.toHaveBeenCalled()
   })
 })
 

--- a/src/shared/lib/notifications/notification-manager.ts
+++ b/src/shared/lib/notifications/notification-manager.ts
@@ -17,6 +17,7 @@ import { getUserSettings } from '@shared/lib/services/user-settings-service'
 import { isAuthMode } from '@shared/lib/auth/mode'
 import { getAgent } from '@shared/lib/services/agent-service'
 import { getSessionMetadata } from '@shared/lib/services/session-service'
+import { isHiddenAutomatedSession } from '@shared/lib/services/session-visibility'
 
 class NotificationManager {
   /**
@@ -81,6 +82,19 @@ class NotificationManager {
   }): Promise<void> {
     const { type, sessionId, agentSlug, title, body, actions, actionContext, extra } = params
 
+    // A blocked automated session must become visible: session lists exclude
+    // non-promoted automated sessions, so a session_waiting notification on one
+    // would raise unread indicators pointing at nothing — and could never be
+    // cleared. Promote first (idempotent, no-op for non-automated sessions),
+    // and before the settings check: visibility isn't a notification pref.
+    if (type === 'session_waiting') {
+      try {
+        await messagePersister.promoteAutomatedSession(sessionId, agentSlug)
+      } catch (error) {
+        console.error('[NotificationManager] Failed to promote automated session:', error)
+      }
+    }
+
     // Skip if notification type is disabled in settings
     if (!this.isNotificationTypeEnabled(type)) {
       return
@@ -132,10 +146,7 @@ class NotificationManager {
     agentName?: string
   ): Promise<void> {
     const meta = await getSessionMetadata(agentSlug, sessionId)
-    if (
-      !meta?.promotedToInteractive &&
-      (meta?.isScheduledExecution || meta?.isWebhookExecution || meta?.isChatIntegrationSession)
-    ) {
+    if (isHiddenAutomatedSession(meta)) {
       return
     }
     const displayName = agentName || await this.getAgentDisplayName(agentSlug)

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -25,6 +25,7 @@ import {
   ensureDirectory,
 } from '@shared/lib/utils/file-storage'
 import { sessionMetadataMapSchema } from './session-metadata-schema'
+import { isHiddenAutomatedSession } from './session-visibility'
 import {
   SessionInfo,
   SessionMetadata,
@@ -374,11 +375,7 @@ export async function listSessions(
   // Read session metadata (includes newly created sessions without JSONL yet)
   const metadata = await readSessionMetadata(agentSlug)
 
-  const isAutomated = (sessionId: string) => {
-    const meta = metadata[sessionId]
-    if (meta?.promotedToInteractive) return false
-    return meta?.isScheduledExecution || meta?.isWebhookExecution || meta?.isChatIntegrationSession
-  }
+  const isAutomated = (sessionId: string) => isHiddenAutomatedSession(metadata[sessionId])
 
   // Track which sessions we've processed
   const processedSessionIds = new Set<string>()
@@ -474,11 +471,7 @@ export async function listSessionsByIds(
 ): Promise<SessionInfo[]> {
   if (sessionIds.length === 0) return []
   const metadata = await readSessionMetadata(agentSlug)
-  const isAutomated = (sessionId: string) => {
-    const meta = metadata[sessionId]
-    if (meta?.promotedToInteractive) return false
-    return meta?.isScheduledExecution || meta?.isWebhookExecution || meta?.isChatIntegrationSession
-  }
+  const isAutomated = (sessionId: string) => isHiddenAutomatedSession(metadata[sessionId])
   const limit = pLimit(10)
   const sessions = await Promise.all(
     [...new Set(sessionIds)].map((sessionId) =>

--- a/src/shared/lib/services/session-visibility.test.ts
+++ b/src/shared/lib/services/session-visibility.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { isHiddenAutomatedSession } from './session-visibility'
+
+describe('isHiddenAutomatedSession', () => {
+  it('is false for missing metadata (unknown sessions are treated as interactive)', () => {
+    expect(isHiddenAutomatedSession(undefined)).toBe(false)
+    expect(isHiddenAutomatedSession(null)).toBe(false)
+  })
+
+  it('is false for a plain interactive session', () => {
+    expect(isHiddenAutomatedSession({ name: 'My session' })).toBe(false)
+  })
+
+  it('is true for each automation kind', () => {
+    expect(isHiddenAutomatedSession({ isScheduledExecution: true })).toBe(true)
+    expect(isHiddenAutomatedSession({ isWebhookExecution: true })).toBe(true)
+    expect(isHiddenAutomatedSession({ isChatIntegrationSession: true })).toBe(true)
+  })
+
+  it('is false once the session is promoted to interactive', () => {
+    expect(isHiddenAutomatedSession({ isScheduledExecution: true, promotedToInteractive: true })).toBe(false)
+    expect(isHiddenAutomatedSession({ isChatIntegrationSession: true, promotedToInteractive: true })).toBe(false)
+  })
+
+  it('is false when automation flags are explicitly false', () => {
+    expect(
+      isHiddenAutomatedSession({
+        isScheduledExecution: false,
+        isWebhookExecution: false,
+        isChatIntegrationSession: false,
+      }),
+    ).toBe(false)
+  })
+})

--- a/src/shared/lib/services/session-visibility.ts
+++ b/src/shared/lib/services/session-visibility.ts
@@ -1,0 +1,14 @@
+import type { SessionMetadata } from '@shared/lib/types/agent'
+
+/**
+ * True when a session is automated (scheduled / webhook / chat integration)
+ * and has not been promoted to interactive. These sessions are excluded from
+ * every user-facing session list (`excludeAutomated`), so per-session signals
+ * derived elsewhere — unread-notification flags, badge dots — must skip them
+ * too: a signal on a hidden session points at nothing the user can see or
+ * clear, and it can never be marked read.
+ */
+export function isHiddenAutomatedSession(meta: SessionMetadata | null | undefined): boolean {
+  if (!meta || meta.promotedToInteractive) return false
+  return !!(meta.isScheduledExecution || meta.isWebhookExecution || meta.isChatIntegrationSession)
+}


### PR DESCRIPTION
## Problem

On the team deployment, agents pulse the blue unread indicator on the home graph (and would show the sidebar dot) with no visible notification behind it: no unread session row appears anywhere, and nothing can ever mark the underlying notifications read.

Root cause is a disagreement between two code paths:

- `enrichAgentsWithSummary` raises `hasUnreadNotifications` for any unread actionable notification whose session transcript exists — including **non-promoted automated sessions** (scheduled / webhook / chat integration).
- Every session list the user sees (`listSessions` / `listSessionsByIds` with `excludeAutomated: true`) hides exactly those sessions.

Live data confirmed 5 agents in this state (one with 237 stuck unread rows). Two populations:

1. Legacy `session_complete` rows on chat-integration sessions, created before creation-time suppression shipped.
2. Ongoing `session_waiting` rows from the **proxy API-review path** (`triggerSessionApiReviewWaiting`), which — unlike the container awaiting-input path — never promoted the automated session to interactive, so the session stayed hidden while the review notifications accrued.

## Fix

- **Flag**: `enrichAgentsWithSummary` skips unread notifications on hidden automated sessions, so the indicator only lights for sessions a list can actually show. Shared predicate `isHiddenAutomatedSession` in `session-visibility.ts` (own module so partial `vi.mock`s of session-service can't clobber it) replaces three inline copies of the rule.
- **Promotion gap**: every `session_waiting` now promotes the automated session first, at the notification-manager chokepoint (covers the review path and all ten message-persister waiting paths). Promotion runs before the notification-settings check — visibility isn't a notification preference. `messagePersister.promoteAutomatedSession` is now public and idempotent-guarded by the same predicate.

Existing stuck rows stop pulsing immediately via the flag fix; a data cleanup of the legacy unread rows is intentionally out of scope.

## Tests

- `session-visibility.test.ts`: predicate cases (missing meta, each automation kind, promoted, explicit-false flags).
- `notification-manager.test.ts`: promotion ordering before `createNotification`, review-path promotion, no promotion on `session_complete`, promotion failure doesn't block the notification, promotion still runs when the waiting notification type is disabled.
- `agents.test.ts`: enrichment counts unread on visible sessions, skips hidden automated sessions, counts promoted automated sessions.

https://claude.ai/code/session_01FVvT23ZDnvAUMqvBJzXSmu