### PR TITLE
Fix cross-agent invocation naming and attribution (SUP-467)

### DIFF
--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -180,6 +180,16 @@ function authedFetch(path: string, body: unknown, token = CALLER_TOKEN) {
   })
 }
 
+async function grantCallerOwnerTargetAccess() {
+  await testDb.insert(schema.agentAcl).values({
+    id: randomUUID(),
+    userId: OWNER_USER_ID,
+    agentSlug: TARGET_SLUG,
+    role: 'user',
+    createdAt: new Date(),
+  })
+}
+
 beforeEach(async () => {
   testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'xagent-test-'))
   // Point the data dir at testDir so the REAL resolveAgentId (not mocked) finds
@@ -190,6 +200,7 @@ beforeEach(async () => {
   await fs.promises.mkdir(path.join(testDir, 'agents', CALLER_SLUG), { recursive: true })
   await fs.promises.mkdir(path.join(testDir, 'agents', TARGET_SLUG), { recursive: true })
   testSqlite = new Database(':memory:')
+  testSqlite.pragma('foreign_keys = ON')
   testDb = drizzle(testSqlite, { schema })
   const migrationsFolder = path.join(process.cwd(), 'src/shared/lib/db/migrations')
   migrate(testDb, { migrationsFolder })
@@ -223,6 +234,7 @@ beforeEach(async () => {
   mockIsSessionAwaitingInput.mockReturnValue(false)
   mockWaitForIdle.mockResolvedValue(undefined)
   mockReadAgentPreferences.mockResolvedValue({})
+  mockGetSessionMetadata.mockResolvedValue(null)
   mockEnsureRunning.mockClear()
   mockEnsureRunning.mockResolvedValue({
     createSession: mockCreateSession,
@@ -458,6 +470,7 @@ describe('/invoke', () => {
     expect(mockCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({ initialMessage: 'hello' }),
     )
+    expect(mockCreateSession.mock.calls[0][0]).not.toHaveProperty('initialMessageUuid')
     expect(mockUpdateSessionMetadata).toHaveBeenCalledWith(
       TARGET_SLUG,
       'new-sess-id',
@@ -495,17 +508,35 @@ describe('/invoke', () => {
     )
   })
 
+  it('falls back to the caller slug when display-name lookup fails', async () => {
+    reviewDecisions.push('allow')
+    mockGetAgent.mockImplementation(async (slug: unknown) => {
+      if (slug === CALLER_SLUG) throw new Error('caller metadata unavailable')
+      return {
+        slug: TARGET_SLUG,
+        frontmatter: { name: 'Target', createdAt: '2024-01-01' },
+        instructions: '',
+      }
+    })
+
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'hello',
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockRegisterSession).toHaveBeenCalledWith(
+      TARGET_SLUG,
+      'new-sess-id',
+      `Invoked by ${CALLER_SLUG}`,
+    )
+  })
+
   it('attributes a new invoked message to the latest sender in a shared caller session', async () => {
     authModeEnabled = true
     reviewDecisions.push('allow')
     const callerSessionId = 'shared-caller-session'
-    await testDb.insert(schema.agentAcl).values({
-      id: randomUUID(),
-      userId: OWNER_USER_ID,
-      agentSlug: TARGET_SLUG,
-      role: 'user',
-      createdAt: new Date(),
-    })
+    await grantCallerOwnerTargetAccess()
     await testDb.insert(schema.messageAuthor).values([
       {
         id: 'owner-message',
@@ -555,17 +586,99 @@ describe('/invoke', () => {
     )
   })
 
+  it('falls back to the session creator when no message author is recorded', async () => {
+    authModeEnabled = true
+    reviewDecisions.push('allow')
+    const callerSessionId = 'legacy-caller-session'
+    await grantCallerOwnerTargetAccess()
+    mockGetSessionMetadata.mockResolvedValue({
+      name: 'Legacy shared session',
+      createdAt: new Date().toISOString(),
+      createdByUserId: OTHER_USER_ID,
+    })
+
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'legacy hello',
+      _callerSessionId: callerSessionId,
+    })
+
+    expect(res.status).toBe(200)
+    const targetAuthors = await testDb
+      .select()
+      .from(schema.messageAuthor)
+      .where(eq(schema.messageAuthor.sessionId, 'new-sess-id'))
+    expect(targetAuthors).toEqual([
+      expect.objectContaining({ userId: OTHER_USER_ID }),
+    ])
+    expect(mockUpdateSessionMetadata).toHaveBeenCalledWith(
+      TARGET_SLUG,
+      'new-sess-id',
+      expect.objectContaining({ createdByUserId: OTHER_USER_ID }),
+    )
+  })
+
+  it('falls back to the caller owner when legacy metadata has no user attribution', async () => {
+    authModeEnabled = true
+    reviewDecisions.push('allow')
+    await grantCallerOwnerTargetAccess()
+
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'owner fallback',
+      _callerSessionId: 'legacy-caller-session',
+    })
+
+    expect(res.status).toBe(200)
+    const targetAuthors = await testDb
+      .select()
+      .from(schema.messageAuthor)
+      .where(eq(schema.messageAuthor.sessionId, 'new-sess-id'))
+    expect(targetAuthors).toEqual([
+      expect.objectContaining({ userId: OWNER_USER_ID }),
+    ])
+    expect(mockUpdateSessionMetadata).toHaveBeenCalledWith(
+      TARGET_SLUG,
+      'new-sess-id',
+      expect.objectContaining({ createdByUserId: OWNER_USER_ID }),
+    )
+  })
+
+  it('continues without attribution when legacy createdByUserId no longer exists', async () => {
+    authModeEnabled = true
+    reviewDecisions.push('allow')
+    await grantCallerOwnerTargetAccess()
+    mockGetSessionMetadata.mockResolvedValue({
+      name: 'Deleted user session',
+      createdAt: new Date().toISOString(),
+      createdByUserId: 'deleted-user',
+    })
+
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'still invoke',
+      _callerSessionId: 'legacy-caller-session',
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockRegisterSession).toHaveBeenCalled()
+    const targetAuthors = await testDb
+      .select()
+      .from(schema.messageAuthor)
+      .where(eq(schema.messageAuthor.sessionId, 'new-sess-id'))
+    expect(targetAuthors).toEqual([])
+    expect(mockUpdateSessionMetadata).toHaveBeenCalledWith(
+      TARGET_SLUG,
+      'new-sess-id',
+      { invokedByAgentSlug: CALLER_SLUG },
+    )
+  })
+
   it('attributes a continued target-session message to the shared-session sender', async () => {
     authModeEnabled = true
     reviewDecisions.push('allow')
     const callerSessionId = 'shared-caller-session'
-    await testDb.insert(schema.agentAcl).values({
-      id: randomUUID(),
-      userId: OWNER_USER_ID,
-      agentSlug: TARGET_SLUG,
-      role: 'user',
-      createdAt: new Date(),
-    })
+    await grantCallerOwnerTargetAccess()
     await testDb.insert(schema.messageAuthor).values({
       id: 'other-message',
       sessionId: callerSessionId,
@@ -601,6 +714,26 @@ describe('/invoke', () => {
     ])
   })
 
+  it('removes continued-session attribution when sendMessage fails', async () => {
+    authModeEnabled = true
+    reviewDecisions.push('allow')
+    await grantCallerOwnerTargetAccess()
+    mockSendMessage.mockRejectedValueOnce(new Error('send failed'))
+
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'follow-up',
+      sessionId: 'existing-sess',
+    })
+
+    expect(res.status).toBe(500)
+    const targetAuthors = await testDb
+      .select()
+      .from(schema.messageAuthor)
+      .where(eq(schema.messageAuthor.sessionId, 'existing-sess'))
+    expect(targetAuthors).toEqual([])
+  })
+
   it('cleans up the container session if registerSession fails (no orphan)', async () => {
     reviewDecisions.push('allow')
     mockRegisterSession.mockRejectedValueOnce(new Error('disk full'))
@@ -612,6 +745,25 @@ describe('/invoke', () => {
     // Container session should have been deleted to avoid burning model budget on an orphan
     expect(mockDeleteSession).toHaveBeenCalledWith('new-sess-id')
     expect(mockCaptureException).toHaveBeenCalled()
+  })
+
+  it('cleans up an attributed author row when registerSession fails', async () => {
+    authModeEnabled = true
+    reviewDecisions.push('allow')
+    await grantCallerOwnerTargetAccess()
+    mockRegisterSession.mockRejectedValueOnce(new Error('disk full'))
+
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'hello',
+    })
+
+    expect(res.status).toBe(500)
+    const targetAuthors = await testDb
+      .select()
+      .from(schema.messageAuthor)
+      .where(eq(schema.messageAuthor.sessionId, 'new-sess-id'))
+    expect(targetAuthors).toEqual([])
   })
 
   it('returns 500 with stage=ensure_running when target container start fails', async () => {

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -12,6 +12,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
 import Database from 'better-sqlite3'
+import { eq } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
 import { randomUUID } from 'crypto'
@@ -462,6 +463,142 @@ describe('/invoke', () => {
       'new-sess-id',
       expect.objectContaining({ invokedByAgentSlug: CALLER_SLUG }),
     )
+  })
+
+  it('names a new session after the caller agent display name', async () => {
+    reviewDecisions.push('allow')
+    mockGetAgent.mockImplementation(async (slug: unknown) => {
+      if (slug === CALLER_SLUG) {
+        return {
+          slug: CALLER_SLUG,
+          frontmatter: { name: 'Business Analyst Agent', createdAt: '2024-01-01' },
+          instructions: '',
+        }
+      }
+      return {
+        slug: TARGET_SLUG,
+        frontmatter: { name: 'Target', createdAt: '2024-01-01' },
+        instructions: '',
+      }
+    })
+
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'hello',
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockRegisterSession).toHaveBeenCalledWith(
+      TARGET_SLUG,
+      'new-sess-id',
+      'Invoked by Business Analyst Agent',
+    )
+  })
+
+  it('attributes a new invoked message to the latest sender in a shared caller session', async () => {
+    authModeEnabled = true
+    reviewDecisions.push('allow')
+    const callerSessionId = 'shared-caller-session'
+    await testDb.insert(schema.agentAcl).values({
+      id: randomUUID(),
+      userId: OWNER_USER_ID,
+      agentSlug: TARGET_SLUG,
+      role: 'user',
+      createdAt: new Date(),
+    })
+    await testDb.insert(schema.messageAuthor).values([
+      {
+        id: 'owner-message',
+        sessionId: callerSessionId,
+        agentSlug: CALLER_SLUG,
+        userId: OWNER_USER_ID,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+      {
+        id: 'other-message',
+        sessionId: callerSessionId,
+        agentSlug: CALLER_SLUG,
+        userId: OTHER_USER_ID,
+        createdAt: new Date('2026-01-01T00:00:01.000Z'),
+      },
+    ])
+    mockGetSessionMetadata.mockResolvedValue({
+      name: 'Shared session',
+      createdAt: new Date().toISOString(),
+      createdByUserId: OWNER_USER_ID,
+    })
+
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'hello from the shared session',
+      _callerSessionId: callerSessionId,
+    })
+
+    expect(res.status).toBe(200)
+    const createArgs = mockCreateSession.mock.calls[0][0] as Record<string, unknown>
+    expect(createArgs.initialMessageUuid).toEqual(expect.any(String))
+    const targetAuthors = await testDb
+      .select()
+      .from(schema.messageAuthor)
+      .where(eq(schema.messageAuthor.sessionId, 'new-sess-id'))
+    expect(targetAuthors).toEqual([
+      expect.objectContaining({
+        id: createArgs.initialMessageUuid,
+        agentSlug: TARGET_SLUG,
+        userId: OTHER_USER_ID,
+      }),
+    ])
+    expect(mockUpdateSessionMetadata).toHaveBeenCalledWith(
+      TARGET_SLUG,
+      'new-sess-id',
+      expect.objectContaining({ createdByUserId: OTHER_USER_ID }),
+    )
+  })
+
+  it('attributes a continued target-session message to the shared-session sender', async () => {
+    authModeEnabled = true
+    reviewDecisions.push('allow')
+    const callerSessionId = 'shared-caller-session'
+    await testDb.insert(schema.agentAcl).values({
+      id: randomUUID(),
+      userId: OWNER_USER_ID,
+      agentSlug: TARGET_SLUG,
+      role: 'user',
+      createdAt: new Date(),
+    })
+    await testDb.insert(schema.messageAuthor).values({
+      id: 'other-message',
+      sessionId: callerSessionId,
+      agentSlug: CALLER_SLUG,
+      userId: OTHER_USER_ID,
+      createdAt: new Date(),
+    })
+
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'follow-up',
+      sessionId: 'existing-sess',
+      _callerSessionId: callerSessionId,
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      'existing-sess',
+      'follow-up',
+      expect.any(String),
+    )
+    const sentMessageUuid = mockSendMessage.mock.calls[0][2]
+    const targetAuthors = await testDb
+      .select()
+      .from(schema.messageAuthor)
+      .where(eq(schema.messageAuthor.sessionId, 'existing-sess'))
+    expect(targetAuthors).toEqual([
+      expect.objectContaining({
+        id: sentMessageUuid,
+        agentSlug: TARGET_SLUG,
+        userId: OTHER_USER_ID,
+      }),
+    ])
   })
 
   it('cleans up the container session if registerSession fails (no orphan)', async () => {
@@ -953,4 +1090,3 @@ describe('display-slug resolution', () => {
     expect(res.status).toBe(404)
   })
 })
-

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -14,9 +14,9 @@ import { Hono } from 'hono'
 import { z } from 'zod'
 import { zValidator } from '@hono/zod-validator'
 import { randomUUID } from 'crypto'
-import { and, eq } from 'drizzle-orm'
+import { and, desc, eq } from 'drizzle-orm'
 import { db } from '@shared/lib/db'
-import { agentAcl } from '@shared/lib/db/schema'
+import { agentAcl, messageAuthor } from '@shared/lib/db/schema'
 import { isAuthMode } from '@shared/lib/auth/mode'
 import { hasMinRole, type AgentRole } from '@shared/lib/types/agent'
 import { runWithOptionalUser } from '@shared/lib/platform-attribution'
@@ -91,6 +91,27 @@ async function getOwnersOfAgent(agentSlug: string): Promise<string[]> {
     .from(agentAcl)
     .where(and(eq(agentAcl.agentSlug, agentSlug), eq(agentAcl.role, 'owner')))
   return rows.map((r) => r.userId)
+}
+
+/**
+ * Resolve the user who sent the message currently driving an agent session.
+ * In shared sessions this can differ from the session creator, so invocation
+ * attribution must prefer the latest per-message author record.
+ */
+async function getLatestMessageAuthorUserId(
+  agentSlug: string,
+  sessionId: string,
+): Promise<string | undefined> {
+  const rows = await db
+    .select({ userId: messageAuthor.userId })
+    .from(messageAuthor)
+    .where(and(
+      eq(messageAuthor.agentSlug, agentSlug),
+      eq(messageAuthor.sessionId, sessionId),
+    ))
+    .orderBy(desc(messageAuthor.createdAt))
+    .limit(1)
+  return rows[0]?.userId
 }
 
 /**
@@ -497,6 +518,12 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
     )
   }
 
+  // Capture the triggering message's author before a review prompt can pause
+  // this request and newer messages can arrive in a shared caller session.
+  const triggeringUserId = isAuthMode() && _callerSessionId
+    ? await getLatestMessageAuthorUserId(callerSlug, _callerSessionId)
+    : undefined
+
   const target = await getAgent(targetSlug)
   if (!target) return c.json({ error: 'Target agent not found' }, 404)
 
@@ -515,8 +542,9 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
     return c.json({ error: policy.reason ?? 'Forbidden' }, 403)
   }
 
-  // Attribute to session creator → caller agent's first owner (auth-mode fallback).
-  let attributedUserId: string | undefined = callerMeta?.createdByUserId
+  // Attribute to the triggering message author. Session creator and caller
+  // owner remain compatibility fallbacks for old sessions without author rows.
+  let attributedUserId: string | undefined = triggeringUserId ?? callerMeta?.createdByUserId
   if (!attributedUserId && isAuthMode()) {
     attributedUserId = (await getOwnersOfAgent(callerSlug))[0]
   }
@@ -537,7 +565,18 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         }
         messagePersister.markSessionActive(existingSessionId, targetSlug)
         stage = 'send_message'
-        await client.sendMessage(existingSessionId, prompt)
+        if (isAuthMode() && attributedUserId) {
+          const messageUuid = randomUUID()
+          await db.insert(messageAuthor).values({
+            id: messageUuid,
+            sessionId: existingSessionId,
+            agentSlug: targetSlug,
+            userId: attributedUserId,
+          })
+          await client.sendMessage(existingSessionId, prompt, messageUuid)
+        } else {
+          await client.sendMessage(existingSessionId, prompt)
+        }
 
         if (sync) {
           try {
@@ -566,11 +605,17 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
       const agentLimits = getEffectiveAgentLimits()
       const customEnvVars = getCustomEnvVars()
       const targetPrefs = await readAgentPreferences(targetSlug)
+      const caller = await getAgent(callerSlug)
+      const callerName = caller?.frontmatter.name || callerSlug
+      const initialMessageUuid = isAuthMode() && attributedUserId
+        ? randomUUID()
+        : undefined
 
       stage = 'create_session'
       const containerSession = await client.createSession({
         availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
         initialMessage: prompt,
+        ...(initialMessageUuid ? { initialMessageUuid } : {}),
         model: targetPrefs.defaultModel ?? getEffectiveModels().agentModel,
         browserModel: getEffectiveModels().browserModel,
         dashboardBuilderModel: getEffectiveModels().dashboardBuilderModel,
@@ -589,7 +634,15 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
 
       stage = 'register_session'
       try {
-        await registerSession(targetSlug, newSessionId, `Invoked by ${callerSlug}`)
+        if (initialMessageUuid && attributedUserId) {
+          await db.insert(messageAuthor).values({
+            id: initialMessageUuid,
+            sessionId: newSessionId,
+            agentSlug: targetSlug,
+            userId: attributedUserId,
+          })
+        }
+        await registerSession(targetSlug, newSessionId, `Invoked by ${callerName}`)
       } catch (registerErr) {
         const message = registerErr instanceof Error ? registerErr.message : String(registerErr)
         console.error('[x-agent] invoke failed', {
@@ -609,6 +662,17 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
             error: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
           })
         })
+        if (initialMessageUuid) {
+          await db
+            .delete(messageAuthor)
+            .where(eq(messageAuthor.id, initialMessageUuid))
+            .catch((cleanupErr) => {
+              console.error('[x-agent] failed to clean up invoked message attribution', {
+                messageUuid: initialMessageUuid,
+                error: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+              })
+            })
+        }
         messagePersister.unsubscribeFromSession(newSessionId)
         return c.json({ error: `Failed to register invoked session: ${message}` }, 500)
       }

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -102,16 +102,73 @@ async function getLatestMessageAuthorUserId(
   agentSlug: string,
   sessionId: string,
 ): Promise<string | undefined> {
-  const rows = await db
-    .select({ userId: messageAuthor.userId })
-    .from(messageAuthor)
-    .where(and(
-      eq(messageAuthor.agentSlug, agentSlug),
-      eq(messageAuthor.sessionId, sessionId),
-    ))
-    .orderBy(desc(messageAuthor.createdAt))
-    .limit(1)
-  return rows[0]?.userId
+  try {
+    const rows = await db
+      .select({ userId: messageAuthor.userId })
+      .from(messageAuthor)
+      .where(and(
+        eq(messageAuthor.agentSlug, agentSlug),
+        eq(messageAuthor.sessionId, sessionId),
+      ))
+      .orderBy(desc(messageAuthor.createdAt), desc(messageAuthor.id))
+      .limit(1)
+    return rows[0]?.userId
+  } catch (error) {
+    // Attribution is optional. A DB/read failure must never block the invoke.
+    console.warn('[x-agent] failed to resolve triggering message author; continuing unattributed', {
+      agentSlug,
+      sessionId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return undefined
+  }
+}
+
+async function insertMessageAuthorBestEffort(params: {
+  id: string
+  sessionId: string
+  agentSlug: string
+  userId: string
+}): Promise<boolean> {
+  try {
+    await db.insert(messageAuthor).values(params)
+    return true
+  } catch (error) {
+    // Includes stale createdByUserId values whose user row has been deleted.
+    // The invocation remains usable; only the optional sender badge is lost.
+    console.warn('[x-agent] failed to record invoked message author; continuing unattributed', {
+      agentSlug: params.agentSlug,
+      sessionId: params.sessionId,
+      userId: params.userId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return false
+  }
+}
+
+async function deleteMessageAuthorBestEffort(messageUuid: string): Promise<void> {
+  try {
+    await db.delete(messageAuthor).where(eq(messageAuthor.id, messageUuid))
+  } catch (error) {
+    console.warn('[x-agent] failed to clean up invoked message attribution', {
+      messageUuid,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+async function getAgentDisplayNameBestEffort(agentSlug: string): Promise<string> {
+  try {
+    const agent = await getAgent(agentSlug)
+    return agent?.frontmatter.name || agentSlug
+  } catch (error) {
+    // Human-readable naming is cosmetic and must not gate agent invocation.
+    console.warn('[x-agent] failed to resolve caller display name; using slug', {
+      agentSlug,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return agentSlug
+  }
 }
 
 /**
@@ -520,6 +577,8 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
 
   // Capture the triggering message's author before a review prompt can pause
   // this request and newer messages can arrive in a shared caller session.
+  // This remains a best-effort "latest author" heuristic until the container
+  // can pass the exact driving message UUID.
   const triggeringUserId = isAuthMode() && _callerSessionId
     ? await getLatestMessageAuthorUserId(callerSlug, _callerSessionId)
     : undefined
@@ -546,7 +605,15 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
   // owner remain compatibility fallbacks for old sessions without author rows.
   let attributedUserId: string | undefined = triggeringUserId ?? callerMeta?.createdByUserId
   if (!attributedUserId && isAuthMode()) {
-    attributedUserId = (await getOwnersOfAgent(callerSlug))[0]
+    try {
+      attributedUserId = (await getOwnersOfAgent(callerSlug))[0]
+    } catch (error) {
+      // ACL checks already ran above; this second lookup is attribution-only.
+      console.warn('[x-agent] failed to resolve caller owner for attribution; continuing unattributed', {
+        callerSlug,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
   }
 
   return runWithOptionalUser(attributedUserId, async () => {
@@ -565,17 +632,26 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         }
         messagePersister.markSessionActive(existingSessionId, targetSlug)
         stage = 'send_message'
+        let messageUuid: string | undefined
         if (isAuthMode() && attributedUserId) {
-          const messageUuid = randomUUID()
-          await db.insert(messageAuthor).values({
-            id: messageUuid,
+          const candidateUuid = randomUUID()
+          const recorded = await insertMessageAuthorBestEffort({
+            id: candidateUuid,
             sessionId: existingSessionId,
             agentSlug: targetSlug,
             userId: attributedUserId,
           })
-          await client.sendMessage(existingSessionId, prompt, messageUuid)
-        } else {
-          await client.sendMessage(existingSessionId, prompt)
+          if (recorded) messageUuid = candidateUuid
+        }
+        try {
+          if (messageUuid) {
+            await client.sendMessage(existingSessionId, prompt, messageUuid)
+          } else {
+            await client.sendMessage(existingSessionId, prompt)
+          }
+        } catch (sendError) {
+          if (messageUuid) await deleteMessageAuthorBestEffort(messageUuid)
+          throw sendError
         }
 
         if (sync) {
@@ -605,8 +681,7 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
       const agentLimits = getEffectiveAgentLimits()
       const customEnvVars = getCustomEnvVars()
       const targetPrefs = await readAgentPreferences(targetSlug)
-      const caller = await getAgent(callerSlug)
-      const callerName = caller?.frontmatter.name || callerSlug
+      const callerName = await getAgentDisplayNameBestEffort(callerSlug)
       const initialMessageUuid = isAuthMode() && attributedUserId
         ? randomUUID()
         : undefined
@@ -632,16 +707,17 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
       // Mark active before any await so waitForIdle sees state if result arrives early.
       messagePersister.markSessionActive(newSessionId, targetSlug)
 
-      stage = 'register_session'
-      try {
-        if (initialMessageUuid && attributedUserId) {
-          await db.insert(messageAuthor).values({
+      const authorRecorded = initialMessageUuid && attributedUserId
+        ? await insertMessageAuthorBestEffort({
             id: initialMessageUuid,
             sessionId: newSessionId,
             agentSlug: targetSlug,
             userId: attributedUserId,
           })
-        }
+        : false
+
+      stage = 'register_session'
+      try {
         await registerSession(targetSlug, newSessionId, `Invoked by ${callerName}`)
       } catch (registerErr) {
         const message = registerErr instanceof Error ? registerErr.message : String(registerErr)
@@ -662,16 +738,8 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
             error: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
           })
         })
-        if (initialMessageUuid) {
-          await db
-            .delete(messageAuthor)
-            .where(eq(messageAuthor.id, initialMessageUuid))
-            .catch((cleanupErr) => {
-              console.error('[x-agent] failed to clean up invoked message attribution', {
-                messageUuid: initialMessageUuid,
-                error: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
-              })
-            })
+        if (authorRecorded && initialMessageUuid) {
+          await deleteMessageAuthorBestEffort(initialMessageUuid)
         }
         messagePersister.unsubscribeFromSession(newSessionId)
         return c.json({ error: `Failed to register invoked session: ${message}` }, 500)
@@ -680,7 +748,7 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
       try {
         await updateSessionMetadata(targetSlug, newSessionId, {
           invokedByAgentSlug: callerSlug,
-          ...(attributedUserId ? { createdByUserId: attributedUserId } : {}),
+          ...(authorRecorded && attributedUserId ? { createdByUserId: attributedUserId } : {}),
         })
       } catch (metaErr) {
         console.warn('[x-agent] updateSessionMetadata failed (session usable, provenance not recorded)', {


### PR DESCRIPTION
## Summary

- name newly invoked sessions with the calling agent's human-readable display name instead of its opaque slug
- attribute invoked prompts to the user whose message triggered the invocation in shared caller sessions
- preserve attribution for both newly created and continued target sessions, with compatibility fallbacks for legacy sessions
- keep all optional naming and attribution work fail-open so it can never block an agent invocation
- add regression coverage for display-name titles and shared-user attribution

## Root cause

The x-agent invoke route interpolated the canonical caller slug directly into the target session title. It also propagated only session-level creator metadata and did not assign invoked prompts a message UUID backed by a `message_author` row, so the triggering user's name was lost when an agent was shared.

## Impact

Invoked sessions now read like `Invoked by Business Analyst Agent`, and target transcripts show the actual user who initiated the triggering turn.

## Reliability

- stale/deleted `createdByUserId` values and attribution database failures degrade to an unattributed message
- caller display-name lookup failures fall back to the canonical slug
- failed continued-session sends and failed new-session registration clean up any author row created for the attempted message
- attribution writes are covered with SQLite foreign-key enforcement enabled in tests

## Known limitation

The caller currently supplies only its session ID, so shared-session attribution uses the latest recorded message author as a best-effort heuristic. A message queued by another user before the invoke tool runs can still win that heuristic. Passing the exact driving message UUID from the container is intentionally left as a broader follow-up.

## Validation

- `npm test -- --run src/api/routes/x-agent.test.ts` — 57 tests passed
- `./node_modules/.bin/eslint src/api/routes/x-agent.ts src/api/routes/x-agent.test.ts`
- `npm run typecheck`
