### PR TITLE
Fix capability reviews silently auto-denying after 10 minutes on unattended sessions

### DIFF
--- a/agent-container/src/capability-gate-hook.test.ts
+++ b/agent-container/src/capability-gate-hook.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  createCapabilityGateHook,
+  CAPABILITY_REVIEW_HOOK_TIMEOUT_S,
+  REVIEW_CANCELLED_REASON,
+  type CapabilityGateContext,
+} from './capability-gate-hook'
+import { inputManager, HUMAN_INPUT_TTL_MS } from './input-manager'
+import type { Capability } from './capability-policies'
+
+function makeContext(overrides: Partial<CapabilityGateContext> = {}): {
+  ctx: CapabilityGateContext
+  grants: Set<Capability>
+  onSessionGrant: ReturnType<typeof vi.fn>
+  onReviewCancelled: ReturnType<typeof vi.fn>
+} {
+  const grants = new Set<Capability>()
+  const onSessionGrant = vi.fn((capability: Capability) => grants.add(capability))
+  const onReviewCancelled = vi.fn()
+  const ctx: CapabilityGateContext = {
+    sessionId: 'session-1',
+    getPolicies: () => ({ subagents: 'review', workflows: 'review' }),
+    getSessionGrants: () => grants,
+    onSessionGrant,
+    onReviewCancelled,
+    ...overrides,
+  }
+  return { ctx, grants, onSessionGrant, onReviewCancelled }
+}
+
+function invoke(ctx: CapabilityGateContext, toolName: string, toolUseId: string, signal?: AbortSignal) {
+  const hook = createCapabilityGateHook(ctx)
+  return hook({ tool_name: toolName } as never, toolUseId, {
+    signal: signal ?? new AbortController().signal,
+  })
+}
+
+describe('createCapabilityGateHook', () => {
+  it('passes non-capability tools through without parking', async () => {
+    const { ctx } = makeContext()
+    const result = await invoke(ctx, 'Bash', 'gate-pass-1')
+    expect(result).toEqual({})
+    expect(inputManager.hasPending('gate-pass-1')).toBe(false)
+  })
+
+  it('denies immediately when the capability is blocked', async () => {
+    const { ctx } = makeContext({ getPolicies: () => ({ subagents: 'review', workflows: 'block' }) })
+    const result = await invoke(ctx, 'Workflow', 'gate-block-1')
+    expect(result).toMatchObject({
+      hookSpecificOutput: { permissionDecision: 'deny' },
+    })
+    expect(inputManager.hasPending('gate-block-1')).toBe(false)
+  })
+
+  it('parks on review and allows after a one-time approval', async () => {
+    const { ctx, onSessionGrant } = makeContext()
+    const promise = invoke(ctx, 'Workflow', 'gate-once-1')
+    expect(inputManager.hasPending('gate-once-1')).toBe(true)
+
+    inputManager.resolve('gate-once-1', { scope: 'once' })
+    expect(await promise).toEqual({})
+    expect(onSessionGrant).not.toHaveBeenCalled()
+  })
+
+  it('records a session grant when the approval is session-scoped', async () => {
+    const { ctx, grants, onSessionGrant } = makeContext()
+    const promise = invoke(ctx, 'Task', 'gate-session-1')
+    inputManager.resolve('gate-session-1', { scope: 'session' })
+    expect(await promise).toEqual({})
+    expect(onSessionGrant).toHaveBeenCalledWith('subagents')
+
+    // A later launch under the grant doesn't park again.
+    const second = await invoke(ctx, 'Task', 'gate-session-2')
+    expect(second).toEqual({})
+    expect(grants.has('subagents')).toBe(true)
+    expect(inputManager.hasPending('gate-session-2')).toBe(false)
+  })
+
+  it('denies with the decline message when the user rejects', async () => {
+    const { ctx, onReviewCancelled } = makeContext()
+    const promise = invoke(ctx, 'Workflow', 'gate-decline-1')
+    inputManager.reject('gate-decline-1', 'User declined')
+
+    const result = await promise
+    expect(result).toMatchObject({
+      hookSpecificOutput: { permissionDecision: 'deny' },
+    })
+    expect(onReviewCancelled).not.toHaveBeenCalled()
+  })
+
+  it('wipes the pending entry and reports cancellation when the CLI aborts the hook', async () => {
+    // The CLI abandons a parked hook on its per-hook timeout AND on turn
+    // aborts/interrupts — both must clean up, or the pending entry zombies
+    // until the 24h TTL while the host renders an unanswerable card.
+    const { ctx, onReviewCancelled } = makeContext()
+    const controller = new AbortController()
+    const promise = invoke(ctx, 'Workflow', 'gate-abort-1', controller.signal)
+    expect(inputManager.hasPending('gate-abort-1')).toBe(true)
+
+    controller.abort()
+
+    const result = await promise
+    expect(inputManager.hasPending('gate-abort-1')).toBe(false)
+    expect(onReviewCancelled).toHaveBeenCalledWith('gate-abort-1', 'workflows')
+    expect(result).toMatchObject({
+      hookSpecificOutput: { permissionDecision: 'deny' },
+    })
+    expect(
+      (result as { hookSpecificOutput: { permissionDecisionReason: string } }).hookSpecificOutput
+        .permissionDecisionReason
+    ).toContain(REVIEW_CANCELLED_REASON)
+  })
+
+  it('does not report cancellation for an abort after the review already settled', async () => {
+    const { ctx, onReviewCancelled } = makeContext()
+    const controller = new AbortController()
+    const promise = invoke(ctx, 'Workflow', 'gate-late-abort-1', controller.signal)
+    inputManager.resolve('gate-late-abort-1', { scope: 'once' })
+    expect(await promise).toEqual({})
+
+    // Listener was removed on settle — a later abort must not touch anything.
+    controller.abort()
+    expect(onReviewCancelled).not.toHaveBeenCalled()
+  })
+
+  it('keeps the hook timeout above the human-input TTL so the container rejects first', () => {
+    expect(CAPABILITY_REVIEW_HOOK_TIMEOUT_S * 1000).toBeGreaterThan(HUMAN_INPUT_TTL_MS)
+  })
+})

