### PR TITLE
Apply the both-shelves awaiting-clear rule at every resolution site (SUP-451)

### DIFF
--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2669,6 +2669,11 @@ agents.post('/:id/sessions/:sessionId/run-script', AgentUser(), async (c) => {
       return c.json({ error: `Script type "${scriptType}" is not supported on ${platform}` }, 400)
     }
 
+    // The user approved — the host now runs the script (up to 30s below). The wait has
+    // flipped from the human to the machine, so clear the awaiting light now instead of
+    // leaving the session stuck "needs input" until the script's tool_result lands.
+    messagePersister.clearPendingScriptRun(c.req.param('sessionId'), toolUseId)
+
     // Execute the script with a 30s timeout
     const { exec, execFile } = await import('child_process')
     const { promisify } = await import('util')

--- a/src/shared/lib/container/awaiting-input-background-subagent.repro.test.ts
+++ b/src/shared/lib/container/awaiting-input-background-subagent.repro.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Repro: the main-path 'user' tool_result clear over-clears the awaiting light
+ * while a background subagent still needs the human.
+ *
+ * A background subagent (run_in_background) runs concurrently with the main turn.
+ * When it hits a blocking input tool its request is registered on the PARENT
+ * session's shelves (pendingInputRequests + isAwaitingInput) via the sidechain
+ * path. Meanwhile the main agent keeps working; when it finishes an ordinary tool
+ * its tool_result arrives as a main-path 'user' message. That handler cleared
+ * isAwaitingInput UNCONDITIONALLY (the one clear site missing the both-shelves
+ * `hasBlockingPendingRequests` guard), so the "needs input" pill vanished while
+ * the subagent was still parked on the user.
+ *
+ * Fix: delete the resolved id first (handleToolResults), then clear only when no
+ * blocking request remains across both shelves.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import type { ContainerClient, StreamMessage } from './types'
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({}),
+  getAgentCapabilitySettings: () => ({ subagents: 'review', workflows: 'review' }),
+  VALID_SCRIPT_TYPES: { darwin: ['applescript', 'shell'], linux: ['shell'], win32: ['powershell'] },
+}))
+vi.mock('@shared/lib/services/session-service', () => ({
+  updateSessionMetadata: vi.fn(() => Promise.resolve()),
+  finalizeAutomationStatus: vi.fn(() => Promise.resolve('not-automation')),
+  getSessionMetadata: vi.fn(() => Promise.resolve(null)),
+}))
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerSessionComplete: vi.fn(() => Promise.resolve()),
+    triggerSessionWaitingInput: vi.fn(() => Promise.resolve()),
+  },
+}))
+vi.mock('@shared/lib/analytics/server-analytics', () => ({ trackServerEvent: vi.fn() }))
+vi.mock('@shared/lib/db', () => ({ db: {} }))
+vi.mock('@shared/lib/db/schema', () => ({ connectedAccounts: {} }))
+vi.mock('drizzle-orm', () => ({ eq: vi.fn() }))
+
+function createReplayClient(): { client: ContainerClient; send: (m: StreamMessage) => void } {
+  let callback: ((message: StreamMessage) => void) | null = null
+  const client = {
+    subscribeToStream: vi.fn((_sid: string, cb: (message: StreamMessage) => void) => {
+      callback = cb
+      return { unsubscribe: vi.fn(), ready: Promise.resolve() }
+    }),
+    start: vi.fn(), stop: vi.fn(), stopSync: vi.fn(), getInfoFromRuntime: vi.fn(), getInfo: vi.fn(),
+    fetch: vi.fn(() => Promise.reject(new Error('no container in test'))),
+    waitForHealthy: vi.fn(), isHealthy: vi.fn(), getStats: vi.fn(), createSession: vi.fn(),
+    getSession: vi.fn(() => Promise.resolve(null)), deleteSession: vi.fn(), sendMessage: vi.fn(),
+    interruptSession: vi.fn(), on: vi.fn(), off: vi.fn(),
+  } as unknown as ContainerClient
+  return { client, send: (m) => callback?.(m) }
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 20))
+
+describe('awaiting-input status while a background subagent is parked on the user', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('keeps awaiting when the main agent completes a tool but the subagent still needs input', async () => {
+    vi.resetModules()
+    const { messagePersister } = await import('./message-persister')
+    const { client, send } = createReplayClient()
+    const sessionId = 'sess-bg-subagent-repro'
+    const agentSlug = 'agent-bg-subagent-repro'
+    const subInputId = 'toolu_subagent_browser_input'
+    const mainToolResultId = 'toolu_main_bash'
+
+    messagePersister.markSessionActive(sessionId, agentSlug)
+    await messagePersister.subscribeToSession(sessionId, client, sessionId, agentSlug)
+
+    // A background subagent (sidechain: parent_tool_use_id set) hits request_browser_input.
+    // Its ask is registered on the PARENT session and marks it awaiting.
+    send({ content: { type: 'assistant', parent_tool_use_id: 'parent-task-1', message: { content: [
+      { type: 'tool_use', id: subInputId, name: 'mcp__user-input__request_browser_input', input: { message: 'Pick an option' } },
+    ] } } } as unknown as StreamMessage)
+    await tick()
+
+    expect(messagePersister.isSessionAwaitingInput(sessionId)).toBe(true) // correct: the subagent needs the human
+
+    // The still-working main agent finishes an ordinary tool; its tool_result arrives on
+    // the MAIN path (no parent_tool_use_id) for a DIFFERENT id than the subagent's ask.
+    send({ content: { type: 'user', message: { content: [
+      { type: 'tool_result', tool_use_id: mainToolResultId, content: 'done', is_error: false },
+    ] } } } as unknown as StreamMessage)
+    await tick()
+
+    // The subagent's browser_input is still pending — the pill must stay up.
+    expect(messagePersister.isSessionAwaitingInput(sessionId)).toBe(true) // was over-cleared to false
+
+    // Sanity: once the subagent's own request resolves, awaiting clears normally.
+    send({ content: { type: 'user', message: { content: [
+      { type: 'tool_result', tool_use_id: subInputId, content: 'option A', is_error: false },
+    ] } } } as unknown as StreamMessage)
+    await tick()
+
+    expect(messagePersister.isSessionAwaitingInput(sessionId)).toBe(false)
+
+    messagePersister.unsubscribeFromSession(sessionId)
+  })
+})

