### PR TITLE
fix: host-owned MicroVM idle via in-memory activity (supersedes #550 & #553)

### DIFF
--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -289,6 +289,11 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     this.config = config
   }
 
+  // Default: no in-memory activity clock — AutoSleepMonitor uses listSessions().
+  getCachedLastActivityMs(): number | undefined {
+    return undefined
+  }
+
   /**
    * Emit an 'error' event without crashing the process.
    *

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -696,6 +696,12 @@ class ContainerManager {
     return this.lastKeepAliveAt.get(agentId)
   }
 
+  // Runtime-provided in-memory activity (e.g. MicroVM proxy traffic). undefined
+  // means AutoSleepMonitor should fall back to listSessions() filesystem I/O.
+  getCachedLastActivityMs(agentId: string): number | undefined {
+    return this.getClient(agentId).getCachedLastActivityMs()
+  }
+
   // Remove a client from the cache
   removeClient(agentId: string): void {
     this.clients.delete(agentId)

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -408,11 +408,32 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(await newClient().getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
   })
 
-  it('getInfoFromRuntime treats SUSPENDED as running (auto-resume on request)', async () => {
+  it('getInfoFromRuntime treats SUSPENDED as stopped (warm idle; local state kept)', async () => {
     const client = newClient()
     await client.start()
     responses.getState = 'SUSPENDED'
-    expect((await client.getInfoFromRuntime()).status).toBe('running')
+    expect(await client.getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
+
+    // Warm-idle must not drop local state — a later start() resumes, not Run.
+    responses.getState = 'RUNNING'
+    sendMock.mockClear()
+    await client.start()
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
+  })
+
+  it('getInfoFromRuntime treats SUSPENDING as stopped (warm idle; local state kept)', async () => {
+    const client = newClient()
+    await client.start()
+    responses.getState = 'SUSPENDING'
+    expect(await client.getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
+  })
+
+  it('stop() then getInfoFromRuntime reports stopped while suspended', async () => {
+    const client = newClient()
+    await client.start()
+    await client.stop()
+    responses.getState = 'SUSPENDED'
+    expect(await client.getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
   })
 
   it('getInfoFromRuntime reports stopped when the VM is TERMINATED and cleans up local state', async () => {
@@ -497,11 +518,16 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(suspendCall![0].input).toEqual({ microvmIdentifier: 'mvm-1' })
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
 
-    // State is preserved: a subsequent start() short-circuits (no new RunMicrovm).
+    // State is preserved: start() resumes via /health (no new RunMicrovm).
     sendMock.mockClear()
     responses.getState = 'SUSPENDED'
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      responses.getState = 'RUNNING'
+      return { ok: true } as Response
+    }))
     await client.start()
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
+    expect((await client.getInfoFromRuntime()).status).toBe('running')
   })
 
   it('a plain stop() is a no-op suspend when already SUSPENDED', async () => {

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -466,13 +466,23 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     stopSpy.mockRestore()
   })
 
-  it('background auto-sleep (escalateToForceStop:false) is a no-op — idlePolicy owns idle', async () => {
+  it('background auto-sleep (escalateToForceStop:false) suspends via host AutoSleepMonitor', async () => {
     const client = newClient()
     await client.start()
     sendMock.mockClear()
     await client.stop({ escalateToForceStop: false })
-    expect(sendMock.mock.calls.some((c) => c[0].type === 'Suspend')).toBe(false)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Suspend')).toBe(true)
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
+  })
+
+  it('seeds in-memory activity on start and exposes it for auto-sleep', async () => {
+    const client = newClient()
+    expect(client.getCachedLastActivityMs()).toBeUndefined()
+    const before = Date.now()
+    await client.start()
+    const activity = client.getCachedLastActivityMs()
+    expect(activity).toBeTypeOf('number')
+    expect(activity!).toBeGreaterThanOrEqual(before)
   })
 
   it('a plain stop() suspends (preserves state for warm resume), not terminate', async () => {
@@ -533,8 +543,16 @@ describe('LocalAuthForwardProxy', () => {
     for (const p of proxies.splice(0)) p.stop()
   })
 
-  function makeProxy(mintToken: () => Promise<Record<string, string>>) {
-    const proxy = new LocalAuthForwardProxy({ endpoint: 'mvm.lambda-microvm.aws', agentPort: 3000, mintToken })
+  function makeProxy(
+    mintToken: () => Promise<Record<string, string>>,
+    onActivity?: () => void,
+  ) {
+    const proxy = new LocalAuthForwardProxy({
+      endpoint: 'mvm.lambda-microvm.aws',
+      agentPort: 3000,
+      mintToken,
+      onActivity,
+    })
     proxies.push(proxy)
     return proxy
   }
@@ -563,6 +581,17 @@ describe('LocalAuthForwardProxy', () => {
     expect(capturedRequest.headers!.host).toBe('mvm.lambda-microvm.aws')
     expect(capturedRequest.headers!['x-custom']).toBe('v')
     expect(capturedRequest.headers!.connection).toBeUndefined()
+  })
+
+  it('touches onActivity for real traffic but not /health liveness probes', async () => {
+    const onActivity = vi.fn()
+    const port = await makeProxy(async () => ({ 'X-aws-proxy-auth': 'tok' }), onActivity).start()
+    await httpGet(port, '/health')
+    expect(onActivity).not.toHaveBeenCalled()
+    await httpGet(port, '/sessions')
+    expect(onActivity).toHaveBeenCalledTimes(1)
+    await httpGet(port, '/health?ready=1')
+    expect(onActivity).toHaveBeenCalledTimes(1)
   })
 
   it('caches the auth token across requests (mints once)', async () => {

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -686,6 +686,10 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   async start(options?: StartOptions): Promise<void> {
     if ((await this.getInfoFromRuntime()).status === 'running') return
 
+    // Suspended VMs are UI-stopped but still warm — resume before RunMicrovm.
+    const existing = agentStates.get(this.config.agentId)
+    if (existing && (await this.resumeExisting(existing))) return
+
     const config = getMicrovmRuntimeConfig()
     // Full env exceeds the 4096-byte payload cap, so stash it host-side and pass the
     // VM only a small bootstrap credential to fetch it at boot via /api/agent-bootstrap.
@@ -783,10 +787,12 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     const config = getMicrovmRuntimeConfig()
     try {
       const mvm = await getMicrovm(config.region, state.microvmId)
-      // SUSPENDED is "running on demand": idlePolicy.autoResumeEnabled wakes it
-      // on the next request through the proxy.
-      if (mvm.state === 'RUNNING' || mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
+      if (mvm.state === 'RUNNING') {
         return { status: 'running', port: state.proxyPort }
+      }
+      // Warm-idle: UI shows stopped; local proxy state is kept so start()/traffic can resume.
+      if (mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
+        return { status: 'stopped', port: null }
       }
       // Terminal: VM is gone — drop state + proxy (mirror NotFound) so it isn't leaked.
       this.cleanupLocal()
@@ -833,6 +839,41 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
       await new Promise((resolve) => setTimeout(resolve, 2_000))
     }
     throw new Error(`Timed out waiting for MicroVM ${microvmId} to become RUNNING`)
+  }
+
+  // Resume a warm-suspended VM. Returns false when local state is stale (caller should Run).
+  // Avoid waitForHealthy here — it treats UI-stopped/suspended as dead and bails early.
+  private async resumeExisting(state: AgentMicrovmState): Promise<boolean> {
+    const config = getMicrovmRuntimeConfig()
+    try {
+      const mvm = await getMicrovm(config.region, state.microvmId)
+      if (mvm.state === 'TERMINATED' || mvm.state === 'TERMINATING') {
+        this.cleanupLocal()
+        return false
+      }
+      if (mvm.state !== 'RUNNING' && mvm.state !== 'SUSPENDED' && mvm.state !== 'SUSPENDING') {
+        this.cleanupLocal()
+        return false
+      }
+
+      const deadline = Date.now() + 120_000
+      while (Date.now() < deadline) {
+        if (await this.isHealthy(state.proxyPort)) break
+        await new Promise((resolve) => setTimeout(resolve, 250))
+      }
+      if (!(await this.isHealthy(state.proxyPort))) {
+        throw new Error(`MicroVM agent ${state.microvmId} failed to become healthy`)
+      }
+      await this.waitForRunning(config.region, state.microvmId, 120_000)
+      touchAgentActivity(this.config.agentId)
+      return true
+    } catch (error) {
+      if (isNotFound(error)) {
+        this.cleanupLocal()
+        return false
+      }
+      throw error
+    }
   }
 
   // Keep local proxy state so the next request auto-resumes the same VM.

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -228,6 +228,8 @@ export interface ProxyOptions {
   agentPort: number
   /** Mints a fresh auth-token map ({ "X-aws-proxy-auth": "<jwe>", ... }). */
   mintToken: () => Promise<MicrovmAuthToken>
