### PR TITLE
feat(microvm): pass agentId to lifecycle /microvm/run

### DIFF
--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -539,7 +539,7 @@ async function serviceFetch<T>(
 
 async function runMicrovm(
   config: MicrovmRuntimeConfig,
-  opts: { runHookPayload: string; clientToken: string; logStream: string },
+  opts: { runHookPayload: string; clientToken: string; logStream: string; agentId: string },
 ): Promise<{ microvmId: string; endpoint: string }> {
   const idlePolicy = {
     maxIdleDurationSeconds: resolveIdleSeconds(config),
@@ -564,6 +564,8 @@ async function runMicrovm(
       maximumDurationInSeconds: config.maxDurationSeconds,
       runHookPayload: opts.runHookPayload,
       clientToken: opts.clientToken,
+      // Lifecycle embeds agentId in the SPIFFE URI SAN on the client cert (Phase C).
+      agentId: opts.agentId,
     })
   }
   const res = (await getMicrovmClient(config.region).send(
@@ -712,6 +714,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
       // InternalFailure on the idempotency conflict).
       clientToken: randomUUID(),
       logStream: this.config.agentId,
+      agentId: this.config.agentId,
     })
 
     const proxy = new LocalAuthForwardProxy({


### PR DESCRIPTION
## Summary
- Include `agentId` on the lifecycle `/microvm/run` body so Phase C can bind the client cert SPIFFE URI SAN to `cell/org/agent/launch`
- No behavior change until gamut-infra Phase C enables cert issuance (`AGENT_GATEWAY_URL` + workload CA)

## Test plan
- [ ] Typecheck / existing microvm runtime tests
- [ ] Deploy before or with gamut-infra Phase C terraform (issuance requires `agentId` once enabled)
- [ ] Staging session launch still succeeds after both land


Made with [Cursor](https://cursor.com)