### PR TITLE
Fix shared agent home width on mobile

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -245,6 +245,16 @@ describe('AgentHome', () => {
     expect(screen.getByText('Test Agent')).toBeInTheDocument()
   })
 
+  it('keeps the non-owner layout full-width below the desktop breakpoint', () => {
+    renderWithProviders(
+      <AgentHome agent={testAgent} onSessionCreated={onSessionCreated} />
+    )
+
+    const layout = screen.getByTestId('agent-home-layout')
+    expect(layout).toHaveClass('w-full', 'xl:max-w-2xl')
+    expect(layout).not.toHaveClass('max-w-2xl')
+  })
+
   it('reuses the agent context menu on the agent title', () => {
     renderWithProviders(
       <AgentHome agent={testAgent} onSessionCreated={onSessionCreated} />

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -297,7 +297,15 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
           </div>
         </div>
       )}
-      <div className={`grid gap-10 items-start ${showRightColumn ? 'grid-cols-1 xl:grid-cols-[1fr_minmax(320px,400px)] w-full max-w-6xl mx-auto' : 'max-w-2xl mx-auto'}`}>
+      <div
+        data-testid="agent-home-layout"
+        className={cn(
+          'grid gap-10 items-start w-full mx-auto',
+          showRightColumn
+            ? 'grid-cols-1 max-w-6xl xl:grid-cols-[1fr_minmax(320px,400px)]'
+            : 'xl:max-w-2xl',
+        )}
+      >
         {/* Left Column — Chat composer + Sessions */}
         <div className="space-y-6 w-full min-w-0 xl:min-w-[480px] xl:max-w-[720px]">
           <div className="flex items-center justify-between gap-2 intro-step intro-step-1">


### PR DESCRIPTION
## Summary

- make non-admin agent homes use the same full mobile width as admin-owned agents
- retain the centered single-column width cap at the desktop breakpoint
- add regression coverage for the responsive non-owner layout

## Root cause

The non-owner layout applied `max-w-2xl` at every viewport size, while the owner layout stayed full-width until the desktop two-column breakpoint. This made shared agent homes visibly narrower on mobile.

## User impact

Shared agent homes now align with normal agent homes on mobile, so the composer, bookmarks, and session list use the expected available width.

## Validation

- `npm run test:run -- src/renderer/components/agents/agent-home/agent-home.test.tsx` (31 tests)
- `npm run typecheck`
- `npx eslint src/renderer/components/agents/agent-home/agent-home.tsx src/renderer/components/agents/agent-home/agent-home.test.tsx`
- `git diff --check`
