### PR TITLE
Shadow registry for pending user-input requests (Phase 2)

### DIFF
--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2679,7 +2679,7 @@ agents.post('/:id/sessions/:sessionId/capability-review', AgentUser(), async (c)
         return c.json({ error: 'Failed to reject capability launch' }, 500)
       }
 
-      messagePersister.completeCapabilityReview(sessionId, toolUseId)
+      messagePersister.completeCapabilityReview(sessionId, toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'capability_review', capability, withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }
@@ -2710,7 +2710,7 @@ agents.post('/:id/sessions/:sessionId/capability-review', AgentUser(), async (c)
     if (scope === 'session') {
       messagePersister.grantSessionCapability(sessionId, capability)
     }
-    messagePersister.completeCapabilityReview(sessionId, toolUseId)
+    messagePersister.completeCapabilityReview(sessionId, toolUseId, 'answered')
 
     trackServerEvent('capability_launch_approved', { capability, scope })
     return c.json({ success: true })
@@ -2976,7 +2976,7 @@ agents.post('/:id/sessions/:sessionId/computer-use', AgentUser(), async (c) => {
         return c.json({ error: 'Failed to reject computer use request' }, 500)
       }
 
-      messagePersister.clearPendingComputerUseRequest(sessionId, toolUseId)
+      messagePersister.clearPendingComputerUseRequest(sessionId, toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'computer_use', method, withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }
@@ -2999,7 +2999,7 @@ agents.post('/:id/sessions/:sessionId/computer-use', AgentUser(), async (c) => {
       if (!resolveResponse.ok) {
         return c.json({ error: 'Failed to resolve computer use request' }, 500)
       }
-      messagePersister.clearPendingComputerUseRequest(sessionId, toolUseId)
+      messagePersister.clearPendingComputerUseRequest(sessionId, toolUseId, 'answered')
       return c.json({ success: true })
     }
 
@@ -3032,7 +3032,9 @@ agents.post('/:id/sessions/:sessionId/computer-use', AgentUser(), async (c) => {
           body: JSON.stringify({ reason: `Error executing ${method}: ${errorMsg}` }),
         }
       ).catch(() => {})
-      messagePersister.clearPendingComputerUseRequest(sessionId, toolUseId)
+      // The user approved but execution blew up — the wait was consumed by a
+      // system failure, not a user decision.
+      messagePersister.clearPendingComputerUseRequest(sessionId, toolUseId, 'invalidated')
       return c.json({ success: true, error: errorMsg })
     }
 
@@ -3085,7 +3087,7 @@ agents.post('/:id/sessions/:sessionId/computer-use', AgentUser(), async (c) => {
       return c.json({ error: 'Failed to resolve computer use request' }, 500)
     }
 
-    messagePersister.clearPendingComputerUseRequest(sessionId, toolUseId)
+    messagePersister.clearPendingComputerUseRequest(sessionId, toolUseId, 'answered')
     trackServerEvent('computer_use_executed', { method, permissionLevel, grantType })
     return c.json({ success: true })
   } catch (error) {

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -1072,6 +1072,46 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(userInputRequestManager.stats.shelfMismatches).toBe(0)
     })
 
+    it('the direct-clear doors record the caller\'s actual outcome, not a blanket answered', async () => {
+      // Capability review declined via the decision route's door.
+      mockAgentCapabilities.subagents = 'allow'
+      mockAgentCapabilities.workflows = 'review'
+      vi.mocked(mockClient.fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({ grants: [] }),
+      } as unknown as Response)
+      simulateToolUse('Workflow', 'shadow-out-1', { script: 'export const meta = {}' })
+      await vi.waitFor(() => {
+        expect(
+          userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id)
+        ).toContain('shadow-out-1')
+      })
+      messagePersister.completeCapabilityReview(SESSION_ID, 'shadow-out-1', 'declined')
+      expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+        id: 'shadow-out-1',
+        kind: 'capability_review',
+        outcome: 'declined',
+      })
+
+      // Computer use denied, then a second one consumed by an execution failure.
+      simulateToolUse('mcp__computer-use__computer_click', 'shadow-out-2', { x: 1, y: 2 })
+      messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'shadow-out-2', 'declined')
+      expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+        id: 'shadow-out-2',
+        kind: 'computer_use',
+        outcome: 'declined',
+      })
+
+      simulateToolUse('mcp__computer-use__computer_click', 'shadow-out-3', { x: 3, y: 4 })
+      messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'shadow-out-3', 'invalidated')
+      expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+        id: 'shadow-out-3',
+        kind: 'computer_use',
+        outcome: 'invalidated',
+      })
+      expect(userInputRequestManager.stats.shelfMismatches).toBe(0)
+    })
+
     it('unsubscribe drops every session-scoped registry entry as invalidated', () => {
       simulateToolUse('mcp__user-input__request_secret', 'shadow-drop-1', {
         secretName: 'API_KEY',

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -397,7 +397,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
         sendToolResult('tool-par-1')
         // KNOWN SPLIT-BRAIN (pinned, not desired): the main-path user-message
-        // handler clears awaiting without consulting the stream shelves — it
+        // handler clears awaiting without consulting the stream stores — it
         // only defers to external review blockers. The second request's
         // replay entry is still parked (the card stack still shows it), but
         // the sidebar/header bit already reads "not waiting". Derived
@@ -414,7 +414,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
   // ==========================================================================
   // Documented divergence: computer-use lives in a separate store with
-  // route-driven clearing (the two-shelf split this suite exists to pin down)
+  // route-driven clearing (the two-store split this suite exists to pin down)
   // ==========================================================================
 
   describe('main stream: computer use (divergent two-store lifecycle)', () => {
@@ -445,10 +445,10 @@ describe('pending user-input request lifecycle (characterization)', () => {
       simulateToolUse(TOOL, 'cu-clear-1', { x: 1, y: 2 })
       expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
-      // KNOWN SPLIT-BRAIN (pinned, not desired): the computer-use shelf is
+      // KNOWN SPLIT-BRAIN (pinned, not desired): the computer-use store is
       // cleared only via the decision route's explicit call, so the entry
       // survives the tool_result — but the main-path user-message handler
-      // still clears the awaiting bit without consulting this shelf. Card
+      // still clears the awaiting bit without consulting this store. Card
       // parked, light off. Derived awaiting state flips the second
       // expectation to `true`.
       sendToolResult('cu-clear-1')
@@ -472,7 +472,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
         expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
         // The route clear applies the shared waiting-light rule: with both
-        // shelves empty and no external blocker, the bit flips AND the wire
+        // stores empty and no external blocker, the bit flips AND the wire
         // says input was provided — together, atomically. (Before the unified
         // dispatch change it broadcast without flipping the bit, leaving the
         // wire and the bit disagreeing until the tool_result landed.)
@@ -495,7 +495,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
       // Clearing the computer-use entry must NOT flip awaiting: the secret
-      // is still parked on the other shelf.
+      // is still parked on the other store.
       messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'cu-clear-3')
       expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
       expect(messagePersister.getPendingComputerUseRequests(SESSION_ID)).toHaveLength(0)
@@ -545,7 +545,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
       expect(sseEvents.filter((e) => e.type === 'capability_review_resolved')).toHaveLength(1)
       // KNOWN SPLIT-BRAIN (pinned, not desired): like the computer-use route
-      // clear, this door empties its shelf and broadcasts but leaves the
+      // clear, this door empties its store and broadcasts but leaves the
       // awaiting bit set — it stays true until later stream traffic (the
       // launched tool's own lifecycle) clears it.
       expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
@@ -553,12 +553,12 @@ describe('pending user-input request lifecycle (characterization)', () => {
   })
 
   // ==========================================================================
-  // Cross-shelf awaiting arithmetic: input store + computer-use store +
+  // Cross-store awaiting arithmetic: input store + computer-use store +
   // external blocker source (the ReviewManager seam). Awaiting must survive
   // until the LAST wait across all three resolves.
   // ==========================================================================
 
-  describe('cross-shelf awaiting arithmetic', () => {
+  describe('cross-store awaiting arithmetic', () => {
     it('a held external blocker keeps awaiting alive through tool_results; the agent door releases it', () => {
       let blockerHeld = true
       const unregister = messagePersister.registerAwaitingBlockerSource(
@@ -585,7 +585,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
         expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
         // Once the blocker releases, the agent-level door clears it: both
-        // stream shelves are empty by now.
+        // stream stores are empty by now.
         blockerHeld = false
         messagePersister.clearAwaitingInputForAgentIfUnblocked(AGENT_SLUG)
         expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
@@ -594,7 +594,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       }
     })
 
-    it('the agent-level door checks stream shelves only — external blockers are the CALLER\'s contract', () => {
+    it('the agent-level door checks stream stores only — external blockers are the CALLER\'s contract', () => {
       let blockerHeld = true
       const unregister = messagePersister.registerAwaitingBlockerSource(
         (agentSlug) => agentSlug === AGENT_SLUG && blockerHeld
@@ -830,7 +830,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
     })
 
-    it('the sidechain resolve applies the both-shelves rule: a parked computer-use keeps awaiting on', () => {
+    it('the sidechain resolve applies the both-stores rule: a parked computer-use keeps awaiting on', () => {
       sendSidechainToolUse(
         'AskUserQuestion',
         'side-q-1',
@@ -917,10 +917,10 @@ describe('pending user-input request lifecycle (characterization)', () => {
   })
 
   // ==========================================================================
-  // Phase 2 shadow registry: every shelf mutation writes through to the
-  // UserInputRequestManager, whose per-shelf view must mirror the legacy
-  // shelves exactly (the persister asserts this inline at every mutation —
-  // shelfMismatches must stay 0). Its DERIVED awaiting projection is compared
+  // Phase 2 shadow registry: every store mutation writes through to the
+  // UserInputRequestManager, whose per-store view must mirror the legacy
+  // stores exactly (the persister asserts this inline at every mutation —
+  // storeMismatches must stay 0). Its DERIVED awaiting projection is compared
   // against the imperative bit: where the pinned split-brains make the bit
   // wrong, the projection is right, and the divergence counter is the
   // telemetry that sizes the Phase 3 flip.
@@ -950,7 +950,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       consoleWarnSpy.mockRestore()
     })
 
-    it('every standard kind registers a typed entry mirroring the replay shelf, and settles with it', async () => {
+    it('every standard kind registers a typed entry mirroring the replay store, and settles with it', async () => {
       for (const kindCase of STANDARD_KINDS) {
         const toolId = `shadow-${kindCase.sseType}`
         simulateToolUse(kindCase.toolName, toolId, kindCase.input)
@@ -966,9 +966,9 @@ describe('pending user-input request lifecycle (characterization)', () => {
         expect(entry.kind, kindCase.label).toBe(KIND_BY_SSE_TYPE[kindCase.sseType])
         expect(entry.scope).toEqual({ agentSlug: AGENT_SLUG, sessionId: SESSION_ID })
 
-        // Exact mirror of the legacy replay shelf.
+        // Exact mirror of the legacy replay store.
         expect(
-          [...userInputRequestManager.getShelfIdsForSession(SESSION_ID, 'stream')].sort()
+          [...userInputRequestManager.getStoreIdsForSession(SESSION_ID, 'stream')].sort()
         ).toEqual(
           messagePersister
             .getPendingInputRequests(SESSION_ID)
@@ -986,31 +986,31 @@ describe('pending user-input request lifecycle (characterization)', () => {
           outcome: 'answered',
         })
       }
-      expect(userInputRequestManager.stats.shelfMismatches).toBe(0)
+      expect(userInputRequestManager.stats.storeMismatches).toBe(0)
     })
 
-    it('a stray main-path tool_result cannot evict the registry\'s computer-use entry (shelf-scoped resolve)', () => {
+    it('a stray main-path tool_result cannot evict the registry\'s computer-use entry (store-scoped resolve)', () => {
       simulateToolUse('mcp__computer-use__computer_click', 'shadow-cu-1', { x: 1, y: 2 })
-      expect(userInputRequestManager.getShelfIdsForSession(SESSION_ID, 'computer_use')).toEqual([
+      expect(userInputRequestManager.getStoreIdsForSession(SESSION_ID, 'computer_use')).toEqual([
         'shadow-cu-1',
       ])
 
-      // Pinned divergence: the tool_result leaves the computer-use shelf
-      // untouched. The registry mirrors the SHELF, not the tool_result — if it
+      // Pinned divergence: the tool_result leaves the computer-use store
+      // untouched. The registry mirrors the STORE, not the tool_result — if it
       // settled here, the inline parity assert would blow up this test.
       sendToolResult('shadow-cu-1')
-      expect(userInputRequestManager.getShelfIdsForSession(SESSION_ID, 'computer_use')).toEqual([
+      expect(userInputRequestManager.getStoreIdsForSession(SESSION_ID, 'computer_use')).toEqual([
         'shadow-cu-1',
       ])
 
       messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'shadow-cu-1')
-      expect(userInputRequestManager.getShelfIdsForSession(SESSION_ID, 'computer_use')).toEqual([])
+      expect(userInputRequestManager.getStoreIdsForSession(SESSION_ID, 'computer_use')).toEqual([])
       expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
         id: 'shadow-cu-1',
         kind: 'computer_use',
         outcome: 'answered',
       })
-      expect(userInputRequestManager.stats.shelfMismatches).toBe(0)
+      expect(userInputRequestManager.stats.storeMismatches).toBe(0)
     })
 
     it('parallel requests: the projection stays awaiting while the bit drops early (split-brain telemetry)', async () => {
@@ -1039,7 +1039,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
       sendToolResult('shadow-par-2')
       expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(false)
-      expect(userInputRequestManager.stats.shelfMismatches).toBe(0)
+      expect(userInputRequestManager.stats.storeMismatches).toBe(0)
     })
 
     it('capability review: the registry settles on complete; the stuck bit is divergence telemetry', async () => {
@@ -1063,13 +1063,13 @@ describe('pending user-input request lifecycle (characterization)', () => {
       messagePersister.completeCapabilityReview(SESSION_ID, 'shadow-cap-1')
       expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
       expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(false)
-      // Pinned: the early-clear door empties its shelf but never flips the
+      // Pinned: the early-clear door empties its store but never flips the
       // bit. Projection right, bit wrong — counted, not thrown.
       expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
       await vi.waitFor(() => {
         expect(userInputRequestManager.stats.awaitingDivergences).toBeGreaterThan(0)
       })
-      expect(userInputRequestManager.stats.shelfMismatches).toBe(0)
+      expect(userInputRequestManager.stats.storeMismatches).toBe(0)
     })
 
     it('the direct-clear doors record the caller\'s actual outcome, not a blanket answered', async () => {
@@ -1109,7 +1109,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
         kind: 'computer_use',
         outcome: 'invalidated',
       })
-      expect(userInputRequestManager.stats.shelfMismatches).toBe(0)
+      expect(userInputRequestManager.stats.storeMismatches).toBe(0)
     })
 
     it('unsubscribe drops every session-scoped registry entry as invalidated', () => {

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -152,6 +152,7 @@ vi.mock('./container-manager', () => ({
 // Import after mocks are set up
 import { messagePersister } from './message-persister'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 
 function createMockClient(): ContainerClient & {
   _messageCallback: ((message: StreamMessage) => void) | null
@@ -912,6 +913,178 @@ describe('pending user-input request lifecycle (characterization)', () => {
       } finally {
         unregister()
       }
+    })
+  })
+
+  // ==========================================================================
+  // Phase 2 shadow registry: every shelf mutation writes through to the
+  // UserInputRequestManager, whose per-shelf view must mirror the legacy
+  // shelves exactly (the persister asserts this inline at every mutation —
+  // shelfMismatches must stay 0). Its DERIVED awaiting projection is compared
+  // against the imperative bit: where the pinned split-brains make the bit
+  // wrong, the projection is right, and the divergence counter is the
+  // telemetry that sizes the Phase 3 flip.
+  // ==========================================================================
+
+  describe('shadow registry equivalence (Phase 2)', () => {
+    const KIND_BY_SSE_TYPE: Record<string, string> = {
+      secret_request: 'secret',
+      user_question_request: 'question',
+      connected_account_request: 'connected_account',
+      file_request: 'file',
+      remote_mcp_request: 'remote_mcp',
+      browser_input_request: 'browser_input',
+      script_run_request: 'script_run',
+    }
+
+    let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      userInputRequestManager.reset()
+      // Divergence telemetry warns on purpose in the split-brain tests below —
+      // keep the test output clean.
+      consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('every standard kind registers a typed entry mirroring the replay shelf, and settles with it', async () => {
+      for (const kindCase of STANDARD_KINDS) {
+        const toolId = `shadow-${kindCase.sseType}`
+        simulateToolUse(kindCase.toolName, toolId, kindCase.input)
+
+        await vi.waitFor(() => {
+          expect(
+            userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id)
+          ).toContain(toolId)
+        })
+        const entry = userInputRequestManager
+          .getOpenRequestsForSession(SESSION_ID)
+          .find((r) => r.id === toolId)!
+        expect(entry.kind, kindCase.label).toBe(KIND_BY_SSE_TYPE[kindCase.sseType])
+        expect(entry.scope).toEqual({ agentSlug: AGENT_SLUG, sessionId: SESSION_ID })
+
+        // Exact mirror of the legacy replay shelf.
+        expect(
+          [...userInputRequestManager.getShelfIdsForSession(SESSION_ID, 'stream')].sort()
+        ).toEqual(
+          messagePersister
+            .getPendingInputRequests(SESSION_ID)
+            .map((r) => r.toolUseId)
+            .sort()
+        )
+
+        sendToolResult(toolId)
+        expect(
+          userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id)
+        ).not.toContain(toolId)
+        expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+          id: toolId,
+          kind: KIND_BY_SSE_TYPE[kindCase.sseType],
+          outcome: 'answered',
+        })
+      }
+      expect(userInputRequestManager.stats.shelfMismatches).toBe(0)
+    })
+
+    it('a stray main-path tool_result cannot evict the registry\'s computer-use entry (shelf-scoped resolve)', () => {
+      simulateToolUse('mcp__computer-use__computer_click', 'shadow-cu-1', { x: 1, y: 2 })
+      expect(userInputRequestManager.getShelfIdsForSession(SESSION_ID, 'computer_use')).toEqual([
+        'shadow-cu-1',
+      ])
+
+      // Pinned divergence: the tool_result leaves the computer-use shelf
+      // untouched. The registry mirrors the SHELF, not the tool_result — if it
+      // settled here, the inline parity assert would blow up this test.
+      sendToolResult('shadow-cu-1')
+      expect(userInputRequestManager.getShelfIdsForSession(SESSION_ID, 'computer_use')).toEqual([
+        'shadow-cu-1',
+      ])
+
+      messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'shadow-cu-1')
+      expect(userInputRequestManager.getShelfIdsForSession(SESSION_ID, 'computer_use')).toEqual([])
+      expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+        id: 'shadow-cu-1',
+        kind: 'computer_use',
+        outcome: 'answered',
+      })
+      expect(userInputRequestManager.stats.shelfMismatches).toBe(0)
+    })
+
+    it('parallel requests: the projection stays awaiting while the bit drops early (split-brain telemetry)', async () => {
+      simulateToolUse('mcp__user-input__request_secret', 'shadow-par-1', {
+        secretName: 'API_KEY',
+        reason: 'Need it',
+      })
+      simulateToolUse('AskUserQuestion', 'shadow-par-2', {
+        questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
+      })
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(true)
+
+      // KNOWN SPLIT-BRAIN (pinned at the main-path user-message handler): the
+      // first tool_result clears the bit while the second card is still
+      // parked. The derived projection keeps the light on — this is the
+      // behavior Phase 3 promotes to authoritative.
+      sendToolResult('shadow-par-1')
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(true)
+
+      // The divergence check is deferred a microtask past the mutation.
+      await vi.waitFor(() => {
+        expect(userInputRequestManager.stats.awaitingDivergences).toBeGreaterThan(0)
+      })
+
+      sendToolResult('shadow-par-2')
+      expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(false)
+      expect(userInputRequestManager.stats.shelfMismatches).toBe(0)
+    })
+
+    it('capability review: the registry settles on complete; the stuck bit is divergence telemetry', async () => {
+      mockAgentCapabilities.subagents = 'allow'
+      mockAgentCapabilities.workflows = 'review'
+      vi.mocked(mockClient.fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({ grants: [] }),
+      } as unknown as Response)
+
+      simulateToolUse('Workflow', 'shadow-cap-1', { script: 'export const meta = {}' })
+      await vi.waitFor(() => {
+        expect(
+          userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id)
+        ).toContain('shadow-cap-1')
+      })
+      expect(
+        userInputRequestManager.getOpenRequestsForSession(SESSION_ID)[0].kind
+      ).toBe('capability_review')
+
+      messagePersister.completeCapabilityReview(SESSION_ID, 'shadow-cap-1')
+      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
+      expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(false)
+      // Pinned: the early-clear door empties its shelf but never flips the
+      // bit. Projection right, bit wrong — counted, not thrown.
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      await vi.waitFor(() => {
+        expect(userInputRequestManager.stats.awaitingDivergences).toBeGreaterThan(0)
+      })
+      expect(userInputRequestManager.stats.shelfMismatches).toBe(0)
+    })
+
+    it('unsubscribe drops every session-scoped registry entry as invalidated', () => {
+      simulateToolUse('mcp__user-input__request_secret', 'shadow-drop-1', {
+        secretName: 'API_KEY',
+        reason: 'Need it',
+      })
+      simulateToolUse('mcp__computer-use__computer_click', 'shadow-drop-2', { x: 1, y: 2 })
+      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(2)
+
+      messagePersister.unsubscribeFromSession(SESSION_ID)
+      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
+      expect(
+        userInputRequestManager.stats.recentResolutions.slice(-2).map((r) => r.outcome)
+      ).toEqual(['invalidated', 'invalidated'])
     })
   })
 })

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -8,6 +8,8 @@ import type { RequestRemoteMcpInput } from '@shared/lib/tool-definitions/request
 import type { RequestBrowserInputInput } from '@shared/lib/tool-definitions/request-browser-input'
 import type { RequestScriptRunInput } from '@shared/lib/tool-definitions/request-script-run'
 import { isBlockingUserInputToolName } from '@shared/lib/tool-definitions/user-input-tools'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
+import { streamEventToPendingRequest } from '@shared/lib/user-input/request-schema'
 import { classifyResult } from './result-classification'
 import { parseBackgroundTasksChanged } from './background-tasks-changed'
 import { parseCommandLifecycle } from './command-lifecycle'
@@ -352,6 +354,8 @@ class MessagePersister {
       this.subscriptions.delete(sessionId)
     }
     this.streamingStates.delete(sessionId)
+    // Shadow registry (Phase 2): every session-scoped entry dies with the state.
+    userInputRequestManager.dropSessionRequests(sessionId, 'invalidated')
     this.containerClients.delete(sessionId)
     // Safe to drop: the container's persisted grants are authoritative, so a
     // resubscribed session repopulates this on the next launch with one GET.
@@ -543,6 +547,8 @@ class MessagePersister {
     const state = this.streamingStates.get(sessionId)
     if (!state) return
     state.pendingInputRequests.delete(toolUseId)
+    userInputRequestManager.resolveIfShelf(toolUseId, 'stream', 'answered')
+    this.shadowRegistryCheck(sessionId, 'completeCapabilityReview')
     this.broadcastToSSE(sessionId, { type: 'capability_review_resolved', toolUseId })
     if (state.pendingInputRequests.size === 0) {
       this.broadcastGlobal({
@@ -558,6 +564,8 @@ class MessagePersister {
     const state = this.streamingStates.get(sessionId)
     if (state) {
       state.pendingComputerUseRequests.delete(toolUseId)
+      userInputRequestManager.resolveIfShelf(toolUseId, 'computer_use', 'answered')
+      this.shadowRegistryCheck(sessionId, 'clearPendingComputerUseRequest')
       // Same waiting-light rule as the sidechain input clear: both shelves,
       // skip auto-approved — and defer to a parked proxy/x-agent review
       // (external blocker), which is also a real wait.
@@ -612,7 +620,11 @@ class MessagePersister {
     // Clear the host-side computer_use bookkeeping explicitly — session_idle only clears
     // pendingInputRequests, so a leftover entry would replay a phantom approval card on reconnect.
     const state = this.streamingStates.get(sessionId)
-    for (const id of computerUseIds) state?.pendingComputerUseRequests.delete(id)
+    for (const id of computerUseIds) {
+      state?.pendingComputerUseRequests.delete(id)
+      if (state) userInputRequestManager.resolveIfShelf(id, 'computer_use', 'superseded')
+    }
+    this.shadowRegistryCheck(sessionId, 'cancelAwaitingInput')
 
     // Cleanup-reject each pending request on the CONTAINER: the query is already aborted, so the
     // reason is never read by the model — this just clears the container-side pending entry so a
@@ -933,6 +945,34 @@ class MessagePersister {
     return false
   }
 
+  // Phase 2 shadow-registry parity (dev/test only, skipped in production).
+  // Shelf comparison runs synchronously — every mutation site writes through to
+  // the registry adjacent to the shelf mutation, so the two must already agree
+  // here. The awaiting-bit comparison is deferred a microtask: the imperative
+  // mark/clear that follows a shelf mutation lands later in the same
+  // synchronous stretch, and comparing early would report phantom divergence.
+  private shadowRegistryCheck(sessionId: string, context: string): void {
+    if (process.env.NODE_ENV === 'production') return
+    const state = this.streamingStates.get(sessionId)
+    if (!state) return
+    userInputRequestManager.verifyShelfParity({
+      sessionId,
+      context,
+      streamShelfIds: [...state.pendingInputRequests.keys()],
+      computerUseShelfIds: [...state.pendingComputerUseRequests.keys()],
+    })
+    queueMicrotask(() => {
+      const current = this.streamingStates.get(sessionId)
+      if (!current) return
+      userInputRequestManager.compareAwaitingProjection({
+        sessionId,
+        context,
+        agentSlug: current.agentSlug,
+        isAwaitingInput: current.isAwaitingInput,
+      })
+    })
+  }
+
   // Surface host-blocking user-input tools (main + sidechain). script_run /
   // computer-use / capability-review keep their own handlers (conditional await).
   // First delivery wins: stream stop and complete-assistant can both carry the same tool_use.
@@ -1090,8 +1130,18 @@ class MessagePersister {
       if (state) {
         if (evt.type === 'session_active' || evt.type === 'session_idle') {
           state.pendingInputRequests.clear()
+          // Shadow registry (Phase 2): mirror the turn-boundary wipe. A new
+          // turn supersedes parked asks; an idle boundary cancels them.
+          userInputRequestManager.clearSessionStreamRequests(
+            sessionId,
+            evt.type === 'session_active' ? 'superseded' : 'cancelled',
+          )
+          this.shadowRegistryCheck(sessionId, `broadcast:${evt.type}`)
         } else if (MessagePersister.INPUT_REQUEST_TYPES.has(evt.type) && typeof evt.toolUseId === 'string') {
           state.pendingInputRequests.set(evt.toolUseId, evt as { type: string; toolUseId: string })
+          const shadow = streamEventToPendingRequest(sessionId, evt as { type: string; toolUseId: string })
+          if (shadow) userInputRequestManager.register(shadow)
+          this.shadowRegistryCheck(sessionId, `broadcast:${evt.type}`)
         }
       }
     }
@@ -4291,7 +4341,16 @@ ${continuation}`
         // Guard against duplicate entries (e.g., SSE event replayed)
         if (!state.pendingComputerUseRequests.has(toolUseId)) {
           state.pendingComputerUseRequests.set(toolUseId, { toolUseId, method, params, permissionLevel, appName, agentSlug })
+          userInputRequestManager.register({
+            id: toolUseId,
+            kind: 'computer_use',
+            scope: { agentSlug, sessionId },
+            blocking: true,
+            autoApproved: false,
+            payload: { method, params, permissionLevel, appName },
+          })
         }
+        this.shadowRegistryCheck(sessionId, 'handleComputerUseRequestTool')
       }
       this.markSessionAwaitingInput(sessionId)
 
@@ -4508,6 +4567,12 @@ ${continuation}`
       if (block.type !== 'tool_result' || !block.tool_use_id) continue
       if (!state.pendingInputRequests.has(block.tool_use_id)) continue
       state.pendingInputRequests.delete(block.tool_use_id)
+      userInputRequestManager.resolveIfShelf(
+        block.tool_use_id,
+        'stream',
+        block.is_error ? 'declined' : 'answered',
+      )
+      this.shadowRegistryCheck(sessionId, 'resolveSidechainInputRequests')
       // Same broadcast the main path emits — the resolving tab already removed
       // its card optimistically; every other tab drops it off this event.
       this.broadcastToSSE(sessionId, {
@@ -4545,6 +4610,14 @@ ${continuation}`
           // reconnects later (e.g. answer one of several parallel requests, then
           // refresh) — its tool_result is in, so drop it from the replay store.
           state?.pendingInputRequests.delete(block.tool_use_id)
+          if (state) {
+            userInputRequestManager.resolveIfShelf(
+              block.tool_use_id,
+              'stream',
+              block.is_error ? 'declined' : 'answered',
+            )
+            this.shadowRegistryCheck(sessionId, 'handleToolResults')
+          }
 
           // Broadcast update to SSE clients
           this.broadcastToSSE(sessionId, {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -9,7 +9,7 @@ import type { RequestBrowserInputInput } from '@shared/lib/tool-definitions/requ
 import type { RequestScriptRunInput } from '@shared/lib/tool-definitions/request-script-run'
 import { isBlockingUserInputToolName } from '@shared/lib/tool-definitions/user-input-tools'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
-import { streamEventToPendingRequest } from '@shared/lib/user-input/request-schema'
+import { streamEventToPendingRequest, type UserInputRequestOutcome } from '@shared/lib/user-input/request-schema'
 import { classifyResult } from './result-classification'
 import { parseBackgroundTasksChanged } from './background-tasks-changed'
 import { parseCommandLifecycle } from './command-lifecycle'
@@ -543,11 +543,15 @@ class MessagePersister {
   // tool_result cleanup at handleToolResult — an approved Task/Workflow runs for
   // minutes before its result arrives, and until then a refresh would replay (and
   // other connected clients would keep) a stale approval card.
-  completeCapabilityReview(sessionId: string, toolUseId: string): void {
+  completeCapabilityReview(
+    sessionId: string,
+    toolUseId: string,
+    outcome: UserInputRequestOutcome = 'answered',
+  ): void {
     const state = this.streamingStates.get(sessionId)
     if (!state) return
     state.pendingInputRequests.delete(toolUseId)
-    userInputRequestManager.resolveIfShelf(toolUseId, 'stream', 'answered')
+    userInputRequestManager.resolveIfShelf(toolUseId, 'stream', outcome)
     this.shadowRegistryCheck(sessionId, 'completeCapabilityReview')
     this.broadcastToSSE(sessionId, { type: 'capability_review_resolved', toolUseId })
     if (state.pendingInputRequests.size === 0) {
@@ -560,11 +564,15 @@ class MessagePersister {
   }
 
   // Clear a pending computer use request (after approval/rejection)
-  clearPendingComputerUseRequest(sessionId: string, toolUseId: string): void {
+  clearPendingComputerUseRequest(
+    sessionId: string,
+    toolUseId: string,
+    outcome: UserInputRequestOutcome = 'answered',
+  ): void {
     const state = this.streamingStates.get(sessionId)
     if (state) {
       state.pendingComputerUseRequests.delete(toolUseId)
-      userInputRequestManager.resolveIfShelf(toolUseId, 'computer_use', 'answered')
+      userInputRequestManager.resolveIfShelf(toolUseId, 'computer_use', outcome)
       this.shadowRegistryCheck(sessionId, 'clearPendingComputerUseRequest')
       // Same waiting-light rule as the sidechain input clear: both shelves,
       // skip auto-approved — and defer to a parked proxy/x-agent review
@@ -1839,7 +1847,7 @@ class MessagePersister {
         // everywhere instead of leaving it dangling until reconnect cleanup.
         if (typeof content.toolUseId === 'string') {
           if (state.pendingInputRequests.has(content.toolUseId)) {
-            this.completeCapabilityReview(sessionId, content.toolUseId)
+            this.completeCapabilityReview(sessionId, content.toolUseId, 'cancelled')
           } else {
             // No card yet — handleCapabilityReviewTool is still awaiting its
             // container grant lookup. Tombstone the id so the handler drops

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -551,7 +551,7 @@ class MessagePersister {
     const state = this.streamingStates.get(sessionId)
     if (!state) return
     state.pendingInputRequests.delete(toolUseId)
-    userInputRequestManager.resolveIfShelf(toolUseId, 'stream', outcome)
+    userInputRequestManager.resolveIfInStore(toolUseId, 'stream', outcome)
     this.shadowRegistryCheck(sessionId, 'completeCapabilityReview')
     this.broadcastToSSE(sessionId, { type: 'capability_review_resolved', toolUseId })
     if (state.pendingInputRequests.size === 0) {
@@ -572,9 +572,9 @@ class MessagePersister {
     const state = this.streamingStates.get(sessionId)
     if (state) {
       state.pendingComputerUseRequests.delete(toolUseId)
-      userInputRequestManager.resolveIfShelf(toolUseId, 'computer_use', outcome)
+      userInputRequestManager.resolveIfInStore(toolUseId, 'computer_use', outcome)
       this.shadowRegistryCheck(sessionId, 'clearPendingComputerUseRequest')
-      // Same waiting-light rule as the sidechain input clear: both shelves,
+      // Same waiting-light rule as the sidechain input clear: both stores,
       // skip auto-approved — and defer to a parked proxy/x-agent review
       // (external blocker), which is also a real wait.
       if (
@@ -630,7 +630,7 @@ class MessagePersister {
     const state = this.streamingStates.get(sessionId)
     for (const id of computerUseIds) {
       state?.pendingComputerUseRequests.delete(id)
-      if (state) userInputRequestManager.resolveIfShelf(id, 'computer_use', 'superseded')
+      if (state) userInputRequestManager.resolveIfInStore(id, 'computer_use', 'superseded')
     }
     this.shadowRegistryCheck(sessionId, 'cancelAwaitingInput')
 
@@ -954,20 +954,20 @@ class MessagePersister {
   }
 
   // Phase 2 shadow-registry parity (dev/test only, skipped in production).
-  // Shelf comparison runs synchronously — every mutation site writes through to
-  // the registry adjacent to the shelf mutation, so the two must already agree
+  // Store comparison runs synchronously — every mutation site writes through to
+  // the registry adjacent to the store mutation, so the two must already agree
   // here. The awaiting-bit comparison is deferred a microtask: the imperative
-  // mark/clear that follows a shelf mutation lands later in the same
+  // mark/clear that follows a store mutation lands later in the same
   // synchronous stretch, and comparing early would report phantom divergence.
   private shadowRegistryCheck(sessionId: string, context: string): void {
     if (process.env.NODE_ENV === 'production') return
     const state = this.streamingStates.get(sessionId)
     if (!state) return
-    userInputRequestManager.verifyShelfParity({
+    userInputRequestManager.verifyStoreParity({
       sessionId,
       context,
-      streamShelfIds: [...state.pendingInputRequests.keys()],
-      computerUseShelfIds: [...state.pendingComputerUseRequests.keys()],
+      streamStoreIds: [...state.pendingInputRequests.keys()],
+      computerUseStoreIds: [...state.pendingComputerUseRequests.keys()],
     })
     queueMicrotask(() => {
       const current = this.streamingStates.get(sessionId)
@@ -4560,7 +4560,7 @@ ${continuation}`
   // requests only: ordinary subagent tool results (Bash, Read, …) stream
   // constantly and must not broadcast main-path `tool_result` events or touch
   // the awaiting flag. Unlike the main path's unconditional clear, awaiting is
-  // cleared only when no OTHER blocking request remains (the shared both-shelves
+  // cleared only when no OTHER blocking request remains (the shared both-stores
   // rule) — a main-agent question or a pending computer-use can be open in
   // parallel with a subagent's browser_input — and never while a proxy/x-agent
   // review is still parked for this agent.
@@ -4575,7 +4575,7 @@ ${continuation}`
       if (block.type !== 'tool_result' || !block.tool_use_id) continue
       if (!state.pendingInputRequests.has(block.tool_use_id)) continue
       state.pendingInputRequests.delete(block.tool_use_id)
-      userInputRequestManager.resolveIfShelf(
+      userInputRequestManager.resolveIfInStore(
         block.tool_use_id,
         'stream',
         block.is_error ? 'declined' : 'answered',
@@ -4619,7 +4619,7 @@ ${continuation}`
           // refresh) — its tool_result is in, so drop it from the replay store.
           state?.pendingInputRequests.delete(block.tool_use_id)
           if (state) {
-            userInputRequestManager.resolveIfShelf(
+            userInputRequestManager.resolveIfInStore(
               block.tool_use_id,
               'stream',
               block.is_error ? 'declined' : 'answered',

--- a/src/shared/lib/proxy/review-manager.test.ts
+++ b/src/shared/lib/proxy/review-manager.test.ts
@@ -7,6 +7,7 @@ vi.mock('./review-broadcast', () => ({
 }))
 
 import { ReviewManager, humanizeActionName, generateReviewDisplayText } from './review-manager'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 
 describe('ReviewManager', () => {
   let manager: ReviewManager
@@ -656,5 +657,125 @@ describe('ReviewManager', () => {
       const call = mockBroadcastReview.mock.calls[0]
       expect(call[1]).not.toHaveProperty('xAgent')
     })
+  })
+})
+
+describe('ReviewManager shadow registry write-through (Phase 2)', () => {
+  let manager: ReviewManager
+
+  const DETAILS = {
+    agentSlug: 'shadow-agent',
+    accountId: 'acc-1',
+    toolkit: 'gmail',
+    method: 'GET',
+    targetPath: '/v1/messages',
+    matchedScopes: ['gmail.readonly'],
+    scopeDescriptions: { 'gmail.readonly': 'Read email' },
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    manager = new ReviewManager()
+    userInputRequestManager.reset()
+  })
+
+  afterEach(() => {
+    manager.rejectAll()
+    vi.useRealTimers()
+  })
+
+  it('requestReview registers an agent-scoped proxy_review envelope', () => {
+    manager.requestReview(DETAILS).catch(() => {})
+    const open = userInputRequestManager.getAgentScopedRequests('shadow-agent')
+    expect(open).toHaveLength(1)
+    expect(open[0].kind).toBe('proxy_review')
+    expect(open[0].scope).toEqual({ agentSlug: 'shadow-agent' })
+    expect(open[0].blocking).toBe(true)
+    // The agent-scoped entry drives the derived projection for every session
+    // of the agent — the seam that replaces registerAwaitingBlockerSource.
+    expect(userInputRequestManager.isAgentAwaiting('shadow-agent')).toBe(true)
+    expect(userInputRequestManager.isSessionAwaiting('any-session', 'shadow-agent')).toBe(true)
+  })
+
+  it('an x-agent review registers as x_agent_review', () => {
+    manager
+      .requestXAgentReview('shadow-agent', 'target-agent', 'Target', 'invoke', 'hi')
+      .catch(() => {})
+    const open = userInputRequestManager.getAgentScopedRequests('shadow-agent')
+    expect(open).toHaveLength(1)
+    expect(open[0].kind).toBe('x_agent_review')
+  })
+
+  it('submitDecision settles the envelope with the decision outcome', async () => {
+    const promise = manager.requestReview(DETAILS)
+    const reviewId = manager.getPendingReviewsForAgent('shadow-agent')[0].id
+
+    manager.submitDecision(reviewId, 'allow')
+    await promise
+    expect(userInputRequestManager.getAgentScopedRequests('shadow-agent')).toHaveLength(0)
+    expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+      id: reviewId,
+      kind: 'proxy_review',
+      outcome: 'answered',
+    })
+    expect(userInputRequestManager.isAgentAwaiting('shadow-agent')).toBe(false)
+  })
+
+  it('the 5-minute auto-deny settles the envelope as timeout', async () => {
+    const promise = manager.requestReview(DETAILS)
+    const reviewId = manager.getPendingReviewsForAgent('shadow-agent')[0].id
+
+    vi.advanceTimersByTime(5 * 60 * 1000)
+    await expect(promise).rejects.toThrow('Review timeout')
+    expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+      id: reviewId,
+      kind: 'proxy_review',
+      outcome: 'timeout',
+    })
+    expect(userInputRequestManager.getAgentScopedRequests('shadow-agent')).toHaveLength(0)
+  })
+
+  it('an aborted request settles the envelope as cancelled', async () => {
+    const controller = new AbortController()
+    const promise = manager.requestReview(DETAILS, controller.signal)
+    const reviewId = manager.getPendingReviewsForAgent('shadow-agent')[0].id
+
+    controller.abort()
+    await expect(promise).rejects.toThrow('Request aborted')
+    expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+      id: reviewId,
+      kind: 'proxy_review',
+      outcome: 'cancelled',
+    })
+  })
+
+  it('denyAllForAgent settles every envelope of the agent as declined', async () => {
+    const p1 = manager.requestReview(DETAILS)
+    const p2 = manager.requestReview({ ...DETAILS, targetPath: '/v1/other' })
+    expect(userInputRequestManager.getAgentScopedRequests('shadow-agent')).toHaveLength(2)
+
+    manager.denyAllForAgent('shadow-agent')
+    await Promise.all([p1, p2])
+    expect(userInputRequestManager.getAgentScopedRequests('shadow-agent')).toHaveLength(0)
+    expect(
+      userInputRequestManager.stats.recentResolutions.slice(-2).map((r) => r.outcome)
+    ).toEqual(['declined', 'declined'])
+  })
+
+  it('resolveMatchingPending sweeps matching envelopes with the decision outcome', async () => {
+    const promise = manager.requestReview(DETAILS)
+    manager.resolveMatchingPending('shadow-agent', 'gmail.readonly', 'allow')
+    await promise
+    expect(userInputRequestManager.getAgentScopedRequests('shadow-agent')).toHaveLength(0)
+    expect(userInputRequestManager.stats.recentResolutions.at(-1)?.outcome).toBe('answered')
+  })
+
+  it('rejectAll settles every envelope as cancelled', async () => {
+    const promise = manager.requestReview(DETAILS)
+    manager.rejectAll()
+    await expect(promise).rejects.toThrow('Review timeout')
+    expect(userInputRequestManager.getAgentScopedRequests('shadow-agent')).toHaveLength(0)
+    expect(userInputRequestManager.stats.recentResolutions.at(-1)?.outcome).toBe('cancelled')
   })
 })

--- a/src/shared/lib/proxy/review-manager.ts
+++ b/src/shared/lib/proxy/review-manager.ts
@@ -3,6 +3,7 @@ import { broadcastReview } from './review-broadcast'
 import { getScopeLabel, type ScopeLabel } from './scope-metadata'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 
 const REVIEW_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
 
@@ -141,6 +142,7 @@ export class ReviewManager {
       const settleTimedOut = () => {
         if (!this.pending.has(id)) return
         this.pending.delete(id)
+        userInputRequestManager.resolve(id, 'timeout')
         broadcastReview(details.agentSlug, {
           type: 'proxy_review_resolved',
           reviewId: id,
@@ -155,6 +157,7 @@ export class ReviewManager {
       const cleanup = () => {
         clearTimeout(timer)
         this.pending.delete(id)
+        userInputRequestManager.resolve(id, 'cancelled')
         broadcastReview(details.agentSlug, {
           type: 'proxy_review_resolved',
           reviewId: id,
@@ -173,6 +176,16 @@ export class ReviewManager {
       }
 
       this.pending.set(id, { id, details, resolve, reject, timer })
+      // Shadow registry (Phase 2): reviews are agent-scoped — no sessionId in
+      // the proxied call, so the envelope carries agentSlug only.
+      userInputRequestManager.register({
+        id,
+        kind: details.xAgent ? 'x_agent_review' : 'proxy_review',
+        scope: { agentSlug: details.agentSlug },
+        blocking: true,
+        autoApproved: false,
+        payload: { ...details },
+      })
 
       const displayText = generateReviewDisplayText(
         details.toolkit,
@@ -240,6 +253,7 @@ export class ReviewManager {
 
     clearTimeout(review.timer)
     this.pending.delete(id)
+    userInputRequestManager.resolve(id, decision === 'allow' ? 'answered' : 'declined')
     review.resolve(decision)
 
     // Broadcast resolution so UIs can dismiss the prompt
@@ -265,6 +279,7 @@ export class ReviewManager {
       ) {
         clearTimeout(review.timer)
         this.pending.delete(id)
+        userInputRequestManager.resolve(id, decision === 'allow' ? 'answered' : 'declined')
         review.resolve(decision)
 
         broadcastReview(agentSlug, {
@@ -297,6 +312,7 @@ export class ReviewManager {
       if (!hasLabel) continue
       clearTimeout(review.timer)
       this.pending.delete(id)
+      userInputRequestManager.resolve(id, decision === 'allow' ? 'answered' : 'declined')
       review.resolve(decision)
       broadcastReview(agentSlug, {
         type: 'proxy_review_resolved',
@@ -325,6 +341,7 @@ export class ReviewManager {
       ) {
         clearTimeout(review.timer)
         this.pending.delete(id)
+        userInputRequestManager.resolve(id, decision === 'allow' ? 'answered' : 'declined')
         review.resolve(decision)
 
         broadcastReview(agentSlug, {
@@ -409,6 +426,7 @@ export class ReviewManager {
       if (review.details.agentSlug !== agentSlug) continue
       clearTimeout(review.timer)
       this.pending.delete(id)
+      userInputRequestManager.resolve(id, 'declined')
       review.resolve('deny')
 
       broadcastReview(agentSlug, {
@@ -425,6 +443,7 @@ export class ReviewManager {
     for (const [id, review] of this.pending) {
       clearTimeout(review.timer)
       this.pending.delete(id)
+      userInputRequestManager.resolve(id, 'cancelled')
       agentSlugs.add(review.details.agentSlug)
       broadcastReview(review.details.agentSlug, {
         type: 'proxy_review_resolved',

--- a/src/shared/lib/proxy/review-manager.ts
+++ b/src/shared/lib/proxy/review-manager.ts
@@ -134,6 +134,18 @@ export class ReviewManager {
     messagePersister.clearAwaitingInputForAgentIfUnblocked(agentSlug)
   }
 
+  // Phase 2 shadow-registry parity (dev/test only): after every mutation of
+  // `pending`, the registry's agent-scoped review view must mirror this store
+  // exactly — a missed or malformed write-through fails tests / logs in dev
+  // instead of silently diverging.
+  private shadowRegistryCheck(agentSlug: string, context: string): void {
+    if (process.env.NODE_ENV === 'production') return
+    const reviewShelfIds = [...this.pending.values()]
+      .filter((review) => review.details.agentSlug === agentSlug)
+      .map((review) => review.id)
+    userInputRequestManager.verifyReviewShelfParity({ agentSlug, context, reviewShelfIds })
+  }
+
   requestReview(details: ReviewDetails, signal?: AbortSignal): Promise<'allow' | 'deny'> {
     this.ensureAwaitingBlockerRegistered()
     const id = crypto.randomUUID()
@@ -143,6 +155,7 @@ export class ReviewManager {
         if (!this.pending.has(id)) return
         this.pending.delete(id)
         userInputRequestManager.resolve(id, 'timeout')
+        this.shadowRegistryCheck(details.agentSlug, 'settleTimedOut')
         broadcastReview(details.agentSlug, {
           type: 'proxy_review_resolved',
           reviewId: id,
@@ -158,6 +171,7 @@ export class ReviewManager {
         clearTimeout(timer)
         this.pending.delete(id)
         userInputRequestManager.resolve(id, 'cancelled')
+        this.shadowRegistryCheck(details.agentSlug, 'abortCleanup')
         broadcastReview(details.agentSlug, {
           type: 'proxy_review_resolved',
           reviewId: id,
@@ -186,6 +200,7 @@ export class ReviewManager {
         autoApproved: false,
         payload: { ...details },
       })
+      this.shadowRegistryCheck(details.agentSlug, 'requestReview')
 
       const displayText = generateReviewDisplayText(
         details.toolkit,
@@ -254,6 +269,7 @@ export class ReviewManager {
     clearTimeout(review.timer)
     this.pending.delete(id)
     userInputRequestManager.resolve(id, decision === 'allow' ? 'answered' : 'declined')
+    this.shadowRegistryCheck(review.details.agentSlug, 'submitDecision')
     review.resolve(decision)
 
     // Broadcast resolution so UIs can dismiss the prompt
@@ -289,6 +305,7 @@ export class ReviewManager {
         })
       }
     }
+    this.shadowRegistryCheck(agentSlug, 'resolveMatchingPending')
     this.clearAgentSessionsAwaitingIfIdle(agentSlug)
   }
 
@@ -320,6 +337,7 @@ export class ReviewManager {
         decision,
       })
     }
+    this.shadowRegistryCheck(agentSlug, 'resolveMatchingPendingByLabel')
     this.clearAgentSessionsAwaitingIfIdle(agentSlug)
   }
 
@@ -351,6 +369,7 @@ export class ReviewManager {
         })
       }
     }
+    this.shadowRegistryCheck(agentSlug, 'resolveMatchingXAgentByOperation')
     this.clearAgentSessionsAwaitingIfIdle(agentSlug)
   }
 
@@ -435,6 +454,7 @@ export class ReviewManager {
         decision: 'deny',
       })
     }
+    this.shadowRegistryCheck(agentSlug, 'denyAllForAgent')
     this.clearAgentSessionsAwaitingIfIdle(agentSlug)
   }
 
@@ -453,6 +473,7 @@ export class ReviewManager {
       review.reject(new Error('Review timeout'))
     }
     for (const agentSlug of agentSlugs) {
+      this.shadowRegistryCheck(agentSlug, 'rejectAll')
       this.clearAgentSessionsAwaitingIfIdle(agentSlug)
     }
   }

--- a/src/shared/lib/proxy/review-manager.ts
+++ b/src/shared/lib/proxy/review-manager.ts
@@ -140,10 +140,10 @@ export class ReviewManager {
   // instead of silently diverging.
   private shadowRegistryCheck(agentSlug: string, context: string): void {
     if (process.env.NODE_ENV === 'production') return
-    const reviewShelfIds = [...this.pending.values()]
+    const reviewStoreIds = [...this.pending.values()]
       .filter((review) => review.details.agentSlug === agentSlug)
       .map((review) => review.id)
-    userInputRequestManager.verifyReviewShelfParity({ agentSlug, context, reviewShelfIds })
+    userInputRequestManager.verifyReviewStoreParity({ agentSlug, context, reviewStoreIds })
   }
 
   requestReview(details: ReviewDetails, signal?: AbortSignal): Promise<'allow' | 'deny'> {

--- a/src/shared/lib/user-input/request-manager.test.ts
+++ b/src/shared/lib/user-input/request-manager.test.ts
@@ -85,8 +85,8 @@ describe('UserInputRequestManager', () => {
     })
   })
 
-  describe('resolveIfShelf', () => {
-    it('refuses to settle a request that lives on a different shelf', () => {
+  describe('resolveIfInStore', () => {
+    it('refuses to settle a request that lives on a different store', () => {
       manager.register({
         id: 'cu-1',
         kind: 'computer_use',
@@ -94,16 +94,16 @@ describe('UserInputRequestManager', () => {
         blocking: true,
         payload: { method: 'click' },
       })
-      // A stray main-path tool_result deletes blindly from the stream shelf —
+      // A stray main-path tool_result deletes blindly from the stream store —
       // it must not evict the computer-use entry its own store still holds.
-      expect(manager.resolveIfShelf('cu-1', 'stream', 'answered')).toBeNull()
+      expect(manager.resolveIfInStore('cu-1', 'stream', 'answered')).toBeNull()
       expect(manager.stats.open).toBe(1)
-      expect(manager.resolveIfShelf('cu-1', 'computer_use', 'answered')).not.toBeNull()
+      expect(manager.resolveIfInStore('cu-1', 'computer_use', 'answered')).not.toBeNull()
       expect(manager.stats.open).toBe(0)
     })
   })
 
-  describe('shelf-scoped clears', () => {
+  describe('store-scoped clears', () => {
     beforeEach(() => {
       manager.register(secretRequest({ id: 'stream-1' }))
       manager.register({
@@ -123,7 +123,7 @@ describe('UserInputRequestManager', () => {
       manager.register(secretRequest({ id: 'other-session', scope: { agentSlug: 'agent-a', sessionId: 'session-2' } }))
     })
 
-    it('clearSessionStreamRequests wipes only the session\'s stream shelf (turn-boundary mirror)', () => {
+    it('clearSessionStreamRequests wipes only the session\'s stream store (turn-boundary mirror)', () => {
       manager.clearSessionStreamRequests('session-1', 'cancelled')
       expect(manager.getOpenRequestsForSession('session-1').map((r) => r.id)).toEqual(['cu-1'])
       expect(manager.getOpenRequestsForSession('session-2')).toHaveLength(1)
@@ -170,31 +170,31 @@ describe('UserInputRequestManager', () => {
   })
 
   describe('shadow diagnostics', () => {
-    it('verifyShelfParity passes silently when both shelves match', () => {
+    it('verifyStoreParity passes silently when both stores match', () => {
       manager.register(secretRequest({ id: 'stream-1' }))
-      manager.verifyShelfParity({
+      manager.verifyStoreParity({
         sessionId: 'session-1',
         context: 'test',
-        streamShelfIds: ['stream-1'],
-        computerUseShelfIds: [],
+        streamStoreIds: ['stream-1'],
+        computerUseStoreIds: [],
       })
-      expect(manager.stats.shelfMismatches).toBe(0)
+      expect(manager.stats.storeMismatches).toBe(0)
     })
 
-    it('verifyShelfParity throws under vitest on a mismatch and counts it', () => {
+    it('verifyStoreParity throws under vitest on a mismatch and counts it', () => {
       manager.register(secretRequest({ id: 'stream-1' }))
       expect(() =>
-        manager.verifyShelfParity({
+        manager.verifyStoreParity({
           sessionId: 'session-1',
           context: 'test',
-          streamShelfIds: ['stream-1', 'stream-2'],
-          computerUseShelfIds: [],
+          streamStoreIds: ['stream-1', 'stream-2'],
+          computerUseStoreIds: [],
         }),
-      ).toThrow(/shadow shelf mismatch/)
-      expect(manager.stats.shelfMismatches).toBe(1)
+      ).toThrow(/shadow store mismatch/)
+      expect(manager.stats.storeMismatches).toBe(1)
     })
 
-    it('verifyReviewShelfParity compares only agent-scoped review entries', () => {
+    it('verifyReviewStoreParity compares only agent-scoped review entries', () => {
       manager.register({
         id: 'review-1',
         kind: 'proxy_review',
@@ -206,24 +206,24 @@ describe('UserInputRequestManager', () => {
       // review comparison.
       manager.register(secretRequest())
 
-      manager.verifyReviewShelfParity({
+      manager.verifyReviewStoreParity({
         agentSlug: 'agent-a',
         context: 'test',
-        reviewShelfIds: ['review-1'],
+        reviewStoreIds: ['review-1'],
       })
-      expect(manager.stats.shelfMismatches).toBe(0)
+      expect(manager.stats.storeMismatches).toBe(0)
     })
 
-    it('verifyReviewShelfParity throws under vitest when a review write-through was missed', () => {
+    it('verifyReviewStoreParity throws under vitest when a review write-through was missed', () => {
       // ReviewManager holds a review the registry never saw.
       expect(() =>
-        manager.verifyReviewShelfParity({
+        manager.verifyReviewStoreParity({
           agentSlug: 'agent-a',
           context: 'test',
-          reviewShelfIds: ['review-orphan'],
+          reviewStoreIds: ['review-orphan'],
         }),
-      ).toThrow(/shadow shelf mismatch/)
-      expect(manager.stats.shelfMismatches).toBe(1)
+      ).toThrow(/shadow store mismatch/)
+      expect(manager.stats.storeMismatches).toBe(1)
     })
 
     it('compareAwaitingProjection counts divergence and warns once per episode', () => {
@@ -255,7 +255,7 @@ describe('UserInputRequestManager', () => {
       manager.reset()
       expect(manager.stats).toEqual({
         open: 0,
-        shelfMismatches: 0,
+        storeMismatches: 0,
         awaitingDivergences: 0,
         recentResolutions: [],
       })

--- a/src/shared/lib/user-input/request-manager.test.ts
+++ b/src/shared/lib/user-input/request-manager.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { UserInputRequestManager } from './request-manager'
+import type { PendingUserInputRequestInput } from './request-schema'
+
+function secretRequest(overrides: Partial<PendingUserInputRequestInput> = {}): PendingUserInputRequestInput {
+  return {
+    id: 'tool-1',
+    kind: 'secret',
+    scope: { agentSlug: 'agent-a', sessionId: 'session-1' },
+    blocking: true,
+    payload: { secretName: 'API_KEY', reason: 'Need it' },
+    ...overrides,
+  } as PendingUserInputRequestInput
+}
+
+describe('UserInputRequestManager', () => {
+  let manager: UserInputRequestManager
+
+  beforeEach(() => {
+    manager = new UserInputRequestManager()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('register', () => {
+    it('parses and stores a request, defaulting autoApproved to false', () => {
+      const stored = manager.register(secretRequest())
+      expect(stored).not.toBeNull()
+      expect(stored!.kind).toBe('secret')
+      expect(stored!.autoApproved).toBe(false)
+      expect(manager.getOpenRequestsForSession('session-1')).toHaveLength(1)
+    })
+
+    it('is first-delivery-wins: re-registering an open id returns the original unchanged', () => {
+      const first = manager.register(secretRequest({ payload: { secretName: 'FIRST' } }))
+      const second = manager.register(secretRequest({ payload: { secretName: 'SECOND' } }))
+      expect(second).toBe(first)
+      const open = manager.getOpenRequestsForSession('session-1')
+      expect(open).toHaveLength(1)
+      expect((open[0].payload as { secretName?: string }).secretName).toBe('FIRST')
+    })
+
+    it('drops a malformed envelope without throwing (shadow mode must never break delivery)', () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const stored = manager.register({
+        id: '',
+        kind: 'secret',
+        scope: {},
+        blocking: true,
+        payload: {},
+      } as PendingUserInputRequestInput)
+      expect(stored).toBeNull()
+      expect(manager.stats.open).toBe(0)
+      expect(consoleError).toHaveBeenCalledTimes(1)
+    })
+
+    it('tolerates malformed payload fields instead of rejecting the request', () => {
+      const stored = manager.register(
+        secretRequest({ payload: { secretName: 42, reason: { nested: true } } }),
+      )
+      expect(stored).not.toBeNull()
+      expect((stored!.payload as { secretName?: string }).secretName).toBeUndefined()
+    })
+  })
+
+  describe('resolve', () => {
+    it('removes the request and records the outcome', () => {
+      manager.register(secretRequest())
+      const resolved = manager.resolve('tool-1', 'answered')
+      expect(resolved?.kind).toBe('secret')
+      expect(manager.stats.open).toBe(0)
+      expect(manager.stats.recentResolutions).toEqual([
+        { id: 'tool-1', kind: 'secret', outcome: 'answered' },
+      ])
+    })
+
+    it('is idempotent: unknown ids are a no-op returning null', () => {
+      expect(manager.resolve('never-registered', 'answered')).toBeNull()
+      manager.register(secretRequest())
+      manager.resolve('tool-1', 'answered')
+      expect(manager.resolve('tool-1', 'answered')).toBeNull()
+      expect(manager.stats.recentResolutions).toHaveLength(1)
+    })
+  })
+
+  describe('resolveIfShelf', () => {
+    it('refuses to settle a request that lives on a different shelf', () => {
+      manager.register({
+        id: 'cu-1',
+        kind: 'computer_use',
+        scope: { agentSlug: 'agent-a', sessionId: 'session-1' },
+        blocking: true,
+        payload: { method: 'click' },
+      })
+      // A stray main-path tool_result deletes blindly from the stream shelf —
+      // it must not evict the computer-use entry its own store still holds.
+      expect(manager.resolveIfShelf('cu-1', 'stream', 'answered')).toBeNull()
+      expect(manager.stats.open).toBe(1)
+      expect(manager.resolveIfShelf('cu-1', 'computer_use', 'answered')).not.toBeNull()
+      expect(manager.stats.open).toBe(0)
+    })
+  })
+
+  describe('shelf-scoped clears', () => {
+    beforeEach(() => {
+      manager.register(secretRequest({ id: 'stream-1' }))
+      manager.register({
+        id: 'cu-1',
+        kind: 'computer_use',
+        scope: { agentSlug: 'agent-a', sessionId: 'session-1' },
+        blocking: true,
+        payload: { method: 'click' },
+      })
+      manager.register({
+        id: 'review-1',
+        kind: 'proxy_review',
+        scope: { agentSlug: 'agent-a' },
+        blocking: true,
+        payload: { toolkit: 'slack' },
+      })
+      manager.register(secretRequest({ id: 'other-session', scope: { agentSlug: 'agent-a', sessionId: 'session-2' } }))
+    })
+
+    it('clearSessionStreamRequests wipes only the session\'s stream shelf (turn-boundary mirror)', () => {
+      manager.clearSessionStreamRequests('session-1', 'cancelled')
+      expect(manager.getOpenRequestsForSession('session-1').map((r) => r.id)).toEqual(['cu-1'])
+      expect(manager.getOpenRequestsForSession('session-2')).toHaveLength(1)
+      expect(manager.getAgentScopedRequests('agent-a')).toHaveLength(1)
+    })
+
+    it('dropSessionRequests removes every session-scoped entry but leaves agent-scoped reviews', () => {
+      manager.dropSessionRequests('session-1')
+      expect(manager.getOpenRequestsForSession('session-1')).toHaveLength(0)
+      expect(manager.getOpenRequestsForSession('session-2')).toHaveLength(1)
+      expect(manager.getAgentScopedRequests('agent-a')).toHaveLength(1)
+    })
+  })
+
+  describe('awaiting projection', () => {
+    it('a session-scoped blocking request makes the session awaiting', () => {
+      manager.register(secretRequest())
+      expect(manager.isSessionAwaiting('session-1')).toBe(true)
+      expect(manager.isSessionAwaiting('session-2')).toBe(false)
+      manager.resolve('tool-1', 'answered')
+      expect(manager.isSessionAwaiting('session-1')).toBe(false)
+    })
+
+    it('auto-approved requests never count as real waits', () => {
+      manager.register(
+        secretRequest({ id: 'auto-1', kind: 'script_run', autoApproved: true, payload: {} }),
+      )
+      expect(manager.isSessionAwaiting('session-1')).toBe(false)
+      expect(manager.isAgentAwaiting('agent-a')).toBe(false)
+    })
+
+    it('an agent-scoped review blocks every session of that agent', () => {
+      manager.register({
+        id: 'review-1',
+        kind: 'proxy_review',
+        scope: { agentSlug: 'agent-a' },
+        blocking: true,
+        payload: { toolkit: 'slack' },
+      })
+      expect(manager.isSessionAwaiting('any-session-of-a', 'agent-a')).toBe(true)
+      expect(manager.isSessionAwaiting('any-session-of-b', 'agent-b')).toBe(false)
+      expect(manager.isAgentAwaiting('agent-a')).toBe(true)
+    })
+  })
+
+  describe('shadow diagnostics', () => {
+    it('verifyShelfParity passes silently when both shelves match', () => {
+      manager.register(secretRequest({ id: 'stream-1' }))
+      manager.verifyShelfParity({
+        sessionId: 'session-1',
+        context: 'test',
+        streamShelfIds: ['stream-1'],
+        computerUseShelfIds: [],
+      })
+      expect(manager.stats.shelfMismatches).toBe(0)
+    })
+
+    it('verifyShelfParity throws under vitest on a mismatch and counts it', () => {
+      manager.register(secretRequest({ id: 'stream-1' }))
+      expect(() =>
+        manager.verifyShelfParity({
+          sessionId: 'session-1',
+          context: 'test',
+          streamShelfIds: ['stream-1', 'stream-2'],
+          computerUseShelfIds: [],
+        }),
+      ).toThrow(/shadow shelf mismatch/)
+      expect(manager.stats.shelfMismatches).toBe(1)
+    })
+
+    it('compareAwaitingProjection counts divergence and warns once per episode', () => {
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      manager.register(secretRequest())
+
+      // Bit says false while a real wait is open: diverged. Two checks in the
+      // same episode → two counts, ONE warn.
+      const diverged = {
+        sessionId: 'session-1',
+        context: 'test',
+        agentSlug: 'agent-a',
+        isAwaitingInput: false,
+      }
+      manager.compareAwaitingProjection(diverged)
+      manager.compareAwaitingProjection(diverged)
+      expect(manager.stats.awaitingDivergences).toBe(2)
+      expect(consoleWarn).toHaveBeenCalledTimes(1)
+
+      // Convergence closes the episode; the next divergence warns again.
+      manager.compareAwaitingProjection({ ...diverged, isAwaitingInput: true })
+      manager.compareAwaitingProjection(diverged)
+      expect(consoleWarn).toHaveBeenCalledTimes(2)
+    })
+
+    it('reset wipes requests and diagnostics', () => {
+      manager.register(secretRequest())
+      manager.resolve('tool-1', 'answered')
+      manager.reset()
+      expect(manager.stats).toEqual({
+        open: 0,
+        shelfMismatches: 0,
+        awaitingDivergences: 0,
+        recentResolutions: [],
+      })
+    })
+  })
+})

--- a/src/shared/lib/user-input/request-manager.test.ts
+++ b/src/shared/lib/user-input/request-manager.test.ts
@@ -194,6 +194,38 @@ describe('UserInputRequestManager', () => {
       expect(manager.stats.shelfMismatches).toBe(1)
     })
 
+    it('verifyReviewShelfParity compares only agent-scoped review entries', () => {
+      manager.register({
+        id: 'review-1',
+        kind: 'proxy_review',
+        scope: { agentSlug: 'agent-a' },
+        blocking: true,
+        payload: { toolkit: 'slack' },
+      })
+      // Session-scoped stream noise for the same agent must not leak into the
+      // review comparison.
+      manager.register(secretRequest())
+
+      manager.verifyReviewShelfParity({
+        agentSlug: 'agent-a',
+        context: 'test',
+        reviewShelfIds: ['review-1'],
+      })
+      expect(manager.stats.shelfMismatches).toBe(0)
+    })
+
+    it('verifyReviewShelfParity throws under vitest when a review write-through was missed', () => {
+      // ReviewManager holds a review the registry never saw.
+      expect(() =>
+        manager.verifyReviewShelfParity({
+          agentSlug: 'agent-a',
+          context: 'test',
+          reviewShelfIds: ['review-orphan'],
+        }),
+      ).toThrow(/shadow shelf mismatch/)
+      expect(manager.stats.shelfMismatches).toBe(1)
+    })
+
     it('compareAwaitingProjection counts divergence and warns once per episode', () => {
       const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       manager.register(secretRequest())

--- a/src/shared/lib/user-input/request-manager.ts
+++ b/src/shared/lib/user-input/request-manager.ts
@@ -1,0 +1,259 @@
+import {
+  pendingUserInputRequestSchema,
+  shelfForKind,
+  type PendingUserInputRequest,
+  type PendingUserInputRequestInput,
+  type UserInputRequestOutcome,
+  type UserInputRequestShelf,
+} from './request-schema'
+
+/**
+ * Host-side registry of every pending user-input request, regardless of which
+ * legacy store owns it (persister stream shelf, computer-use map, ReviewManager).
+ *
+ * Phase 2 — SHADOW MODE: the legacy shelves stay authoritative and every
+ * mutation writes through to this registry; nothing reads it for behavior.
+ * `verifyShelfParity` asserts the mirror is exact at every shelf mutation
+ * (throws under vitest, logs otherwise), and `compareAwaitingProjection`
+ * counts divergence between the imperative awaiting bit and the projection
+ * this registry derives — the known split-brains Phase 3 replaces the bit
+ * to fix.
+ */
+export class UserInputRequestManager {
+  private requests = new Map<string, PendingUserInputRequest>()
+
+  /** Bounded trail of recent settlements, for shadow-mode debugging and tests. */
+  private recentResolutions: Array<{
+    id: string
+    kind: PendingUserInputRequest['kind']
+    outcome: UserInputRequestOutcome
+  }> = []
+
+  private shelfMismatchCount = 0
+  private awaitingDivergenceCount = 0
+  // Sessions currently known-diverged, so we warn once per divergence episode
+  // instead of on every mutation while it persists.
+  private divergedSessions = new Set<string>()
+
+  /**
+   * Register a pending request. First delivery wins: re-registering an id that
+   * is still open returns the original entry unchanged (stream stop and
+   * complete-assistant can both carry the same tool_use).
+   *
+   * Never throws — a malformed envelope is logged and dropped so shadow-mode
+   * registration can never break a production delivery path.
+   */
+  register(input: PendingUserInputRequestInput): PendingUserInputRequest | null {
+    const existing = this.requests.get(input.id)
+    if (existing) return existing
+    const parsed = pendingUserInputRequestSchema.safeParse(input)
+    if (!parsed.success) {
+      console.error(
+        `[UserInputRequestManager] Dropped malformed request registration (id=${input.id}):`,
+        parsed.error.message,
+      )
+      return null
+    }
+    this.requests.set(parsed.data.id, parsed.data)
+    return parsed.data
+  }
+
+  /** Settle and remove a request. Idempotent: unknown ids are a no-op (null). */
+  resolve(id: string, outcome: UserInputRequestOutcome): PendingUserInputRequest | null {
+    const request = this.requests.get(id)
+    if (!request) return null
+    this.requests.delete(id)
+    this.recentResolutions.push({ id, kind: request.kind, outcome })
+    if (this.recentResolutions.length > 100) this.recentResolutions.shift()
+    return request
+  }
+
+  /**
+   * Settle a request only if it lives on the given legacy shelf. Mirrors
+   * shelf-scoped deletes exactly: a main-path tool_result deletes blindly from
+   * the stream shelf, and must not evict a computer-use or review entry that
+   * its own store still holds.
+   */
+  resolveIfShelf(
+    id: string,
+    shelf: UserInputRequestShelf,
+    outcome: UserInputRequestOutcome,
+  ): PendingUserInputRequest | null {
+    const request = this.requests.get(id)
+    if (!request || shelfForKind(request.kind) !== shelf) return null
+    return this.resolve(id, outcome)
+  }
+
+  /** Mirror of the turn-boundary `pendingInputRequests.clear()` — stream shelf only. */
+  clearSessionStreamRequests(sessionId: string, outcome: UserInputRequestOutcome): void {
+    for (const request of [...this.requests.values()]) {
+      if (request.scope.sessionId !== sessionId) continue
+      if (shelfForKind(request.kind) !== 'stream') continue
+      this.resolve(request.id, outcome)
+    }
+  }
+
+  /** Mirror of `streamingStates.delete` — every session-scoped entry dies with the state. */
+  dropSessionRequests(sessionId: string, outcome: UserInputRequestOutcome = 'invalidated'): void {
+    for (const request of [...this.requests.values()]) {
+      if (request.scope.sessionId !== sessionId) continue
+      this.resolve(request.id, outcome)
+    }
+  }
+
+  getOpenRequestsForSession(sessionId: string): PendingUserInputRequest[] {
+    return [...this.requests.values()].filter((r) => r.scope.sessionId === sessionId)
+  }
+
+  /** Session-scoped AND agent-scoped entries for the agent. */
+  getOpenRequestsForAgent(agentSlug: string): PendingUserInputRequest[] {
+    return [...this.requests.values()].filter((r) => r.scope.agentSlug === agentSlug)
+  }
+
+  /** Agent-scoped only (no sessionId) — today: proxy / x-agent reviews. */
+  getAgentScopedRequests(agentSlug: string): PendingUserInputRequest[] {
+    return [...this.requests.values()].filter(
+      (r) => r.scope.agentSlug === agentSlug && r.scope.sessionId === undefined,
+    )
+  }
+
+  getShelfIdsForSession(sessionId: string, shelf: UserInputRequestShelf): string[] {
+    return [...this.requests.values()]
+      .filter((r) => r.scope.sessionId === sessionId && shelfForKind(r.kind) === shelf)
+      .map((r) => r.id)
+  }
+
+  private isRealWait(request: PendingUserInputRequest): boolean {
+    return request.blocking && !request.autoApproved
+  }
+
+  /**
+   * Derived awaiting projection for a session: any open real wait scoped to
+   * the session, plus any agent-scoped real wait of its agent (a parked review
+   * blocks every session of the agent — same semantics the imperative bit
+   * approximates today). Phase 3 flips the persister onto this; Phase 2 only
+   * compares it against the bit.
+   */
+  isSessionAwaiting(sessionId: string, agentSlug?: string): boolean {
+    for (const request of this.requests.values()) {
+      if (!this.isRealWait(request)) continue
+      if (request.scope.sessionId === sessionId) return true
+      if (
+        agentSlug !== undefined &&
+        request.scope.sessionId === undefined &&
+        request.scope.agentSlug === agentSlug
+      ) {
+        return true
+      }
+    }
+    return false
+  }
+
+  isAgentAwaiting(agentSlug: string): boolean {
+    for (const request of this.requests.values()) {
+      if (this.isRealWait(request) && request.scope.agentSlug === agentSlug) return true
+    }
+    return false
+  }
+
+  /**
+   * Shadow invariant: the registry's per-shelf view of a session must equal the
+   * legacy shelf exactly, at every shelf mutation point. Under vitest a
+   * mismatch throws (mutation paths swallow errors in places, so tests should
+   * ALSO assert `stats.shelfMismatches === 0`); in dev it logs.
+   */
+  verifyShelfParity(check: {
+    sessionId: string
+    context: string
+    streamShelfIds: string[]
+    computerUseShelfIds: string[]
+  }): void {
+    const mismatches: string[] = []
+    const compare = (shelf: UserInputRequestShelf, shelfIds: string[]) => {
+      const registryIds = this.getShelfIdsForSession(check.sessionId, shelf)
+      const expected = [...shelfIds].sort()
+      const actual = [...registryIds].sort()
+      if (expected.length !== actual.length || expected.some((id, i) => id !== actual[i])) {
+        mismatches.push(`${shelf}: shelf=[${expected.join(',')}] registry=[${actual.join(',')}]`)
+      }
+    }
+    compare('stream', check.streamShelfIds)
+    compare('computer_use', check.computerUseShelfIds)
+    if (mismatches.length === 0) return
+
+    this.shelfMismatchCount++
+    const message =
+      `[UserInputRequestManager] shadow shelf mismatch (session=${check.sessionId}, ` +
+      `context=${check.context}): ${mismatches.join('; ')}`
+    if (process.env.VITEST) throw new Error(message)
+    console.error(message)
+  }
+
+  /**
+   * Soft comparison of the imperative awaiting bit vs the derived projection.
+   * Never throws: the Phase 0 characterization suite pinned real split-brains
+   * where the bit is wrong, and this counter is the telemetry that sizes them.
+   * Warns once per divergence episode per session.
+   */
+  compareAwaitingProjection(check: {
+    sessionId: string
+    context: string
+    agentSlug: string | undefined
+    isAwaitingInput: boolean
+  }): void {
+    const projected = this.isSessionAwaiting(check.sessionId, check.agentSlug)
+    if (projected === check.isAwaitingInput) {
+      this.divergedSessions.delete(check.sessionId)
+      return
+    }
+    this.awaitingDivergenceCount++
+    if (this.divergedSessions.has(check.sessionId)) return
+    this.divergedSessions.add(check.sessionId)
+    console.warn(
+      `[UserInputRequestManager] awaiting divergence (session=${check.sessionId}, ` +
+        `context=${check.context}): bit=${check.isAwaitingInput} projection=${projected}`,
+    )
+  }
+
+  get stats(): {
+    open: number
+    shelfMismatches: number
+    awaitingDivergences: number
+    recentResolutions: Array<{
+      id: string
+      kind: PendingUserInputRequest['kind']
+      outcome: UserInputRequestOutcome
+    }>
+  } {
+    return {
+      open: this.requests.size,
+      shelfMismatches: this.shelfMismatchCount,
+      awaitingDivergences: this.awaitingDivergenceCount,
+      recentResolutions: [...this.recentResolutions],
+    }
+  }
+
+  /** Test hook: wipe all state including diagnostics. */
+  reset(): void {
+    this.requests.clear()
+    this.recentResolutions = []
+    this.shelfMismatchCount = 0
+    this.awaitingDivergenceCount = 0
+    this.divergedSessions.clear()
+  }
+}
+
+// Use globalThis to persist across dev-server hot reloads, matching
+// messagePersister and reviewManager — both write through to this registry, and
+// they survive reloads, so the registry must too or a reload would strand their
+// open requests in a stale instance.
+const globalForUserInputRequestManager = globalThis as unknown as {
+  userInputRequestManager: UserInputRequestManager | undefined
+}
+
+export const userInputRequestManager =
+  globalForUserInputRequestManager.userInputRequestManager ?? new UserInputRequestManager()
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForUserInputRequestManager.userInputRequestManager = userInputRequestManager
+}

--- a/src/shared/lib/user-input/request-manager.ts
+++ b/src/shared/lib/user-input/request-manager.ts
@@ -1,19 +1,19 @@
 import {
   pendingUserInputRequestSchema,
-  shelfForKind,
+  storeForKind,
   type PendingUserInputRequest,
   type PendingUserInputRequestInput,
   type UserInputRequestOutcome,
-  type UserInputRequestShelf,
+  type UserInputRequestStore,
 } from './request-schema'
 
 /**
  * Host-side registry of every pending user-input request, regardless of which
- * legacy store owns it (persister stream shelf, computer-use map, ReviewManager).
+ * legacy store owns it (persister stream store, computer-use map, ReviewManager).
  *
- * Phase 2 — SHADOW MODE: the legacy shelves stay authoritative and every
+ * Phase 2 — SHADOW MODE: the legacy stores stay authoritative and every
  * mutation writes through to this registry; nothing reads it for behavior.
- * `verifyShelfParity` asserts the mirror is exact at every shelf mutation
+ * `verifyStoreParity` asserts the mirror is exact at every store mutation
  * (throws under vitest, logs otherwise), and `compareAwaitingProjection`
  * counts divergence between the imperative awaiting bit and the projection
  * this registry derives — the known split-brains Phase 3 replaces the bit
@@ -29,7 +29,7 @@ export class UserInputRequestManager {
     outcome: UserInputRequestOutcome
   }> = []
 
-  private shelfMismatchCount = 0
+  private storeMismatchCount = 0
   private awaitingDivergenceCount = 0
   // Sessions currently known-diverged, so we warn once per divergence episode
   // instead of on every mutation while it persists.
@@ -69,26 +69,26 @@ export class UserInputRequestManager {
   }
 
   /**
-   * Settle a request only if it lives on the given legacy shelf. Mirrors
-   * shelf-scoped deletes exactly: a main-path tool_result deletes blindly from
-   * the stream shelf, and must not evict a computer-use or review entry that
+   * Settle a request only if it lives on the given legacy store. Mirrors
+   * store-scoped deletes exactly: a main-path tool_result deletes blindly from
+   * the stream store, and must not evict a computer-use or review entry that
    * its own store still holds.
    */
-  resolveIfShelf(
+  resolveIfInStore(
     id: string,
-    shelf: UserInputRequestShelf,
+    store: UserInputRequestStore,
     outcome: UserInputRequestOutcome,
   ): PendingUserInputRequest | null {
     const request = this.requests.get(id)
-    if (!request || shelfForKind(request.kind) !== shelf) return null
+    if (!request || storeForKind(request.kind) !== store) return null
     return this.resolve(id, outcome)
   }
 
-  /** Mirror of the turn-boundary `pendingInputRequests.clear()` — stream shelf only. */
+  /** Mirror of the turn-boundary `pendingInputRequests.clear()` — stream store only. */
   clearSessionStreamRequests(sessionId: string, outcome: UserInputRequestOutcome): void {
     for (const request of [...this.requests.values()]) {
       if (request.scope.sessionId !== sessionId) continue
-      if (shelfForKind(request.kind) !== 'stream') continue
+      if (storeForKind(request.kind) !== 'stream') continue
       this.resolve(request.id, outcome)
     }
   }
@@ -117,9 +117,9 @@ export class UserInputRequestManager {
     )
   }
 
-  getShelfIdsForSession(sessionId: string, shelf: UserInputRequestShelf): string[] {
+  getStoreIdsForSession(sessionId: string, store: UserInputRequestStore): string[] {
     return [...this.requests.values()]
-      .filter((r) => r.scope.sessionId === sessionId && shelfForKind(r.kind) === shelf)
+      .filter((r) => r.scope.sessionId === sessionId && storeForKind(r.kind) === store)
       .map((r) => r.id)
   }
 
@@ -158,79 +158,79 @@ export class UserInputRequestManager {
 
   private static describeIdMismatch(
     label: string,
-    shelfIds: string[],
+    storeIds: string[],
     registryIds: string[],
   ): string | null {
-    const expected = [...shelfIds].sort()
+    const expected = [...storeIds].sort()
     const actual = [...registryIds].sort()
     if (expected.length === actual.length && expected.every((id, i) => id === actual[i])) {
       return null
     }
-    return `${label}: shelf=[${expected.join(',')}] registry=[${actual.join(',')}]`
+    return `${label}: store=[${expected.join(',')}] registry=[${actual.join(',')}]`
   }
 
-  private reportShelfMismatch(scope: string, context: string, mismatches: string[]): void {
-    this.shelfMismatchCount++
+  private reportStoreMismatch(scope: string, context: string, mismatches: string[]): void {
+    this.storeMismatchCount++
     const message =
-      `[UserInputRequestManager] shadow shelf mismatch (${scope}, ` +
+      `[UserInputRequestManager] shadow store mismatch (${scope}, ` +
       `context=${context}): ${mismatches.join('; ')}`
     if (process.env.VITEST) throw new Error(message)
     console.error(message)
   }
 
   /**
-   * Shadow invariant: the registry's per-shelf view of a session must equal the
-   * legacy shelf exactly, at every shelf mutation point. Under vitest a
+   * Shadow invariant: the registry's per-store view of a session must equal the
+   * legacy store exactly, at every store mutation point. Under vitest a
    * mismatch throws (mutation paths swallow errors in places, so tests should
-   * ALSO assert `stats.shelfMismatches === 0`); in dev it logs.
+   * ALSO assert `stats.storeMismatches === 0`); in dev it logs.
    */
-  verifyShelfParity(check: {
+  verifyStoreParity(check: {
     sessionId: string
     context: string
-    streamShelfIds: string[]
-    computerUseShelfIds: string[]
+    streamStoreIds: string[]
+    computerUseStoreIds: string[]
   }): void {
     const mismatches = [
       UserInputRequestManager.describeIdMismatch(
         'stream',
-        check.streamShelfIds,
-        this.getShelfIdsForSession(check.sessionId, 'stream'),
+        check.streamStoreIds,
+        this.getStoreIdsForSession(check.sessionId, 'stream'),
       ),
       UserInputRequestManager.describeIdMismatch(
         'computer_use',
-        check.computerUseShelfIds,
-        this.getShelfIdsForSession(check.sessionId, 'computer_use'),
+        check.computerUseStoreIds,
+        this.getStoreIdsForSession(check.sessionId, 'computer_use'),
       ),
     ].filter((m): m is string => m !== null)
     if (mismatches.length === 0) return
-    this.reportShelfMismatch(`session=${check.sessionId}`, check.context, mismatches)
+    this.reportStoreMismatch(`session=${check.sessionId}`, check.context, mismatches)
   }
 
   /**
-   * Same invariant for the review shelf: the registry's agent-scoped review
+   * Same invariant for the review store: the registry's agent-scoped review
    * view must equal ReviewManager's pending store for the agent, at every
    * review mutation point.
    */
-  verifyReviewShelfParity(check: {
+  verifyReviewStoreParity(check: {
     agentSlug: string
     context: string
-    reviewShelfIds: string[]
+    reviewStoreIds: string[]
   }): void {
     const registryIds = [...this.requests.values()]
       .filter(
         (r) =>
           r.scope.agentSlug === check.agentSlug &&
           r.scope.sessionId === undefined &&
-          shelfForKind(r.kind) === 'review',
+          storeForKind(r.kind) === 'review',
       )
       .map((r) => r.id)
     const mismatch = UserInputRequestManager.describeIdMismatch(
       'review',
-      check.reviewShelfIds,
+      check.reviewStoreIds,
       registryIds,
     )
     if (mismatch === null) return
-    this.reportShelfMismatch(`agent=${check.agentSlug}`, check.context, [mismatch])
+    this.reportStoreMismatch(`agent=${check.agentSlug}`, check.context, [mismatch])
   }
 
   /**
@@ -261,7 +261,7 @@ export class UserInputRequestManager {
 
   get stats(): {
     open: number
-    shelfMismatches: number
+    storeMismatches: number
     awaitingDivergences: number
     recentResolutions: Array<{
       id: string
@@ -271,7 +271,7 @@ export class UserInputRequestManager {
   } {
     return {
       open: this.requests.size,
-      shelfMismatches: this.shelfMismatchCount,
+      storeMismatches: this.storeMismatchCount,
       awaitingDivergences: this.awaitingDivergenceCount,
       recentResolutions: [...this.recentResolutions],
     }
@@ -281,7 +281,7 @@ export class UserInputRequestManager {
   reset(): void {
     this.requests.clear()
     this.recentResolutions = []
-    this.shelfMismatchCount = 0
+    this.storeMismatchCount = 0
     this.awaitingDivergenceCount = 0
     this.divergedSessions.clear()
   }

--- a/src/shared/lib/user-input/request-manager.ts
+++ b/src/shared/lib/user-input/request-manager.ts
@@ -156,6 +156,28 @@ export class UserInputRequestManager {
     return false
   }
 
+  private static describeIdMismatch(
+    label: string,
+    shelfIds: string[],
+    registryIds: string[],
+  ): string | null {
+    const expected = [...shelfIds].sort()
+    const actual = [...registryIds].sort()
+    if (expected.length === actual.length && expected.every((id, i) => id === actual[i])) {
+      return null
+    }
+    return `${label}: shelf=[${expected.join(',')}] registry=[${actual.join(',')}]`
+  }
+
+  private reportShelfMismatch(scope: string, context: string, mismatches: string[]): void {
+    this.shelfMismatchCount++
+    const message =
+      `[UserInputRequestManager] shadow shelf mismatch (${scope}, ` +
+      `context=${context}): ${mismatches.join('; ')}`
+    if (process.env.VITEST) throw new Error(message)
+    console.error(message)
+  }
+
   /**
    * Shadow invariant: the registry's per-shelf view of a session must equal the
    * legacy shelf exactly, at every shelf mutation point. Under vitest a
@@ -168,25 +190,47 @@ export class UserInputRequestManager {
     streamShelfIds: string[]
     computerUseShelfIds: string[]
   }): void {
-    const mismatches: string[] = []
-    const compare = (shelf: UserInputRequestShelf, shelfIds: string[]) => {
-      const registryIds = this.getShelfIdsForSession(check.sessionId, shelf)
-      const expected = [...shelfIds].sort()
-      const actual = [...registryIds].sort()
-      if (expected.length !== actual.length || expected.some((id, i) => id !== actual[i])) {
-        mismatches.push(`${shelf}: shelf=[${expected.join(',')}] registry=[${actual.join(',')}]`)
-      }
-    }
-    compare('stream', check.streamShelfIds)
-    compare('computer_use', check.computerUseShelfIds)
+    const mismatches = [
+      UserInputRequestManager.describeIdMismatch(
+        'stream',
+        check.streamShelfIds,
+        this.getShelfIdsForSession(check.sessionId, 'stream'),
+      ),
+      UserInputRequestManager.describeIdMismatch(
+        'computer_use',
+        check.computerUseShelfIds,
+        this.getShelfIdsForSession(check.sessionId, 'computer_use'),
+      ),
+    ].filter((m): m is string => m !== null)
     if (mismatches.length === 0) return
+    this.reportShelfMismatch(`session=${check.sessionId}`, check.context, mismatches)
+  }
 
-    this.shelfMismatchCount++
-    const message =
-      `[UserInputRequestManager] shadow shelf mismatch (session=${check.sessionId}, ` +
-      `context=${check.context}): ${mismatches.join('; ')}`
-    if (process.env.VITEST) throw new Error(message)
-    console.error(message)
+  /**
+   * Same invariant for the review shelf: the registry's agent-scoped review
+   * view must equal ReviewManager's pending store for the agent, at every
+   * review mutation point.
+   */
+  verifyReviewShelfParity(check: {
+    agentSlug: string
+    context: string
+    reviewShelfIds: string[]
+  }): void {
+    const registryIds = [...this.requests.values()]
+      .filter(
+        (r) =>
+          r.scope.agentSlug === check.agentSlug &&
+          r.scope.sessionId === undefined &&
+          shelfForKind(r.kind) === 'review',
+      )
+      .map((r) => r.id)
+    const mismatch = UserInputRequestManager.describeIdMismatch(
+      'review',
+      check.reviewShelfIds,
+      registryIds,
+    )
+    if (mismatch === null) return
+    this.reportShelfMismatch(`agent=${check.agentSlug}`, check.context, [mismatch])
   }
 
   /**

--- a/src/shared/lib/user-input/request-schema.ts
+++ b/src/shared/lib/user-input/request-schema.ts
@@ -1,0 +1,200 @@
+import { z } from 'zod'
+
+/**
+ * Typed model for "the agent is blocked on a human" — one envelope for every
+ * pending user-input request regardless of which store currently owns it.
+ *
+ * Phase 2 (shadow registry): this model mirrors the existing shelves via
+ * write-through and is compared against them; nothing reads it for behavior
+ * yet. The envelope is strict (we construct it), the per-kind payloads are
+ * deliberately lenient (`looseObject` + `.catch`) so a malformed tool input
+ * can never make the shadow diverge from the shelf it mirrors.
+ */
+
+export const USER_INPUT_REQUEST_KINDS = [
+  'question',
+  'secret',
+  'connected_account',
+  'file',
+  'remote_mcp',
+  'browser_input',
+  'script_run',
+  'capability_review',
+  'computer_use',
+  'proxy_review',
+  'x_agent_review',
+] as const
+
+export const userInputRequestKindSchema = z.enum(USER_INPUT_REQUEST_KINDS)
+export type UserInputRequestKind = z.infer<typeof userInputRequestKindSchema>
+
+export const userInputRequestOutcomeSchema = z.enum([
+  'answered',
+  'declined',
+  'cancelled',
+  'superseded',
+  'timeout',
+  'invalidated',
+])
+export type UserInputRequestOutcome = z.infer<typeof userInputRequestOutcomeSchema>
+
+/** sessionId absent ⇒ agent-scoped (proxy / x-agent reviews). */
+const requestScopeSchema = z.object({
+  agentSlug: z.string().optional(),
+  sessionId: z.string().optional(),
+})
+export type UserInputRequestScope = z.infer<typeof requestScopeSchema>
+
+const baseRequest = z.object({
+  /** toolUseId for stream/computer-use kinds, reviewId for reviews — one namespace. */
+  id: z.string().min(1),
+  scope: requestScopeSchema,
+  /** Whether an open instance of this request keeps the session "awaiting input". */
+  blocking: z.boolean(),
+  /** Auto-approved asks (e.g. allowlisted script_run) are visible but never block. */
+  autoApproved: z.boolean().default(false),
+})
+
+const lenientString = z.string().optional().catch(undefined)
+
+export const pendingUserInputRequestSchema = z.discriminatedUnion('kind', [
+  baseRequest.extend({
+    kind: z.literal('question'),
+    payload: z.looseObject({ questions: z.unknown().optional() }),
+  }),
+  baseRequest.extend({
+    kind: z.literal('secret'),
+    payload: z.looseObject({ secretName: lenientString, reason: lenientString }),
+  }),
+  baseRequest.extend({
+    kind: z.literal('connected_account'),
+    payload: z.looseObject({ toolkit: lenientString, reason: lenientString }),
+  }),
+  baseRequest.extend({
+    kind: z.literal('file'),
+    payload: z.looseObject({ description: lenientString, fileTypes: z.unknown().optional() }),
+  }),
+  baseRequest.extend({
+    kind: z.literal('remote_mcp'),
+    payload: z.looseObject({
+      url: lenientString,
+      name: lenientString,
+      reason: lenientString,
+      authHint: lenientString,
+    }),
+  }),
+  baseRequest.extend({
+    kind: z.literal('browser_input'),
+    payload: z.looseObject({ message: lenientString, requirements: z.unknown().optional() }),
+  }),
+  baseRequest.extend({
+    kind: z.literal('script_run'),
+    payload: z.looseObject({
+      script: lenientString,
+      explanation: lenientString,
+      scriptType: lenientString,
+    }),
+  }),
+  baseRequest.extend({
+    kind: z.literal('capability_review'),
+    payload: z.looseObject({
+      capability: lenientString,
+      toolName: lenientString,
+      input: z.unknown().optional(),
+    }),
+  }),
+  baseRequest.extend({
+    kind: z.literal('computer_use'),
+    payload: z.looseObject({
+      method: lenientString,
+      params: z.record(z.string(), z.unknown()).optional().catch(undefined),
+      permissionLevel: lenientString,
+      appName: lenientString,
+    }),
+  }),
+  baseRequest.extend({
+    kind: z.literal('proxy_review'),
+    payload: z.looseObject({
+      accountId: lenientString,
+      toolkit: lenientString,
+      method: lenientString,
+      targetPath: lenientString,
+      matchedScopes: z.array(z.string()).optional().catch(undefined),
+      scopeDescriptions: z.record(z.string(), z.string()).optional().catch(undefined),
+      endpointDescription: lenientString,
+    }),
+  }),
+  baseRequest.extend({
+    kind: z.literal('x_agent_review'),
+    payload: z.looseObject({
+      accountId: lenientString,
+      toolkit: lenientString,
+      method: lenientString,
+      targetPath: lenientString,
+      matchedScopes: z.array(z.string()).optional().catch(undefined),
+      xAgent: z
+        .looseObject({
+          targetAgentSlug: lenientString,
+          targetAgentName: lenientString,
+          operation: lenientString,
+          preview: lenientString,
+        })
+        .optional()
+        .catch(undefined),
+    }),
+  }),
+])
+
+export type PendingUserInputRequest = z.infer<typeof pendingUserInputRequestSchema>
+export type PendingUserInputRequestInput = z.input<typeof pendingUserInputRequestSchema>
+
+/**
+ * Which legacy shelf a kind lives on today. The shadow registry uses this to
+ * mirror shelf-scoped operations exactly (e.g. the turn-boundary clear wipes
+ * only the stream shelf; a stray tool_result must never evict a computer-use
+ * entry the shelf still holds).
+ */
+export type UserInputRequestShelf = 'stream' | 'computer_use' | 'review'
+
+export function shelfForKind(kind: UserInputRequestKind): UserInputRequestShelf {
+  if (kind === 'computer_use') return 'computer_use'
+  if (kind === 'proxy_review' || kind === 'x_agent_review') return 'review'
+  return 'stream'
+}
+
+/** Broadcast event type → request kind, for the persister's SSE-intercept feeder. */
+const STREAM_EVENT_TYPE_TO_KIND: Record<string, UserInputRequestKind> = {
+  user_question_request: 'question',
+  secret_request: 'secret',
+  connected_account_request: 'connected_account',
+  file_request: 'file',
+  remote_mcp_request: 'remote_mcp',
+  browser_input_request: 'browser_input',
+  script_run_request: 'script_run',
+  capability_review_request: 'capability_review',
+}
+
+/**
+ * Build a registry envelope from a pending-input broadcast event (the exact
+ * object the persister stores in `pendingInputRequests`). Returns null for
+ * event types that are not user-input requests.
+ */
+export function streamEventToPendingRequest(
+  sessionId: string,
+  evt: { type: string; toolUseId: string; [k: string]: unknown },
+): PendingUserInputRequestInput | null {
+  const kind = STREAM_EVENT_TYPE_TO_KIND[evt.type]
+  if (!kind) return null
+  const { type: _type, toolUseId: _toolUseId, agentSlug, autoApproved, ...payload } = evt
+  return {
+    id: evt.toolUseId,
+    kind,
+    scope: {
+      agentSlug: typeof agentSlug === 'string' ? agentSlug : undefined,
+      sessionId,
+    },
+    blocking: true,
+    autoApproved: autoApproved === true,
+    payload,
+  } as PendingUserInputRequestInput
+}

--- a/src/shared/lib/user-input/request-schema.ts
+++ b/src/shared/lib/user-input/request-schema.ts
@@ -4,11 +4,11 @@ import { z } from 'zod'
  * Typed model for "the agent is blocked on a human" — one envelope for every
  * pending user-input request regardless of which store currently owns it.
  *
- * Phase 2 (shadow registry): this model mirrors the existing shelves via
+ * Phase 2 (shadow registry): this model mirrors the existing stores via
  * write-through and is compared against them; nothing reads it for behavior
  * yet. The envelope is strict (we construct it), the per-kind payloads are
  * deliberately lenient (`looseObject` + `.catch`) so a malformed tool input
- * can never make the shadow diverge from the shelf it mirrors.
+ * can never make the shadow diverge from the store it mirrors.
  */
 
 export const USER_INPUT_REQUEST_KINDS = [
@@ -149,14 +149,14 @@ export type PendingUserInputRequest = z.infer<typeof pendingUserInputRequestSche
 export type PendingUserInputRequestInput = z.input<typeof pendingUserInputRequestSchema>
 
 /**
- * Which legacy shelf a kind lives on today. The shadow registry uses this to
- * mirror shelf-scoped operations exactly (e.g. the turn-boundary clear wipes
- * only the stream shelf; a stray tool_result must never evict a computer-use
- * entry the shelf still holds).
+ * Which legacy store a kind lives on today. The shadow registry uses this to
+ * mirror store-scoped operations exactly (e.g. the turn-boundary clear wipes
+ * only the stream store; a stray tool_result must never evict a computer-use
+ * entry the store still holds).
  */
-export type UserInputRequestShelf = 'stream' | 'computer_use' | 'review'
+export type UserInputRequestStore = 'stream' | 'computer_use' | 'review'
 
-export function shelfForKind(kind: UserInputRequestKind): UserInputRequestShelf {
+export function storeForKind(kind: UserInputRequestKind): UserInputRequestStore {
   if (kind === 'computer_use') return 'computer_use'
   if (kind === 'proxy_review' || kind === 'x_agent_review') return 'review'
   return 'stream'


### PR DESCRIPTION
Phase 2 of the user-input request rearchitecture (follows #560 characterization and #562 unified dispatch). Introduces the typed pending-request model and `UserInputRequestManager` as a **write-through shadow** of the existing stores: the legacy shelves stay authoritative, every mutation mirrors into the registry, and **nothing reads it for behavior yet** — zero behavior change by construction, enforced by assertions rather than by promise.

## What's new

**`src/shared/lib/user-input/request-schema.ts`** — one typed envelope for "the agent is blocked on a human": a Zod discriminated union over all 11 kinds (question, secret, connected_account, file, remote_mcp, browser_input, script_run, capability_review, computer_use, proxy_review, x_agent_review) with `id`, `scope {agentSlug, sessionId?}` (no sessionId ⇒ agent-scoped, i.e. reviews), `blocking`, `autoApproved`, and a per-kind payload. The envelope is strict; payloads are deliberately lenient (`.catch`) so a malformed tool input can never make shadow registration break a real delivery path.

**`src/shared/lib/user-input/request-manager.ts`** — the registry:
- `register` is first-delivery-wins (stream stop and complete-assistant can both carry the same tool_use — same rule the Phase 1 dispatcher enforces).
- `resolve` is idempotent and outcome-tagged (`answered | declined | cancelled | superseded | timeout | invalidated`).
- Resolves are **shelf-scoped** where the legacy delete is: a main-path `tool_result` deletes blindly from the stream shelf today, so `resolveIfShelf` refuses to let it evict a computer-use or review entry whose own store still holds it.
- `isSessionAwaiting` / `isAgentAwaiting` are the derived projections (any open blocking non-auto-approved request in scope; agent-scoped reviews block every session of the agent). Phase 3 promotes these to authoritative; this PR only compares them.

## Write-through wiring

- **Persister (8 hook points)** — nearly everything funnels through the single `broadcastToSSE` interceptor (set on the 8 request event types, clear on turn boundaries), plus the direct-delete doors: `completeCapabilityReview`, `clearPendingComputerUseRequest`, `cancelAwaitingInput`, `handleComputerUseRequestTool`, `resolveSidechainInputRequests`, `handleToolResults`, and `unsubscribeFromSession` (session death invalidates its entries).
- **ReviewManager (all 9 entry/exit paths)** — reviews register as agent-scoped envelopes (`proxy_review` / `x_agent_review` by `details.xAgent`); every exit (decision, sweeps, deny-all, 5-min timeout, abort, rejectAll) settles the envelope with a faithful outcome.

## Equivalence checks (the point of the phase)

- **Strict shelf parity**: at every mutation point (dev/test only, skipped in production) the registry's per-shelf view must equal the legacy shelf exactly — throws under vitest, logs in dev.
- **Awaiting projection vs the imperative bit**: compared a microtask after each mutation (the imperative mark/clear lands later in the same synchronous stretch), warn-once-per-episode + counter, never throws — because Phase 0 proved the bit is genuinely wrong in pinned cases, and this counter is the telemetry that sizes the Phase 3 flip.

## Validation

- `tsc --noEmit` and eslint clean.
- **Full unit suite: 7,718 passed / 0 failed** — with the strict parity assertion live under every existing persister/review test (352 in the directly affected suites, unmodified).
- ~30 new tests: manager unit suite (dedupe, shelf-scoped resolves, projections, diagnostics), an equivalence describe in the lifecycle characterization suite (per-kind mirror + the split-brain pins showing projection right where the bit is wrong), and a ReviewManager write-through describe (all exits → correct outcomes).
- **E2E: 40/40** across the seven request-flow specs (`user-input-requests`, `mixed-pending-requests`, `proxy-review`, `proxy-review-xagent`, `capability-review`, `awaiting-input-status`, `pending-request-reconnect`), with the dev server logging **zero shelf mismatches** and exactly **6 awaiting-divergence episodes — every one `bit=false, projection=true`**: the known split-brains observed live, with the registry on the correct side each time.

## Next (not in this PR)

Phase 3 flips awaiting to the derived projection and deletes `registerAwaitingBlockerSource`; the persister's awaiting-status test matrix is the acceptance suite.

https://claude.ai/code/session_01DLw9AJ5VXVQPzBAz87nNAA