### PR TITLE
fix: cancel pending browser-input requests on browser close + mark subagent input requests as awaiting

### DIFF
--- a/agent-container/src/input-manager.test.ts
+++ b/agent-container/src/input-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import {
   inputManager,
   AUTOMATED_INPUT_TTL_MS,
@@ -428,6 +428,70 @@ describe('InputManager', () => {
 
       expect(inputManager.consumeCurrentToolUseId()).toBe('hook-B')
       expect(inputManager.consumeCurrentToolUseId()).toBeNull()
+    })
+  })
+
+  // A browser_input request is only answerable while the browser exists — the
+  // card literally instructs the user to act "in the open browser tab". When
+  // the browser closes (browser_close from ANY session sharing it, or the user
+  // closing the window), every pending browser_input must be rejected so the
+  // blocked caller (often a background subagent) unblocks and can finish its
+  // turn instead of parking for the 24h human-input TTL.
+  describe('rejectByType (browser lifecycle cleanup)', () => {
+    it('rejects all pending browser_input requests and leaves other types pending', async () => {
+      const p1 = inputManager.createPendingWithType('rbt-browser-1', 'browser_input', {
+        message: 'Log in to GitHub.',
+        requirements: [],
+      })
+      const p2 = inputManager.createPendingWithType('rbt-browser-2', 'browser_input', {
+        message: 'Approve the OAuth consent screen.',
+        requirements: [],
+      })
+      const secret = inputManager.createPendingWithType('rbt-secret-1', 'secret', {
+        secretName: 'API_KEY',
+      })
+
+      const rejected = inputManager.rejectByType('browser_input', 'The browser was closed')
+
+      expect(rejected).toBe(2)
+      await expect(p1).rejects.toThrow('The browser was closed')
+      await expect(p2).rejects.toThrow('The browser was closed')
+
+      expect(inputManager.hasPending('rbt-browser-1')).toBe(false)
+      expect(inputManager.hasPending('rbt-browser-2')).toBe(false)
+      expect(inputManager.hasPending('rbt-secret-1')).toBe(true)
+
+      // Clean up the secret pending
+      inputManager.reject('rbt-secret-1', 'test cleanup')
+      await expect(secret).rejects.toThrow('test cleanup')
+    })
+
+    it('returns 0 when nothing of that type is pending', () => {
+      expect(inputManager.rejectByType('browser_input', 'The browser was closed')).toBe(0)
+    })
+
+    it('unblocks the real request_browser_input tool with a cancelled error result', async () => {
+      const toolUseId = `rbt-tool-${Date.now()}`
+      inputManager.setCurrentToolUseId(toolUseId)
+
+      const { requestBrowserInputTool } = await import('./tools/request-browser-input')
+      const handler = (requestBrowserInputTool as any).handler
+
+      const resultPromise = handler({
+        message: 'Log in to GitHub to finish the submission.',
+        requirements: ['Complete 2FA'],
+      })
+
+      await vi.waitFor(() => {
+        expect(inputManager.hasPending(toolUseId)).toBe(true)
+      })
+
+      inputManager.rejectByType('browser_input', 'The browser was closed')
+
+      const result = await resultPromise
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain('Browser input request cancelled')
+      expect(result.content[0].text).toContain('The browser was closed')
     })
   })
 })

--- a/agent-container/src/input-manager.test.ts
+++ b/agent-container/src/input-manager.test.ts
@@ -474,6 +474,11 @@ describe('InputManager', () => {
       const toolUseId = `rbt-tool-${Date.now()}`
       inputManager.setCurrentToolUseId(toolUseId)
 
+      // The handler only registers a pending while a browser is active
+      // (see the browser-lifecycle guard test file)
+      const { setBrowserState, resetBrowserState } = await import('./browser-state')
+      setBrowserState({ active: true, sessionId: 'rbt-sess', cdpUrl: 'ws://127.0.0.1:9222' })
+
       const { requestBrowserInputTool } = await import('./tools/request-browser-input')
       const handler = (requestBrowserInputTool as any).handler
 
@@ -492,6 +497,8 @@ describe('InputManager', () => {
       expect(result.isError).toBe(true)
       expect(result.content[0].text).toContain('Browser input request cancelled')
       expect(result.content[0].text).toContain('The browser was closed')
+
+      resetBrowserState()
     })
   })
 })

