### PR TITLE
style: cap font weights at Inter Medium (500) across renderer

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -324,8 +324,8 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
                       description: error instanceof Error ? error.message : 'Please try again.',
                     })
                   }}
-                  displayClassName="text-xl font-semibold"
-                  inputClassName="h-9 text-xl font-semibold"
+                  displayClassName="text-xl font-medium"
+                  inputClassName="h-9 text-xl font-medium"
                   saveButtonClassName="h-8 w-8"
                   ariaLabel="Rename agent"
                   saveAriaLabel="Save name"

--- a/src/renderer/components/api-logs/request-logs-table.tsx
+++ b/src/renderer/components/api-logs/request-logs-table.tsx
@@ -40,7 +40,7 @@ function MethodBadge({ method }: { method: string }) {
     DELETE: 'text-red-700 bg-red-100 dark:text-red-300 dark:bg-red-900/40',
   }
   return (
-    <span className={`inline-block rounded px-1.5 py-0.5 text-2xs font-semibold leading-none ${colors[method] ?? 'text-muted-foreground bg-muted'}`}>
+    <span className={`inline-block rounded px-1.5 py-0.5 text-2xs font-medium leading-none ${colors[method] ?? 'text-muted-foreground bg-muted'}`}>
       {method}
     </span>
   )
