### PR TITLE
Make session composer flush with transcript

### DIFF
--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -111,7 +111,9 @@ describe('MessageInput', () => {
     renderWithProviders(
       <MessageInput sessionId="s-1" agentSlug="agent-1" />
     )
-    expect(screen.getByTestId('message-input')).toBeInTheDocument()
+    const input = screen.getByTestId('message-input')
+    expect(input).toBeInTheDocument()
+    expect(input.closest('form')).toHaveClass('pt-0')
     expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument()
   })
 

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -250,7 +250,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
   return (
     <form
       onSubmit={composer.handleSubmit}
-      className={`relative px-4 pt-3 ${composer.isDragOver ? 'ring-2 ring-primary ring-inset' : ''}`}
+      className={`relative px-4 pt-0 ${composer.isDragOver ? 'ring-2 ring-primary ring-inset' : ''}`}
       {...composer.dragHandlers}
     >
       <MountChoiceDialog


### PR DESCRIPTION
## Summary

- remove the session composer's top gap so it begins flush with the transcript boundary
- keep the transcript and working indicator in normal layout flow with no overlap
- add regression coverage for the zero top-padding contract

## Why

The extra top padding made the composer appear visually detached from the session transcript. An overlap treatment introduced layering artifacts around the working indicator, so the final implementation uses ordinary layout flow and simply removes the gap.

## User impact

The session composer now meets the transcript cleanly without text or activity indicators rendering beneath it.

## Validation

- `npm test -- --run src/renderer/components/layout/session-chat-column.test.tsx src/renderer/components/messages/message-list.test.tsx src/renderer/components/messages/message-input.test.tsx` (145 tests passed)
- `npm run typecheck`
- ESLint on the affected session composer files
- `git diff --check`
