### PR TITLE
fix: local-LLM loopback endpoints unreachable on the Apple Container runtime (SUP-447)

### DIFF
--- a/src/renderer/components/layout/agent-banners.tsx
+++ b/src/renderer/components/layout/agent-banners.tsx
@@ -55,9 +55,15 @@ export function AgentBanners({ slug, startAgent }: AgentBannersProps) {
       {/* Start error banner */}
       {startAgent.isError && (
         <div className="shrink-0 border-b bg-destructive/10 px-4 py-2">
-          <div className="flex items-center gap-2 text-xs text-destructive select-text">
-            <AlertCircle className="h-3 w-3 shrink-0" />
-            <span>Failed to start agent: {startAgent.error.message}</span>
+          {/* Start failures may carry multi-line remediation steps (e.g. an
+              unreachable local model naming the bind to change), so keep the
+              newlines and top-align the icon against the first line. Single-line
+              messages are unaffected. */}
+          <div className="flex items-start gap-2 text-xs text-destructive select-text">
+            <AlertCircle className="mt-0.5 h-3 w-3 shrink-0" />
+            <span className="whitespace-pre-line">
+              Failed to start agent: {startAgent.error.message}
+            </span>
           </div>
         </div>
       )}

--- a/src/shared/lib/container/apple-container-client.test.ts
+++ b/src/shared/lib/container/apple-container-client.test.ts
@@ -168,7 +168,8 @@ describe('AppleContainerClient host talk-back (host.docker.internal is NXDOMAIN 
     const client = new AppleContainerClient({ agentId: 'abc123' })
     expect(client.getHostApiBaseUrl()).toBe('http://192.168.64.1:47891')
     expect(client.getHostBridgeIp()).toBe('192.168.64.1')
-    // Cached: one inspect for both calls.
+    expect(client.getContainerHostAddress()).toBe('192.168.64.1')
+    // Cached: one inspect for all three calls.
     expect(mockExecSyncWithPath).toHaveBeenCalledOnce()
   })
 
@@ -176,6 +177,7 @@ describe('AppleContainerClient host talk-back (host.docker.internal is NXDOMAIN 
     mockExecSyncWithPath.mockImplementation(() => { throw new Error('network inspect failed') })
     const client = new AppleContainerClient({ agentId: 'abc123' })
     expect(() => client.getHostApiBaseUrl()).toThrow(/host gateway is unreachable/i)
+    expect(() => client.getContainerHostAddress()).toThrow(/host gateway is unreachable/i)
     expect(client.getHostBridgeIp()).toBeNull()
   })
 })

--- a/src/shared/lib/container/apple-container-client.ts
+++ b/src/shared/lib/container/apple-container-client.ts
@@ -326,20 +326,31 @@ export class AppleContainerClient extends BaseContainerClient {
   }
 
   /**
-   * Containers talk back to the host (LLM proxy, host API) at this URL.
-   * host.docker.internal doesn't resolve here, so use the gateway IP — the
-   * same address Lima aliases that name to via --add-host. Fail closed if
-   * the gateway is unknown: the Docker fallback is NXDOMAIN inside Apple
-   * containers and would start agents with a permanently unreachable proxy.
+   * The vmnet gateway IP, or throw. host.docker.internal doesn't resolve inside
+   * Apple containers, so the gateway IP is the only address they can reach the
+   * host at (the same address Lima aliases that name to via --add-host). Fail
+   * closed when it's unknown: the Docker fallback is NXDOMAIN here and would
+   * start agents with a permanently unreachable host.
    */
-  public getHostApiBaseUrl(): string {
+  private requireGatewayIp(): string {
     const gateway = getAppleGatewayIp()
     if (!gateway) {
       throw new Error(
         'macOS Container host gateway is unreachable. Restart macOS Container and try again.',
       )
     }
-    return `http://${gateway}:${getAppPort()}`
+    return gateway
+  }
+
+  /** Containers talk back to the host (LLM proxy, host API) at this URL. */
+  public getHostApiBaseUrl(): string {
+    return `http://${this.requireGatewayIp()}:${getAppPort()}`
+  }
+
+  /** Loopback LLM endpoints rewrite to this address (host.docker.internal is
+   *  NXDOMAIN here — same fail-closed gateway rule as getHostApiBaseUrl). */
+  getContainerHostAddress(): string {
+    return this.requireGatewayIp()
   }
 
   /** The vmnet gateway is a real host interface — the host-browser CDP proxy

--- a/src/shared/lib/container/base-container-client.test.ts
+++ b/src/shared/lib/container/base-container-client.test.ts
@@ -34,12 +34,22 @@ class TestContainerClient extends BaseContainerClient {
   public testBuildAgentEnv(extra?: Record<string, string>): Record<string, string> {
     return this.buildAgentEnv(extra)
   }
+  public testAssertLocalLlmReachable(): Promise<void> {
+    return this.assertLocalLlmReachable()
+  }
 }
 
 /** Stand-in for Apple: overrides only the host-address hook the runtime owns. */
 class GatewayHostContainerClient extends TestContainerClient {
   getContainerHostAddress(): string {
     return '192.168.64.1'
+  }
+}
+
+/** Stand-in for Apple with an unknown gateway, which fails closed (SUP-447). */
+class UnknownGatewayContainerClient extends TestContainerClient {
+  getContainerHostAddress(): string {
+    throw new Error('macOS Container host gateway is unreachable.')
   }
 }
 
@@ -99,6 +109,31 @@ describe('buildAgentEnv', () => {
       expect.objectContaining({ id: 'podman-agent' }),
       'host.containers.internal',
     )
+  })
+})
+
+describe('assertLocalLlmReachable', () => {
+  afterEach(() => {
+    getContainerHostUrl.mockReturnValue('host.docker.internal')
+    getContainerEnvVars.mockClear()
+  })
+
+  // Byte-identical behavior for Docker/Lima/WSL2/Podman: a forwarding-name host
+  // address reaches the host loopback whatever the bind, so the check must not
+  // consult the provider or touch the network at all.
+  it('does nothing when the runtime host address is a forwarding name', async () => {
+    const client = new TestContainerClient({ agentId: 'docker-agent', envVars: {} })
+    await expect(client.testAssertLocalLlmReachable()).resolves.toBeUndefined()
+    expect(getContainerEnvVars).not.toHaveBeenCalled()
+  })
+
+  // The fail-closed contract this check deliberately defers rather than owns:
+  // it swallows an unknown gateway so the identical throw surfaces from the env
+  // build a few lines later, with the context that belongs to it.
+  it('defers an unknown gateway to the env build, which still fails closed', async () => {
+    const client = new UnknownGatewayContainerClient({ agentId: 'apple-agent', envVars: {} })
+    await expect(client.testAssertLocalLlmReachable()).resolves.toBeUndefined()
+    expect(() => client.testBuildAgentEnv()).toThrow(/gateway is unreachable/i)
   })
 })
 