--- a/src/shared/lib/container/awaiting-input-script-run.repro.test.ts
+++ b/src/shared/lib/container/awaiting-input-script-run.repro.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Repro: a script_run request approved by the user leaves the session pinned to
+ * `awaiting_input` for the whole time the host runs the script (up to the 30s exec
+ * timeout). script_run sets awaiting when it needs approval, but nothing clears it
+ * at approval time — the flag only drops when the script's tool_result lands after
+ * execution. So every status consumer (tray, app menu, sidebar pill, home,
+ * /api/agents) reports "needs input" while the host is actually running the script,
+ * i.e. the wait has already flipped from the human to the machine.
+ *
+ * Sibling of the capability-review bug: both are out-of-band resolutions whose
+ * tool_result backstop is delayed. The run-script route now calls
+ * `clearPendingScriptRun` on approval (before exec); this drives the same clear.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import type { ContainerClient, StreamMessage } from './types'
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({}),
+  getAgentCapabilitySettings: () => ({ subagents: 'review', workflows: 'review' }),
+  VALID_SCRIPT_TYPES: { darwin: ['applescript', 'shell'], linux: ['shell'], win32: ['powershell'] },
+}))
+vi.mock('@shared/lib/services/session-service', () => ({
+  updateSessionMetadata: vi.fn(() => Promise.resolve()),
+  finalizeAutomationStatus: vi.fn(() => Promise.resolve('not-automation')),
+  getSessionMetadata: vi.fn(() => Promise.resolve(null)),
+}))
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerSessionComplete: vi.fn(() => Promise.resolve()),
+    triggerSessionWaitingInput: vi.fn(() => Promise.resolve()),
+  },
+}))
+vi.mock('@shared/lib/analytics/server-analytics', () => ({ trackServerEvent: vi.fn() }))
+vi.mock('@shared/lib/db', () => ({ db: {} }))
+vi.mock('@shared/lib/db/schema', () => ({ connectedAccounts: {} }))
+vi.mock('drizzle-orm', () => ({ eq: vi.fn() }))
+
+function createReplayClient(): { client: ContainerClient; send: (m: StreamMessage) => void } {
+  let callback: ((message: StreamMessage) => void) | null = null
+  const client = {
+    subscribeToStream: vi.fn((_sid: string, cb: (message: StreamMessage) => void) => {
+      callback = cb
+      return { unsubscribe: vi.fn(), ready: Promise.resolve() }
+    }),
+    start: vi.fn(), stop: vi.fn(), stopSync: vi.fn(), getInfoFromRuntime: vi.fn(), getInfo: vi.fn(),
+    fetch: vi.fn(() => Promise.reject(new Error('no container in test'))),
+    waitForHealthy: vi.fn(), isHealthy: vi.fn(), getStats: vi.fn(), createSession: vi.fn(),
+    getSession: vi.fn(() => Promise.resolve(null)), deleteSession: vi.fn(), sendMessage: vi.fn(),
+    interruptSession: vi.fn(), on: vi.fn(), off: vi.fn(),
+  } as unknown as ContainerClient
+  return { client, send: (m) => callback?.(m) }
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 20))
+
+describe('awaiting-input status while an approved host script runs', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('clears awaiting once the script_run launch is approved (before its result arrives)', async () => {
+    vi.resetModules()
+    const { messagePersister } = await import('./message-persister')
+    const { client, send } = createReplayClient()
+    const sessionId = 'sess-script-repro'
+    const agentSlug = 'agent-script-repro'
+    const toolUseId = 'toolu_script_1'
+
+    messagePersister.markSessionActive(sessionId, agentSlug)
+    await messagePersister.subscribeToSession(sessionId, client, sessionId, agentSlug)
+
+    // Drive the real stream path: a request_script_run tool_use that needs approval.
+    send({ content: { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'tool_use', id: toolUseId, name: 'mcp__user-input__request_script_run' } } } } as unknown as StreamMessage)
+    send({ content: { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: JSON.stringify({ script: 'echo hi', scriptType: 'shell', explanation: 'test' }) } } } } as unknown as StreamMessage)
+    send({ content: { type: 'stream_event', event: { type: 'content_block_stop' } } } as unknown as StreamMessage)
+    await tick()
+
+    expect(messagePersister.isSessionAwaitingInput(sessionId)).toBe(true) // correct: awaiting approval
+
+    messagePersister.clearPendingScriptRun(sessionId, toolUseId) // user approves; host now runs the script
+    await tick()
+
+    expect(messagePersister.isSessionAwaitingInput(sessionId)).toBe(false) // was stuck true through execution
+
+    messagePersister.unsubscribeFromSession(sessionId)
+  })
+})

