### PR TITLE
Unify blocking user-input tool dispatch across all delivery paths (Phase 1)

### DIFF
--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -8,10 +8,10 @@
  *
  * This file pins CURRENT behavior — including the known divergences it
  * documents inline (computer-use's separate store, capability review's early
- * clear, and the sidechain kinds that do not surface at all today). The
- * sidechain matrix at the bottom is the acceptance table for the unified
- * dispatch work: entries marked `surfacesToday: false` are the live gap where
- * a subagent's request hangs silently, and that work flips them to true.
+ * clear). The sidechain matrix at the bottom is the acceptance table for the
+ * unified dispatcher: every kind must surface from every delivery path. Rows
+ * were `surfacesToday: false` before the dispatcher landed — those kinds hung
+ * silently when a subagent called them.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type { ContainerClient, StreamMessage } from './types'
@@ -460,7 +460,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(messagePersister.getPendingComputerUseRequests(SESSION_ID)).toHaveLength(0)
     })
 
-    it('the route clear broadcasts session_input_provided but never flips the awaiting bit itself', () => {
+    it('the route clear flips awaiting and broadcasts when it was the last blocking wait', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const globalEvents: any[] = []
       const cleanup = messagePersister.addGlobalNotificationClient((data) => {
@@ -470,20 +470,34 @@ describe('pending user-input request lifecycle (characterization)', () => {
         simulateToolUse(TOOL, 'cu-clear-2', { x: 1, y: 2 })
         expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
-        // KNOWN SPLIT-BRAIN (pinned, not desired): clearPendingComputerUseRequest
-        // broadcasts session_input_provided when its own shelf empties, but by
-        // design leaves isAwaitingInput to "the tool result arriving in the
-        // stream" — so the wire says input was provided while the bit still
-        // says awaiting. Consumers reading the bit and consumers reading the
-        // event disagree until the tool_result lands.
+        // The route clear applies the shared waiting-light rule: with both
+        // shelves empty and no external blocker, the bit flips AND the wire
+        // says input was provided — together, atomically. (Before the unified
+        // dispatch change it broadcast without flipping the bit, leaving the
+        // wire and the bit disagreeing until the tool_result landed.)
         messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'cu-clear-2')
         expect(
           globalEvents.filter((e) => e.type === 'session_input_provided')
         ).toHaveLength(1)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
       } finally {
         cleanup()
       }
+    })
+
+    it('the route clear defers while another input request is still parked', () => {
+      simulateToolUse('mcp__user-input__request_secret', 'cu-mix-secret', {
+        secretName: 'API_KEY',
+        reason: 'Need it',
+      })
+      simulateToolUse(TOOL, 'cu-clear-3', { x: 1, y: 2 })
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+      // Clearing the computer-use entry must NOT flip awaiting: the secret
+      // is still parked on the other shelf.
+      messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'cu-clear-3')
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.getPendingComputerUseRequests(SESSION_ID)).toHaveLength(0)
     })
   })
 