--- a/src/shared/lib/container/base-container-client.test.ts
+++ b/src/shared/lib/container/base-container-client.test.ts
@@ -9,6 +9,11 @@ const enableToolSearch = vi.fn((): boolean | undefined => true)
 vi.mock('@shared/lib/config/settings', () => ({
   getSettings: () => ({ enableToolSearch: enableToolSearch() }),
 }))
+const getContainerHostUrl = vi.fn(() => 'host.docker.internal')
+vi.mock('@shared/lib/proxy/host-url', () => ({
+  getContainerHostUrl: () => getContainerHostUrl(),
+  getAppPort: () => 47891,
+}))
 const getContainerEnvVars = vi.fn(() => ({ ANTHROPIC_API_KEY: 'provider-key' }))
 vi.mock('@shared/lib/llm-provider', () => ({
   getActiveLlmProvider: () => ({ getContainerEnvVars }),
@@ -31,8 +36,19 @@ class TestContainerClient extends BaseContainerClient {
   }
 }
 
+/** Stand-in for Apple: overrides only the host-address hook the runtime owns. */
+class GatewayHostContainerClient extends TestContainerClient {
+  getContainerHostAddress(): string {
+    return '192.168.64.1'
+  }
+}
+
 describe('buildAgentEnv', () => {
-  afterEach(() => enableToolSearch.mockReturnValue(true))
+  afterEach(() => {
+    enableToolSearch.mockReturnValue(true)
+    getContainerHostUrl.mockReturnValue('host.docker.internal')
+    getContainerEnvVars.mockClear()
+  })
 
   it('merges provider env, constants, config.envVars and per-start extra (later wins)', () => {
     const client = new TestContainerClient({
@@ -53,10 +69,35 @@ describe('buildAgentEnv', () => {
     expect(env.ENABLE_TOOL_SEARCH).toBe('false')
   })
 
-  it('passes the agent identity to the provider so it can attribute LLM usage', () => {
+  it('passes the agent identity and runtime host address to the provider', () => {
     new TestContainerClient({ agentId: 'my-agent', envVars: {} }).testBuildAgentEnv()
     expect(getContainerEnvVars).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'my-agent' })
+      expect.objectContaining({ id: 'my-agent' }),
+      'host.docker.internal',
+    )
+  })
+
+  // Composition seam (SUP-447): runtime override → buildAgentEnv → provider.
+  // Apple's unit tests mock away BaseContainerClient, so the inheritance path
+  // is pinned here with a gateway-IP subclass.
+  it('threads an overridden container host address into the provider', () => {
+    new GatewayHostContainerClient({ agentId: 'apple-agent', envVars: {} }).testBuildAgentEnv()
+    expect(getContainerEnvVars).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'apple-agent' }),
+      '192.168.64.1',
+    )
+  })
+
+  // Podman uses host.containers.internal via getContainerHostUrl. Pre-fix the
+  // rewrite hardcoded host.docker.internal for every runtime; aligning with the
+  // shared host-url helper is intentional (same address Podman already uses
+  // for host API talk-back).
+  it('passes Podman host.containers.internal when that is the runtime host URL', () => {
+    getContainerHostUrl.mockReturnValue('host.containers.internal')
+    new TestContainerClient({ agentId: 'podman-agent', envVars: {} }).testBuildAgentEnv()
+    expect(getContainerEnvVars).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'podman-agent' }),
+      'host.containers.internal',
     )
   })
 })

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -25,6 +25,13 @@ import { getContainerHostUrl, getAppPort } from '@shared/lib/proxy/host-url'
 import { getAgentCapabilitySettings, getSettings } from '@shared/lib/config/settings'
 import { getActiveLlmProvider } from '@shared/lib/llm-provider'
 import type { AgentIdentity } from '@shared/lib/llm-provider/base-llm-provider'
+import {
+  describeUnreachableLocalLlm,
+  diagnoseLocalLlm,
+  isLocalInterfaceAddress,
+  resolveLoopbackProbeTarget,
+  type LoopbackProbeTarget,
+} from '@shared/lib/llm-provider/loopback-reachability'
 import { readAgentDisplayNameSync } from '@shared/lib/utils/file-storage'
 import { resolveContainerModel, getContainerModelPromptHints } from './resolve-model'
 import { getActiveWebProvider } from '../web-provider'
@@ -659,6 +666,10 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
       // Find an available port
       let port = await this.findAvailablePort()
