### PR TITLE
fix(chat): host-aware "can't do this in chat" notice with an app link (SUP-453)

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -251,6 +251,7 @@ vi.mock('@shared/lib/services/session-service', () => ({
   getSession: vi.fn(),
   getSessionMetadata: vi.fn(),
   sessionExists: vi.fn().mockResolvedValue(true),
+  isSessionRegistered: vi.fn().mockResolvedValue(false),
   updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
   deleteSession: vi.fn(),
   removeMessage: vi.fn(),
@@ -437,7 +438,8 @@ vi.mock('@shared/lib/utils/file-storage', () => ({
 }))
 
 vi.mock('@anthropic-ai/sdk', () => ({ default: vi.fn() }))
-vi.mock('hono/streaming', () => ({ streamSSE: vi.fn() }))
+const mockStreamSSE = vi.fn((..._args: unknown[]) => new Response(null, { status: 200 }))
+vi.mock('hono/streaming', () => ({ streamSSE: (...args: unknown[]) => mockStreamSSE(...args) }))
 
 // Import the agents router after all mocks are set up
 import agents from './agents'
@@ -451,7 +453,7 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, deleteSession, getSession, readSessionMetadata } from '@shared/lib/services/session-service'
+import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, isSessionRegistered, deleteSession, getSession, readSessionMetadata } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks, listPendingScheduledTasksByAgents } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -820,6 +822,36 @@ describe('session usage — GET /:id/sessions/:sessionId/usage', () => {
 
     expect(res.status).toBe(404)
     expect(mockLoadSessionUsageTotals).not.toHaveBeenCalled()
+  })
+})
+
+describe('session stream access - GET /:id/sessions/:sessionId/stream', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+  })
+
+  it('rejects a session that does not belong to the authorized agent', async () => {
+    vi.mocked(sessionExists).mockResolvedValueOnce(false)
+
+    const res = await getReq(app, '/api/agents/authorized-agent/sessions/foreign-session/stream')
+
+    expect(res.status).toBe(404)
+    expect(sessionExists).toHaveBeenCalledWith('authorized-agent', 'foreign-session')
+    expect(mockStreamSSE).not.toHaveBeenCalled()
+  })
+
+  it('allows a newly registered session before its transcript exists', async () => {
+    vi.mocked(sessionExists).mockResolvedValueOnce(false)
+    vi.mocked(isSessionRegistered).mockResolvedValueOnce(true)
+
+    const res = await getReq(app, '/api/agents/authorized-agent/sessions/new-session/stream')
+
+    expect(res.status).toBe(200)
+    expect(isSessionRegistered).toHaveBeenCalledWith('authorized-agent', 'new-session')
+    expect(mockStreamSSE).toHaveBeenCalledOnce()
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -39,6 +39,7 @@ import {
   getSession,
   getSessionMetadata,
   sessionExists,
+  isSessionRegistered,
   updateSessionMetadata,
   deleteSession,
   removeMessage,
@@ -2124,7 +2125,14 @@ agents.delete('/:id/sessions/:sessionId', AgentAdmin(), async (c) => {
 
 // GET /api/agents/:id/sessions/:sessionId/stream - SSE stream for real-time message updates
 agents.get('/:id/sessions/:sessionId/stream', AgentRead(), async (c) => {
+  const agentSlug = getAgentId(c)
   const sessionId = c.req.param('sessionId')
+  if (
+    !(await sessionExists(agentSlug, sessionId)) &&
+    !(await isSessionRegistered(agentSlug, sessionId))
+  ) {
+    return c.json({ error: 'Session not found' }, 404)
+  }
 
   return streamSSE(c, async (stream) => {
     let pingInterval: ReturnType<typeof setInterval> | null = null
@@ -2144,7 +2152,6 @@ agents.get('/:id/sessions/:sessionId/stream', AgentRead(), async (c) => {
       })
 
       // Send initial connection message (include slash commands for late-joining clients)
-      const agentSlug = getAgentId(c)
       const isActive = messagePersister.isSessionActive(sessionId)
       let slashCommands = messagePersister.getSlashCommands(sessionId)
       // Fall back to persisted metadata (e.g. after container restart)

--- a/src/main/agent-deep-link.test.ts
+++ b/src/main/agent-deep-link.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { parseAgentDeepLink } from './agent-deep-link'
+
+describe('parseAgentDeepLink', () => {
+  it('parses a slug-only link', () => {
+    expect(parseAgentDeepLink('superagent://agent/demo', 'superagent'))
+      .toEqual({ agentSlug: 'demo', sessionId: null })
+  })
+
+  it('parses the position-anchored sessions pair', () => {
+    expect(parseAgentDeepLink('superagent://agent/demo/sessions/sess-1', 'superagent'))
+      .toEqual({ agentSlug: 'demo', sessionId: 'sess-1' })
+  })
+
+  it('ignores a sessions pair that is not immediately after the slug', () => {
+    expect(parseAgentDeepLink('superagent://agent/demo/x/sessions/sess-1', 'superagent'))
+      .toEqual({ agentSlug: 'demo', sessionId: null })
+  })
+
+  it('ignores unknown extra segments (legacy lenience)', () => {
+    expect(parseAgentDeepLink('superagent://agent/demo/anything/else', 'superagent'))
+      .toEqual({ agentSlug: 'demo', sessionId: null })
+  })
+
+  it('ignores a sessions keyword with no id', () => {
+    expect(parseAgentDeepLink('superagent://agent/demo/sessions', 'superagent'))
+      .toEqual({ agentSlug: 'demo', sessionId: null })
+    expect(parseAgentDeepLink('superagent://agent/demo/sessions/', 'superagent'))
+      .toEqual({ agentSlug: 'demo', sessionId: null })
+  })
+
+  it('decodes the slug and the session id', () => {
+    expect(parseAgentDeepLink('superagent://agent/a%2Fb%20c/sessions/s%201', 'superagent'))
+      .toEqual({ agentSlug: 'a/b c', sessionId: 's 1' })
+  })
+
+  it('returns null on malformed slug encoding, degrades on malformed session encoding', () => {
+    expect(parseAgentDeepLink('superagent://agent/%E0%A4%A', 'superagent')).toBeNull()
+    expect(parseAgentDeepLink('superagent://agent/demo/sessions/%E0%A4%A', 'superagent'))
+      .toEqual({ agentSlug: 'demo', sessionId: null })
+  })
+
+  it('returns null for empty slug and non-agent families', () => {
+    expect(parseAgentDeepLink('superagent://agent/', 'superagent')).toBeNull()
+    expect(parseAgentDeepLink('superagent://dashboard/a/b', 'superagent')).toBeNull()
+    expect(parseAgentDeepLink('superagent://oauth-callback?x=1', 'superagent')).toBeNull()
+  })
+
+  it('respects the dev scheme', () => {
+    expect(parseAgentDeepLink('superagent-dev://agent/demo/sessions/s', 'superagent-dev'))
+      .toEqual({ agentSlug: 'demo', sessionId: 's' })
+    expect(parseAgentDeepLink('superagent://agent/demo', 'superagent-dev')).toBeNull()
+  })
+})

--- a/src/main/agent-deep-link.ts
+++ b/src/main/agent-deep-link.ts
@@ -1,0 +1,32 @@
+export interface AgentDeepLink {
+  agentSlug: string
+  sessionId: string | null
+}
+
+/**
+ * Pure parser for the agent deep-link family.
+ * Position-anchored: only `/sessions/<id>` immediately after the slug counts.
+ * Malformed slug encoding → null (no navigation). Malformed session encoding →
+ * degrade to slug-only. Extra/unknown segments ignored (legacy lenience).
+ */
+export function parseAgentDeepLink(url: string, scheme: string): AgentDeepLink | null {
+  const prefix = `${scheme}://agent/`
+  if (!url.startsWith(prefix)) return null
+  const segments = url.slice(prefix.length).split('/')
+  let agentSlug: string
+  try {
+    agentSlug = decodeURIComponent(segments[0])
+  } catch {
+    return null
+  }
+  if (!agentSlug) return null
+  let sessionId: string | null = null
+  if (segments[1] === 'sessions' && segments[2]) {
+    try {
+      sessionId = decodeURIComponent(segments[2])
+    } catch {
+      sessionId = null
+    }
+  }
+  return { agentSlug, sessionId }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -53,6 +53,7 @@ import {
 } from './quick-dispatch-window'
 import { registerGlobalDispatchShortcut, unregisterGlobalDispatchShortcut } from './global-dispatch-shortcut'
 import { filesFromCommandLine } from './opened-files'
+import { parseAgentDeepLink } from './agent-deep-link'
 import { classifyImportPackage } from './import-packages'
 import { isImportPackagePath } from '@shared/lib/utils/package-extensions'
 import { safeOpenExternalFromApp } from './safe-open-external'
@@ -1026,10 +1027,16 @@ function handleDeepLinkUrl(url: string, fromQueue = false) {
     return
   }
 
-  // Agent deep link — navigate to the agent and select its latest session when available.
-  if (url.startsWith(`${PROTOCOL_SCHEME}://agent/`)) {
+  // Agent deep link — session-bearing links navigate directly (ready-gated);
+  // slug-only links keep the legacy fetch-latest flow.
+  const agentLink = parseAgentDeepLink(url, PROTOCOL_SCHEME)
+  if (agentLink) {
+    if (agentLink.sessionId) {
+      focusMainWindowOnSession(agentLink.agentSlug, agentLink.sessionId)
+      return
+    }
     try {
-      const slug = decodeURIComponent(url.replace(`${PROTOCOL_SCHEME}://agent/`, '').split('/')[0])
+      const slug = agentLink.agentSlug
       if (mainWindow && !mainWindow.isDestroyed()) {
         mainWindow.show()
         mainWindow.focus()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1027,8 +1027,10 @@ function handleDeepLinkUrl(url: string, fromQueue = false) {
     return
   }
 
-  // Agent deep link — session-bearing links navigate directly (ready-gated);
-  // slug-only links keep the legacy fetch-latest flow.
+  // Agent deep link — session-bearing links navigate straight to the session;
+  // slug-only links resolve the agent's latest session first. Both bring the
+  // window up the same way, so a link that arrives after the window was closed
+  // recreates it instead of being dropped.
   const agentLink = parseAgentDeepLink(url, PROTOCOL_SCHEME)
   if (agentLink) {
     if (agentLink.sessionId) {
@@ -1037,20 +1039,25 @@ function handleDeepLinkUrl(url: string, fromQueue = false) {
     }
     try {
       const slug = agentLink.agentSlug
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.show()
-        mainWindow.focus()
-        fetch(`http://localhost:${actualApiPort}/api/agents/${slug}/sessions`)
-          .then(res => res.ok ? res.json() : [])
-          .then((sessions: Array<{ id: string; isActive: boolean; updatedAt?: string }>) => {
-            const active = sessions.find(s => s.isActive)
-            const latest = active ?? sessions[0]
-            mainWindow!.webContents.send('navigate-to-agent', slug, latest?.id ?? null)
-          })
-          .catch(() => {
-            mainWindow!.webContents.send('navigate-to-agent', slug, null)
-          })
-      }
+      showOrCreateMainWindow()
+      fetch(`http://localhost:${actualApiPort}/api/agents/${encodeURIComponent(slug)}/sessions`)
+        .then(res => res.ok ? res.json() : [])
+        .then((sessions: Array<{ id: string; isActive: boolean; updatedAt?: string }>) => {
+          if (!Array.isArray(sessions)) return null
+          const active = sessions.find(s => s.isActive)
+          return (active ?? sessions[0])?.id ?? null
+        })
+        .catch(() => null)
+        .then((sessionId: string | null) => {
+          sendToMainWindowWhenReady((win) =>
+            win.webContents.send('navigate-to-agent', slug, sessionId),
+          )
+        })
+        // Terminal catch: an unhandled rejection here is fatal (the process-level
+        // handler quits the app), and a failed deep link must never do that.
+        .catch((error) => {
+          console.error('Failed to navigate to agent from deep link:', error)
+        })
     } catch (error) {
       console.error('Failed to navigate to agent from deep link:', error)
     }

--- a/src/shared/lib/chat-integrations/base-connector.ts
+++ b/src/shared/lib/chat-integrations/base-connector.ts
@@ -189,7 +189,7 @@ export abstract class ChatClientConnector {
    * (Slack Block Kit, Telegram inline keyboards, etc.).
    * Returns the external message ID.
    */
-  abstract sendUserRequestCard(chatId: string, event: UserRequestEvent): Promise<string>
+  abstract sendUserRequestCard(chatId: string, event: UserRequestEvent, sessionId?: string): Promise<string>
 
   /**
    * Resolve an open single-question AskUserQuestion card with a free-typed message as the

--- a/src/shared/lib/chat-integrations/chat-integration-manager-ensure-session-access.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager-ensure-session-access.test.ts
@@ -167,12 +167,12 @@ describe('ChatIntegrationManager.handleSSEEvent — outbound access gate', () =>
     const mgr = chatIntegrationManager as unknown as {
       getChatSessionKey: (i: string, c: string) => string
       chatSessions: Map<string, unknown>
-      handleSSEEvent: (i: string, c: string, e: unknown) => Promise<void>
+      handleSSEEvent: (i: string, c: string, e: unknown, sessionId: string) => Promise<void>
     }
     const key = mgr.getChatSessionKey(INT, 'chat-denied')
     mgr.chatSessions.set(key, { chatId: 'chat-denied', integrationId: INT })
 
-    await mgr.handleSSEEvent(INT, 'chat-denied', { type: 'assistant' })
+    await mgr.handleSSEEvent(INT, 'chat-denied', { type: 'assistant' }, 'sess-test')
 
     // The fail-closed guard returns before reading integration config or forwarding.
     expect(mockGetChatIntegration).not.toHaveBeenCalled()

--- a/src/shared/lib/chat-integrations/chat-integration-manager.sup234.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.sup234.test.ts
@@ -30,9 +30,9 @@ import { chatIntegrationManager } from './chat-integration-manager'
 interface ManagerInternals {
   messageQueues: Map<string, unknown>
   enqueueMessage: (integrationId: string, message: { chatId: string; text?: string }) => void
-  enqueueSSEEvent: (integrationId: string, chatId: string, event: unknown) => void
+  enqueueSSEEvent: (integrationId: string, chatId: string, event: unknown, sessionId: string) => void
   handleIncomingMessage: (integrationId: string, message: unknown) => Promise<void>
-  handleSSEEvent: (integrationId: string, chatId: string, event: unknown) => Promise<void>
+  handleSSEEvent: (integrationId: string, chatId: string, event: unknown, sessionId: string) => Promise<void>
   removeIntegration: (id: string) => Promise<void>
 }
 
@@ -73,7 +73,7 @@ describe('SUP-234: chat integration message queue cleanup', () => {
   it('self-evicts a settled SSE queue entry', async () => {
     vi.spyOn(mgr, 'handleSSEEvent').mockResolvedValue(undefined)
 
-    mgr.enqueueSSEEvent('intg-2', 'chat-2', { type: 'session_idle' })
+    mgr.enqueueSSEEvent('intg-2', 'chat-2', { type: 'session_idle' }, 'sess-test')
     expect(mgr.messageQueues.has('sse:intg-2:chat-2')).toBe(true)
 
     await flushMicrotasks()
@@ -118,7 +118,7 @@ describe('SUP-234: chat integration message queue cleanup', () => {
     for (let c = 0; c < CHATS; c++) {
       for (let i = 0; i < PER_CHAT; i++) {
         mgr.enqueueMessage('vol', { chatId: `chat-${c}`, text: `m${i}` })
-        mgr.enqueueSSEEvent('vol', `chat-${c}`, { type: 'evt' })
+        mgr.enqueueSSEEvent('vol', `chat-${c}`, { type: 'evt' }, 'sess-test')
       }
     }
     expect(mgr.messageQueues.size).toBeGreaterThan(0)
@@ -138,9 +138,9 @@ describe('SUP-234: chat integration message queue cleanup', () => {
     // startsWith(id): 'intg2:c1'.startsWith('intg') is true, but
     // 'intg2:c1'.startsWith('intg:') is false — only the delimiter keeps intg2 safe.
     mgr.enqueueMessage('intg', { chatId: 'c1', text: 'hi' })
-    mgr.enqueueSSEEvent('intg', 'c2', { type: 'evt' })
+    mgr.enqueueSSEEvent('intg', 'c2', { type: 'evt' }, 'sess-test')
     mgr.enqueueMessage('intg2', { chatId: 'c1', text: 'hi' })
-    mgr.enqueueSSEEvent('intg2', 'c2', { type: 'evt' })
+    mgr.enqueueSSEEvent('intg2', 'c2', { type: 'evt' }, 'sess-test')
     await flushMicrotasks()
 
     // All in-flight, so all retained until explicitly removed.

--- a/src/shared/lib/chat-integrations/chat-integration-manager.sup234.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.sup234.test.ts
@@ -82,6 +82,17 @@ describe('SUP-234: chat integration message queue cleanup', () => {
     expect(mgr.messageQueues.size).toBe(0)
   })
 
+  it('keeps each SSE event tied to its originating session', async () => {
+    const handler = vi.spyOn(mgr, 'handleSSEEvent').mockResolvedValue(undefined)
+
+    mgr.enqueueSSEEvent('intg-2', 'chat-2', { type: 'first' }, 'sess-old')
+    mgr.enqueueSSEEvent('intg-2', 'chat-2', { type: 'second' }, 'sess-new')
+    await flushMicrotasks()
+
+    expect(handler).toHaveBeenNthCalledWith(1, 'intg-2', 'chat-2', { type: 'first' }, 'sess-old')
+    expect(handler).toHaveBeenNthCalledWith(2, 'intg-2', 'chat-2', { type: 'second' }, 'sess-new')
+  })
+
   it('keeps in-flight (unsettled) queue entries', async () => {
     vi.spyOn(mgr, 'handleIncomingMessage').mockReturnValue(pendingForever())
 

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -16,7 +16,7 @@ import type { SessionActivity } from '@shared/lib/types/agent'
 import { getToolDefinition } from '@shared/lib/tool-definitions/registry'
 import { formatToolName } from '@shared/lib/tool-definitions/types'
 import { parseChatIntegrationConfig, type ChatProvider } from './config-schema'
-import { formatProviderName, formatSessionTimestamp } from './utils'
+import { formatProviderName, formatSessionTimestamp, resolveAppLinkContext } from './utils'
 import { consumeOrCancelAwaitingInput } from './resolve-awaiting-input'
 import {
   listStartupChatIntegrations,
@@ -558,18 +558,20 @@ class ChatIntegrationManager {
       throw new Error(`Invalid config for ${integration.provider} integration ${integration.id}`)
     }
 
+    const appLink = resolveAppLinkContext(integration.agentSlug)
+
     switch (integration.provider) {
       case 'telegram': {
         const { TelegramConnector } = await import('./telegram-connector')
-        return new TelegramConnector(config as import('./telegram-connector').TelegramConfig)
+        return new TelegramConnector(config as import('./telegram-connector').TelegramConfig, appLink)
       }
       case 'slack': {
         const { SlackConnector } = await import('./slack-connector')
-        return new SlackConnector(config as import('./slack-connector').SlackConfig)
+        return new SlackConnector(config as import('./slack-connector').SlackConfig, appLink)
       }
       case 'imessage': {
         const { IMessageConnector } = await import('./imessage-connector')
-        return new IMessageConnector(config as import('./imessage-connector').IMessageConfig)
+        return new IMessageConnector(config as import('./imessage-connector').IMessageConfig, appLink)
       }
       default:
         throw new Error(`Unknown chat integration provider: ${integration.provider}`)

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -662,7 +662,7 @@ class ChatIntegrationManager {
       armIndicatorIfBusy(session, sessionId, messagePersister.getSessionActivity(sessionId))
       // Serialize SSE event processing per chat session to prevent race conditions
       // (e.g. session_idle arriving while stream_delta's sendStreamingUpdate is still in-flight)
-      this.enqueueSSEEvent(integrationId, chatId, event)
+      this.enqueueSSEEvent(integrationId, chatId, event, sessionId)
     })
     session.sseUnsubscribe = unsubscribe
     // Arm-if-busy from the cold snapshot — the same primitive as the wake. Busy → arm + paint
@@ -677,11 +677,11 @@ class ChatIntegrationManager {
     if (!BUSY_ACTIVITIES.has(coldActivity)) clearIndicator(session)
   }
 
-  private enqueueSSEEvent(integrationId: string, chatId: string, event: unknown): void {
+  private enqueueSSEEvent(integrationId: string, chatId: string, event: unknown, sessionId: string): void {
     const queueKey = `sse:${integrationId}:${chatId}`
     const current = this.messageQueues.get(queueKey) ?? Promise.resolve()
     const next = current.then(() =>
-      this.handleSSEEvent(integrationId, chatId, event).catch((err) => {
+      this.handleSSEEvent(integrationId, chatId, event, sessionId).catch((err) => {
         console.error(`[ChatIntegrationManager] Error handling SSE event:`, err)
         reportError(err, 'sse-event', { integrationId, chatId, eventType: (event as any)?.type })
       })
@@ -1584,7 +1584,7 @@ class ChatIntegrationManager {
 
   // ── SSE event handling ────────────────────────────────────────────
 
-  private async handleSSEEvent(integrationId: string, chatId: string, event: unknown): Promise<void> {
+  private async handleSSEEvent(integrationId: string, chatId: string, event: unknown, sessionId: string): Promise<void> {
     const key = this.getChatSessionKey(integrationId, chatId)
     const session = this.chatSessions.get(key)
     if (!session) return
@@ -1595,7 +1595,7 @@ class ChatIntegrationManager {
     if (!isChatAllowed(integrationId, chatId)) return
 
     const showToolCalls = getChatIntegration(integrationId)?.showToolCalls ?? false
-    await processSSEEvent(session, event, showToolCalls)
+    await processSSEEvent(session, event, showToolCalls, sessionId)
   }
 
   // ── Interactive response handling ─────────────────────────────────
@@ -1873,6 +1873,7 @@ export async function processSSEEvent(
   managed: ManagedConnector,
   event: unknown,
   showToolCalls = false,
+  sessionId?: string,
 ): Promise<void> {
   const data = event as Record<string, unknown>
   const eventType = data.type as string
@@ -1996,7 +1997,7 @@ export async function processSSEEvent(
       // auto-approved script run (card shown but the session stays 'working') keeps its tick.
       clearIndicator(managed)
       try {
-        await managed.connector.sendUserRequestCard(managed.chatId, data as UserRequestEvent)
+        await managed.connector.sendUserRequestCard(managed.chatId, data as UserRequestEvent, sessionId)
       } catch (err) {
         console.error(`[ChatIntegrationManager] Failed to send user request card (${eventType}):`, err)
         reportError(err, 'send-user-request-card', { integrationId: managed.integration.id, provider: managed.integration.provider, eventType })

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -1557,7 +1557,7 @@ class ChatIntegrationManager {
           const key = `${chatSession.integrationId}:${chatSession.externalChatId}`
           const managed = this.chatSessions.get(key)
           if (managed) {
-            await managed.connector.sendUserRequestCard(managed.chatId, card)
+            await managed.connector.sendUserRequestCard(managed.chatId, card, sessionId)
             return
           }
         }

--- a/src/shared/lib/chat-integrations/imessage-connector.ts
+++ b/src/shared/lib/chat-integrations/imessage-connector.ts
@@ -10,7 +10,7 @@ import WebSocket from 'ws'
 import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
 import type { SessionActivity } from '@shared/lib/types/agent'
 import { ChatClientConnector, type OutgoingMessage } from './base-connector'
-import { describeUnsupportedRequest, isUnsupportedInChat, type AppLinkContext } from './utils'
+import { describeUnsupportedRequest, isUnsupportedInChat, withSessionUrl, type AppLinkContext } from './utils'
 import { captureException } from '@shared/lib/error-reporting'
 
 // ── Config ──────────────────────────────────────────────────────────────
@@ -340,10 +340,11 @@ export class IMessageConnector extends ChatClientConnector {
 
   // ── User request cards ──────────────────────────────────────────────
 
-  async sendUserRequestCard(chatId: string, event: UserRequestEvent): Promise<string> {
+  async sendUserRequestCard(chatId: string, event: UserRequestEvent, sessionId?: string): Promise<string> {
+    const appLink = withSessionUrl(this.appLink, sessionId)
     const targetChatId = chatId || this.lastChatId || undefined
     if (isUnsupportedInChat(event)) {
-      return this.sendTextAndReturn(describeUnsupportedRequest(event, this.appLink), targetChatId)
+      return this.sendTextAndReturn(describeUnsupportedRequest(event, appLink), targetChatId)
     }
 
     switch (event.type) {
@@ -370,7 +371,7 @@ export class IMessageConnector extends ChatClientConnector {
       }
 
       default: {
-        return this.sendTextAndReturn(describeUnsupportedRequest(event, this.appLink), targetChatId)
+        return this.sendTextAndReturn(describeUnsupportedRequest(event, appLink), targetChatId)
       }
     }
   }

--- a/src/shared/lib/chat-integrations/imessage-connector.ts
+++ b/src/shared/lib/chat-integrations/imessage-connector.ts
@@ -10,7 +10,7 @@ import WebSocket from 'ws'
 import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
 import type { SessionActivity } from '@shared/lib/types/agent'
 import { ChatClientConnector, type OutgoingMessage } from './base-connector'
-import { describeUnsupportedRequest, isUnsupportedInChat } from './utils'
+import { describeUnsupportedRequest, isUnsupportedInChat, type AppLinkContext } from './utils'
 import { captureException } from '@shared/lib/error-reporting'
 
 // ── Config ──────────────────────────────────────────────────────────────
@@ -104,7 +104,7 @@ export class IMessageConnector extends ChatClientConnector {
   private nextUploadId = 0
   private nextApprovalId = 0
 
-  constructor(private config: IMessageConfig) {
+  constructor(private config: IMessageConfig, private appLink?: AppLinkContext) {
     super()
   }
 
@@ -343,7 +343,7 @@ export class IMessageConnector extends ChatClientConnector {
   async sendUserRequestCard(chatId: string, event: UserRequestEvent): Promise<string> {
     const targetChatId = chatId || this.lastChatId || undefined
     if (isUnsupportedInChat(event)) {
-      return this.sendTextAndReturn(describeUnsupportedRequest(event), targetChatId)
+      return this.sendTextAndReturn(describeUnsupportedRequest(event, this.appLink), targetChatId)
     }
 
     switch (event.type) {
@@ -370,7 +370,7 @@ export class IMessageConnector extends ChatClientConnector {
       }
 
       default: {
-        return this.sendTextAndReturn(describeUnsupportedRequest(event), targetChatId)
+        return this.sendTextAndReturn(describeUnsupportedRequest(event, this.appLink), targetChatId)
       }
     }
   }

--- a/src/shared/lib/chat-integrations/mock-connector.ts
+++ b/src/shared/lib/chat-integrations/mock-connector.ts
@@ -17,7 +17,7 @@ export class MockChatClientConnector extends ChatClientConnector {
   // ── Recorded outputs (for assertions) ─────────────────────────────
 
   sentMessages: { chatId: string; message: OutgoingMessage }[] = []
-  sentCards: { chatId: string; event: UserRequestEvent }[] = []
+  sentCards: { chatId: string; event: UserRequestEvent; sessionId?: string }[] = []
   sentFiles: { chatId: string; filename: string; size: number; caption?: string }[] = []
   streamUpdates: { chatId: string; text: string; existingMessageId?: string }[] = []
   finalizedMessages: { chatId: string; messageId: string; finalText: string }[] = []
@@ -123,9 +123,9 @@ export class MockChatClientConnector extends ChatClientConnector {
     this.stoppedWorking.push(chatId)
   }
 
-  async sendUserRequestCard(chatId: string, event: UserRequestEvent): Promise<string> {
+  async sendUserRequestCard(chatId: string, event: UserRequestEvent, sessionId?: string): Promise<string> {
     const id = `mock-card-${this.nextMessageId++}`
-    this.sentCards.push({ chatId, event })
+    this.sentCards.push({ chatId, event, sessionId })
     return id
   }
 

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -19,7 +19,7 @@ import {
   type OutgoingMessage,
   type SystemPromptContext,
 } from './base-connector'
-import { describeUnsupportedRequest, isUnsupportedInChat, splitChatMessage, type AppLinkContext } from './utils'
+import { describeUnsupportedRequest, isUnsupportedInChat, splitChatMessage, withSessionUrl, type AppLinkContext } from './utils'
 import { isUnrecoverableSlackError } from './slack-error'
 import { captureException } from '@shared/lib/error-reporting'
 
@@ -830,8 +830,9 @@ export class SlackConnector extends ChatClientConnector {
 
   // ── User request cards ──────────────────────────────────────────────
 
-  async sendUserRequestCard(chatId: string, event: UserRequestEvent): Promise<string> {
+  async sendUserRequestCard(chatId: string, event: UserRequestEvent, sessionId?: string): Promise<string> {
     if (!this.app) throw new Error('Slack app not connected')
+    const appLink = withSessionUrl(this.appLink, sessionId)
 
     const { channel, threadTs } = this.resolveChannel(chatId)
     const threadOpt = threadTs ? { thread_ts: threadTs } : {}
@@ -839,7 +840,7 @@ export class SlackConnector extends ChatClientConnector {
     if (isUnsupportedInChat(event)) {
       const result = await this.app.client.chat.postMessage({
         channel,
-        text: describeUnsupportedRequest(event, this.appLink),
+        text: describeUnsupportedRequest(event, appLink),
         mrkdwn: true,
         ...threadOpt,
       })
@@ -935,7 +936,7 @@ export class SlackConnector extends ChatClientConnector {
       default: {
         const result = await this.app.client.chat.postMessage({
           channel,
-          text: describeUnsupportedRequest(event, this.appLink),
+          text: describeUnsupportedRequest(event, appLink),
           mrkdwn: true,
           ...threadOpt,
         })

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -19,7 +19,7 @@ import {
   type OutgoingMessage,
   type SystemPromptContext,
 } from './base-connector'
-import { describeUnsupportedRequest, isUnsupportedInChat, splitChatMessage } from './utils'
+import { describeUnsupportedRequest, isUnsupportedInChat, splitChatMessage, type AppLinkContext } from './utils'
 import { isUnrecoverableSlackError } from './slack-error'
 import { captureException } from '@shared/lib/error-reporting'
 
@@ -370,7 +370,7 @@ export class SlackConnector extends ChatClientConnector {
   // requires a re-mention if it ever resurfaces.
   private static readonly MAX_TRACKED_THREADS = 1000
 
-  constructor(private config: SlackConfig) {
+  constructor(private config: SlackConfig, private appLink?: AppLinkContext) {
     super()
   }
 
@@ -839,7 +839,7 @@ export class SlackConnector extends ChatClientConnector {
     if (isUnsupportedInChat(event)) {
       const result = await this.app.client.chat.postMessage({
         channel,
-        text: `_${describeUnsupportedRequest(event)}_`,
+        text: describeUnsupportedRequest(event, this.appLink),
         mrkdwn: true,
         ...threadOpt,
       })
@@ -935,7 +935,7 @@ export class SlackConnector extends ChatClientConnector {
       default: {
         const result = await this.app.client.chat.postMessage({
           channel,
-          text: `_${describeUnsupportedRequest(event)}_`,
+          text: describeUnsupportedRequest(event, this.appLink),
           mrkdwn: true,
           ...threadOpt,
         })

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -838,6 +838,10 @@ export class SlackConnector extends ChatClientConnector {
     const threadOpt = threadTs ? { thread_ts: threadTs } : {}
 
     if (isUnsupportedInChat(event)) {
+      // Sent unwrapped, NOT as `_…_` italic: the notice ends in a URL, and Slack
+      // refuses to render italic when a URL abuts the closing underscore — the
+      // markers leak into the message as literal characters. mrkdwn still
+      // auto-links the URL.
       const result = await this.app.client.chat.postMessage({
         channel,
         text: describeUnsupportedRequest(event, appLink),
@@ -934,6 +938,7 @@ export class SlackConnector extends ChatClientConnector {
       }
 
       default: {
+        // Unwrapped for the same reason as the isUnsupportedInChat branch above.
         const result = await this.app.client.chat.postMessage({
           channel,
           text: describeUnsupportedRequest(event, appLink),

--- a/src/shared/lib/chat-integrations/slack-unsupported-notice.test.ts
+++ b/src/shared/lib/chat-integrations/slack-unsupported-notice.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
+import { SlackConnector } from './slack-connector'
+import type { AppLinkContext } from './utils'
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function makeConnector(appLink?: AppLinkContext) {
+  const connector = new SlackConnector({ botToken: 'xoxb-fake', appToken: 'xapp-fake' }, appLink)
+  const postMessage = vi.fn().mockResolvedValue({ ok: true, ts: '1000.001' })
+  ;(connector as any).app = {
+    client: {
+      chat: { postMessage, update: vi.fn().mockResolvedValue({ ok: true }) },
+      reactions: { remove: vi.fn().mockResolvedValue({}) },
+    },
+  }
+  return { connector, postMessage }
+}
+
+const SECRET_REQUEST: UserRequestEvent = {
+  type: 'secret_request',
+  toolUseId: 'tu-1',
+  secretName: 'OPENAI_API_KEY',
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe('SlackConnector — unsupported-request notice', () => {
+  let desktop: AppLinkContext
+
+  beforeEach(() => {
+    desktop = { isDesktop: true, url: 'superagent://agent/demo' }
+  })
+
+  it('links to the conversation that raised the request', async () => {
+    const { connector, postMessage } = makeConnector(desktop)
+
+    await connector.sendUserRequestCard('C123', SECRET_REQUEST, 'sess-1')
+
+    expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      channel: 'C123',
+      text: expect.stringContaining('superagent://agent/demo/sessions/sess-1'),
+      mrkdwn: true,
+    }))
+  })
+
+  it('falls back to the agent-home link without a sessionId', async () => {
+    const { connector, postMessage } = makeConnector(desktop)
+
+    await connector.sendUserRequestCard('C123', SECRET_REQUEST)
+
+    const { text } = postMessage.mock.calls[0][0]
+    expect(text).toContain('superagent://agent/demo')
+    expect(text).not.toContain('/sessions/')
+  })
+
+  it('renders the web link and drops the desktop wording on a cloud host', async () => {
+    const { connector, postMessage } = makeConnector({
+      isDesktop: false,
+      url: 'https://app.example.com/agents/demo',
+    })
+
+    await connector.sendUserRequestCard('C123', SECRET_REQUEST, 'sess-1')
+
+    const { text } = postMessage.mock.calls[0][0]
+    expect(text).toContain('https://app.example.com/agents/demo/sessions/sess-1')
+    expect(text).not.toContain('desktop')
+  })
+
+  // The regression this guards: Slack will not render `_…_` italic when a URL
+  // abuts the closing underscore, so wrapping the notice leaves the markers in
+  // the message as literal characters right where the link is.
+  it('sends the notice unwrapped so the trailing URL is not broken by italic markers', async () => {
+    const { connector, postMessage } = makeConnector(desktop)
+
+    await connector.sendUserRequestCard('C123', SECRET_REQUEST, 'sess-1')
+
+    const { text } = postMessage.mock.calls[0][0]
+    expect(text.startsWith('_')).toBe(false)
+    expect(text.endsWith('superagent://agent/demo/sessions/sess-1')).toBe(true)
+  })
+
+  it('applies the same link + unwrapped rule to the unknown-event fallback', async () => {
+    const { connector, postMessage } = makeConnector(desktop)
+
+    await connector.sendUserRequestCard('C123', { type: 'not_a_real_request' } as unknown as UserRequestEvent, 'sess-1')
+
+    const { text } = postMessage.mock.calls[0][0]
+    expect(text).toContain('superagent://agent/demo/sessions/sess-1')
+    expect(text.startsWith('_')).toBe(false)
+    expect(text.endsWith('_')).toBe(false)
+  })
+})

--- a/src/shared/lib/chat-integrations/sse-event-processing.test.ts
+++ b/src/shared/lib/chat-integrations/sse-event-processing.test.ts
@@ -321,6 +321,16 @@ describe('processSSEEvent', () => {
       expect(mock.sentCards.length).toBe(1)
       expect(mock.sentCards[0].event.type).toBe('secret_request')
     })
+
+    it('threads the originating sessionId into sendUserRequestCard', async () => {
+      await processSSEEvent(managed, { type: 'secret_request', secretName: 'K' }, false, 'sess-42')
+      expect(getMock(managed).sentCards[0]?.sessionId).toBe('sess-42')
+    })
+
+    it('sends no sessionId when the caller has none', async () => {
+      await processSSEEvent(managed, { type: 'secret_request', secretName: 'K' }, false)
+      expect(getMock(managed).sentCards[0]?.sessionId).toBeUndefined()
+    })
   })
 
   // ── Typing indicator ────────────────────────────────────────────

--- a/src/shared/lib/chat-integrations/telegram-connector.test.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.test.ts
@@ -680,14 +680,14 @@ describe('TelegramConnector - unsupported-request session link', () => {
   it('renders the session-scoped link when a sessionId is passed', async () => {
     const connector = new TelegramConnector({ botToken: 'fake:TOKEN' }, { isDesktop: true, url: 'superagent://agent/demo' })
     const fake = attachFakeBot(connector)
-    await connector.sendUserRequestCard('123', { type: 'computer_use_request' } as any, 'sess-1')
+    await connector.sendUserRequestCard('123', { type: 'secret_request', toolUseId: 'tu-1', secretName: 'K' }, 'sess-1')
     expect(JSON.stringify(fake.sent)).toContain('superagent://agent/demo/sessions/sess-1')
   })
 
   it('falls back to the agent-home link without a sessionId', async () => {
     const connector = new TelegramConnector({ botToken: 'fake:TOKEN' }, { isDesktop: true, url: 'superagent://agent/demo' })
     const fake = attachFakeBot(connector)
-    await connector.sendUserRequestCard('123', { type: 'computer_use_request' } as any)
+    await connector.sendUserRequestCard('123', { type: 'secret_request', toolUseId: 'tu-1', secretName: 'K' })
     const sent = JSON.stringify(fake.sent)
     expect(sent).toContain('superagent://agent/demo')
     expect(sent).not.toContain('/sessions/')

--- a/src/shared/lib/chat-integrations/telegram-connector.test.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.test.ts
@@ -675,3 +675,21 @@ describe('TelegramConnector — secret/file requests route to the desktop-only f
     expect(md).not.toMatch(/please (upload|send) the file/i)
   })
 })
+
+describe('TelegramConnector - unsupported-request session link', () => {
+  it('renders the session-scoped link when a sessionId is passed', async () => {
+    const connector = new TelegramConnector({ botToken: 'fake:TOKEN' }, { isDesktop: true, url: 'superagent://agent/demo' })
+    const fake = attachFakeBot(connector)
+    await connector.sendUserRequestCard('123', { type: 'computer_use_request' } as any, 'sess-1')
+    expect(JSON.stringify(fake.sent)).toContain('superagent://agent/demo/sessions/sess-1')
+  })
+
+  it('falls back to the agent-home link without a sessionId', async () => {
+    const connector = new TelegramConnector({ botToken: 'fake:TOKEN' }, { isDesktop: true, url: 'superagent://agent/demo' })
+    const fake = attachFakeBot(connector)
+    await connector.sendUserRequestCard('123', { type: 'computer_use_request' } as any)
+    const sent = JSON.stringify(fake.sent)
+    expect(sent).toContain('superagent://agent/demo')
+    expect(sent).not.toContain('/sessions/')
+  })
+})

--- a/src/shared/lib/chat-integrations/telegram-connector.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.ts
@@ -13,7 +13,7 @@ import { Marked, Renderer } from 'marked'
 import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
 import type { SessionActivity } from '@shared/lib/types/agent'
 import { ChatClientConnector, type OutgoingMessage } from './base-connector'
-import { describeUnsupportedRequest, isUnsupportedInChat } from './utils'
+import { describeUnsupportedRequest, isUnsupportedInChat, type AppLinkContext } from './utils'
 import { captureException } from '@shared/lib/error-reporting'
 import { markdownToRichMessage, splitForRichLimits, splitForHtmlLimits, escapeMarkdown, codeSpan } from './telegram-rich-message'
 import type { InputRichMessage } from 'grammy/types'
@@ -166,7 +166,7 @@ export class TelegramConnector extends ChatClientConnector {
   // the current label even when it changes mid-turn (working → thinking → …).
   private workingActivity: Map<string, SessionActivity> = new Map()
 
-  constructor(private config: TelegramConfig) {
+  constructor(private config: TelegramConfig, private appLink?: AppLinkContext) {
     super()
   }
 
@@ -505,7 +505,7 @@ export class TelegramConnector extends ChatClientConnector {
     if (!this.bot) throw new Error('Bot not connected')
 
     if (isUnsupportedInChat(event)) {
-      return this.sendRichOrHtml(chatId, `_${escapeMarkdown(describeUnsupportedRequest(event))}_`)
+      return this.sendRichOrHtml(chatId, `_${escapeMarkdown(describeUnsupportedRequest(event, this.appLink))}_`)
     }
 
     switch (event.type) {
@@ -602,7 +602,7 @@ export class TelegramConnector extends ChatClientConnector {
       }
 
       default:
-        return this.sendRichOrHtml(chatId, `_${escapeMarkdown(describeUnsupportedRequest(event))}_`)
+        return this.sendRichOrHtml(chatId, `_${escapeMarkdown(describeUnsupportedRequest(event, this.appLink))}_`)
     }
   }
 

--- a/src/shared/lib/chat-integrations/telegram-connector.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.ts
@@ -13,7 +13,7 @@ import { Marked, Renderer } from 'marked'
 import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
 import type { SessionActivity } from '@shared/lib/types/agent'
 import { ChatClientConnector, type OutgoingMessage } from './base-connector'
-import { describeUnsupportedRequest, isUnsupportedInChat, type AppLinkContext } from './utils'
+import { describeUnsupportedRequest, isUnsupportedInChat, withSessionUrl, type AppLinkContext } from './utils'
 import { captureException } from '@shared/lib/error-reporting'
 import { markdownToRichMessage, splitForRichLimits, splitForHtmlLimits, escapeMarkdown, codeSpan } from './telegram-rich-message'
 import type { InputRichMessage } from 'grammy/types'
@@ -501,11 +501,12 @@ export class TelegramConnector extends ChatClientConnector {
 
   // ── User request cards ──────────────────────────────────────────────
 
-  async sendUserRequestCard(chatId: string, event: UserRequestEvent): Promise<string> {
+  async sendUserRequestCard(chatId: string, event: UserRequestEvent, sessionId?: string): Promise<string> {
     if (!this.bot) throw new Error('Bot not connected')
+    const appLink = withSessionUrl(this.appLink, sessionId)
 
     if (isUnsupportedInChat(event)) {
-      return this.sendRichOrHtml(chatId, `_${escapeMarkdown(describeUnsupportedRequest(event, this.appLink))}_`)
+      return this.sendRichOrHtml(chatId, `_${escapeMarkdown(describeUnsupportedRequest(event, appLink))}_`)
     }
 
     switch (event.type) {
@@ -602,7 +603,7 @@ export class TelegramConnector extends ChatClientConnector {
       }
 
       default:
-        return this.sendRichOrHtml(chatId, `_${escapeMarkdown(describeUnsupportedRequest(event, this.appLink))}_`)
+        return this.sendRichOrHtml(chatId, `_${escapeMarkdown(describeUnsupportedRequest(event, appLink))}_`)
     }
   }
 

--- a/src/shared/lib/chat-integrations/utils.test.ts
+++ b/src/shared/lib/chat-integrations/utils.test.ts
@@ -6,6 +6,7 @@ import {
   isSettling,
   isUnsupportedInChat,
   resolveAppLinkContext,
+  withSessionUrl,
   type AppLinkContext,
 } from './utils'
 
@@ -211,5 +212,44 @@ describe('isUnsupportedInChat / describeUnsupportedRequest', () => {
     const message = describeUnsupportedRequest(event)
     expect(message).toContain('Open Gamut on your desktop to continue.')
     expect(message).not.toContain('://')
+  })
+})
+
+describe('withSessionUrl', () => {
+  const desktop = { isDesktop: true, url: 'superagent://agent/demo' }
+  const web = { isDesktop: false, url: 'https://host.example/agents/demo' }
+
+  it('suffixes the session path onto a desktop link', () => {
+    expect(withSessionUrl(desktop, 'sess-1')).toEqual({
+      isDesktop: true,
+      url: 'superagent://agent/demo/sessions/sess-1',
+    })
+  })
+
+  it('suffixes the session path onto a web link', () => {
+    expect(withSessionUrl(web, 'sess-1')?.url).toBe('https://host.example/agents/demo/sessions/sess-1')
+  })
+
+  it('strips trailing slashes from the base before appending', () => {
+    expect(withSessionUrl({ isDesktop: false, url: 'https://host.example/agents/demo/' }, 's')?.url)
+      .toBe('https://host.example/agents/demo/sessions/s')
+  })
+
+  it('URI-encodes the session id', () => {
+    expect(withSessionUrl(desktop, 'a/b c')?.url).toBe('superagent://agent/demo/sessions/a%2Fb%20c')
+  })
+
+  it('passes through when the session id is missing or empty', () => {
+    expect(withSessionUrl(desktop)).toBe(desktop)
+    expect(withSessionUrl(desktop, '')).toBe(desktop)
+  })
+
+  it('passes through a null-url context (self-hosted cloud)', () => {
+    const noUrl = { isDesktop: false, url: null }
+    expect(withSessionUrl(noUrl, 'sess-1')).toBe(noUrl)
+  })
+
+  it('passes through undefined context', () => {
+    expect(withSessionUrl(undefined, 'sess-1')).toBeUndefined()
   })
 })

--- a/src/shared/lib/chat-integrations/utils.test.ts
+++ b/src/shared/lib/chat-integrations/utils.test.ts
@@ -1,6 +1,18 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect } from 'vitest'
 import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
-import { describeUnsupportedRequest, formatProviderName, isSettling, isUnsupportedInChat } from './utils'
+import {
+  describeUnsupportedRequest,
+  formatProviderName,
+  isSettling,
+  isUnsupportedInChat,
+  resolveAppLinkContext,
+  type AppLinkContext,
+} from './utils'
+
+const desktopContext: AppLinkContext = {
+  isDesktop: true,
+  url: 'superagent://agent/demo',
+}
 
 describe('formatProviderName', () => {
   it('capitalizes telegram', () => {
@@ -38,12 +50,86 @@ describe('isSettling', () => {
   })
 })
 
+describe('resolveAppLinkContext', () => {
+  const originalType = (process as { type?: string }).type
+  const originalProtocol = process.env.SUPERAGENT_PROTOCOL
+  const originalHostPublicUrl = process.env.HOST_PUBLIC_URL
+
+  afterEach(() => {
+    if (originalType === undefined) {
+      delete (process as { type?: string }).type
+    } else {
+      ;(process as { type?: string }).type = originalType
+    }
+    if (originalProtocol === undefined) {
+      delete process.env.SUPERAGENT_PROTOCOL
+    } else {
+      process.env.SUPERAGENT_PROTOCOL = originalProtocol
+    }
+    if (originalHostPublicUrl === undefined) {
+      delete process.env.HOST_PUBLIC_URL
+    } else {
+      process.env.HOST_PUBLIC_URL = originalHostPublicUrl
+    }
+  })
+
+  it('returns a desktop deeplink when process.type is browser', () => {
+    ;(process as { type?: string }).type = 'browser'
+    process.env.SUPERAGENT_PROTOCOL = 'superagent-dev'
+    delete process.env.HOST_PUBLIC_URL
+
+    expect(resolveAppLinkContext('my-agent')).toEqual({
+      isDesktop: true,
+      url: 'superagent-dev://agent/my-agent',
+    })
+  })
+
+  it('falls back to the superagent scheme when SUPERAGENT_PROTOCOL is unset', () => {
+    ;(process as { type?: string }).type = 'browser'
+    delete process.env.SUPERAGENT_PROTOCOL
+
+    expect(resolveAppLinkContext('demo').url).toBe('superagent://agent/demo')
+  })
+
+  it('returns a web URL when HOST_PUBLIC_URL is set outside Electron', () => {
+    delete (process as { type?: string }).type
+    process.env.HOST_PUBLIC_URL = 'https://app.example.com/'
+
+    expect(resolveAppLinkContext('my-agent')).toEqual({
+      isDesktop: false,
+      url: 'https://app.example.com/agents/my-agent',
+    })
+  })
+
+  it('returns null web url when HOST_PUBLIC_URL is unset or empty', () => {
+    delete (process as { type?: string }).type
+    delete process.env.HOST_PUBLIC_URL
+    expect(resolveAppLinkContext('demo')).toEqual({ isDesktop: false, url: null })
+
+    process.env.HOST_PUBLIC_URL = ''
+    expect(resolveAppLinkContext('demo')).toEqual({ isDesktop: false, url: null })
+
+    process.env.HOST_PUBLIC_URL = '   '
+    expect(resolveAppLinkContext('demo')).toEqual({ isDesktop: false, url: null })
+  })
+
+  it('URI-encodes the agent slug', () => {
+    delete (process as { type?: string }).type
+    process.env.HOST_PUBLIC_URL = 'https://app.example.com'
+    expect(resolveAppLinkContext('a/b c').url).toBe('https://app.example.com/agents/a%2Fb%20c')
+
+    ;(process as { type?: string }).type = 'browser'
+    process.env.SUPERAGENT_PROTOCOL = 'superagent'
+    expect(resolveAppLinkContext('a/b c').url).toBe('superagent://agent/a%2Fb%20c')
+  })
+})
+
 describe('isUnsupportedInChat / describeUnsupportedRequest', () => {
   it('flags connected_account_request as unsupported and names the toolkit', () => {
     const event: UserRequestEvent = { type: 'connected_account_request', toolUseId: 't1', toolkit: 'github' }
     expect(isUnsupportedInChat(event)).toBe(true)
-    expect(describeUnsupportedRequest(event)).toContain('github')
-    expect(describeUnsupportedRequest(event)).toContain('desktop')
+    expect(describeUnsupportedRequest(event, desktopContext)).toContain('github')
+    expect(describeUnsupportedRequest(event, desktopContext)).toContain('desktop')
   })
 
   it('does not flag user_question_request as unsupported', () => {
@@ -54,20 +140,76 @@ describe('isUnsupportedInChat / describeUnsupportedRequest', () => {
   it('flags remote_mcp_request and includes the server name when present', () => {
     const event: UserRequestEvent = { type: 'remote_mcp_request', toolUseId: 't3', url: 'https://x', name: 'Acme MCP' }
     expect(isUnsupportedInChat(event)).toBe(true)
-    expect(describeUnsupportedRequest(event)).toContain('Acme MCP')
+    expect(describeUnsupportedRequest(event, desktopContext)).toContain('Acme MCP')
   })
 
   it('flags secret_request as unsupported (secrets are unsafe to type into chat) and names the secret', () => {
     const event: UserRequestEvent = { type: 'secret_request', toolUseId: 't4', secretName: 'OPENAI_API_KEY' }
     expect(isUnsupportedInChat(event)).toBe(true)
-    expect(describeUnsupportedRequest(event)).toContain('OPENAI_API_KEY')
-    expect(describeUnsupportedRequest(event)).toContain('desktop')
+    expect(describeUnsupportedRequest(event, desktopContext)).toContain('OPENAI_API_KEY')
+    expect(describeUnsupportedRequest(event, desktopContext)).toContain('desktop')
   })
 
   it('flags file_request as unsupported and mentions uploading', () => {
     const event: UserRequestEvent = { type: 'file_request', toolUseId: 't5', description: 'a CSV export' }
     expect(isUnsupportedInChat(event)).toBe(true)
-    expect(describeUnsupportedRequest(event)).toContain('upload')
-    expect(describeUnsupportedRequest(event)).toContain('desktop')
+    expect(describeUnsupportedRequest(event, desktopContext)).toContain('upload')
+    expect(describeUnsupportedRequest(event, desktopContext)).toContain('desktop')
+  })
+
+  it('desktop context includes desktop wording and the deeplink', () => {
+    const event: UserRequestEvent = {
+      type: 'script_run_request',
+      toolUseId: 't6',
+      script: 'echo hi',
+      explanation: 'test',
+      scriptType: 'bash',
+    }
+    const message = describeUnsupportedRequest(event, desktopContext)
+    expect(message).toContain('on your desktop')
+    expect(message).toContain('superagent://agent/demo')
+  })
+
+  it('web context with url omits desktop and includes the url', () => {
+    const event: UserRequestEvent = {
+      type: 'script_run_request',
+      toolUseId: 't7',
+      script: 'echo hi',
+      explanation: 'test',
+      scriptType: 'bash',
+    }
+    const message = describeUnsupportedRequest(event, {
+      isDesktop: false,
+      url: 'https://app.example.com/agents/demo',
+    })
+    expect(message).not.toContain('desktop')
+    expect(message).toContain('Open Gamut to continue: https://app.example.com/agents/demo')
+  })
+
+  it('web context with null url omits desktop, ends with a period, and has no dangling colon', () => {
+    const event: UserRequestEvent = {
+      type: 'script_run_request',
+      toolUseId: 't8',
+      script: 'echo hi',
+      explanation: 'test',
+      scriptType: 'bash',
+    }
+    const message = describeUnsupportedRequest(event, { isDesktop: false, url: null })
+    expect(message).not.toContain('desktop')
+    expect(message).toMatch(/to continue\.$/)
+    expect(message).not.toContain('continue:')
+  })
+
+  it('no-context fallback keeps current desktop wording with no link', () => {
+    const event: UserRequestEvent = {
+      type: 'script_run_request',
+      toolUseId: 't9',
+      script: 'echo hi',
+      explanation: 'test',
+      scriptType: 'bash',
+    }
+    const message = describeUnsupportedRequest(event)
+    expect(message).toContain('Open Gamut on your desktop to continue.')
+    expect(message).not.toContain('://')
   })
 })

--- a/src/shared/lib/chat-integrations/utils.test.ts
+++ b/src/shared/lib/chat-integrations/utils.test.ts
@@ -85,10 +85,12 @@ describe('resolveAppLinkContext', () => {
     })
   })
 
-  it('falls back to the superagent scheme when SUPERAGENT_PROTOCOL is unset', () => {
+  it('falls back to the superagent scheme when SUPERAGENT_PROTOCOL is unset or empty', () => {
     ;(process as { type?: string }).type = 'browser'
     delete process.env.SUPERAGENT_PROTOCOL
+    expect(resolveAppLinkContext('demo').url).toBe('superagent://agent/demo')
 
+    process.env.SUPERAGENT_PROTOCOL = ''
     expect(resolveAppLinkContext('demo').url).toBe('superagent://agent/demo')
   })
 

--- a/src/shared/lib/chat-integrations/utils.ts
+++ b/src/shared/lib/chat-integrations/utils.ts
@@ -120,12 +120,34 @@ export function splitChatMessage(text: string, maxLength: number): string[] {
   return chunks
 }
 
+/** Where to send the user when chat can't fulfill a request. */
+export interface AppLinkContext {
+  isDesktop: boolean
+  url: string | null
+}
+
+/**
+ * Resolve the app surface + optional deep/web link for an agent.
+ * Env reads stay inside this function (SUPERAGENT_PROTOCOL is assigned after
+ * this module is imported in Electron main).
+ */
+export function resolveAppLinkContext(agentSlug: string): AppLinkContext {
+  if (process.type === 'browser') {
+    const scheme = process.env.SUPERAGENT_PROTOCOL ?? 'superagent'
+    return { isDesktop: true, url: `${scheme}://agent/${encodeURIComponent(agentSlug)}` }
+  }
+  const base = process.env.HOST_PUBLIC_URL?.trim().replace(/\/+$/, '')
+  return { isDesktop: false, url: base ? `${base}/agents/${encodeURIComponent(agentSlug)}` : null }
+}
+
 /**
  * Plain-text user-facing message for an event the chat integration can't fulfill.
  * Connectors wrap this in their own formatting (Telegram HTML, Slack mrkdwn).
  */
-export function describeUnsupportedRequest(event: UserRequestEvent): string {
-  const tail = ' Open Gamut on your desktop to continue.'
+export function describeUnsupportedRequest(event: UserRequestEvent, appLink?: AppLinkContext): string {
+  const isDesktop = appLink?.isDesktop ?? true // no-context fallback = current behavior
+  const url = appLink?.url ?? null
+  const tail = ` Open Gamut${isDesktop ? ' on your desktop' : ''} to continue${url ? `: ${url}` : '.'}`
   switch (event.type) {
     case 'connected_account_request':
       return `The agent wants to connect your ${event.toolkit} account, which isn't supported in chat.${tail}`

--- a/src/shared/lib/chat-integrations/utils.ts
+++ b/src/shared/lib/chat-integrations/utils.ts
@@ -141,6 +141,21 @@ export function resolveAppLinkContext(agentSlug: string): AppLinkContext {
 }
 
 /**
+ * Session-scoped variant of an app link: suffix the session path onto the base
+ * link. Passthrough when there is no base URL (self-hosted cloud) or no session
+ * identity (link stays agent-home). One rule serves both surfaces because the
+ * desktop and web base shapes are parallel.
+ */
+export function withSessionUrl(
+  appLink: AppLinkContext | undefined,
+  sessionId?: string,
+): AppLinkContext | undefined {
+  if (!appLink?.url || !sessionId) return appLink
+  const base = appLink.url.replace(/\/+$/, '')
+  return { ...appLink, url: `${base}/sessions/${encodeURIComponent(sessionId)}` }
+}
+
+/**
  * Plain-text user-facing message for an event the chat integration can't fulfill.
  * Connectors wrap this in their own formatting (Telegram HTML, Slack mrkdwn).
  */

--- a/src/shared/lib/chat-integrations/utils.ts
+++ b/src/shared/lib/chat-integrations/utils.ts
@@ -133,7 +133,9 @@ export interface AppLinkContext {
  */
 export function resolveAppLinkContext(agentSlug: string): AppLinkContext {
   if (process.type === 'browser') {
-    const scheme = process.env.SUPERAGENT_PROTOCOL ?? 'superagent'
+    // `||`, not `??`: an empty value must fall back too, or the link degrades to
+    // a scheme-less `://agent/…` that chat clients still render as a dead link.
+    const scheme = process.env.SUPERAGENT_PROTOCOL || 'superagent'
     return { isDesktop: true, url: `${scheme}://agent/${encodeURIComponent(agentSlug)}` }
   }
   const base = process.env.HOST_PUBLIC_URL?.trim().replace(/\/+$/, '')


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-453/slack-chat-integration-when-getting-a-request-for-input-that-cant-be

## What

The shared "can't do this in chat" notice hardcoded `Open Gamut on your desktop to continue.` Two problems on a cloud host: it claims "desktop" when the host isn't one, and it gives the user no way to actually finish the request.

The notice now resolves the surface once per connector and links to the conversation that needs input when its identity is known:

| Host | Message tail |
|---|---|
| Desktop (Electron main) | `Open Gamut on your desktop to continue: superagent://agent/<slug>/sessions/<id>` |
| Cloud (`HOST_PUBLIC_URL` set) | `Open Gamut to continue: <host>/agents/<slug>/sessions/<id>` |
| Conversation identity unavailable | Falls back to the agent-home link |
| Cloud, `HOST_PUBLIC_URL` unset/empty | `Open Gamut to continue.` (link omitted, never a broken URL) |

## How

- `resolveAppLinkContext(agentSlug)` in `utils.ts` resolves the host-aware agent-home link. Surface detection uses the existing Electron guard `process.type === 'browser'`, the scheme comes from `SUPERAGENT_PROTOCOL`, and the cloud base comes from `HOST_PUBLIC_URL`. Slugs are encoded.
- `withSessionUrl(appLink, sessionId)` appends the encoded conversation path when an identity is available and otherwise preserves the agent-home fallback.
- The SSE subscription captures the originating conversation ID and carries it through the per-chat queue into `sendUserRequestCard`. A later conversation rotation cannot retarget a queued notice.
- Desktop agent links are parsed by a pure helper. Session-bearing links reuse the existing ready-gated navigation path; agent-only links keep the existing fetch-latest behavior.

**Env reads stay inside the resolver, at call time.** `main/index.ts` imports the manager before it assigns `SUPERAGENT_PROTOCOL`, so a module-top-level read would silently emit `superagent://` instead of `superagent-dev://` in dev builds.

## Amendment: session-level links

Unsupported-in-chat links now open the conversation that raised the request on desktop and cloud. If the conversation identity is unavailable, the link still falls back to the agent home.

Cloud stream requests verify that the conversation belongs to the authorized agent before opening the event stream. Newly-created conversations remain valid before their transcript file exists.

Slack notices remain plain rather than italic so custom-scheme links render reliably.

## Verified

The original host-aware behavior was smoke-tested live on all three connectors against both host shapes. The cloud host was simulated by running the web build behind a cloudflared tunnel set as `HOST_PUBLIC_URL`.

| Surface | Desktop host | Cloud host |
|---|---|---|
| Slack | wording + clickable deeplink, opens the agent | no "desktop" + clickable https |
| Telegram | wording + deeplink as plain text (see below) | no "desktop" + clickable https |
| iMessage | wording + clickable deeplink | no "desktop" + clickable https |

Link rendering was probed live rather than assumed:

- **Slack** renders a bare custom-scheme URL as a real link (`conversations.history` returns it as a `rich_text` element of `type: link`), so the desktop deeplink is clickable there.
- **Telegram** accepts a custom scheme in a link entity at the API level (`ok: true`), but its client refuses to linkify it, on both MarkdownV2 and HTML. An `https` link linkifies normally. The desktop deeplink therefore renders as plain text on Telegram while the cloud link is clickable everywhere. Making the desktop one clickable would need a public https bouncer that redirects into the scheme, which is separate infrastructure.

Slack previously wrapped this notice in `_..._` for italic. Slack will not render italic when a URL abuts the closing underscore, so adding the link left literal underscores in the message. The notice now sends unwrapped, still with `mrkdwn: true` so the URL auto-links.

Automated verification after the amendment and rebase:

- `npm run typecheck`
- `npm run lint` (0 errors)
- chat integrations and main: 847 passed, 7 skipped
- agent routes: 227 passed

## Deliberately not here

- The sibling `file_delivery` "view in the app" copy. Same class of message, different ticket.

## Post-deploy check

`HOST_PUBLIC_URL` presence on a cloud host cannot be verified from this repo because hosted-plane config is not in git. After deploy, trigger one unsupported request on a cloud instance and confirm the link renders and resolves. The code is null-safe either way: an unset variable omits the link rather than emitting a broken one.