### PR TITLE
Revert "fix: skip host auto-sleep scans for Lambda MicroVM" (#538)

### DIFF
--- a/src/shared/lib/container/base-container-client.test.ts
+++ b/src/shared/lib/container/base-container-client.test.ts
@@ -31,12 +31,6 @@ class TestContainerClient extends BaseContainerClient {
   }
 }
 
-describe('host auto-sleep', () => {
-  it('is enabled by default for container runtimes', () => {
-    expect(new TestContainerClient({ agentId: 'a' }).shouldRunHostAutoSleep()).toBe(true)
-  })
-})
-
 describe('buildAgentEnv', () => {
   afterEach(() => enableToolSearch.mockReturnValue(true))
 

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -289,10 +289,6 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     this.config = config
   }
 
-  shouldRunHostAutoSleep(): boolean {
-    return true
-  }
-
   /**
    * Emit an 'error' event without crashing the process.
    *

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -113,10 +113,6 @@ class ContainerManager {
     return client
   }
 
-  shouldRunHostAutoSleep(agentId: string): boolean {
-    return this.getClient(agentId).shouldRunHostAutoSleep()
-  }
-
   /**
    * Get cached container info. Returns cached status if available,
    * otherwise returns stopped (will be corrected on next sync).

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -475,10 +475,6 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
   })
 
-  it('disables host auto-sleep because idlePolicy owns idle', () => {
-    expect(newClient().shouldRunHostAutoSleep()).toBe(false)
-  })
-
   it('a plain stop() suspends (preserves state for warm resume), not terminate', async () => {
     const client = newClient()
     await client.start()

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -739,10 +739,6 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
 
   // Proxy-level retry handles the suspend→resume 502 window for all HTTP calls.
 
-  shouldRunHostAutoSleep(): boolean {
-    return false
-  }
-
   async stop(options?: StopOptions): Promise<StopResult> {
     this.terminateWebSocketConnections()
     // Auto-sleep is handled by AWS idlePolicy; the host-app sweep is a no-op.

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1920,10 +1920,6 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
 
   // Lifecycle management
 
-  shouldRunHostAutoSleep(): boolean {
-    return true
-  }
-
   async start(options?: StartOptions): Promise<void> {
     this.running = true
     // Surface the container env that carries the proxy credentials so E2E

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -132,7 +132,6 @@ export interface ContainerClient {
   start(options?: StartOptions): Promise<void>
   stop(options?: StopOptions): Promise<StopResult>
   stopSync(): void // Synchronous stop for exit handlers
-  shouldRunHostAutoSleep(): boolean
 
   // Build a -v flag value for a volume mount (hostPath:containerPath with runtime-specific suffix)
   buildVolumeFlag(hostPath: string, containerPath: string): string

--- a/src/shared/lib/scheduler/auto-sleep-monitor.test.ts
+++ b/src/shared/lib/scheduler/auto-sleep-monitor.test.ts
@@ -8,7 +8,6 @@ import type { SessionInfo } from '@shared/lib/types/agent'
 const mockGetRunningAgentIds = vi.fn<() => string[]>(() => [])
 const mockGetContainerStartTime = vi.fn<(id: string) => number | undefined>()
 const mockGetLastKeepAlive = vi.fn<(id: string) => number | undefined>()
-const mockShouldRunHostAutoSleep = vi.fn<(id: string) => boolean>(() => true)
 const mockStopContainer = vi.fn()
 
 vi.mock('@shared/lib/container/container-manager', () => ({
@@ -16,7 +15,6 @@ vi.mock('@shared/lib/container/container-manager', () => ({
     getRunningAgentIds: () => mockGetRunningAgentIds(),
     getContainerStartTime: (id: string) => mockGetContainerStartTime(id),
     getLastKeepAlive: (id: string) => mockGetLastKeepAlive(id),
-    shouldRunHostAutoSleep: (id: string) => mockShouldRunHostAutoSleep(id),
     stopContainer: (...args: unknown[]) => mockStopContainer(...args),
   },
 }))
@@ -75,7 +73,6 @@ describe('AutoSleepMonitor', () => {
     mockListSessions.mockResolvedValue([])
     mockGetContainerStartTime.mockReturnValue(undefined)
     mockGetLastKeepAlive.mockReturnValue(undefined)
-    mockShouldRunHostAutoSleep.mockReturnValue(true)
     mockStopContainer.mockResolvedValue(undefined)
   })
 
@@ -176,19 +173,6 @@ describe('AutoSleepMonitor', () => {
     await autoSleepMonitor.start()
     await tick()
 
-    expect(mockListSessions).not.toHaveBeenCalled()
-    expect(mockStopContainer).not.toHaveBeenCalled()
-  })
-
-  it('skips all session I/O when the runtime owns idle sleep', async () => {
-    mockGetRunningAgentIds.mockReturnValue(['agent-1'])
-    mockShouldRunHostAutoSleep.mockReturnValue(false)
-
-    await autoSleepMonitor.start()
-    await tick()
-
-    expect(mockShouldRunHostAutoSleep).toHaveBeenCalledWith('agent-1')
-    expect(mockHasActiveSessions).not.toHaveBeenCalled()
     expect(mockListSessions).not.toHaveBeenCalled()
     expect(mockStopContainer).not.toHaveBeenCalled()
   })

--- a/src/shared/lib/scheduler/auto-sleep-monitor.ts
+++ b/src/shared/lib/scheduler/auto-sleep-monitor.ts
@@ -16,7 +16,6 @@ class AutoSleepMonitor {
   private isRunning = false
   private pollIntervalMs = 60000 // Check every minute
   private isProcessing = false
-  private hasLoggedRuntimeManagedIdle = false
 
   /**
    * Start the monitor.
@@ -28,7 +27,6 @@ class AutoSleepMonitor {
     }
 
     this.isRunning = true
-    this.hasLoggedRuntimeManagedIdle = false
     console.log('[AutoSleepMonitor] Starting monitor...')
 
     // Start periodic polling
@@ -78,14 +76,6 @@ class AutoSleepMonitor {
 
       for (const agentId of runningAgentIds) {
         try {
-          if (!containerManager.shouldRunHostAutoSleep(agentId)) {
-            if (!this.hasLoggedRuntimeManagedIdle) {
-              console.log('[AutoSleepMonitor] Runtime owns idle sleep; skipping host session scans')
-              this.hasLoggedRuntimeManagedIdle = true
-            }
-            continue
-          }
-
           // Skip if any session is currently processing a request
           if (messagePersister.hasActiveSessionsForAgent(agentId)) {
             continue


### PR DESCRIPTION
Reverts commit 4840b3fd (PR #538), which was merged in error.

The original changes are preserved and re-opened for review in a follow-up PR.

https://claude.ai/code/session_011KXR4aYGTLAmTSd4cn2Dkt