### PR TITLE
Fix silent no-op grant when approving a remote MCP that needs re-auth

### DIFF
--- a/agent-container/src/tools/request-remote-mcp.test.ts
+++ b/agent-container/src/tools/request-remote-mcp.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { inputManager } from '../input-manager'
+
+const mockAddRemoteMcpServer = vi.fn()
+vi.mock('../claude-code', () => ({
+  getCurrentProcess: () => ({
+    addRemoteMcpServer: (...args: unknown[]) => mockAddRemoteMcpServer(...args),
+  }),
+}))
+
+const GRANOLA_MCP = {
+  id: 'mcp-granola-1',
+  name: 'Granola',
+  proxyUrl: 'http://host/api/mcp-proxy/agent/mcp-granola-1',
+  tools: [{ name: 'list_meetings' }, { name: 'get_meetings' }],
+}
+
+describe('requestRemoteMcpTool', () => {
+  let originalRemoteMcps: string | undefined
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    originalRemoteMcps = process.env.REMOTE_MCPS
+  })
+
+  afterEach(() => {
+    if (originalRemoteMcps === undefined) {
+      delete process.env.REMOTE_MCPS
+    } else {
+      process.env.REMOTE_MCPS = originalRemoteMcps
+    }
+  })
+
+  async function invokeTool() {
+    const { requestRemoteMcpTool } = await import('./request-remote-mcp')
+    const handler = (requestRemoteMcpTool as any).handler
+    return handler({ url: 'https://mcp.granola.ai/mcp', name: 'Granola', authHint: 'oauth' })
+  }
+
+  it('reports registered tools when the resolved server is in REMOTE_MCPS', async () => {
+    process.env.REMOTE_MCPS = JSON.stringify([GRANOLA_MCP])
+    const toolUseId = `mcp-test-${Date.now()}-1`
+    inputManager.setCurrentToolUseId(toolUseId)
+    inputManager.resolve(toolUseId, GRANOLA_MCP.id)
+
+    const result = await invokeTool()
+
+    expect(result.isError).toBeUndefined()
+    expect(result.content[0].text).toContain('MCP Server registered as: granola')
+    expect(result.content[0].text).toContain('mcp__granola__list_meetings')
+    expect(mockAddRemoteMcpServer).toHaveBeenCalledWith('Granola')
+  })
+
+  it('returns an explicit error when the resolved server is missing from REMOTE_MCPS', async () => {
+    // The host filters non-active servers out of REMOTE_MCPS — a stale server
+    // can be approved yet never registered. The model must not be told
+    // "granted" in that case.
+    process.env.REMOTE_MCPS = JSON.stringify([])
+    const toolUseId = `mcp-test-${Date.now()}-2`
+    inputManager.setCurrentToolUseId(toolUseId)
+    inputManager.resolve(toolUseId, GRANOLA_MCP.id)
+
+    const result = await invokeTool()
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('NOT registered')
+    expect(result.content[0].text).toContain('re-authenticated')
+    expect(result.content[0].text).not.toContain('has been granted')
+    expect(mockAddRemoteMcpServer).not.toHaveBeenCalled()
+  })
+
+  it('returns an explicit error when REMOTE_MCPS is unset after approval', async () => {
+    delete process.env.REMOTE_MCPS
+    const toolUseId = `mcp-test-${Date.now()}-3`
+    inputManager.setCurrentToolUseId(toolUseId)
+    inputManager.resolve(toolUseId, GRANOLA_MCP.id)
+
+    const result = await invokeTool()
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('NOT registered')
+    expect(mockAddRemoteMcpServer).not.toHaveBeenCalled()
+  })
+
+  it('returns declined message when the request is rejected', async () => {
+    const toolUseId = `mcp-test-${Date.now()}-4`
+    inputManager.setCurrentToolUseId(toolUseId)
+    inputManager.reject(toolUseId, 'User declined to provide MCP access')
+
+    const result = await invokeTool()
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('declined')
+  })
+})

--- a/agent-container/src/tools/request-remote-mcp.ts
+++ b/agent-container/src/tools/request-remote-mcp.ts
@@ -108,6 +108,21 @@ Use this when you need to interact with an MCP server that hasn't been configure
 
       console.log(`[request_remote_mcp] Access to MCP server granted`)
 
