### PR TITLE
Let non-admin users change models (SUP-416)

### DIFF
--- a/e2e/auth/specs/model-picker-roles.spec.ts
+++ b/e2e/auth/specs/model-picker-roles.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '../fixtures/multi-user.fixture'
+import { AuthPage } from '../pages/auth.page'
+import { UserBarPage } from '../pages/user-bar.page'
+import { AppPage } from '../../pages/app.page'
+import { AgentPage } from '../../pages/agent.page'
+
+// Serial narrative: admin signs up first, then a regular (non-admin) member —
+// every later test drives the MEMBER's browser context.
+test.describe.configure({ mode: 'serial' })
+
+const admin = { name: 'Ada Admin', email: 'ada@test.com', password: 'password123' }
+const member = { name: 'Mia Member', email: 'mia@test.com', password: 'password123' }
+const agentName = 'Model Picker Agent'
+
+/**
+ * Non-admin users must still get a working model picker. The model catalog
+ * used to ride only on the admin-gated GET /api/settings, so for a regular
+ * user the composer popover and the agent-home Default Model card rendered
+ * with an EMPTY model list (effort options only) — they could not change
+ * models at all, even on agents they own.
+ */
+test.describe('Model picker for non-admin users', () => {
+  test('admin signs up first', async ({ user1Page }) => {
+    const authPage = new AuthPage(user1Page)
+    const appPage = new AppPage(user1Page)
+    const userBar = new UserBarPage(user1Page)
+
+    await authPage.resetToAuthPage()
+    await authPage.signUpOrSignIn(admin.name, admin.email, admin.password)
+    await appPage.waitForAppLoaded()
+    await appPage.dismissWizardIfVisible()
+    await userBar.expectUserName(admin.name)
+  })
+
+  test('member signs up as a regular user and creates an agent', async ({ user2Page }) => {
+    const authPage = new AuthPage(user2Page)
+    const appPage = new AppPage(user2Page)
+    const userBar = new UserBarPage(user2Page)
+    const agentPage = new AgentPage(user2Page)
+
+    await authPage.resetToAuthPage()
+    await authPage.signUpOrSignIn(member.name, member.email, member.password)
+    await appPage.waitForAppLoaded()
+    await appPage.dismissWizardIfVisible()
+    await userBar.expectUserName(member.name)
+
+    await agentPage.createAgent(agentName)
+    await expect(agentPage.getAgentItem(agentName)).toBeVisible()
+  })
+
+  test('member composer popover lists models, not just effort', async ({ user2Page }) => {
+    await expect(user2Page.locator('[data-testid="home-message-input"]')).toBeVisible()
+
+    await user2Page.locator('[data-testid="composer-options-trigger"]').click()
+
+    // The model section must list the provider's families. With the catalog
+    // gated behind the admin-only settings endpoint these rows are absent and
+    // only the effort slider renders.
+    await expect(user2Page.locator('[data-testid="model-family-opus"]')).toBeVisible()
+    await expect(user2Page.locator('[data-testid="model-family-sonnet"]')).toBeVisible()
+
+    // And a pick actually registers: select Opus, the trigger label follows.
+    await user2Page.locator('[data-testid="model-family-opus"]').click()
+    await user2Page.keyboard.press('Escape')
+    await expect(user2Page.locator('[data-testid="composer-options-trigger"]')).toContainText(/opus/i)
+  })
+
+  test('member can change the agent default model from the home card', async ({ user2Page }) => {
+    const card = user2Page.locator('[data-testid="home-default-model-card"]')
+    await expect(card).toBeVisible()
+
+    await card.locator('[data-testid="settings-model-trigger"]').click()
+
+    // Same catalog, offerLatest surface: family rows carry model-latest-* ids.
+    const opusRow = user2Page.locator('[data-testid="model-latest-opus"]')
+    await expect(opusRow).toBeVisible()
+
+    // Picking a model must persist as the agent default: the trigger label
+    // updates and the "reset to global" affordance appears (custom default set).
+    await opusRow.click()
+    await user2Page.keyboard.press('Escape')
+    await expect(card.locator('[data-testid="settings-model-trigger"]')).toContainText(/opus/i)
+    await expect(card.locator('[data-testid="home-default-model-reset"]')).toBeVisible()
+
+    // Durable proof it hit the server, not just local state.
+    await user2Page.reload()
+    await expect(card.locator('[data-testid="settings-model-trigger"]')).toContainText(/opus/i, { timeout: 15000 })
+  })
+})

