### PR TITLE
Add DialMCP to built-in MCP catalogue

### DIFF
--- a/src/renderer/public/service-icons/dialmcp.svg
+++ b/src/renderer/public/service-icons/dialmcp.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text y=".9em" font-size="90">📞</text>
+</svg>

--- a/src/shared/lib/mcp/common-servers.ts
+++ b/src/shared/lib/mcp/common-servers.ts
@@ -123,6 +123,14 @@ export const COMMON_MCP_SERVERS: CommonMcpServer[] = [
     category: 'Communication',
   },
   {
+    slug: 'dialmcp',
+    displayName: 'DialMCP',
+    description: 'Place phone calls from your number with transcripts and recordings',
+    url: 'https://mcp.dialmcp.com/mcp',
+    authType: 'oauth',
+    category: 'Communication',
+  },
+  {
     slug: 'dialer',
     displayName: 'Dialer',
     description: 'Outbound phone calls',


### PR DESCRIPTION
## Summary

- add DialMCP to the built-in MCP catalogue under Communication
- configure its remote OAuth endpoint at `https://mcp.dialmcp.com/mcp`
- add the official phone-mark service icon

## Why

DialMCP lets agents place phone calls from a user's verified phone number and return transcripts and recordings. Including it in the built-in catalogue makes the integration discoverable and preconfigures the supported OAuth connection flow.

## Validation

- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- `npx vitest run src/renderer/components/connections/unified-rows.test.ts` (10 passed)
- `npx tsx scripts/verify-mcp-server.ts --url https://mcp.dialmcp.com/mcp --auth oauth --name DialMCP` (supported; OAuth metadata, dynamic registration, and login page verified)
- `git diff --check`
