### PR TITLE
SUP-420: Redact chat integration credentials from API responses

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -435,6 +435,7 @@ import { messagePersister } from '@shared/lib/container/message-persister'
 import { containerManager } from '@shared/lib/container/container-manager'
 import { listUserSecrets, setSecret, getSecret, keyToEnvVar, getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { readJsonFileStrict, writeJsonFileAtomic } from '@shared/lib/utils/file-storage'
+import { listChatIntegrations } from '@shared/lib/services/chat-integration-service'
 
 // ============================================================================
 // Test Helpers
@@ -445,6 +446,46 @@ function createApp() {
   app.route('/api/agents', agents)
   return app
 }
+
+describe('SUP-420 — GET /:id/chat-integrations', () => {
+  it('redacts credentials from every list row', async () => {
+    vi.mocked(listChatIntegrations).mockReturnValueOnce([{
+      id: 'integration-1',
+      agentSlug: 'test-agent',
+      provider: 'telegram',
+      name: 'Alerts bot',
+      config: JSON.stringify({
+        botToken: 'telegram-viewer-secret',
+        chatId: 'private-chat-id',
+        draftStreaming: true,
+      }),
+      showToolCalls: false,
+      requireApproval: true,
+      sessionTimeout: null,
+      model: null,
+      effort: null,
+      speed: null,
+      status: 'active',
+      errorMessage: null,
+      createdByUserId: 'owner-user',
+      createdAt: new Date('2026-07-17T00:00:00Z'),
+      updatedAt: new Date('2026-07-17T00:00:00Z'),
+    }])
+
+    const res = await getReq(createApp(), '/api/agents/test-agent/chat-integrations')
+    const body = await res.json() as Array<Record<string, unknown>>
+
+    expect(res.status).toBe(200)
+    expect(body[0]).not.toHaveProperty('config')
+    expect(body[0]).toMatchObject({
+      id: 'integration-1',
+      hasCredentials: true,
+      settings: { draftStreaming: true },
+    })
+    expect(JSON.stringify(body)).not.toContain('telegram-viewer-secret')
+    expect(JSON.stringify(body)).not.toContain('private-chat-id')
+  })
+})
 
 async function patchJson(app: Hono, url: string, body: unknown): Promise<Response> {
   return app.request(`http://localhost${url}`, {

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -447,7 +447,42 @@ function createApp() {
   return app
 }
 
-describe('SUP-420 — GET /:id/chat-integrations', () => {
+async function patchJson(app: Hono, url: string, body: unknown): Promise<Response> {
+  return app.request(`http://localhost${url}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+async function postJson(app: Hono, url: string, body: unknown): Promise<Response> {
+  return app.request(`http://localhost${url}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+async function deleteReq(app: Hono, url: string): Promise<Response> {
+  return app.request(`http://localhost${url}`, { method: 'DELETE' })
+}
+
+async function getReq(app: Hono, url: string): Promise<Response> {
+  return app.request(`http://localhost${url}`, { method: 'GET' })
+}
+
+async function postFormData(app: Hono, url: string, body: FormData): Promise<Response> {
+  return app.request(`http://localhost${url}`, {
+    method: 'POST',
+    body,
+  })
+}
+
+// ============================================================================
+// Chat integrations — GET /:id/chat-integrations
+// ============================================================================
+
+describe('GET /:id/chat-integrations', () => {
   it('redacts credentials from every list row', async () => {
     vi.mocked(listChatIntegrations).mockReturnValueOnce([{
       id: 'integration-1',
@@ -486,37 +521,6 @@ describe('SUP-420 — GET /:id/chat-integrations', () => {
     expect(JSON.stringify(body)).not.toContain('private-chat-id')
   })
 })
-
-async function patchJson(app: Hono, url: string, body: unknown): Promise<Response> {
-  return app.request(`http://localhost${url}`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-}
-
-async function postJson(app: Hono, url: string, body: unknown): Promise<Response> {
-  return app.request(`http://localhost${url}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-}
-
-async function deleteReq(app: Hono, url: string): Promise<Response> {
-  return app.request(`http://localhost${url}`, { method: 'DELETE' })
-}
-
-async function getReq(app: Hono, url: string): Promise<Response> {
-  return app.request(`http://localhost${url}`, { method: 'GET' })
-}
-
-async function postFormData(app: Hono, url: string, body: FormData): Promise<Response> {
-  return app.request(`http://localhost${url}`, {
-    method: 'POST',
-    body,
-  })
-}
 
 describe('session usage — GET /:id/sessions/:sessionId/usage', () => {
   let app: ReturnType<typeof createApp>

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -145,6 +145,7 @@ import { Readable } from 'stream'
 import pLimit from 'p-limit'
 import * as path from 'path'
 import type { ApiAgent } from '@shared/lib/types/api'
+import { toPublicChatIntegration } from '@shared/lib/chat-integrations/public'
 
 function getConfiguredSkillsets() {
   return getSettings().skillsets || []
@@ -2982,7 +2983,7 @@ agents.get('/:id/chat-integrations', AgentRead(), async (c) => {
     // "Connecting…" from the same source of truth as the connector page, instead
     // of guessing from persisted status alone.
     const withConnection = integrations.map((integration) => ({
-      ...integration,
+      ...toPublicChatIntegration(integration),
       connected: chatIntegrationManager.isIntegrationConnected(integration.id),
     }))
     return c.json(withConnection)

--- a/src/api/routes/chat-integrations.access.test.ts
+++ b/src/api/routes/chat-integrations.access.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Hono } from 'hono'
+import { z } from 'zod'
 import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
@@ -67,7 +68,7 @@ const mockGetChatIntegration = vi.fn((id: string) => integrations[id] ?? null)
 vi.mock('@shared/lib/services/chat-integration-service', () => ({
   getChatIntegration: (id: string) => mockGetChatIntegration(id),
   createChatIntegration: vi.fn(),
-  updateChatIntegration: vi.fn(),
+  updateChatIntegration: vi.fn(() => true),
   updateChatIntegrationStatus: vi.fn(),
   deleteChatIntegration: vi.fn(),
   DuplicateBotTokenError: class DuplicateBotTokenError extends Error {},
@@ -86,6 +87,7 @@ const mockNotifyChatApproved = vi.fn().mockResolvedValue(undefined)
 const mockTearDownChatSession = vi.fn().mockResolvedValue(undefined)
 const mockReconcileAccess = vi.fn().mockResolvedValue(undefined)
 const mockClearChatSessionById = vi.fn()
+const mockRemoveIntegration = vi.fn().mockResolvedValue(undefined)
 
 vi.mock('@shared/lib/chat-integrations/chat-integration-manager', () => ({
   chatIntegrationManager: {
@@ -95,7 +97,7 @@ vi.mock('@shared/lib/chat-integrations/chat-integration-manager', () => ({
     reconcileAccess: (...args: unknown[]) => mockReconcileAccess(...args),
     isIntegrationConnected: vi.fn(() => false),
     addIntegration: vi.fn(),
-    removeIntegration: vi.fn(),
+    removeIntegration: (...args: unknown[]) => mockRemoveIntegration(...args),
     pauseIntegration: vi.fn(),
     resumeIntegration: vi.fn(),
   },
@@ -103,7 +105,6 @@ vi.mock('@shared/lib/chat-integrations/chat-integration-manager', () => ({
 
 vi.mock('@shared/lib/chat-integrations/config-schema', () => ({
   validateChatIntegrationConfig: vi.fn(),
-  mergeChatIntegrationConfig: vi.fn((_provider, _stored, patch) => patch),
   parseChatIntegrationConfig: vi.fn((_provider, config) => JSON.parse(config)),
   CHAT_PROVIDERS: ['telegram', 'slack', 'imessage'],
   IMESSAGE_GATEWAY_URL: 'https://imessage.example.com',
@@ -124,7 +125,7 @@ vi.mock('@shared/lib/error-reporting', () => ({
 }))
 
 import chatIntegrationsRouter from './chat-integrations'
-import { createChatIntegration } from '@shared/lib/services/chat-integration-service'
+import { createChatIntegration, updateChatIntegration } from '@shared/lib/services/chat-integration-service'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
 
 function app() {
@@ -209,6 +210,48 @@ describe('chat-integrations access routes', () => {
       expect(JSON.stringify(body)).not.toContain('xoxb-viewer-secret')
       expect(JSON.stringify(body)).not.toContain('xapp-viewer-secret')
       expect(JSON.stringify(body)).not.toContain('C123')
+    })
+  })
+
+  describe('PATCH /:integrationId', () => {
+    it('maps config validation failures from the service to 400', async () => {
+      vi.mocked(updateChatIntegration).mockImplementationOnce(() => {
+        z.object({ botToken: z.string() }).parse({})
+        return true
+      })
+
+      const res = await app().request(
+        `http://localhost/api/chat-integrations/${INTEGRATION_A}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ config: { onlyMentioned: true } }),
+        },
+      )
+
+      expect(res.status).toBe(400)
+      expect(await res.json()).toMatchObject({ error: expect.stringContaining('Invalid config') })
+      expect(mockRemoveIntegration).not.toHaveBeenCalled()
+    })
+
+    it('returns 500 instead of a null success body when the row vanishes', async () => {
+      mockGetChatIntegration
+        .mockReturnValueOnce(integrations[INTEGRATION_A])
+        .mockReturnValueOnce(null as never)
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const res = await app().request(
+        `http://localhost/api/chat-integrations/${INTEGRATION_A}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Renamed' }),
+        },
+      )
+
+      expect(res.status).toBe(500)
+      expect(await res.json()).toEqual({ error: 'Failed to update chat integration' })
+      consoleError.mockRestore()
     })
   })
 
@@ -588,6 +631,21 @@ describe('chat-integrations access routes', () => {
       // default (true). Making a bot public is owner-only via PATCH /require-approval.
       expect(vi.mocked(createChatIntegration)).toHaveBeenCalledTimes(1)
       expect(vi.mocked(createChatIntegration).mock.calls[0][0]).not.toHaveProperty('requireApproval')
+    })
+
+    it('returns 500 instead of a null success body when the created row cannot be read back', async () => {
+      vi.mocked(createChatIntegration).mockReturnValue('missing-int')
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const res = await app().request('http://localhost/api/chat-integrations/agent-a', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider: 'telegram', config: { botToken: 't' } }),
+      })
+
+      expect(res.status).toBe(500)
+      expect(await res.json()).toEqual({ error: 'Failed to create chat integration' })
+      consoleError.mockRestore()
     })
   })
 })

--- a/src/api/routes/chat-integrations.access.test.ts
+++ b/src/api/routes/chat-integrations.access.test.ts
@@ -103,6 +103,8 @@ vi.mock('@shared/lib/chat-integrations/chat-integration-manager', () => ({
 
 vi.mock('@shared/lib/chat-integrations/config-schema', () => ({
   validateChatIntegrationConfig: vi.fn(),
+  mergeChatIntegrationConfig: vi.fn((_provider, _stored, patch) => patch),
+  parseChatIntegrationConfig: vi.fn((_provider, config) => JSON.parse(config)),
   CHAT_PROVIDERS: ['telegram', 'slack', 'imessage'],
   IMESSAGE_GATEWAY_URL: 'https://imessage.example.com',
   imessageSetupSchema: { safeParse: () => ({ success: true, data: {} }) },
@@ -174,6 +176,41 @@ describe('chat-integrations access routes', () => {
   })
 
   // ── GET /:integrationId/access ─────────────────────────────────────────
+
+  describe('GET /:integrationId', () => {
+    it('never serializes provider credentials', async () => {
+      mockAuthRole.current = 'viewer'
+      mockGetChatIntegration.mockReturnValueOnce({
+        id: INTEGRATION_A,
+        agentSlug: 'agent-a',
+        provider: 'slack',
+        name: 'Team bot',
+        config: JSON.stringify({
+          botToken: 'xoxb-viewer-secret',
+          appToken: 'xapp-viewer-secret',
+          channelId: 'C123',
+          onlyMentioned: true,
+        }),
+        status: 'active',
+      } as never)
+
+      const res = await app().request(
+        `http://localhost/api/chat-integrations/${INTEGRATION_A}`,
+      )
+      const body = await res.json() as Record<string, unknown>
+
+      expect(res.status).toBe(200)
+      expect(body).not.toHaveProperty('config')
+      expect(body).toMatchObject({
+        id: INTEGRATION_A,
+        hasCredentials: true,
+        settings: { onlyMentioned: true },
+      })
+      expect(JSON.stringify(body)).not.toContain('xoxb-viewer-secret')
+      expect(JSON.stringify(body)).not.toContain('xapp-viewer-secret')
+      expect(JSON.stringify(body)).not.toContain('C123')
+    })
+  })
 
   describe('GET /:integrationId/access', () => {
     it('returns all access rows for the integration', async () => {

--- a/src/api/routes/chat-integrations.ts
+++ b/src/api/routes/chat-integrations.ts
@@ -25,7 +25,8 @@ import {
 import type { ChatAccessStatus } from '@shared/lib/services/chat-integration-access-service'
 import { listChatIntegrationSessions, archiveChatIntegrationSession, getChatIntegrationSessionById, deleteChatIntegrationSessionsByIntegration } from '@shared/lib/services/chat-integration-session-service'
 import { chatIntegrationManager } from '@shared/lib/chat-integrations/chat-integration-manager'
-import { validateChatIntegrationConfig, CHAT_PROVIDERS, IMESSAGE_GATEWAY_URL, imessageSetupSchema, type ChatProvider } from '@shared/lib/chat-integrations/config-schema'
+import { validateChatIntegrationConfig, mergeChatIntegrationConfig, CHAT_PROVIDERS, IMESSAGE_GATEWAY_URL, imessageSetupSchema, type ChatProvider } from '@shared/lib/chat-integrations/config-schema'
+import { toPublicChatIntegration } from '@shared/lib/chat-integrations/public'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
 import { Authenticated, AgentUser, EntityAgentRole, ResolveAgent, getAgentId } from '../middleware/auth'
@@ -51,8 +52,8 @@ const IntegrationAgentRole = EntityAgentRole({
 // GET /api/chat-integrations/:integrationId - Get a single integration
 chatIntegrationsRouter.get('/:integrationId', IntegrationAgentRole('viewer'), async (c) => {
   try {
-    const integration = c.get('chatIntegration' as never)
-    return c.json(integration)
+    const integration = c.get('chatIntegration' as never) as NonNullable<ReturnType<typeof getChatIntegration>>
+    return c.json(toPublicChatIntegration(integration))
   } catch (error) {
     console.error('Failed to fetch chat integration:', error)
     captureException(error, { tags: { ...SENTRY_TAGS, operation: 'get-integration' }, extra: { integrationId: c.req.param('integrationId') } })
@@ -240,7 +241,7 @@ chatIntegrationsRouter.post('/:id', ResolveAgent(), AgentUser(), async (c) => {
 
     const integration = getChatIntegration(id)
     logAuditEvent({ userId: getCurrentUserId(c), object: 'chat_integration', objectId: id, action: 'created', details: { provider, agentSlug } })
-    return c.json(integration, 201)
+    return c.json(integration ? toPublicChatIntegration(integration) : null, 201)
   } catch (error) {
     console.error('Failed to create chat integration:', error)
     captureException(error, { tags: { ...SENTRY_TAGS, operation: 'create-integration' }, extra: { agentSlug: c.req.param('id') } })
@@ -259,12 +260,19 @@ chatIntegrationsRouter.patch('/:integrationId', IntegrationAgentRole('user'), as
       return c.json({ error: `Invalid speed. Must be one of: ${SPEED_LEVELS.join(', ')}` }, 400)
     }
 
-    // Validate config if provided
+    // Merge with the stored credential-bearing config before validation. API
+    // clients never receive secrets, so omitted or masked credentials must keep
+    // their current values when a non-secret setting changes.
+    let mergedConfig: Record<string, unknown> | undefined
     if (config !== undefined) {
       const integration = c.get('chatIntegration' as never) as Awaited<ReturnType<typeof getChatIntegration>>
       if (integration) {
         try {
-          validateChatIntegrationConfig(integration.provider as ChatProvider, config)
+          mergedConfig = mergeChatIntegrationConfig(
+            integration.provider as ChatProvider,
+            integration.config,
+            config,
+          )
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Invalid config'
           return c.json({ error: `Invalid config: ${message}` }, 400)
@@ -275,7 +283,7 @@ chatIntegrationsRouter.patch('/:integrationId', IntegrationAgentRole('user'), as
     // Step 1: Persist DB updates first (config, name, showToolCalls)
     const updates: Record<string, unknown> = {}
     if (name !== undefined) updates.name = name
-    if (config !== undefined) updates.config = config
+    if (mergedConfig !== undefined) updates.config = mergedConfig
     if (showToolCalls !== undefined) updates.showToolCalls = showToolCalls
     if (sessionTimeout !== undefined) updates.sessionTimeout = sessionTimeout
     if (model !== undefined) updates.model = model
@@ -299,7 +307,7 @@ chatIntegrationsRouter.patch('/:integrationId', IntegrationAgentRole('user'), as
 
     const updated = getChatIntegration(id)
     logAuditEvent({ userId: getCurrentUserId(c), object: 'chat_integration', objectId: id, action: 'updated' })
-    return c.json(updated)
+    return c.json(updated ? toPublicChatIntegration(updated) : null)
   } catch (error) {
     if (error instanceof DuplicateBotTokenError) {
       captureException(error, {
@@ -336,7 +344,7 @@ chatIntegrationsRouter.patch('/:integrationId/require-approval', IntegrationAgen
     }
     const updated = getChatIntegration(id)
     logAuditEvent({ userId: getCurrentUserId(c), object: 'chat_integration', objectId: id, action: 'updated', details: { requireApproval } })
-    return c.json(updated)
+    return c.json(updated ? toPublicChatIntegration(updated) : null)
   } catch (error) {
     captureException(error, { tags: { ...SENTRY_TAGS, operation: 'set-require-approval' }, extra: { integrationId: c.req.param('integrationId') } })
     return c.json({ error: 'Failed to update require approval' }, 500)

--- a/src/api/routes/chat-integrations.ts
+++ b/src/api/routes/chat-integrations.ts
@@ -25,7 +25,7 @@ import {
 import type { ChatAccessStatus } from '@shared/lib/services/chat-integration-access-service'
 import { listChatIntegrationSessions, archiveChatIntegrationSession, getChatIntegrationSessionById, deleteChatIntegrationSessionsByIntegration } from '@shared/lib/services/chat-integration-session-service'
 import { chatIntegrationManager } from '@shared/lib/chat-integrations/chat-integration-manager'
-import { validateChatIntegrationConfig, mergeChatIntegrationConfig, CHAT_PROVIDERS, IMESSAGE_GATEWAY_URL, imessageSetupSchema, type ChatProvider } from '@shared/lib/chat-integrations/config-schema'
+import { validateChatIntegrationConfig, CHAT_PROVIDERS, IMESSAGE_GATEWAY_URL, imessageSetupSchema } from '@shared/lib/chat-integrations/config-schema'
 import { toPublicChatIntegration } from '@shared/lib/chat-integrations/public'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
@@ -240,8 +240,9 @@ chatIntegrationsRouter.post('/:id', ResolveAgent(), AgentUser(), async (c) => {
     }
 
     const integration = getChatIntegration(id)
+    if (!integration) throw new Error('Chat integration disappeared after creation')
     logAuditEvent({ userId: getCurrentUserId(c), object: 'chat_integration', objectId: id, action: 'created', details: { provider, agentSlug } })
-    return c.json(integration ? toPublicChatIntegration(integration) : null, 201)
+    return c.json(toPublicChatIntegration(integration), 201)
   } catch (error) {
     console.error('Failed to create chat integration:', error)
     captureException(error, { tags: { ...SENTRY_TAGS, operation: 'create-integration' }, extra: { agentSlug: c.req.param('id') } })
@@ -260,30 +261,10 @@ chatIntegrationsRouter.patch('/:integrationId', IntegrationAgentRole('user'), as
       return c.json({ error: `Invalid speed. Must be one of: ${SPEED_LEVELS.join(', ')}` }, 400)
     }
 
-    // Merge with the stored credential-bearing config before validation. API
-    // clients never receive secrets, so omitted or masked credentials must keep
-    // their current values when a non-secret setting changes.
-    let mergedConfig: Record<string, unknown> | undefined
-    if (config !== undefined) {
-      const integration = c.get('chatIntegration' as never) as Awaited<ReturnType<typeof getChatIntegration>>
-      if (integration) {
-        try {
-          mergedConfig = mergeChatIntegrationConfig(
-            integration.provider as ChatProvider,
-            integration.config,
-            config,
-          )
-        } catch (err) {
-          const message = err instanceof Error ? err.message : 'Invalid config'
-          return c.json({ error: `Invalid config: ${message}` }, 400)
-        }
-      }
-    }
-
     // Step 1: Persist DB updates first (config, name, showToolCalls)
     const updates: Record<string, unknown> = {}
     if (name !== undefined) updates.name = name
-    if (mergedConfig !== undefined) updates.config = mergedConfig
+    if (config !== undefined) updates.config = config
     if (showToolCalls !== undefined) updates.showToolCalls = showToolCalls
     if (sessionTimeout !== undefined) updates.sessionTimeout = sessionTimeout
     if (model !== undefined) updates.model = model
@@ -291,7 +272,9 @@ chatIntegrationsRouter.patch('/:integrationId', IntegrationAgentRole('user'), as
     if (body.speed !== undefined) updates.speed = parsedSpeed.data ?? null
 
     if (Object.keys(updates).length > 0) {
-      updateChatIntegration(id, updates)
+      if (!updateChatIntegration(id, updates)) {
+        throw new Error('Chat integration disappeared during update')
+      }
     }
 
     // Step 2: Handle lifecycle changes (pause/resume/reconnect)
@@ -306,8 +289,9 @@ chatIntegrationsRouter.patch('/:integrationId', IntegrationAgentRole('user'), as
     }
 
     const updated = getChatIntegration(id)
+    if (!updated) throw new Error('Chat integration disappeared after update')
     logAuditEvent({ userId: getCurrentUserId(c), object: 'chat_integration', objectId: id, action: 'updated' })
-    return c.json(updated ? toPublicChatIntegration(updated) : null)
+    return c.json(toPublicChatIntegration(updated))
   } catch (error) {
     if (error instanceof DuplicateBotTokenError) {
       captureException(error, {
@@ -319,6 +303,10 @@ chatIntegrationsRouter.patch('/:integrationId', IntegrationAgentRole('user'), as
         { error: error.message, code: 'duplicate_bot_token', existingIntegrationId: error.existingIntegrationId },
         409,
       )
+    }
+    if (error instanceof z.ZodError) {
+      const message = error.issues[0]?.message ?? 'Invalid config'
+      return c.json({ error: `Invalid config: ${message}` }, 400)
     }
     console.error('Failed to update chat integration:', error)
     captureException(error, { tags: { ...SENTRY_TAGS, operation: 'update-integration' }, extra: { integrationId: c.req.param('integrationId') } })
@@ -336,15 +324,18 @@ chatIntegrationsRouter.patch('/:integrationId/require-approval', IntegrationAgen
     if (!z.boolean().safeParse(requireApproval).success) {
       return c.json({ error: 'requireApproval must be a boolean' }, 400)
     }
-    updateChatIntegration(id, { requireApproval })
+    if (!updateChatIntegration(id, { requireApproval })) {
+      throw new Error('Chat integration disappeared during approval update')
+    }
     // Secure-by-default: enabling approval must gate already-running sessions whose
     // chat is not explicitly allowed (previously-public conversations).
     if (requireApproval === true) {
       await chatIntegrationManager.reconcileAccess(id)
     }
     const updated = getChatIntegration(id)
+    if (!updated) throw new Error('Chat integration disappeared after approval update')
     logAuditEvent({ userId: getCurrentUserId(c), object: 'chat_integration', objectId: id, action: 'updated', details: { requireApproval } })
-    return c.json(updated ? toPublicChatIntegration(updated) : null)
+    return c.json(toPublicChatIntegration(updated))
   } catch (error) {
     captureException(error, { tags: { ...SENTRY_TAGS, operation: 'set-require-approval' }, extra: { integrationId: c.req.param('integrationId') } })
     return c.json({ error: 'Failed to update require approval' }, 500)

--- a/src/renderer/components/chat-integrations/chat-integration-side-panel.tsx
+++ b/src/renderer/components/chat-integrations/chat-integration-side-panel.tsx
@@ -2,7 +2,7 @@ import { IntegrationStatusCard } from './integration-status-card'
 import { IntegrationSettingsCard } from './integration-settings-card'
 import { DetailCard } from '@renderer/components/triggers/detail-card'
 import { IntegrationModelEffort } from './integration-settings-controls'
-import type { ChatIntegration } from '@shared/lib/db/schema'
+import type { PublicChatIntegration as ChatIntegration } from '@shared/lib/chat-integrations/public'
 
 export interface ChatIntegrationSidePanelProps {
   integration: ChatIntegration

--- a/src/renderer/components/chat-integrations/conversation-history-section.test.tsx
+++ b/src/renderer/components/chat-integrations/conversation-history-section.test.tsx
@@ -2,8 +2,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ConversationHistorySection } from './conversation-history-section'
-import { makeSession, makeAccess } from './test-factories'
-import type { ChatIntegration, ChatIntegrationSession, ChatIntegrationAccess } from '@shared/lib/db/schema'
+import { makeChatIntegration, makeSession, makeAccess } from './test-factories'
+import type { ChatIntegrationSession, ChatIntegrationAccess } from '@shared/lib/db/schema'
 
 vi.mock('@renderer/components/messages/session-thread', () => ({
   SessionThread: (p: any) => <div data-testid="session-thread">{p.sessionId}</div>,
@@ -36,7 +36,12 @@ function s(id: string, ms: number, archived = false, name?: string): ChatIntegra
     createdAt: new Date(ms), updatedAt: new Date(ms),
   })
 }
-const integration = { id: 'int-1', provider: 'telegram', agentSlug: 'a', requireApproval: true } as ChatIntegration
+const integration = makeChatIntegration({
+  id: 'int-1',
+  provider: 'telegram',
+  agentSlug: 'a',
+  requireApproval: true,
+})
 const base = {
   integration, routeNewChatId: null, onSelectWindow: vi.fn(), onNewConversation: vi.fn(),
   agentSlug: 'a', providerName: 'Telegram', canManageAccess: true,

--- a/src/renderer/components/chat-integrations/conversation-history-section.tsx
+++ b/src/renderer/components/chat-integrations/conversation-history-section.tsx
@@ -5,7 +5,8 @@ import { useChatIntegrationAccess } from '@renderer/hooks/use-chat-integrations'
 import { buildChatRows, activeWindow, type ChatRow } from './chat-inbox-model'
 import { ChatListRow } from './chat-list-row'
 import { ConversationDetail } from './conversation-detail'
-import type { ChatIntegration, ChatIntegrationSession } from '@shared/lib/db/schema'
+import type { ChatIntegrationSession } from '@shared/lib/db/schema'
+import type { PublicChatIntegration as ChatIntegration } from '@shared/lib/chat-integrations/public'
 
 interface ConversationHistorySectionProps {
   integration: ChatIntegration

--- a/src/renderer/components/chat-integrations/integration-delete-button.tsx
+++ b/src/renderer/components/chat-integrations/integration-delete-button.tsx
@@ -12,7 +12,7 @@ import {
   AlertDialogTitle,
 } from '@renderer/components/ui/alert-dialog'
 import { useDeleteChatIntegration } from '@renderer/hooks/use-chat-integrations'
-import type { ChatIntegration } from '@shared/lib/db/schema'
+import type { PublicChatIntegration as ChatIntegration } from '@shared/lib/chat-integrations/public'
 
 /**
  * Header action that deletes the integration behind a confirm dialog.

--- a/src/renderer/components/chat-integrations/integration-settings-card.test.tsx
+++ b/src/renderer/components/chat-integrations/integration-settings-card.test.tsx
@@ -16,10 +16,6 @@ vi.mock('./integration-settings-controls', () => ({
   ),
   SessionTimeoutSelect: () => null,
 }))
-vi.mock('@shared/lib/chat-integrations/config-schema', () => ({
-  parseChatIntegrationConfig: (provider: string) =>
-    provider === 'slack' ? { onlyMentioned: false, answerInThread: false, newSessionPerThread: false } : null,
-}))
 
 describe('IntegrationSettingsCard', () => {
   beforeEach(() => { updateMock.mockReset(); setApprovalMock.mockReset() })
@@ -35,6 +31,20 @@ describe('IntegrationSettingsCard', () => {
     expect(screen.queryByLabelText(/only respond when @mentioned/i)).not.toBeInTheDocument()
     rerender(<IntegrationSettingsCard integration={makeIntegration({ provider: 'slack' })} />)
     expect(screen.getByLabelText(/only respond when @mentioned/i)).toBeInTheDocument()
+  })
+
+  it('updates Slack settings without sending credential placeholders', () => {
+    render(<IntegrationSettingsCard integration={makeIntegration({
+      provider: 'slack',
+      settings: { onlyMentioned: false },
+    })} />)
+
+    screen.getByLabelText(/only respond when @mentioned/i).click()
+
+    expect(updateMock).toHaveBeenCalledWith({
+      id: 'int-1',
+      config: { onlyMentioned: true },
+    })
   })
 
   it.each([

--- a/src/renderer/components/chat-integrations/integration-settings-card.tsx
+++ b/src/renderer/components/chat-integrations/integration-settings-card.tsx
@@ -1,11 +1,10 @@
 import { useUpdateChatIntegration, useSetRequireApproval } from '@renderer/hooks/use-chat-integrations'
-import { parseChatIntegrationConfig, type SlackConfig } from '@shared/lib/chat-integrations/config-schema'
 import { ToggleRow, SessionTimeoutSelect } from './integration-settings-controls'
 import { DetailCard } from '@renderer/components/triggers/detail-card'
-import type { ChatIntegration } from '@shared/lib/db/schema'
+import type { PublicChatIntegration } from '@shared/lib/chat-integrations/public'
 
 export function IntegrationSettingsCard({ integration, canManageAccess }: {
-  integration: ChatIntegration
+  integration: PublicChatIntegration
   /** Telegram owner: shows the require-approval gate. */
   canManageAccess?: boolean
 }) {
@@ -51,44 +50,43 @@ export function IntegrationSettingsCard({ integration, canManageAccess }: {
           />
         )}
         {integration.provider === 'slack' && (() => {
-          const config = parseChatIntegrationConfig('slack', integration.config) as SlackConfig | null
-          if (!config) return null
+          const settings = integration.settings
           return (
             <>
               <ToggleRow
                 label="Only respond when @mentioned"
                 helperText="Replies to every message when disabled."
-                checked={!!config.onlyMentioned}
+                checked={!!settings.onlyMentioned}
                 disabled={updateIntegration.isPending}
                 onCheckedChange={(checked) =>
                   updateIntegration.mutate({
                     id: integration.id,
-                    config: { ...config, onlyMentioned: checked },
+                    config: { onlyMentioned: checked },
                   })
                 }
               />
               <ToggleRow
                 label="Reply in thread"
                 helperText="Keep replies in a thread."
-                checked={!!config.answerInThread}
+                checked={!!settings.answerInThread}
                 disabled={updateIntegration.isPending}
                 onCheckedChange={(checked) =>
                   updateIntegration.mutate({
                     id: integration.id,
-                    config: { ...config, answerInThread: checked, ...(!checked ? { newSessionPerThread: false } : {}) },
+                    config: { answerInThread: checked, ...(!checked ? { newSessionPerThread: false } : {}) },
                   })
                 }
               />
-              {!!config.answerInThread && (
+              {!!settings.answerInThread && (
                 <ToggleRow
                   label="Separate conversation per thread"
                   helperText="Separate context per thread."
-                  checked={!!config.newSessionPerThread}
+                  checked={!!settings.newSessionPerThread}
                   disabled={updateIntegration.isPending}
                   onCheckedChange={(checked) =>
                     updateIntegration.mutate({
                       id: integration.id,
-                      config: { ...config, newSessionPerThread: checked },
+                      config: { newSessionPerThread: checked },
                     })
                   }
                 />

--- a/src/renderer/components/chat-integrations/integration-settings-controls.tsx
+++ b/src/renderer/components/chat-integrations/integration-settings-controls.tsx
@@ -11,7 +11,7 @@ import {
 import { useUpdateChatIntegration } from '@renderer/hooks/use-chat-integrations'
 import { SettingsModelSelect } from '@renderer/components/settings/settings-model-select'
 import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
-import type { ChatIntegration } from '@shared/lib/db/schema'
+import type { PublicChatIntegration as ChatIntegration } from '@shared/lib/chat-integrations/public'
 
 export function ToggleRow({ label, helperText, checked, onCheckedChange, disabled }: {
   label: string

--- a/src/renderer/components/chat-integrations/integration-status-card.tsx
+++ b/src/renderer/components/chat-integrations/integration-status-card.tsx
@@ -3,7 +3,7 @@ import { DetailCard } from '@renderer/components/triggers/detail-card'
 import { useUpdateChatIntegration } from '@renderer/hooks/use-chat-integrations'
 import { deriveChatIntegrationState } from '@shared/lib/chat-integrations/utils'
 import { ChatIntegrationPill } from './chat-integration-pill'
-import type { ChatIntegration } from '@shared/lib/db/schema'
+import type { PublicChatIntegration as ChatIntegration } from '@shared/lib/chat-integrations/public'
 
 export function IntegrationStatusCard({ integration, connected }: {
   integration: ChatIntegration

--- a/src/renderer/components/chat-integrations/test-factories.ts
+++ b/src/renderer/components/chat-integrations/test-factories.ts
@@ -1,4 +1,5 @@
-import type { ChatIntegration, ChatIntegrationSession, ChatIntegrationAccess } from '@shared/lib/db/schema'
+import type { ChatIntegrationSession, ChatIntegrationAccess } from '@shared/lib/db/schema'
+import type { PublicChatIntegration as ChatIntegration } from '@shared/lib/chat-integrations/public'
 
 /** Schema-complete ChatIntegration for component tests; override any field. */
 export function makeChatIntegration(overrides: Partial<ChatIntegration> = {}): ChatIntegration {
@@ -7,7 +8,8 @@ export function makeChatIntegration(overrides: Partial<ChatIntegration> = {}): C
     agentSlug: 'a',
     provider: 'telegram',
     name: 'Bot',
-    config: '{}',
+    hasCredentials: true,
+    settings: {},
     showToolCalls: false,
     requireApproval: false,
     sessionTimeout: null,

--- a/src/renderer/hooks/use-chat-integrations.ts
+++ b/src/renderer/hooks/use-chat-integrations.ts
@@ -4,13 +4,15 @@
  * React Query hooks for managing external chat integrations (Telegram, Slack).
  */
 
-import type { ChatIntegration, ChatIntegrationSession, ChatIntegrationAccess } from '@shared/lib/db/schema'
+import type { ChatIntegrationSession, ChatIntegrationAccess } from '@shared/lib/db/schema'
 import type { ChatProvider } from '@shared/lib/chat-integrations/config-schema'
+import type { PublicChatIntegration as ChatIntegration } from '@shared/lib/chat-integrations/public'
 import { isSettling } from '@shared/lib/chat-integrations/utils'
 import { apiFetch } from '@renderer/lib/api'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 
-export type { ChatIntegration, ChatIntegrationSession, ChatIntegrationAccess }
+export type { ChatIntegrationSession, ChatIntegrationAccess }
+export type { PublicChatIntegration as ChatIntegration } from '@shared/lib/chat-integrations/public'
 
 /** A list row plus the live transport state the list route computes, so the
  *  agent-home tag can derive its state from the same `(status, connected)` the

--- a/src/shared/lib/chat-integrations/config-schema.ts
+++ b/src/shared/lib/chat-integrations/config-schema.ts
@@ -53,6 +53,16 @@ export const CHAT_PROVIDERS = ['telegram', 'slack', 'imessage'] as const
 export type ChatProvider = (typeof CHAT_PROVIDERS)[number]
 type ChatConfig = TelegramConfig | SlackConfig | IMessageConfig
 
+const configPatchSchema = z.record(z.string(), z.unknown())
+
+const MASKED_CREDENTIAL = /^(?:(?:\*|•){4,}(?:[A-Za-z0-9_-]{0,4})?|redacted|\[redacted\]|<redacted>)$/i
+
+const CREDENTIAL_FIELDS: Record<ChatProvider, readonly string[]> = {
+  telegram: ['botToken'],
+  slack: ['botToken', 'appToken'],
+  imessage: ['gatewayUrl', 'token'],
+}
+
 /**
  * Validate and parse a config object for the given provider.
  * Throws a descriptive error if validation fails.
@@ -84,4 +94,32 @@ export function parseChatIntegrationConfig(
     console.error(`[ChatIntegration] Invalid config for ${provider}:`, err instanceof Error ? err.message : err)
     return null
   }
+}
+
+/**
+ * Merge an API config patch with the credential-bearing stored config.
+ * Omitted credentials and conventional masked placeholders preserve the
+ * existing value so settings can be edited without ever reading secrets back.
+ */
+export function mergeChatIntegrationConfig(
+  provider: ChatProvider,
+  storedConfigJson: string,
+  patch: unknown,
+): ChatConfig {
+  const stored = parseChatIntegrationConfig(provider, storedConfigJson)
+  if (!stored) {
+    throw new Error(`Stored ${provider} chat integration config is invalid`)
+  }
+
+  const parsedPatch = configPatchSchema.parse(patch)
+  const credentialFields = CREDENTIAL_FIELDS[provider]
+  const unmaskedPatch = Object.fromEntries(
+    Object.entries(parsedPatch).filter(([key, value]) =>
+      !credentialFields.includes(key)
+      || typeof value !== 'string'
+      || !MASKED_CREDENTIAL.test(value),
+    ),
+  )
+
+  return validateChatIntegrationConfig(provider, { ...stored, ...unmaskedPatch })
 }

--- a/src/shared/lib/chat-integrations/config-schema.ts
+++ b/src/shared/lib/chat-integrations/config-schema.ts
@@ -106,11 +106,6 @@ export function mergeChatIntegrationConfig(
   storedConfigJson: string,
   patch: unknown,
 ): ChatConfig {
-  const stored = parseChatIntegrationConfig(provider, storedConfigJson)
-  if (!stored) {
-    throw new Error(`Stored ${provider} chat integration config is invalid`)
-  }
-
   const parsedPatch = configPatchSchema.parse(patch)
   const credentialFields = CREDENTIAL_FIELDS[provider]
   const unmaskedPatch = Object.fromEntries(
@@ -120,6 +115,11 @@ export function mergeChatIntegrationConfig(
       || !MASKED_CREDENTIAL.test(value),
     ),
   )
+
+  const stored = parseChatIntegrationConfig(provider, storedConfigJson)
+  // A corrupt or legacy row must remain repairable. When the old value cannot
+  // be trusted, require the patch itself to be a complete valid replacement.
+  if (!stored) return validateChatIntegrationConfig(provider, unmaskedPatch)
 
   return validateChatIntegrationConfig(provider, { ...stored, ...unmaskedPatch })
 }

--- a/src/shared/lib/chat-integrations/public.test.ts
+++ b/src/shared/lib/chat-integrations/public.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import type { ChatIntegration } from '@shared/lib/db/schema'
+import { toPublicChatIntegration } from './public'
+
+function integration(provider: ChatIntegration['provider'], config: Record<string, unknown>): ChatIntegration {
+  return {
+    id: `${provider}-1`,
+    agentSlug: 'agent-1',
+    provider,
+    name: 'Bot',
+    config: JSON.stringify(config),
+    showToolCalls: false,
+    requireApproval: true,
+    sessionTimeout: null,
+    model: null,
+    effort: null,
+    speed: null,
+    status: 'active',
+    errorMessage: null,
+    createdByUserId: 'owner-1',
+    createdAt: new Date('2026-07-17T00:00:00Z'),
+    updatedAt: new Date('2026-07-17T00:00:00Z'),
+  }
+}
+
+describe('toPublicChatIntegration', () => {
+  it.each([
+    ['telegram', { botToken: 'tg-secret', chatId: 'chat-secret', draftStreaming: true }, { draftStreaming: true }],
+    ['slack', { botToken: 'xoxb-secret', appToken: 'xapp-secret', channelId: 'channel-secret', onlyMentioned: true }, { onlyMentioned: true }],
+    ['imessage', { gatewayUrl: 'https://private.gateway.example', phoneNumber: '+15551234567', token: 'imessage-secret' }, {}],
+  ] as const)('redacts all %s config while retaining safe settings', (provider, config, settings) => {
+    const result = toPublicChatIntegration(integration(provider, config))
+    const serialized = JSON.stringify(result)
+
+    expect(result).not.toHaveProperty('config')
+    expect(result.hasCredentials).toBe(true)
+    expect(result.settings).toEqual(settings)
+    for (const value of Object.values(config)) {
+      if (typeof value === 'string') expect(serialized).not.toContain(value)
+    }
+  })
+
+  it('reports missing credentials for invalid stored config without exposing it', () => {
+    const result = toPublicChatIntegration(integration('slack', { onlyMentioned: true }))
+
+    expect(result).not.toHaveProperty('config')
+    expect(result.hasCredentials).toBe(false)
+    expect(result.settings).toEqual({})
+  })
+})

--- a/src/shared/lib/chat-integrations/public.test.ts
+++ b/src/shared/lib/chat-integrations/public.test.ts
@@ -40,7 +40,7 @@ describe('toPublicChatIntegration', () => {
     }
   })
 
-  it('reports missing credentials for invalid stored config without exposing it', () => {
+  it('reports an invalid stored credential config without exposing it', () => {
     const result = toPublicChatIntegration(integration('slack', { onlyMentioned: true }))
 
     expect(result).not.toHaveProperty('config')

--- a/src/shared/lib/chat-integrations/public.ts
+++ b/src/shared/lib/chat-integrations/public.ts
@@ -20,6 +20,7 @@ export interface PublicChatIntegrationSettings {
 }
 
 export type PublicChatIntegration = Omit<ChatIntegration, 'config'> & {
+  /** True only when the stored credential config validates against the current provider schema. */
   hasCredentials: boolean
   settings: PublicChatIntegrationSettings
 }

--- a/src/shared/lib/chat-integrations/public.ts
+++ b/src/shared/lib/chat-integrations/public.ts
@@ -1,0 +1,56 @@
+import type { ChatIntegration } from '@shared/lib/db/schema'
+import {
+  parseChatIntegrationConfig,
+  type SlackConfig,
+  type TelegramConfig,
+} from './config-schema'
+
+/**
+ * Non-secret provider settings that the renderer may read back and edit.
+ * Credential-bearing and identifying config fields intentionally have no
+ * representation in the public API contract.
+ */
+export interface PublicChatIntegrationSettings {
+  richMessages?: boolean
+  draftStreaming?: boolean
+  skipEntityDetection?: boolean
+  onlyMentioned?: boolean
+  answerInThread?: boolean
+  newSessionPerThread?: boolean
+}
+
+export type PublicChatIntegration = Omit<ChatIntegration, 'config'> & {
+  hasCredentials: boolean
+  settings: PublicChatIntegrationSettings
+}
+
+/**
+ * Convert the internal credential-bearing DB row into its API-safe form.
+ * Keep this as the only serialization boundary for chat integrations: callers
+ * inside the process still receive the full row needed by connectors.
+ */
+export function toPublicChatIntegration(integration: ChatIntegration): PublicChatIntegration {
+  const { config, ...publicFields } = integration
+  const parsed = typeof config === 'string'
+    ? parseChatIntegrationConfig(integration.provider, config)
+    : null
+
+  const settings: PublicChatIntegrationSettings = {}
+  if (parsed && integration.provider === 'telegram') {
+    const telegram = parsed as TelegramConfig
+    settings.richMessages = telegram.richMessages
+    settings.draftStreaming = telegram.draftStreaming
+    settings.skipEntityDetection = telegram.skipEntityDetection
+  } else if (parsed && integration.provider === 'slack') {
+    const slack = parsed as SlackConfig
+    settings.onlyMentioned = slack.onlyMentioned
+    settings.answerInThread = slack.answerInThread
+    settings.newSessionPerThread = slack.newSessionPerThread
+  }
+
+  return {
+    ...publicFields,
+    hasCredentials: parsed !== null,
+    settings,
+  }
+}

--- a/src/shared/lib/services/chat-integration-service.test.ts
+++ b/src/shared/lib/services/chat-integration-service.test.ts
@@ -217,6 +217,63 @@ describe('chat-integration-service', () => {
       })
     })
 
+    it('repairs an invalid stored config when PATCH supplies a complete replacement', () => {
+      const id = createChatIntegration({
+        agentSlug: 'agent-a',
+        provider: 'slack',
+        config: { legacyBotToken: 'obsolete-shape' },
+      })
+
+      expect(updateChatIntegration(id, {
+        config: {
+          botToken: 'xoxb-repaired',
+          appToken: 'xapp-repaired',
+          onlyMentioned: true,
+        },
+      })).toBe(true)
+
+      expect(JSON.parse(getChatIntegration(id)!.config)).toEqual({
+        botToken: 'xoxb-repaired',
+        appToken: 'xapp-repaired',
+        onlyMentioned: true,
+      })
+    })
+
+    it('rejects a partial PATCH when an invalid stored config cannot supply credentials', () => {
+      const id = createChatIntegration({
+        agentSlug: 'agent-a',
+        provider: 'slack',
+        config: { legacyBotToken: 'obsolete-shape' },
+      })
+
+      expect(() => updateChatIntegration(id, {
+        config: { onlyMentioned: true },
+      })).toThrow()
+    })
+
+    it('allows settings-only edits on legacy rows whose token is already duplicated', () => {
+      createChatIntegration({
+        agentSlug: 'agent-a',
+        provider: 'telegram',
+        config: { botToken: 'legacy-duplicate' },
+      })
+      const secondId = createChatIntegration({
+        agentSlug: 'agent-b',
+        provider: 'telegram',
+        config: { botToken: 'originally-unique' },
+      })
+      testSqlite.prepare('UPDATE chat_integrations SET config = ? WHERE id = ?')
+        .run(JSON.stringify({ botToken: 'legacy-duplicate' }), secondId)
+
+      expect(updateChatIntegration(secondId, {
+        config: { draftStreaming: true },
+      })).toBe(true)
+      expect(JSON.parse(getChatIntegration(secondId)!.config)).toEqual({
+        botToken: 'legacy-duplicate',
+        draftStreaming: true,
+      })
+    })
+
     it('throws DuplicateBotTokenError when PATCHing config to an already-used token', () => {
       const firstId = createChatIntegration({
         agentSlug: 'agent-a',

--- a/src/shared/lib/services/chat-integration-service.test.ts
+++ b/src/shared/lib/services/chat-integration-service.test.ts
@@ -171,6 +171,52 @@ describe('chat-integration-service', () => {
   })
 
   describe('updateChatIntegration', () => {
+    it('preserves stored Slack credentials when PATCHing only behavior settings', () => {
+      const id = createChatIntegration({
+        agentSlug: 'agent-a',
+        provider: 'slack',
+        config: {
+          botToken: 'xoxb-secret',
+          appToken: 'xapp-secret',
+          channelId: 'C123',
+          onlyMentioned: false,
+        },
+      })
+
+      expect(updateChatIntegration(id, {
+        config: { onlyMentioned: true },
+      })).toBe(true)
+
+      expect(JSON.parse(getChatIntegration(id)!.config)).toEqual({
+        botToken: 'xoxb-secret',
+        appToken: 'xapp-secret',
+        channelId: 'C123',
+        onlyMentioned: true,
+      })
+    })
+
+    it('preserves stored credentials when a client echoes masked placeholders', () => {
+      const id = createChatIntegration({
+        agentSlug: 'agent-a',
+        provider: 'slack',
+        config: { botToken: 'xoxb-secret', appToken: 'xapp-secret' },
+      })
+
+      updateChatIntegration(id, {
+        config: {
+          botToken: '********',
+          appToken: '••••xapp',
+          answerInThread: true,
+        },
+      })
+
+      expect(JSON.parse(getChatIntegration(id)!.config)).toEqual({
+        botToken: 'xoxb-secret',
+        appToken: 'xapp-secret',
+        answerInThread: true,
+      })
+    })
+
     it('throws DuplicateBotTokenError when PATCHing config to an already-used token', () => {
       const firstId = createChatIntegration({
         agentSlug: 'agent-a',

--- a/src/shared/lib/services/chat-integration-service.ts
+++ b/src/shared/lib/services/chat-integration-service.ts
@@ -252,8 +252,14 @@ export function updateChatIntegration(id: string, params: UpdateChatIntegrationP
     if (!current) return false
 
     nextConfig = mergeChatIntegrationConfig(current.provider, current.config, params.config)
+    const currentConfig = safeParseConfig(current)
+    const currentToken = currentConfig
+      ? extractUniqueKey(current.provider, currentConfig)
+      : null
     const newToken = extractUniqueKey(current.provider, nextConfig)
-    if (newToken) {
+    // Settings-only edits preserve the same unique key. Avoid re-checking those
+    // against legacy duplicate rows that predate the create-time guard.
+    if (newToken && newToken !== currentToken) {
       const duplicate = findIntegrationByUniqueKey(current.provider, newToken, id)
       if (duplicate) {
         throw new DuplicateBotTokenError(duplicate.id, current.provider)

--- a/src/shared/lib/services/chat-integration-service.ts
+++ b/src/shared/lib/services/chat-integration-service.ts
@@ -7,6 +7,7 @@ import { db } from '@shared/lib/db'
 import { chatIntegrations, chatIntegrationSessions } from '@shared/lib/db/schema'
 import type { ChatIntegration, NewChatIntegration } from '@shared/lib/db/schema'
 import type { ChatProvider } from '@shared/lib/chat-integrations/config-schema'
+import { mergeChatIntegrationConfig } from '@shared/lib/chat-integrations/config-schema'
 import { captureException } from '@shared/lib/error-reporting'
 
 export type { ChatIntegration, NewChatIntegration }
@@ -242,17 +243,20 @@ export function listChatIntegrationsByAgents(
 // ── Update ──────────────────────────────────────────────────────────────
 
 export function updateChatIntegration(id: string, params: UpdateChatIntegrationParams): boolean {
+  let nextConfig: Record<string, unknown> | undefined
+
   // Guard against a PATCH moving a token to one that's already owned by
   // another integration — would re-create SUP-150's duplicate-poller scenario.
   if (params.config !== undefined) {
     const current = getChatIntegration(id)
-    if (current) {
-      const newToken = extractUniqueKey(current.provider, params.config)
-      if (newToken) {
-        const duplicate = findIntegrationByUniqueKey(current.provider, newToken, id)
-        if (duplicate) {
-          throw new DuplicateBotTokenError(duplicate.id, current.provider)
-        }
+    if (!current) return false
+
+    nextConfig = mergeChatIntegrationConfig(current.provider, current.config, params.config)
+    const newToken = extractUniqueKey(current.provider, nextConfig)
+    if (newToken) {
+      const duplicate = findIntegrationByUniqueKey(current.provider, newToken, id)
+      if (duplicate) {
+        throw new DuplicateBotTokenError(duplicate.id, current.provider)
       }
     }
   }
@@ -262,7 +266,7 @@ export function updateChatIntegration(id: string, params: UpdateChatIntegrationP
   }
 
   if (params.name !== undefined) updates.name = params.name
-  if (params.config !== undefined) updates.config = JSON.stringify(params.config)
+  if (nextConfig !== undefined) updates.config = JSON.stringify(nextConfig)
   if (params.showToolCalls !== undefined) updates.showToolCalls = params.showToolCalls
   if (params.requireApproval !== undefined) updates.requireApproval = params.requireApproval
   if (params.sessionTimeout !== undefined) updates.sessionTimeout = params.sessionTimeout


### PR DESCRIPTION
## Summary

- introduce a public chat-integration DTO that never includes the credential-bearing `config` column
- use the DTO for single, list, create, update, and approval-toggle API responses
- preserve stored credentials when updates omit them or send masked placeholders
- keep corrupt or legacy rows repairable through a complete replacement config
- move renderer edit state to safe behavior settings and send partial config patches
- add regression coverage for viewer access, agent-scoped lists, all providers, repair flows, and credential-preserving updates

## Root cause

The chat-integration read routes serialized database rows directly. Those rows include the `config` column, which stores Telegram, Slack, and iMessage credentials. A viewer of a shared agent could therefore retrieve and reuse another user's provider tokens.

## Impact

Shared-agent viewers can still inspect integration status and safe behavior settings, but no role can read provider credentials back through the API. Internal managers and connectors continue using the credential-bearing service model.

Config updates merge once in the service. Valid stored credentials survive partial or masked updates; invalid stored configs can be repaired with a complete replacement. Settings-only updates also avoid duplicate-key checks when the unique key did not change, preserving editability for legacy duplicate rows.

## Validation

- focused service/API/renderer suites: 5 files, 260 tests passed
- broader chat-integration sweep: 14 files, 144 tests passed
- ESLint on touched files: no errors (one pre-existing warning in `agents.test.ts`)
- touched chat-integration files are TypeScript-clean
- PR build: macOS and Windows succeeded

## Note

The repository-wide typecheck could not complete in this worktree because the available shared dependency install is missing unrelated Markdown/ProseMirror modules. No type errors remain in the files changed by this PR.
