### PR TITLE
fix: Apple Container host-browser resolves via gateway IP, not host.docker.internal (SUP-428)

### DIFF
--- a/agent-container/src/cdp-host.test.ts
+++ b/agent-container/src/cdp-host.test.ts
@@ -22,10 +22,10 @@ describe('resolveCdpIp', () => {
     expect(ip).toBe('10.4.0.2');
   });
 
-  it('throws "Failed to resolve <name>" when DNS lookup fails', async () => {
+  it('throws "Failed to resolve <name>" with the DNS cause when lookup fails', async () => {
     const lookup = vi.fn().mockRejectedValue(new Error('ENOTFOUND'));
     await expect(
       resolveCdpIp('http://host.docker.internal:47891', lookup),
-    ).rejects.toThrow('Failed to resolve host.docker.internal');
+    ).rejects.toThrow('Failed to resolve host.docker.internal (ENOTFOUND)');
   });
 });

--- a/agent-container/src/cdp-host.test.ts
+++ b/agent-container/src/cdp-host.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveCdpIp } from './cdp-host';
+
+describe('resolveCdpIp', () => {
+  // Apple Container: HOST_APP_URL is the host gateway IP because containers
+  // there can't resolve host.docker.internal (no --add-host equivalent). The
+  // old code always DNS-resolved the hardcoded name and failed NXDOMAIN here.
+  it('uses an IP HOST_APP_URL directly, without DNS', async () => {
+    const lookup = vi.fn();
+    const ip = await resolveCdpIp('http://192.168.64.1:47891', lookup);
+    expect(ip).toBe('192.168.64.1');
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  // Docker/Lima/WSL2: HOST_APP_URL is host.docker.internal, which those
+  // runtimes map (Docker Desktop forwarder, or --add-host). Resolve to an IP so
+  // Chrome's CDP Host-header check (which rejects hostnames) passes.
+  it('resolves a hostname HOST_APP_URL via DNS', async () => {
+    const lookup = vi.fn().mockResolvedValue('10.4.0.2');
+    const ip = await resolveCdpIp('http://host.docker.internal:47891', lookup);
+    expect(lookup).toHaveBeenCalledWith('host.docker.internal');
+    expect(ip).toBe('10.4.0.2');
+  });
+
+  it('throws "Failed to resolve <name>" when DNS lookup fails', async () => {
+    const lookup = vi.fn().mockRejectedValue(new Error('ENOTFOUND'));
+    await expect(
+      resolveCdpIp('http://host.docker.internal:47891', lookup),
+    ).rejects.toThrow('Failed to resolve host.docker.internal');
+  });
+});

--- a/agent-container/src/cdp-host.ts
+++ b/agent-container/src/cdp-host.ts
@@ -1,0 +1,36 @@
+import * as dns from 'dns';
+import * as net from 'net';
+
+/**
+ * Resolve the address the container should use to reach the host's CDP proxy,
+ * derived from HOST_APP_URL - the same host address the launch-host-browser
+ * request already reached the host at.
+ *
+ * Chrome's CDP server validates the Host header and rejects hostnames, so this
+ * always returns an IPv4 address. When HOST_APP_URL is already an IP (Apple
+ * Container, whose containers can't resolve host.docker.internal - no --add-host
+ * equivalent - so its host address is the gateway IP), it is used directly with
+ * no DNS. When it is a hostname (host.docker.internal on Docker/Lima/WSL2, which
+ * those runtimes map to an IPv4), it is resolved via DNS, pinned to IPv4 so the
+ * result is always usable in a host:port authority.
+ *
+ * `lookup` is injectable for tests; it defaults to DNS.
+ */
+export async function resolveCdpIp(
+  hostAppUrl: string,
+  lookup: (hostname: string) => Promise<string> = async (hostname) =>
+    (await dns.promises.lookup(hostname, { family: 4 })).address,
+): Promise<string> {
+  let hostname: string;
+  try {
+    hostname = new URL(hostAppUrl).hostname;
+  } catch {
+    throw new Error(`Invalid HOST_APP_URL: ${hostAppUrl}`);
+  }
+  if (net.isIP(hostname) !== 0) return hostname;
+  try {
+    return await lookup(hostname);
+  } catch {
+    throw new Error(`Failed to resolve ${hostname}`);
+  }
+}

--- a/agent-container/src/cdp-host.ts
+++ b/agent-container/src/cdp-host.ts
@@ -30,7 +30,8 @@ export async function resolveCdpIp(
   if (net.isIP(hostname) !== 0) return hostname;
   try {
     return await lookup(hostname);
-  } catch {
-    throw new Error(`Failed to resolve ${hostname}`);
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to resolve ${hostname} (${cause})`);
   }
 }

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -13,9 +13,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFile, execSync } from 'child_process';
 import { promisify } from 'util';
-import * as dns from 'dns';
 
 import { inputManager } from './input-manager';
+import { resolveCdpIp } from './cdp-host';
 import { startScreenshotJanitor } from './screenshot-janitor';
 import { dashboardManager } from './dashboard-manager';
 import { tabManager } from './tab-manager';
@@ -800,19 +800,14 @@ async function launchHostBrowserIfNeeded(): Promise<HostBrowserInfo | undefined>
     throw new Error('Host browser response missing both cdpUrl and port');
   }
 
-  // Resolve host.docker.internal to its IP address. Chrome's CDP server
-  // validates the Host header and only accepts "localhost" or IP addresses,
-  // rejecting hostnames like "host.docker.internal". Using the resolved IP
-  // ensures the Host header passes Chrome's check for both HTTP requests
-  // and WebSocket connections from agent-browser.
-  const hostDockerInternal = 'host.docker.internal';
-  let cdpIp: string;
-  try {
-    const { address } = await dns.promises.lookup(hostDockerInternal);
-    cdpIp = address;
-  } catch {
-    throw new Error(`Failed to resolve ${hostDockerInternal}`);
-  }
+  // Derive the CDP host from HOST_APP_URL - the same address the
+  // launch-host-browser request above already reached the host at. Chrome's CDP
+  // server validates the Host header and rejects hostnames, so resolveCdpIp
+  // returns an IP. Apple containers can't resolve host.docker.internal (no
+  // --add-host equivalent), so there HOST_APP_URL is the host gateway IP and no
+  // DNS is needed; Docker/Lima/WSL2 keep host.docker.internal, which their
+  // runtime maps.
+  const cdpIp = await resolveCdpIp(hostAppUrl);
 
   // Chrome's CDP requires connecting to the full debugger WebSocket URL
   // (ws://host:port/devtools/browser/<id>), not just ws://host:port.

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -741,6 +741,25 @@ interface HostBrowserInfo {
   hostDownloadDir: string;
 }
 
+// Relay a container-side browser-launch failure to the host for Sentry.
+// Only called for failures after the launch request itself succeeded — the
+// host is known reachable at that point, but has no other way to learn this
+// half of the launch broke (the error otherwise surfaces only in the agent's
+// tool result). Fire-and-forget: reporting must never mask the real error.
+function reportHostBrowserLaunchError(
+  hostAppUrl: string,
+  headers: Record<string, string>,
+  stage: string,
+  err: unknown,
+): void {
+  const message = err instanceof Error ? err.message : String(err);
+  void fetch(`${hostAppUrl}/api/browser/report-launch-error`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ agentId: process.env.AGENT_ID || 'default', stage, message }),
+  }).catch(() => {});
+}
+
 // Launch the host browser via CDP if AGENT_BROWSER_USE_HOST is set.
 // Returns the CDP WebSocket URL and host download dir, or undefined if not using host browser.
 // Throws if host browser mode is enabled but the browser fails to launch.
@@ -807,7 +826,13 @@ async function launchHostBrowserIfNeeded(): Promise<HostBrowserInfo | undefined>
   // --add-host equivalent), so there HOST_APP_URL is the host gateway IP and no
   // DNS is needed; Docker/Lima/WSL2 keep host.docker.internal, which their
   // runtime maps.
-  const cdpIp = await resolveCdpIp(hostAppUrl);
+  let cdpIp: string;
+  try {
+    cdpIp = await resolveCdpIp(hostAppUrl);
+  } catch (err) {
+    reportHostBrowserLaunchError(hostAppUrl, browserAuthHeaders, 'resolve-cdp-host', err);
+    throw err;
+  }
 
   // Chrome's CDP requires connecting to the full debugger WebSocket URL
   // (ws://host:port/devtools/browser/<id>), not just ws://host:port.
@@ -822,12 +847,14 @@ async function launchHostBrowserIfNeeded(): Promise<HostBrowserInfo | undefined>
     versionRes = await fetch(`http://${cdpHost}/json/version`);
   } catch (err) {
     const cause = err instanceof Error ? err.message : String(err);
-    throw new Error(
+    const error = new Error(
       `The host browser launched, but its debugging endpoint at ${cdpHost} is unreachable from inside the agent container (${cause}). ` +
       `This usually means a firewall on the host machine is blocking container-to-host connections ` +
       `(on Windows: Windows Defender Firewall or antivirus blocking the app on the "vEthernet (WSL)" network). ` +
       `Ask the user to allow the app through their firewall, or to switch Browser Host to the built-in browser in Settings.`
     );
+    reportHostBrowserLaunchError(hostAppUrl, browserAuthHeaders, 'cdp-endpoint-unreachable', error);
+    throw error;
   }
   if (!versionRes.ok) {
     throw new Error(`Failed to query CDP /json/version: ${versionRes.status}`);

--- a/src/api/routes/browser-schema.ts
+++ b/src/api/routes/browser-schema.ts
@@ -15,3 +15,17 @@ export const hostBrowserRequestSchema = z.object({
 })
 
 export type HostBrowserRequest = z.infer<typeof hostBrowserRequestSchema>
+
+/**
+ * Request body for `/api/browser/report-launch-error` — a container relaying a
+ * browser-launch failure that happened on its side (after launch-host-browser
+ * succeeded) so the host can report it to Sentry. Lengths are capped because
+ * the body is attacker-influenceable (any container holding a valid token).
+ */
+export const browserLaunchErrorReportSchema = z.object({
+  agentId: z.string().min(1).optional(),
+  stage: z.string().min(1).max(64),
+  message: z.string().min(1).max(4000),
+})
+
+export type BrowserLaunchErrorReport = z.infer<typeof browserLaunchErrorReportSchema>

--- a/src/api/routes/browser.report-launch-error.test.ts
+++ b/src/api/routes/browser.report-launch-error.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+// ---------------------------------------------------------------------------
+// /api/browser/report-launch-error — a container relays a browser-launch
+// failure that happened on its side (after launch-host-browser succeeded) so
+// the host can report it to Sentry. The route must:
+//   - capture the relayed message with the token-bound agentId (never the raw
+//     body agentId),
+//   - reject cross-agent reports (body agentId ≠ token agent) without
+//     capturing,
+//   - reject malformed bodies without capturing.
+// ---------------------------------------------------------------------------
+
+const mockValidateProxyToken = vi.fn<(token: string) => Promise<string | null>>()
+vi.mock('@shared/lib/proxy/token-store', () => ({
+  validateProxyToken: (token: string) => mockValidateProxyToken(token),
+}))
+
+const mockCaptureException = vi.fn()
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}))
+
+vi.mock('../../main/host-browser', () => ({
+  getActiveProvider: () => null,
+  setOnExternalClose: vi.fn(),
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({ app: {} }),
+}))
+
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: { getClient: () => ({ fetch: vi.fn() }) },
+}))
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: { broadcastGlobal: vi.fn() },
+}))
+
+// auth.ts dependencies — use the REAL IsAgent() so the token → slug binding is
+// exercised end to end; these stubs keep its import graph light.
+vi.mock('@shared/lib/auth/mode', () => ({ isAuthMode: () => false }))
+vi.mock('@shared/lib/platform-attribution', () => ({
+  runWithRequestUser: (_id: string, fn: () => unknown) => fn(),
+  runWithOptionalUser: (_id: string | null | undefined, fn: () => unknown) => fn(),
+}))
+vi.mock('@shared/lib/db', () => ({ db: {} }))
+vi.mock('@shared/lib/db/schema', () => ({
+  agentAcl: {}, connectedAccounts: {}, remoteMcpServers: {}, notifications: {},
+}))
+
+// Import after mocks.
+import browser from './browser'
+
+const TOKEN = 'agent-a-token'
+const TOKEN_SLUG = 'agent-a'
+
+function post(body: unknown) {
+  const app = new Hono()
+  app.route('/api/browser', browser)
+  return app.request('http://localhost/api/browser/report-launch-error', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${TOKEN}` },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockValidateProxyToken.mockResolvedValue(TOKEN_SLUG)
+})
+
+describe('POST /api/browser/report-launch-error', () => {
+  it('captures the relayed error under the token-bound agent', async () => {
+    const res = await post({
+      agentId: TOKEN_SLUG,
+      stage: 'resolve-cdp-host',
+      message: 'Failed to resolve host.docker.internal (ENOTFOUND)',
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockCaptureException).toHaveBeenCalledTimes(1)
+    const [err, context] = mockCaptureException.mock.calls[0]
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toBe('Failed to resolve host.docker.internal (ENOTFOUND)')
+    expect(context).toEqual({
+      tags: { component: 'browser', operation: 'container-launch-failure', stage: 'resolve-cdp-host' },
+      extra: { agentId: TOKEN_SLUG },
+    })
+  })
+
+  it('rejects a cross-agent report without capturing', async () => {
+    const res = await post({
+      agentId: 'agent-b',
+      stage: 'resolve-cdp-host',
+      message: 'spoofed',
+    })
+
+    expect(res.status).toBe(403)
+    expect(mockCaptureException).not.toHaveBeenCalled()
+  })
+
+  it('rejects a malformed body without capturing', async () => {
+    const res = await post({ stage: 'resolve-cdp-host' })
+
+    expect(res.status).toBe(400)
+    expect(mockCaptureException).not.toHaveBeenCalled()
+  })
+})

--- a/src/api/routes/browser.ts
+++ b/src/api/routes/browser.ts
@@ -5,7 +5,8 @@ import { getSettings } from '@shared/lib/config/settings'
 import { containerManager } from '@shared/lib/container/container-manager'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { IsAgent } from '../middleware/auth'
-import { hostBrowserRequestSchema } from './browser-schema'
+import { captureException } from '@shared/lib/error-reporting'
+import { hostBrowserRequestSchema, browserLaunchErrorReportSchema } from './browser-schema'
 
 const browser = new Hono()
 
@@ -18,7 +19,7 @@ const browser = new Hono()
  */
 async function resolveTokenBoundAgentId(
   c: Context,
-): Promise<{ agentId: string } | { error: Response }> {
+): Promise<{ agentId: string; raw: unknown } | { error: Response }> {
   const tokenAgentId = c.get('agentSlug' as never) as string | undefined
   if (!tokenAgentId) {
     // IsAgent() should always stash this; fail closed if it did not.
@@ -35,7 +36,7 @@ async function resolveTokenBoundAgentId(
     return { error: c.json({ error: 'Forbidden: agentId does not match token agent' }, 403) }
   }
 
-  return { agentId: tokenAgentId }
+  return { agentId: tokenAgentId, raw }
 }
 
 // POST /api/browser/launch-host-browser - Launch browser on host for CDP connection
@@ -66,6 +67,29 @@ browser.post('/launch-host-browser', IsAgent(), async (c) => {
     console.error('[Browser] Failed to launch host browser:', message)
     return c.json({ error: message }, 503)
   }
+})
+
+// POST /api/browser/report-launch-error - A container reports a browser-launch
+// failure that happened on its side AFTER launch-host-browser succeeded (e.g.
+// it cannot resolve or reach the CDP endpoint). The host is the only side with
+// Sentry, so relay it — otherwise the failure exists only in the agent's tool
+// result and never reaches error tracking.
+browser.post('/report-launch-error', IsAgent(), async (c) => {
+  const resolved = await resolveTokenBoundAgentId(c)
+  if ('error' in resolved) return resolved.error
+
+  const parsed = browserLaunchErrorReportSchema.safeParse(resolved.raw)
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid request body' }, 400)
+  }
+
+  const { stage, message } = parsed.data
+  console.error(`[Browser] Container launch failure (${stage}) for ${resolved.agentId}: ${message}`)
+  captureException(new Error(message), {
+    tags: { component: 'browser', operation: 'container-launch-failure', stage },
+    extra: { agentId: resolved.agentId },
+  })
+  return c.json({ success: true })
 })
 
 // POST /api/browser/stop-host-browser - Stop the host browser process for a specific agent


### PR DESCRIPTION
## What

Agents running in a macOS Apple Container in host-browser mode could not open a browser. It failed with `Failed to resolve host.docker.internal`.

## Why

The host-browser launch path resolved the hardcoded name `host.docker.internal` through the guest DNS resolver to find Chrome's CDP host. Apple's container runtime has no `--add-host` equivalent, so that name is NXDOMAIN inside the guest and the browser never opens. #487 already moved the proxy / host-API path to the host gateway IP for Apple (via `getHostApiBaseUrl()`), but the browser CDP path was left hardcoding the name.

## What changed

The browser path now derives the CDP host from `HOST_APP_URL` - the same address the launch-host-browser request already reached the host at:

- **Apple**: `HOST_APP_URL` is the gateway IP, used directly (no DNS).
- **Docker / Lima / WSL2**: `HOST_APP_URL` is `host.docker.internal`, resolved via DNS exactly as before (those runtimes map it to an IPv4).

Resolution is extracted into a small, unit-tested `resolveCdpIp()` helper. Only the local host-browser (Chrome) path is affected - remote providers (Browserbase) already return a CDP URL directly and never reach this code.

## Verified

- **Unit**: IP-literal (Apple) skips DNS; hostname (Docker/Lima) resolves via DNS; DNS failure surfaces the same error as before.
- **End-to-end in a real Apple Container**: the old hardcoded `dns.lookup('host.docker.internal')` reproduces the NXDOMAIN failure; the fixed path resolves to the gateway IP and reaches the host CDP.
