### PR TITLE
SUP-421: Redact webhook capabilities from shared viewers

### DIFF
--- a/src/api/middleware/auth.test.ts
+++ b/src/api/middleware/auth.test.ts
@@ -65,6 +65,7 @@ import {
   HasNotificationAccess,
   Or,
   EntityAgentRole,
+  getAuthorizedAgentRole,
 } from './auth'
 
 // ---------------------------------------------------------------------------
@@ -215,10 +216,14 @@ describe('Auth Middleware', () => {
       mockAclQuery('viewer')
       const app = new Hono()
       setUser(app, { id: 'user-1', role: 'user' })
-      app.get('/:id', AgentRead(), (c) => c.json({ ok: true }))
+      app.get('/:id', AgentRead(), (c) => c.json({
+        ok: true,
+        authorizedRole: getAuthorizedAgentRole(c),
+      }))
 
       const res = await request(app)
       expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ ok: true, authorizedRole: 'viewer' })
     })
 
     it('allows user with user role', async () => {
@@ -1333,6 +1338,20 @@ describe('Auth Middleware', () => {
       const body = await res.json()
       expect(body.entity).toEqual(entity)
       expect(mockSelect).not.toHaveBeenCalled()
+    })
+
+    it('marks local-mode entity access as owner access', async () => {
+      mockIsAuthMode.mockReturnValue(false)
+      mockLookup.mockResolvedValue({ agentSlug: 'my-agent', name: 'My Entity' })
+      const app = new Hono()
+      app.get('/:entityId', TestEntityRole('viewer'), (c) => c.json({
+        role: getAuthorizedAgentRole(c),
+      }))
+
+      const res = await request(app, '/entity-1')
+
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ role: 'owner' })
     })
 
     it('passes when user has sufficient role', async () => {

--- a/src/api/middleware/auth.ts
+++ b/src/api/middleware/auth.ts
@@ -22,6 +22,22 @@ async function getAuthLazy() {
 export { type AgentRole, ROLE_HIERARCHY, hasMinRole } from '@shared/lib/types/agent'
 import { type AgentRole, hasMinRole } from '@shared/lib/types/agent'
 
+const AUTHORIZED_AGENT_ROLE_CONTEXT_KEY = 'authorizedAgentRole'
+
+function setAuthorizedAgentRole(c: Context, role: AgentRole): void {
+  c.set(AUTHORIZED_AGENT_ROLE_CONTEXT_KEY as never, role as never)
+}
+
+/**
+ * Read the role established by AgentRead/AgentUser/AgentAdmin or
+ * EntityAgentRole. Returns null when no role-aware middleware ran so callers
+ * can default to the least-privileged response shape.
+ */
+export function getAuthorizedAgentRole(c: Context): AgentRole | null {
+  const role = c.get(AUTHORIZED_AGENT_ROLE_CONTEXT_KEY as never) as AgentRole | undefined
+  return role ?? null
+}
+
 /**
  * Authenticated — verifies user session and attaches user to context.
  * No-op when AUTH_MODE is disabled.
@@ -107,15 +123,22 @@ function resolvedAgentSlug(c: Context): string {
  */
 export function AgentRead(): MiddlewareHandler {
   return async (c: Context, next: Next) => {
-    if (!isAuthMode()) return next()
+    if (!isAuthMode()) {
+      setAuthorizedAgentRole(c, 'owner')
+      return next()
+    }
 
     const user = getUser(c)
-    if (isAdmin(user)) return next()
+    if (isAdmin(user)) {
+      setAuthorizedAgentRole(c, 'owner')
+      return next()
+    }
     const agentSlug = resolvedAgentSlug(c)
     const role = await getUserAgentRole(user.id, agentSlug)
-    if (!hasMinRole(role, 'viewer')) {
+    if (!role || !hasMinRole(role, 'viewer')) {
       return c.json({ error: 'Forbidden' }, 403)
     }
+    setAuthorizedAgentRole(c, role)
     return next()
   }
 }
@@ -126,15 +149,22 @@ export function AgentRead(): MiddlewareHandler {
  */
 export function AgentUser(): MiddlewareHandler {
   return async (c: Context, next: Next) => {
-    if (!isAuthMode()) return next()
+    if (!isAuthMode()) {
+      setAuthorizedAgentRole(c, 'owner')
+      return next()
+    }
 
     const user = getUser(c)
-    if (isAdmin(user)) return next()
+    if (isAdmin(user)) {
+      setAuthorizedAgentRole(c, 'owner')
+      return next()
+    }
     const agentSlug = resolvedAgentSlug(c)
     const role = await getUserAgentRole(user.id, agentSlug)
-    if (!hasMinRole(role, 'user')) {
+    if (!role || !hasMinRole(role, 'user')) {
       return c.json({ error: 'Forbidden' }, 403)
     }
+    setAuthorizedAgentRole(c, role)
     return next()
   }
 }
@@ -145,15 +175,22 @@ export function AgentUser(): MiddlewareHandler {
  */
 export function AgentAdmin(): MiddlewareHandler {
   return async (c: Context, next: Next) => {
-    if (!isAuthMode()) return next()
+    if (!isAuthMode()) {
+      setAuthorizedAgentRole(c, 'owner')
+      return next()
+    }
 
     const user = getUser(c)
-    if (isAdmin(user)) return next()
+    if (isAdmin(user)) {
+      setAuthorizedAgentRole(c, 'owner')
+      return next()
+    }
     const agentSlug = resolvedAgentSlug(c)
     const role = await getUserAgentRole(user.id, agentSlug)
-    if (!hasMinRole(role, 'owner')) {
+    if (!role || !hasMinRole(role, 'owner')) {
       return c.json({ error: 'Forbidden' }, 403)
     }
+    setAuthorizedAgentRole(c, role)
     return next()
   }
 }
@@ -206,14 +243,18 @@ export function EntityAgentRole<T extends { agentSlug: string }>(opts: {
       }
       c.set(opts.contextKey as never, entity as never)
 
-      if (!isAuthMode()) return next()
+      if (!isAuthMode()) {
+        setAuthorizedAgentRole(c, 'owner')
+        return next()
+      }
 
       const user = getUser(c)
       const role = await getUserAgentRole(user.id, entity.agentSlug)
-      if (!hasMinRole(role, minRole)) {
+      if (!role || !hasMinRole(role, minRole)) {
         return c.json({ error: 'Forbidden' }, 403)
       }
 
+      setAuthorizedAgentRole(c, role)
       return next()
     }
   }

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -48,15 +48,16 @@ vi.mock('stream', () => ({
 
 // Auth middleware — passthrough (sets mock user on context for auth mode tests)
 const mockAuthUser = { id: 'test-user-id', name: 'Test User', email: 'test@example.com' }
+let mockAuthorizedAgentRole: 'owner' | 'user' | 'viewer' = 'owner'
 // Display-slug -> canonical-id resolution applied by the ResolveAgent mock. Defaults
 // to identity (test slugs are already canonical); a test can override it to exercise
 // routes where the URL display slug differs from the resolved id.
 let mockResolveSlug: (slug: string) => string = (slug) => slug
 vi.mock('../middleware/auth', () => ({
   Authenticated: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
-  AgentRead: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
-  AgentUser: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
-  AgentAdmin: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
+  AgentRead: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); c.set('authorizedAgentRole', mockAuthorizedAgentRole); return next() },
+  AgentUser: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); c.set('authorizedAgentRole', mockAuthorizedAgentRole); return next() },
+  AgentAdmin: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); c.set('authorizedAgentRole', mockAuthorizedAgentRole); return next() },
   // Mirrors the real ResolveAgent: 404 on a missing agent (via the agentExists
   // mock) and stash the resolved id, which getAgentId reads back. For test slugs
   // (already canonical), resolution is the identity.
@@ -67,6 +68,7 @@ vi.mock('../middleware/auth', () => ({
     return next()
   },
   getAgentId: (c: any) => c.get('agentId') ?? c.req.param('id'),
+  getAuthorizedAgentRole: (c: any) => c.get('authorizedAgentRole') ?? null,
 }))
 
 // Container manager
@@ -296,6 +298,12 @@ vi.mock('@shared/lib/services/chat-integration-service', () => ({
   listChatIntegrationsByAgents: vi.fn(() => new Map()),
 }))
 
+vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
+  listWebhookTriggers: vi.fn(() => Promise.resolve([])),
+  listActiveWebhookTriggers: vi.fn(() => Promise.resolve([])),
+  listCancelledWebhookTriggers: vi.fn(() => Promise.resolve([])),
+}))
+
 vi.mock('@shared/lib/services/notification-service', () => ({
   getSessionIdsWithUnreadNotifications: vi.fn(() => Promise.resolve(new Set())),
   getUnreadNotificationsByAgents: vi.fn(() => Promise.resolve(new Map())),
@@ -437,6 +445,7 @@ import { containerManager } from '@shared/lib/container/container-manager'
 import { listUserSecrets, setSecret, getSecret, keyToEnvVar, getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { readJsonFileStrict, writeJsonFileAtomic } from '@shared/lib/utils/file-storage'
 import { listChatIntegrations } from '@shared/lib/services/chat-integration-service'
+import { listWebhookTriggers } from '@shared/lib/services/webhook-trigger-service'
 
 // ============================================================================
 // Test Helpers
@@ -447,6 +456,10 @@ function createApp() {
   app.route('/api/agents', agents)
   return app
 }
+
+beforeEach(() => {
+  mockAuthorizedAgentRole = 'owner'
+})
 
 async function patchJson(app: Hono, url: string, body: unknown): Promise<Response> {
   return app.request(`http://localhost${url}`, {
@@ -478,6 +491,66 @@ async function postFormData(app: Hono, url: string, body: FormData): Promise<Res
     body,
   })
 }
+
+// ============================================================================
+// Webhook triggers — GET /:id/webhook-triggers
+// ============================================================================
+
+describe('GET /:id/webhook-triggers', () => {
+  const trigger = {
+    id: 'trigger-1',
+    agentSlug: 'test-agent',
+    kind: 'custom' as const,
+    composioTriggerId: 'whep_private-id',
+    connectedAccountId: 'account-private-id',
+    triggerType: 'CUSTOM_WEBHOOK',
+    triggerConfig: JSON.stringify({ url: 'https://hooks.example.test/private-capability' }),
+    prompt: 'Handle the event',
+    name: 'Inbound events',
+    status: 'active' as const,
+    lastFiredAt: null,
+    fireCount: 0,
+    lastSessionId: null,
+    createdBySessionId: null,
+    createdByUserId: 'owner-private-id',
+    model: null,
+    effort: null,
+    speed: null,
+    createdAt: new Date('2026-07-17T00:00:00Z'),
+    cancelledAt: null,
+    pausedAt: null,
+  }
+
+  it.each(['viewer', 'user'] as const)('redacts list rows for %s members', async (role) => {
+    mockAuthorizedAgentRole = role
+    vi.mocked(listWebhookTriggers).mockResolvedValueOnce([trigger])
+
+    const res = await getReq(createApp(), '/api/agents/test-agent/webhook-triggers')
+    const body = await res.json() as Array<Record<string, unknown>>
+
+    expect(res.status).toBe(200)
+    expect(body[0]).not.toHaveProperty('triggerConfig')
+    expect(body[0]).not.toHaveProperty('composioTriggerId')
+    expect(body[0]).not.toHaveProperty('connectedAccountId')
+    expect(body[0]).not.toHaveProperty('createdByUserId')
+    expect(JSON.stringify(body)).not.toContain('private-capability')
+  })
+
+  it('retains capability fields in list rows for owners', async () => {
+    vi.mocked(listWebhookTriggers).mockResolvedValueOnce([trigger])
+
+    const res = await getReq(createApp(), '/api/agents/test-agent/webhook-triggers')
+    const body = await res.json() as Array<Record<string, unknown>>
+
+    expect(res.status).toBe(200)
+    expect(body[0]).toMatchObject({
+      triggerConfig: trigger.triggerConfig,
+      composioTriggerId: 'whep_private-id',
+      connectedAccountId: 'account-private-id',
+      createdByUserId: 'owner-private-id',
+    })
+  })
+})
 
 // ============================================================================
 // Chat integrations — GET /:id/chat-integrations

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -6,7 +6,7 @@ import { z } from 'zod'
 import { zValidator } from '@hono/zod-validator'
 import { getPolyfillJs } from '../speech-recognition-polyfill'
 import { getLlmPolyfillJs } from '../llm-polyfill'
-import { Authenticated, AgentRead, AgentUser, AgentAdmin, ResolveAgent, getAgentId } from '../middleware/auth'
+import { Authenticated, AgentRead, AgentUser, AgentAdmin, ResolveAgent, getAgentId, getAuthorizedAgentRole } from '../middleware/auth'
 import {
   listAgentsWithStatus,
   createAgent,
@@ -148,6 +148,7 @@ import pLimit from 'p-limit'
 import * as path from 'path'
 import type { ApiAgent } from '@shared/lib/types/api'
 import { toPublicChatIntegration } from '@shared/lib/chat-integrations/public'
+import { toPublicWebhookTrigger } from '@shared/lib/webhook-triggers/public'
 
 function getConfiguredSkillsets() {
   return getSettings().skillsets || []
@@ -2970,7 +2971,8 @@ agents.get('/:id/webhook-triggers', AgentRead(), async (c) => {
       : status === 'cancelled'
       ? await listCancelledWebhookTriggers(slug)
       : await listWebhookTriggers(slug)
-    return c.json(triggers)
+    const role = getAuthorizedAgentRole(c)
+    return c.json(triggers.map((trigger) => toPublicWebhookTrigger(trigger, role)))
   } catch (error) {
     console.error('Failed to fetch webhook triggers:', error)
     return c.json({ error: 'Failed to fetch webhook triggers' }, 500)

--- a/src/api/routes/webhook-triggers.test.ts
+++ b/src/api/routes/webhook-triggers.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Hono } from 'hono'
+import type { AgentRole } from '@shared/lib/types/agent'
+import type { WebhookTrigger } from '@shared/lib/db/schema'
+
+const mockGetWebhookTrigger = vi.fn()
+const mockPauseWebhookTrigger = vi.fn()
+const mockResumeWebhookTrigger = vi.fn()
+const mockUpdateWebhookTriggerPrompt = vi.fn()
+const mockUpdateWebhookTriggerRuntimeOptions = vi.fn()
+const mockCancelWebhookTriggerWithCleanup = vi.fn()
+
+vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
+  getWebhookTrigger: (...args: unknown[]) => mockGetWebhookTrigger(...args),
+  pauseWebhookTrigger: (...args: unknown[]) => mockPauseWebhookTrigger(...args),
+  resumeWebhookTrigger: (...args: unknown[]) => mockResumeWebhookTrigger(...args),
+  updateWebhookTriggerPrompt: (...args: unknown[]) => mockUpdateWebhookTriggerPrompt(...args),
+  updateWebhookTriggerRuntimeOptions: (...args: unknown[]) => mockUpdateWebhookTriggerRuntimeOptions(...args),
+  cancelWebhookTriggerWithCleanup: (...args: unknown[]) => mockCancelWebhookTriggerWithCleanup(...args),
+}))
+
+vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionsByWebhookTrigger: vi.fn(() => []),
+}))
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: { isSessionActive: vi.fn(() => false) },
+}))
+
+vi.mock('@shared/lib/auth/config', () => ({
+  getCurrentUserId: () => 'request-user',
+}))
+
+vi.mock('@shared/lib/services/audit-log-service', () => ({
+  logAuditEvent: vi.fn(),
+}))
+
+const authState = vi.hoisted(() => ({ role: 'owner' as AgentRole }))
+vi.mock('../middleware/auth', () => ({
+  Authenticated: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  getAuthorizedAgentRole: (c: { get: (key: string) => AgentRole | undefined }) =>
+    c.get('authorizedAgentRole') ?? null,
+  EntityAgentRole: (opts: {
+    paramName: string
+    lookupFn: (id: string) => Promise<WebhookTrigger | null>
+    contextKey: string
+    entityName: string
+  }) => () => async (c: {
+    req: { param: (name: string) => string }
+    get: (key: string) => unknown
+    set: (key: string, value: unknown) => void
+    json: (body: unknown, status?: number) => Response
+  }, next: () => Promise<void>) => {
+    const entity = await opts.lookupFn(c.req.param(opts.paramName))
+    if (!entity) return c.json({ error: `${opts.entityName} not found` }, 404)
+    c.set(opts.contextKey, entity)
+    c.set('authorizedAgentRole', authState.role)
+    return next()
+  },
+}))
+
+import webhookTriggersRouter from './webhook-triggers'
+
+const trigger: WebhookTrigger = {
+  id: 'trigger-1',
+  agentSlug: 'agent-1',
+  kind: 'custom',
+  composioTriggerId: 'whep_private-id',
+  connectedAccountId: 'account-private-id',
+  triggerType: 'CUSTOM_WEBHOOK',
+  triggerConfig: JSON.stringify({ url: 'https://hooks.example.test/private-capability' }),
+  prompt: 'Handle the event',
+  name: 'Inbound events',
+  status: 'active',
+  lastFiredAt: null,
+  fireCount: 0,
+  lastSessionId: null,
+  createdBySessionId: null,
+  createdByUserId: 'owner-private-id',
+  model: null,
+  effort: null,
+  speed: null,
+  createdAt: new Date('2026-07-17T00:00:00Z'),
+  cancelledAt: null,
+  pausedAt: null,
+}
+
+function createApp() {
+  const app = new Hono()
+  app.route('/api/webhook-triggers', webhookTriggersRouter)
+  return app
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  authState.role = 'owner'
+  mockGetWebhookTrigger.mockResolvedValue(trigger)
+  mockPauseWebhookTrigger.mockResolvedValue(true)
+})
+
+describe('webhook trigger response access', () => {
+  it.each(['viewer', 'user'] as const)('redacts the detail response for %s members', async (role) => {
+    authState.role = role
+
+    const res = await createApp().request('http://localhost/api/webhook-triggers/trigger-1')
+    const body = await res.json() as Record<string, unknown>
+
+    expect(res.status).toBe(200)
+    expect(body).not.toHaveProperty('triggerConfig')
+    expect(body).not.toHaveProperty('composioTriggerId')
+    expect(body).not.toHaveProperty('connectedAccountId')
+    expect(body).not.toHaveProperty('createdByUserId')
+    expect(JSON.stringify(body)).not.toContain('private-capability')
+  })
+
+  it('retains capability fields in the detail response for owners', async () => {
+    const res = await createApp().request('http://localhost/api/webhook-triggers/trigger-1')
+    const body = await res.json() as Record<string, unknown>
+
+    expect(res.status).toBe(200)
+    expect(body).toMatchObject({
+      triggerConfig: trigger.triggerConfig,
+      composioTriggerId: 'whep_private-id',
+      connectedAccountId: 'account-private-id',
+      createdByUserId: 'owner-private-id',
+    })
+  })
+
+  it('redacts refreshed rows returned after a user mutation', async () => {
+    authState.role = 'user'
+
+    const res = await createApp().request(
+      'http://localhost/api/webhook-triggers/trigger-1/pause',
+      { method: 'POST' },
+    )
+    const body = await res.json() as Record<string, unknown>
+
+    expect(res.status).toBe(200)
+    expect(body).not.toHaveProperty('triggerConfig')
+    expect(body).not.toHaveProperty('composioTriggerId')
+    expect(body).not.toHaveProperty('connectedAccountId')
+    expect(body).not.toHaveProperty('createdByUserId')
+  })
+})

--- a/src/api/routes/webhook-triggers.ts
+++ b/src/api/routes/webhook-triggers.ts
@@ -39,11 +39,8 @@ const TriggerAgentRole = EntityAgentRole({
 // GET /api/webhook-triggers/:triggerId - Get a single trigger
 webhookTriggersRouter.get('/:triggerId', TriggerAgentRole('viewer'), async (c) => {
   try {
-    const trigger = c.get('webhookTrigger' as never)
-    return c.json(toPublicWebhookTrigger(
-      trigger as NonNullable<Awaited<ReturnType<typeof getWebhookTrigger>>>,
-      getAuthorizedAgentRole(c),
-    ))
+    const trigger = c.get('webhookTrigger' as never) as Awaited<ReturnType<typeof getWebhookTrigger>>
+    return c.json(toPublicWebhookTrigger(trigger!, getAuthorizedAgentRole(c)))
   } catch (error) {
     console.error('Failed to fetch webhook trigger:', error)
     return c.json({ error: 'Failed to fetch webhook trigger' }, 500)

--- a/src/api/routes/webhook-triggers.ts
+++ b/src/api/routes/webhook-triggers.ts
@@ -22,7 +22,8 @@ import {
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
-import { Authenticated, EntityAgentRole } from '../middleware/auth'
+import { toPublicWebhookTrigger } from '@shared/lib/webhook-triggers/public'
+import { Authenticated, EntityAgentRole, getAuthorizedAgentRole } from '../middleware/auth'
 
 const webhookTriggersRouter = new Hono()
 
@@ -39,7 +40,10 @@ const TriggerAgentRole = EntityAgentRole({
 webhookTriggersRouter.get('/:triggerId', TriggerAgentRole('viewer'), async (c) => {
   try {
     const trigger = c.get('webhookTrigger' as never)
-    return c.json(trigger)
+    return c.json(toPublicWebhookTrigger(
+      trigger as NonNullable<Awaited<ReturnType<typeof getWebhookTrigger>>>,
+      getAuthorizedAgentRole(c),
+    ))
   } catch (error) {
     console.error('Failed to fetch webhook trigger:', error)
     return c.json({ error: 'Failed to fetch webhook trigger' }, 500)
@@ -71,8 +75,9 @@ webhookTriggersRouter.post('/:triggerId/pause', TriggerAgentRole('user'), async 
       return c.json({ error: 'Trigger is not active' }, 400)
     }
     const updated = await getWebhookTrigger(trigger!.id)
+    if (!updated) throw new Error('Webhook trigger disappeared after pause')
     logAuditEvent({ userId: getCurrentUserId(c), object: 'trigger', objectId: trigger!.id, action: 'paused' })
-    return c.json(updated)
+    return c.json(toPublicWebhookTrigger(updated, getAuthorizedAgentRole(c)))
   } catch (error) {
     console.error('Failed to pause webhook trigger:', error)
     return c.json({ error: 'Failed to pause webhook trigger' }, 500)
@@ -88,8 +93,9 @@ webhookTriggersRouter.post('/:triggerId/resume', TriggerAgentRole('user'), async
       return c.json({ error: 'Trigger is not paused' }, 400)
     }
     const updated = await getWebhookTrigger(trigger!.id)
+    if (!updated) throw new Error('Webhook trigger disappeared after resume')
     logAuditEvent({ userId: getCurrentUserId(c), object: 'trigger', objectId: trigger!.id, action: 'resumed' })
-    return c.json(updated)
+    return c.json(toPublicWebhookTrigger(updated, getAuthorizedAgentRole(c)))
   } catch (error) {
     console.error('Failed to resume webhook trigger:', error)
     return c.json({ error: 'Failed to resume webhook trigger' }, 500)
@@ -112,8 +118,9 @@ webhookTriggersRouter.patch('/:triggerId/prompt', TriggerAgentRole('user'), asyn
     }
 
     const refreshed = await getWebhookTrigger(trigger!.id)
+    if (!refreshed) throw new Error('Webhook trigger disappeared after prompt update')
     logAuditEvent({ userId: getCurrentUserId(c), object: 'trigger', objectId: trigger!.id, action: 'updated', details: { field: 'prompt' } })
-    return c.json(refreshed)
+    return c.json(toPublicWebhookTrigger(refreshed, getAuthorizedAgentRole(c)))
   } catch (error) {
     console.error('Failed to update webhook trigger prompt:', error)
     return c.json({ error: 'Failed to update prompt' }, 500)
@@ -141,8 +148,9 @@ webhookTriggersRouter.patch('/:triggerId/runtime-options', TriggerAgentRole('use
     }
 
     const refreshed = await getWebhookTrigger(trigger!.id)
+    if (!refreshed) throw new Error('Webhook trigger disappeared after runtime options update')
     logAuditEvent({ userId: getCurrentUserId(c), object: 'trigger', objectId: trigger!.id, action: 'updated', details: { field: 'runtime-options' } })
-    return c.json(refreshed)
+    return c.json(toPublicWebhookTrigger(refreshed, getAuthorizedAgentRole(c)))
   } catch (error) {
     console.error('Failed to update webhook trigger runtime options:', error)
     return c.json({ error: 'Failed to update runtime options' }, 500)

--- a/src/renderer/components/webhook-triggers/webhook-trigger-view.test.tsx
+++ b/src/renderer/components/webhook-triggers/webhook-trigger-view.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { WebhookTriggerView } from './webhook-trigger-view'
+
+const capabilityUrl = 'https://hooks.example.test/private-capability'
+const userState = vi.hoisted(() => ({ canAdmin: true }))
+
+vi.mock('@renderer/hooks/use-webhook-triggers', () => ({
+  useWebhookTrigger: () => ({
+    data: {
+      id: 'trigger-1',
+      agentSlug: 'agent-1',
+      kind: 'custom',
+      triggerType: 'CUSTOM_WEBHOOK',
+      triggerConfig: JSON.stringify({ url: 'https://hooks.example.test/private-capability' }),
+      prompt: 'Handle the event',
+      name: 'Inbound events',
+      status: 'active',
+      fireCount: 0,
+      lastFiredAt: null,
+      model: null,
+      effort: null,
+      speed: null,
+      createdAt: new Date('2026-07-17T00:00:00Z'),
+    },
+    isLoading: false,
+    error: null,
+  }),
+  useWebhookTriggerSessions: () => ({ data: [] }),
+  useCancelWebhookTrigger: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  usePauseWebhookTrigger: () => ({ mutate: vi.fn(), isPending: false }),
+  useResumeWebhookTrigger: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateWebhookTriggerPrompt: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateWebhookTriggerRuntimeOptions: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+vi.mock('@renderer/context/user-context', () => ({
+  useUser: () => ({
+    canUseAgent: () => true,
+    canAdminAgent: () => userState.canAdmin,
+  }),
+}))
+
+vi.mock('@renderer/hooks/use-agents', () => ({
+  useAgents: () => ({ data: [{ slug: 'agent-1' }] }),
+  resolveRouteAgentId: (slug: string) => slug,
+}))
+
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useSettings: () => ({ data: { apiKeyStatus: {} } }),
+}))
+
+vi.mock('@renderer/hooks/use-platform-auth', () => ({
+  usePlatformAuthStatus: () => ({ data: { connected: true } }),
+}))
+
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => vi.fn() }))
+
+vi.mock('@renderer/components/layout/settings-page', () => ({
+  SettingsPageContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PageTitle: ({ title }: { title: string }) => <h1>{title}</h1>,
+}))
+
+vi.mock('@renderer/components/triggers/detail-card', () => ({
+  DetailCard: ({ label, children }: { label: string; children: ReactNode }) => (
+    <section aria-label={label}>{children}</section>
+  ),
+}))
+
+vi.mock('@renderer/components/triggers/status-toggle', () => ({ StatusToggle: () => null }))
+vi.mock('@renderer/components/triggers/run-history-section', () => ({ RunHistorySection: () => null }))
+vi.mock('@renderer/components/triggers/collapsible-prompt-text', () => ({
+  CollapsiblePromptText: ({ text }: { text: string }) => <span>{text}</span>,
+}))
+vi.mock('@renderer/components/triggers/edit-prompt-dialog', () => ({ EditPromptDialog: () => null }))
+vi.mock('@renderer/components/triggers/runtime-options-card', () => ({ RuntimeOptionsCard: () => null }))
+
+vi.mock('@renderer/components/ui/popover', () => ({
+  Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: () => null,
+}))
+
+vi.mock('@renderer/components/ui/alert-dialog', () => ({
+  AlertDialog: () => null,
+  AlertDialogAction: () => null,
+  AlertDialogCancel: () => null,
+  AlertDialogContent: () => null,
+  AlertDialogDescription: () => null,
+  AlertDialogFooter: () => null,
+  AlertDialogHeader: () => null,
+  AlertDialogTitle: () => null,
+}))
+
+afterEach(() => {
+  userState.canAdmin = true
+})
+
+describe('WebhookTriggerView owner-only details', () => {
+  it('does not render a capability URL for a non-owner even if stale data contains it', () => {
+    userState.canAdmin = false
+
+    render(<WebhookTriggerView triggerId="trigger-1" agentSlug="agent-1" />)
+
+    expect(screen.queryByText('Endpoint URL')).not.toBeInTheDocument()
+    expect(screen.queryByText(capabilityUrl)).not.toBeInTheDocument()
+  })
+
+  it('renders the capability URL for an owner', () => {
+    render(<WebhookTriggerView triggerId="trigger-1" agentSlug="agent-1" />)
+
+    expect(screen.getByText('Endpoint URL')).toBeInTheDocument()
+    expect(screen.getByText(capabilityUrl)).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/webhook-triggers/webhook-trigger-view.tsx
+++ b/src/renderer/components/webhook-triggers/webhook-trigger-view.tsx
@@ -57,10 +57,11 @@ export function WebhookTriggerView({ triggerId, agentSlug }: WebhookTriggerViewP
   const updatePrompt = useUpdateWebhookTriggerPrompt()
   const updateRuntimeOptions = useUpdateWebhookTriggerRuntimeOptions()
   const navigate = useNavigate()
-  const { canUseAgent } = useUser()
+  const { canUseAgent, canAdminAgent } = useUser()
   const { data: settings } = useSettings()
   const { data: platformAuth } = usePlatformAuthStatus()
   const canCancel = canUseAgent(agentSlug)
+  const canViewOwnerDetails = canAdminAgent(trigger?.agentSlug ?? agentSlug)
   const { data: agents } = useAgents()
 
   // Canonicalize: triggers are addressed globally by id, so /agents/<wrong>/webhooks/<id>
@@ -106,8 +107,8 @@ export function WebhookTriggerView({ triggerId, agentSlug }: WebhookTriggerViewP
 
   const isCustom = trigger?.kind === 'custom'
   const endpointUrl = useMemo(
-    () => (isCustom ? extractEndpointUrl(trigger?.triggerConfig) : null),
-    [isCustom, trigger?.triggerConfig],
+    () => (isCustom && canViewOwnerDetails ? extractEndpointUrl(trigger?.triggerConfig) : null),
+    [isCustom, canViewOwnerDetails, trigger?.triggerConfig],
   )
   const [urlCopied, setUrlCopied] = useState(false)
   const handleCopyUrl = async () => {
@@ -127,7 +128,7 @@ export function WebhookTriggerView({ triggerId, agentSlug }: WebhookTriggerViewP
   const parsedConfigEntries = useMemo<[string, unknown][]>(() => {
     // For custom endpoints the config IS the endpoint mirror (url/endpointId),
     // which gets its own card — no generic Configuration card to show.
-    if (!trigger?.triggerConfig || isCustom) return []
+    if (!canViewOwnerDetails || !trigger?.triggerConfig || isCustom) return []
     try {
       const config = JSON.parse(trigger.triggerConfig) as Record<string, unknown>
       return Object.entries(config).filter(
@@ -136,7 +137,7 @@ export function WebhookTriggerView({ triggerId, agentSlug }: WebhookTriggerViewP
     } catch {
       return []
     }
-  }, [trigger?.triggerConfig, isCustom])
+  }, [canViewOwnerDetails, trigger?.triggerConfig, isCustom])
 
   const handleCancel = async () => {
     try {
@@ -368,12 +369,12 @@ export function WebhookTriggerView({ triggerId, agentSlug }: WebhookTriggerViewP
                     </dd>
                   </div>
                 )
-              ) : (
+              ) : canViewOwnerDetails && trigger.connectedAccountId ? (
                 <div>
                   <dt className="text-xs text-muted-foreground">Connected Account</dt>
                   <dd className="text-xs font-normal break-all">{trigger.connectedAccountId}</dd>
                 </div>
-              )}
+              ) : null}
             </dl>
           </DetailCard>
 

--- a/src/renderer/hooks/use-webhook-triggers.ts
+++ b/src/renderer/hooks/use-webhook-triggers.ts
@@ -6,7 +6,7 @@
 
 import { apiFetch } from '@renderer/lib/api'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import type { WebhookTrigger } from '@shared/lib/db/schema'
+import type { PublicWebhookTrigger } from '@shared/lib/webhook-triggers/public'
 import {
   useAutomationList,
   useAutomationDetail,
@@ -14,7 +14,7 @@ import {
   useAutomationSessions,
 } from './use-agent-automations'
 
-export type { WebhookTrigger }
+export type WebhookTrigger = PublicWebhookTrigger
 
 const TYPE = 'webhook-triggers' as const
 

--- a/src/shared/lib/webhook-triggers/public.test.ts
+++ b/src/shared/lib/webhook-triggers/public.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import type { WebhookTrigger } from '@shared/lib/db/schema'
+import { toPublicWebhookTrigger } from './public'
+
+const trigger: WebhookTrigger = {
+  id: 'trigger-1',
+  agentSlug: 'agent-1',
+  kind: 'custom',
+  composioTriggerId: 'whep_private-id',
+  connectedAccountId: 'account-private-id',
+  triggerType: 'CUSTOM_WEBHOOK',
+  triggerConfig: JSON.stringify({
+    url: 'https://hooks.example.test/private-capability',
+    endpointId: 'whep_private-id',
+  }),
+  prompt: 'Handle the event',
+  name: 'Inbound events',
+  status: 'active',
+  lastFiredAt: null,
+  fireCount: 0,
+  lastSessionId: null,
+  createdBySessionId: null,
+  createdByUserId: 'owner-private-id',
+  model: null,
+  effort: null,
+  speed: null,
+  createdAt: new Date('2026-07-17T00:00:00Z'),
+  cancelledAt: null,
+  pausedAt: null,
+}
+
+describe('toPublicWebhookTrigger', () => {
+  it.each(['viewer', 'user', null] as const)(
+    'redacts capability and owner fields for %s access',
+    (role) => {
+      const result = toPublicWebhookTrigger(trigger, role)
+      const serialized = JSON.stringify(result)
+
+      expect(result).not.toHaveProperty('triggerConfig')
+      expect(result).not.toHaveProperty('composioTriggerId')
+      expect(result).not.toHaveProperty('connectedAccountId')
+      expect(result).not.toHaveProperty('createdByUserId')
+      expect(result).toMatchObject({ id: 'trigger-1', name: 'Inbound events' })
+      expect(serialized).not.toContain('private-capability')
+      expect(serialized).not.toContain('private-id')
+    },
+  )
+
+  it('retains capability and owner fields for owners', () => {
+    expect(toPublicWebhookTrigger(trigger, 'owner')).toEqual(trigger)
+  })
+})

--- a/src/shared/lib/webhook-triggers/public.ts
+++ b/src/shared/lib/webhook-triggers/public.ts
@@ -1,0 +1,36 @@
+import type { WebhookTrigger } from '@shared/lib/db/schema'
+import type { AgentRole } from '@shared/lib/types/agent'
+
+type OwnerOnlyWebhookTriggerFields = Pick<
+  WebhookTrigger,
+  'triggerConfig' | 'composioTriggerId' | 'connectedAccountId' | 'createdByUserId'
+>
+
+/**
+ * Webhook trigger fields safe for every agent member. Capability-bearing
+ * configuration and owner metadata are present only in owner responses.
+ */
+export type PublicWebhookTrigger = Omit<WebhookTrigger, keyof OwnerOnlyWebhookTriggerFields>
+  & Partial<OwnerOnlyWebhookTriggerFields>
+
+/**
+ * Convert the internal DB row into the role-aware API contract. A missing role
+ * is treated as unprivileged so a route cannot expose capabilities merely by
+ * forgetting to attach authorization context.
+ */
+export function toPublicWebhookTrigger(
+  trigger: WebhookTrigger,
+  role: AgentRole | null,
+): PublicWebhookTrigger {
+  if (role === 'owner') return { ...trigger }
+
+  const {
+    triggerConfig: _triggerConfig,
+    composioTriggerId: _composioTriggerId,
+    connectedAccountId: _connectedAccountId,
+    createdByUserId: _createdByUserId,
+    ...publicFields
+  } = trigger
+
+  return publicFields
+}


### PR DESCRIPTION
## Summary

- add a role-aware public DTO for webhook trigger responses
- redact `triggerConfig`, `composioTriggerId`, `connectedAccountId`, and `createdByUserId` from viewer and user responses
- apply the DTO to trigger detail, list, and mutation responses
- gate capability URLs and owner metadata in the renderer as defense in depth

## Root cause

Webhook trigger routes serialized internal database rows directly. Shared-agent viewers could therefore receive the custom trigger configuration containing the unauthenticated invocation URL, along with internal owner and connected-account metadata.

## Impact

Only agent owners receive webhook capability URLs and owner metadata through the webhook-trigger API and UI responses changed here. Viewers and users retain the safe trigger fields needed for listing, viewing history, and permitted trigger operations.

## Known limitations and follow-ups

- This PR secures the webhook-trigger API/UI serialization boundary; it does not make the capability URL owner-only across every surface. The agent-facing `list_triggers` and endpoint-creation tool results intentionally include the URL, those results persist in session JSONL, and members who can view the session can read them. A user-role member can also ask the agent to run `list_triggers`. Hardening tool-result and transcript visibility is a separate product/authorization decision.
- Scheduled-task API responses still expose `createdByUserId`. They do not carry an invocation capability, but aligning owner-metadata serialization is a follow-up candidate.
- Platform admins are treated as owners by `AgentRead`/`AgentUser`/`AgentAdmin`, while `EntityAgentRole` requires an explicit ACL and has no admin bypass. Normalizing that pre-existing authorization behavior is a separate follow-up.

## Validation

- `npm test -- --run src/shared/lib/webhook-triggers/public.test.ts src/api/middleware/auth.test.ts src/api/routes/webhook-triggers.test.ts src/api/routes/agents.test.ts src/renderer/components/webhook-triggers/webhook-trigger-view.test.tsx` (328 tests)
- `npm run typecheck`
- `npm run lint -- --quiet`
- `git diff --check`
- review follow-up: `npm test -- --run src/api/routes/webhook-triggers.test.ts`, `npm run typecheck`, and targeted ESLint
