### PR TITLE
feat(secrets): standalone Agent Secrets page at /agents/:slug/secrets

### DIFF
--- a/src/renderer/components/agents/agent-secrets/agent-secrets-view.test.tsx
+++ b/src/renderer/components/agents/agent-secrets/agent-secrets-view.test.tsx
@@ -1,0 +1,361 @@
+// @vitest-environment jsdom
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentSecretsView } from './agent-secrets-view'
+
+const defaultSecret = {
+  id: 'SHARED_KEY',
+  key: 'Shared Key',
+  envVar: 'SHARED_KEY',
+  hasValue: true,
+}
+
+const mocks = vi.hoisted(() => ({
+  reveal: vi.fn(),
+  revealReset: vi.fn(),
+  update: vi.fn(),
+  create: vi.fn(),
+  remove: vi.fn(),
+  refetch: vi.fn(),
+  track: vi.fn(),
+  canAdmin: true,
+  querySlugs: [] as Array<string | null>,
+  query: {
+    data: [] as Array<{
+      id: string
+      key: string
+      envVar: string
+      hasValue: boolean
+    }>,
+    isLoading: false,
+    isError: false,
+    error: null as Error | null,
+  },
+}))
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+vi.mock('@renderer/lib/perf', () => ({ useRenderTracker: () => {} }))
+vi.mock('@renderer/context/analytics-context', () => ({
+  useAnalyticsTracking: () => ({ track: mocks.track }),
+}))
+vi.mock('@renderer/context/user-context', () => ({
+  useUser: () => ({
+    isAuthMode: true,
+    rolesReady: true,
+    canAdminAgent: () => mocks.canAdmin,
+  }),
+}))
+vi.mock('@renderer/hooks/use-secrets', () => ({
+  useAgentSecrets: (slug: string | null) => {
+    mocks.querySlugs.push(slug)
+    return { ...mocks.query, refetch: mocks.refetch }
+  },
+  useCreateSecret: () => ({ mutateAsync: mocks.create, isPending: false }),
+  useUpdateSecret: () => ({ mutateAsync: mocks.update, isPending: false }),
+  useDeleteSecret: () => ({ mutateAsync: mocks.remove, isPending: false }),
+  useRevealSecretValue: () => ({
+    mutateAsync: mocks.reveal,
+    reset: mocks.revealReset,
+    isPending: false,
+  }),
+}))
+
+describe('AgentSecretsView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.canAdmin = true
+    mocks.querySlugs = []
+    mocks.query = {
+      data: [defaultSecret],
+      isLoading: false,
+      isError: false,
+      error: null,
+    }
+    mocks.reveal.mockImplementation(
+      async ({ agentSlug }: { agentSlug: string }) => `${agentSlug}-value`,
+    )
+    mocks.update.mockResolvedValue(defaultSecret)
+    mocks.create.mockResolvedValue(defaultSecret)
+    mocks.remove.mockResolvedValue(undefined)
+  })
+
+  it('drops revealed state when the route changes agents', async () => {
+    const rendered = render(<AgentSecretsView agentSlug="agent-a" />)
+    expect(mocks.track).toHaveBeenCalledWith('secrets_viewed', { agentSlug: 'agent-a' })
+    fireEvent.click(screen.getByTestId('secret-reveal-SHARED_KEY'))
+    expect(await screen.findByText('agent-a-value')).toBeInTheDocument()
+
+    rendered.rerender(<AgentSecretsView agentSlug="agent-b" />)
+
+    expect(screen.queryByText('agent-a-value')).not.toBeInTheDocument()
+    expect(mocks.track).toHaveBeenLastCalledWith('secrets_viewed', { agentSlug: 'agent-b' })
+  })
+
+  it('refreshes an already-revealed row after editing its value', async () => {
+    render(<AgentSecretsView agentSlug="agent-a" />)
+    fireEvent.click(screen.getByTestId('secret-reveal-SHARED_KEY'))
+    expect(await screen.findByText('agent-a-value')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('secret-menu-SHARED_KEY'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit' }))
+    fireEvent.change(await screen.findByTestId('secret-dialog-value'), {
+      target: { value: 'new-value' },
+    })
+    fireEvent.click(screen.getByTestId('secret-dialog-submit'))
+    await waitFor(() => expect(mocks.update).toHaveBeenCalled())
+
+    expect(screen.getByText('new-value')).toBeInTheDocument()
+    expect(screen.queryByText('agent-a-value')).not.toBeInTheDocument()
+  })
+
+  it('edits a key without revealing or resubmitting the stored value', async () => {
+    render(<AgentSecretsView agentSlug="agent-a" />)
+    fireEvent.click(screen.getByTestId('secret-menu-SHARED_KEY'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit' }))
+
+    expect(screen.getByTestId('secret-dialog-value')).toHaveValue('')
+    expect(screen.getByTestId('secret-dialog-submit')).toBeDisabled()
+    fireEvent.change(screen.getByTestId('secret-dialog-key'), {
+      target: { value: 'Renamed Key' },
+    })
+    fireEvent.click(screen.getByTestId('secret-dialog-submit'))
+
+    await waitFor(() =>
+      expect(mocks.update).toHaveBeenCalledWith({
+        agentSlug: 'agent-a',
+        secretId: 'SHARED_KEY',
+        key: 'Renamed Key',
+      }),
+    )
+    expect(mocks.reveal).not.toHaveBeenCalled()
+  })
+
+  it('treats a cleared edit value as unchanged instead of blanking the secret', async () => {
+    render(<AgentSecretsView agentSlug="agent-a" />)
+    fireEvent.click(screen.getByTestId('secret-menu-SHARED_KEY'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit' }))
+
+    const valueInput = screen.getByTestId('secret-dialog-value')
+    fireEvent.change(valueInput, { target: { value: 'x' } })
+    fireEvent.change(valueInput, { target: { value: '' } })
+
+    expect(screen.getByTestId('secret-dialog-submit')).toBeDisabled()
+    expect(mocks.update).not.toHaveBeenCalled()
+
+    fireEvent.change(screen.getByTestId('secret-dialog-key'), {
+      target: { value: 'Renamed Key' },
+    })
+    fireEvent.click(screen.getByTestId('secret-dialog-submit'))
+
+    await waitFor(() =>
+      expect(mocks.update).toHaveBeenCalledWith({
+        agentSlug: 'agent-a',
+        secretId: 'SHARED_KEY',
+        key: 'Renamed Key',
+      }),
+    )
+  })
+
+  it('blocks keys that normalize to an empty environment variable', () => {
+    render(<AgentSecretsView agentSlug="agent-a" />)
+    fireEvent.click(screen.getByTestId('secrets-add-button'))
+    fireEvent.change(screen.getByTestId('secret-dialog-key'), {
+      target: { value: 'Ключ' },
+    })
+    fireEvent.change(screen.getByTestId('secret-dialog-value'), {
+      target: { value: 'secret' },
+    })
+
+    expect(screen.getByText('Env var: (invalid)')).toBeInTheDocument()
+    expect(screen.getByTestId('secret-dialog-submit')).toBeDisabled()
+    expect(mocks.create).not.toHaveBeenCalled()
+  })
+  it('blocks reserved keys and duplicate rename destinations', async () => {
+    const rendered = render(<AgentSecretsView agentSlug="agent-a" />)
+    fireEvent.click(screen.getByTestId('secrets-add-button'))
+    fireEvent.change(screen.getByTestId('secret-dialog-key'), {
+      target: { value: 'Proxy Token' },
+    })
+    fireEvent.change(screen.getByTestId('secret-dialog-value'), {
+      target: { value: 'secret' },
+    })
+    expect(screen.getByText(/PROXY_TOKEN \(reserved\)/)).toBeInTheDocument()
+    expect(screen.getByTestId('secret-dialog-submit')).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    mocks.query = {
+      ...mocks.query,
+      data: [
+        defaultSecret,
+        { id: 'OTHER', key: 'Other', envVar: 'OTHER', hasValue: true },
+      ],
+    }
+    rendered.rerender(<AgentSecretsView agentSlug="agent-a" />)
+    fireEvent.click(screen.getByTestId('secret-menu-SHARED_KEY'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit' }))
+    fireEvent.change(screen.getByTestId('secret-dialog-key'), {
+      target: { value: 'Other' },
+    })
+
+    expect(screen.getByText(/OTHER \(duplicate\)/)).toBeInTheDocument()
+    expect(screen.getByTestId('secret-dialog-submit')).toBeDisabled()
+  })
+
+  it('does not query or render secret controls for a non-owner', () => {
+    mocks.canAdmin = false
+    render(<AgentSecretsView agentSlug="agent-a" />)
+
+    expect(screen.getByText('Owner access required')).toBeInTheDocument()
+    expect(screen.getByTestId('secrets-add-button')).toBeDisabled()
+    expect(screen.queryByTestId('secret-row-SHARED_KEY')).not.toBeInTheDocument()
+    expect(mocks.querySlugs.at(-1)).toBeNull()
+  })
+
+  it('keeps an open dialog and its draft through a transient list-query error', () => {
+    const rendered = render(<AgentSecretsView agentSlug="agent-a" />)
+    fireEvent.click(screen.getByTestId('secrets-add-button'))
+    fireEvent.change(screen.getByTestId('secret-dialog-key'), {
+      target: { value: 'Draft Key' },
+    })
+    fireEvent.change(screen.getByTestId('secret-dialog-value'), {
+      target: { value: 'draft-value' },
+    })
+
+    mocks.query = {
+      data: [],
+      isLoading: false,
+      isError: true,
+      error: new Error('Forbidden'),
+    }
+    rendered.rerender(<AgentSecretsView agentSlug="agent-a" />)
+
+    expect(screen.getByText('Forbidden')).toBeInTheDocument()
+    expect(screen.getByTestId('secret-dialog-key')).toHaveValue('Draft Key')
+
+    mocks.query = {
+      data: [defaultSecret],
+      isLoading: false,
+      isError: false,
+      error: null,
+    }
+    rendered.rerender(<AgentSecretsView agentSlug="agent-a" />)
+    expect(screen.getByTestId('secret-dialog-key')).toHaveValue('Draft Key')
+  })
+
+  it('shows the server list error and retries without presenting an empty list', () => {
+    mocks.query = {
+      data: [],
+      isLoading: false,
+      isError: true,
+      error: new Error('Owner access required by server'),
+    }
+    render(<AgentSecretsView agentSlug="agent-a" />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Owner access required by server')
+    expect(screen.queryByText('No secrets yet')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(mocks.refetch).toHaveBeenCalled()
+  })
+
+  it('tracks concurrent reveals independently', async () => {
+    let resolveA!: (value: string) => void
+    let resolveB!: (value: string) => void
+    const revealA = new Promise<string>((resolve) => {
+      resolveA = resolve
+    })
+    const revealB = new Promise<string>((resolve) => {
+      resolveB = resolve
+    })
+    mocks.query = {
+      ...mocks.query,
+      data: [
+        { id: 'A', key: 'A', envVar: 'A', hasValue: true },
+        { id: 'B', key: 'B', envVar: 'B', hasValue: true },
+      ],
+    }
+    mocks.reveal.mockImplementation(
+      ({ secretId }: { secretId: string }) => (secretId === 'A' ? revealA : revealB),
+    )
+    render(<AgentSecretsView agentSlug="agent-a" />)
+
+    fireEvent.click(screen.getByTestId('secret-reveal-A'))
+    fireEvent.click(screen.getByTestId('secret-reveal-B'))
+    expect(screen.getByTestId('secret-reveal-A')).toBeDisabled()
+    expect(screen.getByTestId('secret-reveal-B')).toBeDisabled()
+
+    await act(async () => resolveA('value-a'))
+    expect(await screen.findByText('value-a')).toBeInTheDocument()
+    expect(screen.getByTestId('secret-reveal-A')).not.toBeDisabled()
+    expect(screen.getByTestId('secret-reveal-B')).toBeDisabled()
+
+    await act(async () => resolveB('value-b'))
+    expect(await screen.findByText('value-b')).toBeInTheDocument()
+    expect(screen.getByTestId('secret-reveal-B')).not.toBeDisabled()
+  })
+
+  it('reports reveal failures on the row that failed', async () => {
+    mocks.query = {
+      ...mocks.query,
+      data: [
+        { id: 'A', key: 'Alpha', envVar: 'A', hasValue: true },
+        { id: 'B', key: 'Beta', envVar: 'B', hasValue: true },
+      ],
+    }
+    mocks.reveal.mockRejectedValueOnce(new Error('Audit log is temporarily busy'))
+    render(<AgentSecretsView agentSlug="agent-a" />)
+
+    fireEvent.click(screen.getByTestId('secret-reveal-A'))
+
+    expect(await screen.findByTestId('secret-reveal-error-A')).toHaveTextContent(
+      "Couldn't reveal Alpha: Audit log is temporarily busy",
+    )
+    expect(screen.queryByTestId('secret-reveal-error-B')).not.toBeInTheDocument()
+  })
+
+  it('masks secret values without exposing a password field to password managers', () => {
+    render(<AgentSecretsView agentSlug="agent-a" />)
+    fireEvent.click(screen.getByTestId('secrets-add-button'))
+    const valueInput = screen.getByTestId('secret-dialog-value')
+
+    expect(valueInput).toHaveAttribute('type', 'text')
+    expect(valueInput).toHaveClass('[-webkit-text-security:disc]')
+    expect(valueInput).toHaveAttribute('autocomplete', 'off')
+    expect(valueInput).toHaveAttribute('data-1p-ignore', 'true')
+    expect(valueInput).toHaveAttribute('data-bwignore', 'true')
+    expect(valueInput).toHaveAttribute('data-form-type', 'other')
+    expect(valueInput).toHaveAttribute('data-lpignore', 'true')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show value' }))
+    expect(valueInput).not.toHaveClass('[-webkit-text-security:disc]')
+    fireEvent.click(screen.getByRole('button', { name: 'Hide value' }))
+    expect(valueInput).toHaveClass('[-webkit-text-security:disc]')
+
+    fireEvent.change(screen.getByTestId('secret-dialog-value'), {
+      target: { value: 'temporary-secret' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    fireEvent.click(screen.getByTestId('secrets-add-button'))
+
+    expect(screen.getByTestId('secret-dialog-value')).toHaveValue('')
+  })
+
+  it('deletes a secret from the row action menu', async () => {
+    render(<AgentSecretsView agentSlug="agent-a" />)
+    fireEvent.click(screen.getByTestId('secret-menu-SHARED_KEY'))
+    fireEvent.click(await screen.findByTestId('delete-secret-SHARED_KEY'))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() =>
+      expect(mocks.remove).toHaveBeenCalledWith({
+        agentSlug: 'agent-a',
+        secretId: 'SHARED_KEY',
+      }),
+    )
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/agents/agent-secrets/agent-secrets-view.tsx
+++ b/src/renderer/components/agents/agent-secrets/agent-secrets-view.tsx
@@ -1,0 +1,691 @@
+import { useEffect, useRef, useState, type FormEvent } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { Eye, EyeOff, KeyRound, MoreHorizontal, Pencil, Plus, Trash2 } from 'lucide-react'
+import { Button } from '@renderer/components/ui/button'
+import { Input } from '@renderer/components/ui/input'
+import { Label } from '@renderer/components/ui/label'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@renderer/components/ui/dialog'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@renderer/components/ui/alert-dialog'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+import { PageTitle, SettingsPageContainer } from '@renderer/components/layout/settings-page'
+import { isReservedEnvVar } from '@shared/lib/container/reserved-env-vars'
+import { keyToEnvVar } from '@shared/lib/utils/secrets'
+import { cn } from '@shared/lib/utils/cn'
+import { useUser } from '@renderer/context/user-context'
+import { useAnalyticsTracking } from '@renderer/context/analytics-context'
+import {
+  useAgentSecrets,
+  useCreateSecret,
+  useUpdateSecret,
+  useDeleteSecret,
+  useRevealSecretValue,
+  type ApiSecretDisplay,
+} from '@renderer/hooks/use-secrets'
+import { useRenderTracker } from '@renderer/lib/perf'
+
+interface AgentSecretsViewProps {
+  agentSlug: string
+}
+
+export function AgentSecretsView({ agentSlug }: AgentSecretsViewProps) {
+  useRenderTracker('AgentSecretsView')
+  const navigate = useNavigate()
+  const { track } = useAnalyticsTracking()
+  const { isAuthMode, rolesReady, canAdminAgent } = useUser()
+  const canManage = !isAuthMode || (rolesReady && canAdminAgent(agentSlug))
+  const {
+    data: secrets = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useAgentSecrets(canManage ? agentSlug : null)
+  const [secretDialog, setSecretDialog] = useState<{
+    open: boolean
+    secret?: ApiSecretDisplay
+  }>({ open: false })
+  const [deletingSecret, setDeletingSecret] = useState<ApiSecretDisplay | null>(null)
+  const [revealedValues, setRevealedValues] = useState<Record<string, string>>({})
+  const [revealingSecretIds, setRevealingSecretIds] = useState<Set<string>>(() => new Set())
+  const [revealErrors, setRevealErrors] = useState<Record<string, string>>({})
+  const revealSecret = useRevealSecretValue()
+  const activeAgentRef = useRef(agentSlug)
+
+  useEffect(() => {
+    track('secrets_viewed', { agentSlug })
+  }, [track, agentSlug])
+
+  useEffect(() => {
+    activeAgentRef.current = agentSlug
+    setSecretDialog({ open: false })
+    setDeletingSecret(null)
+    setRevealedValues({})
+    setRevealingSecretIds(new Set())
+    setRevealErrors({})
+    revealSecret.reset()
+    // The mutation object is intentionally excluded: resetting it changes its
+    // observer state and must not retrigger this agent-change cleanup.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentSlug])
+
+  const toggleReveal = async (secret: ApiSecretDisplay) => {
+    if (Object.prototype.hasOwnProperty.call(revealedValues, secret.id)) {
+      setRevealedValues((values) => {
+        const next = { ...values }
+        delete next[secret.id]
+        return next
+      })
+      setRevealErrors((errors) => {
+        if (!Object.prototype.hasOwnProperty.call(errors, secret.id)) return errors
+        const next = { ...errors }
+        delete next[secret.id]
+        return next
+      })
+      revealSecret.reset()
+      return
+    }
+
+    const requestedAgent = agentSlug
+    setRevealErrors((errors) => {
+      if (!Object.prototype.hasOwnProperty.call(errors, secret.id)) return errors
+      const next = { ...errors }
+      delete next[secret.id]
+      return next
+    })
+    setRevealingSecretIds((ids) => new Set(ids).add(secret.id))
+    try {
+      const value = await revealSecret.mutateAsync({ agentSlug, secretId: secret.id })
+      if (activeAgentRef.current === requestedAgent) {
+        setRevealedValues((values) => ({ ...values, [secret.id]: value }))
+      }
+    } catch (error) {
+      if (activeAgentRef.current === requestedAgent) {
+        setRevealErrors((errors) => ({
+          ...errors,
+          [secret.id]: error instanceof Error ? error.message : 'Failed to reveal secret',
+        }))
+      }
+    } finally {
+      revealSecret.reset()
+      if (activeAgentRef.current === requestedAgent) {
+        setRevealingSecretIds((ids) => {
+          const next = new Set(ids)
+          next.delete(secret.id)
+          return next
+        })
+      }
+    }
+  }
+
+  return (
+    <SettingsPageContainer>
+      <PageTitle
+        title="Agent Secrets"
+        back={{
+          onClick: () => {
+            void navigate({ to: '/agents/$slug', params: { slug: agentSlug } })
+          },
+          testId: 'secrets-back-button',
+        }}
+        actions={
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setSecretDialog({ open: true })}
+            disabled={!canManage || isLoading || isError}
+            data-testid="secrets-add-button"
+          >
+            <Plus className="h-4 w-4 mr-1.5" />
+            Add Secret
+          </Button>
+        }
+      />
+
+      <div className="space-y-4">
+        {isAuthMode && !rolesReady ? (
+          <p className="text-sm text-muted-foreground">Checking permissions...</p>
+        ) : !canManage ? (
+          <div className="rounded-xl border bg-background px-6 py-10 text-center">
+            <p className="text-sm font-medium">Owner access required</p>
+            <p className="mx-auto mt-1 max-w-md text-xs text-muted-foreground">
+              Only agent owners can view and manage saved secrets.
+            </p>
+          </div>
+        ) : isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading secrets...</p>
+        ) : isError ? (
+          <div className="rounded-xl border bg-background px-6 py-10 text-center" role="alert">
+            <p className="text-sm font-medium">Couldn&apos;t load secrets</p>
+            <p className="mx-auto mt-1 max-w-md text-xs text-muted-foreground">
+              {error instanceof Error ? error.message : 'Please try again.'}
+            </p>
+            <Button size="sm" variant="outline" className="mt-4" onClick={() => void refetch()}>
+              Retry
+            </Button>
+          </div>
+        ) : secrets.length === 0 ? (
+          <EmptyState onAdd={() => setSecretDialog({ open: true })} />
+        ) : (
+          <SecretsTable
+            secrets={secrets}
+            revealedValues={revealedValues}
+            revealingSecretIds={revealingSecretIds}
+            revealErrors={revealErrors}
+            onToggleReveal={(secret) => void toggleReveal(secret)}
+            onEdit={(secret) => setSecretDialog({ open: true, secret })}
+            onDelete={setDeletingSecret}
+          />
+        )}
+
+        {canManage && !isError && secrets.length > 0 && (
+          <SecretsHelpText className="pt-2" />
+        )}
+      </div>
+
+      {canManage && (
+        <SecretDialog
+          open={secretDialog.open}
+          onOpenChange={(open) =>
+            setSecretDialog((current) => ({ ...current, open }))
+          }
+          agentSlug={agentSlug}
+          existingEnvVars={secrets.map((s) => s.envVar)}
+          secret={secretDialog.secret}
+          onSaved={(value, updated) => {
+            const previous = secretDialog.secret
+            if (!previous) return
+            setRevealErrors((errors) => {
+              if (!Object.prototype.hasOwnProperty.call(errors, previous.id)) return errors
+              const next = { ...errors }
+              delete next[previous.id]
+              return next
+            })
+            setRevealedValues((values) => {
+              if (!Object.prototype.hasOwnProperty.call(values, previous.id)) return values
+              const next = { ...values }
+              const previousValue = next[previous.id]
+              delete next[previous.id]
+              next[updated.id] = value ?? previousValue
+              return next
+            })
+          }}
+        />
+      )}
+      {deletingSecret && (
+        <DeleteSecretDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setDeletingSecret(null)
+          }}
+          agentSlug={agentSlug}
+          secret={deletingSecret}
+          onDeleted={() => {
+            setRevealErrors((errors) => {
+              if (!Object.prototype.hasOwnProperty.call(errors, deletingSecret.id)) return errors
+              const next = { ...errors }
+              delete next[deletingSecret.id]
+              return next
+            })
+            setRevealedValues((values) => {
+              const next = { ...values }
+              delete next[deletingSecret.id]
+              return next
+            })
+            setDeletingSecret(null)
+          }}
+        />
+      )}
+    </SettingsPageContainer>
+  )
+}
+
+function SecretsHelpText({ className = '' }: { className?: string }) {
+  return (
+    <p className={`text-xs text-muted-foreground ${className}`}>
+      Store API keys, tokens etc. securely. Secrets are passed as environment variables to the
+      agent container. (Formatting:{' '}
+      <code className="font-mono">`My API Key` becomes `MY_API_KEY`</code>).
+    </p>
+  )
+}
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div className="rounded-xl border border-dashed bg-background px-6 py-10 text-center">
+      <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+        <KeyRound className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+      </div>
+      <p className="text-sm font-medium">No secrets yet</p>
+      <SecretsHelpText className="mx-auto mt-1 max-w-md" />
+      <Button size="sm" className="mt-4" onClick={onAdd}>
+        <Plus className="h-4 w-4 mr-1.5" />
+        Add Secret
+      </Button>
+    </div>
+  )
+}
+
+interface SecretsTableProps {
+  secrets: ApiSecretDisplay[]
+  revealedValues: Record<string, string>
+  revealingSecretIds: Set<string>
+  revealErrors: Record<string, string>
+  onToggleReveal: (secret: ApiSecretDisplay) => void
+  onEdit: (secret: ApiSecretDisplay) => void
+  onDelete: (secret: ApiSecretDisplay) => void
+}
+
+function SecretsTable({
+  secrets,
+  revealedValues,
+  revealingSecretIds,
+  revealErrors,
+  onToggleReveal,
+  onEdit,
+  onDelete,
+}: SecretsTableProps) {
+  return (
+    <div className="rounded-xl border bg-background overflow-hidden">
+      <div className="divide-y divide-border/50">
+        {secrets.map((secret) => (
+          <SecretRow
+            key={secret.id}
+            secret={secret}
+            revealedValue={revealedValues[secret.id]}
+            isRevealing={revealingSecretIds.has(secret.id)}
+            revealError={revealErrors[secret.id]}
+            onToggleReveal={() => onToggleReveal(secret)}
+            onEdit={() => onEdit(secret)}
+            onDelete={() => onDelete(secret)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface SecretRowProps {
+  secret: ApiSecretDisplay
+  revealedValue?: string
+  isRevealing: boolean
+  revealError?: string
+  onToggleReveal: () => void
+  onEdit: () => void
+  onDelete: () => void
+}
+
+function SecretRow({
+  secret,
+  revealedValue,
+  isRevealing,
+  revealError,
+  onToggleReveal,
+  onEdit,
+  onDelete,
+}: SecretRowProps) {
+  const isRevealed = revealedValue !== undefined
+  return (
+    <div data-testid={`secret-row-${secret.envVar}`}>
+      <div className="flex items-center gap-3 px-4 py-3">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted">
+          <KeyRound className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="font-medium text-sm truncate">{secret.key}</div>
+          <div className="text-xs text-muted-foreground font-mono truncate">{secret.envVar}</div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <span
+            className="text-sm text-muted-foreground font-mono select-text max-w-[260px] truncate"
+            aria-label={isRevealed ? 'Secret value' : 'Hidden value'}
+            title={isRevealed ? revealedValue : undefined}
+          >
+            {isRevealed ? revealedValue : '••••••••••••'}
+          </span>
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-8 w-8 text-muted-foreground hover:text-foreground"
+            onClick={onToggleReveal}
+            disabled={isRevealing}
+            aria-label={isRevealed ? 'Hide value' : 'Show value'}
+            data-testid={`secret-reveal-${secret.envVar}`}
+          >
+            {isRevealed ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+          </Button>
+          <SecretRowMenu onEdit={onEdit} onDelete={onDelete} envVar={secret.envVar} />
+        </div>
+      </div>
+      {revealError && (
+        <p
+          className="px-4 pb-3 text-xs text-destructive"
+          role="alert"
+          data-testid={`secret-reveal-error-${secret.envVar}`}
+        >
+          Couldn&apos;t reveal {secret.key}: {revealError}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function SecretRowMenu({
+  onEdit,
+  onDelete,
+  envVar,
+}: {
+  onEdit: () => void
+  onDelete: () => void
+  envVar: string
+}) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8 text-muted-foreground hover:text-foreground"
+          aria-label="More actions"
+          data-testid={`secret-menu-${envVar}`}
+        >
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-40 p-1">
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(false)
+            onEdit()
+          }}
+          className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-muted text-left"
+        >
+          <Pencil className="h-4 w-4" />
+          Edit
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(false)
+            onDelete()
+          }}
+          className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-muted text-left text-destructive"
+          data-testid={`delete-secret-${envVar}`}
+        >
+          <Trash2 className="h-4 w-4" />
+          Delete
+        </button>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+interface SecretDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  agentSlug: string
+  /** Existing env vars on the agent — used for collision detection. */
+  existingEnvVars: string[]
+  /** When provided, the dialog is in edit mode for this secret. */
+  secret?: ApiSecretDisplay
+  /** Keep an already-revealed row synchronized after a successful edit. */
+  onSaved?: (value: string | undefined, secret: ApiSecretDisplay) => void
+}
+
+function SecretDialog({
+  open,
+  onOpenChange,
+  agentSlug,
+  existingEnvVars,
+  secret,
+  onSaved,
+}: SecretDialogProps) {
+  const isEdit = !!secret
+  const [key, setKey] = useState('')
+  const [value, setValue] = useState('')
+  const [valueTouched, setValueTouched] = useState(false)
+  const [showValue, setShowValue] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const createSecret = useCreateSecret()
+  const updateSecret = useUpdateSecret()
+  const submitting = isEdit ? updateSecret.isPending : createSecret.isPending
+
+  // Keep the edit target in the parent after close so the title does not flip
+  // during the exit animation, while clearing any typed plaintext immediately.
+  useEffect(() => {
+    if (!open) {
+      setKey('')
+      setValue('')
+      setValueTouched(false)
+      setShowValue(false)
+      setError(null)
+      return
+    }
+    setError(null)
+    setShowValue(false)
+    setValueTouched(false)
+    setKey(secret?.key ?? '')
+    setValue('')
+  }, [open, agentSlug, secret?.id, secret?.key])
+
+  const envVarPreview = key ? keyToEnvVar(key) : ''
+  const isInvalidKey = !!key.trim() && !envVarPreview
+  const isRename = isEdit && envVarPreview && envVarPreview !== secret!.envVar
+  const isKeyChanged = isEdit && key.trim() !== secret!.key
+  const isDuplicate =
+    !!envVarPreview &&
+    existingEnvVars.includes(envVarPreview) &&
+    (!isEdit || envVarPreview !== secret!.envVar)
+  // A secret is injected as an env var, so reserved runtime vars are blocked
+  // here too — the server rejects them, this gives instant feedback (SUP-239).
+  const isReserved = !!envVarPreview && isReservedEnvVar(envVarPreview)
+  const valueChanged = valueTouched && value.length > 0
+  const hasChanges = !isEdit || isKeyChanged || valueChanged
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    if (!key.trim()) {
+      setError('Key is required')
+      return
+    }
+    if (isInvalidKey) {
+      setError('Key must contain at least one letter or number')
+      return
+    }
+    if (!isEdit && !value) {
+      setError('Value is required')
+      return
+    }
+    if (isDuplicate) {
+      setError(`A secret with env var "${envVarPreview}" already exists`)
+      return
+    }
+    if (isReserved) {
+      setError(`"${envVarPreview}" is a reserved runtime variable and cannot be used as a secret`)
+      return
+    }
+    try {
+      if (isEdit) {
+        const updated = await updateSecret.mutateAsync({
+          agentSlug,
+          secretId: secret!.id,
+          ...(isKeyChanged ? { key: key.trim() } : {}),
+          ...(valueChanged ? { value } : {}),
+        })
+        onSaved?.(valueChanged ? value : undefined, updated)
+      } else {
+        await createSecret.mutateAsync({ agentSlug, key: key.trim(), value })
+      }
+      onOpenChange(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save secret')
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent data-testid="secret-dialog">
+        <form onSubmit={handleSubmit} className="space-y-4" autoComplete="off">
+          <DialogHeader>
+            <DialogTitle>{isEdit ? 'Edit Secret' : 'Add Secret'}</DialogTitle>
+            <DialogDescription>
+              {isEdit
+                ? 'Update the key or value for this secret.'
+                : 'Secrets are exposed to the agent as environment variables.'}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="secret-dialog-key">Key</Label>
+              <Input
+                id="secret-dialog-key"
+                value={key}
+                onChange={(e) => setKey(e.target.value)}
+                placeholder="e.g. My API Key"
+                autoFocus
+                autoComplete="off"
+                data-testid="secret-dialog-key"
+              />
+              {!!key.trim() && (
+                <p
+                  className={`text-xs font-mono ${
+                    isInvalidKey || isDuplicate || isReserved
+                      ? 'text-destructive'
+                      : 'text-muted-foreground'
+                  }`}
+                >
+                  Env var: {envVarPreview || '(invalid)'}
+                  {isRename && !isDuplicate && !isReserved && ` (was ${secret!.envVar})`}
+                  {isDuplicate && ' (duplicate)'}
+                  {isReserved && ' (reserved)'}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="secret-dialog-value">Value</Label>
+              <div className="relative">
+                <Input
+                  id="secret-dialog-value"
+                  type="text"
+                  value={value}
+                  onChange={(e) => {
+                    setValue(e.target.value)
+                    setValueTouched(true)
+                  }}
+                  placeholder={isEdit ? 'Leave blank to keep current value' : 'Secret value'}
+                  className={cn('pr-9', !showValue && '[-webkit-text-security:disc]')}
+                  autoComplete="off"
+                  data-1p-ignore="true"
+                  data-bwignore="true"
+                  data-form-type="other"
+                  data-lpignore="true"
+                  data-testid="secret-dialog-value"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowValue((v) => !v)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  aria-label={showValue ? 'Hide value' : 'Show value'}
+                >
+                  {showValue ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
+            </div>
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={
+                !key.trim() ||
+                isInvalidKey ||
+                (!isEdit && !value) ||
+                !hasChanges ||
+                isDuplicate ||
+                isReserved ||
+                submitting
+              }
+              data-testid="secret-dialog-submit"
+            >
+              {submitting ? (isEdit ? 'Saving...' : 'Adding...') : isEdit ? 'Save' : 'Add Secret'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+interface DeleteSecretDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  agentSlug: string
+  secret: ApiSecretDisplay
+  onDeleted: () => void
+}
+
+function DeleteSecretDialog({ open, onOpenChange, agentSlug, secret, onDeleted }: DeleteSecretDialogProps) {
+  const deleteSecret = useDeleteSecret()
+
+  const handleDelete = async () => {
+    try {
+      await deleteSecret.mutateAsync({ agentSlug, secretId: secret.id })
+      onDeleted()
+    } catch {
+      // The global mutation handler presents the error and the dialog remains open.
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete secret?</AlertDialogTitle>
+          <AlertDialogDescription>
+            <span className="font-mono">{secret.envVar}</span> will no longer be available to this
+            agent. This cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleteSecret.isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault()
+              void handleDelete()
+            }}
+            disabled={deleteSecret.isPending}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {deleteSecret.isPending ? 'Deleting...' : 'Delete'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/renderer/components/layout/agent-header.tsx
+++ b/src/renderer/components/layout/agent-header.tsx
@@ -38,6 +38,7 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
   const scheduledTaskId = view.kind === 'task' ? view.id : null
   const webhookTriggerId = view.kind === 'webhook' ? view.id : null
   const apiLogsOpen = view.kind === 'apiLogs'
+  const secretsOpen = view.kind === 'secrets'
   const connectionsOpen = view.kind === 'connections'
 
   const { data: agent } = useAgent(slug)
@@ -168,6 +169,12 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
           <div className="flex items-center gap-1.5 min-w-0">
             <span aria-hidden="true" className="text-sm font-light text-muted-foreground shrink-0 hidden md:block">/</span>
             <span className="truncate text-sm font-light text-foreground">API Logs</span>
+          </div>
+        )}
+        {secretsOpen && (
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span aria-hidden="true" className="text-sm font-light text-muted-foreground shrink-0 hidden md:block">/</span>
+            <span className="truncate text-sm font-light text-foreground">Secrets</span>
           </div>
         )}
         {connectionsOpen && (

--- a/src/renderer/components/layout/agent-shell.tsx
+++ b/src/renderer/components/layout/agent-shell.tsx
@@ -24,7 +24,7 @@ const EMPTY_PENDING_MESSAGES: PendingMessage[] = []
  *
  * It is also the shared layout — it owns the agent header chrome (`AgentHeader`)
  * and agent-level banners (`AgentBanners`) above a single `<Outlet/>`, so every
- * sub-view (the agent body index, plus the api-logs/connections leaf routes)
+ * sub-view (the agent body index, plus the api-logs/connections/secrets leaf routes)
  * inherits one mounted header instead of re-rendering its own.
  *
  * The agent slug AND the active sessionId both come from the route:

--- a/src/renderer/hooks/use-document-title.ts
+++ b/src/renderer/hooks/use-document-title.ts
@@ -103,6 +103,8 @@ function titleForAgentView(view: AgentView, input: DocumentTitleInput): string {
       return joinView(agentTitle, cleanTitlePart(input.dashboardName) ?? humanizeIdentifier(view.slug) ?? 'Dashboard')
     case 'apiLogs':
       return joinView(agentTitle, 'API Logs')
+    case 'secrets':
+      return joinView(agentTitle, 'Secrets')
     case 'connections':
       return joinView(agentTitle, view.detail?.view === 'logs' ? 'Connection Logs' : 'Connections')
     case 'notifications':

--- a/src/renderer/hooks/use-secrets.ts
+++ b/src/renderer/hooks/use-secrets.ts
@@ -11,7 +11,10 @@ export function useAgentSecrets(agentSlug: string | null) {
     queryKey: ['agent-secrets', agentSlug],
     queryFn: async () => {
       const res = await apiFetch(`/api/agents/${agentSlug}/secrets`)
-      if (!res.ok) throw new Error('Failed to fetch secrets')
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null
+        throw new Error(body?.error || 'Failed to fetch secrets')
+      }
       return res.json()
     },
     enabled: !!agentSlug,

--- a/src/renderer/router/route-components.tsx
+++ b/src/renderer/router/route-components.tsx
@@ -1,5 +1,6 @@
 import { Outlet, useNavigate, useParams, useSearch } from '@tanstack/react-router'
 import { ApiLogsView } from '@renderer/components/api-logs/api-logs-view'
+import { AgentSecretsView } from '@renderer/components/agents/agent-secrets/agent-secrets-view'
 import { ConnectionsView } from '@renderer/components/connections/connections-view'
 import { ScheduledTaskView } from '@renderer/components/scheduled-tasks/scheduled-task-view'
 import { WebhookTriggerView } from '@renderer/components/webhook-triggers/webhook-trigger-view'
@@ -60,6 +61,13 @@ export function ApiLogsRoute() {
   const slug = useAgentSlug()
   if (!slug) return null
   return <ApiLogsView agentSlug={slug} />
+}
+
+// secrets route: the agent slug is read from the URL.
+export function SecretsRoute() {
+  const slug = useAgentSlug()
+  if (!slug) return null
+  return <AgentSecretsView agentSlug={slug} />
 }
 
 // The open detail overlay travels in the URL search (`?detail&source`),

--- a/src/renderer/router/route-state.test.ts
+++ b/src/renderer/router/route-state.test.ts
@@ -35,6 +35,7 @@ const cases: AppLocation[] = [
   { selectedAgentSlug: SLUG, view: { kind: 'chat', integrationId: 'int-1', sessionId: 'cs-1' } },
   { selectedAgentSlug: SLUG, view: { kind: 'dashboard', slug: 'dash-1' } },
   { selectedAgentSlug: SLUG, view: { kind: 'apiLogs' } },
+  { selectedAgentSlug: SLUG, view: { kind: 'secrets' } },
   { selectedAgentSlug: SLUG, view: { kind: 'connections' } },
   { selectedAgentSlug: SLUG, view: { kind: 'connections', detail: { rowKey: 'account-123', source: 'home' } } },
   { selectedAgentSlug: SLUG, view: { kind: 'connections', detail: { rowKey: 'mcp-456', source: 'list' } } },

--- a/src/renderer/router/route-state.ts
+++ b/src/renderer/router/route-state.ts
@@ -14,6 +14,7 @@ export type AgentView =
   | { kind: 'chat'; integrationId: string; sessionId?: string }
   | { kind: 'dashboard'; slug: string }
   | { kind: 'apiLogs' }
+  | { kind: 'secrets' }
   | {
       kind: 'connections'
       /**
@@ -84,6 +85,8 @@ export function encodeLocation(loc: AppLocation): NavigateOptions {
       return { to: '/agents/$slug/dashboards/$dashSlug', params: { slug, dashSlug: view.slug } }
     case 'apiLogs':
       return { to: '/agents/$slug/api-logs', params: { slug } }
+    case 'secrets':
+      return { to: '/agents/$slug/secrets', params: { slug } }
     case 'connections':
       return {
         to: '/agents/$slug/connections',
@@ -134,6 +137,8 @@ export function decodeLocation(snap: RouteSnapshot): AppLocation {
       return { selectedAgentSlug: p.slug ?? null, view: { kind: 'dashboard', slug: p.dashSlug ?? '' } }
     case '/agents/$slug/api-logs':
       return { selectedAgentSlug: p.slug ?? null, view: { kind: 'apiLogs' } }
+    case '/agents/$slug/secrets':
+      return { selectedAgentSlug: p.slug ?? null, view: { kind: 'secrets' } }
     case '/agents/$slug/connections': {
       const detail = typeof search.detail === 'string' ? search.detail : undefined
       const source = search.source === 'home' || search.source === 'list' ? search.source : undefined

--- a/src/renderer/router/routes.ts
+++ b/src/renderer/router/routes.ts
@@ -18,6 +18,7 @@ import {
   ChatRoute,
   ConnectionsRoute,
   DashboardRoute,
+  SecretsRoute,
   SessionRoute,
   SettingsLayout,
   SettingsIndexRoute,
@@ -154,6 +155,12 @@ export const connectionsRoute = createRoute({
   component: ConnectionsRoute,
 })
 
+export const secretsRoute = createRoute({
+  getParentRoute: () => agentLayoutRoute,
+  path: 'secrets',
+  component: SecretsRoute,
+})
+
 // ── SETTINGS: SIBLING of app-shell → replaces the whole shell (App.tsx) ───────
 // LAYOUT (just an <Outlet/>): so the `$tab` child renders. `?from=` close-target
 // (open-redirect-safe) lives here and is inherited by both children.
@@ -200,6 +207,7 @@ export const routeTree = rootRoute.addChildren([
       dashboardRoute,
       apiLogsRoute,
       connectionsRoute,
+      secretsRoute,
     ]),
   ]),
   settingsRoute.addChildren([settingsIndexRoute, settingsTabRoute]),

--- a/src/renderer/router/search-schemas.ts
+++ b/src/renderer/router/search-schemas.ts
@@ -78,9 +78,9 @@ export const settingsSearchSchema = z
   })
 
 // The 18 GLOBAL settings tabs (settings/global-settings-page.tsx user/admin/auth
-// sections, flattened in display order). NOTE: `system-prompt` and `secrets` are
-// deliberately absent — those are agent-scoped local dialogs, not global settings
-// routes.
+// sections, flattened in display order). NOTE: `system-prompt` (agent-scoped
+// local dialog) and `secrets` (agent-scoped page, /agents/$slug/secrets) are
+// deliberately absent — they are not global settings routes.
 export const SETTINGS_TABS = [
   'profile',
   'general',


### PR DESCRIPTION
Part 2 of 3 splitting #135 into a reviewable stack. Merge order: #545 → this → #135 (cutover). Stacked on #545.

Adds the `AgentSecretsView` page — list, unified add/edit dialog with click-to-reveal (via #545's value endpoint), and delete confirm — wired as a real route following the API Logs / Connections pattern: route definition, route-state codec (+ round-trip test), header breadcrumb, and document title.

- The add/edit dialog blocks reserved runtime vars with instant "(reserved)" feedback, mirroring the server-side SUP-239 rule.
- Transitional: the Secrets tab in the agent settings dialog still exists and its e2e spec still passes at this layer; #135 flips the entry point and removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)