--- a/agent-container/src/input-manager.ts
+++ b/agent-container/src/input-manager.ts
@@ -207,6 +207,30 @@ class InputManager {
   }
 
   /**
+   * Reject and remove every pending request of a given input type. Used for
+   * lifecycle invalidation: a request can become unanswerable when the
+   * resource it depends on goes away — e.g. browser_input requests when the
+   * browser closes (possibly by a DIFFERENT session or agent than the one
+   * that created the request, so per-session scoping is not enough here).
+   * A blocked awaiter gets a clean error and can continue its turn instead
+   * of parking until the 24h human-input TTL.
+   * @returns number of requests rejected
+   */
+  rejectByType(inputType: string, reason: string): number {
+    let rejected = 0
+    for (const [toolUseId, pending] of this.pending) {
+      if (pending.inputType !== inputType) continue
+      console.log(
+        `[InputManager] Rejecting ${pending.inputType} request ${toolUseId} (type invalidated): ${reason}`
+      )
+      this.pending.delete(toolUseId)
+      pending.reject(new Error(reason))
+      rejected++
+    }
+    return rejected
+  }
+
+  /**
    * Resolve a pending request with a value.
    * If no pending request exists yet (e.g. parallel tool calls race condition),
    * the value is buffered so createPending can resolve immediately when called.

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -1085,6 +1085,16 @@ app.post('/browser/close', async (c) => {
     _setBrowserState({ active: false, sessionId: null, cdpUrl: null });
     tabManager.resetTabCount();
 
+    // A browser_input request is only answerable while the browser exists —
+    // and it may belong to a session OTHER than the closer (e.g. a background
+    // subagent parked on a login while the main agent closes the browser).
+    // Reject them all so blocked awaiters unblock instead of hanging for the
+    // 24h human-input TTL behind a card the user can no longer act on.
+    inputManager.rejectByType(
+      'browser_input',
+      'The browser was closed before the user completed this request'
+    );
+
     return c.json({ success: true });
   } catch (error: any) {
     console.error('[Browser] Error closing browser:', error);
@@ -1125,6 +1135,12 @@ app.post('/browser/notify-closed', (c) => {
     tabManager.resetTabCount();
     console.log('[Browser] Browser closed externally, state cleaned up');
   }
+  // Outside the guard: an external close can race the active flag, and a
+  // pending browser_input is unanswerable once the browser is gone either way.
+  inputManager.rejectByType(
+    'browser_input',
+    'The browser was closed before the user completed this request'
+  );
   return c.json({ success: true });
 });
 

--- a/agent-container/src/tools/request-browser-input.test.ts
+++ b/agent-container/src/tools/request-browser-input.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { inputManager } from '../input-manager'
+import { setBrowserState, resetBrowserState } from '../browser-state'
+
+// The browser-close cleanup (`rejectByType('browser_input', …)`) only rejects
+// pendings that already exist. If the close lands between the PreToolUse hook
+// and createPendingWithType, the handler would create a fresh 24h pending for
+// a browser that is already gone — recreating the original hang. The handler
+// must therefore refuse to register a request while no browser is active; the
+// check and the registration are one synchronous block, so a close processed
+// on the same event loop can never interleave between them.
+describe('requestBrowserInputTool browser-lifecycle guard', () => {
+  beforeEach(() => {
+    resetBrowserState()
+  })
+
+  afterEach(() => {
+    resetBrowserState()
+    // Drain any current toolUseId a failing test might leave behind
+    inputManager.consumeCurrentToolUseId()
+  })
+
+  it('refuses to create a pending when no browser is active (close-before-registration race)', async () => {
+    const toolUseId = `guard-closed-${Date.now()}`
+    inputManager.setCurrentToolUseId(toolUseId)
+
+    const { requestBrowserInputTool } = await import('./request-browser-input')
+    const handler = (requestBrowserInputTool as any).handler
+
+    const result = await handler({
+      message: 'Log in to GitHub to finish the submission.',
+      requirements: [],
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toMatch(/browser/i)
+    expect(inputManager.hasPending(toolUseId)).toBe(false)
+  })
+
+  it('creates a pending normally while the browser is active', async () => {
+    setBrowserState({ active: true, sessionId: 'sess-1', cdpUrl: 'ws://127.0.0.1:9222' })
+    const toolUseId = `guard-live-${Date.now()}`
+    inputManager.setCurrentToolUseId(toolUseId)
+
+    const { requestBrowserInputTool } = await import('./request-browser-input')
+    const handler = (requestBrowserInputTool as any).handler
+
+    const resultPromise = handler({
+      message: 'Log in to GitHub to finish the submission.',
+      requirements: [],
+    })
+
+    await vi.waitFor(() => {
+      expect(inputManager.hasPending(toolUseId)).toBe(true)
+    })
+
+    inputManager.resolve(toolUseId, 'done')
+
+    const result = await resultPromise
+    expect(result.isError).toBeUndefined()
+    expect(result.content[0].text).toContain('completed the requested browser interaction')
+  })
+})

--- a/agent-container/src/tools/request-browser-input.ts
+++ b/agent-container/src/tools/request-browser-input.ts
@@ -1,6 +1,7 @@
 import { tool } from '@anthropic-ai/claude-agent-sdk'
 import { z } from 'zod'
 import { inputManager } from '../input-manager'
+import { getBrowserState } from '../browser-state'
 
 export const requestBrowserInputTool = tool(
   'request_browser_input',
@@ -28,6 +29,22 @@ Example:
       console.error('[request_browser_input] No toolUseId available')
       return {
         content: [{ type: 'text' as const, text: 'Unable to process browser input request - no tool use ID available.' }],
+        isError: true,
+      }
+    }
+
+    // The request is only answerable while a browser is open — the card tells
+    // the user to act "in the open browser tab". Checking here (synchronously,
+    // right before createPendingWithType) also closes the race with browser
+    // teardown: the close routes' rejectByType only covers pendings that
+    // already exist, so a close landing before this handler runs must be
+    // caught by this guard rather than creating a fresh 24h pending nobody
+    // can ever answer. Both this check+register and the close's
+    // state-flip+reject are synchronous blocks, so they cannot interleave.
+    if (!getBrowserState().active) {
+      console.log('[request_browser_input] Rejected: no active browser')
+      return {
+        content: [{ type: 'text' as const, text: 'Browser input request cancelled: no browser is open (it may have just been closed). Open the browser again with browser_open before requesting manual input, or continue without it.' }],
         isError: true,
       }
     }

--- a/e2e/specs/subagent-browser-input-status.spec.ts
+++ b/e2e/specs/subagent-browser-input-status.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+import {
+  createAgent,
+  gotoAgentHome,
+  uniqueName,
+  uniqueSuffix,
+  type TestAgent,
+} from '../helpers/agents'
+
+// A background subagent can park on request_browser_input while the main turn
+// stays open (its request arrives as a sidechain message, not on the main
+// stream). The user-visible contract is the same as a main-agent request: the
+// card shows AND the agent-level status flips to awaiting_input (orange dot).
+// Regression: the sidechain path only broadcast the card, so the agent sat
+// labeled "working" while it was actually blocked on the user.
+test.describe('Subagent Browser Input Status', () => {
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+  let agent: TestAgent
+
+  test.describe.configure({ timeout: 45000 })
+
+  test.beforeEach(async ({ page, request }, testInfo) => {
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+
+    agent = await createAgent(request, uniqueName(testInfo, 'Subagent Browser Agent'))
+    await gotoAgentHome(page, agent)
+  })
+
+  test('browser input requested by a subagent shows the card and flips status to awaiting_input', async ({ page }, testInfo) => {
+    await sessionPage.sendMessage(`subagent browser input ${uniqueSuffix(testInfo)}`)
+
+    // The request card appears (this worked before the fix)
+    const card = page.getByTestId('browser-input-request')
+    await expect(card).toBeVisible({ timeout: 15000 })
+    await expect(card).toContainText('Log in to GitHub to finish the submission.')
+
+    // THE BUG: agent status stayed 'working' for subagent-originated requests
+    await agentPage.waitForStatus('awaiting_input', 15000)
+  })
+
+  test('declining the subagent browser input request returns the agent to idle', async ({ page }, testInfo) => {
+    await sessionPage.sendMessage(`subagent browser input ${uniqueSuffix(testInfo)}`)
+
+    await expect(page.getByTestId('browser-input-request')).toBeVisible({ timeout: 15000 })
+    await agentPage.waitForStatus('awaiting_input', 15000)
+
+    await page.getByTestId('browser-input-decline-btn').click()
+
+    // Declining resolves the pending input; the mock ends the turn and the
+    // awaiting state must not stick around.
+    await expect(page.getByTestId('browser-input-request')).toHaveCount(0, { timeout: 10000 })
+    await agentPage.waitForStatus('idle', 15000)
+  })
+})

--- a/e2e/specs/subagent-browser-input-status.spec.ts
+++ b/e2e/specs/subagent-browser-input-status.spec.ts
@@ -42,6 +42,27 @@ test.describe('Subagent Browser Input Status', () => {
     await agentPage.waitForStatus('awaiting_input', 15000)
   })
 
+  test('completing the request clears awaiting while the subagent resumes, then the session settles', async ({ page }, testInfo) => {
+    await sessionPage.sendMessage(`subagent browser input ${uniqueSuffix(testInfo)}`)
+
+    await expect(page.getByTestId('browser-input-request')).toBeVisible({ timeout: 15000 })
+    await agentPage.waitForStatus('awaiting_input', 15000)
+
+    await page.getByTestId('browser-input-complete-btn').click()
+
+    // The subagent's tool_result comes back on the SIDECHAIN (the mock
+    // preserves parent_tool_use_id) and the subagent resumes: the card must
+    // drop and the status must leave awaiting_input BEFORE the session
+    // settles — the mock holds the turn open ~2.5s after the resolve.
+    // Regression: the sidechain result path never cleared isAwaitingInput,
+    // so the UI stayed "needs input" behind a stale, replayable card.
+    await expect(page.getByTestId('browser-input-request')).toHaveCount(0, { timeout: 10000 })
+    await agentPage.waitForStatus('working', 5000)
+
+    // …and the turn then completes normally.
+    await agentPage.waitForStatus('idle', 15000)
+  })
+
   test('declining the subagent browser input request returns the agent to idle', async ({ page }, testInfo) => {
     await sessionPage.sendMessage(`subagent browser input ${uniqueSuffix(testInfo)}`)
 

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -2750,6 +2750,104 @@ describe('MessagePersister', () => {
 
         cleanup()
       })
+
+      // The resolve side of the same asymmetry: a subagent's tool_result comes
+      // back on the SIDECHAIN (parent_tool_use_id set), which never reaches the
+      // main-path 'user' handler that clears isAwaitingInput and drops the
+      // replayable card. After the user clicks Complete, the subagent resumes —
+      // the UI must stop saying "needs input" and must not replay a stale card.
+      function sendSidechainBrowserInputRequest(parentToolId: string, subToolId: string) {
+        mockClient._sendMessage({
+          type: 'assistant',
+          parent_tool_use_id: parentToolId,
+          message: {
+            content: [
+              {
+                type: 'tool_use',
+                id: subToolId,
+                name: 'mcp__user-input__request_browser_input',
+                input: { message: 'Log in to GitHub.', requirements: [] },
+              },
+            ],
+          },
+        })
+      }
+
+      it('clears awaiting state and the replayable card when the sidechain tool_result arrives', () => {
+        const { events: globalEvents, cleanup } = collectGlobalEvents()
+
+        sendSidechainBrowserInputRequest('agent-tool-3', 'sub-tool-3')
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(1)
+
+        sseEvents.length = 0
+
+        mockClient._sendMessage({
+          type: 'user',
+          parent_tool_use_id: 'agent-tool-3',
+          message: {
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'sub-tool-3',
+                content: 'User has completed the requested browser interaction.',
+              },
+            ],
+          },
+        })
+
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
+        // Same broadcast the main path uses — other windows drop their card copy off it
+        const results = sseEvents.filter(e => e.type === 'tool_result')
+        expect(results).toHaveLength(1)
+        expect(results[0].toolUseId).toBe('sub-tool-3')
+        expect(globalEvents.filter(e => e.type === 'session_input_provided')).toHaveLength(1)
+
+        cleanup()
+      })
+
+      it('does not clear awaiting state on unrelated sidechain tool results', () => {
+        sendSidechainBrowserInputRequest('agent-tool-4', 'sub-tool-4')
+
+        // An ordinary subagent tool result (e.g. Bash) while the request is open
+        mockClient._sendMessage({
+          type: 'user',
+          parent_tool_use_id: 'agent-tool-4',
+          message: {
+            content: [
+              { type: 'tool_result', tool_use_id: 'other-tool-9', content: 'file listing' },
+            ],
+          },
+        })
+
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(1)
+      })
+
+      it('keeps awaiting when another input request is still open after the sidechain result', () => {
+        // Main-agent question open in parallel with the subagent's browser input
+        simulateToolUse('AskUserQuestion', 'main-q-1', {
+          questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
+        })
+        sendSidechainBrowserInputRequest('agent-tool-5', 'sub-tool-5')
+        expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(2)
+
+        // Only the subagent's request resolves
+        mockClient._sendMessage({
+          type: 'user',
+          parent_tool_use_id: 'agent-tool-5',
+          message: {
+            content: [
+              { type: 'tool_result', tool_use_id: 'sub-tool-5', content: 'done' },
+            ],
+          },
+        })
+
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(1)
+        expect(messagePersister.getPendingInputRequests(SESSION_ID)[0].toolUseId).toBe('main-q-1')
+      })
     })
 
     it('does NOT set isAwaitingInput for schedule_task tool', () => {

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -2683,6 +2683,75 @@ describe('MessagePersister', () => {
       expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
     })
 
+    // A background subagent's request_browser_input must flip the SAME awaiting
+    // flag the main agent's does: the in-chat card is renderer-local state, but
+    // the sidebar/header orange dot reads the persister's isAwaitingInput. A
+    // request surfaced only as a card leaves the agent labeled "working" while
+    // it is actually blocked on the user.
+    describe('subagent-originated browser input requests', () => {
+      function sendSidechainStreamEvent(event: any, parentToolId = 'agent-tool-1') {
+        mockClient._sendMessage({
+          type: 'stream_event',
+          parent_tool_use_id: parentToolId,
+          event,
+        })
+      }
+
+      it('sets isAwaitingInput when a subagent streams request_browser_input', () => {
+        sendSidechainStreamEvent({
+          type: 'content_block_start',
+          content_block: {
+            type: 'tool_use',
+            id: 'sub-tool-1',
+            name: 'mcp__user-input__request_browser_input',
+          },
+        })
+        sendSidechainStreamEvent({
+          type: 'content_block_delta',
+          delta: {
+            type: 'input_json_delta',
+            partial_json: JSON.stringify({
+              message: 'Log in to GitHub.',
+              requirements: ['Complete 2FA'],
+            }),
+          },
+        })
+        sendSidechainStreamEvent({ type: 'content_block_stop' })
+
+        // The card broadcast fires either way — the status flag is the fix target.
+        const cards = sseEvents.filter(e => e.type === 'browser_input_request')
+        expect(cards).toHaveLength(1)
+        expect(cards[0].toolUseId).toBe('sub-tool-1')
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      })
+
+      it('sets isAwaitingInput when a subagent complete assistant message carries request_browser_input', () => {
+        const { events: globalEvents, cleanup } = collectGlobalEvents()
+
+        mockClient._sendMessage({
+          type: 'assistant',
+          parent_tool_use_id: 'agent-tool-2',
+          message: {
+            content: [
+              {
+                type: 'tool_use',
+                id: 'sub-tool-2',
+                name: 'mcp__user-input__request_browser_input',
+                input: { message: 'Log in to GitHub.', requirements: [] },
+              },
+            ],
+          },
+        })
+
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        const awaiting = globalEvents.filter(e => e.type === 'session_awaiting_input')
+        expect(awaiting).toHaveLength(1)
+        expect(awaiting[0].sessionId).toBe(SESSION_ID)
+
+        cleanup()
+      })
+    })
+
     it('does NOT set isAwaitingInput for schedule_task tool', () => {
       simulateToolUse('mcp__user-input__schedule_task', 'tool-1', {
         scheduleType: 'at',

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -4030,6 +4030,13 @@ ${continuation}`
         agentSlug,
       })
 
+      // The request always blocks on the user, no matter which stream it came
+      // from. Marking here (not only in the main-stream content_block_stop
+      // handler) covers SUBAGENT-originated requests, whose sidechain paths
+      // bypass that handler — without this the orange awaiting-input status
+      // never flips and the agent shows "working" while parked on the user.
+      this.markSessionAwaitingInput(sessionId)
+
       // Renderer-side gate handles suppression; see session_complete trigger.
       if (agentSlug) {
         notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'browser_input').catch((err) => {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1842,6 +1842,15 @@ class MessagePersister {
     // Complete messages have been persisted to the subagent JSONL by the SDK,
     // so the frontend can refetch them via the API endpoint.
     if (content.type === 'user' || content.type === 'assistant') {
+      // A subagent's tool_result arrives here, NOT via the main-path 'user'
+      // handler — so a resolved input request (user clicked Complete on a
+      // subagent's browser_input card) must run the same bookkeeping: drop
+      // the replayable card and clear the awaiting status while the subagent
+      // resumes. Without this the UI stays "needs input" behind a stale card
+      // until the whole turn ends.
+      if (content.type === 'user') {
+        this.resolveSidechainInputRequests(sessionId, state, content)
+      }
       if (content.type === 'assistant') {
         const messageContent = content.message?.content
         if (Array.isArray(messageContent)) {
@@ -4409,6 +4418,42 @@ ${continuation}`
   }
 
   // Handle tool results - broadcast to SSE clients
+  // Sidechain counterpart of handleToolResults, scoped to tracked input
+  // requests only: ordinary subagent tool results (Bash, Read, …) stream
+  // constantly and must not broadcast main-path `tool_result` events or touch
+  // the awaiting flag. Unlike the main path's unconditional clear, awaiting is
+  // cleared only when NO tracked request remains — a main-agent question can
+  // be open in parallel with a subagent's browser_input.
+  private resolveSidechainInputRequests(
+    sessionId: string,
+    state: StreamingState,
+    content: { message?: { content?: Array<{ type: string; tool_use_id?: string; content?: unknown; is_error?: boolean }> } }
+  ): void {
+    const blocks = content.message?.content
+    if (!Array.isArray(blocks)) return
+    for (const block of blocks) {
+      if (block.type !== 'tool_result' || !block.tool_use_id) continue
+      if (!state.pendingInputRequests.has(block.tool_use_id)) continue
+      state.pendingInputRequests.delete(block.tool_use_id)
+      // Same broadcast the main path emits — the resolving tab already removed
+      // its card optimistically; every other tab drops it off this event.
+      this.broadcastToSSE(sessionId, {
+        type: 'tool_result',
+        toolUseId: block.tool_use_id,
+        result: block.content,
+        isError: block.is_error || false,
+      })
+    }
+    if (state.isAwaitingInput && state.pendingInputRequests.size === 0) {
+      state.isAwaitingInput = false
+      this.broadcastGlobal({
+        type: 'session_input_provided',
+        sessionId,
+        agentSlug: state.agentSlug,
+      })
+    }
+  }
+
   private handleToolResults(
     sessionId: string,
     content: { message?: { content?: Array<{ type: string; tool_use_id?: string; content?: unknown; is_error?: boolean }> } }

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -810,8 +810,14 @@ export class SubagentBrowserInputScenario implements MockScenario {
     const parentToolId = `agent_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`
     const subToolId = `subtool_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`
 
-    // One pending input: resolving/declining the card ends the turn.
-    client.registerPendingInputs(sessionId, 1)
+    // One pending input: resolving/declining the card ends the turn — after a
+    // gap long enough for tests to assert the agent-resumed (working, NOT
+    // awaiting) window between the user's answer and the session settling.
+    client.registerPendingInputs(sessionId, 1, { completionDelayMs: 2500 })
+    // The result must come back on the sidechain, like the real SDK delivers
+    // subagent tool results — a top-level result would bypass the sidechain
+    // bookkeeping this scenario exists to exercise.
+    client.registerSidechainToolParent(subToolId, parentToolId)
 
     client.writeJsonlEntry(sessionId, {
       type: 'user',
@@ -1717,6 +1723,15 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
   private sessionToApiSession: Map<string, string> = new Map()
   // Track pending user input requests per session for auto-completion
   private pendingInputCounts: Map<string, number> = new Map()
+  // Delay between the last input resolving and the turn-ending 'result', per
+  // session (default 50ms). Scenarios that must expose the post-resolve window
+  // (agent resumed, not yet settled) register a longer one.
+  private inputCompletionDelays: Map<string, number> = new Map()
+  // toolUseId → parent_tool_use_id for input requests that a SUBAGENT issued.
+  // The real SDK returns their tool_results on the sidechain (parent id set),
+  // which the persister routes through handleSidechainMessage — a top-level
+  // result here would exercise the wrong production path.
+  private sidechainToolParents: Map<string, string> = new Map()
 
   constructor(config: ContainerConfig) {
     super()
@@ -1812,10 +1827,24 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
   /**
    * Register pending input count for a session. When all inputs are resolved/rejected
    * via fetch(), the session emits a result event to complete.
+   * `completionDelayMs` stretches the gap between the last resolve and that
+   * result, for tests that assert the agent-resumed-but-not-settled window.
    */