+
+      // A local model the container provably cannot reach fails here, with the
+      // bind to change, rather than as a connection error on every model call.
+      await this.assertLocalLlmReachable()
 
       // Write env vars to a temp file (avoids command length limits on Windows)
       const { flag: envFileFlag, cleanup: cleanupEnvFile } = this.buildEnvFile(options?.envVars)
@@ -1607,6 +1618,51 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       id: this.config.agentId,
       name: readAgentDisplayNameSync(this.config.agentId),
     }
+  }
+
+  /**
+   * Fail an agent start that would be wired to a local model the container
+   * cannot reach.
+   *
+   * getContainerHostAddress() returning one of our own interfaces (Apple's
+   * vmnet gateway) means the guest arrives over the network rather than
+   * through a loopback forwarder, so a model server bound to 127.0.0.1 is
+   * invisible to it. That is the default bind for Ollama and friends, so the
+   * rewritten ANTHROPIC_BASE_URL is correct yet still refuses every call.
+   * Probing the same address from the host reproduces the guest's verdict
+   * without starting anything.
+   *
+   * No-op on Docker/Lima/WSL2/Podman: their host address is a forwarding name,
+   * so resolveLoopbackProbeTarget returns null before any work is done. Only a
+   * definitive ECONNREFUSED throws — an ambiguous probe never blocks a start.
+   */
+  protected async assertLocalLlmReachable(): Promise<void> {
+    let target: LoopbackProbeTarget | null
+    try {
+      const hostAddress = this.getContainerHostAddress()
+      // Gate before touching the provider so non-Apple runtimes do no extra work.
+      if (!isLocalInterfaceAddress(hostAddress)) return
+      const { ANTHROPIC_BASE_URL } = getActiveLlmProvider().getContainerEnvVars(
+        this.agentIdentityForEnv(),
+        hostAddress,
+      )
+      target = resolveLoopbackProbeTarget(ANTHROPIC_BASE_URL, hostAddress)
+    } catch (error) {
+      // A provider or gateway failure is not this check's to report; the env
+      // build in buildAgentEnv raises it with the right context moments later.
+      console.warn('[Container] Local-LLM reachability check could not run:', error)
+      return
+    }
+    if (!target) return
+
+    const diagnosis = await diagnoseLocalLlm(target)
+    if (diagnosis === 'reachable' || diagnosis === 'unknown') return
+    const err = new Error(describeUnreachableLocalLlm(target, diagnosis))
+    captureException(err, {
+      tags: { component: 'container', operation: 'local-llm-reachability' },
+      extra: { agentId: this.config.agentId, host: target.host, port: target.port, diagnosis },
+    })
+    throw err
   }
 
   // The final agent env, transport-agnostic; subclasses only serialize it.

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -360,6 +360,15 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   }
 
   /**
+   * Hostname/IP the guest should use to reach the host when rewriting a
+   * loopback LLM endpoint. Default is the Docker-convention name (also used
+   * by Lima/WSL2 via --add-host). Apple overrides with the gateway IP.
+   */
+  getContainerHostAddress(): string {
+    return getContainerHostUrl()
+  }
+
+  /**
    * Probe whether a host-side TCP endpoint is reachable from the runner's
    * network side. Default 'unknown' — most runtimes have no vantage point
    * inside the runner network to test from. Runners that do (WSL2) override
@@ -1605,7 +1614,10 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   protected buildAgentEnv(extra?: Record<string, string>): Record<string, string> {
     const settings = getSettings()
     const merged: Record<string, string | undefined> = {
-      ...getActiveLlmProvider().getContainerEnvVars(this.agentIdentityForEnv()),
+      ...getActiveLlmProvider().getContainerEnvVars(
+        this.agentIdentityForEnv(),
+        this.getContainerHostAddress(),
+      ),
       CLAUDE_CONFIG_DIR: '/workspace/.claude',
       ENABLE_TOOL_SEARCH: settings.enableToolSearch !== false ? 'true' : 'false',
       ...this.config.envVars,

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -46,7 +46,10 @@ vi.mock('@shared/lib/llm-provider', () => ({
 
 const autoSleepTimeoutMinutes = vi.fn((): number | undefined => 30)
 vi.mock('@shared/lib/config/settings', () => ({
-  getSettings: () => ({ app: { autoSleepTimeoutMinutes: autoSleepTimeoutMinutes() }, enableToolSearch: true }),
+  // container is always present in real settings; buildAgentEnv now reads
+  // container.containerRunner via getContainerHostUrl (SUP-447). The runner
+  // value is irrelevant for a hosted runtime — the host address is unused.
+  getSettings: () => ({ app: { autoSleepTimeoutMinutes: autoSleepTimeoutMinutes() }, enableToolSearch: true, container: {} }),
 }))
 
 import {

--- a/src/shared/lib/llm-provider/base-llm-provider.ts
+++ b/src/shared/lib/llm-provider/base-llm-provider.ts
@@ -89,8 +89,16 @@ export abstract class BaseLlmProvider {
     }
   }
 
-  /** Get env vars to inject into agent containers. */
-  abstract getContainerEnvVars(agent?: AgentIdentity): Record<string, string | undefined>
+  /**
+   * Get env vars to inject into agent containers.
+   * `hostAddress` is the container-reachable host name/IP the active runtime
+   * supplies (gateway IP on Apple; `host.docker.internal` elsewhere). When
+   * omitted, loopback rewrites keep the Docker-convention default.
+   */
+  abstract getContainerEnvVars(
+    agent?: AgentIdentity,
+    hostAddress?: string,
+  ): Record<string, string | undefined>
 
   /**
    * Validate an API key. `opts.baseUrl` is only meaningful for providers whose

--- a/src/shared/lib/llm-provider/container-url.test.ts
+++ b/src/shared/lib/llm-provider/container-url.test.ts
@@ -14,6 +14,23 @@ describe('rewriteLoopbackForContainer', () => {
   it('leaves non-loopback URLs untouched', () => {
     expect(rewriteLoopbackForContainer('http://ollama.example.com:11434')).toBe('http://ollama.example.com:11434')
   })
+
+  // Apple Container has no --add-host; the runtime's gateway IP is the only
+  // host-reachable address inside the guest (SUP-447).
+  it('rewrites to an explicit host address when one is supplied', () => {
+    expect(rewriteLoopbackForContainer('http://localhost:11434', '192.168.64.1')).toBe(
+      'http://192.168.64.1:11434',
+    )
+  })
+
+  it('honors an explicit host address for IPv6 loopback and trailing slash', () => {
+    expect(rewriteLoopbackForContainer('http://[::1]:11434', '192.168.64.1')).toBe(
+      'http://192.168.64.1:11434',
+    )
+    expect(rewriteLoopbackForContainer('http://localhost:11434/', '192.168.64.1')).toBe(
+      'http://192.168.64.1:11434/',
+    )
+  })
 })
 
 describe('isHostOnlyHostname', () => {

--- a/src/shared/lib/llm-provider/container-url.ts
+++ b/src/shared/lib/llm-provider/container-url.ts
@@ -8,14 +8,6 @@
 const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1', '[::1]'])
 
 /**
- * Rewrite a loopback URL to the container-reachable host gateway
- * (host.docker.internal — forwarded by Docker Desktop/Lima, and added via
- * --add-host on Linux). Matches on the parsed hostname, so loopback IPs are
- * covered and hostnames that merely start with "localhost"
- * (e.g. localhost.mycorp.dev) are left alone. Non-URL input passes through
- * unchanged.
- */
-/**
  * True when a parsed URL hostname is a single-label name (no dots) that only
  * resolves through host-side mechanisms Docker's DNS forwarder does not apply
  * — the host's search domains and scoped resolvers (Tailscale MagicDNS, mDNS
@@ -30,7 +22,20 @@ export function isHostOnlyHostname(hostname: string): boolean {
   return !hostname.includes('.')
 }
 
-export function rewriteLoopbackForContainer(url: string | undefined): string | undefined {
+/**
+ * Rewrite a loopback URL to a container-reachable host address. Matches on the
+ * parsed hostname, so loopback IPs are covered and hostnames that merely start
+ * with "localhost" (e.g. localhost.mycorp.dev) are left alone. Non-URL input
+ * passes through unchanged.
+ *
+ * `hostAddress` defaults to `host.docker.internal` (Docker Desktop/Lima/WSL2
+ * --add-host). Callers that know a different address (Apple's gateway IP)
+ * must pass it — the rewrite cannot pull the runtime itself (module cycle).
+ */
+export function rewriteLoopbackForContainer(
+  url: string | undefined,
+  hostAddress = 'host.docker.internal',
+): string | undefined {
   if (!url) return url
   let parsed: URL
   try {
@@ -39,7 +44,7 @@ export function rewriteLoopbackForContainer(url: string | undefined): string | u
     return url
   }
   if (!LOOPBACK_HOSTNAMES.has(parsed.hostname)) return url
-  parsed.hostname = 'host.docker.internal'
+  parsed.hostname = hostAddress
   const rewritten = parsed.toString()
   // URL.toString() appends a trailing slash to a bare origin; don't introduce
   // one the caller didn't have.

--- a/src/shared/lib/llm-provider/generic-provider.test.ts
+++ b/src/shared/lib/llm-provider/generic-provider.test.ts
@@ -124,6 +124,18 @@ describe('GenericLlmProvider.getContainerEnvVars', () => {
     })
     expect(provider.getContainerEnvVars().ANTHROPIC_BASE_URL).toBe('http://localhost.mycorp.dev:4000')
   })
