### PR TITLE
Fix compact command composer restoration

### DIFF
--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen, fireEvent, act } from '@testing-library/react'
+import { useState } from 'react'
 import { MessageList } from './message-list'
 import { useDraft } from '@renderer/context/drafts-context'
 import { renderWithProviders } from '@renderer/test/test-utils'
@@ -507,6 +508,57 @@ describe('MessageList', () => {
     )
 
     expect(onAppeared).toHaveBeenCalledWith('uuid-1')
+  })
+
+  it('does not restore /compact over a draft typed while manual compaction runs', async () => {
+    vi.useFakeTimers()
+    try {
+      mockMessagesData.data = []
+      mockStreamState.isActive = true
+
+      const CompactRaceHarness = () => {
+        const [pending, setPending] = useState([
+          { localId: 'compact-local', uuid: 'compact-server', text: '/compact', sentAt: Date.now() },
+        ])
+        const [draft, setDraft] = useDraft<string>('session:s-1')
+
+        return (
+          <>
+            <button onClick={() => setDraft('the next message')}>Type next message</button>
+            <MessageList
+              sessionId="s-1"
+              agentSlug="agent-1"
+              pendingUserMessages={pending}
+              onPendingMessageAppeared={(localId) => {
+                setPending((current) => current.filter((message) => message.localId !== localId))
+              }}
+            />
+            <div data-testid="draft-probe">{draft ?? ''}</div>
+          </>
+        )
+      }
+
+      const { rerender } = renderWithProviders(<CompactRaceHarness />)
+
+      // The user starts composing the next turn while /compact is active.
+      fireEvent.click(screen.getByRole('button', { name: 'Type next message' }))
+      expect(screen.getByTestId('draft-probe')).toHaveTextContent('the next message')
+
+      // Manual compaction persists a boundary, not a user message carrying the
+      // POST uuid. The compact command must still be considered delivered.
+      mockMessagesData.data = [createCompactBoundary({ createdAt: new Date() })]
+      mockStreamState.isActive = false
+      rerender(<CompactRaceHarness />)
+
+      await act(async () => {
+        vi.advanceTimersByTime(1500)
+      })
+
+      expect(screen.getByTestId('draft-probe')).toHaveTextContent('the next message')
+      expect(screen.getByTestId('draft-probe')).not.toHaveTextContent('/compact')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('does not call onPendingMessageAppeared when neither uuid nor text matches', () => {

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -178,7 +178,9 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   // mid-turn (queued/steering) are re-id'd by the CLI on enqueue (see
   // normalizeQueuedCommandEntry in session-service), so those — and sends
   // whose POST response hasn't arrived yet — match by trimmed text + arrival
-  // window, claiming each persisted id at most once.
+  // window, claiming each persisted id at most once. Manual /compact is the
+  // exception: the runtime persists its effect as a compact boundary rather
+  // than as a user message, so that boundary materializes the command ghost.
   useEffect(() => {
     if (!messages) return
     const claimed = claimedMessageIdsRef.current
@@ -198,6 +200,15 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       // re-ids them) and sends still awaiting their POST response.
       if (!match && (pending.queued || !pending.uuid)) {
         match = findTextMatch(pending.text, pending.sentAt - 5000)
+        if (match) claimed.add(match.id)
+      }
+      if (!match && /^\/compact(?:\s|$)/.test(pending.text.trim())) {
+        match = messages.find(
+          (m) =>
+            m.type === 'compact_boundary' &&
+            !claimed.has(m.id) &&
+            new Date(m.createdAt).getTime() >= pending.sentAt - 5000
+        )
         if (match) claimed.add(match.id)
       }
       if (match) {


### PR DESCRIPTION
## Summary

- reconcile a pending `/compact` command with the compact boundary persisted by the runtime
- prevent idle message recovery from prepending `/compact` to a draft typed during compaction
- add a component regression test covering the active → draft typed → compact complete → idle race

## Root cause

The renderer tracked `/compact` as an optimistic user message, but the runtime persists a compact boundary rather than a user message with the POST UUID. When compaction finished, the unmatched optimistic command was treated as undelivered and restored ahead of the user's in-progress draft.

## User impact

Messages composed while manual compaction runs remain unchanged when compaction completes.

## Validation

- `npm test -- --run src/renderer/components/messages/message-input.test.tsx src/renderer/hooks/use-message-stream.test.ts src/renderer/components/messages/message-list.test.tsx` (253 tests)
- `npm run typecheck`
- `npm run lint -- --quiet`
- `git diff --check`
