### PR TITLE
feat: give the agent desktop vs web environment awareness (SUP-455)

### DIFF
--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -128,6 +128,29 @@ function parseConnectedAccounts(): Map<string, Array<{ name: string; id: string 
   return accounts;
 }
 
+// Wire mirror of the host's AgentEnvironment (src/shared/lib/container/agent-environment.ts).
+// agent-container is an isolated package, so it re-declares the shape it expects from the
+// AGENT_ENVIRONMENT env var rather than importing the host type - same contract pattern as
+// parseRemoteMcps / parseConnectedAccounts. Kept LENIENT (no .strict()) on purpose: during a
+// rollout the host image can be newer than this container image and send an added field; a
+// strict parse would reject it and wrongly fall back to desktop. Extra keys are harmless here.
+const agentEnvironmentSchema = z.discriminatedUnion('surface', [
+  z.object({ surface: z.literal('desktop') }),
+  z.object({ surface: z.literal('web'), publicUrl: z.string().min(1).optional() }),
+]);
+type AgentEnvironment = z.infer<typeof agentEnvironmentSchema>;
+
+function parseAgentEnvironment(): AgentEnvironment {
+  const raw = process.env.AGENT_ENVIRONMENT;
+  if (!raw) return { surface: 'desktop' };
+  try {
+    const parsed = agentEnvironmentSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : { surface: 'desktop' };
+  } catch {
+    return { surface: 'desktop' };
+  }
+}
+
 /** One toolkit's connected accounts, as the template's `connectedAccounts` list. */
 interface ConnectedAccountGroup {
   displayName: string;
@@ -233,6 +256,9 @@ export interface SystemPromptVars {
   hasEnvVars: boolean;
   envVars: string[];
   userInstructions: string;
+  environmentIsWeb: boolean;
+  environmentHasPublicUrl: boolean;
+  environmentPublicUrl: string;
 }
 
 /**
@@ -256,6 +282,8 @@ export function buildSystemPromptVars(
   const remoteMcps = remoteMcpViews();
   const envVars = agentEnvVars(availableEnvVars);
   const userInstructions = userSystemPrompt?.trim() || '';
+  const environment = parseAgentEnvironment();
+  const environmentPublicUrl = environment.surface === 'web' ? (environment.publicUrl ?? '') : '';
   return {
     CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR || PROMPT_ENV_DEFAULTS.CLAUDE_CONFIG_DIR,
     webSearchToolName: webSearchProvider ? 'mcp__web__web_search' : 'WebSearch',
@@ -276,6 +304,9 @@ export function buildSystemPromptVars(
     hasEnvVars: envVars.length > 0,
     envVars,
     userInstructions,
+    environmentIsWeb: environment.surface === 'web',
+    environmentHasPublicUrl: environmentPublicUrl.length > 0,
+    environmentPublicUrl,
   };
 }
 

--- a/agent-container/src/system-prompt-vars.test.ts
+++ b/agent-container/src/system-prompt-vars.test.ts
@@ -230,3 +230,46 @@ describe('subagent capability gating', () => {
     }
   })
 })
+
+describe('environment awareness', () => {
+  const orig = process.env.AGENT_ENVIRONMENT
+  afterEach(() => {
+    if (orig === undefined) delete process.env.AGENT_ENVIRONMENT
+    else process.env.AGENT_ENVIRONMENT = orig
+  })
+
+  // --- vars: env var → template-var bag (the stable logic layer) ---
+  // absent/malformed both fall back to desktop and must never throw (an
+  // exception in buildSystemPromptVars would fail the case outright).
+  it.each([
+    { name: 'desktop', env: JSON.stringify({ surface: 'desktop' }), isWeb: false, hasUrl: false, url: '' },
+    { name: 'web with url', env: JSON.stringify({ surface: 'web', publicUrl: 'https://app.example.com' }), isWeb: true, hasUrl: true, url: 'https://app.example.com' },
+    { name: 'web without url (self-hosted)', env: JSON.stringify({ surface: 'web' }), isWeb: true, hasUrl: false, url: '' },
+    { name: 'absent → desktop fallback', env: undefined, isWeb: false, hasUrl: false, url: '' },
+    { name: 'malformed → desktop fallback', env: '{not json', isWeb: false, hasUrl: false, url: '' },
+  ])('vars: $name', ({ env, isWeb, hasUrl, url }) => {
+    if (env === undefined) delete process.env.AGENT_ENVIRONMENT
+    else process.env.AGENT_ENVIRONMENT = env
+    const v = buildSystemPromptVars()
+    expect(v.environmentIsWeb).toBe(isWeb)
+    expect(v.environmentHasPublicUrl).toBe(hasUrl)
+    expect(v.environmentPublicUrl).toBe(url)
+  })
+
+  // --- render: proves the template gates on the right vars (thin wiring layer) ---
+  it('render: desktop shows the desktop line, not the web line', () => {
+    process.env.AGENT_ENVIRONMENT = JSON.stringify({ surface: 'desktop' })
+    const p = generateSystemPrompt()
+    expect(p).toContain('desktop app on the user')
+    expect(p).not.toContain('web app')
+  })
+  it('render: web+url names the browser and the url, with no desktop phrasing and no leaked tags', () => {
+    process.env.AGENT_ENVIRONMENT = JSON.stringify({ surface: 'web', publicUrl: 'https://app.example.com' })
+    const p = generateSystemPrompt()
+    expect(p).toContain('web app')
+    expect(p).toContain('https://app.example.com')
+    expect(p).not.toContain('desktop app')
+    expect(p).not.toContain('<%')
+    expect(p).not.toContain('%>')
+  })
+})

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -233,6 +233,15 @@ When the conversation grows long, some or all of the current context is summariz
 
 You operate inside a Gamut container — a long-running, autonomous runtime that persists across sessions, with the platform capabilities described below.
 
+## Environment
+
+<%#environmentIsWeb%>
+You are running as the Gamut web app. The user reaches you in a web browser<%#environmentHasPublicUrl%> at <%environmentPublicUrl%><%/environmentHasPublicUrl%>.
+<%/environmentIsWeb%>
+<%^environmentIsWeb%>
+You are running as the Gamut desktop app on the user's own computer.
+<%/environmentIsWeb%>
+
 ## Standing Instructions — CLAUDE.md
 
 `/workspace/CLAUDE.md` is the agent's standing-instructions file. The runtime automatically prepends its contents to this system prompt at the start of every session — you do not need to Read it yourself, and it may not exist yet (Write creates it on first update). Treat its contents as always-true unless the user explicitly overrides them in the current conversation; current-conversation overrides apply only to the current task and do not modify the file unless the user says the change is permanent.

--- a/src/shared/lib/container/agent-environment.test.ts
+++ b/src/shared/lib/container/agent-environment.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { resolveAgentEnvironment, agentEnvironmentSchema } from './agent-environment'
+
+const origType = (process as { type?: string }).type
+const origUrl = process.env.HOST_PUBLIC_URL
+
+afterEach(() => {
+  if (origType === undefined) delete (process as { type?: string }).type
+  else (process as { type?: string }).type = origType
+  if (origUrl === undefined) delete process.env.HOST_PUBLIC_URL
+  else process.env.HOST_PUBLIC_URL = origUrl
+  vi.restoreAllMocks()
+})
+
+describe('resolveAgentEnvironment', () => {
+  it('returns desktop when running in the Electron main process', () => {
+    ;(process as { type?: string }).type = 'browser'
+    expect(resolveAgentEnvironment()).toEqual({ surface: 'desktop' })
+  })
+
+  it('returns web with publicUrl when non-Electron and HOST_PUBLIC_URL is set', () => {
+    delete (process as { type?: string }).type
+    process.env.HOST_PUBLIC_URL = 'https://app.example.com'
+    expect(resolveAgentEnvironment()).toEqual({ surface: 'web', publicUrl: 'https://app.example.com' })
+  })
+
+  it('returns web WITHOUT publicUrl when non-Electron and HOST_PUBLIC_URL is unset (self-hosted Docker)', () => {
+    delete (process as { type?: string }).type
+    delete process.env.HOST_PUBLIC_URL
+    expect(resolveAgentEnvironment()).toEqual({ surface: 'web' })
+  })
+
+  it('schema rejects the illegal desktop-with-publicUrl state', () => {
+    expect(agentEnvironmentSchema.safeParse({ surface: 'desktop', publicUrl: 'x' }).success).toBe(false)
+  })
+})

--- a/src/shared/lib/container/agent-environment.ts
+++ b/src/shared/lib/container/agent-environment.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+
+/**
+ * The agent's runtime surface, resolved by the host and injected into the system
+ * prompt. Exported so host-side link builders reuse the same shape rather than
+ * re-resolving. `web` covers any browser-reached host - hosted cloud AND
+ * self-hosted; `publicUrl` is present only when the host has a public URL
+ * (absent for self-hosted Docker). `.strict()` forbids the illegal
+ * desktop-with-publicUrl state (Zod 4 is non-strict by default). Precedent:
+ * src/shared/lib/container/runtime-options.ts.
+ */
+export const agentEnvironmentSchema = z.discriminatedUnion('surface', [
+  z.object({ surface: z.literal('desktop') }).strict(),
+  z.object({ surface: z.literal('web'), publicUrl: z.string().min(1).optional() }).strict(),
+])
+
+export type AgentEnvironment = z.infer<typeof agentEnvironmentSchema>
+
+export function resolveAgentEnvironment(): AgentEnvironment {
+  // process.type === 'browser' is the Electron main process - the codebase's
+  // existing desktop guard (auth/mode.ts, url-safety.ts, db/index.ts).
+  if (process.type === 'browser') return { surface: 'desktop' }
+  const publicUrl = process.env.HOST_PUBLIC_URL?.trim()
+  return publicUrl ? { surface: 'web', publicUrl } : { surface: 'web' }
+}

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -20,6 +20,7 @@ import { getMountsWithHealth } from '@shared/lib/services/mount-service'
 import { isPlatformComposioActive } from '@shared/lib/composio/client'
 import { getPlatformAccessToken } from '@shared/lib/services/platform-auth-service'
 import { mergeCustomEnvVars } from './reserved-env-vars'
+import { resolveAgentEnvironment } from './agent-environment'
 
 /** Interval for syncing container status with reality (in ms). Default: 300 seconds */
 const STATUS_SYNC_INTERVAL_MS = parseInt(
@@ -603,6 +604,10 @@ class ContainerManager {
 
       // Tell the agent container which host OS is running (for script type selection)
       envVars['HOST_PLATFORM'] = process.platform
+
+      // Tell the agent container which surface it runs on (desktop vs web) so its
+      // own prose is surface-correct.
+      envVars['AGENT_ENVIRONMENT'] = JSON.stringify(resolveAgentEnvironment())
 
       // Enable Composio webhook trigger tools when platform Composio is active
       if (isPlatformComposioActive()) {

--- a/src/shared/lib/container/reserved-env-vars.test.ts
+++ b/src/shared/lib/container/reserved-env-vars.test.ts
@@ -34,6 +34,10 @@ describe('reserved-env-vars', () => {
     expect(isReservedEnvVar('MY_CUSTOM')).toBe(false)
   })
 
+  it('reserves AGENT_ENVIRONMENT so custom env cannot clobber the resolved surface fact', () => {
+    expect(isReservedEnvVar('AGENT_ENVIRONMENT')).toBe(true)
+  })
+
   describe('mergeCustomEnvVars', () => {
     it('skips reserved keys and warns, but passes non-reserved through', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})

--- a/src/shared/lib/container/reserved-env-vars.ts
+++ b/src/shared/lib/container/reserved-env-vars.ts
@@ -37,6 +37,7 @@ export const RESERVED_ENV_VAR_KEYS: ReadonlySet<string> = new Set([
   // Runtime environment
   'TZ',
   'HOST_PLATFORM',
+  'AGENT_ENVIRONMENT',
   'COMPOSIO_PLATFORM_MODE',
   'PLATFORM_AUTH_ACTIVE',
   'CLAUDE_CODE_ATTRIBUTION_HEADER',


### PR DESCRIPTION
## What

Gives the agent a host-resolved fact about its runtime surface (native desktop app vs browser-reached web) and injects it into the system prompt, so the agent's own free-form prose is surface-correct. Today the prompt assumes desktop unconditionally, so a web-hosted agent tells the user to "open the app on your machine" when there is no desktop app to open.

The surface fact's type is exported so any later host-side consumer that needs the surface (a deep-link or chat-message builder, say) reuses one resolver and one type rather than re-resolving it - but nothing depends on that yet, and this change stands on its own.

## How it works

Extends the existing host-fact -> gated-prompt rail (the same shape as `HOST_PLATFORM` -> `computerUse`), one parallel hop:

- **Host** (`container-manager`) resolves the surface once at container start via `resolveAgentEnvironment()`: `process.type === 'browser'` is the Electron main process (desktop), otherwise web plus an optional public URL. It is stringified into a reserved `AGENT_ENVIRONMENT` env var that custom env cannot clobber.
- **Container** (`claude-code`) reads it, Zod-parses against a lenient mirror schema, and falls back to `desktop` on absent or malformed input (never throws). One gated block in `system-prompt.md` renders the surface-correct line.

Design choices worth knowing:

- Two surfaces (`desktop` / `web`) with an optional `publicUrl`, not a three-way split. No consumer distinguishes self-hosted web from hosted cloud.
- `publicUrl` is optional so a self-hosted web deploy with no public URL still renders as web rather than silently falling back to desktop.
- Host schema is strict, container mirror is lenient, so a newer host image that adds a field is not rejected mid-rollout.
- `computerUse` stays a separate axis. Desktop-Linux is desktop-yet-not-computer-use, so surface and computer-use capability are genuinely orthogonal.

## Verified

- Unit tests: resolver (both arms + fallback + illegal-state rejection), container parse (desktop / web-url / web-no-url / absent / malformed, never throws), prompt render for both surfaces (correct block, no leaked template tags), reserved-key guard.
- Rendered the actual prompt block for every surface and read the copy end to end.
- typecheck + lint green in both packages (host and agent-container).

Note for reviewers: the agent-container prompt is baked into the ghcr image, so a live agent reflects this only after an image rebuild + container recreation.
