### PR TITLE
Open local bookmarks in responsive file preview

### DIFF
--- a/e2e/specs/file-preview.spec.ts
+++ b/e2e/specs/file-preview.spec.ts
@@ -105,6 +105,9 @@ test.describe('File Preview', () => {
 
     await expect(markdown(page).getByRole('heading', { name: 'Version 1' })).toBeVisible({ timeout: 10000 })
 
+    // The file tray intentionally overlays the composer. Close it before asking
+    // the agent to deliver the updated version, then reopen it from the new pill.
+    await page.getByRole('button', { name: 'Hide files panel' }).click()
     seedWorkspaceFile(agentSlug, 'output/report.md', '# Version 2')
     await sessionPage.sendMessage('deliver file')
     await sessionPage.waitForResponse(15000)
@@ -283,11 +286,11 @@ test.describe('File Preview', () => {
       const header = page.getByTestId('file-preview-header')
       await expect(header).toBeVisible({ timeout: 5000 })
 
-      // Poll: the drawer animates open (300ms width transition), during which
-      // header controls are transiently clipped even in the fixed layout.
+      // Poll while the full-width tray slides in. Compact mode replaces the
+      // right-side panel control with a left-side close button.
       const viewportWidth = page.viewportSize()!.width
       await expect(async () => {
-        for (const control of [header.getByTitle('Download file'), header.getByTitle('Hide files panel')]) {
+        for (const control of [header.getByTitle('Close file preview'), header.getByTitle('Download file')]) {
           await expect(control).toBeVisible()
           const box = await control.boundingBox()
           expect(box).not.toBeNull()
@@ -317,6 +320,10 @@ test.describe('File Preview', () => {
     await reportPill.click()
     await expect(page.getByTestId('file-preview-header')).toBeVisible({ timeout: 5000 })
     await expect(markdown(page).getByRole('heading', { name: 'Report Content' })).toBeVisible({ timeout: 10000 })
+
+    // The overlay covers the composer by design, so close it before delivering
+    // the next file. Existing tabs remain available when the tray reopens.
+    await page.getByRole('button', { name: 'Hide files panel' }).click()
 
     // Deliver and open the image file → second tab, image renderer.
     await sessionPage.sendMessage('deliver image')

--- a/src/renderer/components/agents/agent-home/home-bookmarks.test.tsx
+++ b/src/renderer/components/agents/agent-home/home-bookmarks.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HomeBookmarks } from './home-bookmarks'
+
+const openFile = vi.fn()
+
+vi.mock('@renderer/context/file-preview-context', () => ({
+  useFilePreview: () => ({ openFile }),
+}))
+
+vi.mock('@renderer/hooks/use-bookmarks', () => ({
+  useBookmarks: () => ({
+    data: [
+      { name: 'Daily report', file: '/workspace/reports/daily.csv' },
+      { name: 'Project site', link: 'https://example.com/project' },
+    ],
+  }),
+  useUpdateBookmarks: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}))
+
+describe('HomeBookmarks', () => {
+  beforeEach(() => {
+    openFile.mockReset()
+  })
+
+  it('opens workspace files in the file preview context', async () => {
+    const user = userEvent.setup()
+    render(<HomeBookmarks agentSlug="test-agent" />)
+
+    await user.click(screen.getByRole('button', { name: 'Daily report' }))
+
+    expect(openFile).toHaveBeenCalledWith('/workspace/reports/daily.csv', 'test-agent')
+  })
+
+  it('keeps web bookmarks as external links', () => {
+    render(<HomeBookmarks agentSlug="test-agent" />)
+
+    expect(screen.getByRole('link', { name: 'Project site' })).toHaveAttribute(
+      'href',
+      'https://example.com/project',
+    )
+  })
+})

--- a/src/renderer/components/agents/agent-home/home-bookmarks.tsx
+++ b/src/renderer/components/agents/agent-home/home-bookmarks.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { ExternalLink, FileDown, Pencil, Trash2 } from 'lucide-react'
+import { ExternalLink, PanelRightOpen, Pencil, Trash2 } from 'lucide-react'
 import { FileTypeIcon } from '@renderer/components/ui/file-type-icon'
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
@@ -28,8 +28,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@renderer/components/ui/alert-dialog'
-import { getApiBaseUrl } from '@renderer/lib/env'
 import { useBookmarks, useUpdateBookmarks, type Bookmark } from '@renderer/hooks/use-bookmarks'
+import { useFilePreview } from '@renderer/context/file-preview-context'
 
 interface HomeBookmarksProps {
   agentSlug: string
@@ -38,10 +38,6 @@ interface HomeBookmarksProps {
 
 function getFilename(filePath: string): string {
   return filePath.split('/').pop() || filePath
-}
-
-function getRelativePath(filePath: string): string {
-  return filePath.replace(/^\/workspace\//, '')
 }
 
 function faviconUrl(link: string): string | null {
@@ -73,16 +69,16 @@ function LinkIcon({ link }: { link: string }) {
 
 function BookmarkRow({
   bookmark,
-  agentSlug,
   isOwner,
   onRename,
   onDelete,
+  onOpenFile,
 }: {
   bookmark: Bookmark
-  agentSlug: string
   isOwner: boolean
   onRename: () => void
   onDelete: () => void
+  onOpenFile: (filePath: string) => void
 }) {
   const inner = bookmark.link ? (
     <a
@@ -96,16 +92,17 @@ function BookmarkRow({
       <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity ml-auto" />
     </a>
   ) : bookmark.file ? (
-    <a
-      href={`${getApiBaseUrl()}/api/agents/${agentSlug}/files/${getRelativePath(bookmark.file)}`}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="group flex items-center gap-3 py-2.5 px-1 hover:bg-muted/50 transition-colors"
+    <button
+      type="button"
+      onClick={() => onOpenFile(bookmark.file!)}
+      className="group flex w-full items-center gap-3 py-2.5 px-1 text-left hover:bg-muted/50 transition-colors"
+      title={`Preview ${getFilename(bookmark.file)}`}
+      aria-label={bookmark.name}
     >
       <FileTypeIcon filename={getFilename(bookmark.file)} size={16} />
       <span className="text-xs font-medium truncate">{bookmark.name}</span>
-      <FileDown className="h-3 w-3 shrink-0 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity ml-auto" />
-    </a>
+      <PanelRightOpen className="h-3 w-3 shrink-0 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity ml-auto" />
+    </button>
   ) : null
 
   if (!inner) return null
@@ -133,6 +130,7 @@ function BookmarkRow({
 }
 
 export function HomeBookmarks({ agentSlug, isOwner = false }: HomeBookmarksProps) {
+  const { openFile } = useFilePreview()
   const { data: bookmarks } = useBookmarks(agentSlug)
   const updateBookmarks = useUpdateBookmarks(agentSlug)
   const [renameIndex, setRenameIndex] = useState<number | null>(null)
@@ -169,10 +167,10 @@ export function HomeBookmarks({ agentSlug, isOwner = false }: HomeBookmarksProps
           <BookmarkRow
             key={bookmark.link ?? bookmark.file ?? i}
             bookmark={bookmark}
-            agentSlug={agentSlug}
             isOwner={isOwner}
             onRename={() => { setNewName(bookmark.name); setRenameIndex(i) }}
             onDelete={() => setDeleteIndex(i)}
+            onOpenFile={(filePath) => openFile(filePath, agentSlug)}
           />
         ))}
       </div>

--- a/src/renderer/components/file-preview/comments/use-text-selection.ts
+++ b/src/renderer/components/file-preview/comments/use-text-selection.ts
@@ -12,7 +12,7 @@ export interface TextSelectionInfo {
   timestamp?: number
 }
 
-export function useTextSelection(containerRef: RefObject<HTMLElement | null>) {
+export function useTextSelection(containerRef: RefObject<HTMLElement | null>, enabled = true) {
   const [selection, setSelection] = useState<TextSelectionInfo | null>(null)
 
   const clearSelection = useCallback(() => {
@@ -22,7 +22,7 @@ export function useTextSelection(containerRef: RefObject<HTMLElement | null>) {
 
   useEffect(() => {
     const container = containerRef.current
-    if (!container) return
+    if (!container || !enabled) return
 
     const handleMouseUp = () => {
       requestAnimationFrame(() => {
@@ -57,11 +57,11 @@ export function useTextSelection(containerRef: RefObject<HTMLElement | null>) {
     return () => {
       container.removeEventListener('mouseup', handleMouseUp)
     }
-  }, [containerRef])
+  }, [containerRef, enabled])
 
   // Dismiss the pending comment affordance on any mousedown, unless the click
   // is inside the comment overlay itself (marked with data-comment-overlay).
-  useDismissOnOutsideClick(selection != null, () => setSelection(null), DISMISS_IGNORE)
+  useDismissOnOutsideClick(enabled && selection != null, () => setSelection(null), DISMISS_IGNORE)
 
   return { selection, clearSelection }
 }

--- a/src/renderer/components/file-preview/file-preview-tray-content.test.tsx
+++ b/src/renderer/components/file-preview/file-preview-tray-content.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { FilePreviewTrayContent } from './file-preview-tray-content'
+
+vi.mock('@renderer/context/file-preview-context', () => ({
+  useFilePreview: () => ({
+    openFiles: [{
+      filePath: '/workspace/report.md',
+      agentSlug: 'test-agent',
+      displayName: 'report.md',
+      version: 0,
+    }],
+    activeFileIndex: 0,
+    setActiveFile: vi.fn(),
+    closeFile: vi.fn(),
+    comments: new Map(),
+  }),
+}))
+
+vi.mock('./file-tab-bar', () => ({ FileTabBar: () => null }))
+vi.mock('./renderers/file-renderer', () => ({ FileRenderer: () => null }))
+vi.mock('./comments/comment-bar', () => ({ CommentBar: () => null }))
+
+describe('FilePreviewTrayContent', () => {
+  it('exposes container-responsive close controls on opposite sides', () => {
+    const onClose = vi.fn()
+    render(
+      <FilePreviewTrayContent
+        agentSlug="test-agent"
+        sessionId="test-session"
+        onClose={onClose}
+      />,
+    )
+
+    const mobileClose = screen.getByRole('button', { name: 'Close file preview' })
+    const desktopClose = screen.getByRole('button', { name: 'Hide files panel' })
+    expect(mobileClose).toHaveClass('file-preview-compact-close', 'hidden')
+    expect(desktopClose).toHaveClass('file-preview-wide-close', 'inline-flex')
+
+    fireEvent.click(mobileClose)
+    fireEvent.click(desktopClose)
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/components/file-preview/file-preview-tray-content.tsx
+++ b/src/renderer/components/file-preview/file-preview-tray-content.tsx
@@ -1,4 +1,4 @@
-import { Download, FileText, PanelRightClose } from 'lucide-react'
+import { Download, FileText, PanelRightClose, X } from 'lucide-react'
 import { useFilePreview } from '@renderer/context/file-preview-context'
 import { FileTabBar } from './file-tab-bar'
 import { FileRenderer } from './renderers/file-renderer'
@@ -32,6 +32,14 @@ export function FilePreviewTrayContent({ agentSlug, sessionId, onClose }: FilePr
     <div className="contents" data-testid="file-preview-tray">
       {/* Header */}
       <div className="flex items-center gap-2 px-4 py-2 text-sm text-muted-foreground select-none shrink-0" data-testid="file-preview-header">
+        <button
+          className="file-preview-compact-close -ml-1 hidden p-0.5 rounded hover:bg-muted transition-colors"
+          onClick={onClose}
+          title="Close file preview"
+          aria-label="Close file preview"
+        >
+          <X className="h-4 w-4" />
+        </button>
         <FileText className="h-4 w-4 shrink-0" />
         <span className="flex-1 text-xs truncate font-medium">Files</span>
         <a
@@ -44,9 +52,10 @@ export function FilePreviewTrayContent({ agentSlug, sessionId, onClose }: FilePr
           <Download className="h-4 w-4" />
         </a>
         <button
-          className="p-0.5 rounded hover:bg-muted transition-colors"
+          className="file-preview-wide-close inline-flex p-0.5 rounded hover:bg-muted transition-colors"
           onClick={onClose}
           title="Hide files panel"
+          aria-label="Hide files panel"
         >
           <PanelRightClose className="h-4 w-4" />
         </button>

--- a/src/renderer/components/file-preview/renderers/audio-renderer.test.tsx
+++ b/src/renderer/components/file-preview/renderers/audio-renderer.test.tsx
@@ -29,6 +29,18 @@ afterEach(() => {
 })
 
 describe('AudioRenderer', () => {
+  it('hides annotation controls in a read-only preview', () => {
+    render(
+      <AudioRenderer
+        url="/voice-note.mp3"
+        filePath="/workspace/voice-note.mp3"
+        commentsEnabled={false}
+      />,
+    )
+
+    expect(screen.queryByTestId('audio-add-comment')).not.toBeInTheDocument()
+  })
+
   it('renders custom playback controls and a waveform timeline', () => {
     render(<AudioRenderer url="/voice-note.mp3" filePath="/workspace/voice-note.mp3" />)
 

--- a/src/renderer/components/file-preview/renderers/audio-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/audio-renderer.tsx
@@ -8,6 +8,7 @@ import { createFallbackWaveform, createWaveformPeaks } from './audio-waveform'
 interface AudioRendererProps {
   url: string
   filePath: string
+  commentsEnabled?: boolean
 }
 
 interface PendingComment {
@@ -33,7 +34,7 @@ function getFilename(filePath: string): string {
   return filePath.split('/').pop() || filePath
 }
 
-export function AudioRenderer({ url, filePath }: AudioRendererProps) {
+export function AudioRenderer({ url, filePath, commentsEnabled = true }: AudioRendererProps) {
   const audioRef = useRef<HTMLAudioElement>(null)
   const timelineRef = useRef<HTMLDivElement>(null)
   const hoverCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -222,8 +223,8 @@ export function AudioRenderer({ url, filePath }: AudioRendererProps) {
         <div
           className="group relative h-28 rounded-lg border border-border/60 bg-muted/30 focus-within:ring-1 focus-within:ring-primary"
           data-testid="audio-waveform"
-          onPointerMove={handlePointerMove}
-          onPointerLeave={scheduleHoverClose}
+          onPointerMove={commentsEnabled ? handlePointerMove : undefined}
+          onPointerLeave={commentsEnabled ? scheduleHoverClose : undefined}
         >
           {/* Every time-based element lives in this shared inset coordinate
               system so a ratio maps to the same physical x-position. */}
@@ -283,7 +284,7 @@ export function AudioRenderer({ url, filePath }: AudioRendererProps) {
               />
             )}
 
-            {commentMarkers.map((comment, index) => (
+            {commentsEnabled && commentMarkers.map((comment, index) => (
               <button
                 key={comment.id}
                 type="button"
@@ -310,7 +311,7 @@ export function AudioRenderer({ url, filePath }: AudioRendererProps) {
               data-testid="audio-seek"
             />
 
-            {hoverTime != null && !pending && (
+            {commentsEnabled && hoverTime != null && !pending && (
               <div
                 className="pointer-events-none absolute -top-2 z-40 -translate-x-1/2 -translate-y-full pb-1"
                 style={{ left: `${hoverRatio * 100}%` }}
@@ -336,7 +337,7 @@ export function AudioRenderer({ url, filePath }: AudioRendererProps) {
               </div>
             )}
 
-            {pending && (
+            {commentsEnabled && pending && (
               <CommentOverlay
                 selection={{ text: '', rect: pending.rect, timestamp: pending.timestamp }}
                 filePath={filePath}
@@ -360,16 +361,18 @@ export function AudioRenderer({ url, filePath }: AudioRendererProps) {
           <span className="text-xs tabular-nums text-muted-foreground">
             {formatMediaTime(currentTime)} / {formatMediaTime(duration)}
           </span>
-          <button
-            type="button"
-            onClick={() => beginComment(currentTime)}
-            disabled={pending != null}
-            className="ml-auto flex items-center gap-1 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs transition-colors hover:bg-muted disabled:cursor-default disabled:opacity-50"
-            data-testid="audio-add-comment"
-          >
-            <MessageSquarePlus className="h-3.5 w-3.5" />
-            Add Comment
-          </button>
+          {commentsEnabled && (
+            <button
+              type="button"
+              onClick={() => beginComment(currentTime)}
+              disabled={pending != null}
+              className="ml-auto flex items-center gap-1 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs transition-colors hover:bg-muted disabled:cursor-default disabled:opacity-50"
+              data-testid="audio-add-comment"
+            >
+              <MessageSquarePlus className="h-3.5 w-3.5" />
+              Add Comment
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/renderer/components/file-preview/renderers/csv-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/csv-renderer.tsx
@@ -11,6 +11,7 @@ import { useFilePreview } from '@renderer/context/file-preview-context'
 interface CsvRendererProps {
   url: string
   filePath: string
+  commentsEnabled?: boolean
 }
 
 const MAX_ROWS = 1000
@@ -32,6 +33,7 @@ interface CsvTableProps {
   /** "row:col" -> 1-based comment numbers pinned to that cell. */
   commentsByCell: Map<string, number[]>
   onCellClick: CellClickHandler
+  commentsEnabled: boolean
 }
 
 /**
@@ -39,7 +41,7 @@ interface CsvTableProps {
  * `cellTarget` state) doesn't re-render up to MAX_ROWS × columns of cells.
  * Only re-renders when the data or pinned comments actually change.
  */
-const CsvTable = memo(function CsvTable({ rows, columnLabels, commentsByCell, onCellClick }: CsvTableProps) {
+const CsvTable = memo(function CsvTable({ rows, columnLabels, commentsByCell, onCellClick, commentsEnabled }: CsvTableProps) {
   return (
     <table className="border-collapse text-xs font-mono">
       <thead>
@@ -71,9 +73,10 @@ const CsvTable = memo(function CsvTable({ rows, columnLabels, commentsByCell, on
                   <td
                     key={c}
                     data-csv-cell
-                    onClick={(e) => onCellClick(e, rowNum, c, columnLabels[c], value)}
+                    onClick={commentsEnabled ? (e) => onCellClick(e, rowNum, c, columnLabels[c], value) : undefined}
                     className={cn(
-                      'relative px-3 py-1 align-top whitespace-pre-wrap break-words max-w-[28rem] cursor-pointer border-b border-r border-border/30 hover:bg-primary/5',
+                      'relative px-3 py-1 align-top whitespace-pre-wrap break-words max-w-[28rem] border-b border-r border-border/30',
+                      commentsEnabled && 'cursor-pointer hover:bg-primary/5',
                       cellComments && 'bg-primary/10',
                     )}
                   >
@@ -97,7 +100,7 @@ const CsvTable = memo(function CsvTable({ rows, columnLabels, commentsByCell, on
   )
 })
 
-export function CsvRenderer({ url, filePath }: CsvRendererProps) {
+export function CsvRenderer({ url, filePath, commentsEnabled = true }: CsvRendererProps) {
   const [view, setView] = useState<'table' | 'raw'>('table')
   const [cellTarget, setCellTarget] = useState<CellTarget | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -218,7 +221,7 @@ export function CsvRenderer({ url, filePath }: CsvRendererProps) {
       </div>
 
       {view === 'raw' ? (
-        <TextRenderer url={url} filePath={filePath} />
+        <TextRenderer url={url} filePath={filePath} commentsEnabled={commentsEnabled} />
       ) : (
         <>
           <CsvTable
@@ -226,6 +229,7 @@ export function CsvRenderer({ url, filePath }: CsvRendererProps) {
             columnLabels={columnLabels}
             commentsByCell={commentsByCell}
             onCellClick={handleCellClick}
+            commentsEnabled={commentsEnabled}
           />
           {sizeTruncated && (
             <div className="px-4 py-3 border-t text-xs text-muted-foreground text-center">
@@ -242,7 +246,7 @@ export function CsvRenderer({ url, filePath }: CsvRendererProps) {
         </>
       )}
 
-      {cellTarget && (
+      {commentsEnabled && cellTarget && (
         <CommentOverlay
           selection={{
             text: '',

--- a/src/renderer/components/file-preview/renderers/file-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/file-renderer.tsx
@@ -9,6 +9,7 @@ import { VideoRenderer } from './video-renderer'
 import { AudioRenderer } from './audio-renderer'
 import { HtmlRenderer } from './html-renderer'
 import { UnsupportedRenderer } from './unsupported-renderer'
+import { useFilePreview } from '@renderer/context/file-preview-context'
 
 const PdfRenderer = lazy(() => import('./pdf-renderer').then(m => ({ default: m.PdfRenderer })))
 
@@ -33,9 +34,10 @@ interface FileRendererProps {
 
 export function FileRenderer({ filePath, fileUrl, agentSlug }: FileRendererProps) {
   const ext = getFileExtension(filePath)
+  const { commentsEnabled } = useFilePreview()
 
   if (MARKDOWN_EXTS.has(ext)) {
-    return <MarkdownRenderer url={fileUrl} filePath={filePath} />
+    return <MarkdownRenderer url={fileUrl} filePath={filePath} commentsEnabled={commentsEnabled} />
   }
 
   if (ext === 'html' || ext === 'htm') {
@@ -43,23 +45,23 @@ export function FileRenderer({ filePath, fileUrl, agentSlug }: FileRendererProps
   }
 
   if (CSV_EXTS.has(ext)) {
-    return <CsvRenderer url={fileUrl} filePath={filePath} />
+    return <CsvRenderer url={fileUrl} filePath={filePath} commentsEnabled={commentsEnabled} />
   }
 
   if (TEXT_EXTS.has(ext)) {
-    return <TextRenderer url={fileUrl} filePath={filePath} />
+    return <TextRenderer url={fileUrl} filePath={filePath} commentsEnabled={commentsEnabled} />
   }
 
   if (IMAGE_EXTS.has(ext)) {
-    return <ImageRenderer url={fileUrl} filePath={filePath} />
+    return <ImageRenderer url={fileUrl} filePath={filePath} commentsEnabled={commentsEnabled} />
   }
 
   if (VIDEO_EXTS.has(ext)) {
-    return <VideoRenderer key={`${filePath}:${fileUrl}`} url={fileUrl} filePath={filePath} />
+    return <VideoRenderer key={`${filePath}:${fileUrl}`} url={fileUrl} filePath={filePath} commentsEnabled={commentsEnabled} />
   }
 
   if (AUDIO_EXTS.has(ext)) {
-    return <AudioRenderer key={`${filePath}:${fileUrl}`} url={fileUrl} filePath={filePath} />
+    return <AudioRenderer key={`${filePath}:${fileUrl}`} url={fileUrl} filePath={filePath} commentsEnabled={commentsEnabled} />
   }
 
   if (ext === 'pdf') {
@@ -69,7 +71,7 @@ export function FileRenderer({ filePath, fileUrl, agentSlug }: FileRendererProps
           <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
         </div>
       }>
-        <PdfRenderer url={fileUrl} filePath={filePath} />
+        <PdfRenderer url={fileUrl} filePath={filePath} commentsEnabled={commentsEnabled} />
       </Suspense>
     )
   }

--- a/src/renderer/components/file-preview/renderers/image-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/image-renderer.tsx
@@ -8,6 +8,7 @@ import { useDismissOnOutsideClick } from '../comments/use-dismiss-on-outside-cli
 interface ImageRendererProps {
   url: string
   filePath: string
+  commentsEnabled?: boolean
 }
 
 interface ClickPoint {
@@ -18,7 +19,7 @@ interface ClickPoint {
 
 const IMAGE_DISMISS_IGNORE = ['[data-comment-overlay]']
 
-export function ImageRenderer({ url, filePath }: ImageRendererProps) {
+export function ImageRenderer({ url, filePath, commentsEnabled = true }: ImageRendererProps) {
   const [loaded, setLoaded] = useState(false)
   const [clickPoint, setClickPoint] = useState<ClickPoint | null>(null)
   const imgContainerRef = useRef<HTMLDivElement>(null)
@@ -29,6 +30,7 @@ export function ImageRenderer({ url, filePath }: ImageRendererProps) {
   useDismissOnOutsideClick(clickPoint != null, () => setClickPoint(null), IMAGE_DISMISS_IGNORE)
 
   const handleImageClick = useCallback((e: React.MouseEvent<HTMLImageElement>) => {
+    if (!commentsEnabled) return
     const img = e.currentTarget
     const rect = img.getBoundingClientRect()
     const x = ((e.clientX - rect.left) / rect.width) * 100
@@ -45,7 +47,7 @@ export function ImageRenderer({ url, filePath }: ImageRendererProps) {
         0
       ),
     })
-  }, [])
+  }, [commentsEnabled])
 
   return (
     <div ref={imgContainerRef} className="relative flex items-center justify-center p-4 min-h-[200px]">
@@ -59,7 +61,7 @@ export function ImageRenderer({ url, filePath }: ImageRendererProps) {
         <img
           src={url}
           alt={filePath.split('/').pop() || 'Preview'}
-          className="max-w-full max-h-[60vh] object-contain cursor-crosshair rounded"
+          className={`max-w-full max-h-[60vh] object-contain rounded ${commentsEnabled ? 'cursor-crosshair' : ''}`}
           onLoad={() => setLoaded(true)}
           onClick={handleImageClick}
         />

--- a/src/renderer/components/file-preview/renderers/markdown-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/markdown-renderer.tsx
@@ -10,11 +10,12 @@ import { useFileContent } from './use-file-content'
 interface MarkdownRendererProps {
   url: string
   filePath: string
+  commentsEnabled?: boolean
 }
 
-export function MarkdownRenderer({ url, filePath }: MarkdownRendererProps) {
+export function MarkdownRenderer({ url, filePath, commentsEnabled = true }: MarkdownRendererProps) {
   const containerRef = useRef<HTMLDivElement>(null)
-  const { selection, clearSelection } = useTextSelection(containerRef)
+  const { selection, clearSelection } = useTextSelection(containerRef, commentsEnabled)
 
   // Shares the ['file-content', url] cache with the text/CSV renderers, so all
   // consumers of that key must agree on the cached shape (see use-file-content).

--- a/src/renderer/components/file-preview/renderers/pdf-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/pdf-renderer.tsx
@@ -19,15 +19,16 @@ try {
 interface PdfRendererProps {
   url: string
   filePath: string
+  commentsEnabled?: boolean
 }
 
-export function PdfRenderer({ url, filePath }: PdfRendererProps) {
+export function PdfRenderer({ url, filePath, commentsEnabled = true }: PdfRendererProps) {
   const [numPages, setNumPages] = useState<number | null>(null)
   const [currentPage, setCurrentPage] = useState(1)
   const [loadError, setLoadError] = useState(false)
   const [pageWidth, setPageWidth] = useState(400)
   const containerRef = useRef<HTMLDivElement>(null)
-  const { selection, clearSelection } = useTextSelection(containerRef)
+  const { selection, clearSelection } = useTextSelection(containerRef, commentsEnabled)
 
   const updateWidth = useCallback(() => {
     if (containerRef.current) {

--- a/src/renderer/components/file-preview/renderers/text-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/text-renderer.tsx
@@ -7,11 +7,12 @@ import { useFileContent } from './use-file-content'
 interface TextRendererProps {
   url: string
   filePath: string
+  commentsEnabled?: boolean
 }
 
-export function TextRenderer({ url, filePath }: TextRendererProps) {
+export function TextRenderer({ url, filePath, commentsEnabled = true }: TextRendererProps) {
   const containerRef = useRef<HTMLDivElement>(null)
-  const { selection, clearSelection } = useTextSelection(containerRef)
+  const { selection, clearSelection } = useTextSelection(containerRef, commentsEnabled)
 
   const { data, isLoading, error } = useFileContent(url)
   const sizeTruncated = data?.truncated ?? false

--- a/src/renderer/components/file-preview/renderers/video-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/video-renderer.tsx
@@ -8,6 +8,7 @@ import { formatMediaTime } from '../comments/format-media-time'
 interface VideoRendererProps {
   url: string
   filePath: string
+  commentsEnabled?: boolean
 }
 
 /** An in-progress comment: a locked frame time plus a draggable in-frame point. */
@@ -31,7 +32,7 @@ function clampPct(value: number): number {
   return Math.min(100, Math.max(0, value))
 }
 
-export function VideoRenderer({ url, filePath }: VideoRendererProps) {
+export function VideoRenderer({ url, filePath, commentsEnabled = true }: VideoRendererProps) {
   const videoRef = useRef<HTMLVideoElement>(null)
   const frameRef = useRef<HTMLDivElement>(null)
   const draggingRef = useRef(false)
@@ -121,8 +122,8 @@ export function VideoRenderer({ url, filePath }: VideoRendererProps) {
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
       <div
         ref={frameRef}
-        className="relative inline-block max-w-full cursor-crosshair"
-        onClick={handleFrameClick}
+        className={`relative inline-block max-w-full ${commentsEnabled ? 'cursor-crosshair' : ''}`}
+        onClick={commentsEnabled ? handleFrameClick : undefined}
       >
         {/* Agent-delivered videos have no caption track to offer. */}
         {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
@@ -141,14 +142,14 @@ export function VideoRenderer({ url, filePath }: VideoRendererProps) {
         />
 
         {/* Pins for comments anchored near the current frame. */}
-        {videoComments.map((comment, i) =>
+        {commentsEnabled && videoComments.map((comment, i) =>
           comment.x != null && comment.y != null && Math.abs(comment.timestamp - currentTime) <= PIN_VISIBLE_WINDOW ? (
             <CommentPin key={comment.id} x={comment.x} y={comment.y} number={i + 1} />
           ) : null,
         )}
 
         {/* Draggable point for the comment being placed. */}
-        {pending && (
+        {commentsEnabled && pending && (
           <div
             data-comment-box
             role="presentation"
@@ -163,7 +164,7 @@ export function VideoRenderer({ url, filePath }: VideoRendererProps) {
           </div>
         )}
 
-        {pending && (
+        {commentsEnabled && pending && (
           <CommentOverlay
             selection={{
               text: '',
@@ -185,7 +186,7 @@ export function VideoRenderer({ url, filePath }: VideoRendererProps) {
         <div className="space-y-1">
           <div className="relative h-2">
             {maxSeek > 0 &&
-              videoComments.map(comment => (
+              commentsEnabled && videoComments.map(comment => (
                 <button
                   key={comment.id}
                   type="button"
@@ -222,16 +223,18 @@ export function VideoRenderer({ url, filePath }: VideoRendererProps) {
           <span className="text-xs text-muted-foreground tabular-nums">
             {formatMediaTime(currentTime)} / {formatMediaTime(duration)}
           </span>
-          <button
-            type="button"
-            onClick={() => beginComment(null)}
-            disabled={pending != null}
-            className="ml-auto flex items-center gap-1 px-2.5 py-1 text-xs rounded-md border border-border bg-background hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-default"
-            data-testid="video-add-comment"
-          >
-            <MessageSquarePlus className="h-3.5 w-3.5" />
-            Add Comment
-          </button>
+          {commentsEnabled && (
+            <button
+              type="button"
+              onClick={() => beginComment(null)}
+              disabled={pending != null}
+              className="ml-auto flex items-center gap-1 px-2.5 py-1 text-xs rounded-md border border-border bg-background hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-default"
+              data-testid="video-add-comment"
+            >
+              <MessageSquarePlus className="h-3.5 w-3.5" />
+              Add Comment
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/renderer/components/messages/session-thread.tsx
+++ b/src/renderer/components/messages/session-thread.tsx
@@ -44,7 +44,7 @@ export function SessionThread({
   suppressScrollToBottom,
 }: SessionThreadProps) {
   return (
-    <div className="relative flex-1 flex min-h-0">
+    <div className="file-preview-container relative flex flex-1 min-h-0 min-w-0">
       {/* Chat column — grid pins the footer at the bottom */}
       <div className="flex-1 min-w-0 grid grid-rows-[1fr_auto] min-h-0">
         <MessageList

--- a/src/renderer/components/tray/drawer-shell.test.tsx
+++ b/src/renderer/components/tray/drawer-shell.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+import { DrawerShell } from './drawer-shell'
+
+describe('DrawerShell', () => {
+  it('marks the open drawer as an overlay when requested', () => {
+    const { container } = render(
+      <DrawerShell isOpen storageKey="test-tray-width" responsiveFullWidth>
+        <div>Preview</div>
+      </DrawerShell>,
+    )
+
+    const shell = container.firstElementChild as HTMLElement
+    expect(shell).toHaveClass('file-preview-responsive-overlay')
+    expect(shell).not.toHaveClass('file-preview-responsive-overlay-closed')
+    expect(shell.firstElementChild).toHaveClass('file-preview-responsive-resize-handle')
+  })
+
+  it('keeps a requested overlay mounted off-canvas while closed', () => {
+    const { container } = render(
+      <DrawerShell isOpen={false} storageKey="test-tray-width-closed" responsiveFullWidth>
+        <div>Preview</div>
+      </DrawerShell>,
+    )
+
+    const shell = container.firstElementChild as HTMLElement
+    expect(shell).toHaveClass(
+      'file-preview-responsive-overlay',
+      'file-preview-responsive-overlay-closed',
+    )
+  })
+
+  it('retains the resizable side-drawer layout by default', () => {
+    const { container } = render(
+      <DrawerShell isOpen storageKey="test-tray-width-default">
+        <div>Preview</div>
+      </DrawerShell>,
+    )
+
+    const shell = container.firstElementChild as HTMLElement
+    expect(shell).not.toHaveClass('file-preview-responsive-overlay')
+    expect(shell.firstElementChild).not.toHaveClass('file-preview-responsive-resize-handle')
+  })
+})

--- a/src/renderer/components/tray/drawer-shell.tsx
+++ b/src/renderer/components/tray/drawer-shell.tsx
@@ -13,6 +13,8 @@ export interface DrawerShellHandle {
 interface DrawerShellProps {
   isOpen: boolean
   storageKey: string
+  /** Overlay the parent at drawer width, expanding to full width when it is narrow. */
+  responsiveFullWidth?: boolean
   defaultWidth?: number
   minWidth?: number
   maxWidth?: number
@@ -24,6 +26,7 @@ interface DrawerShellProps {
 export const DrawerShell = forwardRef<DrawerShellHandle, DrawerShellProps>(function DrawerShell({
   isOpen,
   storageKey,
+  responsiveFullWidth = false,
   defaultWidth = DEFAULT_WIDTH,
   minWidth = MIN_WIDTH,
   maxWidth = MAX_WIDTH,
@@ -85,6 +88,8 @@ export const DrawerShell = forwardRef<DrawerShellHandle, DrawerShellProps>(funct
     <div
       className={cn(
         'h-full border-l bg-background flex flex-col shrink-0 overflow-hidden relative shadow-[-4px_0_16px_rgba(0,0,0,0.08)] dark:shadow-[-4px_0_16px_rgba(0,0,0,0.3)]',
+        responsiveFullWidth && 'file-preview-responsive-overlay',
+        responsiveFullWidth && !isOpen && 'file-preview-responsive-overlay-closed',
         !isResizing && 'transition-[width] duration-300 ease-in-out',
         className
       )}
@@ -94,7 +99,10 @@ export const DrawerShell = forwardRef<DrawerShellHandle, DrawerShellProps>(funct
       {/* Resize handle on left edge */}
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
       <div
-        className="absolute inset-y-0 left-0 z-20 w-1 cursor-col-resize hover:bg-border transition-colors"
+        className={cn(
+          'absolute inset-y-0 left-0 z-20 w-1 cursor-col-resize hover:bg-border transition-colors',
+          responsiveFullWidth && 'file-preview-responsive-resize-handle',
+        )}
         onMouseDown={handleResizeMouseDown}
       />
       {children}

--- a/src/renderer/components/tray/tray-manager.tsx
+++ b/src/renderer/components/tray/tray-manager.tsx
@@ -188,6 +188,7 @@ export function TrayManager({ agentSlug, sessionId, browserActive }: TrayManager
       ref={drawerRef}
       isOpen={isOpen}
       storageKey={DRAWER_STORAGE_KEY}
+      responsiveFullWidth={activeTray?.id === 'files'}
     >
       <div className="flex flex-1 min-h-0">
         <div className="flex-1 flex flex-col min-w-0 min-h-0">

--- a/src/renderer/context/file-preview-context.test.tsx
+++ b/src/renderer/context/file-preview-context.test.tsx
@@ -15,6 +15,10 @@ function wrapper({ children }: { children: ReactNode }) {
   return createElement(FilePreviewProvider, null, children)
 }
 
+function readOnlyWrapper({ children }: { children: ReactNode }) {
+  return <FilePreviewProvider commentsEnabled={false}>{children}</FilePreviewProvider>
+}
+
 beforeEach(() => {
   mockView = { kind: 'session', id: 'session-1' }
 })
@@ -137,6 +141,15 @@ describe('FilePreviewContext', () => {
   })
 
   describe('comments', () => {
+    it('ignores comments when the preview is read-only', () => {
+      const { result } = renderHook(() => useFilePreview(), { wrapper: readOnlyWrapper })
+
+      expect(result.current.commentsEnabled).toBe(false)
+      act(() => result.current.addComment({ filePath: '/workspace/a.md', text: 'fix this' }))
+
+      expect(result.current.comments.size).toBe(0)
+    })
+
     it('adds a comment with generated id', () => {
       const { result } = renderHook(() => useFilePreview(), { wrapper })
       act(() => result.current.addComment({ filePath: '/workspace/a.md', text: 'fix this', selectedText: 'broken code' }))

--- a/src/renderer/context/file-preview-context.tsx
+++ b/src/renderer/context/file-preview-context.tsx
@@ -38,6 +38,7 @@ interface FilePreviewContextType {
   activeFileIndex: number
   comments: Map<string, FileComment[]>
   isOpen: boolean
+  commentsEnabled: boolean
 
   openFile: (filePath: string, agentSlug: string, description?: string) => void
   closeFile: (filePath: string) => void
@@ -57,7 +58,15 @@ function getDisplayName(filePath: string): string {
 
 let commentIdCounter = 0
 
-export function FilePreviewProvider({ children, sessionId: sessionIdProp }: { children: ReactNode; sessionId?: string | null }) {
+export function FilePreviewProvider({
+  children,
+  sessionId: sessionIdProp,
+  commentsEnabled = true,
+}: {
+  children: ReactNode
+  sessionId?: string | null
+  commentsEnabled?: boolean
+}) {
   const { view } = useRouteLocation()
   // Views that own a session (e.g. chat integrations) can pass it explicitly so
   // state clears when switching sessions; otherwise derive from the active route.
@@ -127,6 +136,7 @@ export function FilePreviewProvider({ children, sessionId: sessionIdProp }: { ch
   }, [])
 
   const addComment = useCallback((comment: Omit<FileComment, 'id'>) => {
+    if (!commentsEnabled) return
     const id = `comment-${++commentIdCounter}`
     setComments(prev => {
       const next = new Map(prev)
@@ -134,7 +144,7 @@ export function FilePreviewProvider({ children, sessionId: sessionIdProp }: { ch
       next.set(comment.filePath, [...existing, { ...comment, id }])
       return next
     })
-  }, [])
+  }, [commentsEnabled])
 
   const removeComment = useCallback((filePath: string, commentId: string) => {
     setComments(prev => {
@@ -162,6 +172,7 @@ export function FilePreviewProvider({ children, sessionId: sessionIdProp }: { ch
     activeFileIndex,
     comments,
     isOpen,
+    commentsEnabled,
     openFile,
     closeFile,
     setActiveFile,
@@ -169,7 +180,7 @@ export function FilePreviewProvider({ children, sessionId: sessionIdProp }: { ch
     addComment,
     removeComment,
     clearComments,
-  }), [openFiles, activeFileIndex, comments, isOpen, openFile, closeFile, setActiveFile, close, addComment, removeComment, clearComments])
+  }), [openFiles, activeFileIndex, comments, isOpen, commentsEnabled, openFile, closeFile, setActiveFile, close, addComment, removeComment, clearComments])
 
   return (
     <FilePreviewContext.Provider value={value}>

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -697,3 +697,50 @@ html[data-keyboard-open] [data-composer-footer] {
   .h-screen { height: 100vh !important; height: 100lvh !important; }
   .min-h-svh { min-height: 100vh !important; min-height: 100lvh !important; }
 }
+
+/*
+  File previews can render in the agent body or in a smaller embedded session
+  mirror. A viewport or app-level query cannot describe both spaces. Make each
+  immediate tray host a query container and switch the file tray between a
+  fixed-width overlay and a full-width overlay at 768px. Neither mode
+  participates in flex layout, so opening a file never reflows or squeezes the
+  content beneath it.
+*/
+.file-preview-container {
+  container-type: inline-size;
+}
+
+.file-preview-responsive-overlay {
+  position: absolute;
+  inset-block: 0;
+  right: 0;
+  z-index: 30;
+}
+
+@container (max-width: 767px) {
+  .file-preview-responsive-overlay {
+    left: 0;
+    width: 100% !important; /* overrides the persisted inline drawer width */
+    border-left-width: 0;
+    box-shadow: none;
+    transform: translateX(0);
+    transition-property: transform;
+  }
+
+  .file-preview-responsive-overlay-closed {
+    transform: translateX(100%);
+    pointer-events: none;
+  }
+
+  .file-preview-responsive-resize-handle {
+    display: none;
+  }
+
+  .file-preview-compact-close {
+    display: inline-flex;
+  }
+
+  .file-preview-wide-close {
+    display: none;
+  }
+}

--- a/src/renderer/router/route-components.tsx
+++ b/src/renderer/router/route-components.tsx
@@ -11,6 +11,9 @@ import { useAgent } from '@renderer/hooks/use-agents'
 import { usePendingMessages } from '@renderer/context/pending-messages-context'
 import { GlobalSettingsPage } from '@renderer/components/settings/global-settings-page'
 import { useDialogs } from '@renderer/context/dialog-context'
+import { FilePreviewProvider } from '@renderer/context/file-preview-context'
+import { WorkflowProvider } from '@renderer/context/workflow-context'
+import { TrayManager } from '@renderer/components/tray/tray-manager'
 
 /**
  * Leaf route components for the agent sub-views. The shared header chrome +
@@ -22,15 +25,26 @@ function useAgentSlug(): string | null {
 }
 
 // The agent `home` index leaf. AgentHome owns its own agent-scoped dialogs and
-// the new-agent morph (via NavTransientContext); this wrapper just resolves the
-// agent + the optimistic-message creator from context. `key` on the slug remounts
-// AgentHome per agent so the morph's first-mount read fires.
+// the new-agent morph (via NavTransientContext); this wrapper resolves the agent,
+// optimistic-message creator, and the read-only file-preview tray used by local
+// bookmarks. `key` on the slug remounts AgentHome per agent so the morph's
+// first-mount read fires.
 export function AgentHomeRoute() {
   const slug = useAgentSlug()
   const { data: agent } = useAgent(slug)
   const { onSessionCreated } = usePendingMessages()
   if (!slug || !agent) return null
-  return <AgentHome key={agent.slug} agent={agent} onSessionCreated={onSessionCreated} />
+  const homePreviewId = `agent-home:${agent.slug}`
+  return (
+    <FilePreviewProvider sessionId={homePreviewId} commentsEnabled={false}>
+      <WorkflowProvider sessionId={homePreviewId}>
+        <div className="file-preview-container relative flex flex-1 min-h-0 min-w-0">
+          <AgentHome key={agent.slug} agent={agent} onSessionCreated={onSessionCreated} />
+          <TrayManager agentSlug={agent.slug} sessionId={homePreviewId} browserActive={false} />
+        </div>
+      </WorkflowProvider>
+    </FilePreviewProvider>
+  )
 }
 
 // api-logs route: the agent slug is read from the URL.


### PR DESCRIPTION
## Summary

- open local-file bookmarks from the agent homepage in the existing file-preview tray
- keep homepage previews read-only while preserving annotations in session previews
- make file previews overlay the page at regular widths instead of splitting and squeezing the underlying UI
- switch to a full-width overlay with a left-side close button when post-navigation content space is below 768px
- slide the complete full-width tray in from the right so its contents do not reflow during the opening animation

## Why

Local bookmarks previously opened as downloads, and the shared drawer participated in flex layout at some sizes. That could compress the agent homepage and made the full-width opening animation visibly squash the preview contents.

The responsive breakpoint now uses each immediate tray host as its query container, so it reflects the actual space available in both the main agent body and embedded conversation mirrors rather than the raw viewport.

## Validation

- `npm run typecheck`
- `npm run lint` (0 errors)
- `npm run build:web`
- `npm run test:run -- src/renderer/components/agents/agent-home/home-bookmarks.test.tsx src/renderer/context/file-preview-context.test.tsx src/renderer/components/file-preview/renderers/audio-renderer.test.tsx src/renderer/components/file-preview/file-preview-tray-content.test.tsx src/renderer/components/tray/drawer-shell.test.tsx` (32 tests passed)

The full local suite is partially blocked by the borrowed dependency tree's `better-sqlite3` Node ABI mismatch and sandbox-restricted socket tests; affected failures are outside this change's scope.
