### PR TITLE
fb: staging MicroVM fixes (#550 + #553 + #554)

### DIFF
--- a/agent-container/src/claude-code.test.ts
+++ b/agent-container/src/claude-code.test.ts
@@ -3,10 +3,37 @@ import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk'
 import {
   AGENT_BROWSER_BASH_WARNING,
   MessageQueue,
+  resolveRemoteMcpProxyUrl,
   resultNeedsResumeErrorFallback,
   startsWithAgentBrowserCommand,
   stillQueuedFromReceipt,
 } from './claude-code'
+
+describe('resolveRemoteMcpProxyUrl', () => {
+  it('re-origins a direct host-app proxyUrl onto the talk-back base', () => {
+    expect(
+      resolveRemoteMcpProxyUrl(
+        'http://10.20.108.29:3000/api/mcp-proxy/agent/mcp-1',
+        'http://127.0.0.1:9412/api',
+      ),
+    ).toBe('http://127.0.0.1:9412/api/mcp-proxy/agent/mcp-1')
+  })
+
+  it('is a no-op when the talk-back origin already matches', () => {
+    expect(
+      resolveRemoteMcpProxyUrl(
+        'http://host.docker.internal:3000/api/mcp-proxy/agent/mcp-1',
+        'http://host.docker.internal:3000/api',
+      ),
+    ).toBe('http://host.docker.internal:3000/api/mcp-proxy/agent/mcp-1')
+  })
+
+  it('returns the original URL when SUPERAGENT_HOST_API_URL is unset or invalid', () => {
+    const direct = 'http://10.20.108.29:3000/api/mcp-proxy/agent/mcp-1'
+    expect(resolveRemoteMcpProxyUrl(direct, undefined)).toBe(direct)
+    expect(resolveRemoteMcpProxyUrl(direct, 'not-a-url')).toBe(direct)
+  })
+})
 
 describe('startsWithAgentBrowserCommand', () => {
   it.each([

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -92,14 +92,33 @@ interface RemoteMcpConfig {
   tools: Array<{ name: string; description?: string; inputSchema?: Record<string, unknown> }>;
 }
 
-/**
- * Parses remote MCP server configs from the REMOTE_MCPS env var.
- */
+// Host may inject a direct private-IP proxyUrl; MicroVM talk-back is rewritten onto
+// SUPERAGENT_HOST_API_URL (local mTLS proxy). Re-origin so mid-session MCP inject works.
+export function resolveRemoteMcpProxyUrl(
+  proxyUrl: string,
+  hostApiUrl: string | undefined = process.env.SUPERAGENT_HOST_API_URL,
+): string {
+  if (!hostApiUrl) return proxyUrl
+  try {
+    const talkback = new URL(hostApiUrl)
+    const target = new URL(proxyUrl)
+    target.protocol = talkback.protocol
+    target.host = talkback.host
+    return target.href
+  } catch {
+    return proxyUrl
+  }
+}
+
 function parseRemoteMcps(): RemoteMcpConfig[] {
   const raw = process.env.REMOTE_MCPS;
   if (!raw) return [];
   try {
-    return JSON.parse(raw) as RemoteMcpConfig[];
+    const parsed = JSON.parse(raw) as RemoteMcpConfig[];
+    return parsed.map((mcp) => ({
+      ...mcp,
+      proxyUrl: resolveRemoteMcpProxyUrl(mcp.proxyUrl),
+    }))
   } catch {
     return [];
   }

--- a/src/shared/lib/container/base-container-client.test.ts
+++ b/src/shared/lib/container/base-container-client.test.ts
@@ -31,6 +31,12 @@ class TestContainerClient extends BaseContainerClient {
   }
 }
 
+describe('host auto-sleep', () => {
+  it('is enabled by default for container runtimes', () => {
+    expect(new TestContainerClient({ agentId: 'a' }).shouldRunHostAutoSleep()).toBe(true)
+  })
+})
+
 describe('buildAgentEnv', () => {
   afterEach(() => enableToolSearch.mockReturnValue(true))
 

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -289,6 +289,10 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     this.config = config
   }
 
+  shouldRunHostAutoSleep(): boolean {
+    return true
+  }
+
   /**
    * Emit an 'error' event without crashing the process.
    *

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -113,6 +113,10 @@ class ContainerManager {
     return client
   }
 
+  shouldRunHostAutoSleep(agentId: string): boolean {
+    return this.getClient(agentId).shouldRunHostAutoSleep()
+  }
+
   /**
    * Get cached container info. Returns cached status if available,
    * otherwise returns stopped (will be corrected on next sync).

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -408,11 +408,32 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(await newClient().getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
   })
 
-  it('getInfoFromRuntime treats SUSPENDED as running (auto-resume on request)', async () => {
+  it('getInfoFromRuntime treats SUSPENDED as stopped (warm idle; local state kept)', async () => {
     const client = newClient()
     await client.start()
     responses.getState = 'SUSPENDED'
-    expect((await client.getInfoFromRuntime()).status).toBe('running')
+    expect(await client.getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
+
+    // Warm-idle must not drop local state — a later start() resumes, not Run.
+    responses.getState = 'RUNNING'
+    sendMock.mockClear()
+    await client.start()
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
+  })
+
+  it('getInfoFromRuntime treats SUSPENDING as stopped (warm idle; local state kept)', async () => {
+    const client = newClient()
+    await client.start()
+    responses.getState = 'SUSPENDING'
+    expect(await client.getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
+  })
+
+  it('stop() then getInfoFromRuntime reports stopped while suspended', async () => {
+    const client = newClient()
+    await client.start()
+    await client.stop()
+    responses.getState = 'SUSPENDED'
+    expect(await client.getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
   })
 
   it('getInfoFromRuntime reports stopped when the VM is TERMINATED and cleans up local state', async () => {
@@ -491,11 +512,16 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(suspendCall![0].input).toEqual({ microvmIdentifier: 'mvm-1' })
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
 
-    // State is preserved: a subsequent start() short-circuits (no new RunMicrovm).
+    // State is preserved: start() resumes via /health (no new RunMicrovm).
     sendMock.mockClear()
     responses.getState = 'SUSPENDED'
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      responses.getState = 'RUNNING'
+      return { ok: true } as Response
+    }))
     await client.start()
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
+    expect((await client.getInfoFromRuntime()).status).toBe('running')
   })
 
   it('a plain stop() is a no-op suspend when already SUSPENDED', async () => {

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -475,6 +475,10 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
   })
 
+  it('disables host auto-sleep because idlePolicy owns idle', () => {
+    expect(newClient().shouldRunHostAutoSleep()).toBe(false)
+  })
+
   it('a plain stop() suspends (preserves state for warm resume), not terminate', async () => {
     const client = newClient()
     await client.start()

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -739,6 +739,10 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
 
   // Proxy-level retry handles the suspend→resume 502 window for all HTTP calls.
 
+  shouldRunHostAutoSleep(): boolean {
+    return false
+  }
+
   async stop(options?: StopOptions): Promise<StopResult> {
     this.terminateWebSocketConnections()
     // Auto-sleep is handled by AWS idlePolicy; the host-app sweep is a no-op.

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -669,6 +669,10 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   async start(options?: StartOptions): Promise<void> {
     if ((await this.getInfoFromRuntime()).status === 'running') return
 
+    // Suspended VMs are UI-stopped but still warm — resume before RunMicrovm.
+    const existing = agentStates.get(this.config.agentId)
+    if (existing && (await this.resumeExisting(existing))) return
+
     const config = getMicrovmRuntimeConfig()
     // Full env exceeds the 4096-byte payload cap, so stash it host-side and pass the
     // VM only a small bootstrap credential to fetch it at boot via /api/agent-bootstrap.
@@ -766,10 +770,12 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     const config = getMicrovmRuntimeConfig()
     try {
       const mvm = await getMicrovm(config.region, state.microvmId)
-      // SUSPENDED is "running on demand": idlePolicy.autoResumeEnabled wakes it
-      // on the next request through the proxy.
-      if (mvm.state === 'RUNNING' || mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
+      if (mvm.state === 'RUNNING') {
         return { status: 'running', port: state.proxyPort }
+      }
+      // Warm-idle: UI shows stopped; local proxy state is kept so start()/traffic can resume.
+      if (mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
+        return { status: 'stopped', port: null }
       }
       // Terminal: VM is gone — drop state + proxy (mirror NotFound) so it isn't leaked.
       this.cleanupLocal()
@@ -816,6 +822,40 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
       await new Promise((resolve) => setTimeout(resolve, 2_000))
     }
     throw new Error(`Timed out waiting for MicroVM ${microvmId} to become RUNNING`)
+  }
+
+  // Resume a warm-suspended VM. Returns false when local state is stale (caller should Run).
+  // Avoid waitForHealthy here — it treats UI-stopped/suspended as dead and bails early.
+  private async resumeExisting(state: AgentMicrovmState): Promise<boolean> {
+    const config = getMicrovmRuntimeConfig()
+    try {
+      const mvm = await getMicrovm(config.region, state.microvmId)
+      if (mvm.state === 'TERMINATED' || mvm.state === 'TERMINATING') {
+        this.cleanupLocal()
+        return false
+      }
+      if (mvm.state !== 'RUNNING' && mvm.state !== 'SUSPENDED' && mvm.state !== 'SUSPENDING') {
+        this.cleanupLocal()
+        return false
+      }
+
+      const deadline = Date.now() + 120_000
+      while (Date.now() < deadline) {
+        if (await this.isHealthy(state.proxyPort)) break
+        await new Promise((resolve) => setTimeout(resolve, 250))
+      }
+      if (!(await this.isHealthy(state.proxyPort))) {
+        throw new Error(`MicroVM agent ${state.microvmId} failed to become healthy`)
+      }
+      await this.waitForRunning(config.region, state.microvmId, 120_000)
+      return true
+    } catch (error) {
+      if (isNotFound(error)) {
+        this.cleanupLocal()
+        return false
+      }
+      throw error
+    }
   }
 
   // Keep local proxy state so the next request auto-resumes the same VM.

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1920,6 +1920,10 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
 
   // Lifecycle management
 
+  shouldRunHostAutoSleep(): boolean {
+    return true
+  }
+
   async start(options?: StartOptions): Promise<void> {
     this.running = true
     // Surface the container env that carries the proxy credentials so E2E

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -132,6 +132,7 @@ export interface ContainerClient {
   start(options?: StartOptions): Promise<void>
   stop(options?: StopOptions): Promise<StopResult>
   stopSync(): void // Synchronous stop for exit handlers
+  shouldRunHostAutoSleep(): boolean
 
   // Build a -v flag value for a volume mount (hostPath:containerPath with runtime-specific suffix)
   buildVolumeFlag(hostPath: string, containerPath: string): string

--- a/src/shared/lib/scheduler/auto-sleep-monitor.test.ts
+++ b/src/shared/lib/scheduler/auto-sleep-monitor.test.ts
@@ -8,6 +8,7 @@ import type { SessionInfo } from '@shared/lib/types/agent'
 const mockGetRunningAgentIds = vi.fn<() => string[]>(() => [])
 const mockGetContainerStartTime = vi.fn<(id: string) => number | undefined>()
 const mockGetLastKeepAlive = vi.fn<(id: string) => number | undefined>()
+const mockShouldRunHostAutoSleep = vi.fn<(id: string) => boolean>(() => true)
 const mockStopContainer = vi.fn()
 
 vi.mock('@shared/lib/container/container-manager', () => ({
@@ -15,6 +16,7 @@ vi.mock('@shared/lib/container/container-manager', () => ({
     getRunningAgentIds: () => mockGetRunningAgentIds(),
     getContainerStartTime: (id: string) => mockGetContainerStartTime(id),
     getLastKeepAlive: (id: string) => mockGetLastKeepAlive(id),
+    shouldRunHostAutoSleep: (id: string) => mockShouldRunHostAutoSleep(id),
     stopContainer: (...args: unknown[]) => mockStopContainer(...args),
   },
 }))
@@ -73,6 +75,7 @@ describe('AutoSleepMonitor', () => {
     mockListSessions.mockResolvedValue([])
     mockGetContainerStartTime.mockReturnValue(undefined)
     mockGetLastKeepAlive.mockReturnValue(undefined)
+    mockShouldRunHostAutoSleep.mockReturnValue(true)
     mockStopContainer.mockResolvedValue(undefined)
   })
 
@@ -173,6 +176,19 @@ describe('AutoSleepMonitor', () => {
     await autoSleepMonitor.start()
     await tick()
 
+    expect(mockListSessions).not.toHaveBeenCalled()
+    expect(mockStopContainer).not.toHaveBeenCalled()
+  })
+
+  it('skips all session I/O when the runtime owns idle sleep', async () => {
+    mockGetRunningAgentIds.mockReturnValue(['agent-1'])
+    mockShouldRunHostAutoSleep.mockReturnValue(false)
+
+    await autoSleepMonitor.start()
+    await tick()
+
+    expect(mockShouldRunHostAutoSleep).toHaveBeenCalledWith('agent-1')
+    expect(mockHasActiveSessions).not.toHaveBeenCalled()
     expect(mockListSessions).not.toHaveBeenCalled()
     expect(mockStopContainer).not.toHaveBeenCalled()
   })

--- a/src/shared/lib/scheduler/auto-sleep-monitor.ts
+++ b/src/shared/lib/scheduler/auto-sleep-monitor.ts
@@ -16,6 +16,7 @@ class AutoSleepMonitor {
   private isRunning = false
   private pollIntervalMs = 60000 // Check every minute
   private isProcessing = false
+  private hasLoggedRuntimeManagedIdle = false
 
   /**
    * Start the monitor.
@@ -27,6 +28,7 @@ class AutoSleepMonitor {
     }
 
     this.isRunning = true
+    this.hasLoggedRuntimeManagedIdle = false
     console.log('[AutoSleepMonitor] Starting monitor...')
 
     // Start periodic polling
@@ -76,6 +78,14 @@ class AutoSleepMonitor {
 
       for (const agentId of runningAgentIds) {
         try {
+          if (!containerManager.shouldRunHostAutoSleep(agentId)) {
+            if (!this.hasLoggedRuntimeManagedIdle) {
+              console.log('[AutoSleepMonitor] Runtime owns idle sleep; skipping host session scans')
+              this.hasLoggedRuntimeManagedIdle = true
+            }
+            continue
+          }
+
           // Skip if any session is currently processing a request
           if (messagePersister.hasActiveSessionsForAgent(agentId)) {
             continue


### PR DESCRIPTION
## Summary
Staging feature-branch bundle so we can test three related MicroVM fixes together before each lands independently:

1. **#553** — skip host auto-sleep scans for Lambda MicroVM (reapply of #538)
2. **#550** — map Lambda MicroVM `SUSPENDED` / `SUSPENDING` to UI `stopped`
3. **#554** — re-origin mid-session `REMOTE_MCPS.proxyUrl` onto `SUPERAGENT_HOST_API_URL` (pooled mTLS talk-back)

Not for merge as a unit — individual PRs remain the review/merge path. This branch is the staging test vehicle.

## Test plan
- [ ] Deploy this `fb/staging-microvm-fixes` host-app + agent-container to staging
- [ ] Stop a MicroVM agent → UI stays `stopped` across refresh (`#550`)
- [ ] Idle MicroVM is not host-auto-slept incorrectly; AWS idle / warm resume still works (`#553`)
- [ ] Approve a remote MCP (e.g. Supabase) mid-session → tools connect (no 30s timeout to `10.20.x.x:3000`) (`#554`)


Made with [Cursor](https://cursor.com)