@@ -564,8 +578,8 @@ describe('pending user-input request lifecycle (characterization)', () => {
         sendToolResult('mix-secret-1')
         expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
-        // The computer-use route clear never flips the bit, so awaiting
-        // survives it too (broadcast fires, bit untouched).
+        // The computer-use route clear defers to the held external blocker
+        // (same waiting-light rule), so awaiting survives it too.
         messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'mix-cu-1')
         expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
@@ -611,11 +625,13 @@ describe('pending user-input request lifecycle (characterization)', () => {
   // ==========================================================================
   // Sidechain delivery matrix — the acceptance table for unified dispatch.
   //
-  // `surfacesToday: false` rows document the LIVE GAP: a subagent calling
-  // that tool parks forever in the container while the host surfaces nothing
-  // — no card, no awaiting status, no notification. The unified-dispatch
-  // change is expected to flip every row to true; each false row here is a
-  // deliberate red-flag pin, not desired behavior.
+  // Every kind must surface from BOTH sidechain delivery paths (subagent
+  // stream events and complete assistant messages), exactly like the main
+  // path: card broadcast + awaiting status. Before the unified dispatcher,
+  // the `false` rows (secret, question, connected account, file, remote MCP)
+  // hung silently — a subagent's ask parked forever in the container with no
+  // card, no status, no notification. A new request kind added to the
+  // dispatcher belongs in this table.
   // ==========================================================================
 
   interface SidechainCase {
@@ -653,7 +669,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       toolName: 'mcp__user-input__request_secret',
       input: { secretName: 'API_KEY', reason: 'Need it' },
       sseType: 'secret_request',
-      surfacesToday: false,
+      surfacesToday: true,
     },
     {
       label: 'question',
@@ -662,28 +678,28 @@ describe('pending user-input request lifecycle (characterization)', () => {
         questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
       },
       sseType: 'user_question_request',
-      surfacesToday: false,
+      surfacesToday: true,
     },
     {
       label: 'connected account',
       toolName: 'mcp__user-input__request_connected_account',
       input: { toolkit: 'github', reason: 'Need access' },
       sseType: 'connected_account_request',
-      surfacesToday: false,
+      surfacesToday: true,
     },
     {
       label: 'file',
       toolName: 'mcp__user-input__request_file',
       input: { description: 'Upload a CSV' },
       sseType: 'file_request',
-      surfacesToday: false,
+      surfacesToday: true,
     },
     {
       label: 'remote MCP',
       toolName: 'mcp__user-input__request_remote_mcp',
       input: { url: 'https://example.com/mcp', name: 'Example', reason: 'Docs' },
       sseType: 'remote_mcp_request',
-      surfacesToday: false,
+      surfacesToday: true,
     },
   ]
 
@@ -739,4 +755,163 @@ describe('pending user-input request lifecycle (characterization)', () => {
       })
     }
   )
+
+  // ==========================================================================
+  // Sidechain dedupe + resolution semantics for dispatcher-surfaced kinds
+  // ==========================================================================
+
+  describe('sidechain dedupe and resolution', () => {
+    function sendSidechainToolUse(
+      toolName: string,
+      toolId: string,
+      input: Record<string, unknown>,
+      parentToolId: string,
+      via: 'stream' | 'complete'
+    ) {
+      if (via === 'complete') {
+        mockClient._sendMessage({
+          type: 'assistant',
+          parent_tool_use_id: parentToolId,
+          message: {
+            content: [{ type: 'tool_use', id: toolId, name: toolName, input }],
+          },
+        })
+        return
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const send = (event: any) =>
+        mockClient._sendMessage({ type: 'stream_event', parent_tool_use_id: parentToolId, event })
+      send({
+        type: 'content_block_start',
+        content_block: { type: 'tool_use', id: toolId, name: toolName },
+      })
+      send({
+        type: 'content_block_delta',
+        delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) },
+      })
+      send({ type: 'content_block_stop' })
+    }
+
+    function sendSidechainToolResult(toolId: string, parentToolId: string) {
+      mockClient._sendMessage({
+        type: 'user',
+        parent_tool_use_id: parentToolId,
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: toolId, content: 'resolved' }],
+        },
+      })
+    }
+
+    it('first delivery wins: stream stop then complete-assistant with the same toolUseId emits ONE card', () => {
+      const input = { secretName: 'DUP_KEY', reason: 'Dedupe check' }
+      sendSidechainToolUse('mcp__user-input__request_secret', 'dup-1', input, 'parent-dup', 'stream')
+      sendSidechainToolUse('mcp__user-input__request_secret', 'dup-1', input, 'parent-dup', 'complete')
+
+      expect(sseEvents.filter((e) => e.type === 'secret_request')).toHaveLength(1)
+      expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(1)
+    })
+
+    it('a sidechain tool_result resolves a dispatcher-surfaced kind: entry dropped, tool_result broadcast, awaiting cleared', () => {
+      sendSidechainToolUse(
+        'mcp__user-input__request_secret',
+        'side-res-1',
+        { secretName: 'SUB_KEY', reason: 'From a subagent' },
+        'parent-res',
+        'complete'
+      )
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      sseEvents.length = 0
+
+      sendSidechainToolResult('side-res-1', 'parent-res')
+
+      expect(sseEvents.filter((e) => e.type === 'tool_result')).toHaveLength(1)
+      expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+    })
+
+    it('the sidechain resolve applies the both-shelves rule: a parked computer-use keeps awaiting on', () => {
+      sendSidechainToolUse(
+        'AskUserQuestion',
+        'side-q-1',
+        { questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }] },
+        'parent-mix',
+        'complete'
+      )
+      simulateToolUse('mcp__computer-use__computer_click', 'side-cu-1', { x: 1, y: 2 })
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+      sendSidechainToolResult('side-q-1', 'parent-mix')
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+      // Clearing the last computer-use entry now flips the light (shared rule).
+      messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'side-cu-1')
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+    })
+
+    it('an auto-approved script replay entry does not keep awaiting on after the last real ask resolves', async () => {
+      mockCheckPermission.mockReturnValue('granted')
+      const fetchMock = vi.fn(() => Promise.resolve({ ok: true } as Response))
+      vi.stubGlobal('fetch', fetchMock)
+      try {
+        sendSidechainToolUse(
+          'mcp__user-input__request_script_run',
+          'side-sr-auto',
+          { script: 'sw_vers', explanation: 'Version', scriptType: 'shell' },
+          'parent-auto',
+          'complete'
+        )
+        expect(
+          messagePersister
+            .getPendingInputRequests(SESSION_ID)
+            .some((r) => r.toolUseId === 'side-sr-auto' && r.autoApproved === true)
+        ).toBe(true)
+
+        mockCheckPermission.mockReturnValue('prompt_needed')
+        sendSidechainToolUse(
+          'mcp__user-input__request_secret',
+          'side-real-1',
+          { secretName: 'REAL_KEY', reason: 'A real ask' },
+          'parent-auto',
+          'complete'
+        )
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+        // The auto-approved script's replay entry is still tracked, but it is
+        // not a real wait — resolving the secret must clear awaiting.
+        sendSidechainToolResult('side-real-1', 'parent-auto')
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      } finally {
+        vi.unstubAllGlobals()
+      }
+    })
+
+    it('the sidechain resolve defers to a held external blocker (parked proxy/x-agent review)', () => {
+      let blockerHeld = true
+      const unregister = messagePersister.registerAwaitingBlockerSource(
+        (agentSlug) => agentSlug === AGENT_SLUG && blockerHeld
+      )
+      try {
+        sendSidechainToolUse(
+          'mcp__user-input__request_secret',
+          'side-blk-1',
+          { secretName: 'BLK_KEY', reason: 'Blocked resolve' },
+          'parent-blk',
+          'complete'
+        )
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+        // The subagent's ask resolves, but the review is still parked — the
+        // waiting light must stay on.
+        sendSidechainToolResult('side-blk-1', 'parent-blk')
+        expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+        blockerHeld = false
+        messagePersister.clearAwaitingInputForAgentIfUnblocked(AGENT_SLUG)
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      } finally {
+        unregister()
+      }
+    })
+  })
 })

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -558,10 +558,15 @@ class MessagePersister {
     const state = this.streamingStates.get(sessionId)
     if (state) {
       state.pendingComputerUseRequests.delete(toolUseId)
-      // Broadcast so the sidebar updates immediately.
-      // Don't clear isAwaitingInput here — other input types (secrets, questions, etc.)
-      // may still be pending. The flag is cleared when the tool result arrives in the stream.
-      if (state.pendingComputerUseRequests.size === 0) {
+      // Same waiting-light rule as the sidechain input clear: both shelves,
+      // skip auto-approved — and defer to a parked proxy/x-agent review
+      // (external blocker), which is also a real wait.
+      if (
+        state.isAwaitingInput &&
+        !this.hasBlockingPendingRequests(state) &&
+        !this.hasExternalAwaitingBlocker(state.agentSlug)
+      ) {
+        state.isAwaitingInput = false
         this.broadcastGlobal({
           type: 'session_input_provided',
           sessionId,
@@ -926,6 +931,43 @@ class MessagePersister {
       if (isBlocking(agentSlug)) return true
     }
     return false
+  }
+
+  // Surface host-blocking user-input tools (main + sidechain). script_run /
+  // computer-use / capability-review keep their own handlers (conditional await).
+  // First delivery wins: stream stop and complete-assistant can both carry the same tool_use.
+  private dispatchBlockingUserInputTool(
+    sessionId: string,
+    toolName: string,
+    toolUseId: string,
+    toolInput: string,
+    agentSlug?: string,
+  ): void {
+    const state = this.streamingStates.get(sessionId)
+    if (state?.pendingInputRequests.has(toolUseId)) return
+
+    if (toolName === 'AskUserQuestion') {
+      this.handleAskUserQuestionTool(sessionId, toolUseId, toolInput, agentSlug)
+    } else if (toolName === 'mcp__user-input__request_secret') {
+      this.handleSecretRequestTool(sessionId, toolUseId, toolInput, agentSlug)
+    } else if (toolName === 'mcp__user-input__request_connected_account') {
+      this.handleConnectedAccountRequestTool(sessionId, toolUseId, toolInput, agentSlug)
+    } else if (toolName === 'mcp__user-input__request_file') {
+      this.handleFileRequestTool(sessionId, toolUseId, toolInput, agentSlug)
+    } else if (toolName === 'mcp__user-input__request_remote_mcp') {
+      this.handleRemoteMcpRequestTool(sessionId, toolUseId, toolInput, agentSlug)
+    } else if (toolName === 'mcp__user-input__request_browser_input') {
+      this.handleBrowserInputRequestTool(sessionId, toolUseId, toolInput, agentSlug)
+    }
+
+    // Only tools with 'request_' prefix actually block waiting for user response
+    // (schedule_task, deliver_file, search_* resolve immediately and don't block).
+    // computer-use AND request_script_run mark awaiting in their own handlers,
+    // which only do so when user approval is actually needed (not when
+    // auto-executed against a cached permission grant).
+    if (isBlockingUserInputToolName(toolName)) {
+      this.markSessionAwaitingInput(sessionId)
+    }
   }
 
   // Recover awaiting-input state from persisted messages when the one-shot
@@ -1967,29 +2009,25 @@ class MessagePersister {
           sub.currentText = newText
 
           for (const block of messageContent) {
-            if (block.type === 'tool_use' && block.name === 'mcp__user-input__request_browser_input') {
-              this.handleBrowserInputRequestTool(
-                sessionId,
-                block.id,
-                JSON.stringify(block.input || {}),
-                state.agentSlug
-              )
+            if (block.type !== 'tool_use') continue
+            const input = JSON.stringify(block.input || {})
+            this.dispatchBlockingUserInputTool(
+              sessionId,
+              block.name,
+              block.id,
+              input,
+              state.agentSlug,
+            )
+            if (block.name === 'mcp__user-input__request_script_run') {
+              this.handleScriptRunRequestTool(sessionId, block.id, input, state.agentSlug)
             }
-            if (block.type === 'tool_use' && block.name === 'mcp__user-input__request_script_run') {
-              this.handleScriptRunRequestTool(
-                sessionId,
-                block.id,
-                JSON.stringify(block.input || {}),
-                state.agentSlug
-              )
-            }
-            if (block.type === 'tool_use' && block.name.startsWith('mcp__computer-use__')) {
+            if (block.name.startsWith('mcp__computer-use__')) {
               this.handleComputerUseRequestTool(
                 sessionId,
                 block.id,
                 block.name,
-                JSON.stringify(block.input || {}),
-                state.agentSlug
+                input,
+                state.agentSlug,
               )
             }
           }
@@ -2239,15 +2277,13 @@ class MessagePersister {
 
       case 'content_block_stop':
         if (sub.currentToolUse) {
-          // Safety net: detect browser input if stream events arrive for subagents
-          if (sub.currentToolUse.name === 'mcp__user-input__request_browser_input') {
-            this.handleBrowserInputRequestTool(
-              sessionId,
-              sub.currentToolUse.id,
-              sub.currentToolInput,
-              state.agentSlug
-            )
-          }
+          this.dispatchBlockingUserInputTool(
+            sessionId,
+            sub.currentToolUse.name,
+            sub.currentToolUse.id,
+            sub.currentToolInput,
+            state.agentSlug,
+          )
 
           if (sub.currentToolUse.name === 'mcp__user-input__request_script_run') {
             this.handleScriptRunRequestTool(
@@ -2388,25 +2424,13 @@ class MessagePersister {
             trackServerEvent(`agent_${action}`, { agentSlug: state.agentSlug })
           }
 
-          // Check if this is a secret request tool
-          if (state.currentToolUse.name === 'mcp__user-input__request_secret') {
-            this.handleSecretRequestTool(
-              sessionId,
-              state.currentToolUse.id,
-              state.currentToolInput,
-              state.agentSlug
-            )
-          }
-
-          // Check if this is a connected account request tool
-          if (state.currentToolUse.name === 'mcp__user-input__request_connected_account') {
-            this.handleConnectedAccountRequestTool(
-              sessionId,
-              state.currentToolUse.id,
-              state.currentToolInput,
-              state.agentSlug
-            )
-          }
+          this.dispatchBlockingUserInputTool(
+            sessionId,
+            state.currentToolUse.name,
+            state.currentToolUse.id,
+            state.currentToolInput,
+            state.agentSlug,
+          )
 
           // Check if this is a schedule task tool
           if (state.currentToolUse.name === 'mcp__user-input__schedule_task') {
@@ -2507,45 +2531,6 @@ class MessagePersister {
             )
           }
 
-          // Check if this is an AskUserQuestion tool
-          if (state.currentToolUse.name === 'AskUserQuestion') {
-            this.handleAskUserQuestionTool(
-              sessionId,
-              state.currentToolUse.id,
-              state.currentToolInput,
-              state.agentSlug
-            )
-          }
-
-          // Check if this is a file request tool
-          if (state.currentToolUse.name === 'mcp__user-input__request_file') {
-            this.handleFileRequestTool(
-              sessionId,
-              state.currentToolUse.id,
-              state.currentToolInput,
-              state.agentSlug
-            )
-          }
-
-          // Check if this is a remote MCP request tool
-          if (state.currentToolUse.name === 'mcp__user-input__request_remote_mcp') {
-            this.handleRemoteMcpRequestTool(
-              sessionId,
-              state.currentToolUse.id,
-              state.currentToolInput,
-              state.agentSlug
-            )
-          }
-
-          if (state.currentToolUse.name === 'mcp__user-input__request_browser_input') {
-            this.handleBrowserInputRequestTool(
-              sessionId,
-              state.currentToolUse.id,
-              state.currentToolInput,
-              state.agentSlug
-            )
-          }
-
           if (state.currentToolUse.name === 'mcp__user-input__request_script_run') {
             this.handleScriptRunRequestTool(
               sessionId,
@@ -2576,16 +2561,6 @@ class MessagePersister {
               state.currentToolInput,
               state.agentSlug
             )
-          }
-
-          // Mark session as awaiting input when a blocking user-input tool fires
-          // Only tools with 'request_' prefix actually block waiting for user response
-          // (schedule_task, deliver_file, search_* resolve immediately and don't block)
-          // Note: computer-use AND request_script_run tools are handled by their own
-          // handlers which only mark awaiting input when user approval is actually
-          // needed (not when auto-executed against a cached permission grant).
-          if (isBlockingUserInputToolName(state.currentToolUse.name)) {
-            this.markSessionAwaitingInput(sessionId)
           }
 
           // Track deliver_file tool calls so the matching tool_result can be
@@ -4518,8 +4493,10 @@ ${continuation}`
   // requests only: ordinary subagent tool results (Bash, Read, …) stream
   // constantly and must not broadcast main-path `tool_result` events or touch
   // the awaiting flag. Unlike the main path's unconditional clear, awaiting is
-  // cleared only when NO tracked request remains — a main-agent question can
-  // be open in parallel with a subagent's browser_input.
+  // cleared only when no OTHER blocking request remains (the shared both-shelves
+  // rule) — a main-agent question or a pending computer-use can be open in
+  // parallel with a subagent's browser_input — and never while a proxy/x-agent
+  // review is still parked for this agent.
   private resolveSidechainInputRequests(
     sessionId: string,
     state: StreamingState,
@@ -4540,7 +4517,11 @@ ${continuation}`
         isError: block.is_error || false,
       })
     }
-    if (state.isAwaitingInput && state.pendingInputRequests.size === 0) {
+    if (
+      state.isAwaitingInput &&
+      !this.hasBlockingPendingRequests(state) &&
+      !this.hasExternalAwaitingBlocker(state.agentSlug)
+    ) {
       state.isAwaitingInput = false
       this.broadcastGlobal({
         type: 'session_input_provided',


### PR DESCRIPTION
## What

Phase 1 of the user-input request rearchitecture: re-implements #510 fresh on current main (that PR pre-dates #527/#528 and is unmergeable — it should be closed in favor of this one).

**The bug this fixes:** a subagent calling `request_secret`, `AskUserQuestion`, `request_file`, `request_connected_account`, or `request_remote_mcp` surfaced nowhere — no card, no awaiting status, no notification. The subagent blocked in the container forever and the whole turn hung silently; only interrupt/restart unblocked it. Sidechain delivery paths had hand-copied per-tool dispatch that only covered browser_input / script_run / computer-use.

## How

- **New `dispatchBlockingUserInputTool`** — one funnel for the six blocking kinds with first-delivery-wins dedupe on toolUseId, called from all three delivery paths: main-stream `content_block_stop` (six per-tool blocks + the standalone awaiting-mark block folded in), the subagent stream-event handler, and the complete-assistant sidechain loop. A new delivery path or request kind can no longer be "forgotten" on N−1 copies of the switchboard.
- **script_run / computer-use / capability review** keep their own handlers — they mark awaiting conditionally (only when approval is actually needed), which the shared funnel deliberately doesn't model.
- **One waiting-light rule on the resolve side.** `resolveSidechainInputRequests` previously cleared awaiting on `pendingInputRequests.size === 0` — ignoring parked computer-use approvals and counting auto-approved script entries as blockers. `clearPendingComputerUseRequest` previously broadcast `session_input_provided` without ever flipping the awaiting bit. Both now share: both shelves, skip auto-approved, **and defer to a parked proxy/x-agent review** via the external-blocker seam from #528 (a guard #510 could not have known about).

## Acceptance evidence

Phase 0's characterization suite (#560) was the acceptance harness. After the production change, the only failures were exactly the intended flips:
- The 10 sidechain-matrix tests for the five silent kinds — rows flipped `surfacesToday: false → true` in this diff.
- The pinned computer-use split-brain (broadcast-without-bit-flip) — test rewritten to assert the fixed atomic behavior, plus a new deferral test when another request is still parked.

New resolution coverage: first-delivery-wins dedupe (stream + complete-assistant same toolUseId → one card), sidechain resolve for a dispatcher-surfaced kind, the both-shelves rule, the auto-approved-script skip, and external-blocker deferral on the sidechain resolve.

## Known deltas (accepted)

- Subagent asks are not analytics-tracked (`trackServerEvent` stays main-path-only, same as #510).
- A subagent ask in an automated (cron/webhook/chat) session now promotes it to the sidebar — `markSessionAwaitingInput` gained promotion after #510 was cut; new-correct behavior for free.
- The main-path user-message awaiting clear (`:1288`) is intentionally untouched — the parallel-requests split-brain pinned in #560 is the derived-awaiting phase's job.

## Validation

- Unit: 310/310 (50 lifecycle + 260 existing persister — main-path behavior preserved)
- E2E (web-chromium): 31/31 across mixed-pending-requests, user-input-requests, awaiting-input-status, subagent-browser-input-status, pending-request-reconnect, concurrent-tabs-request-sync
- `tsc --noEmit` + eslint clean

https://claude.ai/code/session_01DLw9AJ5VXVQPzBAz87nNAA