### PR TITLE
Fix session file preview split layout

### DIFF
--- a/e2e/specs/file-preview.spec.ts
+++ b/e2e/specs/file-preview.spec.ts
@@ -67,6 +67,40 @@ test.describe('File Preview', () => {
 
     await expect(page.getByTestId('file-preview-header')).toBeVisible({ timeout: 5000 })
     await expect(markdown(page).getByRole('heading', { name: 'Test Report' })).toBeVisible({ timeout: 10000 })
+
+    // On a wide Session View, the preview participates in the row layout rather
+    // than covering the chat and composer.
+    await expect.poll(async () => {
+      const [sessionBox, drawerBox] = await Promise.all([
+        page.getByTestId('session-thread-main').boundingBox(),
+        page.getByTestId('tray-drawer').boundingBox(),
+      ])
+      if (!sessionBox || !drawerBox) return Number.POSITIVE_INFINITY
+      return Math.abs(sessionBox.x + sessionBox.width - drawerBox.x)
+    }).toBeLessThanOrEqual(1)
+  })
+
+  test('agent home bookmark preview overlays the wide page', async ({ page }) => {
+    await agentPage.createAgent(`HomeFilePreview ${Date.now()}`)
+    const agentSlug = await getLatestAgentSlug(page)
+    seedWorkspaceFile(agentSlug, 'reports/daily.md', '# Daily Report')
+
+    const bookmarksResponse = await page.request.put(`/api/agents/${agentSlug}/bookmarks`, {
+      data: [{ name: 'Daily report', file: '/workspace/reports/daily.md' }],
+    })
+    expect(bookmarksResponse.ok()).toBeTruthy()
+
+    await page.reload()
+    const bookmark = page.getByRole('button', { name: 'Daily report' })
+    await expect(bookmark).toBeVisible({ timeout: 10000 })
+    await bookmark.click()
+    await expect(markdown(page).getByRole('heading', { name: 'Daily Report' })).toBeVisible({ timeout: 10000 })
+
+    const homeBox = await page.getByTestId('agent-home').boundingBox()
+    const drawerBox = await page.getByTestId('tray-drawer').boundingBox()
+    expect(homeBox).not.toBeNull()
+    expect(drawerBox).not.toBeNull()
+    expect(Math.abs(homeBox!.x + homeBox!.width - (drawerBox!.x + drawerBox!.width))).toBeLessThanOrEqual(1)
   })
 
   test('folder bookmark traverses lazily and opens files while preserving tree state', async ({ page }) => {
@@ -208,9 +242,7 @@ test.describe('File Preview', () => {
 
     await expect(markdown(page).getByRole('heading', { name: 'Version 1' })).toBeVisible({ timeout: 10000 })
 
-    // The file tray intentionally overlays the composer. Close it before asking
-    // the agent to deliver the updated version, then reopen it from the new pill.
-    await page.getByRole('button', { name: 'Hide files panel' }).click()
+    // The wide Session View remains usable while the split preview is open.
     seedWorkspaceFile(agentSlug, 'output/report.md', '# Version 2')
     await sessionPage.sendMessage('deliver file')
     await sessionPage.waitForResponse(15000)
@@ -422,6 +454,13 @@ test.describe('File Preview', () => {
           expect(box!.x + box!.width).toBeLessThanOrEqual(viewportWidth)
         }
       }).toPass({ timeout: 5000 })
+
+      const containerBox = await page.getByTestId('file-preview-container').boundingBox()
+      const drawerBox = await page.getByTestId('tray-drawer').boundingBox()
+      expect(containerBox).not.toBeNull()
+      expect(drawerBox).not.toBeNull()
+      expect(Math.abs(drawerBox!.x - containerBox!.x)).toBeLessThanOrEqual(1)
+      expect(Math.abs(drawerBox!.width - containerBox!.width)).toBeLessThanOrEqual(1)
     })
   })
 
