### PR TITLE
fix(chat): stop Telegram and Slack working indicators stranding at turn end

### DIFF
--- a/src/shared/lib/chat-integrations/base-connector.ts
+++ b/src/shared/lib/chat-integrations/base-connector.ts
@@ -171,8 +171,14 @@ export abstract class ChatClientConnector {
    * Stop the working indicator as the response takes over. Idempotent — safe to
    * call repeatedly. Default no-op for connectors whose indicator is ephemeral
    * and self-expires.
+   *
+   * `yieldingToStream` marks the clear that fires on the first reply token: a
+   * connector whose indicator SHARES the reply surface (Telegram streams the reply
+   * into the same draft the placeholder used) must leave that surface for the
+   * stream rather than tear it down. Connectors with an independent surface (a
+   * Slack reaction, an iMessage typing bubble) ignore the flag and always clear.
    */
-  async stopWorking(_chatId: string): Promise<void> {}
+  async stopWorking(_chatId: string, _opts?: { yieldingToStream?: boolean }): Promise<void> {}
 
   /**
    * Send a file to the chat. Returns the external message ID.

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -1752,11 +1752,16 @@ export function reconcileIndicator(managed: ManagedConnector, activity: SessionA
  * so repeated clears (idle ticks, several clear events in a row) make ZERO connector
  * calls. Clearing is always EXPLICIT — stopping the tick never clears a persistent
  * draft, so the four immediate clears and the non-busy tick all route through here.
+ *
+ * `yieldingToStream` is set only by the first-reply-token clear: the streamed reply
+ * takes over the reply surface, so a connector whose indicator shares that surface
+ * (Telegram's draft) must not tear it down. Every other clear (card, idle, error,
+ * the tick, teardown) tears the surface down authoritatively.
  */
-export function clearIndicator(managed: ManagedConnector): void {
+export function clearIndicator(managed: ManagedConnector, yieldingToStream = false): void {
   if (!managed.indicatorShown) return
   managed.indicatorShown = false
-  managed.connector.stopWorking(managed.chatId).catch(() => {})
+  managed.connector.stopWorking(managed.chatId, { yieldingToStream }).catch(() => {})
 }
 
 /** Pull cadence for the indicator tick. At/under Telegram's draft expiry so drafts stay alive. */
@@ -1880,8 +1885,10 @@ export async function processSSEEvent(
       const text = data.text as string
       if (!text) break
       // First reply token → 'streaming' (non-busy): the streamed text owns the
-      // reply surface, so settle the indicator now. Idempotent; the tick backstops.
-      clearIndicator(managed)
+      // reply surface, so settle the indicator now. Yield the surface — on Telegram
+      // this streamed reply reuses the placeholder's draft, so a hard teardown would
+      // wipe it. Idempotent; the tick backstops.
+      clearIndicator(managed, true)
       managed.streamingState.accumulatedText += text
 
       const now = Date.now()

--- a/src/shared/lib/chat-integrations/finalize-streaming.test.ts
+++ b/src/shared/lib/chat-integrations/finalize-streaming.test.ts
@@ -440,9 +440,15 @@ describe('TelegramConnector.startWorking / stopWorking', () => {
       const second = (sendRichMessageDraft.mock.calls[1][0] as any).draft_id
       expect(second).toBe(first) // stable draft id, so the streaming response replaces it in place
 
+      // stopWorking is authoritative: with no stream to overwrite the placeholder it
+      // tears it down with a single blank draft on the SAME id (cleared in place). Still
+      // no self-heartbeat — advancing time re-sends nothing.
       await connector.stopWorking('999')
+      expect(sendRichMessageDraft).toHaveBeenCalledTimes(3) // one teardown send
+      expect((sendRichMessageDraft.mock.calls[2][0] as any).draft_id).toBe(first)
+      expect((sendRichMessageDraft.mock.calls[2][0] as any).rich_message).toEqual({ html: '' })
       await vi.advanceTimersByTimeAsync(5000)
-      expect(sendRichMessageDraft).toHaveBeenCalledTimes(2) // stop yields the draft; no further sends
+      expect(sendRichMessageDraft).toHaveBeenCalledTimes(3) // no self-heartbeat after teardown
     } finally {
       vi.useRealTimers()
     }

--- a/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
+++ b/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
@@ -116,6 +116,24 @@ describe('reconcileIndicator (idempotent paint/clear)', () => {
     clearIndicator(managed)
     expect(connector.stoppedWorking).toEqual([])
   })
+
+  // Both immediate clears route through stopWorking, but only the first-reply-token
+  // clear yields the shared surface (Telegram's draft becomes the streamed reply);
+  // terminal clears must tear the surface down authoritatively.
+  it('first-token clear yields the surface; terminal clears tear it down', async () => {
+    const connector = new MockChatClientConnector()
+    const managed = makeManaged(connector, 'chat-w')
+    const stop = vi.spyOn(connector, 'stopWorking')
+
+    managed.indicatorShown = true
+    await processSSEEvent(managed, { type: 'stream_delta', text: 'answer' })
+    expect(stop).toHaveBeenCalledWith('chat-w', { yieldingToStream: true })
+
+    stop.mockClear()
+    managed.indicatorShown = true
+    await processSSEEvent(managed, { type: 'session_idle' })
+    expect(stop).toHaveBeenCalledWith('chat-w', { yieldingToStream: false })
+  })
 })
 
 // ── The per-session tick (pull) ────────────────────────────────────────────────
@@ -496,6 +514,23 @@ describe('Telegram: stopWorking tears down a stranded "Working…" draft', () =>
     const { connector, sendRichMessageDraft } = makeRealDmConnector()
     await connector.startWorking(DM_CHAT, 'working')
     await connector.stopWorking(DM_CHAT)
+    sendRichMessageDraft.mockClear()
+    await connector.stopWorking(DM_CHAT)
+    expect(sendRichMessageDraft).not.toHaveBeenCalled()
+  })
+
+  it('a failed teardown send is swallowed and not retried', async () => {
+    const { connector, sendRichMessageDraft } = makeRealDmConnector()
+    await connector.startWorking(DM_CHAT, 'working')
+    sendRichMessageDraft.mockClear()
+    sendRichMessageDraft.mockRejectedValueOnce(new Error('telegram unreachable'))
+
+    // The blank-draft send fails: non-critical (the draft self-expires), so the
+    // failure is swallowed rather than surfaced to the clear path.
+    await expect(connector.stopWorking(DM_CHAT)).resolves.toBeUndefined()
+    expect(sendRichMessageDraft).toHaveBeenCalledTimes(1)
+
+    // Tracking was dropped before the attempt, so a later stop does not retry.
     sendRichMessageDraft.mockClear()
     await connector.stopWorking(DM_CHAT)
     expect(sendRichMessageDraft).not.toHaveBeenCalled()

--- a/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
+++ b/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
@@ -467,3 +467,49 @@ describe('Telegram: the native draft is labeled by activity', () => {
     await connector.stopWorking(DM_CHAT)
   })
 })
+
+// ── Root C: authoritative surface teardown ─────────────────────────────────────
+// The manager settles the indicator correctly, but the connector's VISIBLE surface can
+// outlive that settle: a Telegram "Working…" draft on a no-stream terminal turn (an
+// errored / card-only / file-only turn) lingers until the ~30s draft expiry because
+// stopWorking was a no-op. stopWorking must be authoritative at the surface — while
+// still YIELDING the shared draft to a streamed reply, which reuses the same draft_id
+// and would be wiped by a blank.
+
+describe('Telegram: stopWorking tears down a stranded "Working…" draft', () => {
+  it('replaces the stale draft in place on a no-stream terminal turn (not a ~30s leak)', async () => {
+    const { connector, sendRichMessageDraft } = makeRealDmConnector()
+    await connector.startWorking(DM_CHAT, 'working')
+    const workingDraftId = sendRichMessageDraft.mock.calls[0][0].draft_id
+    sendRichMessageDraft.mockClear()
+
+    // No streamed reply overwrote the draft, so stop must clear it in place rather
+    // than wait out Telegram's ephemeral-draft expiry.
+    await connector.stopWorking(DM_CHAT)
+
+    expect(sendRichMessageDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ draft_id: workingDraftId, rich_message: { html: '' } }),
+    )
+  })
+
+  it('is idempotent: a second stop makes no further draft call (no blank-draft spam)', async () => {
+    const { connector, sendRichMessageDraft } = makeRealDmConnector()
+    await connector.startWorking(DM_CHAT, 'working')
+    await connector.stopWorking(DM_CHAT)
+    sendRichMessageDraft.mockClear()
+    await connector.stopWorking(DM_CHAT)
+    expect(sendRichMessageDraft).not.toHaveBeenCalled()
+  })
+
+  it('yields the draft to an incoming stream: does NOT blank it (the reply reuses the draft_id)', async () => {
+    const { connector, sendRichMessageDraft } = makeRealDmConnector()
+    await connector.startWorking(DM_CHAT, 'working')
+    sendRichMessageDraft.mockClear()
+
+    // The first reply token settles the indicator, but the streamed reply reuses this
+    // draft — blanking here would wipe/renumber the live reply, so stop is a no-op.
+    await connector.stopWorking(DM_CHAT, { yieldingToStream: true })
+
+    expect(sendRichMessageDraft).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/lib/chat-integrations/slack-connector.reactions.test.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.reactions.test.ts
@@ -59,6 +59,30 @@ describe('SlackConnector thinking-reaction teardown', () => {
     )
   })
 
+  it('a sweep over two tracked reactions drops only the confirmed-gone one and retries the other', async () => {
+    const { connector, remove } = makeConnector()
+    // A second message landed mid-turn, so TWO reactions are tracked. The sweep
+    // visits them in insertion order: the first removes cleanly, the second
+    // fails transiently and must stay tracked.
+    remove
+      .mockResolvedValueOnce({ ok: true }) // '100.1' → settled, untracked
+      .mockRejectedValueOnce({ data: { error: 'ratelimited' } }) // '200.2' → kept
+    seedUserMessage(connector, 'C1', '100.1')
+    await connector.startWorking('C1', 'working')
+    seedUserMessage(connector, 'C1', '200.2')
+    await connector.startWorking('C1', 'working')
+
+    await connector.stopWorking('C1') // sweep attempts both
+    expect(remove).toHaveBeenCalledTimes(2)
+    expect(remove).toHaveBeenCalledWith(expect.objectContaining({ timestamp: '100.1' }))
+    expect(remove).toHaveBeenCalledWith(expect.objectContaining({ timestamp: '200.2' }))
+
+    remove.mockClear()
+    await connector.stopWorking('C1') // retry sweep: only the kept key
+    expect(remove).toHaveBeenCalledTimes(1)
+    expect(remove).toHaveBeenCalledWith(expect.objectContaining({ timestamp: '200.2' }))
+  })
+
   it('serializes a paint then clear so the reaction ends up removed even if add resolves late', async () => {
     const { connector, add, remove } = makeConnector()
     let releaseAdd!: () => void

--- a/src/shared/lib/chat-integrations/slack-connector.reactions.test.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.reactions.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest'
+import { SlackConnector } from './slack-connector'
+
+// The thinking-reaction surface is a live Slack reaction that never expires, so a
+// teardown that loses track of a reaction strands "Working…" forever. These tests drive
+// the real startWorking/stopWorking against a mock Slack web client.
+
+function makeConnector() {
+  const add = vi.fn(async () => ({ ok: true }))
+  const remove = vi.fn(async () => ({ ok: true }))
+  const connector = new SlackConnector({ botToken: 'xoxb-test', appToken: 'xapp-test' })
+  // app is private and only built on connect(); inject a mock exposing what reactions use.
+  ;(connector as unknown as { app: unknown }).app = { client: { reactions: { add, remove } } }
+  return { connector, add, remove }
+}
+
+function seedUserMessage(connector: SlackConnector, chatId: string, ts: string) {
+  ;(connector as unknown as { lastUserMessageTs: Map<string, string> }).lastUserMessageTs.set(chatId, ts)
+}
+
+describe('SlackConnector thinking-reaction teardown', () => {
+  it('keeps the reaction tracked when reactions.remove fails transiently, so a later clear retries', async () => {
+    const { connector, remove } = makeConnector()
+    remove
+      .mockRejectedValueOnce({ data: { error: 'ratelimited' } }) // first clear: transient failure
+      .mockResolvedValueOnce({ ok: true }) // second clear: succeeds
+    seedUserMessage(connector, 'C1', '100.1')
+
+    await connector.startWorking('C1', 'working') // add + track
+    await connector.stopWorking('C1') // remove fails transiently → key must stay tracked
+    await connector.stopWorking('C1') // retry → remove attempted again
+
+    expect(remove).toHaveBeenCalledTimes(2)
+  })
+
+  it('drops tracking when the reaction is already gone (no endless retry)', async () => {
+    const { connector, remove } = makeConnector()
+    remove.mockRejectedValue({ data: { error: 'no_reaction' } })
+    seedUserMessage(connector, 'C1', '100.1')
+
+    await connector.startWorking('C1', 'working')
+    await connector.stopWorking('C1') // "no_reaction" means gone → untrack
+    await connector.stopWorking('C1') // nothing tracked → no further remove attempt
+
+    expect(remove).toHaveBeenCalledTimes(1)
+  })
+
+  it('tracks the reaction even when reactions.add throws, so teardown can still remove it', async () => {
+    const { connector, add, remove } = makeConnector()
+    // The add lands on Slack but the client sees an error (lost response after commit).
+    add.mockRejectedValueOnce({ data: { error: 'ratelimited' } })
+    seedUserMessage(connector, 'C1', '100.1')
+
+    await connector.startWorking('C1', 'working') // add "fails" client-side but may be live
+    await connector.stopWorking('C1') // must still attempt to remove it
+
+    expect(remove).toHaveBeenCalledWith(
+      expect.objectContaining({ timestamp: '100.1', name: 'thinking_face' }),
+    )
+  })
+
+  it('serializes a paint then clear so the reaction ends up removed even if add resolves late', async () => {
+    const { connector, add, remove } = makeConnector()
+    let releaseAdd!: () => void
+    const addGate = new Promise<void>((r) => { releaseAdd = r })
+    add.mockImplementationOnce(async () => { await addGate; return { ok: true } }) // slow add
+    seedUserMessage(connector, 'C1', '100.1')
+
+    const painting = connector.startWorking('C1', 'working') // enqueues a slow add
+    const clearing = connector.stopWorking('C1') // enqueues the remove behind it
+    releaseAdd()
+    await Promise.all([painting, clearing])
+
+    // The remove must run AFTER the add completes, so the final state is "removed".
+    expect(add).toHaveBeenCalledTimes(1)
+    expect(remove).toHaveBeenCalledTimes(1)
+    const addOrder = add.mock.invocationCallOrder[0]
+    const removeOrder = remove.mock.invocationCallOrder[0]
+    expect(removeOrder).toBeGreaterThan(addOrder)
+  })
+})

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -307,6 +307,45 @@ export function reactionsForChat(activeReactions: Set<string>, chatId: string): 
     .map((k) => ({ key: k, ts: k.slice(prefix.length) }))
 }
 
+// Slack error codes meaning the reaction (or its message/channel) is already gone,
+// so there is nothing left to remove — safe to stop tracking it.
+const REACTION_GONE_CODES = new Set(['no_reaction', 'message_not_found', 'channel_not_found'])
+
+/**
+ * After attempting reactions.remove, decide whether the thinking reaction is settled
+ * (gone) and can be untracked, or whether the removal failed transiently and the key
+ * must stay tracked for a later retry. A Slack reaction never expires, so untracking a
+ * still-live reaction strands it forever — default to "not settled" on any unknown error.
+ */
+export function reactionRemovalSettled(err: unknown): boolean {
+  if (err == null) return true // removed successfully
+  const code = (err as { data?: { error?: string } })?.data?.error
+  return code !== undefined && REACTION_GONE_CODES.has(code)
+}
+
+/**
+ * Serialize async operations per key: each op chains off the prior op on the same key,
+ * so fire-and-forget calls that would otherwise race at the network (e.g. a reaction add
+ * from one indicator tick and a remove from the next) apply in call order. Mirrors the
+ * per-chat promise-tail idiom used for the message queue in ChatIntegrationManager.
+ */
+export function createPerKeySerializer(): <T>(key: string, op: () => Promise<T>) => Promise<T> {
+  const tails = new Map<string, Promise<unknown>>()
+  return function run<T>(key: string, op: () => Promise<T>): Promise<T> {
+    const prev = tails.get(key) ?? Promise.resolve()
+    // Run op regardless of whether the prior op resolved or rejected, so one failed op
+    // doesn't stall the rest of the queue.
+    const result = prev.then(op, op)
+    const tail = result.catch(() => {}) // swallow so the chain itself never rejects
+    tails.set(key, tail)
+    // Evict once settled, but only if a newer op hasn't already replaced this tail.
+    void tail.finally(() => {
+      if (tails.get(key) === tail) tails.delete(key)
+    })
+    return result
+  }
+}
+
 // ── Connector ───────────────────────────────────────────────────────────
 
 export class SlackConnector extends ChatClientConnector {
@@ -359,6 +398,10 @@ export class SlackConnector extends ChatClientConnector {
 
   // Track whether we have a thinking reaction active
   private activeReactions: Set<string> = new Set() // effectiveChatId:ts
+
+  // Serialize reaction add/remove per chat so a paint (add) from one indicator tick and
+  // a clear (remove) from the next don't race at the network and re-strand the reaction.
+  private runReaction = createPerKeySerializer()
 
   // Thread context: maps effective chatId → real channel + thread anchor ts (for answerInThread)
   private threadContextMap: Map<string, { channel: string; threadTs: string }> = new Map()
@@ -812,16 +855,23 @@ export class SlackConnector extends ChatClientConnector {
     if (this.activeReactions.has(key)) return // Already reacting
 
     const { channel } = this.resolveChannel(chatId)
-    try {
-      await this.app.client.reactions.add({
-        channel,
-        timestamp: lastTs,
-        name: 'thinking_face',
-      })
-      this.activeReactions.add(key)
-    } catch {
-      // Already reacted or message deleted — non-critical
-    }
+    // Track BEFORE the network call: an add that lands on Slack but whose response is
+    // lost (timeout after commit) would otherwise leave a live reaction that no teardown
+    // sweep knows about, so it never clears. Tracking first means the sweep always sees
+    // it; a spurious remove of one that never landed is a harmless no-op.
+    this.activeReactions.add(key)
+    await this.runReaction(chatId, async () => {
+      try {
+        await this.app?.client.reactions.add({
+          channel,
+          timestamp: lastTs,
+          name: 'thinking_face',
+        })
+      } catch {
+        // Already reacted or message deleted — non-critical. The key stays tracked so the
+        // teardown sweep will attempt (and harmlessly no-op) a remove.
+      }
+    })
   }
 
   async stopWorking(chatId: string): Promise<void> {
@@ -1088,22 +1138,30 @@ export class SlackConnector extends ChatClientConnector {
     if (entries.length === 0) return
 
     const { channel } = this.resolveChannel(chatId)
-    for (const { key, ts } of entries) {
-      await this.removeThinkingReaction(channel, ts)
-      this.activeReactions.delete(key)
-    }
+    await this.runReaction(chatId, async () => {
+      for (const { key, ts } of entries) {
+        const settled = await this.removeThinkingReaction(channel, ts)
+        // Only stop tracking once the reaction is confirmed gone. A transient failure
+        // keeps the key so the next clear retries — a Slack reaction never self-expires,
+        // so dropping tracking on a failed remove would strand it forever.
+        if (settled) this.activeReactions.delete(key)
+      }
+    })
   }
 
-  private async removeThinkingReaction(channel: string, ts: string): Promise<void> {
-    if (!this.app) return
+  // Returns whether the reaction is settled (gone) and can be untracked; false on a
+  // transient failure that leaves it possibly-live, so the caller keeps it for retry.
+  private async removeThinkingReaction(channel: string, ts: string): Promise<boolean> {
+    if (!this.app) return false
     try {
       await this.app.client.reactions.remove({
         channel,
         timestamp: ts,
         name: 'thinking_face',
       })
-    } catch {
-      // Reaction already removed or message deleted — non-critical
+      return true
+    } catch (err) {
+      return reactionRemovalSettled(err)
     }
   }
 

--- a/src/shared/lib/chat-integrations/slack-reactions.test.ts
+++ b/src/shared/lib/chat-integrations/slack-reactions.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { reactionRemovalSettled, createPerKeySerializer } from './slack-connector'
+
+// ── reactionRemovalSettled ──────────────────────────────────────────────
+// Decides whether we can stop tracking a thinking reaction after attempting to
+// remove it. "Settled" (true) = the reaction is gone (removed, or never there),
+// so drop the tracking key. Not settled (false) = a transient failure left the
+// reaction live on Slack, so KEEP the key and retry on the next sweep. A Slack
+// reaction never expires, so dropping tracking on a failed remove strands it forever.
+
+describe('reactionRemovalSettled', () => {
+  it('treats a successful removal as settled (drop the key)', () => {
+    expect(reactionRemovalSettled(undefined)).toBe(true)
+    expect(reactionRemovalSettled(null)).toBe(true)
+  })
+
+  it('treats "reaction/message/channel already gone" as settled — nothing left to retry', () => {
+    expect(reactionRemovalSettled({ data: { error: 'no_reaction' } })).toBe(true)
+    expect(reactionRemovalSettled({ data: { error: 'message_not_found' } })).toBe(true)
+    expect(reactionRemovalSettled({ data: { error: 'channel_not_found' } })).toBe(true)
+  })
+
+  it('treats transient failures as NOT settled — keep the key and retry', () => {
+    expect(reactionRemovalSettled({ data: { error: 'ratelimited' } })).toBe(false)
+    expect(reactionRemovalSettled({ data: { error: 'internal_error' } })).toBe(false)
+    // A plain network error has no Slack error code — assume the reaction may still be live.
+    expect(reactionRemovalSettled(new Error('socket hang up'))).toBe(false)
+  })
+})
+
+// ── createPerKeySerializer ──────────────────────────────────────────────
+// Serializes async ops per key so fire-and-forget calls (reaction add from one
+// tick, remove from the next) apply in call order instead of racing at the network.
+
+describe('createPerKeySerializer', () => {
+  it('runs same-key ops in call order even when the first settles later', async () => {
+    const run = createPerKeySerializer()
+    const order: string[] = []
+    let releaseA!: () => void
+    const gateA = new Promise<void>((r) => { releaseA = r })
+
+    const p1 = run('k', async () => { await gateA; order.push('A') }) // slow op enqueued first
+    const p2 = run('k', async () => { order.push('B') })              // must wait behind A
+    releaseA()
+    await Promise.all([p1, p2])
+
+    expect(order).toEqual(['A', 'B'])
+  })
+
+  it('does not serialize across different keys', async () => {
+    const run = createPerKeySerializer()
+    const order: string[] = []
+    let releaseA!: () => void
+    const gateA = new Promise<void>((r) => { releaseA = r })
+
+    const p1 = run('k1', async () => { await gateA; order.push('A') })
+    const p2 = run('k2', async () => { order.push('B') }) // different key runs immediately
+    await p2
+    expect(order).toEqual(['B'])
+
+    releaseA()
+    await p1
+    expect(order).toEqual(['B', 'A'])
+  })
+
+  it('a rejected op does not stall the next op on the same key', async () => {
+    const run = createPerKeySerializer()
+    const order: string[] = []
+
+    const p1 = run('k', async () => { order.push('A'); throw new Error('boom') })
+    const p2 = run('k', async () => { order.push('B') })
+
+    await expect(p1).rejects.toThrow('boom')
+    await p2
+    expect(order).toEqual(['A', 'B'])
+  })
+})

--- a/src/shared/lib/chat-integrations/slack-reactions.test.ts
+++ b/src/shared/lib/chat-integrations/slack-reactions.test.ts
@@ -74,4 +74,11 @@ describe('createPerKeySerializer', () => {
     await p2
     expect(order).toEqual(['A', 'B'])
   })
+
+  it('run resolves with the operation value even after a prior rejection on the same key', async () => {
+    const run = createPerKeySerializer()
+
+    await expect(run('k', async () => { throw new Error('x') })).rejects.toThrow()
+    await expect(run('k', async () => 42)).resolves.toBe(42)
+  })
 })

--- a/src/shared/lib/chat-integrations/telegram-connector.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.ts
@@ -458,10 +458,28 @@ export class TelegramConnector extends ChatClientConnector {
     await this.sendWorkingIndicator(chatId)
   }
 
-  async stopWorking(chatId: string): Promise<void> {
+  async stopWorking(chatId: string, opts?: { yieldingToStream?: boolean }): Promise<void> {
     this.workingActivity.delete(chatId)
-    // The streaming response shares the draft_id and replaces the draft in place,
-    // so the clear yields the surface — there is nothing else to tear down.
+    // The streamed reply reuses this chat's draft_id (the "Working…" placeholder
+    // morphs into the reply text), so when we are yielding to that stream there is
+    // nothing to tear down — blanking here would wipe the live reply.
+    if (opts?.yieldingToStream) return
+    // Otherwise the turn ended with no streamed reply to overwrite the draft (an
+    // errored, card-only, or file-only turn). Telegram has no delete-draft API, so
+    // replace the stale placeholder in place with a blank draft (same draft_id →
+    // animated) — else it lingers showing "Working…" until the ~30s draft expiry.
+    const draftId = this.activeDrafts.get(chatId)
+    if (draftId === undefined || !this.bot) return
+    this.activeDrafts.delete(chatId)
+    try {
+      await this.bot.api.raw.sendRichMessageDraft({
+        chat_id: Number(chatId),
+        draft_id: draftId,
+        rich_message: { html: '' },
+      })
+    } catch {
+      // Non-critical: the stale draft self-expires within ~30s if this send fails.
+    }
   }
 
   /** The native-draft label for a busy activity (`<tg-thinking>` inner HTML). */


### PR DESCRIPTION
8 files, +392/-27. First of five splits out of #405, which is being closed in favor of contained PRs.

## What

Two chat surfaces strand a "Working…" indicator permanently at turn end. Both are fixed here; neither touches session state, the container protocol, or the stream layer.

**Telegram draft.** The working-indicator draft was only cleared authoritatively on session removal, so a turn that ended without the session being torn down left "Working…" showing until the ~30s draft expiry. `stopWorking` now blanks the un-committed draft in place. A `yieldingToStream` flag on `stopWorking`/`clearIndicator` skips the blank on the first-reply-token clear, since the streamed reply reuses that same draft and a hard teardown would wipe it. Independent surfaces (Slack reaction, iMessage typing) ignore the flag and always clear.

**Slack reaction.** A Slack indicator is a reaction, which never expires, so any teardown that loses track of a live one strands it forever. Three fixes: only untrack a reaction once removal is confirmed gone, so a transient `reactions.remove` failure is retried rather than dropped; track the reaction before the add call, so an add that lands server-side but errors client-side is still swept by teardown; serialize add/remove per chat so a paint from one indicator tick cannot land after the clear from the next and re-add the reaction.

## Why this is its own PR

#405 bundled these with a container wire-protocol change behind an image rebuild. They cherry-picked out of it with zero conflicts, which is the evidence they were never coupled: no shared files with the stream work, no shared failure mode.

## Testing

- `src/shared/lib/chat-integrations/`: 663 passed, 7 skipped
- `tsc --noEmit` clean, eslint 0 errors
- Coverage added: manager-level `yieldingToStream` wiring in both regression directions (the first-token clear must yield the surface to the stream, terminal clears must not - previously invisible to every test); a Slack sweep over two tracked reactions dropping only the confirmed-gone one while retrying the transient failure; the per-key serializer resolving a value after a prior rejection on the same key; a failed Telegram blank-draft teardown being swallowed rather than retried.

Not live-smoked against real Telegram/Slack in this pass - the changes are unit-covered and were CI-green as part of #405, but a reviewer should know the manual pass hasn't been re-run since the split.
