### PR TITLE
fix(chat): clear session state when a turn-start send fails

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -123,6 +123,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
     subscribeToSession: vi.fn(),
     unsubscribeFromSession: vi.fn(),
     markSessionActive: vi.fn(),
+    markSessionInterrupted: vi.fn(),
     cancelAwaitingInput: vi.fn(),
     broadcastSessionEvent: vi.fn(),
   },
@@ -3033,6 +3034,43 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
     const body = await res.json()
     expect(body.queued).toBe(true)
     expect(mockSendMessage).toHaveBeenCalledWith('sess-1', 'hello', expect.any(String), {})
+  })
+})
+
+describe('failed send does not strand the working indicator — POST /:id/sessions/:sessionId/messages', () => {
+  let app: ReturnType<typeof createApp>
+  const URL = '/api/agents/test-agent/sessions/sess-1/messages'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    vi.mocked(getAgent).mockResolvedValue({ slug: 'test-agent', name: 'Test Agent' } as any)
+    mockIsAuthMode.mockReturnValue(false)
+  })
+
+  it('clears the freshly-activated session when the container send throws', async () => {
+    // Fresh turn (not queued): the handler marks the session active, then the send fails.
+    vi.mocked(messagePersister.isSessionActive).mockReturnValueOnce(false)
+    mockSendMessage.mockRejectedValueOnce(new Error('container unreachable'))
+
+    const res = await postJson(app, URL, { content: 'hello' })
+
+    expect(res.status).toBe(500)
+    // No turn will run to emit the settling idle, so the working indicator (and the
+    // desktop sidebar) would stay stuck forever unless we clear the session here.
+    expect(messagePersister.markSessionInterrupted).toHaveBeenCalledWith('sess-1')
+  })
+
+  it('does NOT clear the session when a queued send throws (an in-flight turn is still running)', async () => {
+    // wasQueued: the session was already active, so a real turn is mid-flight.
+    vi.mocked(messagePersister.isSessionActive).mockReturnValueOnce(true)
+    mockSendMessage.mockRejectedValueOnce(new Error('boom'))
+
+    const res = await postJson(app, URL, { content: 'hello' })
+
+    expect(res.status).toBe(500)
+    // The original turn will still emit its own idle — clearing here would wrongly settle it.
+    expect(messagePersister.markSessionInterrupted).not.toHaveBeenCalled()
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1861,6 +1861,10 @@ agents.get('/:id/sessions/:sessionId/usage', AgentRead(), async (c) => {
 
 // POST /api/agents/:id/sessions/:sessionId/messages - Send a message
 agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
+  // Set once we mark a fresh turn active. Hoisted so the catch can settle it: if the
+  // send (or the pre-send DB/broadcast work) throws, no turn runs to emit the idle that
+  // would clear the "Working…" indicator, so we must clear it ourselves.
+  let freshTurnSessionId: string | null = null
   try {
     const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
@@ -1904,6 +1908,9 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
     const wasQueued = messagePersister.isSessionActive(sessionId)
 
     messagePersister.markSessionActive(sessionId, agentSlug)
+    // Only a fresh turn: a queued send rides an already-active turn, whose own idle
+    // settles the indicator — clearing it on our send failure would wrongly cut it short.
+    if (!wasQueued) freshTurnSessionId = sessionId
 
     // A mid-turn send must not carry model/effort/speed: the container treats a
     // parameter change as interrupt/restart of the in-flight query. The
@@ -1958,6 +1965,12 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
     return c.json({ success: true, uuid: messageUuid, queued: wasQueued }, 201)
   } catch (error) {
     console.error('Failed to send message:', error)
+    // A fresh turn we marked active never dispatched — clear it so the indicator
+    // doesn't hang (markSessionInterrupted only touches host state; nothing is
+    // running in the container to interrupt).
+    if (freshTurnSessionId) {
+      await messagePersister.markSessionInterrupted(freshTurnSessionId)
+    }
     return c.json({ error: 'Failed to send message' }, 500)
   }
 })

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -104,6 +104,7 @@ vi.mock('@shared/lib/container/container-manager', () => ({
 const mockIsSessionActive = vi.fn((_sessionId?: string): boolean => false)
 const mockIsSessionAwaitingInput = vi.fn((_sessionId?: string): boolean => false)
 const mockWaitForIdle = vi.fn(async (..._args: unknown[]) => {})
+const mockMarkSessionInterrupted = vi.fn(async (..._args: unknown[]) => {})
 vi.mock('@shared/lib/container/message-persister', () => ({
   messagePersister: {
     isSessionActive: (sessionId?: string) => mockIsSessionActive(sessionId),
@@ -113,6 +114,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
     subscribeToSession: vi.fn(),
     unsubscribeFromSession: vi.fn(),
     markSessionActive: vi.fn(),
+    markSessionInterrupted: (...args: unknown[]) => mockMarkSessionInterrupted(...args),
     setSlashCommands: vi.fn(),
   },
 }))
@@ -438,6 +440,24 @@ describe('/invoke', () => {
     mockGetAgent.mockResolvedValue(null)
     const res = await authedFetch('/x-agent/invoke', { slug: 'ghost', prompt: 'hi' })
     expect(res.status).toBe(404)
+  })
+
+  it('clears an existing session when the container send throws (no turn to emit the settling idle)', async () => {
+    reviewDecisions.push('allow')
+    // Existing-session invoke: isSessionActive=false (default) passes the 409 guard, so
+    // the handler marks the session active and dispatches. Make the container send fail.
+    mockSendMessage.mockRejectedValueOnce(new Error('container unreachable'))
+
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'hi',
+      sessionId: 'existing-sess-1',
+    })
+
+    // The send never reached the container, so nothing will emit the idle that settles
+    // the target's "Working…" (desktop sidebar + any mapped chat). Clear it, then fail.
+    expect(mockMarkSessionInterrupted).toHaveBeenCalledWith('existing-sess-1')
+    expect(res.status).toBe(500)
   })
 
   it('blocks invoke when policy is block', async () => {

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -537,7 +537,15 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         }
         messagePersister.markSessionActive(existingSessionId, targetSlug)
         stage = 'send_message'
-        await client.sendMessage(existingSessionId, prompt)
+        try {
+          await client.sendMessage(existingSessionId, prompt)
+        } catch (error) {
+          // The send never reached the container, so no turn will run to emit the idle that
+          // settles the indicator. The 409 guard above guarantees we started this turn fresh,
+          // so clear the active state we just set (host-only — nothing is running to interrupt).
+          await messagePersister.markSessionInterrupted(existingSessionId)
+          throw error
+        }
 
         if (sync) {
           try {


### PR DESCRIPTION
4 files, +80/-1. Second of five splits out of #405.

## What

`markSessionActive` ran before a throwable container send on the app send route and the x-agent invoke route, with no cleanup on failure. Since #339 removed every time-based backstop, a failed send left `isActive` stuck true - a permanent "Working…" on the chat indicator and the desktop sidebar, with nothing running that could ever clear it.

Both routes now clear via `markSessionInterrupted` when the send throws. Host-only: nothing is running in the container to interrupt. The app route guards on `wasQueued` so it never settles an in-flight turn.

## Why this is its own PR

Smallest independent slice of #405 and the only one confined to the API routes. It shares no file with the other four splits and cherry-picked out with zero conflicts.

## Testing

- `src/api/routes/agents.test.ts` + `x-agent.test.ts`: 276 passed
- `tsc --noEmit` clean, eslint 0 errors
- Both routes covered for the throw path: send fails, session settles rather than pinning.

Not live-smoked since the split; unit-covered and was CI-green as part of #405.
