### PR TITLE
Characterization suite for the pending user-input request lifecycle (Phase 0)

### DIFF
--- a/e2e/specs/mixed-pending-requests.spec.ts
+++ b/e2e/specs/mixed-pending-requests.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from '@playwright/test'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+import {
+  createAgent,
+  expectPendingProxyReviewResolved,
+  gotoAgentHome,
+  uniqueName,
+  uniqueSuffix,
+  waitForCurrentSessionId,
+  waitForPendingProxyReview,
+  type TestAgent,
+} from '../helpers/agents'
+
+/**
+ * Mixed pending requests across BOTH stores in one turn: two container-side
+ * input asks (secret + question, persister pendingInputRequests) plus an
+ * agent-scoped proxy review (ReviewManager). No single-store spec can catch a
+ * regression where resolving a wait in one store drops the other store's
+ * cards or the awaiting status — the exact class of bug behind the recent
+ * "Working…" vs parked-review inconsistencies.
+ */
+test.describe('Mixed Pending Requests (cross-store)', () => {
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+  let agent: TestAgent
+
+  test.describe.configure({ timeout: 60000 })
+
+  test.beforeEach(async ({ page, request }, testInfo) => {
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+
+    agent = await createAgent(request, uniqueName(testInfo, 'Mixed Agent'))
+    await gotoAgentHome(page, agent)
+  })
+
+  test('stack shows all three requests; awaiting survives until the last store empties', async ({
+    page,
+    request,
+  }, testInfo) => {
+    await sessionPage.sendMessage(`mixed pending ${uniqueSuffix(testInfo)}`)
+    await waitForCurrentSessionId(page)
+
+    // All three cards must be reachable in the pending-request stack —
+    // the two container inputs and the ReviewManager review.
+    const review = await waitForPendingProxyReview(request, agent, {
+      xAgent: false,
+      toolkit: 'slack',
+      targetPath: 'api/chat.postMessage',
+      matchedScope: 'chat:write',
+    })
+    await sessionPage.waitForSecretRequest('MIXED_SECRET_KEY')
+    await sessionPage.waitForQuestionRequest()
+    await sessionPage.waitForProxyReviewRequestById(review.id, 20000)
+
+    await agentPage.waitForStatus('awaiting_input', 15000)
+
+    // Resolve the ReviewManager wait FIRST. The container inputs are still
+    // parked, so the input cards must survive and the status must not drop.
+    await sessionPage.waitForProxyReviewRequestById(review.id, 20000)
+    await sessionPage.allowProxyReview(review.id)
+    await expectPendingProxyReviewResolved(request, agent, review)
+
+    await sessionPage.waitForSecretRequest('MIXED_SECRET_KEY')
+    await agentPage.waitForStatus('awaiting_input', 15000)
+
+    // Resolve the secret. The question is still parked — status holds.
+    await sessionPage.provideSecret('sk-mixed-test-123', 'MIXED_SECRET_KEY')
+    await expect(sessionPage.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
+
+    await sessionPage.waitForQuestionRequest()
+    await agentPage.waitForStatus('awaiting_input', 15000)
+
+    // Resolve the last wait — only now may the session leave awaiting.
+    await sessionPage.answerQuestion('PostgreSQL')
+    await expect(sessionPage.getQuestionRequests()).toHaveCount(0, { timeout: 10000 })
+
+    await expect(
+      page.getByText('Thank you for providing the information.')
+    ).toBeVisible({ timeout: 15000 })
+    await expect(agentPage.getStatus()).not.toHaveAttribute('data-status', 'awaiting_input', {
+      timeout: 15000,
+    })
+  })
+
+  test('denying the review does not disturb the parked container inputs', async ({
+    page,
+    request,
+  }, testInfo) => {
+    await sessionPage.sendMessage(`mixed pending ${uniqueSuffix(testInfo)}`)
+    await waitForCurrentSessionId(page)
+
+    const review = await waitForPendingProxyReview(request, agent, {
+      xAgent: false,
+      toolkit: 'slack',
+      targetPath: 'api/chat.postMessage',
+      matchedScope: 'chat:write',
+    })
+    await sessionPage.waitForSecretRequest('MIXED_SECRET_KEY')
+    await sessionPage.waitForProxyReviewRequestById(review.id, 20000)
+
+    await sessionPage.denyProxyReview(review.id)
+    await expectPendingProxyReviewResolved(request, agent, review)
+
+    // Both container inputs remain answerable after the deny.
+    await sessionPage.waitForSecretRequest('MIXED_SECRET_KEY')
+    await sessionPage.provideSecret('sk-mixed-test-456', 'MIXED_SECRET_KEY')
+    await expect(sessionPage.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
+
+    await sessionPage.waitForQuestionRequest()
+    await sessionPage.answerQuestion('MongoDB')
+    await expect(sessionPage.getQuestionRequests()).toHaveCount(0, { timeout: 10000 })
+
+    await expect(
+      page.getByText('Thank you for providing the information.')
+    ).toBeVisible({ timeout: 15000 })
+  })
+})

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -279,8 +279,16 @@ describe('pending user-input request lifecycle (characterization)', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let sseEvents: any[]
   let sseCleanup: () => void
+  let originalE2eMock: string | undefined
 
   beforeEach(async () => {
+    // Computer-use interception is platform-gated (darwin/win32 only) with an
+    // explicit E2E escape hatch (message-persister.ts:4269). Set it so the
+    // computer-use rows behave identically on Linux CI and macOS dev machines
+    // — same pattern the main persister suite uses in its computer-use tests.
+    originalE2eMock = process.env.E2E_MOCK
+    process.env.E2E_MOCK = 'true'
+
     mockClient = createMockClient()
     await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
 
@@ -293,6 +301,8 @@ describe('pending user-input request lifecycle (characterization)', () => {
   })
 
   afterEach(() => {
+    if (originalE2eMock === undefined) delete process.env.E2E_MOCK
+    else process.env.E2E_MOCK = originalE2eMock
     sseCleanup()
     messagePersister.unsubscribeFromSession(SESSION_ID)
     vi.clearAllMocks()

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -1,0 +1,732 @@
+/**
+ * Characterization suite for the pending user-input request lifecycle.
+ *
+ * Every user-facing request kind must satisfy the same contract on the main
+ * stream path: open → broadcast exactly one request card → mark the session
+ * awaiting → notify exactly once → resolve → drop the replay entry → clear
+ * awaiting only when it was the last blocking wait.
+ *
+ * This file pins CURRENT behavior — including the known divergences it
+ * documents inline (computer-use's separate store, capability review's early
+ * clear, and the sidechain kinds that do not surface at all today). The
+ * sidechain matrix at the bottom is the acceptance table for the unified
+ * dispatch work: entries marked `surfacesToday: false` are the live gap where
+ * a subagent's request hangs silently, and that work flips them to true.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { ContainerClient, StreamMessage } from './types'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MockFn = (...args: any[]) => any
+
+// Mock external dependencies before importing (same seam set as
+// message-persister.test.ts — the persister pulls these in at module load).
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  createScheduledTask: vi.fn(() => Promise.resolve('task_new_id')),
+  createSessionWake: vi.fn(() => Promise.resolve({ taskId: 'wake_new_id', replaced: null })),
+  listPendingScheduledTasks: vi.fn(() => Promise.resolve([])),
+  getScheduledTask: vi.fn(() => Promise.resolve(null)),
+  cancelScheduledTask: vi.fn(() => Promise.resolve(true)),
+  pauseScheduledTask: vi.fn(() => Promise.resolve(true)),
+  resumeScheduledTask: vi.fn(() => Promise.resolve(true)),
+}))
+vi.mock('@shared/lib/services/session-service', () => ({
+  updateSessionMetadata: vi.fn(() => Promise.resolve()),
+  getSessionMetadata: vi.fn(() => Promise.resolve(null)),
+  finalizeAutomationStatus: vi.fn(() => Promise.resolve('updated')),
+}))
+vi.mock('@shared/lib/services/session-transcript-append', () => ({
+  appendInformationalEntry: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('@shared/lib/services/timezone-resolver', () => ({
+  resolveTimezoneForAgent: vi.fn(() => 'UTC'),
+}))
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerSessionComplete: vi.fn(() => Promise.resolve()),
+    triggerSessionWaitingInput: vi.fn(() => Promise.resolve()),
+  },
+}))
+
+const mockGetSettings = vi.fn((): Record<string, unknown> => ({}))
+const mockAgentCapabilities: Record<'subagents' | 'workflows', 'allow' | 'review' | 'block'> = {
+  subagents: 'allow',
+  workflows: 'review',
+}
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => mockGetSettings(),
+  getAgentCapabilitySettings: () => ({ ...mockAgentCapabilities }),
+  getModelCatalogSettings: () => mockGetSettings().modelCatalog ?? {},
+  VALID_SCRIPT_TYPES: {
+    darwin: ['applescript', 'shell'],
+    linux: ['shell'],
+    win32: ['powershell'],
+  },
+}))
+
+vi.mock('fs', () => ({
+  promises: {
+    readdir: vi.fn(),
+    stat: vi.fn(),
+  },
+}))
+vi.mock('@shared/lib/utils/file-storage', () => ({
+  getAgentSessionsDir: vi.fn(() => '/mock/sessions'),
+}))
+
+const mockCheckPermission = vi.fn(
+  (_agentSlug?: string, _level?: string, _appName?: string): string => 'prompt_needed'
+)
+vi.mock('@shared/lib/computer-use/permission-manager', () => ({
+  computerUsePermissionManager: {
+    checkPermission: (a: string, b: string, c?: string) => mockCheckPermission(a, b, c),
+    getGrabbedApp: vi.fn(() => undefined),
+    setGrabbedApp: vi.fn(),
+    clearGrabbedApp: vi.fn(),
+    consumeOnceGrant: vi.fn(),
+  },
+}))
+vi.mock('@shared/lib/computer-use/types', () => ({
+  computerUseMethodFromToolName: vi.fn((toolName: string) => {
+    const suffix = toolName.replace('mcp__computer-use__computer_', '')
+    return suffix === 'menu' ? 'menuClick' : suffix
+  }),
+  getRequiredPermissionLevel: vi.fn((method: string) =>
+    ['apps', 'windows', 'status', 'displays', 'permissions'].includes(method)
+      ? 'list_apps_windows'
+      : 'use_application'
+  ),
+  resolveTargetApp: vi.fn(() => undefined),
+  READ_ONLY_METHODS: new Set(['apps', 'windows', 'status', 'displays', 'permissions']),
+  TIMED_GRANT_DURATION_MS: 15 * 60 * 1000,
+}))
+
+vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
+  createWebhookTrigger: vi.fn(() => Promise.resolve('trigger_new_id')),
+  listActiveWebhookTriggers: vi.fn(() => Promise.resolve([])),
+  cancelWebhookTriggerWithCleanup: vi.fn(() => Promise.resolve(true)),
+  getWebhookTrigger: vi.fn(() => Promise.resolve(null)),
+  resolvePlatformMemberForCandidates: () => null,
+}))
+vi.mock('@shared/lib/services/webhook-endpoints-client', () => ({
+  createPlatformWebhookEndpoint: vi.fn(),
+  updatePlatformWebhookEndpoint: vi.fn(() => Promise.resolve({})),
+  disablePlatformWebhookEndpoint: vi.fn(() => Promise.resolve()),
+  listPlatformWebhookEvents: vi.fn(() => Promise.resolve({ filterExp: null, events: [] })),
+  testPlatformWebhookFilter: vi.fn(),
+}))
+vi.mock('@shared/lib/services/platform-auth-service', () => ({
+  getStoredPlatformMemberId: () => null,
+  getPlatformAccessToken: () => 'opaque_token',
+}))
+vi.mock('@shared/lib/composio/triggers', () => ({
+  getAvailableTriggers: vi.fn(() => Promise.resolve([])),
+  enableComposioTrigger: vi.fn(() => Promise.resolve('composio_trigger_id')),
+  deleteComposioTrigger: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('@shared/lib/composio/client', () => ({
+  isPlatformComposioActive: () => true,
+}))
+vi.mock('@shared/lib/db', () => ({
+  db: {
+    select: vi.fn(),
+  },
+}))
+vi.mock('@shared/lib/db/schema', () => ({
+  connectedAccounts: {
+    id: 'id',
+    providerConnectionId: 'provider_connection_id',
+    providerName: 'provider_name',
+    toolkitSlug: 'toolkit_slug',
+  },
+}))
+const mockContainerClientFetch = vi.fn<MockFn>(() => Promise.resolve({ ok: true }))
+vi.mock('./container-manager', () => ({
+  containerManager: {
+    getClient: () => ({
+      fetch: (...args: unknown[]) => mockContainerClientFetch(...args),
+    }),
+  },
+}))
+
+// Import after mocks are set up
+import { messagePersister } from './message-persister'
+import { notificationManager } from '@shared/lib/notifications/notification-manager'
+
+function createMockClient(): ContainerClient & {
+  _messageCallback: ((message: StreamMessage) => void) | null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _sendMessage: (content: any) => void
+} {
+  let messageCallback: ((message: StreamMessage) => void) | null = null
+
+  const client = {
+    _messageCallback: null as ((message: StreamMessage) => void) | null,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _sendMessage(content: any) {
+      if (messageCallback) {
+        messageCallback({
+          type: 'message',
+          content,
+          timestamp: new Date(),
+          sessionId: 'test-session',
+        })
+      }
+    },
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopSync: vi.fn(),
+    getInfoFromRuntime: vi.fn(),
+    getInfo: vi.fn(),
+    fetch: vi.fn(),
+    waitForHealthy: vi.fn(),
+    isHealthy: vi.fn(),
+    getStats: vi.fn(),
+    createSession: vi.fn(),
+    getSession: vi.fn(() => Promise.resolve(null)),
+    deleteSession: vi.fn(),
+    sendMessage: vi.fn(),
+    interruptSession: vi.fn(),
+    subscribeToStream: vi.fn((sessionId: string, callback: (message: StreamMessage) => void) => {
+      messageCallback = callback
+      client._messageCallback = callback
+      return {
+        unsubscribe: vi.fn(),
+        ready: Promise.resolve(),
+      }
+    }),
+    on: vi.fn(),
+    off: vi.fn(),
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return client as any
+}
+
+interface RequestKindCase {
+  label: string
+  toolName: string
+  input: Record<string, unknown>
+  sseType: string
+  waitingFor: string
+}
+
+/**
+ * The standard kinds: every row must satisfy the identical lifecycle
+ * contract. A new user-input request kind belongs in this table; if it can't
+ * satisfy the shared contract, that divergence needs its own documented test
+ * below (like computer-use and capability review).
+ */
+const STANDARD_KINDS: RequestKindCase[] = [
+  {
+    label: 'secret',
+    toolName: 'mcp__user-input__request_secret',
+    input: { secretName: 'API_KEY', reason: 'Need it' },
+    sseType: 'secret_request',
+    waitingFor: 'secret',
+  },
+  {
+    label: 'question',
+    toolName: 'AskUserQuestion',
+    input: {
+      questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
+    },
+    sseType: 'user_question_request',
+    waitingFor: 'question',
+  },
+  {
+    label: 'connected account',
+    toolName: 'mcp__user-input__request_connected_account',
+    input: { toolkit: 'github', reason: 'Need access' },
+    sseType: 'connected_account_request',
+    waitingFor: 'connected_account',
+  },
+  {
+    label: 'file',
+    toolName: 'mcp__user-input__request_file',
+    input: { description: 'Upload a CSV' },
+    sseType: 'file_request',
+    waitingFor: 'file',
+  },
+  {
+    label: 'remote MCP',
+    toolName: 'mcp__user-input__request_remote_mcp',
+    input: { url: 'https://example.com/mcp', name: 'Example', reason: 'Docs' },
+    sseType: 'remote_mcp_request',
+    waitingFor: 'remote_mcp',
+  },
+  {
+    label: 'browser input',
+    toolName: 'mcp__user-input__request_browser_input',
+    input: { message: 'Please log in', requirements: ['Enter credentials'] },
+    sseType: 'browser_input_request',
+    waitingFor: 'browser_input',
+  },
+  {
+    label: 'script run',
+    toolName: 'mcp__user-input__request_script_run',
+    input: { script: 'sw_vers', explanation: 'Check macOS version', scriptType: 'shell' },
+    sseType: 'script_run_request',
+    waitingFor: 'script_run',
+  },
+]
+
+describe('pending user-input request lifecycle (characterization)', () => {
+  const SESSION_ID = 'lifecycle-session-1'
+  const AGENT_SLUG = 'lifecycle-agent'
+
+  let mockClient: ReturnType<typeof createMockClient>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let sseEvents: any[]
+  let sseCleanup: () => void
+
+  beforeEach(async () => {
+    mockClient = createMockClient()
+    await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const events: any[] = []
+    sseCleanup = messagePersister.addSSEClient(SESSION_ID, (data) => {
+      events.push(data)
+    })
+    sseEvents = events
+  })
+
+  afterEach(() => {
+    sseCleanup()
+    messagePersister.unsubscribeFromSession(SESSION_ID)
+    vi.clearAllMocks()
+    mockCheckPermission.mockReturnValue('prompt_needed')
+  })
+
+  function simulateToolUse(toolName: string, toolId: string, input: Record<string, unknown>) {
+    mockClient._sendMessage({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        content_block: { type: 'tool_use', id: toolId, name: toolName },
+      },
+    })
+    mockClient._sendMessage({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) },
+      },
+    })
+    mockClient._sendMessage({
+      type: 'stream_event',
+      event: { type: 'content_block_stop' },
+    })
+  }
+
+  function sendToolResult(toolUseId: string) {
+    mockClient._sendMessage({
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: toolUseId,
+            content: 'resolved',
+          },
+        ],
+      },
+    })
+  }
+
+  // ==========================================================================
+  // Main-stream lifecycle contract — one row per standard kind
+  // ==========================================================================
+
+  describe.each(STANDARD_KINDS)(
+    'main stream: $label',
+    ({ toolName, input, sseType, waitingFor }) => {
+      it('opens: broadcasts exactly one card, stores a replay entry, marks awaiting, notifies once', async () => {
+        simulateToolUse(toolName, 'tool-open-1', input)
+
+        const cards = sseEvents.filter((e) => e.type === sseType)
+        expect(cards).toHaveLength(1)
+        expect(cards[0].toolUseId).toBe('tool-open-1')
+
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.hasSessionsAwaitingInputForAgent(AGENT_SLUG)).toBe(true)
+        expect(
+          messagePersister.getPendingInputRequests(SESSION_ID).map((r) => r.toolUseId)
+        ).toContain('tool-open-1')
+
+        await vi.waitFor(() => {
+          expect(notificationManager.triggerSessionWaitingInput).toHaveBeenCalledTimes(1)
+        })
+        const call = vi.mocked(notificationManager.triggerSessionWaitingInput).mock.calls[0]
+        expect(call.slice(0, 3)).toEqual([SESSION_ID, AGENT_SLUG, waitingFor])
+      })
+
+      it('resolves: the tool_result drops the replay entry and clears awaiting', () => {
+        simulateToolUse(toolName, 'tool-resolve-1', input)
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+        sendToolResult('tool-resolve-1')
+
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
+      })
+
+      it('parallel with a second request: awaiting survives until the LAST one resolves', () => {
+        simulateToolUse(toolName, 'tool-par-1', input)
+        // A second, different-kind blocking request in the same turn.
+        simulateToolUse('mcp__user-input__request_secret', 'tool-par-2', {
+          secretName: 'OTHER_KEY',
+          reason: 'Second wait',
+        })
+        // Same-kind case degenerates to a single entry; skip the duplicate.
+        if (toolName === 'mcp__user-input__request_secret') return
+
+        expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(2)
+
+        sendToolResult('tool-par-1')
+        // KNOWN SPLIT-BRAIN (pinned, not desired): the main-path user-message
+        // handler clears awaiting without consulting the stream shelves — it
+        // only defers to external review blockers. The second request's
+        // replay entry is still parked (the card stack still shows it), but
+        // the sidebar/header bit already reads "not waiting". Derived
+        // awaiting state flips this expectation to `true`.
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(1)
+
+        sendToolResult('tool-par-2')
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
+      })
+    }
+  )
+
+  // ==========================================================================
+  // Documented divergence: computer-use lives in a separate store with
+  // route-driven clearing (the two-shelf split this suite exists to pin down)
+  // ==========================================================================
+
+  describe('main stream: computer use (divergent two-store lifecycle)', () => {
+    const TOOL = 'mcp__computer-use__computer_click'
+
+    it('opens into the computer-use store, NOT the input-request store', async () => {
+      simulateToolUse(TOOL, 'cu-open-1', { x: 1, y: 2 })
+
+      const cards = sseEvents.filter((e) => e.type === 'computer_use_request')
+      expect(cards).toHaveLength(1)
+      expect(cards[0].toolUseId).toBe('cu-open-1')
+      expect(cards[0].autoApproved).toBe(false)
+
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(
+        messagePersister.getPendingComputerUseRequests(SESSION_ID).map((r) => r.toolUseId)
+      ).toContain('cu-open-1')
+      expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
+
+      await vi.waitFor(() => {
+        expect(notificationManager.triggerSessionWaitingInput).toHaveBeenCalledTimes(1)
+      })
+      const call = vi.mocked(notificationManager.triggerSessionWaitingInput).mock.calls[0]
+      expect(call.slice(0, 3)).toEqual([SESSION_ID, AGENT_SLUG, 'computer_use'])
+    })
+
+    it('a tool_result alone does NOT drop the parked entry, yet it DOES clear awaiting', () => {
+      simulateToolUse(TOOL, 'cu-clear-1', { x: 1, y: 2 })
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+      // KNOWN SPLIT-BRAIN (pinned, not desired): the computer-use shelf is
+      // cleared only via the decision route's explicit call, so the entry
+      // survives the tool_result — but the main-path user-message handler
+      // still clears the awaiting bit without consulting this shelf. Card
+      // parked, light off. Derived awaiting state flips the second
+      // expectation to `true`.
+      sendToolResult('cu-clear-1')
+      expect(
+        messagePersister.getPendingComputerUseRequests(SESSION_ID).map((r) => r.toolUseId)
+      ).toContain('cu-clear-1')
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+
+      messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'cu-clear-1')
+      expect(messagePersister.getPendingComputerUseRequests(SESSION_ID)).toHaveLength(0)
+    })
+
+    it('the route clear broadcasts session_input_provided but never flips the awaiting bit itself', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const globalEvents: any[] = []
+      const cleanup = messagePersister.addGlobalNotificationClient((data) => {
+        globalEvents.push(data)
+      })
+      try {
+        simulateToolUse(TOOL, 'cu-clear-2', { x: 1, y: 2 })
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+        // KNOWN SPLIT-BRAIN (pinned, not desired): clearPendingComputerUseRequest
+        // broadcasts session_input_provided when its own shelf empties, but by
+        // design leaves isAwaitingInput to "the tool result arriving in the
+        // stream" — so the wire says input was provided while the bit still
+        // says awaiting. Consumers reading the bit and consumers reading the
+        // event disagree until the tool_result lands.
+        messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'cu-clear-2')
+        expect(
+          globalEvents.filter((e) => e.type === 'session_input_provided')
+        ).toHaveLength(1)
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      } finally {
+        cleanup()
+      }
+    })
+  })
+
+  // ==========================================================================
+  // Documented divergence: capability review clears early via its own door
+  // ==========================================================================
+
+  describe('main stream: capability review (early-clear lifecycle)', () => {
+    beforeEach(() => {
+      mockAgentCapabilities.subagents = 'allow'
+      mockAgentCapabilities.workflows = 'review'
+      vi.mocked(mockClient.fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({ grants: [] }),
+      } as unknown as Response)
+    })
+
+    it('opens like a standard kind: card, replay entry, awaiting, one notification', async () => {
+      simulateToolUse('Workflow', 'wf-lifecycle-1', { script: 'export const meta = {}' })
+
+      await vi.waitFor(() => {
+        expect(sseEvents.filter((e) => e.type === 'capability_review_request')).toHaveLength(1)
+      })
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(
+        messagePersister.getPendingInputRequests(SESSION_ID).map((r) => r.toolUseId)
+      ).toContain('wf-lifecycle-1')
+
+      await vi.waitFor(() => {
+        expect(notificationManager.triggerSessionWaitingInput).toHaveBeenCalledTimes(1)
+      })
+      const call = vi.mocked(notificationManager.triggerSessionWaitingInput).mock.calls[0]
+      expect(call.slice(0, 3)).toEqual([SESSION_ID, AGENT_SLUG, 'capability_review_workflows'])
+    })
+
+    it('completeCapabilityReview drops the replay entry and broadcasts, but never flips the awaiting bit', async () => {
+      simulateToolUse('Workflow', 'wf-lifecycle-2', { script: 'export const meta = {}' })
+      await vi.waitFor(() => {
+        expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(1)
+      })
+
+      messagePersister.completeCapabilityReview(SESSION_ID, 'wf-lifecycle-2')
+
+      expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
+      expect(sseEvents.filter((e) => e.type === 'capability_review_resolved')).toHaveLength(1)
+      // KNOWN SPLIT-BRAIN (pinned, not desired): like the computer-use route
+      // clear, this door empties its shelf and broadcasts but leaves the
+      // awaiting bit set — it stays true until later stream traffic (the
+      // launched tool's own lifecycle) clears it.
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+    })
+  })
+
+  // ==========================================================================
+  // Cross-shelf awaiting arithmetic: input store + computer-use store +
+  // external blocker source (the ReviewManager seam). Awaiting must survive
+  // until the LAST wait across all three resolves.
+  // ==========================================================================
+
+  describe('cross-shelf awaiting arithmetic', () => {
+    it('a held external blocker keeps awaiting alive through tool_results; the agent door releases it', () => {
+      let blockerHeld = true
+      const unregister = messagePersister.registerAwaitingBlockerSource(
+        (agentSlug) => agentSlug === AGENT_SLUG && blockerHeld
+      )
+
+      try {
+        simulateToolUse('mcp__user-input__request_secret', 'mix-secret-1', {
+          secretName: 'API_KEY',
+          reason: 'Need it',
+        })
+        simulateToolUse('mcp__computer-use__computer_click', 'mix-cu-1', { x: 1, y: 2 })
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+        // The user-message clear defers to a held external blocker — this is
+        // the ONLY thing that saves the awaiting bit here: the still-parked
+        // computer-use entry would not (see the split-brain pins above).
+        sendToolResult('mix-secret-1')
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+        // The computer-use route clear never flips the bit, so awaiting
+        // survives it too (broadcast fires, bit untouched).
+        messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'mix-cu-1')
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+        // Once the blocker releases, the agent-level door clears it: both
+        // stream shelves are empty by now.
+        blockerHeld = false
+        messagePersister.clearAwaitingInputForAgentIfUnblocked(AGENT_SLUG)
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      } finally {
+        unregister()
+      }
+    })
+
+    it('the agent-level door checks stream shelves only — external blockers are the CALLER\'s contract', () => {
+      let blockerHeld = true
+      const unregister = messagePersister.registerAwaitingBlockerSource(
+        (agentSlug) => agentSlug === AGENT_SLUG && blockerHeld
+      )
+
+      try {
+        messagePersister.markAwaitingInput(SESSION_ID)
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+        // A held user-message clear defers to the blocker source…
+        sendToolResult('unknown-tool-id')
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+        // …but clearAwaitingInputForAgentIfUnblocked does NOT consult
+        // external blocker sources. Its documented contract is that the
+        // caller (ReviewManager) verifies no reviews remain before calling.
+        // Pinned: a caller that forgets this check clears awaiting while a
+        // review is still parked — nothing in the persister stops it.
+        messagePersister.clearAwaitingInputForAgentIfUnblocked(AGENT_SLUG)
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+
+        blockerHeld = false
+      } finally {
+        unregister()
+      }
+    })
+  })
+
+  // ==========================================================================
+  // Sidechain delivery matrix — the acceptance table for unified dispatch.
+  //
+  // `surfacesToday: false` rows document the LIVE GAP: a subagent calling
+  // that tool parks forever in the container while the host surfaces nothing
+  // — no card, no awaiting status, no notification. The unified-dispatch
+  // change is expected to flip every row to true; each false row here is a
+  // deliberate red-flag pin, not desired behavior.
+  // ==========================================================================
+
+  interface SidechainCase {
+    label: string
+    toolName: string
+    input: Record<string, unknown>
+    sseType: string
+    surfacesToday: boolean
+  }
+
+  const SIDECHAIN_MATRIX: SidechainCase[] = [
+    {
+      label: 'browser input',
+      toolName: 'mcp__user-input__request_browser_input',
+      input: { message: 'Log in', requirements: [] },
+      sseType: 'browser_input_request',
+      surfacesToday: true,
+    },
+    {
+      label: 'script run',
+      toolName: 'mcp__user-input__request_script_run',
+      input: { script: 'sw_vers', explanation: 'Version', scriptType: 'shell' },
+      sseType: 'script_run_request',
+      surfacesToday: true,
+    },
+    {
+      label: 'computer use',
+      toolName: 'mcp__computer-use__computer_click',
+      input: { x: 1, y: 2 },
+      sseType: 'computer_use_request',
+      surfacesToday: true,
+    },
+    {
+      label: 'secret',
+      toolName: 'mcp__user-input__request_secret',
+      input: { secretName: 'API_KEY', reason: 'Need it' },
+      sseType: 'secret_request',
+      surfacesToday: false,
+    },
+    {
+      label: 'question',
+      toolName: 'AskUserQuestion',
+      input: {
+        questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
+      },
+      sseType: 'user_question_request',
+      surfacesToday: false,
+    },
+    {
+      label: 'connected account',
+      toolName: 'mcp__user-input__request_connected_account',
+      input: { toolkit: 'github', reason: 'Need access' },
+      sseType: 'connected_account_request',
+      surfacesToday: false,
+    },
+    {
+      label: 'file',
+      toolName: 'mcp__user-input__request_file',
+      input: { description: 'Upload a CSV' },
+      sseType: 'file_request',
+      surfacesToday: false,
+    },
+    {
+      label: 'remote MCP',
+      toolName: 'mcp__user-input__request_remote_mcp',
+      input: { url: 'https://example.com/mcp', name: 'Example', reason: 'Docs' },
+      sseType: 'remote_mcp_request',
+      surfacesToday: false,
+    },
+  ]
+
+  describe.each(SIDECHAIN_MATRIX)(
+    'sidechain: $label (surfaces today: $surfacesToday)',
+    ({ toolName, input, sseType, surfacesToday }) => {
+      function sendSidechainStreamToolUse(toolId: string, parentToolId = 'parent-task-1') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const send = (event: any) =>
+          mockClient._sendMessage({
+            type: 'stream_event',
+            parent_tool_use_id: parentToolId,
+            event,
+          })
+        send({
+          type: 'content_block_start',
+          content_block: { type: 'tool_use', id: toolId, name: toolName },
+        })
+        send({
+          type: 'content_block_delta',
+          delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) },
+        })
+        send({ type: 'content_block_stop' })
+      }
+
+      function sendSidechainCompleteAssistantToolUse(
+        toolId: string,
+        parentToolId = 'parent-task-2'
+      ) {
+        mockClient._sendMessage({
+          type: 'assistant',
+          parent_tool_use_id: parentToolId,
+          message: {
+            content: [{ type: 'tool_use', id: toolId, name: toolName, input }],
+          },
+        })
+      }
+
+      it('subagent stream events: card broadcast and awaiting match the matrix', () => {
+        sendSidechainStreamToolUse('side-stream-1')
+
+        const cards = sseEvents.filter((e) => e.type === sseType)
+        expect(cards).toHaveLength(surfacesToday ? 1 : 0)
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(surfacesToday)
+      })
+
+      it('complete sidechain assistant message: card broadcast and awaiting match the matrix', () => {
+        sendSidechainCompleteAssistantToolUse('side-complete-1')
+
+        const cards = sseEvents.filter((e) => e.type === sseType)
+        expect(cards).toHaveLength(surfacesToday ? 1 : 0)
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(surfacesToday)
+      })
+    }
+  )
+})

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -996,6 +996,64 @@ export class ProxyReviewScenario implements MockScenario {
   }
 }
 
