### PR TITLE
Fix PDF pagination state per tab

### DIFF
--- a/src/renderer/components/file-preview/file-preview-pagination.integration.test.tsx
+++ b/src/renderer/components/file-preview/file-preview-pagination.integration.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { FilePreviewProvider, useFilePreview } from '@renderer/context/file-preview-context'
+import { FilePreviewTrayContent } from './file-preview-tray-content'
+
+vi.mock('@renderer/router/use-route-location', () => ({
+  useRouteLocation: () => ({
+    selectedAgentSlug: 'test-agent',
+    view: { kind: 'session', id: 'test-session' },
+  }),
+}))
+
+vi.mock('./file-tab-bar', () => ({ FileTabBar: () => null }))
+vi.mock('./comments/comment-bar', () => ({ CommentBar: () => null }))
+vi.mock('react-pdf', () => ({
+  pdfjs: { GlobalWorkerOptions: {} },
+  Document: ({
+    children,
+    onLoadSuccess,
+  }: {
+    children: ReactNode
+    onLoadSuccess: (pdf: { numPages: number }) => void
+  }) => (
+    <div>
+      <button onClick={() => onLoadSuccess({ numPages: 3 })}>Load PDF</button>
+      {children}
+    </div>
+  ),
+  Page: ({ pageNumber }: { pageNumber: number }) => (
+    <div data-testid="integrated-pdf-page" data-page-number={pageNumber} />
+  ),
+}))
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', class {
+    observe() {}
+    disconnect() {}
+  })
+})
+
+function PreviewHarness() {
+  const { isOpen, openFile } = useFilePreview()
+
+  return (
+    <>
+      <button onClick={() => openFile('/workspace/report.pdf', 'test-agent')}>
+        Open PDF
+      </button>
+      {isOpen && (
+        <FilePreviewTrayContent
+          sessionId="test-session"
+          onClose={vi.fn()}
+        />
+      )}
+    </>
+  )
+}
+
+describe('PDF preview pagination integration', () => {
+  it('rerenders the visible PDF page after clicking next', async () => {
+    render(
+      <FilePreviewProvider sessionId="test-session">
+        <PreviewHarness />
+      </FilePreviewProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open PDF' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Load PDF' }))
+    expect(screen.getByTestId('integrated-pdf-page')).toHaveAttribute('data-page-number', '1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next PDF page' }))
+    expect(screen.getByTestId('integrated-pdf-page')).toHaveAttribute('data-page-number', '2')
+  })
+})

--- a/src/renderer/components/file-preview/file-preview-tray-content.test.tsx
+++ b/src/renderer/components/file-preview/file-preview-tray-content.test.tsx
@@ -1,26 +1,60 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { FilePreviewTrayContent } from './file-preview-tray-content'
+
+const setPdfPage = vi.fn()
 
 vi.mock('@renderer/context/file-preview-context', () => ({
   useFilePreview: () => ({
     openFiles: [{
-      filePath: '/workspace/report.md',
+      filePath: '/workspace/report.pdf',
       agentSlug: 'test-agent',
-      displayName: 'report.md',
+      displayName: 'report.pdf',
       version: 0,
+      pdfPage: 2,
     }],
     activeFileIndex: 0,
     setActiveFile: vi.fn(),
+    setPdfPage,
     closeFile: vi.fn(),
     comments: new Map(),
+    commentsEnabled: true,
   }),
 }))
 
 vi.mock('./file-tab-bar', () => ({ FileTabBar: () => null }))
-vi.mock('./renderers/file-renderer', () => ({ FileRenderer: () => null }))
 vi.mock('./comments/comment-bar', () => ({ CommentBar: () => null }))
