### PR TITLE
fix(mcp): surface the authorization server's rejection reason when OAuth setup fails

### DIFF
--- a/src/api/routes/remote-mcps.test.ts
+++ b/src/api/routes/remote-mcps.test.ts
@@ -37,6 +37,7 @@ const mockDiscoverOAuthMetadata = vi.fn()
 const mockValidateAndConsumeOAuthErrorResponse = vi.fn()
 
 vi.mock('@shared/lib/mcp/oauth', () => ({
+  McpOAuthSetupError: class McpOAuthSetupError extends Error {},
   initiateOAuthFlow: (...args: unknown[]) => mockInitiateOAuthFlow(...args),
   initiateNewServerOAuth: (...args: unknown[]) => mockInitiateNewServerOAuth(...args),
   completeOAuthFlow: (...args: unknown[]) => mockCompleteOAuthFlow(...args),
@@ -1002,6 +1003,27 @@ describe('SSRF protection', () => {
       const [, , candidates, electron] = mockInitiateNewServerOAuth.mock.calls[0]
       expect(electron).toBe(false)
       expect(candidates).toEqual(['http://localhost:3000/api/remote-mcps/oauth-callback'])
+    })
+  })
+
+  describe('POST /initiate-oauth — surfaces OAuth setup failures', () => {
+    it('returns the setup error message when the authorization server rejects registration', async () => {
+      const { McpOAuthSetupError } = await import('@shared/lib/mcp/oauth')
+      mockInitiateNewServerOAuth.mockRejectedValue(
+        new McpOAuthSetupError(
+          'The authorization server rejected client registration (HTTP 400): redirect_uri is not allowed by the account configuration'
+        )
+      )
+
+      const res = await app.request('http://localhost/api/remote-mcps/initiate-oauth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Locked Down', url: 'https://mcp.example.com/mcp' }),
+      })
+
+      expect(res.status).toBe(500)
+      const body = await res.json()
+      expect(body.error).toContain('redirect_uri is not allowed by the account configuration')
     })
   })
 

--- a/src/api/routes/remote-mcps.ts
+++ b/src/api/routes/remote-mcps.ts
@@ -9,6 +9,7 @@ import {
   completeOAuthFlow,
   validateAndConsumeOAuthErrorResponse,
   discoverOAuthMetadata,
+  McpOAuthSetupError,
 } from '@shared/lib/mcp/oauth'
 import type { McpToolInfo } from '@shared/lib/mcp/types'
 import { getAppBaseUrlFromRequest, getCurrentUserId } from '@shared/lib/auth/config'
