### PR TITLE
Revert "fix: keep pending-request actions reachable on tall cards (SUP-419)"

### DIFF
--- a/src/renderer/components/messages/remote-mcp-request-item.tsx
+++ b/src/renderer/components/messages/remote-mcp-request-item.tsx
@@ -650,7 +650,7 @@ export function RemoteMcpRequestItem({
               />
             ) : null}
           </div>
-          <div className="flex justify-end gap-2 pt-4">
+          <RequestItemActions>
             <DeclineButton
               onDecline={handleDecline}
               disabled={status !== 'pending' && status !== 'oauth_pending'}
@@ -668,7 +668,7 @@ export function RemoteMcpRequestItem({
             >
               Allow Access{selectedMcpIdsForProvide.length > 1 ? ` (${selectedMcpIdsForProvide.length})` : ''}
             </Button>
-          </div>
+          </RequestItemActions>
         </div>
       ) : null}
 

--- a/src/renderer/components/messages/request-item-actions.tsx
+++ b/src/renderer/components/messages/request-item-actions.tsx
@@ -8,12 +8,7 @@ interface RequestItemActionsProps {
 
 export function RequestItemActions({ children, className }: RequestItemActionsProps) {
   return (
-    <div
-      className={cn(
-        'sticky bottom-0 z-10 -mx-4 -mb-4 mt-4 flex justify-end gap-2 border-t border-border bg-background px-4 pb-4 pt-4',
-        className
-      )}
-    >
+    <div className={cn('flex justify-end gap-2 pt-4', className)}>
       {children}
     </div>
   )

--- a/src/renderer/components/messages/request-item-shell.tsx
+++ b/src/renderer/components/messages/request-item-shell.tsx
@@ -161,10 +161,7 @@ export function RequestItemShell({
   const showStopButton = !!(sessionId && agentSlug)
 
   return (
-    <div
-      className="max-h-[50vh] overflow-y-auto border rounded-[12px] bg-muted/30 shadow-md text-sm"
-      {...dataAttrs}
-    >
+    <div className="border rounded-[12px] bg-muted/30 shadow-md text-sm" {...dataAttrs}>
       <div className="p-4">
         <div className="flex-1 min-w-0">
           <div className="flex items-start justify-between gap-3">


### PR DESCRIPTION
## Summary

Reverts #500 (`99ac20ced8fc3d9aa02619eab5ea83db1c0ffe4d`).

- restores the shared `RequestItemActions` component to its previous non-sticky layout
- removes the `50vh` internal scroll container from `RequestItemShell`
- restores the remote-MCP selected-server action row to the shared component

## Why

Post-merge review identified additional layout regressions around hidden submission errors, retained scroll position between question pages, and unclamped read-only cards. This rollback returns `main` to the pre-#500 behavior while a follow-up design can address the original overflow case without those regressions.

## Impact

Pending-request cards return to the behavior shipped at `f0a08efb` (`v0.4.14-rc.2`). The three reverted files are byte-for-byte identical to that pre-#500 commit.

## Validation

- Confirmed `main` had no commits after #500 before creating the revert.
- Confirmed the three affected files match `f0a08efb` exactly.
- `npm run test:run --` across the eight request-card test files: **94 tests passed**.
