### PR TITLE
fix(settings): align Admin tab layout with other settings tabs

### DIFF
--- a/src/renderer/components/settings/admin-tab.tsx
+++ b/src/renderer/components/settings/admin-tab.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react'
-import { Label } from '@renderer/components/ui/label'
+import { useState, type ReactNode } from 'react'
 import { Button } from '@renderer/components/ui/button'
 import {
   AlertDialog,
@@ -16,6 +15,31 @@ import { useSettings, useUpdateSettings, useFactoryReset } from '@renderer/hooks
 import { RotateCcw, Bug } from 'lucide-react'
 import { DebugTab } from './debug-tab'
 import { AutoDeleteSelect } from './auto-delete-select'
+
+const CARD_CLASS = 'rounded-xl border bg-background divide-y divide-border/50 overflow-hidden'
+const SECTION_HEADING = 'text-xs font-medium text-muted-foreground px-1'
+
+interface SettingRowProps {
+  name: string
+  subtitle?: ReactNode
+  right: ReactNode
+}
+
+function SettingRow({ name, subtitle, right }: SettingRowProps) {
+  return (
+    <div className="py-3 px-4">
+      <div className="flex items-center gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-medium truncate">{name}</div>
+          {subtitle && (
+            <div className="text-[11px] text-muted-foreground mt-0.5">{subtitle}</div>
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">{right}</div>
+      </div>
+    </div>
+  )
+}
 
 export function AdminTab() {
   const { data: settings } = useSettings()
@@ -37,59 +61,60 @@ export function AdminTab() {
 
   return (
     <div className="space-y-6">
-      {/* Session Auto-Delete */}
       <div className="space-y-2">
-        <div className="space-y-0.5">
-          <Label>Session Auto-Delete</Label>
-          <p className="text-xs text-muted-foreground">
-            Automatically delete sessions inactive for this duration. Starred sessions are preserved.
-          </p>
+        <h3 className={SECTION_HEADING}>Sessions</h3>
+        <div className={CARD_CLASS}>
+          <SettingRow
+            name="Session Auto-Delete"
+            subtitle="Automatically delete sessions inactive for this duration. Starred sessions are preserved."
+            right={
+              <AutoDeleteSelect
+                value={settings?.app?.autoDeleteInactiveDays}
+                onChange={(days) => {
+                  updateSettings.mutate({ app: { autoDeleteInactiveDays: days } })
+                }}
+              />
+            }
+          />
         </div>
-        <AutoDeleteSelect
-          value={settings?.app?.autoDeleteInactiveDays}
-          onChange={(days) => {
-            updateSettings.mutate({ app: { autoDeleteInactiveDays: days } })
-          }}
-        />
       </div>
 
-      {/* Danger Zone */}
-      <div className="space-y-4">
-        <h3 className="text-sm font-medium text-destructive">Danger Zone</h3>
-        <div className="flex items-center justify-between">
-          <div className="space-y-0.5">
-            <Label>Factory Reset</Label>
-            <p className="text-xs text-muted-foreground">
-              Delete all agents, sessions, files, and settings
-            </p>
-          </div>
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button variant="destructive" size="sm">
-                <RotateCcw className="h-4 w-4 mr-2" />
-                Factory Reset
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Factory Reset</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This will permanently delete all agents, sessions, files, scheduled tasks,
-                  connected accounts, and settings. This action cannot be undone.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel disabled={isResetting}>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={handleFactoryReset}
-                  disabled={isResetting}
-                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                >
-                  {isResetting ? 'Resetting...' : 'Reset Everything'}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+      <div className="space-y-2">
+        <h3 className={SECTION_HEADING}>Danger Zone</h3>
+        <div className={CARD_CLASS}>
+          <SettingRow
+            name="Factory Reset"
+            subtitle="Delete all agents, sessions, files, and settings"
+            right={
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button variant="destructive" size="sm">
+                    <RotateCcw className="h-4 w-4 mr-2" />
+                    Factory Reset
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Factory Reset</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      This will permanently delete all agents, sessions, files, scheduled tasks,
+                      connected accounts, and settings. This action cannot be undone.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel disabled={isResetting}>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={handleFactoryReset}
+                      disabled={isResetting}
+                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    >
+                      {isResetting ? 'Resetting...' : 'Reset Everything'}
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            }
+          />
         </div>
       </div>
 
@@ -97,7 +122,7 @@ export function AdminTab() {
       <div className="space-y-2">
         <button
           onClick={() => setShowDebug(!showDebug)}
-          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          className="flex items-center gap-1.5 px-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
         >
           <Bug className="h-3.5 w-3.5" />
           <span>{showDebug ? 'Hide' : 'Show'} Debug Tools</span>

--- a/src/renderer/components/settings/auto-delete-select.tsx
+++ b/src/renderer/components/settings/auto-delete-select.tsx
@@ -32,13 +32,13 @@ export function AutoDeleteSelect({ value, onChange, disabled }: AutoDeleteSelect
       onValueChange={(val) => onChange(parseInt(val, 10))}
       disabled={disabled}
     >
-      <SelectTrigger className="w-40" aria-label="Session auto-delete">
+      <SelectTrigger className="h-8 w-[140px] text-xs" aria-label="Session auto-delete">
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="0">Never</SelectItem>
+        <SelectItem value="0" className="text-xs">Never</SelectItem>
         {AUTO_DELETE_OPTIONS.map((opt) => (
-          <SelectItem key={opt.value} value={opt.value}>
+          <SelectItem key={opt.value} value={opt.value} className="text-xs">
             {opt.label}
           </SelectItem>
         ))}


### PR DESCRIPTION
## Summary

The Admin settings tab used an older bare-label layout that didn't match the rest of the settings tabs. This brings it in line with the card-based pattern used by General, Capabilities, LLM, etc.

- Restructure Admin tab into section heading + rounded card with `SettingRow` rows (local per-tab copies, matching the existing convention)
- "Sessions" section: Session Auto-Delete row with the select right-aligned in the row
- "Danger Zone" section: Factory Reset as a card row with the destructive button right-aligned; heading uses the standard muted section style (red stays on the button only)
- Compact the auto-delete select to `h-8 w-[140px] text-xs` matching other in-row dropdowns (usage/audit-log tabs), with `text-xs` menu items
- Debug tools toggle aligned with section headings

The agent-settings `AgentAutoDeleteSelect` variant is untouched. No behavior changes — the factory-reset confirmation dialog and all mutations are unchanged.

## Test plan

- [x] `npm run typecheck` passes
- [x] ESLint clean on changed files
- [x] Verified visually in the dev app (Settings → Admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)