+
+  // Seam guard for Apple Container (SUP-447): when the runtime supplies its
+  // gateway IP, the baked ANTHROPIC_BASE_URL must use that address — not the
+  // Docker-only name that is NXDOMAIN inside Apple guests.
+  it('rewrites loopback to the runtime host address when one is supplied', () => {
+    settingsMock.mockReturnValue({
+      apiKeys: { genericApiKey: 'k', genericBaseUrl: 'http://localhost:11434' },
+    })
+    expect(provider.getContainerEnvVars(undefined, '192.168.64.1').ANTHROPIC_BASE_URL).toBe(
+      'http://192.168.64.1:11434',
+    )
+  })
 })
 
 describe('GenericLlmProvider.getApiKeyStatus', () => {

--- a/src/shared/lib/llm-provider/generic-provider.ts
+++ b/src/shared/lib/llm-provider/generic-provider.ts
@@ -1,5 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk'
-import { BaseLlmProvider, type ModelPurpose } from './base-llm-provider'
+import { BaseLlmProvider, type AgentIdentity, type ModelPurpose } from './base-llm-provider'
 import type { ModelDefinition, ModelSearchResult } from './model-catalog-schema'
 import type { EffortLevel } from '../container/types'
 import { getSettings, getModelCatalogSettings, type ApiKeyStatus } from '../config/settings'
@@ -128,11 +128,14 @@ export class GenericLlmProvider extends BaseLlmProvider {
     return process.env[DEFAULT_MODEL_ENV]?.trim() || GENERIC_FALLBACK_MODEL
   }
 
-  getContainerEnvVars(): Record<string, string | undefined> {
+  getContainerEnvVars(
+    _agent?: AgentIdentity,
+    hostAddress?: string,
+  ): Record<string, string | undefined> {
     // A loopback endpoint (e.g. ollama on the host) isn't reachable as
-    // localhost from inside the agent container; rewrite to the host gateway
-    // (same translation the platform provider applies).
-    const containerUrl = rewriteLoopbackForContainer(this.getEffectiveBaseUrl())
+    // localhost from inside the agent container; rewrite to the runtime's
+    // host address (same translation the platform provider applies).
+    const containerUrl = rewriteLoopbackForContainer(this.getEffectiveBaseUrl(), hostAddress)
     return {
       ANTHROPIC_API_KEY: '',
       ANTHROPIC_BASE_URL: containerUrl,

--- a/src/shared/lib/llm-provider/loopback-reachability.test.ts
+++ b/src/shared/lib/llm-provider/loopback-reachability.test.ts
@@ -1,0 +1,138 @@
+import net from 'net'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  describeUnreachableLocalLlm,
+  diagnoseLocalLlm,
+  probeHostInterfacePort,
+  resolveLoopbackProbeTarget,
+  type LoopbackProbeResult,
+  type LoopbackProbeTarget,
+} from './loopback-reachability'
+
+const APPLE_GATEWAY = '192.168.64.1'
+// Only Apple's gateway is one of our interfaces; every other runtime hands back
+// a forwarding name, which must never be probed.
+const isAppleGateway = (address: string) => address === APPLE_GATEWAY
+
+describe('resolveLoopbackProbeTarget', () => {
+  it('targets the rewritten port when the host address is one of our interfaces', () => {
+    expect(
+      resolveLoopbackProbeTarget(`http://${APPLE_GATEWAY}:11434`, APPLE_GATEWAY, isAppleGateway),
+    ).toEqual({ host: APPLE_GATEWAY, port: 11434 })
+  })
+
+  // The byte-identical-behavior guard for Docker/Lima/WSL2/Podman: their host
+  // address is a forwarding name that reaches the host loopback whatever the
+  // bind, so there is nothing to probe and no start to fail.
+  it('never probes a forwarding-name host address', () => {
+    for (const name of ['host.docker.internal', 'host.containers.internal']) {
+      expect(
+        resolveLoopbackProbeTarget(`http://${name}:11434`, name, isAppleGateway),
+      ).toBeNull()
+    }
+  })
+
+  it('ignores an endpoint the loopback rewrite never touched', () => {
+    // A remote model endpoint keeps its own hostname — probing the gateway
+    // would be testing an address this agent will never call.
+    expect(
+      resolveLoopbackProbeTarget('http://ollama.example.com:11434', APPLE_GATEWAY, isAppleGateway),
+    ).toBeNull()
+  })
+
+  it('falls back to the scheme default when the URL carries no port', () => {
+    expect(resolveLoopbackProbeTarget(`http://${APPLE_GATEWAY}`, APPLE_GATEWAY, isAppleGateway))
+      .toEqual({ host: APPLE_GATEWAY, port: 80 })
+    expect(resolveLoopbackProbeTarget(`https://${APPLE_GATEWAY}`, APPLE_GATEWAY, isAppleGateway))
+      .toEqual({ host: APPLE_GATEWAY, port: 443 })
+  })
+
+  it('returns null for a missing or unparseable URL', () => {
+    expect(resolveLoopbackProbeTarget(undefined, APPLE_GATEWAY, isAppleGateway)).toBeNull()
+    expect(resolveLoopbackProbeTarget('not-a-url', APPLE_GATEWAY, isAppleGateway)).toBeNull()
+  })
+})
+
+describe('probeHostInterfacePort', () => {
+  const servers: net.Server[] = []
+
+  afterEach(() => {
+    for (const server of servers.splice(0)) server.close()
+  })
+
+  const listen = (): Promise<LoopbackProbeTarget> =>
+    new Promise((resolve) => {
+      const server = net.createServer()
+      servers.push(server)
+      server.listen(0, '127.0.0.1', () =>
+        resolve({ host: '127.0.0.1', port: (server.address() as net.AddressInfo).port }),
+      )
+    })
+
+  it('reports a listening port as reachable', async () => {
+    expect(await probeHostInterfacePort(await listen())).toBe('reachable')
+  })
+
+  // The verdict that fails an agent start. Nothing bound to the address means
+  // the container's connection would be refused for the same reason.
+  it('reports a refused connection as unreachable', async () => {
+    const target = await listen()
+    for (const server of servers.splice(0)) server.close()
+    expect(await probeHostInterfacePort(target)).toBe('unreachable')
+  })
+
+  // Anything short of a definitive refusal must stay ambiguous, so a probe that
+  // cannot run never blocks a start.
+  it('reports an unresolvable address as unknown, not unreachable', async () => {
+    expect(
+      await probeHostInterfacePort({ host: 'no-such-host.invalid', port: 11434 }),
+    ).toBe('unknown')
+  })
+})
+
+describe('diagnoseLocalLlm', () => {
+  const target: LoopbackProbeTarget = { host: APPLE_GATEWAY, port: 11434 }
+  // Answers per address, so the loopback follow-up probe is what separates
+  // "wrong bind" from "nothing there".
+  const probeReturning = (byHost: Record<string, LoopbackProbeResult>) => (t: LoopbackProbeTarget) =>
+    Promise.resolve(byHost[t.host] ?? 'unreachable')
+
+  it('separates a wrong bind from a server that is not running', async () => {
+    expect(
+      await diagnoseLocalLlm(
+        target,
+        probeReturning({ [APPLE_GATEWAY]: 'unreachable', '127.0.0.1': 'reachable' }),
+      ),
+    ).toBe('loopback-only')
+
+    expect(
+      await diagnoseLocalLlm(
+        target,
+        probeReturning({ [APPLE_GATEWAY]: 'unreachable', '127.0.0.1': 'unreachable' }),
+      ),
+    ).toBe('not-running')
+  })
+
+  it('never blocks on an ambiguous interface probe', async () => {
+    expect(await diagnoseLocalLlm(target, probeReturning({ [APPLE_GATEWAY]: 'unknown' }))).toBe(
+      'unknown',
+    )
+  })
+
+  it('reports a reachable interface without a second probe', async () => {
+    expect(await diagnoseLocalLlm(target, probeReturning({ [APPLE_GATEWAY]: 'reachable' }))).toBe(
+      'reachable',
+    )
+  })
+})
+
+describe('describeUnreachableLocalLlm', () => {
+  const target: LoopbackProbeTarget = { host: APPLE_GATEWAY, port: 11434 }
+
+  // The bind advice is only correct when a bind is actually the problem;
+  // handing it to someone whose server is down sends them after the wrong bug.
+  it('advises a rebind only for a wrong bind, never for a stopped server', () => {
+    expect(describeUnreachableLocalLlm(target, 'loopback-only')).toMatch(/OLLAMA_HOST=0\.0\.0\.0/)
+    expect(describeUnreachableLocalLlm(target, 'not-running')).not.toMatch(/OLLAMA_HOST/)
+  })
+})

--- a/src/shared/lib/llm-provider/loopback-reachability.ts
+++ b/src/shared/lib/llm-provider/loopback-reachability.ts
@@ -1,0 +1,154 @@
+import net from 'net'
+import os from 'os'
+
+/**
+ * Verdict of a host-side reachability probe. Only a positive 'unreachable'
+ * verdict may fail an agent start; anything ambiguous is 'unknown' and never
+ * blocks (same rule the CDP proxy probe follows in chrome-provider.ts).
+ */
+export type LoopbackProbeResult = 'reachable' | 'unreachable' | 'unknown'
+
+export interface LoopbackProbeTarget {
+  host: string
+  port: number
+}
+
+/**
+ * True if `address` is assigned to a local network interface.
+ *
+ * This is the whole gate. A runtime whose container-host address is a real
+ * interface of ours (Apple Container's vmnet gateway) puts the guest on the
+ * network side of that interface, so it only reaches services actually bound
+ * to it. Runtimes that hand back a *name* — host.docker.internal on
+ * Docker/Lima/WSL2, host.containers.internal on Podman — never match, because
+ * those names are forwarders that reach the host's loopback regardless of
+ * bind. Callers therefore no-op on every runtime but Apple.
+ *
+ * chrome-provider.ts carries the same predicate for the CDP bind decision;
+ * SUP-459 is the consolidation point for both.
+ */
+export function isLocalInterfaceAddress(address: string): boolean {
+  return Object.values(os.networkInterfaces()).some((addrs) =>
+    addrs?.some((addr) => addr.address === address),
+  )
+}
+
+/**
+ * Decide whether a container-bound LLM URL is worth probing from the host, and
+ * at which port. Returns null when the check does not apply: no URL, no host
+ * address, an unparseable URL, or a runtime whose host address is a forwarding
+ * name rather than one of our interfaces.
+ *
+ * Only a URL that `rewriteLoopbackForContainer` actually rewrote is a
+ * candidate — its hostname is the runtime host address. A URL pointing
+ * somewhere else (a remote endpoint) was never a loopback problem.
+ */
+export function resolveLoopbackProbeTarget(
+  containerUrl: string | undefined,
+  hostAddress: string | undefined,
+  isLocalInterface: (address: string) => boolean = isLocalInterfaceAddress,
+): LoopbackProbeTarget | null {
+  if (!containerUrl || !hostAddress) return null
+  if (!isLocalInterface(hostAddress)) return null
+
+  let parsed: URL
+  try {
+    parsed = new URL(containerUrl)
+  } catch {
+    return null
+  }
+  if (parsed.hostname !== hostAddress) return null
+
+  // URL rejects non-numeric and out-of-range ports at parse time; 0 is the one
+  // value that survives parsing and still cannot be connected to.
+  const port = parsed.port ? Number(parsed.port) : parsed.protocol === 'https:' ? 443 : 80
+  if (port === 0) return null
+  return { host: hostAddress, port }
+}
+
+/**
+ * TCP-connect to a host interface from the host itself. The host sees the same
+ * refusal the guest would: a service bound only to 127.0.0.1 is absent from
+ * every other interface, so connecting to the gateway IP is refused here for
+ * exactly the reason it is refused inside the container. That makes this probe
+ * a plain socket connect — no container spawn, no runtime-specific transport.
+ *
+ * ECONNREFUSED is the one definitive verdict (nothing is listening on that
+ * interface). Everything else — timeouts, DNS, permission errors — is ambiguous
+ * and reported as 'unknown' so it can never fail a start.
+ */
+export function probeHostInterfacePort(
+  { host, port }: LoopbackProbeTarget,
+  timeoutMs = 1000,
+): Promise<LoopbackProbeResult> {
+  return new Promise((resolve) => {
+    const socket = new net.Socket()
+    const finish = (result: LoopbackProbeResult) => {
+      socket.destroy()
+      resolve(result)
+    }
+    socket.setTimeout(timeoutMs)
+    socket.on('connect', () => finish('reachable'))
+    socket.on('timeout', () => finish('unknown'))
+    socket.on('error', (error: NodeJS.ErrnoException) =>
+      finish(error.code === 'ECONNREFUSED' ? 'unreachable' : 'unknown'),
+    )
+    socket.connect(port, host)
+  })
+}
+
+/**
+ * Why a local model is unreachable from the container. A refusal at the host
+ * interface has two very different causes with two different fixes, so the
+ * loopback address is probed as well to tell them apart:
+ *
+ *   - 'loopback-only': the server answers on 127.0.0.1 but not on the
+ *     interface the guest arrives at. Wrong bind; the port is otherwise fine.
+ *   - 'not-running': nothing answers anywhere. Telling this user to change a
+ *     bind would send them after the wrong problem entirely.
+ */
+export type LocalLlmDiagnosis = 'reachable' | 'loopback-only' | 'not-running' | 'unknown'
+
+export async function diagnoseLocalLlm(
+  target: LoopbackProbeTarget,
+  probe: (t: LoopbackProbeTarget) => Promise<LoopbackProbeResult> = probeHostInterfacePort,
+): Promise<LocalLlmDiagnosis> {
+  const viaInterface = await probe(target)
+  if (viaInterface === 'reachable') return 'reachable'
+  // Anything short of a definitive refusal stays ambiguous and never blocks.
+  if (viaInterface !== 'unreachable') return 'unknown'
+  const viaLoopback = await probe({ host: '127.0.0.1', port: target.port })
+  return viaLoopback === 'reachable' ? 'loopback-only' : 'not-running'
+}
+
+/**
+ * The product-facing explanation for an unreachable local model. Names the
+ * cause the probes actually established and the fix that follows from it.
+ */
+export function describeUnreachableLocalLlm(
+  { host, port }: LoopbackProbeTarget,
+  diagnosis: Extract<LocalLlmDiagnosis, 'loopback-only' | 'not-running'>,
+): string {
+  const preamble =
+    `The local model server on port ${port} is not reachable from the agent container. ` +
+    `Agents run in a VM that reaches this Mac at ${host}`
+
+  if (diagnosis === 'not-running') {
+    return (
+      `${preamble}, and nothing is listening on port ${port} on this Mac at all.\n\n` +
+      `Start the model server, then start the agent again. If it is already running, ` +
+      `check that it is on port ${port} and that the endpoint configured in Settings ` +
+      `matches.`
+    )
+  }
+
+  return (
+    `${preamble}. The server is running but bound to 127.0.0.1 only, so it answers on ` +
+    `this Mac and is invisible to the container. That is the default for Ollama, ` +
+    `LM Studio and llama.cpp.\n\n` +
+    `Restart it bound to all interfaces, then start the agent again:\n` +
+    `  • Ollama: set OLLAMA_HOST=0.0.0.0 (launchctl setenv OLLAMA_HOST 0.0.0.0, then restart Ollama)\n` +
+    `  • LM Studio: enable "Serve on Local Network" in the server settings\n` +
+    `  • llama.cpp: start it with --host 0.0.0.0`
+  )
+}

--- a/src/shared/lib/llm-provider/platform-provider.test.ts
+++ b/src/shared/lib/llm-provider/platform-provider.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // Stub everything with side effects: attribution pulls in the DB, auth-service
 // reads settings storage, config resolves the proxy URL from the environment.
 const currentAttribution = vi.fn()
+const getPlatformProxyBaseUrl = vi.fn(() => 'https://proxy.example/v1')
 vi.mock('@shared/lib/platform-attribution', () => ({
   attribution: { current: () => currentAttribution() },
 }))
@@ -10,7 +11,7 @@ vi.mock('@shared/lib/services/platform-auth-service', () => ({
   getPlatformAccessToken: () => 'platform-token',
 }))
 vi.mock('@shared/lib/platform-auth/config', () => ({
-  getPlatformProxyBaseUrl: () => 'https://proxy.example/v1',
+  getPlatformProxyBaseUrl: () => getPlatformProxyBaseUrl(),
 }))
 vi.mock('../config/settings', () => ({
   getSettings: () => ({}),
@@ -23,6 +24,7 @@ const provider = new PlatformLlmProvider()
 
 beforeEach(() => {
   currentAttribution.mockReturnValue(null)
+  getPlatformProxyBaseUrl.mockReturnValue('https://proxy.example/v1')
 })
 
 describe('getContainerEnvVars agent identity', () => {
@@ -49,6 +51,23 @@ describe('getContainerEnvVars agent identity', () => {
   it('flattens control characters out of the name', () => {
     const env = provider.getContainerEnvVars({ id: 'abc123', name: 'Multi\nLine\tBot' })
     expect(env.SUPERAGENT_AGENT_NAME).toBe('Multi Line Bot')
+  })
+
+  // Symmetric with generic-provider: local-dev loopback platform proxy must
+  // honor the runtime host address (SUP-447).
+  it('rewrites a loopback platform proxy to the runtime host address when supplied', () => {
+    getPlatformProxyBaseUrl.mockReturnValue('http://localhost:47891/v1')
+    const env = provider.getContainerEnvVars({ id: 'abc123' }, '192.168.64.1')
+    expect(env.ANTHROPIC_BASE_URL).toBe('http://192.168.64.1:47891/v1')
+  })
+
+  // Guards the byte-identical default (SUP-447): with no host address, a
+  // loopback platform proxy keeps the Docker-convention name for every
+  // non-Apple runtime, exactly as before the fix.
+  it('keeps host.docker.internal for a loopback platform proxy when no host address is supplied', () => {
+    getPlatformProxyBaseUrl.mockReturnValue('http://localhost:47891/v1')
+    const env = provider.getContainerEnvVars({ id: 'abc123' })
+    expect(env.ANTHROPIC_BASE_URL).toBe('http://host.docker.internal:47891/v1')
   })
 })
 

--- a/src/shared/lib/llm-provider/platform-provider.ts
+++ b/src/shared/lib/llm-provider/platform-provider.ts
@@ -64,9 +64,12 @@ export class PlatformLlmProvider extends BaseLlmProvider {
     }
   }
 
-  getContainerEnvVars(agent?: AgentIdentity): Record<string, string | undefined> {
+  getContainerEnvVars(
+    agent?: AgentIdentity,
+    hostAddress?: string,
+  ): Record<string, string | undefined> {
     const proxyUrl = getPlatformProxyBaseUrl()
-    const containerUrl = rewriteLoopbackForContainer(proxyUrl)
+    const containerUrl = rewriteLoopbackForContainer(proxyUrl, hostAddress)
 
     const auth = attribution.current()
     const authToken = auth?.bearerToken() ?? this.getEffectiveApiKey()


### PR DESCRIPTION
## What

Local-LLM agents reach the model on the Apple Container runtime when the model server is bound to all interfaces, and get a named, actionable failure when it is not.

Two things had to be true and only one of them was:

| Host model server | Before | After |
|---|---|---|
| bound to `0.0.0.0` | dead at DNS | works |
| bound to `127.0.0.1` (Ollama/LM Studio/llama.cpp default) | dead at DNS | start fails, message names the bind and the fix |
| not running | dead at DNS | start fails, message says nothing is listening |

Docker, Lima, WSL2 and Podman are unchanged.

## Why

`rewriteLoopbackForContainer` hardcoded `host.docker.internal`, which is NXDOMAIN inside Apple Container guests - Apple has no `--add-host` equivalent. The agent baked an unreachable `ANTHROPIC_BASE_URL`, so every model call died at DNS.

Threading the runtime's real host address in fixes the address, but not the whole problem. Docker Desktop's `host.docker.internal` is a *proxy* that forwards to the host's loopback. Apple Container's vmnet gateway IP is a *real network interface*, so it only reaches services actually listening on that interface. Same address, same code, different semantics - and loopback-only is the default bind for every common local-model server.

So the corrected address alone still produces a dead agent for the most likely configuration. The failure just moves from `ENOTFOUND` to `ECONNREFUSED`. This PR fixes the address and makes the remaining cases explain themselves instead of failing silently.

## How it works

Before starting a container, if the runtime's host address is one of our own interfaces, probe it. A refusal has two causes with two different fixes, so `127.0.0.1` is probed as well to tell them apart:

```
probe gateway:port
  ├─ connects            → start normally
  ├─ refused → probe 127.0.0.1:port
  │              ├─ connects  → wrong bind    → "bound to 127.0.0.1 only", how to rebind
  │              └─ refused   → not running   → "nothing is listening", start it
  └─ timeout/DNS/other   → unknown → never blocks a start
```

The probe runs on the host, not in a container. A service bound only to `127.0.0.1` is absent from every other interface, so connecting to the gateway IP from the host is refused for exactly the reason it is refused inside the guest. One TCP connect, ~20ms, no container spawn.

## How it was verified

Measured on macOS 26.5.1, Apple Container CLI 1.1.0, Docker 29.6.1, real `superagent-container` image, real Ollama.

Reachability of the baked address, probed from inside a real guest:

| Host service bound to | Apple guest to gateway IP | Docker guest to `host.docker.internal` |
|---|---|---|
| `127.0.0.1` | ECONNREFUSED | reachable |
| `0.0.0.0` | reachable | reachable |

End to end in the running app, generic provider pointed at `http://localhost:11434` on the Apple runtime:

- **Ollama stopped** - start blocked, banner reads "nothing is listening on port 11434 on this Mac at all", no bind advice.
- **Ollama at default bind** (confirmed `127.0.0.1` via `lsof`, not docs) - start blocked, banner names the bind and gives the per-server fix.
- **`OLLAMA_HOST=0.0.0.0`** - agent starts, container's `ANTHROPIC_BASE_URL` is `http://192.168.64.1:11434`, and the guest reaches real Ollama at it.

Suites: full unit run green (7535 passed, 428 files), typecheck and lint clean. Both new guards were mutation-checked - removing the forwarding-name gate and converting the deferral into a rethrow each fail exactly one test.

## Notes for the reviewer

- **New failure mode.** An agent that previously started and then failed on every model call now refuses to start. That is the intended trade, but it is a behavior change beyond the original bug.
- The gate is `isLocalInterfaceAddress(hostAddress)`. Only Apple returns a numeric interface IP; Docker/Lima/WSL2 return `host.docker.internal` and Podman returns `host.containers.internal`, so all four return before the provider is consulted or the network is touched. That is what keeps them byte-identical.
- Only a definitive `ECONNREFUSED` fails a start. Timeouts, DNS and permission errors are `unknown` and never block. Same rule the CDP proxy probe follows in `chrome-provider.ts`.
- Apple still fails closed on an unknown gateway. The check deliberately swallows that error so the identical throw surfaces from the env build a few lines later, where it carries the right context. There is a test pinning this.
- `agent-banners.tsx` gains `whitespace-pre-line` and top-aligns its icon, so multi-line remediation renders as written. Single-line start errors are unaffected. Without it the message collapsed into one unreadable `text-xs` run.
- Podman now uses `host.containers.internal` (via the shared `getContainerHostUrl` helper) instead of the old hardcoded Docker name, matching the address it already uses for host-API talk-back.
- `isLocalInterfaceAddress` is duplicated from `chrome-provider.ts` rather than extracted. SUP-459 consolidates host-address resolution and is stacked on this branch; extracting now would collide with it.

## Known gap, not addressed here

Lima and WSL2 map `host.docker.internal` to a **real** bridge IP via `--add-host`, so they have the same loopback-bind problem as Apple. They are out of scope here to keep this branch byte-identical for them and the SUP-459 rebase clean. Worth a follow-up once SUP-459 lands the unified resolver, since the gate would then be one predicate instead of four.