@@ -61,7 +61,7 @@ function SourceBadge({ source }: { source: RequestLogEntry['source'] }) {
     ? 'text-purple-700 bg-purple-100 dark:text-purple-300 dark:bg-purple-900/40'
     : 'text-sky-700 bg-sky-100 dark:text-sky-300 dark:bg-sky-900/40'
   return (
-    <span className={`inline-block rounded px-1.5 py-0.5 text-2xs font-semibold leading-none ${style}`}>
+    <span className={`inline-block rounded px-1.5 py-0.5 text-2xs font-medium leading-none ${style}`}>
       {source === 'mcp' ? 'MCP' : 'API'}
     </span>
   )
@@ -85,7 +85,7 @@ function PolicyBadge({ decision }: { decision: string | null }) {
   }
   return (
     <span
-      className={`inline-block rounded px-1.5 py-0.5 text-2xs font-semibold leading-none ${styles[decision] ?? 'text-muted-foreground bg-muted'}`}
+      className={`inline-block rounded px-1.5 py-0.5 text-2xs font-medium leading-none ${styles[decision] ?? 'text-muted-foreground bg-muted'}`}
       title={`Policy: ${decision}`}
     >
       {labels[decision] ?? decision}

--- a/src/renderer/components/auth/auth-page.tsx
+++ b/src/renderer/components/auth/auth-page.tsx
@@ -403,7 +403,7 @@ export function AuthPage({ onPendingApproval }: { onPendingApproval?: (pending?:
     <div className="flex items-center justify-center h-screen bg-background" data-testid="auth-page">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <h1 className="text-2xl font-bold">Gamut</h1>
+          <h1 className="text-2xl font-medium">Gamut</h1>
         </CardHeader>
         <CardContent className="space-y-4">
           {isLoading ? (

--- a/src/renderer/components/auth/force-password-change.tsx
+++ b/src/renderer/components/auth/force-password-change.tsx
@@ -48,7 +48,7 @@ export function ForcePasswordChange() {
     <div className="flex items-center justify-center h-screen bg-background">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <h1 className="text-2xl font-bold">Change Your Password</h1>
+          <h1 className="text-2xl font-medium">Change Your Password</h1>
           <p className="text-sm text-muted-foreground mt-2">
             Your account requires a password change before you can continue.
           </p>

--- a/src/renderer/components/browser/browser-tray-content.tsx
+++ b/src/renderer/components/browser/browser-tray-content.tsx
@@ -241,7 +241,7 @@ export function BrowserTrayContent({
 
       {/* Activity log */}
       <div className="flex items-center gap-1 py-1.5 border-b shrink-0 mx-4 mt-4">
-        <span className="text-2xs font-semibold uppercase tracking-wider text-muted-foreground">Activity</span>
+        <span className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">Activity</span>
       </div>
       <BrowserActivityLog sessionId={sessionId} agentSlug={agentSlug} />
 

--- a/src/renderer/components/connections/connection-success-header.tsx
+++ b/src/renderer/components/connections/connection-success-header.tsx
@@ -12,7 +12,7 @@ export function ConnectionSuccessHeader({ toolkit, displayName }: ConnectionSucc
         <ServiceIcon slug={toolkit} fallback="oauth" className="h-6 w-6 text-green-600 dark:text-green-400" />
       </div>
       <div className="text-center">
-        <p className="text-base font-semibold capitalize">
+        <p className="text-base font-medium capitalize">
           {displayName} Successfully Connected!
         </p>
         <p className="text-xs text-muted-foreground mt-1">

--- a/src/renderer/components/file-preview/comments/comment-pin.tsx
+++ b/src/renderer/components/file-preview/comments/comment-pin.tsx
@@ -7,7 +7,7 @@ interface CommentPinProps {
 export function CommentPin({ x, y, number }: CommentPinProps) {
   return (
     <div
-      className="absolute w-5 h-5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary text-primary-foreground text-[10px] font-bold flex items-center justify-center shadow-md border-2 border-background pointer-events-none"
+      className="absolute w-5 h-5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary text-primary-foreground text-[10px] font-medium flex items-center justify-center shadow-md border-2 border-background pointer-events-none"
       style={{ left: `${x}%`, top: `${y}%` }}
     >
       {number}

--- a/src/renderer/components/file-preview/renderers/audio-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/audio-renderer.tsx
@@ -289,7 +289,7 @@ export function AudioRenderer({ url, filePath, commentsEnabled = true }: AudioRe
                 key={comment.id}
                 type="button"
                 onClick={() => seekTo(comment.timestamp)}
-                className="absolute -top-2 z-30 flex h-4 w-4 -translate-x-1/2 items-center justify-center rounded-full bg-primary text-[9px] font-semibold text-primary-foreground shadow ring-2 ring-background transition-transform hover:scale-110"
+                className="absolute -top-2 z-30 flex h-4 w-4 -translate-x-1/2 items-center justify-center rounded-full bg-primary text-[9px] font-medium text-primary-foreground shadow ring-2 ring-background transition-transform hover:scale-110"
                 style={{ left: `${comment.ratio * 100}%` }}
                 title={`Comment at ${formatMediaTime(comment.timestamp)}`}
                 aria-label={`Seek to comment ${index + 1} at ${formatMediaTime(comment.timestamp)}`}

--- a/src/renderer/components/file-preview/renderers/csv-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/csv-renderer.tsx
@@ -52,7 +52,7 @@ const CsvTable = memo(function CsvTable({ rows, columnLabels, commentsByCell, on
           {columnLabels.map((label, c) => (
             <th
               key={c}
-              className="sticky top-0 z-10 bg-muted px-3 py-1.5 text-left font-semibold whitespace-nowrap border-b border-r border-border/40"
+              className="sticky top-0 z-10 bg-muted px-3 py-1.5 text-left font-medium whitespace-nowrap border-b border-r border-border/40"
             >
               {label}
             </th>
@@ -83,7 +83,7 @@ const CsvTable = memo(function CsvTable({ rows, columnLabels, commentsByCell, on
                     {value}
                     {cellComments && (
                       <span
-                        className="absolute top-0.5 right-0.5 min-w-3.5 h-3.5 px-1 rounded-full bg-primary text-primary-foreground text-[9px] font-bold leading-[0.875rem] text-center shadow-sm pointer-events-none"
+                        className="absolute top-0.5 right-0.5 min-w-3.5 h-3.5 px-1 rounded-full bg-primary text-primary-foreground text-[9px] font-medium leading-[0.875rem] text-center shadow-sm pointer-events-none"
                         title={`${cellComments.length} comment${cellComments.length === 1 ? '' : 's'}`}
                       >
                         {cellComments.length}

--- a/src/renderer/components/file-preview/renderers/markdown-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/markdown-renderer.tsx
@@ -60,7 +60,7 @@ export function MarkdownRenderer({ url, filePath, commentsEnabled = true }: Mark
                 </div>
               ),
               th: ({ children }) => (
-                <th className="border-b-2 border-border px-3 py-1.5 text-left font-semibold">{children}</th>
+                <th className="border-b-2 border-border px-3 py-1.5 text-left font-medium">{children}</th>
               ),
               td: ({ children }) => (
                 <td className="border-b border-border px-3 py-1.5">{children}</td>

--- a/src/renderer/components/home/graph/agent-graph.css
+++ b/src/renderer/components/home/graph/agent-graph.css
@@ -156,7 +156,7 @@
   content: '→';
   font-size: 11px;
   line-height: 1;
-  font-weight: 600;
+  font-weight: 500;
   color: rgb(59 130 246);
   opacity: 0;
   transition: opacity 120ms;

--- a/src/renderer/components/home/home-page.tsx
+++ b/src/renderer/components/home/home-page.tsx
@@ -401,7 +401,7 @@ export function HomePage() {
           {/* Agents Section */}
           <section>
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold">Your Agents</h2>
+              <h2 className="text-lg font-medium">Your Agents</h2>
               <Button
                 size="sm"
                 onClick={() => { void createUntitledAgent() }}

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -823,7 +823,7 @@ export function AppSidebar() {
             */}
             <div
               className={cn(
-                'px-2 pb-2 text-base font-semibold select-none transition-[margin-top] duration-200 ease-out flex items-center gap-1',
+                'px-2 pb-2 text-base font-medium select-none transition-[margin-top] duration-200 ease-out flex items-center gap-1',
                 isWindowsElectron && 'app-drag-region'
               )}
               style={{ marginTop: showHeaderBar ? '-8px' : '8px' }}

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -301,7 +301,7 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
                   className={cn(
                     'flex items-center gap-2',
                     todo.status === 'completed' && 'text-muted-foreground line-through',
-                    todo.status === 'in_progress' && 'font-semibold'
+                    todo.status === 'in_progress' && 'font-medium'
                   )}
                 >
                   <span className="text-xs">

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -163,7 +163,7 @@ const MARKDOWN_COMPONENTS: Components = {
   // table to one giant line, while many short columns still drive the breakout.
   th: ({ children }) => (
     <th className={cn(
-      'border-b-2 px-3 py-1.5 text-left font-semibold align-top',
+      'border-b-2 px-3 py-1.5 text-left font-medium align-top',
       'border-border'
     )}>
       <div className="max-w-[32rem]">{children}</div>
@@ -328,7 +328,7 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
               {/* Slash command display */}
               {isSlashCommand && hasText && (
                 <div className="text-sm">
-                  <span className="font-mono font-semibold">
+                  <span className="font-mono font-medium">
                     {text.split(' ')[0]}
                   </span>
                   {text.includes(' ') && (

--- a/src/renderer/components/messages/slash-command-menu.test.tsx
+++ b/src/renderer/components/messages/slash-command-menu.test.tsx
@@ -128,8 +128,8 @@ describe('SlashCommandMenu', () => {
         filter="de"
       />
     )
-    // "de" should be bold in "deploy" and "debug"
-    const boldElements = document.querySelectorAll('.font-bold')
+    // "de" should be highlighted in "deploy" and "debug"
+    const boldElements = document.querySelectorAll('.font-medium')
     expect(boldElements.length).toBeGreaterThanOrEqual(2)
     expect(boldElements[0].textContent).toBe('de')
   })

--- a/src/renderer/components/messages/slash-command-menu.tsx
+++ b/src/renderer/components/messages/slash-command-menu.tsx
@@ -22,7 +22,7 @@ function HighlightedName({ name, filter }: { name: string; filter: string }) {
   return (
     <>
       {name.slice(0, idx)}
-      <span className="font-bold">{name.slice(idx, idx + filter.length)}</span>
+      <span className="font-medium">{name.slice(idx, idx + filter.length)}</span>
       {name.slice(idx + filter.length)}
     </>
   )

--- a/src/renderer/components/messages/stale-session-notice.tsx
+++ b/src/renderer/components/messages/stale-session-notice.tsx
@@ -11,7 +11,7 @@ export interface StaleSessionNoticeProps {
 function TeachingPoint({ lead, children }: { lead: string; children: ReactNode }) {
   return (
     <div className="text-xs">
-      <p className="font-semibold text-foreground">{lead}</p>
+      <p className="font-medium text-foreground">{lead}</p>
       <p className="text-muted-foreground">{children}</p>
     </div>
   )

--- a/src/renderer/components/messages/tool-renderers/ask-user-question.tsx
+++ b/src/renderer/components/messages/tool-renderers/ask-user-question.tsx
@@ -61,7 +61,7 @@ function ExpandedView({ input, result, isError }: ToolRendererProps) {
                 return (
                   <div
                     key={j}
-                    className={`text-xs flex items-start gap-1 ${isSelected ? 'font-semibold text-foreground' : 'text-muted-foreground'}`}
+                    className={`text-xs flex items-start gap-1 ${isSelected ? 'font-medium text-foreground' : 'text-muted-foreground'}`}
                   >
                     <span className="shrink-0">{isSelected ? '✓' : '○'}</span>
                     <span>

--- a/src/renderer/components/settings/runner-setup-error-panel.tsx
+++ b/src/renderer/components/settings/runner-setup-error-panel.tsx
@@ -53,7 +53,7 @@ export function RunnerSetupErrorPanel({ error, className }: RunnerSetupErrorPane
         <AlertTriangle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
         <div className="flex-1 min-w-0 space-y-3">
           <div>
-            <p className="text-sm font-semibold text-destructive">{payload.title}</p>
+            <p className="text-sm font-medium text-destructive">{payload.title}</p>
             <p className="text-sm text-muted-foreground mt-1">{payload.remediation}</p>
           </div>
 

--- a/src/renderer/components/settings/scope-policy-editor.tsx
+++ b/src/renderer/components/settings/scope-policy-editor.tsx
@@ -430,7 +430,7 @@ export function ScopePolicyEditorBody({
                         )}
                       />
                       <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                      <span className="text-xs font-semibold">{g.title}</span>
+                      <span className="text-xs font-medium">{g.title}</span>
                       <span className="text-xs text-muted-foreground tabular-nums">
                         ({rows.length})
                       </span>
@@ -464,7 +464,7 @@ export function ScopePolicyEditorBody({
                       (openGroups.other ?? filtering) && 'rotate-90',
                     )}
                   />
-                  <span className="text-xs font-semibold">Other</span>
+                  <span className="text-xs font-medium">Other</span>
                   <span className="text-xs text-muted-foreground tabular-nums">
                     ({groupedPolicies.other.length})
                   </span>

--- a/src/renderer/components/tray/tray-tab-strip.tsx
+++ b/src/renderer/components/tray/tray-tab-strip.tsx
@@ -45,7 +45,7 @@ export function TrayTabStrip({ trays, selectedTrayId, onSelect }: TrayTabStripPr
               {tray.label}
             </span>
             {tray.badge != null && tray.badge > 0 && (
-              <span className="absolute -top-0.5 -right-0.5 min-w-[14px] h-[14px] rounded-full bg-primary text-primary-foreground text-[9px] font-bold flex items-center justify-center px-0.5">
+              <span className="absolute -top-0.5 -right-0.5 min-w-[14px] h-[14px] rounded-full bg-primary text-primary-foreground text-[9px] font-medium flex items-center justify-center px-0.5">
                 {tray.badge > 9 ? '9+' : tray.badge}
               </span>
             )}

--- a/src/renderer/components/ui/alert-dialog.tsx
+++ b/src/renderer/components/ui/alert-dialog.tsx
@@ -77,7 +77,7 @@ const AlertDialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold", className)}
+    className={cn("text-lg font-medium", className)}
     {...props}
   />
 ))

--- a/src/renderer/components/ui/card.tsx
+++ b/src/renderer/components/ui/card.tsx
@@ -35,7 +35,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      'text-2xl font-semibold leading-none tracking-tight',
+      'text-2xl font-medium leading-none tracking-tight',
       className
     )}
     {...props}

--- a/src/renderer/components/ui/context-menu.tsx
+++ b/src/renderer/components/ui/context-menu.tsx
@@ -258,7 +258,7 @@ const ContextMenuLabel = React.forwardRef<
   <ContextMenuPrimitive.Label
     ref={ref}
     className={cn(
-      "px-2 py-1.5 text-sm font-semibold text-foreground",
+      "px-2 py-1.5 text-sm font-medium text-foreground",
       inset && "pl-8",
       className
     )}

--- a/src/renderer/components/ui/dialog.tsx
+++ b/src/renderer/components/ui/dialog.tsx
@@ -87,7 +87,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      'text-lg font-semibold leading-none tracking-tight',
+      'text-lg font-medium leading-none tracking-tight',
       className
     )}
     {...props}

--- a/src/renderer/components/ui/mount-choice-dialog.tsx
+++ b/src/renderer/components/ui/mount-choice-dialog.tsx
@@ -37,7 +37,7 @@ export function MountChoiceDialog({ open, onChoice, folderName }: MountChoiceDia
             <div>
               <div className="flex items-center gap-2">
                 <span className="font-medium text-sm">Upload a copy</span>
-                <span className="rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300 px-2 py-0.5 text-2xs font-semibold leading-none">Read Only</span>
+                <span className="rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300 px-2 py-0.5 text-2xs font-medium leading-none">Read Only</span>
               </div>
               <div className="text-xs text-muted-foreground">
                 Copies files into the agent workspace. Read-only — changes won&apos;t sync back.
@@ -53,7 +53,7 @@ export function MountChoiceDialog({ open, onChoice, folderName }: MountChoiceDia
             <div>
               <div className="flex items-center gap-2">
                 <span className="font-medium text-sm">Mount folder</span>
-                <span className="rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 px-2 py-0.5 text-2xs font-semibold leading-none">Read &amp; Write</span>
+                <span className="rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 px-2 py-0.5 text-2xs font-medium leading-none">Read &amp; Write</span>
               </div>
               <div className="text-xs text-muted-foreground">
                 Gives the agent direct read-write access. Requires a container restart if the agent is running.

--- a/src/renderer/components/ui/select.tsx
+++ b/src/renderer/components/ui/select.tsx
@@ -103,7 +103,7 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    className={cn("px-2 py-1.5 text-sm font-medium", className)}
     {...props}
   />
 ))

--- a/src/renderer/components/workflow/workflow-tray-content.tsx
+++ b/src/renderer/components/workflow/workflow-tray-content.tsx
@@ -270,7 +270,7 @@ export function WorkflowTrayContent({ agentSlug, sessionId, onClose }: WorkflowT
           <div key={group.title ?? `__ungrouped-${gi}`} className="space-y-1.5">
             {group.title && (
               <div className="flex items-baseline gap-2 px-1">
-                <span className="text-xs font-semibold text-foreground/80">{group.title}</span>
+                <span className="text-xs font-medium text-foreground/80">{group.title}</span>
                 {group.detail && (
                   <span className="text-[11px] text-muted-foreground truncate">{group.detail}</span>
                 )}

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -155,14 +155,14 @@ html[data-keyboard-open] [data-composer-footer] {
   margin-top: .25rem;
 }
 
-.markdown-composer-editor h1 { font-size: 1.25rem; line-height: 1.6rem; font-weight: 700; }
-.markdown-composer-editor h2 { font-size: 1.125rem; line-height: 1.5rem; font-weight: 700; }
+.markdown-composer-editor h1 { font-size: 1.25rem; line-height: 1.6rem; font-weight: 500; }
+.markdown-composer-editor h2 { font-size: 1.125rem; line-height: 1.5rem; font-weight: 500; }
 .markdown-composer-editor h3,
 .markdown-composer-editor h4,
 .markdown-composer-editor h5,
-.markdown-composer-editor h6 { font-size: 1rem; line-height: 1.4rem; font-weight: 650; }
+.markdown-composer-editor h6 { font-size: 1rem; line-height: 1.4rem; font-weight: 500; }
 
-.markdown-composer-editor strong { font-weight: 700; }
+.markdown-composer-editor strong { font-weight: 500; }
 .markdown-composer-editor em { font-style: italic; }
 .markdown-composer-editor s { color: hsl(var(--muted-foreground)); }
 


### PR DESCRIPTION
## Summary
- Migrates every `font-semibold` / `font-bold` in `src/renderer` to `font-medium`, enforcing the DESIGN.md font-weight ceiling of Inter Medium (500) — 30 files, 41 one-line weight swaps
- Composer markdown CSS in `globals.css`: h1/h2 `700 → 500`, h3–h6 `650 → 500`, `strong` `700 → 500`; agent-graph port arrow glyph `600 → 500`
- Covers dialog/alert-dialog/card titles, sidebar + auth wordmarks, mount-choice pills, tray tab badges, select/context-menu labels, chat + file-preview table headers, API-log badges, and scope-policy group titles
- Updates `slash-command-menu.test.tsx`, whose selector asserted on `.font-bold`

## Deliberate exception (reviewer call)
`src/renderer/components/messages/tool-renderers/bash.tsx` keeps `font-bold` on the command line — bold white monospace command on a black terminal box reads as terminal output emulation, not UI typography. Happy to cap it too if preferred.

## Testing
- `npm run lint` — 0 errors (40 pre-existing warnings in untouched files)
- `npm run typecheck` — six pre-existing errors on this branch (markdown-composer-editor implicit-any handlers, Better Auth option in `src/shared/lib/auth/index.ts`); verified identical with this change stashed, tracked separately
- `npx vitest run slash-command-menu.test.tsx` — 9/9 pass
- Visual spot-check in E2E mock mode: computed-style scan across home, agent home (title/cards/composer), and settings surfaces found zero visible elements above weight 500; injected h1/h2/h6/strong in the composer editor all compute to 500

Note: DESIGN.md itself isn't committed to the repo yet (absent from origin/main and history) — worth landing alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)