@@ -306,7 +307,13 @@ remoteMcps.post('/initiate-oauth', async (c) => {
       return c.json({ error: 'MCP server not found' }, 404)
     }
 
-    const result = await initiateOAuthFlow(body.mcpId, server.url, redirectCandidates, !!body.electron, clientNameOverride, clientIdOverride, clientSecretOverride)
+    let result
+    try {
+      result = await initiateOAuthFlow(body.mcpId, server.url, redirectCandidates, !!body.electron, clientNameOverride, clientIdOverride, clientSecretOverride)
+    } catch (e) {
+      if (e instanceof McpOAuthSetupError) return c.json({ error: e.message }, 500)
+      throw e
+    }
 
     if (!result) {
       const discoveryResult = await discoverOAuthMetadata(server.url)
@@ -325,7 +332,13 @@ remoteMcps.post('/initiate-oauth', async (c) => {
     }
 
     // New server: OAuth-first flow (no DB insert yet)
-    const result = await initiateNewServerOAuth(body.url.trim(), body.name.trim(), redirectCandidates, !!body.electron, getCurrentUserId(c), clientNameOverride, clientIdOverride, clientSecretOverride)
+    let result
+    try {
+      result = await initiateNewServerOAuth(body.url.trim(), body.name.trim(), redirectCandidates, !!body.electron, getCurrentUserId(c), clientNameOverride, clientIdOverride, clientSecretOverride)
+    } catch (e) {
+      if (e instanceof McpOAuthSetupError) return c.json({ error: e.message }, 500)
+      throw e
+    }
 
     if (!result) {
       const discoveryResult = await discoverOAuthMetadata(body.url.trim())

--- a/src/shared/lib/mcp/oauth.test.ts
+++ b/src/shared/lib/mcp/oauth.test.ts
@@ -33,6 +33,7 @@ import {
   registerDynamicClient,
   initiateOAuthFlow,
   initiateNewServerOAuth,
+  McpOAuthSetupError,
   completeOAuthFlow,
   validateAndConsumeOAuthErrorResponse,
   refreshMcpToken,
@@ -376,26 +377,62 @@ describe('oauth', () => {
       })
     })
 
-    it('returns null on registration failure', async () => {
+    it('throws with HTTP status on registration failure', async () => {
       mockFetch.mockResolvedValueOnce(new Response(null, { status: 400 }))
 
-      const result = await registerDynamicClient(
-        'https://auth.example.com/register',
-        'http://localhost/callback',
-        'Superagent'
-      )
-      expect(result).toBeNull()
+      await expect(
+        registerDynamicClient(
+          'https://auth.example.com/register',
+          'http://localhost/callback',
+          'Superagent'
+        )
+      ).rejects.toThrow('The authorization server rejected client registration (HTTP 400)')
     })
 
-    it('returns null on network error', async () => {
+    it('surfaces the error_description from a rejection body (Cloudflare Access case)', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: 'invalid_client_metadata',
+            error_description: 'redirect_uri is not allowed by the account configuration',
+          }),
+          { status: 400 }
+        )
+      )
+
+      await expect(
+        registerDynamicClient(
+          'https://auth.example.com/register',
+          'http://localhost/callback',
+          'Superagent'
+        )
+      ).rejects.toThrow(
+        'The authorization server rejected client registration (HTTP 400): invalid_client_metadata: redirect_uri is not allowed by the account configuration'
+      )
+    })
+
+    it('surfaces a bare-text rejection body (Figma case)', async () => {
+      mockFetch.mockResolvedValueOnce(new Response('Forbidden', { status: 403 }))
+
+      await expect(
+        registerDynamicClient(
+          'https://auth.example.com/register',
+          'http://localhost/callback',
+          'Superagent'
+        )
+      ).rejects.toThrow('The authorization server rejected client registration (HTTP 403): Forbidden')
+    })
+
+    it('throws a setup error on network error', async () => {
       mockFetch.mockRejectedValueOnce(new Error('Network error'))
 
-      const result = await registerDynamicClient(
-        'https://auth.example.com/register',
-        'http://localhost/callback',
-        'Superagent'
-      )
-      expect(result).toBeNull()
+      await expect(
+        registerDynamicClient(
+          'https://auth.example.com/register',
+          'http://localhost/callback',
+          'Superagent'
+        )
+      ).rejects.toThrow(McpOAuthSetupError)
     })
   })
 
@@ -711,15 +748,16 @@ describe('oauth', () => {
         { oauthClientId: 'client-id' },
       ])
 
-      const result = await initiateOAuthFlow(
-        'mcp-1',
-        'https://mcp.example.com/mcp',
-        ['http://localhost:3000/callback']
-      )
-      expect(result).toBeNull()
+      await expect(
+        initiateOAuthFlow(
+          'mcp-1',
+          'https://mcp.example.com/mcp',
+          ['http://localhost:3000/callback']
+        )
+      ).rejects.toThrow('does not support the required S256 PKCE method')
     })
 
-    it('returns null when no client_id is available', async () => {
+    it('throws a setup error when no client_id is available', async () => {
       setupDiscoveryMocks()
 
       // DB: no existing oauthClientId, no registration endpoint in metadata
@@ -730,12 +768,54 @@ describe('oauth', () => {
         { oauthClientId: null, oauthClientSecret: null },
       ])
 
+      await expect(
+        initiateOAuthFlow(
+          'mcp-1',
+          'https://mcp.example.com/mcp',
+          ['http://localhost:3000/callback']
+        )
+      ).rejects.toThrow('does not support automatic client registration')
+    })
+
+    it('falls back to the stored client when dynamic registration is rejected', async () => {
+      // Probe: 401
+      mockFetch.mockResolvedValueOnce(
+        new Response(null, {
+          status: 401,
+          headers: { 'WWW-Authenticate': 'Bearer' },
+        })
+      )
+      // Well-known: metadata WITH a registration endpoint
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            registration_endpoint: 'https://auth.example.com/register',
+          }),
+          { status: 200 }
+        )
+      )
+      // Registration: rejected
+      mockFetch.mockResolvedValueOnce(new Response('Forbidden', { status: 403 }))
+
+      // DB: existing server has stored credentials from a prior registration
+      mockDbFrom.mockReturnValue({ where: mockWhere })
+      mockWhere.mockReturnValue({ limit: mockLimit })
+      mockLimit.mockResolvedValue([
+        { oauthClientId: 'stored-client-id', oauthClientSecret: 'stored-secret' },
+      ])
+      mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) })
+
       const result = await initiateOAuthFlow(
         'mcp-1',
         'https://mcp.example.com/mcp',
         ['http://localhost:3000/callback']
       )
