### PR TITLE
SUP-438: First-run "Continue as <email>" via installer-carried download nonce

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -23,6 +23,19 @@
     nsExec::Exec 'netsh advfirewall firewall delete rule name="Gamut agent connections"'
     nsExec::Exec 'netsh advfirewall firewall add rule name="Gamut agent connections" dir=in action=allow program="$INSTDIR\Gamut.exe" enable=yes profile=any'
   ${EndIf}
+
+  ; Download-carried enrollment: the release worker may stamp a one-time
+  ; enrollment code into the installer's filename. NSIS has no regex, so just
+  ; record the filename verbatim; the app parses and validates it on first
+  ; run (and deletes the file either way). $APPDATA\Gamut is the app's
+  ; userData dir for the per-user install this targets.
+  CreateDirectory "$APPDATA\Gamut"
+  ClearErrors
+  FileOpen $R1 "$APPDATA\Gamut\pending-download-source" w
+  ${IfNot} ${Errors}
+    FileWrite $R1 "$EXEFILE"
+    FileClose $R1
+  ${EndIf}
 !macroend
 
 !macro customUnInstall

--- a/e2e/live/download-nonce-harness.mjs
+++ b/e2e/live/download-nonce-harness.mjs
@@ -3,20 +3,28 @@
  * Live end-to-end validation of installer-carried identity.
  *
  * Drives the REAL stack, no mocks on the nonce path:
- *   1. Logs into the locally running platform web app with a seeded user and
- *      clicks the actual "Download for MacOS" button, capturing the stamped
- *      download URL (validates mint + button wiring).
- *   2. Creates a DMG named like a stamped installer and mounts it, so the
- *      app's hdiutil mount-scan channel recovers the code for real.
+ *   1. Logs into the locally running platform web app with a seeded user,
+ *      opens the workspace Get Started tab, and clicks the actual
+ *      "Download for MacOS" button — exercising the memberId threading and
+ *      startStampedDownload() mint for real. The stamped navigation is
+ *      captured at the network layer and the code extracted from its ?dl=.
+ *      Alongside, API negatives: unscoped mint → 400, foreign-membership
+ *      mint → 403.
+ *   2. Creates a DMG named like a stamped installer (or, in worker mode,
+ *      uses the actually-downloaded one) and mounts it, so the app's hdiutil
+ *      mount-scan channel recovers the code for real.
  *   3. Launches the built Electron app with a fresh data dir and
  *      --remote-debugging-port, connects over CDP, and asserts the
  *      onboarding button reads "Continue as <email>".
  *   4. Clicks it and verifies the redeemed plat_sa_ token lands in
  *      settings.json (and, when docker is available, that the nonce row is
- *      consumed in the local Supabase DB).
+ *      consumed in the local Supabase DB). Then replays the redeem with the
+ *      consumed code and requires the uniform 404.
  *   5. Negative pass: relaunches with another fresh data dir while the same
- *      (now consumed) DMG is still mounted and asserts the button falls back
- *      to "Get Started" — flow unchanged.
+ *      (now consumed) DMG is still mounted. The app's own offer endpoint is
+ *      polled until the offer SETTLES (the GET awaits the full scan +
+ *      resolve chain), then the button must read "Get Started" — flow
+ *      unchanged.
  *
  * Prereqs:
  *   - Local Supabase running + seeded (bob@test.io / bobtest exists) with the
@@ -25,6 +33,10 @@
  *   - App built for electron:  npm run build:electron
  *     (with PLATFORM_BASE_URL/PLATFORM_PROXY_URL pointing at the local stack)
  *   - Native modules rebuilt for Electron:  npx electron-rebuild -f
+ *
+ * Note: the platform's nonce endpoints share a 30/min/IP rate limiter across
+ * mint/resolve/redeem — rapid back-to-back runs can surface as 429s; wait a
+ * minute or restart the platform dev server.
  *
  * Run:  node e2e/live/download-nonce-harness.mjs
  */
@@ -52,13 +64,17 @@ const PLATFORM_URL = process.env.HARNESS_PLATFORM_URL || 'http://localhost:3000'
 const WORKER_URL = process.env.HARNESS_WORKER_URL || null
 const LOGIN_EMAIL = process.env.HARNESS_EMAIL || 'bob@test.io'
 const LOGIN_PASSWORD = process.env.HARNESS_PASSWORD || 'bobtest'
-// Seeded membership of the login user (workspace scoping is mandatory at mint).
+// Seeded membership of the login user — the real download button must mint
+// for exactly this membership. Override when the seed's workspace differs.
 const MEMBER_ID = process.env.HARNESS_MEMBER_ID || 'sub_ba2caa9e-476a-4a60-9cc2-6138e6b2b7a8'
 const CDP_PORT = Number(process.env.HARNESS_CDP_PORT || 9333)
 const APP_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..')
 
 const workRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'download-nonce-live-'))
 const cleanups = []
+// { name, logs } per launched app — dumped when any check fails, since the
+// app's own output is usually the only diagnostic for CDP/wizard timeouts.
+const appLogTails = []
 let failures = 0
 
 function step(name) {
@@ -86,10 +102,37 @@ async function expectEventually(fn, what, timeoutMs = 30_000, intervalMs = 250) 
   throw new Error(`Timed out waiting for: ${what}${lastErr ? ` (${lastErr})` : ''}`)
 }
 
-// --- 1. Mint through the real dashboard ------------------------------------
+async function runCleanups() {
+  while (cleanups.length) {
+    const fn = cleanups.pop()
+    try {
+      await fn()
+    } catch {
+      // Best-effort teardown.
+    }
+  }
+}
 
