### PR TITLE
Add workspace folder preview browser

### DIFF
--- a/agent-container/src/file-hooks/bookmarks-hook.test.ts
+++ b/agent-container/src/file-hooks/bookmarks-hook.test.ts
@@ -69,10 +69,18 @@ describe('BookmarksFileHook.onWrite — valid', () => {
     expect(result.warning).toBeUndefined()
   })
 
+  it('accepts a workspace folder bookmark', () => {
+    const content = JSON.stringify([{ name: 'Reports', folder: '/workspace/reports' }])
+    const result = hook.onWrite('/workspace/bookmarks.json', content)
+    expect(result.error).toBeUndefined()
+    expect(result.warning).toBeUndefined()
+  })
+
   it('accepts a mix of link and file bookmarks', () => {
     const content = JSON.stringify([
       { name: 'Sheet', link: 'https://docs.google.com/spreadsheets/d/abc' },
       { name: 'Log', file: '/workspace/output/log.txt' },
+      { name: 'Output', folder: '/workspace/output' },
     ])
     const result = hook.onWrite('/workspace/bookmarks.json', content)
     expect(result.error).toBeUndefined()
@@ -94,6 +102,29 @@ describe('BookmarksFileHook.onWrite — invalid', () => {
     const result = hook.onWrite('/workspace/bookmarks.json', content)
     expect(result.error).toBeDefined()
     expect(result.error).toContain('exactly one')
+  })
+
+  it('rejects a bookmark with multiple resource fields', () => {
+    const content = JSON.stringify([{
+      name: 'Too many',
+      link: 'https://x.com',
+      file: '/workspace/file.txt',
+      folder: '/workspace/reports',
+    }])
+    const result = hook.onWrite('/workspace/bookmarks.json', content)
+    expect(result.error).toContain('exactly one')
+  })
+
+  it('rejects a folder outside the workspace', () => {
+    const content = JSON.stringify([{ name: 'Secrets', folder: '/etc' }])
+    const result = hook.onWrite('/workspace/bookmarks.json', content)
+    expect(result.error).toContain('inside /workspace')
+  })
+
+  it('rejects a workspace-prefixed folder that normalizes outside the workspace', () => {
+    const content = JSON.stringify([{ name: 'Secrets', folder: '/workspace/../../etc' }])
+    const result = hook.onWrite('/workspace/bookmarks.json', content)
+    expect(result.error).toContain('inside /workspace')
   })
 
   it('rejects a bookmark with neither link nor file', () => {

--- a/agent-container/src/file-hooks/bookmarks-hook.test.ts
+++ b/agent-container/src/file-hooks/bookmarks-hook.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { BookmarksFileHook } from './bookmarks-hook'
+import { bookmarkSchema } from './bookmarks-schema'
 import { resolveToolFilePath } from './file-hook'
 
 const hook = new BookmarksFileHook()
@@ -74,6 +75,13 @@ describe('BookmarksFileHook.onWrite — valid', () => {
     const result = hook.onWrite('/workspace/bookmarks.json', content)
     expect(result.error).toBeUndefined()
     expect(result.warning).toBeUndefined()
+  })
+
+  it('canonicalizes trailing slashes on workspace folder bookmarks', () => {
+    const result = bookmarkSchema.safeParse({ name: 'Workspace', folder: '/workspace/' })
+
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.folder).toBe('/workspace')
   })
 
   it('accepts a mix of link and file bookmarks', () => {

--- a/agent-container/src/file-hooks/bookmarks-hook.ts
+++ b/agent-container/src/file-hooks/bookmarks-hook.ts
@@ -10,13 +10,15 @@ Format: a JSON array of objects, each with:
 - "name" (string, required): Display name for the bookmark
 - "link" (string, optional): An https:// URL (for web links)
 - "file" (string, optional): A workspace file path (same paths as deliver_file, e.g. "/workspace/reports/daily.csv")
+- "folder" (string, optional): A workspace folder path (e.g. "/workspace/reports")
 
-Each bookmark must have exactly one of "link" or "file", not both.
+Each bookmark must have exactly one of "link", "file", or "folder".
 
 Example:
 [
   { "name": "Sales Dashboard", "link": "https://docs.google.com/spreadsheets/d/abc123" },
-  { "name": "Daily Report", "file": "/workspace/reports/daily-report.html" }
+  { "name": "Daily Report", "file": "/workspace/reports/daily-report.html" },
+  { "name": "Reports", "folder": "/workspace/reports" }
 ]
 
 Keep bookmarks to important, frequently-accessed resources (max ${MAX_RECOMMENDED_BOOKMARKS} recommended). Remove bookmarks that are no longer relevant.`

--- a/agent-container/src/file-hooks/bookmarks-schema.ts
+++ b/agent-container/src/file-hooks/bookmarks-schema.ts
@@ -1,10 +1,17 @@
 import { z } from 'zod'
 import path from 'path'
 
-function isWorkspaceFolderPath(folderPath: string): boolean {
-  if (!folderPath.startsWith('/') || folderPath.includes('\0')) return false
-  const normalized = path.posix.normalize(folderPath)
+function normalizeWorkspaceFolderPath(folderPath: string): string | null {
+  if (!folderPath.startsWith('/') || folderPath.includes('\0')) return null
+  const normalizedPath = path.posix.normalize(folderPath)
+  const normalized = normalizedPath === '/' ? normalizedPath : normalizedPath.replace(/\/+$/, '')
   return normalized === '/workspace' || normalized.startsWith('/workspace/')
+    ? normalized
+    : null
+}
+
+function isWorkspaceFolderPath(folderPath: string): boolean {
+  return normalizeWorkspaceFolderPath(folderPath) != null
 }
 
 export const bookmarkSchema = z.object({
@@ -17,6 +24,7 @@ export const bookmarkSchema = z.object({
       isWorkspaceFolderPath,
       'Folder path must be inside /workspace',
     )
+    .transform(folderPath => normalizeWorkspaceFolderPath(folderPath) ?? folderPath)
     .optional(),
 }).refine(
   (bookmark) => [bookmark.link, bookmark.file, bookmark.folder].filter((value) => value != null).length === 1,

--- a/agent-container/src/file-hooks/bookmarks-schema.ts
+++ b/agent-container/src/file-hooks/bookmarks-schema.ts
@@ -1,12 +1,26 @@
 import { z } from 'zod'
+import path from 'path'
+
+function isWorkspaceFolderPath(folderPath: string): boolean {
+  if (!folderPath.startsWith('/') || folderPath.includes('\0')) return false
+  const normalized = path.posix.normalize(folderPath)
+  return normalized === '/workspace' || normalized.startsWith('/workspace/')
+}
 
 export const bookmarkSchema = z.object({
   name: z.string().min(1, 'Bookmark name is required'),
   link: z.string().url('Link must be a valid URL starting with https://').startsWith('https://', 'Link must start with https://').optional(),
   file: z.string().min(1, 'File path must not be empty').optional(),
+  folder: z.string()
+    .min(1, 'Folder path must not be empty')
+    .refine(
+      isWorkspaceFolderPath,
+      'Folder path must be inside /workspace',
+    )
+    .optional(),
 }).refine(
-  (b) => (b.link != null) !== (b.file != null),
-  { message: 'Each bookmark must have exactly one of "link" or "file", not both or neither' }
+  (bookmark) => [bookmark.link, bookmark.file, bookmark.folder].filter((value) => value != null).length === 1,
+  { message: 'Each bookmark must have exactly one of "link", "file", or "folder"' }
 )
 
 export const bookmarksSchema = z.array(bookmarkSchema)

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -24,6 +24,13 @@ import { runBrowserUpload } from './browser-upload';
 import { runBrowserDownload } from './browser-download';
 import { updateEnvFileEntry, healEnvFilePermissions } from './env-file-store';
 import { isAgentIdentityEnvKey } from './attribution-headers';
+import {
+  deleteWorkspaceEntry,
+  renameWorkspaceEntry,
+  WorkspaceEntryOperationError,
+  type DeleteWorkspaceEntryRequest,
+  type RenameWorkspaceEntryRequest,
+} from './workspace-entry-operations';
 
 import { getEditingCommands } from './cdp-editing-commands';
 
@@ -202,6 +209,35 @@ app.delete('/sessions/:id/queued-messages/:uuid', async (c) => {
 });
 
 // File system endpoints
+// These host-authenticated mutations deliberately execute inside the container
+// namespace. The workspace is bind-mounted, so changes persist, while a racing
+// symlink can never redirect a destructive operation into the host filesystem.
+app.patch('/workspace/entries', async (c) => {
+  try {
+    const result = await renameWorkspaceEntry(await c.req.json<RenameWorkspaceEntryRequest>());
+    return c.json(result);
+  } catch (error) {
+    if (error instanceof WorkspaceEntryOperationError) {
+      return c.json({ error: error.message }, error.status);
+    }
+    console.error('Error renaming workspace entry:', error);
+    return c.json({ error: error instanceof Error ? error.message : 'Failed to rename workspace entry' }, 500);
+  }
+});
+
+app.delete('/workspace/entries', async (c) => {
+  try {
+    await deleteWorkspaceEntry(await c.req.json<DeleteWorkspaceEntryRequest>());
+    return c.json({ success: true });
+  } catch (error) {
+    if (error instanceof WorkspaceEntryOperationError) {
+      return c.json({ error: error.message }, error.status);
+    }
+    console.error('Error deleting workspace entry:', error);
+    return c.json({ error: error instanceof Error ? error.message : 'Failed to delete workspace entry' }, 500);
+  }
+});
+
 app.get('/files/*', async (c) => {
   const filePath = c.req.param('*') || '';
   const fullPath = path.join('/workspace', filePath);

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -662,9 +662,9 @@ The user can also decline the request, optionally providing a reason.
 
 ### Bookmarks
 
-You can save bookmarks to important resources (web links or workspace files) by editing `/workspace/bookmarks.json`. Bookmarks are displayed on the user's agent homepage for quick access. When the user sends you a link/file or you generate one that seems important and often-visited -- bookmark it!
+You can save bookmarks to important resources (web links, workspace files, or workspace folders) by editing `/workspace/bookmarks.json`. Bookmarks are displayed on the user's agent homepage for quick access. When the user sends you a link/file or you generate one that seems important and often-visited -- bookmark it!
 
-The file is a JSON array — each item has a `name` and either a `link` (https:// URL) or `file` (workspace path). When you create or deliver a file the user will access regularly, consider adding a bookmark for it.
+The file is a JSON array — each item has a `name` and exactly one of: `link` (https:// URL), `file` (workspace file path), or `folder` (a path inside `/workspace`). Use a folder bookmark for a collection the user will browse repeatedly, such as generated reports or exports. When you create or deliver a file the user will access regularly, consider adding a bookmark for it.
 
 ## Web Browsing
 

--- a/agent-container/src/workspace-entry-operations.test.ts
+++ b/agent-container/src/workspace-entry-operations.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  deleteWorkspaceEntry,
+  renameWorkspaceEntry,
+  WorkspaceEntryOperationError,
+} from './workspace-entry-operations';
+
+describe('workspace entry operations', () => {
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'workspace-entry-'));
+    await fs.promises.mkdir(path.join(workspaceRoot, 'reports', 'drafts'), { recursive: true });
+    await fs.promises.writeFile(path.join(workspaceRoot, 'reports', 'notes.md'), 'notes');
+    await fs.promises.writeFile(path.join(workspaceRoot, 'reports', 'drafts', 'old.md'), 'draft');
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it('renames files and returns the container path', async () => {
+    const result = await renameWorkspaceEntry({
+      path: '/workspace/reports/notes.md',
+      name: 'renamed.md',
+      type: 'file',
+    }, workspaceRoot);
+
+    expect(result).toEqual({ path: '/workspace/reports/renamed.md', name: 'renamed.md' });
+    await expect(fs.promises.readFile(path.join(workspaceRoot, 'reports', 'renamed.md'), 'utf8'))
+      .resolves.toBe('notes');
+    expect(fs.existsSync(path.join(workspaceRoot, 'reports', 'notes.md'))).toBe(false);
+  });
+
+  it('recursively deletes directories', async () => {
+    await deleteWorkspaceEntry({
+      path: '/workspace/reports/drafts',
+      type: 'directory',
+    }, workspaceRoot);
+
+    expect(fs.existsSync(path.join(workspaceRoot, 'reports', 'drafts'))).toBe(false);
+  });
+
+  it('does not overwrite an existing entry', async () => {
+    await fs.promises.writeFile(path.join(workspaceRoot, 'reports', 'existing.md'), 'existing');
+
+    await expect(renameWorkspaceEntry({
+      path: '/workspace/reports/notes.md',
+      name: 'existing.md',
+      type: 'file',
+    }, workspaceRoot)).rejects.toMatchObject<Partial<WorkspaceEntryOperationError>>({ status: 409 });
+  });
+
+  it('rejects the workspace root and paths outside the workspace', async () => {
+    await expect(deleteWorkspaceEntry({ path: '/workspace', type: 'directory' }, workspaceRoot))
+      .rejects.toMatchObject<Partial<WorkspaceEntryOperationError>>({ status: 400 });
+    await expect(deleteWorkspaceEntry({ path: '/etc/passwd', type: 'file' }, workspaceRoot))
+      .rejects.toMatchObject<Partial<WorkspaceEntryOperationError>>({ status: 400 });
+  });
+
+  it('rejects leaf symlinks instead of mutating their targets', async () => {
+    if (process.platform === 'win32') return;
+    const targetPath = path.join(workspaceRoot, 'reports', 'notes.md');
+    const linkPath = path.join(workspaceRoot, 'reports', 'linked.md');
+    await fs.promises.symlink(targetPath, linkPath);
+
+    await expect(deleteWorkspaceEntry({
+      path: '/workspace/reports/linked.md',
+      type: 'file',
+    }, workspaceRoot)).rejects.toMatchObject<Partial<WorkspaceEntryOperationError>>({ status: 404 });
+    await expect(fs.promises.readFile(targetPath, 'utf8')).resolves.toBe('notes');
+  });
+});

--- a/agent-container/src/workspace-entry-operations.ts
+++ b/agent-container/src/workspace-entry-operations.ts
@@ -1,0 +1,112 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export type WorkspaceEntryType = 'file' | 'directory';
+
+export interface RenameWorkspaceEntryRequest {
+  path: string;
+  name: string;
+  type: WorkspaceEntryType;
+}
+
+export interface DeleteWorkspaceEntryRequest {
+  path: string;
+  type: WorkspaceEntryType;
+}
+
+export class WorkspaceEntryOperationError extends Error {
+  constructor(
+    message: string,
+    readonly status: 400 | 404 | 409,
+  ) {
+    super(message);
+  }
+}
+
+const CONTAINER_WORKSPACE_ROOT = '/workspace';
+
+function isValidEntryName(name: string): boolean {
+  return name.length > 0
+    && name.length <= 255
+    && name !== '.'
+    && name !== '..'
+    && !name.includes('/')
+    && !name.includes('\\')
+    && !name.includes('\0');
+}
+
+function resolveWorkspaceEntry(rawPath: string, workspaceRoot: string): string {
+  if (!rawPath.startsWith('/') || rawPath.includes('\0')) {
+    throw new WorkspaceEntryOperationError('Invalid workspace path', 400);
+  }
+
+  const normalized = path.posix.normalize(rawPath);
+  const relative = path.posix.relative(CONTAINER_WORKSPACE_ROOT, normalized);
+  if (
+    relative === ''
+    || relative === '..'
+    || relative.startsWith('../')
+    || path.posix.isAbsolute(relative)
+  ) {
+    throw new WorkspaceEntryOperationError('Invalid workspace path', 400);
+  }
+
+  return path.resolve(workspaceRoot, ...relative.split('/').filter(Boolean));
+}
+
+async function assertEntryType(entryPath: string, type: WorkspaceEntryType): Promise<void> {
+  let entryStat: fs.Stats;
+  try {
+    entryStat = await fs.promises.lstat(entryPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new WorkspaceEntryOperationError(`${type === 'file' ? 'File' : 'Directory'} not found`, 404);
+    }
+    throw error;
+  }
+
+  const matchesType = type === 'file' ? entryStat.isFile() : entryStat.isDirectory();
+  if (entryStat.isSymbolicLink() || !matchesType) {
+    throw new WorkspaceEntryOperationError(`${type === 'file' ? 'File' : 'Directory'} not found`, 404);
+  }
+}
+
+export async function renameWorkspaceEntry(
+  request: RenameWorkspaceEntryRequest,
+  workspaceRoot = CONTAINER_WORKSPACE_ROOT,
+): Promise<{ path: string; name: string }> {
+  const trimmedName = request.name.trim();
+  if (!isValidEntryName(trimmedName)) {
+    throw new WorkspaceEntryOperationError('Invalid entry name', 400);
+  }
+
+  const sourcePath = resolveWorkspaceEntry(request.path, workspaceRoot);
+  await assertEntryType(sourcePath, request.type);
+
+  const destinationContainerPath = path.posix.join(path.posix.dirname(request.path), trimmedName);
+  const destinationPath = resolveWorkspaceEntry(destinationContainerPath, workspaceRoot);
+  try {
+    await fs.promises.lstat(destinationPath);
+    throw new WorkspaceEntryOperationError('A file or directory with that name already exists', 409);
+  } catch (error) {
+    if (error instanceof WorkspaceEntryOperationError) throw error;
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+
+  await fs.promises.rename(sourcePath, destinationPath);
+  return { path: destinationContainerPath, name: trimmedName };
+}
+
+export async function deleteWorkspaceEntry(
+  request: DeleteWorkspaceEntryRequest,
+  workspaceRoot = CONTAINER_WORKSPACE_ROOT,
+): Promise<void> {
+  const entryPath = resolveWorkspaceEntry(request.path, workspaceRoot);
+  await assertEntryType(entryPath, request.type);
+
+  if (request.type === 'directory') {
+    await fs.promises.rm(entryPath, { recursive: true });
+  } else {
+    await fs.promises.unlink(entryPath);
+  }
+}

--- a/e2e/specs/file-preview.spec.ts
+++ b/e2e/specs/file-preview.spec.ts
@@ -69,6 +69,109 @@ test.describe('File Preview', () => {
     await expect(markdown(page).getByRole('heading', { name: 'Test Report' })).toBeVisible({ timeout: 10000 })
   })
 
+  test('folder bookmark traverses lazily and opens files while preserving tree state', async ({ page }) => {
+    await agentPage.createAgent(`FolderPreview ${Date.now()}`)
+    const agentSlug = await getLatestAgentSlug(page)
+    seedWorkspaceFile(agentSlug, 'reports/overview.md', '# Reports Overview')
+    seedWorkspaceFile(agentSlug, 'reports/2026/july.md', '# July Report')
+    seedWorkspaceFile(
+      agentSlug,
+      'bookmarks.json',
+      JSON.stringify([{ name: 'Reports', folder: '/workspace/reports' }]),
+    )
+
+    await page.reload()
+    await appPage.waitForAgentsLoaded()
+
+    // The Agent Directory uses the same built-in folder browser on web and
+    // Electron; it no longer delegates to an OS-level directory action.
+    await page.getByTestId('home-agent-directory-open-browser').click()
+    await expect(page.locator(
+      '[data-testid="folder-entry"][data-entry-path="/workspace/reports"]',
+    )).toBeVisible({ timeout: 5000 })
+    await page.getByRole('button', { name: 'Hide files panel' }).click()
+
+    await page.getByRole('button', { name: 'Reports' }).click()
+    await expect(page.getByTestId('folder-browser')).toBeVisible({ timeout: 5000 })
+
+    const year = page.locator(
+      '[data-testid="folder-entry"][data-entry-path="/workspace/reports/2026"]',
+    )
+    await expect(year).toHaveAttribute('aria-expanded', 'false')
+    await year.click({ button: 'right' })
+    await expect(page.getByRole('menuitem', { name: 'Bookmark' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Rename' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Delete' })).toBeVisible()
+    await page.getByRole('menuitem', { name: 'Bookmark' }).click()
+    await expect.poll(async () => {
+      const response = await page.request.get(`/api/agents/${agentSlug}/bookmarks`)
+      return await response.json()
+    }).toContainEqual({ name: '2026', folder: '/workspace/reports/2026' })
+
+    await year.click()
+    await expect(year).toHaveAttribute('aria-expanded', 'true')
+
+    const july = page.locator(
+      '[data-testid="folder-entry"][data-entry-path="/workspace/reports/2026/july.md"]',
+    )
+    await july.click()
+    await expect(markdown(page).getByRole('heading', { name: 'July Report' })).toBeVisible({ timeout: 10000 })
+
+    await fileTab(page, 'reports').click()
+    await expect(year).toHaveAttribute('aria-expanded', 'true')
+    await expect(july).toBeVisible()
+
+    const overview = page.locator(
+      '[data-testid="folder-entry"][data-entry-path="/workspace/reports/overview.md"]',
+    )
+    await overview.click({ button: 'right' })
+    await expect(page.getByRole('menuitem', { name: 'Copy contents' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Bookmark' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Rename' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Delete' })).toBeVisible()
+
+    const downloadPromise = page.waitForEvent('download')
+    await page.getByRole('menuitem', { name: 'Download' }).click()
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toBe('overview.md')
+
+    await overview.click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Rename' }).click()
+    await page.getByRole('textbox', { name: 'File name' }).fill('summary.md')
+    await page.getByRole('dialog').getByRole('button', { name: 'Rename' }).click()
+
+    const summary = page.locator(
+      '[data-testid="folder-entry"][data-entry-path="/workspace/reports/summary.md"]',
+    )
+    await expect(summary).toBeVisible()
+    await summary.click()
+    await expect(markdown(page).getByRole('heading', { name: 'Reports Overview' })).toBeVisible({ timeout: 10000 })
+
+    await fileTab(page, 'reports').click()
+    await summary.click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Delete' }).click()
+    const deleteDialog = page.getByRole('alertdialog')
+    await expect(deleteDialog.getByRole('heading', { name: 'Delete File' })).toBeVisible()
+    await deleteDialog.getByRole('button', { name: 'Delete' }).click()
+    await expect(summary).not.toBeVisible()
+
+    await year.click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Rename' }).click()
+    await page.getByRole('textbox', { name: 'Folder name' }).fill('archive')
+    await page.getByRole('dialog').getByRole('button', { name: 'Rename' }).click()
+
+    const archive = page.locator(
+      '[data-testid="folder-entry"][data-entry-path="/workspace/reports/archive"]',
+    )
+    await expect(archive).toBeVisible()
+    await archive.click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Delete' }).click()
+    const deleteFolderDialog = page.getByRole('alertdialog')
+    await expect(deleteFolderDialog.getByRole('heading', { name: 'Delete Folder' })).toBeVisible()
+    await deleteFolderDialog.getByRole('button', { name: 'Delete' }).click()
+    await expect(archive).not.toBeVisible()
+  })
+
   test('closing last tab closes the tray', async ({ page }) => {
     await agentPage.createAgent(`FileClose ${Date.now()}`)
     const agentSlug = await getLatestAgentSlug(page)

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -7,6 +7,7 @@ import { Hono } from 'hono'
 
 // FS mock (for path traversal tests)
 const mockFsStat = vi.fn()
+const mockFsLstat = vi.fn()
 const mockFsReadFile = vi.fn()
 const mockFsWriteFile = vi.fn()
 const mockFsMkdir = vi.fn()
@@ -14,27 +15,41 @@ const mockFsReaddir = vi.fn()
 const mockFsCp = vi.fn()
 const mockFsExistsSync = vi.fn()
 const mockCreateReadStream = vi.fn()
+const mockFsRealpath = vi.fn(async (value: unknown) => value)
+const mockFsRename = vi.fn()
+const mockFsUnlink = vi.fn()
+const mockFsRm = vi.fn()
 
 vi.mock('fs', () => ({
   default: {
     promises: {
       stat: (...args: unknown[]) => mockFsStat(...args),
+      lstat: (...args: unknown[]) => mockFsLstat(...args),
       readFile: (...args: unknown[]) => mockFsReadFile(...args),
       writeFile: (...args: unknown[]) => mockFsWriteFile(...args),
       mkdir: (...args: unknown[]) => mockFsMkdir(...args),
       readdir: (...args: unknown[]) => mockFsReaddir(...args),
       cp: (...args: unknown[]) => mockFsCp(...args),
+      realpath: (...args: unknown[]) => mockFsRealpath(args[0]),
+      rename: (...args: unknown[]) => mockFsRename(...args),
+      unlink: (...args: unknown[]) => mockFsUnlink(...args),
+      rm: (...args: unknown[]) => mockFsRm(...args),
     },
     existsSync: (...args: unknown[]) => mockFsExistsSync(...args),
     createReadStream: (...args: unknown[]) => mockCreateReadStream(...args),
   },
   promises: {
     stat: (...args: unknown[]) => mockFsStat(...args),
+    lstat: (...args: unknown[]) => mockFsLstat(...args),
     readFile: (...args: unknown[]) => mockFsReadFile(...args),
     writeFile: (...args: unknown[]) => mockFsWriteFile(...args),
     mkdir: (...args: unknown[]) => mockFsMkdir(...args),
     readdir: (...args: unknown[]) => mockFsReaddir(...args),
     cp: (...args: unknown[]) => mockFsCp(...args),
+    realpath: (...args: unknown[]) => mockFsRealpath(args[0]),
+    rename: (...args: unknown[]) => mockFsRename(...args),
+    unlink: (...args: unknown[]) => mockFsUnlink(...args),
+    rm: (...args: unknown[]) => mockFsRm(...args),
   },
   existsSync: (...args: unknown[]) => mockFsExistsSync(...args),
   createReadStream: (...args: unknown[]) => mockCreateReadStream(...args),
@@ -1627,11 +1642,433 @@ describe('path traversal security — GET /:id/files/*', () => {
     expect(res.status).not.toBe(400)
   })
 
+  it('rejects a workspace symlink whose real path escapes the workspace', async () => {
+    mockFsRealpath
+      .mockResolvedValueOnce('/mock/workspace')
+      .mockResolvedValueOnce('/etc/passwd')
+
+    const res = await getReq(app, '/api/agents/test-agent/files/linked-secret.txt')
+
+    expect(res.status).toBe(400)
+    expect(mockCreateReadStream).not.toHaveBeenCalled()
+  })
+
   // Note: path traversal with ../ in URLs (e.g. /files/../../etc/passwd) is typically
   // resolved by the HTTP layer/URL parser before reaching the route handler. The
   // server-side guard (fullPath.startsWith(workspaceDir)) protects against any
   // path that resolves outside the workspace after path.resolve() is called.
   // The absolute path test above (//etc/passwd) tests this guard directly.
+})
+
+// ============================================================================
+// Bookmarked folder browser — GET /:id/folders
+// ============================================================================
+
+describe('bookmarked workspace folder listing', () => {
+  let app: ReturnType<typeof createApp>
+
+  const dirent = (name: string, type: 'file' | 'directory' | 'symlink') => ({
+    name,
+    isFile: () => type === 'file',
+    isDirectory: () => type === 'directory',
+    isSymbolicLink: () => type === 'symlink',
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    mockGetAgentWorkspaceDir.mockReturnValue('/mock/workspace')
+  })
+
+  function folderUrl(root: string, currentPath = root) {
+    const params = new URLSearchParams({ root, path: currentPath })
+    return `/api/agents/test-agent/folders?${params.toString()}`
+  }
+
+  it('lists one level, sorts directories first, and omits symlinks', async () => {
+    mockFsReadFile.mockResolvedValueOnce(JSON.stringify([
+      { name: 'Reports', folder: '/workspace/reports' },
+    ]))
+    mockFsStat.mockResolvedValueOnce({ isDirectory: () => true })
+    mockFsReaddir.mockResolvedValueOnce([
+      dirent('z-last.txt', 'file'),
+      dirent('linked', 'symlink'),
+      dirent('2026', 'directory'),
+      dirent('Alpha.md', 'file'),
+    ])
+
+    const res = await getReq(app, folderUrl('/workspace/reports'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({
+      root: '/workspace/reports',
+      path: '/workspace/reports',
+      truncated: false,
+    })
+    expect(body.entries).toEqual([
+      { name: '2026', path: '/workspace/reports/2026', type: 'directory' },
+      { name: 'Alpha.md', path: '/workspace/reports/Alpha.md', type: 'file' },
+      { name: 'z-last.txt', path: '/workspace/reports/z-last.txt', type: 'file' },
+    ])
+  })
+
+  it('allows a descendant of the bookmarked root', async () => {
+    mockFsReadFile.mockResolvedValueOnce(JSON.stringify([
+      { name: 'Reports', folder: '/workspace/reports' },
+    ]))
+    mockFsStat.mockResolvedValueOnce({ isDirectory: () => true })
+    mockFsReaddir.mockResolvedValueOnce([])
+
+    const res = await getReq(app, folderUrl('/workspace/reports', '/workspace/reports/2026'))
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ path: '/workspace/reports/2026', entries: [] })
+  })
+
+  it('opens the full workspace as the built-in Agent Directory without a bookmark', async () => {
+    mockFsStat.mockResolvedValueOnce({ isDirectory: () => true })
+    mockFsReaddir.mockResolvedValueOnce([dirent('reports', 'directory')])
+
+    const res = await getReq(app, folderUrl('/workspace'))
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({
+      root: '/workspace',
+      entries: [{ name: 'reports', path: '/workspace/reports', type: 'directory' }],
+    })
+    expect(mockFsReadFile).not.toHaveBeenCalled()
+  })
+
+  it.each(['viewer', 'user'] as const)('does not expose the full workspace to the %s role', async (role) => {
+    mockAuthorizedAgentRole = role
+
+    const res = await getReq(app, folderUrl('/workspace'))
+
+    expect(res.status).toBe(403)
+    expect(mockFsStat).not.toHaveBeenCalled()
+    expect(mockFsReaddir).not.toHaveBeenCalled()
+  })
+
+  it('does not expose a workspace folder that is not bookmarked', async () => {
+    mockFsReadFile.mockResolvedValueOnce(JSON.stringify([
+      { name: 'Reports', folder: '/workspace/reports' },
+    ]))
+
+    const res = await getReq(app, folderUrl('/workspace/secrets'))
+
+    expect(res.status).toBe(404)
+    expect(mockFsReaddir).not.toHaveBeenCalled()
+  })
+
+  it('rejects navigation outside the bookmarked root', async () => {
+    const res = await getReq(app, folderUrl('/workspace/reports', '/workspace/other'))
+
+    expect(res.status).toBe(400)
+    expect(mockFsReadFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects a descendant symlink whose canonical path escapes the root', async () => {
+    mockFsReadFile.mockResolvedValueOnce(JSON.stringify([
+      { name: 'Reports', folder: '/workspace/reports' },
+    ]))
+    mockFsRealpath.mockImplementation(async value => {
+      if (value === '/mock/workspace/reports/linked') return '/private/outside'
+      return value
+    })
+
+    const res = await getReq(app, folderUrl('/workspace/reports', '/workspace/reports/linked'))
+
+    expect(res.status).toBe(400)
+    expect(mockFsReaddir).not.toHaveBeenCalled()
+  })
+
+  it('round-trips special characters and Unicode names', async () => {
+    const root = '/workspace/Reports & 2026'
+    mockFsReadFile.mockResolvedValueOnce(JSON.stringify([{ name: 'Reports', folder: root }]))
+    mockFsStat.mockResolvedValueOnce({ isDirectory: () => true })
+    mockFsReaddir.mockResolvedValueOnce([dirent('résumé #1.md', 'file')])
+
+    const res = await getReq(app, folderUrl(root))
+
+    expect(res.status).toBe(200)
+    expect((await res.json()).entries[0]).toEqual({
+      name: 'résumé #1.md',
+      path: '/workspace/Reports & 2026/résumé #1.md',
+      type: 'file',
+    })
+  })
+
+  it('caps a listing at 1,000 entries and reports truncation', async () => {
+    mockFsReadFile.mockResolvedValueOnce(JSON.stringify([
+      { name: 'Reports', folder: '/workspace/reports' },
+    ]))
+    mockFsStat.mockResolvedValueOnce({ isDirectory: () => true })
+    mockFsReaddir.mockResolvedValueOnce(
+      Array.from({ length: 1_001 }, (_, index) => dirent(`file-${index}.txt`, 'file')),
+    )
+
+    const res = await getReq(app, folderUrl('/workspace/reports'))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.entries).toHaveLength(1_000)
+    expect(body.truncated).toBe(true)
+  })
+})
+
+describe('bookmarked workspace folder file actions', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    mockGetAgentWorkspaceDir.mockReturnValue('/mock/workspace')
+    mockContainerFetch.mockImplementation(async (_path: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { path: string; name?: string }
+      if (init?.method === 'PATCH') {
+        return new Response(JSON.stringify({
+          path: `${body.path.slice(0, body.path.lastIndexOf('/'))}/${body.name}`,
+          name: body.name,
+        }), { headers: { 'Content-Type': 'application/json' } })
+      }
+      return new Response(JSON.stringify({ success: true }), {
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+  })
+
+  function seedBookmarkedFile() {
+    mockFsReadFile.mockResolvedValueOnce(JSON.stringify([
+      { name: 'Reports', folder: '/workspace/reports' },
+    ]))
+  }
+
+  it('renames a regular file without overwriting an existing destination', async () => {
+    seedBookmarkedFile()
+
+    const res = await app.request('http://localhost/api/agents/test-agent/folders/file', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        root: '/workspace/reports',
+        path: '/workspace/reports/old.txt',
+        name: 'new.txt',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ path: '/workspace/reports/new.txt', name: 'new.txt' })
+    expect(mockContainerFetch).toHaveBeenCalledWith('/workspace/entries', expect.objectContaining({
+      method: 'PATCH',
+      body: JSON.stringify({ path: '/workspace/reports/old.txt', name: 'new.txt', type: 'file' }),
+    }))
+    expect(mockFsRename).not.toHaveBeenCalled()
+  })
+
+  it('rejects rename when the destination already exists', async () => {
+    seedBookmarkedFile()
+    mockContainerFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({ error: 'A file or directory with that name already exists' }),
+      { status: 409, headers: { 'Content-Type': 'application/json' } },
+    ))
+
+    const res = await app.request('http://localhost/api/agents/test-agent/folders/file', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        root: '/workspace/reports',
+        path: '/workspace/reports/old.txt',
+        name: 'existing.txt',
+      }),
+    })
+
+    expect(res.status).toBe(409)
+    expect(mockFsRename).not.toHaveBeenCalled()
+  })
+
+  it('rejects rename names containing path separators', async () => {
+    const res = await app.request('http://localhost/api/agents/test-agent/folders/file', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        root: '/workspace/reports',
+        path: '/workspace/reports/old.txt',
+        name: '../secret.txt',
+      }),
+    })
+
+    expect(res.status).toBe(400)
+    expect(mockFsReadFile).not.toHaveBeenCalled()
+    expect(mockContainerFetch).not.toHaveBeenCalled()
+  })
+
+  it('deletes a regular file inside the bookmarked root', async () => {
+    seedBookmarkedFile()
+
+    const res = await app.request('http://localhost/api/agents/test-agent/folders/file', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        root: '/workspace/reports',
+        path: '/workspace/reports/old.txt',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockContainerFetch).toHaveBeenCalledWith('/workspace/entries', expect.objectContaining({
+      method: 'DELETE',
+      body: JSON.stringify({ path: '/workspace/reports/old.txt', type: 'file' }),
+    }))
+    expect(mockFsUnlink).not.toHaveBeenCalled()
+  })
+
+  it('propagates a container-side leaf symlink rejection', async () => {
+    mockFsReadFile.mockResolvedValueOnce(JSON.stringify([
+      { name: 'Reports', folder: '/workspace/reports' },
+    ]))
+    mockContainerFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({ error: 'File not found' }),
+      { status: 404, headers: { 'Content-Type': 'application/json' } },
+    ))
+
+    const res = await app.request('http://localhost/api/agents/test-agent/folders/file', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        root: '/workspace/reports',
+        path: '/workspace/reports/linked.txt',
+      }),
+    })
+
+    expect(res.status).toBe(404)
+    expect(mockFsUnlink).not.toHaveBeenCalled()
+  })
+})
+
+describe('workspace folder directory actions and native reveal', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    mockGetAgentWorkspaceDir.mockReturnValue('/mock/workspace')
+    mockContainerFetch.mockImplementation(async (_path: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { path: string; name?: string }
+      if (init?.method === 'PATCH') {
+        return new Response(JSON.stringify({
+          path: `${body.path.slice(0, body.path.lastIndexOf('/'))}/${body.name}`,
+          name: body.name,
+        }), { headers: { 'Content-Type': 'application/json' } })
+      }
+      return new Response(JSON.stringify({ success: true }), {
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+  })
+
+  function seedBookmarkedDirectory() {
+    mockFsReadFile.mockResolvedValueOnce(JSON.stringify([
+      { name: 'Reports', folder: '/workspace/reports' },
+    ]))
+  }
+
+  it('renames a directory without overwriting an existing entry', async () => {
+    seedBookmarkedDirectory()
+
+    const res = await app.request('http://localhost/api/agents/test-agent/folders/directory', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        root: '/workspace/reports',
+        path: '/workspace/reports/drafts',
+        name: 'archive',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ path: '/workspace/reports/archive', name: 'archive' })
+    expect(mockContainerFetch).toHaveBeenCalledWith('/workspace/entries', expect.objectContaining({
+      method: 'PATCH',
+      body: JSON.stringify({ path: '/workspace/reports/drafts', name: 'archive', type: 'directory' }),
+    }))
+    expect(mockFsRename).not.toHaveBeenCalled()
+  })
+
+  it('recursively deletes a nested directory', async () => {
+    seedBookmarkedDirectory()
+
+    const res = await app.request('http://localhost/api/agents/test-agent/folders/directory', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        root: '/workspace/reports',
+        path: '/workspace/reports/drafts',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockContainerFetch).toHaveBeenCalledWith('/workspace/entries', expect.objectContaining({
+      method: 'DELETE',
+      body: JSON.stringify({ path: '/workspace/reports/drafts', type: 'directory' }),
+    }))
+    expect(mockFsRm).not.toHaveBeenCalled()
+  })
+
+  it('never allows deleting the browser root itself', async () => {
+    mockFsReadFile.mockResolvedValueOnce(JSON.stringify([
+      { name: 'Reports', folder: '/workspace/reports' },
+    ]))
+
+    const res = await app.request('http://localhost/api/agents/test-agent/folders/directory', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        root: '/workspace/reports',
+        path: '/workspace/reports',
+      }),
+    })
+
+    expect(res.status).toBe(400)
+    expect(mockContainerFetch).not.toHaveBeenCalled()
+  })
+
+  it('resolves a contained regular entry for Electron reveal', async () => {
+    mockFsReadFile.mockResolvedValueOnce(JSON.stringify([
+      { name: 'Reports', folder: '/workspace/reports' },
+    ]))
+    mockFsLstat.mockResolvedValueOnce({
+      isDirectory: () => false,
+      isFile: () => true,
+      isSymbolicLink: () => false,
+    })
+
+    const res = await app.request('http://localhost/api/agents/test-agent/folders/reveal-path', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        root: '/workspace/reports',
+        path: '/workspace/reports/notes.md',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ hostPath: '/mock/workspace/reports/notes.md' })
+  })
+})
+
+describe('bookmark validation', () => {
+  it('rejects a folder bookmark outside /workspace', async () => {
+    vi.mocked(writeJsonFileAtomic).mockClear()
+    const app = createApp()
+    const res = await app.request('http://localhost/api/agents/test-agent/bookmarks', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify([{ name: 'Secrets', folder: '/etc' }]),
+    })
+
+    expect(res.status).toBe(400)
+    expect(writeJsonFileAtomic).not.toHaveBeenCalled()
+  })
 })
 
 // ============================================================================

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -1749,6 +1749,17 @@ describe('bookmarked workspace folder listing', () => {
     expect(mockFsReaddir).not.toHaveBeenCalled()
   })
 
+  it.each(['viewer', 'user'] as const)('treats a trailing-slash workspace root as owner-only for the %s role', async (role) => {
+    mockAuthorizedAgentRole = role
+
+    const res = await getReq(app, folderUrl('/workspace/'))
+
+    expect(res.status).toBe(403)
+    expect(mockFsReadFile).not.toHaveBeenCalled()
+    expect(mockFsStat).not.toHaveBeenCalled()
+    expect(mockFsReaddir).not.toHaveBeenCalled()
+  })
+
   it('does not expose a workspace folder that is not bookmarked', async () => {
     mockFsReadFile.mockResolvedValueOnce(JSON.stringify([
       { name: 'Reports', folder: '/workspace/reports' },
@@ -2057,8 +2068,30 @@ describe('workspace folder directory actions and native reveal', () => {
 })
 
 describe('bookmark validation', () => {
-  it('rejects a folder bookmark outside /workspace', async () => {
+  beforeEach(() => {
+    mockFsReadFile.mockReset()
     vi.mocked(writeJsonFileAtomic).mockClear()
+  })
+
+  it('returns valid bookmarks individually and canonicalizes folder paths', async () => {
+    mockFsReadFile.mockResolvedValueOnce(JSON.stringify([
+      { name: 'Docs', link: 'https://example.com/docs' },
+      { name: 'Legacy', link: 'http://legacy.example.com' },
+      { name: 'Workspace', folder: '/workspace/' },
+      { name: 'Invalid', file: '/workspace/a.txt', folder: '/workspace/a' },
+    ]))
+    const app = createApp()
+
+    const res = await getReq(app, '/api/agents/test-agent/bookmarks')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([
+      { name: 'Docs', link: 'https://example.com/docs' },
+      { name: 'Workspace', folder: '/workspace' },
+    ])
+  })
+
+  it('rejects a folder bookmark outside /workspace', async () => {
     const app = createApp()
     const res = await app.request('http://localhost/api/agents/test-agent/bookmarks', {
       method: 'PUT',

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -160,7 +160,10 @@ const WorkspaceBookmarkSchema = z.object({
   name: z.string().min(1),
   link: z.string().url().startsWith('https://').optional(),
   file: z.string().min(1).optional(),
-  folder: z.string().min(1).optional(),
+  folder: z.string()
+    .min(1)
+    .transform(folderPath => normalizeWorkspaceContainerPath(folderPath) ?? folderPath)
+    .optional(),
 }).superRefine((bookmark, ctx) => {
   const resourceCount = [bookmark.link, bookmark.file, bookmark.folder]
     .filter(value => value != null).length
@@ -211,7 +214,8 @@ class WorkspaceFolderAccessError extends Error {
 
 function normalizeWorkspaceContainerPath(rawPath: string): string | null {
   if (!rawPath.startsWith('/') || rawPath.includes('\0')) return null
-  const normalized = path.posix.normalize(rawPath)
+  const normalizedPath = path.posix.normalize(rawPath)
+  const normalized = normalizedPath === '/' ? normalizedPath : normalizedPath.replace(/\/+$/, '')
   if (normalized !== '/workspace' && !normalized.startsWith('/workspace/')) return null
   return normalized
 }
@@ -233,8 +237,12 @@ async function readWorkspaceBookmarks(agentSlug: string): Promise<WorkspaceBookm
   const content = await fs.promises.readFile(bookmarksPath, 'utf-8').catch(() => null)
   if (!content) return []
   try {
-    const parsed = WorkspaceBookmarksSchema.safeParse(JSON.parse(content))
-    return parsed.success ? parsed.data : []
+    const parsed = JSON.parse(content)
+    if (!Array.isArray(parsed)) return []
+    return parsed.flatMap((entry): WorkspaceBookmark[] => {
+      const result = WorkspaceBookmarkSchema.safeParse(entry)
+      return result.success ? [result.data] : []
+    })
   } catch {
     return []
   }

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -156,6 +156,187 @@ import {
   toAgentRemoteMcpDto,
 } from '@shared/lib/agent-connections/public'
 
+const WorkspaceBookmarkSchema = z.object({
+  name: z.string().min(1),
+  link: z.string().url().startsWith('https://').optional(),
+  file: z.string().min(1).optional(),
+  folder: z.string().min(1).optional(),
+}).superRefine((bookmark, ctx) => {
+  const resourceCount = [bookmark.link, bookmark.file, bookmark.folder]
+    .filter(value => value != null).length
+  if (resourceCount !== 1) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'Each bookmark must have exactly one of link, file, or folder',
+    })
+  }
+  if (bookmark.folder && normalizeWorkspaceContainerPath(bookmark.folder) == null) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['folder'],
+      message: 'Folder path must be inside /workspace',
+    })
+  }
+})
+
+const WorkspaceBookmarksSchema = z.array(WorkspaceBookmarkSchema)
+type WorkspaceBookmark = z.infer<typeof WorkspaceBookmarkSchema>
+
+const WorkspaceFolderFileSchema = z.object({
+  root: z.string().min(1),
+  path: z.string().min(1),
+})
+
+const RenameWorkspaceFolderFileSchema = WorkspaceFolderFileSchema.extend({
+  name: z.string()
+    .trim()
+    .min(1)
+    .max(255)
+    .refine(
+      name => name !== '.' && name !== '..' && !name.includes('/') && !name.includes('\\') && !name.includes('\0'),
+      'Invalid file name',
+    ),
+})
+
+const MAX_FOLDER_ENTRIES = 1_000
+
+class WorkspaceFolderAccessError extends Error {
+  constructor(
+    message: string,
+    readonly status: 400 | 403 | 404 | 409,
+  ) {
+    super(message)
+  }
+}
+
+function normalizeWorkspaceContainerPath(rawPath: string): string | null {
+  if (!rawPath.startsWith('/') || rawPath.includes('\0')) return null
+  const normalized = path.posix.normalize(rawPath)
+  if (normalized !== '/workspace' && !normalized.startsWith('/workspace/')) return null
+  return normalized
+}
+
+function isContainerPathWithin(basePath: string, candidatePath: string): boolean {
+  const relative = path.posix.relative(basePath, candidatePath)
+  return relative === '' || (!relative.startsWith('../') && relative !== '..' && !path.posix.isAbsolute(relative))
+}
+
+function workspaceContainerPathToHost(workspaceDir: string, containerPath: string): string | null {
+  const normalized = normalizeWorkspaceContainerPath(containerPath)
+  if (!normalized) return null
+  const relative = path.posix.relative('/workspace', normalized)
+  return path.resolve(workspaceDir, ...relative.split('/').filter(Boolean))
+}
+
+async function readWorkspaceBookmarks(agentSlug: string): Promise<WorkspaceBookmark[]> {
+  const bookmarksPath = path.join(getAgentWorkspaceDir(agentSlug), 'bookmarks.json')
+  const content = await fs.promises.readFile(bookmarksPath, 'utf-8').catch(() => null)
+  if (!content) return []
+  try {
+    const parsed = WorkspaceBookmarksSchema.safeParse(JSON.parse(content))
+    return parsed.success ? parsed.data : []
+  } catch {
+    return []
+  }
+}
+
+function workspaceFolderFsError(error: unknown): WorkspaceFolderAccessError | null {
+  const code = error instanceof Error && 'code' in error
+    ? (error as NodeJS.ErrnoException).code
+    : undefined
+  if (code === 'ENOENT' || code === 'ENOTDIR') {
+    return new WorkspaceFolderAccessError('Folder or file not found', 404)
+  }
+  if (code === 'EACCES' || code === 'EPERM') {
+    return new WorkspaceFolderAccessError('Folder is not accessible', 403)
+  }
+  return null
+}
+
+async function resolveBookmarkedWorkspacePath(
+  agentSlug: string,
+  rawRoot: string,
+  rawCurrentPath: string,
+) {
+  const rootPath = normalizeWorkspaceContainerPath(rawRoot)
+  const currentPath = normalizeWorkspaceContainerPath(rawCurrentPath)
+  if (!rootPath || !currentPath || !isContainerPathWithin(rootPath, currentPath)) {
+    throw new WorkspaceFolderAccessError('Invalid folder path', 400)
+  }
+
+  // The full workspace is the built-in Agent Directory root. All other roots
+  // remain bookmark-gated so an arbitrary nested path cannot be promoted into
+  // a browser root by a client request alone.
+  if (rootPath !== '/workspace') {
+    const bookmarks = await readWorkspaceBookmarks(agentSlug)
+    const isBookmarkedRoot = bookmarks.some(bookmark => (
+      bookmark.folder != null && normalizeWorkspaceContainerPath(bookmark.folder) === rootPath
+    ))
+    if (!isBookmarkedRoot) {
+      throw new WorkspaceFolderAccessError('Folder bookmark not found', 404)
+    }
+  }
+
+  const workspaceDir = getAgentWorkspaceDir(agentSlug)
+  const hostRoot = workspaceContainerPathToHost(workspaceDir, rootPath)
+  const hostCurrentPath = workspaceContainerPathToHost(workspaceDir, currentPath)
+  if (!hostRoot || !hostCurrentPath) {
+    throw new WorkspaceFolderAccessError('Invalid folder path', 400)
+  }
+
+  try {
+    const [canonicalWorkspace, canonicalRoot, canonicalCurrentPath] = await Promise.all([
+      fs.promises.realpath(workspaceDir),
+      fs.promises.realpath(hostRoot),
+      fs.promises.realpath(hostCurrentPath),
+    ])
+    if (
+      !isPathWithinDir(canonicalWorkspace, canonicalRoot)
+      || !isPathWithinDir(canonicalRoot, canonicalCurrentPath)
+    ) {
+      throw new WorkspaceFolderAccessError('Invalid folder path', 400)
+    }
+
+    return {
+      rootPath,
+      currentPath,
+      hostCurrentPath,
+      canonicalRoot,
+      canonicalCurrentPath,
+    }
+  } catch (error) {
+    if (error instanceof WorkspaceFolderAccessError) throw error
+    throw workspaceFolderFsError(error) ?? error
+  }
+}
+
+async function requestContainerWorkspaceMutation<T>(
+  agentSlug: string,
+  method: 'PATCH' | 'DELETE',
+  body: {
+    path: string
+    type: 'file' | 'directory'
+    name?: string
+  },
+): Promise<T> {
+  await containerManager.ensureRunning(agentSlug)
+  const response = await containerManager.getClient(agentSlug).fetch('/workspace/entries', {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  const payload = await response.json().catch(() => null) as (T & { error?: string }) | null
+  if (!response.ok) {
+    const message = payload?.error ?? 'Workspace operation failed'
+    if (response.status === 400 || response.status === 404 || response.status === 409) {
+      throw new WorkspaceFolderAccessError(message, response.status)
+    }
+    throw new Error(message)
+  }
+  if (!payload) throw new Error('Workspace operation returned an invalid response')
+  return payload
+}
+
 function getConfiguredSkillsets() {
   return getSettings().skillsets || []
 }
@@ -4389,6 +4570,238 @@ agents.delete('/:id/mounts/:mountId', AgentUser(), async (c) => {
   }
 })
 
+// GET /api/agents/:id/folders - Lazily list one level of a bookmarked workspace folder
+agents.get('/:id/folders', AgentRead(), async (c) => {
+  const agentSlug = getAgentId(c)
+  const rawRoot = c.req.query('root')
+  const rawCurrentPath = c.req.query('path') ?? rawRoot
+  if (!rawRoot || !rawCurrentPath) {
+    return c.json({ error: 'root and path are required' }, 400)
+  }
+
+  // Explicit folder bookmarks are shareable with viewers. The built-in full
+  // workspace browser is an owner-only surface and must not become an API-level
+  // directory enumeration capability for shared users.
+  if (normalizeWorkspaceContainerPath(rawRoot) === '/workspace' && getAuthorizedAgentRole(c) !== 'owner') {
+    return c.json({ error: 'Forbidden' }, 403)
+  }
+
+  try {
+    const { rootPath, currentPath, canonicalCurrentPath } = await resolveBookmarkedWorkspacePath(
+      agentSlug,
+      rawRoot,
+      rawCurrentPath,
+    )
+
+    const stat = await fs.promises.stat(canonicalCurrentPath)
+    if (!stat.isDirectory()) {
+      return c.json({ error: 'Folder not found' }, 404)
+    }
+
+    const dirents = await fs.promises.readdir(canonicalCurrentPath, { withFileTypes: true })
+    const entries = dirents
+      .filter(entry => !entry.isSymbolicLink() && (entry.isDirectory() || entry.isFile()))
+      .map(entry => ({
+        name: entry.name,
+        path: path.posix.join(currentPath, entry.name),
+        type: entry.isDirectory() ? 'directory' as const : 'file' as const,
+      }))
+      .sort((a, b) => {
+        if (a.type !== b.type) return a.type === 'directory' ? -1 : 1
+        return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+      })
+
+    return c.json({
+      root: rootPath,
+      path: currentPath,
+      entries: entries.slice(0, MAX_FOLDER_ENTRIES),
+      truncated: entries.length > MAX_FOLDER_ENTRIES,
+    })
+  } catch (error) {
+    const accessError = error instanceof WorkspaceFolderAccessError
+      ? error
+      : workspaceFolderFsError(error)
+    if (accessError) return c.json({ error: accessError.message }, accessError.status)
+    console.error('Failed to list bookmarked folder:', error)
+    return c.json({ error: 'Failed to list folder' }, 500)
+  }
+})
+
+// PATCH /api/agents/:id/folders/file - Rename a regular file inside a bookmarked folder
+agents.patch('/:id/folders/file', AgentAdmin(), async (c) => {
+  const parsed = RenameWorkspaceFolderFileSchema.safeParse(await c.req.json().catch(() => null))
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid file rename request', issues: parsed.error.issues }, 400)
+  }
+
+  const agentSlug = getAgentId(c)
+  try {
+    const resolved = await resolveBookmarkedWorkspacePath(
+      agentSlug,
+      parsed.data.root,
+      parsed.data.path,
+    )
+    const destinationContainerPath = path.posix.join(
+      path.posix.dirname(resolved.currentPath),
+      parsed.data.name,
+    )
+    if (!isContainerPathWithin(resolved.rootPath, destinationContainerPath)) {
+      throw new WorkspaceFolderAccessError('Invalid file path', 400)
+    }
+
+    const result = await requestContainerWorkspaceMutation<{ path: string; name: string }>(
+      agentSlug,
+      'PATCH',
+      { path: resolved.currentPath, name: parsed.data.name, type: 'file' },
+    )
+    return c.json(result)
+  } catch (error) {
+    const accessError = error instanceof WorkspaceFolderAccessError
+      ? error
+      : workspaceFolderFsError(error)
+    if (accessError) return c.json({ error: accessError.message }, accessError.status)
+    console.error('Failed to rename bookmarked folder file:', error)
+    return c.json({ error: 'Failed to rename file' }, 500)
+  }
+})
+
+// DELETE /api/agents/:id/folders/file - Delete a regular file inside a bookmarked folder
+agents.delete('/:id/folders/file', AgentAdmin(), async (c) => {
+  const parsed = WorkspaceFolderFileSchema.safeParse(await c.req.json().catch(() => null))
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid file delete request', issues: parsed.error.issues }, 400)
+  }
+
+  const agentSlug = getAgentId(c)
+  try {
+    const resolved = await resolveBookmarkedWorkspacePath(
+      agentSlug,
+      parsed.data.root,
+      parsed.data.path,
+    )
+    const result = await requestContainerWorkspaceMutation<{ success: true }>(
+      agentSlug,
+      'DELETE',
+      { path: resolved.currentPath, type: 'file' },
+    )
+    return c.json(result)
+  } catch (error) {
+    const accessError = error instanceof WorkspaceFolderAccessError
+      ? error
+      : workspaceFolderFsError(error)
+    if (accessError) return c.json({ error: accessError.message }, accessError.status)
+    console.error('Failed to delete bookmarked folder file:', error)
+    return c.json({ error: 'Failed to delete file' }, 500)
+  }
+})
+
+// PATCH /api/agents/:id/folders/directory - Rename a directory inside a browser root
+agents.patch('/:id/folders/directory', AgentAdmin(), async (c) => {
+  const parsed = RenameWorkspaceFolderFileSchema.safeParse(await c.req.json().catch(() => null))
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid directory rename request', issues: parsed.error.issues }, 400)
+  }
+
+  const agentSlug = getAgentId(c)
+  try {
+    const resolved = await resolveBookmarkedWorkspacePath(
+      agentSlug,
+      parsed.data.root,
+      parsed.data.path,
+    )
+    if (resolved.currentPath === resolved.rootPath) {
+      throw new WorkspaceFolderAccessError('The browser root cannot be renamed', 400)
+    }
+
+    const destinationContainerPath = path.posix.join(
+      path.posix.dirname(resolved.currentPath),
+      parsed.data.name,
+    )
+    if (!isContainerPathWithin(resolved.rootPath, destinationContainerPath)) {
+      throw new WorkspaceFolderAccessError('Invalid directory path', 400)
+    }
+
+    const result = await requestContainerWorkspaceMutation<{ path: string; name: string }>(
+      agentSlug,
+      'PATCH',
+      { path: resolved.currentPath, name: parsed.data.name, type: 'directory' },
+    )
+    return c.json(result)
+  } catch (error) {
+    const accessError = error instanceof WorkspaceFolderAccessError
+      ? error
+      : workspaceFolderFsError(error)
+    if (accessError) return c.json({ error: accessError.message }, accessError.status)
+    console.error('Failed to rename bookmarked folder directory:', error)
+    return c.json({ error: 'Failed to rename directory' }, 500)
+  }
+})
+
+// DELETE /api/agents/:id/folders/directory - Recursively delete a directory
+agents.delete('/:id/folders/directory', AgentAdmin(), async (c) => {
+  const parsed = WorkspaceFolderFileSchema.safeParse(await c.req.json().catch(() => null))
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid directory delete request', issues: parsed.error.issues }, 400)
+  }
+
+  const agentSlug = getAgentId(c)
+  try {
+    const resolved = await resolveBookmarkedWorkspacePath(
+      agentSlug,
+      parsed.data.root,
+      parsed.data.path,
+    )
+    if (resolved.currentPath === resolved.rootPath) {
+      throw new WorkspaceFolderAccessError('The browser root cannot be deleted', 400)
+    }
+
+    const result = await requestContainerWorkspaceMutation<{ success: true }>(
+      agentSlug,
+      'DELETE',
+      { path: resolved.currentPath, type: 'directory' },
+    )
+    return c.json(result)
+  } catch (error) {
+    const accessError = error instanceof WorkspaceFolderAccessError
+      ? error
+      : workspaceFolderFsError(error)
+    if (accessError) return c.json({ error: accessError.message }, accessError.status)
+    console.error('Failed to delete bookmarked folder directory:', error)
+    return c.json({ error: 'Failed to delete directory' }, 500)
+  }
+})
+
+// POST /api/agents/:id/folders/reveal-path - Resolve an entry to its local host path.
+// The renderer only exposes this action in Electron; keeping resolution here
+// preserves the same root-containment and symlink protections as browsing.
+agents.post('/:id/folders/reveal-path', AgentAdmin(), async (c) => {
+  const parsed = WorkspaceFolderFileSchema.safeParse(await c.req.json().catch(() => null))
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid reveal request', issues: parsed.error.issues }, 400)
+  }
+
+  const agentSlug = getAgentId(c)
+  try {
+    const resolved = await resolveBookmarkedWorkspacePath(
+      agentSlug,
+      parsed.data.root,
+      parsed.data.path,
+    )
+    const sourceStat = await fs.promises.lstat(resolved.hostCurrentPath)
+    if (sourceStat.isSymbolicLink() || (!sourceStat.isDirectory() && !sourceStat.isFile())) {
+      throw new WorkspaceFolderAccessError('File or directory not found', 404)
+    }
+    return c.json({ hostPath: resolved.canonicalCurrentPath })
+  } catch (error) {
+    const accessError = error instanceof WorkspaceFolderAccessError
+      ? error
+      : workspaceFolderFsError(error)
+    if (accessError) return c.json({ error: accessError.message }, accessError.status)
+    console.error('Failed to resolve folder entry for reveal:', error)
+    return c.json({ error: 'Failed to reveal file or directory' }, 500)
+  }
+})
+
 // GET /api/agents/:id/files/* - Download a file from the agent workspace
 agents.get('/:id/files/*', AgentRead(), async (c) => {
   try {
@@ -4420,7 +4833,16 @@ agents.get('/:id/files/*', AgentRead(), async (c) => {
       return c.json({ error: 'Invalid path' }, 400)
     }
 
-    const stat = await fs.promises.stat(fullPath).catch(() => null)
+    const canonicalWorkspace = await fs.promises.realpath(workspaceDir).catch(() => null)
+    const canonicalFile = await fs.promises.realpath(fullPath).catch(() => null)
+    if (!canonicalWorkspace || !canonicalFile) {
+      return c.json({ error: 'File not found' }, 404)
+    }
+    if (!isPathWithinDir(canonicalWorkspace, canonicalFile)) {
+      return c.json({ error: 'Invalid path' }, 400)
+    }
+
+    const stat = await fs.promises.stat(canonicalFile).catch(() => null)
     if (!stat || !stat.isFile()) {
       return c.json({ error: 'File not found' }, 404)
     }
@@ -4453,13 +4875,13 @@ agents.get('/:id/files/*', AgentRead(), async (c) => {
 
     if (parsedRange) {
       const { start, end } = parsedRange
-      const chunk = Readable.toWeb(fs.createReadStream(fullPath, { start, end })) as ReadableStream
+      const chunk = Readable.toWeb(fs.createReadStream(canonicalFile, { start, end })) as ReadableStream
       c.header('Content-Range', `bytes ${start}-${end}/${size}`)
       c.header('Content-Length', (end - start + 1).toString())
       return c.body(chunk, 206)
     }
 
-    const webStream = Readable.toWeb(fs.createReadStream(fullPath)) as ReadableStream
+    const webStream = Readable.toWeb(fs.createReadStream(canonicalFile)) as ReadableStream
     c.header('Content-Length', size.toString())
     return c.body(webStream)
   } catch (error) {
@@ -5241,36 +5663,22 @@ agents.delete('/:id/x-agent-policies/invoke/:target', AgentAdmin(), async (c) =>
 
 // GET /api/agents/:id/bookmarks - Read bookmarks from agent workspace
 agents.get('/:id/bookmarks', AgentRead(), async (c) => {
-  try {
-    const agentSlug = getAgentId(c)
-    const bookmarksPath = path.join(getAgentWorkspaceDir(agentSlug), 'bookmarks.json')
-    const content = await fs.promises.readFile(bookmarksPath, 'utf-8').catch(() => null)
-    if (!content) {
-      return c.json([])
-    }
-    const parsed = JSON.parse(content)
-    if (!Array.isArray(parsed)) {
-      return c.json([])
-    }
-    return c.json(parsed)
-  } catch {
-    return c.json([])
-  }
+  return c.json(await readWorkspaceBookmarks(getAgentId(c)))
 })
 
 // PUT /api/agents/:id/bookmarks - Write bookmarks to agent workspace
 agents.put('/:id/bookmarks', AgentAdmin(), async (c) => {
   try {
     const agentSlug = getAgentId(c)
-    const bookmarks = await c.req.json()
-    if (!Array.isArray(bookmarks)) {
-      return c.json({ error: 'Bookmarks must be an array' }, 400)
+    const parsed = WorkspaceBookmarksSchema.safeParse(await c.req.json())
+    if (!parsed.success) {
+      return c.json({ error: 'Invalid bookmarks', issues: parsed.error.issues }, 400)
     }
     const bookmarksPath = path.join(getAgentWorkspaceDir(agentSlug), 'bookmarks.json')
     // Atomic write: full-replace from client input, but crash-safe so
     // an interrupted write can't truncate bookmarks.json.
-    await writeJsonFileAtomic(bookmarksPath, bookmarks)
-    return c.json(bookmarks)
+    await writeJsonFileAtomic(bookmarksPath, parsed.data)
+    return c.json(parsed.data)
   } catch (error) {
     console.error('Failed to update bookmarks:', error)
     return c.json({ error: 'Failed to update bookmarks' }, 500)

--- a/src/api/routes/security-repro.test.ts
+++ b/src/api/routes/security-repro.test.ts
@@ -453,6 +453,70 @@ describe('SUP-200: GET /api/agents/:id/files/* — workspace containment', () =>
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('hello world')
   })
+
+  it('rejects a file symlink that resolves outside the agent workspace', async () => {
+    if (process.platform === 'win32') return
+    const workspace = path.join(agentDataRoot, 'agent')
+    const outsideFile = path.join(agentDataRoot, 'outside-secret.txt')
+    fs.mkdirSync(workspace, { recursive: true })
+    fs.writeFileSync(outsideFile, 'outside secret')
+    fs.symlinkSync(outsideFile, path.join(workspace, 'linked-secret.txt'))
+
+    const res = await appWithAgents().request('http://localhost/api/agents/agent/files/linked-secret.txt')
+
+    expect(res.status).toBe(400)
+  })
+
+  it('does not delete through a bookmarked-folder symlink that escapes the root', async () => {
+    if (process.platform === 'win32') return
+    const workspace = path.join(agentDataRoot, 'agent')
+    const reports = path.join(workspace, 'reports')
+    const outsideFile = path.join(agentDataRoot, 'outside-secret.txt')
+    fs.mkdirSync(reports, { recursive: true })
+    fs.writeFileSync(path.join(workspace, 'bookmarks.json'), JSON.stringify([
+      { name: 'Reports', folder: '/workspace/reports' },
+    ]))
+    fs.writeFileSync(outsideFile, 'outside secret')
+    fs.symlinkSync(outsideFile, path.join(reports, 'linked-secret.txt'))
+
+    const res = await appWithAgents().request('http://localhost/api/agents/agent/folders/file', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        root: '/workspace/reports',
+        path: '/workspace/reports/linked-secret.txt',
+      }),
+    })
+
+    expect(res.status).toBe(400)
+    expect(fs.existsSync(outsideFile)).toBe(true)
+  })
+
+  it('does not recursively delete through a directory symlink that escapes the root', async () => {
+    if (process.platform === 'win32') return
+    const workspace = path.join(agentDataRoot, 'agent')
+    const reports = path.join(workspace, 'reports')
+    const outsideDirectory = path.join(agentDataRoot, 'outside-directory')
+    fs.mkdirSync(reports, { recursive: true })
+    fs.mkdirSync(outsideDirectory, { recursive: true })
+    fs.writeFileSync(path.join(workspace, 'bookmarks.json'), JSON.stringify([
+      { name: 'Reports', folder: '/workspace/reports' },
+    ]))
+    fs.writeFileSync(path.join(outsideDirectory, 'keep.txt'), 'do not delete')
+    fs.symlinkSync(outsideDirectory, path.join(reports, 'linked-directory'))
+
+    const res = await appWithAgents().request('http://localhost/api/agents/agent/folders/directory', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        root: '/workspace/reports',
+        path: '/workspace/reports/linked-directory',
+      }),
+    })
+
+    expect(res.status).toBe(400)
+    expect(fs.existsSync(path.join(outsideDirectory, 'keep.txt'))).toBe(true)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -683,6 +683,20 @@ ipcMain.handle('show-in-folder', async (_event, rawPath: unknown) => {
   return errorMessage === '' ? null : errorMessage
 })
 
+// Reveal a specific file or directory in the OS file manager. This is kept
+// separate from show-in-folder, whose existing contract opens a mounted
+// directory rather than selecting it in its parent.
+ipcMain.handle('reveal-in-folder', async (_event, rawPath: unknown) => {
+  const hostPath = ShowInFolderPath.parse(rawPath)
+  try {
+    await fs.promises.stat(hostPath)
+    shell.showItemInFolder(hostPath)
+    return null
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).message
+  }
+})
+
 // --- Recent files infrastructure ---
 
 const MIME_TYPES: Record<string, string> = {

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -34,6 +34,7 @@ type ExposedApi = {
   platform: string
   osVersion: string
   openExternal: (url: string) => Promise<void>
+  revealInFolder: (hostPath: string) => Promise<string | null>
   createDockShortcut: (agentSlug: string, dashboardSlug: string, dashboardName: string, iconPng: Uint8Array) => Promise<void>
   getPathForFile: (file: File) => string
   showNotification: (
@@ -94,6 +95,12 @@ describe('preload electronAPI bridge', () => {
 
     await api.openExternal('https://example.com')
     expect(electronMocks.invoke).toHaveBeenLastCalledWith('open-external', 'https://example.com')
+
+    await api.revealInFolder('/workspace/reports/notes.md')
+    expect(electronMocks.invoke).toHaveBeenLastCalledWith(
+      'reveal-in-folder',
+      '/workspace/reports/notes.md',
+    )
 
     await api.showNotification('Ready', 'The job finished', [{ text: 'Open' }], { sessionId: 's1' })
     expect(electronMocks.invoke).toHaveBeenLastCalledWith('show-notification', {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -293,6 +293,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return ipcRenderer.invoke('show-in-folder', hostPath)
   },
 
+  // Select a file or directory in Finder / Explorer / Files
+  revealInFolder: (hostPath: string): Promise<string | null> => {
+    return ipcRenderer.invoke('reveal-in-folder', hostPath)
+  },
+
   // Get recently opened files from the OS
   getRecentFiles: (limit?: number): Promise<{ name: string; path: string; thumbnail?: string }[]> => {
     return ipcRenderer.invoke('get-recent-files', limit)
@@ -500,6 +505,7 @@ declare global {
       getPathForFile: (file: File) => string
       openDirectory: () => Promise<string | null>
       showInFolder: (hostPath: string) => Promise<string | null>
+      revealInFolder: (hostPath: string) => Promise<string | null>
       getRecentFiles: (limit?: number) => Promise<{ name: string; path: string; thumbnail?: string }[]>
       readLocalFile: (filePath: string) => Promise<{ buffer: ArrayBuffer; name: string; type: string } | null>
       setKeepAwake: (enabled: boolean) => Promise<void>

--- a/src/renderer/components/agents/agent-home/home-bookmarks.test.tsx
+++ b/src/renderer/components/agents/agent-home/home-bookmarks.test.tsx
@@ -5,15 +5,17 @@ import userEvent from '@testing-library/user-event'
 import { HomeBookmarks } from './home-bookmarks'
 
 const openFile = vi.fn()
+const openFolder = vi.fn()
 
 vi.mock('@renderer/context/file-preview-context', () => ({
-  useFilePreview: () => ({ openFile }),
+  useFilePreview: () => ({ openFile, openFolder }),
 }))
 
 vi.mock('@renderer/hooks/use-bookmarks', () => ({
   useBookmarks: () => ({
     data: [
       { name: 'Daily report', file: '/workspace/reports/daily.csv' },
+      { name: 'Reports', folder: '/workspace/reports' },
       { name: 'Project site', link: 'https://example.com/project' },
     ],
   }),
@@ -26,6 +28,16 @@ vi.mock('@renderer/hooks/use-bookmarks', () => ({
 describe('HomeBookmarks', () => {
   beforeEach(() => {
     openFile.mockReset()
+    openFolder.mockReset()
+  })
+
+  it('opens workspace folders in the file preview context', async () => {
+    const user = userEvent.setup()
+    render(<HomeBookmarks agentSlug="test-agent" />)
+
+    await user.click(screen.getByRole('button', { name: 'Reports' }))
+
+    expect(openFolder).toHaveBeenCalledWith('/workspace/reports', 'test-agent')
   })
 
   it('opens workspace files in the file preview context', async () => {

--- a/src/renderer/components/agents/agent-home/home-bookmarks.tsx
+++ b/src/renderer/components/agents/agent-home/home-bookmarks.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { ExternalLink, PanelRightOpen, Pencil, Trash2 } from 'lucide-react'
+import { ExternalLink, Folder, PanelRightOpen, Pencil, Trash2 } from 'lucide-react'
 import { FileTypeIcon } from '@renderer/components/ui/file-type-icon'
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
@@ -36,8 +36,9 @@ interface HomeBookmarksProps {
   isOwner?: boolean
 }
 
-function getFilename(filePath: string): string {
-  return filePath.split('/').pop() || filePath
+function getPathName(filePath: string): string {
+  const normalized = filePath.replace(/\/+$/, '')
+  return normalized.split('/').pop() || normalized
 }
 
 function faviconUrl(link: string): string | null {
@@ -73,12 +74,14 @@ function BookmarkRow({
   onRename,
   onDelete,
   onOpenFile,
+  onOpenFolder,
 }: {
   bookmark: Bookmark
   isOwner: boolean
   onRename: () => void
   onDelete: () => void
   onOpenFile: (filePath: string) => void
+  onOpenFolder: (folderPath: string) => void
 }) {
   const inner = bookmark.link ? (
     <a
@@ -91,15 +94,27 @@ function BookmarkRow({
       <span className="text-xs font-medium truncate">{bookmark.name}</span>
       <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity ml-auto" />
     </a>
+  ) : bookmark.folder ? (
+    <button
+      type="button"
+      onClick={() => onOpenFolder(bookmark.folder!)}
+      className="group flex w-full items-center gap-3 py-2.5 px-1 text-left hover:bg-muted/50 transition-colors"
+      title={`Browse ${getPathName(bookmark.folder)}`}
+      aria-label={bookmark.name}
+    >
+      <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+      <span className="text-xs font-medium truncate">{bookmark.name}</span>
+      <PanelRightOpen className="h-3 w-3 shrink-0 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity ml-auto" />
+    </button>
   ) : bookmark.file ? (
     <button
       type="button"
       onClick={() => onOpenFile(bookmark.file!)}
       className="group flex w-full items-center gap-3 py-2.5 px-1 text-left hover:bg-muted/50 transition-colors"
-      title={`Preview ${getFilename(bookmark.file)}`}
+      title={`Preview ${getPathName(bookmark.file)}`}
       aria-label={bookmark.name}
     >
-      <FileTypeIcon filename={getFilename(bookmark.file)} size={16} />
+      <FileTypeIcon filename={getPathName(bookmark.file)} size={16} />
       <span className="text-xs font-medium truncate">{bookmark.name}</span>
       <PanelRightOpen className="h-3 w-3 shrink-0 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity ml-auto" />
     </button>
@@ -130,7 +145,7 @@ function BookmarkRow({
 }
 
 export function HomeBookmarks({ agentSlug, isOwner = false }: HomeBookmarksProps) {
-  const { openFile } = useFilePreview()
+  const { openFile, openFolder } = useFilePreview()
   const { data: bookmarks } = useBookmarks(agentSlug)
   const updateBookmarks = useUpdateBookmarks(agentSlug)
   const [renameIndex, setRenameIndex] = useState<number | null>(null)
@@ -165,12 +180,13 @@ export function HomeBookmarks({ agentSlug, isOwner = false }: HomeBookmarksProps
       <div className="divide-y divide-border/50">
         {bookmarks.map((bookmark, i) => (
           <BookmarkRow
-            key={bookmark.link ?? bookmark.file ?? i}
+            key={bookmark.link ?? bookmark.file ?? bookmark.folder ?? i}
             bookmark={bookmark}
             isOwner={isOwner}
             onRename={() => { setNewName(bookmark.name); setRenameIndex(i) }}
             onDelete={() => setDeleteIndex(i)}
             onOpenFile={(filePath) => openFile(filePath, agentSlug)}
+            onOpenFolder={(folderPath) => openFolder(folderPath, agentSlug)}
           />
         ))}
       </div>

--- a/src/renderer/components/agents/agent-home/home-extras.test.tsx
+++ b/src/renderer/components/agents/agent-home/home-extras.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HomeExtras } from './home-extras'
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  openFolder: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mocks.navigate,
+}))
+
+vi.mock('@renderer/context/file-preview-context', () => ({
+  useFilePreview: () => ({ openFolder: mocks.openFolder }),
+}))
+
+describe('HomeExtras', () => {
+  it('opens Agent Directory in the built-in folder browser', async () => {
+    const user = userEvent.setup()
+    render(<HomeExtras agentSlug="test-agent" />)
+
+    await user.click(screen.getByTestId('home-agent-directory-open-browser'))
+
+    expect(mocks.openFolder).toHaveBeenCalledWith('/workspace', 'test-agent')
+    expect(screen.getByText('Agent Directory')).toBeVisible()
+  })
+})

--- a/src/renderer/components/agents/agent-home/home-extras.tsx
+++ b/src/renderer/components/agents/agent-home/home-extras.tsx
@@ -1,9 +1,8 @@
-import { useState, type ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { useNavigate } from '@tanstack/react-router'
-import { ArrowUpRight, ChevronRight, Copy } from 'lucide-react'
+import { ChevronRight, PanelRightOpen } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
-import { apiFetch } from '@renderer/lib/api'
-import { isElectron } from '@renderer/lib/env'
+import { useFilePreview } from '@renderer/context/file-preview-context'
 
 interface HomeExtrasProps {
   agentSlug: string
@@ -12,43 +11,19 @@ interface HomeExtrasProps {
 }
 
 export function HomeExtras({ agentSlug, onOpenSettings, className }: HomeExtrasProps) {
-  const [error, setError] = useState<string | null>(null)
   const navigate = useNavigate()
-
-  const handleOpenDirectory = async () => {
-    setError(null)
-    try {
-      const res = await apiFetch(`/api/agents/${agentSlug}/open-directory`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ open: isElectron() }),
-      })
-      if (!res.ok) throw new Error('Failed to open agent directory')
-      if (!isElectron()) {
-        const { path } = await res.json()
-        try {
-          await navigator.clipboard.writeText(path)
-        } catch {
-          setError(`Clipboard blocked. Path: ${path}`)
-        }
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to open agent directory')
-    }
-  }
-
-  const directoryHoverIcon = isElectron() ? (
-    <ArrowUpRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-  ) : (
-    <Copy className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-  )
-  const directoryLabel = isElectron() ? 'Agent Directory' : 'Copy Agent Path'
+  const { openFolder } = useFilePreview()
 
   return (
     <div className={cn("rounded-xl border bg-background py-2", className)}>
       <div className="divide-y divide-border/50">
         <ExtrasButton label="System Prompt" onClick={() => onOpenSettings?.('system-prompt')} />
-        <ExtrasButton label={directoryLabel} onClick={handleOpenDirectory} hoverIcon={directoryHoverIcon} />
+        <ExtrasButton
+          label="Agent Directory"
+          onClick={() => openFolder('/workspace', agentSlug)}
+          hoverIcon={<PanelRightOpen className="h-4 w-4 text-muted-foreground" aria-hidden="true" />}
+          testId="home-agent-directory-open-browser"
+        />
         <ExtrasButton label="Secrets" onClick={() => onOpenSettings?.('secrets')} />
         <ExtrasButton
           label="API Logs"
@@ -58,9 +33,6 @@ export function HomeExtras({ agentSlug, onOpenSettings, className }: HomeExtrasP
           testId="home-api-logs-open-page"
         />
       </div>
-      {error && (
-        <p className="px-4 pt-2 text-xs text-destructive" role="alert">{error}</p>
-      )}
     </div>
   )
 }

--- a/src/renderer/components/file-preview/file-preview-tray-content.test.tsx
+++ b/src/renderer/components/file-preview/file-preview-tray-content.test.tsx
@@ -1,28 +1,45 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { FilePreviewTrayContent } from './file-preview-tray-content'
+import type { PreviewTab } from '@renderer/context/file-preview-context'
+
+const mocks = vi.hoisted((): { openTabs: PreviewTab[] } => ({
+  openTabs: [{
+    kind: 'file' as const,
+    filePath: '/workspace/report.md',
+    agentSlug: 'test-agent',
+    displayName: 'report.md',
+    version: 0,
+  }],
+}))
 
 vi.mock('@renderer/context/file-preview-context', () => ({
   useFilePreview: () => ({
-    openFiles: [{
-      filePath: '/workspace/report.md',
-      agentSlug: 'test-agent',
-      displayName: 'report.md',
-      version: 0,
-    }],
-    activeFileIndex: 0,
-    setActiveFile: vi.fn(),
-    closeFile: vi.fn(),
+    openTabs: mocks.openTabs,
+    activeTabIndex: 0,
+    setActiveTab: vi.fn(),
+    closeTab: vi.fn(),
     comments: new Map(),
   }),
 }))
 
 vi.mock('./file-tab-bar', () => ({ FileTabBar: () => null }))
-vi.mock('./renderers/file-renderer', () => ({ FileRenderer: () => null }))
-vi.mock('./comments/comment-bar', () => ({ CommentBar: () => null }))
+vi.mock('./renderers/file-renderer', () => ({ FileRenderer: () => <div data-testid="file-renderer" /> }))
+vi.mock('./folder-browser', () => ({ FolderBrowser: () => <div data-testid="folder-browser" /> }))
+vi.mock('./comments/comment-bar', () => ({ CommentBar: () => <div data-testid="comment-bar" /> }))
 
 describe('FilePreviewTrayContent', () => {
+  beforeEach(() => {
+    mocks.openTabs = [{
+      kind: 'file',
+      filePath: '/workspace/report.md',
+      agentSlug: 'test-agent',
+      displayName: 'report.md',
+      version: 0,
+    }]
+  })
+
   it('exposes container-responsive close controls on opposite sides', () => {
     const onClose = vi.fn()
     render(
@@ -40,5 +57,27 @@ describe('FilePreviewTrayContent', () => {
     fireEvent.click(mobileClose)
     fireEvent.click(desktopClose)
     expect(onClose).toHaveBeenCalledTimes(2)
+  })
+
+  it('shows folder navigation without file-only download and comment actions', () => {
+    mocks.openTabs = [{
+      kind: 'folder',
+      rootPath: '/workspace/reports',
+      agentSlug: 'test-agent',
+      displayName: 'reports',
+      expandedPaths: ['/workspace/reports'],
+      query: '',
+    }]
+
+    render(
+      <FilePreviewTrayContent
+        sessionId="test-session"
+        onClose={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByTestId('folder-browser')).toBeVisible()
+    expect(screen.queryByTitle('Download file')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('comment-bar')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/components/file-preview/file-preview-tray-content.tsx
+++ b/src/renderer/components/file-preview/file-preview-tray-content.tsx
@@ -1,31 +1,32 @@
-import { Download, FileText, PanelRightClose, X } from 'lucide-react'
+import { Download, FileText, Folder, PanelRightClose, X } from 'lucide-react'
 import { useFilePreview } from '@renderer/context/file-preview-context'
 import { FileTabBar } from './file-tab-bar'
 import { FileRenderer } from './renderers/file-renderer'
+import { FolderBrowser } from './folder-browser'
 import { CommentBar } from './comments/comment-bar'
 import { getApiBaseUrl } from '@renderer/lib/env'
+import { getAgentFileApiPath } from '@renderer/lib/workspace-file-url'
+import { cn } from '@shared/lib/utils/cn'
 
 interface FilePreviewTrayContentProps {
   sessionId: string
   onClose: () => void
 }
 
-function getRelativePath(filePath: string): string {
-  return filePath.replace(/^\/workspace\//, '')
-}
-
 export function FilePreviewTrayContent({ sessionId, onClose }: FilePreviewTrayContentProps) {
-  const { openFiles, activeFileIndex, setActiveFile, closeFile, comments } = useFilePreview()
+  const { openTabs, activeTabIndex, setActiveTab, closeTab, comments } = useFilePreview()
 
-  const activeFile = openFiles[activeFileIndex]
-  if (!activeFile) return null
+  const activeTab = openTabs[activeTabIndex]
+  if (!activeTab) return null
 
   const baseUrl = getApiBaseUrl()
-  const relativePath = getRelativePath(activeFile.filePath)
-  const versionParam = activeFile.version > 0 ? `&v=${activeFile.version}` : ''
-  const fileUrl = `${baseUrl}/api/agents/${activeFile.agentSlug}/files/${relativePath}?inline=true${versionParam}`
-  const downloadUrl = `${baseUrl}/api/agents/${activeFile.agentSlug}/files/${relativePath}`
-  const activeComments = comments.get(activeFile.filePath) || []
+  const fileApiPath = activeTab.kind === 'file'
+    ? getAgentFileApiPath(activeTab.agentSlug, activeTab.filePath)
+    : null
+  const versionParam = activeTab.kind === 'file' && activeTab.version > 0 ? `&v=${activeTab.version}` : ''
+  const fileUrl = fileApiPath ? `${baseUrl}${fileApiPath}?inline=true${versionParam}` : null
+  const downloadUrl = fileApiPath ? `${baseUrl}${fileApiPath}` : null
+  const activeComments = activeTab.kind === 'file' ? comments.get(activeTab.filePath) || [] : []
 
   return (
     <div className="contents" data-testid="file-preview-tray">
@@ -39,17 +40,23 @@ export function FilePreviewTrayContent({ sessionId, onClose }: FilePreviewTrayCo
         >
           <X className="h-4 w-4" />
         </button>
-        <FileText className="h-4 w-4 shrink-0" />
+        {activeTab.kind === 'folder' ? (
+          <Folder className="h-4 w-4 shrink-0" />
+        ) : (
+          <FileText className="h-4 w-4 shrink-0" />
+        )}
         <span className="flex-1 text-xs truncate font-medium">Files</span>
-        <a
-          href={downloadUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="p-0.5 rounded hover:bg-muted transition-colors"
-          title="Download file"
-        >
-          <Download className="h-4 w-4" />
-        </a>
+        {downloadUrl && (
+          <a
+            href={downloadUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="p-0.5 rounded hover:bg-muted transition-colors"
+            title="Download file"
+          >
+            <Download className="h-4 w-4" />
+          </a>
+        )}
         <button
           className="file-preview-wide-close inline-flex p-0.5 rounded hover:bg-muted transition-colors"
           onClick={onClose}
@@ -62,27 +69,38 @@ export function FilePreviewTrayContent({ sessionId, onClose }: FilePreviewTrayCo
 
       {/* File tabs */}
       <FileTabBar
-        files={openFiles}
-        activeIndex={activeFileIndex}
-        onTabClick={setActiveFile}
-        onCloseTab={closeFile}
+        tabs={openTabs}
+        activeIndex={activeTabIndex}
+        onTabClick={setActiveTab}
+        onCloseTab={closeTab}
       />
 
       {/* File content */}
-      <div className="flex-1 min-h-0 overflow-auto">
-        <FileRenderer
-          filePath={activeFile.filePath}
-          fileUrl={fileUrl}
-          agentSlug={activeFile.agentSlug}
-        />
+      <div
+        className={cn(
+          'flex-1 min-h-0',
+          activeTab.kind === 'folder' ? 'overflow-hidden' : 'overflow-auto',
+        )}
+      >
+        {activeTab.kind === 'folder' ? (
+          <FolderBrowser folder={activeTab} />
+        ) : fileUrl ? (
+          <FileRenderer
+            filePath={activeTab.filePath}
+            fileUrl={fileUrl}
+            agentSlug={activeTab.agentSlug}
+          />
+        ) : null}
       </div>
 
       {/* Comment bar */}
-      <CommentBar
-        comments={activeComments}
-        filePath={activeFile.filePath}
-        sessionId={sessionId}
-      />
+      {activeTab.kind === 'file' && (
+        <CommentBar
+          comments={activeComments}
+          filePath={activeTab.filePath}
+          sessionId={sessionId}
+        />
+      )}
     </div>
   )
 }

--- a/src/renderer/components/file-preview/file-tab-bar.test.tsx
+++ b/src/renderer/components/file-preview/file-tab-bar.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FileTabBar } from './file-tab-bar'
+import type { PreviewTab } from '@renderer/context/file-preview-context'
+
+const tabs: PreviewTab[] = [
+  {
+    kind: 'folder',
+    rootPath: '/workspace/reports',
+    agentSlug: 'test-agent',
+    displayName: 'reports',
+    expandedPaths: ['/workspace/reports'],
+    query: '',
+  },
+  {
+    kind: 'file',
+    filePath: '/workspace/reports/summary.md',
+    agentSlug: 'test-agent',
+    displayName: 'summary.md',
+    version: 0,
+  },
+]
+
+describe('FileTabBar', () => {
+  it('renders folder and file tabs and closes by discriminated key', async () => {
+    const user = userEvent.setup()
+    const onCloseTab = vi.fn()
+    render(
+      <FileTabBar
+        tabs={tabs}
+        activeIndex={0}
+        onTabClick={vi.fn()}
+        onCloseTab={onCloseTab}
+      />,
+    )
+
+    expect(screen.getByTestId('file-tab-bar').children).toHaveLength(2)
+    expect(screen.getAllByTestId('file-tab')[0]).toHaveAttribute('data-tab-kind', 'folder')
+    const folderClose = screen.getAllByTestId('file-tab-close')[0]
+    await user.click(folderClose)
+
+    expect(onCloseTab).toHaveBeenCalledWith('folder:/workspace/reports')
+  })
+})

--- a/src/renderer/components/file-preview/file-tab-bar.tsx
+++ b/src/renderer/components/file-preview/file-tab-bar.tsx
@@ -1,27 +1,29 @@
-import { X } from 'lucide-react'
+import { Folder, X } from 'lucide-react'
 import { FileTypeIcon } from '@renderer/components/ui/file-type-icon'
 import { cn } from '@shared/lib/utils/cn'
-import type { FileTab } from '@renderer/context/file-preview-context'
+import { getPreviewTabKey, type PreviewTab } from '@renderer/context/file-preview-context'
 
 interface FileTabBarProps {
-  files: FileTab[]
+  tabs: PreviewTab[]
   activeIndex: number
   onTabClick: (index: number) => void
-  onCloseTab: (filePath: string) => void
+  onCloseTab: (tabKey: string) => void
 }
 
-export function FileTabBar({ files, activeIndex, onTabClick, onCloseTab }: FileTabBarProps) {
-  if (files.length === 0) return null
+export function FileTabBar({ tabs, activeIndex, onTabClick, onCloseTab }: FileTabBarProps) {
+  if (tabs.length === 0) return null
 
   return (
     <div className="flex items-center gap-0 border-b border-border/40 shrink-0 overflow-x-auto scrollbar-none" data-testid="file-tab-bar">
-      {files.map((file, index) => (
+      {tabs.map((tab, index) => (
         <button
-          key={file.filePath}
+          key={getPreviewTabKey(tab)}
+          type="button"
           onClick={() => onTabClick(index)}
           data-testid="file-tab"
-          data-file-name={file.displayName}
-          data-file-path={file.filePath}
+          data-tab-kind={tab.kind}
+          data-file-name={tab.displayName}
+          data-path={tab.kind === 'file' ? tab.filePath : tab.rootPath}
           className={cn(
             'group flex items-center gap-1.5 px-3 py-1.5 text-xs border-r border-border/30 shrink-0 max-w-[160px] transition-colors',
             index === activeIndex
@@ -29,23 +31,27 @@ export function FileTabBar({ files, activeIndex, onTabClick, onCloseTab }: FileT
               : 'bg-muted/30 text-muted-foreground hover:bg-muted/60 hover:text-foreground'
           )}
         >
-          <FileTypeIcon filename={file.displayName} size={14} />
-          <span className="truncate">{file.displayName}</span>
+          {tab.kind === 'folder' ? (
+            <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          ) : (
+            <FileTypeIcon filename={tab.displayName} size={14} />
+          )}
+          <span className="truncate">{tab.displayName}</span>
           <span
             role="button"
             tabIndex={0}
             data-testid="file-tab-close"
-            data-file-name={file.displayName}
-            data-file-path={file.filePath}
+            data-file-name={tab.displayName}
+            data-path={tab.kind === 'file' ? tab.filePath : tab.rootPath}
             onClick={(e) => {
               e.stopPropagation()
-              onCloseTab(file.filePath)
+              onCloseTab(getPreviewTabKey(tab))
             }}
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') {
                 e.stopPropagation()
                 e.preventDefault()
-                onCloseTab(file.filePath)
+                onCloseTab(getPreviewTabKey(tab))
               }
             }}
             className="ml-auto p-0.5 rounded hover:bg-muted-foreground/20 opacity-0 group-hover:opacity-100 touch:opacity-100 transition-opacity"

--- a/src/renderer/components/file-preview/file-types.test.ts
+++ b/src/renderer/components/file-preview/file-types.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { isCopyableTextFile } from './file-types'
+
+describe('isCopyableTextFile', () => {
+  it.each(['notes.md', 'data.csv', 'config.json', 'index.html', 'icon.svg', 'Dockerfile'])(
+    'allows copying %s',
+    fileName => expect(isCopyableTextFile(fileName)).toBe(true),
+  )
+
+  it.each(['photo.png', 'clip.mp4', 'document.pdf', 'archive.zip'])(
+    'does not allow copying %s',
+    fileName => expect(isCopyableTextFile(fileName)).toBe(false),
+  )
+})

--- a/src/renderer/components/file-preview/file-types.ts
+++ b/src/renderer/components/file-preview/file-types.ts
@@ -1,0 +1,27 @@
+import { getFileExtension } from '@shared/lib/utils/mime'
+
+export const MARKDOWN_EXTS = new Set(['md', 'markdown'])
+export const CSV_EXTS = new Set(['csv', 'tsv'])
+export const TEXT_EXTS = new Set([
+  'txt', 'log', 'json', 'xml', 'yml', 'yaml', 'toml', 'ini', 'cfg',
+  'env', 'sh', 'bash', 'zsh', 'py', 'js', 'ts', 'tsx', 'jsx', 'css',
+  'scss', 'less', 'sql', 'graphql', 'proto', 'dockerfile', 'makefile',
+  'gitignore', 'editorconfig', 'rs', 'go', 'java', 'kt', 'swift', 'rb', 'php',
+  'c', 'cpp', 'h', 'hpp', 'r',
+])
+export const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'ico'])
+export const VIDEO_EXTS = new Set(['mp4', 'mov', 'webm', 'm4v', 'ogv'])
+export const AUDIO_EXTS = new Set(['mp3', 'wav', 'm4a', 'aac', 'ogg', 'oga', 'opus', 'flac', 'weba'])
+
+const COPYABLE_TEXT_EXTS = new Set([
+  ...MARKDOWN_EXTS,
+  ...CSV_EXTS,
+  ...TEXT_EXTS,
+  'html',
+  'htm',
+  'svg',
+])
+
+export function isCopyableTextFile(filePath: string): boolean {
+  return COPYABLE_TEXT_EXTS.has(getFileExtension(filePath))
+}

--- a/src/renderer/components/file-preview/folder-browser.test.tsx
+++ b/src/renderer/components/file-preview/folder-browser.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FolderBrowser } from './folder-browser'
+import type { FolderTab } from '@renderer/context/file-preview-context'
+
+const mocks = vi.hoisted(() => ({
+  openFile: vi.fn(),
+  toggleFolder: vi.fn(),
+  setFolderQuery: vi.fn(),
+  selectFolderEntry: vi.fn(),
+  useBookmarks: vi.fn((_agentSlug: string) => ({ data: [], isLoading: false })),
+  useUpdateBookmarks: vi.fn((_agentSlug: string) => ({ mutateAsync: vi.fn(), isPending: false })),
+}))
+
+vi.mock('@renderer/context/file-preview-context', async importOriginal => {
+  const actual = await importOriginal<typeof import('@renderer/context/file-preview-context')>()
+  return {
+    ...actual,
+    useFilePreview: () => mocks,
+  }
+})
+
+vi.mock('@renderer/hooks/use-folder-entries', () => ({
+  FolderEntriesError: class FolderEntriesError extends Error {},
+  useFolderEntries: (_agentSlug: string, _rootPath: string, folderPath: string) => ({
+    data: folderPath === '/workspace/reports'
+      ? {
+          root: '/workspace/reports',
+          path: folderPath,
+          truncated: false,
+          entries: [
+            { name: '2026', path: '/workspace/reports/2026', type: 'directory' },
+            { name: 'overview.md', path: '/workspace/reports/overview.md', type: 'file' },
+            { name: 'raw.csv', path: '/workspace/reports/raw.csv', type: 'file' },
+          ],
+        }
+      : {
+          root: '/workspace/reports',
+          path: folderPath,
+          truncated: false,
+          entries: [{ name: 'july.md', path: '/workspace/reports/2026/july.md', type: 'file' }],
+        },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}))
+
+vi.mock('@renderer/hooks/use-bookmarks', () => ({
+  useBookmarks: (agentSlug: string) => mocks.useBookmarks(agentSlug),
+  useUpdateBookmarks: (agentSlug: string) => mocks.useUpdateBookmarks(agentSlug),
+}))
+
+vi.mock('./folder-file-context-menu', () => ({
+  FolderEntryContextMenu: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+const baseFolder: FolderTab = {
+  kind: 'folder',
+  rootPath: '/workspace/reports',
+  agentSlug: 'test-agent',
+  displayName: 'reports',
+  expandedPaths: ['/workspace/reports'],
+  query: '',
+}
+
+describe('FolderBrowser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the lazy tree and expands a directory in place', async () => {
+    const user = userEvent.setup()
+    render(<FolderBrowser folder={baseFolder} />)
+
+    expect(screen.getByRole('button', { name: '2026' })).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByRole('button', { name: 'overview.md' })).toBeVisible()
+
+    await user.click(screen.getByRole('button', { name: '2026' }))
+
+    expect(mocks.toggleFolder).toHaveBeenCalledWith('/workspace/reports', '/workspace/reports/2026')
+  })
+
+  it('renders expanded descendants and opens a file in a separate preview tab', async () => {
+    const user = userEvent.setup()
+    render(
+      <FolderBrowser
+        folder={{ ...baseFolder, expandedPaths: [...baseFolder.expandedPaths, '/workspace/reports/2026'] }}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'july.md' }))
+
+    expect(mocks.selectFolderEntry).toHaveBeenCalledWith(
+      '/workspace/reports',
+      '/workspace/reports/2026/july.md',
+    )
+    expect(mocks.openFile).toHaveBeenCalledWith('/workspace/reports/2026/july.md', 'test-agent')
+  })
+
+  it('filters files while keeping directories available for lazy traversal', () => {
+    render(<FolderBrowser folder={{ ...baseFolder, query: 'overview' }} />)
+
+    expect(screen.getByRole('button', { name: '2026' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'overview.md' })).toBeVisible()
+    expect(screen.getByText('overview', { selector: 'mark' })).toBeVisible()
+    expect(screen.queryByRole('button', { name: 'raw.csv' })).not.toBeInTheDocument()
+  })
+
+  it('highlights every case-insensitive substring match', () => {
+    render(<FolderBrowser folder={{ ...baseFolder, query: 'E' }} />)
+
+    const filename = screen.getByRole('button', { name: 'overview.md' })
+    expect(filename.querySelectorAll('mark')).toHaveLength(2)
+    expect(filename.querySelectorAll('mark')[0]).toHaveTextContent('e')
+    expect(filename).toHaveAccessibleName('overview.md')
+  })
+
+  it('updates the persisted folder query', () => {
+    render(<FolderBrowser folder={baseFolder} />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Filter files' }), {
+      target: { value: 'july' },
+    })
+
+    expect(mocks.setFolderQuery).toHaveBeenCalledWith('/workspace/reports', 'july')
+  })
+
+  it('creates one bookmark observer and updater for the whole tree', () => {
+    render(
+      <FolderBrowser
+        folder={{ ...baseFolder, expandedPaths: [...baseFolder.expandedPaths, '/workspace/reports/2026'] }}
+      />,
+    )
+
+    expect(screen.getAllByTestId('folder-entry')).toHaveLength(4)
+    expect(mocks.useBookmarks).toHaveBeenCalledTimes(1)
+    expect(mocks.useUpdateBookmarks).toHaveBeenCalledTimes(1)
+    expect(mocks.useBookmarks).toHaveBeenCalledWith('test-agent')
+    expect(mocks.useUpdateBookmarks).toHaveBeenCalledWith('test-agent')
+  })
+})

--- a/src/renderer/components/file-preview/folder-browser.test.tsx
+++ b/src/renderer/components/file-preview/folder-browser.test.tsx
@@ -39,7 +39,7 @@ vi.mock('@renderer/hooks/use-folder-entries', () => ({
       : {
           root: '/workspace/reports',
           path: folderPath,
-          truncated: false,
+          truncated: true,
           entries: [{ name: 'july.md', path: '/workspace/reports/2026/july.md', type: 'file' }],
         },
     isLoading: false,
@@ -140,5 +140,15 @@ describe('FolderBrowser', () => {
     expect(mocks.useUpdateBookmarks).toHaveBeenCalledTimes(1)
     expect(mocks.useBookmarks).toHaveBeenCalledWith('test-agent')
     expect(mocks.useUpdateBookmarks).toHaveBeenCalledWith('test-agent')
+  })
+
+  it('shows a response-derived truncation notice for nested directories', () => {
+    render(
+      <FolderBrowser
+        folder={{ ...baseFolder, expandedPaths: [...baseFolder.expandedPaths, '/workspace/reports/2026'] }}
+      />,
+    )
+
+    expect(screen.getByText('Showing the first 1 entry.')).toBeVisible()
   })
 })

--- a/src/renderer/components/file-preview/folder-browser.tsx
+++ b/src/renderer/components/file-preview/folder-browser.tsx
@@ -207,9 +207,9 @@ function FolderDirectory({
           </FolderEntryContextMenu>
         )
       })}
-      {data?.truncated && isRoot && (
+      {data?.truncated && (
         <div className="px-3 py-1.5 text-[11px] text-muted-foreground">
-          Showing the first 1,000 entries.
+          Showing the first {data.entries.length.toLocaleString()} {data.entries.length === 1 ? 'entry' : 'entries'}.
         </div>
       )}
     </>

--- a/src/renderer/components/file-preview/folder-browser.tsx
+++ b/src/renderer/components/file-preview/folder-browser.tsx
@@ -1,0 +1,248 @@
+import { AlertCircle, ChevronRight, Loader2, Search } from 'lucide-react'
+import { FileTypeIcon } from '@renderer/components/ui/file-type-icon'
+import { Input } from '@renderer/components/ui/input'
+import { Button } from '@renderer/components/ui/button'
+import { useFilePreview, type FolderTab } from '@renderer/context/file-preview-context'
+import { FolderEntriesError, useFolderEntries, type FolderEntry } from '@renderer/hooks/use-folder-entries'
+import { useBookmarks, useUpdateBookmarks, type Bookmark } from '@renderer/hooks/use-bookmarks'
+import { cn } from '@shared/lib/utils/cn'
+import { FolderEntryContextMenu } from './folder-file-context-menu'
+
+interface FolderBrowserProps {
+  folder: FolderTab
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof FolderEntriesError) {
+    if (error.status === 404) return 'This folder is no longer available.'
+    if (error.status === 403) return "You don't have permission to view this folder."
+    return error.message
+  }
+  return 'The folder could not be loaded.'
+}
+
+function matchesQuery(entry: FolderEntry, query: string): boolean {
+  if (!query) return true
+  // Keep directories visible: search is deliberately limited to lazily loaded
+  // entries, so hiding a parent would also hide matching loaded descendants.
+  return entry.type === 'directory' || entry.name.toLocaleLowerCase().includes(query)
+}
+
+function HighlightedEntryName({ name, query }: { name: string; query: string }) {
+  const normalizedQuery = query.trim().toLocaleLowerCase()
+  if (!normalizedQuery) return <span className="truncate">{name}</span>
+
+  const normalizedName = name.toLocaleLowerCase()
+  const parts: React.ReactNode[] = []
+  let cursor = 0
+  let matchIndex = normalizedName.indexOf(normalizedQuery)
+
+  while (matchIndex >= 0) {
+    if (matchIndex > cursor) parts.push(name.slice(cursor, matchIndex))
+    const matchEnd = matchIndex + normalizedQuery.length
+    parts.push(
+      <mark
+        key={`${matchIndex}-${matchEnd}`}
+        className="rounded-sm bg-amber-200/80 text-inherit dark:bg-amber-800/60"
+      >
+        {name.slice(matchIndex, matchEnd)}
+      </mark>,
+    )
+    cursor = matchEnd
+    matchIndex = normalizedName.indexOf(normalizedQuery, cursor)
+  }
+
+  if (parts.length === 0) return <span className="truncate">{name}</span>
+  if (cursor < name.length) parts.push(name.slice(cursor))
+  return <span className="truncate">{parts}</span>
+}
+
+function FolderDirectory({
+  folder,
+  path,
+  depth,
+  bookmarks,
+  bookmarksLoading,
+  updateBookmarks,
+}: {
+  folder: FolderTab
+  path: string
+  depth: number
+  bookmarks: Bookmark[]
+  bookmarksLoading: boolean
+  updateBookmarks: ReturnType<typeof useUpdateBookmarks>
+}) {
+  const { openFile, toggleFolder, selectFolderEntry } = useFilePreview()
+  const isRoot = path === folder.rootPath
+  const isExpanded = isRoot || folder.expandedPaths.includes(path)
+  const { data, isLoading, error, refetch } = useFolderEntries(
+    folder.agentSlug,
+    folder.rootPath,
+    path,
+    isExpanded,
+  )
+
+  if (!isExpanded) return null
+
+  if (isLoading) {
+    return (
+      <div
+        className="flex h-7 items-center gap-1.5 text-[11px] text-muted-foreground"
+        style={{ paddingLeft: `${depth * 16 + 14}px` }}
+      >
+        <Loader2 className="h-2.5 w-2.5 animate-spin" />
+        Loading…
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div
+        className="flex items-center gap-1.5 py-1 pr-2 text-[11px] text-muted-foreground"
+        style={{ paddingLeft: `${depth * 16 + 14}px` }}
+        role="alert"
+      >
+        <AlertCircle className="h-2.5 w-2.5 shrink-0" />
+        <span className="min-w-0 flex-1">{errorMessage(error)}</span>
+        <Button type="button" variant="ghost" size="sm" className="h-6 px-1.5 text-[11px]" onClick={() => refetch()}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  const query = folder.query.trim().toLocaleLowerCase()
+  const entries = (data?.entries ?? []).filter(entry => matchesQuery(entry, query))
+
+  if (entries.length === 0) {
+    return isRoot ? (
+      <div className="px-3 py-8 text-center text-xs text-muted-foreground">
+        {query ? 'No matching files in this folder.' : 'This folder is empty.'}
+      </div>
+    ) : null
+  }
+
+  return (
+    <>
+      {entries.map(entry => {
+        const selected = folder.selectedPath === entry.path
+        const entryDepth = depth
+        if (entry.type === 'directory') {
+          const expanded = folder.expandedPaths.includes(entry.path)
+          return (
+            <div key={entry.path}>
+              <FolderEntryContextMenu
+                folder={folder}
+                entry={entry}
+                bookmarks={bookmarks}
+                bookmarksLoading={bookmarksLoading}
+                updateBookmarks={updateBookmarks}
+              >
+                <button
+                  type="button"
+                  className={cn(
+                    'flex h-7 w-full items-center gap-1.5 rounded pr-2 text-left text-xs hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                    selected && 'bg-muted',
+                  )}
+                  style={{ paddingLeft: `${entryDepth * 16 + 10}px` }}
+                  onClick={() => toggleFolder(folder.rootPath, entry.path)}
+                  aria-expanded={expanded}
+                  data-testid="folder-entry"
+                  data-entry-type="directory"
+                  data-entry-path={entry.path}
+                >
+                  <ChevronRight
+                    className={cn(
+                      'h-3 w-3 shrink-0 text-muted-foreground transition-transform',
+                      expanded && 'rotate-90',
+                    )}
+                  />
+                  <HighlightedEntryName name={entry.name} query={folder.query} />
+                </button>
+              </FolderEntryContextMenu>
+              {expanded && (
+                <FolderDirectory
+                  folder={folder}
+                  path={entry.path}
+                  depth={entryDepth + 1}
+                  bookmarks={bookmarks}
+                  bookmarksLoading={bookmarksLoading}
+                  updateBookmarks={updateBookmarks}
+                />
+              )}
+            </div>
+          )
+        }
+
+        return (
+          <FolderEntryContextMenu
+            key={entry.path}
+            folder={folder}
+            entry={entry}
+            bookmarks={bookmarks}
+            bookmarksLoading={bookmarksLoading}
+            updateBookmarks={updateBookmarks}
+          >
+            <button
+              type="button"
+              className={cn(
+                'flex h-7 w-full items-center gap-1.5 rounded pr-2 text-left text-xs hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                selected && 'bg-muted',
+              )}
+              style={{ paddingLeft: `${entryDepth * 16 + 30}px` }}
+              onClick={() => {
+                selectFolderEntry(folder.rootPath, entry.path)
+                openFile(entry.path, folder.agentSlug)
+              }}
+              data-testid="folder-entry"
+              data-entry-type="file"
+              data-entry-path={entry.path}
+            >
+              <span aria-hidden="true" className="shrink-0">
+                <FileTypeIcon filename={entry.name} size={12} />
+              </span>
+              <HighlightedEntryName name={entry.name} query={folder.query} />
+            </button>
+          </FolderEntryContextMenu>
+        )
+      })}
+      {data?.truncated && isRoot && (
+        <div className="px-3 py-1.5 text-[11px] text-muted-foreground">
+          Showing the first 1,000 entries.
+        </div>
+      )}
+    </>
+  )
+}
+
+export function FolderBrowser({ folder }: FolderBrowserProps) {
+  const { setFolderQuery } = useFilePreview()
+  const { data: bookmarks = [], isLoading: bookmarksLoading } = useBookmarks(folder.agentSlug)
+  const updateBookmarks = useUpdateBookmarks(folder.agentSlug)
+
+  return (
+    <div className="flex h-full min-h-0 flex-col" data-testid="folder-browser">
+      <div className="relative shrink-0 px-2 py-2">
+        <Search className="pointer-events-none absolute left-4 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={folder.query}
+          onChange={event => setFolderQuery(folder.rootPath, event.target.value)}
+          placeholder="Filter files..."
+          aria-label="Filter files"
+          className="h-8 rounded-lg pl-8 text-xs"
+        />
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto px-1 pb-2">
+        <FolderDirectory
+          folder={folder}
+          path={folder.rootPath}
+          depth={0}
+          bookmarks={bookmarks}
+          bookmarksLoading={bookmarksLoading}
+          updateBookmarks={updateBookmarks}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/file-preview/folder-file-context-menu.test.tsx
+++ b/src/renderer/components/file-preview/folder-file-context-menu.test.tsx
@@ -1,0 +1,321 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FolderEntryContextMenu } from './folder-file-context-menu'
+import type { FolderTab } from '@renderer/context/file-preview-context'
+import type { FolderEntry } from '@renderer/hooks/use-folder-entries'
+
+const mocks = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+  downloadBlob: vi.fn(),
+  invalidateQueries: vi.fn().mockResolvedValue(undefined),
+  renameFilePath: vi.fn(),
+  removeFilePath: vi.fn(),
+  renameDirectoryPath: vi.fn(),
+  removeDirectoryPath: vi.fn(),
+  updateBookmarks: vi.fn().mockResolvedValue([]),
+  bookmarks: [] as Array<{ name: string; file?: string; folder?: string }>,
+  revealInFolder: vi.fn().mockResolvedValue(null),
+  canManage: true,
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}))
+
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mocks.apiFetch(...args),
+}))
+
+vi.mock('@renderer/lib/download', () => ({
+  downloadBlob: (...args: unknown[]) => mocks.downloadBlob(...args),
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: mocks.invalidateQueries }),
+}))
+
+vi.mock('@renderer/context/file-preview-context', () => ({
+  useFilePreview: () => ({
+    renameFilePath: mocks.renameFilePath,
+    removeFilePath: mocks.removeFilePath,
+    renameDirectoryPath: mocks.renameDirectoryPath,
+    removeDirectoryPath: mocks.removeDirectoryPath,
+  }),
+}))
+
+vi.mock('@renderer/hooks/use-bookmarks', () => ({
+  useBookmarks: () => ({ data: mocks.bookmarks, isLoading: false }),
+  useUpdateBookmarks: () => ({ mutateAsync: mocks.updateBookmarks, isPending: false }),
+}))
+
+vi.mock('@renderer/context/user-context', () => ({
+  useUser: () => ({ canAdminAgent: () => mocks.canManage }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: mocks.toastSuccess, error: mocks.toastError },
+}))
+
+vi.mock('@renderer/components/ui/context-menu', () => ({
+  ContextMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuItem: ({ children, onClick, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" onClick={onClick} {...props}>{children}</button>
+  ),
+  ContextMenuSeparator: () => <hr />,
+}))
+
+vi.mock('@renderer/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) => open ? <>{children}</> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}))
+
+vi.mock('@renderer/components/ui/alert-dialog', () => ({
+  AlertDialog: ({ open, children }: { open: boolean; children: React.ReactNode }) => open ? <>{children}</> : null,
+  AlertDialogAction: ({ children, onClick, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" onClick={onClick} {...props}>{children}</button>
+  ),
+  AlertDialogCancel: ({ children }: { children: React.ReactNode }) => <button type="button">{children}</button>,
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}))
+
+const folder: FolderTab = {
+  kind: 'folder',
+  rootPath: '/workspace/reports',
+  agentSlug: 'test-agent',
+  displayName: 'reports',
+  expandedPaths: ['/workspace/reports'],
+  query: '',
+}
+
+function renderMenu(file: FolderEntry = {
+  name: 'notes.md',
+  path: '/workspace/reports/notes.md',
+  type: 'file',
+}) {
+  return render(
+    <FolderEntryContextMenu
+      folder={folder}
+      entry={file}
+      bookmarks={mocks.bookmarks}
+      bookmarksLoading={false}
+      updateBookmarks={{ mutateAsync: mocks.updateBookmarks, isPending: false }}
+    >
+      <button type="button">notes.md</button>
+    </FolderEntryContextMenu>,
+  )
+}
+
+describe('FolderFileContextMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.canManage = true
+    mocks.bookmarks = []
+    delete window.electronAPI
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    })
+  })
+
+  it('shows copy for text files and owner-only file actions', () => {
+    renderMenu()
+
+    expect(screen.getByRole('button', { name: 'Copy contents' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Download' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Bookmark' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Rename' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeVisible()
+  })
+
+  it('does not offer copy contents for binary files', () => {
+    renderMenu({ name: 'photo.png', path: '/workspace/reports/photo.png', type: 'file' })
+
+    expect(screen.queryByRole('button', { name: 'Copy contents' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Download' })).toBeVisible()
+  })
+
+  it('keeps mutations hidden for users without agent admin access', () => {
+    mocks.canManage = false
+    renderMenu()
+
+    expect(screen.getByRole('button', { name: 'Copy contents' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Download' })).toBeVisible()
+    expect(screen.queryByRole('button', { name: 'Rename' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Bookmark' })).not.toBeInTheDocument()
+  })
+
+  it('offers directory actions without file-only copy and download actions', () => {
+    renderMenu({ name: 'drafts', path: '/workspace/reports/drafts', type: 'directory' })
+
+    expect(screen.queryByRole('button', { name: 'Copy contents' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Download' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Bookmark' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Rename' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeVisible()
+  })
+
+  it('bookmarks files and directories with their workspace paths', async () => {
+    const user = userEvent.setup()
+    const { unmount } = renderMenu()
+    await user.click(screen.getByRole('button', { name: 'Bookmark' }))
+
+    await waitFor(() => expect(mocks.updateBookmarks).toHaveBeenCalledWith([
+      { name: 'notes.md', file: '/workspace/reports/notes.md' },
+    ]))
+
+    unmount()
+    mocks.updateBookmarks.mockClear()
+    renderMenu({ name: 'drafts', path: '/workspace/reports/drafts', type: 'directory' })
+    await user.click(screen.getByRole('button', { name: 'Bookmark' }))
+
+    await waitFor(() => expect(mocks.updateBookmarks).toHaveBeenCalledWith([
+      { name: 'drafts', folder: '/workspace/reports/drafts' },
+    ]))
+  })
+
+  it('removes an existing bookmark', async () => {
+    const user = userEvent.setup()
+    mocks.bookmarks = [
+      { name: 'Notes', file: '/workspace/reports/notes.md' },
+      { name: 'Other', file: '/workspace/reports/other.md' },
+    ]
+    renderMenu()
+
+    await user.click(screen.getByRole('button', { name: 'Remove bookmark' }))
+
+    await waitFor(() => expect(mocks.updateBookmarks).toHaveBeenCalledWith([
+      { name: 'Other', file: '/workspace/reports/other.md' },
+    ]))
+  })
+
+  it('copies fetched text contents to the clipboard', async () => {
+    mocks.apiFetch.mockResolvedValue(new Response('hello world'))
+    renderMenu()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy contents' }))
+
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello world'))
+    expect(mocks.apiFetch).toHaveBeenCalledWith(
+      '/api/agents/test-agent/files/reports/notes.md?inline=true',
+    )
+  })
+
+  it('downloads through the authenticated file route', async () => {
+    const user = userEvent.setup()
+    const response = new Response('file contents')
+    mocks.apiFetch.mockResolvedValue(response)
+    renderMenu()
+
+    await user.click(screen.getByRole('button', { name: 'Download' }))
+
+    await waitFor(() => expect(mocks.downloadBlob).toHaveBeenCalledWith(response, 'notes.md'))
+  })
+
+  it('renames the file and refreshes the folder tree', async () => {
+    const user = userEvent.setup()
+    mocks.apiFetch.mockResolvedValue(new Response(
+      JSON.stringify({ path: '/workspace/reports/renamed.md', name: 'renamed.md' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ))
+    renderMenu()
+
+    await user.click(screen.getByRole('button', { name: 'Rename' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'File name' }), {
+      target: { value: 'renamed.md' },
+    })
+    await user.click(screen.getAllByRole('button', { name: 'Rename' }).at(-1)!)
+
+    await waitFor(() => expect(mocks.renameFilePath).toHaveBeenCalledWith(
+      '/workspace/reports/notes.md',
+      '/workspace/reports/renamed.md',
+    ))
+    expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['folder-entries', 'test-agent', '/workspace/reports'],
+    })
+  })
+
+  it('requires confirmation before deleting the file', async () => {
+    const user = userEvent.setup()
+    mocks.apiFetch.mockResolvedValue(new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    renderMenu()
+
+    await user.click(screen.getByTestId('folder-file-delete'))
+    expect(screen.getByRole('heading', { name: 'Delete File' })).toBeVisible()
+    await user.click(screen.getAllByRole('button', { name: 'Delete' }).at(-1)!)
+
+    await waitFor(() => expect(mocks.removeFilePath).toHaveBeenCalledWith(
+      '/workspace/reports/notes.md',
+    ))
+  })
+
+  it('renames and deletes directories through directory-safe mutations', async () => {
+    const user = userEvent.setup()
+    mocks.apiFetch
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify({ path: '/workspace/reports/archive', name: 'archive' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+    const entry = { name: 'drafts', path: '/workspace/reports/drafts', type: 'directory' as const }
+    const { unmount } = renderMenu(entry)
+
+    await user.click(screen.getByRole('button', { name: 'Rename' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Folder name' }), {
+      target: { value: 'archive' },
+    })
+    await user.click(screen.getAllByRole('button', { name: 'Rename' }).at(-1)!)
+    await waitFor(() => expect(mocks.renameDirectoryPath).toHaveBeenCalledWith(
+      '/workspace/reports/drafts',
+      '/workspace/reports/archive',
+    ))
+
+    unmount()
+    renderMenu(entry)
+    await user.click(screen.getByTestId('folder-directory-delete'))
+    expect(screen.getByRole('heading', { name: 'Delete Folder' })).toBeVisible()
+    await user.click(screen.getAllByRole('button', { name: 'Delete' }).at(-1)!)
+    await waitFor(() => expect(mocks.removeDirectoryPath).toHaveBeenCalledWith(
+      '/workspace/reports/drafts',
+    ))
+  })
+
+  it('reveals files through Electron only', async () => {
+    const user = userEvent.setup()
+    window.electronAPI = {
+      platform: 'darwin',
+      revealInFolder: mocks.revealInFolder,
+    } as unknown as typeof window.electronAPI
+    mocks.apiFetch.mockResolvedValue(new Response(
+      JSON.stringify({ hostPath: '/host/workspace/reports/notes.md' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ))
+    renderMenu()
+
+    await user.click(screen.getByRole('button', { name: 'Reveal in Finder' }))
+
+    await waitFor(() => expect(mocks.revealInFolder).toHaveBeenCalledWith(
+      '/host/workspace/reports/notes.md',
+    ))
+    expect(mocks.apiFetch).toHaveBeenCalledWith(
+      '/api/agents/test-agent/folders/reveal-path',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+})

--- a/src/renderer/components/file-preview/folder-file-context-menu.tsx
+++ b/src/renderer/components/file-preview/folder-file-context-menu.tsx
@@ -1,0 +1,399 @@
+import { useState, type ReactNode } from 'react'
+import {
+  BookmarkMinus,
+  BookmarkPlus,
+  ClipboardCopy,
+  Download,
+  FolderSearch,
+  Pencil,
+  Trash2,
+} from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@renderer/components/ui/context-menu'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@renderer/components/ui/dialog'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@renderer/components/ui/alert-dialog'
+import { Button } from '@renderer/components/ui/button'
+import { Input } from '@renderer/components/ui/input'
+import { useFilePreview, type FolderTab } from '@renderer/context/file-preview-context'
+import { useUser } from '@renderer/context/user-context'
+import { apiFetch } from '@renderer/lib/api'
+import { downloadBlob } from '@renderer/lib/download'
+import { getAgentFileApiPath } from '@renderer/lib/workspace-file-url'
+import type { FolderEntry } from '@renderer/hooks/use-folder-entries'
+import type { Bookmark } from '@renderer/hooks/use-bookmarks'
+import { isCopyableTextFile } from './file-types'
+
+interface FolderEntryContextMenuProps {
+  folder: FolderTab
+  entry: FolderEntry
+  bookmarks: Bookmark[]
+  bookmarksLoading: boolean
+  updateBookmarks: {
+    mutateAsync: (bookmarks: Bookmark[]) => Promise<Bookmark[]>
+    isPending: boolean
+  }
+  children: ReactNode
+}
+
+function isValidFileName(name: string): boolean {
+  return name !== ''
+    && name !== '.'
+    && name !== '..'
+    && !name.includes('/')
+    && !name.includes('\\')
+    && !name.includes('\0')
+}
+
+async function getResponseError(response: Response, fallback: string): Promise<string> {
+  const payload = await response.json().catch(() => null) as { error?: string } | null
+  return payload?.error ?? fallback
+}
+
+function pathAtOrBelow(basePath: string, candidatePath: string): boolean {
+  return candidatePath === basePath || candidatePath.startsWith(`${basePath}/`)
+}
+
+function rebasePath(candidatePath: string, oldPath: string, newPath: string): string {
+  return pathAtOrBelow(oldPath, candidatePath)
+    ? `${newPath}${candidatePath.slice(oldPath.length)}`
+    : candidatePath
+}
+
+function revealLabel(): string {
+  if (window.electronAPI?.platform === 'darwin') return 'Reveal in Finder'
+  if (window.electronAPI?.platform === 'win32') return 'Reveal in File Explorer'
+  return 'Reveal in Files'
+}
+
+export function FolderEntryContextMenu({
+  folder,
+  entry,
+  bookmarks,
+  bookmarksLoading,
+  updateBookmarks,
+  children,
+}: FolderEntryContextMenuProps) {
+  const {
+    renameFilePath,
+    removeFilePath,
+    renameDirectoryPath,
+    removeDirectoryPath,
+  } = useFilePreview()
+  const { canAdminAgent } = useUser()
+  const queryClient = useQueryClient()
+  const [renameOpen, setRenameOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [newName, setNewName] = useState(entry.name)
+  const [isRenaming, setIsRenaming] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const canManage = canAdminAgent(folder.agentSlug)
+  const isDirectory = entry.type === 'directory'
+  const entryKind = isDirectory ? 'directory' : 'file'
+  const entryLabel = isDirectory ? 'Folder' : 'File'
+  const trimmedName = newName.trim()
+  const fileApiPath = getAgentFileApiPath(folder.agentSlug, entry.path)
+  const bookmarkList = bookmarks
+  const isBookmarked = bookmarkList.some(bookmark => (
+    isDirectory ? bookmark.folder === entry.path : bookmark.file === entry.path
+  ))
+  const electronRevealAvailable = !!window.electronAPI?.revealInFolder
+
+  const refreshFolder = () => queryClient.invalidateQueries({
+    queryKey: ['folder-entries', folder.agentSlug, folder.rootPath],
+  })
+
+  const handleCopy = async () => {
+    try {
+      const response = await apiFetch(`${fileApiPath}?inline=true`)
+      if (!response.ok) throw new Error(await getResponseError(response, 'Failed to copy file'))
+      await navigator.clipboard.writeText(await response.text())
+      toast.success(`Copied contents of “${entry.name}”`)
+    } catch (error) {
+      toast.error('Could not copy file contents', {
+        description: error instanceof Error ? error.message : undefined,
+      })
+    }
+  }
+
+  const handleDownload = async () => {
+    try {
+      const response = await apiFetch(fileApiPath)
+      if (!response.ok) throw new Error(await getResponseError(response, 'Failed to download file'))
+      await downloadBlob(response, entry.name)
+    } catch (error) {
+      toast.error('Could not download file', {
+        description: error instanceof Error ? error.message : undefined,
+      })
+    }
+  }
+
+  const handleBookmark = async () => {
+    try {
+      const updated = isBookmarked
+        ? bookmarkList.filter(bookmark => (
+          isDirectory ? bookmark.folder !== entry.path : bookmark.file !== entry.path
+        ))
+        : [
+          ...bookmarkList,
+          isDirectory
+            ? { name: entry.name, folder: entry.path }
+            : { name: entry.name, file: entry.path },
+        ]
+      await updateBookmarks.mutateAsync(updated)
+      toast.success(isBookmarked ? `Removed bookmark for “${entry.name}”` : `Bookmarked “${entry.name}”`)
+    } catch (error) {
+      toast.error(isBookmarked ? 'Could not remove bookmark' : 'Could not add bookmark', {
+        description: error instanceof Error ? error.message : undefined,
+      })
+    }
+  }
+
+  const handleReveal = async () => {
+    const electronApi = window.electronAPI
+    if (!electronApi?.revealInFolder) return
+    try {
+      const response = await apiFetch(
+        `/api/agents/${encodeURIComponent(folder.agentSlug)}/folders/reveal-path`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ root: folder.rootPath, path: entry.path }),
+        },
+      )
+      if (!response.ok) throw new Error(await getResponseError(response, `Failed to reveal ${entryKind}`))
+      const { hostPath } = await response.json() as { hostPath: string }
+      const revealError = await electronApi.revealInFolder(hostPath)
+      if (revealError) throw new Error(revealError)
+    } catch (error) {
+      toast.error(`Could not reveal ${entryKind}`, {
+        description: error instanceof Error ? error.message : undefined,
+      })
+    }
+  }
+
+  const handleRename = async () => {
+    if (!isValidFileName(trimmedName) || trimmedName === entry.name) return
+    setIsRenaming(true)
+    try {
+      const response = await apiFetch(
+        `/api/agents/${encodeURIComponent(folder.agentSlug)}/folders/${entryKind}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ root: folder.rootPath, path: entry.path, name: trimmedName }),
+        },
+      )
+      if (!response.ok) throw new Error(await getResponseError(response, `Failed to rename ${entryKind}`))
+      const result = await response.json() as { path: string }
+      if (isDirectory) renameDirectoryPath(entry.path, result.path)
+      else renameFilePath(entry.path, result.path)
+      setRenameOpen(false)
+      await refreshFolder()
+      const updatedBookmarks = bookmarkList.map(bookmark => {
+        if (bookmark.file && pathAtOrBelow(entry.path, bookmark.file)) {
+          return { ...bookmark, file: rebasePath(bookmark.file, entry.path, result.path) }
+        }
+        if (bookmark.folder && pathAtOrBelow(entry.path, bookmark.folder)) {
+          return { ...bookmark, folder: rebasePath(bookmark.folder, entry.path, result.path) }
+        }
+        return bookmark
+      })
+      if (updatedBookmarks.some((bookmark, index) => bookmark !== bookmarkList[index])) {
+        try {
+          await updateBookmarks.mutateAsync(updatedBookmarks)
+        } catch {
+          toast.error('Renamed successfully, but related bookmarks could not be updated')
+        }
+      }
+      toast.success(`Renamed to “${trimmedName}”`)
+    } catch (error) {
+      toast.error(`Could not rename ${entryKind}`, {
+        description: error instanceof Error ? error.message : undefined,
+      })
+    } finally {
+      setIsRenaming(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    setIsDeleting(true)
+    try {
+      const response = await apiFetch(
+        `/api/agents/${encodeURIComponent(folder.agentSlug)}/folders/${entryKind}`,
+        {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ root: folder.rootPath, path: entry.path }),
+        },
+      )
+      if (!response.ok) throw new Error(await getResponseError(response, `Failed to delete ${entryKind}`))
+      if (isDirectory) removeDirectoryPath(entry.path)
+      else removeFilePath(entry.path)
+      setDeleteOpen(false)
+      await refreshFolder()
+      const updatedBookmarks = bookmarkList.filter(bookmark => (
+        !(bookmark.file && pathAtOrBelow(entry.path, bookmark.file))
+        && !(bookmark.folder && pathAtOrBelow(entry.path, bookmark.folder))
+      ))
+      if (updatedBookmarks.length !== bookmarkList.length) {
+        try {
+          await updateBookmarks.mutateAsync(updatedBookmarks)
+        } catch {
+          toast.error('Deleted successfully, but related bookmarks could not be removed')
+        }
+      }
+      toast.success(`Deleted “${entry.name}”`)
+    } catch (error) {
+      toast.error(`Could not delete ${entryKind}`, {
+        description: error instanceof Error ? error.message : undefined,
+      })
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  // Read-only users still get copy/download for files, but directories have no
+  // non-mutating web actions. Avoid opening a blank context menu for them.
+  if (isDirectory && !canManage) return <>{children}</>
+
+  return (
+    <>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+        <ContextMenuContent className={electronRevealAvailable ? 'w-52' : 'w-44'}>
+          {!isDirectory && isCopyableTextFile(entry.path) && (
+            <ContextMenuItem onClick={handleCopy} data-testid="folder-file-copy">
+              <ClipboardCopy className="mr-2 h-3.5 w-3.5" />
+              Copy contents
+            </ContextMenuItem>
+          )}
+          {!isDirectory && (
+            <ContextMenuItem onClick={handleDownload} data-testid="folder-file-download">
+              <Download className="mr-2 h-3.5 w-3.5" />
+              Download
+            </ContextMenuItem>
+          )}
+          {canManage && (
+            <>
+              {!isDirectory && <ContextMenuSeparator />}
+              <ContextMenuItem
+                onClick={handleBookmark}
+                disabled={bookmarksLoading || updateBookmarks.isPending}
+                data-testid={`folder-${entryKind}-bookmark`}
+              >
+                {isBookmarked ? (
+                  <BookmarkMinus className="mr-2 h-3.5 w-3.5" />
+                ) : (
+                  <BookmarkPlus className="mr-2 h-3.5 w-3.5" />
+                )}
+                {isBookmarked ? 'Remove bookmark' : 'Bookmark'}
+              </ContextMenuItem>
+              {electronRevealAvailable && (
+                <ContextMenuItem onClick={handleReveal} data-testid={`folder-${entryKind}-reveal`}>
+                  <FolderSearch className="mr-2 h-3.5 w-3.5" />
+                  {revealLabel()}
+                </ContextMenuItem>
+              )}
+              <ContextMenuSeparator />
+              <ContextMenuItem
+                onClick={() => {
+                  setNewName(entry.name)
+                  setRenameOpen(true)
+                }}
+                data-testid={`folder-${entryKind}-rename`}
+              >
+                <Pencil className="mr-2 h-3.5 w-3.5" />
+                Rename
+              </ContextMenuItem>
+              <ContextMenuItem
+                className="text-destructive focus:bg-destructive/10 focus:text-destructive"
+                onClick={() => setDeleteOpen(true)}
+                data-testid={`folder-${entryKind}-delete`}
+              >
+                <Trash2 className="mr-2 h-3.5 w-3.5" />
+                Delete
+              </ContextMenuItem>
+            </>
+          )}
+        </ContextMenuContent>
+      </ContextMenu>
+
+      {renameOpen && (
+        <Dialog open onOpenChange={(open) => { if (!isRenaming) setRenameOpen(open) }}>
+          <DialogContent className="overflow-hidden">
+            <DialogHeader>
+              <DialogTitle>Rename {entryLabel}</DialogTitle>
+              <DialogDescription>Enter a new name for “{entry.name}”.</DialogDescription>
+            </DialogHeader>
+            <form onSubmit={(event) => { event.preventDefault(); void handleRename() }}>
+              <Input
+                value={newName}
+                onChange={event => setNewName(event.target.value)}
+                aria-label={`${entryLabel} name`}
+                autoFocus
+              />
+              <DialogFooter className="mt-4">
+                <Button type="button" variant="outline" onClick={() => setRenameOpen(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={isRenaming || !isValidFileName(trimmedName) || trimmedName === entry.name}
+                >
+                  {isRenaming ? 'Renaming...' : 'Rename'}
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {deleteOpen && (
+        <AlertDialog open onOpenChange={(open) => { if (!isDeleting) setDeleteOpen(open) }}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete {entryLabel}</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to permanently delete “{entry.name}”?
+                {isDirectory ? ' Everything inside it will also be deleted.' : ''} This action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleDelete}
+                disabled={isDeleting}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                {isDeleting ? 'Deleting...' : 'Delete'}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </>
+  )
+}

--- a/src/renderer/components/file-preview/renderers/file-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/file-renderer.tsx
@@ -10,21 +10,16 @@ import { AudioRenderer } from './audio-renderer'
 import { HtmlRenderer } from './html-renderer'
 import { UnsupportedRenderer } from './unsupported-renderer'
 import { useFilePreview } from '@renderer/context/file-preview-context'
+import {
+  AUDIO_EXTS,
+  CSV_EXTS,
+  IMAGE_EXTS,
+  MARKDOWN_EXTS,
+  TEXT_EXTS,
+  VIDEO_EXTS,
+} from '../file-types'
 
 const PdfRenderer = lazy(() => import('./pdf-renderer').then(m => ({ default: m.PdfRenderer })))
-
-const MARKDOWN_EXTS = new Set(['md', 'markdown'])
-const CSV_EXTS = new Set(['csv', 'tsv'])
-const TEXT_EXTS = new Set([
-  'txt', 'log', 'json', 'xml', 'yml', 'yaml', 'toml', 'ini', 'cfg',
-  'env', 'sh', 'bash', 'zsh', 'py', 'js', 'ts', 'tsx', 'jsx', 'css',
-  'scss', 'less', 'sql', 'graphql', 'proto', 'dockerfile', 'makefile',
-  'gitignore', 'editorconfig', 'rs', 'go', 'java', 'kt', 'swift', 'rb', 'php',
-  'c', 'cpp', 'h', 'hpp', 'r',
-])
-const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'ico'])
-const VIDEO_EXTS = new Set(['mp4', 'mov', 'webm', 'm4v', 'ogv'])
-const AUDIO_EXTS = new Set(['mp3', 'wav', 'm4a', 'aac', 'ogg', 'oga', 'opus', 'flac', 'weba'])
 
 interface FileRendererProps {
   filePath: string

--- a/src/renderer/components/file-preview/renderers/unsupported-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/unsupported-renderer.tsx
@@ -2,6 +2,7 @@ import { Download, FileQuestion } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { FileTypeIcon } from '@renderer/components/ui/file-type-icon'
 import { getApiBaseUrl } from '@renderer/lib/env'
+import { getAgentFileApiPath } from '@renderer/lib/workspace-file-url'
 
 interface UnsupportedRendererProps {
   filePath: string
@@ -12,14 +13,10 @@ function getFilename(filePath: string): string {
   return filePath.split('/').pop() || filePath
 }
 
-function getRelativePath(filePath: string): string {
-  return filePath.replace(/^\/workspace\//, '')
-}
-
 export function UnsupportedRenderer({ filePath, agentSlug }: UnsupportedRendererProps) {
   const filename = getFilename(filePath)
   const baseUrl = getApiBaseUrl()
-  const downloadUrl = `${baseUrl}/api/agents/${agentSlug}/files/${getRelativePath(filePath)}`
+  const downloadUrl = `${baseUrl}${getAgentFileApiPath(agentSlug, filePath)}`
 
   return (
     <div className="flex flex-col items-center justify-center gap-4 py-16 px-8 text-center">

--- a/src/renderer/components/tray/tray-manager.tsx
+++ b/src/renderer/components/tray/tray-manager.tsx
@@ -19,7 +19,7 @@ interface TrayManagerProps {
 
 export function TrayManager({ agentSlug, sessionId, browserActive }: TrayManagerProps) {
   const filePreview = useFilePreview()
-  const hasOpenFiles = filePreview.openFiles.length > 0 && filePreview.isOpen
+  const hasOpenFiles = filePreview.openTabs.length > 0 && filePreview.isOpen
   const workflow = useWorkflow()
   const hasWorkflow = workflow.openWorkflows.length > 0 && workflow.isOpen
   const [selectedTrayId, setSelectedTrayId] = useState<string>('browser')
@@ -96,7 +96,7 @@ export function TrayManager({ agentSlug, sessionId, browserActive }: TrayManager
       icon: FileText,
       label: 'Files',
       available: hasOpenFiles,
-      badge: filePreview.openFiles.length,
+      badge: filePreview.openTabs.length,
       content: filePreviewTrayContent,
     },
     {
@@ -107,7 +107,7 @@ export function TrayManager({ agentSlug, sessionId, browserActive }: TrayManager
       badge: workflow.openWorkflows.length,
       content: workflowTrayContent,
     },
-  ], [browserActive, hasOpenFiles, filePreview.openFiles.length, browserTrayContent, filePreviewTrayContent, hasWorkflow, workflow.openWorkflows.length, workflowTrayContent])
+  ], [browserActive, hasOpenFiles, filePreview.openTabs.length, browserTrayContent, filePreviewTrayContent, hasWorkflow, workflow.openWorkflows.length, workflowTrayContent])
 
   const availableTrays = trays.filter(t => t.available)
   const anyAvailable = availableTrays.length > 0
@@ -122,7 +122,7 @@ export function TrayManager({ agentSlug, sessionId, browserActive }: TrayManager
     }
   }, [browserActive, userClosed])
 
-  const fileCount = filePreview.openFiles.length
+  const fileCount = filePreview.openTabs.length
   useEffect(() => {
     if (hasOpenFiles && !userClosed) {
       requestAnimationFrame(() => {

--- a/src/renderer/components/ui/file-download-pill.test.tsx
+++ b/src/renderer/components/ui/file-download-pill.test.tsx
@@ -8,12 +8,12 @@ import { FileDownloadPill } from './file-download-pill'
 vi.mock('@renderer/context/file-preview-context', () => ({
   useFilePreview: () => ({
     openFile: vi.fn(),
-    openFiles: [],
-    activeFileIndex: 0,
+    openTabs: [],
+    activeTabIndex: 0,
     comments: new Map(),
     isOpen: false,
-    closeFile: vi.fn(),
-    setActiveFile: vi.fn(),
+    closeTab: vi.fn(),
+    setActiveTab: vi.fn(),
     close: vi.fn(),
     addComment: vi.fn(),
     removeComment: vi.fn(),

--- a/src/renderer/context/file-preview-context.test.tsx
+++ b/src/renderer/context/file-preview-context.test.tsx
@@ -27,17 +27,20 @@ describe('FilePreviewContext', () => {
   describe('openFile', () => {
     it('adds a tab and sets isOpen', () => {
       const { result } = renderHook(() => useFilePreview(), { wrapper })
-      expect(result.current.openFiles).toHaveLength(0)
+      expect(result.current.openTabs).toHaveLength(0)
       expect(result.current.isOpen).toBe(false)
 
       act(() => result.current.openFile('/workspace/report.md', 'agent-1'))
 
-      expect(result.current.openFiles).toHaveLength(1)
-      expect(result.current.openFiles[0].filePath).toBe('/workspace/report.md')
-      expect(result.current.openFiles[0].displayName).toBe('report.md')
-      expect(result.current.openFiles[0].version).toBe(0)
+      expect(result.current.openTabs).toHaveLength(1)
+      expect(result.current.openTabs[0]).toMatchObject({
+        kind: 'file',
+        filePath: '/workspace/report.md',
+        displayName: 'report.md',
+        version: 0,
+      })
       expect(result.current.isOpen).toBe(true)
-      expect(result.current.activeFileIndex).toBe(0)
+      expect(result.current.activeTabIndex).toBe(0)
     })
 
     it('switches to existing tab without duplicating', () => {
@@ -46,40 +49,164 @@ describe('FilePreviewContext', () => {
       act(() => result.current.openFile('/workspace/b.md', 'agent-1'))
       act(() => result.current.openFile('/workspace/a.md', 'agent-1'))
 
-      expect(result.current.openFiles).toHaveLength(2)
-      expect(result.current.activeFileIndex).toBe(0)
+      expect(result.current.openTabs).toHaveLength(2)
+      expect(result.current.activeTabIndex).toBe(0)
     })
 
     it('bumps version on re-delivery of same file', () => {
       const { result } = renderHook(() => useFilePreview(), { wrapper })
       act(() => result.current.openFile('/workspace/report.md', 'agent-1'))
-      expect(result.current.openFiles[0].version).toBe(0)
+      expect(result.current.openTabs[0]).toMatchObject({ version: 0 })
 
       act(() => result.current.openFile('/workspace/report.md', 'agent-1'))
-      expect(result.current.openFiles[0].version).toBe(1)
+      expect(result.current.openTabs[0]).toMatchObject({ version: 1 })
 
       act(() => result.current.openFile('/workspace/report.md', 'agent-1'))
-      expect(result.current.openFiles[0].version).toBe(2)
+      expect(result.current.openTabs[0]).toMatchObject({ version: 2 })
     })
   })
 
-  describe('closeFile', () => {
+  describe('folder tabs', () => {
+    it('opens a folder once and restores it when reopened', () => {
+      const { result } = renderHook(() => useFilePreview(), { wrapper })
+
+      act(() => result.current.openFolder('/workspace/reports/', 'agent-1'))
+      act(() => result.current.toggleFolder('/workspace/reports', '/workspace/reports/2026'))
+      act(() => result.current.setFolderQuery('/workspace/reports', 'july'))
+      act(() => result.current.selectFolderEntry('/workspace/reports', '/workspace/reports/2026/july.md'))
+      act(() => result.current.openFile('/workspace/other.md', 'agent-1'))
+      act(() => result.current.openFolder('/workspace/reports', 'agent-1'))
+
+      expect(result.current.openTabs).toHaveLength(2)
+      expect(result.current.activeTabIndex).toBe(0)
+      expect(result.current.openTabs[0]).toMatchObject({
+        kind: 'folder',
+        rootPath: '/workspace/reports',
+        query: 'july',
+        selectedPath: '/workspace/reports/2026/july.md',
+        expandedPaths: ['/workspace/reports', '/workspace/reports/2026'],
+      })
+    })
+
+    it('updates folder selection, open tabs, and comments after a file rename', () => {
+      const { result } = renderHook(() => useFilePreview(), { wrapper })
+      const oldPath = '/workspace/reports/old.md'
+      const newPath = '/workspace/reports/new.md'
+
+      act(() => result.current.openFolder('/workspace/reports', 'agent-1'))
+      act(() => result.current.selectFolderEntry('/workspace/reports', oldPath))
+      act(() => result.current.openFile(oldPath, 'agent-1'))
+      act(() => result.current.addComment({ filePath: oldPath, text: 'keep me' }))
+      act(() => result.current.renameFilePath(oldPath, newPath))
+
+      expect(result.current.openTabs[0]).toMatchObject({ selectedPath: newPath })
+      expect(result.current.openTabs[1]).toMatchObject({
+        filePath: newPath,
+        displayName: 'new.md',
+        version: 1,
+      })
+      expect(result.current.comments.get(oldPath)).toBeUndefined()
+      expect(result.current.comments.get(newPath)?.[0]).toMatchObject({
+        filePath: newPath,
+        text: 'keep me',
+      })
+    })
+
+    it('removes an open file tab and clears folder selection after deletion', () => {
+      const { result } = renderHook(() => useFilePreview(), { wrapper })
+      const filePath = '/workspace/reports/old.md'
+
+      act(() => result.current.openFolder('/workspace/reports', 'agent-1'))
+      act(() => result.current.selectFolderEntry('/workspace/reports', filePath))
+      act(() => result.current.openFile(filePath, 'agent-1'))
+      act(() => result.current.addComment({ filePath, text: 'remove me' }))
+      act(() => result.current.setActiveTab(0))
+      act(() => result.current.removeFilePath(filePath))
+
+      expect(result.current.openTabs).toHaveLength(1)
+      expect(result.current.openTabs[0]).toMatchObject({ kind: 'folder' })
+      expect(result.current.openTabs[0]).toHaveProperty('selectedPath', undefined)
+      expect(result.current.comments.get(filePath)).toBeUndefined()
+    })
+
+    it('rebases expanded state, open files, folder tabs, and comments after a directory rename', () => {
+      const { result } = renderHook(() => useFilePreview(), { wrapper })
+      const oldPath = '/workspace/reports/drafts'
+      const newPath = '/workspace/reports/archive'
+      const filePath = `${oldPath}/notes.md`
+
+      act(() => result.current.openFolder('/workspace/reports', 'agent-1'))
+      act(() => result.current.toggleFolder('/workspace/reports', oldPath))
+      act(() => result.current.selectFolderEntry('/workspace/reports', filePath))
+      act(() => result.current.openFile(filePath, 'agent-1'))
+      act(() => result.current.addComment({ filePath, text: 'move me' }))
+      act(() => result.current.openFolder(oldPath, 'agent-1'))
+      act(() => result.current.renameDirectoryPath(oldPath, newPath))
+
+      expect(result.current.openTabs[0]).toMatchObject({
+        rootPath: '/workspace/reports',
+        expandedPaths: ['/workspace/reports', newPath],
+        selectedPath: `${newPath}/notes.md`,
+      })
+      expect(result.current.openTabs[1]).toMatchObject({
+        filePath: `${newPath}/notes.md`,
+        displayName: 'notes.md',
+        version: 1,
+      })
+      expect(result.current.openTabs[2]).toMatchObject({
+        rootPath: newPath,
+        displayName: 'archive',
+        expandedPaths: [newPath],
+      })
+      expect(result.current.comments.get(filePath)).toBeUndefined()
+      expect(result.current.comments.get(`${newPath}/notes.md`)?.[0]).toMatchObject({
+        filePath: `${newPath}/notes.md`,
+        text: 'move me',
+      })
+    })
+
+    it('closes descendant tabs and clears tree state after a directory deletion', () => {
+      const { result } = renderHook(() => useFilePreview(), { wrapper })
+      const directoryPath = '/workspace/reports/drafts'
+      const filePath = `${directoryPath}/notes.md`
+
+      act(() => result.current.openFolder('/workspace/reports', 'agent-1'))
+      act(() => result.current.toggleFolder('/workspace/reports', directoryPath))
+      act(() => result.current.selectFolderEntry('/workspace/reports', filePath))
+      act(() => result.current.openFile(filePath, 'agent-1'))
+      act(() => result.current.addComment({ filePath, text: 'remove me' }))
+      act(() => result.current.openFolder(directoryPath, 'agent-1'))
+      act(() => result.current.removeDirectoryPath(directoryPath))
+
+      expect(result.current.openTabs).toHaveLength(1)
+      expect(result.current.openTabs[0]).toMatchObject({
+        kind: 'folder',
+        rootPath: '/workspace/reports',
+        expandedPaths: ['/workspace/reports'],
+        selectedPath: undefined,
+      })
+      expect(result.current.activeTabIndex).toBe(0)
+      expect(result.current.comments.get(filePath)).toBeUndefined()
+    })
+  })
+
+  describe('closeTab', () => {
     it('removes the tab', () => {
       const { result } = renderHook(() => useFilePreview(), { wrapper })
       act(() => result.current.openFile('/workspace/a.md', 'agent-1'))
       act(() => result.current.openFile('/workspace/b.md', 'agent-1'))
-      act(() => result.current.closeFile('/workspace/a.md'))
+      act(() => result.current.closeTab('file:/workspace/a.md'))
 
-      expect(result.current.openFiles).toHaveLength(1)
-      expect(result.current.openFiles[0].filePath).toBe('/workspace/b.md')
+      expect(result.current.openTabs).toHaveLength(1)
+      expect(result.current.openTabs[0]).toMatchObject({ filePath: '/workspace/b.md' })
     })
 
     it('closes tray when last tab is closed', () => {
       const { result } = renderHook(() => useFilePreview(), { wrapper })
       act(() => result.current.openFile('/workspace/a.md', 'agent-1'))
-      act(() => result.current.closeFile('/workspace/a.md'))
+      act(() => result.current.closeTab('file:/workspace/a.md'))
 
-      expect(result.current.openFiles).toHaveLength(0)
+      expect(result.current.openTabs).toHaveLength(0)
       expect(result.current.isOpen).toBe(false)
     })
 
@@ -89,12 +216,12 @@ describe('FilePreviewContext', () => {
       act(() => result.current.openFile('/workspace/b.md', 'agent-1'))
       act(() => result.current.openFile('/workspace/c.md', 'agent-1'))
       // Active is c (index 2)
-      expect(result.current.activeFileIndex).toBe(2)
+      expect(result.current.activeTabIndex).toBe(2)
 
-      act(() => result.current.closeFile('/workspace/a.md'))
+      act(() => result.current.closeTab('file:/workspace/a.md'))
       // c is now at index 1
-      expect(result.current.activeFileIndex).toBe(1)
-      expect(result.current.openFiles[result.current.activeFileIndex].filePath).toBe('/workspace/c.md')
+      expect(result.current.activeTabIndex).toBe(1)
+      expect(result.current.openTabs[result.current.activeTabIndex]).toMatchObject({ filePath: '/workspace/c.md' })
     })
 
     it('adjusts activeFileIndex when closing active tab', () => {
@@ -103,11 +230,11 @@ describe('FilePreviewContext', () => {
       act(() => result.current.openFile('/workspace/b.md', 'agent-1'))
       act(() => result.current.openFile('/workspace/c.md', 'agent-1'))
       // Switch to b (index 1)
-      act(() => result.current.setActiveFile(1))
-      act(() => result.current.closeFile('/workspace/b.md'))
+      act(() => result.current.setActiveTab(1))
+      act(() => result.current.closeTab('file:/workspace/b.md'))
 
       // Should stay at index 1 (now c) or go to 0 if at end
-      expect(result.current.activeFileIndex).toBeLessThan(result.current.openFiles.length)
+      expect(result.current.activeTabIndex).toBeLessThan(result.current.openTabs.length)
     })
 
     it('clears comments for the closed file', () => {
@@ -116,7 +243,7 @@ describe('FilePreviewContext', () => {
       act(() => result.current.addComment({ filePath: '/workspace/a.md', text: 'test' }))
       expect(result.current.comments.get('/workspace/a.md')).toHaveLength(1)
 
-      act(() => result.current.closeFile('/workspace/a.md'))
+      act(() => result.current.closeTab('file:/workspace/a.md'))
       expect(result.current.comments.get('/workspace/a.md')).toBeUndefined()
     })
   })
@@ -127,14 +254,14 @@ describe('FilePreviewContext', () => {
       act(() => result.current.openFile('/workspace/a.md', 'agent-1'))
       act(() => result.current.addComment({ filePath: '/workspace/a.md', text: 'note' }))
 
-      expect(result.current.openFiles).toHaveLength(1)
+      expect(result.current.openTabs).toHaveLength(1)
       expect(result.current.isOpen).toBe(true)
 
       // Change session
       mockView = { kind: 'session', id: 'session-2' }
       rerender()
 
-      expect(result.current.openFiles).toHaveLength(0)
+      expect(result.current.openTabs).toHaveLength(0)
       expect(result.current.isOpen).toBe(false)
       expect(result.current.comments.size).toBe(0)
     })

--- a/src/renderer/context/file-preview-context.tsx
+++ b/src/renderer/context/file-preview-context.tsx
@@ -2,11 +2,28 @@ import { createContext, useContext, useState, useCallback, useEffect, useMemo, t
 import { useRouteLocation } from '@renderer/router/use-route-location'
 
 export interface FileTab {
+  kind: 'file'
   filePath: string
   agentSlug: string
   displayName: string
   description?: string
   version: number
+}
+
+export interface FolderTab {
+  kind: 'folder'
+  rootPath: string
+  agentSlug: string
+  displayName: string
+  expandedPaths: string[]
+  selectedPath?: string
+  query: string
+}
+
+export type PreviewTab = FileTab | FolderTab
+
+export function getPreviewTabKey(tab: PreviewTab): string {
+  return tab.kind === 'file' ? `file:${tab.filePath}` : `folder:${tab.rootPath}`
 }
 
 export interface CellRef {
@@ -34,15 +51,23 @@ export interface FileComment {
 }
 
 interface FilePreviewContextType {
-  openFiles: FileTab[]
-  activeFileIndex: number
+  openTabs: PreviewTab[]
+  activeTabIndex: number
   comments: Map<string, FileComment[]>
   isOpen: boolean
   commentsEnabled: boolean
 
   openFile: (filePath: string, agentSlug: string, description?: string) => void
-  closeFile: (filePath: string) => void
-  setActiveFile: (index: number) => void
+  openFolder: (folderPath: string, agentSlug: string) => void
+  toggleFolder: (rootPath: string, folderPath: string) => void
+  setFolderQuery: (rootPath: string, query: string) => void
+  selectFolderEntry: (rootPath: string, entryPath: string) => void
+  renameFilePath: (oldPath: string, newPath: string) => void
+  removeFilePath: (filePath: string) => void
+  renameDirectoryPath: (oldPath: string, newPath: string) => void
+  removeDirectoryPath: (directoryPath: string) => void
+  closeTab: (tabKey: string) => void
+  setActiveTab: (index: number) => void
   close: () => void
 
   addComment: (comment: Omit<FileComment, 'id'>) => void
@@ -53,7 +78,22 @@ interface FilePreviewContextType {
 const FilePreviewContext = createContext<FilePreviewContextType | null>(null)
 
 function getDisplayName(filePath: string): string {
-  return filePath.split('/').pop() || filePath
+  const normalized = filePath.replace(/\/+$/, '')
+  return normalized.split('/').pop() || normalized
+}
+
+function normalizeFolderPath(folderPath: string): string {
+  return folderPath === '/' ? folderPath : folderPath.replace(/\/+$/, '')
+}
+
+function isPathAtOrBelow(basePath: string, candidatePath: string): boolean {
+  return candidatePath === basePath || candidatePath.startsWith(`${basePath}/`)
+}
+
+function replacePathPrefix(candidatePath: string, oldPath: string, newPath: string): string {
+  return isPathAtOrBelow(oldPath, candidatePath)
+    ? `${newPath}${candidatePath.slice(oldPath.length)}`
+    : candidatePath
 }
 
 let commentIdCounter = 0
@@ -72,47 +112,121 @@ export function FilePreviewProvider({
   // state clears when switching sessions; otherwise derive from the active route.
   const sessionId = sessionIdProp !== undefined ? sessionIdProp : (view.kind === 'session' ? view.id : null)
 
-  const [openFiles, setOpenFiles] = useState<FileTab[]>([])
-  const [activeFileIndex, setActiveFileIndex] = useState(0)
+  const [openTabs, setOpenTabs] = useState<PreviewTab[]>([])
+  const [activeTabIndex, setActiveTabIndex] = useState(0)
   const [comments, setComments] = useState<Map<string, FileComment[]>>(new Map())
   const [isOpen, setIsOpen] = useState(false)
 
   // Clear state when session changes
   useEffect(() => {
-    setOpenFiles([])
-    setActiveFileIndex(0)
+    setOpenTabs([])
+    setActiveTabIndex(0)
     setComments(new Map())
     setIsOpen(false)
   }, [sessionId])
 
   const openFile = useCallback((filePath: string, agentSlug: string, description?: string) => {
-    setOpenFiles(prev => {
-      const existingIndex = prev.findIndex(f => f.filePath === filePath)
+    setOpenTabs(prev => {
+      const existingIndex = prev.findIndex(tab => tab.kind === 'file' && tab.filePath === filePath)
       if (existingIndex >= 0) {
-        setActiveFileIndex(existingIndex)
+        setActiveTabIndex(existingIndex)
         setIsOpen(true)
         const next = [...prev]
-        next[existingIndex] = { ...next[existingIndex], version: next[existingIndex].version + 1 }
+        const existing = next[existingIndex] as FileTab
+        next[existingIndex] = { ...existing, version: existing.version + 1 }
         return next
       }
-      const newTab: FileTab = { filePath, agentSlug, displayName: getDisplayName(filePath), description, version: 0 }
+      const newTab: FileTab = { kind: 'file', filePath, agentSlug, displayName: getDisplayName(filePath), description, version: 0 }
       const next = [...prev, newTab]
-      setActiveFileIndex(next.length - 1)
+      setActiveTabIndex(next.length - 1)
       setIsOpen(true)
       return next
     })
   }, [])
 
-  const closeFile = useCallback((filePath: string) => {
-    setOpenFiles(prev => {
-      const idx = prev.findIndex(f => f.filePath === filePath)
+  const openFolder = useCallback((folderPath: string, agentSlug: string) => {
+    const rootPath = normalizeFolderPath(folderPath)
+    setOpenTabs(prev => {
+      const existingIndex = prev.findIndex(tab => tab.kind === 'folder' && tab.rootPath === rootPath)
+      if (existingIndex >= 0) {
+        setActiveTabIndex(existingIndex)
+        setIsOpen(true)
+        return prev
+      }
+
+      const newTab: FolderTab = {
+        kind: 'folder',
+        rootPath,
+        agentSlug,
+        displayName: getDisplayName(rootPath),
+        expandedPaths: [rootPath],
+        query: '',
+      }
+      const next = [...prev, newTab]
+      setActiveTabIndex(next.length - 1)
+      setIsOpen(true)
+      return next
+    })
+  }, [])
+
+  const toggleFolder = useCallback((rootPath: string, folderPath: string) => {
+    setOpenTabs(prev => prev.map(tab => {
+      if (tab.kind !== 'folder' || tab.rootPath !== rootPath || folderPath === rootPath) return tab
+      const expanded = new Set(tab.expandedPaths)
+      if (expanded.has(folderPath)) expanded.delete(folderPath)
+      else expanded.add(folderPath)
+      return { ...tab, expandedPaths: Array.from(expanded) }
+    }))
+  }, [])
+
+  const setFolderQuery = useCallback((rootPath: string, query: string) => {
+    setOpenTabs(prev => prev.map(tab => (
+      tab.kind === 'folder' && tab.rootPath === rootPath ? { ...tab, query } : tab
+    )))
+  }, [])
+
+  const selectFolderEntry = useCallback((rootPath: string, entryPath: string) => {
+    setOpenTabs(prev => prev.map(tab => (
+      tab.kind === 'folder' && tab.rootPath === rootPath ? { ...tab, selectedPath: entryPath } : tab
+    )))
+  }, [])
+
+  const renameFilePath = useCallback((oldPath: string, newPath: string) => {
+    setOpenTabs(prev => prev.map(tab => {
+      if (tab.kind === 'file' && tab.filePath === oldPath) {
+        return {
+          ...tab,
+          filePath: newPath,
+          displayName: getDisplayName(newPath),
+          version: tab.version + 1,
+        }
+      }
+      if (tab.kind === 'folder' && tab.selectedPath === oldPath) {
+        return { ...tab, selectedPath: newPath }
+      }
+      return tab
+    }))
+    setComments(prev => {
+      const existing = prev.get(oldPath)
+      if (!existing) return prev
+      const next = new Map(prev)
+      next.delete(oldPath)
+      next.set(newPath, existing.map(comment => ({ ...comment, filePath: newPath })))
+      return next
+    })
+  }, [])
+
+  const closeTab = useCallback((tabKey: string) => {
+    const closedFilePath = tabKey.startsWith('file:') ? tabKey.slice('file:'.length) : null
+    setOpenTabs(prev => {
+      const idx = prev.findIndex(tab => getPreviewTabKey(tab) === tabKey)
       if (idx < 0) return prev
       const next = prev.filter((_, i) => i !== idx)
       if (next.length === 0) {
         setIsOpen(false)
-        setActiveFileIndex(0)
+        setActiveTabIndex(0)
       } else {
-        setActiveFileIndex(curr => {
+        setActiveTabIndex(curr => {
           if (curr >= next.length) return next.length - 1
           if (curr > idx) return curr - 1
           return curr
@@ -120,15 +234,109 @@ export function FilePreviewProvider({
       }
       return next
     })
+    if (closedFilePath) {
+      setComments(prev => {
+        const next = new Map(prev)
+        next.delete(closedFilePath!)
+        return next
+      })
+    }
+  }, [])
+
+  const removeFilePath = useCallback((filePath: string) => {
+    closeTab(`file:${filePath}`)
+    setOpenTabs(prev => prev.map(tab => (
+      tab.kind === 'folder' && tab.selectedPath === filePath
+        ? { ...tab, selectedPath: undefined }
+        : tab
+    )))
+  }, [closeTab])
+
+  const renameDirectoryPath = useCallback((oldPath: string, newPath: string) => {
+    setOpenTabs(prev => prev.map(tab => {
+      if (tab.kind === 'file') {
+        const filePath = replacePathPrefix(tab.filePath, oldPath, newPath)
+        return filePath === tab.filePath
+          ? tab
+          : { ...tab, filePath, displayName: getDisplayName(filePath), version: tab.version + 1 }
+      }
+
+      const rootPath = replacePathPrefix(tab.rootPath, oldPath, newPath)
+      const expandedPaths = Array.from(new Set(
+        tab.expandedPaths.map(folderPath => replacePathPrefix(folderPath, oldPath, newPath)),
+      ))
+      const selectedPath = tab.selectedPath
+        ? replacePathPrefix(tab.selectedPath, oldPath, newPath)
+        : undefined
+      return {
+        ...tab,
+        rootPath,
+        displayName: rootPath === tab.rootPath ? tab.displayName : getDisplayName(rootPath),
+        expandedPaths,
+        selectedPath,
+      }
+    }))
     setComments(prev => {
-      const next = new Map(prev)
-      next.delete(filePath)
-      return next
+      let changed = false
+      const next = new Map<string, FileComment[]>()
+      for (const [filePath, fileComments] of prev) {
+        const nextPath = replacePathPrefix(filePath, oldPath, newPath)
+        changed ||= nextPath !== filePath
+        next.set(nextPath, nextPath === filePath
+          ? fileComments
+          : fileComments.map(comment => ({ ...comment, filePath: nextPath })))
+      }
+      return changed ? next : prev
     })
   }, [])
 
-  const setActiveFile = useCallback((index: number) => {
-    setActiveFileIndex(index)
+  const removeDirectoryPath = useCallback((directoryPath: string) => {
+    setOpenTabs(prev => {
+      const next = prev
+        .filter(tab => !isPathAtOrBelow(
+          directoryPath,
+          tab.kind === 'file' ? tab.filePath : tab.rootPath,
+        ))
+        .map(tab => {
+          if (tab.kind !== 'folder') return tab
+          const expandedPaths = tab.expandedPaths.filter(path => !isPathAtOrBelow(directoryPath, path))
+          const selectedPath = tab.selectedPath && isPathAtOrBelow(directoryPath, tab.selectedPath)
+            ? undefined
+            : tab.selectedPath
+          return { ...tab, expandedPaths, selectedPath }
+        })
+
+      if (next.length === 0) {
+        setIsOpen(false)
+        setActiveTabIndex(0)
+      } else {
+        setActiveTabIndex(current => {
+          const activeTab = prev[current]
+          if (activeTab) {
+            const activeKey = getPreviewTabKey(activeTab)
+            const retainedIndex = next.findIndex(tab => getPreviewTabKey(tab) === activeKey)
+            if (retainedIndex >= 0) return retainedIndex
+          }
+          return Math.min(current, next.length - 1)
+        })
+      }
+      return next
+    })
+    setComments(prev => {
+      const next = new Map(prev)
+      let changed = false
+      for (const filePath of next.keys()) {
+        if (isPathAtOrBelow(directoryPath, filePath)) {
+          next.delete(filePath)
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+  }, [])
+
+  const setActiveTab = useCallback((index: number) => {
+    setActiveTabIndex(index)
   }, [])
 
   const close = useCallback(() => {
@@ -168,19 +376,27 @@ export function FilePreviewProvider({
   }, [])
 
   const value = useMemo<FilePreviewContextType>(() => ({
-    openFiles,
-    activeFileIndex,
+    openTabs,
+    activeTabIndex,
     comments,
     isOpen,
     commentsEnabled,
     openFile,
-    closeFile,
-    setActiveFile,
+    openFolder,
+    toggleFolder,
+    setFolderQuery,
+    selectFolderEntry,
+    renameFilePath,
+    removeFilePath,
+    renameDirectoryPath,
+    removeDirectoryPath,
+    closeTab,
+    setActiveTab,
     close,
     addComment,
     removeComment,
     clearComments,
-  }), [openFiles, activeFileIndex, comments, isOpen, commentsEnabled, openFile, closeFile, setActiveFile, close, addComment, removeComment, clearComments])
+  }), [openTabs, activeTabIndex, comments, isOpen, commentsEnabled, openFile, openFolder, toggleFolder, setFolderQuery, selectFolderEntry, renameFilePath, removeFilePath, renameDirectoryPath, removeDirectoryPath, closeTab, setActiveTab, close, addComment, removeComment, clearComments])
 
   return (
     <FilePreviewContext.Provider value={value}>

--- a/src/renderer/hooks/use-bookmarks.ts
+++ b/src/renderer/hooks/use-bookmarks.ts
@@ -5,6 +5,7 @@ export interface Bookmark {
   name: string
   link?: string
   file?: string
+  folder?: string
 }
 
 export function useBookmarks(agentSlug: string | null) {

--- a/src/renderer/hooks/use-file-delivery-watcher.test.ts
+++ b/src/renderer/hooks/use-file-delivery-watcher.test.ts
@@ -18,12 +18,12 @@ vi.mock('./use-message-stream', () => ({
 vi.mock('@renderer/context/file-preview-context', () => ({
   useFilePreview: () => ({
     openFile: mockOpenFile,
-    openFiles: [],
-    activeFileIndex: 0,
+    openTabs: [],
+    activeTabIndex: 0,
     comments: new Map(),
     isOpen: false,
-    closeFile: vi.fn(),
-    setActiveFile: vi.fn(),
+    closeTab: vi.fn(),
+    setActiveTab: vi.fn(),
     close: vi.fn(),
     addComment: vi.fn(),
     removeComment: vi.fn(),

--- a/src/renderer/hooks/use-folder-entries.ts
+++ b/src/renderer/hooks/use-folder-entries.ts
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@renderer/lib/api'
+
+export interface FolderEntry {
+  name: string
+  path: string
+  type: 'file' | 'directory'
+}
+
+export interface FolderEntriesResponse {
+  root: string
+  path: string
+  entries: FolderEntry[]
+  truncated: boolean
+}
+
+export class FolderEntriesError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message)
+  }
+}
+
+export function useFolderEntries(
+  agentSlug: string,
+  rootPath: string,
+  folderPath: string,
+  enabled = true,
+) {
+  return useQuery<FolderEntriesResponse>({
+    queryKey: ['folder-entries', agentSlug, rootPath, folderPath],
+    queryFn: async () => {
+      const params = new URLSearchParams({ root: rootPath, path: folderPath })
+      const res = await apiFetch(
+        `/api/agents/${encodeURIComponent(agentSlug)}/folders?${params.toString()}`,
+      )
+      if (!res.ok) {
+        const payload = await res.json().catch(() => null) as { error?: string } | null
+        throw new FolderEntriesError(payload?.error ?? 'Failed to load folder', res.status)
+      }
+      return res.json()
+    },
+    enabled,
+    staleTime: 5_000,
+    retry: false,
+  })
+}

--- a/src/renderer/lib/workspace-file-url.test.ts
+++ b/src/renderer/lib/workspace-file-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { encodeWorkspaceFilePath, getAgentFileApiPath } from './workspace-file-url'
+
+describe('workspace file URLs', () => {
+  it('encodes every path segment without encoding separators', () => {
+    expect(encodeWorkspaceFilePath('/workspace/Reports & 2026/résumé #1?.md')).toBe(
+      'Reports%20%26%202026/r%C3%A9sum%C3%A9%20%231%3F.md',
+    )
+  })
+
+  it('encodes the agent slug', () => {
+    expect(getAgentFileApiPath('Agent #1', '/workspace/report.md')).toBe(
+      '/api/agents/Agent%20%231/files/report.md',
+    )
+  })
+})

--- a/src/renderer/lib/workspace-file-url.ts
+++ b/src/renderer/lib/workspace-file-url.ts
@@ -1,0 +1,13 @@
+/** Convert a container workspace path into safely encoded API path segments. */
+export function encodeWorkspaceFilePath(filePath: string): string {
+  const relativePath = filePath.replace(/^\/workspace\/?/, '')
+  return relativePath
+    .split('/')
+    .filter(Boolean)
+    .map(segment => encodeURIComponent(segment))
+    .join('/')
+}
+
+export function getAgentFileApiPath(agentSlug: string, filePath: string): string {
+  return `/api/agents/${encodeURIComponent(agentSlug)}/files/${encodeWorkspaceFilePath(filePath)}`
+}

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -15,7 +15,7 @@ import type {
 } from './types'
 import type { RuntimeOptions } from './runtime-options'
 import { resolveContainerModel } from './resolve-model'
-import { getSessionJsonlPath } from '../utils/file-storage'
+import { getAgentWorkspaceDir, getSessionJsonlPath } from '../utils/file-storage'
 import { reviewManager } from '../proxy/review-manager'
 import { db } from '../db'
 import { connectedAccounts } from '../db/schema'
@@ -1977,8 +1977,58 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     return {}
   }
 
-  async fetch(fetchPath: string, _init?: RequestInit): Promise<Response> {
+  async fetch(fetchPath: string, init?: RequestInit): Promise<Response> {
     // Mock fetch - return appropriate empty responses based on path
+
+    // Workspace entry mutations are executed inside the real agent container.
+    // The E2E mock has no container namespace, so mirror the operation against
+    // its test workspace to keep the browser flow representative.
+    if (fetchPath === '/workspace/entries') {
+      try {
+        const body = JSON.parse(String(init?.body)) as {
+          path: string
+          name?: string
+          type: 'file' | 'directory'
+        }
+        const relativePath = path.posix.relative('/workspace', path.posix.normalize(body.path))
+        if (!relativePath || relativePath === '..' || relativePath.startsWith('../')) {
+          return new Response(JSON.stringify({ error: 'Invalid workspace path' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+        const sourcePath = path.join(getAgentWorkspaceDir(this.config.agentId), ...relativePath.split('/'))
+
+        if (init?.method === 'PATCH' && body.name) {
+          const destinationPath = path.join(path.dirname(sourcePath), body.name)
+          await fs.promises.rename(sourcePath, destinationPath)
+          return new Response(JSON.stringify({
+            path: path.posix.join(path.posix.dirname(body.path), body.name),
+            name: body.name,
+          }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+
+        if (init?.method === 'DELETE') {
+          if (body.type === 'directory') await fs.promises.rm(sourcePath, { recursive: true })
+          else await fs.promises.unlink(sourcePath)
+          return new Response(JSON.stringify({ success: true }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+
+        return new Response(JSON.stringify({ error: 'Invalid workspace operation' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code
+        const status = code === 'ENOENT' ? 404 : code === 'EEXIST' ? 409 : 500
+        return new Response(JSON.stringify({
+          error: error instanceof Error ? error.message : 'Workspace operation failed',
+        }), { status, headers: { 'Content-Type': 'application/json' } })
+      }
+    }
 
     // Browser status — used by frontend when WebSocket closes to check if browser is still active
     if (fetchPath === '/browser/status') {


### PR DESCRIPTION
## Summary

- open bookmarked folders and the Agent Directory in the built-in file-preview tray
- add lazy folder traversal, substring-highlighted filtering, and compact file/folder tabs
- add file and directory context menus for bookmarking, downloading, renaming, deleting, copying text, and revealing entries in Electron
- keep the preview tray overlay-only at constrained widths, with a full-width compact state instead of split mode
- restrict full workspace enumeration to agent owners and execute destructive workspace mutations inside the agent container namespace

## Why

Local bookmarks previously only handled individual files, and Agent Directory delegated to the system browser. This adds a native, cross-platform workspace browser without exposing the full workspace to viewers or allowing host-path races during rename/delete operations.

## Validation

- npm run typecheck
- focused app tests: 11 files / 297 tests passed
- focused agent-container tests: 2 files / 33 tests passed
- full app suite: 414 files passed; 2 localhost-binding specs rerun outside the sandbox and passed (48 tests)
- full agent-container suite: 43 files passed, 3 skipped; 716 tests passed, 8 skipped
- npm run lint (0 errors; existing warnings only)
- npm run build:web
- npm run build:api
- npm run build:electron
- npm --prefix agent-container run build
- focused Playwright folder-bookmark flow passed