### PR TITLE
fix: route remote MCP proxyUrl through talk-back origin

### DIFF
--- a/agent-container/src/claude-code.test.ts
+++ b/agent-container/src/claude-code.test.ts
@@ -3,10 +3,37 @@ import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk'
 import {
   AGENT_BROWSER_BASH_WARNING,
   MessageQueue,
+  resolveRemoteMcpProxyUrl,
   resultNeedsResumeErrorFallback,
   startsWithAgentBrowserCommand,
   stillQueuedFromReceipt,
 } from './claude-code'
+
+describe('resolveRemoteMcpProxyUrl', () => {
+  it('re-origins a direct host-app proxyUrl onto the talk-back base', () => {
+    expect(
+      resolveRemoteMcpProxyUrl(
+        'http://10.20.108.29:3000/api/mcp-proxy/agent/mcp-1',
+        'http://127.0.0.1:9412/api',
+      ),
+    ).toBe('http://127.0.0.1:9412/api/mcp-proxy/agent/mcp-1')
+  })
+
+  it('is a no-op when the talk-back origin already matches', () => {
+    expect(
+      resolveRemoteMcpProxyUrl(
+        'http://host.docker.internal:3000/api/mcp-proxy/agent/mcp-1',
+        'http://host.docker.internal:3000/api',
+      ),
+    ).toBe('http://host.docker.internal:3000/api/mcp-proxy/agent/mcp-1')
+  })
+
+  it('returns the original URL when SUPERAGENT_HOST_API_URL is unset or invalid', () => {
+    const direct = 'http://10.20.108.29:3000/api/mcp-proxy/agent/mcp-1'
+    expect(resolveRemoteMcpProxyUrl(direct, undefined)).toBe(direct)
+    expect(resolveRemoteMcpProxyUrl(direct, 'not-a-url')).toBe(direct)
+  })
+})
 
 describe('startsWithAgentBrowserCommand', () => {
   it.each([

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -92,14 +92,33 @@ interface RemoteMcpConfig {
   tools: Array<{ name: string; description?: string; inputSchema?: Record<string, unknown> }>;
 }
 
-/**
- * Parses remote MCP server configs from the REMOTE_MCPS env var.
- */
+// Host may inject a direct private-IP proxyUrl; MicroVM talk-back is rewritten onto
+// SUPERAGENT_HOST_API_URL (local mTLS proxy). Re-origin so mid-session MCP inject works.
+export function resolveRemoteMcpProxyUrl(
+  proxyUrl: string,
+  hostApiUrl: string | undefined = process.env.SUPERAGENT_HOST_API_URL,
+): string {
+  if (!hostApiUrl) return proxyUrl
+  try {
+    const talkback = new URL(hostApiUrl)
+    const target = new URL(proxyUrl)
+    target.protocol = talkback.protocol
+    target.host = talkback.host
+    return target.href
+  } catch {
+    return proxyUrl
+  }
+}
+
 function parseRemoteMcps(): RemoteMcpConfig[] {
   const raw = process.env.REMOTE_MCPS;
   if (!raw) return [];
   try {
-    return JSON.parse(raw) as RemoteMcpConfig[];
+    const parsed = JSON.parse(raw) as RemoteMcpConfig[];
+    return parsed.map((mcp) => ({
+      ...mcp,
+      proxyUrl: resolveRemoteMcpProxyUrl(mcp.proxyUrl),
+    }))
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary
- Mid-session remote MCP approval injects `REMOTE_MCPS.proxyUrl` with the host-app private IP from `getHostApiBaseUrl()` (e.g. `http://10.20.x.x:3000/api/mcp-proxy/...`).
- On pooled MicroVM, that direct `:3000` path is blocked; talk-back must go through the local mTLS proxy (already reflected in `SUPERAGENT_HOST_API_URL`).
- Re-origin each `proxyUrl` onto `SUPERAGENT_HOST_API_URL` when parsing `REMOTE_MCPS`, so MCP HTTP transport uses the reachable talk-back base while keeping the `/api/mcp-proxy/...` path.

## Bug / repro
1. Run an agent on pooled MicroVM (cell-wide mTLS gateway tip).
2. Ask the agent to `request_remote_mcp` for Supabase (or any OAuth remote MCP).
3. Approve the OAuth grant.
4. Agent reports tools registered, then MCP connect times out after 30s with no HTTP status against `http://10.20.x.x:3000/api/mcp-proxy/...`.

## Test plan
- [x] `npm test -- --run src/claude-code.test.ts` in `agent-container`
- [ ] On a pooled MicroVM agent: approve Supabase remote MCP and confirm tools become callable (no 30s connect timeout)
- [ ] On local Docker/desktop: mid-session remote MCP still works (rewrite is a no-op when origins already match)


Made with [Cursor](https://cursor.com)