--- a/agent-container/src/capability-gate-hook.ts
+++ b/agent-container/src/capability-gate-hook.ts
@@ -1,0 +1,102 @@
+import type { HookCallback } from '@anthropic-ai/claude-agent-sdk';
+import { inputManager, HUMAN_INPUT_TTL_MS } from './input-manager';
+import type { AgentCapabilityPolicies } from './types';
+import {
+  blockedCapabilityMessage,
+  capabilityGateFor,
+  parseReviewDecisionScope,
+  reviewDeclinedMessage,
+  type Capability,
+} from './capability-policies';
+
+// The CLI enforces a per-hook timeout on SDK hook callbacks — 10 minutes when
+// the matcher config carries none. A parked review must outlive that: an
+// unattended session (scheduled run) legitimately waits hours for its human.
+// One hour past the input-manager's human TTL so the TTL sweep always rejects
+// first — the model then sees reviewDeclinedMessage instead of the CLI's
+// generic "user doesn't want to take this action" synthesized on hook abort.
+// Unit is SECONDS (HookCallbackMatcher.timeout), not ms.
+export const CAPABILITY_REVIEW_HOOK_TIMEOUT_S = HUMAN_INPUT_TTL_MS / 1000 + 60 * 60;
+
+export const REVIEW_CANCELLED_REASON = 'The approval request was cancelled before anyone decided';
+
+export interface CapabilityGateContext {
+  sessionId: string;
+  getPolicies: () => AgentCapabilityPolicies | undefined;
+  getSessionGrants: () => ReadonlySet<Capability>;
+  onSessionGrant: (capability: Capability) => void;
+  // The CLI stopped waiting for this hook (its timeout elapsed, or the turn
+  // was aborted/interrupted) — the pending review is already rejected; the
+  // host must close the approval card nobody can answer anymore.
+  onReviewCancelled: (toolUseId: string, capability: Capability) => void;
+}
+
+/**
+ * Three-tier launch policy gate for subagents (Task/Agent) and workflows
+ * (Workflow). This MUST be a PreToolUse hook, not a canUseTool branch: under
+ * permissionMode 'bypassPermissions' the SDK auto-approves every regular tool
+ * call before canUseTool is consulted (CLAUDE_SDK_CAN_USE_TOOL_SHADOWED) —
+ * only hook denies still apply. Review parks the launch on a pending input
+ * (same round-trip as AskUserQuestion): the host renders the approval card and
+ * answers via /inputs/:toolUseId/resolve|reject. Block is enforced at query
+ * creation (tools stripped); the deny here is the backstop for a policy that
+ * tightened mid-session.
+ */
+export function createCapabilityGateHook(ctx: CapabilityGateContext): HookCallback {
+  return async (input, toolUseId, { signal }) => {
+    const hookToolName = (input as { tool_name?: string }).tool_name;
+    const gate = capabilityGateFor(hookToolName ?? '', ctx.getPolicies(), ctx.getSessionGrants());
+    if (!gate) return {};
+    if (gate.policy === 'block') {
+      console.log(`[PreToolUse] Denying ${hookToolName} (${gate.capability} blocked)`);
+      return {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse' as const,
+          permissionDecision: 'deny' as const,
+          permissionDecisionReason: blockedCapabilityMessage(gate.capability),
+        },
+      };
+    }
+
+    const requestId = toolUseId || `capability-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+    console.log(`[PreToolUse] Capability review for ${hookToolName} (${gate.capability}), toolUseId: ${requestId}`);
+    // When the CLI abandons this hook it sends a control_cancel_request and
+    // this signal fires. Without the listener the pending entry parks as a
+    // zombie until the 24h TTL and the host keeps a card nobody is waiting on.
+    const onAbort = () => {
+      inputManager.reject(requestId, REVIEW_CANCELLED_REASON);
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    try {
+      // Park until the user decides via the approval card
+      const decision = await inputManager.createPendingWithType<Record<string, string>>(
+        requestId,
+        'capability_review',
+        { capability: gate.capability, toolName: hookToolName },
+        ctx.sessionId
+      );
+      if (parseReviewDecisionScope(decision) === 'session') {
+        console.log(`[PreToolUse] Session-scoped grant for ${gate.capability}`);
+        ctx.onSessionGrant(gate.capability);
+      }
+      return {};
+    } catch (error) {
+      console.log(`[PreToolUse] Capability launch declined:`, error);
+      if (signal.aborted) {
+        ctx.onReviewCancelled(requestId, gate.capability);
+      }
+      return {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse' as const,
+          permissionDecision: 'deny' as const,
+          permissionDecisionReason: reviewDeclinedMessage(
+            gate.capability,
+            error instanceof Error ? error.message : undefined
+          ),
+        },
+      };
+    } finally {
+      signal.removeEventListener('abort', onAbort);
+    }
+  };
+}

--- a/agent-container/src/claude-code-effort.test.ts
+++ b/agent-container/src/claude-code-effort.test.ts
@@ -82,6 +82,7 @@ vi.mock('./file-hooks', () => ({
 
 vi.mock('./input-manager', () => ({
   inputManager: {},
+  HUMAN_INPUT_TTL_MS: 24 * 60 * 60 * 1000,
 }))
 
 import { ClaudeCodeProcess } from './claude-code'

--- a/agent-container/src/claude-code-stop-race.test.ts
+++ b/agent-container/src/claude-code-stop-race.test.ts
@@ -61,7 +61,7 @@ vi.mock('./mcp-server', () => ({
 vi.mock('./tools/browser', () => ({ createBrowserTools: () => [] }))
 vi.mock('./tools/computer-use', () => ({ computerUseTools: [] }))
 vi.mock('./file-hooks', () => ({ fileHooks: {}, resolveToolFilePath: () => '' }))
-vi.mock('./input-manager', () => ({ inputManager: {} }))
+vi.mock('./input-manager', () => ({ inputManager: {}, HUMAN_INPUT_TTL_MS: 24 * 60 * 60 * 1000 }))
 
 import { ClaudeCodeProcess } from './claude-code'
 

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -50,12 +50,10 @@ import {
   applyCapabilityPolicies,
   blockBoundaryChanged,
   blockedCapabilityMessage,
-  capabilityGateFor,
-  parseReviewDecisionScope,
   policyFor,
-  reviewDeclinedMessage,
   type Capability,
 } from './capability-policies';
+import { createCapabilityGateHook, CAPABILITY_REVIEW_HOOK_TIMEOUT_S } from './capability-gate-hook';
 
 // Prefix for system-injected user messages that should be hidden in the UI.
 // Keep in sync with SYSTEM_MESSAGE_PREFIX in src/renderer/components/messages/message-list.tsx
@@ -794,65 +792,32 @@ export class ClaudeCodeProcess extends EventEmitter {
               ],
             },
             {
-              // Three-tier launch policy for subagents (Task/Agent) and
-              // workflows (Workflow). This MUST be a PreToolUse hook, not a
-              // canUseTool branch: under permissionMode 'bypassPermissions'
-              // the SDK auto-approves every regular tool call before
-              // canUseTool is consulted (CLAUDE_SDK_CAN_USE_TOOL_SHADOWED) —
-              // only hook denies still apply. Review parks the launch on a
-              // pending input (same round-trip as AskUserQuestion): the host
-              // renders the approval card and answers via
-              // /inputs/:toolUseId/resolve|reject. Block is enforced at query
-              // creation (tools stripped); the deny here is the backstop for
-              // a policy that tightened mid-session.
+              // Launch-policy gate for subagents/workflows — see
+              // createCapabilityGateHook for why this is a hook and not
+              // canUseTool.
               matcher: '^(Task|Agent|Workflow)$',
+              timeout: CAPABILITY_REVIEW_HOOK_TIMEOUT_S,
               hooks: [
-                async (input, toolUseId) => {
-                  const hookToolName = (input as any).tool_name as string | undefined;
-                  const gate = capabilityGateFor(hookToolName ?? '', this.capabilityPolicies, this.sessionCapabilityGrants);
-                  if (!gate) return {};
-                  if (gate.policy === 'block') {
-                    console.log(`[PreToolUse] Denying ${hookToolName} (${gate.capability} blocked)`);
-                    return {
-                      hookSpecificOutput: {
-                        hookEventName: 'PreToolUse' as const,
-                        permissionDecision: 'deny' as const,
-                        permissionDecisionReason: blockedCapabilityMessage(gate.capability),
-                      },
-                    };
-                  }
-
-                  const requestId = toolUseId || `capability-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
-                  console.log(`[PreToolUse] Capability review for ${hookToolName} (${gate.capability}), toolUseId: ${requestId}`);
-                  try {
-                    // Park until the user decides via the approval card
-                    const decision = await inputManager.createPendingWithType<Record<string, string>>(
-                      requestId,
-                      'capability_review',
-                      { capability: gate.capability, toolName: hookToolName },
-                      this.sessionId
-                    );
-                    if (parseReviewDecisionScope(decision) === 'session') {
-                      console.log(`[PreToolUse] Session-scoped grant for ${gate.capability}`);
-                      this.sessionCapabilityGrants.add(gate.capability);
-                      // Session-manager persists it so the grant survives eviction+resume.
-                      this.emit('capability-grant', { capability: gate.capability });
-                    }
-                    return {};
-                  } catch (error) {
-                    console.log(`[PreToolUse] Capability launch declined:`, error);
-                    return {
-                      hookSpecificOutput: {
-                        hookEventName: 'PreToolUse' as const,
-                        permissionDecision: 'deny' as const,
-                        permissionDecisionReason: reviewDeclinedMessage(
-                          gate.capability,
-                          error instanceof Error ? error.message : undefined
-                        ),
-                      },
-                    };
-                  }
-                },
+                createCapabilityGateHook({
+                  sessionId: this.sessionId,
+                  getPolicies: () => this.capabilityPolicies,
+                  getSessionGrants: () => this.sessionCapabilityGrants,
+                  onSessionGrant: (capability) => {
+                    this.sessionCapabilityGrants.add(capability);
+                    // Session-manager persists it so the grant survives eviction+resume.
+                    this.emit('capability-grant', { capability });
+                  },
+                  onReviewCancelled: (cancelledToolUseId, capability) => {
+                    // Same relay as SDK frames (persister → SSE → renderer),
+                    // so the host closes the orphaned approval card.
+                    this.emit('message', {
+                      type: 'capability_review_cancelled',
+                      toolUseId: cancelledToolUseId,
+                      capability,
+                      session_id: this.claudeSessionId || this.sessionId,
+                    });
+                  },
+                }),
               ],
             },
             {

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -3276,6 +3276,29 @@ describe('MessagePersister', () => {
       expect(sseEvents.filter(e => e.type === 'capability_review_request')).toHaveLength(0)
       expect(mockClient.fetch).not.toHaveBeenCalled()
     })
+
+    it('a container cancellation frame closes the card like a decision does', async () => {
+      // The container's gate hook emits this when the CLI abandons the parked
+      // hook (per-hook timeout or turn abort) — no decision can ever land, so
+      // the card must not linger for live clients or reconnect replay.
+      simulateToolUse('Workflow', 'wf-5', { script: 'export const meta = {}' })
+      await vi.waitFor(() => {
+        expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(1)
+      })
+
+      mockClient._sendMessage({
+        type: 'capability_review_cancelled',
+        toolUseId: 'wf-5',
+        capability: 'workflows',
+      })
+
+      await vi.waitFor(() => {
+        expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
+      })
+      const resolved = sseEvents.filter(e => e.type === 'capability_review_resolved')
+      expect(resolved).toHaveLength(1)
+      expect(resolved[0]).toMatchObject({ toolUseId: 'wf-5' })
+    })
   })
 
   // ============================================================================

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -3277,6 +3277,47 @@ describe('MessagePersister', () => {
       expect(mockClient.fetch).not.toHaveBeenCalled()
     })
 
