### PR TITLE
Soften global focus ring token

### DIFF
--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -22,7 +22,7 @@
     --destructive-foreground: 0 0% 98%;
     --border: 0 0% 89.8%;
     --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
+    --ring: 0 0% 63.9%;
     --radius: 0.5rem;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
@@ -58,7 +58,7 @@
     --destructive-foreground: 0 0% 98%;
     --border: 0 0% 19%;
     --input: 0 0% 19%;
-    --ring: 0 0% 83.1%;
+    --ring: 0 0% 45%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;


### PR DESCRIPTION
## What

The `--ring` CSS token was near-black (3.9% lightness) in light mode and near-white (83.1%) in dark mode, producing a heavy high-contrast outline on every focused control (inputs, selects, tabs, buttons — all 9 ui primitives using `ring-ring`). This softens it to mid-gray: 63.9% light / 45% dark.

## Accessibility note

WCAG 2.4.7 requires a visible focus indicator (still present), and 1.4.11 suggests 3:1 contrast for author-styled indicators. 63.9% gray on white is ~2.6:1 — slightly under that line, though the ring renders on top of existing input borders so the combined indicator remains clearly perceivable. If we want to be strictly conformant, 55% is the lightest neutral gray that passes; happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)