### PR TITLE
Capability-review notification names what needs approving

### DIFF
--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -3915,7 +3915,11 @@ ${continuation}`
       this.markSessionAwaitingInput(sessionId)
 
       if (agentSlug) {
-        notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'capability_review').catch((err) => {
+        notificationManager.triggerSessionWaitingInput(
+          sessionId,
+          agentSlug,
+          capability === 'workflows' ? 'capability_review_workflows' : 'capability_review_subagents'
+        ).catch((err) => {
           console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
         })
       }

--- a/src/shared/lib/notifications/notification-manager.test.ts
+++ b/src/shared/lib/notifications/notification-manager.test.ts
@@ -166,6 +166,19 @@ describe('triggerSessionWaitingInput — NOT gated by automated-session flag', (
     await notificationManager.triggerSessionWaitingInput('sess-1', 'agent-x', 'file')
     expect(mockCreateNotification).toHaveBeenCalledTimes(1)
   })
+
+  it('names the capability under review — a workflow launch is not "launch agents"', async () => {
+    mockGetSessionMetadata.mockResolvedValue(null)
+    await notificationManager.triggerSessionWaitingInput('sess-1', 'agent-x', 'capability_review_workflows')
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.stringContaining('wants to run a workflow') })
+    )
+
+    await notificationManager.triggerSessionWaitingInput('sess-1', 'agent-x', 'capability_review_subagents')
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.stringContaining('wants to launch a subagent') })
+    )
+  })
 })
 
 describe('session_waiting promotes automated sessions to interactive', () => {

--- a/src/shared/lib/notifications/notification-manager.ts
+++ b/src/shared/lib/notifications/notification-manager.ts
@@ -165,7 +165,7 @@ class NotificationManager {
   async triggerSessionWaitingInput(
     sessionId: string,
     agentSlug: string,
-    waitingFor: 'secret' | 'connected_account' | 'question' | 'file' | 'remote_mcp' | 'browser_input' | 'script_run' | 'computer_use' | 'capability_review',
+    waitingFor: 'secret' | 'connected_account' | 'question' | 'file' | 'remote_mcp' | 'browser_input' | 'script_run' | 'computer_use' | 'capability_review_subagents' | 'capability_review_workflows',
     agentName?: string
   ): Promise<void> {
     const displayName = agentName || await this.getAgentDisplayName(agentSlug)
@@ -195,8 +195,14 @@ class NotificationManager {
       case 'computer_use':
         waitingMessage = 'wants to control your computer'
         break
-      case 'capability_review':
-        waitingMessage = 'wants to launch agents'
+      // Mirror the review card's terminology ("Run this workflow?" /
+      // "Launch a subagent?") so the notification names what actually needs
+      // approving.
+      case 'capability_review_subagents':
+        waitingMessage = 'wants to launch a subagent'
+        break
+      case 'capability_review_workflows':
+        waitingMessage = 'wants to run a workflow'
         break
     }
 


### PR DESCRIPTION
## Problem

The Action-Required notification for a capability review always reads **"wants to launch agents"** — including for `Workflow` launches (as seen in this morning's SEO Agent scheduled run), where nothing about agents is being asked.

## Fix

Split the `triggerSessionWaitingInput` waiting type into `capability_review_subagents` / `capability_review_workflows` (the caller in `handleCapabilityReviewTool` already knows the capability) and mirror the review card's terminology:

- workflows → "wants to run a workflow"
- subagents → "wants to launch a subagent"

## Tests

New notification-manager test asserting both copies; `tsc` + `eslint` + notification-manager and message-persister suites green.

Companion to #535 (the 10-minute auto-deny fix from the same investigation).

https://claude.ai/code/session_01D1cNaBPEb5VemoSwSPAFJT