--- a/playwright.auth.config.ts
+++ b/playwright.auth.config.ts
@@ -40,6 +40,13 @@ const authProjects = [
     dataDir: path.join(e2eDataDir, 'graph'),
     viteCacheDir: path.join(e2eDataDir, '.vite', 'graph'),
   },
+  {
+    name: 'auth-models',
+    testMatch: '**/model-picker-roles.spec.ts',
+    port: e2ePort + 4,
+    dataDir: path.join(e2eDataDir, 'models'),
+    viteCacheDir: path.join(e2eDataDir, '.vite', 'models'),
+  },
 ].map((project, index) => ({
   ...project,
   baseURL: index === 0 && process.env.E2E_BASE_URL

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -32,6 +32,7 @@ import {
   type ApiKeySettings,
   type ContainerSettings,
   type GlobalSettingsResponse,
+  type ModelPickerSettingsResponse,
 } from '@shared/lib/config/settings'
 import { agentCapabilitySettingsPatchSchema, DEFAULT_AGENT_CAPABILITIES } from '@shared/lib/config/capability-policy-schema'
 import { validateFaviconDataUrl } from '@shared/lib/config/favicon'
@@ -195,6 +196,27 @@ const FACTORY_RESET_TABLES: SQLiteTable[] = [
 // Custom model icons are used in regular model pickers, so any authenticated
 // user may read them. Writes and the rest of settings stay admin-only.
 settings.get('/model-icons/:fileName', Authenticated(), serveUploadedModelIcon)
+
+// The model catalog drives the composer and default-model pickers, which every
+// authenticated user may use — choosing a model is not an admin action, only
+// editing provider config/catalog is. Serve the picker-safe subset above the
+// admin gate; it carries no secrets (provider ids/names, an isConfigured
+// boolean, catalogs, and default selections).
+settings.get('/models', Authenticated(), (c) => {
+  try {
+    const appSettings = getSettings()
+    const response: ModelPickerSettingsResponse = {
+      llmProvider: appSettings.llmProvider ?? 'anthropic',
+      llmProviderStatus: getAllProviderInfo(),
+      models: getEffectiveModels(),
+      webProvider: resolveEffectiveWebVendor(),
+    }
+    return c.json(response)
+  } catch (error) {
+    console.error('Failed to fetch model settings:', error)
+    return c.json({ error: 'Failed to fetch model settings' }, 500)
+  }
+})
 
 settings.use('*', Authenticated(), IsAdmin())
 

--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -62,9 +62,10 @@ vi.mock('@renderer/hooks/use-sessions', () => ({
 }))
 
 // Settings drive ComposerOptions: the catalog comes from llmProviderStatus,
-// fallback model from settings.models.agentModel.
-vi.mock('@renderer/hooks/use-settings', () => ({
-  useSettings: () => ({
+// fallback model from settings.models.agentModel. The pickers read the
+// non-admin useModelSettings; useSettings stays for any admin-only consumers.
+vi.mock('@renderer/hooks/use-settings', () => {
+  const settings = {
     data: {
       llmProvider: 'anthropic',
       models: { agentModel: 'sonnet' },
@@ -82,8 +83,12 @@ vi.mock('@renderer/hooks/use-settings', () => ({
         },
       ],
     },
-  }),
-}))
+  }
+  return {
+    useSettings: () => settings,
+    useModelSettings: () => settings,
+  }
+})
 
 vi.mock('@renderer/hooks/use-scheduled-tasks', () => ({
   useScheduledTasks: () => ({ data: [] }),

--- a/src/renderer/components/agents/agent-home/home-default-model.test.tsx
+++ b/src/renderer/components/agents/agent-home/home-default-model.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event'
 
 const useSettingsMock = vi.fn()
 vi.mock('@renderer/hooks/use-settings', () => ({
-  useSettings: () => useSettingsMock(),
+  useModelSettings: () => useSettingsMock(),
 }))
 
 const usePreferencesMock = vi.fn()

--- a/src/renderer/components/agents/agent-home/home-default-model.tsx
+++ b/src/renderer/components/agents/agent-home/home-default-model.tsx
@@ -1,7 +1,7 @@
 import { RotateCcw } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
 import { Button } from '@renderer/components/ui/button'
-import { useSettings } from '@renderer/hooks/use-settings'
+import { useModelSettings } from '@renderer/hooks/use-settings'
 import { useAgentPreferences, useUpdateAgentPreferences } from '@renderer/hooks/use-agent-preferences'
 import { SettingsModelSelect } from '@renderer/components/settings/settings-model-select'
 import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
@@ -18,7 +18,8 @@ interface HomeDefaultModelProps {
  * per-trigger or per-session pick still wins over both.
  */
 export function HomeDefaultModel({ agentSlug, className }: HomeDefaultModelProps) {
-  const { data: settings } = useSettings()
+  // Picker-safe endpoint — the card renders for every agent member, admin or not.
+  const { data: settings } = useModelSettings()
   const { data: prefs } = useAgentPreferences(agentSlug)
   const updatePreferences = useUpdateAgentPreferences(agentSlug)
 

--- a/src/renderer/components/chat-integrations/integration-settings-controls.test.tsx
+++ b/src/renderer/components/chat-integrations/integration-settings-controls.test.tsx
@@ -25,8 +25,9 @@ vi.mock('@renderer/hooks/use-chat-integrations', () => ({
   }),
 }))
 
-vi.mock('@renderer/hooks/use-settings', () => ({
-  useSettings: () => ({
+vi.mock('@renderer/hooks/use-settings', () => {
+  // Built lazily — the hoisted factory runs before CATALOG is initialized.
+  const settings = () => ({
     data: {
       llmProvider: 'anthropic',
       llmProviderStatus: [{
@@ -35,8 +36,12 @@ vi.mock('@renderer/hooks/use-settings', () => ({
         defaultModels: { agent: 'opus', summarizer: 'haiku', browser: 'sonnet' },
       }],
     },
-  }),
-}))
+  })
+  return {
+    useSettings: settings,
+    useModelSettings: settings,
+  }
+})
 
 describe('IntegrationModelEffort', () => {
   beforeEach(() => {

--- a/src/renderer/components/messages/composer-options.test.tsx
+++ b/src/renderer/components/messages/composer-options.test.tsx
@@ -3,12 +3,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useComposerOptions, type UseComposerOptionsArgs } from './composer-options'
 
-// Mutable settings the mocked useSettings reads at call time, so tests can
+// Mutable settings the mocked useModelSettings reads at call time, so tests can
 // simulate the query resolving (undefined → loaded) and later refetches.
 const state = vi.hoisted(() => ({ settings: undefined as unknown }))
 
 vi.mock('@renderer/hooks/use-settings', () => ({
-  useSettings: () => ({ data: state.settings }),
+  useModelSettings: () => ({ data: state.settings }),
 }))
 
 const LOADED_SETTINGS = {

--- a/src/renderer/components/messages/composer-options.tsx
+++ b/src/renderer/components/messages/composer-options.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useSettings } from '@renderer/hooks/use-settings'
+import { useModelSettings } from '@renderer/hooks/use-settings'
 import { ComposerOptionsPopover } from './composer-options-popover'
 import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 import type { ModelDefinition } from '@shared/lib/llm-provider'
@@ -110,7 +110,9 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
     followDefaults = false,
   } = args
 
-  const { data: settings } = useSettings()
+  // Picker-safe endpoint — readable by non-admin users too, unlike the
+  // admin-gated full settings (which would leave them an empty catalog).
+  const { data: settings } = useModelSettings()
 
   // ---- Effort ----
   const [effort, setEffortState] = useState<EffortLevel>(initialEffort ?? DEFAULT_EFFORT)

--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -86,6 +86,7 @@ const mockSettings = {
 }
 vi.mock('@renderer/hooks/use-settings', () => ({
   useSettings: () => mockSettings,
+  useModelSettings: () => mockSettings,
 }))
 
 describe('MessageInput', () => {

--- a/src/renderer/components/scheduled-tasks/scheduled-task-view.test.tsx
+++ b/src/renderer/components/scheduled-tasks/scheduled-task-view.test.tsx
@@ -44,8 +44,8 @@ vi.mock('@renderer/hooks/use-humanized-cron', () => ({
   useHumanizedCron: () => 'Every day at 9:00 AM',
 }))
 
-vi.mock('@renderer/hooks/use-settings', () => ({
-  useSettings: () => ({
+vi.mock('@renderer/hooks/use-settings', () => {
+  const settings = {
     data: {
       llmProvider: 'anthropic',
       models: { agentModel: 'sonnet' },
@@ -61,8 +61,12 @@ vi.mock('@renderer/hooks/use-settings', () => ({
         },
       ],
     },
-  }),
-}))
+  }
+  return {
+    useSettings: () => settings,
+    useModelSettings: () => settings,
+  }
+})
 
 vi.mock('@renderer/hooks/use-scheduled-tasks', () => ({
   useScheduledTask: () => ({ data: mockTask, isLoading: false, error: null }),

--- a/src/renderer/components/settings/llm-tab.test.tsx
+++ b/src/renderer/components/settings/llm-tab.test.tsx
@@ -10,6 +10,7 @@ const useProviderModelSearchMock = vi.fn()
 
 vi.mock('@renderer/hooks/use-settings', () => ({
   useSettings: () => useSettingsMock(),
+  useModelSettings: () => useSettingsMock(),
   useProviderModelSearch: (...args: unknown[]) => useProviderModelSearchMock(...args),
   useUpdateSettings: () => ({ mutate: mutateMock }),
 }))

--- a/src/renderer/components/settings/settings-model-select.test.tsx
+++ b/src/renderer/components/settings/settings-model-select.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event'
 
 const useSettingsMock = vi.fn()
 vi.mock('@renderer/hooks/use-settings', () => ({
-  useSettings: () => useSettingsMock(),
+  useModelSettings: () => useSettingsMock(),
 }))
 
 import { SettingsModelSelect } from './settings-model-select'

--- a/src/renderer/components/settings/settings-model-select.tsx
+++ b/src/renderer/components/settings/settings-model-select.tsx
@@ -4,7 +4,7 @@ import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { Separator } from '@renderer/components/ui/separator'
 import { ModelIcon } from '@renderer/components/ui/model-icon'
-import { useSettings } from '@renderer/hooks/use-settings'
+import { useModelSettings } from '@renderer/hooks/use-settings'
 import { ModelFamilyList, findCatalogModel, familyDisplayName } from '@renderer/components/messages/model-family-list'
 import { EFFORT_LABELS, EffortSection, useEffortClamp } from '@renderer/components/messages/effort-slider'
 import { SPEED_LABELS, SpeedSection, availableSpeeds, useSpeedClamp } from '@renderer/components/messages/speed-section'
@@ -56,7 +56,9 @@ function SettingsModelSelectImpl({
   disabled,
   align = 'end',
 }: SettingsModelSelectProps) {
-  const { data: settings } = useSettings()
+  // Picker-safe endpoint — this select also serves non-admin surfaces (the
+  // agent-home Default Model card), where the admin-gated settings 403.
+  const { data: settings } = useModelSettings()
   const activeProvider = (settings?.llmProvider ?? 'anthropic') as LlmProviderId
   const catalog = useMemo(
     () => settings?.llmProviderStatus?.find((p) => p.id === activeProvider)?.catalog ?? [],

--- a/src/renderer/components/webhook-triggers/webhook-trigger-view.test.tsx
+++ b/src/renderer/components/webhook-triggers/webhook-trigger-view.test.tsx
@@ -50,6 +50,7 @@ vi.mock('@renderer/hooks/use-agents', () => ({
 
 vi.mock('@renderer/hooks/use-settings', () => ({
   useSettings: () => ({ data: { apiKeyStatus: {} } }),
+  useModelSettings: () => ({ data: undefined }),
 }))
 
 vi.mock('@renderer/hooks/use-platform-auth', () => ({

--- a/src/renderer/hooks/use-settings.ts
+++ b/src/renderer/hooks/use-settings.ts
@@ -2,6 +2,7 @@ import { apiFetch } from '@renderer/lib/api'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type {
   GlobalSettingsResponse,
+  ModelPickerSettingsResponse,
   ContainerSettings,
   AppPreferences,
   ModelSettings,
@@ -18,7 +19,7 @@ import type { RunnerAvailability } from '@shared/lib/container/client-factory'
 import type { RunnerSetupRemediation } from '@shared/lib/container/wsl2-setup-errors'
 import type { ModelCatalogSettings, ModelSearchResult } from '@shared/lib/llm-provider'
 
-export type { GlobalSettingsResponse, ContainerSettings, AppPreferences, ModelSettings, AgentLimitsSettings, AuthSettings, VoiceSettings, AnalyticsTarget, LlmProviderId, RunnerAvailability, RunnerSetupRemediation }
+export type { GlobalSettingsResponse, ModelPickerSettingsResponse, ContainerSettings, AppPreferences, ModelSettings, AgentLimitsSettings, AuthSettings, VoiceSettings, AnalyticsTarget, LlmProviderId, RunnerAvailability, RunnerSetupRemediation }
 
 export function useSettings(options?: { enabled?: boolean }) {
   return useQuery<GlobalSettingsResponse>({
@@ -30,6 +31,25 @@ export function useSettings(options?: { enabled?: boolean }) {
     },
     refetchInterval: 60000, // Poll less frequently - container status is cached server-side
     enabled: options?.enabled,
+  })
+}
+
+/**
+ * Picker-safe model settings served to EVERY authenticated user. The composer
+ * and default-model pickers must read this — not `useSettings()`, whose
+ * endpoint is admin-gated in auth mode and leaves non-admins with an empty
+ * catalog. The `['settings', …]` key keeps it refreshed by the same broad
+ * invalidations the settings mutations already fire (e.g. a catalog edit).
+ */
+export function useModelSettings() {
+  return useQuery<ModelPickerSettingsResponse>({
+    queryKey: ['settings', 'models'],
+    queryFn: async () => {
+      const res = await apiFetch('/api/settings/models')
+      if (!res.ok) throw new Error('Failed to fetch model settings')
+      return res.json()
+    },
+    staleTime: 60000,
   })
 }
 

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -333,6 +333,18 @@ export interface GlobalSettingsResponse {
 }
 
 /**
+ * Picker-safe subset of {@link GlobalSettingsResponse} served to EVERY
+ * authenticated user (GET /api/settings/models). Choosing a model is not an
+ * admin action — only editing provider config/catalog is — so the composer and
+ * default-model pickers read this instead of the admin-gated full settings.
+ * Must stay free of secrets and infra state.
+ */
+export type ModelPickerSettingsResponse = Pick<
+  GlobalSettingsResponse,
+  'llmProvider' | 'llmProviderStatus' | 'models' | 'webProvider'
+>
+
+/**
  * Default container runner: Lima on macOS (bundled, no install needed),
  * WSL2 on Windows (bundled, no install needed), Docker elsewhere.
  */


### PR DESCRIPTION
## Problem

**SUP-416** — on cloud (auth mode), non-admin users saw a model selector with only effort options, in both the composer popover and the agent-home Default Model card, and could not change models at all.

Root cause: the entire settings API is mounted behind `Authenticated(), IsAdmin()`, and every model picker read its catalog from the admin-gated `GET /api/settings` via `useSettings()`. For a non-admin that request 403s, the catalog resolves to `[]`, and the pickers degrade to effort-only.

Writes were never the bug: the per-message model rides the message payload, and the agent default model goes through `PUT /api/agents/:id/preferences` (agent-level ownership gate). Only the catalog *read* was blocked.

## Fix

- New `GET /api/settings/models` mounted **above** the admin gate (any authenticated user), returning a picker-safe subset typed as `ModelPickerSettingsResponse` (`Pick` of `GlobalSettingsResponse`): `llmProvider`, `llmProviderStatus`, `models`, `webProvider`. No secrets — provider ids/names, an `isConfigured` boolean, catalogs, and default aliases.
- New `useModelSettings()` hook (query key `['settings', 'models']`, so existing `['settings']` invalidations — e.g. an admin editing the catalog — still refresh the pickers).
- Switched the three picker surfaces to it: `composer-options.tsx`, `settings-model-select.tsx`, `home-default-model.tsx`. Admin-only surfaces keep using `useSettings()`.

## Test (failing-first)

New `e2e/auth/specs/model-picker-roles.spec.ts` + an `auth-models` project in `playwright.auth.config.ts`: an admin signs up first, then a regular member creates an agent; the member's composer popover must list model families and a pick must stick, and the member must be able to set the agent default model from the home card, persisted across reload.

Verified red before the fix (`model-family-opus` never renders — the exact ticket symptom), green after.

## Validation

- New auth-models project: 4/4 passed
- Full auth E2E suite: 63/63 passed
- Full unit suite: 7,639 passed (9 test files updated where `vi.mock('@renderer/hooks/use-settings')` needed the new export)
- `tsc --noEmit` clean, eslint clean on changed files

https://claude.ai/code/session_01DRSnTw4P98vAkLzKcwtX3W