### PR TITLE
fix(settings): write PUT response into the user-settings cache

### DIFF
--- a/src/renderer/hooks/use-user-settings.ts
+++ b/src/renderer/hooks/use-user-settings.ts
@@ -32,8 +32,12 @@ export function useUpdateUserSettings() {
       }
       return res.json()
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['user-settings'] })
+    onSuccess: (data) => {
+      // The PUT returns the full merged settings — write them straight into
+      // the cache. (invalidate + refetch left a window where consumers that
+      // clear optimistic state on settle briefly rendered the stale cache,
+      // e.g. a resized home card flickering back to its old size.)
+      queryClient.setQueryData(['user-settings'], data)
     },
   })
 }


### PR DESCRIPTION
Small standalone bugfix, first of a 4-PR stack for the home-page redesign (`1/4`).

`useUpdateUserSettings` invalidated + refetched after a save, leaving a window where consumers that clear optimistic state on settle briefly rendered the stale cache — e.g. a resized home card flickering back to its old size. The PUT already returns the full merged settings, so write them straight into the query cache.

**Stack**: this → #532 halftone → #533 widget-grid → #262 home redesign. Merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)