### PR TITLE
SUP-422: Hide shared-agent connection metadata

### DIFF
--- a/src/api/routes/activity.test.ts
+++ b/src/api/routes/activity.test.ts
@@ -52,6 +52,7 @@ describe('activity API', () => {
       days: 14,
       tzOffsetMinutes: 0,
       isSessionLive: expect.any(Function),
+      ownerId: 'user-123',
     })
   })
 

--- a/src/api/routes/activity.ts
+++ b/src/api/routes/activity.ts
@@ -1,6 +1,5 @@
 import { Hono } from 'hono'
-import { getCurrentUserId } from '@shared/lib/auth/config'
-import { isAuthMode } from '@shared/lib/auth/mode'
+import { getViewerUserId } from '@shared/lib/auth/ownership'
 import {
   DEFAULT_ACTIVITY_DAYS,
   MAX_ACTIVITY_DAYS,
@@ -48,7 +47,13 @@ activityRouter.get('/agents/:id', ResolveAgent(), AgentRead(), async (c) => {
   try {
     const days = parseDays(c.req.query('days'))
     const tzOffsetMinutes = parseTzOffset(c.req.query('tz'))
-    return c.json(await getAgentActivityStats(getAgentId(c), { days, tzOffsetMinutes, isSessionLive }))
+    const ownerId = getViewerUserId(c) ?? undefined
+    return c.json(await getAgentActivityStats(getAgentId(c), {
+      days,
+      tzOffsetMinutes,
+      isSessionLive,
+      ownerId,
+    }))
   } catch (error) {
     console.error('Failed to fetch agent activity statistics:', error)
     return c.json({ error: 'Failed to fetch activity statistics' }, 500)
@@ -59,7 +64,7 @@ activityRouter.get('/connections', async (c) => {
   try {
     const days = parseDays(c.req.query('days'))
     const tzOffsetMinutes = parseTzOffset(c.req.query('tz'))
-    const ownerId = isAuthMode() ? getCurrentUserId(c) : undefined
+    const ownerId = getViewerUserId(c) ?? undefined
     return c.json(await getConnectionActivityStats({ days, tzOffsetMinutes, ownerId }))
   } catch (error) {
     console.error('Failed to fetch connection activity statistics:', error)

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -493,6 +493,177 @@ async function postFormData(app: Hono, url: string, body: FormData): Promise<Res
 }
 
 // ============================================================================
+// Shared-agent connection projections
+// ============================================================================
+
+describe('shared-agent connection projections', () => {
+  const ownAccount = {
+    id: 'own-account',
+    providerConnectionId: 'own-provider-connection',
+    providerName: 'composio',
+    toolkitSlug: 'github',
+    displayName: 'My GitHub',
+    status: 'active' as const,
+    userId: 'test-user-id',
+    createdAt: new Date('2026-07-18T10:00:00Z'),
+    updatedAt: new Date('2026-07-18T11:00:00Z'),
+  }
+  const foreignAccount = {
+    ...ownAccount,
+    id: 'victim-account-id',
+    providerConnectionId: 'victim-provider-connection',
+    toolkitSlug: 'slack',
+    displayName: 'Victim Workspace',
+    userId: 'victim-user-id',
+  }
+  const ownAccountMapping = {
+    id: 'own-account-mapping',
+    agentSlug: 'test-agent',
+    connectedAccountId: ownAccount.id,
+    createdAt: new Date('2026-07-18T12:00:00Z'),
+  }
+  const foreignAccountMapping = {
+    ...ownAccountMapping,
+    id: 'victim-account-mapping',
+    connectedAccountId: foreignAccount.id,
+  }
+  const ownMcp = {
+    id: 'own-mcp',
+    name: 'My MCP',
+    url: 'https://mine.example.test/mcp',
+    userId: 'test-user-id',
+    authType: 'bearer' as const,
+    accessToken: 'own-token',
+    refreshToken: null,
+    tokenExpiresAt: null,
+    oauthTokenEndpoint: null,
+    oauthClientId: null,
+    oauthClientSecret: null,
+    oauthResource: null,
+    toolsJson: JSON.stringify([{ name: 'search', description: 'Search' }]),
+    toolsDiscoveredAt: new Date('2026-07-18T11:00:00Z'),
+    status: 'active' as const,
+    errorMessage: null,
+    createdAt: new Date('2026-07-18T10:00:00Z'),
+    updatedAt: new Date('2026-07-18T11:00:00Z'),
+  }
+  const foreignMcp = {
+    ...ownMcp,
+    id: 'victim-mcp-id',
+    name: 'Victim private MCP',
+    url: 'https://victim.example.test/private-mcp',
+    userId: 'victim-user-id',
+    accessToken: 'victim-token',
+    toolsJson: JSON.stringify([{ name: 'victim_private_tool' }]),
+    errorMessage: 'victim-only error detail',
+  }
+  const ownMcpMapping = {
+    id: 'own-mcp-mapping',
+    agentSlug: 'test-agent',
+    remoteMcpId: ownMcp.id,
+    createdAt: new Date('2026-07-18T12:00:00Z'),
+  }
+  const foreignMcpMapping = {
+    ...ownMcpMapping,
+    id: 'victim-mcp-mapping',
+    remoteMcpId: foreignMcp.id,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAgentExists.mockResolvedValue(true)
+    mockIsAuthMode.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    mockIsAuthMode.mockReturnValue(false)
+  })
+
+  it('returns owned account details and only a capability marker for foreign accounts', async () => {
+    mockDbSelectFrom.mockReturnValue({
+      innerJoin: () => ({
+        where: () => Promise.resolve([
+          { mapping: ownAccountMapping, account: ownAccount },
+          { mapping: foreignAccountMapping, account: foreignAccount },
+        ]),
+      }),
+    })
+
+    const res = await getReq(createApp(), '/api/agents/test-agent/connected-accounts')
+    const body = await res.json() as { accounts: Array<Record<string, unknown>> }
+
+    expect(res.status).toBe(200)
+    expect(body.accounts[0]).toMatchObject({
+      id: 'own-account',
+      providerConnectionId: 'own-provider-connection',
+      mappingId: 'own-account-mapping',
+    })
+    expect(body.accounts[0]).not.toHaveProperty('userId')
+    expect(body.accounts[1]).toEqual({ kind: 'connected-account', toolkitSlug: 'slack' })
+    expect(JSON.stringify(body)).not.toContain('victim-account-id')
+    expect(JSON.stringify(body)).not.toContain('victim-provider-connection')
+    expect(JSON.stringify(body)).not.toContain('Victim Workspace')
+    expect(JSON.stringify(body)).not.toContain('victim-user-id')
+  })
+
+  it('applies the same projection to the account assignment response', async () => {
+    mockDbSelectFrom
+      .mockReturnValueOnce({ where: () => Promise.resolve([ownAccount]) })
+      .mockReturnValueOnce({
+        innerJoin: () => ({
+          where: () => Promise.resolve([
+            { mapping: ownAccountMapping, account: ownAccount },
+            { mapping: foreignAccountMapping, account: foreignAccount },
+          ]),
+        }),
+      })
+
+    const res = await postJson(createApp(), '/api/agents/test-agent/connected-accounts', {
+      accountIds: [ownAccount.id],
+    })
+    const body = await res.json() as { accounts: Array<Record<string, unknown>> }
+
+    expect(res.status).toBe(200)
+    expect(body.accounts[1]).toEqual({ kind: 'connected-account', toolkitSlug: 'slack' })
+    expect(JSON.stringify(body)).not.toContain('victim-account-id')
+    expect(JSON.stringify(body)).not.toContain('victim-provider-connection')
+    expect(JSON.stringify(body)).not.toContain('victim-user-id')
+  })
+
+  it('returns owned MCP details and a fully opaque marker for foreign MCPs', async () => {
+    mockDbSelectFrom.mockReturnValue({
+      innerJoin: () => ({
+        where: () => Promise.resolve([
+          { mapping: ownMcpMapping, mcp: ownMcp },
+          { mapping: foreignMcpMapping, mcp: foreignMcp },
+        ]),
+      }),
+    })
+
+    const res = await getReq(createApp(), '/api/agents/test-agent/remote-mcps')
+    const body = await res.json() as { mcps: Array<Record<string, unknown>> }
+
+    expect(res.status).toBe(200)
+    expect(body.mcps[0]).toMatchObject({
+      id: 'own-mcp',
+      name: 'My MCP',
+      url: 'https://mine.example.test/mcp',
+      tools: [{ name: 'search', description: 'Search' }],
+      mappingId: 'own-mcp-mapping',
+    })
+    expect(body.mcps[0]).not.toHaveProperty('userId')
+    expect(body.mcps[0]).not.toHaveProperty('accessToken')
+    expect(body.mcps[1]).toEqual({ kind: 'remote-mcp' })
+    expect(JSON.stringify(body)).not.toContain('victim-mcp-id')
+    expect(JSON.stringify(body)).not.toContain('Victim private MCP')
+    expect(JSON.stringify(body)).not.toContain('victim.example.test')
+    expect(JSON.stringify(body)).not.toContain('victim_private_tool')
+    expect(JSON.stringify(body)).not.toContain('victim-only error detail')
+    expect(JSON.stringify(body)).not.toContain('victim-user-id')
+  })
+})
+
+// ============================================================================
 // Webhook triggers — GET /:id/webhook-triggers
 // ============================================================================
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -70,7 +70,7 @@ import { connectedAccounts, agentConnectedAccounts, proxyAuditLog, remoteMcpServ
 import { eq, and, inArray, desc, count, like, or } from 'drizzle-orm'
 import { isAuthMode } from '@shared/lib/auth/mode'
 import { getCurrentUserId } from '@shared/lib/auth/config'
-import { ownerScope } from '@shared/lib/auth/ownership'
+import { getViewerUserId, ownerScope } from '@shared/lib/auth/ownership'
 import { getProvider } from '@shared/lib/account-providers'
 // getAgentSkills is superseded by getAgentSkillsWithStatus from skillset-service
 // import { getAgentSkills } from '@shared/lib/skills'
@@ -3141,7 +3141,7 @@ agents.delete('/:id/secrets/:secretId', AgentUser(), async (c) => {
 agents.get('/:id/connected-accounts', AgentRead(), async (c) => {
   try {
     const slug = getAgentId(c)
-    const viewerUserId = isAuthMode() ? getCurrentUserId(c) : null
+    const viewerUserId = getViewerUserId(c)
 
     const mappings = await db
       .select({
@@ -3174,7 +3174,7 @@ agents.get('/:id/connected-accounts', AgentRead(), async (c) => {
 agents.post('/:id/connected-accounts', AgentUser(), async (c) => {
   try {
     const slug = getAgentId(c)
-    const viewerUserId = isAuthMode() ? getCurrentUserId(c) : null
+    const viewerUserId = getViewerUserId(c)
     const body = await c.req.json()
     const { accountIds } = body as { accountIds: string[] }
 
@@ -3289,7 +3289,7 @@ agents.delete('/:id/connected-accounts/:accountId', AgentUser(), async (c) => {
 agents.get('/:id/remote-mcps', AgentRead(), async (c) => {
   try {
     const slug = getAgentId(c)
-    const viewerUserId = isAuthMode() ? getCurrentUserId(c) : null
+    const viewerUserId = getViewerUserId(c)
     const mappings = await db
       .select({ mcp: remoteMcpServers, mapping: agentRemoteMcps })
       .from(agentRemoteMcps)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -149,6 +149,10 @@ import * as path from 'path'
 import type { ApiAgent } from '@shared/lib/types/api'
 import { toPublicChatIntegration } from '@shared/lib/chat-integrations/public'
 import { toPublicWebhookTrigger } from '@shared/lib/webhook-triggers/public'
+import {
+  toAgentConnectedAccountDto,
+  toAgentRemoteMcpDto,
+} from '@shared/lib/agent-connections/public'
 
 function getConfiguredSkillsets() {
   return getSettings().skillsets || []
@@ -3137,7 +3141,7 @@ agents.delete('/:id/secrets/:secretId', AgentUser(), async (c) => {
 agents.get('/:id/connected-accounts', AgentRead(), async (c) => {
   try {
     const slug = getAgentId(c)
-
+    const viewerUserId = isAuthMode() ? getCurrentUserId(c) : null
 
     const mappings = await db
       .select({
@@ -3151,12 +3155,13 @@ agents.get('/:id/connected-accounts', AgentRead(), async (c) => {
       )
       .where(eq(agentConnectedAccounts.agentSlug, slug))
 
-    const accounts = mappings.map(({ mapping, account }) => ({
-      ...account,
-      mappingId: mapping.id,
-      mappedAt: mapping.createdAt,
-      provider: getProvider(account.toolkitSlug),
-    }))
+    const accounts = mappings.map(({ mapping, account }) =>
+      toAgentConnectedAccountDto(
+        mapping,
+        account,
+        viewerUserId,
+        getProvider(account.toolkitSlug),
+      ))
 
     return c.json({ accounts })
   } catch (error) {
@@ -3169,6 +3174,7 @@ agents.get('/:id/connected-accounts', AgentRead(), async (c) => {
 agents.post('/:id/connected-accounts', AgentUser(), async (c) => {
   try {
     const slug = getAgentId(c)
+    const viewerUserId = isAuthMode() ? getCurrentUserId(c) : null
     const body = await c.req.json()
     const { accountIds } = body as { accountIds: string[] }
 
@@ -3227,12 +3233,13 @@ agents.post('/:id/connected-accounts', AgentUser(), async (c) => {
       )
       .where(eq(agentConnectedAccounts.agentSlug, slug))
 
-    const accounts = updatedMappings.map(({ mapping, account }) => ({
-      ...account,
-      mappingId: mapping.id,
-      mappedAt: mapping.createdAt,
-      provider: getProvider(account.toolkitSlug),
-    }))
+    const accounts = updatedMappings.map(({ mapping, account }) =>
+      toAgentConnectedAccountDto(
+        mapping,
+        account,
+        viewerUserId,
+        getProvider(account.toolkitSlug),
+      ))
 
     for (const accountId of insertedAccountIds) { logAuditEvent({ userId: getCurrentUserId(c), object: 'account', objectId: accountId, action: 'assigned', details: { agentSlug: slug } }) }
     return c.json({ accounts })
@@ -3282,6 +3289,7 @@ agents.delete('/:id/connected-accounts/:accountId', AgentUser(), async (c) => {
 agents.get('/:id/remote-mcps', AgentRead(), async (c) => {
   try {
     const slug = getAgentId(c)
+    const viewerUserId = isAuthMode() ? getCurrentUserId(c) : null
     const mappings = await db
       .select({ mcp: remoteMcpServers, mapping: agentRemoteMcps })
       .from(agentRemoteMcps)
@@ -3292,17 +3300,8 @@ agents.get('/:id/remote-mcps', AgentRead(), async (c) => {
       .where(eq(agentRemoteMcps.agentSlug, slug))
 
     return c.json({
-      mcps: mappings.map(({ mcp, mapping }) => ({
-        id: mcp.id,
-        name: mcp.name,
-        url: mcp.url,
-        authType: mcp.authType,
-        status: mcp.status,
-        errorMessage: mcp.errorMessage,
-        tools: mcp.toolsJson ? JSON.parse(mcp.toolsJson) : [],
-        mappingId: mapping.id,
-        mappedAt: mapping.createdAt,
-      })),
+      mcps: mappings.map(({ mcp, mapping }) =>
+        toAgentRemoteMcpDto(mapping, mcp, viewerUserId)),
     })
   } catch (error) {
     console.error('Failed to fetch agent remote MCPs:', error)

--- a/src/renderer/components/agents/agent-home/home-connections.test.tsx
+++ b/src/renderer/components/agents/agent-home/home-connections.test.tsx
@@ -112,4 +112,37 @@ describe('HomeConnections — row navigation', () => {
       `/api/activity/agents/test-agent?days=14&tz=${new Date().getTimezoneOffset()}`,
     )
   })
+
+  it('shows foreign links as non-navigable shared capabilities', async () => {
+    mockApiFetch.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (path === '/api/agents/test-agent/connected-accounts' && method === 'GET') {
+        return Promise.resolve(jsonResponse({
+          accounts: [{ kind: 'connected-account', toolkitSlug: 'slack' }],
+        }))
+      }
+      if (path === '/api/agents/test-agent/remote-mcps' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ mcps: [{ kind: 'remote-mcp' }] }))
+      }
+      if (path.startsWith('/api/activity/agents/test-agent?days=14&tz=') && method === 'GET') {
+        return Promise.resolve(jsonResponse({
+          days: 0,
+          generatedAt: '2026-07-19T12:00:00.000Z',
+          cronByTaskId: {},
+          webhookByTriggerId: {},
+          connectionById: {},
+        }))
+      }
+      throw new Error(`Unexpected request: ${method} ${path}`)
+    })
+
+    renderWithProviders(<HomeConnections agentSlug="test-agent" />)
+
+    expect(await screen.findByText('Slack')).toBeInTheDocument()
+    expect(screen.getByText('Shared MCP connection')).toBeInTheDocument()
+    expect(screen.getAllByText('Connected by another member')).toHaveLength(2)
+    expect(screen.getAllByText('Shared')).toHaveLength(2)
+    expect(screen.queryByRole('button', { name: /connection details/i })).not.toBeInTheDocument()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/components/agents/agent-home/home-connections.tsx
+++ b/src/renderer/components/agents/agent-home/home-connections.tsx
@@ -13,6 +13,11 @@ import { COMMON_MCP_SERVERS } from '@shared/lib/mcp/common-servers'
 import { FeaturedServicesStack } from '@renderer/components/connections/featured-services-stack'
 import { useAgentActivityStats } from '@renderer/hooks/use-activity-stats'
 import { ActivitySparkChart, ActivitySparkChartSkeleton } from '@renderer/components/activity/activity-spark-chart'
+import { getProvider } from '@shared/lib/account-providers/service-catalog'
+import {
+  isForeignAgentConnectedAccount,
+  isForeignAgentRemoteMcp,
+} from '@shared/lib/agent-connections/public'
 
 interface HomeConnectionsProps {
   agentSlug: string
@@ -27,7 +32,9 @@ interface ConnectionRow {
   iconSlug?: string
   iconFallback: 'oauth' | 'mcp' | 'blocks'
   type: 'oauth' | 'mcp'
-  date: string | number
+  date?: string | number
+  /** Opaque link owned by another member; never navigable. */
+  foreign?: true
   mcpStatus?: RemoteMcpServer['status']
   mcpErrorMessage?: string | null
 }
@@ -42,7 +49,20 @@ export function HomeConnections({ agentSlug, className }: HomeConnectionsProps) 
     const rows: ConnectionRow[] = []
 
     const accounts = Array.isArray(accountsData?.accounts) ? accountsData.accounts : []
-    for (const account of accounts) {
+    for (const [index, account] of accounts.entries()) {
+      if (isForeignAgentConnectedAccount(account)) {
+        rows.push({
+          id: `foreign-account-${account.toolkitSlug}-${index}`,
+          name: getProvider(account.toolkitSlug)?.displayName ?? account.toolkitSlug,
+          subtitle: 'Connected by another member',
+          iconSlug: account.toolkitSlug,
+          iconFallback: 'oauth',
+          type: 'oauth',
+          foreign: true,
+        })
+        continue
+      }
+
       rows.push({
         id: `account-${account.id}`,
         name: account.provider?.displayName ?? account.toolkitSlug,
@@ -55,7 +75,19 @@ export function HomeConnections({ agentSlug, className }: HomeConnectionsProps) 
     }
 
     const mcps = Array.isArray(mcpsData?.mcps) ? mcpsData.mcps : []
-    for (const mcp of mcps) {
+    for (const [index, mcp] of mcps.entries()) {
+      if (isForeignAgentRemoteMcp(mcp)) {
+        rows.push({
+          id: `foreign-mcp-${index}`,
+          name: 'Shared MCP connection',
+          subtitle: 'Connected by another member',
+          iconFallback: 'blocks',
+          type: 'mcp',
+          foreign: true,
+        })
+        continue
+      }
+
       rows.push({
         id: `mcp-${mcp.id}`,
         name: mcp.name,
@@ -69,7 +101,11 @@ export function HomeConnections({ agentSlug, className }: HomeConnectionsProps) 
       })
     }
 
-    rows.sort((a, b) => safeDate(b.date).getTime() - safeDate(a.date).getTime())
+    rows.sort((a, b) => {
+      if (a.date === undefined) return b.date === undefined ? 0 : 1
+      if (b.date === undefined) return -1
+      return safeDate(b.date).getTime() - safeDate(a.date).getTime()
+    })
 
     return rows
   }, [accountsData, mcpsData])
@@ -94,22 +130,28 @@ export function HomeConnections({ agentSlug, className }: HomeConnectionsProps) 
                       <span className="truncate">{conn.subtitle}</span>
                     </>
                   )}
-                  <span className="shrink-0">·</span>
-                  <span className="whitespace-nowrap shrink-0">
-                    {formatDistanceToNow(safeDate(conn.date), { addSuffix: true })}
-                  </span>
+                  {conn.date !== undefined && (
+                    <>
+                      <span className="shrink-0">·</span>
+                      <span className="whitespace-nowrap shrink-0">
+                        {formatDistanceToNow(safeDate(conn.date), { addSuffix: true })}
+                      </span>
+                    </>
+                  )}
                 </>
               }
-              onActivate={() => {
+              onActivate={conn.foreign ? undefined : () => {
                 void navigate({
                   to: '/agents/$slug/connections',
                   params: { slug: agentSlug },
                   search: { detail: conn.id, source: 'home' },
                 })
               }}
-              ariaLabel={`Open ${conn.name} connection details`}
+              ariaLabel={conn.foreign ? undefined : `Open ${conn.name} connection details`}
               right={
-                <>
+                conn.foreign ? (
+                  <span className="text-xs text-muted-foreground">Shared</span>
+                ) : <>
                   {activityStats?.connectionById[conn.id] !== undefined ? (
                     <ActivitySparkChart
                       label={`${conn.name} activity`}

--- a/src/renderer/components/agents/agent-home/home-connections.tsx
+++ b/src/renderer/components/agents/agent-home/home-connections.tsx
@@ -13,11 +13,11 @@ import { COMMON_MCP_SERVERS } from '@shared/lib/mcp/common-servers'
 import { FeaturedServicesStack } from '@renderer/components/connections/featured-services-stack'
 import { useAgentActivityStats } from '@renderer/hooks/use-activity-stats'
 import { ActivitySparkChart, ActivitySparkChartSkeleton } from '@renderer/components/activity/activity-spark-chart'
-import { getProvider } from '@shared/lib/account-providers/service-catalog'
 import {
   isForeignAgentConnectedAccount,
   isForeignAgentRemoteMcp,
 } from '@shared/lib/agent-connections/public'
+import { buildForeignConnectionRows } from '@renderer/components/connections/unified-rows'
 
 interface HomeConnectionsProps {
   agentSlug: string
@@ -25,7 +25,7 @@ interface HomeConnectionsProps {
 }
 
 interface ConnectionRow {
-  /** Matches the UnifiedRow key format so it can deep-link to the detail view. */
+  /** Owned rows match UnifiedRow keys for deep links; foreign rows are synthetic. */
   id: string
   name: string
   subtitle?: string
@@ -49,19 +49,9 @@ export function HomeConnections({ agentSlug, className }: HomeConnectionsProps) 
     const rows: ConnectionRow[] = []
 
     const accounts = Array.isArray(accountsData?.accounts) ? accountsData.accounts : []
-    for (const [index, account] of accounts.entries()) {
-      if (isForeignAgentConnectedAccount(account)) {
-        rows.push({
-          id: `foreign-account-${account.toolkitSlug}-${index}`,
-          name: getProvider(account.toolkitSlug)?.displayName ?? account.toolkitSlug,
-          subtitle: 'Connected by another member',
-          iconSlug: account.toolkitSlug,
-          iconFallback: 'oauth',
-          type: 'oauth',
-          foreign: true,
-        })
-        continue
-      }
+    const foreignAccounts = accounts.filter(isForeignAgentConnectedAccount)
+    for (const account of accounts) {
+      if (isForeignAgentConnectedAccount(account)) continue
 
       rows.push({
         id: `account-${account.id}`,
@@ -75,18 +65,9 @@ export function HomeConnections({ agentSlug, className }: HomeConnectionsProps) 
     }
 
     const mcps = Array.isArray(mcpsData?.mcps) ? mcpsData.mcps : []
-    for (const [index, mcp] of mcps.entries()) {
-      if (isForeignAgentRemoteMcp(mcp)) {
-        rows.push({
-          id: `foreign-mcp-${index}`,
-          name: 'Shared MCP connection',
-          subtitle: 'Connected by another member',
-          iconFallback: 'blocks',
-          type: 'mcp',
-          foreign: true,
-        })
-        continue
-      }
+    const foreignMcps = mcps.filter(isForeignAgentRemoteMcp)
+    for (const mcp of mcps) {
+      if (isForeignAgentRemoteMcp(mcp)) continue
 
       rows.push({
         id: `mcp-${mcp.id}`,
@@ -100,6 +81,11 @@ export function HomeConnections({ agentSlug, className }: HomeConnectionsProps) 
         mcpErrorMessage: mcp.errorMessage,
       })
     }
+
+    rows.push(...buildForeignConnectionRows({
+      accounts: foreignAccounts,
+      mcps: foreignMcps,
+    }))
 
     rows.sort((a, b) => {
       if (a.date === undefined) return b.date === undefined ? 0 : 1

--- a/src/renderer/components/connections/connection-detail-page.tsx
+++ b/src/renderer/components/connections/connection-detail-page.tsx
@@ -61,8 +61,12 @@ export function ConnectionDetailPage({ row, onBack, backLabel = 'Connections' }:
           <p className="text-xs text-muted-foreground truncate">
             {row.type === 'oauth' ? 'API' : 'MCP'}
             {row.subtitle ? ` · ${row.subtitle}` : ''}
-            {' · '}
-            <span className="tabular-nums">{formatCompactDistance(safeDate(row.date))}</span>
+            {row.date !== undefined && (
+              <>
+                {' · '}
+                <span className="tabular-nums">{formatCompactDistance(safeDate(row.date))}</span>
+              </>
+            )}
           </p>
         </div>
         <div className="shrink-0">

--- a/src/renderer/components/connections/connection-row.tsx
+++ b/src/renderer/components/connections/connection-row.tsx
@@ -68,10 +68,14 @@ export function ConnectionRow({
               <span className="truncate">{row.subtitle}</span>
             </>
           )}
-          <span className="shrink-0">·</span>
-          <span className="whitespace-nowrap shrink-0 tabular-nums">
-            {formatCompactDistance(safeDate(row.date))}
-          </span>
+          {row.date !== undefined && (
+            <>
+              <span className="shrink-0">·</span>
+              <span className="whitespace-nowrap shrink-0 tabular-nums">
+                {formatCompactDistance(safeDate(row.date))}
+              </span>
+            </>
+          )}
           {subtitleExtra}
         </>
       }

--- a/src/renderer/components/connections/connections-list.test.tsx
+++ b/src/renderer/components/connections/connections-list.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { ConnectionsList } from './connections-list'
+import { renderWithProviders } from '@renderer/test/test-utils'
+
+const mockMutateAsync = vi.fn()
+
+vi.mock('@renderer/hooks/use-connected-accounts', () => ({
+  useConnectedAccounts: () => ({ data: { accounts: [] }, isLoading: false }),
+  useAgentConnectedAccounts: () => ({
+    data: {
+      accounts: [{ kind: 'connected-account', toolkitSlug: 'slack' }],
+    },
+    isLoading: false,
+  }),
+  useAssignAccountsToAgent: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+    variables: undefined,
+  }),
+  useRemoveAgentConnectedAccount: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+    variables: undefined,
+  }),
+}))
+
+vi.mock('@renderer/hooks/use-remote-mcps', () => ({
+  useRemoteMcps: () => ({ data: { servers: [] }, isLoading: false }),
+  useAgentRemoteMcps: () => ({
+    data: { mcps: [{ kind: 'remote-mcp' }] },
+    isLoading: false,
+  }),
+  useAssignMcpToAgent: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+    variables: undefined,
+  }),
+  useRemoveMcpFromAgent: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+    variables: undefined,
+  }),
+}))
+
+vi.mock('@renderer/hooks/use-oauth-reconnect', () => ({
+  useOAuthReconnect: () => ({
+    reconnect: vi.fn(),
+    pendingAccountId: null,
+    canCancelPendingReconnect: false,
+    cancelReconnect: vi.fn(),
+  }),
+}))
+
+describe('ConnectionsList shared capabilities', () => {
+  it('does not expose detail navigation or access controls for foreign links', () => {
+    renderWithProviders(
+      <ConnectionsList
+        agentSlug="test-agent"
+        detailRowKey={null}
+        onDetailRowKeyChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Slack')).toBeInTheDocument()
+    expect(screen.getByText('Shared MCP connection')).toBeInTheDocument()
+    expect(screen.getAllByText('Connected by another member')).toHaveLength(2)
+    expect(screen.getAllByText('Shared')).toHaveLength(2)
+    expect(screen.queryByRole('button', { name: /connection details/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+  })
+
+  it('rejects a synthetic foreign detail key', async () => {
+    const onDetailRowKeyChange = vi.fn()
+
+    renderWithProviders(
+      <ConnectionsList
+        agentSlug="test-agent"
+        detailRowKey="foreign-account-slack-0"
+        onDetailRowKeyChange={onDetailRowKeyChange}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(onDetailRowKeyChange).toHaveBeenCalledWith(null)
+    })
+    expect(screen.getByText('Slack')).toBeInTheDocument()
+    expect(screen.queryByText('Connection details')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/connections/connections-list.tsx
+++ b/src/renderer/components/connections/connections-list.tsx
@@ -26,6 +26,12 @@ import {
 } from '@renderer/hooks/use-remote-mcps'
 import { buildUnifiedRows, type UnifiedRow } from '@renderer/components/connections/unified-rows'
 import { startViewTransition } from '@renderer/lib/view-transition'
+import {
+  isForeignAgentConnectedAccount,
+  isForeignAgentRemoteMcp,
+  isPublicAgentConnectedAccount,
+  isPublicAgentRemoteMcp,
+} from '@shared/lib/agent-connections/public'
 
 interface ConnectionsListProps {
   agentSlug: string
@@ -143,8 +149,14 @@ function AllConnectionsList({ agentSlug, detailRowKey, detailBackLabel, onDetail
     const rows = buildUnifiedRows({
       allAccounts,
       allMcps,
-      agentAccountIds: new Set(agentAccounts.map((a) => a.id)),
-      agentMcpIds: new Set(agentMcps.map((m) => m.id)),
+      agentAccountIds: new Set(
+        agentAccounts.filter(isPublicAgentConnectedAccount).map((account) => account.id),
+      ),
+      agentMcpIds: new Set(
+        agentMcps.filter(isPublicAgentRemoteMcp).map((mcp) => mcp.id),
+      ),
+      foreignAccounts: agentAccounts.filter(isForeignAgentConnectedAccount),
+      foreignMcps: agentMcps.filter(isForeignAgentRemoteMcp),
       grantOverrides,
     })
 
@@ -161,10 +173,14 @@ function AllConnectionsList({ agentSlug, detailRowKey, detailBackLabel, onDetail
   useEffect(() => {
     if (Object.keys(grantOverrides).length === 0) return
     const agentAccountIds = new Set(
-      (Array.isArray(agentAccountsData?.accounts) ? agentAccountsData.accounts : []).map((a) => a.id),
+      (Array.isArray(agentAccountsData?.accounts) ? agentAccountsData.accounts : [])
+        .filter(isPublicAgentConnectedAccount)
+        .map((account) => account.id),
     )
     const agentMcpIds = new Set(
-      (Array.isArray(agentMcpsData?.mcps) ? agentMcpsData.mcps : []).map((m) => m.id),
+      (Array.isArray(agentMcpsData?.mcps) ? agentMcpsData.mcps : [])
+        .filter(isPublicAgentRemoteMcp)
+        .map((mcp) => mcp.id),
     )
     setGrantOverrides((prev) => {
       let changed = false
@@ -186,6 +202,8 @@ function AllConnectionsList({ agentSlug, detailRowKey, detailBackLabel, onDetail
     isLoadingAllAccounts || isLoadingAgentAccounts || isLoadingAllMcps || isLoadingAgentMcps
 
   const handleToggle = async (row: UnifiedRow, next: boolean) => {
+    if (row.foreign) return
+
     // Optimistic flip wrapped in View Transitions so the row animates to its
     // new section. flushSync forces the optimistic state into the DOM before
     // startViewTransition snapshots the "before" image — without it the
@@ -229,6 +247,8 @@ function AllConnectionsList({ agentSlug, detailRowKey, detailBackLabel, onDetail
   }
 
   const isRowPending = (row: UnifiedRow): boolean => {
+    if (row.foreign) return false
+
     if (row.type === 'oauth') {
       if (assignAccounts.isPending && assignAccounts.variables?.accountIds.includes(row.id)) return true
       if (removeAccount.isPending && removeAccount.variables?.accountId === row.id) return true
@@ -242,7 +262,7 @@ function AllConnectionsList({ agentSlug, detailRowKey, detailBackLabel, onDetail
   // Resolve the selected row from the freshest data so the detail page stays
   // live across renames; clear the selection once the row is truly gone.
   const selectedRow = detailRowKey
-    ? [...grantedRows, ...notGrantedRows].find((r) => r.key === detailRowKey) ?? null
+    ? [...grantedRows, ...notGrantedRows].find((r) => r.key === detailRowKey && !r.foreign) ?? null
     : null
   if (detailRowKey && !selectedRow && !isLoading) {
     // Defer clearing to next tick to avoid setState during render.
@@ -266,9 +286,9 @@ function AllConnectionsList({ agentSlug, detailRowKey, detailBackLabel, onDetail
         key={row.key}
         row={row}
         viewTransitionName={`integration-${row.key}`}
-        onActivate={() => onDetailRowKeyChange(row.key)}
-        ariaLabel={`Open ${row.name} connection details`}
-        onReconnect={row.type === 'oauth' && row.accountStatus && row.accountStatus !== 'active' && row.toolkit
+        onActivate={row.foreign ? undefined : () => onDetailRowKeyChange(row.key)}
+        ariaLabel={row.foreign ? undefined : `Open ${row.name} connection details`}
+        onReconnect={!row.foreign && row.type === 'oauth' && row.accountStatus && row.accountStatus !== 'active' && row.toolkit
           ? () => oauthReconnect(row.id, row.toolkit!)
           : undefined}
         onCancelReconnect={
@@ -278,7 +298,9 @@ function AllConnectionsList({ agentSlug, detailRowKey, detailBackLabel, onDetail
         }
         reconnecting={pendingAccountId === row.id}
         right={
-          <>
+          row.foreign ? (
+            <span className="text-xs text-muted-foreground">Shared</span>
+          ) : <>
             {/* Slides in on row hover/focus; -ml-2 swallows the flex gap while hidden. */}
             <span
               aria-hidden="true"

--- a/src/renderer/components/connections/integration-row-actions.test.tsx
+++ b/src/renderer/components/connections/integration-row-actions.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event'
 import { IntegrationRowActions } from './integration-row-actions'
 import { useAgentConnectedAccounts } from '@renderer/hooks/use-connected-accounts'
 import { renderWithProviders } from '@renderer/test/test-utils'
+import { isPublicAgentConnectedAccount } from '@shared/lib/agent-connections/public'
 
 // Mock apiFetch so the real mutation hooks run end-to-end against a fake
 // network. This is the level of integration that exercises the cache-key
@@ -44,7 +45,11 @@ function jsonResponse(body: unknown, ok = true): Response {
 function AgentAccountsProbe() {
   const { data } = useAgentConnectedAccounts('test-agent')
   const accounts = Array.isArray(data?.accounts) ? data.accounts : []
-  return <div data-testid="agent-accounts">{accounts.map((a) => a.displayName).join(',')}</div>
+  return (
+    <div data-testid="agent-accounts">
+      {accounts.filter(isPublicAgentConnectedAccount).map((a) => a.displayName).join(',')}
+    </div>
+  )
 }
 
 describe('IntegrationRowActions — delete account flow', () => {

--- a/src/renderer/components/connections/unified-rows.test.ts
+++ b/src/renderer/components/connections/unified-rows.test.ts
@@ -140,4 +140,35 @@ describe('buildUnifiedRows', () => {
     expect(rows[0].toolkit).toBe('slack')
     expect(rows[0].type).toBe('oauth')
   })
+
+  it('renders foreign links as generic, granted rows without resource metadata', () => {
+    const rows = buildUnifiedRows({
+      allAccounts: [],
+      allMcps: [],
+      foreignAccounts: [{ kind: 'connected-account', toolkitSlug: 'github' }],
+      foreignMcps: [{ kind: 'remote-mcp' }],
+    })
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        key: 'foreign-account-github-0',
+        name: 'GitHub',
+        subtitle: 'Connected by another member',
+        type: 'oauth',
+        granted: true,
+        foreign: true,
+      }),
+      expect.objectContaining({
+        key: 'foreign-mcp-0',
+        name: 'Shared MCP connection',
+        subtitle: 'Connected by another member',
+        type: 'mcp',
+        granted: true,
+        foreign: true,
+      }),
+    ])
+    expect(rows.every((row) => row.date === undefined)).toBe(true)
+    expect(rows.every((row) => row.mcpTools === undefined)).toBe(true)
+    expect(rows.every((row) => row.mcpErrorMessage === undefined)).toBe(true)
+  })
 })

--- a/src/renderer/components/connections/unified-rows.ts
+++ b/src/renderer/components/connections/unified-rows.ts
@@ -40,6 +40,49 @@ interface BuildArgs {
   grantOverrides?: Record<string, boolean>
 }
 
+interface ForeignRowsArgs {
+  accounts?: ForeignAgentConnectedAccount[]
+  mcps?: ForeignAgentRemoteMcp[]
+}
+
+/** Build noninteractive client-only rows for links owned by another member. */
+export function buildForeignConnectionRows({
+  accounts = [],
+  mcps = [],
+}: ForeignRowsArgs): UnifiedRow[] {
+  const rows: UnifiedRow[] = accounts.map((account, index) => {
+    const provider = getProvider(account.toolkitSlug)
+    const id = `foreign-account-${account.toolkitSlug}-${index}`
+    return {
+      key: id,
+      id,
+      name: provider?.displayName ?? account.toolkitSlug,
+      subtitle: 'Connected by another member',
+      iconSlug: account.toolkitSlug,
+      iconFallback: 'oauth',
+      type: 'oauth',
+      granted: true,
+      foreign: true,
+    }
+  })
+
+  mcps.forEach((_mcp, index) => {
+    const id = `foreign-mcp-${index}`
+    rows.push({
+      key: id,
+      id,
+      name: 'Shared MCP connection',
+      subtitle: 'Connected by another member',
+      iconFallback: 'blocks',
+      type: 'mcp',
+      granted: true,
+      foreign: true,
+    })
+  })
+
+  return rows
+}
+
 /**
  * Build the unified list of OAuth + MCP rows. When `agentAccountIds` /
  * `agentMcpIds` are provided, rows are flagged `granted` based on those sets;
@@ -94,35 +137,10 @@ export function buildUnifiedRows({
     })
   }
 
-  foreignAccounts.forEach((account, index) => {
-    const provider = getProvider(account.toolkitSlug)
-    const id = `foreign-account-${account.toolkitSlug}-${index}`
-    out.push({
-      key: id,
-      id,
-      name: provider?.displayName ?? account.toolkitSlug,
-      subtitle: 'Connected by another member',
-      iconSlug: account.toolkitSlug,
-      iconFallback: 'oauth',
-      type: 'oauth',
-      granted: true,
-      foreign: true,
-    })
-  })
-
-  foreignMcps.forEach((_mcp, index) => {
-    const id = `foreign-mcp-${index}`
-    out.push({
-      key: id,
-      id,
-      name: 'Shared MCP connection',
-      subtitle: 'Connected by another member',
-      iconFallback: 'blocks',
-      type: 'mcp',
-      granted: true,
-      foreign: true,
-    })
-  })
+  out.push(...buildForeignConnectionRows({
+    accounts: foreignAccounts,
+    mcps: foreignMcps,
+  }))
 
   return out.sort(
     (a, b) => {

--- a/src/renderer/components/connections/unified-rows.ts
+++ b/src/renderer/components/connections/unified-rows.ts
@@ -1,6 +1,11 @@
 import type { ConnectedAccount } from '@renderer/hooks/use-connected-accounts'
 import type { RemoteMcpServer } from '@renderer/hooks/use-remote-mcps'
 import { COMMON_MCP_SERVERS } from '@shared/lib/mcp/common-servers'
+import { getProvider } from '@shared/lib/account-providers/service-catalog'
+import type {
+  ForeignAgentConnectedAccount,
+  ForeignAgentRemoteMcp,
+} from '@shared/lib/agent-connections/public'
 import { safeDate } from './utils'
 
 export interface UnifiedRow {
@@ -11,8 +16,10 @@ export interface UnifiedRow {
   iconSlug?: string
   iconFallback: 'oauth' | 'mcp' | 'blocks'
   type: 'oauth' | 'mcp'
-  date: string | number
+  date?: string | number
   granted: boolean
+  /** Opaque link owned by another member; never navigable or mutable. */
+  foreign?: true
   toolkit?: string
   mcpTools?: Array<{ name: string; description?: string }>
   mcpStatus?: RemoteMcpServer['status']
@@ -23,6 +30,8 @@ export interface UnifiedRow {
 interface BuildArgs {
   allAccounts: ConnectedAccount[]
   allMcps: RemoteMcpServer[]
+  foreignAccounts?: ForeignAgentConnectedAccount[]
+  foreignMcps?: ForeignAgentRemoteMcp[]
   /** Account IDs the agent currently has access to. Omit for global views. */
   agentAccountIds?: Set<string>
   /** MCP IDs the agent currently has access to. Omit for global views. */
@@ -40,6 +49,8 @@ interface BuildArgs {
 export function buildUnifiedRows({
   allAccounts,
   allMcps,
+  foreignAccounts = [],
+  foreignMcps = [],
   agentAccountIds,
   agentMcpIds,
   grantOverrides,
@@ -83,7 +94,41 @@ export function buildUnifiedRows({
     })
   }
 
+  foreignAccounts.forEach((account, index) => {
+    const provider = getProvider(account.toolkitSlug)
+    const id = `foreign-account-${account.toolkitSlug}-${index}`
+    out.push({
+      key: id,
+      id,
+      name: provider?.displayName ?? account.toolkitSlug,
+      subtitle: 'Connected by another member',
+      iconSlug: account.toolkitSlug,
+      iconFallback: 'oauth',
+      type: 'oauth',
+      granted: true,
+      foreign: true,
+    })
+  })
+
+  foreignMcps.forEach((_mcp, index) => {
+    const id = `foreign-mcp-${index}`
+    out.push({
+      key: id,
+      id,
+      name: 'Shared MCP connection',
+      subtitle: 'Connected by another member',
+      iconFallback: 'blocks',
+      type: 'mcp',
+      granted: true,
+      foreign: true,
+    })
+  })
+
   return out.sort(
-    (a, b) => safeDate(b.date).getTime() - safeDate(a.date).getTime(),
+    (a, b) => {
+      if (a.date === undefined) return b.date === undefined ? 0 : 1
+      if (b.date === undefined) return -1
+      return safeDate(b.date).getTime() - safeDate(a.date).getTime()
+    },
   )
 }

--- a/src/renderer/hooks/use-connected-accounts.ts
+++ b/src/renderer/hooks/use-connected-accounts.ts
@@ -4,6 +4,10 @@ import { useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import type { Provider } from '@shared/lib/account-providers/service-catalog'
+import type {
+  AgentConnectedAccountDto,
+  PublicAgentConnectedAccount,
+} from '@shared/lib/agent-connections/public'
 
 export interface ConnectedAccount {
   id: string
@@ -17,10 +21,7 @@ export interface ConnectedAccount {
   provider?: Provider
 }
 
-export interface AgentConnectedAccount extends ConnectedAccount {
-  mappingId: string
-  mappedAt: string
-}
+export type AgentConnectedAccount = PublicAgentConnectedAccount
 
 interface ConnectedAccountsResponse {
   accounts: ConnectedAccount[]
@@ -50,7 +51,7 @@ export function useConnectedAccounts() {
  * Hook to fetch connected accounts assigned to a specific agent
  */
 export function useAgentConnectedAccounts(agentSlug: string) {
-  return useQuery<{ accounts: AgentConnectedAccount[] }>({
+  return useQuery<{ accounts: AgentConnectedAccountDto[] }>({
     queryKey: ['agent-connected-accounts', agentSlug],
     queryFn: async () => {
       const res = await apiFetch(`/api/agents/${agentSlug}/connected-accounts`)

--- a/src/renderer/hooks/use-remote-mcps.ts
+++ b/src/renderer/hooks/use-remote-mcps.ts
@@ -2,6 +2,10 @@ import { apiFetch } from '@renderer/lib/api'
 
 import { useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import type {
+  AgentRemoteMcpDto,
+  PublicAgentRemoteMcp,
+} from '@shared/lib/agent-connections/public'
 
 export interface RemoteMcpServer {
   id: string
@@ -16,10 +20,7 @@ export interface RemoteMcpServer {
   updatedAt: string
 }
 
-export interface AgentRemoteMcp extends RemoteMcpServer {
-  mappingId: string
-  mappedAt: string
-}
+export type AgentRemoteMcp = PublicAgentRemoteMcp
 
 /**
  * Fetch all registered remote MCP servers
@@ -39,7 +40,7 @@ export function useRemoteMcps() {
  * Fetch remote MCPs assigned to a specific agent
  */
 export function useAgentRemoteMcps(agentSlug: string) {
-  return useQuery<{ mcps: AgentRemoteMcp[] }>({
+  return useQuery<{ mcps: AgentRemoteMcpDto[] }>({
     queryKey: ['agent-remote-mcps', agentSlug],
     queryFn: async () => {
       const res = await apiFetch(`/api/agents/${agentSlug}/remote-mcps`)

--- a/src/shared/lib/agent-connections/public.test.ts
+++ b/src/shared/lib/agent-connections/public.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  AgentConnectedAccount,
+  AgentRemoteMcp,
+  ConnectedAccount,
+  RemoteMcpServer,
+} from '@shared/lib/db/schema'
+import {
+  toAgentConnectedAccountDto,
+  toAgentRemoteMcpDto,
+} from './public'
+
+const createdAt = new Date('2026-07-18T10:00:00Z')
+const updatedAt = new Date('2026-07-18T11:00:00Z')
+const mappedAt = new Date('2026-07-18T12:00:00Z')
+
+function account(overrides: Partial<ConnectedAccount> = {}): ConnectedAccount {
+  return {
+    id: 'account-1',
+    providerConnectionId: 'provider-connection-1',
+    providerName: 'composio',
+    toolkitSlug: 'github',
+    displayName: 'My GitHub',
+    status: 'active',
+    userId: 'owner-1',
+    createdAt,
+    updatedAt,
+    ...overrides,
+  }
+}
+
+function accountMapping(overrides: Partial<AgentConnectedAccount> = {}): AgentConnectedAccount {
+  return {
+    id: 'account-mapping-1',
+    agentSlug: 'shared-agent',
+    connectedAccountId: 'account-1',
+    createdAt: mappedAt,
+    ...overrides,
+  }
+}
+
+function mcp(overrides: Partial<RemoteMcpServer> = {}): RemoteMcpServer {
+  return {
+    id: 'mcp-1',
+    name: 'Private MCP',
+    url: 'https://private.example.test/mcp',
+    userId: 'owner-1',
+    authType: 'bearer',
+    accessToken: 'secret-access-token',
+    refreshToken: 'secret-refresh-token',
+    tokenExpiresAt: updatedAt,
+    oauthTokenEndpoint: 'https://private.example.test/token',
+    oauthClientId: 'secret-client-id',
+    oauthClientSecret: 'secret-client-secret',
+    oauthResource: 'private-resource',
+    toolsJson: JSON.stringify([{ name: 'search', inputSchema: { type: 'object' } }]),
+    toolsDiscoveredAt: updatedAt,
+    status: 'active',
+    errorMessage: null,
+    createdAt,
+    updatedAt,
+    ...overrides,
+  }
+}
+
+function mcpMapping(overrides: Partial<AgentRemoteMcp> = {}): AgentRemoteMcp {
+  return {
+    id: 'mcp-mapping-1',
+    agentSlug: 'shared-agent',
+    remoteMcpId: 'mcp-1',
+    createdAt: mappedAt,
+    ...overrides,
+  }
+}
+
+describe('agent connection DTOs', () => {
+  it('keeps a foreign account marker free of row, owner, and provider identifiers', () => {
+    const result = toAgentConnectedAccountDto(accountMapping(), account(), 'viewer-2')
+
+    expect(result).toEqual({ kind: 'connected-account', toolkitSlug: 'github' })
+    expect(JSON.stringify(result)).not.toContain('account-1')
+    expect(JSON.stringify(result)).not.toContain('owner-1')
+    expect(JSON.stringify(result)).not.toContain('provider-connection-1')
+  })
+
+  it('returns safe owned account details without the owner id', () => {
+    const result = toAgentConnectedAccountDto(accountMapping(), account(), 'owner-1')
+
+    expect(result).toMatchObject({
+      id: 'account-1',
+      providerConnectionId: 'provider-connection-1',
+      mappingId: 'account-mapping-1',
+      createdAt: createdAt.toISOString(),
+      mappedAt: mappedAt.toISOString(),
+    })
+    expect(result).not.toHaveProperty('userId')
+  })
+
+  it('preserves account details in single-user local mode', () => {
+    const result = toAgentConnectedAccountDto(
+      accountMapping(),
+      account({ userId: null }),
+      null,
+    )
+
+    expect(result).toMatchObject({ id: 'account-1', displayName: 'My GitHub' })
+  })
+
+  it('uses a fully opaque marker for a foreign MCP', () => {
+    const result = toAgentRemoteMcpDto(mcpMapping(), mcp(), 'viewer-2')
+
+    expect(result).toEqual({ kind: 'remote-mcp' })
+    expect(JSON.stringify(result)).not.toContain('mcp-1')
+    expect(JSON.stringify(result)).not.toContain('private.example.test')
+    expect(JSON.stringify(result)).not.toContain('search')
+  })
+
+  it('returns safe owned MCP details without credentials or owner metadata', () => {
+    const result = toAgentRemoteMcpDto(mcpMapping(), mcp(), 'owner-1')
+
+    expect(result).toMatchObject({
+      id: 'mcp-1',
+      name: 'Private MCP',
+      tools: [{ name: 'search', inputSchema: { type: 'object' } }],
+      mappingId: 'mcp-mapping-1',
+      mappedAt: mappedAt.toISOString(),
+    })
+    expect(result).not.toHaveProperty('userId')
+    expect(result).not.toHaveProperty('accessToken')
+    expect(result).not.toHaveProperty('refreshToken')
+    expect(result).not.toHaveProperty('oauthClientSecret')
+  })
+})

--- a/src/shared/lib/agent-connections/public.ts
+++ b/src/shared/lib/agent-connections/public.ts
@@ -57,10 +57,6 @@ const mcpToolInfoSchema = z.object({
 
 const mcpToolsSchema = z.array(mcpToolInfoSchema)
 
-function serializeDate(value: Date): string {
-  return value.toISOString()
-}
-
 function parseMcpTools(value: string | null): McpToolInfo[] {
   if (!value) return []
   try {
@@ -92,10 +88,10 @@ export function toAgentConnectedAccountDto(
     toolkitSlug: account.toolkitSlug,
     displayName: account.displayName,
     status: account.status,
-    createdAt: serializeDate(account.createdAt),
-    updatedAt: serializeDate(account.updatedAt),
+    createdAt: account.createdAt.toISOString(),
+    updatedAt: account.updatedAt.toISOString(),
     mappingId: mapping.id,
-    mappedAt: serializeDate(mapping.createdAt),
+    mappedAt: mapping.createdAt.toISOString(),
     provider,
   }
 }
@@ -119,14 +115,14 @@ export function toAgentRemoteMcpDto(
     errorMessage: mcp.errorMessage,
     tools: parseMcpTools(mcp.toolsJson),
     mappingId: mapping.id,
-    mappedAt: serializeDate(mapping.createdAt),
+    mappedAt: mapping.createdAt.toISOString(),
   }
 }
 
 export function isForeignAgentConnectedAccount(
   account: AgentConnectedAccountDto,
 ): account is ForeignAgentConnectedAccount {
-  return 'kind' in account
+  return 'kind' in account && account.kind === 'connected-account'
 }
 
 export function isPublicAgentConnectedAccount(
@@ -138,7 +134,7 @@ export function isPublicAgentConnectedAccount(
 export function isForeignAgentRemoteMcp(
   mcp: AgentRemoteMcpDto,
 ): mcp is ForeignAgentRemoteMcp {
-  return 'kind' in mcp
+  return 'kind' in mcp && mcp.kind === 'remote-mcp'
 }
 
 export function isPublicAgentRemoteMcp(

--- a/src/shared/lib/agent-connections/public.ts
+++ b/src/shared/lib/agent-connections/public.ts
@@ -1,0 +1,148 @@
+import { z } from 'zod'
+import type {
+  AgentConnectedAccount,
+  AgentRemoteMcp,
+  ConnectedAccount,
+  RemoteMcpServer,
+} from '@shared/lib/db/schema'
+import type { Provider } from '@shared/lib/account-providers/service-catalog'
+import type { McpToolInfo } from '@shared/lib/mcp/types'
+
+export interface PublicAgentConnectedAccount {
+  id: string
+  providerConnectionId: string
+  providerName: string
+  toolkitSlug: string
+  displayName: string
+  status: ConnectedAccount['status']
+  createdAt: string
+  updatedAt: string
+  mappingId: string
+  mappedAt: string
+  provider?: Provider
+}
+
+/** Minimal capability marker for a connected account owned by another user. */
+export interface ForeignAgentConnectedAccount {
+  kind: 'connected-account'
+  toolkitSlug: string
+}
+
+export type AgentConnectedAccountDto = PublicAgentConnectedAccount | ForeignAgentConnectedAccount
+
+export interface PublicAgentRemoteMcp {
+  id: string
+  name: string
+  url: string
+  authType: RemoteMcpServer['authType']
+  status: RemoteMcpServer['status']
+  errorMessage: string | null
+  tools: McpToolInfo[]
+  mappingId: string
+  mappedAt: string
+}
+
+/** Minimal capability marker for a remote MCP owned by another user. */
+export interface ForeignAgentRemoteMcp {
+  kind: 'remote-mcp'
+}
+
+export type AgentRemoteMcpDto = PublicAgentRemoteMcp | ForeignAgentRemoteMcp
+
+const mcpToolInfoSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  inputSchema: z.record(z.string(), z.unknown()).optional(),
+}).loose()
+
+const mcpToolsSchema = z.array(mcpToolInfoSchema)
+
+function serializeDate(value: Date): string {
+  return value.toISOString()
+}
+
+function parseMcpTools(value: string | null): McpToolInfo[] {
+  if (!value) return []
+  try {
+    const parsed = mcpToolsSchema.safeParse(JSON.parse(value))
+    return parsed.success ? parsed.data : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Project an agent-linked account for the current caller. `viewerUserId=null`
+ * denotes local mode, where every resource belongs to the single local user.
+ */
+export function toAgentConnectedAccountDto(
+  mapping: AgentConnectedAccount,
+  account: ConnectedAccount,
+  viewerUserId: string | null,
+  provider?: Provider,
+): AgentConnectedAccountDto {
+  if (viewerUserId !== null && account.userId !== viewerUserId) {
+    return { kind: 'connected-account', toolkitSlug: account.toolkitSlug }
+  }
+
+  return {
+    id: account.id,
+    providerConnectionId: account.providerConnectionId,
+    providerName: account.providerName,
+    toolkitSlug: account.toolkitSlug,
+    displayName: account.displayName,
+    status: account.status,
+    createdAt: serializeDate(account.createdAt),
+    updatedAt: serializeDate(account.updatedAt),
+    mappingId: mapping.id,
+    mappedAt: serializeDate(mapping.createdAt),
+    provider,
+  }
+}
+
+/** Project an agent-linked MCP without exposing another user's server row. */
+export function toAgentRemoteMcpDto(
+  mapping: AgentRemoteMcp,
+  mcp: RemoteMcpServer,
+  viewerUserId: string | null,
+): AgentRemoteMcpDto {
+  if (viewerUserId !== null && mcp.userId !== viewerUserId) {
+    return { kind: 'remote-mcp' }
+  }
+
+  return {
+    id: mcp.id,
+    name: mcp.name,
+    url: mcp.url,
+    authType: mcp.authType,
+    status: mcp.status,
+    errorMessage: mcp.errorMessage,
+    tools: parseMcpTools(mcp.toolsJson),
+    mappingId: mapping.id,
+    mappedAt: serializeDate(mapping.createdAt),
+  }
+}
+
+export function isForeignAgentConnectedAccount(
+  account: AgentConnectedAccountDto,
+): account is ForeignAgentConnectedAccount {
+  return 'kind' in account
+}
+
+export function isPublicAgentConnectedAccount(
+  account: AgentConnectedAccountDto,
+): account is PublicAgentConnectedAccount {
+  return !isForeignAgentConnectedAccount(account)
+}
+
+export function isForeignAgentRemoteMcp(
+  mcp: AgentRemoteMcpDto,
+): mcp is ForeignAgentRemoteMcp {
+  return 'kind' in mcp
+}
+
+export function isPublicAgentRemoteMcp(
+  mcp: AgentRemoteMcpDto,
+): mcp is PublicAgentRemoteMcp {
+  return !isForeignAgentRemoteMcp(mcp)
+}

--- a/src/shared/lib/auth/ownership.test.ts
+++ b/src/shared/lib/auth/ownership.test.ts
@@ -9,13 +9,28 @@ const { mockIsAuthMode, mockGetCurrentUserId } = vi.hoisted(() => ({
 vi.mock('@shared/lib/auth/mode', () => ({ isAuthMode: mockIsAuthMode }))
 vi.mock('@shared/lib/auth/config', () => ({ getCurrentUserId: mockGetCurrentUserId }))
 
-import { ownerScope, isOwnedByCaller } from './ownership'
+import { getViewerUserId, ownerScope, isOwnedByCaller } from './ownership'
 import { connectedAccounts } from '@shared/lib/db/schema'
 
 const c = {} as Context
 
 beforeEach(() => {
   vi.clearAllMocks()
+})
+
+describe('getViewerUserId', () => {
+  it('returns null without reading user context in non-auth mode', () => {
+    mockIsAuthMode.mockReturnValue(false)
+    expect(getViewerUserId(c)).toBeNull()
+    expect(mockGetCurrentUserId).not.toHaveBeenCalled()
+  })
+
+  it('returns the acting user in auth mode', () => {
+    mockIsAuthMode.mockReturnValue(true)
+    mockGetCurrentUserId.mockReturnValue('user-123')
+    expect(getViewerUserId(c)).toBe('user-123')
+    expect(mockGetCurrentUserId).toHaveBeenCalledWith(c)
+  })
 })
 
 describe('ownerScope', () => {

--- a/src/shared/lib/auth/ownership.ts
+++ b/src/shared/lib/auth/ownership.ts
@@ -9,6 +9,7 @@
  *
  * These helpers encapsulate the `isAuthMode() && ... getCurrentUserId(c)`
  * boilerplate so call sites stay readable:
+ *   - getViewerUserId(c)       → acting user id, or null in non-auth mode
  *   - ownerScope(c, col)        → a WHERE fragment, or undefined in non-auth mode
  *   - isOwnedByCaller(c, record) → boolean (always true in non-auth mode)
  *
@@ -20,6 +21,11 @@ import { eq, type Column, type SQL } from 'drizzle-orm'
 import { isAuthMode } from './mode'
 import { getCurrentUserId } from './config'
 
+/** Acting user id in auth mode, or `null` in local/single-user mode. */
+export function getViewerUserId(c: Context): string | null {
+  return isAuthMode() ? getCurrentUserId(c) : null
+}
+
 /**
  * A drizzle WHERE fragment scoping `column` to the acting user — or `undefined`
  * in non-auth mode. `and()` ignores undefined, so spread it directly:
@@ -27,8 +33,8 @@ import { getCurrentUserId } from './config'
  *   .where(and(inArray(table.id, ids), ownerScope(c, table.userId)))
  */
 export function ownerScope(c: Context, column: Column): SQL | undefined {
-  if (!isAuthMode()) return undefined
-  return eq(column, getCurrentUserId(c))
+  const viewerUserId = getViewerUserId(c)
+  return viewerUserId === null ? undefined : eq(column, viewerUserId)
 }
 
 /**
@@ -41,6 +47,6 @@ export function isOwnedByCaller(
   c: Context,
   record: { userId?: string | null } | null | undefined,
 ): boolean {
-  if (!isAuthMode()) return true
-  return !!record && record.userId === getCurrentUserId(c)
+  const viewerUserId = getViewerUserId(c)
+  return viewerUserId === null || (!!record && record.userId === viewerUserId)
 }

--- a/src/shared/lib/services/activity-stats-service.test.ts
+++ b/src/shared/lib/services/activity-stats-service.test.ts
@@ -196,6 +196,55 @@ describe('activity stats data pathways', () => {
     expect(result.connectionById).not.toHaveProperty('account-account-not-mapped')
   })
 
+  it('owner-scopes connection IDs and usage in shared-agent activity', async () => {
+    await insertUser('owner-a')
+    await insertUser('owner-b')
+    await insertAccount('account-a', 'owner-a')
+    await insertAccount('account-b-private', 'owner-b')
+    await insertMcp('mcp-a', 'owner-a')
+    await insertMcp('mcp-b-private', 'owner-b')
+
+    await testDb.insert(schema.agentConnectedAccounts).values([
+      { id: 'map-account-a', agentSlug: 'shared-agent', connectedAccountId: 'account-a', createdAt: NOW },
+      { id: 'map-account-b', agentSlug: 'shared-agent', connectedAccountId: 'account-b-private', createdAt: NOW },
+    ])
+    await testDb.insert(schema.agentRemoteMcps).values([
+      { id: 'map-mcp-a', agentSlug: 'shared-agent', remoteMcpId: 'mcp-a', createdAt: NOW },
+      { id: 'map-mcp-b', agentSlug: 'shared-agent', remoteMcpId: 'mcp-b-private', createdAt: NOW },
+    ])
+    await testDb.insert(schema.proxyAuditLog).values([
+      { id: 'account-a-call', agentSlug: 'shared-agent', accountId: 'account-a', toolkit: 'github', targetHost: 'api.github.com', targetPath: 'repos', method: 'GET', statusCode: 200, createdAt: NOW },
+      { id: 'account-b-call', agentSlug: 'shared-agent', accountId: 'account-b-private', toolkit: 'github', targetHost: 'api.github.com', targetPath: 'repos', method: 'GET', statusCode: 200, createdAt: NOW },
+    ])
+    await testDb.insert(schema.mcpAuditLog).values([
+      { id: 'mcp-a-call', agentSlug: 'shared-agent', remoteMcpId: 'mcp-a', remoteMcpName: 'mcp-a', method: 'POST', requestPath: '/tools/call', statusCode: 200, createdAt: NOW },
+      { id: 'mcp-b-call', agentSlug: 'shared-agent', remoteMcpId: 'mcp-b-private', remoteMcpName: 'mcp-b', method: 'POST', requestPath: '/tools/call', statusCode: 200, createdAt: NOW },
+    ])
+
+    const result = await getAgentActivityStats('shared-agent', {
+      days: 1,
+      ownerId: 'owner-a',
+      now: NOW,
+    })
+
+    expect(Object.keys(result.connectionById).sort()).toEqual([
+      'account-account-a',
+      'mcp-mcp-a',
+    ])
+    expect(JSON.stringify(result.connectionById)).not.toContain('account-b-private')
+    expect(JSON.stringify(result.connectionById)).not.toContain('mcp-b-private')
+    expect(result.connectionById['account-account-a'][0]).toEqual({
+      date: '2026-07-09',
+      succeeded: 1,
+      failed: 0,
+    })
+    expect(result.connectionById['mcp-mcp-a'][0]).toEqual({
+      date: '2026-07-09',
+      succeeded: 1,
+      failed: 0,
+    })
+  })
+
   it('owner-scopes global connection activity and still returns zero-filled visible rows', async () => {
     await insertUser('owner-a')
     await insertUser('owner-b')

--- a/src/shared/lib/services/activity-stats-service.ts
+++ b/src/shared/lib/services/activity-stats-service.ts
@@ -31,6 +31,8 @@ import { readSessionMetadata } from './session-service'
 
 export interface ActivityStatsOptions {
   days: number
+  /** Undefined in local/single-user mode; set to the acting user in auth mode. */
+  ownerId?: string
   /** Viewer's `Date.prototype.getTimezoneOffset()`; buckets days locally. */
   tzOffsetMinutes?: number
   now?: Date
@@ -45,10 +47,7 @@ export interface ActivityStatsOptions {
   isSessionLive?: (sessionId: string) => boolean
 }
 
-export interface ConnectionStatsOptions extends ActivityStatsOptions {
-  /** Undefined in local/single-user mode; set to the acting user in auth mode. */
-  ownerId?: string
-}
+export type ConnectionStatsOptions = ActivityStatsOptions
 
 function dailyEventsById(
   ids: string[],
@@ -178,6 +177,12 @@ export async function getAgentActivityStats(
   const now = options.now ?? new Date()
   const tzOffsetMinutes = options.tzOffsetMinutes ?? 0
   const from = getActivityWindowStart(options.days, now, tzOffsetMinutes)
+  const accountOwnerCondition = options.ownerId
+    ? eq(connectedAccounts.userId, options.ownerId)
+    : undefined
+  const mcpOwnerCondition = options.ownerId
+    ? eq(remoteMcpServers.userId, options.ownerId)
+    : undefined
 
   const [
     tasks,
@@ -193,10 +198,24 @@ export async function getAgentActivityStats(
     readSessionMetadata(agentSlug),
     db.select({ id: agentConnectedAccounts.connectedAccountId })
       .from(agentConnectedAccounts)
-      .where(eq(agentConnectedAccounts.agentSlug, agentSlug)),
+      .innerJoin(
+        connectedAccounts,
+        eq(agentConnectedAccounts.connectedAccountId, connectedAccounts.id),
+      )
+      .where(and(
+        eq(agentConnectedAccounts.agentSlug, agentSlug),
+        accountOwnerCondition,
+      )),
     db.select({ id: agentRemoteMcps.remoteMcpId })
       .from(agentRemoteMcps)
-      .where(eq(agentRemoteMcps.agentSlug, agentSlug)),
+      .innerJoin(
+        remoteMcpServers,
+        eq(agentRemoteMcps.remoteMcpId, remoteMcpServers.id),
+      )
+      .where(and(
+        eq(agentRemoteMcps.agentSlug, agentSlug),
+        mcpOwnerCondition,
+      )),
     auditRollupQuery(proxyAuditLog, proxyAuditLog.accountId, and(
       eq(proxyAuditLog.agentSlug, agentSlug),
       gte(proxyAuditLog.createdAt, from),

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -363,34 +363,3 @@ export interface ApiNotification {
   createdAt: Date
   readAt: Date | null
 }
-
-// ============================================================================
-// Connected Account API Types
-// ============================================================================
-
-/**
- * Provider info
- */
-export interface ApiProvider {
-  slug: string
-  displayName: string
-  icon?: string
-}
-
-/**
- * Connected account response
- */
-export interface ApiConnectedAccount {
-  id: string
-  providerConnectionId: string
-  providerName: string
-  toolkitSlug: string
-  displayName: string
-  status: 'active' | 'revoked' | 'expired'
-  createdAt: Date
-  updatedAt: Date
-  provider?: ApiProvider
-  // Only present when fetched for a specific agent
-  mappingId?: string
-  mappedAt?: Date
-}


### PR DESCRIPTION
## Summary

- project agent-linked connected accounts and remote MCPs according to the current caller
- return minimal capability markers for links owned by another member, while preserving full safe details for caller-owned resources and local mode
- apply the same projection to the connected-account assignment response
- render foreign links as generic, noninteractive shared capabilities without IDs, URLs, owner metadata, tools, errors, navigation, or access controls
- add serializer, API, and renderer regression coverage

## Why

The agent-scoped read routes joined and serialized every linked resource row. On a shared agent, a member could therefore inspect another user's connected-account identifiers and display metadata, or an MCP server's ID, name, URL, auth type, discovered tools, and error text. The connected-account POST response repeated the same exposure.

## Impact

Shared-agent members can still see that an API toolkit or an opaque MCP capability is available, so the UI remains honest about agent capabilities, but foreign resource metadata is no longer exposed or actionable. Single-user local mode and caller-owned resource details are unchanged.

## Validation

- `npm run typecheck`
- 223 focused tests across route, DTO, unified-row, connections-list, agent-home, and cache-invalidation coverage
- targeted ESLint: 0 errors

Environment note: the complete Vitest run reached 7,000 passing tests; SQLite-backed suites could not load the local `better-sqlite3` native binding, and one socket test was blocked from listening by the sandbox.
