### PR TITLE
Rebrand MCP OAuth client name from Superagent to Gamut

### DIFF
--- a/src/api/routes/remote-mcps.test.ts
+++ b/src/api/routes/remote-mcps.test.ts
@@ -413,7 +413,7 @@ describe('discoverTools (via POST /)', () => {
     expect(initCall[0]).toBe('https://mcp.example.com')
     const initBody = JSON.parse(initCall[1].body)
     expect(initBody.method).toBe('initialize')
-    expect(initBody.params.clientInfo.name).toBe('Superagent')
+    expect(initBody.params.clientInfo.name).toBe('Gamut')
 
     // Call 2: notifications/initialized — includes session ID
     const notifCall = mockFetch.mock.calls[1]

--- a/src/api/routes/remote-mcps.ts
+++ b/src/api/routes/remote-mcps.ts
@@ -624,7 +624,7 @@ remoteMcps.post('/:id/test-connection', Or(UsersMcpServer(), IsAdmin()), async (
         params: {
           protocolVersion: '2025-03-26',
           capabilities: {},
-          clientInfo: { name: 'Superagent', version: '1.0.0' },
+          clientInfo: { name: 'Gamut', version: '1.0.0' },
         },
         id: 1,
       }),

--- a/src/shared/lib/mcp/discover-tools.ts
+++ b/src/shared/lib/mcp/discover-tools.ts
@@ -55,7 +55,7 @@ export async function discoverTools(url: string, accessToken?: string | null): P
       params: {
         protocolVersion: '2025-03-26',
         capabilities: {},
-        clientInfo: { name: 'Superagent', version: '1.0.0' },
+        clientInfo: { name: 'Gamut', version: '1.0.0' },
       },
       id: 1,
     }),

--- a/src/shared/lib/mcp/oauth.test.ts
+++ b/src/shared/lib/mcp/oauth.test.ts
@@ -368,7 +368,7 @@ describe('oauth', () => {
       const result = await registerDynamicClient(
         'https://auth.example.com/register',
         'http://localhost/callback',
-        'Superagent'
+        'Gamut'
       )
       expect(result).toEqual({
         clientId: 'new-client-id',
@@ -384,7 +384,7 @@ describe('oauth', () => {
         registerDynamicClient(
           'https://auth.example.com/register',
           'http://localhost/callback',
-          'Superagent'
+          'Gamut'
         )
       ).rejects.toThrow('The authorization server rejected client registration (HTTP 400)')
     })
@@ -404,7 +404,7 @@ describe('oauth', () => {
         registerDynamicClient(
           'https://auth.example.com/register',
           'http://localhost/callback',
-          'Superagent'
+          'Gamut'
         )
       ).rejects.toThrow(
         'The authorization server rejected client registration (HTTP 400): invalid_client_metadata: redirect_uri is not allowed by the account configuration'
@@ -418,7 +418,7 @@ describe('oauth', () => {
         registerDynamicClient(
           'https://auth.example.com/register',
           'http://localhost/callback',
-          'Superagent'
+          'Gamut'
         )
       ).rejects.toThrow('The authorization server rejected client registration (HTTP 403): Forbidden')
     })
@@ -430,7 +430,7 @@ describe('oauth', () => {
         registerDynamicClient(
           'https://auth.example.com/register',
           'http://localhost/callback',
-          'Superagent'
+          'Gamut'
         )
       ).rejects.toThrow(McpOAuthSetupError)
     })

--- a/src/shared/lib/mcp/oauth.ts
+++ b/src/shared/lib/mcp/oauth.ts
@@ -444,7 +444,7 @@ export async function initiateOAuthFlow(
       const registration = await registerDynamicClientWithFallback(
         metadata.registration_endpoint,
         redirectCandidates,
-        clientNameOverride && clientNameOverride.length > 0 ? clientNameOverride : 'Superagent',
+        clientNameOverride && clientNameOverride.length > 0 ? clientNameOverride : 'Gamut',
       )
       clientId = registration.clientId
       clientSecret = registration.clientSecret
@@ -584,7 +584,7 @@ export async function initiateNewServerOAuth(
     const registration = await registerDynamicClientWithFallback(
       metadata.registration_endpoint,
       redirectCandidates,
-      clientNameOverride && clientNameOverride.length > 0 ? clientNameOverride : 'Superagent',
+      clientNameOverride && clientNameOverride.length > 0 ? clientNameOverride : 'Gamut',
     )
     clientId = registration.clientId
     clientSecret = registration.clientSecret


### PR DESCRIPTION
## Summary
Users connecting an MCP server saw "Superagent" on the provider's OAuth consent screen. This renames the client-facing identity to **Gamut**:

- `src/shared/lib/mcp/oauth.ts` — default `client_name` for dynamic client registration (the consent-screen string); the user-supplied override field still wins when set
- `src/shared/lib/mcp/discover-tools.ts` / `src/api/routes/remote-mcps.ts` — `clientInfo.name` in the MCP initialize handshake

Display strings only — no identifiers, schemes, or storage keys touched (per the bridge-first rebrand rules).

## Notes
- Applies on next (re)connect: re-auth prefers fresh DCR, so reconnecting an existing MCP re-registers as "Gamut"; a provider's authorized-apps list may show the old name until then.
- Providers with DCR client-name allowlists (e.g. Figma) reject "Gamut" just as they rejected "Superagent" — no behavior change; the override field remains the workaround.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] eslint clean on touched files
- [x] `vitest` on `oauth.test.ts` + `remote-mcps.test.ts` — 109 tests pass (assertions updated)

https://claude.ai/code/session_01UJrAahoabuPPBa5zo1u92R