@@ -446,11 +485,8 @@ test.describe('File Preview', () => {
     await expect(page.getByTestId('file-preview-header')).toBeVisible({ timeout: 5000 })
     await expect(markdown(page).getByRole('heading', { name: 'Report Content' })).toBeVisible({ timeout: 10000 })
 
-    // The overlay covers the composer by design, so close it before delivering
-    // the next file. Existing tabs remain available when the tray reopens.
-    await page.getByRole('button', { name: 'Hide files panel' }).click()
-
-    // Deliver and open the image file → second tab, image renderer.
+    // Deliver while the split preview remains open, then open the image file →
+    // second tab, image renderer.
     await sessionPage.sendMessage('deliver image')
     await sessionPage.waitForResponse(15000)
     const chartPill = getFilePill(page, 'chart.png').first()

--- a/src/renderer/components/messages/session-thread.tsx
+++ b/src/renderer/components/messages/session-thread.tsx
@@ -44,9 +44,15 @@ export function SessionThread({
   suppressScrollToBottom,
 }: SessionThreadProps) {
   return (
-    <div className="file-preview-container relative flex flex-1 min-h-0 min-w-0">
+    <div
+      className="file-preview-container relative flex flex-1 min-h-0 min-w-0"
+      data-testid="file-preview-container"
+    >
       {/* Chat column — grid pins the footer at the bottom */}
-      <div className="flex-1 min-w-0 grid grid-rows-[1fr_auto] min-h-0">
+      <div
+        className="flex-1 min-w-0 grid grid-rows-[1fr_auto] min-h-0"
+        data-testid="session-thread-main"
+      >
         <MessageList
           key={sessionId}
           sessionId={sessionId}

--- a/src/renderer/components/tray/drawer-shell.test.tsx
+++ b/src/renderer/components/tray/drawer-shell.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react'
 import { DrawerShell } from './drawer-shell'
 
 describe('DrawerShell', () => {
-  it('marks the open drawer as an overlay when requested', () => {
+  it('marks the drawer for a full-width overlay only at the responsive breakpoint', () => {
     const { container } = render(
       <DrawerShell isOpen storageKey="test-tray-width" responsiveFullWidth>
         <div>Preview</div>
@@ -15,6 +15,36 @@ describe('DrawerShell', () => {
     expect(shell).toHaveClass('file-preview-responsive-overlay')
     expect(shell).not.toHaveClass('file-preview-responsive-overlay-closed')
     expect(shell.firstElementChild).toHaveClass('file-preview-responsive-resize-handle')
+  })
+
+  it('can overlay wide content independently of its responsive behavior', () => {
+    const { container } = render(
+      <DrawerShell isOpen storageKey="test-tray-width-wide" wideOverlay>
+        <div>Preview</div>
+      </DrawerShell>,
+    )
+
+    const shell = container.firstElementChild as HTMLElement
+    expect(shell).toHaveClass('file-preview-wide-overlay')
+    expect(shell).not.toHaveClass('file-preview-responsive-overlay')
+  })
+
+  it('combines wide and responsive overlays for the agent home file preview', () => {
+    const { container } = render(
+      <DrawerShell
+        isOpen
+        storageKey="test-tray-width-agent-home"
+        responsiveFullWidth
+        wideOverlay
+      >
+        <div>Preview</div>
+      </DrawerShell>,
+    )
+
+    expect(container.firstElementChild).toHaveClass(
+      'file-preview-responsive-overlay',
+      'file-preview-wide-overlay',
+    )
   })
 
   it('keeps a requested overlay mounted off-canvas while closed', () => {
@@ -40,6 +70,7 @@ describe('DrawerShell', () => {
 
     const shell = container.firstElementChild as HTMLElement
     expect(shell).not.toHaveClass('file-preview-responsive-overlay')
+    expect(shell).not.toHaveClass('file-preview-wide-overlay')
     expect(shell.firstElementChild).not.toHaveClass('file-preview-responsive-resize-handle')
   })
 })

--- a/src/renderer/components/tray/drawer-shell.tsx
+++ b/src/renderer/components/tray/drawer-shell.tsx
@@ -13,8 +13,10 @@ export interface DrawerShellHandle {
 interface DrawerShellProps {
   isOpen: boolean
   storageKey: string
-  /** Overlay the parent at drawer width, expanding to full width when it is narrow. */
+  /** Expand to a full-width overlay when the containing layout is narrow. */
   responsiveFullWidth?: boolean
+  /** Overlay the parent instead of participating in its wide-screen flex layout. */
+  wideOverlay?: boolean
   defaultWidth?: number
   minWidth?: number
   maxWidth?: number
@@ -27,6 +29,7 @@ export const DrawerShell = forwardRef<DrawerShellHandle, DrawerShellProps>(funct
   isOpen,
   storageKey,
   responsiveFullWidth = false,
+  wideOverlay = false,
   defaultWidth = DEFAULT_WIDTH,
   minWidth = MIN_WIDTH,
   maxWidth = MAX_WIDTH,
@@ -90,11 +93,13 @@ export const DrawerShell = forwardRef<DrawerShellHandle, DrawerShellProps>(funct
         'h-full border-l bg-background flex flex-col shrink-0 overflow-hidden relative shadow-[-4px_0_16px_rgba(0,0,0,0.08)] dark:shadow-[-4px_0_16px_rgba(0,0,0,0.3)]',
         responsiveFullWidth && 'file-preview-responsive-overlay',
         responsiveFullWidth && !isOpen && 'file-preview-responsive-overlay-closed',
+        wideOverlay && 'file-preview-wide-overlay',
         !isResizing && 'transition-[width] duration-300 ease-in-out',
         className
       )}
       style={{ width: isOpen ? drawerWidth : 0, maxWidth: '100%', contain: 'layout paint', willChange: 'transform' }}
       onTransitionEnd={onTransitionEnd}
+      data-testid="tray-drawer"
     >
       {/* Resize handle on left edge */}
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}

--- a/src/renderer/components/tray/tray-manager.tsx
+++ b/src/renderer/components/tray/tray-manager.tsx
@@ -15,9 +15,16 @@ interface TrayManagerProps {
   agentSlug: string
   sessionId: string
   browserActive: boolean
+  /** Wide-screen file previews split the layout by default; Agent Home opts into an overlay. */
+  filePreviewWideLayout?: 'split' | 'overlay'
 }
 
-export function TrayManager({ agentSlug, sessionId, browserActive }: TrayManagerProps) {
+export function TrayManager({
+  agentSlug,
+  sessionId,
+  browserActive,
+  filePreviewWideLayout = 'split',
+}: TrayManagerProps) {
   const filePreview = useFilePreview()
   const hasOpenFiles = filePreview.openTabs.length > 0 && filePreview.isOpen
   const workflow = useWorkflow()
@@ -188,6 +195,7 @@ export function TrayManager({ agentSlug, sessionId, browserActive }: TrayManager
       isOpen={isOpen}
       storageKey={DRAWER_STORAGE_KEY}
       responsiveFullWidth={activeTray?.id === 'files'}
+      wideOverlay={activeTray?.id === 'files' && filePreviewWideLayout === 'overlay'}
     >
       <div className="flex flex-1 min-h-0">
         <div className="flex-1 flex flex-col min-w-0 min-h-0">

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -701,16 +701,15 @@ html[data-keyboard-open] [data-composer-footer] {
 /*
   File previews can render in the agent body or in a smaller embedded session
   mirror. A viewport or app-level query cannot describe both spaces. Make each
-  immediate tray host a query container and switch the file tray between a
-  fixed-width overlay and a full-width overlay at 768px. Neither mode
-  participates in flex layout, so opening a file never reflows or squeezes the
-  content beneath it.
+  immediate tray host a query container. Above 768px, Session View keeps its
+  file tray in the flex layout while Agent Home opts into an overlay. Below the
+  breakpoint, both use the same full-width overlay.
 */
 .file-preview-container {
   container-type: inline-size;
 }
 
-.file-preview-responsive-overlay {
+.file-preview-wide-overlay {
   position: absolute;
   inset-block: 0;
   right: 0;
@@ -719,6 +718,10 @@ html[data-keyboard-open] [data-composer-footer] {
 
 @container (max-width: 767px) {
   .file-preview-responsive-overlay {
+    position: absolute;
+    inset-block: 0;
+    right: 0;
+    z-index: 30;
     left: 0;
     width: 100% !important; /* overrides the persisted inline drawer width */
     border-left-width: 0;

--- a/src/renderer/router/route-components.tsx
+++ b/src/renderer/router/route-components.tsx
@@ -38,9 +38,17 @@ export function AgentHomeRoute() {
   return (
     <FilePreviewProvider sessionId={homePreviewId} commentsEnabled={false}>
       <WorkflowProvider sessionId={homePreviewId}>
-        <div className="file-preview-container relative flex flex-1 min-h-0 min-w-0">
+        <div
+          className="file-preview-container relative flex flex-1 min-h-0 min-w-0"
+          data-testid="file-preview-container"
+        >
           <AgentHome key={agent.slug} agent={agent} onSessionCreated={onSessionCreated} />
-          <TrayManager agentSlug={agent.slug} sessionId={homePreviewId} browserActive={false} />
+          <TrayManager
+            agentSlug={agent.slug}
+            sessionId={homePreviewId}
+            browserActive={false}
+            filePreviewWideLayout="overlay"
+          />
         </div>
       </WorkflowProvider>
     </FilePreviewProvider>


### PR DESCRIPTION
## Summary

- restore split-pane file previews in Session View on wide layouts
- keep Agent Home bookmark previews layered over the page
- preserve the existing full-page file preview below the 768px container breakpoint
- add regression coverage for wide Session View, wide Agent Home, narrow layouts, and composer use while a preview remains open

## Root cause

The responsive file-preview modifier introduced for Agent Home made every file preview drawer absolutely positioned. Because Session View uses the same shared drawer, its preview stopped participating in the flex layout and began covering the chat and composer as well.

This change separates the wide-screen overlay choice from the responsive full-width behavior. Session View uses the default split layout, while Agent Home explicitly opts into the wide overlay. Both still use the full-width overlay below the existing breakpoint.

## User impact

Opening a file tab in a wide Session View now shrinks the conversation alongside the preview instead of covering it. Agent Home retains its intended overlay behavior, and compact layouts remain full-page.

## Validation

- `npm run typecheck`
- focused ESLint checks for changed TypeScript and E2E files
- DrawerShell and file-preview Vitest coverage
- focused Playwright checks for Session View split layout, Agent Home overlay, narrow full-page layout, re-delivery with the preview open, and multiple file tabs
