### PR TITLE
fix: map Lambda MicroVM SUSPENDED to UI stopped

### DIFF
--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -408,11 +408,32 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(await newClient().getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
   })
 
-  it('getInfoFromRuntime treats SUSPENDED as running (auto-resume on request)', async () => {
+  it('getInfoFromRuntime treats SUSPENDED as stopped (warm idle; local state kept)', async () => {
     const client = newClient()
     await client.start()
     responses.getState = 'SUSPENDED'
-    expect((await client.getInfoFromRuntime()).status).toBe('running')
+    expect(await client.getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
+
+    // Warm-idle must not drop local state — a later start() resumes, not Run.
+    responses.getState = 'RUNNING'
+    sendMock.mockClear()
+    await client.start()
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
+  })
+
+  it('getInfoFromRuntime treats SUSPENDING as stopped (warm idle; local state kept)', async () => {
+    const client = newClient()
+    await client.start()
+    responses.getState = 'SUSPENDING'
+    expect(await client.getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
+  })
+
+  it('stop() then getInfoFromRuntime reports stopped while suspended', async () => {
+    const client = newClient()
+    await client.start()
+    await client.stop()
+    responses.getState = 'SUSPENDED'
+    expect(await client.getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
   })
 
   it('getInfoFromRuntime reports stopped when the VM is TERMINATED and cleans up local state', async () => {
@@ -491,11 +512,16 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(suspendCall![0].input).toEqual({ microvmIdentifier: 'mvm-1' })
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
 
-    // State is preserved: a subsequent start() short-circuits (no new RunMicrovm).
+    // State is preserved: start() resumes via /health (no new RunMicrovm).
     sendMock.mockClear()
     responses.getState = 'SUSPENDED'
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      responses.getState = 'RUNNING'
+      return { ok: true } as Response
+    }))
     await client.start()
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
+    expect((await client.getInfoFromRuntime()).status).toBe('running')
   })
 
   it('a plain stop() is a no-op suspend when already SUSPENDED', async () => {

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -669,6 +669,10 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   async start(options?: StartOptions): Promise<void> {
     if ((await this.getInfoFromRuntime()).status === 'running') return
 
+    // Suspended VMs are UI-stopped but still warm — resume before RunMicrovm.
+    const existing = agentStates.get(this.config.agentId)
+    if (existing && (await this.resumeExisting(existing))) return
+
     const config = getMicrovmRuntimeConfig()
     // Full env exceeds the 4096-byte payload cap, so stash it host-side and pass the
     // VM only a small bootstrap credential to fetch it at boot via /api/agent-bootstrap.
@@ -766,10 +770,12 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     const config = getMicrovmRuntimeConfig()
     try {
       const mvm = await getMicrovm(config.region, state.microvmId)
-      // SUSPENDED is "running on demand": idlePolicy.autoResumeEnabled wakes it
-      // on the next request through the proxy.
-      if (mvm.state === 'RUNNING' || mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
+      if (mvm.state === 'RUNNING') {
         return { status: 'running', port: state.proxyPort }
+      }
+      // Warm-idle: UI shows stopped; local proxy state is kept so start()/traffic can resume.
+      if (mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
+        return { status: 'stopped', port: null }
       }
       // Terminal: VM is gone — drop state + proxy (mirror NotFound) so it isn't leaked.
       this.cleanupLocal()
@@ -816,6 +822,40 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
       await new Promise((resolve) => setTimeout(resolve, 2_000))
     }
     throw new Error(`Timed out waiting for MicroVM ${microvmId} to become RUNNING`)
+  }
+
+  // Resume a warm-suspended VM. Returns false when local state is stale (caller should Run).
+  // Avoid waitForHealthy here — it treats UI-stopped/suspended as dead and bails early.
+  private async resumeExisting(state: AgentMicrovmState): Promise<boolean> {
+    const config = getMicrovmRuntimeConfig()
+    try {
+      const mvm = await getMicrovm(config.region, state.microvmId)
+      if (mvm.state === 'TERMINATED' || mvm.state === 'TERMINATING') {
+        this.cleanupLocal()
+        return false
+      }
+      if (mvm.state !== 'RUNNING' && mvm.state !== 'SUSPENDED' && mvm.state !== 'SUSPENDING') {
+        this.cleanupLocal()
+        return false
+      }
+
+      const deadline = Date.now() + 120_000
+      while (Date.now() < deadline) {
+        if (await this.isHealthy(state.proxyPort)) break
+        await new Promise((resolve) => setTimeout(resolve, 250))
+      }
+      if (!(await this.isHealthy(state.proxyPort))) {
+        throw new Error(`MicroVM agent ${state.microvmId} failed to become healthy`)
+      }
+      await this.waitForRunning(config.region, state.microvmId, 120_000)
+      return true
+    } catch (error) {
+      if (isNotFound(error)) {
+        this.cleanupLocal()
+        return false
+      }
+      throw error
+    }
   }
 
   // Keep local proxy state so the next request auto-resumes the same VM.


### PR DESCRIPTION
## Summary
- Lambda MicroVM `SUSPENDED` / `SUSPENDING` now map to UI `stopped` (binary running/stopped), so manual Stop survives refresh and AWS idle can surface as stopped after status sync.
- `start()` resumes a warm-suspended VM through the existing proxy `/health` kick instead of allocating a new `RunMicrovm`.
- Local proxy state is kept across warm idle; only terminal/NotFound cleans it up.

## Bug
1. Top-right Stop showed stopped, but refresh flipped back to running (`getInfoFromRuntime` treated suspend as running).
2. After the 30m idle window, UI never turned idle/stopped (host auto-sleep is skipped for MicroVM; AWS suspend still reported as running).

## Test plan
- [x] `npm test -- --run src/shared/lib/container/lambda-microvm-runtime.test.ts`
- [ ] Manual: Stop agent → UI stopped → refresh stays stopped → Wake Up resumes same VM (no new Run)
- [ ] Manual: leave idle past auto-sleep timeout → after status sync cycle UI shows stopped

Made with [Cursor](https://cursor.com)