+vi.mock('react-pdf', () => ({
+  pdfjs: { GlobalWorkerOptions: {} },
+  Document: ({
+    children,
+    onLoadSuccess,
+  }: {
+    children: ReactNode
+    onLoadSuccess: (pdf: { numPages: number }) => void
+  }) => (
+    <div>
+      <button onClick={() => onLoadSuccess({ numPages: 3 })}>Load PDF</button>
+      {children}
+    </div>
+  ),
+  Page: ({ pageNumber }: { pageNumber: number }) => (
+    <div data-testid="tray-pdf-page" data-page-number={pageNumber} />
+  ),
+}))
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', class {
+    observe() {}
+    disconnect() {}
+  })
+})
+
+beforeEach(() => {
+  setPdfPage.mockReset()
+})
 
 describe('FilePreviewTrayContent', () => {
   it('exposes container-responsive close controls on opposite sides', () => {
@@ -40,5 +74,20 @@ describe('FilePreviewTrayContent', () => {
     fireEvent.click(mobileClose)
     fireEvent.click(desktopClose)
     expect(onClose).toHaveBeenCalledTimes(2)
+  })
+
+  it('wires the active PDF page and page changes through the tray', async () => {
+    render(
+      <FilePreviewTrayContent
+        sessionId="test-session"
+        onClose={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Load PDF' }))
+    expect(screen.getByTestId('tray-pdf-page')).toHaveAttribute('data-page-number', '2')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next PDF page' }))
+    expect(setPdfPage).toHaveBeenCalledWith('/workspace/report.pdf', 3)
   })
 })

--- a/src/renderer/components/file-preview/file-preview-tray-content.tsx
+++ b/src/renderer/components/file-preview/file-preview-tray-content.tsx
@@ -15,7 +15,7 @@ function getRelativePath(filePath: string): string {
 }
 
 export function FilePreviewTrayContent({ sessionId, onClose }: FilePreviewTrayContentProps) {
-  const { openFiles, activeFileIndex, setActiveFile, closeFile, comments } = useFilePreview()
+  const { openFiles, activeFileIndex, setActiveFile, setPdfPage, closeFile, comments } = useFilePreview()
 
   const activeFile = openFiles[activeFileIndex]
   if (!activeFile) return null
@@ -74,6 +74,8 @@ export function FilePreviewTrayContent({ sessionId, onClose }: FilePreviewTrayCo
           filePath={activeFile.filePath}
           fileUrl={fileUrl}
           agentSlug={activeFile.agentSlug}
+          pdfPage={activeFile.pdfPage}
+          onPdfPageChange={(page) => setPdfPage(activeFile.filePath, page)}
         />
       </div>
 

--- a/src/renderer/components/file-preview/renderers/audio-renderer.test.tsx
+++ b/src/renderer/components/file-preview/renderers/audio-renderer.test.tsx
@@ -181,6 +181,8 @@ describe('AudioRenderer', () => {
         filePath="/workspace/a.mp3"
         fileUrl="/files/a.mp3"
         agentSlug="agent-1"
+        pdfPage={1}
+        onPdfPageChange={vi.fn()}
       />,
     )
 
@@ -192,6 +194,8 @@ describe('AudioRenderer', () => {
         filePath="/workspace/b.mp3"
         fileUrl="/files/b.mp3"
         agentSlug="agent-1"
+        pdfPage={1}
+        onPdfPageChange={vi.fn()}
       />,
     )
 

--- a/src/renderer/components/file-preview/renderers/file-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/file-renderer.tsx
@@ -30,16 +30,16 @@ interface FileRendererProps {
   filePath: string
   fileUrl: string
   agentSlug: string
-  pdfPage?: number
-  onPdfPageChange?: (page: number) => void
+  pdfPage: number
+  onPdfPageChange: (page: number) => void
 }
 
 export function FileRenderer({
   filePath,
   fileUrl,
   agentSlug,
-  pdfPage = 1,
-  onPdfPageChange = () => {},
+  pdfPage,
+  onPdfPageChange,
 }: FileRendererProps) {
   const ext = getFileExtension(filePath)
   const { commentsEnabled } = useFilePreview()

--- a/src/renderer/components/file-preview/renderers/file-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/file-renderer.tsx
@@ -30,9 +30,17 @@ interface FileRendererProps {
   filePath: string
   fileUrl: string
   agentSlug: string
+  pdfPage?: number
+  onPdfPageChange?: (page: number) => void
 }
 
-export function FileRenderer({ filePath, fileUrl, agentSlug }: FileRendererProps) {
+export function FileRenderer({
+  filePath,
+  fileUrl,
+  agentSlug,
+  pdfPage = 1,
+  onPdfPageChange = () => {},
+}: FileRendererProps) {
   const ext = getFileExtension(filePath)
   const { commentsEnabled } = useFilePreview()
 
@@ -71,7 +79,14 @@ export function FileRenderer({ filePath, fileUrl, agentSlug }: FileRendererProps
           <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
         </div>
       }>
-        <PdfRenderer url={fileUrl} filePath={filePath} commentsEnabled={commentsEnabled} />
+        <PdfRenderer
+          key={`${filePath}:${fileUrl}`}
+          url={fileUrl}
+          filePath={filePath}
+          pageNumber={pdfPage}
+          onPageChange={onPdfPageChange}
+          commentsEnabled={commentsEnabled}
+        />
       </Suspense>
     )
   }

--- a/src/renderer/components/file-preview/renderers/pdf-renderer.test.tsx
+++ b/src/renderer/components/file-preview/renderers/pdf-renderer.test.tsx
@@ -61,6 +61,7 @@ describe('PdfRenderer', () => {
       />,
     )
 
+    expect(screen.queryByTestId('pdf-page')).not.toBeInTheDocument()
     act(() => mockDocumentProps.onLoadSuccess({ numPages: 3 }))
 
     expect(onPageChange).toHaveBeenCalledWith(3)

--- a/src/renderer/components/file-preview/renderers/pdf-renderer.test.tsx
+++ b/src/renderer/components/file-preview/renderers/pdf-renderer.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { PdfRenderer } from './pdf-renderer'
+
+interface MockDocumentProps {
+  children: ReactNode
+  onLoadSuccess: (pdf: { numPages: number }) => void
+}
+
+let mockDocumentProps: MockDocumentProps
+
+vi.mock('react-pdf', () => ({
+  pdfjs: { GlobalWorkerOptions: {} },
+  Document: (props: MockDocumentProps) => {
+    mockDocumentProps = props
+    return <div data-testid="pdf-document">{props.children}</div>
+  },
+  Page: ({ pageNumber }: { pageNumber: number }) => (
+    <div data-testid="pdf-page" data-page-number={pageNumber} />
+  ),
+}))
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', class {
+    observe() {}
+    disconnect() {}
+  })
+})
+
+describe('PdfRenderer', () => {
+  it('renders and paginates from its controlled tab page', () => {
+    const onPageChange = vi.fn()
+    render(
+      <PdfRenderer
+        url="/files/report.pdf"
+        filePath="/workspace/report.pdf"
+        pageNumber={4}
+        onPageChange={onPageChange}
+      />,
+    )
+
+    act(() => mockDocumentProps.onLoadSuccess({ numPages: 5 }))
+
+    expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '4')
+    expect(screen.getByText('4 / 5')).toBeVisible()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next PDF page' }))
+    expect(onPageChange).toHaveBeenCalledWith(5)
+  })
+
+  it('clamps a saved page when a PDF has fewer pages', () => {
+    const onPageChange = vi.fn()
+    render(
+      <PdfRenderer
+        url="/files/short.pdf"
+        filePath="/workspace/short.pdf"
+        pageNumber={8}
+        onPageChange={onPageChange}
+      />,
+    )
+
+    act(() => mockDocumentProps.onLoadSuccess({ numPages: 3 }))
+
+    expect(onPageChange).toHaveBeenCalledWith(3)
+    expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '3')
+    expect(screen.getByText('3 / 3')).toBeVisible()
+  })
+})

--- a/src/renderer/components/file-preview/renderers/pdf-renderer.test.tsx
+++ b/src/renderer/components/file-preview/renderers/pdf-renderer.test.tsx
@@ -45,8 +45,11 @@ describe('PdfRenderer', () => {
 
     expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '4')
     expect(screen.getByText('4 / 5')).toBeVisible()
+    expect(screen.getByTestId('pdf-pagination')).toHaveClass('z-10')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Next PDF page' }))
+    const nextPage = screen.getByRole('button', { name: 'Next PDF page' })
+    expect(nextPage).toHaveAttribute('type', 'button')
+    fireEvent.click(nextPage)
     expect(onPageChange).toHaveBeenCalledWith(5)
   })
 

--- a/src/renderer/components/file-preview/renderers/pdf-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/pdf-renderer.tsx
@@ -90,8 +90,12 @@ export function PdfRenderer({
       </Document>
 
       {numPages && numPages > 1 && currentPage !== null && (
-        <div className="sticky bottom-0 flex items-center gap-2 py-2 px-3 bg-background/90 backdrop-blur-sm border-t border-border/40 w-full justify-center">
+        <div
+          data-testid="pdf-pagination"
+          className="sticky bottom-0 z-10 flex items-center gap-2 py-2 px-3 bg-background/90 backdrop-blur-sm border-t border-border/40 w-full justify-center"
+        >
           <button
+            type="button"
             onClick={() => onPageChange(Math.max(1, currentPage - 1))}
             disabled={currentPage <= 1}
             aria-label="Previous PDF page"
@@ -103,6 +107,7 @@ export function PdfRenderer({
             {currentPage} / {numPages}
           </span>
           <button
+            type="button"
             onClick={() => onPageChange(Math.min(numPages, currentPage + 1))}
             disabled={currentPage >= numPages}
             aria-label="Next PDF page"

--- a/src/renderer/components/file-preview/renderers/pdf-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/pdf-renderer.tsx
@@ -19,12 +19,19 @@ try {
 interface PdfRendererProps {
   url: string
   filePath: string
+  pageNumber: number
+  onPageChange: (page: number) => void
   commentsEnabled?: boolean
 }
 
-export function PdfRenderer({ url, filePath, commentsEnabled = true }: PdfRendererProps) {
+export function PdfRenderer({
+  url,
+  filePath,
+  pageNumber,
+  onPageChange,
+  commentsEnabled = true,
+}: PdfRendererProps) {
   const [numPages, setNumPages] = useState<number | null>(null)
-  const [currentPage, setCurrentPage] = useState(1)
   const [loadError, setLoadError] = useState(false)
   const [pageWidth, setPageWidth] = useState(400)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -43,11 +50,19 @@ export function PdfRenderer({ url, filePath, commentsEnabled = true }: PdfRender
     return () => observer.disconnect()
   }, [updateWidth])
 
+  const currentPage = numPages ? Math.min(pageNumber, numPages) : pageNumber
+
+  const handleLoadSuccess = ({ numPages: loadedPages }: { numPages: number }) => {
+    setNumPages(loadedPages)
+    setLoadError(false)
+    if (pageNumber > loadedPages) onPageChange(loadedPages)
+  }
+
   return (
     <div ref={containerRef} className="relative flex flex-col items-center">
       <Document
         file={url}
-        onLoadSuccess={({ numPages: n }) => setNumPages(n)}
+        onLoadSuccess={handleLoadSuccess}
         onLoadError={() => setLoadError(true)}
         loading={
           <div className="flex items-center justify-center py-12">
@@ -75,8 +90,9 @@ export function PdfRenderer({ url, filePath, commentsEnabled = true }: PdfRender
       {numPages && numPages > 1 && (
         <div className="sticky bottom-0 flex items-center gap-2 py-2 px-3 bg-background/90 backdrop-blur-sm border-t border-border/40 w-full justify-center">
           <button
-            onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+            onClick={() => onPageChange(Math.max(1, currentPage - 1))}
             disabled={currentPage <= 1}
+            aria-label="Previous PDF page"
             className="p-1 rounded hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
           >
             <ChevronLeft className="h-4 w-4" />
@@ -85,8 +101,9 @@ export function PdfRenderer({ url, filePath, commentsEnabled = true }: PdfRender
             {currentPage} / {numPages}
           </span>
           <button
-            onClick={() => setCurrentPage(p => Math.min(numPages, p + 1))}
+            onClick={() => onPageChange(Math.min(numPages, currentPage + 1))}
             disabled={currentPage >= numPages}
+            aria-label="Next PDF page"
             className="p-1 rounded hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
           >
             <ChevronRight className="h-4 w-4" />

--- a/src/renderer/components/file-preview/renderers/pdf-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/pdf-renderer.tsx
@@ -50,7 +50,9 @@ export function PdfRenderer({
     return () => observer.disconnect()
   }, [updateWidth])
 
-  const currentPage = numPages ? Math.min(pageNumber, numPages) : pageNumber
+  const currentPage = numPages === null
+    ? null
+    : Math.max(1, Math.min(pageNumber, numPages))
 
   const handleLoadSuccess = ({ numPages: loadedPages }: { numPages: number }) => {
     setNumPages(loadedPages)
@@ -76,7 +78,7 @@ export function PdfRenderer({
           </div>
         }
       >
-        {!loadError && (
+        {!loadError && currentPage !== null && (
           <Page
             pageNumber={currentPage}
             width={pageWidth}
@@ -87,7 +89,7 @@ export function PdfRenderer({
         )}
       </Document>
 
-      {numPages && numPages > 1 && (
+      {numPages && numPages > 1 && currentPage !== null && (
         <div className="sticky bottom-0 flex items-center gap-2 py-2 px-3 bg-background/90 backdrop-blur-sm border-t border-border/40 w-full justify-center">
           <button
             onClick={() => onPageChange(Math.max(1, currentPage - 1))}

--- a/src/renderer/context/file-preview-context.test.tsx
+++ b/src/renderer/context/file-preview-context.test.tsx
@@ -36,6 +36,7 @@ describe('FilePreviewContext', () => {
       expect(result.current.openFiles[0].filePath).toBe('/workspace/report.md')
       expect(result.current.openFiles[0].displayName).toBe('report.md')
       expect(result.current.openFiles[0].version).toBe(0)
+      expect(result.current.openFiles[0].pdfPage).toBe(1)
       expect(result.current.isOpen).toBe(true)
       expect(result.current.activeFileIndex).toBe(0)
     })
@@ -60,6 +61,34 @@ describe('FilePreviewContext', () => {
 
       act(() => result.current.openFile('/workspace/report.md', 'agent-1'))
       expect(result.current.openFiles[0].version).toBe(2)
+    })
+  })
+
+  describe('PDF pagination', () => {
+    it('keeps a separate page for each open file', () => {
+      const { result } = renderHook(() => useFilePreview(), { wrapper })
+      act(() => result.current.openFile('/workspace/long.pdf', 'agent-1'))
+      act(() => result.current.openFile('/workspace/short.pdf', 'agent-1'))
+
+      act(() => result.current.setPdfPage('/workspace/long.pdf', 8))
+      act(() => result.current.setPdfPage('/workspace/short.pdf', 2))
+
+      expect(result.current.openFiles[0].pdfPage).toBe(8)
+      expect(result.current.openFiles[1].pdfPage).toBe(2)
+
+      act(() => result.current.setActiveFile(0))
+      expect(result.current.openFiles[result.current.activeFileIndex].pdfPage).toBe(8)
+      act(() => result.current.setActiveFile(1))
+      expect(result.current.openFiles[result.current.activeFileIndex].pdfPage).toBe(2)
+    })
+
+    it('clamps page updates to the first page', () => {
+      const { result } = renderHook(() => useFilePreview(), { wrapper })
+      act(() => result.current.openFile('/workspace/report.pdf', 'agent-1'))
+
+      act(() => result.current.setPdfPage('/workspace/report.pdf', 0))
+
+      expect(result.current.openFiles[0].pdfPage).toBe(1)
     })
   })
 

--- a/src/renderer/context/file-preview-context.tsx
+++ b/src/renderer/context/file-preview-context.tsx
@@ -7,6 +7,8 @@ export interface FileTab {
   displayName: string
   description?: string
   version: number
+  /** 1-based page currently shown when this tab contains a PDF. */
+  pdfPage: number
 }
 
 export interface CellRef {
@@ -43,6 +45,7 @@ interface FilePreviewContextType {
   openFile: (filePath: string, agentSlug: string, description?: string) => void
   closeFile: (filePath: string) => void
   setActiveFile: (index: number) => void
+  setPdfPage: (filePath: string, page: number) => void
   close: () => void
 
   addComment: (comment: Omit<FileComment, 'id'>) => void
@@ -95,7 +98,14 @@ export function FilePreviewProvider({
         next[existingIndex] = { ...next[existingIndex], version: next[existingIndex].version + 1 }
         return next
       }
-      const newTab: FileTab = { filePath, agentSlug, displayName: getDisplayName(filePath), description, version: 0 }
+      const newTab: FileTab = {
+        filePath,
+        agentSlug,
+        displayName: getDisplayName(filePath),
+        description,
+        version: 0,
+        pdfPage: 1,
+      }
       const next = [...prev, newTab]
       setActiveFileIndex(next.length - 1)
       setIsOpen(true)
@@ -129,6 +139,18 @@ export function FilePreviewProvider({
 
   const setActiveFile = useCallback((index: number) => {
     setActiveFileIndex(index)
+  }, [])
+
+  const setPdfPage = useCallback((filePath: string, page: number) => {
+    const nextPage = Number.isFinite(page) ? Math.max(1, Math.floor(page)) : 1
+    setOpenFiles(prev => {
+      const index = prev.findIndex(file => file.filePath === filePath)
+      if (index < 0 || prev[index].pdfPage === nextPage) return prev
+
+      const next = [...prev]
+      next[index] = { ...next[index], pdfPage: nextPage }
+      return next
+    })
   }, [])
 
   const close = useCallback(() => {
@@ -176,11 +198,12 @@ export function FilePreviewProvider({
     openFile,
     closeFile,
     setActiveFile,
+    setPdfPage,
     close,
     addComment,
     removeComment,
     clearComments,
-  }), [openFiles, activeFileIndex, comments, isOpen, commentsEnabled, openFile, closeFile, setActiveFile, close, addComment, removeComment, clearComments])
+  }), [openFiles, activeFileIndex, comments, isOpen, commentsEnabled, openFile, closeFile, setActiveFile, setPdfPage, close, addComment, removeComment, clearComments])
 
   return (
     <FilePreviewContext.Provider value={value}>


### PR DESCRIPTION
## Summary

- store the current PDF page on each file-preview tab
- control the PDF renderer from the active tab's page state
- clamp saved page positions when a PDF has fewer pages
- keep sticky pagination controls above react-pdf's interactive layers
- add accessible, non-submit pagination controls
- add regression coverage for provider-to-tray page transitions

## Root cause

The file preview tray reused a single `PdfRenderer` instance while switching tabs, but the renderer kept `currentPage` as component-local state. That page number therefore leaked from one PDF into the next, including values beyond the second PDF's page count.

After moving the page into tab state, the sticky control bar still had no stacking level. React-pdf's full-page text and annotation layers use higher stacking levels, so they could sit above the visible controls and intercept pointer input.

## User impact

Each open PDF now keeps its own pagination position. Switching between PDFs restores the correct page for that tab, refreshed or shorter PDFs cannot remain on a page that does not exist, and the pagination buttons remain clickable over rendered PDF content.

## Validation

- 33 focused file-preview tests passed
- `npm run typecheck` passed
- ESLint passed for all changed files
- `git diff --check` passed
