### PR TITLE
chore: log event_loop_stall on cloud host-app event-loop lag

### DIFF
--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -80,10 +80,8 @@ async function gracefulShutdown(signal: string) {
 process.on('SIGTERM', () => gracefulShutdown('SIGTERM'))
 process.on('SIGINT', () => gracefulShutdown('SIGINT'))
 
-// Cloud host-app only: log when the event loop stalls past 500ms (health-check hangs).
+// Log when the event loop stalls past 500ms (helps diagnose health-check hangs). Silent when healthy.
 function startEventLoopStallLog(): void {
-  if (process.env.SUPERAGENT_DIAG === '0') return
-  if (process.env.SUPERAGENT_DIAG !== '1' && !process.env.SUPERAGENT_ORG_ID) return
   const h = monitorEventLoopDelay({ resolution: 20 })
   h.enable()
   setInterval(() => {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -1,6 +1,7 @@
 import { serveStatic } from '@hono/node-server/serve-static'
 import { Hono } from 'hono'
 import { existsSync } from 'fs'
+import { monitorEventLoopDelay } from 'node:perf_hooks'
 import api from '../api'
 import { shutdownServices, setupServerHandlers } from '@shared/lib/startup'
 import { bindServerWithRetry, type BoundServer } from '@shared/lib/server-bind'
@@ -79,6 +80,27 @@ async function gracefulShutdown(signal: string) {
 process.on('SIGTERM', () => gracefulShutdown('SIGTERM'))
 process.on('SIGINT', () => gracefulShutdown('SIGINT'))
 
+// Cloud host-app only: log when the event loop stalls past 500ms (health-check hangs).
+function startEventLoopStallLog(): void {
+  if (process.env.SUPERAGENT_DIAG === '0') return
+  if (process.env.SUPERAGENT_DIAG !== '1' && !process.env.SUPERAGENT_ORG_ID) return
+  const h = monitorEventLoopDelay({ resolution: 20 })
+  h.enable()
+  setInterval(() => {
+    const delay_ms = Math.round(h.max / 1e6)
+    h.reset()
+    if (delay_ms < 500) return
+    console.error(
+      JSON.stringify({
+        event: 'event_loop_stall',
+        ts: new Date().toISOString(),
+        org_id: process.env.SUPERAGENT_ORG_ID ?? null,
+        delay_ms,
+      })
+    )
+  }, 1000).unref()
+}
+
 async function start() {
   const defaultPort = parseInt(process.env.PORT || '47891', 10)
 
@@ -95,6 +117,7 @@ async function start() {
 
   // Set up server-level handlers (WebSocket proxies, etc.)
   setupServerHandlers(server)
+  startEventLoopStallLog()
 }
 
 start().catch((error) => {


### PR DESCRIPTION
## Summary
- Add a tiny `monitorEventLoopDelay` sampler in `src/web/server.ts` that logs JSON `event_loop_stall` when the Node event loop lags ≥500ms.
- Always on; silent when healthy (no env flag).
- Goal: catch the silent gap before ECS `host_health_failed` / `AbortError` kills (e.g. datawizz morning flaps).

## Where logs go
- `console.error` → process stderr
- Cloud host-app: awslogs → CloudWatch log group `/ecs/gamut-host-app` (per-org stream)
- Desktop/local: terminal stderr only

## Test plan
- [ ] Local: no spam while idle; optional busy-loop should emit `event_loop_stall`
- [ ] Deploy to datawizz; confirm no spam while healthy
- [ ] On next health-check flap, search `/ecs/gamut-host-app` for `"event":"event_loop_stall"` near `host_health_failed` AbortError