+/**
+ * Mixed cross-store pending requests: two container-side input asks (secret +
+ * question) stream in one turn while an agent-scoped proxy review parks in
+ * the real ReviewManager. The three waits live in DIFFERENT stores (persister
+ * pendingInputRequests × 2, ReviewManager pending × 1), so this scenario
+ * exercises the aggregation no single-store scenario can: the pending-request
+ * stack must show all three, and the awaiting indicator must survive until
+ * the LAST wait of either store resolves. The review decision deliberately
+ * does NOT end the turn — the input machinery does, once both inputs resolve.
+ */
+export class MixedPendingRequestsScenario implements MockScenario {
+  private inputScenario = new UserInputRequestScenario([
+    {
+      name: 'mcp__user-input__request_secret',
+      input: { secretName: 'MIXED_SECRET_KEY', reason: 'Needed alongside a review' },
+    },
+    {
+      name: 'AskUserQuestion',
+      input: {
+        questions: [{
+          question: 'Which database should we use?',
+          header: 'Database',
+          options: [
+            { label: 'PostgreSQL', description: 'Reliable relational database' },
+            { label: 'MongoDB', description: 'Flexible document store' },
+          ],
+          multiSelect: false,
+        }],
+      },
+    },
+  ])
+
+  execute(sessionId: string, client: MockContainerClient, userMessage: string): void {
+    this.inputScenario.execute(sessionId, client, userMessage)
+
+    const agentSlug = client.getAgentId()
+    const accountId = getMessageParam(userMessage, 'account_id') ?? MOCK_ACCOUNT_ID
+    // Kick the review after the input tool stream has finished (its delay
+    // budget is ~200ms for two tools); exact ordering is not load-bearing —
+    // specs wait for all three cards independently.
+    setTimeout(async () => {
+      await seedMockConnectedAccount(accountId)
+      reviewManager.requestReview({
+        agentSlug,
+        accountId,
+        toolkit: 'slack',
+        method: 'POST',
+        targetPath: 'api/chat.postMessage',
+        matchedScopes: ['chat:write'],
+        scopeDescriptions: { 'chat:write': 'Send messages to channels' },
+      }).catch(() => {
+        // Denied or timed out — the turn lifecycle is owned by the input
+        // machinery, so nothing to do here.
+      })
+    }, 400)
+  }
+}
+
 export class XAgentReviewScenario implements MockScenario {
   constructor(
     private targetAgentSlug: string,
@@ -1532,6 +1590,8 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     ])],
     ['subagent browser input', new SubagentBrowserInputScenario()],
     // Proxy review scenario for E2E tests