+    it('a cancellation racing ahead of the grant lookup suppresses the card entirely', async () => {
+      // handleCapabilityReviewTool awaits the container grant lookup before
+      // storing/broadcasting the card. A capability_review_cancelled frame
+      // landing during that await must tombstone the id — otherwise the
+      // handler resurrects an unanswerable card and re-marks the session
+      // awaiting input after its own cancellation.
+      let releaseLookup!: (value: unknown) => void
+      vi.mocked(mockClient.fetch).mockReturnValue(
+        new Promise((resolve) => { releaseLookup = resolve }) as never
+      )
+
+      simulateToolUse('Workflow', 'wf-race', { script: 'export const meta = {}' })
+      await flush()
+      mockClient._sendMessage({
+        type: 'capability_review_cancelled',
+        toolUseId: 'wf-race',
+        capability: 'workflows',
+      })
+      await flush()
+
+      releaseLookup({ ok: true, json: async () => ({ grants: [] }) })
+      await flush()
+      await flush()
+
+      expect(sseEvents.filter(e => e.type === 'capability_review_request')).toHaveLength(0)
+      expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
+
+      // The tombstone is consumed — a later review with a fresh id is unaffected.
+      vi.mocked(mockClient.fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({ grants: [] }),
+      } as unknown as Response)
+      simulateToolUse('Workflow', 'wf-after-race', { script: 'export const meta = {}' })
+      await vi.waitFor(() => {
+        expect(sseEvents.filter(e => e.type === 'capability_review_request')).toHaveLength(1)
+      })
+      expect(sseEvents.filter(e => e.type === 'capability_review_request')[0]).toMatchObject({
+        toolUseId: 'wf-after-race',
+      })
+    })
+
     it('a container cancellation frame closes the card like a decision does', async () => {
       // The container's gate hook emits this when the CLI abandons the parked
       // hook (per-hook timeout or turn abort) — no decision can ever land, so

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1674,6 +1674,16 @@ class MessagePersister {
         })
         break
 
+      case 'capability_review_cancelled':
+        // The container's gate hook stopped waiting for this review (the CLI
+        // abandoned the parked hook — its timeout elapsed or the turn was
+        // aborted). No decision can land anymore: close the approval card
+        // everywhere instead of leaving it dangling until reconnect cleanup.
+        if (typeof content.toolUseId === 'string') {
+          this.completeCapabilityReview(sessionId, content.toolUseId)
+        }
+        break
+
       case 'connection_closed':
         // WebSocket connection to container was lost
         // Check if session is still actually running in the container

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -119,6 +119,15 @@ interface StreamingState {
   // that connects AFTER they fire would never see them; we store the exact payloads here and the
   // /stream route replays them on (re)connect. Cleared at turn boundaries (session_active/idle).
   pendingInputRequests: Map<string, { type: string; toolUseId: string; [k: string]: unknown }>
+  // Tombstones for capability reviews cancelled BEFORE their card was stored:
+  // handleCapabilityReviewTool awaits a container grant lookup before it
+  // broadcasts, so a capability_review_cancelled frame can win that race —
+  // the handler must then drop the card instead of resurrecting it. NOT
+  // cleared at turn boundaries: a hung grant lookup can outlive the turn
+  // (interrupts kill the container the fetch is talking to), and a tool_use
+  // id never recurs, so a straggler can only ever suppress its own stale
+  // card. Entries are consumed on match; the rest die with this state.
+  cancelledCapabilityReviews: Set<string>
   lastApiErrorCode: string | null // SDK error code from last assistant message (e.g., 'authentication_failed', 'rate_limit')
   // Backgrounded Bash commands + dynamic workflows still running, keyed by the SDK task_id.
   // For workflows we also carry the launching tool's id, the meta.name, and — once the
@@ -303,6 +312,7 @@ class MessagePersister {
       isAwaitingInput: priorIsAwaitingInput,
       pendingComputerUseRequests: new Map(),
       pendingInputRequests: new Map(),
+      cancelledCapabilityReviews: new Set(),
       lastApiErrorCode: null,
       activeBackgroundTasks: priorBackgroundTasks,
       bgTasksSnapshot: prior?.bgTasksSnapshot ?? null,
@@ -800,6 +810,7 @@ class MessagePersister {
         isAwaitingInput: false,
         pendingComputerUseRequests: new Map(),
         pendingInputRequests: new Map(),
+        cancelledCapabilityReviews: new Set(),
         lastApiErrorCode: null,
         activeBackgroundTasks: new Map(),
         bgTasksSnapshot: null,
@@ -1680,7 +1691,14 @@ class MessagePersister {
         // aborted). No decision can land anymore: close the approval card
         // everywhere instead of leaving it dangling until reconnect cleanup.
         if (typeof content.toolUseId === 'string') {
-          this.completeCapabilityReview(sessionId, content.toolUseId)
+          if (state.pendingInputRequests.has(content.toolUseId)) {
+            this.completeCapabilityReview(sessionId, content.toolUseId)
+          } else {
+            // No card yet — handleCapabilityReviewTool is still awaiting its
+            // container grant lookup. Tombstone the id so the handler drops
+            // the card instead of broadcasting it after this cancellation.
+            state.cancelledCapabilityReviews.add(content.toolUseId)
+          }
         }
         break
 
@@ -3905,6 +3923,15 @@ ${continuation}`
           // on beats a launch that silently skips review.
           console.warn('[MessagePersister] Capability grant lookup failed; showing review card:', error)
         }
+      }
+
+      // The grant lookup above is async — a capability_review_cancelled frame
+      // may have arrived while we awaited it (interrupts make this common).
+      // Its completeCapabilityReview found nothing to delete, so consume the
+      // tombstone here: broadcasting now would resurrect an unanswerable card
+      // and re-mark the session as awaiting input.
+      if (this.streamingStates.get(sessionId)?.cancelledCapabilityReviews.delete(toolUseId)) {
+        return
       }
 
       let input: Record<string, unknown> = {}


### PR DESCRIPTION
## Problem

The SEO Agent's scheduled run this morning (session `6399fe0b`, 13:01 UTC) called `Workflow` under the default `review` policy. The approval card, session promotion, and Action-Required notification all fired correctly — but at exactly **+10:00** the launch was denied with the CLI's generic *"The user doesn't want to take this action right now"*, and the turn ended reporting success. Nobody had declined anything.

Root cause: the capability gate is a PreToolUse hook (canUseTool is shadowed under `bypassPermissions`), and the CLI enforces a **default 600s per-hook timeout** on SDK hook callbacks when the matcher config carries no `timeout`. The "park indefinitely awaiting a human" design was only proven for canUseTool (AskUserQuestion), which has no such ceiling. The container's 24h human-input TTL never got a chance.

## Fix

- **Extend the hook timeout**: the gate matcher now passes `timeout` (seconds) = 25h — one hour past `HUMAN_INPUT_TTL_MS`, so the container's TTL sweep always rejects first with the real `reviewDeclinedMessage` instead of the CLI's blunt abort.
- **Detect abandonment**: the CLI signals any abandonment of a parked hook (timeout, interrupt, parent abort) via `control_cancel_request`, which the SDK surfaces as the hook callback's `AbortSignal` — previously ignored. The gate (extracted to `capability-gate-hook.ts` for testability) now listens: on abort it rejects the parked pending entry (no more 24h zombie in the input manager) and emits a `capability_review_cancelled` frame.
- **Close the card**: the host handles the new frame with the existing `completeCapabilityReview` → `capability_review_resolved` SSE, so an unanswerable approval card is closed everywhere instead of dangling. This also covers the interrupt path, which previously stranded the container-side pending entry the same way.

## Tests

- New `capability-gate-hook.test.ts`: pass-through / block / park+approve (once & session scope) / user decline / **abort → pending wiped + cancellation reported** / late abort after settle is a no-op / hook timeout stays above the human TTL.
- `message-persister.test.ts`: a container cancellation frame clears the replay store and broadcasts `capability_review_resolved` like a decision does.
- `tsc`, `eslint`, and the adjacent container suites (claude-code, capability-policies, input-manager, session-manager-settings) are green. Two partial `vi.mock('./input-manager')` factories gained the newly imported `HUMAN_INPUT_TTL_MS` export.

Notification-copy follow-up ("wants to launch agents" for workflow launches) is split into its own PR.

https://claude.ai/code/session_01D1cNaBPEb5VemoSwSPAFJT