+  /** Called on real user/agent traffic (not /health liveness probes). */
+  onActivity?: () => void
 }
 
 export class LocalAuthForwardProxy {
@@ -338,6 +340,7 @@ export class LocalAuthForwardProxy {
 
   // Replay requests across the brief resume window, where AWS may 502/refuse.
   private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    if (!isLivenessProbePath(req.url)) this.options.onActivity?.()
     let body: Buffer
     try {
       body = await this.readBody(req)
@@ -385,6 +388,7 @@ export class LocalAuthForwardProxy {
   }
 
   private async handleUpgrade(req: http.IncomingMessage, socket: net.Socket, head: Buffer): Promise<void> {
+    this.options.onActivity?.()
     // A WS upgrade can't be replayed once piped, so kick the VM awake over HTTP
     // (with the same resume-retry HTTP requests get) before opening the stream.
     if (!(await this.waitForUpstreamReady())) {
@@ -461,9 +465,9 @@ export class LocalAuthForwardProxy {
 // ---------------------------------------------------------------------------
 
 // MicroVM ids are AWS-generated (no deterministic name, no tag-filtered lookup),
-// so the agentId→microvm mapping + its loopback proxy live in process memory.
-// Lost on host-app restart: the orphaned VM is reclaimed by its idlePolicy
-// (idle→suspend→suspended-timeout→terminate) and the next start() re-runs.
+// so the agentId→microvm mapping + loopback proxy + activity clock live in RAM.
+// Lost on host-app restart: orphaned VMs are reclaimed by idlePolicy
+// (idle→suspend→suspended-timeout→terminate); the next start() re-runs.
 interface AgentMicrovmState {
   microvmId: string
   endpoint: string
@@ -471,6 +475,19 @@ interface AgentMicrovmState {
   proxyPort: number
 }
 const agentStates = new Map<string, AgentMicrovmState>()
+
+// Host-side activity clock for AutoSleepMonitor (avoids S3 Files listSessions I/O).
+// Touched on real proxy traffic + start; /health liveness probes are excluded.
+const agentLastActivityAt = new Map<string, number>()
+
+function touchAgentActivity(agentId: string): void {
+  agentLastActivityAt.set(agentId, Date.now())
+}
+
+function isLivenessProbePath(url: string | undefined): boolean {
+  const path = (url ?? '/').split('?')[0] ?? '/'
+  return path === '/health'
+}
 
 type MicrovmDetail = { state?: string; endpoint?: string }
 
@@ -718,6 +735,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
       endpoint: run.endpoint,
       agentPort: config.agentPort,
       mintToken: () => this.mintToken(run.microvmId),
+      onActivity: () => touchAgentActivity(this.config.agentId),
     })
     const proxyPort = await proxy.start()
     // Stop any stale proxy before overwriting state (no leaked port/listener); stash
@@ -725,6 +743,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     this.cleanupLocal()
     if (hasEnv) setBootstrapEnv(this.config.agentId, env)
     agentStates.set(this.config.agentId, { microvmId: run.microvmId, endpoint: run.endpoint, proxy, proxyPort })
+    touchAgentActivity(this.config.agentId)
 
     try {
       await this.waitForRunning(config.region, run.microvmId, 300_000)
@@ -739,14 +758,16 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
 
   // Proxy-level retry handles the suspend→resume 502 window for all HTTP calls.
 
-  async stop(options?: StopOptions): Promise<StopResult> {
+  async stop(_options?: StopOptions): Promise<StopResult> {
     this.terminateWebSocketConnections()
-    // Auto-sleep is handled by AWS idlePolicy; the host-app sweep is a no-op.
-    if (options?.escalateToForceStop === false) {
-      return { forceStopUsed: false, stopped: true }
-    }
+    // Host AutoSleepMonitor owns product idle via in-memory activity; both the
+    // background sweep and an explicit stop suspend (idlePolicy is the orphan GC).
     await this.suspend()
     return { forceStopUsed: false, stopped: true }
+  }
+
+  getCachedLastActivityMs(): number | undefined {
+    return agentLastActivityAt.get(this.config.agentId)
   }
 
   stopSync(): void {
@@ -855,6 +876,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     const state = agentStates.get(this.config.agentId)
     state?.proxy.stop()
     agentStates.delete(this.config.agentId)
+    agentLastActivityAt.delete(this.config.agentId)
     clearBootstrapEnv(this.config.agentId)
   }
 }
@@ -862,6 +884,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
 export function resetMicrovmRuntimeForTests(): void {
   for (const state of agentStates.values()) state.proxy.stop()
   agentStates.clear()
+  agentLastActivityAt.clear()
   memoizedClient = null
   memoizedConfig = null
   memoizedHostPrivateIp = undefined

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -2214,6 +2214,10 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     }
   }
 
+  getCachedLastActivityMs(): number | undefined {
+    return undefined
+  }
+
   getWebSocketBaseUrl(port: number): string {
     return `ws://127.0.0.1:${port}`
   }

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -176,6 +176,10 @@ export interface ContainerClient {
   // Resource stats (memory, CPU usage)
   getStats(): Promise<ContainerStats | null>
 
+  // Host-side last activity for auto-sleep without session filesystem I/O.
+  // undefined = AutoSleepMonitor falls back to listSessions().
+  getCachedLastActivityMs(): number | undefined
+
   // Session management (proxied to container API)
   createSession(options: CreateSessionOptions): Promise<ContainerSession>
   getSession(sessionId: string): Promise<ContainerSession | null>

--- a/src/shared/lib/scheduler/auto-sleep-monitor.test.ts
+++ b/src/shared/lib/scheduler/auto-sleep-monitor.test.ts
@@ -8,6 +8,7 @@ import type { SessionInfo } from '@shared/lib/types/agent'
 const mockGetRunningAgentIds = vi.fn<() => string[]>(() => [])
 const mockGetContainerStartTime = vi.fn<(id: string) => number | undefined>()
 const mockGetLastKeepAlive = vi.fn<(id: string) => number | undefined>()
+const mockGetCachedLastActivityMs = vi.fn<(id: string) => number | undefined>()
 const mockStopContainer = vi.fn()
 
 vi.mock('@shared/lib/container/container-manager', () => ({
@@ -15,6 +16,7 @@ vi.mock('@shared/lib/container/container-manager', () => ({
     getRunningAgentIds: () => mockGetRunningAgentIds(),
     getContainerStartTime: (id: string) => mockGetContainerStartTime(id),
     getLastKeepAlive: (id: string) => mockGetLastKeepAlive(id),
+    getCachedLastActivityMs: (id: string) => mockGetCachedLastActivityMs(id),
     stopContainer: (...args: unknown[]) => mockStopContainer(...args),
   },
 }))
@@ -73,6 +75,8 @@ describe('AutoSleepMonitor', () => {
     mockListSessions.mockResolvedValue([])
     mockGetContainerStartTime.mockReturnValue(undefined)
     mockGetLastKeepAlive.mockReturnValue(undefined)
+    mockGetCachedLastActivityMs.mockReturnValue(undefined)
+    mockHasActiveSessions.mockReturnValue(false)
     mockStopContainer.mockResolvedValue(undefined)
   })
 
@@ -194,6 +198,36 @@ describe('AutoSleepMonitor', () => {
     await autoSleepMonitor.start()
     await tick()
 
+    expect(mockStopContainer).not.toHaveBeenCalled()
+  })
+
+  it('uses in-memory activity and skips listSessions when the runtime provides a cache', async () => {
+    const now = Date.now()
+    mockGetRunningAgentIds.mockReturnValue(['agent-1'])
+    mockGetCachedLastActivityMs.mockReturnValue(now - THIRTY_MINUTES_MS - 1000)
+    mockGetContainerStartTime.mockReturnValue(now - THIRTY_MINUTES_MS - 1000)
+
+    await autoSleepMonitor.start()
+    await tick()
+
+    expect(mockListSessions).not.toHaveBeenCalled()
+    expect(mockStopContainer).toHaveBeenCalledWith('agent-1', {
+      stopTimeoutMs: 60_000,
+      killTimeoutMs: 30_000,
+      escalateToForceStop: false,
+    })
+  })
+
+  it('does not stop when in-memory activity is recent', async () => {
+    const now = Date.now()
+    mockGetRunningAgentIds.mockReturnValue(['agent-1'])
+    mockGetCachedLastActivityMs.mockReturnValue(now - 5 * 60 * 1000)
+    mockGetContainerStartTime.mockReturnValue(now - THIRTY_MINUTES_MS - 1000)
+
+    await autoSleepMonitor.start()
+    await tick()
+
+    expect(mockListSessions).not.toHaveBeenCalled()
     expect(mockStopContainer).not.toHaveBeenCalled()
   })
 })

--- a/src/shared/lib/scheduler/auto-sleep-monitor.ts
+++ b/src/shared/lib/scheduler/auto-sleep-monitor.ts
@@ -81,14 +81,6 @@ class AutoSleepMonitor {
             continue
           }
 
-          // Check last activity across all sessions
-          const sessions = await listSessions(agentId)
-
-          // No sessions — container was just started, skip it
-          if (sessions.length === 0) {
-            continue
-          }
-
           // Use container start time as a floor — when an agent is woken up
           // to view its dashboard, session timestamps are stale from before
           // the previous sleep and would cause immediate re-sleep.
@@ -97,11 +89,33 @@ class AutoSleepMonitor {
           const lastKeepAlive =
             containerManager.getLastKeepAlive(agentId) ?? 0
 
-          const lastActivity = Math.max(
-            containerStartTime,
-            lastKeepAlive,
-            ...sessions.map((s) => s.lastActivityAt.getTime())
-          )
+          // Runtimes with an in-memory activity clock (Lambda MicroVM) skip
+          // listSessions — that path hits S3 Files and was pure cost when the
+          // eventual stop was a no-op / when activity is already known in RAM.
+          const cachedActivity =
+            containerManager.getCachedLastActivityMs(agentId)
+
+          let lastActivity: number
+          if (cachedActivity !== undefined) {
+            lastActivity = Math.max(
+              containerStartTime,
+              lastKeepAlive,
+              cachedActivity
+            )
+          } else {
+            const sessions = await listSessions(agentId)
+
+            // No sessions — container was just started, skip it
+            if (sessions.length === 0) {
+              continue
+            }
+
+            lastActivity = Math.max(
+              containerStartTime,
+              lastKeepAlive,
+              ...sessions.map((s) => s.lastActivityAt.getTime())
+            )
+          }
 
           if (now - lastActivity > timeoutMs) {
             console.log(


### PR DESCRIPTION
## Summary
- Host `AutoSleepMonitor` owns Lambda MicroVM product idle via an in-memory activity clock (proxy traffic), so it no longer scans session files on S3 Files.
- Background + manual `stop()` both suspend again (drops the AutoSleep no-op); AWS `idlePolicy` remains orphan GC after host restart only.
- Folds warm-suspend UI from #550: `SUSPENDED`/`SUSPENDING` map to UI `stopped`, local proxy is kept, and `start()` warm-resumes via `/health` instead of a new `RunMicrovm`.

Supersedes #550 and #553:
- #550 — warm-suspend UI mapping (folded here; that branch was off pre-revert #538).
- #553 — skip-scan workaround (replaced by host-owned idle + cheap in-memory activity instead of disabling the monitor).

## Bug / why
1. AutoSleepMonitor `listSessions()` on S3 Files saturated Fargate network and contributed to unhealthy `healthz` probes; MicroVM background stop was a no-op so the scan paid for nothing.
2. Dual sleep owners (AWS `idlePolicy` + host no-op) made debugging/status sync risky (#553 review).
3. Manual Stop / AWS suspend reported as running after refresh (#550).

## Test plan
- [x] `npm test -- --run src/shared/lib/container/lambda-microvm-runtime.test.ts src/shared/lib/scheduler/auto-sleep-monitor.test.ts`
- [ ] Manual: Stop agent → UI stopped → refresh stays stopped → Wake Up resumes same VM (no new Run)
- [ ] Manual: idle past auto-sleep timeout → host suspends → UI shows stopped after status sync
- [ ] Staging: confirm AutoSleep cycle does not drive heavy S3 Files `/data` RX like the old `listSessions` sweep