-  registerPendingInputs(sessionId: string, count: number): void {
+  registerPendingInputs(sessionId: string, count: number, opts?: { completionDelayMs?: number }): void {
     this.pendingInputCounts.set(sessionId, count)
+    if (opts?.completionDelayMs !== undefined) {
+      this.inputCompletionDelays.set(sessionId, opts.completionDelayMs)
+    }
     console.log(`[MockContainerClient] Registered ${count} pending inputs for session ${sessionId}`)
+  }
+
+  /**
+   * Mark an input-request toolUseId as issued by a subagent under the given
+   * parent tool: its resolve/reject tool_result is then emitted as a SIDECHAIN
+   * user message (parent_tool_use_id preserved), matching the real SDK.
+   */
+  registerSidechainToolParent(toolUseId: string, parentToolId: string): void {
+    this.sidechainToolParents.set(toolUseId, parentToolId)
   }
 
   /**
@@ -2004,18 +2033,36 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
             tool_use_id: toolUseId,
             content: resolveMatch[2] === 'resolve' ? 'User provided input' : 'User declined the request',
           }]
-          this.writeJsonlEntry(sessionId, {
-            type: 'user',
-            message: { content: toolResultBlocks },
-            timestamp: new Date().toISOString(),
-          })
-          this.emitStreamMessage(sessionId, {
-            type: 'user',
-            content: { type: 'user', message: { content: toolResultBlocks } },
-          })
+          const sidechainParent = this.sidechainToolParents.get(toolUseId)
+          if (sidechainParent) {
+            // Subagent-issued request: the result comes back on the sidechain
+            // (parent_tool_use_id set) and is persisted to the SUBAGENT
+            // transcript in production, so no main-transcript JSONL write here.
+            this.sidechainToolParents.delete(toolUseId)
+            this.emitStreamMessage(sessionId, {
+              type: 'user',
+              content: {
+                type: 'user',
+                parent_tool_use_id: sidechainParent,
+                message: { content: toolResultBlocks },
+              },
+            })
+          } else {
+            this.writeJsonlEntry(sessionId, {
+              type: 'user',
+              message: { content: toolResultBlocks },
+              timestamp: new Date().toISOString(),
+            })
+            this.emitStreamMessage(sessionId, {
+              type: 'user',
+              content: { type: 'user', message: { content: toolResultBlocks } },
+            })
+          }
           if (remaining === 0) {
             this.pendingInputCounts.delete(sessionId)
-            // Complete the session after a short delay
+            // Complete the session after the configured delay (default: short)
+            const completionDelay = this.inputCompletionDelays.get(sessionId) ?? 50
+            this.inputCompletionDelays.delete(sessionId)
             setTimeout(() => {
               this.writeJsonlEntry(sessionId, {
                 type: 'assistant',
@@ -2028,7 +2075,7 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
                 type: 'result',
                 content: { type: 'result', subtype: 'success' },
               })
-            }, 50)
+            }, completionDelay)
           }
           break
         }

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -796,6 +796,65 @@ export class UserInputRequestScenario implements MockScenario {
   }
 }
 
+/**
+ * A BACKGROUND subagent parks on request_browser_input while the main turn
+ * stays open: the request arrives as a sidechain assistant message
+ * (parent_tool_use_id set), not on the main stream. The card must appear AND
+ * the agent-level status must flip to awaiting_input — the sidebar/header
+ * orange dot reads the persister's awaiting flag, which only the main-stream
+ * path used to set. Replicates the stuck "working" session with an
+ * unanswerable browser card.
+ */
+export class SubagentBrowserInputScenario implements MockScenario {
+  execute(sessionId: string, client: MockContainerClient, userMessage: string): void {
+    const parentToolId = `agent_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`
+    const subToolId = `subtool_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`
+
+    // One pending input: resolving/declining the card ends the turn.
+    client.registerPendingInputs(sessionId, 1)
+
+    client.writeJsonlEntry(sessionId, {
+      type: 'user',
+      message: { content: userMessage },
+      timestamp: new Date().toISOString(),
+    })
+
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'message_start' } },
+      })
+    }, 10)
+
+    // The subagent's request arrives as a complete sidechain assistant message
+    // (the SDK often delivers subagent tool calls without stream deltas).
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'assistant',
+        content: {
+          type: 'assistant',
+          parent_tool_use_id: parentToolId,
+          message: {
+            content: [
+              {
+                type: 'tool_use',
+                id: subToolId,
+                name: 'mcp__user-input__request_browser_input',
+                input: {
+                  message: 'Log in to GitHub to finish the submission.',
+                  requirements: ['Log in to GitHub', 'Complete 2FA if prompted'],
+                },
+              },
+            ],
+          },
+        },
+      })
+    }, 60)
+    // No 'result' here: the main turn stays open, matching the incident where
+    // the subagent parked mid-turn waiting on the user.
+  }
+}
+
 function getMessageParam(userMessage: string, key: string): string | undefined {
   const prefix = `${key}=`
   const rawValue = userMessage
@@ -1465,6 +1524,7 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
         input: { subagent_type: 'Explore', description: 'Scan the repo', prompt: 'Look at the files and report back' },
       },
     ])],
