### PR TITLE
Fix workflow drawer for scriptPath runs + size fan-outs from invocation args

### DIFF
--- a/src/renderer/components/workflow/workflow-tray-content.test.ts
+++ b/src/renderer/components/workflow/workflow-tray-content.test.ts
@@ -48,10 +48,22 @@ describe('overlayLiveStatus', () => {
     expect(out[0].result).toBe('live result')
   })
 
-  it('surfaces a live failed state (disk never produces failed)', () => {
+  it('surfaces a live failed state', () => {
     const base = [node({ agentId: 'a', status: 'running', result: null })]
     const out = overlayLiveStatus(base, { a: { status: 'failed', result: null } })
     expect(out[0].status).toBe('failed')
+  })
+
+  it('does NOT let a stale live running override a tree failed (trailing-error detection)', () => {
+    const base = [node({ agentId: 'a', status: 'failed', result: 'request_too_large: 413' })]
+    const out = overlayLiveStatus(base, { a: { status: 'running', result: null } })
+    expect(out[0]).toMatchObject({ status: 'failed', result: 'request_too_large: 413' })
+  })
+
+  it('lets done win over failed when the sources disagree (a result is definitive)', () => {
+    const base = [node({ agentId: 'a', status: 'failed', result: 'err' })]
+    const out = overlayLiveStatus(base, { a: { status: 'done', result: 'late result' } })
+    expect(out[0].status).toBe('done')
   })
 
   it('overlays live tokens/toolCount/lastTool onto the node', () => {

--- a/src/renderer/components/workflow/workflow-tray-content.test.ts
+++ b/src/renderer/components/workflow/workflow-tray-content.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { overlayLiveStatus, workflowProgressSegments } from './workflow-tray-content'
+import { overlayLiveStatus, progressSummary, workflowProgressSegments } from './workflow-tray-content'
 import type { WorkflowAgentNode } from '@shared/lib/workflows/workflow-schemas'
 
 function node(over: Partial<WorkflowAgentNode>): WorkflowAgentNode {
@@ -98,5 +98,17 @@ describe('workflowProgressSegments', () => {
     const agents = [node({ agentId: 'a', status: 'done' })]
     // The estimate said 3 but the run finished with 1 — whatever didn't start never will.
     expect(workflowProgressSegments(agents, 3, false)).toEqual(['done'])
+  })
+})
+
+describe('progressSummary', () => {
+  it('reads "N/M agents done" when nothing failed', () => {
+    expect(progressSummary(['done', 'done', 'running', 'pending'])).toBe('2/4 agents done')
+  })
+
+  it('counts failed agents as finished and calls them out', () => {
+    // 22 done + 1 failed + 1 running must not read "22/24 done" — 23 have finished.
+    const segs = Array<'done' | 'failed' | 'running'>(22).fill('done').concat('failed', 'running')
+    expect(progressSummary(segs)).toBe('23/24 agents finished · 1 failed')
   })
 })

--- a/src/renderer/components/workflow/workflow-tray-content.test.ts
+++ b/src/renderer/components/workflow/workflow-tray-content.test.ts
@@ -93,4 +93,10 @@ describe('workflowProgressSegments', () => {
     const agents = [node({ agentId: 'a', status: 'done' }), node({ agentId: 'b', status: 'failed' })]
     expect(workflowProgressSegments(agents, 0)).toEqual(['done', 'failed'])
   })
+
+  it('drops pending cells once the run is no longer active', () => {
+    const agents = [node({ agentId: 'a', status: 'done' })]
+    // The estimate said 3 but the run finished with 1 — whatever didn't start never will.
+    expect(workflowProgressSegments(agents, 3, false)).toEqual(['done'])
+  })
 })

--- a/src/renderer/components/workflow/workflow-tray-content.tsx
+++ b/src/renderer/components/workflow/workflow-tray-content.tsx
@@ -64,10 +64,15 @@ export function overlayLiveStatus(
   return base.map((a) => {
     const live = liveAgents[a.agentId]
     if (!live) return a
-    // `failed` is live-only and wins; otherwise `done` from either source wins; a stale
-    // live `running` never overrides a tree `done` (the tailer can miss the last line).
+    // `done` from either source wins (a result on disk or wire is definitive), then
+    // `failed` from either (the tree detects it durably from a trailing transcript
+    // error frame); a stale `running` on one side never downgrades the other.
     const status: WorkflowAgentNode['status'] =
-      live.status === 'failed' ? 'failed' : a.status === 'done' || live.status === 'done' ? 'done' : 'running'
+      a.status === 'done' || live.status === 'done'
+        ? 'done'
+        : a.status === 'failed' || live.status === 'failed'
+          ? 'failed'
+          : 'running'
     return {
       ...a,
       status,
@@ -335,8 +340,16 @@ function WorkflowAgentRow({
             <span className="text-[11px] text-muted-foreground/70 truncate min-w-0 font-mono">{agent.lastTool}</span>
           </>
         )}
-        {agent.status === 'done' && agent.result && (
-          <span className="text-[11px] text-muted-foreground/80 truncate min-w-0">{agent.result}</span>
+        {/* Terminal agents show their return value — or, for failed ones, the error. */}
+        {(agent.status === 'done' || agent.status === 'failed') && agent.result && (
+          <span
+            className={cn(
+              'text-[11px] truncate min-w-0',
+              agent.status === 'failed' ? 'text-destructive/80' : 'text-muted-foreground/80'
+            )}
+          >
+            {agent.result}
+          </span>
         )}
         <span className="ml-auto shrink-0 text-muted-foreground/60">
           {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
@@ -351,10 +364,14 @@ function WorkflowAgentRow({
             </div>
           )}
           <StatsLine durationMs={agent.durationMs} toolCount={agent.toolCount} tokens={agent.tokens} />
-          {agent.status === 'done' && agent.result && (
+          {(agent.status === 'done' || agent.status === 'failed') && agent.result && (
             <div className="text-[11px] break-words">
-              <span className="font-medium text-foreground/70">Result: </span>
-              <span className="text-muted-foreground">{agent.result}</span>
+              <span className="font-medium text-foreground/70">
+                {agent.status === 'failed' ? 'Error: ' : 'Result: '}
+              </span>
+              <span className={agent.status === 'failed' ? 'text-destructive' : 'text-muted-foreground'}>
+                {agent.result}
+              </span>
             </div>
           )}
           <WorkflowAgentTranscript messages={messages.data} agentSlug={agentSlug} isRunning={isRunning} />

--- a/src/renderer/components/workflow/workflow-tray-content.tsx
+++ b/src/renderer/components/workflow/workflow-tray-content.tsx
@@ -102,6 +102,18 @@ export function workflowProgressSegments(
   return segs
 }
 
+/**
+ * Summary line under the bar. Failed agents are FINISHED — counting only green
+ * would read "22/24" with 23 over ("22 done, 1 failed"), so the numerator counts
+ * both and failures get called out explicitly.
+ */
+export function progressSummary(segments: ProgressSegment[]): string {
+  const done = segments.filter((s) => s === 'done').length
+  const failed = segments.filter((s) => s === 'failed').length
+  if (failed === 0) return `${done}/${segments.length} agents done`
+  return `${done + failed}/${segments.length} agents finished · ${failed} failed`
+}
+
 const SEGMENT_CLASS: Record<ProgressSegment, string> = {
   done: 'bg-emerald-500',
   running: 'bg-blue-500 animate-pulse',
@@ -120,7 +132,6 @@ function WorkflowProgressBar({
 }) {
   const segments = workflowProgressSegments(agents, expectedAgents, active)
   if (segments.length === 0) return null
-  const done = segments.filter((s) => s === 'done').length
   return (
     <div className="px-4 pt-2.5 pb-2 shrink-0">
       <div className="flex items-center gap-1">
@@ -128,9 +139,7 @@ function WorkflowProgressBar({
           <div key={i} className={cn('h-1.5 flex-1 rounded-full transition-colors', SEGMENT_CLASS[s])} />
         ))}
       </div>
-      <div className="mt-1 text-[10px] text-muted-foreground">
-        {done}/{segments.length} agents done
-      </div>
+      <div className="mt-1 text-[10px] text-muted-foreground">{progressSummary(segments)}</div>
     </div>
   )
 }

--- a/src/renderer/components/workflow/workflow-tray-content.tsx
+++ b/src/renderer/components/workflow/workflow-tray-content.tsx
@@ -84,17 +84,20 @@ export type ProgressSegment = 'done' | 'running' | 'failed' | 'pending'
 
 /**
  * One progress cell per agent: known agents colored by status, plus gray "pending"
- * cells for declared-but-not-yet-started agents (`expectedAgents` = script call sites,
- * a lower bound — so a dynamic fan-out just grows the bar, never shows phantom pending).
+ * cells for expected-but-not-yet-started agents (`expectedAgents` sizes `args`
+ * fan-outs from the invocation but is still a lower bound — a runtime fan-out just
+ * grows the bar, never shows phantom pending). A finished run (`active` false)
+ * never shows pending: whatever didn't start by then never will.
  */
 export function workflowProgressSegments(
   agents: Pick<WorkflowAgentNode, 'status'>[],
-  expectedAgents: number
+  expectedAgents: number,
+  active = true
 ): ProgressSegment[] {
   const segs: ProgressSegment[] = agents.map((a) =>
     a.status === 'done' ? 'done' : a.status === 'failed' ? 'failed' : 'running'
   )
-  const pending = Math.max(0, expectedAgents - agents.length)
+  const pending = active ? Math.max(0, expectedAgents - agents.length) : 0
   for (let i = 0; i < pending; i++) segs.push('pending')
   return segs
 }
@@ -109,11 +112,13 @@ const SEGMENT_CLASS: Record<ProgressSegment, string> = {
 function WorkflowProgressBar({
   agents,
   expectedAgents,
+  active,
 }: {
   agents: WorkflowAgentNode[]
   expectedAgents: number
+  active: boolean
 }) {
-  const segments = workflowProgressSegments(agents, expectedAgents)
+  const segments = workflowProgressSegments(agents, expectedAgents, active)
   if (segments.length === 0) return null
   const done = segments.filter((s) => s === 'done').length
   return (
@@ -206,7 +211,7 @@ export function WorkflowTrayContent({ agentSlug, sessionId, onClose }: WorkflowT
         </button>
       </div>
 
-      <WorkflowProgressBar agents={agents} expectedAgents={treeQuery.data?.expectedAgents ?? 0} />
+      <WorkflowProgressBar agents={agents} expectedAgents={treeQuery.data?.expectedAgents ?? 0} active={isActive} />
 
       {openWorkflows.length > 1 && (
         <div className="px-4 pb-2 shrink-0">
@@ -312,7 +317,8 @@ function WorkflowAgentRow({
         <span className="flex h-4 w-4 shrink-0 items-center justify-center">
           <StatusIndicator status={indicatorStatus} />
         </span>
-        <span className="text-xs text-foreground/80 truncate">{agent.label}</span>
+        {/* shrink-0 + cap: a long result/tool string must truncate itself, not crush the label to zero width */}
+        <span className="text-xs text-foreground/80 truncate shrink-0 max-w-[70%]">{agent.label}</span>
         {/* While running, show the current tool (live from the wire). */}
         {isRunning && agent.lastTool && (
           <>

--- a/src/shared/lib/workflows/workflow-schemas.ts
+++ b/src/shared/lib/workflows/workflow-schemas.ts
@@ -100,9 +100,11 @@ export const WorkflowAgentNodeSchema = z.object({
   /** Resolved display label, e.g. `word-alpha` or `fact:Mars`; falls back to `agent N`. */
   label: z.string(),
   phase: z.string().nullable(),
-  // Disk (journal) only knows running/done; `failed` comes from the live wire snapshot.
+  // running/done come from the journal; `failed` from either the live wire snapshot
+  // or, durably, a transcript that ends on a synthetic error frame with no result.
   status: z.enum(['running', 'done', 'failed']),
-  /** Display string of the agent's return value (JSON-stringified if structured). */
+  /** Display string of the agent's return value (JSON-stringified if structured);
+   *  for failed agents, the error details from the trailing error frame. */
   result: z.string().nullable(),
   /** How the agentId→call join was made (for debuggability + tests). */
   resolved: z.enum(['prompt-regex', 'ordinal-fallback']),

--- a/src/shared/lib/workflows/workflow-schemas.ts
+++ b/src/shared/lib/workflows/workflow-schemas.ts
@@ -79,6 +79,9 @@ export const ParsedAgentCallSchema = z.object({
   sourceIndex: z.number().int(),
   /** True if this call sits inside a `parallel([...])` span. */
   inParallel: z.boolean(),
+  /** `args` key this call fans out over (`args.<key>.map(...)` / `pipeline(args.<key>, ...)`),
+   *  so the expected agent count can be sized from the invocation's actual array. */
+  fanOutArgsKey: z.string().nullable(),
 })
 export type ParsedAgentCall = z.infer<typeof ParsedAgentCallSchema>
 
@@ -120,9 +123,11 @@ export const WorkflowTreeSchema = z.object({
   description: z.string().nullable(),
   phases: z.array(WorkflowPhaseSchema),
   agents: z.array(WorkflowAgentNodeSchema),
-  /** Number of `agent()` call sites in the script — a LOWER bound on total agents
-   *  (a parallel/map call site spawns N). Used to render not-yet-started agents as
-   *  "pending" in the progress bar; never over-counts dynamic fan-outs. */
+  /** Estimated total agents: call sites that fan out over a Workflow `args` array
+   *  count as that array's actual length (mined from the invocation's tool_use);
+   *  every other call site counts as 1. Still a LOWER bound — fan-outs over
+   *  runtime-computed collections can't be sized statically. Used to render
+   *  not-yet-started agents as "pending" in the progress bar. */
   expectedAgents: z.number().int().nonnegative(),
   /** Workflow-wide rollups: summed tools/tokens, and the wall-clock span across all
    *  agents (max end − min start; parallel-aware, NOT a sum of per-agent durations). */

--- a/src/shared/lib/workflows/workflow-script-parser.test.ts
+++ b/src/shared/lib/workflows/workflow-script-parser.test.ts
@@ -95,6 +95,46 @@ describe('parseWorkflowScript — synthetic edge cases', () => {
     )
   })
 
+  it('tags agent() calls inside args.<key>.map fan-outs with fanOutArgsKey', () => {
+    const src = [
+      "export const meta = { name: 'v', description: 'd', phases: [{ title: 'Analyze' }] }",
+      "phase('Analyze')",
+      'const analyses = (await parallel(args.videos.map(v => () => agent(`analyze ${v.id}`, { label: `analyze:${v.id}` })))).filter(Boolean)',
+      "const plan = await agent('merge everything', { label: 'plan:merge' })",
+    ].join('\n')
+    const parsed = parseWorkflowScript(src)
+    expect(parsed.agentCalls).toHaveLength(2)
+    expect(parsed.agentCalls[0].fanOutArgsKey).toBe('videos')
+    expect(parsed.agentCalls[1].fanOutArgsKey).toBeNull()
+  })
+
+  it('tags agent() calls inside pipeline(args.<key>, ...) stages', () => {
+    const src = [
+      "export const meta = { name: 'p', description: 'd', phases: [] }",
+      "const out = await pipeline(args.items, x => agent(`do ${x}`, { label: `do:${x}` }), r => agent(`check ${r}`, { label: 'check' }))",
+      "const done = await agent('wrap up', { label: 'wrap' })",
+    ].join('\n')
+    const parsed = parseWorkflowScript(src)
+    expect(parsed.agentCalls).toHaveLength(3)
+    expect(parsed.agentCalls[0].fanOutArgsKey).toBe('items')
+    expect(parsed.agentCalls[1].fanOutArgsKey).toBe('items')
+    expect(parsed.agentCalls[2].fanOutArgsKey).toBeNull()
+  })
+
+  it('does not size fan-outs over non-args or filtered collections', () => {
+    const src = [
+      "export const meta = { name: 'n', description: 'd', phases: [] }",
+      // Runtime collection — length unknowable.
+      'const a = await parallel(plan.techniques.map(t => () => agent(`build ${t}`, {})))',
+      // Filtered args — args.videos.length would OVER-estimate; must stay untagged.
+      'const b = await parallel(args.videos.filter(v => v.ok).map(v => () => agent(`redo ${v}`, {})))',
+    ].join('\n')
+    const parsed = parseWorkflowScript(src)
+    expect(parsed.agentCalls).toHaveLength(2)
+    expect(parsed.agentCalls[0].fanOutArgsKey).toBeNull()
+    expect(parsed.agentCalls[1].fanOutArgsKey).toBeNull()
+  })
+
   it('does not match `agent` inside an identifier or string', () => {
     const src = [
       "export const meta = { name: 'x', description: 'y', phases: [] }",

--- a/src/shared/lib/workflows/workflow-script-parser.ts
+++ b/src/shared/lib/workflows/workflow-script-parser.ts
@@ -304,11 +304,20 @@ function callParenAt(src: string, i: number, kw: string): number {
   return src[j] === '(' ? j : -1
 }
 
+// `args.<key>.map(` — a fan-out over a Workflow `args` array. Direct `.map` only:
+// an intervening `.filter(...)` would make args[key].length an OVER-estimate, and
+// pending cells that can never fill must not be rendered.
+const ARGS_MAP_RE = /args\s*\.\s*([A-Za-z0-9_$]+)\s*\.\s*(?:map|flatMap)\s*\(/y
+// `pipeline(args.<key>,` / `parallel(args.<key>.` — first arg is the fan-out list.
+const ARGS_FIRST_ARG_RE = /\s*args\s*\.\s*([A-Za-z0-9_$]+)\s*[,)]/y
+
 export function parseWorkflowScript(src: string): ParsedScript {
   const { name, description, phases } = extractMeta(src)
   const agentCalls: ParsedAgentCall[] = []
   let currentSourcePhase: string | null = null
   let parallelEnd = -1
+  let fanOutEnd = -1
+  let fanOutKey: string | null = null
   let sourceIndex = 0
 
   let i = 0
@@ -345,6 +354,32 @@ export function parseWorkflowScript(src: string): ParsedScript {
       continue
     }
 
+    // pipeline(args.<key>, stage1, ...) — every stage runs once per element.
+    const pipelineParen = callParenAt(src, i, 'pipeline')
+    if (pipelineParen >= 0) {
+      ARGS_FIRST_ARG_RE.lastIndex = pipelineParen + 1
+      const firstArg = ARGS_FIRST_ARG_RE.exec(src)
+      if (firstArg) {
+        fanOutKey = firstArg[1]
+        fanOutEnd = skipBalanced(src, pipelineParen, '(', ')')
+      }
+      i = pipelineParen + 1 // walk INTO it so inner agent() calls are seen
+      continue
+    }
+
+    // args.<key>.map(cb) — agent() calls inside cb spawn once per element.
+    if (c === 'a' && !isIdentChar(src[i - 1])) {
+      ARGS_MAP_RE.lastIndex = i
+      const m = ARGS_MAP_RE.exec(src)
+      if (m) {
+        const mapParen = i + m[0].length - 1
+        fanOutKey = m[1]
+        fanOutEnd = skipBalanced(src, mapParen, '(', ')')
+        i = mapParen + 1 // walk INTO the callback
+        continue
+      }
+    }
+
     const agentParen = callParenAt(src, i, 'agent')
     if (agentParen >= 0) {
       const end = skipBalanced(src, agentParen, '(', ')')
@@ -359,6 +394,7 @@ export function parseWorkflowScript(src: string): ParsedScript {
         sourcePhase: currentSourcePhase,
         sourceIndex: sourceIndex++,
         inParallel: agentParen < parallelEnd,
+        fanOutArgsKey: agentParen < fanOutEnd ? fanOutKey : null,
       })
       i = end
       continue

--- a/src/shared/lib/workflows/workflow-tree.test.ts
+++ b/src/shared/lib/workflows/workflow-tree.test.ts
@@ -183,6 +183,106 @@ describe('buildWorkflowTree — synthetic edge cases', () => {
     })
   })
 
+  it('falls back to the transcript-referenced script for scriptPath invocations', async () => {
+    // scriptPath runs persist nothing under <session>/workflows/scripts — the only
+    // pointer to the script is the Workflow tool result in the session transcript.
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-tree-sp-'))
+    tmpDirs.push(tmp)
+    const workspace = path.join(tmp, 'workspace')
+    const sessionsDir = path.join(workspace, '.claude', 'projects', '-workspace')
+    const runDir = path.join(sessionsDir, 's1', 'subagents', 'workflows', 'wf_sp')
+    await fs.mkdir(runDir, { recursive: true })
+    await fs.writeFile(
+      path.join(runDir, 'journal.jsonl'),
+      JSON.stringify({ type: 'started', key: 'v2:1', agentId: 'k1' }) + '\n'
+    )
+    await fs.writeFile(
+      path.join(runDir, 'agent-k1.jsonl'),
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'analyze v01' } }) + '\n'
+    )
+    const skillScripts = path.join(workspace, '.claude', 'skills', 'probe', 'scripts')
+    await fs.mkdir(skillScripts, { recursive: true })
+    await fs.writeFile(
+      path.join(skillScripts, 'wf.js'),
+      [
+        "export const meta = { name: 'probe', description: 'd', phases: [{ title: 'Analyze' }] }",
+        "phase('Analyze')",
+        'const r = await parallel(args.videos.map(v => () => agent(`analyze ${v}`, { label: `analyze:${v}`, phase: \'Analyze\' })))',
+        "const merged = await agent('merge it all', { label: 'merge' })",
+      ].join('\n')
+    )
+    // The invocation as it appears in the transcript: the assistant tool_use carries
+    // scriptPath + args; the paired tool_result names the script and the run id.
+    const toolUseLine = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu1',
+            name: 'Workflow',
+            input: {
+              scriptPath: '/workspace/.claude/skills/probe/scripts/wf.js',
+              args: { videos: ['v01', 'v02', 'v03'] },
+            },
+          },
+        ],
+      },
+    })
+    const toolResultLine = JSON.stringify({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu1',
+            content:
+              'Workflow launched in background.\nScript file: /workspace/.claude/skills/probe/scripts/wf.js\nRun ID: wf_sp',
+          },
+        ],
+      },
+    })
+    await fs.writeFile(path.join(sessionsDir, 's1.jsonl'), toolUseLine + '\n' + toolResultLine + '\n')
+    const tree = await buildWorkflowTree({ sessionsDir, sessionId: 's1', runId: 'wf_sp' })
+    expect(tree!.name).toBe('probe')
+    expect(tree!.phases.map((p) => p.title)).toEqual(['Analyze'])
+    // args.videos fan-out (3) + the single merge call site.
+    expect(tree!.expectedAgents).toBe(4)
+    expect(tree!.agents[0]).toMatchObject({ label: 'analyze:v01', phase: 'Analyze' })
+  })
+
+  it('rejects a transcript script path that escapes the workspace', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-tree-esc-'))
+    tmpDirs.push(tmp)
+    const workspace = path.join(tmp, 'workspace')
+    const sessionsDir = path.join(workspace, '.claude', 'projects', '-workspace')
+    const runDir = path.join(sessionsDir, 's1', 'subagents', 'workflows', 'wf_esc')
+    await fs.mkdir(runDir, { recursive: true })
+    await fs.writeFile(
+      path.join(runDir, 'journal.jsonl'),
+      JSON.stringify({ type: 'started', key: 'v2:1', agentId: 'k1' }) + '\n'
+    )
+    // A script OUTSIDE the workspace that a traversal path would otherwise reach.
+    await fs.writeFile(
+      path.join(tmp, 'evil.js'),
+      "export const meta = { name: 'evil', description: 'd', phases: [] }"
+    )
+    await fs.writeFile(
+      path.join(sessionsDir, 's1.jsonl'),
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', content: 'Script file: /workspace/../evil.js\nRun ID: wf_esc' }],
+        },
+      }) + '\n'
+    )
+    const tree = await buildWorkflowTree({ sessionsDir, sessionId: 's1', runId: 'wf_esc' })
+    expect(tree!.name).toBeNull() // traversal path ignored → degraded (script-less) tree
+  })
+
   it('marks a still-running agent (started, no result yet) as running', async () => {
     const script = [
       "export const meta = { name: 'r', description: 'd', phases: [{ title: 'Go' }] }",

--- a/src/shared/lib/workflows/workflow-tree.test.ts
+++ b/src/shared/lib/workflows/workflow-tree.test.ts
@@ -111,7 +111,7 @@ afterEach(async () => {
 async function scaffold(opts: {
   script: string
   journal: Array<Record<string, unknown>>
-  agents: Array<{ agentId: string; firstPrompt: string }>
+  agents: Array<{ agentId: string; firstPrompt: string; extraLines?: Array<Record<string, unknown>> }>
 }): Promise<string> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-tree-'))
   tmpDirs.push(root)
@@ -122,13 +122,11 @@ async function scaffold(opts: {
   await fs.mkdir(path.join(root, sid, 'workflows', 'scripts'), { recursive: true })
   await fs.writeFile(path.join(runDir, 'journal.jsonl'), opts.journal.map((j) => JSON.stringify(j)).join('\n'))
   for (const a of opts.agents) {
-    const line = JSON.stringify({
-      type: 'user',
-      isSidechain: true,
-      agentId: a.agentId,
-      message: { role: 'user', content: a.firstPrompt },
-    })
-    await fs.writeFile(path.join(runDir, `agent-${a.agentId}.jsonl`), line + '\n')
+    const lines = [
+      { type: 'user', isSidechain: true, agentId: a.agentId, message: { role: 'user', content: a.firstPrompt } },
+      ...(a.extraLines ?? []),
+    ]
+    await fs.writeFile(path.join(runDir, `agent-${a.agentId}.jsonl`), lines.map((l) => JSON.stringify(l)).join('\n') + '\n')
   }
   await fs.writeFile(path.join(root, sid, 'workflows', 'scripts', `probe-${run}.js`), opts.script)
   return root
@@ -296,5 +294,74 @@ describe('buildWorkflowTree — synthetic edge cases', () => {
     })
     const tree = await buildWorkflowTree({ sessionsDir: root, sessionId: 's1', runId: 'wf_test' })
     expect(tree!.agents[0]).toMatchObject({ label: 'worker', phase: 'Go', status: 'running', result: null })
+  })
+
+  it('marks a result-less agent whose transcript ends on an error frame as failed', async () => {
+    // The journal has no failure event — a dead agent is a `started` with no
+    // `result`. The durable marker is the trailing synthetic error entry.
+    const script = "export const meta = { name: 'f', description: 'd', phases: [] }\nawait agent('doomed', {})"
+    const root = await scaffold({
+      script,
+      journal: [{ type: 'started', key: 'v2:1', agentId: 'f1' }],
+      agents: [
+        {
+          agentId: 'f1',
+          firstPrompt: 'doomed',
+          extraLines: [
+            {
+              type: 'assistant',
+              agentId: 'f1',
+              message: { model: '<synthetic>', role: 'assistant', content: [{ type: 'text', text: 'Request too large' }] },
+              error: 'invalid_request',
+              errorDetails: 'request_too_large: 413',
+            },
+          ],
+        },
+      ],
+    })
+    const tree = await buildWorkflowTree({ sessionsDir: root, sessionId: 's1', runId: 'wf_test' })
+    expect(tree!.agents[0]).toMatchObject({ status: 'failed', result: 'request_too_large: 413' })
+  })
+
+  it('does not fail an agent that recovered from a mid-transcript error', async () => {
+    const script = "export const meta = { name: 'f', description: 'd', phases: [] }\nawait agent('resilient', {})"
+    const root = await scaffold({
+      script,
+      journal: [{ type: 'started', key: 'v2:1', agentId: 'r1' }],
+      agents: [
+        {
+          agentId: 'r1',
+          firstPrompt: 'resilient',
+          extraLines: [
+            { type: 'assistant', agentId: 'r1', message: { model: '<synthetic>', role: 'assistant' }, error: 'overloaded' },
+            // A later entry means the agent kept going — the error was transient.
+            { type: 'assistant', agentId: 'r1', message: { role: 'assistant', content: [{ type: 'text', text: 'ok' }] } },
+          ],
+        },
+      ],
+    })
+    const tree = await buildWorkflowTree({ sessionsDir: root, sessionId: 's1', runId: 'wf_test' })
+    expect(tree!.agents[0]).toMatchObject({ status: 'running', result: null })
+  })
+
+  it('journal result always wins over a trailing error frame', async () => {
+    // A result on disk is definitive completion, whatever the transcript tail says.
+    const script = "export const meta = { name: 'f', description: 'd', phases: [] }\nawait agent('finisher', {})"
+    const root = await scaffold({
+      script,
+      journal: [
+        { type: 'started', key: 'v2:1', agentId: 'd1' },
+        { type: 'result', key: 'v2:1', agentId: 'd1', result: 'all good' },
+      ],
+      agents: [
+        {
+          agentId: 'd1',
+          firstPrompt: 'finisher',
+          extraLines: [{ type: 'assistant', agentId: 'd1', message: { model: '<synthetic>' }, error: 'overloaded' }],
+        },
+      ],
+    })
+    const tree = await buildWorkflowTree({ sessionsDir: root, sessionId: 's1', runId: 'wf_test' })
+    expect(tree!.agents[0]).toMatchObject({ status: 'done', result: 'all good' })
   })
 })

--- a/src/shared/lib/workflows/workflow-tree.ts
+++ b/src/shared/lib/workflows/workflow-tree.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
 import { promises as fs } from 'fs'
+import { isPathWithinDir } from '../utils/path-safety'
 import { parseWorkflowScript } from './workflow-script-parser'
 import {
   JournalLineSchema,
@@ -23,6 +24,9 @@ type JoinedAgent = Omit<WorkflowAgentNode, 'prompt' | 'toolCount' | 'tokens' | '
  *   <sessionsDir>/<sessionId>/subagents/workflows/<runId>/journal.jsonl   (status + result, ordered)
  *   <sessionsDir>/<sessionId>/subagents/workflows/<runId>/agent-<id>.jsonl (first user msg = the join key)
  *   <sessionsDir>/<sessionId>/workflows/scripts/<name>-<runId>.js          (phases + per-call label/phase)
+ *   — plus the Workflow invocation mined from <sessionsDir>/<sessionId>.jsonl:
+ *     the executed script's path for `scriptPath` runs (no session-dir copy
+ *     exists) and the `args` input, which sizes `args.<key>` fan-outs.
  *
  * Returns null when the run dir / journal doesn't exist (→ the route 404s).
  */
@@ -70,7 +74,8 @@ export async function buildWorkflowTree(opts: {
     }
   }
 
-  const script = await loadScript(sessionsDir, sessionId, runId)
+  const invocation = await findWorkflowInvocation(sessionsDir, sessionId, runId)
+  const script = await loadScript(sessionsDir, sessionId, runId, invocation.scriptHostPath)
   const stats = new Map<string, AgentStats>()
   await Promise.all(
     startedOrder.map(async (agentId) => {
@@ -106,7 +111,7 @@ export async function buildWorkflowTree(opts: {
     description: script.description,
     phases: script.phases,
     agents,
-    expectedAgents: script.agentCalls.length,
+    expectedAgents: expectedAgentCount(script, invocation.args),
     totals,
   })
 }
@@ -185,22 +190,123 @@ function resolveLabel(
   return unresolved ? fallback : label
 }
 
-async function loadScript(sessionsDir: string, sessionId: string, runId: string): Promise<ParsedScript> {
+async function loadScript(
+  sessionsDir: string,
+  sessionId: string,
+  runId: string,
+  invocationScriptPath: string | null
+): Promise<ParsedScript> {
   const empty: ParsedScript = { name: null, description: null, phases: [], agentCalls: [] }
+  // Canonical location: inline-`script` invocations get a copy persisted here.
   const scriptsDir = path.join(sessionsDir, sessionId, 'workflows', 'scripts')
-  let entries: string[]
   try {
-    entries = await fs.readdir(scriptsDir)
+    const entries = await fs.readdir(scriptsDir)
+    const file = entries.find((f) => f.endsWith(`${runId}.js`))
+    if (file) return parseWorkflowScript(await fs.readFile(path.join(scriptsDir, file), 'utf8'))
   } catch {
-    return empty
+    // fall through to the invocation-referenced path
   }
-  const file = entries.find((f) => f.endsWith(`${runId}.js`))
-  if (!file) return empty
+  // `scriptPath` invocations run a caller-owned file (e.g. a skill's script) and
+  // persist nothing under the session dir — read the file the invocation named.
+  if (invocationScriptPath) {
+    try {
+      return parseWorkflowScript(await fs.readFile(invocationScriptPath, 'utf8'))
+    } catch {
+      // unreadable/unparsable script → same degraded tree as before
+    }
+  }
+  return empty
+}
+
+/**
+ * Estimated total agents for the run: a call site fanning out over a Workflow
+ * `args` array counts as that array's actual length; every other call site counts
+ * as 1. Still a lower bound — fan-outs over runtime-computed collections (an
+ * earlier phase's output) can't be sized statically.
+ */
+function expectedAgentCount(script: ParsedScript, args: unknown): number {
+  const argsObj =
+    args !== null && typeof args === 'object' && !Array.isArray(args) ? (args as Record<string, unknown>) : null
+  return script.agentCalls.reduce((n, call) => {
+    if (call.fanOutArgsKey && argsObj) {
+      const list = argsObj[call.fanOutArgsKey]
+      if (Array.isArray(list)) return n + list.length
+    }
+    return n + 1
+  }, 0)
+}
+
+interface WorkflowInvocation {
+  /** Host path of the executed script, contained within the agent workspace; null if unknown. */
+  scriptHostPath: string | null
+  /** The invocation's `args` input, verbatim; undefined if unknown. */
+  args: unknown
+}
+
+/**
+ * Mine the run's Workflow invocation out of the parent session transcript: the
+ * tool_result names the executed script (`Script file: <container path>`) and its
+ * paired tool_use input carries `args` (sizes fan-outs) and, for `scriptPath`
+ * invocations, the caller-owned script location. Container paths (`/workspace/...`)
+ * are mapped onto the host workspace dir; anything escaping it is ignored.
+ */
+async function findWorkflowInvocation(
+  sessionsDir: string,
+  sessionId: string,
+  runId: string
+): Promise<WorkflowInvocation> {
+  const none: WorkflowInvocation = { scriptHostPath: null, args: undefined }
+  let raw: string
   try {
-    return parseWorkflowScript(await fs.readFile(path.join(scriptsDir, file), 'utf8'))
+    raw = await fs.readFile(path.join(sessionsDir, `${sessionId}.jsonl`), 'utf8')
   } catch {
-    return empty
+    return none
   }
+  // sessionsDir = <workspace>/.claude/projects/-workspace
+  const workspaceDir = path.resolve(sessionsDir, '..', '..', '..')
+
+  const inputsByToolUseId = new Map<string, Record<string, unknown>>()
+  let resultText: string | null = null
+  let resultToolUseId: string | null = null
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    let entry: { message?: { content?: unknown } }
+    try {
+      entry = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    const content = entry.message?.content
+    if (!Array.isArray(content)) continue
+    for (const block of content as Array<Record<string, unknown>>) {
+      if (block?.type === 'tool_use' && block.name === 'Workflow' && typeof block.id === 'string') {
+        const input = block.input
+        inputsByToolUseId.set(block.id, input !== null && typeof input === 'object' ? (input as Record<string, unknown>) : {})
+      }
+      if (resultText === null && block?.type === 'tool_result') {
+        const text = messageText(block.content)
+        if (text.includes(runId)) {
+          resultText = text
+          resultToolUseId = typeof block.tool_use_id === 'string' ? block.tool_use_id : null
+        }
+      }
+    }
+  }
+  if (resultText === null) return none
+
+  const input = resultToolUseId !== null ? inputsByToolUseId.get(resultToolUseId) : undefined
+  // Prefer the result's `Script file:` line (present for inline-`script` runs too,
+  // pointing at the persisted copy); fall back to the tool_use's own scriptPath.
+  const containerPath =
+    /Script file: (\/workspace\/\S+)/.exec(resultText)?.[1] ??
+    (typeof input?.scriptPath === 'string' ? input.scriptPath : null)
+  let scriptHostPath: string | null = null
+  if (containerPath?.startsWith('/workspace/')) {
+    const host = path.join(workspaceDir, containerPath.slice('/workspace/'.length))
+    if (isPathWithinDir(workspaceDir, host)) scriptHostPath = host
+  }
+  return { scriptHostPath, args: input?.args }
 }
 
 interface AgentStats {

--- a/src/shared/lib/workflows/workflow-tree.ts
+++ b/src/shared/lib/workflows/workflow-tree.ts
@@ -86,8 +86,14 @@ export async function buildWorkflowTree(opts: {
   const firstPrompts = new Map([...stats].map(([id, s]) => [id, s.firstPrompt]))
   const agents = joinAgents({ startedOrder, statusByAgent, firstPrompts, script }).map((node) => {
     const s = stats.get(node.agentId)
+    // The journal has no failure event — a dead agent is a `started` with no
+    // `result`, forever. The durable marker is the transcript ending on a
+    // synthetic error frame; self-correcting if the agent appends more entries.
+    const failed = node.status === 'running' && s?.trailingError != null
     return {
       ...node,
+      status: failed ? ('failed' as const) : node.status,
+      result: node.result ?? (failed ? s.trailingError : null),
       prompt: s?.firstPrompt ?? '',
       toolCount: s?.toolCount ?? 0,
       tokens: s?.tokens ?? 0,
@@ -162,7 +168,7 @@ function joinAgents(input: {
       agentId,
       label: resolveLabel(chosen, captures, index),
       phase: chosen ? chosen.phase ?? chosen.sourcePhase : null,
-      status: st.status,
+      status: st.status, // 'running' may be promoted to 'failed' once transcript stats are layered on
       result: displayAgentResult(st.result),
       resolved,
     })
@@ -315,6 +321,9 @@ interface AgentStats {
   tokens: number
   firstTs: number | null
   lastTs: number | null
+  /** Error text when the transcript's FINAL entry is a synthetic error frame
+   *  (`error` + `errorDetails` fields) — the durable marker of a dead agent. */
+  trailingError: string | null
 }
 
 function messageText(content: unknown): string {
@@ -334,7 +343,14 @@ function messageText(content: unknown): string {
  * first/last timestamps (for duration). Tolerant of a half-written trailing line.
  */
 async function readAgentStats(filePath: string): Promise<AgentStats> {
-  const empty: AgentStats = { firstPrompt: '', toolCount: 0, tokens: 0, firstTs: null, lastTs: null }
+  const empty: AgentStats = {
+    firstPrompt: '',
+    toolCount: 0,
+    tokens: 0,
+    firstTs: null,
+    lastTs: null,
+    trailingError: null,
+  }
   let raw: string
   try {
     raw = await fs.readFile(filePath, 'utf8')
@@ -346,12 +362,15 @@ async function readAgentStats(filePath: string): Promise<AgentStats> {
   let tokens = 0
   let firstTs: number | null = null
   let lastTs: number | null = null
+  let trailingError: string | null = null
   for (const line of raw.split('\n')) {
     const trimmed = line.trim()
     if (!trimmed) continue
     let entry: {
       type?: string
       timestamp?: string
+      error?: unknown
+      errorDetails?: unknown
       message?: { content?: unknown; usage?: { output_tokens?: number } }
     }
     try {
@@ -359,6 +378,14 @@ async function readAgentStats(filePath: string): Promise<AgentStats> {
     } catch {
       continue
     }
+    // Track the error marker of the LAST entry only: a mid-transcript error the
+    // agent recovered from must not read as failure, so any later entry clears it.
+    trailingError =
+      typeof entry.error === 'string'
+        ? typeof entry.errorDetails === 'string'
+          ? entry.errorDetails
+          : entry.error
+        : null
     if (typeof entry.timestamp === 'string') {
       const t = Date.parse(entry.timestamp)
       if (!Number.isNaN(t)) {
@@ -377,5 +404,5 @@ async function readAgentStats(filePath: string): Promise<AgentStats> {
       tokens += entry.message?.usage?.output_tokens ?? 0
     }
   }
-  return { firstPrompt, toolCount, tokens, firstTs, lastTs }
+  return { firstPrompt, toolCount, tokens, firstTs, lastTs, trailingError }
 }


### PR DESCRIPTION
## Problem

A workflow launched via `scriptPath` (e.g. a skill-owned script like vox-learn's `learn-workflow.js`) persists **no script copy** under `<session>/workflows/scripts/` — the only place `buildWorkflowTree` looked. With an empty parsed script, the drawer degraded all at once:

- **Names broken** — every label fell back to `agent N`; the first row looked even worse because the label span had no `shrink-0`, so a huge JSON result string crushed the label to zero width, making the raw JSON look like the agent's name.
- **No phases** — `meta.phases` comes from the same missing script, so all agents landed in one ungrouped bucket.
- **No pending agents** — `expectedAgents` (script call-site count) was 0, so the progress bar showed only started agents.

## Fix

- **`workflow-tree.ts`** — new `findWorkflowInvocation`: JSON-parses the parent session transcript, pairs the run's tool_result (by `tool_use_id`) with its `Workflow` tool_use, and recovers both the executed script's path (`Script file:` line / `input.scriptPath`, container `/workspace/...` mapped onto the host workspace and containment-checked via `isPathWithinDir`) and the invocation's `args`.
- **`workflow-script-parser.ts`** — call sites inside `args.<key>.map(...)` / `.flatMap(...)` or `pipeline(args.<key>, ...)` stages are tagged with `fanOutArgsKey`. Only *direct* fan-outs over `args`: an intervening `.filter()` or a runtime collection stays untagged so the estimate never over-counts (pending cells that can never fill).
- **`expectedAgents`** — fan-out call sites count as `args[key].length`; everything else counts as 1. Still a documented lower bound for runtime-computed fan-outs.
- **`workflow-tray-content.tsx`** — `workflowProgressSegments` takes an `active` flag: finished runs drop unfilled pending cells. Label span gets `shrink-0 max-w-[70%]` so long result/tool strings truncate themselves instead of erasing the label.

## Validation

- 30 workflow tests pass (8 new: scriptPath fallback end-to-end, traversal-path rejection, map/pipeline fan-out tagging, filtered/runtime negatives, args-sized `expectedAgents`, inactive pending clamp); `tsc` + `eslint` clean.
- Ran `buildWorkflowTree` against the real broken vox-learn run on disk: was `name: null`, 0 phases, `agent N` labels, `expectedAgents: 0` → now `vox-learn`, all 5 phases with detail strings, all 23 agents labeled `analyze:v01`…`analyze:v23` via prompt-regex join, `expectedAgents: 27` (23 mined from `args.videos` + 4 single call sites) vs 23 started → 4 pending cells render.

https://claude.ai/code/session_017rupa6opiv5DN3yUGyvsfq