### PR TITLE
fix(chat): Slack session conversation context + own-chat send guard

### DIFF
--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -634,7 +634,7 @@ export class ClaudeCodeProcess extends EventEmitter {
           'browser': createBrowserMcpServer(browserMcpTools),
           'dashboards': createDashboardsMcpServer(),
           'agents': createAgentsMcpServer(() => this.sessionId),
-          'chat': createChatMcpServer(),
+          'chat': createChatMcpServer(() => this.sessionId),
           ...((this.webSearchProvider || this.webFetchProvider)
             ? { 'web': createWebMcpServer({ search: !!this.webSearchProvider, fetch: !!this.webFetchProvider }) }
             : {}),

--- a/agent-container/src/mcp-server.ts
+++ b/agent-container/src/mcp-server.ts
@@ -49,7 +49,7 @@ import { getSessionTranscriptTool } from './tools/agents/get-session-transcript'
 import { listAvailableChatProvidersTool } from './tools/chat/list-available-chat-providers'
 import { listChatIntegrationsTool } from './tools/chat/list-chat-integrations'
 import { addChatIntegrationTool } from './tools/chat/add-chat-integration'
-import { sendChatMessageTool } from './tools/chat/send-chat-message'
+import { makeSendChatMessageTool } from './tools/chat/send-chat-message'
 
 // TODO: refactor - every MCP should be exported from its own file instead of having one giant factory with conditional logic for which tools to include. This will make it easier to maintain and add new MCPs in the future without modifying existing code.
 
@@ -142,7 +142,13 @@ export function createAgentsMcpServer(getCallerSessionId: () => string) {
   })
 }
 