+    // Cross-store mix: container input asks + a parked ReviewManager review
+    ['mixed pending', new MixedPendingRequestsScenario()],
     ['proxy review', new ProxyReviewScenario(
       'slack',
       'POST',


### PR DESCRIPTION
## What

Phase 0 of the user-input request rearchitecture: **tests only, zero production changes** (the one non-test file touched, `mock-container-client.ts`, is E2E-mock infrastructure). Pins current behavior across every pending-request kind so the follow-up refactors (unified sidechain dispatch, derived awaiting state) have an acceptance suite and honest red→green diffs.

## Contents

**`message-persister.request-lifecycle.test.ts`** (44 tests)
- **Table-driven lifecycle contract** over the 7 standard kinds (secret, question, connected account, file, remote MCP, browser input, script run): open → exactly one card broadcast → replay entry → awaiting set → exactly one notification with the right `waitingFor` → tool_result drops the entry.
- **Documented divergences** for computer-use (separate store, route-driven clearing) and capability review (early clear via its own door).
- **Cross-shelf awaiting arithmetic**: input store + computer-use store + an external blocker source (the ReviewManager seam), including the caller-contract semantics of `clearAwaitingInputForAgentIfUnblocked`.
- **Sidechain delivery matrix** (8 kinds × 2 delivery paths): rows with `surfacesToday: false` pin the live gap where a subagent's secret/question/file/connected-account/remote-MCP request hangs silently. The Phase 1 unified-dispatch PR flips those rows to `true` — that diff is the acceptance criterion.

**`MixedPendingRequestsScenario`** (mock) + **`mixed-pending-requests.spec.ts`** (2 E2E tests)
- First scenario spanning BOTH pending stores in one turn: two container input asks stream through the real `MessagePersister` while a real `reviewManager.requestReview` parks.
- Asserts all three cards are reachable in the pending-request stack, the awaiting status survives until the last wait of either store resolves, and denying the review doesn't disturb the parked inputs.

## Split-brains discovered while calibrating (pinned with loud comments, NOT fixed here)

1. Answering one of two **parallel** requests clears the awaiting bit while the second request is still parked — the main-path user-message clear (`message-persister.ts:1288`) consults external review blockers but never the stream shelves. The card stack (renderer-local) still shows the second card; the sidebar/header bit lies.
2. `clearPendingComputerUseRequest` broadcasts `session_input_provided` without flipping the awaiting bit.
3. `completeCapabilityReview` — same broadcast-without-flip.

All three are structurally resolved by the derived-awaiting phase of the plan; pinning them now means those PRs show up as deliberate expectation flips.

## Validation

- New suite: 44/44
- Existing `message-persister.test.ts`: 260/260
- E2E (web-chromium): 2/2
- `tsc --noEmit` + eslint clean

https://claude.ai/code/session_01DLw9AJ5VXVQPzBAz87nNAA