### PR TITLE
Restyle Browser Use settings tab to match global settings design

### DIFF
--- a/e2e/specs/settings.spec.ts
+++ b/e2e/specs/settings.spec.ts
@@ -202,7 +202,7 @@ test.describe('Settings Page', () => {
 
     await expect(page.locator('[data-testid="settings-model-trigger"]')).toBeVisible()
     await expect(page.locator('#max-browser-tabs')).toBeVisible()
-    await expect(page.locator('#browser-host')).toBeVisible()
+    await expect(page.locator('[data-testid="browser-host-card-container"]')).toBeVisible()
   })
 
   test('closes settings page', async ({ page }) => {

--- a/e2e/specs/settings.spec.ts
+++ b/e2e/specs/settings.spec.ts
@@ -333,18 +333,18 @@ test.describe('Settings persistence', () => {
       await openSettings(page)
       await goToTab(page, 'browser')
 
-      const input = page.locator('#max-browser-tabs')
-      await expect(input).toHaveValue('10')
+      const trigger = page.locator('#max-browser-tabs')
+      await expect(trigger).toContainText('10')
 
       const savePromise = waitForSettingsSave(page)
-      await input.fill('5')
+      await pickSelectOption(page, 'max-browser-tabs', '5')
       await savePromise
-      await expect(input).toHaveValue('5')
+      await expect(trigger).toContainText('5')
 
       await closeSettings(page)
       await openSettings(page)
       await goToTab(page, 'browser')
-      await expect(page.locator('#max-browser-tabs')).toHaveValue('5')
+      await expect(page.locator('#max-browser-tabs')).toContainText('5')
 
       const persisted = await settings(request)
       expect(persisted.app.maxBrowserTabs).toBe(5)

--- a/src/main/host-browser/platform-provider.ts
+++ b/src/main/host-browser/platform-provider.ts
@@ -40,7 +40,7 @@ export class PlatformBrowserProvider implements HostBrowserProvider {
         id: this.id,
         name: this.name,
         available: false,
-        reason: 'Platform proxy URL is not configured',
+        reason: 'proxy URL not configured',
       }
     }
     if (!getPlatformAccessToken()) {

--- a/src/main/host-browser/platform-provider.ts
+++ b/src/main/host-browser/platform-provider.ts
@@ -48,7 +48,7 @@ export class PlatformBrowserProvider implements HostBrowserProvider {
         id: this.id,
         name: this.name,
         available: false,
-        reason: 'Sign in to Platform to use this provider',
+        reason: 'sign in required',
       }
     }
     return { id: this.id, name: this.name, available: true }

--- a/src/renderer/components/settings/browser-tab.tsx
+++ b/src/renderer/components/settings/browser-tab.tsx
@@ -59,7 +59,7 @@ function FieldRow({ name, subtitle, right, htmlFor, stack }: FieldRowProps) {
   return (
     <div className={cn('flex gap-3', stack ? 'flex-col items-stretch md:flex-row md:items-center' : 'items-center')}>
       <div className="min-w-0 flex-1">
-        <Name htmlFor={htmlFor} className="text-xs font-medium truncate block cursor-default">{name}</Name>
+        <Name htmlFor={htmlFor} className={cn('text-xs font-medium truncate block', htmlFor ? 'cursor-pointer' : 'cursor-default')}>{name}</Name>
         {subtitle && <div className="text-[11px] text-muted-foreground mt-0.5">{subtitle}</div>}
       </div>
       <div className={cn('flex items-center gap-2 shrink-0', stack && 'w-full md:w-auto')}>{right}</div>

--- a/src/renderer/components/settings/browser-tab.tsx
+++ b/src/renderer/components/settings/browser-tab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { Label } from '@renderer/components/ui/label'
 import { Input } from '@renderer/components/ui/input'
 import { Button } from '@renderer/components/ui/button'
@@ -10,10 +10,11 @@ import {
   SelectValue,
 } from '@renderer/components/ui/select'
 import { Switch } from '@renderer/components/ui/switch'
+import { cn } from '@shared/lib/utils/cn'
 import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { apiFetch } from '@renderer/lib/api'
-import { Check, Loader2 } from 'lucide-react'
+import { Check, Loader2, Lock } from 'lucide-react'
 import { RequestError } from '@renderer/components/messages/request-error'
 import type { HostBrowserProviderId, BrowserbaseStealthOs } from '@shared/lib/config/settings'
 import { ChromeProfileSelect } from '@renderer/components/settings/chrome-profile-select'
@@ -21,6 +22,145 @@ import { SettingsModelSelect } from '@renderer/components/settings/settings-mode
 
 // Value used for "Container (built-in)" — no host browser provider
 const CONTAINER_VALUE = '__container__'
+
+// Preset tiers for the max-tabs picker. No 1: popup/OAuth flows need a second tab.
+const MAX_TABS_OPTIONS = [5, 10, 20]
+
+const CARD_CLASS = 'rounded-xl border bg-background divide-y divide-border/50 overflow-hidden'
+const SECTION_HEADING = 'text-xs font-medium text-muted-foreground px-1'
+
+const HOST_DESCRIPTIONS: Record<string, ReactNode> = {
+  [CONTAINER_VALUE]: 'Built-in headless browser. No stored passwords or cookies — agents need you to log in to sites.',
+  chrome: "Your agents can use sites you're already logged into Chrome.",
+  browserbase: (
+    <>
+      Remote cloud browser that reduces bot detection and supports persistent sessions.
+      <br />
+      Requires a Browserbase account.
+    </>
+  ),
+  platform: 'Managed cloud browser using your Platform account.',
+}
+
+interface FieldRowProps {
+  name: string
+  subtitle?: ReactNode
+  right: ReactNode
+  htmlFor?: string
+  /** Stack the control under the label below `md` — for wide controls (selects,
+      text inputs) that would otherwise crush the label on mobile. */
+  stack?: boolean
+}
+
+/** The row anatomy shared by card rows and expanded-card fields: name +
+    supporting line on the left, control on the right. */
+function FieldRow({ name, subtitle, right, htmlFor, stack }: FieldRowProps) {
+  const Name = htmlFor ? 'label' : 'div'
+  return (
+    <div className={cn('flex gap-3', stack ? 'flex-col items-stretch md:flex-row md:items-center' : 'items-center')}>
+      <div className="min-w-0 flex-1">
+        <Name htmlFor={htmlFor} className="text-xs font-medium truncate block cursor-default">{name}</Name>
+        {subtitle && <div className="text-[11px] text-muted-foreground mt-0.5">{subtitle}</div>}
+      </div>
+      <div className={cn('flex items-center gap-2 shrink-0', stack && 'w-full md:w-auto')}>{right}</div>
+    </div>
+  )
+}
+
+interface SettingRowProps {
+  name: string
+  subtitle: ReactNode
+  right: ReactNode
+  htmlFor?: string
+}
+
+function SettingRow({ name, subtitle, right, htmlFor }: SettingRowProps) {
+  return (
+    <div className="py-3 px-4">
+      <FieldRow name={name} subtitle={subtitle} right={right} htmlFor={htmlFor} />
+    </div>
+  )
+}
+
+interface HostCardProps {
+  id: string
+  name: string
+  description?: ReactNode
+  selected: boolean
+  disabled?: boolean
+  disabledReason?: string
+  onSelect: () => void
+  children?: ReactNode
+}
+
+/** Radio card that expands its provider-specific settings when selected —
+    mirrors ProviderCard from the LLM provider tab. */
+function HostCard({
+  id,
+  name,
+  description,
+  selected,
+  disabled = false,
+  disabledReason,
+  onSelect,
+  children,
+}: HostCardProps) {
+  return (
+    <div
+      className={`rounded-xl border bg-background transition-colors ${
+        selected ? 'border-primary' : disabled ? 'opacity-60' : 'hover:border-muted-foreground/40'
+      }`}
+      data-testid={`browser-host-card-${id === CONTAINER_VALUE ? 'container' : id}`}
+    >
+      <button
+        type="button"
+        role="radio"
+        onClick={disabled ? undefined : onSelect}
+        disabled={disabled}
+        className="w-full flex items-start gap-3 px-4 py-3 text-left disabled:cursor-not-allowed"
+        aria-checked={selected}
+        aria-disabled={disabled || undefined}
+      >
+        <div
+          className={`mt-0.5 h-4 w-4 rounded-full border-2 shrink-0 flex items-center justify-center ${
+            selected ? 'border-primary' : 'border-muted-foreground/40'
+          }`}
+        >
+          {selected && <div className="h-2 w-2 rounded-full bg-primary" />}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium">{name}</span>
+            {disabled && disabledReason && (
+              <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+                <Lock className="h-3 w-3" />
+                {disabledReason}
+              </span>
+            )}
+          </div>
+          {description && (
+            <div className="text-[11px] text-muted-foreground mt-0.5">{description}</div>
+          )}
+        </div>
+      </button>
+
+      {/* Expanded settings area when selected */}
+      <div
+        className={`grid transition-all duration-200 ease-in-out ${
+          selected && children ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+        }`}
+      >
+        <div className="overflow-hidden">
+          {/* Only mount when selected: a collapsed grid-rows-[0fr] still leaves
+              inputs in the DOM and keyboard tab order, so render conditionally. */}
+          {selected && children && (
+            <div className="px-4 pb-6 pt-5 border-t border-border/50">{children}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
 
 export function BrowserTab() {
   const { data: settings, isLoading } = useSettings()
@@ -42,231 +182,232 @@ export function BrowserTab() {
   const chromeProvider = providers.find((p) => p.id === 'chrome')
   const chromeProfiles = chromeProvider?.profiles ?? []
 
+  // Values stored by the old free-form input (1–20) may fall outside the presets;
+  // surface them so the trigger doesn't render empty.
+  const maxTabs = settings?.app?.maxBrowserTabs ?? 10
+  const maxTabsIsCustom = !MAX_TABS_OPTIONS.includes(maxTabs)
+
+  const handleSelectProvider = (value: string) => {
+    const providerId = value === CONTAINER_VALUE ? null : value as HostBrowserProviderId
+    setHostProvider(value)
+    track('browser_host_changed', { using: value === CONTAINER_VALUE ? 'container' : value })
+    updateSettings.mutate({
+      app: { hostBrowserProvider: providerId as HostBrowserProviderId | undefined },
+    })
+  }
+
+  // Rendered inside both the Browserbase and Platform cards — platform-managed
+  // sessions run on Browserbase too, so the same session knobs apply.
+  const sessionSettings = (
+    <BrowserbaseSessionSettings
+      advancedStealth={settings?.app?.browserbaseAdvancedStealth ?? false}
+      stealthOs={settings?.app?.browserbaseStealthOs}
+      proxies={settings?.app?.browserbaseProxies ?? false}
+      proxyCountry={settings?.app?.browserbaseProxyCountry ?? ''}
+      proxyState={settings?.app?.browserbaseProxyState ?? ''}
+      proxyCity={settings?.app?.browserbaseProxyCity ?? ''}
+      disabled={isLoading}
+      onUpdate={(updates) => updateSettings.mutate({ app: updates })}
+    />
+  )
+
   return (
     <div className="space-y-6">
-      {/* Browser Agent Model */}
       <div className="space-y-2">
-        <Label>Browser Agent Model</Label>
-        <div>
-          <SettingsModelSelect
-            model={settings?.models?.browserModel}
-            onModelChange={(value) => updateSettings.mutate({ models: { browserModel: value } })}
-            disabled={isLoading}
-            // The trigger is left-aligned in its block, so its LEFT edge is the
-            // fixed one — anchoring 'end' would slide the popover on every pick.
-            align="start"
+        <h3 className={SECTION_HEADING}>Browser Agent</h3>
+        <div className={CARD_CLASS}>
+          <SettingRow
+            name="Browser Agent Model"
+            subtitle="Model used for the web browser subagent"
+            right={
+              <SettingsModelSelect
+                model={settings?.models?.browserModel}
+                onModelChange={(value) => updateSettings.mutate({ models: { browserModel: value } })}
+                disabled={isLoading}
+              />
+            }
+          />
+          <SettingRow
+            name="Max Browser Tabs"
+            subtitle="Maximum number of browser tabs the agent can have open at once (default: 10)"
+            htmlFor="max-browser-tabs"
+            right={
+              <Select
+                value={String(maxTabs)}
+                onValueChange={(value) => {
+                  updateSettings.mutate({ app: { maxBrowserTabs: parseInt(value, 10) } })
+                }}
+                disabled={isLoading}
+              >
+                <SelectTrigger id="max-browser-tabs" className="h-8 w-24">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {maxTabsIsCustom && (
+                    <SelectItem value={String(maxTabs)}>{maxTabs} (custom)</SelectItem>
+                  )}
+                  {MAX_TABS_OPTIONS.map((n) => (
+                    <SelectItem key={n} value={String(n)}>
+                      {n}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            }
           />
         </div>
-        <p className="text-xs text-muted-foreground">
-          Model used for the web browser subagent
-        </p>
       </div>
 
-      {/* Max Browser Tabs */}
+      {/* Host selection — radio cards, expanded card shows provider settings */}
       <div className="space-y-2">
-        <Label htmlFor="max-browser-tabs">Max Browser Tabs</Label>
-        <Input
-          id="max-browser-tabs"
-          type="number"
-          min={1}
-          max={20}
-          value={settings?.app?.maxBrowserTabs ?? 10}
-          onChange={(e) => {
-            const value = parseInt(e.target.value)
-            if (value >= 1 && value <= 20) {
-              updateSettings.mutate({ app: { maxBrowserTabs: value } })
-            }
-          }}
-          disabled={isLoading}
-        />
-        <p className="text-xs text-muted-foreground">
-          Maximum number of browser tabs the agent can have open at once (default: 10)
-        </p>
-      </div>
-
-      {/* Browser Host selector */}
-      <div className="space-y-2">
-        <Label htmlFor="browser-host">Browser Host</Label>
-        <Select
-          value={effectiveProvider}
-          onValueChange={(value) => {
-            const providerId = value === CONTAINER_VALUE ? null : value as HostBrowserProviderId
-            setHostProvider(value)
-            track('browser_host_changed', { using: value === CONTAINER_VALUE ? 'container' : value })
-            updateSettings.mutate({
-              app: { hostBrowserProvider: providerId as HostBrowserProviderId | undefined },
-            })
-          }}
-          disabled={isLoading}
-        >
-          <SelectTrigger id="browser-host">
-            <SelectValue placeholder="Select browser host" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={CONTAINER_VALUE}>
-              Container (built-in)
-            </SelectItem>
-            {providers.map((provider) => {
-              const showReason =
-                !provider.available && (provider.id === 'chrome' || provider.id === 'platform')
-              return (
-                <SelectItem
-                  key={provider.id}
-                  value={provider.id}
-                  disabled={showReason}
-                >
-                  {provider.name}
-                  {showReason && provider.reason ? ` (${provider.reason})` : ''}
-                </SelectItem>
-              )
-            })}
-          </SelectContent>
-        </Select>
-        <p className="text-xs text-muted-foreground">
-          Choose where the browser runs. &quot;Container&quot; uses a built-in headless browser.
-          External hosts reduce bot detection and support persistent sessions.
-        </p>
-      </div>
-
-      {/* Chrome-specific: Profile selector */}
-      {effectiveProvider === 'chrome' && chromeProfiles.length > 0 && (
-        <ChromeProfileSelect
-          profiles={chromeProfiles}
-          value={effectiveChromeProfileId}
-          onValueChange={(profileId) => {
-            setChromeProfileId(profileId)
-            updateSettings.mutate({ app: { chromeProfileId: profileId } })
-          }}
-          idPrefix="chrome-profile"
-          disabled={isLoading}
-        />
-      )}
-
-      {/* Chrome-specific: Headless mode */}
-      {effectiveProvider === 'chrome' && (
-        <div className="flex items-center justify-between">
-          <div className="space-y-0.5">
-            <Label htmlFor="chrome-headless">Headless Mode</Label>
-            <p className="text-xs text-muted-foreground">
-              Run Chrome without a visible window. Prevents Chrome from stealing
-              focus while the agent browses. The browser preview still works normally.
-            </p>
-          </div>
-          <Switch
-            id="chrome-headless"
-            checked={settings?.app?.chromeHeadless ?? false}
-            onCheckedChange={(checked) => {
-              updateSettings.mutate({ app: { chromeHeadless: checked } })
-            }}
+        <h3 className={SECTION_HEADING}>Browser Host</h3>
+        <div role="radiogroup" aria-label="Browser host" className="space-y-3">
+          <HostCard
+            id={CONTAINER_VALUE}
+            name="Container (built-in)"
+            description={HOST_DESCRIPTIONS[CONTAINER_VALUE]}
+            selected={effectiveProvider === CONTAINER_VALUE}
             disabled={isLoading}
+            onSelect={() => handleSelectProvider(CONTAINER_VALUE)}
           />
+
+          {providers.map((provider) => {
+            const unavailable =
+              !provider.available && (provider.id === 'chrome' || provider.id === 'platform')
+            return (
+              <HostCard
+                key={provider.id}
+                id={provider.id}
+                name={provider.name}
+                description={HOST_DESCRIPTIONS[provider.id]}
+                selected={effectiveProvider === provider.id}
+                disabled={unavailable || isLoading}
+                disabledReason={unavailable ? provider.reason : undefined}
+                onSelect={() => handleSelectProvider(provider.id)}
+              >
+                {provider.id === 'chrome' ? (
+                  <div className="space-y-4">
+                    {chromeProfiles.length > 0 && (
+                      <FieldRow
+                        name="Chrome Profile"
+                        subtitle="Browse with an existing profile's logins and cookies"
+                        htmlFor="chrome-profile-select"
+                        stack
+                        right={
+                          <div className="w-full md:w-[260px]">
+                            <ChromeProfileSelect
+                              profiles={chromeProfiles}
+                              value={effectiveChromeProfileId}
+                              onValueChange={(profileId) => {
+                                setChromeProfileId(profileId)
+                                updateSettings.mutate({ app: { chromeProfileId: profileId } })
+                              }}
+                              idPrefix="chrome-profile"
+                              disabled={isLoading}
+                            />
+                          </div>
+                        }
+                      />
+                    )}
+                    <FieldRow
+                      name="Headless Mode"
+                      subtitle="Run Chrome without a visible window. Prevents Chrome from stealing focus."
+                      htmlFor="chrome-headless"
+                      right={
+                        <Switch
+                          id="chrome-headless"
+                          checked={settings?.app?.chromeHeadless ?? false}
+                          onCheckedChange={(checked) => {
+                            updateSettings.mutate({ app: { chromeHeadless: checked } })
+                          }}
+                          disabled={isLoading}
+                        />
+                      }
+                    />
+                  </div>
+                ) : provider.id === 'browserbase' ? (
+                  <div className="space-y-4">
+                    <BrowserbaseSettings
+                      layout="rows"
+                      apiKey={browserbaseApiKey}
+                      projectId={browserbaseProjectId}
+                      onApiKeyChange={(v) => { setBrowserbaseApiKey(v); setValidationResult(null) }}
+                      onProjectIdChange={(v) => { setBrowserbaseProjectId(v); setValidationResult(null) }}
+                      isValidating={isValidating}
+                      validationResult={validationResult}
+                      hasSavedCredentials={
+                        !!providers.find((p) => p.id === 'browserbase')?.available
+                        || !!settings?.apiKeyStatus?.browserbase?.isConfigured
+                      }
+                      credentialSource={settings?.apiKeyStatus?.browserbase?.source}
+                      disabled={isLoading}
+                      onValidateAndSave={async () => {
+                        if (!browserbaseApiKey.trim() || !browserbaseProjectId.trim()) return
+                        setIsValidating(true)
+                        setValidationResult(null)
+
+                        try {
+                          const res = await apiFetch('/api/settings/validate-browserbase', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({
+                              apiKey: browserbaseApiKey.trim(),
+                              projectId: browserbaseProjectId.trim(),
+                            }),
+                          })
+                          const result = await res.json()
+                          setValidationResult(result)
+
+                          if (result.valid) {
+                            await updateSettings.mutateAsync({
+                              apiKeys: {
+                                browserbaseApiKey: browserbaseApiKey.trim(),
+                                browserbaseProjectId: browserbaseProjectId.trim(),
+                              },
+                            })
+                            // Clear inputs so the button hides — saved state is shown via placeholder
+                            setBrowserbaseApiKey('')
+                            setBrowserbaseProjectId('')
+                          }
+                        } catch {
+                          setValidationResult({ valid: false, error: 'Failed to validate credentials' })
+                        } finally {
+                          setIsValidating(false)
+                        }
+                      }}
+                      onRemove={async () => {
+                        setIsValidating(true)
+                        try {
+                          await updateSettings.mutateAsync({
+                            apiKeys: {
+                              browserbaseApiKey: '',
+                              browserbaseProjectId: '',
+                            },
+                          })
+                          setBrowserbaseApiKey('')
+                          setBrowserbaseProjectId('')
+                          setValidationResult(null)
+                        } finally {
+                          setIsValidating(false)
+                        }
+                      }}
+                    />
+                    {sessionSettings}
+                  </div>
+                ) : provider.id === 'platform' ? (
+                  <div className="space-y-4">
+                    <p className="text-xs text-muted-foreground">
+                      Browser sessions run on Browserbase using your Platform account&apos;s
+                      credentials — no API key configuration needed.
+                    </p>
+                    {sessionSettings}
+                  </div>
+                ) : null}
+              </HostCard>
+            )
+          })}
         </div>
-      )}
-
-      {/* Browserbase-specific settings */}
-      {effectiveProvider === 'browserbase' && (
-        <>
-          <BrowserbaseSettings
-            apiKey={browserbaseApiKey}
-            projectId={browserbaseProjectId}
-            onApiKeyChange={(v) => { setBrowserbaseApiKey(v); setValidationResult(null) }}
-            onProjectIdChange={(v) => { setBrowserbaseProjectId(v); setValidationResult(null) }}
-            isValidating={isValidating}
-            validationResult={validationResult}
-            hasSavedCredentials={
-              !!providers.find((p) => p.id === 'browserbase')?.available
-              || !!settings?.apiKeyStatus?.browserbase?.isConfigured
-            }
-            credentialSource={settings?.apiKeyStatus?.browserbase?.source}
-            disabled={isLoading}
-            onValidateAndSave={async () => {
-              if (!browserbaseApiKey.trim() || !browserbaseProjectId.trim()) return
-              setIsValidating(true)
-              setValidationResult(null)
-
-              try {
-                const res = await apiFetch('/api/settings/validate-browserbase', {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({
-                    apiKey: browserbaseApiKey.trim(),
-                    projectId: browserbaseProjectId.trim(),
-                  }),
-                })
-                const result = await res.json()
-                setValidationResult(result)
-
-                if (result.valid) {
-                  await updateSettings.mutateAsync({
-                    apiKeys: {
-                      browserbaseApiKey: browserbaseApiKey.trim(),
-                      browserbaseProjectId: browserbaseProjectId.trim(),
-                    },
-                  })
-                  // Clear inputs so the button hides — saved state is shown via placeholder
-                  setBrowserbaseApiKey('')
-                  setBrowserbaseProjectId('')
-                }
-              } catch {
-                setValidationResult({ valid: false, error: 'Failed to validate credentials' })
-              } finally {
-                setIsValidating(false)
-              }
-            }}
-            onRemove={async () => {
-              setIsValidating(true)
-              try {
-                await updateSettings.mutateAsync({
-                  apiKeys: {
-                    browserbaseApiKey: '',
-                    browserbaseProjectId: '',
-                  },
-                })
-                setBrowserbaseApiKey('')
-                setBrowserbaseProjectId('')
-                setValidationResult(null)
-              } finally {
-                setIsValidating(false)
-              }
-            }}
-          />
-
-          <BrowserbaseSessionSettings
-            advancedStealth={settings?.app?.browserbaseAdvancedStealth ?? false}
-            stealthOs={settings?.app?.browserbaseStealthOs}
-            proxies={settings?.app?.browserbaseProxies ?? false}
-            proxyCountry={settings?.app?.browserbaseProxyCountry ?? ''}
-            proxyState={settings?.app?.browserbaseProxyState ?? ''}
-            proxyCity={settings?.app?.browserbaseProxyCity ?? ''}
-            disabled={isLoading}
-            onUpdate={(updates) => updateSettings.mutate({ app: updates })}
-          />
-        </>
-      )}
-
-      {/* Platform-managed Browserbase: no credentials needed, just show session settings */}
-      {effectiveProvider === 'platform' && (
-        <>
-          <div className="rounded-lg border p-4 space-y-1 bg-muted/30">
-            <p className="text-sm font-medium">Managed by Platform</p>
-            <p className="text-xs text-muted-foreground">
-              Browser sessions run on Browserbase using your Platform account&apos;s
-              credentials — no API key configuration needed.
-            </p>
-          </div>
-
-          <BrowserbaseSessionSettings
-            advancedStealth={settings?.app?.browserbaseAdvancedStealth ?? false}
-            stealthOs={settings?.app?.browserbaseStealthOs}
-            proxies={settings?.app?.browserbaseProxies ?? false}
-            proxyCountry={settings?.app?.browserbaseProxyCountry ?? ''}
-            proxyState={settings?.app?.browserbaseProxyState ?? ''}
-            proxyCity={settings?.app?.browserbaseProxyCity ?? ''}
-            disabled={isLoading}
-            onUpdate={(updates) => updateSettings.mutate({ app: updates })}
-          />
-        </>
-      )}
+      </div>
     </div>
   )
 }
@@ -299,6 +440,8 @@ interface BrowserbaseSessionSettingsProps {
   }>) => void
 }
 
+/** Browserbase session config, rendered inside the expanded host card — used by
+    both the Browserbase card (below credentials) and the Platform card. */
 function BrowserbaseSessionSettings({
   advancedStealth,
   stealthOs,
@@ -310,92 +453,87 @@ function BrowserbaseSessionSettings({
   onUpdate,
 }: BrowserbaseSessionSettingsProps) {
   return (
-    <div className="space-y-4 rounded-lg border p-4">
-      <h4 className="text-sm font-medium">Session Settings</h4>
-
-      {/* Advanced Stealth */}
-      <div className="flex items-center justify-between">
-        <div className="space-y-0.5">
-          <Label htmlFor="bb-stealth">Advanced Stealth Mode</Label>
-          <p className="text-xs text-muted-foreground">
-            Uses a custom Chromium browser to avoid bot detection. Requires Scale plan.
-          </p>
-        </div>
-        <Switch
-          id="bb-stealth"
-          checked={advancedStealth}
-          onCheckedChange={(checked) => {
-            onUpdate({
-              browserbaseAdvancedStealth: checked,
-              // Clear OS when disabling stealth
-              ...(!checked && { browserbaseStealthOs: undefined }),
-            })
-          }}
-          disabled={disabled}
-        />
-      </div>
-
-      {/* OS Selection (only when stealth is on) */}
-      {advancedStealth && (
-        <div className="space-y-2 pl-1">
-          <Label htmlFor="bb-stealth-os">Operating System</Label>
-          <Select
-            value={stealthOs ?? NO_OS_VALUE}
-            onValueChange={(value) => {
+    <div className="space-y-4">
+      <FieldRow
+        name="Advanced Stealth Mode"
+        subtitle="Uses a custom Chromium browser to avoid bot detection. Requires Scale plan."
+        htmlFor="bb-stealth"
+        right={
+          <Switch
+            id="bb-stealth"
+            checked={advancedStealth}
+            onCheckedChange={(checked) => {
               onUpdate({
-                browserbaseStealthOs: value === NO_OS_VALUE ? undefined : value as BrowserbaseStealthOs,
+                browserbaseAdvancedStealth: checked,
+                // Clear OS when disabling stealth
+                ...(!checked && { browserbaseStealthOs: undefined }),
               })
             }}
             disabled={disabled}
-          >
-            <SelectTrigger id="bb-stealth-os">
-              <SelectValue placeholder="Default (auto)" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={NO_OS_VALUE}>Default (auto)</SelectItem>
-              {STEALTH_OS_OPTIONS.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <p className="text-xs text-muted-foreground">
-            Changes the user agent and browser environment signals to match the selected platform.
-          </p>
-        </div>
+          />
+        }
+      />
+
+      {/* OS Selection (only when stealth is on) */}
+      {advancedStealth && (
+        <FieldRow
+          name="Operating System"
+          subtitle="Changes the user agent and browser environment signals to match the selected platform"
+          htmlFor="bb-stealth-os"
+          right={
+            <Select
+              value={stealthOs ?? NO_OS_VALUE}
+              onValueChange={(value) => {
+                onUpdate({
+                  browserbaseStealthOs: value === NO_OS_VALUE ? undefined : value as BrowserbaseStealthOs,
+                })
+              }}
+              disabled={disabled}
+            >
+              <SelectTrigger id="bb-stealth-os" className="h-8 w-[160px]">
+                <SelectValue placeholder="Default (auto)" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NO_OS_VALUE}>Default (auto)</SelectItem>
+                {STEALTH_OS_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          }
+        />
       )}
 
-      {/* Proxies */}
-      <div className="flex items-center justify-between">
-        <div className="space-y-0.5">
-          <Label htmlFor="bb-proxies">Enable Proxies</Label>
-          <p className="text-xs text-muted-foreground">
-            Route traffic through residential proxies for higher CAPTCHA success rates and geo-targeting.
-          </p>
-        </div>
-        <Switch
-          id="bb-proxies"
-          checked={proxies}
-          onCheckedChange={(checked) => {
-            onUpdate({
-              browserbaseProxies: checked,
-              // Clear geolocation when disabling
-              ...(!checked && {
-                browserbaseProxyCountry: '',
-                browserbaseProxyState: '',
-                browserbaseProxyCity: '',
-              }),
-            })
-          }}
-          disabled={disabled}
-        />
-      </div>
+      <FieldRow
+        name="Enable Proxies"
+        subtitle="Route traffic through residential proxies for higher CAPTCHA success rates and geo-targeting"
+        htmlFor="bb-proxies"
+        right={
+          <Switch
+            id="bb-proxies"
+            checked={proxies}
+            onCheckedChange={(checked) => {
+              onUpdate({
+                browserbaseProxies: checked,
+                // Clear geolocation when disabling
+                ...(!checked && {
+                  browserbaseProxyCountry: '',
+                  browserbaseProxyState: '',
+                  browserbaseProxyCity: '',
+                }),
+              })
+            }}
+            disabled={disabled}
+          />
+        }
+      />
 
       {/* Proxy Geolocation (only when proxies are on) */}
       {proxies && (
-        <div className="space-y-3 pl-1">
-          <p className="text-xs text-muted-foreground">
+        <div className="space-y-3">
+          <p className="text-[11px] text-muted-foreground">
             Optionally specify a proxy location. Leave empty for best-effort US proxy.
           </p>
           <div className="grid grid-cols-3 gap-3">
@@ -408,6 +546,7 @@ function BrowserbaseSessionSettings({
                 onChange={(e) => onUpdate({ browserbaseProxyCountry: e.target.value.toUpperCase() })}
                 disabled={disabled}
                 maxLength={2}
+                className="h-8"
               />
             </div>
             <div className="space-y-1">
@@ -419,6 +558,7 @@ function BrowserbaseSessionSettings({
                 onChange={(e) => onUpdate({ browserbaseProxyState: e.target.value.toUpperCase() })}
                 disabled={disabled}
                 maxLength={2}
+                className="h-8"
               />
             </div>
             <div className="space-y-1">
@@ -429,6 +569,7 @@ function BrowserbaseSessionSettings({
                 value={proxyCity}
                 onChange={(e) => onUpdate({ browserbaseProxyCity: e.target.value.toUpperCase() })}
                 disabled={disabled}
+                className="h-8"
               />
             </div>
           </div>
@@ -450,6 +591,10 @@ export interface BrowserbaseSettingsProps {
   disabled: boolean
   onValidateAndSave: () => void
   onRemove: () => void
+  /** 'rows' puts label + supporting text left, input right (settings tab).
+      'stacked' (default) keeps label-above-input for narrow containers
+      like the setup wizard's 480px column. */
+  layout?: 'stacked' | 'rows'
 }
 
 export function BrowserbaseSettings({
@@ -464,8 +609,33 @@ export function BrowserbaseSettings({
   disabled,
   onValidateAndSave,
   onRemove,
+  layout = 'stacked',
 }: BrowserbaseSettingsProps) {
   const hasInput = apiKey.trim().length > 0 && projectId.trim().length > 0
+  const rows = layout === 'rows'
+
+  const apiKeyInput = (
+    <Input
+      id="browserbase-api-key"
+      type="password"
+      placeholder={hasSavedCredentials ? '••••••••••••••••' : 'bb-api-...'}
+      value={apiKey}
+      onChange={(e) => onApiKeyChange(e.target.value)}
+      disabled={disabled || isValidating}
+      className={cn('bg-background', rows && 'h-8 w-full md:w-[340px]')}
+    />
+  )
+  const projectIdInput = (
+    <Input
+      id="browserbase-project-id"
+      type="text"
+      placeholder={hasSavedCredentials ? '••••••••••••••••' : 'bb-proj-...'}
+      value={projectId}
+      onChange={(e) => onProjectIdChange(e.target.value)}
+      disabled={disabled || isValidating}
+      className={cn('bg-background', rows && 'h-8 w-full md:w-[340px]')}
+    />
+  )
 
   return (
     <div className="space-y-4">
@@ -477,31 +647,35 @@ export function BrowserbaseSettings({
         </div>
       )}
 
-      <div className="space-y-2">
-        <Label htmlFor="browserbase-api-key" className="font-normal text-muted-foreground">Browserbase API Key</Label>
-        <Input
-          id="browserbase-api-key"
-          type="password"
-          placeholder={hasSavedCredentials ? '••••••••••••••••' : 'bb-api-...'}
-          value={apiKey}
-          onChange={(e) => onApiKeyChange(e.target.value)}
-          disabled={disabled || isValidating}
-          className="bg-background"
-        />
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="browserbase-project-id" className="font-normal text-muted-foreground">Browserbase Project ID</Label>
-        <Input
-          id="browserbase-project-id"
-          type="text"
-          placeholder={hasSavedCredentials ? '••••••••••••••••' : 'bb-proj-...'}
-          value={projectId}
-          onChange={(e) => onProjectIdChange(e.target.value)}
-          disabled={disabled || isValidating}
-          className="bg-background"
-        />
-      </div>
+      {rows ? (
+        <>
+          <FieldRow
+            name="API Key"
+            subtitle="Secret key from your Browserbase dashboard"
+            htmlFor="browserbase-api-key"
+            stack
+            right={apiKeyInput}
+          />
+          <FieldRow
+            name="Project ID"
+            subtitle="Found in your Browserbase project settings"
+            htmlFor="browserbase-project-id"
+            stack
+            right={projectIdInput}
+          />
+        </>
+      ) : (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor="browserbase-api-key" className="font-normal text-muted-foreground">Browserbase API Key</Label>
+            {apiKeyInput}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="browserbase-project-id" className="font-normal text-muted-foreground">Browserbase Project ID</Label>
+            {projectIdInput}
+          </div>
+        </>
+      )}
 
       <div className="flex justify-end gap-2">
         {hasInput && (


### PR DESCRIPTION
## Summary

Brings the Browser Use tab in line with the global settings design system (General tab et al.): section headings, rounded cards, and rows with the name + supporting text on the left and the control on the right.

The browser host selection now follows the LLM provider tab's interaction pattern — radio cards that expand to reveal provider-specific settings when selected:

- **Container (built-in)** — no extra settings
- **Google Chrome** — profile picker + headless mode toggle
- **Browserbase** — credentials plus session settings (stealth, OS, proxies, proxy geolocation)
- **Platform** — managed-by-platform note plus the same session settings (platform sessions run on Browserbase too)

Unavailable hosts render disabled with a lock icon and the reason inline on the card.

## Behavior changes (not just styling)

- **Max Browser Tabs** is now a dropdown with 5 / 10 / 20 presets instead of a free 1–20 number input. Previously stored off-list values surface as an "n (custom)" option until a preset is picked, so the trigger never renders empty.
- **Host selection** moved from a `<Select>` dropdown to radio cards.
- **Copy**: headless-mode subtitle shortened; Browserbase credential labels trimmed to "API Key" / "Project ID" (they sit inside the Browserbase card now) with short supporting lines.
- **Platform provider reason** trimmed from "Platform proxy URL is not configured" to "proxy URL not configured" at the source (`platform-provider.ts`), fixing the "Platform (Platform …)" doubling wherever `name (reason)` is rendered.

## Shared component note

`BrowserbaseSettings` (also used by the setup wizard) gains an opt-in `layout="rows"` prop for the left/right row anatomy. The wizard keeps the stacked label-above-input default — its 480px column would crush side-by-side rows — so wizard behavior is unchanged.

## Testing

- `tsc --noEmit` and eslint clean.
- Manually verified all host states (Container, Chrome incl. profile/headless, Browserbase incl. stealth/proxy toggles, disabled Platform) in the running app.
- e2e: `settings.spec.ts` now asserts the `browser-host-card-container` testid instead of the removed `#browser-host` select. Not run locally (worktree's better-sqlite3 is on the Electron ABI for dev-app testing) — should be validated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)