### PR TITLE
fix: keep pending-request actions reachable on tall cards (SUP-419)

### DIFF
--- a/src/renderer/components/messages/remote-mcp-request-item.tsx
+++ b/src/renderer/components/messages/remote-mcp-request-item.tsx
@@ -12,6 +12,7 @@ import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
 import { ToolPolicyEditor } from '@renderer/components/settings/tool-policy-editor'
 import { DeclineButton } from './decline-button'
+import { RequestError } from './request-error'
 import { RequestItemShell } from './request-item-shell'
 import { RequestItemActions } from './request-item-actions'
 import { cn } from '@shared/lib/utils/cn'
@@ -635,41 +636,44 @@ export function RemoteMcpRequestItem({
       ) : null}
 
       {selectedServer ? (
-        <div className="flex items-end justify-between gap-3">
-          <div className="min-w-0 self-end pt-4">
-            {status !== 'oauth_pending' ? (
-              <McpServicePicker
-                open={isMcpPickerOpen}
-                onOpenChange={setIsMcpPickerOpen}
-                options={pickerServiceOptions}
-                selectedServiceKey={selectedServiceKey}
-                onSelect={(_serviceKey, serverId) => {
-                  setSelectedMcpIds(new Set([serverId]))
-                }}
-                disabled={status !== 'pending'}
+        <>
+          <div className="flex items-end justify-between gap-3">
+            <div className="min-w-0 self-end pt-4">
+              {status !== 'oauth_pending' ? (
+                <McpServicePicker
+                  open={isMcpPickerOpen}
+                  onOpenChange={setIsMcpPickerOpen}
+                  options={pickerServiceOptions}
+                  selectedServiceKey={selectedServiceKey}
+                  onSelect={(_serviceKey, serverId) => {
+                    setSelectedMcpIds(new Set([serverId]))
+                  }}
+                  disabled={status !== 'pending'}
+                />
+              ) : null}
+            </div>
+            <RequestItemActions inline>
+              <DeclineButton
+                onDecline={handleDecline}
+                disabled={status !== 'pending' && status !== 'oauth_pending'}
+                label="Deny"
+                showIcon={false}
+                className="border-border text-foreground hover:bg-muted"
               />
-            ) : null}
-          </div>
-          <div className="flex justify-end gap-2 pt-4">
-            <DeclineButton
-              onDecline={handleDecline}
-              disabled={status !== 'pending' && status !== 'oauth_pending'}
-              label="Deny"
-              showIcon={false}
-              className="border-border text-foreground hover:bg-muted"
-            />
 
-            <Button
-              onClick={handleProvide}
-              loading={status === 'submitting'}
-              disabled={selectedMcpIdsForProvide.length === 0 || status !== 'pending'}
-              size="xs"
-              className="bg-blue-600 hover:bg-blue-700 text-white"
-            >
-              Allow Access{selectedMcpIdsForProvide.length > 1 ? ` (${selectedMcpIdsForProvide.length})` : ''}
-            </Button>
+              <Button
+                onClick={handleProvide}
+                loading={status === 'submitting'}
+                disabled={selectedMcpIdsForProvide.length === 0 || status !== 'pending'}
+                size="xs"
+                className="bg-blue-600 hover:bg-blue-700 text-white"
+              >
+                Allow Access{selectedMcpIdsForProvide.length > 1 ? ` (${selectedMcpIdsForProvide.length})` : ''}
+              </Button>
+            </RequestItemActions>
           </div>
-        </div>
+          {error ? <RequestError message={error} /> : null}
+        </>
       ) : null}
 
       {policyEditorMcp && (

--- a/src/renderer/components/messages/remote-mcp-request-item.tsx
+++ b/src/renderer/components/messages/remote-mcp-request-item.tsx
@@ -650,7 +650,7 @@ export function RemoteMcpRequestItem({
               />
             ) : null}
           </div>
-          <RequestItemActions>
+          <div className="flex justify-end gap-2 pt-4">
             <DeclineButton
               onDecline={handleDecline}
               disabled={status !== 'pending' && status !== 'oauth_pending'}
@@ -668,7 +668,7 @@ export function RemoteMcpRequestItem({
             >
               Allow Access{selectedMcpIdsForProvide.length > 1 ? ` (${selectedMcpIdsForProvide.length})` : ''}
             </Button>
-          </RequestItemActions>
+          </div>
         </div>
       ) : null}
 

--- a/src/renderer/components/messages/request-item-actions.tsx
+++ b/src/renderer/components/messages/request-item-actions.tsx
@@ -1,20 +1,31 @@
-import type { ReactNode } from 'react'
+import { createContext, useContext, type ReactNode } from 'react'
 import { cn } from '@shared/lib/utils/cn'
+import { RequestError } from './request-error'
+
+export const RequestItemErrorContext = createContext<string | null>(null)
 
 interface RequestItemActionsProps {
   children: ReactNode
   className?: string
+  /** Plain end-aligned row (no sticky footer / full-width divider). */
+  inline?: boolean
 }
 
-export function RequestItemActions({ children, className }: RequestItemActionsProps) {
+export function RequestItemActions({ children, className, inline }: RequestItemActionsProps) {
+  const error = useContext(RequestItemErrorContext)
+
+  if (inline) {
+    return (
+      <div className={cn('flex justify-end gap-2 pt-4', className)}>
+        {children}
+      </div>
+    )
+  }
+
   return (
-    <div
-      className={cn(
-        'sticky bottom-0 z-10 -mx-4 -mb-4 mt-4 flex justify-end gap-2 border-t border-border bg-background px-4 pb-4 pt-4',
-        className
-      )}
-    >
-      {children}
+    <div className="sticky bottom-0 z-10 -mx-4 -mb-4 mt-4 flex flex-col gap-2 border-t border-border bg-background px-4 pb-4 pt-4">
+      <div className={cn('flex justify-end gap-2', className)}>{children}</div>
+      {error ? <RequestError message={error} className="mt-0" /> : null}
     </div>
   )
 }

--- a/src/renderer/components/messages/request-item-actions.tsx
+++ b/src/renderer/components/messages/request-item-actions.tsx
@@ -10,7 +10,7 @@ export function RequestItemActions({ children, className }: RequestItemActionsPr
   return (
     <div
       className={cn(
-        'sticky bottom-0 z-10 -mx-4 -mb-4 flex justify-end gap-2 border-t border-border bg-background px-4 pb-4 pt-4',
+        'sticky bottom-0 z-10 -mx-4 -mb-4 mt-4 flex justify-end gap-2 border-t border-border bg-background px-4 pb-4 pt-4',
         className
       )}
     >

--- a/src/renderer/components/messages/request-item-actions.tsx
+++ b/src/renderer/components/messages/request-item-actions.tsx
@@ -8,7 +8,12 @@ interface RequestItemActionsProps {
 
 export function RequestItemActions({ children, className }: RequestItemActionsProps) {
   return (
-    <div className={cn('flex justify-end gap-2 pt-4', className)}>
+    <div
+      className={cn(
+        'sticky bottom-0 z-10 -mx-4 -mb-4 flex justify-end gap-2 border-t border-border bg-background px-4 pb-4 pt-4',
+        className
+      )}
+    >
       {children}
     </div>
   )

--- a/src/renderer/components/messages/request-item-shell.test.tsx
+++ b/src/renderer/components/messages/request-item-shell.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { RequestItemShell } from './request-item-shell'
+import { RequestItemActions } from './request-item-actions'
 import { PendingRequestStack } from './pending-request-stack'
 import { HelpCircle, Key, Terminal } from 'lucide-react'
 
@@ -39,6 +40,9 @@ describe('RequestItemShell', () => {
       render(
         <RequestItemShell title="Test" icon={<HelpCircle />} theme="blue" error="Something failed">
           <div>Content</div>
+          <RequestItemActions>
+            <button type="button">Submit</button>
+          </RequestItemActions>
         </RequestItemShell>
       )
 
@@ -49,6 +53,9 @@ describe('RequestItemShell', () => {
       render(
         <RequestItemShell title="Test" icon={<HelpCircle />} theme="blue" error={null}>
           <div>Content</div>
+          <RequestItemActions>
+            <button type="button">Submit</button>
+          </RequestItemActions>
         </RequestItemShell>
       )
 

--- a/src/renderer/components/messages/request-item-shell.tsx
+++ b/src/renderer/components/messages/request-item-shell.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
-import { RequestError } from './request-error'
+import { RequestItemErrorContext } from './request-item-actions'
 import { usePagination } from './pending-request-stack'
 import { StopSessionButton } from './stop-session-button'
 
@@ -184,8 +184,9 @@ export function RequestItemShell({
             )}
           </div>
           {subtitleNode}
-          {children}
-          <RequestError message={error ?? null} />
+          <RequestItemErrorContext.Provider value={error ?? null}>
+            {children}
+          </RequestItemErrorContext.Provider>
         </div>
       </div>
     </div>

--- a/src/renderer/components/messages/request-item-shell.tsx
+++ b/src/renderer/components/messages/request-item-shell.tsx
@@ -161,7 +161,10 @@ export function RequestItemShell({
   const showStopButton = !!(sessionId && agentSlug)
 
   return (
-    <div className="border rounded-[12px] bg-muted/30 shadow-md text-sm" {...dataAttrs}>
+    <div
+      className="max-h-[50vh] overflow-y-auto border rounded-[12px] bg-muted/30 shadow-md text-sm"
+      {...dataAttrs}
+    >
       <div className="p-4">
         <div className="flex-1 min-w-0">
           <div className="flex items-start justify-between gap-3">


### PR DESCRIPTION
Re-applies the SUP-419 fix from #500, which was reverted in #504 because it merged without review. Same change, now up for review.

## The bug

When the agent asks a question and you pick "Other" then paste a long answer, the "Other" box grew unbounded and pushed Submit below the viewport with no way to scroll to it - the answer couldn't be submitted. The pending-request card lives in a footer slot that sizes to its content, so only the message list scrolled, never the card.

## The fix (at the shared request-card shell, not per-card)

- Clamp the card to half the viewport height and let it scroll internally.
- Pin the action row to the card bottom with a full-width divider so Allow/Submit stay reachable across every pending-request kind (question, script, connected-account, MCP, etc.), not just the "Other" case reported.
- Give the content above the divider the same 16px breathing room the buttons already have below it, so the divider doesn't crowd inputs.

The remote-MCP card has a second layout where the buttons sit beside a service picker; there it keeps a plain button row, since the full-width divider only makes sense where the row spans the card.

## Verification

Exercised in the E2E mock: with a 60-line paste the card clamps to 360px and scrolls internally while Submit stays on-screen and submits. Question / multi / script / secret / connected-account / default-MCP cards checked the same way. The MCP side-by-side layout isn't reachable in the mock (needs a live registered MCP server); it reverts to the pre-existing plain button row, so no visual change there.
