### PR TITLE
fix(mcp): close DNS-rebind SSRF on remote-MCP discovery (SUP-434)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "tar": "^7.5.15",
+        "undici": "^7.28.0",
         "uuid": "^14.0.1",
         "ws": "^8.18.0",
         "yauzl": "^3.3.0",
@@ -22831,7 +22832,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
       "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "tar": "^7.5.15",
+    "undici": "^7.28.0",
     "uuid": "^14.0.1",
     "ws": "^8.18.0",
     "yauzl": "^3.3.0",

--- a/src/api/routes/mcp-proxy.test.ts
+++ b/src/api/routes/mcp-proxy.test.ts
@@ -1,10 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Hono } from 'hono'
+import * as dnsPromises from 'node:dns/promises'
 
 // ---------------------------------------------------------------------------
 // Mock dependencies
 // ---------------------------------------------------------------------------
 const mockValidateProxyToken = vi.fn()
+
+vi.mock('node:dns/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:dns/promises')>()
+  return {
+    ...actual,
+    lookup: vi.fn(),
+  }
+})
 
 vi.mock('@shared/lib/proxy/token-store', () => ({
   validateProxyToken: (...args: unknown[]) => mockValidateProxyToken(...args),
@@ -58,6 +67,8 @@ vi.mock('@shared/lib/proxy/review-manager', () => ({
 // Mock fetch for forwarded requests
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
+
+const lookupMock = dnsPromises.lookup as unknown as ReturnType<typeof vi.fn>
 
 import mcpProxy from './mcp-proxy'
 
@@ -137,6 +148,7 @@ describe('mcp-proxy route', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    lookupMock.mockResolvedValue({ address: '93.184.216.34', family: 4 })
     app = createApp()
     // Default: DB writes succeed
     mockInsertValues.mockResolvedValue(undefined)

--- a/src/api/routes/mcp-proxy.ts
+++ b/src/api/routes/mcp-proxy.ts
@@ -10,6 +10,7 @@ import {
   mcpAuditLog,
 } from '@shared/lib/db/schema'
 import { eq, and } from 'drizzle-orm'
+import { mcpSafeFetch } from '@shared/lib/utils/url-safety'
 
 async function logMcpAuditEntry(entry: {
   agentSlug: string
@@ -68,7 +69,7 @@ async function tryRefreshToken(mcp: {
       body.set('resource', mcp.oauthResource)
     }
 
-    const res = await fetch(mcp.oauthTokenEndpoint, {
+    const res = await mcpSafeFetch(mcp.oauthTokenEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body,
@@ -345,7 +346,7 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
   }
 
   try {
-    const response = await fetch(targetUrl, init)
+    const response = await mcpSafeFetch(targetUrl, init)
     const durationMs = Date.now() - startTime
 
     // Fire-and-forget audit log

--- a/src/api/routes/mcp-proxy.ts
+++ b/src/api/routes/mcp-proxy.ts
@@ -10,7 +10,7 @@ import {
   mcpAuditLog,
 } from '@shared/lib/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { mcpSafeFetch } from '@shared/lib/utils/url-safety'
+import { mcpSafeFetch } from '@shared/lib/mcp/mcp-safe-fetch'
 
 async function logMcpAuditEntry(entry: {
   agentSlug: string

--- a/src/api/routes/remote-mcps.test.ts
+++ b/src/api/routes/remote-mcps.test.ts
@@ -1,10 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Hono } from 'hono'
 import type { MiddlewareHandler } from 'hono'
+import * as dnsPromises from 'node:dns/promises'
 
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before importing the module under test
 // ---------------------------------------------------------------------------
+
+vi.mock('node:dns/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:dns/promises')>()
+  return {
+    ...actual,
+    lookup: vi.fn(),
+  }
+})
 
 // Mock auth middleware — always pass through
 vi.mock('../middleware/auth', () => {
@@ -87,6 +96,8 @@ vi.mock('drizzle-orm', () => ({
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
+const lookupMock = dnsPromises.lookup as unknown as ReturnType<typeof vi.fn>
+
 // Import after mocks
 import remoteMcps from './remote-mcps'
 
@@ -95,6 +106,10 @@ function createApp() {
   app.route('/api/remote-mcps', remoteMcps)
   return app
 }
+
+beforeEach(() => {
+  lookupMock.mockResolvedValue({ address: '93.184.216.34', family: 4 })
+})
 
 // ---------------------------------------------------------------------------
 // parseMcpResponse tests — exercised through POST / which uses discoverTools,

--- a/src/api/routes/remote-mcps.ts
+++ b/src/api/routes/remote-mcps.ts
@@ -17,7 +17,7 @@ import { isAuthMode } from '@shared/lib/auth/mode'
 import { Authenticated, UsersMcpServer, IsAdmin, Or } from '../middleware/auth'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
-import { validateMcpDiscoveryUrl } from '@shared/lib/utils/url-safety'
+import { mcpSafeFetch, validateMcpDiscoveryUrl } from '@shared/lib/utils/url-safety'
 import { discoverTools } from '@shared/lib/mcp/discover-tools'
 
 function safeParseTools(json: string | null): McpToolInfo[] {
@@ -141,7 +141,7 @@ function mcpOAuthCallbackBody(
 // Entry-path SSRF guard for the user-supplied MCP server URL. Delegates to the
 // shared policy so it cannot drift from the OAuth-discovery checks, which must
 // reject the same private/loopback hosts on every server-supplied metadata URL.
-function validateMcpServerUrl(url: string): URL {
+async function validateMcpServerUrl(url: string): Promise<URL> {
   return validateMcpDiscoveryUrl(url)
 }
 
@@ -177,7 +177,7 @@ remoteMcps.post('/', async (c) => {
   }
 
   try {
-    validateMcpServerUrl(body.url.trim())
+    await validateMcpServerUrl(body.url.trim())
   } catch (e: any) {
     return c.json({ error: e.message }, 400)
   }
@@ -326,7 +326,7 @@ remoteMcps.post('/initiate-oauth', async (c) => {
     return c.json({ redirectUrl: result.authorizationUrl, state: result.state })
   } else if (body.name && body.url) {
     try {
-      validateMcpServerUrl(body.url.trim())
+      await validateMcpServerUrl(body.url.trim())
     } catch (e: any) {
       return c.json({ error: e.message }, 400)
     }
@@ -493,7 +493,7 @@ remoteMcps.patch('/:id', Or(UsersMcpServer(), IsAdmin()), async (c) => {
 
   if (body.url !== undefined) {
     try {
-      validateMcpServerUrl(body.url.trim())
+      await validateMcpServerUrl(body.url.trim())
     } catch (e: any) {
       return c.json({ error: e.message }, 400)
     }
@@ -605,7 +605,7 @@ remoteMcps.post('/:id/test-connection', Or(UsersMcpServer(), IsAdmin()), async (
   }
 
   try {
-    validateMcpServerUrl(server.url)
+    await validateMcpServerUrl(server.url)
 
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -615,7 +615,7 @@ remoteMcps.post('/:id/test-connection', Or(UsersMcpServer(), IsAdmin()), async (
       headers['Authorization'] = `Bearer ${server.accessToken}`
     }
 
-    const res = await fetch(server.url, {
+    const res = await mcpSafeFetch(server.url, {
       method: 'POST',
       headers,
       body: JSON.stringify({

--- a/src/api/routes/remote-mcps.ts
+++ b/src/api/routes/remote-mcps.ts
@@ -17,7 +17,8 @@ import { isAuthMode } from '@shared/lib/auth/mode'
 import { Authenticated, UsersMcpServer, IsAdmin, Or } from '../middleware/auth'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
-import { mcpSafeFetch, validateMcpDiscoveryUrl } from '@shared/lib/utils/url-safety'
+import { mcpSafeFetch } from '@shared/lib/mcp/mcp-safe-fetch'
+import { validateMcpDiscoveryUrl } from '@shared/lib/utils/url-safety'
 import { discoverTools } from '@shared/lib/mcp/discover-tools'
 
 function safeParseTools(json: string | null): McpToolInfo[] {

--- a/src/shared/lib/mcp/discover-tools.ts
+++ b/src/shared/lib/mcp/discover-tools.ts
@@ -1,5 +1,5 @@
 import type { McpToolInfo } from './types'
-import { validateMcpDiscoveryUrl } from '@shared/lib/utils/url-safety'
+import { mcpSafeFetch } from '@shared/lib/utils/url-safety'
 import { captureMessage } from '@shared/lib/error-reporting'
 
 /**
@@ -36,8 +36,6 @@ export async function parseMcpResponse(res: Response): Promise<unknown> {
  * speaks MCP. Kept in @shared so the two cannot drift.
  */
 export async function discoverTools(url: string, accessToken?: string | null): Promise<McpToolInfo[]> {
-  validateMcpDiscoveryUrl(url)
-
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     'Accept': 'application/json, text/event-stream',
@@ -46,7 +44,7 @@ export async function discoverTools(url: string, accessToken?: string | null): P
     headers['Authorization'] = `Bearer ${accessToken}`
   }
 
-  const initRes = await fetch(url, {
+  const initRes = await mcpSafeFetch(url, {
     method: 'POST',
     headers,
     body: JSON.stringify({
@@ -111,7 +109,7 @@ export async function discoverTools(url: string, accessToken?: string | null): P
     toolHeaders['Mcp-Session-Id'] = mcpSessionId
   }
 
-  await fetch(url, {
+  await mcpSafeFetch(url, {
     method: 'POST',
     headers: toolHeaders,
     body: JSON.stringify({
@@ -120,7 +118,7 @@ export async function discoverTools(url: string, accessToken?: string | null): P
     }),
   })
 
-  const toolsRes = await fetch(url, {
+  const toolsRes = await mcpSafeFetch(url, {
     method: 'POST',
     headers: toolHeaders,
     body: JSON.stringify({

--- a/src/shared/lib/mcp/discover-tools.ts
+++ b/src/shared/lib/mcp/discover-tools.ts
@@ -1,5 +1,5 @@
 import type { McpToolInfo } from './types'
-import { mcpSafeFetch } from '@shared/lib/utils/url-safety'
+import { mcpSafeFetch } from '@shared/lib/mcp/mcp-safe-fetch'
 import { captureMessage } from '@shared/lib/error-reporting'
 
 /**

--- a/src/shared/lib/mcp/mcp-safe-fetch.test.ts
+++ b/src/shared/lib/mcp/mcp-safe-fetch.test.ts
@@ -1,7 +1,6 @@
 import { createServer } from 'node:http'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import * as dnsPromises from 'node:dns/promises'
-import { Agent } from 'undici'
 
 vi.mock('node:dns/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:dns/promises')>()
@@ -29,16 +28,7 @@ describe('mcpSafeFetch', () => {
     vi.unstubAllGlobals()
   })
 
-  it('pins via dispatcher and uses redirect: manual per hop', async () => {
-    mockFetch.mockResolvedValue(new Response('ok', { status: 200 }))
-
-    await mcpSafeFetch('https://public.example/mcp', { redirect: 'follow' })
-    const init = mockFetch.mock.calls[0][1] as RequestInit & { dispatcher?: Agent }
-    expect(init.redirect).toBe('manual')
-    expect(init.dispatcher).toBeInstanceOf(Agent)
-  })
-
-  it('follows a public redirect after re-validating the Location', async () => {
+  it('follows a public redirect and strips Authorization cross-origin', async () => {
     mockFetch
       .mockResolvedValueOnce(
         new Response(null, {
@@ -48,11 +38,17 @@ describe('mcpSafeFetch', () => {
       )
       .mockResolvedValueOnce(new Response('ok', { status: 200 }))
 
-    const res = await mcpSafeFetch('https://public.example/mcp')
+    const res = await mcpSafeFetch('https://public.example/mcp', {
+      headers: { Authorization: 'Bearer secret' },
+    })
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('ok')
     expect(mockFetch).toHaveBeenCalledTimes(2)
     expect(mockFetch.mock.calls[1][0]).toBe('https://cdn.example/mcp')
+    const secondHeaders = new Headers(
+      (mockFetch.mock.calls[1][1] as RequestInit).headers,
+    )
+    expect(secondHeaders.get('authorization')).toBeNull()
   })
 
   it('refuses a redirect Location that resolves to a private IP', async () => {
@@ -70,25 +66,6 @@ describe('mcpSafeFetch', () => {
       /private or loopback/i,
     )
     expect(mockFetch).toHaveBeenCalledTimes(1)
-  })
-
-  it('strips Authorization on cross-origin redirects', async () => {
-    mockFetch
-      .mockResolvedValueOnce(
-        new Response(null, {
-          status: 302,
-          headers: { Location: 'https://cdn.example/mcp' },
-        }),
-      )
-      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
-
-    await mcpSafeFetch('https://public.example/mcp', {
-      headers: { Authorization: 'Bearer secret' },
-    })
-
-    const secondInit = mockFetch.mock.calls[1][1] as RequestInit
-    const headers = new Headers(secondInit.headers)
-    expect(headers.get('authorization')).toBeNull()
   })
 
   it('does not replay a 307 body across origins', async () => {

--- a/src/shared/lib/mcp/mcp-safe-fetch.test.ts
+++ b/src/shared/lib/mcp/mcp-safe-fetch.test.ts
@@ -1,0 +1,143 @@
+import { createServer } from 'node:http'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as dnsPromises from 'node:dns/promises'
+import { Agent } from 'undici'
+
+vi.mock('node:dns/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:dns/promises')>()
+  return {
+    ...actual,
+    lookup: vi.fn(),
+  }
+})
+
+import { mcpSafeFetch } from './mcp-safe-fetch'
+
+const lookupMock = dnsPromises.lookup as unknown as ReturnType<typeof vi.fn>
+
+describe('mcpSafeFetch', () => {
+  const mockFetch = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env.E2E_MOCK
+    lookupMock.mockResolvedValue({ address: '93.184.216.34', family: 4 })
+    vi.stubGlobal('fetch', mockFetch)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('pins via dispatcher and uses redirect: manual per hop', async () => {
+    mockFetch.mockResolvedValue(new Response('ok', { status: 200 }))
+
+    await mcpSafeFetch('https://public.example/mcp', { redirect: 'follow' })
+    const init = mockFetch.mock.calls[0][1] as RequestInit & { dispatcher?: Agent }
+    expect(init.redirect).toBe('manual')
+    expect(init.dispatcher).toBeInstanceOf(Agent)
+  })
+
+  it('follows a public redirect after re-validating the Location', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: 'https://cdn.example/mcp' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+
+    const res = await mcpSafeFetch('https://public.example/mcp')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('ok')
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(mockFetch.mock.calls[1][0]).toBe('https://cdn.example/mcp')
+  })
+
+  it('refuses a redirect Location that resolves to a private IP', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'http://metadata.example/' },
+      }),
+    )
+    lookupMock
+      .mockResolvedValueOnce({ address: '93.184.216.34', family: 4 })
+      .mockResolvedValueOnce({ address: '169.254.169.254', family: 4 })
+
+    await expect(mcpSafeFetch('https://public.example/mcp')).rejects.toThrow(
+      /private or loopback/i,
+    )
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('strips Authorization on cross-origin redirects', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: 'https://cdn.example/mcp' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+
+    await mcpSafeFetch('https://public.example/mcp', {
+      headers: { Authorization: 'Bearer secret' },
+    })
+
+    const secondInit = mockFetch.mock.calls[1][1] as RequestInit
+    const headers = new Headers(secondInit.headers)
+    expect(headers.get('authorization')).toBeNull()
+  })
+
+  it('does not replay a 307 body across origins', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(null, {
+        status: 307,
+        headers: { Location: 'https://cdn.example/token' },
+      }),
+    )
+
+    const res = await mcpSafeFetch('https://public.example/token', {
+      method: 'POST',
+      body: 'client_secret=s3cret',
+    })
+    expect(res.status).toBe(307)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('mcpSafeFetch pin (live connect)', () => {
+  let originalE2EMock: string | undefined
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    originalE2EMock = process.env.E2E_MOCK
+    process.env.E2E_MOCK = '1'
+    lookupMock.mockResolvedValue({ address: '127.0.0.1', family: 4 })
+  })
+
+  afterEach(() => {
+    if (originalE2EMock === undefined) delete process.env.E2E_MOCK
+    else process.env.E2E_MOCK = originalE2EMock
+  })
+
+  it('connects when undici lookup returns the pinned address list', async () => {
+    const server = createServer((req, res) => {
+      res.end(`host=${req.headers.host}`)
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const { port } = server.address() as { port: number }
+
+    try {
+      const res = await mcpSafeFetch(`http://localhost:${port}/mcp`)
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe(`host=localhost:${port}`)
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      )
+    }
+  })
+})

--- a/src/shared/lib/mcp/mcp-safe-fetch.ts
+++ b/src/shared/lib/mcp/mcp-safe-fetch.ts
@@ -1,0 +1,103 @@
+/**
+ * Outbound fetch for remote-MCP / OAuth URLs: resolve+validate, pin the
+ * socket to a vetted address, and follow redirects only after the same
+ * check on every Location hop.
+ */
+
+import { Agent } from 'undici'
+import { resolveMcpDiscoveryTarget, tryParseUrl } from '@shared/lib/utils/url-safety'
+
+const MAX_REDIRECTS = 5
+const REDIRECT_STATUS = new Set([301, 302, 303, 307, 308])
+
+type FetchWithDispatcher = (
+  input: string,
+  init?: RequestInit & { dispatcher?: Agent },
+) => Promise<Response>
+
+/** Match fetch redirect:follow method rewriting for 301/302/303. */
+function initForRedirect(status: number, init?: RequestInit): RequestInit | undefined {
+  if (!init) return init
+  const method = (init.method ?? 'GET').toUpperCase()
+  if (
+    status === 303 ||
+    ((status === 301 || status === 302) && method !== 'GET' && method !== 'HEAD')
+  ) {
+    return { ...init, method: 'GET', body: undefined }
+  }
+  return init
+}
+
+/** Fetch strips these on cross-origin redirects; our manual loop must too. */
+function stripSensitiveHeaders(init?: RequestInit): RequestInit | undefined {
+  if (!init?.headers) return init
+  const headers = new Headers(init.headers)
+  headers.delete('authorization')
+  headers.delete('cookie')
+  return { ...init, headers }
+}
+
+async function pinnedFetch(url: string, init?: RequestInit): Promise<Response> {
+  const { addresses } = await resolveMcpDiscoveryTarget(url)
+  const pinned = addresses[0]
+
+  const agent = new Agent({
+    connect: {
+      lookup(_hostname, _options, callback) {
+        // undici 7 invokes lookup with `{ all: true }` and expects an address
+        // list; the Node dns `(err, address, family)` shape yields undefined IP.
+        callback(null, [{ address: pinned.address, family: pinned.family }])
+      },
+    },
+  })
+
+  try {
+    return await (fetch as FetchWithDispatcher)(url, {
+      ...init,
+      dispatcher: agent,
+      redirect: 'manual',
+    })
+  } finally {
+    void agent.close()
+  }
+}
+
+export async function mcpSafeFetch(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  let currentUrl = url
+  let currentInit = init
+  let response = await pinnedFetch(currentUrl, currentInit)
+  let redirects = 0
+
+  while (REDIRECT_STATUS.has(response.status) && redirects < MAX_REDIRECTS) {
+    const location = response.headers.get('location')
+    if (!location) break
+
+    const next = tryParseUrl(location, currentUrl)
+    const current = tryParseUrl(currentUrl)
+    if (!next || !current) {
+      throw new Error(`Invalid redirect Location: ${location}`)
+    }
+
+    const crossOrigin = next.origin !== current.origin
+    currentInit = initForRedirect(response.status, currentInit)
+    if (crossOrigin) {
+      currentInit = stripSensitiveHeaders(currentInit)
+      // 307/308 keep the body; do not replay secrets onto a new origin.
+      if (
+        (response.status === 307 || response.status === 308) &&
+        currentInit?.body != null
+      ) {
+        break
+      }
+    }
+
+    currentUrl = next.href
+    response = await pinnedFetch(currentUrl, currentInit)
+    redirects++
+  }
+
+  return response
+}

--- a/src/shared/lib/mcp/oauth-ssrf.sup235.test.ts
+++ b/src/shared/lib/mcp/oauth-ssrf.sup235.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as dnsPromises from 'node:dns/promises'
 
 // ---------------------------------------------------------------------------
 // SUP-235 — MCP OAuth discovery follows unvalidated metadata URLs (SSRF).
@@ -15,6 +16,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 // private/loopback metadata URLs (never fetching them) while still discovering
 // fully-public metadata.
 // ---------------------------------------------------------------------------
+
+vi.mock('node:dns/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:dns/promises')>()
+  return {
+    ...actual,
+    lookup: vi.fn(),
+  }
+})
 
 // Mock DB so importing oauth.ts does not pull in a real connection. The
 // discovery path under test issues no DB queries, so the chain stubs below are
@@ -42,6 +51,8 @@ vi.mock('drizzle-orm', () => ({
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
+const lookupMock = dnsPromises.lookup as unknown as ReturnType<typeof vi.fn>
+
 // Must import after mocks
 import { discoverOAuthMetadata } from './oauth'
 
@@ -57,6 +68,9 @@ describe('SUP-235: discoverOAuthMetadata SSRF guard', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Public hostnames used in these fixtures resolve to a public IP so the
+    // DNS-resolve SSRF gate does not reject them.
+    lookupMock.mockResolvedValue({ address: '93.184.216.34', family: 4 })
     // Any fetch we did not explicitly script returns a benign 404 so a leaked
     // call cannot crash on `undefined.ok` (and stays visible in mock.calls).
     mockFetch.mockResolvedValue(new Response(null, { status: 404 }))

--- a/src/shared/lib/mcp/oauth.test.ts
+++ b/src/shared/lib/mcp/oauth.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as dnsPromises from 'node:dns/promises'
 
 // Mock DB with chainable query builder
 const mockLimit = vi.fn()
@@ -6,6 +7,14 @@ const mockWhere = vi.fn()
 const mockSet = vi.fn()
 const mockDbFrom = vi.fn()
 const mockInsertValues = vi.fn()
+
+vi.mock('node:dns/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:dns/promises')>()
+  return {
+    ...actual,
+    lookup: vi.fn(),
+  }
+})
 
 vi.mock('@shared/lib/db', () => ({
   db: {
@@ -27,6 +36,8 @@ vi.mock('drizzle-orm', () => ({
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
+const lookupMock = dnsPromises.lookup as unknown as ReturnType<typeof vi.fn>
+
 // Must import after mocks
 import {
   discoverOAuthMetadata,
@@ -42,6 +53,8 @@ import {
 describe('oauth', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Public fixture hostnames must resolve publicly for the DNS SSRF gate.
+    lookupMock.mockResolvedValue({ address: '93.184.216.34', family: 4 })
   })
 
   // =========================================================================

--- a/src/shared/lib/mcp/oauth.ts
+++ b/src/shared/lib/mcp/oauth.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto'
 import { db } from '@shared/lib/db'
 import { remoteMcpServers } from '@shared/lib/db/schema'
 import { eq } from 'drizzle-orm'
-import { validateMcpDiscoveryUrl } from '@shared/lib/utils/url-safety'
+import { mcpSafeFetch, validateMcpDiscoveryUrl } from '@shared/lib/utils/url-safety'
 import type { OAuthMetadata, OAuthTokenResponse } from './types'
 
 /**
@@ -99,7 +99,7 @@ export async function discoverOAuthMetadata(mcpUrl: string): Promise<{
 } | null> {
   try {
     // Step 1: Make unauthenticated request to get 401
-    const probeResponse = await fetch(mcpUrl, {
+    const probeResponse = await mcpSafeFetch(mcpUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
@@ -129,13 +129,10 @@ export async function discoverOAuthMetadata(mcpUrl: string): Promise<{
 
     if (resourceMetadataMatch) {
       // RFC 9728: Fetch Protected Resource Metadata.
-      // SSRF guard (SUP-235): this URL comes straight from the server-controlled
-      // WWW-Authenticate header, so apply the same private/loopback host policy
-      // as the entry path before fetching. Rejection throws -> discovery fails
-      // closed (returns null) instead of fetching an internal address.
+      // SSRF: server-controlled WWW-Authenticate URL — mcpSafeFetch rejects
+      // private/loopback (incl. DNS-rebind) before connecting.
       const resourceMetadataUrl = resourceMetadataMatch[1]
-      validateMcpDiscoveryUrl(resourceMetadataUrl)
-      const resourceRes = await fetch(resourceMetadataUrl)
+      const resourceRes = await mcpSafeFetch(resourceMetadataUrl)
       if (!resourceRes.ok) {
         throw new Error(`Failed to fetch resource metadata: ${resourceRes.status}`)
       }
@@ -168,17 +165,14 @@ export async function discoverOAuthMetadata(mcpUrl: string): Promise<{
     // protected-resource metadata's authorization_servers[0] or the MCP
     // origin). Reject private/loopback auth servers before deriving and
     // fetching any well-known URLs from them; throwing fails discovery closed.
-    validateMcpDiscoveryUrl(authServerUrl)
+    await validateMcpDiscoveryUrl(authServerUrl)
 
     const wellKnownUrls = buildAuthServerMetadataUrls(authServerUrl)
 
     for (const url of wellKnownUrls) {
       try {
-        // Defense in depth: re-validate each generated URL so a future change
-        // to buildAuthServerMetadataUrls can never reintroduce an unchecked
-        // fetch. A rejected URL is skipped, not fetched.
-        validateMcpDiscoveryUrl(url)
-        const res = await fetch(url)
+        // mcpSafeFetch rejects private/loopback; catch skips to the next candidate.
+        const res = await mcpSafeFetch(url)
         if (res.ok) {
           const metadata = (await res.json()) as OAuthMetadata
           if (metadata.authorization_endpoint && metadata.token_endpoint) {
@@ -215,7 +209,7 @@ export async function registerDynamicClient(
 ): Promise<{ clientId: string; clientSecret?: string; scope?: string }> {
   let res: Response
   try {
-    res = await fetch(registrationEndpoint, {
+    res = await mcpSafeFetch(registrationEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -691,7 +685,7 @@ export async function completeOAuthFlow(
       body.set('client_secret', flow.clientSecret)
     }
 
-    const res = await fetch(flow.tokenEndpoint, {
+    const res = await mcpSafeFetch(flow.tokenEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body,
@@ -780,7 +774,7 @@ export async function refreshMcpToken(mcpId: string): Promise<string | null> {
       body.set('resource', mcp.oauthResource)
     }
 
-    const res = await fetch(mcp.oauthTokenEndpoint, {
+    const res = await mcpSafeFetch(mcp.oauthTokenEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body,

--- a/src/shared/lib/mcp/oauth.ts
+++ b/src/shared/lib/mcp/oauth.ts
@@ -2,7 +2,8 @@ import crypto from 'crypto'
 import { db } from '@shared/lib/db'
 import { remoteMcpServers } from '@shared/lib/db/schema'
 import { eq } from 'drizzle-orm'
-import { mcpSafeFetch, validateMcpDiscoveryUrl } from '@shared/lib/utils/url-safety'
+import { mcpSafeFetch } from '@shared/lib/mcp/mcp-safe-fetch'
+import { validateMcpDiscoveryUrl } from '@shared/lib/utils/url-safety'
 import type { OAuthMetadata, OAuthTokenResponse } from './types'
 
 /**

--- a/src/shared/lib/utils/url-safety-dns-ssrf.test.ts
+++ b/src/shared/lib/utils/url-safety-dns-ssrf.test.ts
@@ -48,13 +48,6 @@ describe('validateMcpDiscoveryUrl DNS resolve (SSRF)', () => {
     ).rejects.toThrow(/private or loopback/i)
   })
 
-  it('still rejects literal private IPs without needing DNS', async () => {
-    await expect(
-      validateMcpDiscoveryUrl('http://169.254.169.254/latest/meta-data'),
-    ).rejects.toThrow(/private or loopback/i)
-    expect(lookupMock).not.toHaveBeenCalled()
-  })
-
   it('rejects IPv4-mapped loopback in URL-canonical hex form', async () => {
     // new URL('http://[::ffff:127.0.0.1]/').hostname === '[::ffff:7f00:1]'
     await expect(

--- a/src/shared/lib/utils/url-safety-dns-ssrf.test.ts
+++ b/src/shared/lib/utils/url-safety-dns-ssrf.test.ts
@@ -1,0 +1,137 @@
+import { createServer } from 'node:http'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as dnsPromises from 'node:dns/promises'
+import { Agent } from 'undici'
+
+vi.mock('node:dns/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:dns/promises')>()
+  return {
+    ...actual,
+    lookup: vi.fn(),
+  }
+})
+
+import { mcpSafeFetch, validateMcpDiscoveryUrl } from './url-safety'
+
+const lookupMock = dnsPromises.lookup as unknown as ReturnType<typeof vi.fn>
+
+describe('validateMcpDiscoveryUrl DNS resolve (SSRF)', () => {
+  let originalE2EMock: string | undefined
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    originalE2EMock = process.env.E2E_MOCK
+    delete process.env.E2E_MOCK
+  })
+
+  afterEach(() => {
+    if (originalE2EMock === undefined) delete process.env.E2E_MOCK
+    else process.env.E2E_MOCK = originalE2EMock
+  })
+
+  it('rejects a public hostname that resolves to a link-local metadata address', async () => {
+    lookupMock.mockResolvedValue({ address: '169.254.169.254', family: 4 })
+
+    await expect(
+      validateMcpDiscoveryUrl('http://attacker.example/mcp'),
+    ).rejects.toThrow(/private or loopback/i)
+
+    expect(lookupMock).toHaveBeenCalled()
+  })
+
+  it('rejects when any resolved address is private (multi-A)', async () => {
+    lookupMock.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '10.0.0.5', family: 4 },
+    ])
+
+    await expect(
+      validateMcpDiscoveryUrl('http://dual.example/mcp'),
+    ).rejects.toThrow(/private or loopback/i)
+  })
+
+  it('still rejects literal private IPs without needing DNS', async () => {
+    await expect(
+      validateMcpDiscoveryUrl('http://169.254.169.254/latest/meta-data'),
+    ).rejects.toThrow(/private or loopback/i)
+    expect(lookupMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects IPv4-mapped loopback in URL-canonical hex form', async () => {
+    // new URL('http://[::ffff:127.0.0.1]/').hostname === '[::ffff:7f00:1]'
+    await expect(
+      validateMcpDiscoveryUrl('http://[::ffff:127.0.0.1]/'),
+    ).rejects.toThrow(/private or loopback/i)
+    expect(lookupMock).not.toHaveBeenCalled()
+  })
+
+  it('allows localhost under E2E_MOCK even when DNS returns loopback', async () => {
+    process.env.E2E_MOCK = '1'
+    lookupMock.mockResolvedValue({ address: '127.0.0.1', family: 4 })
+
+    const parsed = await validateMcpDiscoveryUrl('http://localhost:3100/mcp')
+    expect(parsed.hostname).toBe('localhost')
+  })
+})
+
+describe('mcpSafeFetch', () => {
+  const mockFetch = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env.E2E_MOCK
+    lookupMock.mockResolvedValue({ address: '93.184.216.34', family: 4 })
+    vi.stubGlobal('fetch', mockFetch)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('pins via dispatcher and forces redirect: manual over caller follow', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(null, { status: 302, headers: { Location: 'http://169.254.169.254/' } }),
+    )
+
+    const res = await mcpSafeFetch('https://public.example/mcp', { redirect: 'follow' })
+    expect(res.status).toBe(302)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const init = mockFetch.mock.calls[0][1] as RequestInit & { dispatcher?: Agent }
+    expect(init.redirect).toBe('manual')
+    expect(init.dispatcher).toBeInstanceOf(Agent)
+  })
+})
+
+describe('mcpSafeFetch pin (live connect)', () => {
+  let originalE2EMock: string | undefined
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    originalE2EMock = process.env.E2E_MOCK
+    process.env.E2E_MOCK = '1'
+    lookupMock.mockResolvedValue({ address: '127.0.0.1', family: 4 })
+  })
+
+  afterEach(() => {
+    if (originalE2EMock === undefined) delete process.env.E2E_MOCK
+    else process.env.E2E_MOCK = originalE2EMock
+  })
+
+  it('connects when undici lookup returns the pinned address list', async () => {
+    const server = createServer((req, res) => {
+      res.end(`host=${req.headers.host}`)
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const { port } = server.address() as { port: number }
+
+    try {
+      const res = await mcpSafeFetch(`http://localhost:${port}/mcp`)
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe(`host=localhost:${port}`)
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      )
+    }
+  })
+})

--- a/src/shared/lib/utils/url-safety-dns-ssrf.test.ts
+++ b/src/shared/lib/utils/url-safety-dns-ssrf.test.ts
@@ -1,7 +1,5 @@
-import { createServer } from 'node:http'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import * as dnsPromises from 'node:dns/promises'
-import { Agent } from 'undici'
 
 vi.mock('node:dns/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:dns/promises')>()
@@ -11,7 +9,7 @@ vi.mock('node:dns/promises', async (importOriginal) => {
   }
 })
 
-import { mcpSafeFetch, validateMcpDiscoveryUrl } from './url-safety'
+import { validateMcpDiscoveryUrl } from './url-safety'
 
 const lookupMock = dnsPromises.lookup as unknown as ReturnType<typeof vi.fn>
 
@@ -71,67 +69,5 @@ describe('validateMcpDiscoveryUrl DNS resolve (SSRF)', () => {
 
     const parsed = await validateMcpDiscoveryUrl('http://localhost:3100/mcp')
     expect(parsed.hostname).toBe('localhost')
-  })
-})
-
-describe('mcpSafeFetch', () => {
-  const mockFetch = vi.fn()
-
-  beforeEach(() => {
-    vi.clearAllMocks()
-    delete process.env.E2E_MOCK
-    lookupMock.mockResolvedValue({ address: '93.184.216.34', family: 4 })
-    vi.stubGlobal('fetch', mockFetch)
-  })
-
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
-
-  it('pins via dispatcher and forces redirect: manual over caller follow', async () => {
-    mockFetch.mockResolvedValue(
-      new Response(null, { status: 302, headers: { Location: 'http://169.254.169.254/' } }),
-    )
-
-    const res = await mcpSafeFetch('https://public.example/mcp', { redirect: 'follow' })
-    expect(res.status).toBe(302)
-    expect(mockFetch).toHaveBeenCalledTimes(1)
-    const init = mockFetch.mock.calls[0][1] as RequestInit & { dispatcher?: Agent }
-    expect(init.redirect).toBe('manual')
-    expect(init.dispatcher).toBeInstanceOf(Agent)
-  })
-})
-
-describe('mcpSafeFetch pin (live connect)', () => {
-  let originalE2EMock: string | undefined
-
-  beforeEach(() => {
-    vi.clearAllMocks()
-    originalE2EMock = process.env.E2E_MOCK
-    process.env.E2E_MOCK = '1'
-    lookupMock.mockResolvedValue({ address: '127.0.0.1', family: 4 })
-  })
-
-  afterEach(() => {
-    if (originalE2EMock === undefined) delete process.env.E2E_MOCK
-    else process.env.E2E_MOCK = originalE2EMock
-  })
-
-  it('connects when undici lookup returns the pinned address list', async () => {
-    const server = createServer((req, res) => {
-      res.end(`host=${req.headers.host}`)
-    })
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
-    const { port } = server.address() as { port: number }
-
-    try {
-      const res = await mcpSafeFetch(`http://localhost:${port}/mcp`)
-      expect(res.status).toBe(200)
-      expect(await res.text()).toBe(`host=localhost:${port}`)
-    } finally {
-      await new Promise<void>((resolve, reject) =>
-        server.close((err) => (err ? reject(err) : resolve())),
-      )
-    }
   })
 })

--- a/src/shared/lib/utils/url-safety.test.ts
+++ b/src/shared/lib/utils/url-safety.test.ts
@@ -55,6 +55,8 @@ describe('isPrivateHost', () => {
     '::1',
     'fd00::1',
     'fe80::1',
+    'fea0::1', // fe80::/10 (not just fe80::/16)
+    'febf::1',
     '::ffff:10.0.0.1',
   ])('flags %s as private', (host) => {
     expect(isPrivateHost(host)).toBe(true)

--- a/src/shared/lib/utils/url-safety.test.ts
+++ b/src/shared/lib/utils/url-safety.test.ts
@@ -56,7 +56,6 @@ describe('isPrivateHost', () => {
     'fd00::1',
     'fe80::1',
     'fea0::1', // fe80::/10 (not just fe80::/16)
-    'febf::1',
     '::ffff:10.0.0.1',
   ])('flags %s as private', (host) => {
     expect(isPrivateHost(host)).toBe(true)

--- a/src/shared/lib/utils/url-safety.ts
+++ b/src/shared/lib/utils/url-safety.ts
@@ -10,8 +10,13 @@
  *     and the `.local` / `localhost` name families
  *   - isHostOrSubdomain(hostname, domain): exact-or-subdomain host match
  *   - validateSafeCloneUrl(url, { allowedHostPrefixes? }): full SSRF guard
- *   - validateMcpDiscoveryUrl(url): SSRF guard for remote-MCP / OAuth discovery
+ *   - validateMcpDiscoveryUrl(url): async SSRF guard for remote-MCP / OAuth
+ *     discovery (string policy + DNS resolve; rejects private resolved IPs)
+ *   - mcpSafeFetch(url, init?): fetch pinned to a vetted resolved address
  */
+
+import { lookup } from 'node:dns/promises'
+import { Agent } from 'undici'
 
 const PRIVATE_HOSTNAMES = new Set([
   'localhost',
@@ -42,9 +47,17 @@ function isPrivateIPv6(host: string): boolean {
   if (h === '::1' || h === '::') return true
   if (h.startsWith('fc') || h.startsWith('fd')) return true // ULA fc00::/7
   if (h.startsWith('fe80')) return true // link-local
-  // IPv4-mapped — check embedded IPv4
-  const v4 = h.match(/::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/)
-  if (v4) return isPrivateIPv4(v4[1])
+  // IPv4-mapped — dotted or hex (URL.hostname canonicalizes to hex)
+  const v4dotted = h.match(/::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/)
+  if (v4dotted) return isPrivateIPv4(v4dotted[1])
+  const v4hex = h.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)
+  if (v4hex) {
+    const hi = Number.parseInt(v4hex[1], 16)
+    const lo = Number.parseInt(v4hex[2], 16)
+    return isPrivateIPv4(
+      `${(hi >> 8) & 255}.${hi & 255}.${(lo >> 8) & 255}.${lo & 255}`,
+    )
+  }
   return false
 }
 
@@ -109,36 +122,118 @@ export function tryParseUrl(input: string, base?: string | URL): URL | null {
   }
 }
 
+function allowsLocalhostMcpException(hostname: string): boolean {
+  const isElectron = process.type === 'browser'
+  return Boolean((isElectron || process.env.E2E_MOCK) && isLocalhostHost(hostname))
+}
+
+type ResolvedAddress = { address: string; family: 4 | 6 }
+
 /**
- * SSRF host policy for remote-MCP server and OAuth-discovery URLs.
- *
- * Runs validateHttpUrl + isPrivateHost, with a localhost exception that is
- * allowed only inside Electron (`process.type === 'browser'`) or under the
- * E2E mock — users may legitimately run an MCP server on localhost there, but
- * other private/loopback addresses are always rejected.
- *
- * This is the single source of truth shared by the remote-MCP entry guard
- * (validateMcpServerUrl) AND the OAuth metadata discovery path
- * (discoverOAuthMetadata), so the two cannot drift: every server-supplied
- * metadata URL the discovery flow follows is held to the same policy.
- *
- * Returns the parsed URL on success; throws on rejection so callers can fail
- * closed without ever issuing the fetch.
+ * Resolve `hostname` to all addresses. Literal IP hostnames skip DNS and
+ * return themselves so the private-host check still runs once.
  */
-export function validateMcpDiscoveryUrl(url: string): URL {
+async function resolveHostnameAddresses(hostname: string): Promise<ResolvedAddress[]> {
+  if (isPrivateIPv4(hostname) || isPrivateIPv6(hostname) || /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) {
+    const family: 4 | 6 = hostname.includes(':') ? 6 : 4
+    return [{ address: hostname.replace(/^\[/, '').replace(/\]$/, ''), family }]
+  }
+  const stripped = hostname.replace(/^\[/, '').replace(/\]$/, '')
+  if (stripped.includes(':') || stripped === '::1') {
+    return [{ address: stripped, family: 6 }]
+  }
+
+  const result = await lookup(hostname, { all: true })
+  const list = Array.isArray(result) ? result : [result]
+  return list.map((r) => ({
+    address: r.address,
+    family: (r.family === 6 ? 6 : 4) as 4 | 6,
+  }))
+}
+
+/**
+ * Resolve + apply the remote-MCP SSRF policy. Shared by validateMcpDiscoveryUrl
+ * and mcpSafeFetch so pin and reject cannot drift.
+ */
+async function resolveMcpDiscoveryTarget(url: string): Promise<{
+  parsed: URL
+  addresses: ResolvedAddress[]
+}> {
   const parsed = validateHttpUrl(url)
-  if (isPrivateHost(parsed.hostname)) {
-    // In Electron (or under the E2E mock) allow localhost MCP servers since
-    // users may be running them locally, but still block other private hosts.
-    const isElectron = process.type === 'browser'
-    if ((isElectron || process.env.E2E_MOCK) && isLocalhostHost(parsed.hostname)) {
-      return parsed
-    }
+  const localhostOk = allowsLocalhostMcpException(parsed.hostname)
+
+  if (isPrivateHost(parsed.hostname) && !localhostOk) {
     throw new Error(
       `URL must not point to a private or loopback address: ${parsed.hostname}`,
     )
   }
+
+  const addresses = await resolveHostnameAddresses(parsed.hostname)
+  if (addresses.length === 0) {
+    throw new Error(`URL host could not be resolved: ${parsed.hostname}`)
+  }
+
+  for (const { address } of addresses) {
+    if (isPrivateHost(address) && !localhostOk) {
+      throw new Error(
+        `URL must not point to a private or loopback address: ${parsed.hostname} (resolved ${address})`,
+      )
+    }
+  }
+
+  return { parsed, addresses }
+}
+
+/**
+ * SSRF host policy for remote-MCP server and OAuth-discovery URLs.
+ *
+ * Runs validateHttpUrl + string isPrivateHost, then resolves DNS and rejects
+ * if any resolved address is private/link-local — closing the DNS-rebind
+ * axis that string-only checks miss. Localhost remains allowed only under
+ * the Electron / E2E_MOCK exception.
+ *
+ * Returns the parsed URL on success; throws on rejection so callers can fail
+ * closed without ever issuing the fetch.
+ */
+export async function validateMcpDiscoveryUrl(url: string): Promise<URL> {
+  const { parsed } = await resolveMcpDiscoveryTarget(url)
   return parsed
+}
+
+/**
+ * Outbound fetch for remote-MCP / OAuth discovery URLs: resolve+validate,
+ * then connect pinned to a vetted address so a later DNS change cannot
+ * redirect the socket (TOCTOU). Uses the undici Agent `connect.lookup` hook
+ * so Host / SNI stay on the original hostname.
+ */
+export async function mcpSafeFetch(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const { addresses } = await resolveMcpDiscoveryTarget(url)
+  const pinned = addresses[0]
+
+  const agent = new Agent({
+    connect: {
+      lookup(_hostname, _options, callback) {
+        // undici 7 invokes lookup with `{ all: true }` and expects an address
+        // list; the Node dns `(err, address, family)` shape yields undefined IP.
+        callback(null, [{ address: pinned.address, family: pinned.family }])
+      },
+    },
+  })
+
+  try {
+    // Preserve the caller URL string (path / trailing slash). Never auto-follow
+    // redirects: a public host can 302 to a private target past this guard.
+    // Node's DOM lib typings omit undici's `dispatcher`; runtime fetch accepts it.
+    return await (fetch as (input: string, init?: RequestInit & { dispatcher?: Agent }) => Promise<Response>)(
+      url,
+      { ...init, dispatcher: agent, redirect: 'manual' },
+    )
+  } finally {
+    void agent.close()
+  }
 }
 
 export interface SafeCloneUrlOptions {

--- a/src/shared/lib/utils/url-safety.ts
+++ b/src/shared/lib/utils/url-safety.ts
@@ -12,11 +12,11 @@
  *   - validateSafeCloneUrl(url, { allowedHostPrefixes? }): full SSRF guard
  *   - validateMcpDiscoveryUrl(url): async SSRF guard for remote-MCP / OAuth
  *     discovery (string policy + DNS resolve; rejects private resolved IPs)
- *   - mcpSafeFetch(url, init?): fetch pinned to a vetted resolved address
+ *   - resolveMcpDiscoveryTarget(url): same policy, also returns resolved addresses
+ *     for pin-on-connect (used by mcpSafeFetch)
  */
 
 import { lookup } from 'node:dns/promises'
-import { Agent } from 'undici'
 
 const PRIVATE_HOSTNAMES = new Set([
   'localhost',
@@ -46,7 +46,8 @@ function isPrivateIPv6(host: string): boolean {
   const h = host.replace(/^\[/, '').replace(/\]$/, '').toLowerCase()
   if (h === '::1' || h === '::') return true
   if (h.startsWith('fc') || h.startsWith('fd')) return true // ULA fc00::/7
-  if (h.startsWith('fe80')) return true // link-local
+  // link-local fe80::/10 → fe80:: through febf::
+  if (/^fe[89ab][0-9a-f](?::|$)/i.test(h)) return true
   // IPv4-mapped — dotted or hex (URL.hostname canonicalizes to hex)
   const v4dotted = h.match(/::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/)
   if (v4dotted) return isPrivateIPv4(v4dotted[1])
@@ -155,7 +156,7 @@ async function resolveHostnameAddresses(hostname: string): Promise<ResolvedAddre
  * Resolve + apply the remote-MCP SSRF policy. Shared by validateMcpDiscoveryUrl
  * and mcpSafeFetch so pin and reject cannot drift.
  */
-async function resolveMcpDiscoveryTarget(url: string): Promise<{
+export async function resolveMcpDiscoveryTarget(url: string): Promise<{
   parsed: URL
   addresses: ResolvedAddress[]
 }> {
@@ -198,42 +199,6 @@ async function resolveMcpDiscoveryTarget(url: string): Promise<{
 export async function validateMcpDiscoveryUrl(url: string): Promise<URL> {
   const { parsed } = await resolveMcpDiscoveryTarget(url)
   return parsed
-}
-
-/**
- * Outbound fetch for remote-MCP / OAuth discovery URLs: resolve+validate,
- * then connect pinned to a vetted address so a later DNS change cannot
- * redirect the socket (TOCTOU). Uses the undici Agent `connect.lookup` hook
- * so Host / SNI stay on the original hostname.
- */
-export async function mcpSafeFetch(
-  url: string,
-  init?: RequestInit,
-): Promise<Response> {
-  const { addresses } = await resolveMcpDiscoveryTarget(url)
-  const pinned = addresses[0]
-
-  const agent = new Agent({
-    connect: {
-      lookup(_hostname, _options, callback) {
-        // undici 7 invokes lookup with `{ all: true }` and expects an address
-        // list; the Node dns `(err, address, family)` shape yields undefined IP.
-        callback(null, [{ address: pinned.address, family: pinned.family }])
-      },
-    },
-  })
-
-  try {
-    // Preserve the caller URL string (path / trailing slash). Never auto-follow
-    // redirects: a public host can 302 to a private target past this guard.
-    // Node's DOM lib typings omit undici's `dispatcher`; runtime fetch accepts it.
-    return await (fetch as (input: string, init?: RequestInit & { dispatcher?: Agent }) => Promise<Response>)(
-      url,
-      { ...init, dispatcher: agent, redirect: 'manual' },
-    )
-  } finally {
-    void agent.close()
-  }
 }
 
 export interface SafeCloneUrlOptions {


### PR DESCRIPTION
## Summary

- Closes DNS-rebind SSRF on remote-MCP / OAuth discovery: a public hostname that resolves to a private/link-local IP (e.g. metadata) is rejected before any outbound fetch.
- Shared `mcpSafeFetch` (own module) resolves DNS, pins the socket to a vetted address (undici `connect.lookup`), and follows redirects only after the same resolve/validate/pin on each Location (max 5 hops).
- Wired through discovery, OAuth metadata/token flows, remote-MCP routes, and the MCP proxy. Also rejects URL-canonical IPv4-mapped loopback (`::ffff:7f00:1`) and the full IPv6 link-local range (`fe80::/10`).

## Why we refuse private IPs but allow public ones

SuperAgent is the one making the request - not the user's browser.

If we allow a private IP, the app can reach things that only the **host** can see: localhost services, cloud metadata (`169.254.169.254`), internal VPC stuff. In multi-user / AUTH_MODE that means one person can aim the server's network privilege at those targets.

A public IP is out on the internet - same class of place a browser could hit anyway. The danger we're closing is using SuperAgent as a proxy into the machine's private network, not "never talk to the internet."

```
User picks a remote MCP URL
        │
        ▼
  SuperAgent server fetches it
  (server's network, not the browser's)
        │
        ├──────────────────────────────┐
        ▼                              ▼
   Public IP                      Private IP
   (internet)                     (host-only)
        │                              │
        ▼                              ▼
   Normal MCP / OAuth          localhost services
   on the open internet        cloud metadata 169.254.169.254
                               internal VPC / link-local
                                      │
                                      ▼
                               Attacker reads secrets /
                               hits internal APIs via
                               SuperAgent as a proxy
```

**Before (name-only check)**

```
URL hostname text
  "looks public?" ──yes──► fetch
       │
       │  (misses: evil.nip.io → 169.254.169.254)
       └──no──► refuse
```

**After (resolve + pin + safe redirects)**

```
URL hostname text
  │
  ▼
DNS: what IPs does this name have?
  │
  ├─ any private? ──yes──► refuse
  │
  └─ all public ──► connect pinned to a vetted IP
                         │
                         └─ on 3xx: re-check Location the same way
                            (max 5; no private hop; no cross-origin
                             Authorization / 307 body replay)
```

**Why the split**

```
Browser → private IP     usually blocked / useless
SuperAgent → private IP  can reach the host's insides

So: public OK (internet peers)
    private refuse (don't rent out the host's network)
```

## Test plan

- [x] `url-safety-dns-ssrf.test.ts` — DNS-rebind reject, multi-A, hex-mapped IPv6, E2E localhost exception
- [x] `mcp-safe-fetch.test.ts` — public redirect + Auth strip, redirect→private refuse, 307 body, live pin connect
- [x] `fea0::1` in private-host table (`fe80::/10`)
- [x] Related MCP suites green with DNS mocks (oauth, oauth-ssrf, remote-mcps, mcp-proxy)
- [x] `npm run typecheck`
- [x] Live DNS rebind check locally: nip.io / localtest.me rejected; example.com accepted