--- a/src/shared/lib/container/awaiting-input-subagent-review.repro.test.ts
+++ b/src/shared/lib/container/awaiting-input-subagent-review.repro.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Repro: a subagent/workflow launch approved under a 'review' policy leaves the
+ * parent session pinned to `awaiting_input` for the whole time the subagent runs.
+ * `completeCapabilityReview` closes the card but never clears `isAwaitingInput`;
+ * the flag only drops when the Task's tool_result arrives (minutes later). Every
+ * status consumer (tray, app menu, sidebar pill, home, /api/agents) then reports
+ * "needs input" while the agent is actually working, waiting on the subagent.
+ * Only manifests under 'review' policy (default 'allow' never pauses the launch).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import type { ContainerClient, StreamMessage } from './types'
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({}),
+  getAgentCapabilitySettings: () => ({ subagents: 'review', workflows: 'review' }),
+  VALID_SCRIPT_TYPES: { darwin: ['applescript', 'shell'], linux: ['shell'], win32: ['powershell'] },
+}))
+vi.mock('@shared/lib/services/session-service', () => ({
+  updateSessionMetadata: vi.fn(() => Promise.resolve()),
+  finalizeAutomationStatus: vi.fn(() => Promise.resolve('not-automation')),
+  getSessionMetadata: vi.fn(() => Promise.resolve(null)),
+}))
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerSessionComplete: vi.fn(() => Promise.resolve()),
+    triggerSessionWaitingInput: vi.fn(() => Promise.resolve()),
+  },
+}))
+vi.mock('@shared/lib/analytics/server-analytics', () => ({ trackServerEvent: vi.fn() }))
+vi.mock('@shared/lib/db', () => ({ db: {} }))
+vi.mock('@shared/lib/db/schema', () => ({ connectedAccounts: {} }))
+vi.mock('drizzle-orm', () => ({ eq: vi.fn() }))
+
+function createReplayClient(): { client: ContainerClient; send: (m: StreamMessage) => void } {
+  let callback: ((message: StreamMessage) => void) | null = null
+  const client = {
+    subscribeToStream: vi.fn((_sid: string, cb: (message: StreamMessage) => void) => {
+      callback = cb
+      return { unsubscribe: vi.fn(), ready: Promise.resolve() }
+    }),
+    start: vi.fn(), stop: vi.fn(), stopSync: vi.fn(), getInfoFromRuntime: vi.fn(), getInfo: vi.fn(),
+    fetch: vi.fn(() => Promise.reject(new Error('no container in test'))),
+    waitForHealthy: vi.fn(), isHealthy: vi.fn(), getStats: vi.fn(), createSession: vi.fn(),
+    getSession: vi.fn(() => Promise.resolve(null)), deleteSession: vi.fn(), sendMessage: vi.fn(),
+    interruptSession: vi.fn(), on: vi.fn(), off: vi.fn(),
+  } as unknown as ContainerClient
+  return { client, send: (m) => callback?.(m) }
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 20))
+
+describe('awaiting-input status while an approved subagent runs (review policy)', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('clears awaiting once the subagent launch is approved (before its result arrives)', async () => {
+    vi.resetModules()
+    const { messagePersister } = await import('./message-persister')
+    const { client, send } = createReplayClient()
+    const sessionId = 'sess-review-repro'
+    const agentSlug = 'agent-review-repro'
+    const toolUseId = 'toolu_task_1'
+
+    messagePersister.markSessionActive(sessionId, agentSlug)
+    await messagePersister.subscribeToSession(sessionId, client, sessionId, agentSlug)
+
+    send({ content: { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'tool_use', id: toolUseId, name: 'Task' } } } } as unknown as StreamMessage)
+    send({ content: { type: 'stream_event', event: { type: 'content_block_stop' } } } as unknown as StreamMessage)
+    await tick()
+
+    expect(messagePersister.isSessionAwaitingInput(sessionId)).toBe(true) // correct: awaiting approval
+
+    messagePersister.completeCapabilityReview(sessionId, toolUseId) // user approves
+    await tick()
+
+    expect(messagePersister.isSessionAwaitingInput(sessionId)).toBe(false) // was stuck true
+
+    messagePersister.unsubscribeFromSession(sessionId)
+  })
+})

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -564,6 +564,26 @@ class MessagePersister {
     }
   }
 
