### PR TITLE
Add connection usage charts and request logs

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -33,6 +33,7 @@ import { getLlmPolyfillJs } from './llm-polyfill'
 import { ANTHROPIC_SDK_BUNDLE } from './llm-sdk-bundle'
 import adminUsersRouter from './routes/admin-users'
 import auditLogRouter from './routes/audit-log'
+import connectionLogsRouter from './routes/connection-logs'
 import debugRouter from './routes/debug'
 import platformAuth from './routes/platform-auth'
 import agentBootstrap from './routes/agent-bootstrap'
@@ -200,6 +201,7 @@ app.route('/api/runtime-status', runtimeStatusRouter)
 app.route('/api/firewall', firewallRouter)
 app.route('/api/admin/users', adminUsersRouter)
 app.route('/api/audit-log', auditLogRouter)
+app.route('/api/connection-logs', connectionLogsRouter)
 app.route('/api/platform-auth', platformAuth)
 app.route('/api/stt', sttRouter)
 app.route('/api/llm', llmRouter)

--- a/src/api/pagination.ts
+++ b/src/api/pagination.ts
@@ -1,0 +1,17 @@
+const DEFAULT_PAGE_LIMIT = 20
+const MAX_PAGE_LIMIT = 100
+
+export function parsePagination(
+  rawOffset: string | undefined,
+  rawLimit: string | undefined,
+) {
+  const parsedOffset = Number.parseInt(rawOffset ?? '0', 10)
+  const parsedLimit = Number.parseInt(rawLimit ?? String(DEFAULT_PAGE_LIMIT), 10)
+
+  return {
+    offset: Number.isFinite(parsedOffset) ? Math.max(0, parsedOffset) : 0,
+    limit: Number.isFinite(parsedLimit)
+      ? Math.min(MAX_PAGE_LIMIT, Math.max(1, parsedLimit))
+      : DEFAULT_PAGE_LIMIT,
+  }
+}

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -2104,6 +2104,27 @@ describe('audit log — GET /:id/audit-log', () => {
     expect(body.entries).toHaveLength(20)
   })
 