-export function createChatMcpServer() {
+/**
+ * @param getCallerSessionId - getter that returns the current Claude session ID
+ *   at tool-invocation time (same pattern as createAgentsMcpServer). Lets the
+ *   host recognize sends coming from a chat-conversation session and block the
+ *   ones that would double-post into that session's own chat.
+ */
+export function createChatMcpServer(getCallerSessionId: () => string) {
   return createSdkMcpServer({
     name: 'chat',
     version: '1.0.0',
@@ -150,7 +156,7 @@ export function createChatMcpServer() {
       listAvailableChatProvidersTool,
       listChatIntegrationsTool,
       addChatIntegrationTool,
-      sendChatMessageTool,
+      makeSendChatMessageTool(getCallerSessionId),
     ],
   })
 }

--- a/agent-container/src/tools/chat/send-chat-message.ts
+++ b/agent-container/src/tools/chat/send-chat-message.ts
@@ -7,33 +7,44 @@ interface SendResult {
   provider: string
 }
 
-export const sendChatMessageTool = tool(
-  'send_chat_message',
-  `Send a message to a user through a chat integration (Telegram, Slack, or iMessage).
+/**
+ * @param getCallerSessionId - getter for the current Claude session ID at
+ *   tool-invocation time. Sent with each request so the host can tell when the
+ *   caller is itself a chat-conversation session and reject sends that would
+ *   double-post into the caller's own chat (replies already stream there).
+ */
+export function makeSendChatMessageTool(getCallerSessionId: () => string) {
+  return tool(
+    'send_chat_message',
+    `Proactively send a message to a chat through a connected chat integration (Telegram, Slack, or iMessage).
 
-The message is delivered immediately to the external chat. It is also logged in the agent's session history so follow-up conversations have context.
+Use this ONLY to initiate contact outside the current conversation — e.g. a scheduled or background run notifying someone, or messaging a DIFFERENT chat than the one this session is responding in (like DMing a specific person while working a channel thread).
 
-The chat_id is optional when the integration has exactly one active chat. If there are multiple active chats, you must specify which one — use list_chat_integrations to see available chat IDs.
+If this session was started by an incoming chat message, do NOT use this tool to reply to that conversation: everything you write in your response is already delivered to it automatically, and sending it here too would post it twice.
 
-Use the optional context parameter to attach internal notes that help the agent understand the message's purpose on follow-up. Context is NOT sent to the user — it is only recorded in the session log.`,
-  {
-    integration_id: z.string().describe('ID of the chat integration to send through'),
-    message: z.string().describe('The message text to send to the user'),
-    chat_id: z.string().optional().describe('Target chat ID. Required if the integration has multiple active chats.'),
-    context: z.string().optional().describe('Internal context for session continuity. Not sent to the user — only recorded in the session log.'),
-  },
-  async ({ integration_id, message, chat_id, context }) => {
-    try {
-      const data = await callChatHost<SendResult>('send', {
-        integration_id,
-        message,
-        chat_id,
-        context,
-      })
-      return textResult(`Message sent via ${data.provider} to chat ${data.chatId}.`)
-    } catch (error) {
-      const msg = error instanceof XAgentError ? error.message : String(error)
-      return textResult(`Failed to send chat message: ${msg}`, true)
-    }
-  },
-)
+The chat_id selects the destination — use list_chat_integrations to see available chat IDs. It is optional only when the integration has exactly one active chat.
+
+Use the optional context parameter to attach internal notes that help the receiving chat's agent session understand the message's purpose on follow-up. Context is NOT sent to the user — it is only recorded in the session log.`,
+    {
+      integration_id: z.string().describe('ID of the chat integration to send through'),
+      message: z.string().describe('The message text to deliver to the chat'),
+      chat_id: z.string().optional().describe('Target chat ID. Required if the integration has multiple active chats.'),
+      context: z.string().optional().describe('Internal context for session continuity. Not sent to the user — only recorded in the session log.'),
+    },
+    async ({ integration_id, message, chat_id, context }) => {
+      try {
+        const data = await callChatHost<SendResult>('send', {
+          integration_id,
+          message,
+          chat_id,
+          context,
+          session_id: getCallerSessionId(),
+        })
+        return textResult(`Message sent via ${data.provider} to chat ${data.chatId}.`)
+      } catch (error) {
+        const msg = error instanceof XAgentError ? error.message : String(error)
+        return textResult(`Failed to send chat message: ${msg}`, true)
+      }
+    },
+  )
+}

--- a/src/api/routes/x-agent-chat.test.ts
+++ b/src/api/routes/x-agent-chat.test.ts
@@ -44,9 +44,11 @@ vi.mock('@shared/lib/services/chat-integration-service', () => ({
 }))
 
 const mockListChatIntegrationSessions = vi.fn()
+const mockGetChatIntegrationSessionBySessionId = vi.fn()
 
 vi.mock('@shared/lib/services/chat-integration-session-service', () => ({
   listChatIntegrationSessions: (...args: unknown[]) => mockListChatIntegrationSessions(...args),
+  getChatIntegrationSessionBySessionId: (...args: unknown[]) => mockGetChatIntegrationSessionBySessionId(...args),
 }))
 
 const mockAddIntegration = vi.fn()
@@ -161,6 +163,7 @@ describe('x-agent chat route', () => {
     mockListChatIntegrationSessions.mockReturnValue([
       { externalChatId: 'chat-1', displayName: 'General', archivedAt: null },
     ])
+    mockGetChatIntegrationSessionBySessionId.mockReturnValue(null)
     mockGetConnector.mockReturnValue(connector)
     mockGetActiveIntegrationIds.mockReturnValue(['integration-1'])
     mockEnsureSession.mockResolvedValue('session-1')
@@ -311,6 +314,116 @@ describe('x-agent chat route', () => {
     expect(res.status).toBe(403)
     expect(await res.json()).toEqual({ error: 'This conversation is not approved for this integration.' })
     expect(connector.sendMessage).not.toHaveBeenCalled()
+  })
+
+  // Own-chat guard: a chat-conversation session's replies already stream back
+  // to its chat, so sends into that same chat are rejected as double-posts.
+
+  it('rejects a send from a chat session that omits chat_id (own chat implied)', async () => {
+    mockGetChatIntegrationSessionBySessionId.mockReturnValue({
+      integrationId: 'integration-1', externalChatId: 'chat-1', displayName: 'General', archivedAt: null,
+    })
+
+    const res = await app.request('http://localhost/api/x-agent/chat/send', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer good-token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        integration_id: 'integration-1',
+        message: 'Thanks for the feedback!',
+        session_id: 'caller-session',
+      }),
+    })
+
+    expect(res.status).toBe(400)
+    const { error } = await res.json() as { error: string }
+    expect(error).toContain('chat chat-1 (General)')
+    expect(error).toContain('delivered to that chat automatically')
+    expect(mockGetChatIntegrationSessionBySessionId).toHaveBeenCalledWith('caller-session')
+    expect(connector.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('rejects a send from a chat session that explicitly targets its own chat', async () => {
+    mockGetChatIntegrationSessionBySessionId.mockReturnValue({
+      integrationId: 'integration-1', externalChatId: 'chat-1', displayName: null, archivedAt: null,
+    })
+
+    const res = await app.request('http://localhost/api/x-agent/chat/send', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer good-token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        integration_id: 'integration-1',
+        message: 'Thanks for the feedback!',
+        chat_id: 'chat-1',
+        session_id: 'caller-session',
+      }),
+    })
+
+    expect(res.status).toBe(400)
+    expect(((await res.json()) as { error: string }).error).toContain('post it twice')
+    expect(connector.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('allows a chat session to message a different chat on the same integration', async () => {
+    immediateTimeout()
+    mockGetChatIntegrationSessionBySessionId.mockReturnValue({
+      integrationId: 'integration-1', externalChatId: 'chat-1', displayName: 'General', archivedAt: null,
+    })
+
+    const res = await app.request('http://localhost/api/x-agent/chat/send', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer good-token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        integration_id: 'integration-1',
+        message: 'Heads up — your order arrived.',
+        chat_id: 'dm-other-user',
+        session_id: 'caller-session',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(connector.sendMessage).toHaveBeenCalledWith('dm-other-user', { text: 'Heads up — your order arrived.' })
+  })
+
+  it('does not guard sends from an archived chat session (streaming is torn down)', async () => {
+    immediateTimeout()
+    mockGetChatIntegrationSessionBySessionId.mockReturnValue({
+      integrationId: 'integration-1', externalChatId: 'chat-1', displayName: 'General', archivedAt: new Date(),
+    })
+
+    const res = await app.request('http://localhost/api/x-agent/chat/send', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer good-token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        integration_id: 'integration-1',
+        message: 'Follow-up after rotation',
+        chat_id: 'chat-1',
+        session_id: 'caller-session',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(connector.sendMessage).toHaveBeenCalledWith('chat-1', { text: 'Follow-up after rotation' })
+  })
+
+  it('does not guard sends whose calling session serves a different integration', async () => {
+    immediateTimeout()
+    mockGetChatIntegrationSessionBySessionId.mockReturnValue({
+      integrationId: 'integration-2', externalChatId: 'chat-1', displayName: null, archivedAt: null,
+    })
+
+    const res = await app.request('http://localhost/api/x-agent/chat/send', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer good-token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        integration_id: 'integration-1',
+        message: 'Cross-integration notify',
+        chat_id: 'chat-1',
+        session_id: 'caller-session',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(connector.sendMessage).toHaveBeenCalledWith('chat-1', { text: 'Cross-integration notify' })
   })
 
   it('sends message when the integration has no access restriction (real DB allows it)', async () => {

--- a/src/api/routes/x-agent-chat.ts
+++ b/src/api/routes/x-agent-chat.ts
@@ -13,6 +13,7 @@ import {
 } from '@shared/lib/services/chat-integration-service'
 import {
   listChatIntegrationSessions,
+  getChatIntegrationSessionBySessionId,
 } from '@shared/lib/services/chat-integration-session-service'
 import { chatIntegrationManager } from '@shared/lib/chat-integrations/chat-integration-manager'
 import {
@@ -168,7 +169,7 @@ xAgentChat.post('/send', async (c) => {
   try {
     const callerSlug = getCallerSlug(c)
     const body = await c.req.json()
-    const { integration_id, message, chat_id, context } = body
+    const { integration_id, message, chat_id, context, session_id } = body
 
     if (!integration_id || !message) {
       return c.json({ error: 'Missing required fields: integration_id, message' }, 400)
@@ -180,6 +181,29 @@ xAgentChat.post('/send', async (c) => {
     }
     if (integration.agentSlug !== callerSlug) {
       return c.json({ error: 'Chat integration does not belong to this agent' }, 403)
+    }
+
+    // A session spawned BY a chat conversation already has its replies streamed
+    // back to that chat, so a send targeting its own chat would double-post —
+    // and omitting chat_id historically made such agents guess a target from
+    // the integration-wide list and misroute DMs. Reject both; explicit sends
+    // to a DIFFERENT chat stay allowed (the legitimate "DM someone while
+    // responding in a channel" case). Archived rows don't guard: once a chat
+    // session is rotated out, its SSE forwarding is torn down, so an outbound
+    // send is the only remaining delivery path.
+    if (session_id) {
+      const callerChatSession = getChatIntegrationSessionBySessionId(session_id)
+      if (
+        callerChatSession
+        && !callerChatSession.archivedAt
+        && callerChatSession.integrationId === integration_id
+        && (!chat_id || chat_id === callerChatSession.externalChatId)
+      ) {
+        const label = callerChatSession.displayName ? ` (${callerChatSession.displayName})` : ''
+        return c.json({
+          error: `Not sent: this session IS the live conversation for chat ${callerChatSession.externalChatId}${label}. Everything you write in your response is delivered to that chat automatically — sending it here too would post it twice. To message a different chat, pass its chat_id (see list_chat_integrations).`,
+        }, 400)
+      }
     }
 
     // Resolve chatId

--- a/src/shared/lib/chat-integrations/base-connector.ts
+++ b/src/shared/lib/chat-integrations/base-connector.ts
@@ -37,10 +37,32 @@ export type InteractiveResponseHandler = (toolUseId: string, response: unknown, 
 export type ErrorHandler = (error: Error) => void
 export type TypingHintHandler = (chatId: string) => void
 
+/** Context available at chat-session creation, passed to generateSystemPrompt. */
+export type SystemPromptContext = Pick<IncomingMessage, 'chatId' | 'chatName' | 'userName'>
+
+/**
+ * Static surface of a connector class, for capability lookups that never
+ * construct (concrete connectors have provider-specific constructor args, so
+ * `typeof ChatClientConnector` — which carries a construct signature — would
+ * not admit them).
+ */
+export type ChatConnectorClass = Pick<typeof ChatClientConnector, 'generateSystemPrompt'>
+
 // ── Abstract class ──────────────────────────────────────────────────────
 
 export abstract class ChatClientConnector {
   abstract readonly provider: ChatProvider
+
+  /**
+   * Optional provider-specific system prompt attached to every NEW chat
+   * session for this provider. Implement it to tell the agent what kind of
+   * conversation it is serving (e.g. Slack DM vs channel thread) and any
+   * provider conventions (delivery semantics, reaction tags, …).
+   *
+   * Static rather than an instance method: the prompt derives from the
+   * incoming message alone and must not depend on live connection state.
+   */
+  static generateSystemPrompt?: (message: SystemPromptContext) => string
 
   protected messageHandlers: MessageHandler[] = []
   protected interactiveResponseHandlers: InteractiveResponseHandler[] = []

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -98,6 +98,32 @@ const IMESSAGE_SYSTEM_PROMPT = `This is an iMessage-based conversation. Follow t
 - You can react to the user's last message by starting your response with a reaction tag. Available reactions: [[reaction:heart]], [[reaction:thumbs_up]], [[reaction:thumbs_down]], [[reaction:haha]], [[reaction:emphasize]], [[reaction:question]]. The tag will be stripped from the message and sent as a tapback reaction. If your entire response is just a reaction tag, only the reaction is sent (no text message).
 - The user may send voice notes which are automatically transcribed.`
 
+/**
+ * Session-level context for Slack conversations, built per session so it names
+ * the concrete destination (DM vs channel vs thread). Without this the agent
+ * cannot tell where its replies land or that its transcript streams straight
+ * into the chat — it has misrouted messages by replying through
+ * send_chat_message and guessing a DM target.
+ */
+export function buildSlackSystemPrompt(
+  message: Pick<IncomingMessage, 'chatId' | 'chatName' | 'userName'>,
+): string {
+  const pipeIdx = message.chatId.indexOf('|')
+  const isThread = pipeIdx > 0
+  const channelLabel = message.chatName || (isThread ? `channel ${message.chatId.slice(0, pipeIdx)}` : undefined)
+  const where = isThread
+    ? `a message thread in ${channelLabel}`
+    : channelLabel
+      ? `the channel ${channelLabel}`
+      : `a direct message conversation with ${message.userName || 'a Slack user'}`
+  const isGroupContext = isThread || !!message.chatName
+  return `This session is a live Slack conversation: you are responding inside ${where} (chat id: ${message.chatId}). Follow these rules:
+- Everything you write is posted to this conversation as the bot. Your response text IS the Slack message participants read, delivered automatically — including interim text between tool calls. There is no private narration; write only what participants should see.
+- Never use send_chat_message to reply to this conversation — your reply is already delivered automatically, so that would post it twice. Only use send_chat_message to reach a DIFFERENT chat (for example, to DM a specific person or post to another channel).${isGroupContext ? `
+- Multiple people can take part. Incoming messages are prefixed with the sender's name (for example "[Jane Doe]: ..."); the prefix is added for attribution — the sender did not type it. Keep track of who is asking for what.` : ''}
+- Keep responses concise and conversational — this is a chat, not a document.`
+}
+
 const HEALTH_CHECK_INTERVAL_MS = 5 * 60 * 1000
 const HEALTH_CHECK_ERROR_THRESHOLD_MS = 5 * 60 * 1000
 const HEALTH_CHECK_MAX_CONSECUTIVE_FAILURES = 15
@@ -1121,6 +1147,7 @@ class ChatIntegrationManager {
       ...(effort ? { effort: effort as EffortLevel } : {}),
       ...(speed ? { speed: speed as SpeedLevel } : {}),
       ...(integration.provider === 'imessage' ? { systemPrompt: IMESSAGE_SYSTEM_PROMPT } : {}),
+      ...(integration.provider === 'slack' ? { systemPrompt: buildSlackSystemPrompt(message) } : {}),
     })
 
     const sessionId = containerSession.id

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -10,7 +10,7 @@
  * Follows the TaskScheduler / TriggerManager singleton pattern.
  */
 
-import type { ChatClientConnector, IncomingMessage } from './base-connector'
+import type { ChatClientConnector, ChatConnectorClass, IncomingMessage } from './base-connector'
 import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
 import type { SessionActivity } from '@shared/lib/types/agent'
 import { getToolDefinition } from '@shared/lib/tool-definitions/registry'
@@ -90,39 +90,6 @@ function isTrustedSlackDownloadHost(u: URL): boolean {
 }
 
 // ── Constants ───────────────────────────────────────────────────────────
-
-const IMESSAGE_SYSTEM_PROMPT = `This is an iMessage-based conversation. Follow these rules:
-- Keep responses concise and conversational — this is a text message, not a document.
-- Use tools, skills, and capabilities as you normally would.
-- Prefer asking questions directly in natural language rather than using the ask questions tool.
-- You can react to the user's last message by starting your response with a reaction tag. Available reactions: [[reaction:heart]], [[reaction:thumbs_up]], [[reaction:thumbs_down]], [[reaction:haha]], [[reaction:emphasize]], [[reaction:question]]. The tag will be stripped from the message and sent as a tapback reaction. If your entire response is just a reaction tag, only the reaction is sent (no text message).
-- The user may send voice notes which are automatically transcribed.`
-
-/**
- * Session-level context for Slack conversations, built per session so it names
- * the concrete destination (DM vs channel vs thread). Without this the agent
- * cannot tell where its replies land or that its transcript streams straight
- * into the chat — it has misrouted messages by replying through
- * send_chat_message and guessing a DM target.
- */
-export function buildSlackSystemPrompt(
-  message: Pick<IncomingMessage, 'chatId' | 'chatName' | 'userName'>,
-): string {
-  const pipeIdx = message.chatId.indexOf('|')
-  const isThread = pipeIdx > 0
-  const channelLabel = message.chatName || (isThread ? `channel ${message.chatId.slice(0, pipeIdx)}` : undefined)
-  const where = isThread
-    ? `a message thread in ${channelLabel}`
-    : channelLabel
-      ? `the channel ${channelLabel}`
-      : `a direct message conversation with ${message.userName || 'a Slack user'}`
-  const isGroupContext = isThread || !!message.chatName
-  return `This session is a live Slack conversation: you are responding inside ${where} (chat id: ${message.chatId}). Follow these rules:
-- Everything you write is posted to this conversation as the bot. Your response text IS the Slack message participants read, delivered automatically — including interim text between tool calls. There is no private narration; write only what participants should see.
-- Never use send_chat_message to reply to this conversation — your reply is already delivered automatically, so that would post it twice. Only use send_chat_message to reach a DIFFERENT chat (for example, to DM a specific person or post to another channel).${isGroupContext ? `
-- Multiple people can take part. Incoming messages are prefixed with the sender's name (for example "[Jane Doe]: ..."); the prefix is added for attribution — the sender did not type it. Keep track of who is asking for what.` : ''}
-- Keep responses concise and conversational — this is a chat, not a document.`
-}
 
 const HEALTH_CHECK_INTERVAL_MS = 5 * 60 * 1000
 const HEALTH_CHECK_ERROR_THRESHOLD_MS = 5 * 60 * 1000
@@ -606,6 +573,26 @@ class ChatIntegrationManager {
       }
       default:
         throw new Error(`Unknown chat integration provider: ${integration.provider}`)
+    }
+  }
+
+  /**
+   * Resolve a provider's connector CLASS for static capability lookups (e.g.
+   * generateSystemPrompt). Mirrors createConnector's lazy imports — connector
+   * modules stay unloaded until their provider is actually used. Returns
+   * undefined for unknown providers rather than throwing: static lookups are
+   * best-effort decorations, not connection attempts.
+   */
+  private async getConnectorClass(provider: string): Promise<ChatConnectorClass | undefined> {
+    switch (provider) {
+      case 'telegram':
+        return (await import('./telegram-connector')).TelegramConnector
+      case 'slack':
+        return (await import('./slack-connector')).SlackConnector
+      case 'imessage':
+        return (await import('./imessage-connector')).IMessageConnector
+      default:
+        return undefined
     }
   }
 
@@ -1132,6 +1119,9 @@ class ChatIntegrationManager {
     const { readAgentPreferences } = await import('@shared/lib/services/agent-preferences-service')
 
     const availableEnvVars = await getSecretEnvVars(integration.agentSlug)
+    // Provider-specific session context (DM vs channel vs thread, delivery
+    // semantics) — owned by each connector class, not the manager.
+    const systemPrompt = (await this.getConnectorClass(integration.provider))?.generateSystemPrompt?.(message)
     // Model/effort/speed preference order: integration override > agent default > global default.
     const models = getEffectiveModels()
     const agentPrefs = await readAgentPreferences(integration.agentSlug)
@@ -1146,8 +1136,7 @@ class ChatIntegrationManager {
       dashboardBuilderModel: models.dashboardBuilderModel,
       ...(effort ? { effort: effort as EffortLevel } : {}),
       ...(speed ? { speed: speed as SpeedLevel } : {}),
-      ...(integration.provider === 'imessage' ? { systemPrompt: IMESSAGE_SYSTEM_PROMPT } : {}),
-      ...(integration.provider === 'slack' ? { systemPrompt: buildSlackSystemPrompt(message) } : {}),
+      ...(systemPrompt ? { systemPrompt } : {}),
     })
 
     const sessionId = containerSession.id

--- a/src/shared/lib/chat-integrations/imessage-connector.ts
+++ b/src/shared/lib/chat-integrations/imessage-connector.ts
@@ -60,10 +60,21 @@ interface PendingQuestion {
   }>
 }
 
+// ── Session system prompt ───────────────────────────────────────────────
+
+const IMESSAGE_SYSTEM_PROMPT = `This is an iMessage-based conversation. Follow these rules:
+- Keep responses concise and conversational — this is a text message, not a document.
+- Use tools, skills, and capabilities as you normally would.
+- Prefer asking questions directly in natural language rather than using the ask questions tool.
+- You can react to the user's last message by starting your response with a reaction tag. Available reactions: [[reaction:heart]], [[reaction:thumbs_up]], [[reaction:thumbs_down]], [[reaction:haha]], [[reaction:emphasize]], [[reaction:question]]. The tag will be stripped from the message and sent as a tapback reaction. If your entire response is just a reaction tag, only the reaction is sent (no text message).
+- The user may send voice notes which are automatically transcribed.`
+
 // ── Connector ───────────────────────────────────────────────────────────
 
 export class IMessageConnector extends ChatClientConnector {
   readonly provider = 'imessage' as const
+
+  static generateSystemPrompt = () => IMESSAGE_SYSTEM_PROMPT
 
   private ws: WebSocket | null = null
   private _connected = false

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -129,13 +129,20 @@ export function markdownToSlackMrkdwn(md: string): string {
 export function buildSlackSystemPrompt(message: SystemPromptContext): string {
   const pipeIdx = message.chatId.indexOf('|')
   const isThread = pipeIdx > 0
-  const channelLabel = message.chatName || (isThread ? `channel ${message.chatId.slice(0, pipeIdx)}` : undefined)
+  const baseChannelId = isThread ? message.chatId.slice(0, pipeIdx) : message.chatId
+  // Classify by conversation-id prefix (D* = DM, C*/G* = channel/group), NOT
+  // by whether chatName resolved: resolveChannelName returns undefined when
+  // conversations.info fails, and misclassifying a channel as a DM would drop
+  // the multi-user attribution guidance below.
+  const isDm = baseChannelId.startsWith('D')
   const where = isThread
-    ? `a message thread in ${channelLabel}`
-    : channelLabel
-      ? `the channel ${channelLabel}`
-      : `a direct message conversation with ${message.userName || 'a Slack user'}`
-  const isGroupContext = isThread || !!message.chatName
+    ? `a message thread in ${message.chatName || `channel ${baseChannelId}`}`
+    : isDm
+      ? `a direct message conversation with ${message.userName || 'a Slack user'}`
+      : message.chatName
+        ? `the channel ${message.chatName}`
+        : `a channel (id ${baseChannelId})`
+  const isGroupContext = !isDm
   return `This session is a live Slack conversation: you are responding inside ${where} (chat id: ${message.chatId}). Follow these rules:
 - Everything you write is posted to this conversation as the bot. Your response text IS the Slack message participants read, delivered automatically — including interim text between tool calls. There is no private narration; write only what participants should see.
 - Never use send_chat_message to reply to this conversation — your reply is already delivered automatically, so that would post it twice. Only use send_chat_message to reach a DIFFERENT chat (for example, to DM a specific person or post to another channel).${isGroupContext ? `

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -10,7 +10,7 @@
 import { App as SlackApp, SocketModeReceiver } from '@slack/bolt'
 import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
 import type { SessionActivity } from '@shared/lib/types/agent'
-import { ChatClientConnector, type OutgoingMessage } from './base-connector'
+import { ChatClientConnector, type OutgoingMessage, type SystemPromptContext } from './base-connector'
 import { describeUnsupportedRequest, isUnsupportedInChat, splitChatMessage } from './utils'
 import { isUnrecoverableSlackError } from './slack-error'
 import { captureException } from '@shared/lib/error-reporting'
@@ -115,6 +115,32 @@ export function markdownToSlackMrkdwn(md: string): string {
   result = result.replace(/\n{3,}/g, '\n\n')
 
   return result.trim()
+}
+
+// ── Session system prompt ───────────────────────────────────────────────
+
+/**
+ * Session-level context for Slack conversations, built per session so it names
+ * the concrete destination (DM vs channel vs thread). Without this the agent
+ * cannot tell where its replies land or that its transcript streams straight
+ * into the chat — it has misrouted messages by replying through
+ * send_chat_message and guessing a DM target.
+ */
+export function buildSlackSystemPrompt(message: SystemPromptContext): string {
+  const pipeIdx = message.chatId.indexOf('|')
+  const isThread = pipeIdx > 0
+  const channelLabel = message.chatName || (isThread ? `channel ${message.chatId.slice(0, pipeIdx)}` : undefined)
+  const where = isThread
+    ? `a message thread in ${channelLabel}`
+    : channelLabel
+      ? `the channel ${channelLabel}`
+      : `a direct message conversation with ${message.userName || 'a Slack user'}`
+  const isGroupContext = isThread || !!message.chatName
+  return `This session is a live Slack conversation: you are responding inside ${where} (chat id: ${message.chatId}). Follow these rules:
+- Everything you write is posted to this conversation as the bot. Your response text IS the Slack message participants read, delivered automatically — including interim text between tool calls. There is no private narration; write only what participants should see.
+- Never use send_chat_message to reply to this conversation — your reply is already delivered automatically, so that would post it twice. Only use send_chat_message to reach a DIFFERENT chat (for example, to DM a specific person or post to another channel).${isGroupContext ? `
+- Multiple people can take part. Incoming messages are prefixed with the sender's name (for example "[Jane Doe]: ..."); the prefix is added for attribution — the sender did not type it. Keep track of who is asking for what.` : ''}
+- Keep responses concise and conversational — this is a chat, not a document.`
 }
 
 // ── Message routing (exported for testing) ──────────────────────────────
@@ -255,6 +281,8 @@ export function reactionsForChat(activeReactions: Set<string>, chatId: string): 
 
 export class SlackConnector extends ChatClientConnector {
   readonly provider = 'slack' as const
+
+  static generateSystemPrompt = buildSlackSystemPrompt
 
   private app: SlackApp | null = null
   private receiver: SocketModeReceiver | null = null

--- a/src/shared/lib/chat-integrations/slack-system-prompt.test.ts
+++ b/src/shared/lib/chat-integrations/slack-system-prompt.test.ts
@@ -80,14 +80,35 @@ vi.mock('@shared/lib/services/agent-preferences-service', () => ({
 }))
 
 // Both connector classes return the shared mock so one harness drives slack
-// and telegram integrations alike.
-vi.mock('./slack-connector', () => ({
-  SlackConnector: class {
-    constructor() {
-      return mockConnector
-    }
-  },
-}))
+// and telegram integrations alike. The slack mock keeps the REAL static
+// generateSystemPrompt (and the module's other exports): the manager resolves
+// the connector CLASS through this module for static capability lookups, so
+// stripping the static would silently disable the very wiring under test.
+vi.mock('./slack-connector', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./slack-connector')>()
+  return {
+    ...actual,
+    SlackConnector: class {
+      static generateSystemPrompt = actual.SlackConnector.generateSystemPrompt
+      constructor() {
+        return mockConnector
+      }
+    },
+  }
+})
+
+vi.mock('./imessage-connector', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./imessage-connector')>()
+  return {
+    ...actual,
+    IMessageConnector: class {
+      static generateSystemPrompt = actual.IMessageConnector.generateSystemPrompt
+      constructor() {
+        return mockConnector
+      }
+    },
+  }
+})
 
 vi.mock('./telegram-connector', () => ({
   TelegramConnector: class {
@@ -99,7 +120,8 @@ vi.mock('./telegram-connector', () => ({
 
 // ── Imports (after mocks) ──────────────────────────────────────────────
 
-import { chatIntegrationManager, buildSlackSystemPrompt } from './chat-integration-manager'
+import { chatIntegrationManager } from './chat-integration-manager'
+import { buildSlackSystemPrompt } from './slack-connector'
 import { createChatIntegration } from '@shared/lib/services/chat-integration-service'
 import { containerManager } from '@shared/lib/container/container-manager'
 import { MockContainerClient } from '@shared/lib/container/mock-container-client'
@@ -198,16 +220,20 @@ describe('slack session system prompt wiring', () => {
     await fs.promises.rm(testDir, { recursive: true, force: true }).catch(() => {})
   })
 
+  const TEST_CONFIGS = {
+    slack: { botToken: 'xoxb-test', appToken: 'xapp-test' },
+    telegram: { botToken: 'test-token-123' },
+    imessage: { gatewayUrl: 'https://imsgw.example.com', phoneNumber: '+15551234567', token: 'imsg-token' },
+  } as const
+
   async function startSession(
-    provider: 'slack' | 'telegram',
+    provider: keyof typeof TEST_CONFIGS,
     messageOpts: { chatId: string; userName?: string; chatName?: string },
   ) {
     const integrationId = createChatIntegration({
       agentSlug: 'test-agent',
       provider,
-      config: provider === 'slack'
-        ? { botToken: 'xoxb-test', appToken: 'xapp-test' }
-        : { botToken: 'test-token-123' },
+      config: TEST_CONFIGS[provider],
       name: 'Test Bot',
     })
     // These tests exercise session-spawn context, not access control — disable
@@ -232,6 +258,11 @@ describe('slack session system prompt wiring', () => {
   it('passes a channel-flavored system prompt for slack channel messages', async () => {
     const args = await startSession('slack', { chatId: 'C0BBB222', userName: 'Iddo Gino', chatName: '#office' })
     expect(args.systemPrompt).toContain('the channel #office')
+  })
+
+  it('passes the iMessage system prompt for imessage sessions', async () => {
+    const args = await startSession('imessage', { chatId: '+15559876543', userName: 'Iddo Gino' })
+    expect(args.systemPrompt).toContain('iMessage-based conversation')
   })
 
   it('does not attach a system prompt for telegram sessions', async () => {

--- a/src/shared/lib/chat-integrations/slack-system-prompt.test.ts
+++ b/src/shared/lib/chat-integrations/slack-system-prompt.test.ts
@@ -173,6 +173,21 @@ describe('buildSlackSystemPrompt', () => {
     expect(prompt).toContain('a message thread in channel C0BBB222')
   })
 
+  it('still classifies an unnamed top-level channel as a channel, not a DM', () => {
+    // resolveChannelName returns undefined when conversations.info fails, so a
+    // missing chatName must not demote a channel to DM treatment.
+    const prompt = buildSlackSystemPrompt({ chatId: 'C0BBB222', userName: 'Iddo Gino' })
+    expect(prompt).toContain('a channel (id C0BBB222)')
+    expect(prompt).not.toContain('direct message conversation')
+    expect(prompt).toContain('[Jane Doe]')
+  })
+
+  it('classifies unnamed private groups (G-prefix) as group contexts', () => {
+    const prompt = buildSlackSystemPrompt({ chatId: 'G0CCC333', userName: 'Iddo Gino' })
+    expect(prompt).toContain('a channel (id G0CCC333)')
+    expect(prompt).toContain('[Jane Doe]')
+  })
+
   it('always explains automatic delivery and forbids self-sends', () => {
     for (const message of [
       { chatId: 'D0AAA111', userName: 'Iddo Gino' },

--- a/src/shared/lib/chat-integrations/slack-system-prompt.test.ts
+++ b/src/shared/lib/chat-integrations/slack-system-prompt.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Slack session system prompt tests.
+ *
+ * A Slack chat session must be told what it is: which conversation it serves
+ * (DM vs channel vs thread) and that its transcript streams straight into that
+ * conversation. Without this context an agent can treat the transcript as
+ * private narration and reply through send_chat_message instead — guessing a
+ * chat target and misrouting DMs.
+ *
+ * Covers the pure prompt builder and, via the e2e harness wiring
+ * (MockChatClientConnector → ChatIntegrationManager → MockContainerClient),
+ * that createSession receives the prompt for slack sessions only.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import * as schema from '../db/schema'
+import { MockChatClientConnector } from './mock-connector'
+
+// ── Test state ─────────────────────────────────────────────────────────
+
+let testDir: string
+let testDb: ReturnType<typeof drizzle>
+let testSqlite: InstanceType<typeof Database>
+let mockConnector: MockChatClientConnector
+let mockContainerClient: InstanceType<typeof MockContainerClient>
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('../db', () => ({
+  get db() { return testDb },
+  get sqlite() { return testSqlite },
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+  addErrorBreadcrumb: vi.fn(),
+}))
+
+vi.mock('@shared/lib/platform-attribution', () => ({
+  runWithOptionalUser: (_userId: string | undefined, fn: () => unknown) => fn(),
+}))
+
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: {
+    ensureRunning: vi.fn(),
+  },
+}))
+
+vi.mock('@shared/lib/services/agent-service', () => ({
+  agentExists: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('@shared/lib/services/session-service', () => ({
+  registerSession: vi.fn().mockResolvedValue(undefined),
+  updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
+  getSessionMetadata: vi.fn().mockResolvedValue(null),
+  finalizeAutomationStatus: vi.fn().mockResolvedValue('not-automation'),
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getEffectiveModels: () => ({
+    agentModel: 'claude-sonnet-4-20250514',
+    browserModel: 'claude-sonnet-4-20250514',
+  }),
+  getSettings: () => ({}),
+}))
+
+vi.mock('@shared/lib/services/secrets-service', () => ({
+  getSecretEnvVars: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('@shared/lib/services/agent-preferences-service', () => ({
+  readAgentPreferences: vi.fn().mockResolvedValue({}),
+}))
+
+// Both connector classes return the shared mock so one harness drives slack
+// and telegram integrations alike.
+vi.mock('./slack-connector', () => ({
+  SlackConnector: class {
+    constructor() {
+      return mockConnector
+    }
+  },
+}))
+
+vi.mock('./telegram-connector', () => ({
+  TelegramConnector: class {
+    constructor() {
+      return mockConnector
+    }
+  },
+}))
+
+// ── Imports (after mocks) ──────────────────────────────────────────────
+
+import { chatIntegrationManager, buildSlackSystemPrompt } from './chat-integration-manager'
+import { createChatIntegration } from '@shared/lib/services/chat-integration-service'
+import { containerManager } from '@shared/lib/container/container-manager'
+import { MockContainerClient } from '@shared/lib/container/mock-container-client'
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function waitForCondition(
+  check: () => boolean,
+  timeoutMs = 2000,
+  intervalMs = 10,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs
+    const poll = () => {
+      if (check()) return resolve()
+      if (Date.now() > deadline) return reject(new Error('Timed out waiting for condition'))
+      setTimeout(poll, intervalMs)
+    }
+    poll()
+  })
+}
+
+// ── Pure builder ───────────────────────────────────────────────────────
+
+describe('buildSlackSystemPrompt', () => {
+  it('describes a direct message conversation when there is no channel name', () => {
+    const prompt = buildSlackSystemPrompt({ chatId: 'D0AAA111', userName: 'Iddo Gino' })
+    expect(prompt).toContain('a direct message conversation with Iddo Gino')
+    expect(prompt).toContain('chat id: D0AAA111')
+    // DM prompts must not describe multi-party attribution prefixes
+    expect(prompt).not.toContain('[Jane Doe]')
+  })
+
+  it('describes the channel and the attribution prefix for channel sessions', () => {
+    const prompt = buildSlackSystemPrompt({ chatId: 'C0BBB222', chatName: '#office', userName: 'Iddo Gino' })
+    expect(prompt).toContain('the channel #office')
+    expect(prompt).toContain('[Jane Doe]')
+  })
+
+  it('describes a thread via the composite chat id', () => {
+    const prompt = buildSlackSystemPrompt({ chatId: 'C0BBB222|1784571878.344849', chatName: '#office', userName: 'Mike Reid' })
+    expect(prompt).toContain('a message thread in #office')
+    expect(prompt).toContain('chat id: C0BBB222|1784571878.344849')
+    expect(prompt).toContain('[Jane Doe]')
+  })
+
+  it('falls back to the channel id when a thread message has no resolved channel name', () => {
+    const prompt = buildSlackSystemPrompt({ chatId: 'C0BBB222|1784571878.344849' })
+    expect(prompt).toContain('a message thread in channel C0BBB222')
+  })
+
+  it('always explains automatic delivery and forbids self-sends', () => {
+    for (const message of [
+      { chatId: 'D0AAA111', userName: 'Iddo Gino' },
+      { chatId: 'C0BBB222', chatName: '#office', userName: 'Iddo Gino' },
+    ]) {
+      const prompt = buildSlackSystemPrompt(message)
+      expect(prompt).toContain('delivered automatically')
+      expect(prompt).toContain('Never use send_chat_message to reply to this conversation')
+    }
+  })
+})
+
+// ── createSession pass-through ─────────────────────────────────────────
+
+describe('slack session system prompt wiring', () => {
+  let createSessionSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(async () => {
+    testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'chat-slack-prompt-test-'))
+    process.env.SUPERAGENT_DATA_DIR = testDir
+
+    testSqlite = new Database(':memory:')
+    testDb = drizzle(testSqlite, { schema })
+    migrate(testDb, { migrationsFolder: path.join(process.cwd(), 'src/shared/lib/db/migrations') })
+
+    mockConnector = new MockChatClientConnector()
+
+    mockContainerClient = new MockContainerClient({ agentId: 'test-agent' })
+    await mockContainerClient.start()
+    MockContainerClient.resetCallRecords()
+    createSessionSpy = vi.spyOn(mockContainerClient, 'createSession') as ReturnType<typeof vi.spyOn>;
+
+    (containerManager.ensureRunning as ReturnType<typeof vi.fn>).mockResolvedValue(mockContainerClient)
+
+    // connectIntegration cancels itself on a stopped manager; this harness
+    // drives addIntegration directly (no start()), so mark the manager running.
+    ;(chatIntegrationManager as unknown as { isRunning: boolean }).isRunning = true
+  })
+
+  afterEach(async () => {
+    chatIntegrationManager.stop()
+    // Let pending async handlers drain before closing the DB
+    await new Promise(r => setTimeout(r, 50))
+    testSqlite?.close()
+    await fs.promises.rm(testDir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  async function startSession(
+    provider: 'slack' | 'telegram',
+    messageOpts: { chatId: string; userName?: string; chatName?: string },
+  ) {
+    const integrationId = createChatIntegration({
+      agentSlug: 'test-agent',
+      provider,
+      config: provider === 'slack'
+        ? { botToken: 'xoxb-test', appToken: 'xapp-test' }
+        : { botToken: 'test-token-123' },
+      name: 'Test Bot',
+    })
+    // These tests exercise session-spawn context, not access control — disable
+    // the owner-approval gate telegram integrations get by default.
+    testSqlite.prepare('UPDATE chat_integrations SET require_approval = 0 WHERE id = ?').run(integrationId)
+    await chatIntegrationManager.addIntegration(integrationId)
+
+    mockConnector.simulateIncomingMessage('Hello agent!', messageOpts.chatId, 'user-1', {
+      userName: messageOpts.userName,
+      chatName: messageOpts.chatName,
+    })
+    await waitForCondition(() => createSessionSpy.mock.calls.length > 0)
+    return createSessionSpy.mock.calls[0][0] as Record<string, unknown>
+  }
+
+  it('passes a DM-flavored system prompt for slack direct messages', async () => {
+    const args = await startSession('slack', { chatId: 'D0AAA111', userName: 'Iddo Gino' })
+    expect(args.systemPrompt).toContain('a direct message conversation with Iddo Gino')
+    expect(args.systemPrompt).toContain('delivered automatically')
+  })
+
+  it('passes a channel-flavored system prompt for slack channel messages', async () => {
+    const args = await startSession('slack', { chatId: 'C0BBB222', userName: 'Iddo Gino', chatName: '#office' })
+    expect(args.systemPrompt).toContain('the channel #office')
+  })
+
+  it('does not attach a system prompt for telegram sessions', async () => {
+    const args = await startSession('telegram', { chatId: 'chat-1', userName: 'Iddo Gino' })
+    expect('systemPrompt' in args).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

Incident (2026-07-20, Office Manager agent): responding in a #office thread, the agent replied via `send_chat_message` instead of its transcript, guessed a target from the integration-wide chat list, and sent five Mike-addressed messages into Iddo's DM — while its internal narration streamed into the public thread. Root causes: Slack sessions get no context about which conversation they serve or that their transcript streams back automatically, and `send_chat_message` lets a chat session post into its own chat (double-post) with no session awareness.

## Changes

- **Slack session system prompt** — `buildSlackSystemPrompt()` attaches per-session context on creation: which conversation this is (DM with X / channel #Y / thread in #Y, plus chat id), that everything written — including interim text between tool calls — is posted to the conversation automatically, that `send_chat_message` must never be used to reply there, and (in group contexts) that `[Name]:` prefixes are attribution metadata.
- **Own-chat send guard** — `send_chat_message` now sends the calling session id (same `getCallerSessionId` pattern as the agents MCP server). `/x-agent/chat/send` rejects a send when the caller is an active chat session on that integration and the target is its own chat (explicit or implied by omitting `chat_id`), with an error explaining replies are delivered automatically. Still allowed: explicit sends to a different chat (DM someone while working a channel thread), cron/manual sessions, and archived chat sessions (their streaming is torn down, so outbound send is their only delivery path).
- **Sharpened tool description** — scoped to proactive/out-of-band messaging; explicitly warns against replying through it.

Follow-up (discovery primitives: list users/channels, DM by user id) tracked in SUP-449.

## Testing

- 5 new route tests for the guard (omitted chat_id, explicit own chat, different chat allowed, archived not guarded, cross-integration not guarded)
- 8 new tests for the system prompt (DM/channel/thread wording, channel-id fallback, delivery rules, createSession pass-through for slack, telegram unaffected)
- Typecheck + lint clean in root and agent-container; agent-container suites touching the MCP wiring pass (25/25)

Note: the prompt only attaches to new sessions — existing chat sessions keep prior behavior until they rotate.

https://claude.ai/code/session_01G5bvbYmN42Hx7AFu97k2Qw