### PR TITLE
fix: skip host auto-sleep scans for Lambda MicroVM

### DIFF
--- a/src/shared/lib/container/base-container-client.test.ts
+++ b/src/shared/lib/container/base-container-client.test.ts
@@ -31,6 +31,12 @@ class TestContainerClient extends BaseContainerClient {
   }
 }
 
+describe('host auto-sleep', () => {
+  it('is enabled by default for container runtimes', () => {
+    expect(new TestContainerClient({ agentId: 'a' }).shouldRunHostAutoSleep()).toBe(true)
+  })
+})
+
 describe('buildAgentEnv', () => {
   afterEach(() => enableToolSearch.mockReturnValue(true))
 

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -289,6 +289,10 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     this.config = config
   }
 
+  shouldRunHostAutoSleep(): boolean {
+    return true
+  }
+
   /**
    * Emit an 'error' event without crashing the process.
    *

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -113,6 +113,10 @@ class ContainerManager {
     return client
   }
 
+  shouldRunHostAutoSleep(agentId: string): boolean {
+    return this.getClient(agentId).shouldRunHostAutoSleep()
+  }
+
   /**
    * Get cached container info. Returns cached status if available,
    * otherwise returns stopped (will be corrected on next sync).

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -475,6 +475,10 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
   })
 
+  it('disables host auto-sleep because idlePolicy owns idle', () => {
+    expect(newClient().shouldRunHostAutoSleep()).toBe(false)
+  })
+
   it('a plain stop() suspends (preserves state for warm resume), not terminate', async () => {
     const client = newClient()
     await client.start()

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -739,6 +739,10 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
 
   // Proxy-level retry handles the suspend→resume 502 window for all HTTP calls.
 
+  shouldRunHostAutoSleep(): boolean {
+    return false
+  }
+
   async stop(options?: StopOptions): Promise<StopResult> {
     this.terminateWebSocketConnections()
     // Auto-sleep is handled by AWS idlePolicy; the host-app sweep is a no-op.

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1920,6 +1920,10 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
 
   // Lifecycle management
 
+  shouldRunHostAutoSleep(): boolean {
+    return true
+  }
+
   async start(options?: StartOptions): Promise<void> {
     this.running = true
     // Surface the container env that carries the proxy credentials so E2E

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -132,6 +132,7 @@ export interface ContainerClient {
   start(options?: StartOptions): Promise<void>
   stop(options?: StopOptions): Promise<StopResult>
   stopSync(): void // Synchronous stop for exit handlers
+  shouldRunHostAutoSleep(): boolean
 
   // Build a -v flag value for a volume mount (hostPath:containerPath with runtime-specific suffix)
   buildVolumeFlag(hostPath: string, containerPath: string): string

--- a/src/shared/lib/scheduler/auto-sleep-monitor.test.ts
+++ b/src/shared/lib/scheduler/auto-sleep-monitor.test.ts
@@ -8,6 +8,7 @@ import type { SessionInfo } from '@shared/lib/types/agent'
 const mockGetRunningAgentIds = vi.fn<() => string[]>(() => [])
 const mockGetContainerStartTime = vi.fn<(id: string) => number | undefined>()
 const mockGetLastKeepAlive = vi.fn<(id: string) => number | undefined>()
+const mockShouldRunHostAutoSleep = vi.fn<(id: string) => boolean>(() => true)
 const mockStopContainer = vi.fn()
 
 vi.mock('@shared/lib/container/container-manager', () => ({
@@ -15,6 +16,7 @@ vi.mock('@shared/lib/container/container-manager', () => ({
     getRunningAgentIds: () => mockGetRunningAgentIds(),
     getContainerStartTime: (id: string) => mockGetContainerStartTime(id),
     getLastKeepAlive: (id: string) => mockGetLastKeepAlive(id),
+    shouldRunHostAutoSleep: (id: string) => mockShouldRunHostAutoSleep(id),
     stopContainer: (...args: unknown[]) => mockStopContainer(...args),
   },
 }))
@@ -73,6 +75,7 @@ describe('AutoSleepMonitor', () => {
     mockListSessions.mockResolvedValue([])
     mockGetContainerStartTime.mockReturnValue(undefined)
     mockGetLastKeepAlive.mockReturnValue(undefined)
+    mockShouldRunHostAutoSleep.mockReturnValue(true)
     mockStopContainer.mockResolvedValue(undefined)
   })
 
@@ -173,6 +176,19 @@ describe('AutoSleepMonitor', () => {
     await autoSleepMonitor.start()
     await tick()
 
+    expect(mockListSessions).not.toHaveBeenCalled()
+    expect(mockStopContainer).not.toHaveBeenCalled()
+  })
+
+  it('skips all session I/O when the runtime owns idle sleep', async () => {
+    mockGetRunningAgentIds.mockReturnValue(['agent-1'])
+    mockShouldRunHostAutoSleep.mockReturnValue(false)
+
+    await autoSleepMonitor.start()
+    await tick()
+
+    expect(mockShouldRunHostAutoSleep).toHaveBeenCalledWith('agent-1')
+    expect(mockHasActiveSessions).not.toHaveBeenCalled()
     expect(mockListSessions).not.toHaveBeenCalled()
     expect(mockStopContainer).not.toHaveBeenCalled()
   })

--- a/src/shared/lib/scheduler/auto-sleep-monitor.ts
+++ b/src/shared/lib/scheduler/auto-sleep-monitor.ts
@@ -76,6 +76,10 @@ class AutoSleepMonitor {
 
       for (const agentId of runningAgentIds) {
         try {
+          if (!containerManager.shouldRunHostAutoSleep(agentId)) {
+            continue
+          }
+
           // Skip if any session is currently processing a request
           if (messagePersister.hasActiveSessionsForAgent(agentId)) {
             continue

--- a/src/shared/lib/scheduler/auto-sleep-monitor.ts
+++ b/src/shared/lib/scheduler/auto-sleep-monitor.ts
@@ -16,6 +16,7 @@ class AutoSleepMonitor {
   private isRunning = false
   private pollIntervalMs = 60000 // Check every minute
   private isProcessing = false
+  private hasLoggedRuntimeManagedIdle = false
 
   /**
    * Start the monitor.
@@ -27,6 +28,7 @@ class AutoSleepMonitor {
     }
 
     this.isRunning = true
+    this.hasLoggedRuntimeManagedIdle = false
     console.log('[AutoSleepMonitor] Starting monitor...')
 
     // Start periodic polling
@@ -77,6 +79,10 @@ class AutoSleepMonitor {
       for (const agentId of runningAgentIds) {
         try {
           if (!containerManager.shouldRunHostAutoSleep(agentId)) {
+            if (!this.hasLoggedRuntimeManagedIdle) {
+              console.log('[AutoSleepMonitor] Runtime owns idle sleep; skipping host session scans')
+              this.hasLoggedRuntimeManagedIdle = true
+            }
             continue
           }
 


### PR DESCRIPTION
## Bug

For Lambda MicroVM agents, the host `AutoSleepMonitor` still walks every running agent once a minute and calls `listSessions()` — session metadata lives on the S3 Files-backed `/data` mount (network filesystem I/O). That scan is wasted work: background auto-sleep already ends in `stop({ escalateToForceStop: false })`, which is a no-op on this runtime because AWS `idlePolicy` performs suspend/resume. So we pay network I/O every minute and reclaim nothing.

Staging already showed how expensive sync work on that mount is: SQLite on `/data` blocked Node for 5.268s and tripped the same 4s ECS health-probe `AbortError` at only ~10.5% CPU. This PR removes one redundant source of `/data` pressure; it does not fix broader SQLite isolation.

## Reproduction

1. Run host-app with `containerRunner=lambda-microvm` and one or more running agents.
2. Wait for the one-minute `AutoSleepMonitor` cycle.
3. Observe `listSessions()` (and related `/data` reads) for each agent even though the eventual MicroVM auto-sleep `stop()` does not suspend or terminate.

## What changed

- Add polymorphic `shouldRunHostAutoSleep()` (default `true` for container runtimes).
- Lambda MicroVM returns `false` so the monitor skips session / keep-alive scans when they cannot reclaim anything.
- Gate that check **before** active-session checks or session filesystem reads.
- Tests: default runtimes stay on host sweep; MicroVM opts out; monitor path does no session I/O when opted out.

## Why this shape (not “host must never Suspend”)

The goal of this PR is **less session / `/data` I/O on S3 Files**, not a claim that host-driven `Suspend` is impossible. Auto-resume on the next inbound request works either way. We skip the host sweep here because, with today’s no-op auto-sleep `stop()`, the scan is pure cost.

## Test plan

- [x] Focused tests: 142 passed
- [x] `npm run lint`: 0 errors (40 existing warnings)
- [ ] `npm run typecheck`: existing missing optional `e2b` / `@daytonaio/sdk` tool dependencies
- [ ] Full `npm run test:run`: 7,516 passed; one unrelated existing failure in `webhook-trigger-service.sup226.test.ts`