+  it('falls back to default pagination for invalid query values', async () => {
+    const entries = Array.from({ length: 25 }, (_, i) => ({
+      id: `p${i}`,
+      agentSlug: 'test-agent',
+      toolkit: `toolkit-${i}`,
+      targetHost: 'https://example.com',
+      targetPath: `/${i}`,
+      method: 'GET',
+      statusCode: 200,
+      errorMessage: null,
+      createdAt: new Date(2026, 0, 1, 0, i).toISOString(),
+    }))
+
+    setupAuditLogMocks(entries, 25, [], 0)
+
+    const res = await getReq(app, `${AUDIT_URL}?offset=invalid&limit=invalid`)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.entries).toHaveLength(20)
+  })
+
   it('caps limit at 100', async () => {
     setupAuditLogMocks([], 0, [], 0)
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -6,6 +6,7 @@ import { z } from 'zod'
 import { zValidator } from '@hono/zod-validator'
 import { getPolyfillJs } from '../speech-recognition-polyfill'
 import { getLlmPolyfillJs } from '../llm-polyfill'
+import { parsePagination } from '../pagination'
 import { Authenticated, AgentRead, AgentUser, AgentAdmin, ResolveAgent, getAgentId, getAuthorizedAgentRole } from '../middleware/auth'
 import {
   listAgentsWithStatus,
@@ -4087,8 +4088,7 @@ agents.get('/:id/audit-log', AgentAdmin(), async (c) => {
   try {
     const slug = getAgentId(c)
 
-    const offset = parseInt(c.req.query('offset') ?? '0', 10)
-    const limit = Math.min(parseInt(c.req.query('limit') ?? '20', 10), 100)
+    const { offset, limit } = parsePagination(c.req.query('offset'), c.req.query('limit'))
 
     // Fetch a window from each table (offset+limit from each, already sorted by time desc)
     // then merge, sort, and slice for the requested page

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -71,6 +71,7 @@ import { eq, and, inArray, desc, count, like, or } from 'drizzle-orm'
 import { isAuthMode } from '@shared/lib/auth/mode'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { getViewerUserId, ownerScope } from '@shared/lib/auth/ownership'
+import { normalizeMcpRequestLog, normalizeProxyRequestLog } from '@shared/lib/types/request-log'
 import { getProvider } from '@shared/lib/account-providers'
 // getAgentSkills is superseded by getAgentSkillsWithStatus from skillset-service
 // import { getAgentSkills } from '@shared/lib/skills'
@@ -4115,36 +4116,10 @@ agents.get('/:id/audit-log', AgentAdmin(), async (c) => {
         .where(eq(mcpAuditLog.agentSlug, slug)),
     ])
 
-    // Normalize to a common shape
+    // Normalize to the shared request-log shape used by connection logs too.
     const normalized = [
-      ...proxyEntries.map((e) => ({
-        id: e.id,
-        source: 'proxy' as const,
-        agentSlug: e.agentSlug,
-        label: e.toolkit,
-        targetUrl: `${e.targetHost}/${e.targetPath}`,
-        method: e.method,
-        statusCode: e.statusCode ?? null,
-        errorMessage: e.errorMessage ?? null,
-        durationMs: e.durationMs ?? null,
-        policyDecision: e.policyDecision ?? null,
-        matchedScopes: e.matchedScopes ?? null,
-        createdAt: e.createdAt,
-      })),
-      ...mcpEntries.map((e) => ({
-        id: e.id,
-        source: 'mcp' as const,
-        agentSlug: e.agentSlug,
-        label: e.remoteMcpName,
-        targetUrl: e.requestPath,
-        method: e.method,
-        statusCode: e.statusCode ?? null,
-        errorMessage: e.errorMessage ?? null,
-        durationMs: e.durationMs ?? null,
-        policyDecision: e.policyDecision ?? null,
-        matchedScopes: e.matchedTool ? JSON.stringify([e.matchedTool]) : null,
-        createdAt: e.createdAt,
-      })),
+      ...proxyEntries.map(normalizeProxyRequestLog),
+      ...mcpEntries.map(normalizeMcpRequestLog),
     ]
 
     // Sort by time descending, then paginate

--- a/src/api/routes/connection-logs.test.ts
+++ b/src/api/routes/connection-logs.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   limited: vi.fn(),
   offset: vi.fn(),
   viewerUserId: 'user-1' as string | null,
+  ownerScope: vi.fn(),
 }))
 
 vi.mock('../middleware/auth', () => ({
@@ -16,7 +17,7 @@ vi.mock('../middleware/auth', () => ({
 }))
 
 vi.mock('@shared/lib/auth/ownership', () => ({
-  getViewerUserId: () => mocks.viewerUserId,
+  ownerScope: (...args: unknown[]) => mocks.ownerScope(...args),
 }))
 
 vi.mock('@shared/lib/db/schema', () => ({
@@ -87,6 +88,9 @@ describe('connection request logs API', () => {
     mocks.auditRows = []
     mocks.total = 0
     mocks.viewerUserId = 'user-1'
+    mocks.ownerScope.mockImplementation((_context, column) => (
+      mocks.viewerUserId === null ? undefined : { eq: [column, mocks.viewerUserId] }
+    ))
   })
 
   it('returns normalized, paginated API requests for an owned account', async () => {
@@ -160,6 +164,16 @@ describe('connection request logs API', () => {
       targetUrl: '/tools/call',
       matchedScopes: '["search_docs"]',
     })
+  })
+
+  it('falls back to safe pagination defaults for invalid query values', async () => {
+    const response = await createApp().request(
+      'http://localhost/api/connection-logs/account/connection-1?offset=invalid&limit=invalid',
+    )
+
+    expect(response.status).toBe(200)
+    expect(mocks.limited).toHaveBeenCalledWith(20)
+    expect(mocks.offset).toHaveBeenCalledWith(0)
   })
 
   it('does not expose logs when the owned connection cannot be resolved', async () => {

--- a/src/api/routes/connection-logs.test.ts
+++ b/src/api/routes/connection-logs.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Hono } from 'hono'
+
+const mocks = vi.hoisted(() => ({
+  resourceRows: [] as unknown[],
+  auditRows: [] as unknown[],
+  total: 0,
+  selected: vi.fn(),
+  limited: vi.fn(),
+  offset: vi.fn(),
+  viewerUserId: 'user-1' as string | null,
+}))
+
+vi.mock('../middleware/auth', () => ({
+  Authenticated: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}))
+
+vi.mock('@shared/lib/auth/ownership', () => ({
+  getViewerUserId: () => mocks.viewerUserId,
+}))
+
+vi.mock('@shared/lib/db/schema', () => ({
+  connectedAccounts: { table: 'accounts', id: 'account_id', userId: 'account_user_id' },
+  remoteMcpServers: { table: 'mcps', id: 'mcp_id', userId: 'mcp_user_id' },
+  proxyAuditLog: { table: 'proxy_logs', accountId: 'account_id', createdAt: 'created_at' },
+  mcpAuditLog: { table: 'mcp_logs', remoteMcpId: 'remote_mcp_id', createdAt: 'created_at' },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  and: (...conditions: unknown[]) => ({ and: conditions }),
+  count: () => 'count',
+  desc: (column: unknown) => ({ desc: column }),
+  eq: (column: unknown, value: unknown) => ({ eq: [column, value] }),
+}))
+
+vi.mock('@shared/lib/db', () => ({
+  db: {
+    select: (selection?: unknown) => {
+      mocks.selected(selection)
+      return {
+        from: (table: { table: string }) => {
+          if (table.table === 'accounts' || table.table === 'mcps') {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve(mocks.resourceRows),
+              }),
+            }
+          }
+          if (selection) {
+            return {
+              where: () => Promise.resolve([{ count: mocks.total }]),
+            }
+          }
+          return {
+            where: () => ({
+              orderBy: () => ({
+                limit: (limit: number) => {
+                  mocks.limited(limit)
+                  return {
+                    offset: (offset: number) => {
+                      mocks.offset(offset)
+                      return Promise.resolve(mocks.auditRows)
+                    },
+                  }
+                },
+              }),
+            }),
+          }
+        },
+      }
+    },
+  },
+}))
+
+import connectionLogsRouter from './connection-logs'
+
+function createApp() {
+  const app = new Hono()
+  app.route('/api/connection-logs', connectionLogsRouter)
+  return app
+}
+
+describe('connection request logs API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.resourceRows = [{ id: 'connection-1' }]
+    mocks.auditRows = []
+    mocks.total = 0
+    mocks.viewerUserId = 'user-1'
+  })
+
+  it('returns normalized, paginated API requests for an owned account', async () => {
+    mocks.auditRows = [{
+      id: 'request-1',
+      agentSlug: 'agent-1',
+      accountId: 'connection-1',
+      toolkit: 'github',
+      targetHost: 'https://api.github.com',
+      targetPath: 'repos/openai/codex',
+      method: 'GET',
+      statusCode: 200,
+      errorMessage: null,
+      durationMs: 42,
+      policyDecision: 'allow',
+      matchedScopes: '["repo.read"]',
+      createdAt: new Date('2026-07-20T12:00:00.000Z'),
+    }]
+    mocks.total = 31
+
+    const response = await createApp().request(
+      'http://localhost/api/connection-logs/account/connection-1?offset=15&limit=15',
+    )
+
+    expect(response.status).toBe(200)
+    expect(mocks.limited).toHaveBeenCalledWith(15)
+    expect(mocks.offset).toHaveBeenCalledWith(15)
+    expect(await response.json()).toEqual({
+      entries: [{
+        id: 'request-1',
+        source: 'proxy',
+        agentSlug: 'agent-1',
+        label: 'github',
+        targetUrl: 'https://api.github.com/repos/openai/codex',
+        method: 'GET',
+        statusCode: 200,
+        errorMessage: null,
+        durationMs: 42,
+        policyDecision: 'allow',
+        matchedScopes: '["repo.read"]',
+        createdAt: '2026-07-20T12:00:00.000Z',
+      }],
+      total: 31,
+    })
+  })
+
+  it('normalizes MCP tool calls for a server connection', async () => {
+    mocks.auditRows = [{
+      id: 'request-2',
+      agentSlug: 'agent-2',
+      remoteMcpId: 'connection-1',
+      remoteMcpName: 'Docs',
+      method: 'POST',
+      requestPath: '/tools/call',
+      statusCode: 500,
+      errorMessage: 'upstream failed',
+      durationMs: 90,
+      policyDecision: null,
+      matchedTool: 'search_docs',
+      createdAt: new Date('2026-07-20T13:00:00.000Z'),
+    }]
+    mocks.total = 1
+
+    const response = await createApp().request('http://localhost/api/connection-logs/mcp/connection-1')
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.entries[0]).toMatchObject({
+      source: 'mcp',
+      agentSlug: 'agent-2',
+      targetUrl: '/tools/call',
+      matchedScopes: '["search_docs"]',
+    })
+  })
+
+  it('does not expose logs when the owned connection cannot be resolved', async () => {
+    mocks.resourceRows = []
+
+    const response = await createApp().request('http://localhost/api/connection-logs/account/other-user-account')
+
+    expect(response.status).toBe(404)
+    expect(await response.json()).toEqual({ error: 'Connection not found' })
+    expect(mocks.limited).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unknown connection kind', async () => {
+    const response = await createApp().request('http://localhost/api/connection-logs/unknown/connection-1')
+
+    expect(response.status).toBe(400)
+    expect(mocks.selected).not.toHaveBeenCalled()
+  })
+})

--- a/src/api/routes/connection-logs.ts
+++ b/src/api/routes/connection-logs.ts
@@ -1,0 +1,112 @@
+import { Hono } from 'hono'
+import { and, count, desc, eq } from 'drizzle-orm'
+import { db } from '@shared/lib/db'
+import {
+  connectedAccounts,
+  mcpAuditLog,
+  proxyAuditLog,
+  remoteMcpServers,
+} from '@shared/lib/db/schema'
+import { getViewerUserId } from '@shared/lib/auth/ownership'
+import {
+  normalizeMcpRequestLog,
+  normalizeProxyRequestLog,
+} from '@shared/lib/types/request-log'
+import { Authenticated } from '../middleware/auth'
+
+const connectionLogsRouter = new Hono()
+
+connectionLogsRouter.use('*', Authenticated())
+
+function parsePagination(rawOffset: string | undefined, rawLimit: string | undefined) {
+  const parsedOffset = Number.parseInt(rawOffset ?? '0', 10)
+  const parsedLimit = Number.parseInt(rawLimit ?? '20', 10)
+  return {
+    offset: Number.isFinite(parsedOffset) ? Math.max(0, parsedOffset) : 0,
+    limit: Number.isFinite(parsedLimit) ? Math.min(100, Math.max(1, parsedLimit)) : 20,
+  }
+}
+
+/**
+ * Connection-wide request logs. Ownership is checked against the selected
+ * account/server before its append-only audit rows are queried.
+ */
+connectionLogsRouter.get('/:kind/:id', async (c) => {
+  try {
+    const kind = c.req.param('kind')
+    if (kind !== 'account' && kind !== 'mcp') {
+      return c.json({ error: 'Invalid connection kind' }, 400)
+    }
+
+    const id = c.req.param('id')
+    const ownerId = getViewerUserId(c)
+    const { offset, limit } = parsePagination(c.req.query('offset'), c.req.query('limit'))
+
+    if (kind === 'account') {
+      const [account] = await db
+        .select({ id: connectedAccounts.id })
+        .from(connectedAccounts)
+        .where(and(
+          eq(connectedAccounts.id, id),
+          ownerId ? eq(connectedAccounts.userId, ownerId) : undefined,
+        ))
+        .limit(1)
+
+      if (!account) return c.json({ error: 'Connection not found' }, 404)
+
+      const [entries, totalResult] = await Promise.all([
+        db
+          .select()
+          .from(proxyAuditLog)
+          .where(eq(proxyAuditLog.accountId, id))
+          .orderBy(desc(proxyAuditLog.createdAt))
+          .limit(limit)
+          .offset(offset),
+        db
+          .select({ count: count() })
+          .from(proxyAuditLog)
+          .where(eq(proxyAuditLog.accountId, id)),
+      ])
+
+      return c.json({
+        entries: entries.map(normalizeProxyRequestLog),
+        total: totalResult[0]?.count ?? 0,
+      })
+    }
+
+    const [server] = await db
+      .select({ id: remoteMcpServers.id })
+      .from(remoteMcpServers)
+      .where(and(
+        eq(remoteMcpServers.id, id),
+        ownerId ? eq(remoteMcpServers.userId, ownerId) : undefined,
+      ))
+      .limit(1)
+
+    if (!server) return c.json({ error: 'Connection not found' }, 404)
+
+    const [entries, totalResult] = await Promise.all([
+      db
+        .select()
+        .from(mcpAuditLog)
+        .where(eq(mcpAuditLog.remoteMcpId, id))
+        .orderBy(desc(mcpAuditLog.createdAt))
+        .limit(limit)
+        .offset(offset),
+      db
+        .select({ count: count() })
+        .from(mcpAuditLog)
+        .where(eq(mcpAuditLog.remoteMcpId, id)),
+    ])
+
+    return c.json({
+      entries: entries.map(normalizeMcpRequestLog),
+      total: totalResult[0]?.count ?? 0,
+    })
+  } catch (error) {
+    console.error('Failed to fetch connection request logs:', error)
+    return c.json({ error: 'Failed to fetch request logs' }, 500)
+  }
+})
+
+export default connectionLogsRouter

--- a/src/api/routes/connection-logs.ts
+++ b/src/api/routes/connection-logs.ts
@@ -7,25 +7,17 @@ import {
   proxyAuditLog,
   remoteMcpServers,
 } from '@shared/lib/db/schema'
-import { getViewerUserId } from '@shared/lib/auth/ownership'
+import { ownerScope } from '@shared/lib/auth/ownership'
 import {
   normalizeMcpRequestLog,
   normalizeProxyRequestLog,
 } from '@shared/lib/types/request-log'
 import { Authenticated } from '../middleware/auth'
+import { parsePagination } from '../pagination'
 
 const connectionLogsRouter = new Hono()
 
 connectionLogsRouter.use('*', Authenticated())
-
-function parsePagination(rawOffset: string | undefined, rawLimit: string | undefined) {
-  const parsedOffset = Number.parseInt(rawOffset ?? '0', 10)
-  const parsedLimit = Number.parseInt(rawLimit ?? '20', 10)
-  return {
-    offset: Number.isFinite(parsedOffset) ? Math.max(0, parsedOffset) : 0,
-    limit: Number.isFinite(parsedLimit) ? Math.min(100, Math.max(1, parsedLimit)) : 20,
-  }
-}
 
 /**
  * Connection-wide request logs. Ownership is checked against the selected
@@ -39,7 +31,6 @@ connectionLogsRouter.get('/:kind/:id', async (c) => {
     }
 
     const id = c.req.param('id')
-    const ownerId = getViewerUserId(c)
     const { offset, limit } = parsePagination(c.req.query('offset'), c.req.query('limit'))
 
     if (kind === 'account') {
@@ -48,7 +39,7 @@ connectionLogsRouter.get('/:kind/:id', async (c) => {
         .from(connectedAccounts)
         .where(and(
           eq(connectedAccounts.id, id),
-          ownerId ? eq(connectedAccounts.userId, ownerId) : undefined,
+          ownerScope(c, connectedAccounts.userId),
         ))
         .limit(1)
 
@@ -79,7 +70,7 @@ connectionLogsRouter.get('/:kind/:id', async (c) => {
       .from(remoteMcpServers)
       .where(and(
         eq(remoteMcpServers.id, id),
-        ownerId ? eq(remoteMcpServers.userId, ownerId) : undefined,
+        ownerScope(c, remoteMcpServers.userId),
       ))
       .limit(1)
 

--- a/src/renderer/components/activity/activity-spark-chart.tsx
+++ b/src/renderer/components/activity/activity-spark-chart.tsx
@@ -109,7 +109,7 @@ export function ActivitySparkChart({ label, data, className }: ActivitySparkChar
 const activityChartConfig = {
   succeeded: {
     label: 'Succeeded',
-    color: 'hsl(142 71% 45%)',
+    color: 'hsl(160 84% 39%)',
   },
   failed: {
     label: 'Failed',

--- a/src/renderer/components/activity/activity-spark-chart.tsx
+++ b/src/renderer/components/activity/activity-spark-chart.tsx
@@ -4,6 +4,13 @@ import {
   type DailyActivityPoint,
 } from '@shared/lib/types/activity'
 import { cn } from '@shared/lib/utils/cn'
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from '@renderer/components/ui/chart'
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 
 const WIDTH = 96
 const HEIGHT = 26
@@ -43,10 +50,14 @@ function plural(value: number, singular: string, multiple = `${singular}s`): str
   return value === 1 ? singular : multiple
 }
 
-export function ActivitySparkChart({ label, data, className }: ActivitySparkChartProps) {
+export function summarizeDailyActivity(data: DailyActivityPoint[]) {
   const succeeded = data.reduce((sum, point) => sum + point.succeeded, 0)
   const failed = data.reduce((sum, point) => sum + point.failed, 0)
-  const total = succeeded + failed
+  return { succeeded, failed, total: succeeded + failed }
+}
+
+export function ActivitySparkChart({ label, data, className }: ActivitySparkChartProps) {
+  const { succeeded, failed, total } = summarizeDailyActivity(data)
   const max = Math.max(1, ...data.map((point) => point.succeeded + point.failed))
   const barWidth = data.length > 0
     ? Math.max(1, (WIDTH - BAR_GAP * (data.length - 1)) / data.length)
@@ -92,6 +103,84 @@ export function ActivitySparkChart({ label, data, className }: ActivitySparkChar
         )
       })}
     </svg>
+  )
+}
+
+const activityChartConfig = {
+  succeeded: {
+    label: 'Succeeded',
+    color: 'hsl(142 71% 45%)',
+  },
+  failed: {
+    label: 'Failed',
+    color: 'hsl(0 84% 60%)',
+  },
+} satisfies ChartConfig
+
+interface ActivityBarChartProps {
+  label: string
+  data: DailyActivityPoint[]
+  className?: string
+}
+
+/** Larger companion to ActivitySparkChart with a real date axis + hover data. */
+export function ActivityBarChart({ label, data, className }: ActivityBarChartProps) {
+  const { succeeded, failed, total } = summarizeDailyActivity(data)
+  const ticks = data.length > 1
+    ? [data[0].date, data[data.length - 1].date]
+    : data.map((point) => point.date)
+  const accessibleLabel = total === 0
+    ? `${label}: no calls over the last ${data.length} ${plural(data.length, 'day')}.`
+    : `${label}: ${total} ${plural(total, 'call')} over ${data.length} ${plural(data.length, 'day')}, ${succeeded} succeeded and ${failed} failed.`
+
+  return (
+    <ChartContainer
+      config={activityChartConfig}
+      className={cn('h-[150px] w-full aspect-auto', className)}
+      role="img"
+      aria-label={accessibleLabel}
+      data-testid="activity-bar-chart"
+    >
+      <BarChart data={data} margin={{ top: 8, right: 4, bottom: 0, left: 4 }}>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" />
+        <XAxis
+          dataKey="date"
+          ticks={ticks}
+          tickFormatter={dayLabel}
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          interval={0}
+          padding={{ left: 12, right: 12 }}
+        />
+        <YAxis hide allowDecimals={false} />
+        <ChartTooltip
+          cursor={{ fill: 'hsl(var(--muted) / 0.45)' }}
+          content={
+            <ChartTooltipContent
+              labelFormatter={(value) => dayLabel(String(value))}
+              valueFormatter={(value) => `${value} ${plural(value, 'call')}`}
+            />
+          }
+        />
+        <Bar
+          dataKey="succeeded"
+          stackId="requests"
+          fill="var(--color-succeeded)"
+          radius={[2, 2, 0, 0]}
+          maxBarSize={22}
+          isAnimationActive={false}
+        />
+        <Bar
+          dataKey="failed"
+          stackId="requests"
+          fill="var(--color-failed)"
+          radius={[2, 2, 0, 0]}
+          maxBarSize={22}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ChartContainer>
   )
 }
 

--- a/src/renderer/components/api-logs/api-logs-view.tsx
+++ b/src/renderer/components/api-logs/api-logs-view.tsx
@@ -11,7 +11,7 @@ import {
   RequestLogsTable,
 } from '@renderer/components/api-logs/request-logs-table'
 import { useRenderTracker } from '@renderer/lib/perf'
-import type { RequestLogPage } from '@shared/lib/types/request-log'
+import { requestLogPageSchema } from '@shared/lib/types/request-log'
 
 interface ApiLogsViewProps {
   agentSlug: string
@@ -27,14 +27,14 @@ export function ApiLogsView({ agentSlug }: ApiLogsViewProps) {
     track('api_logs_viewed')
   }, [track])
 
-  const { data, isLoading, refetch, isRefetching } = useQuery<RequestLogPage>({
+  const { data, isLoading, refetch, isRefetching } = useQuery({
     queryKey: ['agent-audit-log', agentSlug, page],
     queryFn: async () => {
       const res = await apiFetch(
         `/api/agents/${agentSlug}/audit-log?offset=${page * REQUEST_LOG_PAGE_SIZE}&limit=${REQUEST_LOG_PAGE_SIZE}`,
       )
       if (!res.ok) throw new Error('Failed to fetch audit log')
-      return res.json()
+      return requestLogPageSchema.parse(await res.json())
     },
   })
 

--- a/src/renderer/components/api-logs/api-logs-view.tsx
+++ b/src/renderer/components/api-logs/api-logs-view.tsx
@@ -1,179 +1,42 @@
-import { Loader2, RefreshCw, ChevronLeft, ChevronRight, ChevronDown, ChevronUp } from 'lucide-react'
-import { Fragment, useState, useEffect } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { format } from 'date-fns'
+import { useEffect, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { RefreshCw } from 'lucide-react'
 import { apiFetch } from '@renderer/lib/api'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { Button } from '@renderer/components/ui/button'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@renderer/components/ui/table'
 import { PageTitle, SettingsPageContainer } from '@renderer/components/layout/settings-page'
+import {
+  REQUEST_LOG_PAGE_SIZE,
+  RequestLogsTable,
+} from '@renderer/components/api-logs/request-logs-table'
 import { useRenderTracker } from '@renderer/lib/perf'
-
-interface AuditLogEntry {
-  id: string
-  source: 'proxy' | 'mcp'
-  agentSlug: string
-  label: string
-  targetUrl: string
-  method: string
-  statusCode: number | null
-  errorMessage: string | null
-  durationMs: number | null
-  policyDecision: string | null
-  matchedScopes: string | null
-  createdAt: string
-}
+import type { RequestLogPage } from '@shared/lib/types/request-log'
 
 interface ApiLogsViewProps {
   agentSlug: string
-}
-
-const PAGE_SIZE = 15
-
-function MethodBadge({ method }: { method: string }) {
-  const colors: Record<string, string> = {
-    GET: 'text-blue-700 bg-blue-100 dark:text-blue-300 dark:bg-blue-900/40',
-    POST: 'text-green-700 bg-green-100 dark:text-green-300 dark:bg-green-900/40',
-    PUT: 'text-amber-700 bg-amber-100 dark:text-amber-300 dark:bg-amber-900/40',
-    PATCH: 'text-amber-700 bg-amber-100 dark:text-amber-300 dark:bg-amber-900/40',
-    DELETE: 'text-red-700 bg-red-100 dark:text-red-300 dark:bg-red-900/40',
-  }
-  return (
-    <span className={`inline-block rounded px-1.5 py-0.5 text-2xs font-semibold leading-none ${colors[method] ?? 'text-muted-foreground bg-muted'}`}>
-      {method}
-    </span>
-  )
-}
-
-function StatusBadge({ status }: { status: number | null }) {
-  if (status === null) {
-    return <span className="text-xs text-muted-foreground">—</span>
-  }
-  const color =
-    status >= 200 && status < 300
-      ? 'text-green-700 dark:text-green-400'
-      : status >= 400
-        ? 'text-red-700 dark:text-red-400'
-        : 'text-muted-foreground'
-  return <span className={`text-xs font-mono font-medium ${color}`}>{status}</span>
-}
-
-function SourceBadge({ source }: { source: 'proxy' | 'mcp' }) {
-  const style = source === 'mcp'
-    ? 'text-purple-700 bg-purple-100 dark:text-purple-300 dark:bg-purple-900/40'
-    : 'text-sky-700 bg-sky-100 dark:text-sky-300 dark:bg-sky-900/40'
-  return (
-    <span className={`inline-block rounded px-1.5 py-0.5 text-2xs font-semibold leading-none ${style}`}>
-      {source === 'mcp' ? 'MCP' : 'API'}
-    </span>
-  )
-}
-
-function PolicyBadge({ decision }: { decision: string | null }) {
-  if (!decision) return null
-  const styles: Record<string, string> = {
-    allow: 'text-green-700 bg-green-100 dark:text-green-300 dark:bg-green-900/40',
-    approved_by_user: 'text-blue-700 bg-blue-100 dark:text-blue-300 dark:bg-blue-900/40',
-    block: 'text-red-700 bg-red-100 dark:text-red-300 dark:bg-red-900/40',
-    denied_by_user: 'text-red-700 bg-red-100 dark:text-red-300 dark:bg-red-900/40',
-    review_timeout: 'text-orange-700 bg-orange-100 dark:text-orange-300 dark:bg-orange-900/40',
-  }
-  const labels: Record<string, string> = {
-    allow: 'auto-allowed',
-    approved_by_user: 'user-approved',
-    block: 'auto-blocked',
-    denied_by_user: 'user-denied',
-    review_timeout: 'timeout',
-  }
-  return (
-    <span
-      className={`inline-block rounded px-1.5 py-0.5 text-2xs font-semibold leading-none ${styles[decision] ?? 'text-muted-foreground bg-muted'}`}
-      title={`Policy: ${decision}`}
-    >
-      {labels[decision] ?? decision}
-    </span>
-  )
-}
-
-function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
-  return (
-    <div className="flex gap-2">
-      <span className="text-muted-foreground shrink-0 w-24">{label}</span>
-      <span className="min-w-0 break-all">{value}</span>
-    </div>
-  )
-}
-
-function EntryDetails({ entry }: { entry: AuditLogEntry }) {
-  const scopes: string[] = entry.matchedScopes ? (() => {
-    try { return JSON.parse(entry.matchedScopes) } catch { return [] }
-  })() : []
-  const ts = new Date(entry.createdAt)
-
-  return (
-    <div className="text-xs space-y-1.5 pt-1">
-      <DetailRow label="Full path" value={<span className="font-mono">{entry.targetUrl}</span>} />
-      <DetailRow label="Source" value={entry.source === 'mcp' ? 'MCP Proxy' : 'API Proxy'} />
-      <DetailRow label="Toolkit / MCP" value={entry.label} />
-      <DetailRow label="Method" value={entry.method} />
-      <DetailRow label="Status" value={entry.statusCode ?? '—'} />
-      {entry.policyDecision && (
-        <DetailRow label="Policy" value={<PolicyBadge decision={entry.policyDecision} />} />
-      )}
-      {scopes.length > 0 && (
-        <DetailRow
-          label="Scopes"
-          value={
-            <div className="flex flex-wrap gap-1">
-              {scopes.map((s: string) => (
-                <span key={s} className="font-mono bg-muted rounded px-1 py-0.5">{s}</span>
-              ))}
-            </div>
-          }
-        />
-      )}
-      {entry.durationMs !== null && (
-        <DetailRow label="Duration" value={`${entry.durationMs}ms`} />
-      )}
-      {entry.errorMessage && (
-        <DetailRow label="Error" value={<span className="text-red-600 dark:text-red-400">{entry.errorMessage}</span>} />
-      )}
-      <DetailRow label="Timestamp" value={format(ts, 'yyyy-MM-dd HH:mm:ss.SSS')} />
-    </div>
-  )
 }
 
 export function ApiLogsView({ agentSlug }: ApiLogsViewProps) {
   useRenderTracker('ApiLogsView')
   const navigate = useNavigate()
   const [page, setPage] = useState(0)
-  const [expandedId, setExpandedId] = useState<string | null>(null)
   const { track } = useAnalyticsTracking()
 
   useEffect(() => {
     track('api_logs_viewed')
   }, [track])
 
-  const { data, isLoading, refetch, isRefetching } = useQuery<{ entries: AuditLogEntry[]; total: number }>({
+  const { data, isLoading, refetch, isRefetching } = useQuery<RequestLogPage>({
     queryKey: ['agent-audit-log', agentSlug, page],
     queryFn: async () => {
-      const res = await apiFetch(`/api/agents/${agentSlug}/audit-log?offset=${page * PAGE_SIZE}&limit=${PAGE_SIZE}`)
+      const res = await apiFetch(
+        `/api/agents/${agentSlug}/audit-log?offset=${page * REQUEST_LOG_PAGE_SIZE}&limit=${REQUEST_LOG_PAGE_SIZE}`,
+      )
       if (!res.ok) throw new Error('Failed to fetch audit log')
       return res.json()
     },
   })
-
-  const entries = data?.entries ?? []
-  const total = data?.total ?? 0
-  const totalPages = Math.ceil(total / PAGE_SIZE)
 
   return (
     <SettingsPageContainer fullScreen>
@@ -198,147 +61,14 @@ export function ApiLogsView({ agentSlug }: ApiLogsViewProps) {
         }
       />
 
-      {isLoading ? (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          Loading log...
-        </div>
-      ) : entries.length === 0 && page === 0 ? (
-        <div className="rounded-xl border border-dashed p-8 text-center text-sm text-muted-foreground">
-          No requests logged yet.
-        </div>
-      ) : (
-        <>
-          <Table className="min-w-[900px] text-xs [&_th]:px-3 [&_td]:px-3">
-            <TableHeader>
-              <TableRow className="hover:bg-transparent">
-                <TableHead className="whitespace-nowrap">Timestamp</TableHead>
-                <TableHead className="whitespace-nowrap">Duration</TableHead>
-                <TableHead>Source</TableHead>
-                <TableHead>Method</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead className="whitespace-nowrap">Policy</TableHead>
-                <TableHead>Toolkit</TableHead>
-                <TableHead className="w-full min-w-[240px]">Path (error)</TableHead>
-                <TableHead className="w-[88px]" aria-label="Toggle details" />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {entries.map((entry) => {
-                const time = format(new Date(entry.createdAt), 'MM/dd/yy, HH:mm:ss')
-                const isExpanded = expandedId === entry.id
-
-                return (
-                  <Fragment key={entry.id}>
-                    <TableRow
-                      role="button"
-                      tabIndex={0}
-                      data-state={isExpanded ? 'selected' : undefined}
-                      className={`group cursor-pointer hover:bg-muted/30 ${isExpanded ? 'bg-muted/30 border-b-0' : ''}`}
-                      onClick={() => setExpandedId(isExpanded ? null : entry.id)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault()
-                          setExpandedId(isExpanded ? null : entry.id)
-                        }
-                      }}
-                    >
-                      <TableCell className="text-muted-foreground whitespace-nowrap">{time}</TableCell>
-                      <TableCell className="text-muted-foreground tabular-nums whitespace-nowrap">
-                        {entry.durationMs !== null ? `${entry.durationMs}ms` : '—'}
-                      </TableCell>
-                      <TableCell><SourceBadge source={entry.source} /></TableCell>
-                      <TableCell><MethodBadge method={entry.method} /></TableCell>
-                      <TableCell><StatusBadge status={entry.statusCode} /></TableCell>
-                      <TableCell className="whitespace-nowrap">
-                        {entry.policyDecision ? <PolicyBadge decision={entry.policyDecision} /> : null}
-                      </TableCell>
-                      <TableCell className="max-w-[120px]">
-                        <span className="text-muted-foreground font-medium truncate block" title={entry.label}>
-                          {entry.label}
-                        </span>
-                      </TableCell>
-                      <TableCell className="min-w-0 w-full">
-                        <p
-                          className="font-mono truncate"
-                          title={entry.errorMessage ? `${entry.targetUrl} (${entry.errorMessage})` : entry.targetUrl}
-                        >
-                          {entry.targetUrl}
-                          {entry.errorMessage && (
-                            <span className="text-red-600 dark:text-red-400"> ({entry.errorMessage})</span>
-                          )}
-                        </p>
-                      </TableCell>
-                      <TableCell className="w-[88px] text-right">
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          className={`h-7 px-2 text-xs transition-opacity ${isExpanded ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100'}`}
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            setExpandedId(isExpanded ? null : entry.id)
-                          }}
-                        >
-                          {isExpanded ? (
-                            <>
-                              Less
-                              <ChevronUp className="h-3.5 w-3.5" />
-                            </>
-                          ) : (
-                            <>
-                              More
-                              <ChevronDown className="h-3.5 w-3.5" />
-                            </>
-                          )}
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                    {isExpanded && (
-                      <TableRow className="bg-muted/30 hover:bg-muted/30">
-                        <TableCell colSpan={9} className="pb-3">
-                          <EntryDetails entry={entry} />
-                        </TableCell>
-                      </TableRow>
-                    )}
-                  </Fragment>
-                )
-              })}
-            </TableBody>
-          </Table>
-
-          {totalPages > 1 && (
-            <div className="flex items-center justify-between pt-2">
-              <span className="text-xs text-muted-foreground">
-                {total} total entries
-              </span>
-              <div className="flex items-center gap-1">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 w-7 p-0"
-                  onClick={() => setPage((p) => p - 1)}
-                  disabled={page === 0}
-                >
-                  <ChevronLeft className="h-3.5 w-3.5" />
-                </Button>
-                <span className="text-xs text-muted-foreground px-2">
-                  {page + 1} / {totalPages}
-                </span>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 w-7 p-0"
-                  onClick={() => setPage((p) => p + 1)}
-                  disabled={page >= totalPages - 1}
-                >
-                  <ChevronRight className="h-3.5 w-3.5" />
-                </Button>
-              </div>
-            </div>
-          )}
-        </>
-      )}
+      <RequestLogsTable
+        entries={data?.entries ?? []}
+        total={data?.total ?? 0}
+        page={page}
+        onPageChange={setPage}
+        isLoading={isLoading}
+        columns={{ source: true, toolkit: true }}
+      />
     </SettingsPageContainer>
   )
 }

--- a/src/renderer/components/api-logs/request-logs-table.test.tsx
+++ b/src/renderer/components/api-logs/request-logs-table.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RequestLogsTable } from './request-logs-table'
+import type { RequestLogEntry } from '@shared/lib/types/request-log'
+
+const entry: RequestLogEntry = {
+  id: 'request-1',
+  source: 'proxy',
+  agentSlug: 'agent-1',
+  label: 'github',
+  targetUrl: '/repos/openai/codex',
+  method: 'GET',
+  statusCode: 200,
+  errorMessage: null,
+  durationMs: 35,
+  policyDecision: 'allow',
+  matchedScopes: '["repo.read"]',
+  createdAt: '2026-07-20T12:00:00.000Z',
+}
+
+describe('RequestLogsTable', () => {
+  it('uses the connection column set and paginates', async () => {
+    const onPageChange = vi.fn()
+    render(
+      <RequestLogsTable
+        entries={[entry]}
+        total={16}
+        page={0}
+        onPageChange={onPageChange}
+        isLoading={false}
+        columns={{ agent: true }}
+        agentLabel={() => 'Research Agent'}
+      />,
+    )
+
+    expect(screen.getByRole('columnheader', { name: 'Agent' })).toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'Source' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'Toolkit' })).not.toBeInTheDocument()
+    expect(screen.getByText('Research Agent')).toBeInTheDocument()
+    expect(screen.getByText('1 / 2')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Next page' }))
+    expect(onPageChange).toHaveBeenCalledWith(1)
+  })
+
+  it('expands a row with request details', async () => {
+    render(
+      <RequestLogsTable
+        entries={[entry]}
+        total={1}
+        page={0}
+        onPageChange={vi.fn()}
+        isLoading={false}
+        columns={{ source: true, toolkit: true }}
+      />,
+    )
+
+    await userEvent.click(screen.getByText('/repos/openai/codex'))
+
+    expect(screen.getByText('Full path')).toBeInTheDocument()
+    expect(screen.getByText('API Proxy')).toBeInTheDocument()
+    expect(screen.getByText('repo.read')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/api-logs/request-logs-table.tsx
+++ b/src/renderer/components/api-logs/request-logs-table.tsx
@@ -1,0 +1,314 @@
+import { Fragment, useEffect, useState, type ReactNode } from 'react'
+import { format } from 'date-fns'
+import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Loader2 } from 'lucide-react'
+import { Button } from '@renderer/components/ui/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@renderer/components/ui/table'
+import type { RequestLogEntry } from '@shared/lib/types/request-log'
+
+export const REQUEST_LOG_PAGE_SIZE = 15
+
+export interface RequestLogColumns {
+  source?: boolean
+  toolkit?: boolean
+  agent?: boolean
+}
+
+interface RequestLogsTableProps {
+  entries: RequestLogEntry[]
+  total: number
+  page: number
+  onPageChange: (page: number) => void
+  isLoading: boolean
+  columns: RequestLogColumns
+  agentLabel?: (agentSlug: string) => ReactNode
+  emptyMessage?: string
+}
+
+function MethodBadge({ method }: { method: string }) {
+  const colors: Record<string, string> = {
+    GET: 'text-blue-700 bg-blue-100 dark:text-blue-300 dark:bg-blue-900/40',
+    POST: 'text-green-700 bg-green-100 dark:text-green-300 dark:bg-green-900/40',
+    PUT: 'text-amber-700 bg-amber-100 dark:text-amber-300 dark:bg-amber-900/40',
+    PATCH: 'text-amber-700 bg-amber-100 dark:text-amber-300 dark:bg-amber-900/40',
+    DELETE: 'text-red-700 bg-red-100 dark:text-red-300 dark:bg-red-900/40',
+  }
+  return (
+    <span className={`inline-block rounded px-1.5 py-0.5 text-2xs font-semibold leading-none ${colors[method] ?? 'text-muted-foreground bg-muted'}`}>
+      {method}
+    </span>
+  )
+}
+
+function StatusBadge({ status }: { status: number | null }) {
+  if (status === null) return <span className="text-xs text-muted-foreground">—</span>
+  const color = status >= 200 && status < 300
+    ? 'text-green-700 dark:text-green-400'
+    : status >= 400
+      ? 'text-red-700 dark:text-red-400'
+      : 'text-muted-foreground'
+  return <span className={`text-xs font-mono font-medium ${color}`}>{status}</span>
+}
+
+function SourceBadge({ source }: { source: RequestLogEntry['source'] }) {
+  const style = source === 'mcp'
+    ? 'text-purple-700 bg-purple-100 dark:text-purple-300 dark:bg-purple-900/40'
+    : 'text-sky-700 bg-sky-100 dark:text-sky-300 dark:bg-sky-900/40'
+  return (
+    <span className={`inline-block rounded px-1.5 py-0.5 text-2xs font-semibold leading-none ${style}`}>
+      {source === 'mcp' ? 'MCP' : 'API'}
+    </span>
+  )
+}
+
+function PolicyBadge({ decision }: { decision: string | null }) {
+  if (!decision) return null
+  const styles: Record<string, string> = {
+    allow: 'text-green-700 bg-green-100 dark:text-green-300 dark:bg-green-900/40',
+    approved_by_user: 'text-blue-700 bg-blue-100 dark:text-blue-300 dark:bg-blue-900/40',
+    block: 'text-red-700 bg-red-100 dark:text-red-300 dark:bg-red-900/40',
+    denied_by_user: 'text-red-700 bg-red-100 dark:text-red-300 dark:bg-red-900/40',
+    review_timeout: 'text-orange-700 bg-orange-100 dark:text-orange-300 dark:bg-orange-900/40',
+  }
+  const labels: Record<string, string> = {
+    allow: 'auto-allowed',
+    approved_by_user: 'user-approved',
+    block: 'auto-blocked',
+    denied_by_user: 'user-denied',
+    review_timeout: 'timeout',
+  }
+  return (
+    <span
+      className={`inline-block rounded px-1.5 py-0.5 text-2xs font-semibold leading-none ${styles[decision] ?? 'text-muted-foreground bg-muted'}`}
+      title={`Policy: ${decision}`}
+    >
+      {labels[decision] ?? decision}
+    </span>
+  )
+}
+
+function DetailRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="flex gap-2">
+      <span className="text-muted-foreground shrink-0 w-24">{label}</span>
+      <span className="min-w-0 break-all">{value}</span>
+    </div>
+  )
+}
+
+function EntryDetails({
+  entry,
+  columns,
+  agentLabel,
+}: {
+  entry: RequestLogEntry
+  columns: RequestLogColumns
+  agentLabel?: (agentSlug: string) => ReactNode
+}) {
+  const scopes: string[] = entry.matchedScopes ? (() => {
+    try {
+      const parsed: unknown = JSON.parse(entry.matchedScopes)
+      return Array.isArray(parsed) && parsed.every((value) => typeof value === 'string') ? parsed : []
+    } catch { return [] }
+  })() : []
+  const ts = new Date(entry.createdAt)
+
+  return (
+    <div className="text-xs space-y-1.5 pt-1">
+      <DetailRow label="Full path" value={<span className="font-mono">{entry.targetUrl}</span>} />
+      {columns.agent && <DetailRow label="Agent" value={agentLabel?.(entry.agentSlug) ?? entry.agentSlug} />}
+      {columns.source && <DetailRow label="Source" value={entry.source === 'mcp' ? 'MCP Proxy' : 'API Proxy'} />}
+      {columns.toolkit && <DetailRow label="Toolkit / MCP" value={entry.label} />}
+      <DetailRow label="Method" value={entry.method} />
+      <DetailRow label="Status" value={entry.statusCode ?? '—'} />
+      {entry.policyDecision && <DetailRow label="Policy" value={<PolicyBadge decision={entry.policyDecision} />} />}
+      {scopes.length > 0 && (
+        <DetailRow
+          label="Scopes"
+          value={
+            <div className="flex flex-wrap gap-1">
+              {scopes.map((scope) => (
+                <span key={scope} className="font-mono bg-muted rounded px-1 py-0.5">{scope}</span>
+              ))}
+            </div>
+          }
+        />
+      )}
+      {entry.durationMs !== null && <DetailRow label="Duration" value={`${entry.durationMs}ms`} />}
+      {entry.errorMessage && (
+        <DetailRow label="Error" value={<span className="text-red-600 dark:text-red-400">{entry.errorMessage}</span>} />
+      )}
+      <DetailRow label="Timestamp" value={format(ts, 'yyyy-MM-dd HH:mm:ss.SSS')} />
+    </div>
+  )
+}
+
+export function RequestLogsTable({
+  entries,
+  total,
+  page,
+  onPageChange,
+  isLoading,
+  columns,
+  agentLabel,
+  emptyMessage = 'No requests logged yet.',
+}: RequestLogsTableProps) {
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const totalPages = Math.ceil(total / REQUEST_LOG_PAGE_SIZE)
+  const columnCount = 7 + Number(!!columns.source) + Number(!!columns.toolkit) + Number(!!columns.agent)
+
+  useEffect(() => setExpandedId(null), [page])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading log...
+      </div>
+    )
+  }
+
+  if (entries.length === 0 && page === 0) {
+    return (
+      <div className="rounded-xl border border-dashed p-8 text-center text-sm text-muted-foreground">
+        {emptyMessage}
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <Table className="min-w-[820px] text-xs [&_th]:px-3 [&_td]:px-3">
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead className="whitespace-nowrap">Timestamp</TableHead>
+            <TableHead className="whitespace-nowrap">Duration</TableHead>
+            {columns.source && <TableHead>Source</TableHead>}
+            {columns.agent && <TableHead>Agent</TableHead>}
+            <TableHead>Method</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="whitespace-nowrap">Policy</TableHead>
+            {columns.toolkit && <TableHead>Toolkit</TableHead>}
+            <TableHead className="w-full min-w-[240px]">Path (error)</TableHead>
+            <TableHead className="w-[88px]" aria-label="Toggle details" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {entries.map((entry) => {
+            const time = format(new Date(entry.createdAt), 'MM/dd/yy, HH:mm:ss')
+            const isExpanded = expandedId === entry.id
+            return (
+              <Fragment key={`${entry.source}-${entry.id}`}>
+                <TableRow
+                  role="button"
+                  tabIndex={0}
+                  data-state={isExpanded ? 'selected' : undefined}
+                  className={`group cursor-pointer hover:bg-muted/30 ${isExpanded ? 'bg-muted/30 border-b-0' : ''}`}
+                  onClick={() => setExpandedId(isExpanded ? null : entry.id)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault()
+                      setExpandedId(isExpanded ? null : entry.id)
+                    }
+                  }}
+                >
+                  <TableCell className="text-muted-foreground whitespace-nowrap">{time}</TableCell>
+                  <TableCell className="text-muted-foreground tabular-nums whitespace-nowrap">
+                    {entry.durationMs !== null ? `${entry.durationMs}ms` : '—'}
+                  </TableCell>
+                  {columns.source && <TableCell><SourceBadge source={entry.source} /></TableCell>}
+                  {columns.agent && (
+                    <TableCell className="max-w-[160px]">
+                      <span className="font-medium truncate block" title={entry.agentSlug}>
+                        {agentLabel?.(entry.agentSlug) ?? entry.agentSlug}
+                      </span>
+                    </TableCell>
+                  )}
+                  <TableCell><MethodBadge method={entry.method} /></TableCell>
+                  <TableCell><StatusBadge status={entry.statusCode} /></TableCell>
+                  <TableCell className="whitespace-nowrap">
+                    {entry.policyDecision ? <PolicyBadge decision={entry.policyDecision} /> : null}
+                  </TableCell>
+                  {columns.toolkit && (
+                    <TableCell className="max-w-[120px]">
+                      <span className="text-muted-foreground font-medium truncate block" title={entry.label}>
+                        {entry.label}
+                      </span>
+                    </TableCell>
+                  )}
+                  <TableCell className="min-w-0 w-full">
+                    <p
+                      className="font-mono truncate"
+                      title={entry.errorMessage ? `${entry.targetUrl} (${entry.errorMessage})` : entry.targetUrl}
+                    >
+                      {entry.targetUrl}
+                      {entry.errorMessage && (
+                        <span className="text-red-600 dark:text-red-400"> ({entry.errorMessage})</span>
+                      )}
+                    </p>
+                  </TableCell>
+                  <TableCell className="w-[88px] text-right">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className={`h-7 px-2 text-xs transition-opacity ${isExpanded ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100'}`}
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        setExpandedId(isExpanded ? null : entry.id)
+                      }}
+                    >
+                      {isExpanded ? <><span>Less</span><ChevronUp className="h-3.5 w-3.5" /></> : <><span>More</span><ChevronDown className="h-3.5 w-3.5" /></>}
+                    </Button>
+                  </TableCell>
+                </TableRow>
+                {isExpanded && (
+                  <TableRow className="bg-muted/30 hover:bg-muted/30">
+                    <TableCell colSpan={columnCount} className="pb-3">
+                      <EntryDetails entry={entry} columns={columns} agentLabel={agentLabel} />
+                    </TableCell>
+                  </TableRow>
+                )}
+              </Fragment>
+            )
+          })}
+        </TableBody>
+      </Table>
+
+      <div className="flex items-center justify-between pt-2">
+        <span className="text-xs text-muted-foreground">{total} total entries</span>
+        {totalPages > 1 && (
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0"
+              aria-label="Previous page"
+              onClick={() => onPageChange(page - 1)}
+              disabled={page === 0}
+            >
+              <ChevronLeft className="h-3.5 w-3.5" />
+            </Button>
+            <span className="text-xs text-muted-foreground px-2">{page + 1} / {totalPages}</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0"
+              aria-label="Next page"
+              onClick={() => onPageChange(page + 1)}
+              disabled={page >= totalPages - 1}
+            >
+              <ChevronRight className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/src/renderer/components/connections/connection-detail-page.tsx
+++ b/src/renderer/components/connections/connection-detail-page.tsx
@@ -3,6 +3,7 @@ import { Button } from '@renderer/components/ui/button'
 import { ServiceIcon } from '@renderer/components/ui/service-icon'
 import { ConnectionAgentsList } from '@renderer/components/connections/connection-agents-list'
 import { IntegrationRowActions } from '@renderer/components/connections/integration-row-actions'
+import { ConnectionUsageCard } from '@renderer/components/connections/connection-usage-card'
 import { ScopePolicyEditorBody } from '@renderer/components/settings/scope-policy-editor'
 import { ToolPolicyEditorBody } from '@renderer/components/settings/tool-policy-editor'
 import {
@@ -20,13 +21,14 @@ interface ConnectionDetailPageProps {
    * the agent connections page, or the agent's name for a home-card deep link.
    */
   backLabel?: string
+  onViewLogs: () => void
 }
 
 /**
  * Detail view for a single connection: two columns showing which agents have
  * access and the per-scope / per-tool permissions for the connection.
  */
-export function ConnectionDetailPage({ row, onBack, backLabel = 'Connections' }: ConnectionDetailPageProps) {
+export function ConnectionDetailPage({ row, onBack, onViewLogs, backLabel = 'Connections' }: ConnectionDetailPageProps) {
   // Hide the default SettingsPage header — the detail page owns its own — and
   // use the full inset width so the two columns can lay out like the agent home.
   useHideSettingsHeader(true)
@@ -90,23 +92,27 @@ export function ConnectionDetailPage({ row, onBack, backLabel = 'Connections' }:
         </section>
 
         {/* Permissions column */}
-        <section className="space-y-2 min-w-0">
-          <h3 className="text-xs font-normal text-muted-foreground">Permissions</h3>
-          <div className="rounded-xl border bg-background p-3">
-            {row.type === 'oauth' && row.toolkit ? (
-              <ScopePolicyEditorBody accountId={row.id} toolkit={row.toolkit} />
-            ) : row.type === 'mcp' ? (
-              <ToolPolicyEditorBody
-                mcpId={row.id}
-                tools={row.mcpTools ?? []}
-              />
-            ) : (
-              <p className="text-sm text-muted-foreground py-4 text-center">
-                No permissions configurable for this connection.
-              </p>
-            )}
-          </div>
-        </section>
+        <div className="space-y-4 min-w-0">
+          <ConnectionUsageCard row={row} onViewLogs={onViewLogs} />
+
+          <section className="space-y-2 min-w-0">
+            <h3 className="text-xs font-normal text-muted-foreground">Permissions</h3>
+            <div className="rounded-xl border bg-background p-3">
+              {row.type === 'oauth' && row.toolkit ? (
+                <ScopePolicyEditorBody accountId={row.id} toolkit={row.toolkit} />
+              ) : row.type === 'mcp' ? (
+                <ToolPolicyEditorBody
+                  mcpId={row.id}
+                  tools={row.mcpTools ?? []}
+                />
+              ) : (
+                <p className="text-sm text-muted-foreground py-4 text-center">
+                  No permissions configurable for this connection.
+                </p>
+              )}
+            </div>
+          </section>
+        </div>
       </div>
     </div>
   )

--- a/src/renderer/components/connections/connection-logs-view.tsx
+++ b/src/renderer/components/connections/connection-logs-view.tsx
@@ -14,7 +14,7 @@ import {
   RequestLogsTable,
 } from '@renderer/components/api-logs/request-logs-table'
 import type { UnifiedRow } from '@renderer/components/connections/unified-rows'
-import type { RequestLogPage } from '@shared/lib/types/request-log'
+import { requestLogPageSchema } from '@shared/lib/types/request-log'
 
 interface ConnectionLogsViewProps {
   row: UnifiedRow
@@ -33,14 +33,14 @@ export function ConnectionLogsView({ row, onBack }: ConnectionLogsViewProps) {
 
   useEffect(() => setPage(0), [row.key])
 
-  const { data, isLoading, refetch, isRefetching } = useQuery<RequestLogPage>({
+  const { data, isLoading, refetch, isRefetching } = useQuery({
     queryKey: ['connection-request-log', kind, row.id, page],
     queryFn: async () => {
       const response = await apiFetch(
         `/api/connection-logs/${kind}/${encodeURIComponent(row.id)}?offset=${page * REQUEST_LOG_PAGE_SIZE}&limit=${REQUEST_LOG_PAGE_SIZE}`,
       )
       if (!response.ok) throw new Error('Failed to fetch connection request logs')
-      return response.json()
+      return requestLogPageSchema.parse(await response.json())
     },
   })
 

--- a/src/renderer/components/connections/connection-logs-view.tsx
+++ b/src/renderer/components/connections/connection-logs-view.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { RefreshCw } from 'lucide-react'
+import { apiFetch } from '@renderer/lib/api'
+import { useAgents } from '@renderer/hooks/use-agents'
+import { Button } from '@renderer/components/ui/button'
+import { PageTitle } from '@renderer/components/layout/settings-page'
+import {
+  useFullWidthSettingsContent,
+  useHideSettingsHeader,
+} from '@renderer/components/settings/settings-page'
+import {
+  REQUEST_LOG_PAGE_SIZE,
+  RequestLogsTable,
+} from '@renderer/components/api-logs/request-logs-table'
+import type { UnifiedRow } from '@renderer/components/connections/unified-rows'
+import type { RequestLogPage } from '@shared/lib/types/request-log'
+
+interface ConnectionLogsViewProps {
+  row: UnifiedRow
+  onBack: () => void
+}
+
+const selectAgentNames = (agents: Array<{ slug: string; name: string }>) =>
+  Object.fromEntries(agents.map((agent) => [agent.slug, agent.name]))
+
+export function ConnectionLogsView({ row, onBack }: ConnectionLogsViewProps) {
+  useHideSettingsHeader(true)
+  useFullWidthSettingsContent(true)
+  const [page, setPage] = useState(0)
+  const { data: agentNames = {} } = useAgents({ select: selectAgentNames })
+  const kind = row.type === 'oauth' ? 'account' : 'mcp'
+
+  useEffect(() => setPage(0), [row.key])
+
+  const { data, isLoading, refetch, isRefetching } = useQuery<RequestLogPage>({
+    queryKey: ['connection-request-log', kind, row.id, page],
+    queryFn: async () => {
+      const response = await apiFetch(
+        `/api/connection-logs/${kind}/${encodeURIComponent(row.id)}?offset=${page * REQUEST_LOG_PAGE_SIZE}&limit=${REQUEST_LOG_PAGE_SIZE}`,
+      )
+      if (!response.ok) throw new Error('Failed to fetch connection request logs')
+      return response.json()
+    },
+  })
+
+  return (
+    <div className="space-y-6 w-full max-w-5xl mx-auto">
+      <PageTitle
+        title={
+          <div>
+            <h2 className="text-xl font-medium">Connection Logs</h2>
+            <p className="mt-1 text-xs text-muted-foreground">{row.name}</p>
+          </div>
+        }
+        back={{ onClick: onBack, label: row.name, testId: 'connection-logs-back' }}
+        actions={
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => refetch()}
+            disabled={isRefetching}
+          >
+            <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${isRefetching ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        }
+      />
+
+      <RequestLogsTable
+        entries={data?.entries ?? []}
+        total={data?.total ?? 0}
+        page={page}
+        onPageChange={setPage}
+        isLoading={isLoading}
+        columns={{ agent: true }}
+        agentLabel={(agentSlug) => agentNames[agentSlug] ?? agentSlug}
+      />
+    </div>
+  )
+}

--- a/src/renderer/components/connections/connection-usage-card.test.tsx
+++ b/src/renderer/components/connections/connection-usage-card.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ConnectionUsageCard } from './connection-usage-card'
+import type { UnifiedRow } from './unified-rows'
+
+const mockUseConnectionActivityStats = vi.fn()
+vi.mock('@renderer/hooks/use-activity-stats', () => ({
+  useConnectionActivityStats: () => mockUseConnectionActivityStats(),
+}))
+
+const row: UnifiedRow = {
+  key: 'account-account-1',
+  id: 'account-1',
+  name: 'Work GitHub',
+  iconFallback: 'oauth',
+  type: 'oauth',
+  granted: true,
+  toolkit: 'github',
+}
+
+describe('ConnectionUsageCard', () => {
+  beforeAll(() => {
+    vi.stubGlobal('ResizeObserver', class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    })
+  })
+
+  beforeEach(() => {
+    mockUseConnectionActivityStats.mockReturnValue({
+      data: {
+        days: 14,
+        connectionById: {
+          [row.key]: [
+            { date: '2026-07-07', succeeded: 2, failed: 0 },
+            { date: '2026-07-20', succeeded: 3, failed: 1 },
+          ],
+        },
+      },
+    })
+  })
+
+  it('shows connection-wide usage and opens logs', async () => {
+    const onViewLogs = vi.fn()
+    render(<ConnectionUsageCard row={row} onViewLogs={onViewLogs} />)
+
+    expect(screen.getByText('6 calls')).toBeInTheDocument()
+    expect(screen.getByText('5 succeeded')).toBeInTheDocument()
+    expect(screen.getByText('1 failed')).toBeInTheDocument()
+    expect(screen.getByRole('img', {
+      name: 'Work GitHub activity: 6 calls over 2 days, 5 succeeded and 1 failed.',
+    })).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'View logs' }))
+    expect(onViewLogs).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/components/connections/connection-usage-card.tsx
+++ b/src/renderer/components/connections/connection-usage-card.tsx
@@ -1,0 +1,77 @@
+import { ArrowRight, Loader2 } from 'lucide-react'
+import { Button } from '@renderer/components/ui/button'
+import {
+  ActivityBarChart,
+  summarizeDailyActivity,
+} from '@renderer/components/activity/activity-spark-chart'
+import { useConnectionActivityStats } from '@renderer/hooks/use-activity-stats'
+import type { UnifiedRow } from '@renderer/components/connections/unified-rows'
+
+interface ConnectionUsageCardProps {
+  row: UnifiedRow
+  onViewLogs: () => void
+}
+
+export function ConnectionUsageCard({ row, onViewLogs }: ConnectionUsageCardProps) {
+  const { data: activityStats, isPending } = useConnectionActivityStats()
+  const activity = activityStats?.connectionById[row.key]
+  const summary = activity ? summarizeDailyActivity(activity) : null
+
+  return (
+    <section className="space-y-2 min-w-0">
+      <h3 className="text-xs font-normal text-muted-foreground">Usage</h3>
+      <div className="rounded-xl border bg-background overflow-hidden" data-testid="connection-usage-card">
+        <div className="p-4 pb-2">
+          <div className="flex items-start justify-between gap-3 mb-2">
+            <div>
+              <p className="text-sm font-medium tabular-nums">
+                {summary ? summary.total.toLocaleString() : '—'} calls
+              </p>
+              <p className="text-[11px] text-muted-foreground">
+                Last {activityStats?.days ?? 14} days
+              </p>
+            </div>
+            {summary && (
+              <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="h-2 w-2 rounded-sm bg-emerald-500" aria-hidden="true" />
+                  {summary.succeeded.toLocaleString()} succeeded
+                </span>
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="h-2 w-2 rounded-sm bg-red-500" aria-hidden="true" />
+                  {summary.failed.toLocaleString()} failed
+                </span>
+              </div>
+            )}
+          </div>
+
+          {activity ? (
+            <ActivityBarChart label={`${row.name} activity`} data={activity} />
+          ) : isPending ? (
+            <div className="h-[150px] flex items-center justify-center text-xs text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin mr-2" />
+              Loading usage...
+            </div>
+          ) : (
+            <div className="h-[150px] flex items-center justify-center text-xs text-muted-foreground">
+              Usage data is unavailable.
+            </div>
+          )}
+        </div>
+
+        <div className="border-t px-2 py-1.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8 w-full justify-between text-xs"
+            onClick={onViewLogs}
+          >
+            View logs
+            <ArrowRight className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/components/connections/connections-list.test.tsx
+++ b/src/renderer/components/connections/connections-list.test.tsx
@@ -59,6 +59,8 @@ describe('ConnectionsList shared capabilities', () => {
       <ConnectionsList
         agentSlug="test-agent"
         detailRowKey={null}
+        detailView="details"
+        onDetailViewChange={vi.fn()}
         onDetailRowKeyChange={vi.fn()}
       />,
     )
@@ -78,6 +80,8 @@ describe('ConnectionsList shared capabilities', () => {
       <ConnectionsList
         agentSlug="test-agent"
         detailRowKey="foreign-account-slack-0"
+        detailView="details"
+        onDetailViewChange={vi.fn()}
         onDetailRowKeyChange={onDetailRowKeyChange}
       />,
     )

--- a/src/renderer/components/connections/connections-list.tsx
+++ b/src/renderer/components/connections/connections-list.tsx
@@ -6,6 +6,7 @@ import { ChevronRight, Loader2, Plus } from 'lucide-react'
 import { IntegrationDirectoryDialog, type NewApiConnection, type NewMcpConnection } from '@renderer/components/connections/integration-directory-dialog'
 import { IntegrationList } from '@renderer/components/connections/integration-row'
 import { ConnectionDetailPage } from '@renderer/components/connections/connection-detail-page'
+import { ConnectionLogsView } from '@renderer/components/connections/connection-logs-view'
 import { ConnectionRow } from '@renderer/components/connections/connection-row'
 import { ScopePolicyEditor } from '@renderer/components/settings/scope-policy-editor'
 import { ToolPolicyEditor } from '@renderer/components/settings/tool-policy-editor'
@@ -37,19 +38,23 @@ interface ConnectionsListProps {
   agentSlug: string
   /** Key of the row whose detail page is shown instead of the list. */
   detailRowKey: string | null
+  detailView: 'details' | 'logs'
   /** Breadcrumb label for the detail page's Back button. */
   detailBackLabel?: string
   onDetailRowKeyChange: (key: string | null) => void
+  onDetailViewChange: (view: 'details' | 'logs') => void
 }
 
-export function ConnectionsList({ agentSlug, detailRowKey, detailBackLabel, onDetailRowKeyChange }: ConnectionsListProps) {
+export function ConnectionsList({ agentSlug, detailRowKey, detailView, detailBackLabel, onDetailRowKeyChange, onDetailViewChange }: ConnectionsListProps) {
   return (
     <div className="flex flex-col gap-4">
       <AllConnectionsList
         agentSlug={agentSlug}
         detailRowKey={detailRowKey}
+        detailView={detailView}
         detailBackLabel={detailBackLabel}
         onDetailRowKeyChange={onDetailRowKeyChange}
+        onDetailViewChange={onDetailViewChange}
       />
     </div>
   )
@@ -111,11 +116,13 @@ export function NewIntegrationButton() {
 interface AllConnectionsListProps {
   agentSlug: string
   detailRowKey: string | null
+  detailView: 'details' | 'logs'
   detailBackLabel?: string
   onDetailRowKeyChange: (key: string | null) => void
+  onDetailViewChange: (view: 'details' | 'logs') => void
 }
 
-function AllConnectionsList({ agentSlug, detailRowKey, detailBackLabel, onDetailRowKeyChange }: AllConnectionsListProps) {
+function AllConnectionsList({ agentSlug, detailRowKey, detailView, detailBackLabel, onDetailRowKeyChange, onDetailViewChange }: AllConnectionsListProps) {
   const { data: allAccountsData, isLoading: isLoadingAllAccounts } = useConnectedAccounts()
   const { data: agentAccountsData, isLoading: isLoadingAgentAccounts } = useAgentConnectedAccounts(agentSlug)
   const { data: allMcpsData, isLoading: isLoadingAllMcps } = useRemoteMcps()
@@ -270,11 +277,20 @@ function AllConnectionsList({ agentSlug, detailRowKey, detailBackLabel, onDetail
   }
 
   if (selectedRow) {
+    if (detailView === 'logs') {
+      return (
+        <ConnectionLogsView
+          row={selectedRow}
+          onBack={() => onDetailViewChange('details')}
+        />
+      )
+    }
     return (
       <ConnectionDetailPage
         row={selectedRow}
         backLabel={detailBackLabel}
         onBack={() => onDetailRowKeyChange(null)}
+        onViewLogs={() => onDetailViewChange('logs')}
       />
     )
   }

--- a/src/renderer/components/connections/connections-view.tsx
+++ b/src/renderer/components/connections/connections-view.tsx
@@ -7,7 +7,7 @@ import { useRenderTracker } from '@renderer/lib/perf'
 interface ConnectionsViewProps {
   agentSlug: string
   /** Open detail overlay, decoded from the route's `?detail&source` search. */
-  detail: { rowKey: string; source: 'home' | 'list' } | null
+  detail: { rowKey: string; source: 'home' | 'list'; view?: 'logs' } | null
 }
 
 export function ConnectionsView({ agentSlug, detail }: ConnectionsViewProps) {
@@ -34,6 +34,18 @@ export function ConnectionsView({ agentSlug, detail }: ConnectionsViewProps) {
       search: { detail: rowKey, source: 'list' },
     })
   }
+  const setDetailView = (view: 'details' | 'logs') => {
+    if (!detail) return
+    void navigate({
+      to: '/agents/$slug/connections',
+      params: { slug: agentSlug },
+      search: {
+        detail: detail.rowKey,
+        source: detail.source,
+        connectionView: view === 'logs' ? 'logs' : undefined,
+      },
+    })
+  }
   // Back returns to wherever the detail view was opened from: the agent home for
   // a home-card deep link, otherwise the connections list.
   const closeDetail = () => {
@@ -56,7 +68,9 @@ export function ConnectionsView({ agentSlug, detail }: ConnectionsViewProps) {
       <ConnectionsList
         agentSlug={agentSlug}
         detailRowKey={detail?.rowKey ?? null}
+        detailView={detail?.view ?? 'details'}
         detailBackLabel={detail?.source === 'home' ? agentName : `${agentName} Connections`}
+        onDetailViewChange={setDetailView}
         onDetailRowKeyChange={(key) => {
           if (key) openDetail(key)
           else closeDetail()

--- a/src/renderer/components/layout/agent-header.tsx
+++ b/src/renderer/components/layout/agent-header.tsx
@@ -365,13 +365,14 @@ function AgentHeaderMobileMenu({
  * an open detail view appends the connection name — including the
  * "Connections" segment (clickable, back to the list) only when the detail
  * was opened from the list, so a home-card deep link reads "Agent / Account".
+ * The logs subview makes the connection crumb clickable and appends "/ Logs".
  */
 function ConnectionsCrumbs({
   slug,
   detail,
 }: {
   slug: string
-  detail: { rowKey: string; source: 'home' | 'list' } | null
+  detail: { rowKey: string; source: 'home' | 'list'; view?: 'logs' } | null
 }) {
   const { data: accountsData } = useConnectedAccounts()
   const { data: mcpsData } = useRemoteMcps()
@@ -415,8 +416,26 @@ function ConnectionsCrumbs({
       )}
       <div className="flex items-center gap-1.5 min-w-0">
         {separator}
-        <span className="truncate text-sm font-light text-foreground">{connectionName}</span>
+        {detail.view === 'logs' ? (
+          <AppLink
+            to="/agents/$slug/connections"
+            params={{ slug }}
+            search={{ detail: detail.rowKey, source: detail.source }}
+            noDrag
+            className="truncate text-sm font-light text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {connectionName}
+          </AppLink>
+        ) : (
+          <span className="truncate text-sm font-light text-foreground">{connectionName}</span>
+        )}
       </div>
+      {detail.view === 'logs' && (
+        <div className="flex items-center gap-1.5 min-w-0">
+          {separator}
+          <span className="truncate text-sm font-light text-foreground">Logs</span>
+        </div>
+      )}
     </>
   )
 }

--- a/src/renderer/components/settings/connections-tab.tsx
+++ b/src/renderer/components/settings/connections-tab.tsx
@@ -14,6 +14,7 @@ import { FeaturedServicesStack } from '@renderer/components/connections/featured
 import { ConnectionRow } from '@renderer/components/connections/connection-row'
 import { ConnectionAgentCount } from '@renderer/components/connections/connection-agent-count'
 import { ConnectionDetailPage } from '@renderer/components/connections/connection-detail-page'
+import { ConnectionLogsView } from '@renderer/components/connections/connection-logs-view'
 import { buildUnifiedRows, type UnifiedRow } from '@renderer/components/connections/unified-rows'
 import { useOAuthReconnect } from '@renderer/hooks/use-oauth-reconnect'
 import { useConnectionActivityStats } from '@renderer/hooks/use-activity-stats'
@@ -37,14 +38,25 @@ export function ConnectionsTab() {
   // so it's deep-linkable + reload-durable + back/forward-able — parity with the
   // agent connections route, which is also URL-driven. (Was local useState.)
   const navigate = useNavigate()
-  const search = useSearch({ strict: false }) as { detail?: string }
+  const search = useSearch({ strict: false }) as { detail?: string; connectionView?: string }
   const selectedRowKey = typeof search.detail === 'string' ? search.detail : null
+  const selectedView = search.connectionView === 'logs' ? 'logs' : 'details'
   const setDetail = useCallback(
     (key: string | null) => {
       void navigate({
         to: '/settings/$tab',
         params: { tab: 'connections' },
-        search: (prev) => ({ ...prev, detail: key ?? undefined }),
+        search: (prev) => ({ ...prev, detail: key ?? undefined, connectionView: undefined }),
+      })
+    },
+    [navigate],
+  )
+  const setDetailView = useCallback(
+    (view: 'details' | 'logs') => {
+      void navigate({
+        to: '/settings/$tab',
+        params: { tab: 'connections' },
+        search: (prev) => ({ ...prev, connectionView: view === 'logs' ? 'logs' : undefined }),
       })
     },
     [navigate],
@@ -73,10 +85,14 @@ export function ConnectionsTab() {
   }, [selectedRowKey, selectedRow, isLoading, setDetail])
 
   if (selectedRow) {
+    if (selectedView === 'logs') {
+      return <ConnectionLogsView row={selectedRow} onBack={() => setDetailView('details')} />
+    }
     return (
       <ConnectionDetailPage
         row={selectedRow}
         onBack={() => setDetail(null)}
+        onViewLogs={() => setDetailView('logs')}
       />
     )
   }

--- a/src/renderer/hooks/use-document-title.test.tsx
+++ b/src/renderer/hooks/use-document-title.test.tsx
@@ -62,6 +62,13 @@ describe('getDocumentTitle', () => {
     expect(getDocumentTitle({ location: location({ kind: 'connections' }, 'agent-one'), agentName: 'Agent One' })).toBe(
       `Agent One${DASH}Connections`,
     )
+    expect(getDocumentTitle({
+      location: location({
+        kind: 'connections',
+        detail: { rowKey: 'account-1', source: 'home', view: 'logs' },
+      }, 'agent-one'),
+      agentName: 'Agent One',
+    })).toBe(`Agent One${DASH}Connection Logs`)
     expect(getDocumentTitle({ location: location({ kind: 'apiLogs' }, 'agent-one'), agentName: 'Agent One' })).toBe(
       `Agent One${DASH}API Logs`,
     )

--- a/src/renderer/hooks/use-document-title.ts
+++ b/src/renderer/hooks/use-document-title.ts
@@ -104,7 +104,7 @@ function titleForAgentView(view: AgentView, input: DocumentTitleInput): string {
     case 'apiLogs':
       return joinView(agentTitle, 'API Logs')
     case 'connections':
-      return joinView(agentTitle, 'Connections')
+      return joinView(agentTitle, view.detail?.view === 'logs' ? 'Connection Logs' : 'Connections')
     case 'notifications':
       return joinWithBrand('Notifications')
     default:

--- a/src/renderer/router/route-components.tsx
+++ b/src/renderer/router/route-components.tsx
@@ -45,11 +45,14 @@ export function ApiLogsRoute() {
 // present and well-formed, else fall back to list.
 export function ConnectionsRoute() {
   const slug = useAgentSlug()
-  const search = useSearch({ strict: false }) as { detail?: unknown; source?: unknown }
+  const search = useSearch({ strict: false }) as { detail?: unknown; source?: unknown; connectionView?: unknown }
   const detailKey = typeof search.detail === 'string' ? search.detail : undefined
   const source: 'home' | 'list' | undefined =
     search.source === 'home' ? 'home' : search.source === 'list' ? 'list' : undefined
-  const detail = detailKey && source ? { rowKey: detailKey, source } : null
+  const detailView = search.connectionView === 'logs' ? 'logs' as const : undefined
+  const detail = detailKey && source
+    ? { rowKey: detailKey, source, ...(detailView ? { view: detailView } : {}) }
+    : null
   if (!slug) return null
   return <ConnectionsView agentSlug={slug} detail={detail} />
 }

--- a/src/renderer/router/route-state.test.ts
+++ b/src/renderer/router/route-state.test.ts
@@ -38,6 +38,7 @@ const cases: AppLocation[] = [
   { selectedAgentSlug: SLUG, view: { kind: 'connections' } },
   { selectedAgentSlug: SLUG, view: { kind: 'connections', detail: { rowKey: 'account-123', source: 'home' } } },
   { selectedAgentSlug: SLUG, view: { kind: 'connections', detail: { rowKey: 'mcp-456', source: 'list' } } },
+  { selectedAgentSlug: SLUG, view: { kind: 'connections', detail: { rowKey: 'account-123', source: 'home', view: 'logs' } } },
 ]
 
 describe('route-state codec', () => {

--- a/src/renderer/router/route-state.ts
+++ b/src/renderer/router/route-state.ts
@@ -21,7 +21,7 @@ export type AgentView =
        * is where it was opened from — it decides the breadcrumb trail and where
        * Back leads (agent home vs. the connections list).
        */
-      detail?: { rowKey: string; source: 'home' | 'list' }
+      detail?: { rowKey: string; source: 'home' | 'list'; view?: 'logs' }
     }
   | { kind: 'notifications' }
 
@@ -88,7 +88,13 @@ export function encodeLocation(loc: AppLocation): NavigateOptions {
       return {
         to: '/agents/$slug/connections',
         params: { slug },
-        search: view.detail ? { detail: view.detail.rowKey, source: view.detail.source } : {},
+        search: view.detail
+          ? {
+              detail: view.detail.rowKey,
+              source: view.detail.source,
+              ...(view.detail.view ? { connectionView: view.detail.view } : {}),
+            }
+          : {},
       }
     default:
       return assertNever(view)
@@ -131,9 +137,15 @@ export function decodeLocation(snap: RouteSnapshot): AppLocation {
     case '/agents/$slug/connections': {
       const detail = typeof search.detail === 'string' ? search.detail : undefined
       const source = search.source === 'home' || search.source === 'list' ? search.source : undefined
+      const detailView = search.connectionView === 'logs' ? 'logs' : undefined
       return {
         selectedAgentSlug: p.slug ?? null,
-        view: { kind: 'connections', ...(detail && source ? { detail: { rowKey: detail, source } } : {}) },
+        view: {
+          kind: 'connections',
+          ...(detail && source
+            ? { detail: { rowKey: detail, source, ...(detailView ? { view: detailView } : {}) } }
+            : {}),
+        },
       }
     }
     default:

--- a/src/renderer/router/search-schemas.test.ts
+++ b/src/renderer/router/search-schemas.test.ts
@@ -34,6 +34,10 @@ describe('connectionsSearchSchema (detail+source coupling)', () => {
   it('accepts account/mcp detail with a source', () => {
     expect(connectionsSearchSchema.safeParse({ detail: 'mcp-1', source: 'list' }).success).toBe(true)
     expect(connectionsSearchSchema.safeParse({ detail: 'account-9', source: 'home' }).success).toBe(true)
+    expect(connectionsSearchSchema.safeParse({ detail: 'account-9', source: 'home', connectionView: 'logs' }).success).toBe(true)
+  })
+  it('rejects logs without a selected connection', () => {
+    expect(connectionsSearchSchema.safeParse({ connectionView: 'logs' }).success).toBe(false)
   })
   it('rejects a malformed detail prefix', () => {
     expect(connectionsSearchSchema.safeParse({ detail: 'garbage', source: 'home' }).success).toBe(false)
@@ -99,6 +103,10 @@ describe('settingsSearchSchema (from close-target)', () => {
   })
   it('accepts no from', () => {
     expect(settingsSearchSchema.safeParse({}).success).toBe(true)
+  })
+  it('accepts connection logs only with a selected connection', () => {
+    expect(settingsSearchSchema.safeParse({ detail: 'account-1', connectionView: 'logs' }).success).toBe(true)
+    expect(settingsSearchSchema.safeParse({ connectionView: 'logs' }).success).toBe(false)
   })
 })
 

--- a/src/renderer/router/search-schemas.ts
+++ b/src/renderer/router/search-schemas.ts
@@ -32,9 +32,13 @@ export const connectionsSearchSchema = z
   .object({
     detail: connectionDetailKey.optional(),
     source: z.enum(['home', 'list']).optional(),
+    connectionView: z.literal('logs').optional(),
   })
   .refine((s) => (s.detail == null) === (s.source == null), {
     message: 'detail and source must be set together',
+  })
+  .refine((s) => !s.connectionView || !!s.detail, {
+    message: 'a connection subview requires detail',
   })
 
 // Open-redirect-safe internal path. ONE definition for the whole app: the same
@@ -63,10 +67,15 @@ export const homeSearchSchema = z.object({
 // URL-driven for parity with the agent connections route (deep-linkable +
 // reload-durable). Only the Connections tab reads it; `lenient()` drops it on
 // other tabs. No `source` here — settings detail always returns to its own list.
-export const settingsSearchSchema = z.object({
-  from: internalPath.optional(),
-  detail: connectionDetailKey.optional(),
-})
+export const settingsSearchSchema = z
+  .object({
+    from: internalPath.optional(),
+    detail: connectionDetailKey.optional(),
+    connectionView: z.literal('logs').optional(),
+  })
+  .refine((s) => !s.connectionView || !!s.detail, {
+    message: 'a connection subview requires detail',
+  })
 
 // The 18 GLOBAL settings tabs (settings/global-settings-page.tsx user/admin/auth
 // sections, flattened in display order). NOTE: `system-prompt` and `secrets` are

--- a/src/shared/lib/types/request-log.test.ts
+++ b/src/shared/lib/types/request-log.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { requestLogPageSchema } from './request-log'
+
+const validPage = {
+  entries: [{
+    id: 'request-1',
+    source: 'proxy',
+    agentSlug: 'research-agent',
+    label: 'github',
+    targetUrl: 'https://api.github.com/repos/openai/codex',
+    method: 'GET',
+    statusCode: 200,
+    errorMessage: null,
+    durationMs: 42,
+    policyDecision: 'allow',
+    matchedScopes: '["repo.read"]',
+    createdAt: '2026-07-20T12:00:00.000Z',
+  }],
+  total: 1,
+}
+
+describe('requestLogPageSchema', () => {
+  it('accepts the request-log transport shape', () => {
+    expect(requestLogPageSchema.parse(validPage)).toEqual(validPage)
+  })
+
+  it('rejects a response with an invalid entry shape', () => {
+    expect(() => requestLogPageSchema.parse({
+      ...validPage,
+      entries: [{ ...validPage.entries[0], statusCode: '200' }],
+    })).toThrow()
+  })
+})

--- a/src/shared/lib/types/request-log.ts
+++ b/src/shared/lib/types/request-log.ts
@@ -1,0 +1,56 @@
+import type { McpAuditLogEntry, ProxyAuditLogEntry } from '@shared/lib/db/schema'
+
+export interface RequestLogEntry {
+  id: string
+  source: 'proxy' | 'mcp'
+  agentSlug: string
+  label: string
+  targetUrl: string
+  method: string
+  statusCode: number | null
+  errorMessage: string | null
+  durationMs: number | null
+  policyDecision: string | null
+  matchedScopes: string | null
+  /** Date on the server; ISO string after JSON transport. */
+  createdAt: Date | string
+}
+
+export interface RequestLogPage {
+  entries: RequestLogEntry[]
+  total: number
+}
+
+export function normalizeProxyRequestLog(entry: ProxyAuditLogEntry): RequestLogEntry {
+  return {
+    id: entry.id,
+    source: 'proxy',
+    agentSlug: entry.agentSlug,
+    label: entry.toolkit,
+    targetUrl: `${entry.targetHost}/${entry.targetPath}`,
+    method: entry.method,
+    statusCode: entry.statusCode ?? null,
+    errorMessage: entry.errorMessage ?? null,
+    durationMs: entry.durationMs ?? null,
+    policyDecision: entry.policyDecision ?? null,
+    matchedScopes: entry.matchedScopes ?? null,
+    createdAt: entry.createdAt,
+  }
+}
+
+export function normalizeMcpRequestLog(entry: McpAuditLogEntry): RequestLogEntry {
+  return {
+    id: entry.id,
+    source: 'mcp',
+    agentSlug: entry.agentSlug,
+    label: entry.remoteMcpName,
+    targetUrl: entry.requestPath,
+    method: entry.method,
+    statusCode: entry.statusCode ?? null,
+    errorMessage: entry.errorMessage ?? null,
+    durationMs: entry.durationMs ?? null,
+    policyDecision: entry.policyDecision ?? null,
+    matchedScopes: entry.matchedTool ? JSON.stringify([entry.matchedTool]) : null,
+    createdAt: entry.createdAt,
+  }
+}

--- a/src/shared/lib/types/request-log.ts
+++ b/src/shared/lib/types/request-log.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import type { McpAuditLogEntry, ProxyAuditLogEntry } from '@shared/lib/db/schema'
 
 export interface RequestLogEntry {
@@ -20,6 +21,26 @@ export interface RequestLogPage {
   entries: RequestLogEntry[]
   total: number
 }
+
+export const requestLogEntrySchema = z.object({
+  id: z.string(),
+  source: z.enum(['proxy', 'mcp']),
+  agentSlug: z.string(),
+  label: z.string(),
+  targetUrl: z.string(),
+  method: z.string(),
+  statusCode: z.number().nullable(),
+  errorMessage: z.string().nullable(),
+  durationMs: z.number().nullable(),
+  policyDecision: z.string().nullable(),
+  matchedScopes: z.string().nullable(),
+  createdAt: z.string(),
+}) satisfies z.ZodType<RequestLogEntry>
+
+export const requestLogPageSchema = z.object({
+  entries: z.array(requestLogEntrySchema),
+  total: z.number().int().nonnegative(),
+}) satisfies z.ZodType<RequestLogPage>
 
 export function normalizeProxyRequestLog(entry: ProxyAuditLogEntry): RequestLogEntry {
   return {


### PR DESCRIPTION
## Summary

- add a connection usage card above permissions with a dated chart, hover tooltip, and success/failure totals
- add a connection-scoped logs view linked from the card, including Agent and pagination while omitting Toolkit and Source
- extract shared request-log table and normalization types so agent API Logs and connection logs reuse the same UI and data handling
- support connection log routing, breadcrumbs, and document titles across agent and Settings connection views

## Why

Connection usage was visible only as a small homepage spark chart. This carries the same insight into connection details and provides a direct path to inspect requests across agents.

## Validation

- 279 focused tests passed across 11 test files
- TypeScript typecheck passed
- focused ESLint checks passed
- API production build passed
- web production build currently reaches bundling but is blocked by the existing unresolved markdown-it dependency in the shared node_modules tree