+  // Clear a pending script_run request once the user approves it, before the host
+  // runs the script. Like an approved subagent, an approved script runs on the host
+  // (up to a 30s timeout) before its tool_result lands — the wait now belongs to the
+  // machine, not the human — so drop the awaiting light here instead of leaving it
+  // stuck until the result arrives. Same both-shelves rule as the other clear sites.
+  clearPendingScriptRun(sessionId: string, toolUseId: string): void {
+    const state = this.streamingStates.get(sessionId)
+    if (state) {
+      state.pendingInputRequests.delete(toolUseId)
+      if (state.isAwaitingInput && !this.hasBlockingPendingRequests(state)) {
+        state.isAwaitingInput = false
+        this.broadcastGlobal({
+          type: 'session_input_provided',
+          sessionId,
+          agentSlug: state.agentSlug,
+        })
+      }
+    }
+  }
+
   // When a new message arrives while the session is awaiting user input, cancel the
   // pending request(s) so the message starts a fresh turn instead of deadlocking behind
   // the blocked tool.

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1281,8 +1281,16 @@ class MessagePersister {
           this.broadcastToSSE(sessionId, { type: 'messages_updated' })
           break
         }
-        // Clear awaiting input when tool results arrive (user provided input)
-        if (state.isAwaitingInput) {
+        // Tool results come as 'user' type messages. Delete the resolved input
+        // requests from the pending map FIRST (handleToolResults does the delete)
+        // so the both-shelves check below reflects only requests still open.
+        this.handleToolResults(sessionId, content)
+        // Clear awaiting only when no genuine wait remains across BOTH shelves.
+        // A background subagent's ask (or a parallel top-level ask, or a pending
+        // computer_use) can still need the human while this main-agent tool_result
+        // lands — the old unconditional clear dropped the "needs input" pill in
+        // those cases. Same rule as every other clear site.
+        if (state.isAwaitingInput && !this.hasBlockingPendingRequests(state)) {
           state.isAwaitingInput = false
           this.broadcastGlobal({
             type: 'session_input_provided',
@@ -1290,8 +1298,6 @@ class MessagePersister {
             agentSlug: state.agentSlug,
           })
         }
-        // Tool results come as 'user' type messages
-        this.handleToolResults(sessionId, content)
         // Broadcast refresh so frontend can detect the persisted user message
         // and clear the optimistic pending copy promptly.
         this.broadcastToSSE(sessionId, { type: 'messages_updated' })

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -534,7 +534,11 @@ class MessagePersister {
     if (!state) return
     state.pendingInputRequests.delete(toolUseId)
     this.broadcastToSSE(sessionId, { type: 'capability_review_resolved', toolUseId })
-    if (state.pendingInputRequests.size === 0) {
+    // Approval flips the wait from the human to the subagent — an approved
+    // Task/Workflow runs for minutes before its tool_result arrives, so clear the
+    // awaiting light here instead of leaving it stuck until the result lands.
+    if (state.isAwaitingInput && !this.hasBlockingPendingRequests(state)) {
+      state.isAwaitingInput = false
       this.broadcastGlobal({
         type: 'session_input_provided',
         sessionId,


### PR DESCRIPTION
## What

Apply the both-shelves awaiting-clear rule at three remaining resolution sites, so the "needs input" pill turns off exactly when the human's turn ends - not while the machine is still working.

**Stacked on #510** (base `fix/subagent-input-surfacing`): reuses its `hasBlockingPendingRequests` helper, so it can't build off `main` alone. Retarget to `main` once #510 lands. Linear: SUP-451.

## The bug class

`isAwaitingInput` should be true exactly when a human must act. #510 introduced `hasBlockingPendingRequests` (both request shelves - pending input asks + pending computer-use, skipping auto-approved) and used it at the sidechain clear. Three other resolution sites still cleared on the wrong condition:

| Site | Was | Now |
|---|---|---|
| capability-review approve (`completeCapabilityReview`) | never cleared - waited for the Task's tool_result, minutes later | clears on approval, both-shelves rule |
| script_run approve (`clearPendingScriptRun`, new) | never cleared - waited for the script's tool_result after a ≤30s host exec | clears on approval, before the script runs |
| main-path tool_result | cleared unconditionally on ANY tool_result | delete resolved id first, then clear only if no blocking request remains |

## Why each matters

- **capability-review / script_run**: after you approve, the wait belongs to the machine (a Task running for minutes / a host script for ≤30s), but the session stayed orange "needs input" the whole time - tray, app menu, sidebar, home, `/api/agents`.
- **main-path over-clear**: with a background subagent parked on the user, its ask lives on the parent session's shelves while the main agent keeps working. The main agent finishing an ordinary tool cleared the pill even though the subagent still needed you. Found by an adversarial review pass over the branch.

All five awaiting-clear sites now share the one `hasBlockingPendingRequests` rule.

## Verification

- Three repro tests, each red-before / green-after, driving the real stream + resolution paths:
  - `awaiting-input-subagent-review.repro.test.ts`
  - `awaiting-input-script-run.repro.test.ts`
  - `awaiting-input-background-subagent.repro.test.ts`
- Full `message-persister.test.ts` suite green (267); typecheck + lint clean.

## Footprint

5 files, +307/-5 (2 source, 3 repros).
