### PR TITLE
Fix flaky platform auth attribution initialization

### DIFF
--- a/src/shared/lib/platform-attribution/index.ts
+++ b/src/shared/lib/platform-attribution/index.ts
@@ -7,8 +7,11 @@ import { authAccount } from '@shared/lib/db/schema'
 import { getPlatformAccessToken, getStoredPlatformMemberId } from '@shared/lib/services/platform-auth-service'
 import { decodeOrgIdFromToken } from '@shared/lib/platform-auth/decode-org-id'
 
+import { getRequestUserId } from './request-context'
+
 // Re-export so existing consumers keep importing from here.
 export { decodeOrgIdFromToken }
+export { runWithOptionalUser, runWithRequestUser } from './request-context'
 
 const PLATFORM_PROVIDER_ID = 'platform'
 
@@ -71,21 +74,7 @@ function buildAttribution(memberId: string | null): Attribution | null {
   return new PlatformAttribution(token, memberId, orgScoped)
 }
 
-const userContext = new AsyncLocalStorage<{ userId: string }>()
 const attributionContext = new AsyncLocalStorage<{ auth: Attribution }>()
-
-// Lazy: stores userId; memberId / token are resolved at attribution.current() time.
-export function runWithRequestUser<T>(userId: string, fn: () => Promise<T> | T): Promise<T> | T {
-  return userContext.run({ userId }, fn)
-}
-
-// Same as runWithRequestUser, but a null/undefined userId is a no-op scope.
-export function runWithOptionalUser<T>(
-  userId: string | null | undefined,
-  fn: () => Promise<T> | T,
-): Promise<T> | T {
-  return userId ? userContext.run({ userId }, fn) : fn()
-}
 
 // Eager override: stores a pre-resolved Attribution; takes precedence over
 // the request-user scope. Use when the natural request user isn't who we
@@ -98,7 +87,7 @@ export function runWithAttribution<T>(
 }
 
 function fromCurrentRequest(): Attribution | null {
-  const userId = userContext.getStore()?.userId
+  const userId = getRequestUserId()
   return userId ? buildAttribution(resolveMemberIdForUserId(userId)) : null
 }
 

--- a/src/shared/lib/platform-attribution/request-context.test.ts
+++ b/src/shared/lib/platform-attribution/request-context.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { getRequestUserId, runWithOptionalUser, runWithRequestUser } from './request-context'
+
+describe('platform attribution request context', () => {
+  it('keeps the request user across asynchronous work and restores the outer scope', async () => {
+    expect(getRequestUserId()).toBeUndefined()
+
+    await runWithRequestUser('outer-user', async () => {
+      await Promise.resolve()
+      expect(getRequestUserId()).toBe('outer-user')
+
+      await runWithRequestUser('inner-user', async () => {
+        await Promise.resolve()
+        expect(getRequestUserId()).toBe('inner-user')
+      })
+
+      expect(getRequestUserId()).toBe('outer-user')
+    })
+
+    expect(getRequestUserId()).toBeUndefined()
+  })
+
+  it('preserves the active scope when the optional user is missing', async () => {
+    await runWithRequestUser('outer-user', () =>
+      runWithOptionalUser(null, () => {
+        expect(getRequestUserId()).toBe('outer-user')
+      }),
+    )
+  })
+})

--- a/src/shared/lib/platform-attribution/request-context.ts
+++ b/src/shared/lib/platform-attribution/request-context.ts
@@ -1,0 +1,20 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+const userContext = new AsyncLocalStorage<{ userId: string }>()
+
+// Lazy: stores userId; memberId / token are resolved at attribution.current() time.
+export function runWithRequestUser<T>(userId: string, fn: () => Promise<T> | T): Promise<T> | T {
+  return userContext.run({ userId }, fn)
+}
+
+// Same as runWithRequestUser, but a null/undefined userId is a no-op scope.
+export function runWithOptionalUser<T>(
+  userId: string | null | undefined,
+  fn: () => Promise<T> | T,
+): Promise<T> | T {
+  return userId ? userContext.run({ userId }, fn) : fn()
+}
+
+export function getRequestUserId(): string | undefined {
+  return userContext.getStore()?.userId
+}

--- a/src/shared/lib/services/platform-auth-service.ts
+++ b/src/shared/lib/services/platform-auth-service.ts
@@ -11,6 +11,7 @@ import { getAuthProviderIssuer } from '@shared/lib/auth/provider-config'
 import { verifyOidcJwt } from '@shared/lib/auth/oidc-jwt'
 import { db } from '@shared/lib/db'
 import { authAccount } from '@shared/lib/db/schema'
+import { runWithRequestUser } from '@shared/lib/platform-attribution/request-context'
 
 export type PlatformAuthRecord = PlatformAuthSettings
 
@@ -373,9 +374,6 @@ async function introspectEnvManagedAccount(userId: string): Promise<EnrichedEnvA
   const token = getPlatformAccessToken()
   if (!token) return null
   try {
-    // Dynamic import breaks the module cycle (platform-attribution imports this
-    // service for the token + stored member id).
-    const { runWithRequestUser } = await import('@shared/lib/platform-attribution')
     const account = await runWithRequestUser(userId, () =>
       fetchPlatformJson({
         path: '/v1/account',


### PR DESCRIPTION
## Summary

- move the request-user `AsyncLocalStorage` into a dependency-free attribution context module
- have platform auth introspection import that leaf module directly, eliminating the circular initialization path
- preserve the existing attribution barrel exports and add coverage for async scope propagation, nesting, and restoration

## Root cause

`platform-auth-service` dynamically imported the platform-attribution barrel, while that barrel statically imported `platform-auth-service`. Under full-suite parallel module loading, the cycle could expose the attribution module before `userContext` initialized. The introspection error handler then swallowed the resulting `ReferenceError`, cached a null account, and the test observed zero `fetch` calls.

This matches the recent CI flake signature in three inspected failed runs:

- https://github.com/SkillfulAgents/SuperAgent/actions/runs/29791014525
- https://github.com/SkillfulAgents/SuperAgent/actions/runs/29790908581
- https://github.com/SkillfulAgents/SuperAgent/actions/runs/29781329986

All three failed only `enriches env-managed status with email/orgName/role from /v1/account`, with `fetch` called zero times. Locally, the unmodified suite reproduced twice in five runs; temporarily surfacing the swallowed exception produced `ReferenceError: Cannot access 'userContext' before initialization` at the call through `runWithRequestUser`.

## Validation

- `npm run typecheck`
- ESLint on all changed files
- affected Vitest tests: 58 passed
- `npm run test:coverage` (the exact CI unit-test command)
- five additional full-suite parallel runs: 5/5 passed, 7,454 passing tests per run
