### PR TITLE
SUP-432: Reconcile queued messages when picked up

### DIFF
--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -2327,6 +2327,22 @@ describe('useMessageStream', () => {
       expect(invalidateSpy).not.toHaveBeenCalled()
     })
 
+    it('does not retry after the picked-up command completes before another response starts', async () => {
+      const { es, queryClient } = await setupHook('cmd-s5')
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+      act(() => {
+        es.simulateMessage({ type: 'command_lifecycle', commandUuid: 'u1', state: 'started' })
+        es.simulateMessage({ type: 'command_lifecycle', commandUuid: 'u1', state: 'completed' })
+      })
+
+      invalidateSpy.mockClear()
+      act(() => {
+        es.simulateMessage({ type: 'stream_start' })
+      })
+      expect(invalidateSpy).not.toHaveBeenCalled()
+    })
+
     it('consumeDiscardedCommand removes a single uuid once acted upon', async () => {
       const { mod, result, es } = await setupHook('cmd-s3')
 

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -2256,7 +2256,7 @@ describe('useMessageStream', () => {
     })
   })
 
-  describe('command lifecycle (queued-ghost rescue signal)', () => {
+  describe('command lifecycle', () => {
     async function setupHook(sessionId: string) {
       const mod = await getHookModule()
       const wrapper = createWrapper()
@@ -2271,7 +2271,7 @@ describe('useMessageStream', () => {
       act(() => {
         es.simulateMessage({ type: 'connected', isActive: true })
       })
-      return { mod, result, es }
+      return { mod, result, es, queryClient: wrapper.queryClient }
     }
 
     it('accumulates terminal-dead command uuids (discarded/cancelled), deduped', async () => {
@@ -2287,7 +2287,7 @@ describe('useMessageStream', () => {
       expect(result.current.discardedCommandUuids).toEqual(['u1', 'u2'])
     })
 
-    it('ignores non-terminal states and frames without a uuid', async () => {
+    it('does not treat non-terminal states or malformed frames as discarded', async () => {
       const { result, es } = await setupHook('cmd-s2')
 
       act(() => {
@@ -2298,6 +2298,33 @@ describe('useMessageStream', () => {
       })
 
       expect(result.current.discardedCommandUuids).toEqual([])
+    })
+
+    it('refetches at queued-command pickup and again when its model response starts', async () => {
+      const { es, queryClient } = await setupHook('cmd-s4')
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+      act(() => {
+        es.simulateMessage({ type: 'command_lifecycle', commandUuid: 'u1', state: 'started' })
+      })
+
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['messages', 'cmd-s4'] })
+
+      // The pickup refetch can race the CLI's queued_command transcript write.
+      // A model response proves the command has been incorporated, so it must
+      // trigger one bounded reconciliation retry.
+      invalidateSpy.mockClear()
+      act(() => {
+        es.simulateMessage({ type: 'stream_start' })
+      })
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['messages', 'cmd-s4'] })
+
+      // The marker is consumed: later model iterations do not keep polling.
+      invalidateSpy.mockClear()
+      act(() => {
+        es.simulateMessage({ type: 'stream_start' })
+      })
+      expect(invalidateSpy).not.toHaveBeenCalled()
     })
 
     it('consumeDiscardedCommand removes a single uuid once acted upon', async () => {

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -378,6 +378,14 @@ function getOrCreateEventSource(
   eventSources.set(key, es)
   refCounts.set(key, 1)
 
+  // A command_lifecycle:started frame is the authoritative queued-message
+  // pickup signal. The CLI writes the queued_command transcript attachment
+  // around the same time, so the pickup invalidate below can beat that write.
+  // Keep the command marked until the next model response starts; by then the
+  // command has necessarily been incorporated into the request and a second,
+  // conditional refetch can materialize its optimistic ghost reliably.
+  const startedCommandsAwaitingTranscript = new Set<string>()
+
   es.onmessage = (event) => {
     try {
       const data = JSON.parse(event.data)
@@ -586,20 +594,34 @@ function getOrCreateEventSource(
         queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
         queryClient.invalidateQueries({ queryKey: ['sessions'] })
       }
-      // Per-command lifecycle (runtime >= CLI 2.1.206). Terminal dead states
-      // name a queued message that will never run — the deterministic rescue
-      // signal. 'cancelled' for a command that already materialized is
-      // harmless: rescue only fires while its ghost still exists.
+      // Per-command lifecycle (runtime >= CLI 2.1.206). A started command
+      // drives queued-ghost reconciliation; terminal dead states name a
+      // message that will never run — the deterministic rescue signal.
+      // 'cancelled' for a command that already materialized is harmless:
+      // rescue only fires while its ghost still exists.
       else if (data.type === 'command_lifecycle') {
+        const commandUuid = typeof data.commandUuid === 'string' ? data.commandUuid : null
+        if (commandUuid && data.state === 'started') {
+          startedCommandsAwaitingTranscript.add(commandUuid)
+          // Fast path: in the common case the transcript attachment is already
+          // readable. stream_start below provides the bounded read-after-write
+          // retry when this invalidate lands a moment too early.
+          queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+        } else if (
+          commandUuid &&
+          (data.state === 'completed' || data.state === 'discarded' || data.state === 'cancelled')
+        ) {
+          startedCommandsAwaitingTranscript.delete(commandUuid)
+        }
         if (
           current &&
           (data.state === 'discarded' || data.state === 'cancelled') &&
-          typeof data.commandUuid === 'string' &&
-          !current.discardedCommandUuids.includes(data.commandUuid)
+          commandUuid &&
+          !current.discardedCommandUuids.includes(commandUuid)
         ) {
           streamStates.set(sessionId, {
             ...current,
-            discardedCommandUuids: [...current.discardedCommandUuids, data.commandUuid],
+            discardedCommandUuids: [...current.discardedCommandUuids, commandUuid],
           })
         }
       }
@@ -697,6 +719,10 @@ function getOrCreateEventSource(
       }
       // Streaming events - update streaming state, preserve isActive
       else if (data.type === 'stream_start') {
+        if (startedCommandsAwaitingTranscript.size > 0) {
+          startedCommandsAwaitingTranscript.clear()
+          queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+        }
         // Capture slash commands from init event (piggybacked on stream_start)
         if (Array.isArray(data.slashCommands)) {
           sessionSlashCommands.set(sessionId, data.slashCommands)


### PR DESCRIPTION
## Summary

- refetch the session transcript when `command_lifecycle: started` confirms a queued message was picked up
- perform one bounded follow-up reconciliation when the model response starts, after the queued command has been incorporated
- consume the retry marker so later model iterations do not add polling

## Root cause

The existing `messages_updated` refetch could race the CLI's queued-command transcript write. When that happened, the optimistic message remained labeled **Queued** even though the next response was already processing it, until a later transcript event or safety poll corrected the UI.

## User impact

Queued messages now materialize promptly as regular transcript messages as soon as the agent starts handling them, including while background subagents are still running.

## Validation

- `npm test -- --run src/renderer/hooks/use-message-stream.test.ts` (117 tests)
- `npm run typecheck`
- `npx eslint src/renderer/hooks/use-message-stream.ts src/renderer/hooks/use-message-stream.test.ts`