+      // Approval resolved but the server never made it into REMOTE_MCPS (e.g.
+      // it is not active and was filtered out). Without this warning the model
+      // is told "granted" and then hunts for tools that will never register.
+      if (!mcpInfo) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'The remote MCP request was approved, but the server is not active in this session and its tools were NOT registered. The server most likely needs to be re-authenticated. Tell the user the MCP connection needs to be reconnected (via its connection settings) before its tools can be used — do not assume the tools are available.',
+            },
+          ],
+          isError: true,
+        }
+      }
+
       return {
         content: [
           {

--- a/e2e/specs/connected-accounts.spec.ts
+++ b/e2e/specs/connected-accounts.spec.ts
@@ -364,6 +364,61 @@ test.describe('Remote MCP - Full Connection Flow', () => {
     })
   })
 
+  test('stale server blocks granting until reconnected', async ({ page, request }, testInfo) => {
+    await withMockMcp(async (mockMcp) => {
+      const mcpName = uniqueName(testInfo, 'Stale MCP')
+      const mcpUrl = mockMcp.url
+      const mcp = await createRemoteMcp(request, { name: mcpName, url: mcpUrl })
+
+      try {
+        // Simulate a broken credential (e.g. expired OAuth / revoked token)
+        const patchResponse = await request.patch(`/api/remote-mcps/${mcp.id}`, {
+          data: { status: 'auth_required' },
+        })
+        expect(patchResponse.ok()).toBeTruthy()
+
+        const { agent, requestCard, sessionPage, agentPage } = await openRemoteMcpRequest(page, request, testInfo, {
+          label: 'MCP Stale',
+          mcpUrl,
+          mcpName,
+        })
+
+        await expect(requestCard.getByText(mcpName)).toBeVisible({ timeout: 10000 })
+        await expect(requestCard).toContainText('Re-auth needed')
+        await expect(requestCard.getByRole('button', { name: /^Reconnect$/ })).toBeVisible()
+        await expect(requestCard.getByRole('button', { name: /Allow Access/i })).toBeDisabled()
+
+        // The provide endpoint refuses non-active servers outright — a grant
+        // that resolves while the server is filtered out of REMOTE_MCPS would
+        // be a silent no-op the agent can't detect.
+        const provideResponse = await request.post(
+          `/api/agents/${agent.slug}/sessions/e2e-stale-check/provide-remote-mcp`,
+          { data: { toolUseId: 'e2e-stale-check', remoteMcpIds: [mcp.id] } },
+        )
+        expect(provideResponse.status()).toBe(409)
+        const provideBody = await provideResponse.json() as { needsReauth?: boolean }
+        expect(provideBody.needsReauth).toBe(true)
+
+        // Reconnect re-probes the (unauthenticated) server and restores it
+        await requestCard.getByRole('button', { name: /^Reconnect$/ }).click()
+
+        await expect(requestCard).not.toContainText('Re-auth needed', { timeout: 10000 })
+        const grantBtn = requestCard.getByRole('button', { name: /Allow Access/i })
+        await expect(grantBtn).toBeEnabled()
+
+        const recovered = await expectRemoteMcpByUrl(request, mcpUrl, mcpName)
+        expect(recovered.status).toBe('active')
+
+        await grantBtn.click()
+        await sessionPage.waitForInputEnabled(15000)
+        await agentPage.waitForStatus('idle', 10000)
+        await expectAgentHasRemoteMcp(request, agent.slug, mcp.id)
+      } finally {
+        await deleteRemoteMcp(request, mcp.id)
+      }
+    })
+  })
+
   test('previously registered MCP server appears in selection list', async ({ page, request }, testInfo) => {
     await withMockMcp(async (mockMcp) => {
       const mcpName = uniqueName(testInfo, 'Existing MCP')

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -3459,6 +3459,31 @@ agents.post('/:id/sessions/:sessionId/provide-remote-mcp', AgentUser(), async (c
       return c.json({ success: true, status: 'declined' })
     }
 
+    // Reject non-active servers instead of resolving a no-op grant: the env
+    // update below filters to status 'active', so a stale server (e.g. expired
+    // OAuth → 'auth_required') would be silently dropped while the agent is
+    // still told access was granted and waits for tools that never appear.
+    const requestedServers = await db
+      .select({
+        id: remoteMcpServers.id,
+        name: remoteMcpServers.name,
+        status: remoteMcpServers.status,
+      })
+      .from(remoteMcpServers)
+      .where(inArray(remoteMcpServers.id, requestedMcpIds))
+    const inactiveServers = requestedServers.filter((s) => s.status !== 'active')
+    if (inactiveServers.length > 0) {
+      const names = inactiveServers.map((s) => s.name).join(', ')
+      return c.json(
+        {
+          error: `MCP server${inactiveServers.length > 1 ? 's' : ''} ${names} need${inactiveServers.length > 1 ? '' : 's'} re-authentication. Reconnect before granting access.`,
+          needsReauth: true,
+          inactiveMcpIds: inactiveServers.map((s) => s.id),
+        },
+        409
+      )
+    }
+
     // Map MCP to agent if not already mapped
     const existingMapping = await db
       .select()

--- a/src/api/routes/provide-remote-mcp.test.ts
+++ b/src/api/routes/provide-remote-mcp.test.ts
@@ -375,6 +375,13 @@ describe('provide-remote-mcp handler', () => {
   }
 
   it('writes REMOTE_MCPS proxyUrl from getHostApiBaseUrl, not host.docker.internal', async () => {
+    // requested servers status check → active
+    mockSelectFrom.mockReturnValueOnce({
+      where: vi.fn().mockResolvedValue([
+        { id: 'mcp-1', name: 'DialMCP', status: 'active' },
+      ]),
+    })
+
     // existing mappings lookup → none yet
     mockSelectFrom.mockReturnValueOnce({
       where: vi.fn().mockResolvedValue([]),
@@ -417,5 +424,30 @@ describe('provide-remote-mcp handler', () => {
     expect(configs).toHaveLength(1)
     expect(configs[0].proxyUrl).toBe('http://10.20.107.8:3000/api/mcp-proxy/test-agent/mcp-1')
     expect(configs[0].proxyUrl).not.toContain('host.docker.internal')
+  })
+
+  it('rejects non-active servers with 409 instead of resolving a no-op grant', async () => {
+    // requested servers status check → needs re-auth
+    mockSelectFrom.mockReturnValueOnce({
+      where: vi.fn().mockResolvedValue([
+        { id: 'mcp-1', name: 'Granola', status: 'auth_required' },
+      ]),
+    })
+
+    const res = await postJson({
+      toolUseId: 'tu-1',
+      remoteMcpId: 'mcp-1',
+    })
+
+    expect(res.status).toBe(409)
+    const body = await res.json() as { error: string; needsReauth: boolean; inactiveMcpIds: string[] }
+    expect(body.needsReauth).toBe(true)
+    expect(body.inactiveMcpIds).toEqual(['mcp-1'])
+    expect(body.error).toContain('Granola')
+    expect(body.error).toContain('re-authentication')
+
+    // Neither the agent mapping nor the pending input in the container is touched
+    expect(mockInsertValues).not.toHaveBeenCalled()
+    expect(mockContainerFetch).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/messages/mcp-server-card.tsx
+++ b/src/renderer/components/messages/mcp-server-card.tsx
@@ -4,6 +4,7 @@ import {
   Check,
   MoreVertical,
   Pencil,
+  RefreshCw,
   X,
 } from 'lucide-react'
 import { COMMON_MCP_SERVERS } from '@shared/lib/mcp/common-servers'
@@ -11,6 +12,7 @@ import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { ToolPolicySummaryPill } from '@renderer/components/ui/tool-policy-summary-pill'
+import { McpStatusPill } from '@renderer/components/connections/mcp-status-pill'
 import { cn } from '@shared/lib/utils/cn'
 
 export interface RemoteMcpServer {
@@ -18,7 +20,8 @@ export interface RemoteMcpServer {
   name: string
   url: string
   authType: string
-  status: string
+  status: 'active' | 'error' | 'auth_required'
+  errorMessage?: string | null
   tools: Array<{ name: string; description?: string }>
 }
 
@@ -82,6 +85,8 @@ export interface McpServerCardProps {
   onStartRename: () => void
   // Policy
   onOpenPolicies: () => void
+  // Re-auth (shown when the server is not active)
+  onReconnect?: () => void
   // State
   disabled?: boolean
 }
@@ -100,9 +105,27 @@ export function McpServerCard({
   onMenuOpenChange,
   onStartRename,
   onOpenPolicies,
+  onReconnect,
   disabled,
 }: McpServerCardProps) {
   const serverSlug = COMMON_MCP_SERVERS.find((commonServer) => commonServer.url === server.url)?.slug || ''
+  const needsReauth = server.status !== 'active'
+
+  const reconnectButton = onReconnect ? (
+    <Button
+      size="xs"
+      variant="outline"
+      className="mx-1 h-6 shrink-0 gap-1 px-2 text-xs"
+      disabled={disabled}
+      onClick={(e) => {
+        e.stopPropagation()
+        onReconnect()
+      }}
+    >
+      <RefreshCw className="h-3 w-3" />
+      Reconnect
+    </Button>
+  ) : null
 
   const renameMenu = (
     <Popover
@@ -213,6 +236,7 @@ export function McpServerCard({
           <p className="truncate text-sm font-normal text-foreground">
             {server.name}
           </p>
+          <McpStatusPill status={server.status} errorMessage={server.errorMessage} />
         </div>
         <p className="truncate text-xs text-muted-foreground">
           {server.url}
@@ -233,13 +257,14 @@ export function McpServerCard({
 
   // Selectable variant (used in lists with multiple servers)
   if (onToggle) {
+    const canToggle = !disabled && !needsReauth
     return (
       <div
         role="button"
         tabIndex={0}
-        onClick={() => !disabled && onToggle()}
+        onClick={() => canToggle && onToggle()}
         onKeyDown={(e) => {
-          if ((e.key === 'Enter' || e.key === ' ') && !disabled) {
+          if ((e.key === 'Enter' || e.key === ' ') && canToggle) {
             e.preventDefault()
             onToggle()
           }
@@ -249,17 +274,21 @@ export function McpServerCard({
           selected
             ? 'border-blue-300 bg-blue-50 dark:border-blue-700 dark:bg-blue-950/40'
             : 'border-border bg-white hover:bg-muted/40 dark:bg-background',
-          disabled && 'cursor-not-allowed opacity-70'
+          needsReauth ? 'cursor-default' : disabled && 'cursor-not-allowed opacity-70'
         )}
       >
-        <input
-          type="checkbox"
-          checked={selected ?? false}
-          disabled={disabled}
-          onChange={() => !disabled && onToggle()}
-          onClick={(e) => e.stopPropagation()}
-          className="mx-1 shrink-0"
-        />
+        {needsReauth && reconnectButton ? (
+          reconnectButton
+        ) : (
+          <input
+            type="checkbox"
+            checked={selected ?? false}
+            disabled={disabled || needsReauth}
+            onChange={() => canToggle && onToggle()}
+            onClick={(e) => e.stopPropagation()}
+            className="mx-1 shrink-0"
+          />
+        )}
         {displayContent}
       </div>
     )
@@ -269,6 +298,7 @@ export function McpServerCard({
   return (
     <div className="group rounded-[12px] border border-border bg-white px-4 py-3 dark:bg-background">
       <div className="flex items-center gap-2">
+        {needsReauth && reconnectButton ? reconnectButton : null}
         {displayContent}
       </div>
     </div>

--- a/src/renderer/components/messages/remote-mcp-request-item.test.tsx
+++ b/src/renderer/components/messages/remote-mcp-request-item.test.tsx
@@ -267,4 +267,79 @@ describe('RemoteMcpRequestItem', () => {
       expect(screen.getByTestId('remote-mcp-request')).toBeInTheDocument()
     })
   })
+
+  describe('stale server needing re-auth', () => {
+    const staleServer = {
+      ...defaultServer,
+      status: 'auth_required',
+      errorMessage: 'Token refresh failed',
+    }
+
+    beforeEach(() => {
+      mockServerListResponse([staleServer])
+    })
+
+    it('shows re-auth pill and Reconnect instead of allowing access', async () => {
+      renderWithProviders(<RemoteMcpRequestItem {...defaultProps} />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Example MCP')).toBeInTheDocument()
+      })
+
+      expect(screen.getByText('Re-auth needed')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Reconnect/i })).toBeInTheDocument()
+      // Nothing providable is selected, so Allow Access must be disabled
+      expect(screen.getByRole('button', { name: /Allow Access/i })).toBeDisabled()
+    })
+
+    it('starts re-auth OAuth for the existing server on Reconnect', async () => {
+      const user = userEvent.setup()
+      mockInitiateOAuthMutateAsync.mockResolvedValue({ redirectUrl: 'https://auth.example.com/oauth' })
+
+      renderWithProviders(<RemoteMcpRequestItem {...defaultProps} />)
+
+      await user.click(await screen.findByRole('button', { name: /Reconnect/i }))
+
+      await waitFor(() => {
+        expect(mockInitiateOAuthMutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({ mcpId: 'mcp-1' })
+        )
+      })
+      // Re-auth targets the existing server, never a new registration
+      expect(mockInitiateOAuthMutateAsync).not.toHaveBeenCalledWith(
+        expect.objectContaining({ url: expect.anything() })
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText(/Waiting for authorization/i)).toBeInTheDocument()
+      })
+    })
+
+    it('enables Allow Access after re-auth completes and the server is active', async () => {
+      const user = userEvent.setup()
+      mockInitiateOAuthMutateAsync.mockResolvedValue({ redirectUrl: 'https://auth.example.com/oauth' })
+
+      renderWithProviders(<RemoteMcpRequestItem {...defaultProps} />)
+
+      await user.click(await screen.findByRole('button', { name: /Reconnect/i }))
+
+      await waitFor(() => {
+        expect(mockUseMcpOAuthListener).toHaveBeenCalledWith(true, expect.any(Function))
+      })
+
+      // Server comes back active after OAuth
+      mockServerListResponse([{ ...defaultServer }])
+
+      const activeCall = mockUseMcpOAuthListener.mock.calls.find(([active]) => active === true)
+      const onOAuthComplete = activeCall?.[1] as ((result: { success: boolean; error?: string }) => void) | undefined
+      act(() => {
+        onOAuthComplete?.({ success: true })
+      })
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Allow Access/i })).toBeEnabled()
+      })
+      expect(screen.queryByText('Re-auth needed')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/src/renderer/components/messages/remote-mcp-request-item.test.tsx
+++ b/src/renderer/components/messages/remote-mcp-request-item.test.tsx
@@ -271,6 +271,7 @@ describe('RemoteMcpRequestItem', () => {
   describe('stale server needing re-auth', () => {
     const staleServer = {
       ...defaultServer,
+      authType: 'oauth',
       status: 'auth_required',
       errorMessage: 'Token refresh failed',
     }
@@ -328,7 +329,7 @@ describe('RemoteMcpRequestItem', () => {
       })
 
       // Server comes back active after OAuth
-      mockServerListResponse([{ ...defaultServer }])
+      mockServerListResponse([{ ...defaultServer, authType: 'oauth' }])
 
       const activeCall = mockUseMcpOAuthListener.mock.calls.find(([active]) => active === true)
       const onOAuthComplete = activeCall?.[1] as ((result: { success: boolean; error?: string }) => void) | undefined
@@ -340,6 +341,104 @@ describe('RemoteMcpRequestItem', () => {
         expect(screen.getByRole('button', { name: /Allow Access/i })).toBeEnabled()
       })
       expect(screen.queryByText('Re-auth needed')).not.toBeInTheDocument()
+    })
+
+    it('selects the reconnected server, not a sibling sharing the same URL', async () => {
+      const user = userEvent.setup()
+      const serverA = { ...defaultServer, id: 'mcp-a', name: 'Account A' }
+      const serverB = { ...staleServer, id: 'mcp-b', name: 'Account B' }
+      mockServerListResponse([serverA, serverB])
+      mockInitiateOAuthMutateAsync.mockResolvedValue({ redirectUrl: 'https://auth.example.com/oauth' })
+
+      renderWithProviders(<RemoteMcpRequestItem {...defaultProps} />)
+
+      // Only the stale sibling offers Reconnect (exact name: the selectable row
+      // is itself role=button and its accessible name contains the button text)
+      await user.click(await screen.findByRole('button', { name: /^Reconnect$/ }))
+      await waitFor(() => {
+        expect(mockInitiateOAuthMutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({ mcpId: 'mcp-b' })
+        )
+      })
+
+      // Both servers now active — a URL match alone would pick Account A
+      mockServerListResponse([serverA, { ...serverB, status: 'active' }])
+      const activeCall = mockUseMcpOAuthListener.mock.calls.find(([active]) => active === true)
+      const onOAuthComplete = activeCall?.[1] as ((result: { success: boolean; error?: string }) => void) | undefined
+      act(() => {
+        onOAuthComplete?.({ success: true })
+      })
+
+      // Auto-selected Account A stays; reconnected Account B is added
+      const allowButton = await screen.findByRole('button', { name: /Allow Access \(2\)/i })
+      await user.click(allowButton)
+
+      await waitFor(() => {
+        expect(mockApiFetch).toHaveBeenCalledWith(
+          expect.stringContaining('provide-remote-mcp'),
+          expect.objectContaining({ body: expect.stringContaining('mcp-b') })
+        )
+      })
+    })
+
+    it('recovers a bearer server via a new token, not OAuth', async () => {
+      const user = userEvent.setup()
+      mockServerListResponse([{ ...staleServer, authType: 'bearer' }])
+
+      renderWithProviders(<RemoteMcpRequestItem {...defaultProps} />)
+
+      await user.click(await screen.findByRole('button', { name: /Reconnect/i }))
+
+      // Token input appears instead of an OAuth popup
+      const tokenInput = await screen.findByPlaceholderText('New bearer token')
+      expect(mockInitiateOAuthMutateAsync).not.toHaveBeenCalled()
+
+      // Server becomes active once the new token is saved and rediscovery runs
+      mockServerListResponse([{ ...defaultServer, authType: 'bearer' }])
+      await user.type(tokenInput, 'fresh-token')
+      await user.click(screen.getByRole('button', { name: /Save Token/i }))
+
+      await waitFor(() => {
+        expect(mockApiFetch).toHaveBeenCalledWith(
+          '/api/remote-mcps/mcp-1',
+          expect.objectContaining({
+            method: 'PATCH',
+            body: expect.stringContaining('fresh-token'),
+          })
+        )
+      })
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        '/api/remote-mcps/mcp-1/discover-tools',
+        expect.objectContaining({ method: 'POST' })
+      )
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Allow Access/i })).toBeEnabled()
+      })
+    })
+
+    it('recovers an unauthenticated server by re-probing, not OAuth', async () => {
+      const user = userEvent.setup()
+      mockServerListResponse([{ ...staleServer, authType: 'none', status: 'error', errorMessage: 'Connection failed' }])
+
+      renderWithProviders(<RemoteMcpRequestItem {...defaultProps} />)
+
+      // Server is reachable again once re-probed
+      const reconnectButton = await screen.findByRole('button', { name: /Reconnect/i })
+      mockServerListResponse([defaultServer])
+      await user.click(reconnectButton)
+
+      await waitFor(() => {
+        expect(mockApiFetch).toHaveBeenCalledWith(
+          '/api/remote-mcps/mcp-1/discover-tools',
+          expect.objectContaining({ method: 'POST' })
+        )
+      })
+      expect(mockInitiateOAuthMutateAsync).not.toHaveBeenCalled()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Allow Access/i })).toBeEnabled()
+      })
     })
   })
 })

--- a/src/renderer/components/messages/remote-mcp-request-item.tsx
+++ b/src/renderer/components/messages/remote-mcp-request-item.tsx
@@ -105,11 +105,18 @@ export function RemoteMcpRequestItem({
     [selectedServiceKey, servers]
   )
   const connectCardSlug = COMMON_MCP_SERVERS.find((server) => server.url === targetUrl)?.slug || mcpSlug
+  // Only active servers can be provided — a non-active server (e.g. expired
+  // OAuth) would be dropped from the container env and the grant becomes a
+  // silent no-op. Those servers get a Reconnect affordance instead.
+  const activeServerIds = useMemo(
+    () => new Set(servers.filter((server) => server.status === 'active').map((server) => server.id)),
+    [servers]
+  )
   const selectedMcpIdsForProvide = useMemo(() => {
-    if (selectedMcpIds.size > 0) return Array.from(selectedMcpIds)
-    if (displayedServiceServers.length <= 1 && activeMcpId) return [activeMcpId]
+    if (selectedMcpIds.size > 0) return Array.from(selectedMcpIds).filter((id) => activeServerIds.has(id))
+    if (displayedServiceServers.length <= 1 && activeMcpId && activeServerIds.has(activeMcpId)) return [activeMcpId]
     return []
-  }, [activeMcpId, displayedServiceServers.length, selectedMcpIds])
+  }, [activeMcpId, activeServerIds, displayedServiceServers.length, selectedMcpIds])
   const pickerServiceOptions = useMemo(() => {
     const grouped = new Map<
       string,
@@ -145,11 +152,14 @@ export function RemoteMcpRequestItem({
     return Array.from(grouped.values())
   }, [servers])
 
-  // Auto-select matching server on first load only
+  // Auto-select matching server on first load only. Non-active servers are
+  // never auto-selected — they need re-auth before they can be provided.
   const hasAutoSelected = useRef(false)
   useEffect(() => {
     if (hasAutoSelected.current) return
-    const initialSelection = servers.find((server) => server.url === targetUrl) || targetServiceServers[0]
+    const initialSelection =
+      servers.find((server) => server.url === targetUrl && server.status === 'active') ||
+      targetServiceServers.find((server) => server.status === 'active')
     if (initialSelection) {
       setSelectedMcpIds(new Set([initialSelection.id]))
       hasAutoSelected.current = true
@@ -163,7 +173,7 @@ export function RemoteMcpRequestItem({
       // Refetch servers to find the newly created one
       refetch().then(({ data: refreshedData }) => {
         const refreshedServers = Array.isArray(refreshedData?.servers) ? refreshedData.servers : []
-        const newServer = refreshedServers.find((s) => s.url === targetUrl)
+        const newServer = refreshedServers.find((s) => s.url === targetUrl && s.status === 'active')
         if (newServer) {
           setSelectedMcpIds(new Set([newServer.id]))
         }
@@ -181,14 +191,18 @@ export function RemoteMcpRequestItem({
     handleOAuthComplete(success, oauthError)
   })
 
-  const startOAuthFlow = async (popup: ReturnType<typeof prepareOAuthPopup>) => {
+  const startOAuthFlow = async (
+    popup: ReturnType<typeof prepareOAuthPopup>,
+    // Pass { mcpId } to re-authenticate an existing server instead of registering a new one.
+    params?: { mcpId: string }
+  ) => {
     try {
       const isElectron = !!window.electronAPI
-      const result = await initiateOAuth.mutateAsync({
-        name: newName.trim() || url,
-        url: targetUrl,
-        electron: isElectron,
-      })
+      const result = await initiateOAuth.mutateAsync(
+        params
+          ? { mcpId: params.mcpId, electron: isElectron }
+          : { name: newName.trim() || url, url: targetUrl, electron: isElectron }
+      )
 
       if (result.redirectUrl) {
         await popup.navigate(result.redirectUrl)
@@ -203,6 +217,13 @@ export function RemoteMcpRequestItem({
       setError(oauthErr instanceof Error ? oauthErr.message : 'Failed to initiate OAuth')
       setStatus('pending')
     }
+  }
+
+  const handleReconnect = async (server: RemoteMcpServer) => {
+    setStatus('registering')
+    setError(null)
+    const popup = prepareOAuthPopup()
+    await startOAuthFlow(popup, { mcpId: server.id })
   }
 
   const handleRegisterNew = async () => {
@@ -466,6 +487,7 @@ export function RemoteMcpRequestItem({
     onMenuOpenChange: (open: boolean) => setMenuOpenMcpId(open ? server.id : null),
     onStartRename: () => handleStartRename(server),
     onOpenPolicies: () => openPolicyEditor(server),
+    onReconnect: server.status !== 'active' ? () => handleReconnect(server) : undefined,
   })
 
   // Build completed config

--- a/src/renderer/components/messages/remote-mcp-request-item.tsx
+++ b/src/renderer/components/messages/remote-mcp-request-item.tsx
@@ -59,6 +59,9 @@ export function RemoteMcpRequestItem({
   const [newUrl, setNewUrl] = useState(url)
   const [showTokenInput, setShowTokenInput] = useState(authHint === 'bearer')
   const [bearerToken, setBearerToken] = useState('')
+  // Bearer-server re-auth: which stale server is getting a replacement token
+  const [reauthMcpId, setReauthMcpId] = useState<string | null>(null)
+  const [reauthToken, setReauthToken] = useState('')
   const [isMcpPickerOpen, setIsMcpPickerOpen] = useState(false)
   const [editingMcpId, setEditingMcpId] = useState<string | null>(null)
   const [editMcpName, setEditMcpName] = useState('')
@@ -166,16 +169,25 @@ export function RemoteMcpRequestItem({
     }
   }, [servers, targetServiceServers, targetUrl])
 
+  // When re-authenticating an existing server, remember which one: several
+  // servers can share the same URL (multiple accounts), so a URL match after
+  // OAuth could select a sibling instead of the server that was reconnected.
+  const reconnectMcpIdRef = useRef<string | null>(null)
+
   // Handle OAuth completion from Electron IPC, postMessage, BroadcastChannel, or storage fallback.
   const handleOAuthComplete = useCallback((success: boolean, errorMessage?: string) => {
     if (success) {
       setError(null)
-      // Refetch servers to find the newly created one
+      // Refetch servers to find the reconnected or newly created one
       refetch().then(({ data: refreshedData }) => {
         const refreshedServers = Array.isArray(refreshedData?.servers) ? refreshedData.servers : []
-        const newServer = refreshedServers.find((s) => s.url === targetUrl && s.status === 'active')
-        if (newServer) {
-          setSelectedMcpIds(new Set([newServer.id]))
+        const reconnectedId = reconnectMcpIdRef.current
+        reconnectMcpIdRef.current = null
+        const completedServer = reconnectedId
+          ? refreshedServers.find((s) => s.id === reconnectedId && s.status === 'active')
+          : refreshedServers.find((s) => s.url === targetUrl && s.status === 'active')
+        if (completedServer) {
+          setSelectedMcpIds((prev) => new Set(prev).add(completedServer.id))
         }
         setStatus('pending')
       }).catch(() => {
@@ -196,6 +208,7 @@ export function RemoteMcpRequestItem({
     // Pass { mcpId } to re-authenticate an existing server instead of registering a new one.
     params?: { mcpId: string }
   ) => {
+    reconnectMcpIdRef.current = params?.mcpId ?? null
     try {
       const isElectron = !!window.electronAPI
       const result = await initiateOAuth.mutateAsync(
@@ -219,11 +232,81 @@ export function RemoteMcpRequestItem({
     }
   }
 
+  // Recovery for a non-active server depends on how it authenticates: OAuth
+  // servers re-run the OAuth flow, bearer servers need a fresh token, and
+  // unauthenticated servers just get re-probed (the outage may have passed).
   const handleReconnect = async (server: RemoteMcpServer) => {
+    setError(null)
+    if (server.authType === 'oauth') {
+      setStatus('registering')
+      const popup = prepareOAuthPopup()
+      await startOAuthFlow(popup, { mcpId: server.id })
+      return
+    }
+    if (server.authType === 'bearer') {
+      setReauthMcpId(server.id)
+      setReauthToken('')
+      return
+    }
+    await rediscoverServer(server.id)
+  }
+
+  // Re-probe a server via discover-tools, which flips it back to active on
+  // success, then select it so it can be provided.
+  const rediscoverServer = async (mcpId: string) => {
+    setStatus('registering')
+    try {
+      const response = await apiFetch(`/api/remote-mcps/${mcpId}/discover-tools`, {
+        method: 'POST',
+      })
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || 'Server is still unreachable')
+      }
+      queryClient.invalidateQueries({ queryKey: ['remote-mcps'] })
+      await refetch()
+      setSelectedMcpIds((prev) => new Set(prev).add(mcpId))
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Reconnect failed')
+    } finally {
+      setStatus('pending')
+    }
+  }
+
+  const handleSubmitReauthToken = async () => {
+    const mcpId = reauthMcpId
+    const token = reauthToken.trim()
+    if (!mcpId || !token) return
+
     setStatus('registering')
     setError(null)
-    const popup = prepareOAuthPopup()
-    await startOAuthFlow(popup, { mcpId: server.id })
+    try {
+      const patchResponse = await apiFetch(`/api/remote-mcps/${mcpId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ accessToken: token }),
+      })
+      if (!patchResponse.ok) {
+        const data = await patchResponse.json().catch(() => ({}))
+        throw new Error(data.error || 'Failed to update token')
+      }
+      const discoverResponse = await apiFetch(`/api/remote-mcps/${mcpId}/discover-tools`, {
+        method: 'POST',
+      })
+      if (!discoverResponse.ok) {
+        const data = await discoverResponse.json().catch(() => ({}))
+        throw new Error(data.error || 'The server rejected the token')
+      }
+      queryClient.invalidateQueries({ queryKey: ['remote-mcps'] })
+      await refetch()
+      setSelectedMcpIds((prev) => new Set(prev).add(mcpId))
+      setReauthMcpId(null)
+      setReauthToken('')
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to update token')
+    } finally {
+      setStatus('pending')
+    }
   }
 
   const handleRegisterNew = async () => {
@@ -642,6 +725,47 @@ export function RemoteMcpRequestItem({
             )}
           </div>
         )}
+        {reauthMcpId && status !== 'oauth_pending' ? (
+          <div className="mt-2 flex items-center gap-2">
+            <Input
+              type="password"
+              value={reauthToken}
+              onChange={(e) => setReauthToken(e.target.value)}
+              placeholder="New bearer token"
+              className="h-8 flex-1 text-sm"
+              autoFocus
+              disabled={status !== 'pending'}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleSubmitReauthToken()
+                if (e.key === 'Escape') {
+                  setReauthMcpId(null)
+                  setReauthToken('')
+                }
+              }}
+            />
+            <Button
+              size="xs"
+              onClick={handleSubmitReauthToken}
+              loading={status === 'registering'}
+              disabled={!reauthToken.trim() || status !== 'pending'}
+              className="shrink-0 bg-foreground text-background hover:bg-foreground/90"
+            >
+              Save Token
+            </Button>
+            <Button
+              size="xs"
+              variant="ghost"
+              onClick={() => {
+                setReauthMcpId(null)
+                setReauthToken('')
+              }}
+              disabled={status === 'registering'}
+              className="shrink-0 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              Cancel
+            </Button>
+          </div>
+        ) : null}
       </div>
 
       {/* Action buttons */}


### PR DESCRIPTION
## Problem

Approving a `request_remote_mcp` request against an **existing** MCP server whose OAuth has expired (`status: 'auth_required'`) silently does nothing:

1. `provide-remote-mcp` rebuilds `REMOTE_MCPS` with `.filter(mcp.status === 'active')` — the stale server is dropped — but **still resolves the pending input as a success**.
2. The container tool can't find the resolved ID in `REMOTE_MCPS`, so it skips the query restart / tool injection, yet returns the bare "Access to the remote MCP server has been granted."
3. The model is told "granted" twice, hunts for tools that never register, and gives up.

Seen in the wild on a sales agent whose Granola MCP token had expired: two approvals both no-oped; it only recovered after the stale registration was deleted and a fresh OAuth connect ran. Fresh connects always work, which is why this doesn't repro locally without a stale record.

## Fix (three layers)

- **Approval UI** (`remote-mcp-request-item.tsx`, `mcp-server-card.tsx`): port the connected-account pattern. Non-active servers are never auto-selected and can't be toggled; their card shows the `McpStatusPill` ("Re-auth needed") and a **Reconnect** button that drives the existing `initiate-oauth` `mcpId` re-auth flow. Once the server comes back `active`, it's selected and Allow Access enables. Also tightened the card's `status` type from `string` to the `'active' | 'error' | 'auth_required'` union.
- **Backend guard** (`agents.ts` provide-remote-mcp): if any requested server isn't `active`, return 409 with `needsReauth: true` + server names instead of resolving the pending input.
- **Honest container message** (`agent-container/src/tools/request-remote-mcp.ts`): if an approval resolves but the server never lands in `REMOTE_MCPS`, return an explicit error saying the tools were NOT registered and the connection needs re-authentication, instead of the bare success.

## Testing

- `npx tsc --noEmit` clean in root and `agent-container`
- eslint clean on changed files
- New tests: 409 guard in `provide-remote-mcp.test.ts`; stale-server pill/Reconnect/re-auth-then-allow flow in `remote-mcp-request-item.test.tsx`
- Adjacent suites (`agents`, `remote-mcps`, `mcp-proxy`, `security-repro`, `connected-account-request-item`) all pass
- Not exercised end-to-end against a real expired-token server (needs a seeded stale registration)

https://claude.ai/code/session_01CZ3s61NJW8vkhTpZ6yxnc8