### PR TITLE
Persist fatal crash marker to disk before self-quit

### DIFF
--- a/src/main/crash-marker-schema.ts
+++ b/src/main/crash-marker-schema.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+
+export const crashMarkerEntrySchema = z.object({
+  timestamp: z.string(),
+  type: z.enum(['uncaughtException', 'unhandledRejection']),
+  name: z.string(),
+  message: z.string(),
+  stack: z.string().optional(),
+})
+
+export const crashMarkerSchema = z.object({
+  version: z.literal(1),
+  appVersion: z.string(),
+  // Incremented before each delivery attempt so a crash-looping app can't
+  // retry the same marker forever.
+  reportAttempts: z.number().int().nonnegative(),
+  entries: z.array(crashMarkerEntrySchema).min(1),
+})
+
+export type CrashMarkerEntry = z.infer<typeof crashMarkerEntrySchema>
+export type CrashMarker = z.infer<typeof crashMarkerSchema>

--- a/src/main/crash-marker.test.ts
+++ b/src/main/crash-marker.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { captureMessage, flushErrorReporting, getErrorReporter } from '@shared/lib/error-reporting'
+import {
+  recordFatalError,
+  reportCrashMarkerFromLastRun,
+  toReportableError,
+  getCrashMarkerPath,
+} from './crash-marker'
+import { crashMarkerSchema } from './crash-marker-schema'
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureMessage: vi.fn(() => 'event-id'),
+  flushErrorReporting: vi.fn(async () => true),
+  getErrorReporter: vi.fn(() => ({}) as never),
+}))
+
+let tmpDir: string
+let savedDataDir: string | undefined
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crash-marker-test-'))
+  savedDataDir = process.env.SUPERAGENT_DATA_DIR
+  process.env.SUPERAGENT_DATA_DIR = tmpDir
+  vi.mocked(captureMessage).mockClear()
+  vi.mocked(flushErrorReporting).mockClear()
+  vi.mocked(flushErrorReporting).mockResolvedValue(true)
+  vi.mocked(getErrorReporter).mockReturnValue({} as never)
+})
+
+afterEach(() => {
+  if (savedDataDir === undefined) {
+    delete process.env.SUPERAGENT_DATA_DIR
+  } else {
+    process.env.SUPERAGENT_DATA_DIR = savedDataDir
+  }
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function readMarkerFile() {
+  return crashMarkerSchema.parse(JSON.parse(fs.readFileSync(getCrashMarkerPath(), 'utf8')))
+}
+
+describe('toReportableError', () => {
+  it('passes Error instances through unchanged', () => {
+    const err = new TypeError('boom')
+    expect(toReportableError(err)).toBe(err)
+  })
+
+  it('describes an undefined reason instead of producing "Error: undefined"', () => {
+    const err = toReportableError(undefined)
+    expect(err.message).toContain('Non-Error fatal reason')
+    expect(err.message).toContain('undefined')
+  })
+
+  it('inspects non-Error object reasons', () => {
+    const err = toReportableError({ code: 'ECONNRESET', attempt: 3 })
+    expect(err.message).toContain('ECONNRESET')
+    expect(err.message).toContain('attempt')
+  })
+})
+
+describe('recordFatalError', () => {
+  it('writes a schema-valid marker with the error details', () => {
+    const boom = new Error('it broke')
+    recordFatalError('uncaughtException', boom)
+
+    const marker = readMarkerFile()
+    expect(marker.entries).toHaveLength(1)
+    expect(marker.entries[0]).toMatchObject({
+      type: 'uncaughtException',
+      name: 'Error',
+      message: 'it broke',
+    })
+    expect(marker.entries[0].stack).toContain('it broke')
+    expect(marker.reportAttempts).toBe(0)
+  })
+
+  it('records an undefined rejection reason with usable context', () => {
+    recordFatalError('unhandledRejection', undefined)
+
+    const marker = readMarkerFile()
+    expect(marker.entries[0].message).toContain('Non-Error fatal reason')
+  })
+
+  it('appends pile-on fatals without displacing the original, capped at 5', () => {
+    recordFatalError('unhandledRejection', new Error('original cause'))
+    for (let i = 0; i < 10; i++) {
+      recordFatalError('unhandledRejection', new Error(`pile-on ${i}`))
+    }
+
+    const marker = readMarkerFile()
+    expect(marker.entries).toHaveLength(5)
+    expect(marker.entries[0].message).toBe('original cause')
+  })
+
+  it('creates the data dir if missing and never throws', () => {
+    process.env.SUPERAGENT_DATA_DIR = path.join(tmpDir, 'does', 'not', 'exist')
+    expect(() => recordFatalError('uncaughtException', new Error('boom'))).not.toThrow()
+    expect(fs.existsSync(getCrashMarkerPath())).toBe(true)
+  })
+
+  it('does not throw even when the marker path is unwritable', () => {
+    // A file where the data dir should be makes mkdir/write fail.
+    const blocked = path.join(tmpDir, 'blocked')
+    fs.writeFileSync(blocked, '')
+    process.env.SUPERAGENT_DATA_DIR = path.join(blocked, 'nested')
+    expect(() => recordFatalError('uncaughtException', new Error('boom'))).not.toThrow()
+  })
+
+  it('truncates oversized messages and stacks', () => {
+    const huge = new Error('x'.repeat(10_000))
+    recordFatalError('uncaughtException', huge)
+
+    const marker = readMarkerFile()
+    expect(marker.entries[0].message.length).toBeLessThanOrEqual(2000)
+    expect((marker.entries[0].stack ?? '').length).toBeLessThanOrEqual(8000)
+  })
+})
+
+describe('reportCrashMarkerFromLastRun', () => {
+  it('does nothing when no marker exists', async () => {
+    await reportCrashMarkerFromLastRun()
+    expect(captureMessage).not.toHaveBeenCalled()
+  })
+
+  it('reports the marker as fatal and deletes it once the flush succeeds', async () => {
+    recordFatalError('unhandledRejection', new Error('the real cause'))
+
+    await reportCrashMarkerFromLastRun()
+
+    expect(captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('the real cause'),
+      expect.objectContaining({
+        level: 'fatal',
+        tags: expect.objectContaining({ type: 'unhandledRejection', crashedLastSession: 'true' }),
+      }),
+    )
+    expect(fs.existsSync(getCrashMarkerPath())).toBe(false)
+  })
+
+  it('includes all entries and the crashed version in extra data', async () => {
+    recordFatalError('uncaughtException', new Error('first'))
+    recordFatalError('unhandledRejection', new Error('second'))
+
+    await reportCrashMarkerFromLastRun()
+
+    const extra = vi.mocked(captureMessage).mock.calls[0][1]?.extra
+    expect(extra?.entries).toHaveLength(2)
+    expect(extra?.crashedAppVersion).toBeTruthy()
+  })
+
+  it('keeps the marker and burns an attempt when the flush fails', async () => {
+    vi.mocked(flushErrorReporting).mockResolvedValue(false)
+    recordFatalError('uncaughtException', new Error('boom'))
+
+    await reportCrashMarkerFromLastRun()
+
+    expect(captureMessage).toHaveBeenCalled()
+    expect(readMarkerFile().reportAttempts).toBe(1)
+  })
+
+  it('gives up after the attempt budget is exhausted', async () => {
+    recordFatalError('uncaughtException', new Error('boom'))
+    const marker = readMarkerFile()
+    fs.writeFileSync(getCrashMarkerPath(), JSON.stringify({ ...marker, reportAttempts: 5 }))
+
+    await reportCrashMarkerFromLastRun()
+
+    expect(captureMessage).not.toHaveBeenCalled()
+    expect(fs.existsSync(getCrashMarkerPath())).toBe(false)
+  })
+
+  it('deletes a corrupt marker without reporting or throwing', async () => {
+    fs.writeFileSync(getCrashMarkerPath(), 'not json{{')
+
+    await expect(reportCrashMarkerFromLastRun()).resolves.toBeUndefined()
+
+    expect(captureMessage).not.toHaveBeenCalled()
+    expect(fs.existsSync(getCrashMarkerPath())).toBe(false)
+  })
+
+  it('leaves the marker untouched when error reporting is not initialized', async () => {
+    vi.mocked(getErrorReporter).mockReturnValue(null as never)
+    recordFatalError('uncaughtException', new Error('boom'))
+
+    await reportCrashMarkerFromLastRun()
+
+    expect(captureMessage).not.toHaveBeenCalled()
+    expect(readMarkerFile().reportAttempts).toBe(0)
+  })
+
+  it('survives capture throwing mid-report and keeps the marker', async () => {
+    // The crash vector here is deliberately independent of the code under
+    // test: the reporting layer itself blows up.
+    vi.mocked(captureMessage).mockImplementation(() => {
+      throw new Error('reporter exploded')
+    })
+    recordFatalError('uncaughtException', new Error('boom'))
+
+    await expect(reportCrashMarkerFromLastRun()).resolves.toBeUndefined()
+    expect(fs.existsSync(getCrashMarkerPath())).toBe(true)
+  })
+})

--- a/src/main/crash-marker.ts
+++ b/src/main/crash-marker.ts
@@ -1,0 +1,131 @@
+/**
+ * Durable record of fatal main-process errors.
+ *
+ * The uncaughtException/unhandledRejection handlers in index.ts quit the app,
+ * and the Sentry event they capture is lost whenever the network is down at
+ * that moment (the transport has no offline queue). This module writes the
+ * fatal to disk *synchronously, before any async work*, so the record survives
+ * a dead network, a hung flush, or a second error during shutdown. The next
+ * launch reports the marker to Sentry and deletes it only once the flush
+ * confirms delivery.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { inspect } from 'util'
+import { getDataDir } from '@shared/lib/config/data-dir'
+import { APP_VERSION } from '@shared/lib/config/version'
+import { captureMessage, flushErrorReporting, getErrorReporter } from '@shared/lib/error-reporting'
+import { crashMarkerSchema, type CrashMarker, type CrashMarkerEntry } from './crash-marker-schema'
+
+const MARKER_FILENAME = 'fatal-crash-marker.json'
+// A fatal during shutdown often triggers pile-on rejections from torn-down
+// services; keep the earliest few, which include the original cause.
+const MAX_ENTRIES = 5
+const MAX_REPORT_ATTEMPTS = 5
+const MAX_MESSAGE_LENGTH = 2000
+const MAX_STACK_LENGTH = 8000
+const REPORT_FLUSH_TIMEOUT_MS = 10_000
+
+export function getCrashMarkerPath(): string {
+  return path.join(getDataDir(), MARKER_FILENAME)
+}
+
+/**
+ * Normalize a fatal reason into an Error without destroying context.
+ * unhandledRejection reasons are frequently not Errors — some dependencies
+ * reject with plain objects or literally `undefined` — and stringifying those
+ * as `new Error(String(reason))` yields the useless "Error: undefined".
+ */
+export function toReportableError(reason: unknown): Error {
+  if (reason instanceof Error) return reason
+  return new Error(`Non-Error fatal reason: ${inspect(reason, { depth: 4 }).slice(0, MAX_MESSAGE_LENGTH)}`)
+}
+
+function readMarker(): CrashMarker | null {
+  try {
+    return crashMarkerSchema.parse(JSON.parse(fs.readFileSync(getCrashMarkerPath(), 'utf8')))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Record a fatal error to disk. Synchronous and non-throwing — this runs
+ * inside the fatal handlers, before flush/shutdown, and must never make a
+ * bad situation worse. If a marker already exists (pile-on fatals in the same
+ * shutdown, or an undelivered marker from a previous run), the entry is
+ * appended up to MAX_ENTRIES so the original cause is never displaced.
+ */
+export function recordFatalError(type: CrashMarkerEntry['type'], reason: unknown): void {
+  try {
+    const error = toReportableError(reason)
+    const entry: CrashMarkerEntry = {
+      timestamp: new Date().toISOString(),
+      type,
+      name: error.name,
+      message: error.message.slice(0, MAX_MESSAGE_LENGTH),
+      stack: error.stack?.slice(0, MAX_STACK_LENGTH),
+    }
+    const existing = readMarker()
+    const marker: CrashMarker = existing
+      ? {
+          ...existing,
+          entries:
+            existing.entries.length >= MAX_ENTRIES ? existing.entries : [...existing.entries, entry],
+        }
+      : { version: 1, appVersion: APP_VERSION, reportAttempts: 0, entries: [entry] }
+    fs.mkdirSync(getDataDir(), { recursive: true })
+    fs.writeFileSync(getCrashMarkerPath(), JSON.stringify(marker, null, 2))
+  } catch {
+    // Never throw from a fatal handler.
+  }
+}
+
+/**
+ * If the previous session died in a fatal handler, report it now and delete
+ * the marker once the flush confirms delivery. Call at startup, after
+ * initErrorReporting. Non-throwing; a failed delivery keeps the marker for
+ * the next launch (bounded by MAX_REPORT_ATTEMPTS).
+ */
+export async function reportCrashMarkerFromLastRun(): Promise<void> {
+  try {
+    if (!fs.existsSync(getCrashMarkerPath())) return
+    const marker = readMarker()
+    if (!marker) {
+      // Unparseable — nothing recoverable, don't retry forever.
+      fs.unlinkSync(getCrashMarkerPath())
+      return
+    }
+    // Error reporting never initialized (dev mode, or init failure): leave the
+    // marker alone rather than consuming it unreported — flush() reports
+    // success when there is no provider.
+    if (!getErrorReporter()) return
+    if (marker.reportAttempts >= MAX_REPORT_ATTEMPTS) {
+      fs.unlinkSync(getCrashMarkerPath())
+      return
+    }
+    // Persist the attempt count before trying so a crash loop during startup
+    // still burns down the retry budget.
+    fs.writeFileSync(
+      getCrashMarkerPath(),
+      JSON.stringify({ ...marker, reportAttempts: marker.reportAttempts + 1 }, null, 2),
+    )
+    const first = marker.entries[0]
+    captureMessage(`Previous session ended by fatal ${first.type}: ${first.message}`, {
+      level: 'fatal',
+      tags: { type: first.type, crashedLastSession: 'true' },
+      extra: {
+        crashedAppVersion: marker.appVersion,
+        reportAttempts: marker.reportAttempts + 1,
+        entries: marker.entries,
+      },
+    })
+    const delivered = await flushErrorReporting(REPORT_FLUSH_TIMEOUT_MS)
+    if (delivered) {
+      fs.unlinkSync(getCrashMarkerPath())
+    }
+  } catch {
+    // Keep the marker for the next launch.
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -90,10 +90,14 @@ console.log(`Data directory: ${process.env.SUPERAGENT_DATA_DIR}`)
 
 // Initialize error reporting as early as possible (after data dir is set)
 import { initErrorReporting, captureException, flushErrorReporting } from '@shared/lib/error-reporting'
+import { recordFatalError, reportCrashMarkerFromLastRun, toReportableError } from './crash-marker'
 
 // Only report errors in production builds — dev mode generates too much noise
 if (app.isPackaged) {
   initErrorReporting({ environment: 'electron' })
+  // If the last session died in a fatal handler, its Sentry event may have
+  // been lost (no offline transport) — deliver the on-disk record now.
+  void reportCrashMarkerFromLastRun()
 }
 
 // Register auto-update IPC handlers early (before window creation)
@@ -1707,6 +1711,10 @@ app.on('before-quit', async (event) => {
 // Handle uncaught exceptions
 process.on('uncaughtException', async (error) => {
   console.error('Uncaught exception:', error)
+  // Persist to disk before any async work — if the network is down (or flush
+  // hangs, or shutdown throws again) the Sentry event below is lost, and the
+  // marker is then the only record that this exit was a crash.
+  recordFatalError('uncaughtException', error)
   captureException(error, { tags: { type: 'uncaughtException' }, level: 'fatal' })
   await flushErrorReporting(3000)
   await gracefulShutdown()
@@ -1717,7 +1725,8 @@ process.on('uncaughtException', async (error) => {
 // Handle unhandled promise rejections
 process.on('unhandledRejection', async (reason) => {
   console.error('Unhandled rejection:', reason)
-  captureException(reason instanceof Error ? reason : new Error(String(reason)), { tags: { type: 'unhandledRejection' }, level: 'fatal' })
+  recordFatalError('unhandledRejection', reason)
+  captureException(toReportableError(reason), { tags: { type: 'unhandledRejection' }, level: 'fatal' })
   await flushErrorReporting(3000)
   await gracefulShutdown()
   // See before-quit handler above for why this is deferred


### PR DESCRIPTION
## Problem

The main process quits itself on any `uncaughtException`/`unhandledRejection` (capture → flush → graceful shutdown → quit). Two failure modes make these exits invisible:

1. **The Sentry event is lost exactly when it matters.** The transport (`@sentry/node`) has no offline queue, and these fatals are frequently *caused by* network failure — so the 3s flush fails and the only record of the crash dies with the process. Confirmed twice on 0.4.16-rc.1 (exits at 13:19 / 14:34 PT on 7/21) via system-log forensics: clean exit 0, orderly teardown, no crash report, **no Sentry fatal**.
2. **Non-Error rejection reasons are destroyed.** `new Error(String(reason))` turns a dependency rejecting with `undefined` into the fleet-wide `Error: undefined` events (seen across 0.4.5–0.4.13, multiple users) — no stack, no context, culprit pointing at the handler itself.

## Fix

- **`recordFatalError()`** — called first in both fatal handlers, before any async work: synchronously writes a marker file (`fatal-crash-marker.json` in the data dir) with type, message, stack, timestamp. Survives dead network, hung flush, and repeat errors during shutdown (pile-on entries append, capped at 5, original cause never displaced). Never throws.
- **`reportCrashMarkerFromLastRun()`** — called at startup after `initErrorReporting`: reports the marker as a fatal `captureMessage` (tagged `crashedLastSession`, full entries in extra) and deletes it **only after `flush()` confirms delivery**; otherwise it's retried next launch with a bounded attempt budget (5) so a crash loop can't spin forever.
- **`toReportableError()`** — preserves non-Error reasons via `util.inspect` instead of `String()`; used both for the marker and for the live `captureException`.

Marker file is Zod-validated on read (`crash-marker-schema.ts`); corrupt markers are discarded, unparseable ≠ crash loop.

## Deliberately out of scope (phase 2)

The UX: the app still exits silently. The marker is the natural trigger for a future "last session crashed → relaunch/notify" flow.

## Testing

- 17 new unit tests (`crash-marker.test.ts`): serialization of Error/undefined/object reasons, append+cap semantics, truncation, unwritable paths, delivery-confirmed deletion, failed-flush retention, attempt exhaustion, corrupt marker, uninitialized reporter, reporter throwing mid-report (crash vector independent of the code under test).
- Full `src/main` suite: 171 passed. `tsc --noEmit` and eslint clean.