### PR TITLE
Fix composer bold shortcut propagation

### DIFF
--- a/src/renderer/components/messages/markdown-composer-editor.test.tsx
+++ b/src/renderer/components/messages/markdown-composer-editor.test.tsx
@@ -96,6 +96,26 @@ describe('MarkdownComposerEditor', () => {
     expect(screen.getByTestId('markdown-value').textContent).toBe('**important**')
   })
 
+  it('keeps Cmd/Ctrl+B inside the editor while applying bold', async () => {
+    const user = userEvent.setup()
+    const onWindowKeyDown = vi.fn()
+    window.addEventListener('keydown', onWindowKeyDown)
+
+    try {
+      render(<ControlledEditor />)
+      const editor = screen.getByTestId('markdown-editor')
+
+      fireEvent.keyDown(editor, { key: 'b', metaKey: true })
+      fireEvent.keyDown(editor, { key: 'b', ctrlKey: true })
+
+      expect(onWindowKeyDown).not.toHaveBeenCalled()
+      await user.type(editor, 'bold')
+      expect(editor.querySelector('strong')).toHaveTextContent('bold')
+    } finally {
+      window.removeEventListener('keydown', onWindowKeyDown)
+    }
+  })
+
   it('does not interpret intraword underscores inside a typed secret', async () => {
     const user = userEvent.setup()
     const token = 'github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'

--- a/src/renderer/components/messages/markdown-composer-editor.tsx
+++ b/src/renderer/components/messages/markdown-composer-editor.tsx
@@ -693,6 +693,13 @@ export function MarkdownComposerEditor({
         keydown: (editorView, event) => {
           if (event.isComposing) return false
 
+          // Cmd/Ctrl+B belongs to the rich-text editor. Keep it from reaching
+          // window-level shortcuts (notably the sidebar toggle) without
+          // preventing ProseMirror's strong-mark keymap from handling it.
+          if (event.key === 'b' && (event.metaKey || event.ctrlKey)) {
+            event.stopPropagation()
+          }
+
           if ((event.key === 'Backspace' || event.key === 'Delete') && latestRef.current.onRemoveSecuredSecrets) {
             const { from, to, empty } = editorView.state.selection
             const matches = findSecretMatches(


### PR DESCRIPTION
## Summary

- stop Cmd/Ctrl-B keydown events from escaping the rich-text message composer
- preserve ProseMirror's existing bold-mark handling
- add regression coverage for both shortcut isolation and bold formatting

## Root cause

The composer handled `Mod-b` through ProseMirror, but the same keydown continued bubbling to the sidebar's window-level Cmd/Ctrl-B listener. As a result, applying bold also toggled the sidebar.

## User impact

Cmd-B now applies bold in the message composer without changing the sidebar state. The equivalent Ctrl-B behavior is covered as well.

## Validation

- `npm test -- --run src/renderer/components/messages/markdown-composer-editor.test.tsx` (22 tests)
- `npm run typecheck`
- `npx eslint src/renderer/components/messages/markdown-composer-editor.tsx src/renderer/components/messages/markdown-composer-editor.test.tsx`
- `git diff --check`