-      expect(result).toBeNull()
+
+      expect(result).not.toBeNull()
+      const url = new URL(result!.authorizationUrl)
+      expect(url.searchParams.get('client_id')).toBe('stored-client-id')
     })
   })
 
@@ -878,6 +958,42 @@ describe('oauth', () => {
       expect(JSON.parse(registerCalls[1][1].body).redirect_uris).toEqual([loopback])
     })
 
+    it('propagates the last rejection reason when DCR rejects every redirect candidate', async () => {
+      setupNewServerDcrDiscovery()
+      // DCR #1: custom scheme rejected.
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: 'invalid_client_metadata',
+            error_description: 'redirect_uri is not allowed by the account configuration',
+          }),
+          { status: 400 }
+        )
+      )
+      // DCR #2: loopback rejected too.
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: 'invalid_client_metadata',
+            error_description: 'redirect_uri is not allowed by the account configuration',
+          }),
+          { status: 400 }
+        )
+      )
+
+      await expect(
+        initiateNewServerOAuth(
+          'https://mcp.example.com/mcp',
+          'Locked Down',
+          ['superagent://mcp-oauth-callback', 'http://localhost:47891/api/remote-mcps/oauth-callback'],
+          true,
+          'user-1'
+        )
+      ).rejects.toThrow(
+        'The authorization server rejected client registration (HTTP 400): invalid_client_metadata: redirect_uri is not allowed by the account configuration'
+      )
+    })
+
     it('uses the preferred (custom scheme) redirect when DCR accepts it', async () => {
       setupNewServerDcrDiscovery()
       // DCR #1: custom scheme accepted — no fallback needed.
@@ -974,7 +1090,7 @@ describe('oauth', () => {
       expect(url.searchParams.get('client_id')).toBe('manual-client-id')
     })
 
-    it('returns null when dynamic registration is not available', async () => {
+    it('throws a setup error when dynamic registration is not available', async () => {
       // Discovery without registration_endpoint
       mockFetch.mockResolvedValueOnce(
         new Response(null, {
@@ -993,12 +1109,13 @@ describe('oauth', () => {
         )
       )
 
-      const result = await initiateNewServerOAuth(
-        'https://mcp.example.com/mcp',
-        'New MCP',
-        ['http://localhost/callback']
-      )
-      expect(result).toBeNull()
+      await expect(
+        initiateNewServerOAuth(
+          'https://mcp.example.com/mcp',
+          'New MCP',
+          ['http://localhost/callback']
+        )
+      ).rejects.toThrow('does not support automatic client registration')
     })
   })
 

--- a/src/shared/lib/mcp/oauth.ts
+++ b/src/shared/lib/mcp/oauth.ts
@@ -6,6 +6,39 @@ import { validateMcpDiscoveryUrl } from '@shared/lib/utils/url-safety'
 import type { OAuthMetadata, OAuthTokenResponse } from './types'
 
 /**
+ * OAuth setup failure whose message is safe to show in the UI verbatim. Carries
+ * the authorization server's own error/error_description (e.g. a dynamic client
+ * registration rejection reason) so users see why a connection failed instead
+ * of a generic "Failed to initiate OAuth flow".
+ */
+export class McpOAuthSetupError extends Error {}
+
+/**
+ * Summarize an OAuth error response body for a user-facing message: prefer the
+ * RFC 6749 error/error_description fields, fall back to the raw (truncated)
+ * body — some servers reject with a bare-text body (e.g. Figma's "Forbidden").
+ */
+async function describeOAuthErrorBody(res: Response): Promise<string> {
+  let text: string
+  try {
+    text = (await res.text()).trim()
+  } catch {
+    return ''
+  }
+  if (!text) return ''
+  try {
+    const parsed = JSON.parse(text) as { error?: unknown; error_description?: unknown }
+    const detail = [parsed.error, parsed.error_description]
+      .filter((v): v is string => typeof v === 'string' && v.length > 0)
+      .join(': ')
+    if (detail) return `: ${detail}`
+  } catch {
+    // Not JSON — fall through to the raw body
+  }
+  return `: ${text.slice(0, 200)}`
+}
+
+/**
  * Build the candidate well-known metadata URLs for an authorization server.
  *
  * For issuers with a path, RFC 8414 inserts /.well-known/<name> between origin
@@ -173,14 +206,16 @@ export async function discoverOAuthMetadata(mcpUrl: string): Promise<{
 
 /**
  * Register a dynamic client with the authorization server (RFC 7591).
+ * Throws McpOAuthSetupError with the server's rejection reason on failure.
  */
 export async function registerDynamicClient(
   registrationEndpoint: string,
   redirectUri: string,
   clientName: string,
-): Promise<{ clientId: string; clientSecret?: string; scope?: string } | null> {
+): Promise<{ clientId: string; clientSecret?: string; scope?: string }> {
+  let res: Response
   try {
-    const res = await fetch(registrationEndpoint, {
+    res = await fetch(registrationEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -191,18 +226,27 @@ export async function registerDynamicClient(
         token_endpoint_auth_method: 'none',
       }),
     })
-
-    if (!res.ok) return null
-
-    const data = (await res.json()) as {
-      client_id: string
-      client_secret?: string
-      scope?: string
-    }
-    return { clientId: data.client_id, clientSecret: data.client_secret, scope: data.scope }
-  } catch {
-    return null
+  } catch (error) {
+    throw new McpOAuthSetupError(
+      `Could not reach the authorization server's registration endpoint: ${error instanceof Error ? error.message : String(error)}`,
+    )
   }
+
+  if (!res.ok) {
+    throw new McpOAuthSetupError(
+      `The authorization server rejected client registration (HTTP ${res.status})${await describeOAuthErrorBody(res)}`,
+    )
+  }
+
+  let data: { client_id: string; client_secret?: string; scope?: string }
+  try {
+    data = await res.json()
+  } catch {
+    throw new McpOAuthSetupError(
+      'The authorization server returned an invalid client registration response',
+    )
+  }
+  return { clientId: data.client_id, clientSecret: data.client_secret, scope: data.scope }
 }
 
 /**
@@ -219,14 +263,19 @@ async function registerDynamicClientWithFallback(
   registrationEndpoint: string,
   redirectCandidates: string[],
   clientName: string,
-): Promise<{ clientId: string; clientSecret?: string; scope?: string; redirectUri: string } | null> {
+): Promise<{ clientId: string; clientSecret?: string; scope?: string; redirectUri: string }> {
+  let lastError: McpOAuthSetupError | undefined
   for (const redirectUri of redirectCandidates) {
-    const registration = await registerDynamicClient(registrationEndpoint, redirectUri, clientName)
-    if (registration) {
+    try {
+      const registration = await registerDynamicClient(registrationEndpoint, redirectUri, clientName)
       return { ...registration, redirectUri }
+    } catch (error) {
+      if (!(error instanceof McpOAuthSetupError)) throw error
+      console.error(`[mcp/oauth] Dynamic registration failed for redirect ${redirectUri}:`, error.message)
+      lastError = error
     }
   }
-  return null
+  throw lastError ?? new McpOAuthSetupError('No redirect URLs available for client registration')
 }
 
 type PendingOAuthFlow = {
@@ -362,7 +411,9 @@ export async function initiateOAuthFlow(
   const supportedMethods = metadata.code_challenge_methods_supported || []
   if (supportedMethods.length > 0 && !supportedMethods.includes('S256')) {
     console.error('[mcp/oauth] Server does not support S256 PKCE')
-    return null
+    throw new McpOAuthSetupError(
+      `The authorization server does not support the required S256 PKCE method (supports: ${supportedMethods.join(', ')})`,
+    )
   }
 
   // Resolve client credentials: explicit override > dynamic registration > stored.
@@ -389,20 +440,25 @@ export async function initiateOAuthFlow(
     // self-heals which redirect the AS accepts (custom scheme vs http loopback)
     // and re-binds to the current loopback port, so a client first registered
     // against a rejected scheme or a stale port doesn't break reconnection.
-    const registration = await registerDynamicClientWithFallback(
-      metadata.registration_endpoint,
-      redirectCandidates,
-      clientNameOverride && clientNameOverride.length > 0 ? clientNameOverride : 'Superagent',
-    )
-    if (registration) {
+    try {
+      const registration = await registerDynamicClientWithFallback(
+        metadata.registration_endpoint,
+        redirectCandidates,
+        clientNameOverride && clientNameOverride.length > 0 ? clientNameOverride : 'Superagent',
+      )
       clientId = registration.clientId
       clientSecret = registration.clientSecret
       registeredScope = registration.scope
       redirectUri = registration.redirectUri
-    } else if (existing?.oauthClientId) {
-      // Registration failed unexpectedly — fall back to the stored client.
-      clientId = existing.oauthClientId
-      clientSecret = existing.oauthClientSecret || undefined
+    } catch (error) {
+      if (!(error instanceof McpOAuthSetupError)) throw error
+      if (existing?.oauthClientId) {
+        // Registration failed unexpectedly — fall back to the stored client.
+        clientId = existing.oauthClientId
+        clientSecret = existing.oauthClientSecret || undefined
+      } else {
+        throw error
+      }
     }
   } else if (existing?.oauthClientId) {
     clientId = existing.oauthClientId
@@ -411,7 +467,9 @@ export async function initiateOAuthFlow(
 
   if (!clientId) {
     console.error('[mcp/oauth] No client_id available')
-    return null
+    throw new McpOAuthSetupError(
+      'The authorization server does not support automatic client registration — provide an OAuth Client ID in the advanced connection options',
+    )
   }
 
   // Generate PKCE and state
@@ -506,7 +564,9 @@ export async function initiateNewServerOAuth(
   const supportedMethods = metadata.code_challenge_methods_supported || []
   if (supportedMethods.length > 0 && !supportedMethods.includes('S256')) {
     console.error('[mcp/oauth] Server does not support S256 PKCE')
-    return null
+    throw new McpOAuthSetupError(
+      `The authorization server does not support the required S256 PKCE method (supports: ${supportedMethods.join(', ')})`,
+    )
   }
 
   let clientId: string | undefined
@@ -526,17 +586,17 @@ export async function initiateNewServerOAuth(
       redirectCandidates,
       clientNameOverride && clientNameOverride.length > 0 ? clientNameOverride : 'Superagent',
     )
-    if (registration) {
-      clientId = registration.clientId
-      clientSecret = registration.clientSecret
-      registeredScope = registration.scope
-      redirectUri = registration.redirectUri
-    }
+    clientId = registration.clientId
+    clientSecret = registration.clientSecret
+    registeredScope = registration.scope
+    redirectUri = registration.redirectUri
   }
 
   if (!clientId) {
     console.error('[mcp/oauth] No client_id available — provide an OAuth Client ID or use a server that supports dynamic registration')
-    return null
+    throw new McpOAuthSetupError(
+      'The authorization server does not support automatic client registration — provide an OAuth Client ID in the advanced connection options',
+    )
   }
 
   const { codeVerifier, codeChallenge } = generatePKCE()


### PR DESCRIPTION
## Problem

A user reported `Error: Failed to initiate OAuth flow` on the in-chat MCP connect card for two different servers (Figma MCP and a Cloudflare Access-protected Postgres MCP). Probing both showed two unrelated root causes that rendered identically because every OAuth setup failure collapsed into the same generic message:

- **Figma** (`mcp.figma.com/mcp`): the DCR endpoint allowlists client names — `client_name: "Superagent"` gets a bare-text `403 Forbidden` regardless of redirect URI.
- **Cloudflare Access** (`pg-mcp.mindtrip.ai/mcp`): DCR accepts only loopback redirects — the hosted web app's https redirect gets `400 invalid_client_metadata: redirect_uri is not allowed by the account configuration`.

Neither reason was visible in the UI or logs: `registerDynamicClient` returned `null` on any `!res.ok` without reading the body.

## Change

- New `McpOAuthSetupError` in `src/shared/lib/mcp/oauth.ts` whose message is safe to surface verbatim. Registration failures now throw it, carrying the AS's RFC 6749 `error`/`error_description` when the body is JSON, falling back to the raw text (truncated) for bare-text rejections like Figma's.
- The other silent-null paths throw typed errors too: no S256 PKCE support (includes what the server does support) and no registration endpoint (points at the Client ID advanced option). `initiateOAuthFlow`'s re-auth fallback to the stored client is preserved; `null` now cleanly means discovery failed / no auth required, keeping the route's re-discovery check intact.
- `/api/remote-mcps/initiate-oauth` catches `McpOAuthSetupError` and returns its message, which the connect card and connections dialog already display as-is.

The two reported cases now render as:
- `The authorization server rejected client registration (HTTP 400): invalid_client_metadata: redirect_uri is not allowed by the account configuration`
- `The authorization server rejected client registration (HTTP 403): Forbidden`

## Tests

Updated the null-contract tests to expect throws and added coverage for the probe-verified shapes: CF Access's `error_description` body, Figma's bare-text 403, all-redirect-candidates-rejected propagating the last reason, stored-client re-auth fallback on rejected registration, and a route test asserting the message reaches the HTTP response. 109/109 pass; lint clean; tsc failures are pre-existing in an untouched file (`markdown-composer-editor.tsx`).

https://claude.ai/code/session_01NHL9GbvNgFAiC19e6PnK2i