-async function mintNonceViaDownloadClick() {
-  step('Mint: platform login + real download click')
+// Ctrl-C must not leave Electron instances and mounted DMGs behind — a stale
+// app on the CDP port poisons the next run's connectOverCDP.
+for (const sig of ['SIGINT', 'SIGTERM']) {
+  process.once(sig, () => {
+    process.stdout.write(`\n${sig} received — cleaning up\n`)
+    runCleanups().finally(() => process.exit(130))
+  })
+}
+
+function dumpAppLogTails() {
+  for (const { name, logs } of appLogTails) {
+    const tail = logs.join('').split('\n').slice(-40).join('\n').trim()
+    process.stdout.write(`\n--- app log tail (${name}) ---\n${tail || '(no output)'}\n`)
+  }
+}
+
+// --- 1. Mint through the real dashboard download button ---------------------
+
+async function mintViaRealDownloadClick() {
+  step('Mint: platform login + real "Download for MacOS" click')
   const browser = await chromium.launch({ headless: true })
   cleanups.push(() => browser.close().catch(() => {}))
   const context = await browser.newContext()
@@ -124,36 +167,64 @@ async function mintNonceViaDownloadClick() {
   await page.getByPlaceholder('Email').fill(LOGIN_EMAIL)
   await page.getByPlaceholder('Password', { exact: true }).fill(LOGIN_PASSWORD)
   await page.locator('button[type="submit"]').first().click()
-  // Generous: a cold Next dev server compiles routes on first hit.
-  await page.waitForURL(/dashboard/, { timeout: 60_000 })
-  pass(`logged in as ${LOGIN_EMAIL}`)
+  // Generous: a cold Next dev server compiles routes on first hit. /dashboard
+  // redirects to the user's workspace page, which carries the org id.
+  await page.waitForURL(/\/dashboard\/organizations\/[^/?]+/, { timeout: 60_000 })
+  const orgId = new URL(page.url()).pathname.split('/')[3]
+  pass(`logged in as ${LOGIN_EMAIL} (workspace ${orgId})`)
 
-  // Mint through the real authenticated endpoint (shares the page's cookies).
-  // Workspace scoping is mandatory: an unscoped mint must be refused, and the
-  // scoped one must come back stamped for exactly the requested membership.
+  // API negatives through the page's session cookies: workspace scoping is
+  // mandatory (no guessing), and other users' memberships are off-limits.
   const unscoped = await page.request.post(`${PLATFORM_URL}/api/download-nonce/mint`, {
     data: {},
   })
   if (unscoped.status() === 400) pass('unscoped mint refused (400) — no workspace guessing')
   else fail(`unscoped mint not refused: ${unscoped.status()}`)
 
-  const minted = await page.request.post(`${PLATFORM_URL}/api/download-nonce/mint`, {
-    data: { member_id: MEMBER_ID },
+  const foreign = await page.request.post(`${PLATFORM_URL}/api/download-nonce/mint`, {
+    data: { member_id: 'sub_00000000-0000-0000-0000-000000000000' },
   })
-  if (!minted.ok()) throw new Error(`mint failed: ${minted.status()}`)
-  const { code } = await minted.json()
-  if (!code || !/^[a-f0-9]{40,64}$/.test(code)) {
-    throw new Error(`mint returned no valid code`)
-  }
-  pass(`mint issued a code for ${MEMBER_ID}: ${code.slice(0, 8)}… (${code.length} hex chars)`)
+  if (foreign.status() === 403) pass('foreign-membership mint refused (403)')
+  else fail(`foreign-membership mint not refused: ${foreign.status()}`)
 
-  // Navigate the branded download URL like the stamped button would.
+  // The real button lives on the Get Started tab, behind the phone
+  // verification card for fresh users — skip that gate if it's up.
+  await page.goto(`${PLATFORM_URL}/dashboard/organizations/${orgId}?tab=getting-started`, {
+    waitUntil: 'domcontentloaded',
+  })
+  const macButton = page.getByRole('link', { name: 'Download for MacOS' })
+  const skipLink = page.getByText('Skip for now')
+  await expectEventually(
+    async () =>
+      (await macButton.isVisible().catch(() => false)) ||
+      (await skipLink.isVisible().catch(() => false)),
+    'Get Started tab content',
+    30_000,
+  )
+  if (!(await macButton.isVisible().catch(() => false))) {
+    await skipLink.click()
+    pass('skipped the phone-verification gate')
+  }
+  await macButton.waitFor({ state: 'visible', timeout: 30_000 })
+
+  const downloadPromise = WORKER_URL ? page.waitForEvent('download', { timeout: 30_000 }) : null
+  await macButton.click()
+  await expectEventually(() => capturedUrl, 'stamped download navigation captured', 30_000)
+
+  const captured = new URL(capturedUrl)
+  const code = captured.searchParams.get('dl') || ''
+  // Exactly 48 hex — anything shorter would be an entropy downgrade even if
+  // the redeem path (40-64) still accepted it.
+  if (!/^[a-f0-9]{48}$/.test(code)) {
+    throw new Error(`captured download URL not stamped as expected: ${capturedUrl}`)
+  }
+  if (!captured.pathname.endsWith('/download/mac')) {
+    fail(`unexpected download path: ${captured.pathname}`)
+  }
+  pass(`real button minted + navigated stamped URL: dl=${code.slice(0, 8)}… (48 hex chars)`)
+
   let downloadedDmg = null
   if (WORKER_URL) {
-    const downloadPromise = page.waitForEvent('download', { timeout: 30_000 })
-    await page
-      .goto(`https://updates.gamutagents.com/download/mac?dl=${code}`)
-      .catch(() => {}) // download navigations abort the goto; that's expected
     const download = await downloadPromise
     const suggested = download.suggestedFilename()
     if (new RegExp(`-${code}\\.dmg$`).test(suggested)) {
@@ -164,11 +235,6 @@ async function mintNonceViaDownloadClick() {
     downloadedDmg = path.join(workRoot, suggested)
     await download.saveAs(downloadedDmg)
     pass('installer really downloaded through the local release worker')
-  } else {
-    await page
-      .goto(`https://updates.gamutagents.com/download/mac?dl=${code}`)
-      .catch(() => {}) // route aborts the request; we only need the capture
-    await expectEventually(() => capturedUrl, 'download navigation captured', 15_000)
   }
 
   await browser.close()
@@ -201,7 +267,15 @@ async function mountStampedDmg(code, downloadedDmg) {
 
 // --- 3./5. Launch the app and inspect the onboarding button over CDP --------
 
-async function launchApp({ dataDir, cdpPort }) {
+async function launchApp({ dataDir, cdpPort, name }) {
+  // A leftover instance from an aborted prior run would make connectOverCDP
+  // attach to stale state — refuse to run instead.
+  const stale = await chromium.connectOverCDP(`http://127.0.0.1:${cdpPort}`).catch(() => null)
+  if (stale) {
+    await stale.close().catch(() => {})
+    throw new Error(`something already answers CDP on :${cdpPort} — stale harness run? Kill it first.`)
+  }
+
   await fs.mkdir(dataDir, { recursive: true })
   const electronBin = require('electron')
   const mainEntry = path.join(APP_ROOT, 'dist', 'main', 'index.js')
@@ -222,6 +296,7 @@ async function launchApp({ dataDir, cdpPort }) {
     stdio: ['ignore', 'pipe', 'pipe'],
   })
   const logs = []
+  appLogTails.push({ name, logs })
   child.stdout.on('data', (d) => logs.push(d.toString()))
   child.stderr.on('data', (d) => logs.push(d.toString()))
   cleanups.push(() => {
@@ -231,6 +306,18 @@ async function launchApp({ dataDir, cdpPort }) {
       // Already exited.
     }
   })
+
+  // The bound port is dynamic (bindServerWithRetry walks past busy ports);
+  // the startup log line is the source of truth.
+  const apiPort = await expectEventually(
+    () => {
+      const m = logs.join('').match(/API server running on http:\/\/localhost:(\d+)/)
+      return m ? Number(m[1]) : null
+    },
+    'app API port in startup logs',
+    60_000,
+    250,
+  )
 
   const cdp = await expectEventually(
     () => chromium.connectOverCDP(`http://127.0.0.1:${cdpPort}`).catch(() => null),
@@ -251,7 +338,7 @@ async function launchApp({ dataDir, cdpPort }) {
     60_000,
     500,
   )
-  return { child, cdp, page, logs }
+  return { child, cdp, page, apiPort }
 }
 
 async function assertContinueAs(page) {
@@ -292,8 +379,9 @@ async function redeemAndVerify(page, button, dataDir, code) {
   else fail(`unexpected token shape: ${auth.token.slice(0, 12)}…`)
   if (auth.email === LOGIN_EMAIL) pass(`connected as ${auth.email}`)
   else fail(`connected email mismatch: ${auth.email}`)
-  if (auth.memberId?.startsWith('sub_')) pass(`member-scoped: ${auth.memberId}`)
-  else fail(`memberId missing/odd: ${auth.memberId}`)
+  // The button minted this itself — proves the memberId threading end to end.
+  if (auth.memberId === MEMBER_ID) pass(`scoped to the expected membership: ${auth.memberId}`)
+  else fail(`memberId mismatch: got ${auth.memberId}, expected ${MEMBER_ID} (override HARNESS_MEMBER_ID if the seed changed)`)
 
   await expectEventually(
     async () => (await page.locator('[data-testid="wizard-platform-login"]').count()) === 0
@@ -304,6 +392,16 @@ async function redeemAndVerify(page, button, dataDir, code) {
     () => pass('wizard advanced past welcome step'),
     () => fail('wizard did not advance'),
   )
+
+  // Replay: the code is consumed now; the platform must return the uniform
+  // 404 (no oracle distinguishing consumed from never-existed).
+  const replay = await fetch(`${PLATFORM_URL}/api/download-nonce/redeem`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code }),
+  })
+  if (replay.status === 404) pass('redeem replay of consumed code → uniform 404')
+  else fail(`redeem replay not refused: ${replay.status}`)
 
   // DB-side verification (best effort: needs local docker supabase). Only the
   // code's hash is at rest — plaintext never touches the platform DB.
@@ -327,12 +425,32 @@ async function redeemAndVerify(page, button, dataDir, code) {
 async function assertFallbackFlow() {
   step('Negative: consumed nonce → flow unchanged ("Get Started")')
   const dataDir2 = path.join(workRoot, 'app-data-negative')
-  const { cdp, page } = await launchApp({ dataDir: dataDir2, cdpPort: CDP_PORT + 1 })
-  const button = page.locator('[data-testid="wizard-platform-login"]')
-  // Give the offer query time to resolve (it 404s against the consumed nonce),
-  // then require the plain label. The label must never be "Continue as".
-  await new Promise((r) => setTimeout(r, 4000))
-  const text = (await button.textContent()) || ''
+  const { cdp, page, apiPort } = await launchApp({
+    dataDir: dataDir2,
+    cdpPort: CDP_PORT + 1,
+    name: 'negative pass',
+  })
+
+  // Deterministic settling instead of a sleep: the offer GET awaits the full
+  // scan + resolve chain before responding, so a response proves resolution
+  // ran against the consumed nonce. Read twice — the transient-failure branch
+  // also reports unavailable but leaves the offer unresolved, and a second
+  // read re-runs it.
+  const offerUrl = `http://127.0.0.1:${apiPort}/api/platform-auth/download-nonce`
+  const readOffer = async () => {
+    const res = await fetch(offerUrl)
+    if (!res.ok) throw new Error(`offer endpoint returned ${res.status}`)
+    return res.json()
+  }
+  const first = await expectEventually(readOffer, 'offer endpoint to respond', 30_000)
+  const second = await readOffer()
+  if (first.available === false && second.available === false) {
+    pass('offer settled as unavailable (consumed nonce rejected by resolve)')
+  } else {
+    fail(`offer unexpectedly available: ${JSON.stringify(second)}`)
+  }
+
+  const text = (await page.locator('[data-testid="wizard-platform-login"]').textContent()) || ''
   if (text.includes('Get Started') && !text.includes('Continue as')) {
     pass(`fallback intact: button reads "${text.trim()}"`)
   } else {
@@ -344,21 +462,39 @@ async function assertFallbackFlow() {
 // --- Run ---------------------------------------------------------------------
 
 try {
-  const { code, downloadedDmg } = await mintNonceViaDownloadClick()
+  const { code, downloadedDmg } = await mintViaRealDownloadClick()
   await mountStampedDmg(code, downloadedDmg)
 
   const dataDir = path.join(workRoot, 'app-data')
-  const { cdp, page } = await launchApp({ dataDir, cdpPort: CDP_PORT })
-  const button = await assertContinueAs(page)
-  await redeemAndVerify(page, button, dataDir, code)
-  await cdp.close().catch(() => {})
+  const appA = await launchApp({ dataDir, cdpPort: CDP_PORT, name: 'positive pass' })
+  const button = await assertContinueAs(appA.page)
+  await redeemAndVerify(appA.page, button, dataDir, code)
+  await appA.cdp.close().catch(() => {})
+  // Kill the first instance before the negative pass runs — one app at a
+  // time keeps ports and mounted-volume access unambiguous.
+  try {
+    appA.child.kill('SIGKILL')
+  } catch {
+    // Already exited.
+  }
 
   await assertFallbackFlow()
 } catch (err) {
   fail(`harness aborted: ${err?.stack || err}`)
 } finally {
-  for (const fn of cleanups.reverse()) await fn()
+  await runCleanups()
 }
 
-process.stdout.write(`\n${failures === 0 ? 'ALL CHECKS PASSED' : `${failures} CHECK(S) FAILED`}\n`)
-process.exit(failures === 0 ? 0 : 1)
+if (failures > 0) {
+  dumpAppLogTails()
+  process.stdout.write(`\n  INFO  work dir kept for debugging: ${workRoot}\n`)
+} else {
+  await fs.rm(workRoot, { recursive: true, force: true }).catch(() => {})
+}
+
+// Write the verdict through the callback so a piped stdout (tee) can't lose
+// the final line to process.exit.
+process.stdout.write(
+  `\n${failures === 0 ? 'ALL CHECKS PASSED' : `${failures} CHECK(S) FAILED`}\n`,
+  () => process.exit(failures === 0 ? 0 : 1),
+)

--- a/e2e/live/download-nonce-harness.mjs
+++ b/e2e/live/download-nonce-harness.mjs
@@ -29,6 +29,7 @@
  * Run:  node e2e/live/download-nonce-harness.mjs
  */
 
+import crypto from 'node:crypto'
 import { spawn, execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import { promises as fs } from 'node:fs'
@@ -51,6 +52,8 @@ const PLATFORM_URL = process.env.HARNESS_PLATFORM_URL || 'http://localhost:3000'
 const WORKER_URL = process.env.HARNESS_WORKER_URL || null
 const LOGIN_EMAIL = process.env.HARNESS_EMAIL || 'bob@test.io'
 const LOGIN_PASSWORD = process.env.HARNESS_PASSWORD || 'bobtest'
+// Seeded membership of the login user (workspace scoping is mandatory at mint).
+const MEMBER_ID = process.env.HARNESS_MEMBER_ID || 'sub_ba2caa9e-476a-4a60-9cc2-6138e6b2b7a8'
 const CDP_PORT = Number(process.env.HARNESS_CDP_PORT || 9333)
 const APP_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..')
 
@@ -125,25 +128,32 @@ async function mintNonceViaDownloadClick() {
   await page.waitForURL(/dashboard/, { timeout: 60_000 })
   pass(`logged in as ${LOGIN_EMAIL}`)
 
-  // DownloadButtons render on the profile page for every user.
-  await page.goto(`${PLATFORM_URL}/dashboard/profile`, { waitUntil: 'domcontentloaded' })
-  const macLink = page.getByRole('link', { name: /download for macos/i })
-  await macLink.waitFor({ timeout: 15_000 })
+  // Mint through the real authenticated endpoint (shares the page's cookies).
+  // Workspace scoping is mandatory: an unscoped mint must be refused, and the
+  // scoped one must come back stamped for exactly the requested membership.
+  const unscoped = await page.request.post(`${PLATFORM_URL}/api/download-nonce/mint`, {
+    data: {},
+  })
+  if (unscoped.status() === 400) pass('unscoped mint refused (400) — no workspace guessing')
+  else fail(`unscoped mint not refused: ${unscoped.status()}`)
 
-  const downloadPromise = WORKER_URL
-    ? page.waitForEvent('download', { timeout: 30_000 })
-    : null
-  await macLink.click()
-
-  await expectEventually(() => capturedUrl, 'stamped download navigation', 15_000)
-  const code = new URL(capturedUrl).searchParams.get('dl')
+  const minted = await page.request.post(`${PLATFORM_URL}/api/download-nonce/mint`, {
+    data: { member_id: MEMBER_ID },
+  })
+  if (!minted.ok()) throw new Error(`mint failed: ${minted.status()}`)
+  const { code } = await minted.json()
   if (!code || !/^[a-f0-9]{40,64}$/.test(code)) {
-    throw new Error(`download URL not stamped with a valid code: ${capturedUrl}`)
+    throw new Error(`mint returned no valid code`)
   }
-  pass(`download URL stamped: ...?dl=${code.slice(0, 8)}… (${code.length} hex chars)`)
+  pass(`mint issued a code for ${MEMBER_ID}: ${code.slice(0, 8)}… (${code.length} hex chars)`)
 
+  // Navigate the branded download URL like the stamped button would.
   let downloadedDmg = null
-  if (downloadPromise) {
+  if (WORKER_URL) {
+    const downloadPromise = page.waitForEvent('download', { timeout: 30_000 })
+    await page
+      .goto(`https://updates.gamutagents.com/download/mac?dl=${code}`)
+      .catch(() => {}) // download navigations abort the goto; that's expected
     const download = await downloadPromise
     const suggested = download.suggestedFilename()
     if (new RegExp(`-${code}\\.dmg$`).test(suggested)) {
@@ -154,6 +164,11 @@ async function mintNonceViaDownloadClick() {
     downloadedDmg = path.join(workRoot, suggested)
     await download.saveAs(downloadedDmg)
     pass('installer really downloaded through the local release worker')
+  } else {
+    await page
+      .goto(`https://updates.gamutagents.com/download/mac?dl=${code}`)
+      .catch(() => {}) // route aborts the request; we only need the capture
+    await expectEventually(() => capturedUrl, 'download navigation captured', 15_000)
   }
 
   await browser.close()
@@ -290,14 +305,20 @@ async function redeemAndVerify(page, button, dataDir, code) {
     () => fail('wizard did not advance'),
   )
 
-  // DB-side verification (best effort: needs local docker supabase).
+  // DB-side verification (best effort: needs local docker supabase). Only the
+  // code's hash is at rest — plaintext never touches the platform DB.
+  const codeHash = crypto.createHash('sha256').update(code).digest('hex')
   try {
     const { stdout } = await execFileAsync('docker', [
       'exec', 'supabase_db_platform', 'psql', '-U', 'postgres', '-d', 'postgres', '-Atc',
-      `select consumed_at is not null from public.download_nonce where code = '${code}';`,
+      `select (consumed_at is not null) || '|' || coalesce(created_ua, '-') || '|' || coalesce(consumed_ua, '-') from public.download_nonce where code_hash = '${codeHash}';`,
     ])
-    if (stdout.trim() === 't') pass('nonce row consumed in DB')
+    const [consumed, createdUa, consumedUa] = stdout.trim().split('|')
+    // `boolean || text` renders as 'true'/'false', not psql's bare 't'/'f'.
+    if (consumed === 'true') pass('nonce row consumed in DB (by hash — plaintext not at rest)')
     else fail(`nonce row not consumed (got: ${stdout.trim() || 'no row'})`)
+    // Proxy-derived context is best-effort in local dev (no trusted proxy).
+    process.stdout.write(`  INFO  audit context — mint ua: ${createdUa.slice(0, 40)} · redeem ua: ${consumedUa.slice(0, 40)}\n`)
   } catch {
     process.stdout.write('  SKIP  DB check (docker/supabase not reachable)\n')
   }

--- a/e2e/live/download-nonce-harness.mjs
+++ b/e2e/live/download-nonce-harness.mjs
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+/**
+ * Live end-to-end validation of installer-carried identity.
+ *
+ * Drives the REAL stack, no mocks on the nonce path:
+ *   1. Logs into the locally running platform web app with a seeded user and
+ *      clicks the actual "Download for MacOS" button, capturing the stamped
+ *      download URL (validates mint + button wiring).
+ *   2. Creates a DMG named like a stamped installer and mounts it, so the
+ *      app's hdiutil mount-scan channel recovers the code for real.
+ *   3. Launches the built Electron app with a fresh data dir and
+ *      --remote-debugging-port, connects over CDP, and asserts the
+ *      onboarding button reads "Continue as <email>".
+ *   4. Clicks it and verifies the redeemed plat_sa_ token lands in
+ *      settings.json (and, when docker is available, that the nonce row is
+ *      consumed in the local Supabase DB).
+ *   5. Negative pass: relaunches with another fresh data dir while the same
+ *      (now consumed) DMG is still mounted and asserts the button falls back
+ *      to "Get Started" — flow unchanged.
+ *
+ * Prereqs:
+ *   - Local Supabase running + seeded (bob@test.io / bobtest exists) with the
+ *     download_nonce migration applied.
+ *   - Platform web dev server on http://localhost:3000.
+ *   - App built for electron:  npm run build:electron
+ *     (with PLATFORM_BASE_URL/PLATFORM_PROXY_URL pointing at the local stack)
+ *   - Native modules rebuilt for Electron:  npx electron-rebuild -f
+ *
+ * Run:  node e2e/live/download-nonce-harness.mjs
+ */
+
+import { spawn, execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { promises as fs } from 'node:fs'
+import { createRequire } from 'node:module'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+
+import { chromium } from '@playwright/test'
+
+const execFileAsync = promisify(execFile)
+const require = createRequire(import.meta.url)
+
+const PLATFORM_URL = process.env.HARNESS_PLATFORM_URL || 'http://localhost:3000'
+// When set (e.g. http://127.0.0.1:8790 from `wrangler dev` in gamut-releases),
+// updates.gamutagents.com traffic is proxied to the local release worker and
+// the browser REALLY downloads the stamped installer — validating the
+// redirect + Content-Disposition leg too. Unset → the download nav is merely
+// captured and a synthetic stamped DMG is used instead.
+const WORKER_URL = process.env.HARNESS_WORKER_URL || null
+const LOGIN_EMAIL = process.env.HARNESS_EMAIL || 'bob@test.io'
+const LOGIN_PASSWORD = process.env.HARNESS_PASSWORD || 'bobtest'
+const CDP_PORT = Number(process.env.HARNESS_CDP_PORT || 9333)
+const APP_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..')
+
+const workRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'download-nonce-live-'))
+const cleanups = []
+let failures = 0
+
+function step(name) {
+  process.stdout.write(`\n=== ${name}\n`)
+}
+function pass(msg) {
+  process.stdout.write(`  PASS  ${msg}\n`)
+}
+function fail(msg) {
+  failures += 1
+  process.stdout.write(`  FAIL  ${msg}\n`)
+}
+async function expectEventually(fn, what, timeoutMs = 30_000, intervalMs = 250) {
+  const deadline = Date.now() + timeoutMs
+  let lastErr
+  while (Date.now() < deadline) {
+    try {
+      const value = await fn()
+      if (value) return value
+    } catch (err) {
+      lastErr = err
+    }
+    await new Promise((r) => setTimeout(r, intervalMs))
+  }
+  throw new Error(`Timed out waiting for: ${what}${lastErr ? ` (${lastErr})` : ''}`)
+}
+
+// --- 1. Mint through the real dashboard ------------------------------------
+
+async function mintNonceViaDownloadClick() {
+  step('Mint: platform login + real download click')
+  const browser = await chromium.launch({ headless: true })
+  cleanups.push(() => browser.close().catch(() => {}))
+  const context = await browser.newContext()
+  const page = await context.newPage()
+
+  let capturedUrl = null
+  if (WORKER_URL) {
+    // Proxy the branded host to the local worker; its 302 Location points at
+    // 127.0.0.1 directly, so the browser follows and downloads for real.
+    await context.route(/updates\.gamutagents\.com/, async (route) => {
+      const u = new URL(route.request().url())
+      capturedUrl = u.toString()
+      const upstream = await fetch(`${WORKER_URL}${u.pathname}${u.search}`, {
+        redirect: 'manual',
+      })
+      const headers = {}
+      for (const [k, v] of upstream.headers) headers[k] = v
+      return route.fulfill({
+        status: upstream.status,
+        headers,
+        body: Buffer.from(await upstream.arrayBuffer()),
+      })
+    })
+  } else {
+    await context.route(/updates\.gamutagents\.com/, (route) => {
+      capturedUrl = route.request().url()
+      return route.abort()
+    })
+  }
+
+  await page.goto(`${PLATFORM_URL}/auth/login`, { waitUntil: 'domcontentloaded' })
+  await page.getByPlaceholder('Email').fill(LOGIN_EMAIL)
+  await page.getByPlaceholder('Password', { exact: true }).fill(LOGIN_PASSWORD)
+  await page.locator('button[type="submit"]').first().click()
+  // Generous: a cold Next dev server compiles routes on first hit.
+  await page.waitForURL(/dashboard/, { timeout: 60_000 })
+  pass(`logged in as ${LOGIN_EMAIL}`)
+
+  // DownloadButtons render on the profile page for every user.
+  await page.goto(`${PLATFORM_URL}/dashboard/profile`, { waitUntil: 'domcontentloaded' })
+  const macLink = page.getByRole('link', { name: /download for macos/i })
+  await macLink.waitFor({ timeout: 15_000 })
+
+  const downloadPromise = WORKER_URL
+    ? page.waitForEvent('download', { timeout: 30_000 })
+    : null
+  await macLink.click()
+
+  await expectEventually(() => capturedUrl, 'stamped download navigation', 15_000)
+  const code = new URL(capturedUrl).searchParams.get('dl')
+  if (!code || !/^[a-f0-9]{40,64}$/.test(code)) {
+    throw new Error(`download URL not stamped with a valid code: ${capturedUrl}`)
+  }
+  pass(`download URL stamped: ...?dl=${code.slice(0, 8)}… (${code.length} hex chars)`)
+
+  let downloadedDmg = null
+  if (downloadPromise) {
+    const download = await downloadPromise
+    const suggested = download.suggestedFilename()
+    if (new RegExp(`-${code}\\.dmg$`).test(suggested)) {
+      pass(`worker stamped the saved filename: ${suggested}`)
+    } else {
+      fail(`saved filename not stamped: ${suggested}`)
+    }
+    downloadedDmg = path.join(workRoot, suggested)
+    await download.saveAs(downloadedDmg)
+    pass('installer really downloaded through the local release worker')
+  }
+
+  await browser.close()
+  return { code, downloadedDmg }
+}
+
+// --- 2. Stamped DMG, really mounted -----------------------------------------
+
+async function mountStampedDmg(code, downloadedDmg) {
+  step(downloadedDmg ? 'Mount: attach the actually-downloaded DMG' : 'Mount: create + attach stamped DMG')
+  let dmgPath = downloadedDmg
+  if (!dmgPath) {
+    const srcDir = path.join(workRoot, 'dmg-src')
+    await fs.mkdir(srcDir, { recursive: true })
+    await fs.writeFile(path.join(srcDir, 'README.txt'), 'harness payload\n')
+    dmgPath = path.join(workRoot, `Gamut-0.0.0-${code}.dmg`)
+    await execFileAsync('hdiutil', [
+      'create', '-volname', 'Gamut', '-srcfolder', srcDir, '-format', 'UDZO', '-ov', dmgPath,
+    ])
+  }
+  const { stdout } = await execFileAsync('hdiutil', ['attach', '-nobrowse', '-readonly', dmgPath])
+  const mountPoint = stdout.split('\n').flatMap((l) => l.split('\t')).find((f) => f.trim().startsWith('/Volumes/'))
+  if (!mountPoint) throw new Error(`could not find mount point in: ${stdout}`)
+  cleanups.push(() =>
+    execFileAsync('hdiutil', ['detach', mountPoint.trim(), '-force']).catch(() => {}),
+  )
+  pass(`mounted ${path.basename(dmgPath)} at ${mountPoint.trim()}`)
+  return dmgPath
+}
+
+// --- 3./5. Launch the app and inspect the onboarding button over CDP --------
+
+async function launchApp({ dataDir, cdpPort }) {
+  await fs.mkdir(dataDir, { recursive: true })
+  const electronBin = require('electron')
+  const mainEntry = path.join(APP_ROOT, 'dist', 'main', 'index.js')
+  await fs.access(mainEntry).catch(() => {
+    throw new Error('dist/main/index.js missing — run `npm run build:electron` first')
+  })
+  const child = spawn(electronBin, [mainEntry, `--remote-debugging-port=${cdpPort}`], {
+    cwd: APP_ROOT,
+    env: {
+      ...process.env,
+      SUPERAGENT_DATA_DIR: dataDir,
+      PLATFORM_BASE_URL: PLATFORM_URL,
+      E2E_MOCK: 'true',
+      // The single-instance lock is shared with the installed app; opt out so
+      // the harness can run while the user's Gamut is open (dev-only gate).
+      SUPERAGENT_DISABLE_SINGLE_INSTANCE: '1',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  const logs = []
+  child.stdout.on('data', (d) => logs.push(d.toString()))
+  child.stderr.on('data', (d) => logs.push(d.toString()))
+  cleanups.push(() => {
+    try {
+      child.kill('SIGKILL')
+    } catch {
+      // Already exited.
+    }
+  })
+
+  const cdp = await expectEventually(
+    () => chromium.connectOverCDP(`http://127.0.0.1:${cdpPort}`).catch(() => null),
+    `CDP endpoint on :${cdpPort}`,
+    60_000,
+    500,
+  )
+  const page = await expectEventually(
+    async () => {
+      for (const context of cdp.contexts()) {
+        for (const p of context.pages()) {
+          if (await p.locator('[data-testid="wizard-platform-login"]').count()) return p
+        }
+      }
+      return null
+    },
+    'app window with onboarding wizard',
+    60_000,
+    500,
+  )
+  return { child, cdp, page, logs }
+}
+
+async function assertContinueAs(page) {
+  step('Assert: onboarding button offers "Continue as <email>" (via CDP)')
+  const button = page.locator('[data-testid="wizard-platform-login"]')
+  await expectEventually(
+    async () => ((await button.textContent()) || '').includes(`Continue as ${LOGIN_EMAIL}`),
+    `button text "Continue as ${LOGIN_EMAIL}"`,
+    30_000,
+  )
+  pass(`button reads "Continue as ${LOGIN_EMAIL}"`)
+  const notYou = page.locator('[data-testid="wizard-nonce-dismiss"]')
+  if ((await notYou.count()) > 0) pass('"Not you?" escape hatch rendered')
+  else fail('"Not you?" escape hatch missing')
+  return button
+}
+
+async function redeemAndVerify(page, button, dataDir, code) {
+  step('Redeem: click through and verify persisted connection')
+  await button.click()
+  const settings = await expectEventually(
+    async () => {
+      const raw = await fs.readFile(path.join(dataDir, 'settings.json'), 'utf8').catch(() => null)
+      if (!raw) return null
+      let parsed
+      try {
+        parsed = JSON.parse(raw)
+      } catch {
+        return null // mid-write; poll again
+      }
+      return parsed.platformAuth?.token ? parsed : null
+    },
+    'platformAuth record in settings.json',
+    30_000,
+  )
+  const auth = settings.platformAuth
+  if (auth.token.startsWith('plat_sa_')) pass(`plat_sa_ token persisted (${auth.tokenPreview ?? 'preview n/a'})`)
+  else fail(`unexpected token shape: ${auth.token.slice(0, 12)}…`)
+  if (auth.email === LOGIN_EMAIL) pass(`connected as ${auth.email}`)
+  else fail(`connected email mismatch: ${auth.email}`)
+  if (auth.memberId?.startsWith('sub_')) pass(`member-scoped: ${auth.memberId}`)
+  else fail(`memberId missing/odd: ${auth.memberId}`)
+
+  await expectEventually(
+    async () => (await page.locator('[data-testid="wizard-platform-login"]').count()) === 0
+      || !((await page.locator('[data-testid="wizard-platform-login"]').textContent().catch(() => '')) || '').includes('Continue as'),
+    'wizard advanced past the welcome step',
+    20_000,
+  ).then(
+    () => pass('wizard advanced past welcome step'),
+    () => fail('wizard did not advance'),
+  )
+
+  // DB-side verification (best effort: needs local docker supabase).
+  try {
+    const { stdout } = await execFileAsync('docker', [
+      'exec', 'supabase_db_platform', 'psql', '-U', 'postgres', '-d', 'postgres', '-Atc',
+      `select consumed_at is not null from public.download_nonce where code = '${code}';`,
+    ])
+    if (stdout.trim() === 't') pass('nonce row consumed in DB')
+    else fail(`nonce row not consumed (got: ${stdout.trim() || 'no row'})`)
+  } catch {
+    process.stdout.write('  SKIP  DB check (docker/supabase not reachable)\n')
+  }
+}
+
+async function assertFallbackFlow() {
+  step('Negative: consumed nonce → flow unchanged ("Get Started")')
+  const dataDir2 = path.join(workRoot, 'app-data-negative')
+  const { cdp, page } = await launchApp({ dataDir: dataDir2, cdpPort: CDP_PORT + 1 })
+  const button = page.locator('[data-testid="wizard-platform-login"]')
+  // Give the offer query time to resolve (it 404s against the consumed nonce),
+  // then require the plain label. The label must never be "Continue as".
+  await new Promise((r) => setTimeout(r, 4000))
+  const text = (await button.textContent()) || ''
+  if (text.includes('Get Started') && !text.includes('Continue as')) {
+    pass(`fallback intact: button reads "${text.trim()}"`)
+  } else {
+    fail(`unexpected button text on consumed nonce: "${text.trim()}"`)
+  }
+  await cdp.close().catch(() => {})
+}
+
+// --- Run ---------------------------------------------------------------------
+
+try {
+  const { code, downloadedDmg } = await mintNonceViaDownloadClick()
+  await mountStampedDmg(code, downloadedDmg)
+
+  const dataDir = path.join(workRoot, 'app-data')
+  const { cdp, page } = await launchApp({ dataDir, cdpPort: CDP_PORT })
+  const button = await assertContinueAs(page)
+  await redeemAndVerify(page, button, dataDir, code)
+  await cdp.close().catch(() => {})
+
+  await assertFallbackFlow()
+} catch (err) {
+  fail(`harness aborted: ${err?.stack || err}`)
+} finally {
+  for (const fn of cleanups.reverse()) await fn()
+}
+
+process.stdout.write(`\n${failures === 0 ? 'ALL CHECKS PASSED' : `${failures} CHECK(S) FAILED`}\n`)
+process.exit(failures === 0 ? 0 : 1)

--- a/src/api/routes/platform-auth.ts
+++ b/src/api/routes/platform-auth.ts
@@ -15,6 +15,12 @@ import {
   savePlatformAuth,
   revokePlatformToken,
 } from '@shared/lib/services/platform-auth-service'
+import {
+  dismissDownloadNonceOffer,
+  getDownloadNonceOffer,
+  redeemDownloadNonce,
+  DownloadNonceUnavailableError,
+} from '@shared/lib/services/download-nonce-service'
 import { platformService } from '@shared/lib/services/platform-service'
 import { PlatformRequestError } from '@shared/lib/platform-auth/platform-fetch'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
@@ -140,6 +146,42 @@ platformAuth.post('/complete', rejectMutationInAuthMode, async (c) => {
   })
 
   return c.json(status)
+})
+
+// Download-carried enrollment: a nonce recovered from the installer's
+// surroundings (filename / download-URL metadata) lets onboarding offer
+// "Continue as <email>" instead of the browser handoff. No nonce → these
+// endpoints report unavailable and the flow is unchanged.
+platformAuth.get('/download-nonce', async (c) => {
+  return c.json(await getDownloadNonceOffer())
+})
+
+platformAuth.post('/download-nonce/redeem', rejectMutationInAuthMode, async (c) => {
+  const userId = getCurrentUserId(c)
+  let status
+  try {
+    status = await redeemDownloadNonce(userId)
+  } catch (error) {
+    if (error instanceof DownloadNonceUnavailableError) {
+      return c.json({ error: error.message, expired: true }, 410)
+    }
+    if (error instanceof PlatformRequestError) {
+      return c.json({ error: error.message }, error.status as ContentfulStatusCode)
+    }
+    throw error
+  }
+
+  setErrorReportingUser({
+    id: status.tokenPreview || undefined,
+    email: status.email || undefined,
+  })
+
+  return c.json(status)
+})
+
+platformAuth.post('/download-nonce/dismiss', (c) => {
+  dismissDownloadNonceOffer()
+  return c.json({ success: true })
 })
 
 platformAuth.post('/revoke', rejectMutationInAuthMode, async (c) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -106,6 +106,7 @@ import api from '../api'
 import { initializeServices, shutdownServices } from '@shared/lib/startup'
 import { setupServerHandlers } from '@shared/lib/startup'
 import { bindServerWithRetry } from '@shared/lib/server-bind'
+import { configureDownloadNonceRecovery } from '@shared/lib/services/download-nonce-service'
 import { chatIntegrationManager } from '@shared/lib/chat-integrations/chat-integration-manager'
 import { getUserSettings } from '@shared/lib/services/user-settings-service'
 
@@ -1341,6 +1342,24 @@ function stopNotificationListener(): void {
 
 // Start the API server and app
 async function startApp() {
+  // Download-carried enrollment nonce recovery. The channels are all
+  // best-effort reads of the install's surroundings; the handoff file is the
+  // Windows installer's note of its own (stamped) filename, and the dev-only
+  // override lets a harness point the scanner at a fake install source.
+  configureDownloadNonceRecovery({
+    // The literal 'Gamut' must match the installer's `$APPDATA\Gamut` drop
+    // location in build/installer.nsh (NOT getPath('userData'), which the
+    // legacy 'SuperAgent' app.name pins elsewhere).
+    windowsHandoffFile:
+      process.platform === 'win32'
+        ? path.join(app.getPath('appData'), 'Gamut', 'pending-download-source')
+        : undefined,
+    testSourcePath:
+      !app.isPackaged && process.env.SUPERAGENT_FAKE_INSTALLER_SOURCE
+        ? process.env.SUPERAGENT_FAKE_INSTALLER_SOURCE
+        : undefined,
+  })
+
   // Bind the API server atomically, retrying on a port race until a port is
   // claimed (no probe-then-bind TOCTOU gap; an EADDRINUSE retries instead of
   // crashing the app via uncaughtException). See bindServerWithRetry.
@@ -1580,7 +1599,14 @@ app.on('open-file', (event, filePath) => {
 // second process spawns. It MUST bail out immediately — if it falls through to
 // startApp() it boots its own API server and briefly shows a window before the
 // quit lands, which is the "ghost window" flash on re-launch.
-const gotTheLock = app.requestSingleInstanceLock()
+// Dev/test escape hatch: the lock identity derives from app.name
+// ('SuperAgent', shared with installed builds), so a dev instance silently
+// dies whenever the installed app is running. Harnesses that use their own
+// SUPERAGENT_DATA_DIR can opt out; packaged builds never can.
+const gotTheLock =
+  !app.isPackaged && process.env.SUPERAGENT_DISABLE_SINGLE_INSTANCE === '1'
+    ? true
+    : app.requestSingleInstanceLock()
 
 if (!gotTheLock) {
   // Exit hard without running startApp() or the before-quit graceful-shutdown

--- a/src/renderer/components/wizard/welcome-step.tsx
+++ b/src/renderer/components/wizard/welcome-step.tsx
@@ -5,7 +5,12 @@ import { Button } from '@renderer/components/ui/button'
 import { RequestError } from '@renderer/components/messages/request-error'
 import { ManualAccessKeyInput } from '@renderer/components/settings/manual-access-key-input'
 import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
-import { usePlatformConnect } from '@renderer/hooks/use-platform-auth'
+import {
+  useDismissDownloadNonce,
+  useDownloadNonceOffer,
+  usePlatformConnect,
+  useRedeemDownloadNonce,
+} from '@renderer/hooks/use-platform-auth'
 
 interface WelcomeStepProps {
   onChoosePlatform?: () => void
@@ -43,6 +48,24 @@ export function WelcomeStep({ onChoosePlatform, onContinueToManualSetup }: Welco
 
   const isPlatformAvailable = !isLoadingPlatformAuth && Boolean(platformAuth?.platformBaseUrl)
 
+  // Installer-carried enrollment: when the main process recovered a download
+  // nonce, the primary button becomes one-click "Continue as <email>". No
+  // nonce (or any failure) leaves the flow exactly as before.
+  const { data: nonceOffer } = useDownloadNonceOffer(isPlatformAvailable && !isPlatformConnected)
+  const redeemNonce = useRedeemDownloadNonce()
+  const dismissNonce = useDismissDownloadNonce()
+  const nonceEmail = nonceOffer?.available ? nonceOffer.email : undefined
+
+  async function handleContinueAsOffer() {
+    try {
+      await redeemNonce.mutateAsync()
+      onChoosePlatform?.()
+    } catch {
+      // The mutation exposes the error below; the offer query refetches and
+      // the button falls back to the regular flow if the nonce is gone.
+    }
+  }
+
   async function handleManualSetup() {
     try {
       if (settings?.llmProvider === 'platform') {
@@ -68,28 +91,59 @@ export function WelcomeStep({ onChoosePlatform, onContinueToManualSetup }: Welco
         {isPlatformAvailable && (
           <div className="space-y-3">
             <div className="flex items-center gap-3">
-              <Button
-                type="button"
-                variant="default"
-                size="lg"
-                onClick={() => void handleConnect()}
-                data-testid="wizard-platform-login"
-                disabled={isLaunching}
-                className="w-full max-w-[380px]"
-              >
-                {isLaunching ? (
-                  <><Loader2 className="h-4 w-4 animate-spin mr-2" />Logging in...</>
-                ) : (
-                  'Get Started'
-                )}
-              </Button>
+              {nonceEmail ? (
+                <Button
+                  type="button"
+                  variant="default"
+                  size="lg"
+                  onClick={() => void handleContinueAsOffer()}
+                  data-testid="wizard-platform-login"
+                  disabled={redeemNonce.isPending}
+                  className="w-full max-w-[380px]"
+                >
+                  {redeemNonce.isPending ? (
+                    <><Loader2 className="h-4 w-4 animate-spin mr-2" />Signing in...</>
+                  ) : (
+                    `Continue as ${nonceEmail}`
+                  )}
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="default"
+                  size="lg"
+                  onClick={() => void handleConnect()}
+                  data-testid="wizard-platform-login"
+                  disabled={isLaunching}
+                  className="w-full max-w-[380px]"
+                >
+                  {isLaunching ? (
+                    <><Loader2 className="h-4 w-4 animate-spin mr-2" />Logging in...</>
+                  ) : (
+                    'Get Started'
+                  )}
+                </Button>
+              )}
             </div>
+            {nonceEmail && !redeemNonce.isPending && (
+              <p className="text-sm text-muted-foreground">
+                Not you?{' '}
+                <button
+                  type="button"
+                  onClick={() => dismissNonce.mutate()}
+                  data-testid="wizard-nonce-dismiss"
+                  className="underline underline-offset-2 hover:text-foreground transition-colors"
+                >
+                  Use a different account
+                </button>
+              </p>
+            )}
             {isLaunching && (
               <ManualAccessKeyInput prefixText="Log in issues?" className="text-sm text-muted-foreground" />
             )}
           </div>
         )}
-        <RequestError message={platformError ?? null} />
+        <RequestError message={platformError ?? redeemNonce.error?.message ?? null} />
         {isPlatformAvailable ? (
           <p className="text-sm text-muted-foreground">
             Need to bring your own keys?{' '}

--- a/src/renderer/components/wizard/welcome-step.tsx
+++ b/src/renderer/components/wizard/welcome-step.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 
 import { Button } from '@renderer/components/ui/button'
@@ -55,6 +55,9 @@ export function WelcomeStep({ onChoosePlatform, onContinueToManualSetup }: Welco
   const redeemNonce = useRedeemDownloadNonce()
   const dismissNonce = useDismissDownloadNonce()
   const nonceEmail = nonceOffer?.available ? nonceOffer.email : undefined
+  // Broken/blocked avatar URLs degrade to the text-only button.
+  const [avatarFailed, setAvatarFailed] = useState(false)
+  const nonceAvatarUrl = !avatarFailed && nonceOffer?.available ? nonceOffer.avatarUrl : undefined
 
   async function handleContinueAsOffer() {
     try {
@@ -104,7 +107,17 @@ export function WelcomeStep({ onChoosePlatform, onContinueToManualSetup }: Welco
                   {redeemNonce.isPending ? (
                     <><Loader2 className="h-4 w-4 animate-spin mr-2" />Signing in...</>
                   ) : (
-                    `Continue as ${nonceEmail}`
+                    <>
+                      {nonceAvatarUrl && (
+                        <img
+                          src={nonceAvatarUrl}
+                          alt=""
+                          className="h-5 w-5 rounded-full object-cover mr-2 shrink-0"
+                          onError={() => setAvatarFailed(true)}
+                        />
+                      )}
+                      <span className="truncate">{`Continue as ${nonceEmail}`}</span>
+                    </>
                   )}
                 </Button>
               ) : (

--- a/src/renderer/hooks/use-platform-auth.ts
+++ b/src/renderer/hooks/use-platform-auth.ts
@@ -152,6 +152,7 @@ export interface DownloadNonceOffer {
   available: boolean
   email?: string
   orgName?: string
+  avatarUrl?: string
 }
 
 export function useDownloadNonceOffer(enabled: boolean) {

--- a/src/renderer/hooks/use-platform-auth.ts
+++ b/src/renderer/hooks/use-platform-auth.ts
@@ -141,6 +141,83 @@ export interface PlatformConnectOptions {
   successMessage?: string | ((wasConnected: boolean) => string | null) | null
 }
 
+// ---------------------------------------------------------------------------
+// Download-carried enrollment ("Continue as X"): the main process may recover
+// a single-use nonce from the installer's surroundings. When it resolves, the
+// onboarding button offers one-click sign-in; redeeming runs through the same
+// completion path as the manual access-key flow.
+// ---------------------------------------------------------------------------
+
+export interface DownloadNonceOffer {
+  available: boolean
+  email?: string
+  orgName?: string
+}
+
+export function useDownloadNonceOffer(enabled: boolean) {
+  return useQuery<DownloadNonceOffer>({
+    queryKey: ['download-nonce-offer'],
+    enabled,
+    // The offer only changes through redeem/dismiss, which update the cache
+    // directly.
+    staleTime: Infinity,
+    queryFn: async () => {
+      const res = await apiFetch('/api/platform-auth/download-nonce')
+      if (!res.ok) return { available: false }
+      return res.json()
+    },
+  })
+}
+
+export function useRedeemDownloadNonce() {
+  const queryClient = useQueryClient()
+  const applyPlatformDefaults = useApplyPlatformDefaults()
+
+  return useMutation<unknown, Error>({
+    meta: { skipGlobalErrorToast: true },
+    mutationFn: async () => {
+      const res = await apiFetch('/api/platform-auth/download-nonce/redeem', {
+        method: 'POST',
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error || 'Failed to sign in.')
+      }
+      return res.json()
+    },
+    onSuccess: async () => {
+      window.localStorage.setItem(PLATFORM_AUTH_CHOICE_STORAGE_KEY, 'platform')
+      queryClient.invalidateQueries({ queryKey: ['platform-auth'] })
+      queryClient.setQueryData<DownloadNonceOffer>(['download-nonce-offer'], { available: false })
+      await applyPlatformDefaults().catch(() => {})
+
+      triggerPlatformSkillsetSync(queryClient)
+    },
+    onError: () => {
+      // Whatever went wrong (expired, consumed elsewhere, offline), the offer
+      // may be gone — refetch so the button falls back to the normal flow.
+      queryClient.invalidateQueries({ queryKey: ['download-nonce-offer'] })
+    },
+  })
+}
+
+export function useDismissDownloadNonce() {
+  const queryClient = useQueryClient()
+
+  return useMutation<unknown, Error>({
+    meta: { skipGlobalErrorToast: true },
+    mutationFn: async () => {
+      const res = await apiFetch('/api/platform-auth/download-nonce/dismiss', {
+        method: 'POST',
+      })
+      return res.ok ? res.json() : {}
+    },
+    onSuccess: () => {
+      queryClient.setQueryData<DownloadNonceOffer>(['download-nonce-offer'], { available: false })
+    },
+  })
+}
+
 export function useSavePlatformAccessKey() {
   const queryClient = useQueryClient()
   const applyPlatformDefaults = useApplyPlatformDefaults()

--- a/src/shared/lib/services/download-nonce-schema.ts
+++ b/src/shared/lib/services/download-nonce-schema.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod'
+
+// Boundary schemas for the platform's download-nonce endpoints. The code is
+// hex so it survives every carrier (installer filename, URL query, xattr).
+export const DownloadNonceCodeSchema = z.string().regex(/^[a-f0-9]{40,64}$/)
+
+export const DownloadNonceIdentitySchema = z.object({
+  email: z.string().min(1),
+  org_name: z.string().optional().default(''),
+  role: z.string().optional().default(''),
+})
+export type DownloadNonceIdentity = z.infer<typeof DownloadNonceIdentitySchema>
+
+export const DownloadNonceRedeemResponseSchema = z.object({
+  token: z.string().min(1),
+  email: z.string().optional().default(''),
+  label: z.string().optional().default(''),
+  org_id: z.string().optional().default(''),
+  org_name: z.string().optional().default(''),
+  role: z.string().optional().default(''),
+  user_id: z.string().optional().default(''),
+  member_id: z.string().optional().default(''),
+})
+export type DownloadNonceRedeemResponse = z.infer<typeof DownloadNonceRedeemResponseSchema>

--- a/src/shared/lib/services/download-nonce-schema.ts
+++ b/src/shared/lib/services/download-nonce-schema.ts
@@ -8,6 +8,11 @@ export const DownloadNonceIdentitySchema = z.object({
   email: z.string().min(1),
   org_name: z.string().optional().default(''),
   role: z.string().optional().default(''),
+  // Rendered in an <img src>; anything non-http(s) is dropped at the boundary.
+  avatar_url: z
+    .string()
+    .nullish()
+    .transform((v) => (v && /^https?:\/\//.test(v) ? v : null)),
 })
 export type DownloadNonceIdentity = z.infer<typeof DownloadNonceIdentitySchema>
 

--- a/src/shared/lib/services/download-nonce-service.test.ts
+++ b/src/shared/lib/services/download-nonce-service.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   deriveMacBundlePath,
   extractNonceFromFileName,
-  extractNonceFromHdiutilPlist,
+  extractNoncesFromHdiutilPlist,
   extractNonceFromUrlText,
   extractNonceFromWhereFromsHex,
 } from './download-nonce-service'
@@ -83,32 +83,48 @@ describe('extractNonceFromWhereFromsHex', () => {
   })
 })
 
-describe('extractNonceFromHdiutilPlist', () => {
-  const plist = (imagePath: string) => `<?xml version="1.0" encoding="UTF-8"?>
+describe('extractNoncesFromHdiutilPlist', () => {
+  const plist = (...imagePaths: string[]) => `<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0"><dict>
-  <key>images</key><array><dict>
-    <key>image-path</key><string>${imagePath}</string>
+  <key>images</key><array>${imagePaths
+    .map(
+      (p) => `<dict>
+    <key>image-path</key><string>${p}</string>
     <key>system-entities</key><array><dict>
       <key>mount-point</key><string>/Volumes/Gamut</string>
     </dict></array>
-  </dict></array>
+  </dict>`,
+    )
+    .join('')}</array>
 </dict></plist>`
 
   it('recovers the code from a mounted stamped DMG', () => {
     expect(
-      extractNonceFromHdiutilPlist(plist(`/Users/x/Downloads/Gamut-1.2.3-${NONCE}.dmg`)),
-    ).toBe(NONCE)
+      extractNoncesFromHdiutilPlist(plist(`/Users/x/Downloads/Gamut-1.2.3-${NONCE}.dmg`)),
+    ).toEqual([NONCE])
+  })
+
+  it('returns every stamped product DMG — a stale mount must not shadow a fresh one', () => {
+    const STALE = 'ffff'.repeat(12)
+    expect(
+      extractNoncesFromHdiutilPlist(
+        plist(
+          `/Users/x/Downloads/Gamut-1.2.2-${STALE}.dmg`,
+          `/Users/x/Downloads/Gamut-1.2.3-${NONCE}.dmg`,
+        ),
+      ),
+    ).toEqual([STALE, NONCE])
   })
 
   it('ignores non-product DMGs even when their names carry hex runs', () => {
     expect(
-      extractNonceFromHdiutilPlist(plist(`/Users/x/Downloads/OtherApp-${NONCE}.dmg`)),
-    ).toBeNull()
+      extractNoncesFromHdiutilPlist(plist(`/Users/x/Downloads/OtherApp-${NONCE}.dmg`)),
+    ).toEqual([])
   })
 
   it('ignores unstamped product DMGs and non-DMG strings', () => {
-    expect(extractNonceFromHdiutilPlist(plist('/Users/x/Downloads/Gamut-1.2.3.dmg'))).toBeNull()
-    expect(extractNonceFromHdiutilPlist('<string>/Volumes/whatever</string>')).toBeNull()
+    expect(extractNoncesFromHdiutilPlist(plist('/Users/x/Downloads/Gamut-1.2.3.dmg'))).toEqual([])
+    expect(extractNoncesFromHdiutilPlist('<string>/Volumes/whatever</string>')).toEqual([])
   })
 })
 

--- a/src/shared/lib/services/download-nonce-service.test.ts
+++ b/src/shared/lib/services/download-nonce-service.test.ts
@@ -62,19 +62,37 @@ describe('extractNonceFromUrlText', () => {
 })
 
 describe('extractNonceFromWhereFromsHex', () => {
-  it('recovers the code from xattr hex output of a binary plist', () => {
-    // Real kMDItemWhereFroms values are binary plists; the URL is stored as a
-    // plain UTF-8 run inside, which is all the parser relies on.
+  it('recovers the code from real `xattr -px` output', () => {
+    // Verbatim `xattr -px com.apple.metadata:kMDItemWhereFroms` output
+    // (macOS 15) for a binary-plist WhereFroms of
+    //   [https://updates.gamutagents.com/download/mac?dl=<NONCE>,
+    //    https://platform.gamutagents.com/]
+    // — uppercase hex pairs, 16 per line, trailing space before each newline.
+    const realXattrOutput = [
+      '62 70 6C 69 73 74 30 30 A2 01 02 5F 10 60 68 74 ',
+      '74 70 73 3A 2F 2F 75 70 64 61 74 65 73 2E 67 61 ',
+      '6D 75 74 61 67 65 6E 74 73 2E 63 6F 6D 2F 64 6F ',
+      '77 6E 6C 6F 61 64 2F 6D 61 63 3F 64 6C 3D 61 31 ',
+      '62 32 63 33 64 34 65 35 66 36 61 37 62 38 63 39 ',
+      '64 30 61 31 62 32 63 33 64 34 65 35 66 36 61 37 ',
+      '62 38 63 39 64 30 61 31 62 32 63 33 64 34 5F 10 ',
+      '21 68 74 74 70 73 3A 2F 2F 70 6C 61 74 66 6F 72 ',
+      '6D 2E 67 61 6D 75 74 61 67 65 6E 74 73 2E 63 6F ',
+      '6D 2F 08 0B 6E 00 00 00 00 00 00 01 01 00 00 00 ',
+      '00 00 00 00 03 00 00 00 00 00 00 00 00 00 00 00 ',
+      '00 00 00 00 92',
+      '',
+    ].join('\n')
+    expect(extractNonceFromWhereFromsHex(realXattrOutput)).toBe(NONCE)
+  })
+
+  it('tolerates lowercase, unspaced hex', () => {
     const fakePlist = Buffer.concat([
       Buffer.from('bplist00\xa2\x01\x02_\x10', 'latin1'),
       Buffer.from(`https://updates.gamutagents.com/download/mac?dl=${NONCE}`),
       Buffer.from('_\x10https://platform.gamutagents.com/', 'latin1'),
     ])
-    const hex = fakePlist
-      .toString('hex')
-      .replace(/(..)/g, '$1 ')
-      .trim()
-    expect(extractNonceFromWhereFromsHex(hex)).toBe(NONCE)
+    expect(extractNonceFromWhereFromsHex(fakePlist.toString('hex'))).toBe(NONCE)
   })
 
   it('returns null for empty or malformed output', () => {

--- a/src/shared/lib/services/download-nonce-service.test.ts
+++ b/src/shared/lib/services/download-nonce-service.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  deriveMacBundlePath,
+  extractNonceFromFileName,
+  extractNonceFromHdiutilPlist,
+  extractNonceFromUrlText,
+  extractNonceFromWhereFromsHex,
+} from './download-nonce-service'
+
+const NONCE = 'a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2c3d4'
+
+describe('extractNonceFromFileName', () => {
+  it('finds the code in a stamped Windows installer name', () => {
+    expect(extractNonceFromFileName(`Gamut-1.2.3-Setup-${NONCE}.exe`)).toBe(NONCE)
+  })
+
+  it('finds the code in a stamped DMG name', () => {
+    expect(extractNonceFromFileName(`Gamut-1.2.3-arm64-${NONCE}.dmg`)).toBe(NONCE)
+  })
+
+  it('survives browser duplicate-download suffixes', () => {
+    expect(extractNonceFromFileName(`Gamut-1.2.3-Setup-${NONCE} (1).exe`)).toBe(NONCE)
+  })
+
+  it('works on full paths', () => {
+    expect(extractNonceFromFileName(`/Users/x/Downloads/Gamut-1.2.3-${NONCE}.dmg`)).toBe(NONCE)
+  })
+
+  it('normalizes uppercase hex', () => {
+    expect(extractNonceFromFileName(`Gamut-Setup-${NONCE.toUpperCase()}.exe`)).toBe(NONCE)
+  })
+
+  it('rejects unstamped names', () => {
+    expect(extractNonceFromFileName('Gamut-1.2.3-Setup.exe')).toBeNull()
+    expect(extractNonceFromFileName('Gamut-1.2.3-arm64.dmg')).toBeNull()
+  })
+
+  it('rejects hex runs that are too short or embedded in longer words', () => {
+    expect(extractNonceFromFileName('Gamut-deadbeef.dmg')).toBeNull()
+    expect(extractNonceFromFileName(`Gamut-x${NONCE}.dmg`)).toBeNull()
+  })
+})
+
+describe('extractNonceFromUrlText', () => {
+  it('finds the dl query param', () => {
+    expect(
+      extractNonceFromUrlText(`https://updates.gamutagents.com/download/mac?dl=${NONCE}`),
+    ).toBe(NONCE)
+  })
+
+  it('finds it among other params', () => {
+    expect(
+      extractNonceFromUrlText(`https://x.test/download/win?v=1&dl=${NONCE}&utm=y`),
+    ).toBe(NONCE)
+  })
+
+  it('ignores lookalike params and invalid codes', () => {
+    expect(extractNonceFromUrlText(`https://x.test/?adl=${NONCE}`)).toBeNull()
+    expect(extractNonceFromUrlText('https://x.test/?dl=nothex')).toBeNull()
+  })
+})
+
+describe('extractNonceFromWhereFromsHex', () => {
+  it('recovers the code from xattr hex output of a binary plist', () => {
+    // Real kMDItemWhereFroms values are binary plists; the URL is stored as a
+    // plain UTF-8 run inside, which is all the parser relies on.
+    const fakePlist = Buffer.concat([
+      Buffer.from('bplist00\xa2\x01\x02_\x10', 'latin1'),
+      Buffer.from(`https://updates.gamutagents.com/download/mac?dl=${NONCE}`),
+      Buffer.from('_\x10https://platform.gamutagents.com/', 'latin1'),
+    ])
+    const hex = fakePlist
+      .toString('hex')
+      .replace(/(..)/g, '$1 ')
+      .trim()
+    expect(extractNonceFromWhereFromsHex(hex)).toBe(NONCE)
+  })
+
+  it('returns null for empty or malformed output', () => {
+    expect(extractNonceFromWhereFromsHex('')).toBeNull()
+    expect(extractNonceFromWhereFromsHex('zz zz')).toBeNull()
+  })
+})
+
+describe('extractNonceFromHdiutilPlist', () => {
+  const plist = (imagePath: string) => `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+  <key>images</key><array><dict>
+    <key>image-path</key><string>${imagePath}</string>
+    <key>system-entities</key><array><dict>
+      <key>mount-point</key><string>/Volumes/Gamut</string>
+    </dict></array>
+  </dict></array>
+</dict></plist>`
+
+  it('recovers the code from a mounted stamped DMG', () => {
+    expect(
+      extractNonceFromHdiutilPlist(plist(`/Users/x/Downloads/Gamut-1.2.3-${NONCE}.dmg`)),
+    ).toBe(NONCE)
+  })
+
+  it('ignores non-product DMGs even when their names carry hex runs', () => {
+    expect(
+      extractNonceFromHdiutilPlist(plist(`/Users/x/Downloads/OtherApp-${NONCE}.dmg`)),
+    ).toBeNull()
+  })
+
+  it('ignores unstamped product DMGs and non-DMG strings', () => {
+    expect(extractNonceFromHdiutilPlist(plist('/Users/x/Downloads/Gamut-1.2.3.dmg'))).toBeNull()
+    expect(extractNonceFromHdiutilPlist('<string>/Volumes/whatever</string>')).toBeNull()
+  })
+})
+
+describe('deriveMacBundlePath', () => {
+  it('extracts the bundle root from a packaged executable path', () => {
+    expect(deriveMacBundlePath('/Applications/Gamut.app/Contents/MacOS/Gamut')).toBe(
+      '/Applications/Gamut.app',
+    )
+  })
+
+  it('returns null outside a bundle', () => {
+    expect(deriveMacBundlePath('/usr/local/bin/node')).toBeNull()
+  })
+})

--- a/src/shared/lib/services/download-nonce-service.ts
+++ b/src/shared/lib/services/download-nonce-service.ts
@@ -214,6 +214,7 @@ export interface DownloadNonceOffer {
   available: boolean
   email?: string
   orgName?: string
+  avatarUrl?: string
 }
 
 /**
@@ -223,9 +224,7 @@ export interface DownloadNonceOffer {
 export async function getDownloadNonceOffer(): Promise<DownloadNonceOffer> {
   if (isAuthMode() || getPlatformAuthStatus().connected) return { available: false }
   if (cachedOffer !== undefined) {
-    return cachedOffer
-      ? { available: true, email: cachedOffer.identity.email, orgName: cachedOffer.identity.org_name }
-      : { available: false }
+    return cachedOffer ? offerFromIdentity(cachedOffer.identity) : { available: false }
   }
 
   const code = await recoverNonceOnce()
@@ -248,7 +247,16 @@ export async function getDownloadNonceOffer(): Promise<DownloadNonceOffer> {
   }
 
   cachedOffer = { code, identity: parsed.data }
-  return { available: true, email: parsed.data.email, orgName: parsed.data.org_name }
+  return offerFromIdentity(parsed.data)
+}
+
+function offerFromIdentity(identity: DownloadNonceIdentity): DownloadNonceOffer {
+  return {
+    available: true,
+    email: identity.email,
+    orgName: identity.org_name,
+    avatarUrl: identity.avatar_url ?? undefined,
+  }
 }
 
 export function dismissDownloadNonceOffer(): void {

--- a/src/shared/lib/services/download-nonce-service.ts
+++ b/src/shared/lib/services/download-nonce-service.ts
@@ -29,7 +29,6 @@ const RESOLVE_TIMEOUT_MS = 5_000
 // A download nonce arrives out-of-band with the installer (filename, download
 // URL metadata) and is only ever an upgrade hint: every failure below degrades
 // to "no offer" and the normal onboarding flow.
-const NONCE_PATTERN = /[a-f0-9]{40,64}/
 const FILENAME_NONCE_RE = /(?:^|[-_ ])([a-f0-9]{40,64})(?=$|[-_ .()])/i
 // The terminator is simply "next char isn't hex": inside xattr binary-plist
 // bytes the URL run is followed by an arbitrary object-marker byte, not a
@@ -83,9 +82,12 @@ export function extractNonceFromWhereFromsHex(hexOutput: string): string | null 
 /**
  * Scans `hdiutil info -plist` output for mounted disk images whose backing
  * file is a stamped installer DMG. Restricted to images that look like ours
- * so an unrelated mounted DMG can't inject a candidate.
+ * so an unrelated mounted DMG can't inject a candidate. Returns EVERY match:
+ * a stale stamped DMG can be mounted next to the fresh one, and only the
+ * platform can tell which code is still live.
  */
-export function extractNonceFromHdiutilPlist(plistXml: string): string | null {
+export function extractNoncesFromHdiutilPlist(plistXml: string): string[] {
+  const found: string[] = []
   const stringValues = plistXml.match(/<string>([^<]*)<\/string>/g) ?? []
   for (const tag of stringValues) {
     const value = tag.slice('<string>'.length, -'</string>'.length)
@@ -93,9 +95,9 @@ export function extractNonceFromHdiutilPlist(plistXml: string): string | null {
     const base = path.basename(value)
     if (!/gamut|superagent/i.test(base)) continue
     const nonce = extractNonceFromFileName(base)
-    if (nonce) return nonce
+    if (nonce && !found.includes(nonce)) found.push(nonce)
   }
-  return null
+  return found
 }
 
 async function readWhereFromsNonce(targetPath: string): Promise<string | null> {
@@ -112,15 +114,15 @@ async function readWhereFromsNonce(targetPath: string): Promise<string | null> {
   }
 }
 
-async function readMountedDmgNonce(): Promise<string | null> {
+async function readMountedDmgNonces(): Promise<string[]> {
   try {
     const { stdout } = await execFileAsync('hdiutil', ['info', '-plist'], {
       timeout: EXEC_TIMEOUT_MS,
       maxBuffer: EXEC_MAX_BUFFER,
     })
-    return extractNonceFromHdiutilPlist(stdout)
+    return extractNoncesFromHdiutilPlist(stdout)
   } catch {
-    return null
+    return []
   }
 }
 
@@ -143,7 +145,7 @@ export function deriveMacBundlePath(execPath: string): string | null {
 }
 
 let config: DownloadNonceRecoveryConfig = {}
-let scanPromise: Promise<string | null> | undefined
+let scanPromise: Promise<string[]> | undefined
 // undefined = not attempted; null = terminally no offer (missing nonce,
 // resolve 404, dismissed, or redeemed). A transient resolve failure leaves
 // this undefined so a later status query retries.
@@ -160,37 +162,42 @@ export function resetDownloadNonceStateForTests(): void {
   cachedOffer = undefined
 }
 
-async function scanForNonce(): Promise<string | null> {
+/**
+ * Ordered, deduped candidates from every channel. All of them are offered to
+ * the platform in turn — a stale code (expired DMG still mounted, re-used
+ * installer) must not shadow a live one.
+ */
+async function scanForNonceCandidates(): Promise<string[]> {
+  const candidates: string[] = []
+  const add = (value: string | null) => {
+    if (value && !candidates.includes(value)) candidates.push(value)
+  }
+
   if (config.windowsHandoffFile) {
-    const fromHandoff = await readWindowsHandoffNonce(config.windowsHandoffFile)
-    if (fromHandoff) return fromHandoff
+    add(await readWindowsHandoffNonce(config.windowsHandoffFile))
   }
 
   if (process.platform === 'darwin') {
     const bundlePath = config.macBundlePath ?? deriveMacBundlePath(process.execPath)
     if (bundlePath) {
-      const fromXattr = await readWhereFromsNonce(bundlePath)
-      if (fromXattr) return fromXattr
+      add(await readWhereFromsNonce(bundlePath))
     }
     if (!config.disableMountScan) {
-      const fromMount = await readMountedDmgNonce()
-      if (fromMount) return fromMount
+      for (const nonce of await readMountedDmgNonces()) add(nonce)
     }
   }
 
   if (config.testSourcePath) {
-    const fromTestXattr = await readWhereFromsNonce(config.testSourcePath)
-    if (fromTestXattr) return fromTestXattr
-    const fromTestName = extractNonceFromFileName(config.testSourcePath)
-    if (fromTestName && NONCE_PATTERN.test(fromTestName)) return fromTestName
+    add(await readWhereFromsNonce(config.testSourcePath))
+    add(extractNonceFromFileName(config.testSourcePath))
   }
 
-  return null
+  return candidates
 }
 
-function recoverNonceOnce(): Promise<string | null> {
+function recoverNonceCandidatesOnce(): Promise<string[]> {
   if (!scanPromise) {
-    scanPromise = scanForNonce().catch(() => null)
+    scanPromise = scanForNonceCandidates().catch(() => [])
   }
   return scanPromise
 }
@@ -227,27 +234,26 @@ export async function getDownloadNonceOffer(): Promise<DownloadNonceOffer> {
     return cachedOffer ? offerFromIdentity(cachedOffer.identity) : { available: false }
   }
 
-  const code = await recoverNonceOnce()
-  if (!code) {
+  const candidates = await recoverNonceCandidatesOnce()
+  if (candidates.length === 0) {
     cachedOffer = null
     return { available: false }
   }
 
-  const res = await postDownloadNonce('/api/download-nonce/resolve', { code })
-  if (!res) return { available: false } // transient: leave undefined for retry
-  if (!res.ok) {
-    cachedOffer = null
-    return { available: false }
+  for (const code of candidates) {
+    const res = await postDownloadNonce('/api/download-nonce/resolve', { code })
+    if (!res) return { available: false } // transient: leave undefined for retry
+    if (!res.ok) continue // dead candidate (expired/consumed); try the next
+
+    const parsed = DownloadNonceIdentitySchema.safeParse(await res.json().catch(() => null))
+    if (!parsed.success) continue
+
+    cachedOffer = { code, identity: parsed.data }
+    return offerFromIdentity(parsed.data)
   }
 
-  const parsed = DownloadNonceIdentitySchema.safeParse(await res.json().catch(() => null))
-  if (!parsed.success) {
-    cachedOffer = null
-    return { available: false }
-  }
-
-  cachedOffer = { code, identity: parsed.data }
-  return offerFromIdentity(parsed.data)
+  cachedOffer = null
+  return { available: false }
 }
 
 function offerFromIdentity(identity: DownloadNonceIdentity): DownloadNonceOffer {

--- a/src/shared/lib/services/download-nonce-service.ts
+++ b/src/shared/lib/services/download-nonce-service.ts
@@ -1,0 +1,302 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+
+import { getPlatformBaseUrl } from '@shared/lib/platform-auth/config'
+import {
+  DownloadNonceIdentitySchema,
+  DownloadNonceRedeemResponseSchema,
+  type DownloadNonceIdentity,
+} from '@shared/lib/services/download-nonce-schema'
+import {
+  getPlatformAuthStatus,
+  savePlatformAuth,
+  type PlatformAuthStatus,
+} from '@shared/lib/services/platform-auth-service'
+import {
+  getOrCreatePlatformClientInstanceId,
+  getPlatformDeviceName,
+} from '@shared/lib/services/platform-device-service'
+import { isAuthMode } from '@shared/lib/auth/mode'
+
+const execFileAsync = promisify(execFile)
+const EXEC_TIMEOUT_MS = 5_000
+// hdiutil's plist grows with every mounted image; keep headroom.
+const EXEC_MAX_BUFFER = 4 * 1024 * 1024
+const RESOLVE_TIMEOUT_MS = 5_000
+
+// A download nonce arrives out-of-band with the installer (filename, download
+// URL metadata) and is only ever an upgrade hint: every failure below degrades
+// to "no offer" and the normal onboarding flow.
+const NONCE_PATTERN = /[a-f0-9]{40,64}/
+const FILENAME_NONCE_RE = /(?:^|[-_ ])([a-f0-9]{40,64})(?=$|[-_ .()])/i
+// The terminator is simply "next char isn't hex": inside xattr binary-plist
+// bytes the URL run is followed by an arbitrary object-marker byte, not a
+// URL delimiter.
+const URL_NONCE_RE = /[?&]dl=([a-f0-9]{40,64})(?![a-f0-9])/i
+const WHERE_FROMS_ATTR = 'com.apple.metadata:kMDItemWhereFroms'
+
+export interface DownloadNonceRecoveryConfig {
+  /** Absolute path of the installed .app bundle (macOS xattr channel). */
+  macBundlePath?: string
+  /** File the Windows installer drops containing the installer's filename. */
+  windowsHandoffFile?: string
+  /**
+   * Dev/test-only extra probe: a path whose xattrs and filename are scanned
+   * exactly like the real channels. Callers must gate this on non-packaged
+   * builds.
+   */
+  testSourcePath?: string
+  /** Skip spawning hdiutil (non-macOS or tests). */
+  disableMountScan?: boolean
+}
+
+export function extractNonceFromFileName(fileName: string): string | null {
+  const base = path.basename(fileName)
+  const match = FILENAME_NONCE_RE.exec(base)
+  return match ? match[1].toLowerCase() : null
+}
+
+export function extractNonceFromUrlText(text: string): string | null {
+  const match = URL_NONCE_RE.exec(text)
+  return match ? match[1].toLowerCase() : null
+}
+
+/**
+ * `xattr -p com.apple.metadata:kMDItemWhereFroms` prints the value as hex
+ * bytes of a binary plist. URLs are stored as plain UTF-8 runs inside it, so
+ * decoding the bytes and scanning for the `dl` query param is sufficient —
+ * no plist parser needed.
+ */
+export function extractNonceFromWhereFromsHex(hexOutput: string): string | null {
+  const hex = hexOutput.replace(/[^0-9a-fA-F]/g, '')
+  if (hex.length < 2) return null
+  try {
+    const decoded = Buffer.from(hex, 'hex').toString('latin1')
+    return extractNonceFromUrlText(decoded)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Scans `hdiutil info -plist` output for mounted disk images whose backing
+ * file is a stamped installer DMG. Restricted to images that look like ours
+ * so an unrelated mounted DMG can't inject a candidate.
+ */
+export function extractNonceFromHdiutilPlist(plistXml: string): string | null {
+  const stringValues = plistXml.match(/<string>([^<]*)<\/string>/g) ?? []
+  for (const tag of stringValues) {
+    const value = tag.slice('<string>'.length, -'</string>'.length)
+    if (!value.toLowerCase().endsWith('.dmg')) continue
+    const base = path.basename(value)
+    if (!/gamut|superagent/i.test(base)) continue
+    const nonce = extractNonceFromFileName(base)
+    if (nonce) return nonce
+  }
+  return null
+}
+
+async function readWhereFromsNonce(targetPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      'xattr',
+      ['-p', WHERE_FROMS_ATTR, targetPath],
+      { timeout: EXEC_TIMEOUT_MS, maxBuffer: EXEC_MAX_BUFFER },
+    )
+    return extractNonceFromWhereFromsHex(stdout)
+  } catch {
+    // Attribute missing (xattr exits non-zero) or tool unavailable.
+    return null
+  }
+}
+
+async function readMountedDmgNonce(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('hdiutil', ['info', '-plist'], {
+      timeout: EXEC_TIMEOUT_MS,
+      maxBuffer: EXEC_MAX_BUFFER,
+    })
+    return extractNonceFromHdiutilPlist(stdout)
+  } catch {
+    return null
+  }
+}
+
+/** One-shot read: the handoff file is deleted after the first look. */
+async function readWindowsHandoffNonce(handoffFile: string): Promise<string | null> {
+  let content: string
+  try {
+    content = await fs.readFile(handoffFile, 'utf8')
+  } catch {
+    return null
+  }
+  await fs.rm(handoffFile, { force: true }).catch(() => {})
+  return extractNonceFromFileName(content.trim())
+}
+
+/** Derives the installed .app bundle root from the running executable path. */
+export function deriveMacBundlePath(execPath: string): string | null {
+  const match = /^(.*?\.app)\/Contents\/MacOS\//.exec(execPath)
+  return match ? match[1] : null
+}
+
+let config: DownloadNonceRecoveryConfig = {}
+let scanPromise: Promise<string | null> | undefined
+// undefined = not attempted; null = terminally no offer (missing nonce,
+// resolve 404, dismissed, or redeemed). A transient resolve failure leaves
+// this undefined so a later status query retries.
+let cachedOffer: { code: string; identity: DownloadNonceIdentity } | null | undefined
+
+export function configureDownloadNonceRecovery(next: DownloadNonceRecoveryConfig): void {
+  config = next
+}
+
+/** Test hook: clears all cached recovery/resolve state. */
+export function resetDownloadNonceStateForTests(): void {
+  config = {}
+  scanPromise = undefined
+  cachedOffer = undefined
+}
+
+async function scanForNonce(): Promise<string | null> {
+  if (config.windowsHandoffFile) {
+    const fromHandoff = await readWindowsHandoffNonce(config.windowsHandoffFile)
+    if (fromHandoff) return fromHandoff
+  }
+
+  if (process.platform === 'darwin') {
+    const bundlePath = config.macBundlePath ?? deriveMacBundlePath(process.execPath)
+    if (bundlePath) {
+      const fromXattr = await readWhereFromsNonce(bundlePath)
+      if (fromXattr) return fromXattr
+    }
+    if (!config.disableMountScan) {
+      const fromMount = await readMountedDmgNonce()
+      if (fromMount) return fromMount
+    }
+  }
+
+  if (config.testSourcePath) {
+    const fromTestXattr = await readWhereFromsNonce(config.testSourcePath)
+    if (fromTestXattr) return fromTestXattr
+    const fromTestName = extractNonceFromFileName(config.testSourcePath)
+    if (fromTestName && NONCE_PATTERN.test(fromTestName)) return fromTestName
+  }
+
+  return null
+}
+
+function recoverNonceOnce(): Promise<string | null> {
+  if (!scanPromise) {
+    scanPromise = scanForNonce().catch(() => null)
+  }
+  return scanPromise
+}
+
+async function postDownloadNonce(pathName: string, body: unknown): Promise<Response | null> {
+  const base = getPlatformBaseUrl()
+  if (!base) return null
+  try {
+    return await fetch(new URL(pathName, base), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(RESOLVE_TIMEOUT_MS),
+    })
+  } catch {
+    return null
+  }
+}
+
+export interface DownloadNonceOffer {
+  available: boolean
+  email?: string
+  orgName?: string
+}
+
+/**
+ * Returns the "Continue as X" offer for the onboarding screen, running the
+ * one-time channel scan and a non-consuming platform resolve on first call.
+ */
+export async function getDownloadNonceOffer(): Promise<DownloadNonceOffer> {
+  if (isAuthMode() || getPlatformAuthStatus().connected) return { available: false }
+  if (cachedOffer !== undefined) {
+    return cachedOffer
+      ? { available: true, email: cachedOffer.identity.email, orgName: cachedOffer.identity.org_name }
+      : { available: false }
+  }
+
+  const code = await recoverNonceOnce()
+  if (!code) {
+    cachedOffer = null
+    return { available: false }
+  }
+
+  const res = await postDownloadNonce('/api/download-nonce/resolve', { code })
+  if (!res) return { available: false } // transient: leave undefined for retry
+  if (!res.ok) {
+    cachedOffer = null
+    return { available: false }
+  }
+
+  const parsed = DownloadNonceIdentitySchema.safeParse(await res.json().catch(() => null))
+  if (!parsed.success) {
+    cachedOffer = null
+    return { available: false }
+  }
+
+  cachedOffer = { code, identity: parsed.data }
+  return { available: true, email: parsed.data.email, orgName: parsed.data.org_name }
+}
+
+export function dismissDownloadNonceOffer(): void {
+  cachedOffer = null
+}
+
+/**
+ * Redeems the recovered nonce (single-use on the platform) and completes the
+ * connection through the same persistence path as the interactive flow.
+ */
+export async function redeemDownloadNonce(userId: string): Promise<PlatformAuthStatus> {
+  const offer = cachedOffer
+  if (!offer) {
+    throw new DownloadNonceUnavailableError()
+  }
+
+  const res = await postDownloadNonce('/api/download-nonce/redeem', {
+    code: offer.code,
+    client_instance_id: getOrCreatePlatformClientInstanceId(),
+    device_name: getPlatformDeviceName(),
+  })
+  if (!res) {
+    throw new Error('Could not reach the platform. Check your connection and try again.')
+  }
+  if (!res.ok) {
+    // The nonce is spent or expired; the offer is gone either way.
+    cachedOffer = null
+    throw new DownloadNonceUnavailableError()
+  }
+
+  const payload = DownloadNonceRedeemResponseSchema.parse(await res.json())
+  const status = await savePlatformAuth(userId, {
+    token: payload.token,
+    email: payload.email || null,
+    label: payload.label || null,
+    orgId: payload.org_id || null,
+    orgName: payload.org_name || null,
+    role: payload.role || null,
+    userId: payload.user_id || null,
+    memberId: payload.member_id || null,
+  })
+  cachedOffer = null
+  return status
+}
+
+export class DownloadNonceUnavailableError extends Error {
+  constructor() {
+    super('This sign-in link has expired. Use the regular login instead.')
+    this.name = 'DownloadNonceUnavailableError'
+  }
+}

--- a/src/shared/lib/services/download-nonce-service.ts
+++ b/src/shared/lib/services/download-nonce-service.ts
@@ -102,9 +102,11 @@ export function extractNoncesFromHdiutilPlist(plistXml: string): string[] {
 
 async function readWhereFromsNonce(targetPath: string): Promise<string | null> {
   try {
+    // -x is required: without it xattr prints the attribute's raw binary
+    // plist bytes, which the hex parser below would reduce to garbage.
     const { stdout } = await execFileAsync(
       'xattr',
-      ['-p', WHERE_FROMS_ATTR, targetPath],
+      ['-px', WHERE_FROMS_ATTR, targetPath],
       { timeout: EXEC_TIMEOUT_MS, maxBuffer: EXEC_MAX_BUFFER },
     )
     return extractNonceFromWhereFromsHex(stdout)


### PR DESCRIPTION
Part of SUP-436 (installer-carried identity). App half — platform endpoints are in the companion platform PR; worker filename stamping is in the gamut-releases PR.

## What

When a signed-in member clicks Download on the platform, a single-use, short-TTL enrollment code rides along with the installer (filename / download-URL metadata — never the bytes; signing, notarization and CDN caching untouched). On first run the app recovers it and the onboarding button becomes **"Continue as <email>"** — one click completes platform connect. No code, expired code, or any failure → onboarding is exactly unchanged.

## How

- `download-nonce-service.ts`: three best-effort recovery channels, first hit wins —
  1. Windows: handoff file written by NSIS (`installer.nsh` records `$EXEFILE`; the stamped installer filename carries the code)
  2. macOS: `kMDItemWhereFroms` xattr on the .app (browsers record the download URL; Finder propagates it on drag-install)
  3. macOS: `hdiutil info -plist` scan for a mounted stamped DMG (covers curl downloads; disjoint failure modes from the xattr)
- Non-consuming platform resolve powers the button label; redeem is only called on explicit click and lands in the existing `savePlatformAuth` path (same record shape as the browser flow, member-scoped token).
- Zod schemas at both response boundaries; uniform silent fallback on every failure mode.
- Dev-only `SUPERAGENT_DISABLE_SINGLE_INSTANCE=1`: the lock identity is shared with installed builds through `app.name`, so dev/harness instances silently died whenever installed Gamut was running (long-standing dev annoyance, root-caused here).

## Validation

- 17 unit tests on the extraction/parsing helpers (incl. browser ` (1)` duplicate suffixes, binary-plist xattr decoding).
- `e2e/live/download-nonce-harness.mjs` — live end-to-end against a locally running platform + release worker: real login and download click, browser genuinely downloads the stamped DMG through the worker, app launched on a fresh data dir with CDP, button text asserted, redeem verified in settings.json and DB (`consumed_at`), plus a negative pass proving the consumed-nonce fallback. All checks green.
- Wizard mock E2E suite (10 tests) passes — normal flow unregressed.

https://claude.ai/code/session_01NuonFbzZt9kMWGQ7wYW1Ro