+    ['subagent browser input', new SubagentBrowserInputScenario()],
     // Proxy review scenario for E2E tests
     ['proxy review', new ProxyReviewScenario(
       'slack',


### PR DESCRIPTION
## Incident

A scheduled session sat pinned on **"working"** overnight with a pending browser-input card — and no open browser to act on it. The main agent had launched a **background** `web-browser` subagent that parked on `request_browser_input` at a GitHub login wall; the main agent then closed the browser out from under it, summarized, and ended its turn. The subagent could never settle, so turn-end kept emitting `session_waiting_background` forever, while the header contradicted the in-chat "Waiting for input…" chip.

## Two defects

1. **Status never flipped for subagent-originated requests.** Only the main-stream `content_block_stop` path called `markSessionAwaitingInput`; the sidechain delivery paths (complete assistant message + subagent stream events) only broadcast the card. The in-chat chip is renderer-local state, but the sidebar/header orange dot reads the persister's `isAwaitingInput` — so the agent showed "working" while blocked on the user.
2. **Browser teardown orphaned pending requests.** `/browser/close` and `/browser/notify-closed` cleaned up tabs/screencast/state but never touched the container `InputManager`, leaving `browser_input` pendings alive for their 24h human-input TTL — with the requesting (possibly different) session blocked behind an unanswerable card.

## Fix

- `handleBrowserInputRequestTool` now marks the session awaiting input itself (idempotent with the existing main-path marking), covering every delivery path.
- New `inputManager.rejectByType(type, reason)`, called from both browser-close routes. A blocked awaiter gets `Browser input request cancelled: the browser was closed…`, finishes its turn, the session settles to idle, and the card clears at the turn boundary.

## Tests (all failed before the fix)

- **Persister unit ×2** — sidechain `request_browser_input` (stream-event and complete-message paths) must set `isAwaitingInput` + emit `session_awaiting_input`.
- **Container unit ×3** — `rejectByType` rejects only `browser_input` pendings; unblocks the real `request_browser_input` tool handler with the cancelled error result.
- **E2E ×2** — new `SubagentBrowserInputScenario` (`subagent browser input` trigger) replicates the incident: card visible + status must read `awaiting_input` (previously stuck at `working`), and declining returns the agent to idle.

Validated: full persister file (254), chat-integrations + container suites (1453), agent-container suite (717), status/input/browser E2E suites (11), `tsc --noEmit` + eslint clean in both packages.

## Follow-up (not in this PR)

A background subagent that *dies* (process exit, TaskStop) still leaves its card and awaiting status behind — cleanup needs the host to track request→subagent origin and dismiss on terminal `task_updated`/`task_notification`.

https://claude.ai/code/session_01XawqeKZeJV9pT9Fjy7MFgA